### PR TITLE
Set specific version number for updated Roslyn nuget package

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -12,4 +12,4 @@ nuget structuremap
 
 
 source https://www.myget.org/F/roslyn-nightly/
-nuget Microsoft.CodeAnalysis.CSharp >= 1.2.0 prerelease
+nuget Microsoft.CodeAnalysis.CSharp = 1.2.0-beta-20151106-02 prerelease


### PR DESCRIPTION
When I run paket install I had following error
`Paket failed with: Could not retrieve data from https://www.myget.org/F/roslyn-nightly/odata/Packages(Id='Microsoft.CodeAnalysis.CSharp',Version='1.2.0-beta-20151028-07') Message: One or more errors occurred.`
changing the roslyn packaing in the dependencies file to the new specific version nuget `Microsoft.CodeAnalysis.CSharp = 1.2.0-beta-20151106-02 prerelease` solved it

Not sure if this is the best way to do it..