### PR TITLE
Optimize first

### DIFF
--- a/src/Marten.Testing/Linq/invoking_queryable_through_first_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_through_first_Tests.cs
@@ -44,28 +44,28 @@ namespace Marten.Testing.Linq
                 .ShouldBeNull();
         }
 
-        public void first_hit_with_more_than_one_match()
+        public void first_correct_hit_with_more_than_one_match()
         {
             theSession.Store(new Target { Number = 1 });
-            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 2, Flag = true });
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 4 });
             theSession.SaveChanges();
 
-            theSession.Query<Target>().Where(x => x.Number == 2).First()
-                .ShouldNotBeNull();
+            theSession.Query<Target>().Where(x => x.Number == 2).First().Flag
+                .ShouldBeTrue();
         }
 
-        public void first_or_default_hit_with_more_than_one_match()
+        public void first_or_default_correct_hit_with_more_than_one_match()
         {
             theSession.Store(new Target { Number = 1 });
-            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 2, Flag = true });
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 4 });
             theSession.SaveChanges();
 
-            theSession.Query<Target>().Where(x => x.Number == 2).FirstOrDefault()
-                .ShouldNotBeNull();
+            theSession.Query<Target>().Where(x => x.Number == 2).FirstOrDefault().Flag
+                .ShouldBeTrue();
         }
 
         public void first_miss()

--- a/src/Marten/Linq/DocumentQuery.cs
+++ b/src/Marten/Linq/DocumentQuery.cs
@@ -92,7 +92,18 @@ namespace Marten.Linq
             var take =
                 _query.ResultOperators.OfType<TakeResultOperator>().OrderByDescending(x => x.Count).FirstOrDefault();
 
-            return take == null ? sql : sql + " LIMIT " + take.Count + " ";
+            var first = _query.ResultOperators.OfType<FirstResultOperator>().FirstOrDefault();
+
+            string limitNumber = null;
+            if (take != null)
+            {
+                limitNumber = take.Count.ToString();
+            }
+            else if (first != null)
+            {
+                limitNumber = "1";
+            }
+            return limitNumber == null ? sql : sql + " LIMIT " + limitNumber + " ";
         }
 
         private string toOrderClause()

--- a/src/Marten/Linq/MartenQueryExecutor.cs
+++ b/src/Marten/Linq/MartenQueryExecutor.cs
@@ -63,7 +63,6 @@ namespace Marten.Linq
 
         T IQueryExecutor.ExecuteSingle<T>(QueryModel queryModel, bool returnDefaultWhenEmpty)
         {
-            var isFirst = queryModel.ResultOperators.OfType<FirstResultOperator>().Any();
             var isLast = queryModel.ResultOperators.OfType<LastResultOperator>().Any();
 
             // TODO -- optimize by using Top 1
@@ -73,11 +72,7 @@ namespace Marten.Linq
             if (returnDefaultWhenEmpty && all.Length == 0) return default(T);
 
             string data = null;
-            if (isFirst)
-            {
-                data = all.First();
-            }
-            else if (isLast)
+            if (isLast)
             {
                 data = all.Last();
             }


### PR DESCRIPTION
@jeremydmiller, A first stab at implementing #89 

I've made the first tests slightly harder to pass by checking the returned result has flag set but this may not be such a good move as we actually guarantee postgresql will return the results in insertion order (http://www.postgresql.org/docs/9.1/static/queries-order.html says results will come back in "unspecified order" if no sort is set). What do you think?

Last is a little trickier to push down. Either as you suggested in #87, we reverse the order but we can't do this if there's no user provided order. Or we can do the wrap the original query and skip the count of this subquery minus one but that's quite a big change to the query construction.