### PR TITLE
Added xunit attribute for initial dnx needs

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -12,3 +12,4 @@ nuget Shouldly
 nuget Storyteller 3.0.0.280-alpha
 nuget structuremap
 nuget Microsoft.CodeAnalysis.CSharp prerelease
+nuget xunit

--- a/paket.lock
+++ b/paket.lock
@@ -30,56 +30,62 @@ NUGET
     Storyteller (3.0.0.280-alpha)
     structuremap (3.1.6.186)
     System.Collections (4.0.10) - framework: dnxcore50
-      System.Diagnostics.Debug (>= 4.0.0)
-      System.Resources.ResourceManager (>= 4.0.0)
-      System.Runtime (>= 4.0.0)
-      System.Runtime (>= 4.0.20)
-      System.Runtime.Extensions (>= 4.0.0)
-      System.Threading (>= 4.0.0)
+      System.Diagnostics.Debug (>= 4.0.0) - framework: dnxcore50
+      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.0) - framework: dnxcore50
+      System.Threading (>= 4.0.0) - framework: dnxcore50
     System.Collections.Immutable (1.1.37)
-      System.Collections (>= 4.0.0)
-      System.Diagnostics.Debug (>= 4.0.0)
-      System.Globalization (>= 4.0.0)
-      System.Linq (>= 4.0.0)
-      System.Resources.ResourceManager (>= 4.0.0)
-      System.Runtime (>= 4.0.0)
-      System.Runtime.Extensions (>= 4.0.0)
-      System.Threading (>= 4.0.0)
+      System.Collections (>= 4.0.0) - framework: dnxcore50
+      System.Diagnostics.Debug (>= 4.0.0) - framework: dnxcore50
+      System.Globalization (>= 4.0.0) - framework: dnxcore50
+      System.Linq (>= 4.0.0) - framework: dnxcore50
+      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.0) - framework: dnxcore50
+      System.Threading (>= 4.0.0) - framework: dnxcore50
     System.Diagnostics.Contracts (4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0)
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
     System.Diagnostics.Debug (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0)
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
     System.Globalization (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0)
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
     System.IO (4.0.10) - framework: dnxcore50
-      System.Globalization (>= 4.0.0)
-      System.Runtime (>= 4.0.20)
-      System.Text.Encoding (>= 4.0.0)
-      System.Text.Encoding (>= 4.0.10)
-      System.Text.Encoding.Extensions (>= 4.0.0)
-      System.Threading (>= 4.0.0)
-      System.Threading.Tasks (>= 4.0.0)
+      System.Globalization (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Text.Encoding (>= 4.0.0) - framework: dnxcore50
+      System.Text.Encoding (>= 4.0.10) - framework: dnxcore50
+      System.Text.Encoding.Extensions (>= 4.0.0) - framework: dnxcore50
+      System.Threading (>= 4.0.0) - framework: dnxcore50
+      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
     System.Linq (4.0.0) - framework: dnxcore50
-      System.Collections (>= 4.0.10)
-      System.Diagnostics.Debug (>= 4.0.10)
-      System.Resources.ResourceManager (>= 4.0.0)
-      System.Runtime (>= 4.0.20)
-      System.Runtime.Extensions (>= 4.0.10)
+      System.Collections (>= 4.0.10) - framework: dnxcore50
+      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
+      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
+    System.ObjectModel (4.0.10) - framework: dnxcore50
+      System.Collections (>= 4.0.10) - framework: dnxcore50
+      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
+      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Threading (>= 4.0.10) - framework: dnxcore50
     System.Private.Uri (4.0.0) - framework: dnxcore50
     System.Reflection (4.0.10) - framework: dnxcore50
-      System.IO (>= 4.0.0)
-      System.Reflection.Primitives (>= 4.0.0)
-      System.Runtime (>= 4.0.20)
+      System.IO (>= 4.0.0) - framework: dnxcore50
+      System.Reflection.Primitives (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
     System.Reflection.Extensions (4.0.0)
-      System.Diagnostics.Debug (>= 4.0.10)
-      System.Reflection (>= 4.0.0)
-      System.Reflection (>= 4.0.10)
-      System.Reflection.Primitives (>= 4.0.0)
-      System.Reflection.TypeExtensions (>= 4.0.0)
-      System.Resources.ResourceManager (>= 4.0.0)
-      System.Runtime (>= 4.0.0)
-      System.Runtime (>= 4.0.20)
-      System.Runtime.Extensions (>= 4.0.10)
+      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
+      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.10) - framework: dnxcore50
+      System.Reflection.Primitives (>= 4.0.0) - framework: dnxcore50
+      System.Reflection.TypeExtensions (>= 4.0.0) - framework: dnxcore50
+      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
     System.Reflection.Metadata (1.1.0)
       System.Collections (>= 4.0.0)
       System.Collections.Immutable (>= 1.1.37)
@@ -96,43 +102,83 @@ NUGET
       System.Text.Encoding.Extensions (>= 4.0.0)
       System.Threading (>= 4.0.0)
     System.Reflection.Primitives (4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0)
-      System.Threading (>= 4.0.0)
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Threading (>= 4.0.0) - framework: dnxcore50
     System.Reflection.TypeExtensions (4.0.0) - framework: dnxcore50
-      System.Diagnostics.Contracts (>= 4.0.0)
-      System.Diagnostics.Debug (>= 4.0.10)
-      System.Linq (>= 4.0.0)
-      System.Reflection (>= 4.0.0)
-      System.Reflection (>= 4.0.10)
-      System.Reflection.Primitives (>= 4.0.0)
-      System.Resources.ResourceManager (>= 4.0.0)
-      System.Runtime (>= 4.0.0)
-      System.Runtime (>= 4.0.20)
-      System.Runtime.Extensions (>= 4.0.10)
+      System.Diagnostics.Contracts (>= 4.0.0) - framework: dnxcore50
+      System.Diagnostics.Debug (>= 4.0.10) - framework: dnxcore50
+      System.Linq (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.10) - framework: dnxcore50
+      System.Reflection.Primitives (>= 4.0.0) - framework: dnxcore50
+      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
     System.Resources.ResourceManager (4.0.0) - framework: dnxcore50
-      System.Globalization (>= 4.0.0)
-      System.Reflection (>= 4.0.0)
-      System.Reflection (>= 4.0.10)
-      System.Runtime (>= 4.0.0)
-      System.Runtime (>= 4.0.20)
+      System.Globalization (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.10) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
     System.Runtime (4.0.20) - framework: dnxcore50
-      System.Private.Uri (>= 4.0.0)
+      System.Private.Uri (>= 4.0.0) - framework: dnxcore50
     System.Runtime.Extensions (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.20)
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
     System.Runtime.Handles (4.0.0) - framework: dnxcore50
-      System.Runtime (>= 4.0.0)
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
     System.Runtime.InteropServices (4.0.20)
-      System.Reflection (>= 4.0.0)
-      System.Reflection.Primitives (>= 4.0.0)
-      System.Runtime (>= 4.0.0)
-      System.Runtime.Handles (>= 4.0.0)
+      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Reflection.Primitives (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime.Handles (>= 4.0.0) - framework: dnxcore50
     System.Text.Encoding (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0)
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
     System.Text.Encoding.Extensions (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0)
-      System.Text.Encoding (>= 4.0.10)
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Text.Encoding (>= 4.0.10) - framework: dnxcore50
+    System.Text.RegularExpressions (4.0.10) - framework: dnxcore50
+      System.Collections (>= 4.0.10) - framework: dnxcore50
+      System.Globalization (>= 4.0.10) - framework: dnxcore50
+      System.Resources.ResourceManager (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.20) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.10) - framework: dnxcore50
+      System.Threading (>= 4.0.10) - framework: dnxcore50
     System.Threading (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0)
-      System.Threading.Tasks (>= 4.0.0)
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
     System.Threading.Tasks (4.0.10) - framework: dnxcore50
-      System.Runtime (>= 4.0.0)
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+    xunit (2.1.0)
+      xunit.assert (2.1.0)
+      xunit.core (2.1.0)
+    xunit.abstractions (2.0.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.1, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
+    xunit.assert (2.1.0)
+      System.Collections (>= 4.0.0) - framework: dnxcore50
+      System.Diagnostics.Debug (>= 4.0.0) - framework: dnxcore50
+      System.Globalization (>= 4.0.0) - framework: dnxcore50
+      System.Linq (>= 4.0.0) - framework: dnxcore50
+      System.ObjectModel (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Reflection.Extensions (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.0) - framework: dnxcore50
+      System.Text.RegularExpressions (>= 4.0.0) - framework: dnxcore50
+      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
+    xunit.core (2.1.0)
+      System.Collections (>= 4.0.0) - framework: dnxcore50
+      System.Diagnostics.Debug (>= 4.0.0) - framework: dnxcore50
+      System.Globalization (>= 4.0.0) - framework: dnxcore50
+      System.Linq (>= 4.0.0) - framework: dnxcore50
+      System.Reflection (>= 4.0.0) - framework: dnxcore50
+      System.Reflection.Extensions (>= 4.0.0) - framework: dnxcore50
+      System.Runtime (>= 4.0.0) - framework: dnxcore50
+      System.Runtime.Extensions (>= 4.0.0) - framework: dnxcore50
+      System.Threading.Tasks (>= 4.0.0) - framework: dnxcore50
+      xunit.abstractions (>= 2.0.0) - framework: dnxcore50
+      xunit.extensibility.core (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.1, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
+      xunit.extensibility.execution (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.1, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
+    xunit.extensibility.core (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.1, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
+      xunit.abstractions (2.0.0)
+    xunit.extensibility.execution (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.1, wpv8.0, portable-net45+win80+wp80+wpa81, >= net45
+      xunit.extensibility.core (2.1.0) - framework: dnx451, dnxcore50, monoandroid, monotouch, xamarinios, winv4.5, wpv8.1, wpv8.0, >= net45

--- a/src/Marten.Testing/Events/EventGraphTests.cs
+++ b/src/Marten.Testing/Events/EventGraphTests.cs
@@ -1,5 +1,6 @@
 ﻿using Marten.Events;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Events
 {
@@ -7,18 +8,21 @@ namespace Marten.Testing.Events
     {
         private readonly EventGraph theGraph = new EventGraph();
 
+        [Fact]
         public void find_stream_mapping_initially()
         {
             theGraph.StreamMappingFor<Issue>()
                 .DocumentType.ShouldBe(typeof(Issue));
         }
 
+        [Fact]
         public void caches_the_stream_mapping()
         {
             theGraph.StreamMappingFor<Issue>()
                 .ShouldBeSameAs(theGraph.StreamMappingFor<Issue>());
         }
 
+        [Fact]
         public void register_event_types_and_retrieve()
         {
             theGraph.StreamMappingFor<Issue>().AddEvent(typeof (IssueAssigned));
@@ -34,6 +38,7 @@ namespace Marten.Testing.Events
         }
 
 
+        [Fact]
         public void find_event_by_event_type_name()
         {
             theGraph.StreamMappingFor<Issue>().AddEvent(typeof(IssueAssigned));

--- a/src/Marten.Testing/Events/EventMappingTests.cs
+++ b/src/Marten.Testing/Events/EventMappingTests.cs
@@ -1,10 +1,12 @@
 using Marten.Events;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Events
 {
     public class EventMappingTests
     {
+        [Fact]
         public void event_name_for_event_type()
         {
             var mapping = new EventMapping(new StreamMapping(typeof(Quest)), typeof(MembersJoined));

--- a/src/Marten.Testing/Events/StreamMappingTests.cs
+++ b/src/Marten.Testing/Events/StreamMappingTests.cs
@@ -1,17 +1,20 @@
 using System;
 using Marten.Events;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Events
 {
     public class StreamMappingTests
     {
+        [Fact]
         public void derives_the_stream_type_name()
         {
             new StreamMapping(typeof(HouseRemodeling)).StreamTypeName.ShouldBe("house_remodeling");
             new StreamMapping(typeof(Quest)).StreamTypeName.ShouldBe("quest");
         }
 
+        [Fact]
         public void has_event_type()
         {
             var mapping = new StreamMapping(typeof(Quest));

--- a/src/Marten.Testing/Events/end_to_end_event_capture_and_fetching_the_stream_Tests.cs
+++ b/src/Marten.Testing/Events/end_to_end_event_capture_and_fetching_the_stream_Tests.cs
@@ -3,6 +3,7 @@ using Marten.Schema;
 using Marten.Services;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing.Events
 {
@@ -10,6 +11,7 @@ namespace Marten.Testing.Events
     {
         private readonly IContainer _container = Container.For<DevelopmentModeRegistry>();
 
+        [Fact]
         public void capture_events_to_a_new_stream_and_fetch_the_events_back()
         {
             var schema = _container.GetInstance<IDocumentSchema>();

--- a/src/Marten.Testing/Events/event_administration_Tests.cs
+++ b/src/Marten.Testing/Events/event_administration_Tests.cs
@@ -6,6 +6,7 @@ using Marten.Schema;
 using Marten.Services;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing.Events
 {
@@ -22,6 +23,7 @@ namespace Marten.Testing.Events
             events.RebuildEventStoreSchema();
         }
 
+        [Fact]
         public void has_the_event_tables()
         {
             var schema = theContainer.GetInstance<IDocumentSchema>();
@@ -32,6 +34,7 @@ namespace Marten.Testing.Events
             tableNames.ShouldContain("mt_projections");
         }
 
+        [Fact]
         public void has_the_commands_for_appending_events()
         {
             var schema = theContainer.GetInstance<IDocumentSchema>();
@@ -42,6 +45,7 @@ namespace Marten.Testing.Events
         }
 
 
+        [Fact]
         public void has_the_command_for_transforming_events()
         {
             var schema = theContainer.GetInstance<IDocumentSchema>();
@@ -50,6 +54,7 @@ namespace Marten.Testing.Events
             functions.ShouldContain("mt_apply_transform");
         }
 
+        [Fact]
         public void has_the_command_for_applying_aggregation()
         {
             var schema = theContainer.GetInstance<IDocumentSchema>();
@@ -58,6 +63,7 @@ namespace Marten.Testing.Events
             functions.ShouldContain("mt_apply_aggregation");
         }
 
+        [Fact]
         public void has_the_command_for_starting_a_new_aggregate()
         {
             var schema = theContainer.GetInstance<IDocumentSchema>();
@@ -66,6 +72,7 @@ namespace Marten.Testing.Events
             functions.ShouldContain("mt_start_aggregation");
         }
 
+        [Fact]
         public void loads_the_mt_transform_module()
         {
             var runner = theContainer.GetInstance<ICommandRunner>();
@@ -74,6 +81,7 @@ namespace Marten.Testing.Events
             loadedModules.ShouldContain("mt_transforms");
         }
 
+        [Fact]
         public void loads_the_initialize_projections_function()
         {
             var schema = theContainer.GetInstance<IDocumentSchema>();
@@ -82,6 +90,7 @@ namespace Marten.Testing.Events
             functions.ShouldContain("mt_initialize_projections");
         }
 
+        [Fact]
         public void loads_the_get_projection_usage_function()
         {
             var schema = theContainer.GetInstance<IDocumentSchema>();
@@ -91,6 +100,7 @@ namespace Marten.Testing.Events
         }
 
 
+        [Fact]
         public void load_projections()
         {
             var directory =
@@ -113,6 +123,7 @@ namespace Marten.Testing.Events
             list.ShouldContain("party");
         }
 
+        [Fact]
         public void load_projections_and_initialize()
         {
             var directory =
@@ -146,6 +157,7 @@ Projection party (snapshot) for Event quest_started executed inline
     */
         }
 
+        [Fact]
         public void initialize_can_run_without_blowing_up()
         {
             var events = theContainer.GetInstance<EventStore>();

--- a/src/Marten.Testing/Events/plv8_transformation_functions_Tests.cs
+++ b/src/Marten.Testing/Events/plv8_transformation_functions_Tests.cs
@@ -5,6 +5,7 @@ using Marten.Events;
 using Marten.Schema;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing.Events
 {
@@ -34,6 +35,7 @@ namespace Marten.Testing.Events
 
         }
 
+        [Fact]
         public void apply_a_simple_transformation()
         {
             var joined = new MembersJoined
@@ -54,6 +56,7 @@ namespace Marten.Testing.Events
             json.ShouldBe(expectation);
         }
 
+        [Fact]
         public void start_an_aggregate()
         {
             var aggregate = theEvents.Transforms.StartSnapshot<FakeAggregate>(new EventA {Name = "Alex Smith"});
@@ -61,6 +64,7 @@ namespace Marten.Testing.Events
             aggregate.ANames.Single().ShouldBe("Alex Smith");
         }
 
+        [Fact]
         public void alter_an_existing_aggregate()
         {
             var aggregate = new FakeAggregate

--- a/src/Marten.Testing/Events/using_the_schema_objects_Tests.cs
+++ b/src/Marten.Testing/Events/using_the_schema_objects_Tests.cs
@@ -2,11 +2,13 @@
 using Marten.Services;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing.Events
 {
     public class using_the_schema_objects_Tests
     {
+        [Fact]
         public void can_build_the_mt_stream_schema_objects()
         {
             var container = Container.For<DevelopmentModeRegistry>();

--- a/src/Marten.Testing/Linq/MartenExpressionParserTests.cs
+++ b/src/Marten.Testing/Linq/MartenExpressionParserTests.cs
@@ -1,11 +1,13 @@
 ﻿using System.Linq.Expressions;
 using Marten.Linq;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
     public class MartenExpressionParserTests
     {
+        [Fact]
         public void value_of_constant()
         {
             var constant = Expression.Constant("foo");

--- a/src/Marten.Testing/Linq/deep_searches_Tests.cs
+++ b/src/Marten.Testing/Linq/deep_searches_Tests.cs
@@ -2,11 +2,13 @@
 using Marten.Schema;
 using Marten.Services;
 using Marten.Testing.Fixtures;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
     public class deep_searches_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void query_two_deep()
         {
             theSession.Store(new Target{Inner = new Target{Number = 1, String = "Jeremy"}});
@@ -22,6 +24,7 @@ namespace Marten.Testing.Linq
                 .ShouldHaveTheSameElementsAs("Lindsey", "Max");
         }
 
+        [Fact]
         public void query_three_deep()
         {
             theSession.Store(new Target{Number = 1, Inner = new Target{Inner = new Target{Long = 1}}});
@@ -35,6 +38,7 @@ namespace Marten.Testing.Linq
                 .ShouldHaveTheSameElementsAs(1, 3);
         }
 
+        [Fact]
         public void order_by_2_deep()
         {
             theSession.Store(new Target { Inner = new Target { Number = 1, String = "Jeremy" } });
@@ -50,6 +54,7 @@ namespace Marten.Testing.Linq
                 .ShouldHaveTheSameElementsAs("Lindsey", "Max");
         }
 
+        [Fact]
         public void query_two_deep_with_containment_operator()
         {
             theStore.Schema.MappingFor(typeof(Target)).PropertySearching = PropertySearching.ContainmentOperator;
@@ -67,6 +72,7 @@ namespace Marten.Testing.Linq
                 .ShouldHaveTheSameElementsAs("Lindsey", "Max");
         }
 
+        [Fact]
         public void query_three_deep_with_containment_operator()
         {
             theStore.Schema.MappingFor(typeof(Target)).PropertySearching = PropertySearching.ContainmentOperator;
@@ -82,6 +88,7 @@ namespace Marten.Testing.Linq
                 .ShouldHaveTheSameElementsAs(1, 3);
         }
 
+        [Fact]
         public void order_by_2_deep_with_containment_operator()
         {
             theStore.Schema.MappingFor(typeof(Target)).PropertySearching = PropertySearching.ContainmentOperator;

--- a/src/Marten.Testing/Linq/invoking_query_with_select_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_query_with_select_Tests.cs
@@ -2,11 +2,13 @@
 using System.Linq;
 using Marten.Services;
 using Marten.Testing.Documents;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
     public class invoking_query_with_select_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void use_select_in_query()
         {
             theSession.Store(new User {FirstName = "Hank"});

--- a/src/Marten.Testing/Linq/invoking_queryable_any_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_any_Tests.cs
@@ -1,12 +1,14 @@
 using System.Linq;
 using Marten.Services;
 using Marten.Testing.Fixtures;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
     public class invoking_queryable_any_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
 
+        [Fact]
         public void any_miss_with_query()
         {
             theSession.Store(new Target { Number = 1 });
@@ -21,6 +23,7 @@ namespace Marten.Testing.Linq
         }
 
         
+        [Fact]
         public void naked_any_miss()
         {
             theSession.Query<Target>().Any()
@@ -28,6 +31,7 @@ namespace Marten.Testing.Linq
 
         }
         
+        [Fact]
         public void naked_any_hit()
         {
             theSession.Store(new Target { Number = 1 });
@@ -40,6 +44,7 @@ namespace Marten.Testing.Linq
         }
         
         
+        [Fact]
         public void any_hit_with_only_one_document()
         {
             theSession.Store(new Target { Number = 1 });
@@ -53,6 +58,7 @@ namespace Marten.Testing.Linq
         }
         
 
+        [Fact]
         public void any_hit_with_more_than_one_match()
         {
             theSession.Store(new Target { Number = 1 });

--- a/src/Marten.Testing/Linq/invoking_queryable_count_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_count_Tests.cs
@@ -2,12 +2,14 @@
 using Marten.Services;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
     public class invoking_queryable_count_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
         
+        [Fact]
         public void count_without_any_where()
         {
             theSession.Store(new Target { Number = 1 });
@@ -19,6 +21,7 @@ namespace Marten.Testing.Linq
             theSession.Query<Target>().Count().ShouldBe(4);
         }
 
+        [Fact]
         // SAMPLE: using_count
         public void count_with_a_where_clause()
         {

--- a/src/Marten.Testing/Linq/invoking_queryable_through_first_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_through_first_Tests.cs
@@ -3,11 +3,13 @@ using System.Linq;
 using Marten.Services;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
     public class invoking_queryable_through_first_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void first_hit_with_only_one_document()
         {
             theSession.Store(new Target { Number = 1 });
@@ -20,6 +22,7 @@ namespace Marten.Testing.Linq
                 .ShouldNotBeNull();
         }
 
+        [Fact]
         public void first_or_default_hit_with_only_one_document()
         {
             theSession.Store(new Target { Number = 1 });
@@ -32,6 +35,7 @@ namespace Marten.Testing.Linq
                 .ShouldNotBeNull();
         }
 
+        [Fact]
         public void first_or_default_miss()
         {
             theSession.Store(new Target { Number = 1 });
@@ -44,6 +48,7 @@ namespace Marten.Testing.Linq
                 .ShouldBeNull();
         }
 
+        [Fact]
         public void first_correct_hit_with_more_than_one_match()
         {
             theSession.Store(new Target { Number = 1 });
@@ -56,6 +61,7 @@ namespace Marten.Testing.Linq
                 .ShouldBeTrue();
         }
 
+        [Fact]
         public void first_or_default_correct_hit_with_more_than_one_match()
         {
             theSession.Store(new Target { Number = 1 });
@@ -68,6 +74,7 @@ namespace Marten.Testing.Linq
                 .ShouldBeTrue();
         }
 
+        [Fact]
         public void first_miss()
         {
             theSession.Store(new Target { Number = 1 });

--- a/src/Marten.Testing/Linq/invoking_queryable_through_last_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_through_last_Tests.cs
@@ -3,11 +3,13 @@ using System.Linq;
 using Marten.Services;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
     public class invoking_queryable_through_last_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void last_hit_with_only_one_document()
         {
             theSession.Store(new Target { Number = 1 });
@@ -20,6 +22,7 @@ namespace Marten.Testing.Linq
                 .ShouldNotBeNull();
         }
 
+        [Fact]
         public void last_or_default_hit_with_only_one_document()
         {
             theSession.Store(new Target { Number = 1 });
@@ -32,6 +35,7 @@ namespace Marten.Testing.Linq
                 .ShouldNotBeNull();
         }
 
+        [Fact]
         public void last_or_default_miss()
         {
             theSession.Store(new Target { Number = 1 });
@@ -44,6 +48,7 @@ namespace Marten.Testing.Linq
                 .ShouldBeNull();
         }
 
+        [Fact]
         public void last_correct_hit_with_more_than_one_match()
         {
             theSession.Store(new Target { Number = 1 });
@@ -56,6 +61,7 @@ namespace Marten.Testing.Linq
                 .Flag.ShouldBe(true);
         }
 
+        [Fact]
         public void last_or_default_correct_hit_with_more_than_one_match()
         {
             theSession.Store(new Target { Number = 1 });
@@ -68,6 +74,7 @@ namespace Marten.Testing.Linq
                 .Flag.ShouldBe(true);
         }
 
+        [Fact]
         public void last_miss()
         {
             theSession.Store(new Target { Number = 1 });

--- a/src/Marten.Testing/Linq/invoking_queryable_through_single_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_through_single_Tests.cs
@@ -3,12 +3,14 @@ using System.Linq;
 using Marten.Services;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
     public class invoking_queryable_through_single_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
         // SAMPLE: single_and_single_or_default
+        [Fact]
         public void single_hit_with_only_one_document()
         {
             theSession.Store(new Target{Number = 1});
@@ -21,6 +23,7 @@ namespace Marten.Testing.Linq
                 .ShouldNotBeNull();
         }
 
+        [Fact]
         public void single_or_default_hit_with_only_one_document()
         {
             theSession.Store(new Target { Number = 1 });
@@ -34,6 +37,7 @@ namespace Marten.Testing.Linq
         }
         // ENDSAMPLE
 
+        [Fact]
         public void single_or_default_miss()
         {
             theSession.Store(new Target { Number = 1 });
@@ -46,6 +50,7 @@ namespace Marten.Testing.Linq
                 .ShouldBeNull();
         }
 
+        [Fact]
         public void single_hit_with_more_than_one_match()
         {
             theSession.Store(new Target { Number = 1 });
@@ -60,6 +65,7 @@ namespace Marten.Testing.Linq
             });
         }
 
+        [Fact]
         public void single_or_default_hit_with_more_than_one_match()
         {
             theSession.Store(new Target { Number = 1 });
@@ -74,6 +80,7 @@ namespace Marten.Testing.Linq
             });
         }
 
+        [Fact]
         public void single_miss()
         {
             theSession.Store(new Target { Number = 1 });

--- a/src/Marten.Testing/Linq/query_against_dateoffset_Tests.cs
+++ b/src/Marten.Testing/Linq/query_against_dateoffset_Tests.cs
@@ -2,11 +2,13 @@
 using System.Linq;
 using Marten.Services;
 using Marten.Testing.Fixtures;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
     public class query_against_dateoffset_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void query()
         {
             theSession.Store(new Target{Number = 1, DateOffset = DateTimeOffset.Now.AddMinutes(5)});

--- a/src/Marten.Testing/Linq/query_against_primitive_array_Tests.cs
+++ b/src/Marten.Testing/Linq/query_against_primitive_array_Tests.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Linq;
 using Marten.Services;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
     public class query_against_primitive_array_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void query_against_number_array()
         {
             var doc1 = new DocWithArrays {Numbers = new int[] {1, 2, 3}};
@@ -23,6 +25,7 @@ namespace Marten.Testing.Linq
                 .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc1.Id, doc2.Id);
         }
 
+        [Fact]
         // SAMPLE: query_against_string_array
         public void query_against_string_array()
         {
@@ -42,6 +45,7 @@ namespace Marten.Testing.Linq
         }
         // ENDSAMPLE
 
+        [Fact]
         public void query_against_date_array()
         {
             var doc1 = new DocWithArrays {Dates = new [] {DateTime.Today, DateTime.Today.AddDays(1), DateTime.Today.AddDays(2)}};

--- a/src/Marten.Testing/Linq/query_with_enums_Tests.cs
+++ b/src/Marten.Testing/Linq/query_with_enums_Tests.cs
@@ -1,11 +1,13 @@
 ﻿using System.Linq;
 using Marten.Services;
 using Marten.Testing.Fixtures;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
     public class query_with_enums_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void use_enum_values()
         {
             theSession.Store(new Target{Color = Colors.Blue, Number = 1});

--- a/src/Marten.Testing/Linq/query_with_nullable_types_Tests.cs
+++ b/src/Marten.Testing/Linq/query_with_nullable_types_Tests.cs
@@ -2,11 +2,13 @@
 using Marten.Services;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
     public class query_with_nullable_types_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void query_against_non_null()
         {
             theSession.Store(new Target {NullableNumber = 3});
@@ -21,6 +23,7 @@ namespace Marten.Testing.Linq
                 .ShouldBe(3);
         }
 
+        [Fact]
         public void query_against_null_1()
         {
             theSession.Store(new Target { NullableNumber = 3 });
@@ -35,6 +38,7 @@ namespace Marten.Testing.Linq
                 .ShouldBe(3);
         }
 
+        [Fact]
         public void query_against_null_2()
         {
             theSession.Store(new Target { NullableNumber = 3 });
@@ -50,6 +54,7 @@ namespace Marten.Testing.Linq
 
         }
 
+        [Fact]
         public void query_against_not_null()
         {
             theSession.Store(new Target { NullableNumber = 3 });

--- a/src/Marten.Testing/Linq/using_containment_operator_in_linq_Tests.cs
+++ b/src/Marten.Testing/Linq/using_containment_operator_in_linq_Tests.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using Baseline;
 using Marten.Services;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
@@ -17,6 +17,7 @@ namespace Marten.Testing.Linq
             });
         }
 
+        [Fact]
         public void query_by_string()
         {
             theSession.Store(new Target {String = "Python"});
@@ -30,6 +31,7 @@ namespace Marten.Testing.Linq
             theSession.Query<Target>().Where(x => x.String == "Python").Single().String.ShouldBe("Python");
         }
 
+        [Fact]
         public void query_by_number()
         {
             theSession.Store(new Target {Number = 1});
@@ -44,6 +46,7 @@ namespace Marten.Testing.Linq
             theSession.Query<Target>().Where(x => x.Number == 3).Single().Number.ShouldBe(3);
         }
 
+        [Fact]
         public void query_by_date()
         {
             var targets = Target.GenerateRandomData(6).ToArray();

--- a/src/Marten.Testing/Linq/using_multiple_where_clauses_Tests.cs
+++ b/src/Marten.Testing/Linq/using_multiple_where_clauses_Tests.cs
@@ -1,11 +1,13 @@
 ﻿using System.Linq;
 using Marten.Services;
 using Marten.Testing.Fixtures;
+using Xunit;
 
 namespace Marten.Testing.Linq
 {
     public class using_multiple_where_clauses_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void two_where_clauses()
         {
             var target1 = new Target{Number = 1, String = "Foo"};
@@ -25,6 +27,7 @@ namespace Marten.Testing.Linq
                 .ShouldHaveTheSameElementsAs(target1.Id, target4.Id);
         }
 
+        [Fact]
         public void three_where_clauses()
         {
             var target1 = new Target { Number = 1, String = "Foo", Long = 5};

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -937,4 +937,138 @@
       </ItemGroup>
     </When>
   </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="xunit.abstractions">
+          <HintPath>..\..\packages\xunit.abstractions\lib\net35\xunit.abstractions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="xunit.abstractions">
+          <HintPath>..\..\packages\xunit.abstractions\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="xunit.assert">
+          <HintPath>..\..\packages\xunit.assert\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETCore' And $(TargetFrameworkVersion) == 'v4.5.1'">
+      <PropertyGroup>
+        <__paket__xunit_core_props>win81\xunit.core</__paket__xunit_core_props>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhoneApp'">
+      <PropertyGroup>
+        <__paket__xunit_core_props>wpa81\xunit.core</__paket__xunit_core_props>
+      </PropertyGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <PropertyGroup>
+        <__paket__xunit_core_props>portable-net45+win8+wp8+wpa81\xunit.core</__paket__xunit_core_props>
+      </PropertyGroup>
+    </When>
+  </Choose>
+  <Import Project="..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props" Condition="Exists('..\..\packages\xunit.core\build\$(__paket__xunit_core_props).props')" Label="Paket" />
+  <Choose>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="xunit.core">
+          <HintPath>..\..\packages\xunit.extensibility.core\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETCore'">
+      <ItemGroup>
+        <Reference Include="xunit.execution.dotnet">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\win8\xunit.execution.dotnet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="xunit.execution.desktop">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\net45\xunit.execution.desktop.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'MonoAndroid'">
+      <ItemGroup>
+        <Reference Include="xunit.execution.dotnet">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\monoandroid\xunit.execution.dotnet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'MonoTouch'">
+      <ItemGroup>
+        <Reference Include="xunit.execution.dotnet">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\monotouch\xunit.execution.dotnet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')">
+      <ItemGroup>
+        <Reference Include="xunit.execution.dotnet">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\wp8\xunit.execution.dotnet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhoneApp'">
+      <ItemGroup>
+        <Reference Include="xunit.execution.dotnet">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\wpa81\xunit.execution.dotnet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Xamarin.iOS'">
+      <ItemGroup>
+        <Reference Include="xunit.execution.dotnet">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\xamarinios\xunit.execution.dotnet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="xunit.execution.dotnet">
+          <HintPath>..\..\packages\xunit.extensibility.execution\lib\portable-net45+win8+wp8+wpa81\xunit.execution.dotnet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/src/Marten.Testing/MartenRegistryTests.cs
+++ b/src/Marten.Testing/MartenRegistryTests.cs
@@ -5,6 +5,7 @@ using Marten.Schema;
 using Marten.Testing.Documents;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing
 {
@@ -19,26 +20,28 @@ namespace Marten.Testing
             theSchema.Alter<TestRegistry>();
         }
 
-
-
+        [Fact]
         public void property_searching_override()
         {
             theSchema.MappingFor(typeof(User))
                 .PropertySearching.ShouldBe(PropertySearching.JSON_Locator_Only);
         }
 
+        [Fact]
         public void picks_up_searchable_on_property()
         {
             theSchema.MappingFor(typeof (Organization))
                 .FieldFor(nameof(Organization.Name)).ShouldBeOfType<DuplicatedField>();
         }
 
+        [Fact]
         public void picks_up_searchable_on_field()
         {
             theSchema.MappingFor(typeof(Organization))
                 .FieldFor(nameof(Organization.OtherName)).ShouldBeOfType<DuplicatedField>();
         }
 
+        [Fact]
         public void searchable_field_is_also_indexed()
         {
             var mapping = theSchema.MappingFor(typeof (Organization));
@@ -49,6 +52,7 @@ namespace Marten.Testing
         }
 
 
+        [Fact]
         public void can_customize_the_index_on_a_searchable_field()
         {
             var mapping = theSchema.MappingFor(typeof(Organization));
@@ -58,6 +62,7 @@ namespace Marten.Testing
             index.Columns.ShouldHaveTheSameElementsAs("other_name");
         }
 
+        [Fact]
         public void can_set_up_gin_index_on_json_data()
         {
             var mapping = theSchema.MappingFor(typeof(Organization));
@@ -69,6 +74,7 @@ namespace Marten.Testing
             index.Expression.ShouldBe("? jsonb_path_ops");
         }
 
+        [Fact]
         public void mapping_is_set_to_containment_if_gin_index_is_added()
         {
             var mapping = theSchema.MappingFor(typeof(Organization));

--- a/src/Marten.Testing/PlayingTests.cs
+++ b/src/Marten.Testing/PlayingTests.cs
@@ -7,11 +7,13 @@ using Marten.Testing.Fixtures;
 using Marten.Testing.Github;
 using Octokit;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing
 {
     public class PlayingTests
     {
+        [Fact]
         public void generate_code()
         {
             var mapping = new DocumentMapping(typeof (Target));
@@ -22,6 +24,7 @@ namespace Marten.Testing
             Debug.WriteLine(code);
         }
 
+        [Fact]
         public void linq_spike()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())
@@ -47,6 +50,7 @@ namespace Marten.Testing
         }
 
 
+        [Fact]
         public void try_ocktokit()
         {
             var basicAuth = new Credentials("jeremydmiller", "FAKE");

--- a/src/Marten.Testing/Properties/AssemblyInfo.cs
+++ b/src/Marten.Testing/Properties/AssemblyInfo.cs
@@ -1,8 +1,10 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Marten.Testing")]
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/Marten.Testing/Schema/DocumentCleanerTests.cs
+++ b/src/Marten.Testing/Schema/DocumentCleanerTests.cs
@@ -5,11 +5,13 @@ using Marten.Testing.Documents;
 using Marten.Testing.Fixtures;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing.Schema
 {
     public class DocumentCleanerTests
     {
+        [Fact]
         public void clean_table()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())
@@ -33,6 +35,7 @@ namespace Marten.Testing.Schema
             }
         }
 
+        [Fact]
         public void delete_all_documents()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())
@@ -58,6 +61,7 @@ namespace Marten.Testing.Schema
             }
         }
 
+        [Fact]
         public void completely_remove_document_type()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())
@@ -83,6 +87,7 @@ namespace Marten.Testing.Schema
             }
         }
 
+        [Fact]
         public void completely_remove_document_removes_the_upsert_command_too()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())
@@ -109,6 +114,7 @@ namespace Marten.Testing.Schema
             }
         }
 
+        [Fact]
         public void completely_remove_everything()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())
@@ -134,6 +140,7 @@ namespace Marten.Testing.Schema
             }
         }
 
+        [Fact]
         public void delete_except_types()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())

--- a/src/Marten.Testing/Schema/DocumentMappingTests.cs
+++ b/src/Marten.Testing/Schema/DocumentMappingTests.cs
@@ -7,23 +7,27 @@ using Marten.Schema.Sequences;
 using Marten.Testing.Documents;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing.Schema
 {
     public class DocumentMappingTests
     {
+        [Fact]
         public void default_table_name()
         {
             var mapping = new DocumentMapping(typeof (User));
             mapping.TableName.ShouldBe("mt_doc_user");
         }
 
+        [Fact]
         public void default_search_mode_is_jsonb_to_record()
         {
             var mapping = new DocumentMapping(typeof(User));
             mapping.PropertySearching.ShouldBe(PropertySearching.JSON_Locator_Only);
         }
 
+        [Fact]
         public void pick_up_upper_case_property_id()
         {
             var mapping = new DocumentMapping(typeof (UpperCaseProperty));
@@ -31,6 +35,7 @@ namespace Marten.Testing.Schema
                 .Name.ShouldBe(nameof(UpperCaseProperty.Id));
         }
 
+        [Fact]
         public void pick_up_lower_case_property_id()
         {
             var mapping = new DocumentMapping(typeof (LowerCaseProperty));
@@ -38,6 +43,7 @@ namespace Marten.Testing.Schema
                 .Name.ShouldBe(nameof(LowerCaseProperty.id));
         }
 
+        [Fact]
         public void pick_up_lower_case_field_id()
         {
             var mapping = new DocumentMapping(typeof (LowerCaseField));
@@ -45,6 +51,7 @@ namespace Marten.Testing.Schema
                 .Name.ShouldBe(nameof(LowerCaseField.id));
         }
 
+        [Fact]
         public void pick_up_upper_case_field_id()
         {
             var mapping = new DocumentMapping(typeof (UpperCaseField));
@@ -52,6 +59,7 @@ namespace Marten.Testing.Schema
                 .Name.ShouldBe(nameof(UpperCaseField.Id));
         }
 
+        [Fact]
         public void generate_simple_document_table()
         {
             var mapping = new DocumentMapping(typeof (MySpecialDocument));
@@ -65,6 +73,7 @@ namespace Marten.Testing.Schema
             sql.ShouldContain("jsonb NOT NULL");
         }
 
+        [Fact]
         public void generate_table_with_indexes()
         {
             var mapping = new DocumentMapping(typeof(User));
@@ -84,6 +93,7 @@ namespace Marten.Testing.Schema
 
         }
 
+        [Fact]
         public void generate_a_document_table_with_duplicated_tables()
         {
             var mapping = DocumentMapping.For<User>();
@@ -94,6 +104,7 @@ namespace Marten.Testing.Schema
             table.Columns.Any(x => x.Name == "first_name").ShouldBeTrue();
         }
 
+        [Fact]
         public void generate_a_table_to_the_database_with_duplicated_field()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())
@@ -112,6 +123,7 @@ namespace Marten.Testing.Schema
         }
 
 
+        [Fact]
         public void write_upsert_sql()
         {
             var mapping = new DocumentMapping(typeof (MySpecialDocument));
@@ -125,18 +137,21 @@ namespace Marten.Testing.Schema
             sql.ShouldContain("CREATE OR REPLACE FUNCTION mt_upsert_myspecialdocument");
         }
 
+        [Fact]
         public void table_name_for_document()
         {
             DocumentMapping.TableNameFor(typeof (MySpecialDocument))
                 .ShouldBe("mt_doc_myspecialdocument");
         }
 
+        [Fact]
         public void upsert_name_for_document_type()
         {
             DocumentMapping.UpsertNameFor(typeof (MySpecialDocument))
                 .ShouldBe("mt_upsert_myspecialdocument");
         }
 
+        [Fact]
         public void find_field_for_immediate_property_that_is_not_duplicated()
         {
             var mapping = DocumentMapping.For<UpperCaseProperty>();
@@ -145,6 +160,7 @@ namespace Marten.Testing.Schema
                 .Name.ShouldBe("Id");
         }
 
+        [Fact]
         public void find_field_for_immediate_field_that_is_not_duplicated()
         {
             var mapping = DocumentMapping.For<UpperCaseField>();
@@ -153,6 +169,7 @@ namespace Marten.Testing.Schema
                 .Name.ShouldBe("Id");
         }
 
+        [Fact]
         public void duplicate_a_field()
         {
             var mapping = DocumentMapping.For<User>();
@@ -166,6 +183,7 @@ namespace Marten.Testing.Schema
             mapping.FieldFor("LastName").ShouldNotBeOfType<DuplicatedField>();
         }
 
+        [Fact]
         public void switch_to_only_using_json_locator_fields()
         {
             var mapping = DocumentMapping.For<User>();
@@ -181,6 +199,7 @@ namespace Marten.Testing.Schema
             mapping.FieldFor("FirstName").ShouldBeOfType<DuplicatedField>();
         }
 
+        [Fact]
         public void switch_back_to_lateral_join_searching_changes_the_non_duplicated_fields()
         {
             var mapping = DocumentMapping.For<User>();
@@ -199,6 +218,7 @@ namespace Marten.Testing.Schema
             mapping.FieldFor("FirstName").ShouldBeOfType<DuplicatedField>();
         }
 
+        [Fact]
         public void picks_up_searchable_attribute_on_fields()
         {
             var mapping = DocumentMapping.For<Organization>();
@@ -207,6 +227,7 @@ namespace Marten.Testing.Schema
             mapping.FieldFor(nameof(Organization.OtherField)).ShouldNotBeOfType<DuplicatedField>();
         }
 
+        [Fact]
         public void picks_up_searchable_attribute_on_properties()
         {
             var mapping = DocumentMapping.For<Organization>();
@@ -215,30 +236,35 @@ namespace Marten.Testing.Schema
             mapping.FieldFor(nameof(Organization.OtherProp)).ShouldNotBeOfType<DuplicatedField>();
         }
 
+        [Fact]
         public void picks_up_marten_attibute_on_document_type()
         {
             var mapping = DocumentMapping.For<Organization>();
             mapping.PropertySearching.ShouldBe(PropertySearching.JSON_Locator_Only);
         }
 
+        [Fact]
         public void use_string_id_generation_for_string()
         {
             var mapping = DocumentMapping.For<StringId>();
             mapping.IdStrategy.ShouldBeOfType<StringIdGeneration>();
         }
 
+        [Fact]
         public void use_guid_id_generation_for_guid_id()
         {
             var mapping = DocumentMapping.For<UpperCaseProperty>();
             mapping.IdStrategy.ShouldBeOfType<GuidIdGeneration>();
         }
 
+        [Fact]
         public void use_hilo_id_generation_for_int_id()
         {
             DocumentMapping.For<IntId>()
                 .IdStrategy.ShouldBeOfType<HiloIdGeneration>();
         }
 
+        [Fact]
         public void use_hilo_id_generation_for_long_id()
         {
             DocumentMapping.For<LongId>()

--- a/src/Marten.Testing/Schema/DocumentSchemaTests.cs
+++ b/src/Marten.Testing/Schema/DocumentSchemaTests.cs
@@ -6,6 +6,7 @@ using Marten.Schema;
 using Marten.Testing.Documents;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing.Schema
 {
@@ -25,12 +26,14 @@ namespace Marten.Testing.Schema
             _schema.Dispose();
         }
 
+        [Fact]
         public void can_create_a_new_storage_for_an_IDocument_type()
         {
             var storage = _schema.StorageFor(typeof (User));
             storage.ShouldNotBeNull();
         }
 
+        [Fact]
         public void caches_storage_for_a_document_type()
         {
             _schema.StorageFor(typeof (User))
@@ -43,6 +46,7 @@ namespace Marten.Testing.Schema
                 .ShouldBeSameAs(_schema.StorageFor(typeof (Company)));
         }
 
+        [Fact]
         public void generate_ddl()
         {
             _schema.StorageFor(typeof (User));
@@ -60,6 +64,7 @@ namespace Marten.Testing.Schema
             sql.ShouldContain("CREATE TABLE mt_doc_company");
         }
 
+        [Fact]
         public void builds_schema_objects_on_the_fly_as_needed()
         {
             _schema.StorageFor(typeof (User)).ShouldNotBeNull();
@@ -80,6 +85,7 @@ namespace Marten.Testing.Schema
             functions.ShouldContain(DocumentMapping.UpsertNameFor(typeof (Company)).ToLower());
         }
 
+        [Fact]
         public void do_not_rebuild_a_table_that_already_exists()
         {
             using (var container1 = Container.For<DevelopmentModeRegistry>())

--- a/src/Marten.Testing/Schema/DocumentStorageBuilderTests.cs
+++ b/src/Marten.Testing/Schema/DocumentStorageBuilderTests.cs
@@ -5,11 +5,13 @@ using Marten.Testing.Documents;
 using NpgsqlTypes;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing.Schema
 {
     public class DocumentStorageBuilderTests
     {
+        [Fact]
         public void do_not_blow_up_building_one()
         {
             var storage = DocumentStorageBuilder.Build(null, new DocumentMapping(typeof(User)));
@@ -20,6 +22,7 @@ namespace Marten.Testing.Schema
             storage.IdType.ShouldBe(NpgsqlDbType.Uuid);
         }
 
+        [Fact]
         public void implements_the_id_type()
         {
             DocumentStorageBuilder.Build(null, new DocumentMapping(typeof(User))).IdType.ShouldBe(NpgsqlDbType.Uuid);
@@ -33,6 +36,7 @@ namespace Marten.Testing.Schema
 
 
 
+        [Fact]
         public void implements_the_identity_method()
         {
             var schema = Container.For<DevelopmentModeRegistry>().GetInstance<IDocumentSchema>();
@@ -47,6 +51,7 @@ namespace Marten.Testing.Schema
 
         }
 
+        [Fact]
         public void do_not_blow_up_building_more_than_one()
         {
             var mappings = new DocumentMapping[]

--- a/src/Marten.Testing/Schema/DuplicatedFieldTests.cs
+++ b/src/Marten.Testing/Schema/DuplicatedFieldTests.cs
@@ -3,6 +3,7 @@ using Baseline.Reflection;
 using Marten.Schema;
 using Marten.Testing.Documents;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Schema
 {
@@ -10,12 +11,14 @@ namespace Marten.Testing.Schema
     {
         private DuplicatedField theField = new DuplicatedField(new MemberInfo[] { ReflectionHelper.GetProperty<User>(x => x.FirstName)});
 
+        [Fact]
         public void default_role_is_search()
         {
             theField
                 .Role.ShouldBe(DuplicatedFieldRole.Search);
         }
 
+        [Fact]
         public void create_table_column_for_non_indexed_search()
         {
             var column = theField.ToColumn(null);
@@ -23,6 +26,7 @@ namespace Marten.Testing.Schema
             column.Type.ShouldBe("varchar");
         }
 
+        [Fact]
         public void upsert_argument_defaults()
         {
             theField.UpsertArgument.Arg.ShouldBe("arg_first_name");
@@ -30,17 +34,20 @@ namespace Marten.Testing.Schema
             theField.UpsertArgument.PostgresType.ShouldBe("varchar");
         }
 
+        [Fact]
         public void sql_locator_with_default_column_name()
         {
             theField.SqlLocator.ShouldBe("d.first_name");
         }
 
+        [Fact]
         public void sql_locator_with_custom_column_name()
         {
             theField.ColumnName = "x_first_name";
             theField.SqlLocator.ShouldBe("d.x_first_name");
         }
 
+        [Fact]
         public void lateral_join_is_always_null()
         {
             theField.LateralJoinDeclaration.ShouldBeNull();

--- a/src/Marten.Testing/Schema/IndexDefinitionTests.cs
+++ b/src/Marten.Testing/Schema/IndexDefinitionTests.cs
@@ -1,6 +1,7 @@
 ﻿using Marten.Schema;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Schema
 {
@@ -8,42 +9,50 @@ namespace Marten.Testing.Schema
     {
         private readonly DocumentMapping mapping = new DocumentMapping(typeof(Target));
 
+        [Fact]
         public void default_index_name_with_one_column()
         {
             new IndexDefinition(mapping, "long").IndexName.ShouldBe("mt_doc_target_idx_long");
         }
 
+        [Fact]
         public void default_index_name_with_multiple_columns()
         {
             new IndexDefinition(mapping, "foo", "bar").IndexName.ShouldBe("mt_doc_target_idx_foo_bar");
         }
 
+        [Fact]
         public void default_method_is_btree()
         {
             new IndexDefinition(mapping, "foo").Method.ShouldBe(IndexMethod.btree);
         }
 
+        [Fact]
         public void default_unique_is_false()
         {
             new IndexDefinition(mapping, "foo").IsUnique.ShouldBeFalse();
         }
 
+        [Fact]
         public void default_concurrent_is_false()
         {
             new IndexDefinition(mapping, "foo").IsConcurrent.ShouldBeFalse();
         }
 
+        [Fact]
         public void default_modifier_is_null()
         {
             new IndexDefinition(mapping, "foo").Modifier.ShouldBeNull();
         }
 
+        [Fact]
         public void generate_ddl_for_single_column_all_defaults()
         {
             new IndexDefinition(mapping, "foo").ToDDL()
                 .ShouldBe("CREATE INDEX mt_doc_target_idx_foo ON mt_doc_target (foo)");
         }
 
+        [Fact]
         public void generate_ddl_for_single_column_unique()
         {
             var definition = new IndexDefinition(mapping, "foo");
@@ -53,6 +62,7 @@ namespace Marten.Testing.Schema
                 .ShouldBe("CREATE UNIQUE INDEX mt_doc_target_idx_foo ON mt_doc_target (foo)");
         }
 
+        [Fact]
         public void generate_ddl_with_modifier()
         {
             var definition = new IndexDefinition(mapping, "foo");
@@ -63,6 +73,7 @@ namespace Marten.Testing.Schema
                 .ShouldBe("CREATE UNIQUE INDEX mt_doc_target_idx_foo ON mt_doc_target (foo) WITH (fillfactor = 70)");
         }
 
+        [Fact]
         public void generate_ddl_for_concurrent_index()
         {
             var definition = new IndexDefinition(mapping, "foo");
@@ -72,6 +83,7 @@ namespace Marten.Testing.Schema
                 .ShouldBe("CREATE INDEX CONCURRENTLY mt_doc_target_idx_foo ON mt_doc_target (foo)");
         }
 
+        [Fact]
         public void generate_ddl_for_concurrent_unique_index()
         {
             var definition = new IndexDefinition(mapping, "foo");
@@ -82,6 +94,7 @@ namespace Marten.Testing.Schema
                 .ShouldBe("CREATE UNIQUE INDEX CONCURRENTLY mt_doc_target_idx_foo ON mt_doc_target (foo)");
         }
 
+        [Fact]
         public void generate_ddl_for_gin_index()
         {
             var definition = new IndexDefinition(mapping, "foo");
@@ -91,6 +104,7 @@ namespace Marten.Testing.Schema
                 .ShouldBe("CREATE INDEX mt_doc_target_idx_foo ON mt_doc_target USING gin (foo)");
         }
 
+        [Fact]
         public void generate_ddl_for_gin_with_jsonb_path_ops_index()
         {
             var definition = new IndexDefinition(mapping, "foo");
@@ -101,6 +115,7 @@ namespace Marten.Testing.Schema
                 .ShouldBe("CREATE INDEX mt_doc_target_idx_foo ON mt_doc_target USING gin (foo jsonb_path_ops)");
         }
 
+        [Fact]
         public void generate_ddl_for_gist_index()
         {
             var definition = new IndexDefinition(mapping, "foo");
@@ -110,6 +125,7 @@ namespace Marten.Testing.Schema
                 .ShouldBe("CREATE INDEX mt_doc_target_idx_foo ON mt_doc_target USING gist (foo)");
         }
 
+        [Fact]
         public void generate_ddl_for_hash_index()
         {
             var definition = new IndexDefinition(mapping, "foo");

--- a/src/Marten.Testing/Schema/JsonLocatorFieldTests.cs
+++ b/src/Marten.Testing/Schema/JsonLocatorFieldTests.cs
@@ -6,6 +6,7 @@ using Marten.Schema;
 using Marten.Testing.Documents;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Schema
 {
@@ -15,32 +16,38 @@ namespace Marten.Testing.Schema
         public readonly JsonLocatorField theNumberField = JsonLocatorField.For<User>(x => x.Age);
         public readonly JsonLocatorField theEnumField = JsonLocatorField.For<Target>(x => x.Color);
 
+        [Fact]
         public void member_name_is_derived()
         {
             theStringField.MemberName.ShouldBe("FirstName");
         }
 
+        [Fact]
         public void has_the_member_path()
         {
             theStringField.Members.Single().ShouldBeAssignableTo<PropertyInfo>()
                 .Name.ShouldBe("FirstName");
         }
 
+        [Fact]
         public void locator_for_string()
         {
             theStringField.SqlLocator.ShouldBe("d.data ->> 'FirstName'");
         }
 
+        [Fact]
         public void locator_for_number()
         {
             theNumberField.SqlLocator.ShouldBe("CAST(d.data ->> 'Age' as integer)");
         }
 
+        [Fact]
         public void locator_for_enum()
         {
             theEnumField.SqlLocator.ShouldBe("CAST(d.data ->> 'Color' as integer)");
         }
 
+        [Fact]
         public void the_lateral_join_declaration_is_null()
         {
             theStringField.LateralJoinDeclaration.ShouldBeNull();
@@ -48,6 +55,7 @@ namespace Marten.Testing.Schema
             theEnumField.LateralJoinDeclaration.ShouldBeNull();
         }
 
+        [Fact]
         public void two_deep_members_json_locator()
         {
             var inner = ReflectionHelper.GetProperty<Target>(x => x.Inner);
@@ -59,6 +67,7 @@ namespace Marten.Testing.Schema
         }
 
 
+        [Fact]
         public void three_deep_members_json_locator()
         {
             var inner = ReflectionHelper.GetProperty<Target>(x => x.Inner);
@@ -69,6 +78,7 @@ namespace Marten.Testing.Schema
             deep.SqlLocator.ShouldBe("CAST(d.data -> 'Inner' -> 'Inner' ->> 'Number' as integer)");
         }
 
+        [Fact]
         public void three_deep_members_json_locator_for_string_property()
         {
             var inner = ReflectionHelper.GetProperty<Target>(x => x.Inner);

--- a/src/Marten.Testing/Schema/LateralJoinFieldTests.cs
+++ b/src/Marten.Testing/Schema/LateralJoinFieldTests.cs
@@ -4,6 +4,7 @@ using Marten.Schema;
 using Marten.Testing.Documents;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Schema
 {
@@ -13,37 +14,44 @@ namespace Marten.Testing.Schema
         public readonly LateralJoinField theNumberField = LateralJoinField.For<User>(x => x.Age);
         public readonly LateralJoinField theEnumField = LateralJoinField.For<Target>(x => x.Color);
 
+        [Fact]
         public void member_name_is_derived()
         {
             theStringField.MemberName.ShouldBe("FirstName");
         }
 
+        [Fact]
         public void has_the_member_path()
         {
             theStringField.Members.Single().ShouldBeAssignableTo<PropertyInfo>()
                 .Name.ShouldBe("FirstName");
         }
 
+        [Fact]
         public void locator_for_string()
         {
             theStringField.SqlLocator.ShouldBe("l.\"FirstName\"");
         }
 
+        [Fact]
         public void locator_for_number()
         {
             theNumberField.SqlLocator.ShouldBe("l.\"Age\"");
         }
 
+        [Fact]
         public void lateral_join_declaration_for_string()
         {
             theStringField.LateralJoinDeclaration.ShouldBe("\"FirstName\" varchar");
         }
 
+        [Fact]
         public void lateral_join_declaration_for_number()
         {
             theNumberField.LateralJoinDeclaration.ShouldBe("\"Age\" integer");
         }
 
+        [Fact]
         public void lateral_join_declaration_for_enum()
         {
             theEnumField.LateralJoinDeclaration.ShouldBe("\"Color\" integer");

--- a/src/Marten.Testing/Schema/ProductionModeSchemeCreationTests.cs
+++ b/src/Marten.Testing/Schema/ProductionModeSchemeCreationTests.cs
@@ -3,11 +3,13 @@ using System.Linq;
 using Marten.Schema;
 using Marten.Testing.Documents;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing.Schema
 {
     public class ProductionModeSchemeCreationTests
     {
+        [Fact]
         public void work_with_existing_tables()
         {
             using (var c1 = Container.For<DevelopmentModeRegistry>())
@@ -34,6 +36,7 @@ namespace Marten.Testing.Schema
 
         }
 
+        [Fact]
         public void throw_exception_when_table_does_not_exist()
         {
             using (var c1 = Container.For<DevelopmentModeRegistry>())

--- a/src/Marten.Testing/Schema/SchemaBuilderTests.cs
+++ b/src/Marten.Testing/Schema/SchemaBuilderTests.cs
@@ -1,9 +1,11 @@
 ﻿using Marten.Schema;
+using Xunit;
 
 namespace Marten.Testing.Schema
 {
     public class SchemaBuilderTests
     {
+        [Fact]
         public void can_read_text_from_resource()
         {
             SchemaBuilder.GetText("mt_hilo").ShouldContain("mt_hilo");

--- a/src/Marten.Testing/Schema/Sequences/HiLoIdGenerationTests.cs
+++ b/src/Marten.Testing/Schema/Sequences/HiLoIdGenerationTests.cs
@@ -4,11 +4,13 @@ using Marten.Schema.Sequences;
 using Marten.Testing.Fixtures;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing.Schema.Sequences
 {
     public class HiLoIdGenerationTests
     {
+        [Fact]
         public void create_argument_value()
         {
             var container = Container.For<DevelopmentModeRegistry>();
@@ -22,6 +24,7 @@ namespace Marten.Testing.Schema.Sequences
  
         }
 
+        [Fact]
         public void arguments_just_returns_itself()
         {
             var generation = new HiloIdGeneration(typeof(Target));

--- a/src/Marten.Testing/Schema/Sequences/HiLoSequenceTests.cs
+++ b/src/Marten.Testing/Schema/Sequences/HiLoSequenceTests.cs
@@ -6,6 +6,7 @@ using Marten.Schema.Sequences;
 using Marten.Services;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing.Schema.Sequences
 {
@@ -28,6 +29,7 @@ namespace Marten.Testing.Schema.Sequences
             theSequence = new HiLoSequence(_runner, "foo", new HiloDef());
         }
 
+        [Fact]
         public void default_values()
         {
             theSequence.CurrentHi.ShouldBe(-1);
@@ -35,11 +37,13 @@ namespace Marten.Testing.Schema.Sequences
             theSequence.MaxLo.ShouldBe(1000);
         }
 
+        [Fact]
         public void should_advance_initial_case()
         {
             theSequence.ShouldAdvanceHi().ShouldBeTrue();
         }
 
+        [Fact]
         public void advance_to_next_hi_from_initial_state()
         {
             theSequence.AdvanceToNextHi();
@@ -48,6 +52,7 @@ namespace Marten.Testing.Schema.Sequences
             theSequence.CurrentHi.ShouldBe(0);
         }
 
+        [Fact]
         public void advance_to_next_hi_several_times()
         {
             theSequence.AdvanceToNextHi();
@@ -62,6 +67,7 @@ namespace Marten.Testing.Schema.Sequences
             theSequence.CurrentHi.ShouldBe(3);
         }
 
+        [Fact]
         public void advance_value_from_initial_state()
         {
             // Gotta do this at least once
@@ -74,6 +80,7 @@ namespace Marten.Testing.Schema.Sequences
             theSequence.AdvanceValue().ShouldBe(5);
         }
 
+        [Fact]
         public void read_from_a_single_thread_from_0_to_5000()
         {
             for (var i = 0; i < 5000; i++)
@@ -98,6 +105,7 @@ namespace Marten.Testing.Schema.Sequences
         }
 
 
+        [Fact]
         public void is_thread_safe()
         {
             var tasks = new Task<List<int>>[] {startThread(), startThread(), startThread(), startThread(), startThread(), startThread()};

--- a/src/Marten.Testing/Schema/Sequences/SequenceFactoryTests.cs
+++ b/src/Marten.Testing/Schema/Sequences/SequenceFactoryTests.cs
@@ -3,6 +3,7 @@ using Marten.Schema.Sequences;
 using Marten.Testing.Fixtures;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing.Schema.Sequences
 {
@@ -15,6 +16,7 @@ namespace Marten.Testing.Schema.Sequences
             _container.GetInstance<DocumentCleaner>().CompletelyRemoveAll();
         }
 
+        [Fact]
         public void can_create_table_on_fly_if_necessary()
         {
             var factory = _container.GetInstance<SequenceFactory>();

--- a/src/Marten.Testing/Schema/duplicate_deep_accessor_and_query_Tests.cs
+++ b/src/Marten.Testing/Schema/duplicate_deep_accessor_and_query_Tests.cs
@@ -5,11 +5,13 @@ using Baseline;
 using Marten.Schema;
 using Marten.Services;
 using Marten.Testing.Fixtures;
+using Xunit;
 
 namespace Marten.Testing.Schema
 {
     public class duplicate_deep_accessor_and_query_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void duplicate_and_search_off_of_deep_accessor_by_number()
         {
             var targets = Target.GenerateRandomData(10).ToArray();
@@ -30,6 +32,7 @@ namespace Marten.Testing.Schema
 
         }
 
+        [Fact]
         public void duplicate_and_search_off_of_deep_accessor_by_date()
         {
             var targets = Target.GenerateRandomData(10).ToArray();

--- a/src/Marten.Testing/Services/DirtyTrackingIdentityMapTests.cs
+++ b/src/Marten.Testing/Services/DirtyTrackingIdentityMapTests.cs
@@ -5,11 +5,13 @@ using Baseline;
 using Marten.Services;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Services
 {
     public class DirtyTrackingIdentityMapTests
     {
+        [Fact]
         public void get_value_on_first_request()
         {
             var target = Target.Random();
@@ -24,6 +26,7 @@ namespace Marten.Testing.Services
             target2.ShouldNotBeTheSameAs(target);
         }
 
+        [Fact]
         public void get_value_on_subsequent_requests()
         {
             var target = Target.Random();
@@ -47,6 +50,7 @@ namespace Marten.Testing.Services
             target2.ShouldBeTheSameAs(target5);
         }
 
+        [Fact]
         public void get_value_on_first_request_with_lazy_json()
         {
             var target = Target.Random();
@@ -61,6 +65,7 @@ namespace Marten.Testing.Services
             target2.ShouldNotBeTheSameAs(target);
         }
 
+        [Fact]
         public void get_value_on_subsequent_requests_with_lazy_json()
         {
             var target = Target.Random();
@@ -84,6 +89,7 @@ namespace Marten.Testing.Services
             target2.ShouldBeTheSameAs(target5);
         }
 
+        [Fact]
         public void detect_changes_with_no_changes()
         {
             var a = Target.Random();
@@ -107,6 +113,7 @@ namespace Marten.Testing.Services
         }
 
 
+        [Fact]
         public void detect_changes_with_multiple_dirties()
         {
             var a = Target.Random();
@@ -135,6 +142,7 @@ namespace Marten.Testing.Services
             changes.Any(x => x.Id.As<Guid>() == c1.Id).ShouldBeTrue();
         }
 
+        [Fact]
         public void detect_changes_then_clear_the_changes()
         {
             var a = Target.Random();
@@ -165,6 +173,7 @@ namespace Marten.Testing.Services
             map.DetectChanges().Any().ShouldBeFalse();
         }
 
+        [Fact]
         public void remove_item()
         {
             var target = Target.Random();
@@ -185,6 +194,8 @@ namespace Marten.Testing.Services
             target4.ShouldNotBeTheSameAs(target3);
 
         }
+
+        [Fact]
         public void store()
         {
             var target = Target.Random();
@@ -198,6 +209,7 @@ namespace Marten.Testing.Services
             map.Get<Target>(target.Id, "").ShouldBeTheSameAs(target);
         }
 
+        [Fact]
         public void get_with_miss_in_database()
         {
             var serializer = new JilSerializer();
@@ -206,6 +218,7 @@ namespace Marten.Testing.Services
             map.Get<Target>(Guid.NewGuid(), () => null).ShouldBeNull();
         }
 
+        [Fact]
         public void has_positive()
         {
             var target = Target.Random();
@@ -219,6 +232,7 @@ namespace Marten.Testing.Services
 
         }
 
+        [Fact]
         public void has_negative()
         {
             var serializer = new JilSerializer();
@@ -227,6 +241,7 @@ namespace Marten.Testing.Services
             map.Has<Target>(Guid.NewGuid()).ShouldBeFalse();
         }
 
+        [Fact]
         public void retrieve()
         {
             var target = Target.Random();

--- a/src/Marten.Testing/Services/IdentityMapTests.cs
+++ b/src/Marten.Testing/Services/IdentityMapTests.cs
@@ -3,11 +3,13 @@ using Marten.Services;
 using Marten.Testing.Fixtures;
 using Octokit;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Services
 {
     public class IdentityMapTests
     {
+        [Fact]
         public void get_value_on_first_request()
         {
             var target = Target.Random();
@@ -22,6 +24,7 @@ namespace Marten.Testing.Services
             target2.ShouldNotBeTheSameAs(target);
         }
 
+        [Fact]
         public void get_value_on_subsequent_requests()
         {
             var target = Target.Random();
@@ -45,6 +48,7 @@ namespace Marten.Testing.Services
             target2.ShouldBeTheSameAs(target5);
         }
 
+        [Fact]
         public void remove_item()
         {
             var target = Target.Random();
@@ -66,6 +70,7 @@ namespace Marten.Testing.Services
 
         }
 
+        [Fact]
         public void get_value_on_first_request_with_lazy_json()
         {
             var target = Target.Random();
@@ -80,6 +85,7 @@ namespace Marten.Testing.Services
             target2.ShouldNotBeTheSameAs(target);
         }
 
+        [Fact]
         public void get_value_on_subsequent_requests_with_lazy_json()
         {
             var target = Target.Random();
@@ -103,6 +109,7 @@ namespace Marten.Testing.Services
             target2.ShouldBeTheSameAs(target5);
         }
 
+        [Fact]
         public void store()
         {
             var target = Target.Random();
@@ -116,6 +123,7 @@ namespace Marten.Testing.Services
             map.Get<Target>(target.Id, "").ShouldBeTheSameAs(target);
         }
 
+        [Fact]
         public void get_with_miss_in_database()
         {
             var serializer = new JilSerializer();
@@ -124,6 +132,7 @@ namespace Marten.Testing.Services
             map.Get<Target>(Guid.NewGuid(), () => null).ShouldBeNull();
         }
 
+        [Fact]
         public void has_positive()
         {
             var target = Target.Random();
@@ -137,6 +146,7 @@ namespace Marten.Testing.Services
 
         }
 
+        [Fact]
         public void has_negative()
         {
             var serializer = new JilSerializer();
@@ -145,6 +155,7 @@ namespace Marten.Testing.Services
             map.Has<Target>(Guid.NewGuid()).ShouldBeFalse();
         }
 
+        [Fact]
         public void retrieve()
         {
             var target = Target.Random();

--- a/src/Marten.Testing/Services/NulloIdentityMapTests.cs
+++ b/src/Marten.Testing/Services/NulloIdentityMapTests.cs
@@ -2,11 +2,13 @@
 using Marten.Services;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Services
 {
     public class NulloIdentityMapTests
     {
+        [Fact]
         public void lazy_get_hit()
         {
             var serializer = new JilSerializer();
@@ -20,6 +22,7 @@ namespace Marten.Testing.Services
            
         }
 
+        [Fact]
         public void lazy_get_miss()
         {
             var map = new NulloIdentityMap(new JilSerializer());
@@ -27,6 +30,7 @@ namespace Marten.Testing.Services
             map.Get<Target>(Guid.NewGuid(), () => null).ShouldBeNull();
         }
 
+        [Fact]
         public void get_with_json()
         {
             var serializer = new JilSerializer();

--- a/src/Marten.Testing/Services/TrackedEntityTests.cs
+++ b/src/Marten.Testing/Services/TrackedEntityTests.cs
@@ -2,17 +2,20 @@
 using Marten.Services;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Services
 {
     public class TrackedEntityTests
     {
+        [Fact]
         public void detect_changes_with_no_document()
         {
             var entity = new TrackedEntity(Guid.NewGuid(), new JilSerializer(), typeof (Target), null);
             entity.DetectChange().ShouldBeNull();
         }
 
+        [Fact]
         public void detect_changes_positive()
         {
             var target = Target.Random();
@@ -27,6 +30,7 @@ namespace Marten.Testing.Services
             change.Json.ShouldBe(new JilSerializer().ToJson(target));
         }
 
+        [Fact]
         public void detect_changes_negative()
         {
             var target = Target.Random();
@@ -35,6 +39,7 @@ namespace Marten.Testing.Services
             entity.DetectChange().ShouldBeNull();
         }
 
+        [Fact]
         public void change_is_cleared()
         {
             var target = Target.Random();

--- a/src/Marten.Testing/Session/document_session_load_already_loaded_document_Tests.cs
+++ b/src/Marten.Testing/Session/document_session_load_already_loaded_document_Tests.cs
@@ -2,6 +2,7 @@
 using Marten.Services;
 using Marten.Testing.Documents;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Session
 {
@@ -10,8 +11,9 @@ namespace Marten.Testing.Session
     public class document_session_load_already_loaded_document_with_IdentityMap_Tests : document_session_load_already_loaded_document_Tests<IdentityMap> { }
     public class document_session_load_already_loaded_document_with_DirtyTracking_Tests : document_session_load_already_loaded_document_Tests<DirtyTrackingIdentityMap> { }
 
-    public class document_session_load_already_loaded_document_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
+    public abstract class document_session_load_already_loaded_document_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
     {
+        [Fact]
         public void when_loading_then_a_different_document_should_be_returned()
         {
             var user = new User { FirstName = "Tim", LastName = "Cools" };
@@ -27,6 +29,7 @@ namespace Marten.Testing.Session
             }
         }
 
+        [Fact]
         public void when_loading_by_ids_then_a_different_document_should_be_returned()
         {
             var user = new User { FirstName = "Tim", LastName = "Cools" };

--- a/src/Marten.Testing/Session/document_session_load_not_yet_persisted_document_Tests.cs
+++ b/src/Marten.Testing/Session/document_session_load_not_yet_persisted_document_Tests.cs
@@ -2,11 +2,13 @@
 using Marten.Services;
 using Marten.Testing.Documents;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Session
 {
     public class not_tracked_document_session_load_not_yet_persisted_document_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void then_a_new_document_should_be_returned()
         {
             var user1 = new User { FirstName = "Tim", LastName = "Cools" };
@@ -18,6 +20,7 @@ namespace Marten.Testing.Session
             fromSession.ShouldNotBeSameAs(user1);
         }
 
+        [Fact]
         public void given_document_is_already_added_then_a_new_document_should_be_returned()
         {
             var user1 = new User { FirstName = "Tim", LastName = "Cools" };
@@ -30,6 +33,7 @@ namespace Marten.Testing.Session
             fromSession.ShouldNotBeSameAs(user1);
         }
 
+        [Fact]
         public void given_document_with_same_id_is_already_added_then_exception_should_occur()
         {
             var user1 = new User { FirstName = "Tim", LastName = "Cools" };

--- a/src/Marten.Testing/Session/document_session_update_existing_document_without_dirty_checking_Tests.cs
+++ b/src/Marten.Testing/Session/document_session_update_existing_document_without_dirty_checking_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using Marten.Services;
 using Marten.Testing.Documents;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Session
 {
@@ -9,8 +10,9 @@ namespace Marten.Testing.Session
 
 
 
-    public class document_session_update_existing_document_without_dirty_checking_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
+    public abstract class document_session_update_existing_document_without_dirty_checking_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
     {
+        [Fact]
         public void store_a_document()
         {
             var user = new User { FirstName = "James", LastName = "Worthy" };
@@ -26,6 +28,7 @@ namespace Marten.Testing.Session
             }
         }
 
+        [Fact]
         public void store_and_update_a_document_then_document_should_not_be_updated()
         {
             var user = new User { FirstName = "James", LastName = "Worthy" };
@@ -52,6 +55,7 @@ namespace Marten.Testing.Session
             }
         }
 
+        [Fact]
         public void store_and_update_a_document_in_same_session_then_document_should_not_be_updated()
         {
             var user = new User { FirstName = "James", LastName = "Worthy" };
@@ -71,6 +75,7 @@ namespace Marten.Testing.Session
             }
         }
 
+        [Fact]
         public void store_reload_and_update_a_document_in_same_session_then_document_should_not_be_updated()
         {
             var user = new User { FirstName = "James", LastName = "Worthy" };

--- a/src/Marten.Testing/TrackingSession/document_session_load_already_loaded_document_Tests.cs
+++ b/src/Marten.Testing/TrackingSession/document_session_load_already_loaded_document_Tests.cs
@@ -2,14 +2,16 @@
 using Marten.Services;
 using Marten.Testing.Documents;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.TrackingSession
 {
     public class document_session_load_already_loaded_document_with_IdentityMap_Tests : document_session_load_already_loaded_document_Tests<IdentityMap> { }
     public class document_session_load_already_loaded_document_with_DirtyTracking_Tests : document_session_load_already_loaded_document_Tests<DirtyTrackingIdentityMap> { }
 
-    public class document_session_load_already_loaded_document_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
+    public abstract class document_session_load_already_loaded_document_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
     {
+        [Fact]
         public void when_loading_then_the_document_should_be_returned()
         {
             var user = new User { FirstName = "Tim", LastName = "Cools" };
@@ -25,6 +27,7 @@ namespace Marten.Testing.TrackingSession
             }
         }
 
+        [Fact]
         public void when_loading_by_ids_then_the_same_document_should_be_returned()
         {
             var user = new User { FirstName = "Tim", LastName = "Cools" };

--- a/src/Marten.Testing/TrackingSession/document_session_load_not_yet_persisted_document_Tests.cs
+++ b/src/Marten.Testing/TrackingSession/document_session_load_not_yet_persisted_document_Tests.cs
@@ -2,14 +2,16 @@
 using Marten.Services;
 using Marten.Testing.Documents;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.TrackingSession
 {
     public class document_session_load_not_yet_persisted_document_IdentityMap_Tests : document_session_load_not_yet_persisted_document_Tests<IdentityMap> { }
     public class document_session_load_not_yet_persisted_document_DirtyChecking_Tests : document_session_load_not_yet_persisted_document_Tests<DirtyTrackingIdentityMap> { }
 
-    public class document_session_load_not_yet_persisted_document_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
+    public abstract class document_session_load_not_yet_persisted_document_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
     {
+        [Fact]
         public void then_the_document_should_be_returned()
         {
             var user1 = new User { FirstName = "Tim", LastName = "Cools" };
@@ -21,6 +23,7 @@ namespace Marten.Testing.TrackingSession
             fromSession.ShouldBeSameAs(user1);
         }
 
+        [Fact]
         public void given_document_is_already_added_then_document_should_be_returned()
         {
             var user1 = new User { FirstName = "Tim", LastName = "Cools" };
@@ -33,6 +36,7 @@ namespace Marten.Testing.TrackingSession
             fromSession.ShouldBeSameAs(user1);
         }
 
+        [Fact]
         public void given_document_with_same_id_is_already_added_then_exception_should_occur()
         {
             var user1 = new User { FirstName = "Tim", LastName = "Cools" };

--- a/src/Marten.Testing/TrackingSession/document_session_update_existing_document_Tests.cs
+++ b/src/Marten.Testing/TrackingSession/document_session_update_existing_document_Tests.cs
@@ -1,12 +1,14 @@
 ﻿using Marten.Services;
 using Marten.Testing.Documents;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.TrackingSession
 {
 
     public class document_session_update_existing_document_Tests : DocumentSessionFixture<DirtyTrackingIdentityMap>
     {
+        [Fact]
         public void store_a_document()
         {
             var user = new User { FirstName = "James", LastName = "Worthy" };
@@ -22,6 +24,7 @@ namespace Marten.Testing.TrackingSession
             }
         }
 
+        [Fact]
         public void store_and_update_a_document()
         {
             var user = new User { FirstName = "James", LastName = "Worthy" };
@@ -48,6 +51,7 @@ namespace Marten.Testing.TrackingSession
             }
         }
 
+        [Fact]
         public void store_and_update_a_document_in_same_session()
         {
             var user = new User { FirstName = "James", LastName = "Worthy" };
@@ -67,6 +71,7 @@ namespace Marten.Testing.TrackingSession
             }
         }
 
+        [Fact]
         public void store_reload_and_update_a_document_in_same_session()
         {
             var user = new User { FirstName = "James", LastName = "Worthy" };

--- a/src/Marten.Testing/TypeMappingsTests.cs
+++ b/src/Marten.Testing/TypeMappingsTests.cs
@@ -2,17 +2,20 @@
 using Marten.Util;
 using NpgsqlTypes;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing
 {
     public class TypeMappingsTests
     {
+        [Fact]
         public void execute_to_db_type_as_date()
         {
             // I'm overriding the behavior in Npgsql itself here.
             TypeMappings.ToDbType(typeof(DateTime)).ShouldBe(NpgsqlDbType.Date);
         }
 
+        [Fact]
         public void execute_to_db_type_as_int()
         {
             TypeMappings.ToDbType(typeof(int)).ShouldBe(NpgsqlDbType.Integer);

--- a/src/Marten.Testing/UnitOfWorkTests.cs
+++ b/src/Marten.Testing/UnitOfWorkTests.cs
@@ -4,6 +4,7 @@ using Marten.Testing.Documents;
 using Marten.Testing.Schema;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing
 {
@@ -16,6 +17,7 @@ namespace Marten.Testing
             theSession = theContainer.GetInstance<IDocumentStore>().OpenSession();
         }
 
+        [Fact]
         public void update_mixed_document_types()
         {
             var user1 = new User ();
@@ -41,6 +43,7 @@ namespace Marten.Testing
             theSession.Query<Company>().ToArray().Select(x => x.Id).ShouldHaveTheSameElementsAs(company1.Id, company2.Id);
         }
 
+        [Fact]
         public void apply_updates_via_the_actual_document()
         {
             var stringDoc1 = new StringDoc {Id = "Foo"};
@@ -78,6 +81,7 @@ namespace Marten.Testing
 
 
 
+        [Fact]
         public void apply_updates_via_the_id()
         {
             var stringDoc1 = new StringDoc { Id = "Foo" };

--- a/src/Marten.Testing/Util/CommandExtensionsTests.cs
+++ b/src/Marten.Testing/Util/CommandExtensionsTests.cs
@@ -2,11 +2,13 @@
 using Npgsql;
 using NpgsqlTypes;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Util
 {
     public class CommandExtensionsTests
     {
+        [Fact]
         public void add_first_parameter()
         {
             var command = new NpgsqlCommand();
@@ -21,6 +23,7 @@ namespace Marten.Testing.Util
             command.Parameters.ShouldContain(param);
         }
 
+        [Fact]
         public void add_second_parameter()
         {
             var command = new NpgsqlCommand();

--- a/src/Marten.Testing/Util/update_batch_Tests.cs
+++ b/src/Marten.Testing/Util/update_batch_Tests.cs
@@ -8,6 +8,7 @@ using Marten.Util;
 using NpgsqlTypes;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing.Util
 {
@@ -22,6 +23,7 @@ namespace Marten.Testing.Util
             theSession = theContainer.GetInstance<IDocumentStore>().OpenSession();
         }
 
+        [Fact]
         public void write_multiple_calls()
         {
             // Just forcing the table and schema objects to be created
@@ -55,6 +57,7 @@ namespace Marten.Testing.Util
         }
 
 
+        [Fact]
         public void write_multiple_calls_with_json_supplied()
         {
             // Just forcing the table and schema objects to be created

--- a/src/Marten.Testing/auto_assign_missing_guid_ids_Tests.cs
+++ b/src/Marten.Testing/auto_assign_missing_guid_ids_Tests.cs
@@ -2,11 +2,13 @@
 using Marten.Services;
 using Marten.Testing.Documents;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing
 {
     public class auto_assign_missing_guid_ids_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void should_auto_assign()
         {
             var user = new User();

--- a/src/Marten.Testing/bulk_loading_Tests.cs
+++ b/src/Marten.Testing/bulk_loading_Tests.cs
@@ -4,11 +4,13 @@ using Marten.Schema;
 using Marten.Services;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing
 {
     public class bulk_loading_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void load_with_small_batch()
         {
             // SAMPLE: using_bulk_insert
@@ -30,6 +32,7 @@ namespace Marten.Testing
             Debug.WriteLine(DocumentStorageBuilder.GenerateDocumentStorageCode(new DocumentMapping[] {new DocumentMapping(typeof(Target)), }));
         }
 
+        [Fact]
         public void load_with_small_batch_and_duplicated_fields()
         {
             theContainer.GetInstance<IDocumentSchema>().Alter(_ =>
@@ -47,6 +50,7 @@ namespace Marten.Testing
                 .ShouldBeTrue();
         }
 
+        [Fact]
         public void load_with_small_batch_and_duplicated_data_field()
         {
             theContainer.GetInstance<IDocumentSchema>().Alter(_ =>
@@ -65,6 +69,7 @@ namespace Marten.Testing
         }
 
 
+        [Fact]
         public void load_with_multiple_batches()
         {
             var data = Target.GenerateRandomData(100).ToArray();

--- a/src/Marten.Testing/document_session_delete_a_single_document_Tests.cs
+++ b/src/Marten.Testing/document_session_delete_a_single_document_Tests.cs
@@ -1,11 +1,13 @@
 ﻿using Marten.Services;
 using Marten.Testing.Documents;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing
 {
-    public class document_session_delete_a_single_document_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
+    public abstract class document_session_delete_a_single_document_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
     {
+        [Fact]
         public void persist_and_delete_a_document_by_entity()
         {
             var user = new User {FirstName = "Mychal", LastName = "Thompson"};
@@ -24,6 +26,7 @@ namespace Marten.Testing
             }
         }
 
+        [Fact]
         public void persist_and_delete_a_document_by_id()
         {
             var user = new User { FirstName = "Mychal", LastName = "Thompson" };

--- a/src/Marten.Testing/document_session_persist_and_load_single_documents_Tests.cs
+++ b/src/Marten.Testing/document_session_persist_and_load_single_documents_Tests.cs
@@ -4,6 +4,7 @@ using Baseline;
 using Marten.Services;
 using Marten.Testing.Documents;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing
 {
@@ -13,8 +14,9 @@ namespace Marten.Testing
 
 
 
-    public class document_session_persist_and_load_single_documents_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
+    public abstract class document_session_persist_and_load_single_documents_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
     {
+        [Fact]
         public void persist_a_single_document()
         {
             var user = new User {FirstName = "Magic", LastName = "Johnson"};
@@ -38,6 +40,7 @@ namespace Marten.Testing
             
         }
 
+        [Fact]
         public void persist_and_reload_a_document()
         {
             var user = new User { FirstName = "James", LastName = "Worthy" };
@@ -58,11 +61,13 @@ namespace Marten.Testing
             }
         }
 
+        [Fact]
         public void try_to_load_a_document_that_does_not_exist()
         {
             theSession.Load<User>(Guid.NewGuid()).ShouldBeNull();
         }
 
+        [Fact]
         public void load_by_id_array()
         {
             var user1 = new User { FirstName = "Magic", LastName = "Johnson" };

--- a/src/Marten.Testing/duplicate_fields_in_table_and_upsert_Tests.cs
+++ b/src/Marten.Testing/duplicate_fields_in_table_and_upsert_Tests.cs
@@ -3,11 +3,13 @@ using Marten.Services;
 using Marten.Testing.Documents;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing
 {
     public class duplicate_fields_in_table_and_upsert_Tests
     {
+        [Fact]
         public void end_to_end()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())

--- a/src/Marten.Testing/insert_timing.cs
+++ b/src/Marten.Testing/insert_timing.cs
@@ -9,6 +9,7 @@ using Marten.Services;
 using Marten.Testing.Fixtures;
 using StructureMap;
 using StructureMap.Util;
+using Xunit;
 
 namespace Marten.Testing
 {
@@ -63,6 +64,7 @@ namespace Marten.Testing
         }
 
 
+        [Fact]
         public void run_all_inserts()
         {
             var data = Target.GenerateRandomData(500).ToArray();

--- a/src/Marten.Testing/paket.references
+++ b/src/Marten.Testing/paket.references
@@ -10,3 +10,4 @@ Microsoft.CodeAnalysis.CSharp
 Jil
 HtmlTags
 Baseline
+xunit

--- a/src/Marten.Testing/persist_and_deleting_multiple_documents_Tests.cs
+++ b/src/Marten.Testing/persist_and_deleting_multiple_documents_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using Marten.Services;
 using Marten.Testing.Documents;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing
 {
@@ -8,8 +9,9 @@ namespace Marten.Testing
     public class persist_and_deleting_multiple_documents_with_IdentityMap_Tests : persist_and_deleting_multiple_documents_Tests<IdentityMap> { }
     public class persist_and_deleting_multiple_documents_with_DirtyTracking_Tests : persist_and_deleting_multiple_documents_Tests<DirtyTrackingIdentityMap> { }
 
-    public class persist_and_deleting_multiple_documents_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
+    public abstract class persist_and_deleting_multiple_documents_Tests<T> : DocumentSessionFixture<T> where T : IIdentityMap
     {
+        [Fact]
         public void multiple_documents()
         {
             var user1 = new User {FirstName = "Jeremy", LastName = "Miller"};

--- a/src/Marten.Testing/persist_and_load_documents_with_int_ids_Tests.cs
+++ b/src/Marten.Testing/persist_and_load_documents_with_int_ids_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Marten.Services;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing
 {
@@ -11,6 +12,7 @@ namespace Marten.Testing
 
     public class persist_and_load_documents_with_int_ids_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void persist_and_load()
         {
             var IntDoc = new IntDoc { Id = 456 };
@@ -29,6 +31,7 @@ namespace Marten.Testing
 
         }
 
+        [Fact]
         public void auto_assign_id_for_0_id()
         {
             var doc = new IntDoc {Id = 0};
@@ -45,6 +48,7 @@ namespace Marten.Testing
             doc2.Id.ShouldNotBe(doc.Id);
         }
 
+        [Fact]
         public void persist_and_delete()
         {
             var IntDoc = new IntDoc { Id = 567 };
@@ -65,6 +69,7 @@ namespace Marten.Testing
             }
         }
 
+        [Fact]
         public void load_by_array_of_ids()
         {
             theSession.Store(new IntDoc { Id = 3 });

--- a/src/Marten.Testing/persist_and_load_documents_with_long_ids_Tests.cs
+++ b/src/Marten.Testing/persist_and_load_documents_with_long_ids_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Marten.Services;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing
 {
@@ -11,6 +12,7 @@ namespace Marten.Testing
 
     public class persist_and_load_documents_with_long_ids_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void persist_and_load()
         {
             var LongDoc = new LongDoc { Id = 456 };
@@ -29,6 +31,7 @@ namespace Marten.Testing
 
         }
 
+        [Fact]
         public void auto_assign_id_for_0_id()
         {
             var doc = new LongDoc { Id = 0 };
@@ -45,6 +48,7 @@ namespace Marten.Testing
             doc2.Id.ShouldNotBe(doc.Id);
         }
 
+        [Fact]
         public void persist_and_delete()
         {
             var LongDoc = new LongDoc { Id = 567 };
@@ -65,6 +69,7 @@ namespace Marten.Testing
             }
         }
 
+        [Fact]
         public void load_by_array_of_ids()
         {
             theSession.Store(new LongDoc{Id = 3});

--- a/src/Marten.Testing/persisting_document_with_string_id_Tests.cs
+++ b/src/Marten.Testing/persisting_document_with_string_id_Tests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Marten.Services;
 using Shouldly;
+using Xunit;
 
 namespace Marten.Testing
 {
@@ -12,6 +13,7 @@ namespace Marten.Testing
 
     public class persisting_document_with_string_id_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        [Fact]
         public void persist_and_load()
         {
             var account = new Account{Id = "email@server.com"};
@@ -30,6 +32,7 @@ namespace Marten.Testing
 
         }
 
+        [Fact]
         public void throws_exception_if_trying_to_save_null_id()
         {
             var account = new Account {Id = null};
@@ -43,6 +46,7 @@ namespace Marten.Testing
         }
 
 
+        [Fact]
         public void throws_exception_if_trying_to_save_empty_id()
         {
             var account = new Account { Id = string.Empty };
@@ -55,6 +59,7 @@ namespace Marten.Testing
 
         }
 
+        [Fact]
         public void persist_and_delete()
         {
             var account = new Account { Id = "email@server.com" };
@@ -75,6 +80,7 @@ namespace Marten.Testing
             }
         }
 
+        [Fact]
         public void load_by_array_of_ids()
         {
             theSession.Store(new Account { Id = "A" });

--- a/src/Marten.Testing/query_by_sql_where_clause_Tests.cs
+++ b/src/Marten.Testing/query_by_sql_where_clause_Tests.cs
@@ -3,6 +3,7 @@ using Marten.Schema;
 using Marten.Testing.Documents;
 using Shouldly;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing
 {
@@ -16,6 +17,7 @@ namespace Marten.Testing
             }
         }
 
+        [Fact]
         public void query_with_select_in_query()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())
@@ -35,6 +37,7 @@ namespace Marten.Testing
             }
         }
 
+        [Fact]
         // SAMPLE: query_with_only_the_where_clause
         public void query_for_single_document()
         {
@@ -54,6 +57,7 @@ namespace Marten.Testing
         }
         // ENDSAMPLE
 
+        [Fact]
         public void query_for_multiple_documents()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())
@@ -77,6 +81,7 @@ namespace Marten.Testing
             }
         }
 
+        [Fact]
         public void query_by_one_parameter()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())
@@ -100,6 +105,7 @@ namespace Marten.Testing
             }
         }
 
+        [Fact]
         public void query_by_two_parameters()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())
@@ -124,6 +130,7 @@ namespace Marten.Testing
         }
 
 
+        [Fact]
         public void query_for_multiple_documents_with_ordering()
         {
             using (var container = Container.For<DevelopmentModeRegistry>())

--- a/src/Marten.Testing/show_document_storage_code_in_diagnostics_Tests.cs
+++ b/src/Marten.Testing/show_document_storage_code_in_diagnostics_Tests.cs
@@ -2,11 +2,13 @@
 using Marten.Schema;
 using Marten.Testing.Fixtures;
 using StructureMap;
+using Xunit;
 
 namespace Marten.Testing
 {
     public class show_document_storage_code_in_diagnostics_Tests
     {
+        [Fact]
         public void show_code()
         {
             var container = Container.For<DevelopmentModeRegistry>();


### PR DESCRIPTION
First inconsequential contribution.

Added xunit attribute for future dnx needs. Fixie doesn't seem to be maintained very often and given our shorter term needs this will be necessary for now. I will likely leave the fixie cli test runner there for now and replace it with the eventual dnx equivalent down the road rather than doing it twice.