### PR TITLE
Add async methods

### DIFF
--- a/src/Marten.Testing/Linq/invoking_queryable_any_async_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_any_async_Tests.cs
@@ -1,0 +1,71 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Marten.Services;
+using Marten.Testing.Fixtures;
+using Marten.Util;
+using Xunit;
+
+namespace Marten.Testing.Linq
+{
+    public class invoking_queryable_any_async_Tests : DocumentSessionFixture<NulloIdentityMap>
+    {
+        [Fact]
+        public async Task any_miss_with_query()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var result = await theSession.Query<Target>().AnyAsync(x => x.Number == 11);
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task naked_any_miss()
+        {
+            var result = await theSession.Query<Target>().AnyAsync();
+            result.ShouldBeFalse();
+        }
+        
+        [Fact]
+        public async Task naked_any_hit()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            theSession.SaveChanges();
+
+            var result = await theSession.Query<Target>().AnyAsync();
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task any_hit_with_only_one_document()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            theSession.SaveChanges();
+
+            var result = await theSession.Query<Target>().AnyAsync(x => x.Number == 3);
+            result.ShouldBeTrue();
+        }
+        
+        [Fact]
+        public async Task any_hit_with_more_than_one_match()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 4 });
+            theSession.SaveChanges();
+
+            var result = await theSession.Query<Target>().Where(x => x.Number == 2).AnyAsync();
+            result.ShouldBeTrue();
+        }
+    }
+}

--- a/src/Marten.Testing/Linq/invoking_queryable_count_async_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_count_async_Tests.cs
@@ -1,0 +1,68 @@
+﻿using System.Threading.Tasks;
+using Marten.Services;
+using Marten.Testing.Fixtures;
+using Marten.Util;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Linq
+{
+    public class invoking_queryable_count_async_Tests : DocumentSessionFixture<NulloIdentityMap>
+    {
+        [Fact]
+        public async Task count_without_any_where()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var result = await theSession.Query<Target>().CountAsync();
+            result.ShouldBe(4);
+        }
+
+        [Fact]
+        public async Task long_count_without_any_where()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var result = await theSession.Query<Target>().LongCountAsync();
+            result.ShouldBe(4);
+        }
+
+        [Fact]
+        public async Task count_with_a_where_clause()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            theSession.Store(new Target { Number = 5 });
+            theSession.Store(new Target { Number = 6 });
+            await theSession.SaveChangesAsync();
+
+            var result = await theSession.Query<Target>().CountAsync(x => x.Number > 3);
+            result.ShouldBe(3);
+        }
+
+        [Fact]
+        public async Task long_count_with_a_where_clause()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            theSession.Store(new Target { Number = 5 });
+            theSession.Store(new Target { Number = 6 });
+            await theSession.SaveChangesAsync();
+
+            var result = await theSession.Query<Target>().LongCountAsync(x => x.Number > 3);
+            result.ShouldBe(3);
+        }
+    }
+}

--- a/src/Marten.Testing/Linq/invoking_queryable_through_first_async_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_through_first_async_Tests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using Marten.Services;
+using Marten.Testing.Fixtures;
+using Xunit;
+using System.Threading.Tasks;
+using Marten.Util;
+
+namespace Marten.Testing.Linq
+{
+    public class invoking_queryable_through_first_async_Tests : DocumentSessionFixture<NulloIdentityMap>
+    {
+        [Fact]
+        public async Task first_hit_with_only_one_document()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().FirstAsync(x => x.Number == 3);
+            target.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public async Task first_or_default_hit_with_only_one_document()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().FirstOrDefaultAsync(x => x.Number == 3);
+            target.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public async Task first_or_default_miss()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().FirstOrDefaultAsync(x => x.Number == 11);
+            target.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task first_correct_hit_with_more_than_one_match()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2, Flag = true });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().Where(x => x.Number == 2).FirstAsync();
+            target.Flag.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task first_or_default_correct_hit_with_more_than_one_match()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2, Flag = true });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().Where(x => x.Number == 2).FirstOrDefaultAsync();
+            target.Flag.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task first_miss()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            await Exception<InvalidOperationException>.ShouldBeThrownByAsync(async () =>
+            {
+                await theSession.Query<Target>().Where(x => x.Number == 11).FirstAsync();
+            });
+        }
+    }
+}

--- a/src/Marten.Testing/Linq/invoking_queryable_through_last_async_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_through_last_async_Tests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten.Services;
+using Marten.Testing.Fixtures;
+using Marten.Util;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Linq
+{
+    public class invoking_queryable_through_last_async_Tests : DocumentSessionFixture<NulloIdentityMap>
+    {
+        [Fact]
+        public async Task last_hit_with_only_one_document()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().LastAsync(x => x.Number == 3);
+            target.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public async Task last_or_default_hit_with_only_one_document()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().LastOrDefaultAsync(x => x.Number == 3);
+            target.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public async Task last_or_default_miss()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().LastOrDefaultAsync(x => x.Number == 11);
+            target.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task last_correct_hit_with_more_than_one_match()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 2, Flag = true });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().Where(x => x.Number == 2).LastAsync();
+            target.Flag.ShouldBe(true);
+        }
+
+        [Fact]
+        public async Task last_or_default_correct_hit_with_more_than_one_match()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 2, Flag = true });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().Where(x => x.Number == 2).LastOrDefaultAsync();
+            target.Flag.ShouldBe(true);
+        }
+
+        [Fact]
+        public async Task last_miss()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 3 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            await Exception<InvalidOperationException>.ShouldBeThrownByAsync(async () =>
+            {
+                await theSession.Query<Target>().Where(x => x.Number == 11).LastAsync();
+            });
+        }
+    }
+}

--- a/src/Marten.Testing/Linq/invoking_queryable_through_single_async_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_through_single_async_Tests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten.Services;
+using Marten.Testing.Fixtures;
+using Marten.Util;
+using Xunit;
+
+namespace Marten.Testing.Linq
+{
+    public class invoking_queryable_through_single_async_Tests : DocumentSessionFixture<NulloIdentityMap>
+    {
+        [Fact]
+        public async Task single_hit_with_only_one_document()
+        {
+            theSession.Store(new Target {Number = 1});
+            theSession.Store(new Target {Number = 2});
+            theSession.Store(new Target {Number = 3});
+            theSession.Store(new Target {Number = 4});
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().SingleAsync(x => x.Number == 3);
+            target.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public async Task single_or_default_hit_with_only_one_document()
+        {
+            theSession.Store(new Target {Number = 1});
+            theSession.Store(new Target {Number = 2});
+            theSession.Store(new Target {Number = 3});
+            theSession.Store(new Target {Number = 4});
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().SingleOrDefaultAsync(x => x.Number == 3);
+            target.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public async Task single_or_default_miss()
+        {
+            theSession.Store(new Target {Number = 1});
+            theSession.Store(new Target {Number = 2});
+            theSession.Store(new Target {Number = 3});
+            theSession.Store(new Target {Number = 4});
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().SingleOrDefaultAsync(x => x.Number == 11);
+            target.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task single_hit_with_more_than_one_match()
+        {
+            theSession.Store(new Target {Number = 1});
+            theSession.Store(new Target {Number = 2});
+            theSession.Store(new Target {Number = 2});
+            theSession.Store(new Target {Number = 4});
+            await theSession.SaveChangesAsync();
+
+            await Exception<InvalidOperationException>.ShouldBeThrownByAsync(async () =>
+            {
+                await theSession.Query<Target>().Where(x => x.Number == 2).SingleAsync();
+            });
+        }
+
+        [Fact]
+        public async Task single_or_default_hit_with_more_than_one_match()
+        {
+            theSession.Store(new Target {Number = 1});
+            theSession.Store(new Target {Number = 2});
+            theSession.Store(new Target {Number = 2});
+            theSession.Store(new Target {Number = 4});
+            await theSession.SaveChangesAsync();
+
+            await Exception<InvalidOperationException>.ShouldBeThrownByAsync(async () =>
+            {
+                await theSession.Query<Target>().Where(x => x.Number == 2).SingleOrDefaultAsync();
+            });
+        }
+
+        [Fact]
+        public async Task single_miss()
+        {
+            theSession.Store(new Target {Number = 1});
+            theSession.Store(new Target {Number = 2});
+            theSession.Store(new Target {Number = 3});
+            theSession.Store(new Target {Number = 4});
+            await theSession.SaveChangesAsync();
+
+            await Exception<InvalidOperationException>.ShouldBeThrownByAsync(async () =>
+            {
+                await theSession.Query<Target>().Where(x => x.Number == 11).SingleAsync();
+            });
+        }
+    }
+}

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -88,6 +88,11 @@
     <Compile Include="Github\GitHubExporter.cs" />
     <Compile Include="Github\RepositoryHistory.cs" />
     <Compile Include="insert_timing.cs" />
+    <Compile Include="Linq\invoking_queryable_any_async_Tests.cs" />
+    <Compile Include="Linq\invoking_queryable_count_async_Tests.cs" />
+    <Compile Include="Linq\invoking_queryable_through_first_async_Tests.cs" />
+    <Compile Include="Linq\invoking_queryable_through_last_async_Tests.cs" />
+    <Compile Include="Linq\invoking_queryable_through_single_async_Tests.cs" />
     <Compile Include="Linq\deep_searches_Tests.cs" />
     <Compile Include="Linq\invoking_queryable_any_Tests.cs">
       <SubType>Code</SubType>

--- a/src/Marten.Testing/SpecificationExtensions.cs
+++ b/src/Marten.Testing/SpecificationExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using Baseline;
 using Shouldly;
 
@@ -25,11 +26,27 @@ namespace Marten.Testing
 
             exception.ShouldNotBeNull("An exception was expected, but not thrown by the given action.");
 
+            return exception;
+        }
+
+        public static async Task<T> ShouldBeThrownByAsync(Func<Task> action)
+        {
+            T exception = null;
+
+            try
+            {
+                await action();
+            }
+            catch (Exception e)
+            {
+                exception = e.ShouldBeOfType<T>();
+            }
+
+            exception.ShouldNotBeNull("An exception was expected, but not thrown by the given action.");
 
             return exception;
         }
     }
-
 
     public delegate void MethodThatThrows();
 

--- a/src/Marten/Linq/IMartenQueryExecutor.cs
+++ b/src/Marten/Linq/IMartenQueryExecutor.cs
@@ -12,5 +12,6 @@ namespace Marten.Linq
         NpgsqlCommand BuildCommand(QueryModel queryModel);
         NpgsqlCommand BuildCommand<T>(IQueryable<T> queryable);
         Task<IEnumerable<T>> ExecuteCollectionAsync<T>(QueryModel queryModel, CancellationToken token);
+        Task<T> ExecuteAsync<T>(QueryModel queryModel, CancellationToken token);
     }
 }

--- a/src/Marten/Linq/IMartenQueryProvider.cs
+++ b/src/Marten/Linq/IMartenQueryProvider.cs
@@ -9,5 +9,6 @@ namespace Marten.Linq
     public interface IMartenQueryProvider : IQueryProvider
     {
         Task<IEnumerable<TResult>> ExecuteCollectionAsync<TResult>(Expression expression, CancellationToken token);
+        Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken token);
     }
 }

--- a/src/Marten/Linq/MartenQueryProvider.cs
+++ b/src/Marten/Linq/MartenQueryProvider.cs
@@ -29,5 +29,12 @@ namespace Marten.Linq
             var queryExecutor = (IMartenQueryExecutor)Executor;
             return await queryExecutor.ExecuteCollectionAsync<T>(queryModel, token);
         }
+
+        public async Task<T> ExecuteAsync<T>(Expression expression, CancellationToken token)
+        {
+            var queryModel = QueryParser.GetParsedQuery(expression);
+            var queryExecutor = (IMartenQueryExecutor)Executor;
+            return await queryExecutor.ExecuteAsync<T>(queryModel, token);
+        }
     }
 }

--- a/src/Marten/Util/QueryableExtensions.cs
+++ b/src/Marten/Util/QueryableExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Linq;
@@ -9,16 +11,335 @@ namespace Marten.Util
 {
     public static class QueryableExtensions
     {
-        public static async Task<List<T>> ToListAsync<T>(this IQueryable<T> queryable, CancellationToken token = default(CancellationToken))
+        #region ToList
+
+        public static async Task<List<T>> ToListAsync<T>(this IQueryable<T> queryable,
+            CancellationToken token = default(CancellationToken))
         {
             var martenQueryable = queryable as IMartenQueryable<T>;
             if (martenQueryable == null)
             {
-                throw new InvalidOperationException($"{typeof(T)} is not IMartenQueryable<>");
+                throw new InvalidOperationException($"{typeof (T)} is not IMartenQueryable<>");
             }
 
             var enumerable = await martenQueryable.ExecuteCollectionAsync(token).ConfigureAwait(false);
             return enumerable.ToList();
         }
+
+        #endregion
+
+        #region Any
+
+        private static readonly MethodInfo _any = GetMethod(nameof(Queryable.Any));
+
+        public static Task<bool> AnyAsync<TSource>(
+            this IQueryable<TSource> source,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return ExecuteAsync<TSource, bool>(_any, source, cancellationToken);
+        }
+
+        private static readonly MethodInfo _anyPredicate = GetMethod(nameof(Queryable.Any), 1);
+
+        public static Task<bool> AnyAsync<TSource>(
+            this IQueryable<TSource> source,
+            Expression<Func<TSource, bool>> predicate,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return ExecuteAsync<TSource, bool>(_anyPredicate, source, predicate, cancellationToken);
+        }
+
+        #endregion
+
+        #region Count/LongCount
+
+        private static readonly MethodInfo _count = GetMethod(nameof(Queryable.Count));
+
+        public static Task<int> CountAsync<TSource>(
+            this IQueryable<TSource> source,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return ExecuteAsync<TSource, int>(_count, source, cancellationToken);
+        }
+
+        private static readonly MethodInfo _countPredicate = GetMethod(nameof(Queryable.Count), 1);
+
+        public static Task<int> CountAsync<TSource>(
+            this IQueryable<TSource> source,
+            Expression<Func<TSource, bool>> predicate,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return ExecuteAsync<TSource, int>(_countPredicate, source, predicate, cancellationToken);
+        }
+
+        private static readonly MethodInfo _longCount = GetMethod(nameof(Queryable.LongCount));
+
+        public static Task<long> LongCountAsync<TSource>(
+            this IQueryable<TSource> source,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return ExecuteAsync<TSource, long>(_longCount, source, cancellationToken);
+        }
+
+        private static readonly MethodInfo _longCountPredicate = GetMethod(nameof(Queryable.LongCount), 1);
+
+        public static Task<long> LongCountAsync<TSource>(
+            this IQueryable<TSource> source,
+            Expression<Func<TSource, bool>> predicate,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return ExecuteAsync<TSource, long>(_longCountPredicate, source, predicate, cancellationToken);
+        }
+
+        #endregion
+
+        #region First/FirstOrDefault
+
+        private static readonly MethodInfo _first = GetMethod(nameof(Queryable.First));
+
+        public static Task<TSource> FirstAsync<TSource>(
+            this IQueryable<TSource> source,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return ExecuteAsync<TSource, TSource>(_first, source, cancellationToken);
+        }
+
+        private static readonly MethodInfo _firstPredicate = GetMethod(nameof(Queryable.First), 1);
+
+        public static Task<TSource> FirstAsync<TSource>(
+            this IQueryable<TSource> source,
+            Expression<Func<TSource, bool>> predicate,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return ExecuteAsync<TSource, TSource>(_firstPredicate, source, predicate, cancellationToken);
+        }
+
+        private static readonly MethodInfo _firstOrDefault = GetMethod(nameof(Queryable.FirstOrDefault));
+
+        public static Task<TSource> FirstOrDefaultAsync<TSource>(
+            this IQueryable<TSource> source,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return ExecuteAsync<TSource, TSource>(_firstOrDefault, source, cancellationToken);
+        }
+
+        private static readonly MethodInfo _firstOrDefaultPredicate = GetMethod(nameof(Queryable.FirstOrDefault), 1);
+
+        public static Task<TSource> FirstOrDefaultAsync<TSource>(
+            this IQueryable<TSource> source,
+            Expression<Func<TSource, bool>> predicate,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return ExecuteAsync<TSource, TSource>(_firstOrDefaultPredicate, source, predicate, cancellationToken);
+        }
+
+        #endregion
+
+        #region Single/SingleOrDefault
+
+        private static readonly MethodInfo _single = GetMethod(nameof(Queryable.Single));
+
+        public static Task<TSource> SingleAsync<TSource>(
+            this IQueryable<TSource> source,
+            CancellationToken token = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return ExecuteAsync<TSource, TSource>(_single, source, token);
+        }
+
+        private static readonly MethodInfo _singlePredicate = GetMethod(nameof(Queryable.Single), 1);
+
+        public static Task<TSource> SingleAsync<TSource>(
+            this IQueryable<TSource> source,
+            Expression<Func<TSource, bool>> predicate,
+            CancellationToken token = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return ExecuteAsync<TSource, TSource>(_singlePredicate, source, predicate, token);
+        }
+
+        private static readonly MethodInfo _singleOrDefault = GetMethod(nameof(Queryable.SingleOrDefault));
+
+        public static Task<TSource> SingleOrDefaultAsync<TSource>(
+            this IQueryable<TSource> source,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return ExecuteAsync<TSource, TSource>(_singleOrDefault, source, cancellationToken);
+        }
+
+        private static readonly MethodInfo _singleOrDefaultPredicate = GetMethod(nameof(Queryable.SingleOrDefault), 1);
+
+        public static Task<TSource> SingleOrDefaultAsync<TSource>(
+            this IQueryable<TSource> source,
+            Expression<Func<TSource, bool>> predicate,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return ExecuteAsync<TSource, TSource>(_singleOrDefaultPredicate, source, predicate, cancellationToken);
+        }
+
+        #endregion
+
+        #region Last/LastOrDefault
+
+        private static readonly MethodInfo _last = GetMethod(nameof(Queryable.Last));
+
+        public static Task<TSource> LastAsync<TSource>(
+            this IQueryable<TSource> source,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return ExecuteAsync<TSource, TSource>(_last, source, cancellationToken);
+        }
+
+        private static readonly MethodInfo _lastPredicate = GetMethod(nameof(Queryable.Last), 1);
+
+        public static Task<TSource> LastAsync<TSource>(
+            this IQueryable<TSource> source,
+            Expression<Func<TSource, bool>> predicate,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return ExecuteAsync<TSource, TSource>(_lastPredicate, source, predicate, cancellationToken);
+        }
+
+        private static readonly MethodInfo _lastOrDefault = GetMethod(nameof(Queryable.LastOrDefault));
+
+        public static Task<TSource> LastOrDefaultAsync<TSource>(
+            this IQueryable<TSource> source,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return ExecuteAsync<TSource, TSource>(_lastOrDefault, source, cancellationToken);
+        }
+
+        private static readonly MethodInfo _lastOrDefaultPredicate = GetMethod(nameof(Queryable.LastOrDefault), 1);
+
+        public static Task<TSource> LastOrDefaultAsync<TSource>(
+            this IQueryable<TSource> source,
+            Expression<Func<TSource, bool>> predicate,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return ExecuteAsync<TSource, TSource>(_lastOrDefaultPredicate, source, predicate, cancellationToken);
+        }
+
+        #endregion
+
+        #region Shared
+
+        private static Task<TResult> ExecuteAsync<TSource, TResult>(
+            MethodInfo operatorMethodInfo,
+            IQueryable<TSource> source,
+            CancellationToken token = default(CancellationToken))
+        {
+            var provider = source.Provider as IMartenQueryProvider;
+            if (provider == null)
+            {
+                throw new InvalidOperationException($"{source.Provider.GetType()} is not IMartenQueryProvider");
+            }
+
+            if (operatorMethodInfo.IsGenericMethod)
+            {
+                operatorMethodInfo = operatorMethodInfo.MakeGenericMethod(typeof (TSource));
+            }
+
+            return provider.ExecuteAsync<TResult>(
+                Expression.Call(null, operatorMethodInfo, source.Expression),
+                token);
+        }
+
+        private static Task<TResult> ExecuteAsync<TSource, TResult>(
+            MethodInfo operatorMethodInfo,
+            IQueryable<TSource> source,
+            LambdaExpression expression,
+            CancellationToken token = default(CancellationToken))
+        {
+            return ExecuteAsync<TSource, TResult>(operatorMethodInfo, source, Expression.Quote(expression), token);
+        }
+
+        private static Task<TResult> ExecuteAsync<TSource, TResult>(
+            MethodInfo operatorMethodInfo,
+            IQueryable<TSource> source,
+            Expression expression,
+            CancellationToken token = default(CancellationToken))
+        {
+            var provider = source.Provider as IMartenQueryProvider;
+            if (provider == null)
+            {
+                throw new InvalidOperationException($"{source.Provider.GetType()} is not IMartenQueryProvider");
+            }
+
+            operatorMethodInfo
+                = operatorMethodInfo.GetGenericArguments().Length == 2
+                    ? operatorMethodInfo.MakeGenericMethod(typeof (TSource), typeof (TResult))
+                    : operatorMethodInfo.MakeGenericMethod(typeof (TSource));
+
+            return provider.ExecuteAsync<TResult>(
+                Expression.Call(
+                    null,
+                    operatorMethodInfo,
+                    new[] {source.Expression, expression}),
+                token);
+        }
+
+        private static MethodInfo GetMethod(
+            string name,
+            int parameterCount = 0,
+            Func<MethodInfo, bool> predicate = null)
+        {
+            return typeof (Queryable)
+                .GetTypeInfo()
+                .GetDeclaredMethods(name)
+                .Single(methodInfo =>
+                {
+                    if (methodInfo.GetParameters().Length != parameterCount + 1)
+                    {
+                        return false;
+                    }
+
+                    return predicate == null || predicate(methodInfo);
+                });
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Added async versions: Any, Count/LongCount, First/FirstOrDefault, Single/SingleOrDefault, Last/LastOrDefault.
Code of extensions was taken from EF7 [EntityFrameworkQueryableExtensions](https://github.com/aspnet/EntityFramework/blob/0b96c132f41442a10064156798d18d2526c3c0a7/src/EntityFramework.Core/EntityFrameworkQueryableExtensions.cs).
Is it a problem?

