### PR TITLE
fixes issue with multiple searchable properties

### DIFF
--- a/src/Marten.Testing/Fixtures/Target.cs
+++ b/src/Marten.Testing/Fixtures/Target.cs
@@ -19,6 +19,8 @@ namespace Marten.Testing.Fixtures
         private static string[] _strings = new[]
         {"Red", "Orange", "Yellow", "Green", "Blue", "Purple", "Violet", "Pink", "Gray", "Black"};
 
+        private static string[] _otherStrings = new[]
+            {"one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"};
 
         public static IEnumerable<Target> GenerateRandomData(int number)
         {
@@ -35,8 +37,8 @@ namespace Marten.Testing.Fixtures
         {
             var target = new Target();
             target.String = _strings[_random.Next(0, 10)];
+            target.AnotherString = _otherStrings[_random.Next(0, 10)];
             target.Number = _random.Next();
-
 
             target.NumberArray = new int[] {_random.Next(0, 10), _random.Next(0, 10), _random.Next(0, 10) };
 
@@ -86,6 +88,7 @@ namespace Marten.Testing.Fixtures
         public int Number { get; set; }
         public long Long { get; set; }
         public string String { get; set; }
+        public string AnotherString { get; set; }
 
         public Target Inner { get; set; }
 

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -123,6 +123,7 @@
     <Compile Include="performance_tuning.cs" />
     <Compile Include="persisting_document_with_string_id_Tests.cs" />
     <Compile Include="Schema\IndexDefinitionTests.cs" />
+    <Compile Include="searchable_properties_Tests.cs" />
     <Compile Include="Services\DirtyTrackingIdentityMapTests.cs" />
     <Compile Include="Services\IdentityMapTests.cs" />
     <Compile Include="Services\NulloIdentityMapTests.cs" />

--- a/src/Marten.Testing/searchable_properties_Tests.cs
+++ b/src/Marten.Testing/searchable_properties_Tests.cs
@@ -1,0 +1,29 @@
+﻿using Marten.Schema;
+using Marten.Services;
+using Marten.Testing.Fixtures;
+using System.Linq;
+using Xunit;
+
+namespace Marten.Testing
+{
+    public class searchable_properties_Tests : DocumentSessionFixture<IdentityMap>
+    {
+        [Fact]
+        public void load_with_small_batch_and_duplicated_fields()
+        {
+            theContainer.GetInstance<IDocumentSchema>().Alter(_ =>
+            {
+                _.For<Target>().Searchable(x => x.String)
+                    .Searchable(x => x.AnotherString);
+            });
+
+            var data = Target.GenerateRandomData(1).First();
+
+            using (var session = CreateSession())
+            {
+                session.Store(data);
+                session.SaveChanges();
+            }
+        }
+    }
+}

--- a/src/Marten/Schema/IndexDefinition.cs
+++ b/src/Marten/Schema/IndexDefinition.cs
@@ -68,7 +68,7 @@ namespace Marten.Schema
                 index += " " + Modifier;
             }
 
-            return index;
+            return index + ";";
         }
     }
 


### PR DESCRIPTION
@jeremydmiller this fixes the issue with multiple searchable properties with the Legacy schema update option.

Exception was being thrown when specifying multiple searchable properties:

> Result StackTrace:
at Npgsql.NpgsqlConnector.DoReadSingleMessage(DataRowLoadingMode dataRowLoadingMode, Boolean returnNullForAsyncMessage, Boolean isPrependedMessage)
at Npgsql.NpgsqlConnector.ReadSingleMessage(DataRowLoadingMode dataRowLoadingMode, Boolean returnNullForAsyncMessage)
at Npgsql.NpgsqlCommand.Execute(CommandBehavior behavior)
at Npgsql.NpgsqlCommand.ExecuteNonQueryInternal()
at Npgsql.NpgsqlCommand.ExecuteNonQuery()
at Marten.Services.CommandRunner.<>cDisplayClass6_0.<Execute>b0(NpgsqlConnection conn)
at Marten.Services.CommandRunner.ExecuteT
at Marten.Services.CommandRunner.Execute(String sql)
at Marten.Schema.DevelopmentSchemaCreation.CreateSchema(IDocumentSchema schema, DocumentMapping mapping)
at Marten.Schema.DocumentSchema.<>cDisplayClass7_0.<StorageFor>b0(Type type)
at System.Collections.Concurrent.ConcurrentDictionary2.GetOrAdd(TKey key, Func2 valueFactory)
at Marten.Schema.DocumentSchema.StorageFor(Type documentType)
at Marten.DocumentSession.StoreT
...
Result Message: Npgsql.NpgsqlException : 42601: syntax error at or near "CREATE"