### PR TITLE
Added failing test for collection change tracking

### DIFF
--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Schema\Sequences\SequenceFactoryTests.cs" />
     <Compile Include="show_document_storage_code_in_diagnostics_Tests.cs" />
     <Compile Include="SpecificationExtensions.cs" />
+    <Compile Include="TrackingSession\document_session_update_existing_documents_in_collection_Tests.cs" />
     <Compile Include="TrackingSession\document_session_update_existing_document_Tests.cs" />
     <Compile Include="TypeMappingsTests.cs" />
     <Compile Include="UnitOfWorkTests.cs" />

--- a/src/Marten.Testing/TrackingSession/document_session_update_existing_documents_in_collection_Tests.cs
+++ b/src/Marten.Testing/TrackingSession/document_session_update_existing_documents_in_collection_Tests.cs
@@ -1,0 +1,83 @@
+﻿using System.Linq;
+using Marten.Services;
+using Marten.Testing.Documents;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.TrackingSession
+{
+    public class document_session_update_existing_documents_in_collection_Tests
+    {
+        public class IdentityMapTests : DocumentSessionFixture<DirtyTrackingIdentityMap>
+        {
+            [Fact]
+            public void when_querying_and_modifying_multiple_documents_should_track_and_persist()
+            {
+                var user1 = new User { FirstName = "James", LastName = "Worthy 1" };
+                var user2 = new User { FirstName = "James", LastName = "Worthy 2" };
+                var user3 = new User { FirstName = "James", LastName = "Worthy 3" };
+
+                theSession.Store(user1);
+                theSession.Store(user2);
+                theSession.Store(user3);
+
+                theSession.SaveChanges();
+
+                using (var session2 = CreateSession())
+                {
+                    var users = session2.Query<User>().Where(x => x.FirstName == "James").ToList();
+
+                    foreach (var user in users)
+                    {
+                        user.LastName += " - updated";
+                    }
+
+                    session2.SaveChanges();
+                }
+
+                using (var session2 = CreateSession())
+                {
+                    var users = session2.Query<User>().Where(x => x.FirstName == "James").ToList();
+
+                    users.Select(x => x.LastName).ShouldHaveTheSameElementsAs("Worthy 1 - updated", "Worthy 2 - updated", "Worthy 3 - updated");
+                }
+            }
+        }
+
+        public class DirtyTrackingIdentityMapTests : DocumentSessionFixture<DirtyTrackingIdentityMap>
+        {
+            [Fact]
+            public void when_querying_and_modifying_multiple_documents_should_track_and_persist()
+            {
+                var user1 = new User { FirstName = "James", LastName = "Worthy 1" };
+                var user2 = new User { FirstName = "James", LastName = "Worthy 2" };
+                var user3 = new User { FirstName = "James", LastName = "Worthy 3" };
+
+                theSession.Store(user1);
+                theSession.Store(user2);
+                theSession.Store(user3);
+
+                theSession.SaveChanges();
+
+                using (var session2 = CreateSession())
+                {
+                    var users = session2.Query<User>().Where(x => x.FirstName == "James").ToList();
+
+                    foreach (var user in users)
+                    {
+                        user.LastName += " - updated";
+                    }
+
+                    session2.SaveChanges();
+                }
+
+                using (var session2 = CreateSession())
+                {
+                    var users = session2.Query<User>().Where(x => x.FirstName == "James").ToList();
+
+                    users.Select(x => x.LastName).ShouldHaveTheSameElementsAs("Worthy 1 - updated", "Worthy 2 - updated", "Worthy 3 - updated");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add's failing test for `DirtyTrackingIdentityMap` and `IdentityMap` for #117 