### PR TITLE
Syntax spike for Compiled Queries

### DIFF
--- a/src/Marten.Testing/CompileQueryDemonstrator.cs
+++ b/src/Marten.Testing/CompileQueryDemonstrator.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Baseline;
+using Marten.Linq;
+using Marten.Testing.Documents;
+using StructureMap;
+using Xunit;
+
+namespace Marten.Testing
+{
+    public class CompileQueryDemonstrator
+    {
+        [Fact]
+        public void look_at_compiled_queries()
+        {
+            var container = Container.For<DevelopmentModeRegistry>();
+
+            var store = container.GetInstance<IDocumentStore>();
+
+            // Compile a Linq query that "remembers" the underlying NpgsqlCommand object for the query
+            var query1 = store.CompileQuery<User, string, string>()
+                .For<IList<User>>((q, first, last) => q.Where(x => x.FirstName == first && x.LastName == last).ToList());
+
+            using (var session = store.QuerySession())
+            {
+                // Execute the compiled query against the current Session
+                var users = query1.Query(session, "Jeremy", "Miller");
+
+                users.Each(x => Debug.WriteLine(x.FullName));
+            }
+
+        }
+    }
+}

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Bugs\ability_to_persist_nested_types_Tests.cs" />
     <Compile Include="Bugs\Bug118_bad_exception_message_Tests.cs" />
     <Compile Include="bulk_loading_Tests.cs" />
+    <Compile Include="CompileQueryDemonstrator.cs" />
     <Compile Include="document_session_storing_from_another_assembly_Tests.cs" />
     <Compile Include="codegen_spike.cs" />
     <Compile Include="ConnectionSource.cs" />

--- a/src/Marten/Linq/CompiledQuery.cs
+++ b/src/Marten/Linq/CompiledQuery.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace Marten.Linq
+{
+    public static class CompiledQueryExtensions
+    {
+        public static ICompileQueryBody<TDoc, T1> CompileQuery<TDoc, T1>(this IDocumentStore store)
+        {
+            throw new NotSupportedException();
+        }
+
+        public static ICompileQueryBody<TDoc, T1, T2> CompileQuery<TDoc, T1, T2>(this IDocumentStore store)
+        {
+            throw new NotSupportedException();
+        }
+
+        public static ICompileQueryBody<TDoc, T1, T2, T3> CompileQuery<TDoc, T1, T2, T3>(this IDocumentStore store)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+
+    public interface ICompileQueryBody<TDoc, T1>
+    {
+        ICompiledQuery<T1, TOut> For<TOut>(Expression<Func<IMartenQueryable<TDoc>, T1, TOut>>  expression);
+    }
+
+    public interface ICompileQueryBody<TDoc, T1, T2>
+    {
+        ICompiledQuery<T1, T2, TOut> For<TOut>(Expression<Func<IMartenQueryable<TDoc>, T1, T2, TOut>> expression);
+    }
+
+    public interface ICompileQueryBody<TDoc, T1, T2, T3>
+    {
+        ICompiledQuery<T1, T2, T3, TOut> For<TOut>(Expression<Func<IMartenQueryable<TDoc>, T1, T2, T3, TOut>> expression);
+    }
+
+    public interface ICompiledQuery<T1, TOut>
+    {
+        TOut Query(IQuerySession session, T1 input1);
+    }
+
+    public interface ICompiledQuery<T1, T2, TOut>
+    {
+        TOut Query(IQuerySession session, T1 input1, T2 input2);
+    }
+
+    public interface ICompiledQuery<T1, T2, T3, TOut>
+    {
+        TOut Query(IQuerySession session, T1 input1, T2 input2, T3 input3);
+    }
+}

--- a/src/Marten/Linq/IMartenQueryable.cs
+++ b/src/Marten/Linq/IMartenQueryable.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Marten.Linq
 {
-    public interface IMartenQueryable<T>
+    public interface IMartenQueryable<T> : IQueryable<T>
     {
         Task<IEnumerable<T>> ExecuteCollectionAsync(CancellationToken token);
     }

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -51,6 +51,7 @@
     <Compile Include="IDiagnostics.cs" />
     <Compile Include="LambdaConnectionFactory.cs" />
     <Compile Include="Linq\CollectionAnyContainmentWhereFragment.cs" />
+    <Compile Include="Linq\CompiledQuery.cs" />
     <Compile Include="Linq\ContainmentWhereFragment.cs" />
     <Compile Include="Linq\IMartenQueryable.cs" />
     <Compile Include="Linq\IMartenQueryProvider.cs" />


### PR DESCRIPTION
Just demonstrating one possibility for the CompiledQuery syntax. This is somewhat inspired by [EF's support](https://msdn.microsoft.com/library/bb896297(v=vs.100).aspx).

Another alternative that would be a touch trickier behind the scenes would be:

``` csharp

IDocumentQuery<IList<User>, string, string> query = CompiledQuery
    .Against<User, string, string>()
    .For((users, first, last) => users.Where(x => x.FirstName == first && x.LastName == last));

// Against an IQuerySession, you'd get:
var users = query.Execute(session, "Lebron", "James");

```

I'm assuming that there'd be some overloads for selecting first/single/count and whatever else makes sense.

What do you think?