### PR TITLE
Spike of what IMartenLogger might look like

### DIFF
--- a/src/Marten/IMartenLogger.cs
+++ b/src/Marten/IMartenLogger.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Npgsql;
+
+namespace Marten
+{
+    // Use this to inject default session loggers into DocumentSessions when opened
+    public interface IMartenLogger
+    {
+        // Somehow, I'd like to be able to associate the description
+        // with what the system is doing. In our web based systems, I'd
+        // like to make that the URL of the request and maybe a user
+        IMartenSessionLogger StartSession(string description);
+    }
+
+    // This would be injected into a DocumentSession.
+    // Might expose IQuerySession.Logger as a settable property
+    public interface IMartenSessionLogger
+    {
+        // Using the Func or Action allows us to optionally capture
+        // performance timings or exceptions.
+        T Log<T>(NpgsqlCommand command, Func<T> func);
+        void Log(NpgsqlCommand command, Action action);
+    }
+}

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -49,6 +49,7 @@
     <Compile Include="DocumentStore.cs" />
     <Compile Include="DocumentTracking.cs" />
     <Compile Include="IDiagnostics.cs" />
+    <Compile Include="IMartenLogger.cs" />
     <Compile Include="LambdaConnectionFactory.cs" />
     <Compile Include="Linq\CollectionAnyContainmentWhereFragment.cs" />
     <Compile Include="Linq\ContainmentWhereFragment.cs" />


### PR DESCRIPTION
This is in regards to https://github.com/JasperFx/marten/issues/148.

I'm proposing these two new, pluggable interfaces as a mechanism to basically listen for any kind of information at runtime. This would allow the request governor approach or performance metrics or just exceptions from the sql being executed.

*My* big wish from the diagnostics is being able to associate DB activity with semantic elements of the application like "what HTTP URL was this" or "what message was the service bus handling?"