### PR TITLE
Change DateTime mapping to timestamp without time zone

### DIFF
--- a/src/Marten.Testing/Schema/configuring_searchable_fields_Tests.cs
+++ b/src/Marten.Testing/Schema/configuring_searchable_fields_Tests.cs
@@ -15,7 +15,7 @@ namespace Marten.Testing.Schema
             var mapping = DocumentMapping.For<Organization>();
             var duplicate = mapping.DuplicatedFields.Single(x => x.MemberName == "Time2");
 
-            duplicate.PgType.ShouldBe("date");
+            duplicate.PgType.ShouldBe("timestamp without time zone");
         }
 
         [Fact]

--- a/src/Marten.Testing/TypeMappingsTests.cs
+++ b/src/Marten.Testing/TypeMappingsTests.cs
@@ -1,20 +1,12 @@
-﻿using System;
-using Marten.Util;
+﻿using Marten.Util;
 using NpgsqlTypes;
 using Shouldly;
 using Xunit;
 
 namespace Marten.Testing
 {
-    public class TypeMappingsTests
+	public class TypeMappingsTests
     {
-        [Fact]
-        public void execute_to_db_type_as_date()
-        {
-            // I'm overriding the behavior in Npgsql itself here.
-            TypeMappings.ToDbType(typeof(DateTime)).ShouldBe(NpgsqlDbType.Date);
-        }
-
         [Fact]
         public void execute_to_db_type_as_int()
         {

--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -18,7 +18,7 @@ namespace Marten.Util
             {typeof (Boolean), "boolean"},
             {typeof (double), "double precision"},
             {typeof (decimal), "decimal"},
-            {typeof (DateTime), "date"},
+            {typeof (DateTime), "timestamp without time zone"},
             {typeof (DateTimeOffset), "timestamp with time zone"}
         };
 
@@ -58,8 +58,6 @@ namespace Marten.Util
         public static NpgsqlDbType ToDbType(Type type)
         {
             if (type.IsNullable()) return ToDbType(type.GetInnerTypeFromNullable());
-
-            if (type == typeof (DateTime)) return NpgsqlDbType.Date;
 
             return (NpgsqlDbType) _getNgpsqlDbTypeMethod.Invoke(null, new object[] {type});
         }


### PR DESCRIPTION
Fixes issue #175 

Changed `DateTime` mapping to `timestamp without time zone` and removed manual override from the `Npgsql.TypeHandlerRegistry` which returns `Timestamp`