### PR TITLE
Support StartStream with known ID

### DIFF
--- a/src/Marten/Events/EventStore.cs
+++ b/src/Marten/Events/EventStore.cs
@@ -48,9 +48,8 @@ namespace Marten.Events
             }
         }
 
-        public Guid StartStream<T>(params IEvent[] events) where T : IAggregate
+        public Guid StartStream<T>(Guid id, params IEvent[] events) where T : IAggregate
         {
-            var id = Guid.NewGuid();
             var stream = new EventStream(id, events)
             {
                 AggregateType = typeof(T)
@@ -59,6 +58,11 @@ namespace Marten.Events
             _session.Store(stream);
 
             return id;
+        }
+
+        public Guid StartStream<T>(params IEvent[] events) where T : IAggregate
+        {
+            return StartStream<T>(Guid.NewGuid(), events);
         }
 
         public T FetchSnapshot<T>(Guid streamId) where T : IAggregate

--- a/src/Marten/Events/IEventStore.cs
+++ b/src/Marten/Events/IEventStore.cs
@@ -9,6 +9,7 @@ namespace Marten.Events
 
         void AppendEvents(Guid stream, params IEvent[] events);
 
+        Guid StartStream<T>(Guid id, params IEvent[] events) where T : IAggregate;
         Guid StartStream<T>(params IEvent[] events) where T : IAggregate;
 
         T FetchSnapshot<T>(Guid streamId) where T : IAggregate;


### PR DESCRIPTION
I needed the provide a known ID when calling StartStream. In some cases I generate the aggregate ID on the client.