### PR TITLE
Failing test for appendingevents to a newstream

### DIFF
--- a/src/Marten.Testing/Events/end_to_end_event_capture_and_fetching_the_stream_Tests.cs
+++ b/src/Marten.Testing/Events/end_to_end_event_capture_and_fetching_the_stream_Tests.cs
@@ -10,17 +10,7 @@ namespace Marten.Testing.Events
         [Fact]
         public void capture_events_to_a_new_stream_and_fetch_the_events_back()
         {
-            var store = DocumentStore.For(_ =>
-            {
-                _.AutoCreateSchemaObjects = AutoCreate.All;
-
-                _.Connection(ConnectionSource.ConnectionString);
-
-                _.Events.AddEventType(typeof (MembersJoined));
-                _.Events.AddEventType(typeof (MembersDeparted));
-            });
-
-            store.Advanced.Clean.DeleteAllEventData();
+            var store = InitStore();
 
             using (var session = store.OpenSession())
             {
@@ -41,17 +31,7 @@ namespace Marten.Testing.Events
         [Fact]
         public void capture_events_to_a_new_stream_and_fetch_the_events_back_with_stream_id_provided()
         {
-            var store = DocumentStore.For(_ =>
-            {
-                _.AutoCreateSchemaObjects = AutoCreate.All;
-
-                _.Connection(ConnectionSource.ConnectionString);
-
-                _.Events.AddEventType(typeof(MembersJoined));
-                _.Events.AddEventType(typeof(MembersDeparted));
-            });
-
-            store.Advanced.Clean.DeleteAllEventData();
+            var store = InitStore();
 
             using (var session = store.OpenSession())
             {
@@ -68,6 +48,49 @@ namespace Marten.Testing.Events
                 streamEvents.ElementAt(0).ShouldBeOfType<MembersJoined>();
                 streamEvents.ElementAt(1).ShouldBeOfType<MembersDeparted>();
             }
+        }
+
+
+        [Fact]
+        public void capture_events_to_a_non_existing_stream_and_fetch_the_events_back()
+        {
+            var store = InitStore();
+
+            using (var session = store.OpenSession())
+            {
+                var joined = new MembersJoined { Members = new string[] { "Rand", "Matt", "Perrin", "Thom" } };
+                var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+                var id = Guid.NewGuid();
+                session.Events.AppendEvents(id, joined, departed);
+                session.SaveChanges();
+
+                //Throws a   Marten.Testing.Events.end_to_end_event_capture_and_fetching_the_stream_Tests.capture_events_to_a_non_existing_stream_and_fetch_the_events_back [FAIL]
+                //Npgsql.NpgsqlException : 23502: null value in column "type" violates not-null constraint
+                //>>>>  "type" is stream_type in this case.
+                var streamEvents = session.Events.FetchStream<Quest>(id);
+
+                streamEvents.Count().ShouldBe(2);
+                streamEvents.ElementAt(0).ShouldBeOfType<MembersJoined>();
+                streamEvents.ElementAt(1).ShouldBeOfType<MembersDeparted>();
+            }
+        }
+
+
+        private static DocumentStore InitStore()
+        {
+            var store = DocumentStore.For(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+
+                _.Connection(ConnectionSource.ConnectionString);
+
+                _.Events.AddEventType(typeof(MembersJoined));
+                _.Events.AddEventType(typeof(MembersDeparted));
+            });
+
+            store.Advanced.Clean.DeleteAllEventData();
+            return store;
         }
     }
 }


### PR DESCRIPTION
Failing test when appending events to a new stream:

It throws:

Marten.Testing.Events.end_to_end_event_capture_and_fetching_the_stream_Tests.capture_events_to_a_non_existing_stream_and_fetch_the_events_back [FAIL]
Npgsql.NpgsqlException : 23502: null value in column "type" violates not-null constraint

Where "type" is stream_type in this case.

This is because, unlike in StartStream, the AggregateType is not set:

StartStream: 
var stream = new EventStream(id, events)
            {
                AggregateType = typeof(T)
            };

AppendEvents:
var stream = new EventStream(id, events);

I like to support this scenario because I can write infrastructure logic that is unaware of the fact whether a stream (aggregate) already exists. 

But this can only be solved it we add the Aggregate type as Generic parameter. Is this a valid solution for you?

I can also implement the void Append<T>(Guid stream, T @event) where T : IEvent method. Maybe it should be renamed to AppendEvent ?