### PR TITLE
Elementary support for projections: fetch only the json fields used i…

### DIFF
--- a/src/Marten.Testing/Extras/project_document_Tests.cs
+++ b/src/Marten.Testing/Extras/project_document_Tests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Marten.Extras;
+using Marten.Services;
+using Xunit;
+
+namespace Marten.Testing.Extras
+{
+    public class ProjectionSource
+    {
+        public Guid Id = Guid.NewGuid();
+
+        public string Value { get; set; }
+        public int AnotherValue { get; set; }
+        public object ThirdValue { get; set; }
+    }
+
+    public class ProjectionTarget
+    {
+        public string Value { get; set; }
+        public object ThirdValue { get; set; }
+    }
+
+    public class project_document_Tests : DocumentSessionFixture<NulloIdentityMap>
+    {
+        [Fact]
+        public void project_a_persisted_document_from_store()
+        {
+            var projectionSource = new ProjectionSource() {Value = "Value", AnotherValue = int.MaxValue, ThirdValue = DateTime.UtcNow };
+
+            theSession.Store(projectionSource);
+            theSession.SaveChanges();
+
+            var projection = ProjectionBuilder<ProjectionSource>.Project().Include(i => i.Value).Include(i => i.ThirdValue).To<ProjectionTarget>();
+
+            var projectedValue = theContainer.GetInstance<IDocumentStore>().Project(projectionSource.Id, projection);
+
+            Assert.Equal(projectionSource.Value, projectedValue.Value);
+            Assert.Equal(projectionSource.ThirdValue, projectedValue.ThirdValue);
+        }
+
+        [Fact]
+        public void project_a_persisted_document_from_session()
+        {
+            var projectionSource = new ProjectionSource() { Value = "Value", AnotherValue = int.MaxValue, ThirdValue = DateTime.UtcNow };
+
+            theSession.Store(projectionSource);
+            theSession.SaveChanges();
+
+            var projection = ProjectionBuilder<ProjectionSource>.Project().Include(i => i.Value).Include(i => i.ThirdValue).To<ProjectionTarget>();
+
+            var projectedValue = theSession.Project(projectionSource.Id, projection);
+
+            Assert.Equal(projectionSource.Value, projectedValue.Value);
+            Assert.Equal(projectionSource.ThirdValue, projectedValue.ThirdValue);
+        }
+    }
+}

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Examples\Searching_Within_Child_Collections.cs" />
     <Compile Include="Examples\SimpleSessionListener.cs" />
     <Compile Include="Examples\UnitOfWorkMechanics.cs" />
+    <Compile Include="Extras\project_document_Tests.cs" />
     <Compile Include="Fixtures\EventStore\EventStoreFixture.cs" />
     <Compile Include="Fixtures\EventStore\QuestEventFixture.cs" />
     <Compile Include="Fixtures\LinqFixture.cs" />

--- a/src/Marten/DocumentSession.cs
+++ b/src/Marten/DocumentSession.cs
@@ -22,7 +22,7 @@ namespace Marten
         private readonly IDocumentSchema _schema;
         private readonly UnitOfWork _unitOfWork;
 
-        public DocumentSession(StoreOptions options, IDocumentSchema schema, ISerializer serializer, IManagedConnection connection, IQueryParser parser, IIdentityMap identityMap) : base(schema, serializer, connection, parser, identityMap, options)
+        public DocumentSession(IDocumentStore store, StoreOptions options, IDocumentSchema schema, ISerializer serializer, IManagedConnection connection, IQueryParser parser, IIdentityMap identityMap) : base(store, schema, serializer, connection, parser, identityMap, options)
         {
             _options = options;
             _schema = schema;

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -211,7 +211,7 @@ namespace Marten
         public IDocumentSession OpenSession(DocumentTracking tracking = DocumentTracking.IdentityOnly, IsolationLevel isolationLevel = IsolationLevel.ReadUncommitted)
         {
             var map = createMap(tracking);
-            var session = new DocumentSession(_options, Schema, _serializer, new ManagedConnection(_connectionFactory, CommandRunnerMode.Transactional, isolationLevel), _parser, map);
+            var session = new DocumentSession(this, _options, Schema, _serializer, new ManagedConnection(_connectionFactory, CommandRunnerMode.Transactional, isolationLevel), _parser, map);
 
             session.Logger = _logger.StartSession(session);
 
@@ -250,7 +250,7 @@ namespace Marten
         {
             var parser = new MartenQueryParser();
             
-            var session = new QuerySession(Schema, _serializer, new ManagedConnection(_connectionFactory, CommandRunnerMode.ReadOnly), parser, new NulloIdentityMap(_serializer), _options);
+            var session = new QuerySession(this, Schema, _serializer, new ManagedConnection(_connectionFactory, CommandRunnerMode.ReadOnly), parser, new NulloIdentityMap(_serializer), _options);
 
             session.Logger = _logger.StartSession(session);
 

--- a/src/Marten/Extras/Projection.cs
+++ b/src/Marten/Extras/Projection.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Marten.Extras
+{
+    public class Projection<TSource, TProjection>
+    {
+        public readonly IEnumerable<string> PropertiesToInclude;
+        public Projection(IEnumerable<string> propertiesToInclude)
+        {
+            PropertiesToInclude = propertiesToInclude;
+        }
+    }
+}

--- a/src/Marten/Extras/ProjectionBuilder.cs
+++ b/src/Marten/Extras/ProjectionBuilder.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Marten.Extras
+{
+    public class ProjectionBuilder<TSource>
+    {
+        private readonly IEnumerable<string> _propertiesToInclude;
+
+        private ProjectionBuilder()
+        {
+            _propertiesToInclude = Enumerable.Empty<string>();
+        }
+
+        public ProjectionBuilder(IEnumerable<string> propertiesToInclude)
+        {
+            this._propertiesToInclude = propertiesToInclude;
+        }
+
+        public static ProjectionBuilder<TSource> Project()
+        {
+            return new ProjectionBuilder<TSource>();
+        }
+
+        public ProjectionBuilder<TSource> Include(Expression<Func<TSource, object>> field)
+        {
+            var expression = (MemberExpression)field.Body;
+            var name = expression.Member.Name;
+            return new ProjectionBuilder<TSource>(_propertiesToInclude.Concat(new[] { name }));
+        }
+
+        public Projection<TSource, TProjection> To<TProjection>()
+        {
+            return new Projection<TSource, TProjection>(_propertiesToInclude);
+        }
+    }
+}

--- a/src/Marten/Extras/QuerySessionExtensions.cs
+++ b/src/Marten/Extras/QuerySessionExtensions.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq;
+using Marten.Util;
+
+namespace Marten.Extras
+{
+    public static class QuerySessionExtensions
+    {
+        /// <summary>
+        /// Get a document and project it another type, fetching only the fields used in the projection.
+        /// </summary>        
+        public static TProjection Project<TSource, TProjection>(this IQuerySession session, object id, Projection<TSource, TProjection> projection) where TSource : class where TProjection : class
+        {
+            if (projection == null) throw new ArgumentNullException(nameof(projection));
+
+            var mapping = session.Store.Schema.MappingFor(typeof(TSource));
+
+            var jsonSelectors = string.Join(",", projection.PropertiesToInclude.Select(x => $"'{x}',{mapping.TableName}.data->'{x}'"));
+
+            var projectionQuery = session.Connection.CreateCommand($"select json_build_object({ jsonSelectors }) from { mapping.TableName } where id = :id").With("id", id);
+
+            using (var reader = projectionQuery.ExecuteReader())
+            {
+                var found = reader.Read();
+
+                return found ? session.Store.Advanced.Options.Serializer().FromJson<TProjection>(reader.GetString(0)) : null;
+            }
+
+        }
+
+        /// <summary>
+        /// Get a document and project it another type, fetching only the fields used in the projection.
+        /// </summary>        
+        public static TProjection Project<TSource, TProjection>(this IDocumentStore store, object id, Projection<TSource, TProjection> projection) where TSource : class where TProjection : class
+        {
+            if (projection == null) throw new ArgumentNullException(nameof(projection));
+
+            using (var session = store.QuerySession())
+            {
+                return session.Project(id, projection);
+            }
+        }
+    }
+}

--- a/src/Marten/IDocumentSession.cs
+++ b/src/Marten/IDocumentSession.cs
@@ -135,6 +135,11 @@ namespace Marten
         /// with custom diagnostics
         /// </summary>
         IMartenSessionLogger Logger { get; set; }
+
+        /// <summary>
+        /// The store hosting the query session
+        /// </summary>
+        IDocumentStore Store { get; }
     }
 
     /// <summary>

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -53,6 +53,9 @@
     <Compile Include="Events\EventStore.cs" />
     <Compile Include="Events\EventStoreAdmin.cs" />
     <Compile Include="Events\EventStream.cs" />
+    <Compile Include="Extras\Projection.cs" />
+    <Compile Include="Extras\ProjectionBuilder.cs" />
+    <Compile Include="Extras\QuerySessionExtensions.cs" />
     <Compile Include="Generation\TableDiff.cs" />
     <Compile Include="IDiagnostics.cs" />
     <Compile Include="IDocumentSessionListener.cs" />

--- a/src/Marten/QuerySession.cs
+++ b/src/Marten/QuerySession.cs
@@ -29,7 +29,7 @@ namespace Marten
         private readonly IQueryParser _parser;
         private readonly IIdentityMap _identityMap;
 
-        public QuerySession(IDocumentSchema schema, ISerializer serializer, IManagedConnection connection, IQueryParser parser, IIdentityMap identityMap, StoreOptions options)
+        public QuerySession(IDocumentStore store, IDocumentSchema schema, ISerializer serializer, IManagedConnection connection, IQueryParser parser, IIdentityMap identityMap, StoreOptions options)
         {
             _schema = schema;
             _serializer = serializer;
@@ -38,6 +38,7 @@ namespace Marten
             _identityMap = identityMap;
 
             Parser = new MartenExpressionParser(_serializer, options);
+            Store = store;
         }
 
         internal MartenExpressionParser Parser { get; }
@@ -332,6 +333,8 @@ namespace Marten
             get { return _connection.As<ManagedConnection>().Logger; }
             set { _connection.As<ManagedConnection>().Logger = value; }
         }
+
+        public IDocumentStore Store { get; }
 
         public void Dispose()
         {


### PR DESCRIPTION
…n a given projection.

Expose IDocumentStore from IQuerySession - this should allow for more flexible extension methods