### PR TITLE
Add document loaded/addedForStorage interception methods

### DIFF
--- a/src/Marten.Testing/Services/DirtyTrackingIdentityMapTests.cs
+++ b/src/Marten.Testing/Services/DirtyTrackingIdentityMapTests.cs
@@ -18,7 +18,7 @@ namespace Marten.Testing.Services
 
             var serializer = new JilSerializer();
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
 
             var target2 = map.Get<Target>(target.Id, serializer.ToJson(target));
 
@@ -34,7 +34,7 @@ namespace Marten.Testing.Services
 
             var json = serializer.ToJson(camaro);
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
 
             map.Get<NulloIdentityMapTests.Car>(camaro.Id, typeof(NulloIdentityMapTests.Camaro), json)
                 .ShouldBeOfType<NulloIdentityMapTests.Camaro>()
@@ -50,7 +50,7 @@ namespace Marten.Testing.Services
 
             var serializer = new JilSerializer();
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
 
             var target2 = map.Get<Target>(target.Id, serializer.ToJson(target));
             var target3 = map.Get<Target>(target.Id, serializer.ToJson(target));
@@ -74,7 +74,7 @@ namespace Marten.Testing.Services
 
             var serializer = new JilSerializer();
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
 
             var json = serializer.ToJson(target);
             var clonedTarget = serializer.FromJson<Target>(json);
@@ -96,7 +96,7 @@ namespace Marten.Testing.Services
 
             var serializer = new JilSerializer();
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
 
             var target2 = map.Get<Target>(target.Id, () => new FetchResult<Target>(target, serializer.ToJson(target)));
             var target3 = map.Get<Target>(target.Id, () => new FetchResult<Target>(target, serializer.ToJson(target)));
@@ -123,7 +123,7 @@ namespace Marten.Testing.Services
 
             var serializer = new JilSerializer();
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
 
 
             var a1 = map.Get<Target>(a.Id, serializer.ToJson(a));
@@ -147,7 +147,7 @@ namespace Marten.Testing.Services
 
             var serializer = new JilSerializer();
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
 
 
             var a1 = map.Get<Target>(a.Id, serializer.ToJson(a));
@@ -176,7 +176,7 @@ namespace Marten.Testing.Services
 
             var serializer = new JilSerializer();
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
 
 
             var a1 = map.Get<Target>(a.Id, serializer.ToJson(a));
@@ -206,7 +206,7 @@ namespace Marten.Testing.Services
 
             var serializer = new JilSerializer();
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
 
             var target3 = map.Get<Target>(target.Id, serializer.ToJson(target));
 
@@ -225,7 +225,7 @@ namespace Marten.Testing.Services
             var target = Target.Random();
             var serializer = new JilSerializer();
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
 
             map.Store(target.Id, target);
 
@@ -238,7 +238,7 @@ namespace Marten.Testing.Services
         {
             var serializer = new JilSerializer();
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
             map.Get<Target>(Guid.NewGuid(), () => null).ShouldBeNull();
         }
 
@@ -248,7 +248,7 @@ namespace Marten.Testing.Services
             var target = Target.Random();
             var serializer = new JilSerializer();
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
 
             map.Store(target.Id, target);
 
@@ -261,7 +261,7 @@ namespace Marten.Testing.Services
         {
             var serializer = new JilSerializer();
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
             map.Has<Target>(Guid.NewGuid()).ShouldBeFalse();
         }
 
@@ -271,13 +271,11 @@ namespace Marten.Testing.Services
             var target = Target.Random();
             var serializer = new JilSerializer();
 
-            var map = new DirtyTrackingIdentityMap(serializer);
+            var map = new DirtyTrackingIdentityMap(serializer, null);
 
             map.Store(target.Id, target);
 
             map.Retrieve<Target>(target.Id).ShouldBeTheSameAs(target);
-
         }
-
     }
 }

--- a/src/Marten.Testing/Services/IdentityMapTests.cs
+++ b/src/Marten.Testing/Services/IdentityMapTests.cs
@@ -16,7 +16,7 @@ namespace Marten.Testing.Services
 
             var serializer = new JilSerializer();
 
-            var map = new IdentityMap(serializer);
+            var map = new IdentityMap(serializer, null);
 
             var target2 = map.Get<Target>(target.Id, serializer.ToJson(target));
 
@@ -32,7 +32,7 @@ namespace Marten.Testing.Services
 
             var json = serializer.ToJson(camaro);
 
-            var map = new IdentityMap(serializer);
+            var map = new IdentityMap(serializer, null);
 
             map.Get<NulloIdentityMapTests.Car>(camaro.Id, typeof(NulloIdentityMapTests.Camaro), json)
                 .ShouldBeOfType<NulloIdentityMapTests.Camaro>()
@@ -48,7 +48,7 @@ namespace Marten.Testing.Services
 
             var serializer = new JilSerializer();
 
-            var map = new IdentityMap(serializer);
+            var map = new IdentityMap(serializer, null);
 
             var target2 = map.Get<Target>(target.Id, serializer.ToJson(target));
             var target3 = map.Get<Target>(target.Id, serializer.ToJson(target));
@@ -74,7 +74,7 @@ namespace Marten.Testing.Services
 
             var serializer = new JilSerializer();
 
-            var map = new IdentityMap(serializer);
+            var map = new IdentityMap(serializer, null);
 
             var target3 = map.Get<Target>(target.Id, serializer.ToJson(target));
 
@@ -94,7 +94,7 @@ namespace Marten.Testing.Services
 
             var serializer = new JilSerializer();
 
-            var map = new IdentityMap(serializer);
+            var map = new IdentityMap(serializer, null);
 
             var json = serializer.ToJson(target);
             var clonedTarget = serializer.FromJson<Target>(json);
@@ -116,7 +116,7 @@ namespace Marten.Testing.Services
 
             var serializer = new JilSerializer();
 
-            var map = new IdentityMap(serializer);
+            var map = new IdentityMap(serializer, null);
 
             var target2 = map.Get<Target>(target.Id, () => new FetchResult<Target>(target, serializer.ToJson(target)));
             var target3 = map.Get<Target>(target.Id, () => new FetchResult<Target>(target, serializer.ToJson(target)));
@@ -139,7 +139,7 @@ namespace Marten.Testing.Services
             var target = Target.Random();
             var serializer = new JilSerializer();
 
-            var map = new IdentityMap(serializer);
+            var map = new IdentityMap(serializer, null);
 
             map.Store(target.Id, target);
 
@@ -152,7 +152,7 @@ namespace Marten.Testing.Services
         {
             var serializer = new JilSerializer();
 
-            var map = new IdentityMap(serializer);
+            var map = new IdentityMap(serializer, null);
             map.Get<Target>(Guid.NewGuid(), () => null).ShouldBeNull();
         }
 
@@ -162,7 +162,7 @@ namespace Marten.Testing.Services
             var target = Target.Random();
             var serializer = new JilSerializer();
 
-            var map = new IdentityMap(serializer);
+            var map = new IdentityMap(serializer, null);
 
             map.Store(target.Id, target);
 
@@ -175,7 +175,7 @@ namespace Marten.Testing.Services
         {
             var serializer = new JilSerializer();
 
-            var map = new IdentityMap(serializer);
+            var map = new IdentityMap(serializer, null);
             map.Has<Target>(Guid.NewGuid()).ShouldBeFalse();
         }
 
@@ -185,7 +185,7 @@ namespace Marten.Testing.Services
             var target = Target.Random();
             var serializer = new JilSerializer();
 
-            var map = new IdentityMap(serializer);
+            var map = new IdentityMap(serializer, null);
 
             map.Store(target.Id, target);
 

--- a/src/Marten.Testing/Using_DocumentSessionListener_Tests.cs
+++ b/src/Marten.Testing/Using_DocumentSessionListener_Tests.cs
@@ -1,5 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
 using Marten.Testing.Documents;
+using Shouldly;
 using Xunit;
 
 namespace Marten.Testing
@@ -65,10 +70,157 @@ namespace Marten.Testing
                 }
             }
         }
+
+        [Fact]
+        public void call_listener_events_on_document_store()
+        {
+            var stub1 = new StubDocumentSessionListener();
+            var stub2 = new StubDocumentSessionListener();
+
+            using (var store = DocumentStore.For(_ =>
+            {
+                _.Connection(ConnectionSource.ConnectionString);
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+
+                _.Listeners.Add(stub1);
+                _.Listeners.Add(stub2);
+            }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    var user1 = new User { Id = Guid.NewGuid() };
+                    var user2 = new User { Id = Guid.NewGuid() };
+
+                    session.Store(user1, user2);
+
+                    stub1.StoredDocuments.ShouldContainKeyAndValue(user1.Id, user1);
+                    stub1.StoredDocuments.ShouldContainKeyAndValue(user2.Id, user2);
+
+                    stub2.StoredDocuments.ShouldContainKeyAndValue(user1.Id, user1);
+                    stub2.StoredDocuments.ShouldContainKeyAndValue(user2.Id, user2);
+                }
+            }
+        }
+
+        [Fact]
+        public void call_listener_events_on_document_store_objects()
+        {
+            var stub1 = new StubDocumentSessionListener();
+            var stub2 = new StubDocumentSessionListener();
+
+            using (var store = DocumentStore.For(_ =>
+            {
+                _.Connection(ConnectionSource.ConnectionString);
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+
+                _.Listeners.Add(stub1);
+                _.Listeners.Add(stub2);
+            }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    var user1 = new User { Id = Guid.NewGuid() };
+                    var user2 = new User { Id = Guid.NewGuid() };
+
+                    session.StoreObjects(new [] { user1, user2 });
+
+                    stub1.StoredDocuments.ShouldContainKeyAndValue(user1.Id, user1);
+                    stub1.StoredDocuments.ShouldContainKeyAndValue(user2.Id, user2);
+
+                    stub2.StoredDocuments.ShouldContainKeyAndValue(user1.Id, user1);
+                    stub2.StoredDocuments.ShouldContainKeyAndValue(user2.Id, user2);
+                }
+            }
+        }
+
+        [Fact]
+        public void call_listener_events_on_document_load()
+        {
+            var stub1 = new StubDocumentSessionListener();
+            var stub2 = new StubDocumentSessionListener();
+
+            using (var store = DocumentStore.For(_ =>
+            {
+                _.Connection(ConnectionSource.ConnectionString);
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+
+                _.Listeners.Add(stub1);
+                _.Listeners.Add(stub2);
+            }))
+            {
+                var user1 = new User { Id = Guid.NewGuid() };
+                var user2 = new User { Id = Guid.NewGuid() };
+
+                using (var session = store.OpenSession())
+                {
+                    session.StoreObjects(new[] { user1, user2 });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>(user1.Id);
+
+                    stub1.LoadedDocuments.ShouldContainKeyAndValue(user1.Id, user);
+                    stub2.LoadedDocuments.ShouldContainKeyAndValue(user1.Id, user);
+                }
+            }
+        }
+
+        [Fact]
+        public void call_listener_events_on_document_query()
+        {
+            var stub1 = new StubDocumentSessionListener();
+            var stub2 = new StubDocumentSessionListener();
+
+            using (var store = DocumentStore.For(_ =>
+            {
+                _.Connection(ConnectionSource.ConnectionString);
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+
+                _.Listeners.Add(stub1);
+                _.Listeners.Add(stub2);
+            }))
+            {
+                var user1 = new User { Id = Guid.NewGuid() };
+                var user2 = new User { Id = Guid.NewGuid() };
+
+                using (var session = store.OpenSession())
+                {
+                    session.StoreObjects(new[] { user1, user2 });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var users = session.Query<User>().ToList();
+
+                    stub1.LoadedDocuments.ShouldContainKeyAndValue(user1.Id, users.FirstOrDefault(where => where.Id == user1.Id));
+                    stub1.LoadedDocuments.ShouldContainKeyAndValue(user2.Id, users.FirstOrDefault(where => where.Id == user2.Id));
+
+                    stub2.LoadedDocuments.ShouldContainKeyAndValue(user1.Id, users.FirstOrDefault(where => where.Id == user1.Id));
+                    stub2.LoadedDocuments.ShouldContainKeyAndValue(user2.Id, users.FirstOrDefault(where => where.Id == user2.Id));
+                }
+            }
+        }
     }
 
     public class StubDocumentSessionListener : DocumentSessionListenerBase
     {
+        public override void DocumentLoaded(object id, object document)
+        {
+            LoadedDocuments.Add(id, document);
+        }
+
+        public IDictionary<object, object> LoadedDocuments { get; } = new Dictionary<object, object>();
+
+        public override void DocumentAddedForStorage(object id, object document)
+        {
+            StoredDocuments.Add(id, document);
+        }
+
+        public IDictionary<object, object> StoredDocuments { get; } = new Dictionary<object, object>();
+
         public override void BeforeSaveChanges(IDocumentSession session)
         {
             SaveChangesSession = session;

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -226,10 +226,10 @@ namespace Marten
                     return new NulloIdentityMap(_serializer);
 
                 case DocumentTracking.IdentityOnly:
-                    return new IdentityMap(_serializer);
+                    return new IdentityMap(_serializer, _options.Listeners);
 
                 case DocumentTracking.DirtyTracking:
-                    return new DirtyTrackingIdentityMap(_serializer);
+                    return new DirtyTrackingIdentityMap(_serializer, _options.Listeners);
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(tracking));

--- a/src/Marten/IDocumentSessionListener.cs
+++ b/src/Marten/IDocumentSessionListener.cs
@@ -22,6 +22,17 @@ namespace Marten
         void AfterCommit(IDocumentSession session);
 
         Task AfterCommitAsync(IDocumentSession session);
+
+
+        /// <summary>
+        /// After a document is loaded
+        /// </summary>
+        void DocumentLoaded(object id, object document);
+
+        /// <summary>
+        /// After a document is added for storage
+        /// </summary>
+        void DocumentAddedForStorage(object id, object document);
     }
 
     public abstract class DocumentSessionListenerBase : IDocumentSessionListener
@@ -31,7 +42,7 @@ namespace Marten
             // Nothing
         }
 
-        public async virtual Task BeforeSaveChangesAsync(IDocumentSession session)
+        public virtual async Task BeforeSaveChangesAsync(IDocumentSession session)
         {
             await Task.Run(() => BeforeSaveChanges(session));
         }
@@ -44,6 +55,16 @@ namespace Marten
         public virtual async Task AfterCommitAsync(IDocumentSession session)
         {
             await Task.Run(() => AfterCommit(session));
+        }
+
+        public virtual void DocumentLoaded(object id, object document)
+        {
+            // Nothing
+        }
+
+        public virtual void DocumentAddedForStorage(object id, object document)
+        {
+            // Nothing
         }
     }
 }


### PR DESCRIPTION
I added two methods to the IDocumentSessionListener to intercept when documents are loaded/stored.

void DocumentLoaded(object id, object document);
void DocumentAddedForStorage(object id, object document);

This interception is currently implemented in the default and DirtyChecking IdentityMap.

I was tempted to split the IDocumentSessionListener into a IDocumentSessionListener and IDocumentListener. The latter would contain the new methods. But I decided to go for the simplest implementation for now. Let me know what your thoughts are about this?

If you agree I can add this also to the documentation if you want.

