### PR TITLE
2nd Spike for compiled query api

### DIFF
--- a/src/Marten.Testing/CompileQueryDemonstrator.cs
+++ b/src/Marten.Testing/CompileQueryDemonstrator.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Marten.Linq;
+using Marten.Testing.Documents;
+using Shouldly;
+using StructureMap;
+using Xunit;
+
+namespace Marten.Testing
+{
+    public class CompileQueryDemonstrator
+    {
+        [Fact]
+        public void single_item_compiled_query()
+        {
+            var container = Container.For<DevelopmentModeRegistry>();
+
+            var store = container.GetInstance<IDocumentStore>();
+
+            using (var session = store.QuerySession())
+            {
+                var user = session.Query(new UserByUsername {UserName = "myusername"});
+                user.ShouldNotBeNull();
+            }
+        }
+
+        [Fact]
+        public void multiple_item_compiled_query()
+        {
+            var container = Container.For<DevelopmentModeRegistry>();
+
+            var store = container.GetInstance<IDocumentStore>();
+
+            using (var session = store.QuerySession())
+            {
+                var users = session.Query(new UsersByFirstName {FirstName = "Corey"}).ToList();
+                users.ShouldNotBeEmpty();
+            }
+        }
+    }
+
+    public class UserByUsername : ISingleItemCompiledQuery<User, string>
+    {
+        public string UserName { get; set; }
+
+        public Expression<Func<IQueryable<User>, string>> QueryIs()
+        {
+            return query => query.Where(x => x.UserName == UserName)
+                .Select(x => x.UserName)
+                .FirstOrDefault();
+        }
+    }
+
+    public class UsersByFirstName : IMultipleItemCompiledQuery<User, User>
+    {
+        public string FirstName { get; set; }
+
+        public Expression<Func<IQueryable<User>, IEnumerable<User>>> QueryIs()
+        {
+            return query => query.Where(x => x.FirstName == FirstName);
+        }
+    }
+}

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Bugs\Bug_187_not_assigning_id_in_BulkInsert_Tests.cs" />
     <Compile Include="bulk_loading_Tests.cs" />
     <Compile Include="Codegen\dumping_the_complete_source_code_Tests.cs" />
+    <Compile Include="CompileQueryDemonstrator.cs" />
     <Compile Include="delete_many_documents_by_query_Tests.cs" />
     <Compile Include="detecting_insert_or_update_Tests.cs" />
     <Compile Include="DocumentMappingTests.cs" />

--- a/src/Marten/IDocumentSession.cs
+++ b/src/Marten/IDocumentSession.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Events;
+using Marten.Linq;
 using Marten.Services;
 using Marten.Services.BatchQuerying;
 using Npgsql;
@@ -97,6 +98,9 @@ namespace Marten
         /// <returns></returns>
         IQueryable<T> Query<T>();
         // ENDSAMPLE
+
+        TOut Query<TDoc, TOut>(ISingleItemCompiledQuery<TDoc, TOut> query);
+        IEnumerable<TOut> Query<TDoc, TOut>(IMultipleItemCompiledQuery<TDoc, TOut> query);
 
         /// <summary>
         /// Queries the document storage table for the document type T by supplied SQL. See http://jasperfx.github.io/marten/documentation/documents/sql/ for more information on usage.

--- a/src/Marten/Linq/CompiledQuery.cs
+++ b/src/Marten/Linq/CompiledQuery.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Marten.Linq
+{
+    public interface ISingleItemCompiledQuery<TDoc, TOut>
+    {
+        Expression<Func<IQueryable<TDoc>, TOut>> QueryIs();
+    }
+
+    public interface IMultipleItemCompiledQuery<TDoc, TOut>
+    {
+        Expression<Func<IQueryable<TDoc>, IEnumerable<TOut>>> QueryIs();
+    }
+}

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -61,6 +61,7 @@
     <Compile Include="LinqExtensions.cs" />
     <Compile Include="Linq\BadLinqExpressionException.cs" />
     <Compile Include="Linq\CollectionAnyContainmentWhereFragment.cs" />
+    <Compile Include="Linq\CompiledQuery.cs" />
     <Compile Include="Linq\ContainmentWhereFragment.cs" />
     <Compile Include="Linq\DeserializeSelector.cs" />
     <Compile Include="Linq\ExpressionExtensions.cs" />

--- a/src/Marten/QuerySession.cs
+++ b/src/Marten/QuerySession.cs
@@ -50,6 +50,18 @@ namespace Marten
             return new MartenQueryable<T>(queryProvider);
         }
 
+        public TOut Query<TDoc, TOut>(ISingleItemCompiledQuery<TDoc, TOut> query)
+        {
+            //precompiled first use and cached by type, parameters will be substituted for current query
+            //via precompiled func's as well.
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<TOut> Query<TDoc, TOut>(IMultipleItemCompiledQuery<TDoc, TOut> query)
+        {
+            throw new NotImplementedException();
+        }
+
         public IEnumerable<T> Query<T>(string sql, params object[] parameters)
         {
             using (var cmd = BuildCommand<T>(sql, parameters))


### PR DESCRIPTION
This is here for feedback on a new way to do compiled queries. I think this approach has a few benefits.

1. Doesn't hugely deviate from existing API in a way that would make it unappealing to use.
1. Encourages query re-use by type instead of instance of a compiled func.
1. Low-bar on complexity of use.
1. Minimizes generic parameter explosion for overloads.
1. Should be easier to play nice with async, batch, etc.