### PR TITLE
Async usage

### DIFF
--- a/src/Marten/DocumentSession.cs
+++ b/src/Marten/DocumentSession.cs
@@ -140,12 +140,11 @@ namespace Marten
         {
             foreach (var listener in _options.Listeners)
             {
-                await listener.BeforeSaveChangesAsync(this);
+                await listener.BeforeSaveChangesAsync(this).ConfigureAwait(false);
             }
 
-
             var batch = new UpdateBatch(_options, _serializer, _connection);
-            var changes = await _unitOfWork.ApplyChangesAsync(batch, token);
+            var changes = await _unitOfWork.ApplyChangesAsync(batch, token).ConfigureAwait(false);
 
             _changes.Add(changes);
 
@@ -155,7 +154,7 @@ namespace Marten
 
             foreach (var listener in _options.Listeners)
             {
-                await listener.AfterCommitAsync(this);
+                await listener.AfterCommitAsync(this).ConfigureAwait(false);
             }
         }
 

--- a/src/Marten/Linq/MartenQueryExecutor.cs
+++ b/src/Marten/Linq/MartenQueryExecutor.cs
@@ -102,12 +102,12 @@ namespace Marten.Linq
             return command;
         }
 
-        async Task<IEnumerable<T>> IMartenQueryExecutor.ExecuteCollectionAsync<T>(QueryModel queryModel, CancellationToken token)
+        Task<IEnumerable<T>> IMartenQueryExecutor.ExecuteCollectionAsync<T>(QueryModel queryModel, CancellationToken token)
         {
             ISelector<T> selector = null;
             var cmd = BuildCommand<T>(queryModel, out selector);
 
-            return await _runner.ResolveAsync(cmd,selector, _identityMap, token).ConfigureAwait(false);
+            return _runner.ResolveAsync(cmd, selector, _identityMap, token);
         }
 
         public async Task<T> ExecuteAsync<T>(QueryModel queryModel, CancellationToken token)

--- a/src/Marten/Linq/ScalarQueryExecution.cs
+++ b/src/Marten/Linq/ScalarQueryExecution.cs
@@ -61,7 +61,7 @@ namespace Marten.Linq
             var sumCommand = GetSumCommand(queryModel);
 
             return _runner.ExecuteAsync(sumCommand, async (c, tkn) => {
-                var returnValue = await c.ExecuteScalarAsync(tkn);
+                var returnValue = await c.ExecuteScalarAsync(tkn).ConfigureAwait(false);
                 return typeof(TResult).IsNullable() ? 
                 Convert.ChangeType(returnValue, typeof(TResult).GetInnerTypeFromNullable()).As<TResult>() 
                 : Convert.ChangeType(returnValue, typeof(TResult)).As<TResult>();

--- a/src/Marten/QuerySession.cs
+++ b/src/Marten/QuerySession.cs
@@ -241,9 +241,9 @@ namespace Marten
                 return ConcatDocuments(hits, documents);
             }
 
-            public async Task<IList<TDoc>> ByIdAsync<TKey>(params TKey[] keys)
+            public Task<IList<TDoc>> ByIdAsync<TKey>(params TKey[] keys)
             {
-                return await ByIdAsync(keys, CancellationToken.None).ConfigureAwait(false);
+                return ByIdAsync(keys, CancellationToken.None);
             }
 
             public IList<TDoc> ById<TKey>(IEnumerable<TKey> keys)

--- a/src/Marten/QuerySession.cs
+++ b/src/Marten/QuerySession.cs
@@ -122,9 +122,6 @@ namespace Marten
                     return found ? new FetchResult<T>(resolver.Build(reader, _serializer), reader.GetString(0)) : null;
                 }
             });
-
-
-
         }
 
         public Task<FetchResult<T>> LoadDocumentAsync<T>(object id, CancellationToken token) where T : class
@@ -134,18 +131,16 @@ namespace Marten
 
             var cmd = storage.LoaderCommand(id);
 
-            return _connection.ExecuteAsync(cmd, async (c, executeAsyncToken) =>
+            return _connection.ExecuteAsync(cmd, async (c, tkn) =>
             {
-                using (var reader = await cmd.ExecuteReaderAsync(executeAsyncToken).ConfigureAwait(false))
+                using (var reader = await cmd.ExecuteReaderAsync(tkn).ConfigureAwait(false))
                 {
-                    var found = reader.Read();
+                    var found = await reader.ReadAsync(tkn).ConfigureAwait(false);
                     return found ? new FetchResult<T>(resolver.Build(reader, _serializer), reader.GetString(0)) : null;
                 }
 
             }, token);
         }
-
-
         
         public T Load<T>(string id) where T : class
         {

--- a/src/Marten/Services/BatchQuerying/BatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQuery.cs
@@ -230,9 +230,9 @@ namespace Marten.Services.BatchQuerying
             return reader.ReturnValue.ContinueWith(r => r.Result.SingleOrDefault());
         }
 
-        public async Task Execute(CancellationToken token = default(CancellationToken))
+        public Task Execute(CancellationToken token = default(CancellationToken))
         {
-            await _runner.ExecuteAsync(_command, async (cmd, tk) =>
+            return _runner.ExecuteAsync(_command, async (cmd, tk) =>
             {
                 using (var reader = await _command.ExecuteReaderAsync(tk).ConfigureAwait(false))
                 {

--- a/src/Marten/Services/BatchQuerying/DataReaderAdvancer.cs
+++ b/src/Marten/Services/BatchQuerying/DataReaderAdvancer.cs
@@ -23,7 +23,7 @@ namespace Marten.Services.BatchQuerying
                 throw new InvalidOperationException("There is no next result to read over.");
             }
 
-            await _inner.Handle(reader, token);
+            await _inner.Handle(reader, token).ConfigureAwait(false);
         }
     }
 }

--- a/src/Marten/Services/CommandRunnerExtensions.cs
+++ b/src/Marten/Services/CommandRunnerExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Baseline;
@@ -38,9 +39,9 @@ namespace Marten.Services
             });
         }
 
-        public static async Task<IEnumerable<T>> ResolveAsync<T>(this IManagedConnection runner, NpgsqlCommand cmd, ISelector<T> selector, IIdentityMap map, CancellationToken token)
+        public static Task<IEnumerable<T>> ResolveAsync<T>(this IManagedConnection runner, NpgsqlCommand cmd, ISelector<T> selector, IIdentityMap map, CancellationToken token)
         {
-            return await runner.ExecuteAsync(cmd, async (c, tkn) =>
+            return runner.ExecuteAsync(cmd, async (c, tkn) =>
             {
                 var list = new List<T>();
                 using (var reader = await cmd.ExecuteReaderAsync(tkn).ConfigureAwait(false))
@@ -53,8 +54,8 @@ namespace Marten.Services
                     reader.Close();
                 }
 
-                return list;
-            }, token).ConfigureAwait(false);
+                return list.AsEnumerable();
+            }, token);
         }
 
         public static IEnumerable<string> QueryJson(this IManagedConnection runner, NpgsqlCommand cmd)
@@ -76,9 +77,9 @@ namespace Marten.Services
             });
         }
 
-        public static async Task<IEnumerable<string>> QueryJsonAsync(this IManagedConnection runner, NpgsqlCommand cmd, CancellationToken token)
+        public static Task<IEnumerable<string>> QueryJsonAsync(this IManagedConnection runner, NpgsqlCommand cmd, CancellationToken token)
         {
-            return await runner.ExecuteAsync(cmd, async (c, tkn) =>
+            return runner.ExecuteAsync(cmd, async (c, tkn) =>
             {
                 var list = new List<string>();
                 using (var reader = await cmd.ExecuteReaderAsync(tkn).ConfigureAwait(false))
@@ -91,8 +92,8 @@ namespace Marten.Services
                     reader.Close();
                 }
 
-                return list;
-            }, token).ConfigureAwait(false);
+                return list.AsEnumerable();
+            }, token);
         }
 
         public static IList<string> GetStringList(this IManagedConnection runner, string sql, params object[] parameters)
@@ -121,8 +122,6 @@ namespace Marten.Services
 
             return list;
         }
-
-
 
         public static T QueryScalar<T>(this IManagedConnection runner, string sql)
         {

--- a/src/Marten/Services/ManagedConnection.cs
+++ b/src/Marten/Services/ManagedConnection.cs
@@ -119,7 +119,7 @@ namespace Marten.Services
 
             try
             {
-                await action(cmd, token);
+                await action(cmd, token).ConfigureAwait(false);
                 Logger.LogSuccess(cmd);
             }
             catch (Exception e)
@@ -137,7 +137,7 @@ namespace Marten.Services
 
             try
             {
-                await action(cmd, token);
+                await action(cmd, token).ConfigureAwait(false);
                 Logger.LogSuccess(cmd);
             }
             catch (Exception e)
@@ -155,7 +155,7 @@ namespace Marten.Services
 
             try
             {
-                var returnValue = await func(cmd, token);
+                var returnValue = await func(cmd, token).ConfigureAwait(false);
                 Logger.LogSuccess(cmd);
                 return returnValue;
             }
@@ -174,7 +174,7 @@ namespace Marten.Services
 
             try
             {
-                var returnValue = await func(cmd, token);
+                var returnValue = await func(cmd, token).ConfigureAwait(false);
                 Logger.LogSuccess(cmd);
                 return returnValue;
             }

--- a/src/Marten/Services/UpdateBatch.cs
+++ b/src/Marten/Services/UpdateBatch.cs
@@ -51,10 +51,7 @@ namespace Marten.Services
         {
             foreach (var batch in _commands.ToArray())
             {
-                await Connection.ExecuteAsync(batch.BuildCommand(), async (c, tkn) =>
-                {
-                    await c.ExecuteNonQueryAsync(tkn).ConfigureAwait(false);
-                }, token);
+                await Connection.ExecuteAsync(batch.BuildCommand(), (c, tkn) => c.ExecuteNonQueryAsync(tkn), token).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
* A few `ConfigureAwait(false)` missing
* A few micro-optimizations to return instead of `await`
 * I used two times `AsEnumerable` to be able to return instead of `await`. `AsEnumerable` directly returns the source enumerable. This change is questionable since it could lead to more allocations. But I figured it can be neglected because we are returning an enumerable anyway on the public method and I think `await` is actually more expensive. BUT, I didn`t measure. So I could be wrong.
