### PR TITLE
Support for IEnumerable.Contains

### DIFF
--- a/src/Marten.Testing/Linq/query_with_is_in_generic_enumerable_Tests.cs
+++ b/src/Marten.Testing/Linq/query_with_is_in_generic_enumerable_Tests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Marten.Services;
+using Xunit;
+
+namespace Marten.Testing.Linq
+{
+    public class query_with_is_in_generic_enumerable_Tests : DocumentSessionFixture<NulloIdentityMap>
+    {
+        [Fact]
+        public void can_query_against_number_in_iList()
+        {
+            var doc1 = new DocWithNumber { Number = 1 };
+            var doc2 = new DocWithNumber { Number = 2 };
+            var doc3 = new DocWithNumber { Number = 3 };
+
+
+            theSession.Store(doc1);
+            theSession.Store(doc2);
+            theSession.Store(doc3);
+
+            theSession.SaveChanges();
+
+            IList<int> searchValues = new List<int> {2, 4, 5};
+
+            theSession.Query<DocWithNumber>().Where(x=>searchValues.Contains(x.Number)).ToArray()
+                .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc2.Id);
+        }
+
+        [Fact]
+        public void can_query_against_number_in_List()
+        {
+            var doc1 = new DocWithNumber { Number = 1 };
+            var doc2 = new DocWithNumber { Number = 2 };
+            var doc3 = new DocWithNumber { Number = 3 };
+
+
+            theSession.Store(doc1);
+            theSession.Store(doc2);
+            theSession.Store(doc3);
+
+            theSession.SaveChanges();
+
+            List<int> searchValues = new List<int> { 2, 4, 5 };
+
+            theSession.Query<DocWithNumber>().Where(x => searchValues.Contains(x.Number)).ToArray()
+                .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc2.Id);
+        }
+
+        public class DocWithNumber
+        {
+            public Guid Id;
+            public int Number;
+        }
+    }
+
+    
+}

--- a/src/Marten.Testing/Linq/query_with_is_one_of_Tests.cs
+++ b/src/Marten.Testing/Linq/query_with_is_one_of_Tests.cs
@@ -33,29 +33,6 @@ namespace Marten.Testing.Linq
                 .ShouldHaveTheSameElementsAs(expected);
         }
 
-        [Fact]
-        public void can_query_against_integers_using_contains()
-        {
-            var targets = Target.GenerateRandomData(100).ToArray();
-            theStore.BulkInsert(targets);
-
-            var validNumbers = targets.Select(x => x.Number).Distinct().Take(3).ToArray();
-
-            var found = theSession.Query<Target>().Where(x => validNumbers.Contains(x.Number)).ToArray();
-
-            found.Count().ShouldBeLessThan(100);
-
-            var expected = targets
-                .Where(x => validNumbers
-                .Contains(x.Number))
-                .OrderBy(x => x.Id)
-                .Select(x => x.Id)
-                .ToArray();
-
-            found.OrderBy(x => x.Id).Select(x => x.Id)
-                .ShouldHaveTheSameElementsAs(expected);
-        }
-
         public void is_one_of_example()
         {
             // SAMPLE: is_one_of

--- a/src/Marten.Testing/Linq/query_with_is_one_of_Tests.cs
+++ b/src/Marten.Testing/Linq/query_with_is_one_of_Tests.cs
@@ -33,6 +33,29 @@ namespace Marten.Testing.Linq
                 .ShouldHaveTheSameElementsAs(expected);
         }
 
+        [Fact]
+        public void can_query_against_integers_using_contains()
+        {
+            var targets = Target.GenerateRandomData(100).ToArray();
+            theStore.BulkInsert(targets);
+
+            var validNumbers = targets.Select(x => x.Number).Distinct().Take(3).ToArray();
+
+            var found = theSession.Query<Target>().Where(x => validNumbers.Contains(x.Number)).ToArray();
+
+            found.Count().ShouldBeLessThan(100);
+
+            var expected = targets
+                .Where(x => validNumbers
+                .Contains(x.Number))
+                .OrderBy(x => x.Id)
+                .Select(x => x.Id)
+                .ToArray();
+
+            found.OrderBy(x => x.Id).Select(x => x.Id)
+                .ShouldHaveTheSameElementsAs(expected);
+        }
+
         public void is_one_of_example()
         {
             // SAMPLE: is_one_of

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Linq\ExpressionExtensionsTests.cs" />
     <Compile Include="Linq\previewing_the_command_from_a_queryable_Tests.cs" />
     <Compile Include="Linq\query_against_dateoffset_Tests.cs" />
+    <Compile Include="Linq\query_with_is_in_generic_enumerable_Tests.cs" />
     <Compile Include="Linq\query_against_primitive_array_Tests.cs" />
     <Compile Include="Linq\query_running_through_the_IdentityMap_Tests.cs" />
     <Compile Include="Linq\query_with_any_within_child_collection_Tests.cs" />

--- a/src/Marten/Linq/MartenExpressionParser.cs
+++ b/src/Marten/Linq/MartenExpressionParser.cs
@@ -60,7 +60,8 @@ namespace Marten.Linq
             new StringStartsWith(),
 
             // Added
-            new IsOneOf()
+            new IsOneOf(),
+            new IsInGenericEnumerable()
         };
 
 

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Linq\FindMembers.cs" />
     <Compile Include="Linq\Handlers\EnumerableContains.cs" />
     <Compile Include="Linq\Handlers\IMethodCallParser.cs" />
+    <Compile Include="Linq\Handlers\IsInGenericEnumerable.cs" />
     <Compile Include="Linq\Handlers\MethodCallParser.cs" />
     <Compile Include="Linq\Handlers\StringContains.cs" />
     <Compile Include="Linq\Handlers\StringEndsWith.cs" />


### PR DESCRIPTION
First attempt: I've created another method call parser, called IsInGenericEnumerable. Basically the same as IsOneOf, but now you can use IEnumerable.Contains.