### PR TITLE
ResolveAsync all the way

### DIFF
--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -159,6 +159,14 @@ namespace Marten.Events
             return map.Get<T>(id, json);
         }
 
+        public async Task<T> ResolveAsync(DbDataReader reader, IIdentityMap map, CancellationToken token)
+        {
+            var id = await reader.GetFieldValueAsync<Guid>(0, token).ConfigureAwait(false);
+            var json = await reader.GetFieldValueAsync<string>(1, token).ConfigureAwait(false);
+
+            return map.Get<T>(id, json);
+        }
+
         public T Build(DbDataReader reader, ISerializer serializer)
         {
             return serializer.FromJson<T>(reader.GetString(0));

--- a/src/Marten/Linq/DeserializeSelector.cs
+++ b/src/Marten/Linq/DeserializeSelector.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 using Marten.Schema;
 using Marten.Services;
 
@@ -17,6 +19,11 @@ namespace Marten.Linq
         public T Resolve(DbDataReader reader, IIdentityMap map)
         {
             return _serializer.FromJson<T>(reader.GetString(0));
+        }
+
+        public async Task<T> ResolveAsync(DbDataReader reader, IIdentityMap map, CancellationToken token)
+        {
+            return _serializer.FromJson<T>(await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false));
         }
 
         public string SelectClause(IDocumentMapping mapping)

--- a/src/Marten/Linq/ISelector.cs
+++ b/src/Marten/Linq/ISelector.cs
@@ -1,4 +1,6 @@
 ﻿using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 using Marten.Schema;
 using Marten.Services;
 
@@ -7,6 +9,8 @@ namespace Marten.Linq
     public interface ISelector<T>
     {
         T Resolve(DbDataReader reader, IIdentityMap map);
+
+        Task<T> ResolveAsync(DbDataReader reader, IIdentityMap map, CancellationToken token);
 
         string SelectClause(IDocumentMapping mapping);
     }

--- a/src/Marten/Linq/SingleFieldSelector.cs
+++ b/src/Marten/Linq/SingleFieldSelector.cs
@@ -2,6 +2,8 @@
 using System.Data.Common;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Marten.Schema;
 using Marten.Services;
 
@@ -24,6 +26,12 @@ namespace Marten.Linq
         public T Resolve(DbDataReader reader, IIdentityMap map)
         {
             var raw = reader[0];
+            return raw == DBNull.Value ? default(T) : (T)raw;
+        }
+
+        public async Task<T> ResolveAsync(DbDataReader reader, IIdentityMap map, CancellationToken token)
+        {
+            var raw = await reader.GetFieldValueAsync<object>(0, token).ConfigureAwait(false);
             return raw == DBNull.Value ? default(T) : (T)raw;
         }
 

--- a/src/Marten/Linq/TargetObject.cs
+++ b/src/Marten/Linq/TargetObject.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Baseline;
 using Marten.Schema;
 using Marten.Services;
@@ -45,6 +47,12 @@ namespace Marten.Linq
         public T Resolve(DbDataReader reader, IIdentityMap map)
         {
             var json = reader.GetString(0);
+            return map.Serializer.FromJson<T>(json);
+        }
+
+        public async Task<T> ResolveAsync(DbDataReader reader, IIdentityMap map, CancellationToken token)
+        {
+            var json = await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false);
             return map.Serializer.FromJson<T>(json);
         }
 

--- a/src/Marten/Linq/WholeDocumentSelector.cs
+++ b/src/Marten/Linq/WholeDocumentSelector.cs
@@ -1,4 +1,6 @@
 using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 using Marten.Schema;
 using Marten.Services;
 
@@ -16,6 +18,11 @@ namespace Marten.Linq
         public T Resolve(DbDataReader reader, IIdentityMap map)
         {
             return _resolver.Resolve(reader, map);
+        }
+
+        public Task<T> ResolveAsync(DbDataReader reader, IIdentityMap map, CancellationToken token)
+        {
+            return _resolver.ResolveAsync(reader, map, token);
         }
 
         public string SelectClause(IDocumentMapping mapping)

--- a/src/Marten/QuerySession.cs
+++ b/src/Marten/QuerySession.cs
@@ -308,7 +308,7 @@ namespace Marten
                     {
                         while (await reader.ReadAsync(tkn).ConfigureAwait(false))
                         {
-                            var doc = resolver.Resolve(reader, _parent._identityMap);
+                            var doc = await resolver.ResolveAsync(reader, _parent._identityMap, tkn).ConfigureAwait(false);
                             list.Add(doc);
                         }
                     }

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -520,6 +520,14 @@ var typeAlias = reader.GetString(2);
 
 return map.Get<{typeName}>(id, _hierarchy.TypeFor(typeAlias), json);
 END
+
+BLOCK:public async Task<{typeName}> ResolveAsync(DbDataReader reader, IIdentityMap map, CancellationToken token)
+var json = await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false);
+var id = await reader.GetFieldValueAsync<object>(1, token).ConfigureAwait(false);
+var typeAlias = await reader.GetFieldValueAsync<string>(2, token).ConfigureAwait(false);
+
+return map.Get<{typeName}>(id, _hierarchy.TypeFor(typeAlias), json);
+END
 ";
             }
 
@@ -528,6 +536,13 @@ BLOCK:public {typeName} Resolve(DbDataReader reader, IIdentityMap map)
 var json = reader.GetString(0);
 var id = reader[1];
             
+return map.Get<{typeName}>(id, json);
+END
+
+BLOCK:public async Task<{typeName}> ResolveAsync(DbDataReader reader, IIdentityMap map, CancellationToken token)
+var json = await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false);
+var id = await reader.GetFieldValueAsync<object>(1, token).ConfigureAwait(false);
+
 return map.Get<{typeName}>(id, json);
 END
 ";

--- a/src/Marten/Schema/Hierarchies/SubClassDocumentStorage.cs
+++ b/src/Marten/Schema/Hierarchies/SubClassDocumentStorage.cs
@@ -71,6 +71,14 @@ namespace Marten.Schema.Hierarchies
             return map.Get<TBase>(id, typeof(T), json) as T;
         }
 
+        public async Task<T> ResolveAsync(DbDataReader reader, IIdentityMap map, CancellationToken token)
+        {
+            var json = await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false);
+            var id = await reader.GetFieldValueAsync<object>(1, token).ConfigureAwait(false);
+
+            return map.Get<TBase>(id, typeof(T), json) as T;
+        }
+
         public T Build(DbDataReader reader, ISerializer serializer)
         {
             // TODO -- watch this, will need to validate that it's the right type first

--- a/src/Marten/Schema/IResolver.cs
+++ b/src/Marten/Schema/IResolver.cs
@@ -8,6 +8,7 @@ namespace Marten.Schema
     public interface IResolver<T>
     {
         T Resolve(DbDataReader reader, IIdentityMap map);
+        Task<T> ResolveAsync(DbDataReader reader, IIdentityMap map, CancellationToken token);
         T Build(DbDataReader reader, ISerializer serializer);
 
         T Resolve(IIdentityMap map, ILoader loader, object id);

--- a/src/Marten/Services/BatchQuerying/MultipleResultsReader.cs
+++ b/src/Marten/Services/BatchQuerying/MultipleResultsReader.cs
@@ -38,7 +38,7 @@ namespace Marten.Services.BatchQuerying
     public class MultipleResultsReader<T> : IDataReaderHandler
     {
         private readonly TaskCompletionSource<IList<T>> _taskSource = new TaskCompletionSource<IList<T>>();
-        private ISelector<T> _selector;
+        private readonly ISelector<T> _selector;
         private readonly IIdentityMap _map;
 
         public MultipleResultsReader(ISelector<T> selector, IIdentityMap map)
@@ -55,7 +55,7 @@ namespace Marten.Services.BatchQuerying
 
             while (await reader.ReadAsync(token).ConfigureAwait(false))
             {
-                var doc = _selector.Resolve(reader, _map);
+                var doc = await _selector.ResolveAsync(reader, _map, token).ConfigureAwait(false);
                 list.Add(doc);
             }
 

--- a/src/Marten/Services/BatchQuerying/SingleResultReader.cs
+++ b/src/Marten/Services/BatchQuerying/SingleResultReader.cs
@@ -27,7 +27,7 @@ namespace Marten.Services.BatchQuerying
                 _taskSource.SetResult(null);
             }
 
-            var doc = _storage.As<IResolver<T>>().Resolve(reader, _map);
+            var doc = await _storage.As<IResolver<T>>().ResolveAsync(reader, _map, token).ConfigureAwait(false);
             _taskSource.SetResult(doc);
         }
     }

--- a/src/Marten/Services/CommandRunnerExtensions.cs
+++ b/src/Marten/Services/CommandRunnerExtensions.cs
@@ -48,7 +48,7 @@ namespace Marten.Services
                 {
                     while (await reader.ReadAsync(tkn).ConfigureAwait(false))
                     {
-                        list.Add(selector.Resolve(reader, map));
+                        list.Add(await selector.ResolveAsync(reader, map, token).ConfigureAwait(false));
                     }
 
                     reader.Close();


### PR DESCRIPTION
Introduces `ResolveAsync`

Caveat: I'm not a DbReader expert. So I could be horribly wrong!

Based on my quick research the indexers of the DbReader and SqlDbReader do internal IO-bound calls if the value is not already fetched. This PR introduces a fully async path to resolve the json documents with `GetFieldValueAsync`.