### PR TITLE
DocumentSessionListenerBase should not use Task.Run to dispatch sync methods

### DIFF
--- a/src/Marten/IDocumentSessionListener.cs
+++ b/src/Marten/IDocumentSessionListener.cs
@@ -54,9 +54,10 @@ namespace Marten
             // Nothing
         }
 
-        public virtual async Task BeforeSaveChangesAsync(IDocumentSession session)
+        public virtual Task BeforeSaveChangesAsync(IDocumentSession session)
         {
-            await Task.Run(() => BeforeSaveChanges(session));
+            // Nothing
+            return Task.CompletedTask;
         }
 
         public virtual void AfterCommit(IDocumentSession session)
@@ -64,9 +65,10 @@ namespace Marten
             // Nothing
         }
 
-        public virtual async Task AfterCommitAsync(IDocumentSession session)
+        public virtual Task AfterCommitAsync(IDocumentSession session)
         {
-            await Task.Run(() => AfterCommit(session));
+            // Nothing
+            return Task.CompletedTask;
         }
 
         public virtual void DocumentLoaded(object id, object document)


### PR DESCRIPTION
This PR removes the `Task.Run` usage from `DocumentSessionListenerBase`. `DocumentSession` makes sure that the appropriate methods are called based on the sync or async path. No need to magically double dispatch and unnecessary task scheduling.