### PR TITLE
Getting rid of GetAwaiter().GetResult() calls in tests by marking them async

### DIFF
--- a/src/Marten.Testing/Linq/query_with_aggregate_functions.cs
+++ b/src/Marten.Testing/Linq/query_with_aggregate_functions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Marten.Services;
 using Marten.Testing.Fixtures;
 using Marten.Util;
@@ -24,7 +25,7 @@ namespace Marten.Testing.Linq
         }
 
         [Fact]
-        public void get_max_async()
+        public async Task get_max_async()
         {
             theSession.Store(new Target { Color = Colors.Blue, Number = 1 });
             theSession.Store(new Target { Color = Colors.Red, Number = 42 });
@@ -32,7 +33,7 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Color = Colors.Blue, Number = 4 });
 
             theSession.SaveChanges();
-            var maxNumber = theSession.Query<Target>().MaxAsync(t => t.Number).GetAwaiter().GetResult();
+            var maxNumber = await theSession.Query<Target>().MaxAsync(t => t.Number);
             maxNumber.ShouldBe(42);
         }
 
@@ -50,7 +51,7 @@ namespace Marten.Testing.Linq
         }
 
         [Fact]
-        public void get_min_async()
+        public async Task get_min_async()
         {
             theSession.Store(new Target { Color = Colors.Blue, Number = 1 });
             theSession.Store(new Target { Color = Colors.Red, Number = 42 });
@@ -58,7 +59,7 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Color = Colors.Blue, Number = 4 });
 
             theSession.SaveChanges();
-            var maxNumber = theSession.Query<Target>().MinAsync(t => t.Number).GetAwaiter().GetResult();
+            var maxNumber = await theSession.Query<Target>().MinAsync(t => t.Number);
             maxNumber.ShouldBe(-5);
         }
 
@@ -76,7 +77,7 @@ namespace Marten.Testing.Linq
         }
 
         [Fact]
-        public void get_average_async()
+        public async Task get_average_async()
         {
             theSession.Store(new Target { Color = Colors.Blue, Number = 1 });
             theSession.Store(new Target { Color = Colors.Red, Number = 42 });
@@ -84,7 +85,7 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Color = Colors.Blue, Number = 2 });
 
             theSession.SaveChanges();
-            var maxNumber = theSession.Query<Target>().AverageAsync(t => t.Number).GetAwaiter().GetResult();
+            var maxNumber = await theSession.Query<Target>().AverageAsync(t => t.Number);
             maxNumber.ShouldBe(10);
         }
     }

--- a/src/Marten.Testing/query_scalar_values_with_select_in_query_async.cs
+++ b/src/Marten.Testing/query_scalar_values_with_select_in_query_async.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using Marten.Services;
 using Marten.Testing.Fixtures;
 using Shouldly;
@@ -9,7 +10,7 @@ namespace Marten.Testing
     public class query_scalar_values_with_select_in_query_async : DocumentSessionFixture<NulloIdentityMap>
     {
         [Fact]
-        public void get_sum_of_integers_asynchronously()
+        public async Task get_sum_of_integers_asynchronously()
         {
             theSession.Store(new Target { Color = Colors.Blue, Number = 1 });
             theSession.Store(new Target { Color = Colors.Red, Number = 2 });
@@ -17,13 +18,13 @@ namespace Marten.Testing
             theSession.Store(new Target { Color = Colors.Blue, Number = 4 });
 
             theSession.SaveChanges();
-            var sumResults = theSession.QueryAsync<int>("select sum(CAST(d.data ->> 'Number' as integer)) as number from mt_doc_target as d").GetAwaiter().GetResult();
+            var sumResults = await theSession.QueryAsync<int>("select sum(CAST(d.data ->> 'Number' as integer)) as number from mt_doc_target as d");
             var sum = sumResults.Single();
             sum.ShouldBe(10);
         }
 
         [Fact]
-        public void get_count_asynchronously()
+        public async Task get_count_asynchronously()
         {
             theSession.Store(new Target { Color = Colors.Blue, Number = 1 });
             theSession.Store(new Target { Color = Colors.Red, Number = 2 });
@@ -31,7 +32,7 @@ namespace Marten.Testing
             theSession.Store(new Target { Color = Colors.Blue, Number = 4 });
 
             theSession.SaveChanges();
-            var sumResults = theSession.QueryAsync<int>("select count(*) from mt_doc_target").GetAwaiter().GetResult();
+            var sumResults = await theSession.QueryAsync<int>("select count(*) from mt_doc_target");
             var sum = sumResults.Single();
             sum.ShouldBe(4);
         }


### PR DESCRIPTION
Since the testing framework properly supports async tests we don't need to use `GetAwaiter().GetResult()`