### PR TITLE
Added support for Explain queries

### DIFF
--- a/src/Marten.Testing/Linq/explain_query.cs
+++ b/src/Marten.Testing/Linq/explain_query.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Linq;
+using Marten.Linq;
+using Marten.Services;
+
+namespace Marten.Testing.Linq
+{
+    public class explain_query : DocumentSessionFixture<NulloIdentityMap>
+    {
+        public void retrieves_query_plan()
+        {
+            var user1 = new SimpleUser
+            {
+                UserName = "Mr Fouine",
+                Number = 5,
+                Birthdate = new DateTime(1986, 10, 4),
+                Address = new Address { HouseNumber = "12bis", Street = "rue de la martre" }
+            };
+            var user2 = new SimpleUser
+            {
+                UserName = "Mrs Fouine",
+                Number = 6,
+                Birthdate = new DateTime(1987, 10, 4),
+                Address = new Address { HouseNumber = "12bis", Street = "rue de la martre" }
+            };
+            theSession.Store(user1, user2);
+            theSession.SaveChanges();
+
+            var plan = theSession.Query<SimpleUser>().Explain();
+            plan.ShouldNotBeNull();
+            plan.PlanWidth.ShouldBeGreaterThan(0);
+            plan.PlanRows.ShouldBeGreaterThan(0);
+            plan.TotalCost.ShouldBeGreaterThan(0m);
+        }
+
+        public void retrieves_query_plan_with_where()
+        {
+            var user1 = new SimpleUser
+            {
+                UserName = "Mr Fouine",
+                Number = 5,
+                Birthdate = new DateTime(1986, 10, 4),
+                Address = new Address { HouseNumber = "12bis", Street = "rue de la martre" }
+            };
+            var user2 = new SimpleUser
+            {
+                UserName = "Mrs Fouine",
+                Number = 6,
+                Birthdate = new DateTime(1987, 10, 4),
+                Address = new Address { HouseNumber = "12bis", Street = "rue de la martre" }
+            };
+            theSession.Store(user1, user2);
+            theSession.SaveChanges();
+
+            var plan = theSession.Query<SimpleUser>().Where(u=>u.Number > 5).Explain();
+            plan.ShouldNotBeNull();
+            plan.PlanWidth.ShouldBeGreaterThan(0);
+            plan.PlanRows.ShouldBeGreaterThan(0);
+            plan.TotalCost.ShouldBeGreaterThan(0m);
+        }
+    }
+}

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Github\RepositoryHistory.cs" />
     <Compile Include="insert_timing.cs" />
     <Compile Include="Linq\DeserializeSelectorTests.cs" />
+    <Compile Include="Linq\explain_query.cs" />
     <Compile Include="Linq\invoking_queryable_any_async_Tests.cs" />
     <Compile Include="Linq\invoking_queryable_count_async_Tests.cs" />
     <Compile Include="Linq\invoking_queryable_through_first_async_Tests.cs" />

--- a/src/Marten/Linq/FetchType.cs
+++ b/src/Marten/Linq/FetchType.cs
@@ -1,0 +1,28 @@
+namespace Marten.Linq
+{
+    /// <summary>
+    /// In basic terms, how is the IQueryable going to be executed?
+    /// </summary>
+    public enum FetchType
+    {
+        /// <summary>
+        /// First/FirstOrDefault/Single/SingleOrDefault
+        /// </summary>
+        FetchOne,
+
+        /// <summary>
+        /// Any execution that returns an IEnumerable (ToArray()/ToList()/etc.)
+        /// </summary>
+        FetchMany,
+
+        /// <summary>
+        /// Using IQueryable.Count()
+        /// </summary>
+        Count,
+
+        /// <summary>
+        /// Using IQueryable.Any()
+        /// </summary>
+        Any
+    }
+}

--- a/src/Marten/Linq/MartenQueryExecutor.cs
+++ b/src/Marten/Linq/MartenQueryExecutor.cs
@@ -165,8 +165,8 @@ namespace Marten.Linq
         private IEnumerable<string> executeJson<T>(QueryModel queryModel, ResultOperatorBase resultOperator)
         {
             var cmd = prepareCommand<T>(queryModel, resultOperator);
-            var all = _runner.QueryJson(cmd);
-            return all;
+            var queryResult = _runner.QueryJson(cmd);
+            return queryResult;
         }
 
         private NpgsqlCommand prepareCommand<T>(QueryModel queryModel, ResultOperatorBase resultOperator)

--- a/src/Marten/Linq/MartenQueryExecutor.cs
+++ b/src/Marten/Linq/MartenQueryExecutor.cs
@@ -49,7 +49,15 @@ namespace Marten.Linq
         {
             return _schema.StorageFor(typeof (T)).As<IResolver<T>>();
         }
-            
+
+        public QueryPlan ExecuteExplain<T>(QueryModel queryModel)
+        {
+            ISelector<T> selector = null;
+            var cmd = BuildCommand(queryModel, out selector);
+
+            return _runner.ExplainQuery(cmd);
+        }
+
         T IQueryExecutor.ExecuteScalar<T>(QueryModel queryModel)
         {
             var executors = new List<IScalarQueryExecution<T>> {
@@ -88,8 +96,7 @@ namespace Marten.Linq
 
             return all.Single();
         }
-
-
+        
         IEnumerable<T> IQueryExecutor.ExecuteCollection<T>(QueryModel queryModel)
         {
             ISelector<T> selector = null;

--- a/src/Marten/Linq/MartenQueryable.cs
+++ b/src/Marten/Linq/MartenQueryable.cs
@@ -28,6 +28,14 @@ namespace Marten.Linq
             return queryProvider.ExecuteCollectionAsync<T>(Expression, token);
         }
 
+        public QueryPlan Explain()
+        {
+            var model = new MartenQueryParser().GetParsedQuery(Expression);
+            var executor = Provider.As<MartenQueryProvider>().Executor.As<MartenQueryExecutor>();
+
+            return executor.ExecuteExplain<T>(model);
+        }
+
         public string ToListJson()
         {
             var model = new MartenQueryParser().GetParsedQuery(Expression);

--- a/src/Marten/Linq/MartenQueryable.cs
+++ b/src/Marten/Linq/MartenQueryable.cs
@@ -30,59 +30,53 @@ namespace Marten.Linq
 
         public QueryPlan Explain()
         {
-            var model = new MartenQueryParser().GetParsedQuery(Expression);
-            var executor = Provider.As<MartenQueryProvider>().Executor.As<MartenQueryExecutor>();
-
-            return executor.ExecuteExplain<T>(model);
+            return executeJsonQuery((executor, model) => executor.ExecuteExplain<T>(model));
         }
 
         public string ToListJson()
         {
-            var model = new MartenQueryParser().GetParsedQuery(Expression);
-            var executor = Provider.As<MartenQueryProvider>().Executor.As<MartenQueryExecutor>();
-
-            var listJsons = executor.ExecuteCollectionToJson<T>(model).ToArray();
+            var listJsons = executeJsonQuery((executor, model) => executor.ExecuteCollectionToJson<T>(model)).ToArray();
             return $"[{listJsons.Join(",")}]";
         }
 
         public Task<string> ToListJsonAsync(CancellationToken token)
         {
-            var model = new MartenQueryParser().GetParsedQuery(Expression);
-            var executor = Provider.As<MartenQueryProvider>().Executor.As<MartenQueryExecutor>();
-
-            return executor.ExecuteCollectionToJsonAsync<T>(model, token).ContinueWith(task => $"[{task.Result.Join(",")}]", token);
+            var getListTask = executeJsonQueryAsync((executor, model) => executor.ExecuteCollectionToJsonAsync<T>(model, token));
+            return getListTask.ContinueWith(task => $"[{task.Result.Join(",")}]", token);
         }
 
         public string SingleJson(bool returnDefaultWhenEmpty)
         {
-            var model = new MartenQueryParser().GetParsedQuery(Expression);
-            var executor = Provider.As<MartenQueryProvider>().Executor.As<MartenQueryExecutor>();
-
-            return executor.ExecuteSingleToJson<T>(model, returnDefaultWhenEmpty);
+            return executeJsonQuery((executor, model) => executor.ExecuteSingleToJson<T>(model, returnDefaultWhenEmpty));
         }
 
         public Task<string> SingleJsonAsync(bool returnDefaultWhenEmpty, CancellationToken token)
         {
-            var model = new MartenQueryParser().GetParsedQuery(Expression);
-            var executor = Provider.As<MartenQueryProvider>().Executor.As<MartenQueryExecutor>();
-
-            return executor.ExecuteSingleToJsonAsync<T>(model, returnDefaultWhenEmpty, token);
+            return executeJsonQueryAsync((executor, model) => executor.ExecuteSingleToJsonAsync<T>(model, returnDefaultWhenEmpty, token));
         }
 
         public string FirstJson(bool returnDefaultWhenEmpty)
         {
-            var model = new MartenQueryParser().GetParsedQuery(Expression);
-            var executor = Provider.As<MartenQueryProvider>().Executor.As<MartenQueryExecutor>();
-
-            return executor.ExecuteFirstToJson<T>(model, returnDefaultWhenEmpty);
+            return executeJsonQuery((executor, model) => executor.ExecuteFirstToJson<T>(model, returnDefaultWhenEmpty));
         }
 
         public Task<string> FirstJsonAsync(bool returnDefaultWhenEmpty, CancellationToken token)
         {
+            return executeJsonQueryAsync((executor,model)=>executor.ExecuteFirstToJsonAsync<T>(model,returnDefaultWhenEmpty,token));
+        }
+
+        public TResult executeJsonQuery<TResult>(Func<MartenQueryExecutor, QueryModel, TResult> execute)
+        {
             var model = new MartenQueryParser().GetParsedQuery(Expression);
             var executor = Provider.As<MartenQueryProvider>().Executor.As<MartenQueryExecutor>();
+            return execute(executor, model);
+        }
 
-            return executor.ExecuteFirstToJsonAsync<T>(model, returnDefaultWhenEmpty, token);
+        public Task<TResult> executeJsonQueryAsync<TResult>(Func<MartenQueryExecutor, QueryModel, Task<TResult>> execute)
+        {
+            var model = new MartenQueryParser().GetParsedQuery(Expression);
+            var executor = Provider.As<MartenQueryProvider>().Executor.As<MartenQueryExecutor>();
+            return execute(executor, model);
         }
 
         public IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback, JoinType joinType = JoinType.Inner) where TInclude : class
@@ -166,31 +160,5 @@ namespace Marten.Linq
 
             return cmd;
         }
-    }
-
-    /// <summary>
-    /// In basic terms, how is the IQueryable going to be executed?
-    /// </summary>
-    public enum FetchType
-    {
-        /// <summary>
-        /// First/FirstOrDefault/Single/SingleOrDefault
-        /// </summary>
-        FetchOne,
-
-        /// <summary>
-        /// Any execution that returns an IEnumerable (ToArray()/ToList()/etc.)
-        /// </summary>
-        FetchMany,
-
-        /// <summary>
-        /// Using IQueryable.Count()
-        /// </summary>
-        Count,
-
-        /// <summary>
-        /// Using IQueryable.Any()
-        /// </summary>
-        Any
     }
 }

--- a/src/Marten/Linq/QueryPlan.cs
+++ b/src/Marten/Linq/QueryPlan.cs
@@ -1,0 +1,26 @@
+using Newtonsoft.Json;
+
+namespace Marten.Linq
+{
+    public class QueryPlan
+    {
+        [JsonProperty(PropertyName = "Node Type")]
+        public string NodeType { get; set; }
+        [JsonProperty(PropertyName = "Relation Name")]
+        public string RelationName { get; set; }
+        public string Alias { get; set; }
+        [JsonProperty(PropertyName = "Startup Cost")]
+        public decimal StartupCost { get; set; }
+        [JsonProperty(PropertyName = "Total Cost")]
+        public decimal TotalCost { get; set; }
+        [JsonProperty(PropertyName = "Plan Rows")]
+        public int PlanRows { get; set; }
+        [JsonProperty(PropertyName = "Plan Width")]
+        public int PlanWidth { get; set; }
+    }
+
+    class QueryPlanContainer
+    {
+        public QueryPlan Plan { get; set; }
+    }
+}

--- a/src/Marten/Linq/QueryableExtensions.cs
+++ b/src/Marten/Linq/QueryableExtensions.cs
@@ -11,36 +11,28 @@ namespace Marten.Linq
     {
         public static NpgsqlCommand ToCommand<T>(this IQueryable<T> queryable, FetchType fetchType)
         {
-            var q = queryable as MartenQueryable<T>;
-
-            if (q == null)
-            {
-                throw new InvalidOperationException($"{nameof(ToCommand)} is only valid on Marten IQueryable objects");
-            }
+            var q = GetMartenQueryable(queryable, nameof(ToCommand));
 
             return q.BuildCommand(fetchType);
         }
 
+        public static QueryPlan Explain<T>(this IQueryable<T> queryable)
+        {
+            var q = GetMartenQueryable(queryable, nameof(Explain));
+
+            return q.Explain();
+        }
+
         public static string ToListJson<T>(this IQueryable<T> queryable)
         {
-            var q = queryable as MartenQueryable<T>;
-
-            if (q == null)
-            {
-                throw new InvalidOperationException($"{nameof(ToListJson)} is only valid on Marten IQueryable objects");
-            }
+            var q = GetMartenQueryable(queryable, nameof(ToListJson));
 
             return q.ToListJson();
         }
 
         public static Task<string> ToListJsonAsync<T>(this IQueryable<T> queryable, CancellationToken token = default(CancellationToken))
         {
-            var q = queryable as MartenQueryable<T>;
-
-            if (q == null)
-            {
-                throw new InvalidOperationException($"{nameof(ToListJsonAsync)} is only valid on Marten IQueryable objects");
-            }
+            var q = GetMartenQueryable(queryable, nameof(ToListJsonAsync));
 
             return q.ToListJsonAsync(token);
         }
@@ -68,7 +60,7 @@ namespace Marten.Linq
 
         public static Task<string> SingleOrDefaultJsonAsync<T>(this IQueryable<T> queryable, Expression<Func<T, bool>> predicate = null, CancellationToken token = default(CancellationToken))
         {
-            var q = GetMartenQueryable(queryable, predicate, nameof(SingleOrDefaultJson));
+            var q = GetMartenQueryable(queryable, predicate, nameof(SingleOrDefaultJsonAsync));
 
             return q.SingleJsonAsync(true, token);
         }
@@ -104,6 +96,17 @@ namespace Marten.Linq
         private static MartenQueryable<T> GetMartenQueryable<T>(IQueryable<T> queryable, Expression<Func<T, bool>> predicate, string methodName)
         {
             var q = predicate != null ? queryable.Where(predicate) as MartenQueryable<T> : queryable as MartenQueryable<T>;
+
+            if (q == null)
+            {
+                throw new InvalidOperationException($"{methodName} is only valid on Marten IQueryable objects");
+            }
+            return q;
+        }
+
+        private static MartenQueryable<T> GetMartenQueryable<T>(IQueryable<T> queryable, string methodName)
+        {
+            var q = queryable as MartenQueryable<T>;
 
             if (q == null)
             {

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Linq\ContainmentWhereFragment.cs" />
     <Compile Include="Linq\DeserializeSelector.cs" />
     <Compile Include="Linq\ExpressionExtensions.cs" />
+    <Compile Include="Linq\FetchType.cs" />
     <Compile Include="Linq\FindMembers.cs" />
     <Compile Include="Linq\Handlers\EnumerableContains.cs" />
     <Compile Include="Linq\Handlers\IMethodCallParser.cs" />

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Linq\MartenQueryProvider.cs" />
     <Compile Include="Linq\Handlers\IsOneOf.cs" />
     <Compile Include="Linq\QueryableExtensions.cs" />
+    <Compile Include="Linq\QueryPlan.cs" />
     <Compile Include="Linq\ScalarQueryExecution.cs" />
     <Compile Include="Linq\SelectorParser.cs" />
     <Compile Include="Linq\SelectTransformer.cs" />

--- a/src/Marten/Services/CommandRunnerExtensions.cs
+++ b/src/Marten/Services/CommandRunnerExtensions.cs
@@ -20,6 +20,19 @@ namespace Marten.Services
             return runner.Execute(cmd => cmd.WithText(sql).ExecuteNonQuery());
         }
 
+        public static QueryPlan ExplainQuery(this IManagedConnection runner, NpgsqlCommand cmd)
+        {
+            var serializer = new JsonNetSerializer();
+            cmd.CommandText = string.Concat("explain (format json) ",cmd.CommandText);
+            return runner.Execute(cmd, c =>
+            {
+                using (var reader = cmd.ExecuteReader())
+                {
+                    var queryPlans = reader.Read() ? serializer.FromJson<QueryPlanContainer[]>(reader.GetString(0)) : null;
+                    return queryPlans?[0].Plan;
+                }
+            });
+        }
 
         public static IEnumerable<T> Resolve<T>(this IManagedConnection runner, NpgsqlCommand cmd, ISelector<T> selector, IIdentityMap map)
         {


### PR DESCRIPTION
targeting #152 
I just noticed the issue talks about adding the explain to the **diagnostics** - I've got a feeling I missed the point.
This executes explain (and returns a QueryPlan object with all the data) on non-aggregates, non-scalar queries- do we need explain on count/single/first/sum/min/max etc'..?

Let me know if it's not exactly what you had in mind.