### PR TITLE
added ability to dynamically add subclass hierarchy & docs

### DIFF
--- a/documentation/documentation/documents/hierarchies.md
+++ b/documentation/documentation/documents/hierarchies.md
@@ -4,6 +4,8 @@
 Marten now allows you to specify that hierarchies of document types should be stored in one table and allow you
 to query for either the base class or any of the subclasses.
 
+## One Level Hierarchies
+
 To make that concrete, let's say you have a document type named `User` that has a pair of specialized subclasses
 called `SuperUser` and `AdminUser`. To use the document hierarchy storage, we need to tell Marten that
 `SuperUser` and `AdminUser` should just be stored as subclasses of `User` like this:
@@ -25,3 +27,26 @@ There's a couple things to be aware of with type hierarchies:
   but may in the future
 * Internally, the subclass type documents are also stored as the parent type in the Identity Map mechanics. Many, many hours of
   banging my head on my desk were required to add this feature.
+
+## Multi Level Hierarchies
+
+Say you have a document type named `ISmurf` that is implemented by `Smurf`. Now, say the latter has a pair of specialized
+subclasses called `PapaSmurf` and `PapySmurf` and that both implement `IPapaSmurf` and that `PapaSmurf` has the subclass 
+`BrainySmurf` like so:
+
+<[sample:smurfs-hierarchy]>
+
+If you wish to query over one of hierarchy classes and be able to get all of its documents as well as its subclasses,
+first you will need to map the hierarchy like so:
+
+<[sample:add-subclass-hierarchy]>
+
+Note that if you wish to use aliases on certain subclasses, you could pass a `MappedType`, which contains the type to map 
+and its alias. Since `Type` implicitly converts to `MappedType` and the methods takes in `params MappedType[]`, you could
+use a mix of both like so:
+
+<[sample:add-subclass-hierarchy-with-aliases]>
+
+Now you can query the "complex" hierarchy in the following ways:
+
+<[sample:query-subclass-hierarchy]>

--- a/src/Marten.Testing/Linq/query_with_inheritance.cs
+++ b/src/Marten.Testing/Linq/query_with_inheritance.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace Marten.Testing.Linq
 {
+    // SAMPLE: smurfs-hierarchy
     public interface ISmurf
     {
         string Ability { get; set; }
@@ -21,7 +22,8 @@ namespace Marten.Testing.Linq
     public interface IPapaSmurf : ISmurf{}
     public class PapaSmurf : Smurf, IPapaSmurf{}
     public class PapySmurf : Smurf, IPapaSmurf{}
-    public class BrainySmurf : PapaSmurf{}
+    public class BrainySmurf : PapaSmurf{ }
+    // ENDSAMPLE
 
     public class query_with_inheritance_and_aliases : DocumentSessionFixture<NulloIdentityMap>
     {
@@ -29,6 +31,7 @@ namespace Marten.Testing.Linq
         {
             StoreOptions(_ =>
             {
+                // SAMPLE: add-subclass-hierarchy-with-aliases
                 _.Schema.For<ISmurf>()
                     .AddSubclassHierarchy(
                         typeof(Smurf), 
@@ -37,6 +40,7 @@ namespace Marten.Testing.Linq
                         typeof(IPapaSmurf), 
                         typeof(BrainySmurf)
                     );
+                // ENDSAMPLE
 
                 _.Connection(ConnectionSource.ConnectionString);
                 _.AutoCreateSchemaObjects = AutoCreate.All;
@@ -62,12 +66,20 @@ namespace Marten.Testing.Linq
 
     public class query_with_inheritance : DocumentSessionFixture<NulloIdentityMap>
     {
+        // SAMPLE: add-subclass-hierarchy
         public query_with_inheritance()
         {
             StoreOptions(_ =>
             {
                 _.Schema.For<ISmurf>()
                     .AddSubclassHierarchy(typeof(Smurf), typeof(PapaSmurf), typeof(PapySmurf), typeof(IPapaSmurf), typeof(BrainySmurf));
+
+                // Alternatively, you can use the following:
+                // _.Schema.For<ISmurf>().AddSubclassHierarchy();
+                // this, however, will use the assembly
+                // of type ISmurf to get all its' subclasses/implementations. 
+                // In projects with many types, this approach will be undvisable.
+
 
                 _.Connection(ConnectionSource.ConnectionString);
                 _.AutoCreateSchemaObjects = AutoCreate.All;
@@ -76,7 +88,9 @@ namespace Marten.Testing.Linq
                 _.Schema.For<ISmurf>().GinIndexJsonData();
             });
         }
+        // ENDSAMPLE
 
+        // SAMPLE: query-subclass-hierarchy
         [Fact]
         public void get_all_subclasses_of_a_subclass()
         {
@@ -129,5 +143,6 @@ namespace Marten.Testing.Linq
 
             theSession.Query<IPapaSmurf>().Count().ShouldBe(3);
         }
+        // ENDSAMPLE
     }
 }

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -251,6 +251,26 @@ namespace Marten
                 return this;
             }
 
+            /// <summary>
+            /// Programmatically directs Marten to map all the subclasses of <cref name="T"/> to a hierarchy of types. <c>Unadvised in projects with many types.</c>
+            /// </summary>
+            /// <returns></returns>
+            public DocumentMappingExpression<T> AddSubclassHierarchy()
+            {
+                var baseType = typeof (T);
+                var allSubclassTypes = baseType.Assembly.GetTypes()
+                    .Where(t => t.IsSubclassOf(baseType) || baseType.IsInterface && t.GetInterfaces().Contains(baseType))
+                    .Select(t=>(MappedType)t).ToList();
+                alter = mapping => allSubclassTypes.Each<MappedType>(subclassType => 
+                    mapping.AddSubClass(
+                        subclassType.Type, 
+                        allSubclassTypes.Except<MappedType>(new [] {subclassType}),
+                        null
+                    )
+                );
+                return this;
+            }
+
 
             public DocumentMappingExpression<T> AddSubclass<TSubclass>(string alias = null) where TSubclass : T
             {


### PR DESCRIPTION
I started this work just doing the doc side of things, then wanted to show an example of how this could be done by using dynamic type discovery as you suggested [here](https://github.com/JasperFx/marten/pull/266#discussion_r58878614). 
This turned out a bit messy and I decided to add this to the framework while adding intelliSense comments that advise users to beware of using this feature willy-nilly. The sample in the docs also gives out this warning.
If you're not happy with this feature, I can easily remove it; the docs should be in there though I believe.