### PR TITLE
Documentation

### DIFF
--- a/documentation/documentation/documents/async.md
+++ b/documentation/documentation/documents/async.md
@@ -34,6 +34,10 @@ Marten adds extension methods to `IQueryable` for the asynchronous invocation of
 
 * `AnyAsync()`
 * `CountAsync()`
+* `MinAsync()`
+* `MaxAsync()`
+* `AverageAsync()`
+* `SumAsync()`
 * `LongCountAsync()`
 * `FirstAsync()/FirstOrDefaultAsync()`
 * `SingleAsync()/SingleOrDefaultAsync()`

--- a/documentation/documentation/documents/linq.md
+++ b/documentation/documentation/documents/linq.md
@@ -48,7 +48,7 @@ Marten's Linq support will allow you to make "deep" searches on properties of pr
 
 ## Searching on String Fields
 
-Marten supports a subset of the common substring searches:
+Marten supports a subset of the common sub/string searches:
 
 <[sample:searching_within_string_fields]>
 

--- a/documentation/documentation/documents/linq.md
+++ b/documentation/documentation/documents/linq.md
@@ -107,7 +107,7 @@ Marten supports the `IQueryable` methods for returning only a single document at
 <[sample:select_a_single_value]>
 
 
-## Querying withing Value IEnumerables
+## Querying within Value IEnumerables
 
 As of now, Marten allows you to do "contains" searches within Arrays, Lists & ILists of primitive values like string or numbers:
 

--- a/documentation/documentation/documents/linq.md
+++ b/documentation/documentation/documents/linq.md
@@ -83,11 +83,15 @@ Marten supports the `IQueryable` methods for returning only a single document at
 <[sample:select_a_single_value]>
 
 
-## Querying withing Value Arrays
+## Querying withing Value IEnumerables
 
-As of now, Marten allows you to do "contains" searches within arrays of primitive values like string or numbers:
+As of now, Marten allows you to do "contains" searches within Arrays, Lists & ILists of primitive values like string or numbers:
 
 <[sample:query_against_string_array]>
+
+Marten also allows you to query over IEnumerables using the Any method for equality (similar to Contains):
+
+<[sample:query_any_string_array]>
 
 ## Searching with Boolean Flags
 

--- a/documentation/documentation/documents/linq.md
+++ b/documentation/documentation/documents/linq.md
@@ -62,6 +62,30 @@ Marten supports the `IQueryable.Count()` method:
 
 <[sample:using_count]>
 
+## Min()
+
+Marten supports the `IQueryable.Min()` method:
+
+<[sample:using_min]>
+
+## Max()
+
+Marten supports the `IQueryable.Max()` method:
+
+<[sample:using_max]>
+
+## Average()
+
+Marten supports the `IQueryable.Average()` method:
+
+<[sample:using_average]>
+
+## Sum()
+
+Marten supports the `IQueryable.Sum()` method:
+
+<[sample:using_sum]>
+
 ## Ordering Results
 
 Marten contains support for expressing ordering in both ascending and descending order in Linq queries:

--- a/documentation/documentation/documents/linq.md
+++ b/documentation/documentation/documents/linq.md
@@ -52,7 +52,9 @@ Marten supports a subset of the common substring searches:
 
 <[sample:searching_within_string_fields]>
 
-Marten does not yet support case insensitive substring searches. We'd love pull requests!
+Marten also supports case insensitive substring searches:
+
+<[sample:searching_within_case_insensitive_string_fields]>
 
 ## Count()
 

--- a/documentation/documentation/documents/projections.md
+++ b/documentation/documentation/documents/projections.md
@@ -1,4 +1,38 @@
 <!--Title:Document Projections-->
 <!--Url:projections-->
 
-There's nothing here yet, but our thought is to take advantage of Postgresql's PLV8 extension that allows you to run Google's V8 javascript engine inside of Postgresql to write and define projections against persisted documents with javascript.
+Marten has now the capacity to run [projection queries](https://en.wikipedia.org/wiki/Projection_(relational_algebra)), where only specific document properties are retrieved. The projection queries are executed by using the linq `IQueryable.Select()` method.
+
+## Projection Queries
+
+When you wish to retrieve an IEnumerable of a certain document property for example:
+
+<[sample:one_field_projection]>
+
+When you wish to retrieve certain properties and transform them into another type:
+
+<[sample:other_type_projection]>
+
+When you wish to retrieve certain properties and transform them into an anonymous type:
+
+<[sample:anonymous_type_projection]>
+
+Marten also allows you to run projection queries on deep (nested) properties:
+
+<[sample:deep_properties_projection]>
+
+## Chaining other Linq Methods
+
+After calling Select, you'd be able to chain other linq methods such as `First()`, `FirstOrDefault()`, `Single()` and so on, like so:
+
+<[sample:get_first_projection]>
+
+## Async Projections
+
+Marten also supports asynchronously running projection queries. You'd be able to achieve this by simply chaining the asynchronous resolving method you are after. For example:
+
+* `ToListAsync()`
+* `FirstAsync()`
+* `SingleOrDefaultAsync()`
+
+And so on...

--- a/src/Marten.Testing/Examples/LinqExamples.cs
+++ b/src/Marten.Testing/Examples/LinqExamples.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using Marten.Testing.Fixtures;
 using Shouldly;
+using Marten.Util;
 
 namespace Marten.Testing.Examples
 {
@@ -58,6 +60,17 @@ namespace Marten.Testing.Examples
             session.Query<Target>().Where(x => x.String.EndsWith("Suffix"));
 
             session.Query<Target>().Where(x => x.String.Contains("something"));
+        }
+        // ENDSAMPLE
+
+        // SAMPLE: searching_within_case_insensitive_string_fields
+        public void case_insensitive_string_fields(IDocumentSession session)
+        {
+            session.Query<Target>().Where(x => x.String.StartsWith("A",true,CultureInfo.InvariantCulture));
+            session.Query<Target>().Where(x => x.String.EndsWith("SuFfiX", true, CultureInfo.InvariantCulture));
+
+            // using Marten.Util
+            session.Query<Target>().Where(x => x.String.Contains("soMeThiNg", StringComparison.OrdinalIgnoreCase));
         }
         // ENDSAMPLE
 

--- a/src/Marten.Testing/Examples/LinqExamples.cs
+++ b/src/Marten.Testing/Examples/LinqExamples.cs
@@ -60,6 +60,7 @@ namespace Marten.Testing.Examples
             session.Query<Target>().Where(x => x.String.EndsWith("Suffix"));
 
             session.Query<Target>().Where(x => x.String.Contains("something"));
+            session.Query<Target>().Where(x => x.String.Equals("The same thing"));
         }
         // ENDSAMPLE
 

--- a/src/Marten.Testing/Linq/invoking_query_with_select_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_query_with_select_Tests.cs
@@ -13,6 +13,7 @@ namespace Marten.Testing.Linq
 {
     public class invoking_query_with_select_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        // SAMPLE: one_field_projection
         [Fact]
         public void use_select_in_query_for_one_field()
         {
@@ -27,6 +28,7 @@ namespace Marten.Testing.Linq
                 .ShouldHaveTheSameElementsAs("Bill", "Hank", "Sam", "Tom");
 
         }
+        // ENDSAMPLE
 
         [Fact]
         public void use_select_in_query_for_one_field_and_first()
@@ -74,7 +76,7 @@ namespace Marten.Testing.Linq
                 .ShouldHaveTheSameElementsAs("Bill", "Hank", "Sam", "Tom");
         }
 
-
+        // SAMPLE: get_first_projection
         [Fact]
         public void use_select_to_another_type_with_first()
         {
@@ -89,7 +91,7 @@ namespace Marten.Testing.Linq
                 .FirstOrDefault()
                 .Name.ShouldBe("Bill");
         }
-
+        // ENDSAMPLE
 
 
         [Fact]
@@ -112,10 +114,8 @@ namespace Marten.Testing.Linq
             users.Select(x => x.Name)
                 .ShouldHaveTheSameElementsAs("Bill", "Hank", "Sam", "Tom");
         }
-
-
-
-
+        
+        // SAMPLE: anonymous_type_projection
         [Fact]
         public void use_select_to_transform_to_an_anonymous_type()
         {
@@ -131,6 +131,7 @@ namespace Marten.Testing.Linq
                 .Select(x => x.Name)
                 .ShouldHaveTheSameElementsAs("Bill", "Hank", "Sam", "Tom");
         }
+        // ENDSAMPLE
 
         [Fact]
         public void use_select_with_multiple_fields_in_anonymous()
@@ -153,7 +154,7 @@ namespace Marten.Testing.Linq
             });
         }
 
-
+        // SAMPLE: other_type_projection
         [Fact]
         public void use_select_with_multiple_fields_to_other_type()
         {
@@ -174,7 +175,7 @@ namespace Marten.Testing.Linq
                 x.Last.ShouldNotBeNull();
             });
         }
-
+        // ENDSAMPLE
 
         public class User2
         {
@@ -204,6 +205,7 @@ namespace Marten.Testing.Linq
                 .ShouldHaveTheSameElementsAs("Bill", "Hank", "Sam", "Tom");
         }
 
+        // SAMPLE: deep_properties_projection
         [Fact]
         public void transform_with_deep_properties()
         {
@@ -216,11 +218,8 @@ namespace Marten.Testing.Linq
             var expected = targets.Where(x => x.Number == targets[0].Number).Select(x => x.Inner.Number).Distinct();
 
             actual.ShouldHaveTheSameElementsAs(expected);
-
-
-
         }
-
+        // ENDSAMPLE
 
     }
 

--- a/src/Marten.Testing/Linq/query_against_primitive_array_Tests.cs
+++ b/src/Marten.Testing/Linq/query_against_primitive_array_Tests.cs
@@ -98,7 +98,7 @@ namespace Marten.Testing.Linq
                 .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc1.Id, doc2.Id);
         }
 
-
+        // SAMPLE: query_any_string_array
         [Fact]
         public void query_against_number_list_with_any()
         {
@@ -116,6 +116,7 @@ namespace Marten.Testing.Linq
             theSession.Query<DocWithLists>().Where(x => x.Numbers.Any(_ => _ == 3)).ToArray()
                 .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc1.Id, doc2.Id);
         }
+        // ENDSAMPLE
 
         [Fact]
         public void query_against_number_IList()

--- a/src/Marten.Testing/Linq/query_for_sum_Tests.cs
+++ b/src/Marten.Testing/Linq/query_for_sum_Tests.cs
@@ -8,6 +8,7 @@ namespace Marten.Testing.Linq
 {
     public class query_for_sum_Tests : DocumentSessionFixture<NulloIdentityMap>
     {
+        // SAMPLE: using_sum
         [Fact]
         public void get_sum_of_integers()
         {
@@ -20,6 +21,7 @@ namespace Marten.Testing.Linq
             theSession.Query<Target>().Sum(x => x.Number)
                 .ShouldBe(10);
         }
+        // ENDSAMPLE
 
         [Fact]
         public void get_sum_of_decimals()

--- a/src/Marten.Testing/Linq/query_with_aggregate_functions.cs
+++ b/src/Marten.Testing/Linq/query_with_aggregate_functions.cs
@@ -11,6 +11,7 @@ namespace Marten.Testing.Linq
 {
     public class query_with_aggregate_functions : DocumentSessionFixture<NulloIdentityMap>
     {
+        // SAMPLE: using_max
         [Fact]
         public void get_max()
         {
@@ -23,6 +24,7 @@ namespace Marten.Testing.Linq
             var maxNumber = theSession.Query<Target>().Max(t => t.Number);
             maxNumber.ShouldBe(42);
         }
+        // ENDSAMPLE
 
         [Fact]
         public async Task get_max_async()
@@ -37,6 +39,7 @@ namespace Marten.Testing.Linq
             maxNumber.ShouldBe(42);
         }
 
+        // SAMPLE: using_min
         [Fact]
         public void get_min()
         {
@@ -49,6 +52,7 @@ namespace Marten.Testing.Linq
             var minNumber = theSession.Query<Target>().Min(t => t.Number);
             minNumber.ShouldBe(-5);
         }
+        // ENDSAMPLE
 
         [Fact]
         public async Task get_min_async()
@@ -63,7 +67,7 @@ namespace Marten.Testing.Linq
             maxNumber.ShouldBe(-5);
         }
 
-        [Fact]
+        // SAMPLE: using_average
         public void get_average()
         {
             theSession.Store(new Target { Color = Colors.Blue, Number = 1 });
@@ -75,6 +79,7 @@ namespace Marten.Testing.Linq
             var average = theSession.Query<Target>().Average(t => t.Number);
             average.ShouldBe(10);
         }
+        // ENDSAMPLE
 
         [Fact]
         public async Task get_average_async()


### PR DESCRIPTION
First batch for #278 
Added documentation for:
* Select() transforms (projections)
* Case insensitive searches by string
* string.Equals Linq searches.
* Contains() / Any() searches with IEnumerable, IList, List
* min/max/avg/sum operators in the Linq support