### PR TITLE
Support custom aggregator

### DIFF
--- a/src/Marten.Testing/Events/Projections/AggregatorTests.cs
+++ b/src/Marten.Testing/Events/Projections/AggregatorTests.cs
@@ -69,7 +69,7 @@ namespace Marten.Testing.Events.Projections
                 .Add(new MembersJoined {Members = new string[] {"Gandalf", "Boromir", "Gimli", "Legolas"}})
                 .Add(new MembersDeparted() {Members = new string[] {"Frodo", "Sam"}});
 
-            var party = theAggregator.Build(stream.Events);
+            var party = theAggregator.Build(stream.Events, null);
 
             party.Name.ShouldBe("Destroy the Ring");
 

--- a/src/Marten/Events/AggregationQueryHandler.cs
+++ b/src/Marten/Events/AggregationQueryHandler.cs
@@ -11,10 +11,10 @@ namespace Marten.Events
 {
     internal class AggregationQueryHandler<T> : IQueryHandler<T> where T : class, new()
     {
-        private readonly Aggregator<T> _aggregator;
+        private readonly IAggregator<T> _aggregator;
         private readonly EventQueryHandler _inner;
 
-        public AggregationQueryHandler(Aggregator<T> aggregator, EventQueryHandler inner)
+        public AggregationQueryHandler(IAggregator<T> aggregator, EventQueryHandler inner)
         {
             _aggregator = aggregator;
             _inner = inner;

--- a/src/Marten/Events/AggregationQueryHandler.cs
+++ b/src/Marten/Events/AggregationQueryHandler.cs
@@ -13,11 +13,13 @@ namespace Marten.Events
     {
         private readonly IAggregator<T> _aggregator;
         private readonly EventQueryHandler _inner;
+        private readonly IDocumentSession _session;
 
-        public AggregationQueryHandler(IAggregator<T> aggregator, EventQueryHandler inner)
+        public AggregationQueryHandler(IAggregator<T> aggregator, EventQueryHandler inner, IDocumentSession session = null)
         {
             _aggregator = aggregator;
             _inner = inner;
+            _session = session;
         }
 
         public void ConfigureCommand(NpgsqlCommand command)
@@ -31,14 +33,14 @@ namespace Marten.Events
         {
             var @events = _inner.Handle(reader, map);
 
-            return _aggregator.Build(@events);
+            return _aggregator.Build(@events, _session);
         }
 
         public async Task<T> HandleAsync(DbDataReader reader, IIdentityMap map, CancellationToken token)
         {
             var @events = await _inner.HandleAsync(reader, map, token).ConfigureAwait(false);
 
-            return _aggregator.Build(@events);
+            return _aggregator.Build(@events, _session);
         }
     }
 }

--- a/src/Marten/Events/Event.cs
+++ b/src/Marten/Events/Event.cs
@@ -9,7 +9,7 @@ namespace Marten.Events
         int Version { get; set; }
         object Data { get; }
 
-        void Apply<TAggregate>(TAggregate state, Aggregator<TAggregate> aggregator)
+        void Apply<TAggregate>(TAggregate state, IAggregator<TAggregate> aggregator)
             where TAggregate : class, new();
     }
 
@@ -26,7 +26,7 @@ namespace Marten.Events
 
         object IEvent.Data => Data;
 
-        public virtual void Apply<TAggregate>(TAggregate state, Aggregator<TAggregate> aggregator)
+        public virtual void Apply<TAggregate>(TAggregate state, IAggregator<TAggregate> aggregator)
             where TAggregate : class, new()
         {
             aggregator.AggregatorFor<T>()?.Apply(state, Data);

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -208,11 +208,16 @@ namespace Marten.Events
             throw new NotSupportedException();
         }
 
-        public Aggregator<T> AggregateFor<T>() where T : class, new()
+        public void AggregateFor<T>(IAggregator<T> aggregator) where T : class, new()
+        {
+            _aggregates.AddOrUpdate(typeof (T), aggregator, (type, previous) => aggregator);
+        }
+
+        public IAggregator<T> AggregateFor<T>() where T : class, new()
         {
             return _aggregates
                 .GetOrAdd(typeof (T), type => new Aggregator<T>())
-                .As<Aggregator<T>>();
+                .As<IAggregator<T>>();
         }
 
 
@@ -224,7 +229,7 @@ namespace Marten.Events
             }).AggregateType;
         }
 
-        public Aggregator<T> AggregateStreamsInlineWith<T>() where T : class, new()
+        public IAggregator<T> AggregateStreamsInlineWith<T>() where T : class, new()
         {
             var aggregator = AggregateFor<T>();
             var finder = new AggregateFinder<T>();

--- a/src/Marten/Events/EventStore.cs
+++ b/src/Marten/Events/EventStore.cs
@@ -83,7 +83,7 @@ namespace Marten.Events
         {
             var inner = new EventQueryHandler(_selector, streamId, version, timestamp);
             var aggregator = _schema.Events.AggregateFor<T>();
-            var handler = new AggregationQueryHandler<T>(aggregator, inner);
+            var handler = new AggregationQueryHandler<T>(aggregator, inner, _session);
 
             return _connection.Fetch(handler, null);
         }
@@ -93,7 +93,7 @@ namespace Marten.Events
         {
             var inner = new EventQueryHandler(_selector, streamId, version, timestamp);
             var aggregator = _schema.Events.AggregateFor<T>();
-            var handler = new AggregationQueryHandler<T>(aggregator, inner);
+            var handler = new AggregationQueryHandler<T>(aggregator, inner, _session);
 
             return _connection.FetchAsync(handler, null, token);
         }

--- a/src/Marten/Events/IEventStoreConfiguration.cs
+++ b/src/Marten/Events/IEventStoreConfiguration.cs
@@ -17,9 +17,11 @@ namespace Marten.Events
         IEnumerable<IAggregator> AllAggregates();
         EventMapping EventMappingFor(string eventType);
         bool IsActive { get; }
-        Aggregator<T> AggregateFor<T>() where T : class, new();
+
+        void AggregateFor<T>(IAggregator<T> aggregator) where T : class, new();
+        IAggregator<T> AggregateFor<T>() where T : class, new();
         Type AggregateTypeFor(string aggregateTypeName);
-        Aggregator<T> AggregateStreamsInlineWith<T>() where T : class, new();
+        IAggregator<T> AggregateStreamsInlineWith<T>() where T : class, new();
 
         void TransformEventsInlineWith<TEvent, TView>(ITransform<TEvent, TView> transform);
         void InlineTransformation(IProjection projection);

--- a/src/Marten/Events/Projections/AggregationProjection.cs
+++ b/src/Marten/Events/Projections/AggregationProjection.cs
@@ -9,9 +9,9 @@ namespace Marten.Events.Projections
     public class AggregationProjection<T> : IProjection where T : class, new()
     {
         private readonly IAggregationFinder<T> _finder;
-        private readonly Aggregator<T> _aggregator;
+        private readonly IAggregator<T> _aggregator;
 
-        public AggregationProjection(IAggregationFinder<T> finder, Aggregator<T> aggregator)
+        public AggregationProjection(IAggregationFinder<T> finder, IAggregator<T> aggregator)
         {
             _finder = finder;
             _aggregator = aggregator;
@@ -52,6 +52,5 @@ namespace Marten.Events.Projections
             return session.PendingChanges.AllChangedFor<EventStream>()
                 .Where(_aggregator.AppliesTo).ToArray();
         }
-
     }
 }

--- a/src/Marten/Events/Projections/Aggregator.cs
+++ b/src/Marten/Events/Projections/Aggregator.cs
@@ -34,7 +34,7 @@ namespace Marten.Events.Projections
 
         public string Alias { get; }
 
-        public T Build(IEnumerable<IEvent> events)
+        public T Build(IEnumerable<IEvent> events, IDocumentSession session)
         {
             var state = new T();
 

--- a/src/Marten/Events/Projections/Aggregator.cs
+++ b/src/Marten/Events/Projections/Aggregator.cs
@@ -7,7 +7,7 @@ using Marten.Util;
 
 namespace Marten.Events.Projections
 {
-    public class Aggregator<T> : IAggregator where T : class, new()
+    public class Aggregator<T> : IAggregator<T> where T : class, new()
     {
         public static readonly string ApplyMethod = "Apply";
 

--- a/src/Marten/Events/Projections/IAggregator.cs
+++ b/src/Marten/Events/Projections/IAggregator.cs
@@ -1,10 +1,18 @@
 using System;
+using System.Collections.Generic;
 
 namespace Marten.Events.Projections
 {
-    public interface IAggregator 
+    public interface IAggregator
     {
         Type AggregateType { get; }
         string Alias { get; }
+        bool AppliesTo(EventStream stream);
+    }
+
+    public interface IAggregator<T> : IAggregator
+    {
+        IAggregation<T, TEvent> AggregatorFor<TEvent>();
+        T Build(IEnumerable<IEvent> events);
     }
 }

--- a/src/Marten/Events/Projections/IAggregator.cs
+++ b/src/Marten/Events/Projections/IAggregator.cs
@@ -13,6 +13,6 @@ namespace Marten.Events.Projections
     public interface IAggregator<T> : IAggregator
     {
         IAggregation<T, TEvent> AggregatorFor<TEvent>();
-        T Build(IEnumerable<IEvent> events);
+        T Build(IEnumerable<IEvent> events, IDocumentSession session);
     }
 }

--- a/src/Marten/QuerySession.cs
+++ b/src/Marten/QuerySession.cs
@@ -9,7 +9,6 @@ using Marten.Linq.QueryHandlers;
 using Marten.Schema;
 using Marten.Services;
 using Marten.Services.BatchQuerying;
-using Marten.Util;
 using Npgsql;
 using Remotion.Linq.Parsing.Structure;
 

--- a/src/Marten/Services/BatchQuerying/BatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQuery.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Baseline;


### PR DESCRIPTION
This update makes the event Aggregator fully pluggable. This was not possible because the implementation was used instead of the interface in many places. 

I use it to support a different way to build aggregates. (See https://gist.github.com/tim-cools/694ba34dbb93b7a0cdf710886aa29275) 