### PR TITLE
BulkInsert timeout bug

### DIFF
--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Bugs\Bug_336_completely_remove_crosses_schema_lines.cs" />
     <Compile Include="Bugs\Bug_382_bulk_insert_that_causes_multiple_batches.cs" />
     <Compile Include="Bugs\Bug_393_issue_with_identity_map.cs" />
+    <Compile Include="bulk_loader_overwrite_sql_tests.cs" />
     <Compile Include="Events\capturing_event_versions_on_existing_streams_after_append.cs" />
     <Compile Include="Events\EventStreamTester.cs" />
     <Compile Include="Events\fetch_a_single_event_with_metadata.cs" />

--- a/src/Marten.Testing/bulk_loader_overwrite_sql_tests.cs
+++ b/src/Marten.Testing/bulk_loader_overwrite_sql_tests.cs
@@ -1,0 +1,26 @@
+using Marten.Schema;
+using Marten.Schema.BulkLoading;
+using Marten.Testing.Documents;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing
+{
+    public class bulk_loader_overwrite_sql_tests : IntegratedFixture
+    {
+        private BulkLoader<Issue> _bulkLoader;
+
+        public bulk_loader_overwrite_sql_tests()
+        {
+            _bulkLoader = new BulkLoader<Issue>(theStore.Advanced.Serializer, DocumentMapping.For<Issue>(), null);
+        }
+
+        [Fact]
+        public void Should_generate_overwrite_update_sql_statement()
+        {
+            var sql = _bulkLoader.OverwriteDuplicatesFromTempTable();
+
+            sql.ShouldBe(@"update public.mt_doc_issue target SET data = source.data, mt_last_modified = source.mt_last_modified, mt_version = source.mt_version, mt_dotnet_type = source.mt_dotnet_type FROM mt_doc_issue_temp source WHERE source.id = target.id");
+        }
+    }
+}

--- a/src/Marten.Testing/bulk_loading_Tests.cs
+++ b/src/Marten.Testing/bulk_loading_Tests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Linq;
-using Marten.Schema;
+using Marten.Schema.Identity;
 using Marten.Services;
 using Marten.Testing.Fixtures;
 using Shouldly;

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -246,10 +246,10 @@ namespace Marten
             }
             else if (mode == BulkInsertMode.OverwriteExisting)
             {
-                var copy = loader.CopyNewDocumentsFromTempTable();
                 var overwrite = loader.OverwriteDuplicatesFromTempTable();
-
-                conn.RunSql(copy, overwrite);
+                var copy = loader.CopyNewDocumentsFromTempTable();
+                
+                conn.RunSql(overwrite, copy);
             }
         }
 

--- a/src/Marten/Schema/BulkLoading/BulkLoader.cs
+++ b/src/Marten/Schema/BulkLoading/BulkLoader.cs
@@ -77,12 +77,8 @@ namespace Marten.Schema.BulkLoading
             var columns = table.Columns.Select(x => $"\"{x.Name}\"").Join(", ");
             var selectColumns = table.Columns.Select(x => $"{_tempTableName}.\"{x.Name}\"").Join(", ");
 
-
-
             return $@"insert into {storageTable} ({columns}) (select {selectColumns} from {_tempTableName} 
                          left join {storageTable} on {_tempTableName}.id = {storageTable}.id where {storageTable}.id is null)";
-
-
         }
 
         public string OverwriteDuplicatesFromTempTable()
@@ -90,18 +86,10 @@ namespace Marten.Schema.BulkLoading
             var table = _mapping.SchemaObjects.StorageTable();
             var storageTable = table.Table.QualifiedName;
 
-
-
             var updates = table.Columns.Where(x => x.Name != "id")
-                .Select(x => $"\"{x.Name}\"").Join(", ");
+                .Select(x => $"{x.Name} = source.{x.Name}").Join(", ");
 
-            var values = table.Columns.Where(x => x.Name != "id")
-                .Select(x => $"temp.\"{x.Name}\"").Join(", ");
-
-
-            return $@"update {storageTable} as docs set ({updates}) = ({values}) 
-                         from {_tempTableName} as temp where temp.id in (select id from {storageTable})";
-
+            return $@"update {storageTable} target SET {updates} FROM {_tempTableName} source WHERE source.id = target.id";
         }
 
         public string CreateTempTableForCopying()
@@ -130,3 +118,4 @@ namespace Marten.Schema.BulkLoading
         }
     }
 }
+ 


### PR DESCRIPTION
Changed the SQL statement for updating the original table with the newly bulk inserted documents

Changed the order of execution for when using bulk insert in mode `OverwriteExisting`. First, all the duplicates are updated, after that the new documents are inserted .

Should fix #388 