### PR TITLE
added support to delete where true

### DIFF
--- a/src/Marten.Testing/Schema/Hierarchies/end_to_end_document_hierarchy_usage_Tests.cs
+++ b/src/Marten.Testing/Schema/Hierarchies/end_to_end_document_hierarchy_usage_Tests.cs
@@ -23,6 +23,19 @@ namespace Marten.Testing.Schema.Hierarchies
         }
 
         [Fact]
+        public void can_delete_all_subclass()
+        {
+            loadData();
+
+            theSession.DeleteWhere<SuperUser>(x => true);
+            theSession.SaveChanges();
+
+            theSession.Query<SuperUser>().Count().ShouldBe(0);
+            theSession.Query<AdminUser>().Count().ShouldBe(2);
+            theSession.Query<User>().Count().ShouldBe(4);
+        }
+
+        [Fact]
         public void can_delete_by_the_hierarchy()
         {
             loadData();

--- a/src/Marten/Linq/WhereClauseVisitor.cs
+++ b/src/Marten/Linq/WhereClauseVisitor.cs
@@ -97,6 +97,12 @@ namespace Marten.Linq
                 return base.VisitUnary(node);
             }
 
+            protected override Expression VisitConstant(ConstantExpression node)
+            {
+                if (node.Type == typeof(bool) && (bool)node.Value) _top = new WhereFragment("true");
+                return base.VisitConstant(node);
+            }
+
             public class NotVisitor : RelinqExpressionVisitor
             {
                 private readonly WhereClauseVisitor _parent;


### PR DESCRIPTION
If you'd rather this work with session.DeleteWhere<SuperUser>() or session.Delete<SuperUser>(), I can implement it; I thought though it'd be better to be more explicit about deleting all documents of a certain type...