### PR TITLE
Support for configuration on .Index(...)

### DIFF
--- a/src/Marten.Testing/Acceptance/computed_indexes.cs
+++ b/src/Marten.Testing/Acceptance/computed_indexes.cs
@@ -7,6 +7,10 @@ using Xunit.Abstractions;
 
 namespace Marten.Testing.Acceptance
 {
+    using System;
+    using Marten.Schema;
+    using Npgsql;
+
     public class computed_indexes : IntegratedFixture
     {
         private readonly ITestOutputHelper _output;
@@ -31,14 +35,44 @@ namespace Marten.Testing.Acceptance
             using (var session = theStore.QuerySession())
             {
                 var cmd = session.Query<Target>().Where(x => x.Number == 3)
-                    .ToCommand();
+                                 .ToCommand();
 
                 // I used this to manually verify that the index was used in the query
                 // by doing Analyze in PGAdmin III
                 _output.WriteLine(cmd.CommandText);
 
                 session.Query<Target>().Where(x => x.Number == data.First().Number)
-                    .Select(x => x.Id).ToList().ShouldContain(data.First().Id);
+                       .Select(x => x.Id).ToList().ShouldContain(data.First().Id);
+            }
+        }
+
+        [Fact]
+        public void create_unique()
+        {
+            StoreOptions(_ => _.Schema.For<Target>().Index(x => x.String, x =>
+            {
+                x.IsUnique = true;
+                x.Casing = ComputedIndex.Casings.Lower;
+            }));
+
+            var data = Target.GenerateRandomData(10).ToArray();
+            data.Each(x => x.String += Guid.NewGuid().ToString());
+            theStore.BulkInsert(data.ToArray());
+
+            theStore.Schema.DbObjects.AllIndexes().Select(x => x.Name)
+                    .ShouldContain("mt_doc_target_uidx_string");
+            
+            using (var session = theStore.LightweightSession())
+            {
+                var item = session.Query<Target>().First(x => x.Number > 0);
+
+                var newItem = Target.GenerateRandomData(1).First();
+
+                newItem.String = item.String;
+
+                session.Store(newItem);
+
+                Assert.Throws<NpgsqlException>(() => session.SaveChanges()).Message.ShouldContain("duplicate");
             }
         }
 

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -138,7 +138,7 @@ namespace Marten
             /// <param name="pgType">Optional, overrides the Postgresql column type for the duplicated field</param>
             /// <param name="configure">Optional, allows you to customize the Postgresql database index configured for the duplicated field</param>
             /// <returns></returns>
-            public DocumentMappingExpression<T> Duplicate(Expression<Func<T, object>> expression, string pgType, Action<IndexDefinition> configure)
+            public DocumentMappingExpression<T> Duplicate(Expression<Func<T, object>> expression, string pgType = null, Action<IndexDefinition> configure = null)
             {
                 var visitor = new FindMembers();
                 visitor.Visit(expression);
@@ -153,7 +153,7 @@ namespace Marten
                 return this;
             }
 
-            public DocumentMappingExpression<T> Index(Expression<Func<T, object>> expression)
+            public DocumentMappingExpression<T> Index(Expression<Func<T, object>> expression, Action<ComputedIndex> configure = null)
             {
                 var visitor = new FindMembers();
                 visitor.Visit(expression);
@@ -161,6 +161,7 @@ namespace Marten
                 alter = mapping =>
                 {
                     var index = new ComputedIndex(mapping, visitor.Members.ToArray());
+                    configure?.Invoke(index);
                     mapping.Indexes.Add(index);
                 };
 

--- a/src/Marten/Schema/ComputedIndex.cs
+++ b/src/Marten/Schema/ComputedIndex.cs
@@ -6,29 +6,109 @@ namespace Marten.Schema
 {
     public class ComputedIndex : IIndexDefinition
     {
+        private readonly MemberInfo[] _members;
         private readonly string _locator;
         private readonly TableName _table;
-
+        private string _indexName;
 
         public ComputedIndex(DocumentMapping mapping, MemberInfo[] members)
         {
+            _members = members;
             var field = mapping.FieldFor(members);
             _locator = field.SqlLocator.Replace("d.", "");
             _table = mapping.Table;
-
-            IndexName = $"{mapping.Table.Name}_idx_{members.ToTableAlias()}";
         }
 
-        public string IndexName { get; }
+        /// <summary>
+        /// Creates the index as UNIQUE
+        /// </summary>
+        public bool IsUnique { get; set; }
+
+        /// <summary>
+        /// Specifies the index should be created in the background and not block/lock
+        /// </summary>
+        public bool IsConcurrent { get; set; }
+
+        /// <summary>
+        /// Specify the name of the index explicity
+        /// </summary>
+        public string IndexName
+        {
+            get { return _indexName ?? GenerateIndexName(); }
+            set { _indexName = value; }
+        }
+
+        /// <summary>
+        /// Allows you to specify a where clause on the index
+        /// </summary>
+        public string Where { get; set; }
+
+        /// <summary>
+        /// Marks the column value as upper/lower casing
+        /// </summary>
+        public Casings Casing { get; set; }
 
         public string ToDDL()
         {
-            return $"CREATE INDEX {IndexName} ON {_table.QualifiedName} (({_locator}))";
+            var index = IsUnique ? "CREATE UNIQUE INDEX" : "CREATE INDEX";
+            if (IsConcurrent)
+            {
+                index += " CONCURRENTLY";
+            }
+
+            index += $" {IndexName} ON {_table.QualifiedName}";
+
+            switch (Casing)
+            {
+                case Casings.Upper:
+                    index += $" (upper({_locator}))";
+                    break;
+                case Casings.Lower:
+                    index += $" (lower({_locator}))";
+                    break;
+                default:
+                    index += $" (({_locator}))";
+                    break;
+            }
+
+            if (Where.IsNotEmpty())
+            {
+                index += $" ({Where})";
+            }
+
+            return index + ";";
+        }
+
+        private string GenerateIndexName()
+        {
+            var name = _table.Name;
+
+            name += IsUnique ? "_uidx_" : "_idx_";
+
+            name += _members.ToTableAlias();
+
+            return name;
         }
 
         public bool Matches(ActualIndex index)
         {
             return index != null;
+        }
+
+        public enum Casings
+        {
+            /// <summary>
+            /// Leave the casing as is (default)
+            /// </summary>
+            Default,
+            /// <summary>
+            /// Change the casing to uppercase
+            /// </summary>
+            Upper,
+            /// <summary>
+            /// Change the casing to lowercase
+            /// </summary>
+            Lower
         }
     }
 }

--- a/src/Marten/Schema/ComputedIndex.cs
+++ b/src/Marten/Schema/ComputedIndex.cs
@@ -34,7 +34,15 @@ namespace Marten.Schema
         /// </summary>
         public string IndexName
         {
-            get { return _indexName ?? GenerateIndexName(); }
+            get
+            {
+                if (_indexName.IsNotEmpty())
+                {
+                    return "mt_" + _indexName;
+                }
+
+                return GenerateIndexName();
+            }
             set { _indexName = value; }
         }
 
@@ -51,6 +59,7 @@ namespace Marten.Schema
         public string ToDDL()
         {
             var index = IsUnique ? "CREATE UNIQUE INDEX" : "CREATE INDEX";
+
             if (IsConcurrent)
             {
                 index += " CONCURRENTLY";
@@ -73,7 +82,7 @@ namespace Marten.Schema
 
             if (Where.IsNotEmpty())
             {
-                index += $" ({Where})";
+                index += $" WHERE ({Where})";
             }
 
             return index + ";";


### PR DESCRIPTION
- [x] Can mark index as Unique
- [x] Can mark index as Concurrent
- [x] Support for Where Clauses
- [x] Support for naming the index
- [x] Support for casing of the value

This is my first cut at supporting some arguments on the `.Index` 

Notes:

- Cannot add unit test for Concurrent index as concurrent only exists for the creation of the index. It's not concurrent after the creation. 
- Named index's will be pre-fixed with `mt_` to ensure that we can pull them from the database as 'marten related indexes' and not adhoc indexes put into the system outside of marten.
- Where clauses take a string, they work but its a bit fiddly. 


I also made `Duplicate` arguments optional. 