### PR TITLE
Fixes test throwing InvalidOperationException: An operation is already in progress.

### DIFF
--- a/src/Marten.Testing/Events/Projections/inline_transformation_of_events.cs
+++ b/src/Marten.Testing/Events/Projections/inline_transformation_of_events.cs
@@ -98,11 +98,11 @@ namespace Marten.Testing.Events.Projections
 
             monsterEvents.Length.ShouldBe(2); // precondition
 
-            monsterEvents.Each(async e =>
+            foreach (var e in monsterEvents)
             {
                 var doc = await theSession.LoadAsync<MonsterDefeated>(e.Id);
                 doc.Monster.ShouldBe(e.Data.Name);
-            });
+            }
         }
 
     }


### PR DESCRIPTION
The Each() extension method was being used with an async action.  Npgsql's "op already in progress message" was accurate.  Changed to a simple foreach and can no longer repro the exception.