### PR TITLE
Added default value when adding the version column

### DIFF
--- a/src/Marten/Schema/DocumentSchemaObjects.cs
+++ b/src/Marten/Schema/DocumentSchemaObjects.cs
@@ -195,7 +195,10 @@ namespace Marten.Schema
             {
                 Directive = "DEFAULT transaction_timestamp()"
             });
-            table.Columns.Add(new TableColumn(DocumentMapping.VersionColumn, "uuid") {Directive = "NOT NULL"});
+            table.Columns.Add(new TableColumn(DocumentMapping.VersionColumn, "uuid")
+            {
+                Directive = "NOT NULL default(md5(random()::text || clock_timestamp()::text)::uuid)"
+            });
             table.Columns.Add(new TableColumn(DocumentMapping.DotNetTypeColumn, "varchar"));
 
             _mapping.DuplicatedFields.Select(x => x.ToColumn()).Each(x => table.Columns.Add(x));


### PR DESCRIPTION
Added default value to the `mt_version` column. 

`default(md5(random()::text || clock_timestamp()::text)::uuid)`

I setup the guid this way because it seems you need an extension to do it without, so to avoid Marten having a dependency on an extension I went with the recommended approach from http://stackoverflow.com/a/21327318/456813

I couldn't find any corresponding unit tests and wasn't sure how to add a test for this.