### PR TITLE
Add index method to Computed Index

### DIFF
--- a/src/Marten/Schema/ComputedIndex.cs
+++ b/src/Marten/Schema/ComputedIndex.cs
@@ -56,6 +56,11 @@ namespace Marten.Schema
         /// </summary>
         public Casings Casing { get; set; }
 
+        /// <summary>
+        /// Specifies the type of index to create
+        /// </summary>
+        public IndexMethod Method { get; set; } = IndexMethod.btree;
+
         public string ToDDL()
         {
             var index = IsUnique ? "CREATE UNIQUE INDEX" : "CREATE INDEX";
@@ -66,6 +71,11 @@ namespace Marten.Schema
             }
 
             index += $" {IndexName} ON {_table.QualifiedName}";
+            
+            if (Method != IndexMethod.btree)
+            {
+                index += $" USING {Method}";
+            }
 
             switch (Casing)
             {

--- a/src/Marten/Schema/IndexDefinition.cs
+++ b/src/Marten/Schema/IndexDefinition.cs
@@ -102,6 +102,7 @@ namespace Marten.Schema
         btree,
         hash,
         gist,
-        gin
+        gin,
+        brin
     }
 }


### PR DESCRIPTION
Added brin to the index method list now that we support 9.5+

Set the index type if set to anything other than btree. 

I suspect we will have to a lot of re-working around index types require the index definitions to be different in certain scenarios. Hopefully people will use this as a starting point so we can get a list of indexes people are trying to create and use that to figure out how best to abstract it out.