### PR TITLE
Add remove from collection patch

### DIFF
--- a/documentation/documentation/documents/advanced/patch_api.md
+++ b/documentation/documentation/documents/advanced/patch_api.md
@@ -1,7 +1,7 @@
 <!--Title:The Patching API-->
 
 <div class="alert alert-info">
-Using the Patching API in Marten requires the usage of Postgresql's <a href="https://github.com/plv8/plv8">PLV8 extension</a>. 
+Using the Patching API in Marten requires the usage of Postgresql's <a href="https://github.com/plv8/plv8">PLV8 extension</a>.
 </div>
 
 Marten's Patching API is a mechanism to update persisted documents without having to first load the document into memory.
@@ -14,6 +14,7 @@ As of 1.0, Marten supports mechanisms to:
 1. Increment a numeric value by some increment (1 by default)
 1. Append an element to a child array, list, or collection at the end
 1. Insert an element into a child array, list, or collection at a given position
+1. Remove an element from a child array, list, or collection
 1. Rename a persisted field or property to a new name for structural document changes
 
 The patch operation can be configured to either execute against a single document by supplying its id, or with a _Where_ clause expression.
@@ -27,7 +28,7 @@ To apply a patch to all documents matching a given criteria, use the following s
 
 ## Setting a single Property/Field
 
-The usage of `IDocumentSession.Patch().Set()` to change the value of a single persisted field is 
+The usage of `IDocumentSession.Patch().Set()` to change the value of a single persisted field is
 shown below:
 
 <[sample:set_an_immediate_property_by_id]>
@@ -59,13 +60,26 @@ being 0 so that a new item would be inserted at the beginning of the child colle
 
 <[sample:insert_first_complex_element]>
 
+## Remove an Element from a Child Collection
+
+The `Patch.Remove()` operation removes the given item from a child collection:
+
+<[sample:remove_primitive_element]>
+
+Removing complex items can also be accomplished, matching is performed on all fields:
+
+<[sample:remove_complex_element]>
+
+To remove reoccurring values from a collection specify `RemoveAction.RemoveAll`:
+
+<[sample:remove_repeated_primitive_element]>
+
 ## Rename a Property/Field
 
-In the case of changing the name of a property or field in your document type that's already persisted 
-in your Marten database, you have the option to apply a patch that will move the value from the 
-old name to the new name. 
+In the case of changing the name of a property or field in your document type that's already persisted
+in your Marten database, you have the option to apply a patch that will move the value from the
+old name to the new name.
 
 <[sample:rename_deep_prop]>
 
 Renaming can be used on nested values.
-

--- a/javascript/mt_patching.js
+++ b/javascript/mt_patching.js
@@ -1,23 +1,25 @@
+'use strict';
+
 function findDeep(doc, parts){
     var element = doc;
-    
+
     for (var i = 0; i < parts.length; i++){
         var child = parts[i];
         if (!element.hasOwnProperty(child)){
             element[child] = {};
         }
-        
+
         element = element[child];
     }
-    
+
     return element;
 }
 
 function locate(doc, patch){
     var parts = patch.path.split('.');
-    
+
     var element, prop;
-    
+
     if (parts.length > 0){
         prop = parts.pop();
         element = findDeep(doc, parts);
@@ -26,13 +28,13 @@ function locate(doc, patch){
         prop = patch.path;
         element = doc;
     }
-    
+
     return {element: element, prop: prop};
 }
 
 function setValue(doc, patch, location){
     location.element[location.prop] = patch.value;
-    
+
     return doc;
 }
 
@@ -43,14 +45,14 @@ function incrementValue(doc, patch, location){
     if (patch.increment){
         interval = parseInt(patch.increment);
     }
-    
+
     var existing = 0;
     if (location.element[location.prop]){
         existing = parseInt(location.element[location.prop]);
     }
-    
+
     location.element[location.prop] = existing + interval;
-    
+
     return doc;
 }
 
@@ -59,14 +61,14 @@ function incrementFloat(doc, patch, location){
     if (patch.increment){
         interval = parseFloat(patch.increment);
     }
-    
+
     var existing = 0;
     if (location.element[location.prop]){
         existing = parseFloat(location.element[location.prop]);
     }
-    
+
     location.element[location.prop] = existing + interval;
-    
+
     return doc;
 }
 
@@ -74,9 +76,9 @@ function appendElement(doc, patch, location){
     if (!location.element[location.prop]){
         location.element[location.prop] = [];
     }
-    
+
     location.element[location.prop].push(patch.value);
-    
+
     return doc;
 }
 
@@ -84,29 +86,58 @@ function insertElement(doc, patch, location){
     if (!location.element[location.prop]){
         location.element[location.prop] = [];
     }
-    
+
     var array = location.element[location.prop];
-    
+
     var index = 0;
     if (patch.index){
         index = parseInt(patch.index);
     }
-    
+
     array.splice(index, 0, patch.value);
-    
+
     return doc;
 }
 
 function rename(doc, patch, location){
     var actual = location.element[location.prop];
     delete location.element[location.prop];
-    
+
     location.element[patch.to] = actual;
-    
+
     return doc;
 }
 
+function removeElement(doc, patch, location){
+    var array = location.element[location.prop];
+    if (!array) return doc;
 
+    var indices = [];
+    array.every(function(element, index, _array) {
+      if (!deepEquals(patch.value, element)) return true;
+      indices.push(index);
+      return patch.action === 1;
+    });
+
+    for (var i = indices.length - 1; i > -1; i--) {
+      array.splice(indices[i], 1);
+    }
+
+    return doc;
+}
+
+function deepEquals(x, y) {
+    if (x === null || x === undefined || y === null || y === undefined) { return x === y; }
+    if (x === y || x.valueOf() === y.valueOf()) { return true; }
+    if (Array.isArray(x) && x.length !== y.length) { return false; }
+
+    if (!(x instanceof Object)) { return false; }
+    if (!(y instanceof Object)) { return false; }
+
+    var p = Object.keys(x);
+    return Object.keys(y).every(function (i) { return p.indexOf(i) !== -1; }) &&
+        p.every(function (i) { return deepEquals(x[i], y[i]); });
+}
 
 var ops = {
     'set': setValue,
@@ -114,15 +145,15 @@ var ops = {
     'increment_float': incrementFloat,
     'append': appendElement,
     'rename': rename,
-    'insert': insertElement
-    
+    'insert': insertElement,
+    'remove': removeElement
 }
 
 module.exports = function(doc, patch){
     // TODO -- throw if not a handler
     var handler = ops[patch.type];
-    
+
     var location = locate(doc, patch);
-    
-    return handler(doc, patch, location);    
+
+    return handler(doc, patch, location);
 }

--- a/src/Marten.Testing/Patching/PatchExpressionTests.cs
+++ b/src/Marten.Testing/Patching/PatchExpressionTests.cs
@@ -251,5 +251,27 @@ namespace Marten.Testing.Patching
             expression.Patch["to"].ShouldBe("Double");
             expression.Patch["path"].ShouldBe("Inner.Inner.Old");
         }
+
+        [Fact]
+        public void remove_first()
+        {
+            expression.Remove(x => x.NumberArray, 5);
+
+            expression.Patch["type"].ShouldBe("remove");
+            expression.Patch["value"].ShouldBe(5);
+            expression.Patch["path"].ShouldBe("NumberArray");
+            expression.Patch["action"].ShouldBe((int)RemoveAction.RemoveFirst);
+        }
+
+        [Fact]
+        public void remove_all()
+        {
+            expression.Remove(x => x.NumberArray, 5, RemoveAction.RemoveAll);
+
+            expression.Patch["type"].ShouldBe("remove");
+            expression.Patch["value"].ShouldBe(5);
+            expression.Patch["path"].ShouldBe("NumberArray");
+            expression.Patch["action"].ShouldBe((int) RemoveAction.RemoveAll);
+        }
     }
 }

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Patching\IPatchExpression.cs" />
     <Compile Include="Patching\PatchExpression.cs" />
     <Compile Include="Patching\PatchOperation.cs" />
+    <Compile Include="Patching\RemoveAction.cs" />
     <Compile Include="QuerySession.cs" />
     <Compile Include="Schema\Arguments\CurrentVersionArgument.cs" />
     <Compile Include="Schema\BulkLoading\BulkLoader.cs" />

--- a/src/Marten/Patching/IPatchExpression.cs
+++ b/src/Marten/Patching/IPatchExpression.cs
@@ -64,6 +64,15 @@ namespace Marten.Patching
         /// <param name="index"></param>
         void Insert<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, int index = 0);
 
+	    /// <summary>
+	    /// Remove element from a child collection on the persisted document
+	    /// </summary>
+	    /// <typeparam name="TElement"></typeparam>
+	    /// <param name="expression"></param>
+	    /// <param name="element"></param>
+	    /// <param name="action"></param>
+	    void Remove<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, RemoveAction action = RemoveAction.RemoveFirst);
+
         /// <summary>
         /// Rename a property or field in the persisted JSON document
         /// </summary>

--- a/src/Marten/Patching/PatchExpression.cs
+++ b/src/Marten/Patching/PatchExpression.cs
@@ -88,6 +88,17 @@ namespace Marten.Patching
             apply();
         }
 
+        public void Remove<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, 
+            RemoveAction action = RemoveAction.RemoveFirst)
+        {
+            Patch.Add("type", "remove");
+            Patch.Add("value", element);
+            Patch.Add("path", toPath(expression));
+            Patch.Add("action", (int) action);
+
+            apply();
+        }
+
         public void Rename(string oldName, Expression<Func<T, object>> expression)
         {
             Patch.Add("type", "rename");

--- a/src/Marten/Patching/RemoveAction.cs
+++ b/src/Marten/Patching/RemoveAction.cs
@@ -1,0 +1,8 @@
+namespace Marten.Patching
+{
+    public enum RemoveAction
+    {
+        RemoveFirst,
+        RemoveAll
+    }
+}

--- a/test/test_mt_patching.js
+++ b/test/test_mt_patching.js
@@ -4,195 +4,235 @@ var expect = require('chai').expect;
 describe('Patching API', function() {
   it('can set the first level prop', function() {
     var doc = {name: 'Frodo'};
-    
+
     var patch = {type: 'set', path: 'name', value: 'Bilbo'};
-    
-    expect(Patch(doc, patch)).to.deep.equal({name: 'Bilbo'}); 
+
+    expect(Patch(doc, patch)).to.deep.equal({name: 'Bilbo'});
   });
-  
+
   it('can set a deep prop that already exists', function() {
-     var doc = {member: {name: 'Frodo'}}; 
+     var doc = {member: {name: 'Frodo'}};
      var patch = {type: 'set', path: 'member.name', value: 'Bilbo'};
-     
-     expect(Patch(doc, patch)).to.deep.equal({member: {name: 'Bilbo'}}); 
+
+     expect(Patch(doc, patch)).to.deep.equal({member: {name: 'Bilbo'}});
   });
-  
+
   it('can set a deep prop does not already exists', function() {
-     var doc = {}; 
+     var doc = {};
      var patch = {type: 'set', path: 'member.name', value: 'Bilbo'};
-     
-     expect(Patch(doc, patch)).to.deep.equal({member: {name: 'Bilbo'}}); 
+
+     expect(Patch(doc, patch)).to.deep.equal({member: {name: 'Bilbo'}});
   });
-  
+
   it('can set a 3 deep prop that already exists', function() {
-     var doc = {quest: {member: {name: 'Frodo'}}}; 
+     var doc = {quest: {member: {name: 'Frodo'}}};
      var patch = {type: 'set', path: 'quest.member.name', value: 'Bilbo'};
-     
-     expect(Patch(doc, patch)).to.deep.equal({quest: {member: {name: 'Bilbo'}}}); 
+
+     expect(Patch(doc, patch)).to.deep.equal({quest: {member: {name: 'Bilbo'}}});
   });
-  
+
   it('can set a 3 deep prop that does not yet exists', function() {
-     var doc = {}; 
+     var doc = {};
      var patch = {type: 'set', path: 'quest.member.name', value: 'Bilbo'};
-     
-     expect(Patch(doc, patch)).to.deep.equal({quest: {member: {name: 'Bilbo'}}}); 
+
+     expect(Patch(doc, patch)).to.deep.equal({quest: {member: {name: 'Bilbo'}}});
   });
-  
+
   it('can increment int first level', function() {
     var doc = {count: 5};
     var patch = {type: 'increment', path: 'count', increment: 1};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({count: 6});
   });
-  
+
   it('can increment int first level, non default increment', function() {
     var doc = {count: 5};
     var patch = {type: 'increment', path: 'count', increment: 3};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({count: 8});
   });
-  
+
   it('can increment int first level default increment', function() {
     var doc = {count: 5};
     var patch = {type: 'increment', path: 'count'};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({count: 6});
   });
-  
+
   it('can increment int 2 deep', function() {
     var doc = {summary: {count: 5}};
     var patch = {type: 'increment', path: 'summary.count'};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({summary: {count: 6}});
   });
-  
+
   it('can increment int 3 deep', function() {
     var doc = {region: {summary: {count: 5}}};
     var patch = {type: 'increment', path: 'region.summary.count'};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({region: {summary: {count: 6}}});
   });
-  
+
   it('can increment float first level', function() {
     var doc = {count: 5.1};
     var patch = {type: 'increment_float', path: 'count', increment: 1};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({count: 6.1});
   });
-  
+
   it('can increment float first level, non default increment', function() {
     var doc = {count: 5.1};
     var patch = {type: 'increment_float', path: 'count', increment: 3.2};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({count: 8.3});
   });
-  
+
   it('can increment float first level default increment', function() {
     var doc = {count: 5.1};
     var patch = {type: 'increment_float', path: 'count'};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({count: 6.1});
   });
-  
+
   it('can increment float 2 deep', function() {
     var doc = {summary: {count: 5.1}};
     var patch = {type: 'increment_float', path: 'summary.count'};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({summary: {count: 6.1}});
   });
-  
+
   it('can increment float 3 deep', function() {
     var doc = {region: {summary: {count: 5.3}}};
     var patch = {type: 'increment_float', path: 'region.summary.count', increment: 1.1};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({region: {summary: {count: 6.4}}});
   });
-  
+
   it('can append to a first level array', function() {
     var doc = {numbers: []};
-    
+
     var patch = {type: 'append', path: 'numbers', value: 5};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({numbers: [5]});
   });
-  
+
   it('can append to a first level array with existing elements', function() {
     var doc = {numbers: [3, 4]};
-    
+
     var patch = {type: 'append', path: 'numbers', value: 5};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({numbers: [3, 4, 5]});
   });
-  
+
   it('can append to a first level array when the array does not already exist', function() {
     var doc = {};
-    
+
     var patch = {type: 'append', path: 'numbers', value: 5};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({numbers: [5]});
   });
-  
+
   it('can append to a 2nd level array when the array does not already exist', function() {
     var doc = {};
-    
+
     var patch = {type: 'append', path: 'region.numbers', value: 5};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({region: {numbers: [5]}});
   });
-  
+
   it('can append to a 3rd level array when the array does not already exist', function() {
     var doc = {division: {region: {numbers: [3, 4]}}};
-    
+
     var patch = {type: 'append', path: 'division.region.numbers', value: 5};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({division: {region: {numbers: [3, 4, 5]}}});
   });
-  
+
   it('can rename a prop shallow', function() {
     var doc = {number: 1};
-    
+
     var patch = {type: 'rename', path: 'number', to: 'value'};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({value: 1});
   });
-  
+
   it('can rename a prop 2 deep', function() {
     var doc = {region: {number: 1}};
-    
+
     var patch = {type: 'rename', path: 'region.number', to: 'value'};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({region: {value: 1}});
   });
-  
+
   it('can rename a prop 3 deep', function() {
     var doc = {country: {region: {number: 1}}};
-    
+
     var patch = {type: 'rename', path: 'country.region.number', to: 'value'};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({country: {region: {value: 1}}});
   });
-  
+
   it('can insert into a child collection with default', function() {
     var doc = {numbers: [3, 4]};
-    
+
     var patch = {type: 'insert', path: 'numbers', value: 5};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({numbers: [5, 3, 4]});
   });
-  
+
   it('can insert into a child collection with designated index', function() {
     var doc = {numbers: [3, 4]};
-    
+
     var patch = {type: 'insert', path: 'numbers', value: 5, index: 1};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({numbers: [3, 5, 4]});
   });
-  
+
   it('can insert into a 2 deep child collection with designated index', function() {
     var doc = {region: {numbers: [3, 4]}};
-    
+
     var patch = {type: 'insert', path: 'region.numbers', value: 5, index: 1};
-    
+
     expect(Patch(doc, patch)).to.deep.equal({region: {numbers: [3, 5, 4]}});
+  });
+
+  it('can remove from array', function() {
+    var doc = {items: ['foo', 'bar']};
+
+    var patch = {type: 'remove', path: 'items', value: 'bar'};
+
+    expect(Patch(doc, patch)).to.deep.equal({items: ['foo']});
+  });
+
+  it('can remove multiple occurances from array', function() {
+    var doc = {items: [0, 1, 0, 1, 0, 1]};
+
+    var patch = {type: 'remove', path: 'items', value: 1, action: 1};
+
+    expect(Patch(doc, patch)).to.deep.equal({items: [0, 0, 0]});
+  });
+
+  it('can remove from array when item not present', function() {
+    var doc = {items: ['foo']};
+
+    var patch = {type: 'remove', path: 'items', value: 'bar'};
+
+    expect(Patch(doc, patch)).to.deep.equal({items: ['foo']});
+  });
+
+  it('can remove from array when array does not exist', function() {
+    var doc = {};
+
+    var patch = {type: 'remove', path: 'items', value: 'bar'};
+
+    expect(Patch(doc, patch)).to.deep.equal({});
+  });
+
+  it('can remove object from array', function() {
+    var doc = {children: [{name: 'first'}, {name: 'second'}, {name: 'third'}]};
+
+    var patch = {type: 'remove', path: 'children', value: {name: 'second'}};
+
+    expect(Patch(doc, patch)).to.deep.equal({children: [{name: 'first'}, {name: 'third'}]});
   });
 });


### PR DESCRIPTION
Equality on complex child collections compares all fields, could possibly inspect for identity field as an optimisation.