### PR TITLE
FetchAll added to EventStore

### DIFF
--- a/src/Marten/Events/EventStore.cs
+++ b/src/Marten/Events/EventStore.cs
@@ -80,6 +80,18 @@ namespace Marten.Events
             return _connection.FetchAsync(handler, null, token);
         }
 
+        public IList<IEvent> FetchAll(DateTime? before = null, DateTime? after = null, int version = 0)
+        {
+            var handler = new EventsQueryHandler(_selector, before, after, version);
+            return _connection.Fetch(handler, null);
+        }
+
+        public Task<IList<IEvent>> FetchAllAsync(DateTime? before = null, DateTime? after = null, int version = 0, CancellationToken token = default(CancellationToken))
+        {
+            var handler = new EventsQueryHandler(_selector, before, after, version);
+            return _connection.FetchAsync(handler, null, token);
+        }
+
         public T AggregateStream<T>(Guid streamId, int version = 0, DateTime? timestamp = null) where T : class, new()
         {
             var inner = new EventQueryHandler(_selector, streamId, version, timestamp);

--- a/src/Marten/Events/EventsQueryHandler.cs
+++ b/src/Marten/Events/EventsQueryHandler.cs
@@ -1,0 +1,62 @@
+using System;
+using Marten.Linq.QueryHandlers;
+using Marten.Util;
+using Npgsql;
+
+namespace Marten.Events
+{
+    internal class EventsQueryHandler : ListQueryHandler<IEvent>
+    {
+        private readonly DateTime? _before;
+        private readonly DateTime? _after;
+        private readonly int _version;
+
+        public EventsQueryHandler(EventSelector selector, DateTime? before = null, DateTime? after = null, int version = 0) 
+            : base(selector)
+        {
+            if (before != null && before.Value.Kind != DateTimeKind.Utc)
+            {
+                throw new ArgumentOutOfRangeException(nameof(before), "This method only accepts UTC dates");
+            }
+
+            if (after != null && after.Value.Kind != DateTimeKind.Utc)
+            {
+                throw new ArgumentOutOfRangeException(nameof(before), "This method only accepts UTC dates");
+            }
+
+            _before = before;
+            _after = after;
+            _version = version;
+        }
+
+        public override Type SourceType => typeof(IEvent);
+
+        public override void ConfigureCommand(NpgsqlCommand command)
+        {
+            var sql = Selector.ToSelectClause(null);
+            sql += $" where 1 = 1";
+
+            if (_version > 0)
+            {
+                var versionParam = command.AddParameter(_version);
+                sql += " and version <= :" + versionParam.ParameterName;
+            }
+            
+            if (_before.HasValue)
+            {
+                var beforeParam = command.AddParameter(_before.Value);
+                sql += " and timestamp <= :" + beforeParam.ParameterName;
+            }
+
+            if (_after.HasValue)
+            {
+                var afterParam = command.AddParameter(_after.Value);
+                sql += " and timestamp >= :" + afterParam.ParameterName;
+            }
+
+            sql += " order by version";
+
+            command.AppendQuery(sql);
+        }        
+    }
+}

--- a/src/Marten/Events/IEventStore.cs
+++ b/src/Marten/Events/IEventStore.cs
@@ -52,6 +52,25 @@ namespace Marten.Events
         Task<IList<IEvent>> FetchStreamAsync(Guid streamId, int version = 0, DateTime? timestamp = null, CancellationToken token = default(CancellationToken));
 
         /// <summary>
+        /// Synchronously fetches all of the events
+        /// </summary>
+        /// <param name="before">If set, queries for events captured on or before this timestamp</param>
+        /// <param name="after">If set, queries for events captured on or after this timestamp</param>
+        /// <param name="version">If set, queries for events up to and including this version</param>
+        /// <returns></returns>
+        IList<IEvent> FetchAll(DateTime? before = null, DateTime? after = null, int version = 0);
+
+        /// <summary>
+        /// Asynchronously fetches all of the events for the named stream
+        /// </summary>
+        /// <param name="before">If set, queries for events captured on or before this timestamp</param>
+        /// <param name="after">If set, queries for events captured on or after this timestamp</param>
+        /// <param name="version">If set, queries for events up to and including this version</param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task<IList<IEvent>> FetchAllAsync(DateTime? before = null, DateTime? after = null, int version = 0, CancellationToken token = default(CancellationToken));
+
+        /// <summary>
         /// Perform a live aggregation of the raw events in this stream to a T object
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Events\Event.cs" />
     <Compile Include="Events\EventQueryHandler.cs" />
     <Compile Include="Events\EventSelector.cs" />
+    <Compile Include="Events\EventsQueryHandler.cs" />
     <Compile Include="Events\EventStore.cs" />
     <Compile Include="Events\EventStoreDatabaseObjects.cs" />
     <Compile Include="Events\EventStream.cs" />


### PR DESCRIPTION
This should allow users to retrieve **all** events regardless
of event type. They also have the option of using `before` and
`after` datetimes which allow for event windows. Finally, they
can still use versions to retrieve versioned events.