### PR TITLE
Clarify when ID is set when persisting documents

### DIFF
--- a/documentation/documentation/documents/basics/persisting.md
+++ b/documentation/documentation/documents/basics/persisting.md
@@ -7,6 +7,7 @@ At this point, the `IDocumentSession` is the sole [unit of work](http://martinfo
    what documents have changed
 1. The "dirty checking" session tries to determine which documents loaded from that `IDocumentSession` has any changes when `IDocumentSession.SaveChanges()` is called
 
+<div class="alert alert-info">When using a `Guid`/`CombGuid`, `Int`, or `Long` identifier, Marten will ensure the identity is set immediately after calling `IDocumentSession.Store` on the entity.</div>
 
 ## Storing Multiple Documents
 

--- a/documentation/documentation/documents/identity/index.md
+++ b/documentation/documentation/documents/identity/index.md
@@ -13,6 +13,8 @@ Besides being serializable, Marten's only other requirement for a .Net type to b
 1. When the ID member of a document is not settable or not-public a `NoOpIdGeneration` strategy is used. This ensures that Marten does not set the ID itself, so the ID should be generated manually.
 1. A `Custom` ID generator strategy is used to implement the ID generation strategy yourself.
 
+<div class="alert alert-info">When using a `Guid`/`CombGuid`, `Int`, or `Long` identifier, Marten will ensure the identity is set immediately after calling `IDocumentSession.Store` on the entity.</div>
+
 See these topics for more information about specific Id types:
 
 <[TableOfContents]>


### PR DESCRIPTION
> When using a `Guid`/`CombGuid`, `Int`, or `Long` identifier, Marten will ensure the identity is set immediately after calling `IDocumentSession.Store` on the entity.

- Updated Identity page
- Updated Basics/Persisting page

Let me know if you'd like the wording changed.