### PR TITLE
Update EventsQueryHandler exception parameter naming

### DIFF
--- a/src/Marten.Testing/Events/query_against_event_documents_Tests.cs
+++ b/src/Marten.Testing/Events/query_against_event_documents_Tests.cs
@@ -109,7 +109,7 @@ namespace Marten.Testing.Events
 
             theSession.SaveChanges();
 
-            var now = DateTime.UtcNow;        
+            var now = DateTime.UtcNow;
             var results = theSession.Events.FetchAll(before: now);
 
             results.Count.ShouldBe(0);
@@ -118,8 +118,13 @@ namespace Marten.Testing.Events
         [Fact]
         public void can_fetch_all_events_utc_only()
         {
-            Should.Throw<Exception>(() => theSession.Events.FetchAll(before: DateTime.Now));
-            Should.Throw<Exception>(() => theSession.Events.FetchAll(after: DateTime.Now));
+            Should
+                .Throw<ArgumentOutOfRangeException>(() => theSession.Events.FetchAll(before: DateTime.Now))
+                .ParamName.ShouldBe("before");
+
+            Should
+                .Throw<ArgumentOutOfRangeException>(() => theSession.Events.FetchAll(after: DateTime.Now))
+                .ParamName.ShouldBe("after");
         }
     }
 }

--- a/src/Marten/Events/EventsQueryHandler.cs
+++ b/src/Marten/Events/EventsQueryHandler.cs
@@ -21,7 +21,7 @@ namespace Marten.Events
 
             if (after != null && after.Value.Kind != DateTimeKind.Utc)
             {
-                throw new ArgumentOutOfRangeException(nameof(before), "This method only accepts UTC dates");
+                throw new ArgumentOutOfRangeException(nameof(after), "This method only accepts UTC dates");
             }
 
             _before = before;


### PR DESCRIPTION
Previous behavior used `before` parameter name with throwing an exception for the `after` parameter.
Also, remove trailing whitespace from related test.