### PR TITLE
Address Dictionary query generation

### DIFF
--- a/src/Marten.Testing/Linq/dictionary_is_translated.cs
+++ b/src/Marten.Testing/Linq/dictionary_is_translated.cs
@@ -1,4 +1,5 @@
 ﻿using Marten.Services;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -13,8 +14,8 @@ namespace Marten.Testing.Linq
             var query = theSession.Query<Target>().Where(t => t.StringDict.ContainsKey("foo"));
             var command = query.ToCommand(Marten.Linq.FetchType.FetchMany);
             var dictParam = command.Parameters[0];
-            dictParam.DbType.ShouldBeTheSameAs(System.Data.DbType.Object);
-            dictParam.Value.ShouldBeTheSameAs(new Dictionary<string, string> { { "foo", null } });
+            (dictParam.DbType == System.Data.DbType.String).ShouldBeTrue();
+            (dictParam.Value.ToString() == "foo").ShouldBeTrue();
         }
 
         [Fact]
@@ -23,8 +24,8 @@ namespace Marten.Testing.Linq
             var query = theSession.Query<Target>().Where(t => t.StringDict.Contains(new KeyValuePair<string, string>("foo", "bar")));
             var command = query.ToCommand(Marten.Linq.FetchType.FetchMany);
             var dictParam = command.Parameters[0];
-            dictParam.DbType.ShouldBeTheSameAs(System.Data.DbType.Object);
-            dictParam.Value.ShouldBeTheSameAs(new Dictionary<string, string> { { "foo", "bar" } });
+            (dictParam.DbType == System.Data.DbType.String).ShouldBeTrue();
+            (dictParam.Value.ToString() == "{\"foo\":\"bar\"}").ShouldBeTrue();
         }
 
         [Fact]
@@ -33,8 +34,8 @@ namespace Marten.Testing.Linq
             var query = theSession.Query<Target>().Where(t => ((IEnumerable<KeyValuePair<string,string>>) t.StringDict).Contains(new KeyValuePair<string, string>("foo", "bar")));
             var command = query.ToCommand(Marten.Linq.FetchType.FetchMany);
             var dictParam = command.Parameters[0];
-            dictParam.DbType.ShouldBeTheSameAs(System.Data.DbType.Object);
-            dictParam.Value.ShouldBeTheSameAs(new Dictionary<string, string> { { "foo", "bar" } });
+            (dictParam.DbType == System.Data.DbType.String).ShouldBeTrue();
+            (dictParam.Value.ToString() == "{\"foo\":\"bar\"}").ShouldBeTrue();
         }
     }
 }

--- a/src/Marten.Testing/Linq/dictionary_is_translated.cs
+++ b/src/Marten.Testing/Linq/dictionary_is_translated.cs
@@ -1,0 +1,40 @@
+﻿using Marten.Services;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Marten.Testing.Linq
+{
+    public class dictionary_is_translated : DocumentSessionFixture<NulloIdentityMap>
+    {
+        [Fact]
+        public void dictionary_containskey_is_translated_to_json_map()
+        {
+            var query = theSession.Query<Target>().Where(t => t.StringDict.ContainsKey("foo"));
+            var command = query.ToCommand(Marten.Linq.FetchType.FetchMany);
+            var dictParam = command.Parameters[0];
+            dictParam.DbType.ShouldBeTheSameAs(System.Data.DbType.Object);
+            dictParam.Value.ShouldBeTheSameAs(new Dictionary<string, string> { { "foo", null } });
+        }
+
+        [Fact]
+        public void icollection_keyvaluepair_contains_is_translated_to_json_map()
+        {
+            var query = theSession.Query<Target>().Where(t => t.StringDict.Contains(new KeyValuePair<string, string>("foo", "bar")));
+            var command = query.ToCommand(Marten.Linq.FetchType.FetchMany);
+            var dictParam = command.Parameters[0];
+            dictParam.DbType.ShouldBeTheSameAs(System.Data.DbType.Object);
+            dictParam.Value.ShouldBeTheSameAs(new Dictionary<string, string> { { "foo", "bar" } });
+        }
+
+        [Fact]
+        public void ienumerable_keyvaluepair_contains_is_translated_to_json_map()
+        {
+            var query = theSession.Query<Target>().Where(t => ((IEnumerable<KeyValuePair<string,string>>) t.StringDict).Contains(new KeyValuePair<string, string>("foo", "bar")));
+            var command = query.ToCommand(Marten.Linq.FetchType.FetchMany);
+            var dictParam = command.Parameters[0];
+            dictParam.DbType.ShouldBeTheSameAs(System.Data.DbType.Object);
+            dictParam.Value.ShouldBeTheSameAs(new Dictionary<string, string> { { "foo", "bar" } });
+        }
+    }
+}

--- a/src/Marten.Testing/Linq/dictionary_is_translated.cs
+++ b/src/Marten.Testing/Linq/dictionary_is_translated.cs
@@ -8,6 +8,11 @@ namespace Marten.Testing.Linq
 {
     public class dictionary_is_translated : DocumentSessionFixture<NulloIdentityMap>
     {
+        public dictionary_is_translated()
+        {
+            theStore.BulkInsert(Target.GenerateRandomData(100).ToArray());
+        }
+
         [Fact]
         public void dictionary_containskey_is_translated_to_json_map()
         {
@@ -18,23 +23,30 @@ namespace Marten.Testing.Linq
             (dictParam.Value.ToString() == "foo").ShouldBeTrue();
         }
 
+        // using key0 and value0 for these because the last node, which is deep, should have at least a single dict node
+
+        [Fact]
+        public void dict_can_query_using_containskey()
+        {
+            var results = theSession.Query<Target>().Where(x => x.StringDict.ContainsKey("key0")).ToList();
+            results.All(r => r.StringDict.ContainsKey("key0")).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void dict_can_query_using_containsKVP()
+        {
+            var kvp = new KeyValuePair<string, string>("key0", "value0");
+            var results = theSession.Query<Target>().Where(x => x.StringDict.Contains(kvp)).ToList();
+            results.All(r => r.StringDict.Contains(kvp)).ShouldBeTrue();
+        }
+
         [Fact]
         public void icollection_keyvaluepair_contains_is_translated_to_json_map()
         {
             var query = theSession.Query<Target>().Where(t => t.StringDict.Contains(new KeyValuePair<string, string>("foo", "bar")));
             var command = query.ToCommand(Marten.Linq.FetchType.FetchMany);
             var dictParam = command.Parameters[0];
-            (dictParam.DbType == System.Data.DbType.String).ShouldBeTrue();
-            (dictParam.Value.ToString() == "{\"foo\":\"bar\"}").ShouldBeTrue();
-        }
-
-        [Fact]
-        public void ienumerable_keyvaluepair_contains_is_translated_to_json_map()
-        {
-            var query = theSession.Query<Target>().Where(t => ((IEnumerable<KeyValuePair<string,string>>) t.StringDict).Contains(new KeyValuePair<string, string>("foo", "bar")));
-            var command = query.ToCommand(Marten.Linq.FetchType.FetchMany);
-            var dictParam = command.Parameters[0];
-            (dictParam.DbType == System.Data.DbType.String).ShouldBeTrue();
+            (dictParam.NpgsqlDbType == NpgsqlTypes.NpgsqlDbType.Jsonb).ShouldBeTrue();
             (dictParam.Value.ToString() == "{\"foo\":\"bar\"}").ShouldBeTrue();
         }
     }

--- a/src/Marten.Testing/Linq/query_for_json_format.cs
+++ b/src/Marten.Testing/Linq/query_for_json_format.cs
@@ -36,7 +36,7 @@ namespace Marten.Testing.Linq
 }}, 
 ""UserName"": ""{UserName}"", 
 ""Birthdate"": ""{Birthdate.ToString("s")}""
-}}".Replace("\r\n", "");
+}}".Replace("\r\n", "").Replace("\n", "");
         }
     }
 

--- a/src/Marten.Testing/Target.cs
+++ b/src/Marten.Testing/Target.cs
@@ -91,6 +91,7 @@ namespace Marten.Testing
         public Target()
         {
             Id = Guid.NewGuid();
+            StringDict = new Dictionary<string, string>();
         }
 
         public Guid Id { get; set; }
@@ -125,6 +126,9 @@ namespace Marten.Testing
         public int? NullableNumber { get; set; }
         public DateTime? NullableDateTime { get; set; }
         public bool? NullableBoolean { get; set; }
+
+        public IDictionary<string,string> StringDict { get; set; }
+
     }
 
     public class Address

--- a/src/Marten.Testing/Target.cs
+++ b/src/Marten.Testing/Target.cs
@@ -83,6 +83,8 @@ namespace Marten.Testing
                 {
                     target.Children[i] = Random();
                 }
+
+                target.StringDict = Enumerable.Range(0, _random.Next(1, 10)).ToDictionary(i => $"key{i}", i => $"value{i}");
             }
 
             return target;

--- a/src/Marten/Linq/MartenExpressionParser.cs
+++ b/src/Marten/Linq/MartenExpressionParser.cs
@@ -69,7 +69,10 @@ namespace Marten.Linq
 
             // soft deletes
             new MaybeDeletedParser(),
-            new IsDeletedParser()
+            new IsDeletedParser(),
+
+            // dictionaries
+            new DictionaryExpressions()
         };
 
 

--- a/src/Marten/Linq/Parsing/DictionaryExpressions.cs
+++ b/src/Marten/Linq/Parsing/DictionaryExpressions.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq.Expressions;
+using Marten.Schema;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Marten.Linq.Parsing
+{
+    public class DictionaryExpressions : IMethodCallParser
+    {
+        static readonly MethodInfo ICollectionKVPStringStringContains = typeof(ICollection<KeyValuePair<string, string>>).GetMethod("Contains");
+        static readonly MethodInfo IDictionaryStringStringContainsKey = typeof(IDictionary<string, string>).GetMethod("ContainsKey");
+        static readonly MethodInfo IEnumerableKVPStringStringContains = typeof(IEnumerable<KeyValuePair<string, string>>).GetMethod("Contains");
+        public bool Matches(MethodCallExpression expression)
+        {
+            return 
+                expression.Method == ICollectionKVPStringStringContains 
+                || expression.Method == IDictionaryStringStringContainsKey 
+                || expression.Method == IEnumerableKVPStringStringContains;
+        }
+
+        public IWhereFragment Parse(IQueryableDocument mapping, ISerializer serializer, MethodCallExpression expression)
+        {
+            var finder = new FindMembers();
+            finder.Visit(expression);
+            var members = finder.Members;
+            var fieldlocator = mapping.FieldFor(members).SqlLocator;
+
+            if (expression.Method == ICollectionKVPStringStringContains)
+            {
+                return QueryFromICollectionContains(expression, fieldlocator, serializer);
+            }
+            else if (expression.Method == IDictionaryStringStringContainsKey)
+            {
+                return QueryFromDictionaryContainsKey(expression, fieldlocator);
+            }
+            else if (expression.Method == IEnumerableKVPStringStringContains)
+            {
+                return QueryFromIEnumerableContains(expression, fieldlocator, serializer);
+            }
+            else throw new NotImplementedException("Could not understand the format of the dictionary access");
+        }
+
+        static IWhereFragment QueryFromIEnumerableContains(MethodCallExpression expression, string fieldlocator, ISerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        static IWhereFragment QueryFromDictionaryContainsKey(MethodCallExpression expression, string fieldLocator)
+        {
+            var key = (string)expression.Arguments[0].Value();
+            return new WhereFragment($"{fieldLocator} ? ?", key);
+        }
+
+        static IWhereFragment QueryFromICollectionContains(MethodCallExpression expression, string fieldPath, ISerializer serializer)
+        {
+            var constant = expression.Arguments[0] as ConstantExpression;
+            var kvp = (KeyValuePair<string, string>)constant.Value;
+            var dict = serializer.ToJson(new Dictionary<string, string> { { kvp.Key, kvp.Value } });
+            return new WhereFragment($"{fieldPath} @> ?", dict);
+        }
+    }
+}

--- a/src/Marten/Linq/WhereFragment.cs
+++ b/src/Marten/Linq/WhereFragment.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Baseline;
 using Marten.Util;
 using Npgsql;
@@ -9,11 +8,15 @@ namespace Marten.Linq
     {
         private readonly string _sql;
         private readonly object[] _parameters;
+        private readonly string _token;
 
-        public WhereFragment(string sql, params object[] parameters)
+
+        public WhereFragment(string sql, params object[] parameters) : this(sql, "?", parameters) { }
+        public WhereFragment(string sql, string paramReplacementToken, params object[] parameters)
         {
             _sql = sql;
             _parameters = parameters;
+            _token = paramReplacementToken;
         }
 
         public string ToSql(NpgsqlCommand command)
@@ -22,7 +25,7 @@ namespace Marten.Linq
             _parameters.Each(x =>
             {
                 var param = command.AddParameter(x);
-                sql = sql.ReplaceFirst("?", ":" + param.ParameterName);
+                sql = sql.ReplaceFirst(_token, ":" + param.ParameterName);
             });
 
             return sql;

--- a/src/Marten/Linq/WhereFragment.cs
+++ b/src/Marten/Linq/WhereFragment.cs
@@ -1,18 +1,19 @@
 using Baseline;
 using Marten.Util;
 using Npgsql;
+using System;
+using System.Linq;
 
 namespace Marten.Linq
 {
-    public class WhereFragment : IWhereFragment
+    public class CustomizableWhereFragment : IWhereFragment
     {
         private readonly string _sql;
-        private readonly object[] _parameters;
+        private readonly Tuple<object, NpgsqlTypes.NpgsqlDbType?>[] _parameters;
         private readonly string _token;
 
 
-        public WhereFragment(string sql, params object[] parameters) : this(sql, "?", parameters) { }
-        public WhereFragment(string sql, string paramReplacementToken, params object[] parameters)
+        public CustomizableWhereFragment(string sql, string paramReplacementToken, params Tuple<object, NpgsqlTypes.NpgsqlDbType?>[] parameters)
         {
             _sql = sql;
             _parameters = parameters;
@@ -24,7 +25,7 @@ namespace Marten.Linq
             var sql = _sql;
             _parameters.Each(x =>
             {
-                var param = command.AddParameter(x);
+                var param = command.AddParameter(x.Item1, x.Item2);
                 sql = sql.ReplaceFirst(_token, ":" + param.ParameterName);
             });
 
@@ -35,5 +36,10 @@ namespace Marten.Linq
         {
             return _sql.Contains(sqlText);
         }
+    }
+
+    public class WhereFragment : CustomizableWhereFragment
+    {
+        public WhereFragment(string sql, params object[] parameters) : base(sql, "?", parameters.Select(x => Tuple.Create<object, NpgsqlTypes.NpgsqlDbType?>(x, null)).ToArray()) { }
     }
 }

--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -20,7 +20,8 @@ namespace Marten.Util
             {typeof (decimal), "decimal"},
             {typeof(float), "decimal" },
             {typeof(DateTime), "timestamp without time zone" },
-            {typeof (DateTimeOffset), "timestamp with time zone"}
+            {typeof (DateTimeOffset), "timestamp with time zone"},
+            {typeof (IDictionary<,>), "jsonb" },
         };
 
         private static readonly MethodInfo _getNgpsqlDbTypeMethod;
@@ -104,6 +105,9 @@ namespace Marten.Util
             {
                 return GetPgType(memberType.GetInnerTypeFromNullable());
             }
+
+            if (memberType.IsGenericType) return PgTypes[memberType.GetGenericTypeDefinition()];
+
 
             return PgTypes[memberType];
         }

--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -106,8 +106,7 @@ namespace Marten.Util
                 return GetPgType(memberType.GetInnerTypeFromNullable());
             }
 
-            if (memberType.IsGenericType) return PgTypes[memberType.GetGenericTypeDefinition()];
-
+            if (memberType.IsConstructedGenericType) return PgTypes[memberType.GetGenericTypeDefinition()];
 
             return PgTypes[memberType];
         }


### PR DESCRIPTION
Addresses #459 

There are some dramatic changes in this.
Applying fixes for the `IDictionary<,>.ContainsKey('tkey)` and `ICollection<KVP<,>>.Contains(KVP<,>)` cases was easy enough because those fit into the existing method-call based plugin architecture. There was a wrinkle in that the operator that I want to use in postgres is `?`, which is already used by the `WhereFragment` expansion, so I also took the opportunity to make a version of WhereFragment that has a configurable separator.

The drastic thing was adding in a pluggable `IBinaryExpressionParser` interface.  This was required so that I could easily get at cases where we're indexing into a dictionary on the right or left sides to pull out the keys and values to construct the comparison dictionary.  As you'd expect a ton of things broke right off the bat, so I spent some time tweaking the `Matches` condition on the `SimplePropertyBinaryExpressionParser`. Please  please please please please please sanity check me on that.  The tests pass on my local box now but there's no way they're exhaustive in this circumstance.

- [x] Should we add a publicly-facing extension point for `IBinaryExpressionParser` instances like there are for `IMethodCallParser` instances?
- [x] I'd also like to add some more tests actually storing and querying for data based on these dictionaries before I take the [WIP] off of this.
- [x] Also, thoughts about generic dictionary access?  I think it's safe to say that the most extreme we could go is `IDictionary<string, TValue>`, because json maps must have string keys, so is that worth going ahead and doing here?
- [x] Also, I want to buff out the binary parsing some more to accept more than dict["key"] == "value".