### PR TITLE
void Append(Guid stream, int expectedVersion, params object[] events)…

### DIFF
--- a/documentation/documentation/events/appending.md
+++ b/documentation/documentation/events/appending.md
@@ -49,3 +49,10 @@ If you have an existing stream, you can later append additional events with `IEv
 
 <[sample:append-events]>
 
+### Appending & Assertions ###
+
+`IEventStore.Append()` supports an overload taking in a parameter `int expectedVersion` that can be used to assert that events are inserted into the
+event stream if and only if the maximum event id for the stream matches the expected version after event insertions. Otherwise the transaction is aborted
+and a `EventStreamUnexpectedMaxEventIdException` exception is thrown.
+
+<[sample:append-events-assert-on-eventid]> 

--- a/src/Marten.Testing/Events/asserting_on_expected_event_version_on_append.cs
+++ b/src/Marten.Testing/Events/asserting_on_expected_event_version_on_append.cs
@@ -1,0 +1,58 @@
+using Shouldly;
+using Marten.Services;
+using Npgsql;
+using Xunit;
+
+namespace Marten.Testing.Events
+{
+    public class asserting_on_expected_event_version_on_append : DocumentSessionFixture<NulloIdentityMap>
+    {    
+        [Fact]
+        public void should_check_max_event_id_on_append()
+        {
+            var joined = new MembersJoined { Members = new string[] { "Rand", "Matt", "Perrin", "Thom" } };
+            var departed = new MembersDeparted { Members = new[] { "Thom" } };
+            
+            var stream = theSession.Events.StartStream<Quest>(joined);
+            theSession.Events.Append(stream, 2, departed);
+
+            theSession.SaveChanges();
+
+            var state = theSession.Events.FetchStreamState(stream);
+
+            state.Id.ShouldBe(stream);
+            state.Version.ShouldBe(2);
+        }
+
+        [Fact]
+        public void should_not_append_events_when_unexpected_max_version()
+        {
+            var joined = new MembersJoined { Members = new string[] { "Rand", "Matt", "Perrin", "Thom" } };            
+            var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+            var stream = theSession.Events.StartStream<Quest>(joined);
+            theSession.SaveChanges();
+
+            theSession.Events.Append(stream, 2, departed);
+
+            using (var session = theStore.OpenSession())
+            {                
+                var joined3 = new MembersJoined {Members = new[] {"Egwene"}};
+                var departed3 = new MembersDeparted {Members = new[] {"Perrin"}};
+
+                session.Events.Append(stream, joined3, departed3);
+                session.SaveChanges();
+            }
+
+            Assert.Throws<PostgresException>(() => theSession.SaveChanges());
+
+            using (var session = theStore.OpenSession())
+            {
+                var state = session.Events.FetchStreamState(stream);
+
+                state.Id.ShouldBe(stream);
+                state.Version.ShouldBe(3);
+            }
+        }
+    }
+}

--- a/src/Marten.Testing/Events/asserting_on_expected_event_version_on_append.cs
+++ b/src/Marten.Testing/Events/asserting_on_expected_event_version_on_append.cs
@@ -44,7 +44,7 @@ namespace Marten.Testing.Events
                 session.SaveChanges();
             }
 
-            Assert.Throws<PostgresException>(() => theSession.SaveChanges());
+            Assert.Throws<EventStreamUnexpectedMaxEventIdException>(() => theSession.SaveChanges());
 
             using (var session = theStore.OpenSession())
             {

--- a/src/Marten/Events/EventStore.cs
+++ b/src/Marten/Events/EventStore.cs
@@ -8,6 +8,8 @@ using Baseline;
 using Marten.Linq;
 using Marten.Schema;
 using Marten.Services;
+using Marten.Services.Deletes;
+using Marten.Services.Events;
 
 namespace Marten.Events
 {
@@ -48,6 +50,12 @@ namespace Marten.Events
 
                 _unitOfWork.StoreStream(eventStream);
             }
+        }
+
+        public void Append(Guid stream, int expectedVersion, params object[] events)
+        {
+            Append(stream, events);
+            _unitOfWork.Add(new AssertEventStreamMaxEventId(stream, expectedVersion, _schema.Events.Table.QualifiedName));
         }
 
         public Guid StartStream<T>(Guid id, params object[] events) where T : class, new()

--- a/src/Marten/Events/IEventStore.cs
+++ b/src/Marten/Events/IEventStore.cs
@@ -16,6 +16,15 @@ namespace Marten.Events
         void Append(Guid stream, params object[] events);
 
         /// <summary>
+        /// Append one or more events in order to an existing stream and verify that maximum event id for the stream
+        /// matches supplied expected version or transaction is aborted.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="expectedVersion">Expected maximum event version after append</param>
+        /// <param name="events"></param>
+        void Append(Guid stream, int expectedVersion, params object[] events);
+
+        /// <summary>
         /// Creates a new event stream based on a user-supplied Guid and appends the events in order to the new stream
         /// </summary>
         /// <typeparam name="TAggregate"></typeparam>

--- a/src/Marten/Services/EventStreamUnexpectedMaxEventIdException.cs
+++ b/src/Marten/Services/EventStreamUnexpectedMaxEventIdException.cs
@@ -1,0 +1,13 @@
+using System;
+using Marten.Services.Events;
+
+namespace Marten.Services
+{
+    public class EventStreamUnexpectedMaxEventIdException : Exception
+    {
+        public EventStreamUnexpectedMaxEventIdException(Exception inner) : base(EventContracts.UnexpectedMaxEventIdForStream, inner)
+        {
+            
+        }
+    }
+}

--- a/src/Marten/Services/Events/AssertEventStreamMaxEventId.cs
+++ b/src/Marten/Services/Events/AssertEventStreamMaxEventId.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Text;
+
+namespace Marten.Services.Events
+{
+    /// <summary>
+    /// Raise exception inside transaction if expected maximum id for event stream
+    /// does not match expectation
+    /// </summary>
+    public class AssertEventStreamMaxEventId : IStorageOperation
+    {
+        private readonly Guid stream;
+        private readonly int expectedVersion;
+        private readonly string tableName;
+
+        public AssertEventStreamMaxEventId(Guid stream, int expectedVersion, string tableName)
+        {
+            this.stream = stream;
+            this.expectedVersion = expectedVersion;
+            this.tableName = tableName;
+        }
+
+        public string _sql;
+        
+        void ICall.WriteToSql(StringBuilder builder)
+        {
+            builder.Append(_sql);
+        }
+
+        public void AddParameters(IBatchCommand batch)
+        {
+            // Parameterized queries won't work here: https://github.com/npgsql/npgsql/issues/331
+            // In order to parameterize, sproc would need to be created            
+            _sql = $@"DO $$ BEGIN IF
+  (SELECT max(events.version)
+   FROM {tableName} AS events
+   WHERE events.stream_id = '{stream}') <> {expectedVersion} THEN 
+RAISE EXCEPTION 'Unexpected MAX(id) for event stream'; END IF; END; $$;";
+        }
+
+        public override string ToString()
+        {
+            return _sql;
+        }
+    }
+}

--- a/src/Marten/Services/Events/AssertEventStreamMaxEventId.cs
+++ b/src/Marten/Services/Events/AssertEventStreamMaxEventId.cs
@@ -35,7 +35,7 @@ namespace Marten.Services.Events
   (SELECT max(events.version)
    FROM {tableName} AS events
    WHERE events.stream_id = '{stream}') <> {expectedVersion} THEN 
-RAISE EXCEPTION 'Unexpected MAX(id) for event stream'; END IF; END; $$;";
+RAISE EXCEPTION '{EventContracts.UnexpectedMaxEventIdForStream.Value}'; END IF; END; $$;";
         }
 
         public override string ToString()

--- a/src/Marten/Services/Events/EventContracts.cs
+++ b/src/Marten/Services/Events/EventContracts.cs
@@ -1,0 +1,36 @@
+﻿namespace Marten.Services.Events
+{
+    public sealed class EventContracts
+    {
+        public readonly string Value;
+
+        private bool Equals(EventContracts other)
+        {
+            return string.Equals(Value, other.Value);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is EventContracts && Equals((EventContracts) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value?.GetHashCode() ?? 0;
+        }
+
+        public static readonly EventContracts UnexpectedMaxEventIdForStream = new EventContracts("Unexpected MAX(id) for event stream");
+        
+        public static implicit operator string(EventContracts item)
+        {
+            return item.Value;
+        }
+
+        private EventContracts(string value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/src/Marten/Services/ManagedConnection.cs
+++ b/src/Marten/Services/ManagedConnection.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 using Baseline;
+using Marten.Services.Events;
 using Npgsql;
 
 namespace Marten.Services
@@ -50,6 +51,11 @@ namespace Marten.Services
             {
                 action(cmd);
                 Logger.LogSuccess(cmd);
+            }
+            catch (NpgsqlException e) when (e.Message.IndexOf(EventContracts.UnexpectedMaxEventIdForStream, StringComparison.Ordinal) > -1)
+            {
+                Logger.LogFailure(cmd, e);
+                throw new EventStreamUnexpectedMaxEventIdException(e);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
… for asserting event stream version on append.

This would be one way of asserting event stream version with batched execution, i.e. without issuing additional commands before commit. Don't know if it's the most elegant solution (query parametrization would require a sproc), but I'm throwing it out there as a solution...