### PR TITLE
Small fixes for Fetcher

### DIFF
--- a/src/Marten/Events/Projections/Async/EventPage.cs
+++ b/src/Marten/Events/Projections/Async/EventPage.cs
@@ -77,7 +77,5 @@ namespace Marten.Events.Projections.Async
         {
             return $"Event Page From: {From}, To: {To}, Count: {Count}";
         }
-
- 
     }
 }


### PR DESCRIPTION
- Fetcher assigns EventTypeNames property
- Removed unnecessary awaits
- Fixed continuation bug for logger which would run when proxy is completed

`Task.Factory.StartNew `with an async lambda will return a proxy task of type `Task<Task>`. This means the continuation would run immediately since the proxy task is completed before the inner task is completed. The simplest solution in the case we have here is to use `Task.Run` since the long-running flag is more harmful than helpful with async lambdas. 

http://blog.i3arnon.com/2015/07/02/task-run-long-running/

I decided to hint the scheduler that the continuation can run synchronously (on the transition of the antecedent task to completed, reusing the worker thread) since I think for logging we don't need to reschedule a task. Thoughts?