### PR TITLE
Moving sql closer to usage to avoid closure capturing

### DIFF
--- a/src/Marten/Events/Projections/Async/Daemon.cs
+++ b/src/Marten/Events/Projections/Async/Daemon.cs
@@ -210,12 +210,11 @@ namespace Marten.Events.Projections.Async
 
         private async Task<long> currentEventNumber(CancellationToken token)
         {
-            var sql = $"select max(seq_id) from {_store.Schema.Events.Table}";
             using (var conn = _store.Advanced.OpenConnection())
             {
                 return await conn.ExecuteAsync(async (cmd, tkn) =>
                 {
-                    cmd.Sql(sql);
+                    cmd.Sql($"select max(seq_id) from {_store.Schema.Events.Table}");
                     using (var reader = await cmd.ExecuteReaderAsync(tkn).ConfigureAwait(false))
                     {
                         var any = await reader.ReadAsync(tkn).ConfigureAwait(false);


### PR DESCRIPTION
By moving the sql statement closer to the command definition you capture in the closure only the `this` reference (which can be optimized) and therefore you opt-in for better delegate caching and less allocation (save additional display class generation)