### PR TITLE
Fix event stream fetchall with before|after

### DIFF
--- a/src/Marten.Testing/Acceptance/patching_api.cs
+++ b/src/Marten.Testing/Acceptance/patching_api.cs
@@ -1,8 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Marten.Patching;
 using Marten.Services;
-using Marten.Testing.Fixtures;
 using Shouldly;
 using Xunit;
 
@@ -355,9 +355,10 @@ namespace Marten.Testing.Acceptance
             var target2 = query.Load<Target>(target.Id);
             target2.NumberArray.Length.ShouldBe(initialCount - 1);
 
-            target2.NumberArray.ShouldHaveTheSameElementsAs(target.NumberArray.Except(new[] {child}));
+            target2.NumberArray.ShouldHaveTheSameElementsAs(target.NumberArray.ExceptFirst(child));
         }
     }
+
         // ENDSAMPLE
 
         // SAMPLE: remove_repeated_primitive_element
@@ -394,7 +395,7 @@ namespace Marten.Testing.Acceptance
         // ENDSAMPLE
 
         // SAMPLE: remove_complex_element
-        [Fact]
+    [Fact]
     public void remove_complex_element()
     {
         var target = Target.Random(true);
@@ -418,5 +419,24 @@ namespace Marten.Testing.Acceptance
         }
     }
         // ENDSAMPLE
+    }
+
+    internal static class EnumerableExtensions
+    {
+        public static IEnumerable<T> ExceptFirst<T>(this IEnumerable<T> enumerable, T item)
+        {
+            var encountered = false;
+            var expected = new List<T>();
+            foreach (var val in enumerable)
+            {
+                if (!encountered && val.Equals(item))
+                {
+                    encountered = true;
+                    continue;
+                }
+                expected.Add(val);
+            }
+            return expected;
+        }
     }
 }

--- a/src/Marten.Testing/Events/query_against_event_documents_Tests.cs
+++ b/src/Marten.Testing/Events/query_against_event_documents_Tests.cs
@@ -112,7 +112,26 @@ namespace Marten.Testing.Events
             var now = DateTime.UtcNow;
             var results = theSession.Events.FetchAll(before: now);
 
-            results.Count.ShouldBe(0);
+            results.Count.ShouldBe(4);
+        }
+
+        [Fact]
+        public void can_fetch_all_events_between_two_timestamps()
+        {
+            theSession.Events.StartStream<Quest>(joined1);
+            theSession.SaveChanges();
+
+            var from = DateTime.UtcNow;
+            theSession.Events.StartStream<Quest>(departed1, joined2);
+            theSession.SaveChanges();
+
+            var to = DateTime.UtcNow;
+            theSession.Events.StartStream<Quest>(departed2);
+            theSession.SaveChanges();
+
+            var results = theSession.Events.FetchAll(after: from, before: to);
+
+            results.Count.ShouldBe(2);
         }
 
         [Fact]

--- a/src/Marten/Events/EventsQueryHandler.cs
+++ b/src/Marten/Events/EventsQueryHandler.cs
@@ -2,6 +2,7 @@ using System;
 using Marten.Linq.QueryHandlers;
 using Marten.Util;
 using Npgsql;
+using NpgsqlTypes;
 
 namespace Marten.Events
 {
@@ -44,13 +45,13 @@ namespace Marten.Events
             
             if (_before.HasValue)
             {
-                var beforeParam = command.AddParameter(_before.Value);
+                var beforeParam = command.AddParameter(_before.Value, NpgsqlDbType.Timestamp);
                 sql += " and timestamp <= :" + beforeParam.ParameterName;
             }
 
             if (_after.HasValue)
             {
-                var afterParam = command.AddParameter(_after.Value);
+                var afterParam = command.AddParameter(_after.Value, NpgsqlDbType.Timestamp);
                 sql += " and timestamp >= :" + afterParam.ParameterName;
             }
 


### PR DESCRIPTION
Tests can_fetch_all_events_after_now and can_fetch_all_events_before_now were repeatedly failing running in BST timezone.

The Column `mt_events.timestamp` is defined as `timestamp without time zone` and is always populated with insertion time taken from the UTC time zone. Also EventsQueryHandler enforces that the DateTime given for either `before` or `after` parameters must have `DateTimeKind` of UTC.

However, the parameters for the query were prepared as `NpgsqlDbType.TimestampTZ` which causes Postgres to adjust the given value appropriate to the server's time zone.