### PR TITLE
One possible implementation of #318 Support overriding Command Timeou…

### DIFF
--- a/src/Marten.Testing/SessionOptionsTests.cs
+++ b/src/Marten.Testing/SessionOptionsTests.cs
@@ -13,18 +13,18 @@ namespace Marten.Testing
         {
             var container = Container.For<DevelopmentModeRegistry>();
             var store = container.GetInstance<IDocumentStore>();
-            
-            var options = new SessionOptions(timeout: 1);
+
+            var options = new SessionOptions() { Timeout = 1 };
 
             using (var session = store.OpenSession(options))
-            {                
+            {
                 var e = Assert.Throws<NpgsqlException>(() =>
                 {
                     session.Query<QuerySessionTests.FryGuy>("select pg_sleep(2)");
                 });
 
                 Assert.Contains("connected party did not properly respond after a period of time", e.InnerException.Message);
-            }            
+            }
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace Marten.Testing
                 session.SaveChanges();
             }
 
-            var options = new SessionOptions(timeout: 15);
+            var options = new SessionOptions() { Timeout = 15 };
 
             using (var query = store.QuerySession(options).As<QuerySession>())
             {

--- a/src/Marten.Testing/SessionOptionsTests.cs
+++ b/src/Marten.Testing/SessionOptionsTests.cs
@@ -1,0 +1,54 @@
+﻿using Baseline;
+using Marten.Services;
+using Npgsql;
+using StructureMap;
+using Xunit;
+
+namespace Marten.Testing
+{
+    public class SessionOptionsTests
+    {
+        [Fact]
+        public void can_choke_on_custom_timeout()
+        {
+            var container = Container.For<DevelopmentModeRegistry>();
+            var store = container.GetInstance<IDocumentStore>();
+            
+            var options = new SessionOptions(timeout: 1);
+
+            using (var session = store.OpenSession(options))
+            {                
+                var e = Assert.Throws<NpgsqlException>(() =>
+                {
+                    session.Query<QuerySessionTests.FryGuy>("select pg_sleep(2)");
+                });
+
+                Assert.Contains("connected party did not properly respond after a period of time", e.InnerException.Message);
+            }            
+        }
+
+        [Fact]
+        public void can_define_custom_timeout()
+        {
+            var container = Container.For<DevelopmentModeRegistry>();
+            var store = container.GetInstance<IDocumentStore>();
+
+            var guy1 = new QuerySessionTests.FryGuy();
+            var guy2 = new QuerySessionTests.FryGuy();
+            var guy3 = new QuerySessionTests.FryGuy();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(guy1, guy2, guy3);
+                session.SaveChanges();
+            }
+
+            var options = new SessionOptions(timeout: 15);
+
+            using (var query = store.QuerySession(options).As<QuerySession>())
+            {
+                query.LoadDocument<QuerySessionTests.FryGuy>(guy2.id).ShouldNotBeNull();
+            }
+        }
+    }
+}

--- a/src/Marten/IDocumentStore.cs
+++ b/src/Marten/IDocumentStore.cs
@@ -4,6 +4,7 @@ using System.Data;
 using Marten.Events.Projections;
 using Marten.Events.Projections.Async;
 using Marten.Schema;
+using Marten.Services;
 using Marten.Transforms;
 
 namespace Marten
@@ -43,6 +44,13 @@ namespace Marten
         /// <returns></returns>
         IDocumentSession OpenSession(DocumentTracking tracking = DocumentTracking.IdentityOnly,
             IsolationLevel isolationLevel = IsolationLevel.ReadCommitted);
+        /// <summary>
+        ///     Open a new IDocumentSession with the supplied DocumentTracking.
+        ///     "IdentityOnly" is the default.
+        /// </summary>
+        /// <param name="options">Additional options for session</param>
+        /// <returns></returns>
+        IDocumentSession OpenSession(SessionOptions options);
 
         /// <summary>
         ///     Convenience method to create a new "lightweight" IDocumentSession with no IdentityMap
@@ -64,6 +72,14 @@ namespace Marten
         /// </summary>
         /// <returns></returns>
         IQuerySession QuerySession();
+
+        /// <summary>
+        ///     Opens a read-only IQuerySession to the current document store for efficient
+        ///     querying without any underlying object tracking.
+        /// </summary>
+        /// <param name="options">Additional options for session. DocumentTracking is not applicable for IQuerySession.</param>        
+        /// <returns></returns>
+        IQuerySession QuerySession(SessionOptions options);
 
         /// <summary>
         ///     Bulk insert a potentially mixed enumerable of document types

--- a/src/Marten/Services/ManagedConnection.cs
+++ b/src/Marten/Services/ManagedConnection.cs
@@ -16,9 +16,10 @@ namespace Marten.Services
         {
         }
 
-        public ManagedConnection(IConnectionFactory factory, CommandRunnerMode mode, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted)
+        // 30 is NpgsqlCommand.DefaultTimeout - ok to burn it to the call site?
+        public ManagedConnection(IConnectionFactory factory, CommandRunnerMode mode, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, int commandTimeout = 30)
         {
-            _connection = new Lazy<TransactionState>(() => new TransactionState(factory, mode, isolationLevel));
+            _connection = new Lazy<TransactionState>(() => new TransactionState(factory, mode, isolationLevel, commandTimeout));
         }
 
         public IMartenSessionLogger Logger { get; set; } = new NulloMartenLogger();

--- a/src/Marten/Services/SessionOptions.cs
+++ b/src/Marten/Services/SessionOptions.cs
@@ -1,0 +1,29 @@
+﻿using System.Data;
+
+namespace Marten.Services
+{
+    public sealed  class SessionOptions
+    {
+        /// <summary>
+        /// Default to DocumentTracking.IdentityOnly
+        /// </summary>
+        public readonly DocumentTracking Tracking;
+
+        /// <summary>
+        /// Default to 30 seconds
+        /// </summary>
+        public readonly int Timeout;
+
+        /// <summary>
+        /// Default to IsolationLevel.ReadCommitted
+        /// </summary>
+        public readonly IsolationLevel IsolationLevel;
+
+        public SessionOptions(DocumentTracking tracking = DocumentTracking.IdentityOnly, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, int timeout = 30)
+        {
+            Tracking = tracking;
+            Timeout = timeout;
+            IsolationLevel = isolationLevel;
+        }
+    }
+}

--- a/src/Marten/Services/SessionOptions.cs
+++ b/src/Marten/Services/SessionOptions.cs
@@ -7,23 +7,16 @@ namespace Marten.Services
         /// <summary>
         /// Default to DocumentTracking.IdentityOnly
         /// </summary>
-        public readonly DocumentTracking Tracking;
+        public DocumentTracking Tracking { get; set; } = DocumentTracking.IdentityOnly;
 
         /// <summary>
         /// Default to 30 seconds
         /// </summary>
-        public readonly int Timeout;
+        public int Timeout { get; set; } = 30;
 
         /// <summary>
         /// Default to IsolationLevel.ReadCommitted
         /// </summary>
-        public readonly IsolationLevel IsolationLevel;
-
-        public SessionOptions(DocumentTracking tracking = DocumentTracking.IdentityOnly, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, int timeout = 30)
-        {
-            Tracking = tracking;
-            Timeout = timeout;
-            IsolationLevel = isolationLevel;
-        }
+        public IsolationLevel IsolationLevel { get; set; } = IsolationLevel.ReadCommitted;
     }
 }

--- a/src/Marten/Services/TransactionState.cs
+++ b/src/Marten/Services/TransactionState.cs
@@ -9,11 +9,13 @@ namespace Marten.Services
     {
         private readonly CommandRunnerMode _mode;
         private readonly IsolationLevel _isolationLevel;
+        private readonly int _commandTimeout;
 
-        public TransactionState(IConnectionFactory factory, CommandRunnerMode mode, IsolationLevel isolationLevel)
+        public TransactionState(IConnectionFactory factory, CommandRunnerMode mode, IsolationLevel isolationLevel, int commandTimeout)
         {
             _mode = mode;
             _isolationLevel = isolationLevel;
+            this._commandTimeout = commandTimeout;
             Connection = factory.Create();
             Connection.Open();
             BeginTransaction();
@@ -39,6 +41,7 @@ namespace Marten.Services
         {
             cmd.Connection = Connection;
             cmd.Transaction = Transaction;
+            cmd.CommandTimeout = _commandTimeout;
         }
 
         public NpgsqlTransaction Transaction { get; private set; }


### PR DESCRIPTION
…ts for a DocumentSession.

Burns 30, i.e. NpgsqlCommand.DefaultTimeout, to the callsite as default. Easy to refactor if not ok
and this PR is acceptable implementation for #318.