### PR TITLE
Use PG object comments to record metadata (IDocumentStore FQN)

### DIFF
--- a/src/Marten.Testing/Schema/add_origin_Tests.cs
+++ b/src/Marten.Testing/Schema/add_origin_Tests.cs
@@ -1,0 +1,39 @@
+﻿using Marten.Testing.Documents;
+using Marten.Util;
+using Xunit;
+
+namespace Marten.Testing.Schema
+{
+    public class add_origin_Tests
+    {     
+        [Fact]
+        public void origin_is_added_to_tables()
+        {
+            var user1 = new User { FirstName = "Jeremy" };
+            var user2 = new User { FirstName = "Max" };
+            var user3 = new User { FirstName = "Declan" };
+
+            using (var store = DocumentStore.For(ConnectionSource.ConnectionString))
+            {                
+                store.Advanced.Clean.CompletelyRemoveAll();
+
+                store.BulkInsert(new User[] { user1, user2, user3 });
+            }
+
+            using (var store = DocumentStore.For(ConnectionSource.ConnectionString))
+            using (var session = store.QuerySession())
+            using (var cmd = session.Connection.CreateCommand())
+            {
+                var mapping = store.Schema.MappingFor(typeof(User));
+
+                cmd.CommandText = "SELECT description from pg_description " +
+                                  "join pg_class on pg_description.objoid = pg_class.oid where relname = :name";
+                cmd.AddParameter("name", mapping.Table.Name);
+
+                var result = (string)cmd.ExecuteScalar();  
+                Assert.NotNull(result);              
+                Assert.Contains(typeof(IDocumentStore).AssemblyQualifiedName, result);
+            }
+        }
+    }
+}

--- a/src/Marten/Generation/OriginWriter.cs
+++ b/src/Marten/Generation/OriginWriter.cs
@@ -1,0 +1,17 @@
+namespace Marten.Generation
+{
+    internal static class OriginWriter
+    {        
+        private static readonly string MartenFqn = typeof(IDocumentStore).AssemblyQualifiedName;
+
+        public static string OriginStatement(string objectType, string objectName)
+        {
+            return $"COMMENT ON {objectType} {objectName} IS 'origin:{MartenFqn}';";
+        }
+
+        public static string OriginStatement(this TableDefinition definition)
+        {
+            return OriginStatement("TABLE", definition.Table.QualifiedName);
+        }
+    }
+}

--- a/src/Marten/Generation/TableDefinition.cs
+++ b/src/Marten/Generation/TableDefinition.cs
@@ -91,6 +91,8 @@ namespace Marten.Generation
             {
                 writer.WriteLine($"GRANT SELECT ({Columns.Select(x => x.Name).Join(", ")}) ON TABLE {Table.QualifiedName} TO \"{role}\";");
             });
+
+            writer.WriteLine(this.OriginStatement());
         }
 
         public TableColumn Column(string name)


### PR DESCRIPTION
Record Marten related metadata in PG object comments - first for tables created (so I can e.g. 
```
SELECT relname, description from pg_description
join pg_class on pg_description.objoid = pg_class.oid
where description like 'origin:Marten.IDocumentStore, Marten, Version=1.0.0.51046%'
```