### PR TITLE
Fix The UTC time represented when the offset is applied must be betwe…

### DIFF
--- a/src/Marten.Testing/Events/end_to_end_event_capture_and_fetching_the_stream_Tests.cs
+++ b/src/Marten.Testing/Events/end_to_end_event_capture_and_fetching_the_stream_Tests.cs
@@ -42,7 +42,7 @@ namespace Marten.Testing.Events
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
                 streamEvents.ElementAt(1).Version.ShouldBe(2);
 
-                streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTime)));
+                streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
             }
         }
 
@@ -71,7 +71,7 @@ namespace Marten.Testing.Events
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
                 streamEvents.ElementAt(1).Version.ShouldBe(2);
 
-                streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTime)));
+                streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
             }
         }
 
@@ -102,7 +102,7 @@ namespace Marten.Testing.Events
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
                 streamEvents.ElementAt(1).Version.ShouldBe(2);
 
-                streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTime)));
+                streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
             }
         }
 
@@ -133,7 +133,7 @@ namespace Marten.Testing.Events
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
                 streamEvents.ElementAt(1).Version.ShouldBe(2);
 
-                streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTime)));
+                streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
             }
         }
 


### PR DESCRIPTION
…en year 0 and 10,000 in tests

Got the error: The UTC time represented when the offset is applied must be between year 0 and 10,000.
while running theses tests. The fix below...