### PR TITLE
Ensure Index Names are always prefixed

### DIFF
--- a/src/Marten.Testing/MartenRegistryTests.cs
+++ b/src/Marten.Testing/MartenRegistryTests.cs
@@ -70,7 +70,7 @@ namespace Marten.Testing
 
             var index = mapping.IndexesFor("data").Single();
 
-            index.IndexName.ShouldBe("my_gin_index");
+            index.IndexName.ShouldBe("mt_my_gin_index");
             index.Method.ShouldBe(IndexMethod.gin);
             index.Expression.ShouldBe("? jsonb_path_ops");
         }

--- a/src/Marten.Testing/Schema/IndexDefinitionTests.cs
+++ b/src/Marten.Testing/Schema/IndexDefinitionTests.cs
@@ -60,6 +60,16 @@ namespace Marten.Testing.Schema
         }
 
         [Fact]
+        public void generate_ddl_for_custom_index_name()
+        {
+            var definition = new IndexDefinition(mapping, "foo");
+            definition.IndexName = "bar";
+
+            definition.ToDDL()
+                .ShouldBe("CREATE INDEX mt_bar ON public.mt_doc_target (\"foo\");");
+        }
+
+        [Fact]
         public void generate_ddl_for_single_column_unique()
         {
             var definition = new IndexDefinition(mapping, "foo");

--- a/src/Marten.Testing/Schema/configuring_searchable_fields_Tests.cs
+++ b/src/Marten.Testing/Schema/configuring_searchable_fields_Tests.cs
@@ -32,7 +32,7 @@ namespace Marten.Testing.Schema
         public void can_override_index_type_and_name_on_the_attribute()
         {
             var mapping = DocumentMapping.For<Organization>();
-            var indexDefinition = (IndexDefinition)mapping.Indexes.Single(x => x.IndexName == "idx_foo");
+            var indexDefinition = (IndexDefinition)mapping.Indexes.Single(x => x.IndexName == "mt_idx_foo");
 
             indexDefinition.Method.ShouldBe(IndexMethod.hash);
         }

--- a/src/Marten/Schema/ComputedIndex.cs
+++ b/src/Marten/Schema/ComputedIndex.cs
@@ -38,7 +38,7 @@ namespace Marten.Schema
             {
                 if (_indexName.IsNotEmpty())
                 {
-                    return "mt_" + _indexName;
+                    return DocumentMapping.MartenPrefix + _indexName;
                 }
 
                 return GenerateIndexName();

--- a/src/Marten/Schema/IndexDefinition.cs
+++ b/src/Marten/Schema/IndexDefinition.cs
@@ -27,7 +27,13 @@ namespace Marten.Schema
         {
             get
             {
-                return _indexName ?? $"{_parent.Table.Name}_idx_{_columns.Join("_")}";
+                if (_indexName.IsNotEmpty())
+                {
+                    return _indexName.StartsWith(DocumentMapping.MartenPrefix)
+                        ? _indexName
+                        : DocumentMapping.MartenPrefix + _indexName;
+                }
+                return $"{_parent.Table.Name}_idx_{_columns.Join("_")}";
             }
             set { _indexName = value; }
         }


### PR DESCRIPTION
In case anyone was already working around this defect will not append prefix to prefixed names, e.g. will not generate mt_mt_my_index