### PR TITLE
Add basic intersection support via the ?| jsonb operator

### DIFF
--- a/src/Marten.Testing/Linq/query_with_intersect.cs
+++ b/src/Marten.Testing/Linq/query_with_intersect.cs
@@ -1,0 +1,166 @@
+﻿using System.Linq;
+using Marten.Services;
+using Shouldly;
+using Xunit;
+using System.Collections.Generic;
+using System;
+
+namespace Marten.Testing.Linq
+{
+    public class query_with_intersect_Tests : DocumentSessionFixture<NulloIdentityMap>
+    {
+
+        private Guid[] favAuthors = new Guid[] { Guid.NewGuid(), Guid.NewGuid() };
+
+        public query_with_intersect_Tests()
+        {
+            // test fixtures
+            theSession.Store(new Article
+            {
+                Long = 1,
+                CategoryArray = new string[] { "sports", "finance", "health" },
+                CategoryList = new List<string> { "sports", "finance", "health" },
+                AuthorArray = favAuthors,
+                Published = true,
+            });
+
+            theSession.Store(new Article
+            {
+                Long = 2,
+                CategoryArray = new string[] { "sports", "astrology" },
+                AuthorArray = favAuthors.Take(1).ToArray(),
+            });
+
+            theSession.Store(new Article
+            {
+                Long = 3,
+                CategoryArray = new string[] { "health", "finance" },
+                CategoryList = new List<string> { "sports", "health" },
+                AuthorArray = favAuthors.Skip(1).ToArray(),
+            });
+
+            theSession.Store(new Article
+            {
+                Long = 4,
+                CategoryArray = new string[] { "health", "astrology" },
+                AuthorList = new List<Guid> { Guid.NewGuid() },
+                Published = true,
+            });
+
+            theSession.Store(new Article
+            {
+                Long = 5,
+                CategoryArray = new string[] { "sports", "nested" },
+                AuthorList = new List<Guid> { Guid.NewGuid(), favAuthors[1] },
+            });
+
+            theSession.Store(new Article
+            {
+                Long = 6,
+                AuthorArray = new Guid[] { favAuthors[0], Guid.NewGuid() },
+                ReferencedArticle = new Article
+                {
+                    CategoryArray = new string[] { "nested" },
+                }
+            });
+            theSession.SaveChanges();
+        }
+
+        [Fact]
+        public void query_string_array_intersects_array()
+        {
+            var interests = new string[] { "finance", "astrology" };
+            var res = theSession.Query<Article>()
+                .Where(x => x.CategoryArray.Any(s => interests.Contains(s)))
+                .OrderBy(x => x.Long)
+                .ToList();
+
+            res.Count.ShouldBe(4);
+            res[0].Long.ShouldBe(1);
+            res[1].Long.ShouldBe(2);
+            res[2].Long.ShouldBe(3);
+            res[3].Long.ShouldBe(4);
+        }
+
+        [Fact]
+        public void query_string_list_intersects_array()
+        {
+            var interests = new string[] { "health", "astrology" };
+            var res = theSession.Query<Article>()
+                .Where(x => x.CategoryList.Any(s => interests.Contains(s)))
+                .OrderBy(x => x.Long)
+                .ToList();
+
+            res.Count.ShouldBe(2);
+            res[0].Long.ShouldBe(1);
+            res[1].Long.ShouldBe(3);
+        }
+
+        [Fact]
+        public void query_nested_string_array_intersects_array()
+        {
+            var interests = new string[] { "nested" };
+            var res = theSession.Query<Article>()
+                .Where(x => x.ReferencedArticle.CategoryArray.Any(s => interests.Contains(s)))
+                .OrderBy(x => x.Long)
+                .ToList();
+
+            res.Count.ShouldBe(1);
+            res[0].Long.ShouldBe(6);
+        }
+
+        [Fact]
+        public void query_string_array_intersects_array_with_boolean_and()
+        {
+            var interests = new string[] { "finance", "astrology" };
+            var res = theSession.Query<Article>()
+                .Where(x => x.CategoryArray.Any(s => interests.Contains(s)) && x.Published)
+                .OrderBy(x => x.Long)
+                .ToList();
+            res.Count.ShouldBe(2);
+            res[0].Long.ShouldBe(1);
+            res[1].Long.ShouldBe(4);
+        }
+
+        [Fact]
+        public void query_guid_array_intersects_array()
+        {
+            var res = theSession.Query<Article>()
+                .Where(x => x.AuthorArray.Any(s => favAuthors.Contains(s)))
+                .OrderBy(x => x.Long)
+                .ToList();
+
+            res.Count.ShouldBe(4);
+            res[0].Long.ShouldBe(1);
+            res[1].Long.ShouldBe(2);
+            res[2].Long.ShouldBe(3);
+            res[3].Long.ShouldBe(6);
+        }
+
+        [Fact]
+        public void query_guid_list_intersects_array()
+        {
+            var res = theSession.Query<Article>()
+                .Where(x => x.AuthorList.Any(s => favAuthors.Contains(s)))
+                .OrderBy(x => x.Long)
+                .ToList();
+
+            res.Count.ShouldBe(1);
+            res[0].Long.ShouldBe(5);
+        }
+
+    }
+
+    public class Article
+    {
+        public Guid Id { get; set; }
+        public long Long { get; set; }
+        public string[] CategoryArray { get; set; }
+        public List<string> CategoryList { get; set; }
+        public Guid[] AuthorArray { get; set; }
+        public List<Guid> AuthorList { get; set; }
+        public Article ReferencedArticle { get; set; }
+        public bool Published { get; set; }
+    }
+
+}

--- a/src/Marten/Linq/CollectionAnyContainmentWhereFragment.cs
+++ b/src/Marten/Linq/CollectionAnyContainmentWhereFragment.cs
@@ -8,12 +8,16 @@ using Npgsql;
 using NpgsqlTypes;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
+using System.Reflection;
+using System.Collections;
 
 namespace Marten.Linq
 {
     // TODO -- this is going to have to get redone
     public class CollectionAnyContainmentWhereFragment : IWhereFragment
     {
+        private static readonly Type[] supportedTypes = new Type[] { typeof(string), typeof(Guid) };
         private readonly ISerializer _serializer;
         private readonly SubQueryExpression _expression;
 
@@ -33,17 +37,31 @@ namespace Marten.Linq
                 .Select(x => x.Predicate)
                 .ToArray();
 
-            if (!wheres.All(x => x is BinaryExpression))
+            if (!wheres.All(x => x is BinaryExpression || x is SubQueryExpression))
             {
                 throw new NotImplementedException();
             }
 
+            var binaryExpressions = wheres.OfType<BinaryExpression>().ToArray();
+            var subQueryExpressions = wheres.OfType<SubQueryExpression>().ToArray();
+
+            var conditions = new List<string>();
+            conditions.AddRange(buildBinary(binaryExpressions, command));
+            conditions.AddRange(subQueryExpressions.Select(s => buildSubQuery(s, command)));
+            return conditions.Join(" AND ");
+        }
+
+        private IEnumerable<string> buildBinary(BinaryExpression[] binaryExpressions, NpgsqlCommand command)
+        {
+            if (!binaryExpressions.Any())
+            {
+                yield break;
+            }
 
             var visitor = new FindMembers();
             visitor.Visit(_expression.QueryModel.MainFromClause.FromExpression);
 
             var members = visitor.Members;
-            var binaryExpressions = wheres.OfType<BinaryExpression>().ToArray();
             var dictionary = new Dictionary<string, object>();
 
             // Are we querying directly againt the elements as you would for primitive types?
@@ -88,7 +106,7 @@ namespace Marten.Linq
             param.NpgsqlDbType = NpgsqlDbType.Jsonb;
 
 
-            return $"d.data @> :{param.ParameterName}";
+            yield return $"d.data @> :{param.ParameterName}";
         }
 
         public bool Contains(string sqlText)
@@ -112,5 +130,78 @@ namespace Marten.Linq
                 throw new NotSupportedException();
             }
         }
+
+        private string buildSubQuery(SubQueryExpression subQuery, NpgsqlCommand command)
+        {
+            var contains = subQuery.QueryModel.ResultOperators.OfType<ContainsResultOperator>().FirstOrDefault();
+            if (contains == null)
+            {
+                throw new NotSupportedException("Only the Contains() operator is supported on subqueries within Collection.Any() searches");
+            }
+
+            // build rhs of ?|
+            var from = subQuery.QueryModel.MainFromClause.FromExpression as ConstantExpression;
+            if (from == null || !supportedTypes.Any(supp => isListOrArrayOf(from.Type, supp)))
+            {
+                throwNotSupportedContains();
+            }
+            var fromParam = command.AddParameter(from.Value);
+            fromParam.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Text;
+
+            // check/build lhs of ?|
+            var item = contains.Item as QuerySourceReferenceExpression;
+            if (item == null)
+            {
+                throwNotSupportedContains();
+            }
+            if (!supportedTypes.Any(supp => supp == item.ReferencedQuerySource.ItemType))
+            {
+                throwNotSupportedContains();
+            }
+            var itemSource = item.ReferencedQuerySource as MainFromClause;
+            if (itemSource == null)
+            {
+                throwNotSupportedContains();
+            }
+            var member = itemSource.FromExpression as MemberExpression;
+            if (member == null)
+            {
+                throwNotSupportedContains();
+            }
+
+            return $"data->'{pathTo(member)}' ?| :{fromParam.ParameterName}";
+        }
+
+        private void throwNotSupportedContains()
+        {
+            throw new NotSupportedException($"The Contains() operator on subqueries within Collection.Any() searches only supports constant array/lists of {string.Join(" or ", supportedTypes.Select(t => t.Name))} expressions");
+        }
+
+        private string pathTo(MemberExpression memberExpression)
+        {
+            var path = new List<string> { memberExpression.Member.Name };
+            while (memberExpression.Expression.NodeType == ExpressionType.MemberAccess)
+            {
+                var propInfo = memberExpression.Expression.GetType().GetProperty("Member");
+                var propValue = propInfo.GetValue(memberExpression.Expression, null) as PropertyInfo;
+                path.Add(propValue.Name);
+                memberExpression = memberExpression.Expression as MemberExpression;
+            }
+            return path.AsEnumerable().Reverse().Join("'->'");
+        }
+
+        private bool isListOrArrayOf(Type value, Type valid)
+        {
+            if (value.IsArray && valid.IsAssignableFrom(value.GetElementType()))
+                return true;
+            if (value.IsGenericEnumerable())
+            {
+                var typeDef = value.GetGenericTypeDefinition();
+                if (typeDef.IsAssignableFrom(typeof(List<>)) && valid.IsAssignableFrom(typeDef.GenericTypeArguments[0]))
+                    return true;
+            }
+            return false;
+        }
+
     }
 }


### PR DESCRIPTION
This PR adds basic intersection support to Arrays/Lists that serialize to a "array of strings" representation in JSON (this is a limitation/requirement of the `?|` jsonb-operator). As of now only `string` and `Guid` lists/arrays are supported, other types are not tested and yield a `NotSupportedException`.

This PR should provide functionality for a quite common use case for a document store: Suppose you have a document with a collection of "tags":
`public class Article {
    public string[] Tags { get; set }
}`

and you want to query all documents that have one or more "tags" in common with your "interest": `var interests = new string[] { "finance", "astrology" };`

You can now do the following:
`theSession.Query<Article>()
                .Where(x => x.Tags.Any(s => interests.Contains(s)))
`

This is essentially an intersection query with a funny syntax but matches the way the `?|` json operator works.

Note that due to the tight coupling of the query to the `?|`, (as of now) the query in fact must look like specified above; in particular, the "query parameter" `interests` must be a `string[]` and the `.Any`-predicate must be a single `Contains` condition.
