### PR TITLE
Fix stream time zone issue

### DIFF
--- a/src/Marten/Events/Projections/Async/Fetcher.cs
+++ b/src/Marten/Events/Projections/Async/Fetcher.cs
@@ -128,8 +128,8 @@ namespace Marten.Events.Projections.Async
                     var lastPossible = lastEncountered + _options.PageSize;
                     var sql =
                         $@"
-select seq_id from {_selector.Events.DatabaseSchemaName}.mt_events where seq_id > :last and seq_id <= :limit and age(transaction_timestamp() at time zone 'utc', {_selector.Events.DatabaseSchemaName}.mt_events.timestamp) >= :buffer order by seq_id;
-{_selector.ToSelectClause(null)} where seq_id > :last and seq_id <= :limit and type = ANY(:types) and age(transaction_timestamp() at time zone 'utc', {_selector.Events.DatabaseSchemaName}.mt_events.timestamp) >= :buffer order by seq_id;
+select seq_id from {_selector.Events.DatabaseSchemaName}.mt_events where seq_id > :last and seq_id <= :limit and age(transaction_timestamp(), {_selector.Events.DatabaseSchemaName}.mt_events.timestamp) >= :buffer order by seq_id;
+{_selector.ToSelectClause(null)} where seq_id > :last and seq_id <= :limit and type = ANY(:types) and age(transaction_timestamp(), {_selector.Events.DatabaseSchemaName}.mt_events.timestamp) >= :buffer order by seq_id;
 ".Replace(" as d", "");
 
                     var cmd = conn.CreateCommand(sql)

--- a/src/Marten/Schema/SQL/mt_stream.sql
+++ b/src/Marten/Schema/SQL/mt_stream.sql
@@ -5,7 +5,7 @@ CREATE TABLE {databaseSchema}.mt_streams (
 	id					uuid CONSTRAINT pk_mt_streams PRIMARY KEY,
 	type				varchar(100) NULL,
 	version				integer NOT NULL,
-	timestamp           timestamptz default (now() at time zone 'utc') NOT NULL,
+	timestamp			timestamptz default (now()) NOT NULL,
 	snapshot			jsonb,
 	snapshot_version	integer	
 );
@@ -15,13 +15,13 @@ CREATE SEQUENCE {databaseSchema}.mt_events_sequence;
 
 DROP TABLE IF EXISTS {databaseSchema}.mt_events;
 CREATE TABLE {databaseSchema}.mt_events (
-    seq_id		    bigint CONSTRAINT pk_mt_events PRIMARY KEY,
-	id 	uuid NOT NULL,
+	seq_id		bigint CONSTRAINT pk_mt_events PRIMARY KEY,
+	id		uuid NOT NULL,
 	stream_id	uuid REFERENCES {databaseSchema}.mt_streams ON DELETE CASCADE,
 	version		integer NOT NULL,
 	data		jsonb NOT NULL,
 	type 		varchar(100) NOT NULL,
-	timestamp	timestamp with time zone default (now()) NOT NULL,
+	timestamp	timestamptz default (now()) NOT NULL,
 	CONSTRAINT pk_mt_events_stream_and_version UNIQUE(stream_id, version),
 	CONSTRAINT pk_mt_events_id_unique UNIQUE(id)
 );
@@ -92,14 +92,3 @@ INSERT INTO {databaseSchema}.mt_event_progression (name, last_seq_id) VALUES (na
 
 END;
 $function$;
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
I had problems running the AsyncDaemonFixture derived tests, eventually tracked it down to two issues.

First when comparing `timestamp timestamptz` on `mt_events` in the `Fetcher` the `transaction_timestamp` was being coerced to 'UTC' but the stored values were local (e.g. `now()`) which meant no events were being found to be due causing no projections to be built.

Second was that the code to load the project json files was not finding the correct directory, looks like it was based on the previous test runner setting working dir to bin\Debug. Most of the tests passed asserting that 0 == 0!

All tests now passing on my environment (UTC+1)

The schema checks look like they only check for the table existence so existing event stores will not be modified to use the new version of the table definition but that shouldn't make a difference as as far as I can see the column defaults are never actually used, timestamp is always set on insert and update. 