### PR TITLE
Identifier checks for null, empty, whitespace, embedded space

### DIFF
--- a/src/Marten/PostgresqlIdentifierInvalidException.cs
+++ b/src/Marten/PostgresqlIdentifierInvalidException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Marten
+{
+    public class PostgresqlIdentifierInvalidException : Exception
+    {
+        public string Name { get; set; }
+
+        public PostgresqlIdentifierInvalidException(string name) 
+            : base($"Database identifier {name} is not valid. See https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html for valid unquoted identifiers (Marten does not quote identifiers).")
+        {
+            Name = name;
+        }
+    }
+}

--- a/src/Marten/PostgresqlIdentifierTooLongException.cs
+++ b/src/Marten/PostgresqlIdentifierTooLongException.cs
@@ -7,7 +7,8 @@ namespace Marten
         public int Length { get; set; }
         public string Name { get; set; }
 
-        public PostgresqlIdentifierTooLongException(int length, string name) : base($"Database identifier {name} would be truncated. The {nameof(StoreOptions)}{nameof(StoreOptions.NameDataLength)} property is currently {length}. You may want to change this value with a corresponding change to Postgresql's NAMEDATALEN")
+        public PostgresqlIdentifierTooLongException(int length, string name) 
+            : base($"Database identifier {name} would be truncated. The {nameof(StoreOptions)}{nameof(StoreOptions.NameDataLength)} property is currently {length}. You may want to change this value with a corresponding change to Postgresql's NAMEDATALEN")
         {
             Length = length;
             Name = name;

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -249,10 +249,12 @@ namespace Marten
 
         public void AssertValidIdentifier(string name)
         {
-            if (name.Length >= (NameDataLength - 1))
-            {
-                throw new PostgresqlIdentifierTooLongException(NameDataLength, name);
-            }
+            if (string.IsNullOrWhiteSpace(name))
+                throw new PostgresqlIdentifierInvalidException(name);
+            if (name.IndexOf(' ') >= 0)
+                throw new PostgresqlIdentifierInvalidException(name);
+            if (name.Length < NameDataLength) return;
+            throw new PostgresqlIdentifierTooLongException(NameDataLength, name);
         }
 
         internal IDocumentMapping FindMapping(Type documentType)


### PR DESCRIPTION
Length check changed to accept less than NameDataLength.
Added check for any spaces in strings, no identifiers are quoted in generated sql.
Added check for whitespace strings, for instance `IndexDefinition` and `ComputedIndex` both verify null or empty but do not verify an index name given as all whitespace (who does that!)