### PR TITLE
Possible implementation for #562, albeit not overly elegant. Speciali…

### DIFF
--- a/src/Marten.Testing/Linq/invoking_queryable_any_nopredicate_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_any_nopredicate_Tests.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using Marten.Services;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Linq
+{
+    public class invoking_queryable_any_nopredicate_Tests : DocumentSessionFixture<NulloIdentityMap>
+    {
+        
+        [Fact]
+        public void naked_any_hit()
+        {
+            var targetithchildren = new Target {Number = 1};
+            targetithchildren.Children = new[] {new Target(),};
+            var nochildrennullarray = new Target { Number = 2 };
+            var nochildrenemptyarray = new Target { Number = 3 };
+            nochildrenemptyarray.Children = new Target[] {};
+            theSession.Store(nochildrennullarray);
+            theSession.Store(nochildrenemptyarray);
+            theSession.Store(targetithchildren);
+            theSession.SaveChanges();
+
+            var items = theSession.Query<Target>().Where(x => x.Children.Any()).ToList();
+
+            items.Count.ShouldBe(1);
+        }
+                                     
+    }
+}

--- a/src/Marten/Linq/CollectionAnyNoPredicateWhereFragment.cs
+++ b/src/Marten/Linq/CollectionAnyNoPredicateWhereFragment.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using Baseline;
+using Npgsql;
+using Remotion.Linq.Clauses.Expressions;
+
+namespace Marten.Linq
+{
+    /// <summary>
+    /// Handle Any() with JSONB_ARRAY_LENGTH introduced in PostgreSQL 9.4
+    /// </summary>
+    public class CollectionAnyNoPredicateWhereFragment : IWhereFragment
+    {
+        private readonly SubQueryExpression _expression;
+
+        public CollectionAnyNoPredicateWhereFragment(SubQueryExpression expression)
+        {            
+            _expression = expression;
+        }
+
+        public string ToSql(NpgsqlCommand command)
+        {            
+            var visitor = new FindMembers();
+            visitor.Visit(_expression.QueryModel.MainFromClause.FromExpression);
+            var path = visitor.Members.Select(m => m.Name).Join("'->'");
+
+            var query = $"JSONB_ARRAY_LENGTH(COALESCE(case when data->>'{path}' is not null then data->'{path}' else '[]' end)) > 0";
+            return query;
+        }
+     
+        public bool Contains(string sqlText)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Marten/Linq/WhereClauseVisitor.cs
+++ b/src/Marten/Linq/WhereClauseVisitor.cs
@@ -163,6 +163,14 @@ namespace Marten.Linq
 
                 if (expression.QueryModel.ResultOperators.Any(x => x is AnyResultOperator))
                 {
+                    // Any() without predicate
+                    if (!expression.QueryModel.BodyClauses.Any())
+                    {
+                        var @where_any_nopredicate = new CollectionAnyNoPredicateWhereFragment(expression);
+
+                        _register.Peek()(@where_any_nopredicate);
+                        return null;
+                    }
                     var @where = new CollectionAnyContainmentWhereFragment(_parent._serializer, expression);
 
                     _register.Peek()(@where);


### PR DESCRIPTION
…zed case for .Any() with no predicate -> uses JSONB_ARRAY_LENGTH.

Does not generalize (e.g. for nested arrays) as executed only on paths where expression.QueryModel.BodyClauses is empty.