### PR TITLE
Unify aggregator lookup in ProjectionCollection to use the same aggre…

### DIFF
--- a/documentation/documentation/events/projections/index.md
+++ b/documentation/documentation/events/projections/index.md
@@ -77,6 +77,11 @@ At this point, you would be able to query against `QuestParty` as just another d
 
 
 `EventGraph.UseAggregatorLookup(IAggregatorLookup aggregatorLookup)` can be used to register an `IAggregatorLookup` that is used to look up `IAggregator<T>` for aggregations. This allows e.g. for generic aggregation strategy to be used, rathen than registering aggregators 
-case-by-case through `EventGraphAddAggregator<T>(IAggregator<T> aggregator)`.   
+case-by-case through `EventGraphAddAggregator<T>(IAggregator<T> aggregator)`. 
+
+A shorthand extension method `EventGraph.UseAggregatorLookup(this EventGraph eventGraph, AggregationLookupStrategy strategy)` can be used to set default aggregation lookup, whereby 
+
+- `AggregationLookupStrategy.UsePublicApply` resolves aggregators that use public Apply
+- `AggregationLookupStrategy.UsePrivateApply` resolves aggregators that use private Apply  
 
 <[sample:register-custom-aggregator-lookup]>

--- a/documentation/documentation/order.txt
+++ b/documentation/documentation/order.txt
@@ -3,4 +3,4 @@ cli
 documents
 events
 precompiling
-
+scenarios

--- a/documentation/documentation/scenarios/immutable_projections_readmodel.md
+++ b/documentation/documentation/scenarios/immutable_projections_readmodel.md
@@ -1,0 +1,23 @@
+<!--Title: Immutable projections as read model-->
+
+This use case demonstrates how to create immutable projections from event streams.
+
+## Scenario
+
+To make projections immutable, the event application methods invoked by aggregators need to be made private, as well as any property setters.
+
+<[sample:scenarios-immutableprojections-projection]>
+
+To run aggregators against such projections, aggregator lookup strategy is configured to use aggregators that look for private `Apply([Event Type])` methods. Furthermore, document deserialization is configured to look for private property setters, allowing hydration of the projected objects from the database.
+
+This can be done in the store configuration as follows:
+
+<[sample:scenarios-immutableprojections-storesetup]>
+
+The serializer contract applied customises the default behaviour of the Json.NET serializer:
+
+<[sample:scenarios-immutableprojections-serializer]>
+ 
+Given the setup, a stream can now be projected using `AggregateWithPrivateEventApply` shown above. Furthermore, the created projection can be hydrated from the document store:
+
+<[sample:scenarios-immutableprojections-projectstream]>

--- a/documentation/documentation/scenarios/index.md
+++ b/documentation/documentation/scenarios/index.md
@@ -1,0 +1,8 @@
+<!--Title:Scenarios-->
+<!--Url:scenarios-->
+
+This page documents various use cases with a sample implementation using Marten. 
+
+## Scenarios
+
+<[TableOfContents]>

--- a/src/Marten/Events/EventGraphExtensions.cs
+++ b/src/Marten/Events/EventGraphExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Marten.Events.Projections;
+using Marten.Services.Events;
+using Baseline;
+
+namespace Marten.Events
+{
+    public static class EventGraphExtensions
+    {
+        public static EventGraph UseAggregatorLookup(this EventGraph eventGraph, AggregationLookupStrategy strategy)
+        {
+            if (strategy == AggregationLookupStrategy.UsePublicApply)
+            {
+                eventGraph.UseAggregatorLookup(new AggregatorLookup(type => typeof(Aggregator<>).CloseAndBuildAs<IAggregator>(type)));
+            }
+            else if (strategy == AggregationLookupStrategy.UsePrivateApply)
+            {
+                eventGraph.UseAggregatorLookup(new AggregatorLookup(type => typeof(AggregatorApplyPrivate<>).CloseAndBuildAs<IAggregator>(type)));
+            }
+
+            return eventGraph;
+        }
+    }
+}

--- a/src/Marten/Events/Projections/Aggregator.cs
+++ b/src/Marten/Events/Projections/Aggregator.cs
@@ -14,10 +14,15 @@ namespace Marten.Events.Projections
         private readonly IDictionary<Type, object> _aggregations = new Dictionary<Type, object>();
 
 
-        public Aggregator() 
+        public Aggregator() : this(typeof(T).GetMethods()
+                .Where(x => x.Name == ApplyMethod && x.GetParameters().Length == 1))
+        {           
+            Alias = typeof(T).Name.ToTableAlias();
+        }
+
+        protected Aggregator(IEnumerable<MethodInfo> overrideMethodLookup)
         {
-            typeof (T).GetMethods()
-                .Where(x => x.Name == ApplyMethod && x.GetParameters().Length == 1)
+            overrideMethodLookup
                 .Each(method =>
                 {
                     object step = null;
@@ -36,11 +41,9 @@ namespace Marten.Events.Projections
 
                     _aggregations.Add(eventType, step);
                 });
-
-            Alias = typeof (T).Name.ToTableAlias();
         }
 
-        public Type AggregateType => typeof (T);
+        public Type AggregateType => typeof(T);
 
         public string Alias { get; }
 
@@ -57,9 +60,9 @@ namespace Marten.Events.Projections
 
         public Aggregator<T> Add<TEvent>(IAggregation<T, TEvent> aggregation)
         {
-            if (_aggregations.ContainsKey(typeof (TEvent)))
+            if (_aggregations.ContainsKey(typeof(TEvent)))
             {
-                _aggregations[typeof (TEvent)] = aggregation;
+                _aggregations[typeof(TEvent)] = aggregation;
             }
             else
             {
@@ -76,8 +79,8 @@ namespace Marten.Events.Projections
 
         public IAggregation<T, TEvent> AggregatorFor<TEvent>()
         {
-            return _aggregations.ContainsKey(typeof (TEvent))
-                ? _aggregations[typeof (TEvent)].As<IAggregation<T, TEvent>>()
+            return _aggregations.ContainsKey(typeof(TEvent))
+                ? _aggregations[typeof(TEvent)].As<IAggregation<T, TEvent>>()
                 : null;
         }
 

--- a/src/Marten/Events/Projections/AggregatorApplyPrivate.cs
+++ b/src/Marten/Events/Projections/AggregatorApplyPrivate.cs
@@ -1,0 +1,16 @@
+﻿using System.Linq;
+using System.Reflection;
+
+namespace Marten.Events.Projections
+{
+    /// <summary>
+    /// Customize behaviour of <see cref="Aggregator{T}" /> by using private Apply methods in aggregation.
+    /// </summary>    
+    public class AggregatorApplyPrivate<T> : Aggregator<T> where T : class, new()
+    {
+        public AggregatorApplyPrivate() : base(typeof(T).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Where(x => x.Name == ApplyMethod && x.GetParameters().Length == 1))
+        {
+        }
+    }
+}

--- a/src/Marten/Events/Projections/ProjectionCollection.cs
+++ b/src/Marten/Events/Projections/ProjectionCollection.cs
@@ -26,8 +26,8 @@ namespace Marten.Events.Projections
         }
 
         public AggregationProjection<T> AggregateStreamsWith<T>() where T : class, new()
-        {
-            var aggregator = new Aggregator<T>();
+        {            
+            var aggregator = _options.Events.AggregateFor<T>();
             var finder = new AggregateFinder<T>();
             var projection = new AggregationProjection<T>(finder, aggregator);
 

--- a/src/Marten/Services/Events/AggregationLookupStrategy.cs
+++ b/src/Marten/Services/Events/AggregationLookupStrategy.cs
@@ -1,0 +1,37 @@
+﻿namespace Marten.Services.Events
+{
+    public sealed class AggregationLookupStrategy
+    {
+        public readonly short Value;
+
+        private bool Equals(AggregationLookupStrategy other)
+        {
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is AggregationLookupStrategy && Equals((AggregationLookupStrategy) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        public static readonly AggregationLookupStrategy UsePublicApply = new AggregationLookupStrategy(0);
+        public static readonly AggregationLookupStrategy UsePrivateApply = new AggregationLookupStrategy(1);
+
+        public static implicit operator short(AggregationLookupStrategy item)
+        {
+            return item.Value;
+        }
+
+        private AggregationLookupStrategy(short value)
+        {
+            Value = value;
+        }
+    }
+}


### PR DESCRIPTION
…gator lookup as EventStore.AggregateStream (instead of hardcoded Aggregator).

Allows for immutable projections (as demonstrated in unit test).