### PR TITLE
Bug in subinterface query

### DIFF
--- a/src/Marten.Testing/Linq/query_with_inheritance.cs
+++ b/src/Marten.Testing/Linq/query_with_inheritance.cs
@@ -142,5 +142,22 @@ namespace Marten.Testing.Linq
             theSession.Query<IPapaSmurf>().Count().ShouldBe(3);
         }
         // ENDSAMPLE
+
+        [Fact]
+        public void get_all_subclasses_of_an_interface_and_instantiate_them()
+        {
+            var smurf = new Smurf { Ability = "Follow the herd" };
+            var papa = new PapaSmurf { Ability = "Lead" };
+            var papy = new PapySmurf { Ability = "Lead" };
+            var brainy = new BrainySmurf { Ability = "Invent" };
+            theSession.Store(smurf, papa, brainy, papy);
+
+            theSession.SaveChanges();
+
+            var list = theSession.Query<IPapaSmurf>().ToList();
+            list.Count().ShouldBe(3);
+            list.Where(s => s.Ability == "Invent").Count().ShouldBe(1);
+        }
+
     }
 }

--- a/src/Marten/Schema/SubClassMapping.cs
+++ b/src/Marten/Schema/SubClassMapping.cs
@@ -114,7 +114,7 @@ namespace Marten.Schema
         public IDocumentStorage BuildStorage(IDocumentSchema schema)
         {
             var parentStorage = Parent.As<IDocumentMapping>().BuildStorage(schema);
-            return typeof(SubClassDocumentStorage<,>).CloseAndBuildAs<IDocumentStorage>(parentStorage, DocumentType,
+            return typeof(SubClassDocumentStorage<,>).CloseAndBuildAs<IDocumentStorage>(parentStorage, this, DocumentType,
                 Parent.DocumentType);
         }
 
@@ -146,6 +146,11 @@ namespace Marten.Schema
             Action<TOther> callback)
         {
             return Parent.JoinToInclude(joinType, other, members, callback);
+        }
+
+        public Type TypeFor(string alias)
+        {
+            return Parent.TypeFor(alias);
         }
 
         private static string GetTypeMartenAlias(Type documentType)


### PR DESCRIPTION
If an `IPapaSmurf` is queried, `SubClassDocumentStorage` would try to deserialize to objects of type `IPapaSmurf` instead of the actual types.

This bug was not triggered by the ST test case in the documentation because `.Count()` does not actually instantiate the classes.

The attached commits borrows the type resolving from `HierarchicalResolver` by delegating to `SubClassMapping`.  (I've seen the TODOs in `SubClassDocumentStorage.cs` but that's a larger architectural change that's currently beyond my abilities in the Marten codebase :) )

Note: A plethora of tests fails on my local machine mainly due to (appearently) broken PLV8 extension on my dev machine. I could therefore not reliably confirm that the change breaks no other tests.