### PR TITLE
[WIP] Buffer pooling for JSON serialization

### DIFF
--- a/src/Marten.Testing/Schema/deriving_delete_sql_for_document_type.cs
+++ b/src/Marten.Testing/Schema/deriving_delete_sql_for_document_type.cs
@@ -13,7 +13,7 @@ namespace Marten.Testing.Schema
             var mapping = DocumentMapping.For<User>();
             mapping.DeleteStyle = DeleteStyle.Remove;
 
-            var resolver = new Resolver<User>(new TestsSerializer(), mapping);
+            var resolver = new Resolver<User>(new TestsSerializer(), mapping, false);
 
             resolver.DeleteByIdSql.ShouldBe("delete from public.mt_doc_user where id = ?");
         }
@@ -24,7 +24,7 @@ namespace Marten.Testing.Schema
             var mapping = DocumentMapping.For<User>();
             mapping.DeleteStyle = DeleteStyle.SoftDelete;
 
-            var resolver = new Resolver<User>(new TestsSerializer(), mapping);
+            var resolver = new Resolver<User>(new TestsSerializer(), mapping, false);
 
             resolver.DeleteByIdSql.ShouldBe("update public.mt_doc_user set mt_deleted = True, mt_deleted_at = now() where id = ?");
         }
@@ -35,7 +35,7 @@ namespace Marten.Testing.Schema
             var mapping = DocumentMapping.For<User>();
             mapping.DeleteStyle = DeleteStyle.Remove;
 
-            var resolver = new Resolver<User>(new TestsSerializer(), mapping);
+            var resolver = new Resolver<User>(new TestsSerializer(), mapping, false);
 
             resolver.DeleteByWhereSql.ShouldBe("delete from public.mt_doc_user as d where ?");
         }
@@ -47,7 +47,7 @@ namespace Marten.Testing.Schema
             var mapping = DocumentMapping.For<User>();
             mapping.DeleteStyle = DeleteStyle.SoftDelete;
 
-            var resolver = new Resolver<User>(new TestsSerializer(), mapping);
+            var resolver = new Resolver<User>(new TestsSerializer(), mapping, false);
 
             resolver.DeleteByWhereSql.ShouldBe("update public.mt_doc_user as d set mt_deleted = True, mt_deleted_at = now() where ?");
         }

--- a/src/Marten.Testing/Schema/executing_upsert_with_char_buffer_pooling_enabled.cs
+++ b/src/Marten.Testing/Schema/executing_upsert_with_char_buffer_pooling_enabled.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Marten.Schema;
+using Marten.Services;
+using Marten.Testing.Documents;
+using Npgsql;
+using NpgsqlTypes;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Schema
+{
+    public class executing_upsert_with_char_buffer_pooling_enabled
+    {
+        [Fact]
+        public void uses_buffers()
+        {
+            var releasedWriters = new List<CharArrayTextWriter>();
+            var mapping = DocumentMapping.For<User>();
+            var resolver = new Resolver<User>(new Serializer(), mapping, true);
+
+            var connection = Substitute.For<IManagedConnection>();
+
+            var pool = Substitute.For<CharArrayTextWriter.IPool>();
+            pool.Lease().Returns(c => new CharArrayTextWriter());
+            pool.WhenForAnyArgs(p => p.Release(default(IEnumerable<CharArrayTextWriter>))).
+                Do(ci => releasedWriters.AddRange((IEnumerable<CharArrayTextWriter>) ci.Args()[0]));
+
+            var batch = new UpdateBatch(new StoreOptions(), new Serializer(), connection, new VersionTracker(), pool);
+            resolver.RegisterUpdate(batch, new User { FirstName = "Bruce" });
+            batch.Execute();
+
+            var json = GetJsonBParameter(connection);
+            var jsonContent = new string( (char[]) json.Value,0, json.Size);
+
+            jsonContent.ShouldBe(Serializer.WriterValue);
+            releasedWriters.ShouldHaveSingleItem();
+        }
+
+        static NpgsqlParameter GetJsonBParameter(IManagedConnection connection)
+        {
+            var call = connection.ReceivedCalls().Single();
+            var cmd = (NpgsqlCommand) call.GetArguments()[0];
+            var json = cmd.Parameters.Single(p => p.NpgsqlDbType == NpgsqlDbType.Jsonb);
+            return json;
+        }
+
+        class Serializer : ISerializer
+        {
+            public const string WriterValue = "ThisIsWriterValue";
+
+            public void ToJson(object document, TextWriter writer)
+            {
+                writer.Write(WriterValue);
+            }
+
+            public string ToJson(object document)
+            {
+                return ""; //dummy
+            }
+
+            public T FromJson<T>(string json)
+            {
+                throw new NotImplementedException();
+            }
+
+            public object FromJson(Type type, string json)
+            {
+                throw new NotImplementedException();
+            }
+
+            public T FromJson<T>(TextReader reader)
+            {
+                throw new NotImplementedException();
+            }
+
+            public object FromJson(Type type, TextReader reader)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string ToCleanJson(object document)
+            {
+                throw new NotImplementedException();
+            }
+
+            public EnumStorage EnumStorage { get; }
+        }
+    }
+}

--- a/src/Marten.Testing/Services/CharArrayTextWriterTests.cs
+++ b/src/Marten.Testing/Services/CharArrayTextWriterTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Marten.Services;
 using Shouldly;
 using Xunit;
@@ -14,7 +15,7 @@ namespace Marten.Testing.Services
 
             writer.Write('z');
 
-            var written = writer.ToRawArraySegment();
+            var written = ToCharSegment(writer);
 
             written.ShouldBe('z'.ToString());
         }
@@ -30,7 +31,7 @@ namespace Marten.Testing.Services
             const int take = 1;
             writer.Write(chars, offset, take);
 
-            var written = writer.ToRawArraySegment();
+            var written = ToCharSegment(writer);
 
             written.ShouldBe(chars.Skip(offset).Take(take));
         }
@@ -42,7 +43,7 @@ namespace Marten.Testing.Services
 
             writer.Write("test");
 
-            var written = writer.ToRawArraySegment();
+            var written = ToCharSegment(writer);
 
             written.ShouldBe("test");
         }
@@ -56,9 +57,14 @@ namespace Marten.Testing.Services
 
             writer.Write(s);
 
-            var written = writer.ToRawArraySegment();
+            var written = ToCharSegment(writer);
 
             written.ShouldBe(s);
+        }
+
+        static ArraySegment<char> ToCharSegment(CharArrayTextWriter writer)
+        {
+            return new ArraySegment<char>(writer.Buffer,0,writer.Size);
         }
     }
 }

--- a/src/Marten.Testing/Services/CharArrayTextWriterTests.cs
+++ b/src/Marten.Testing/Services/CharArrayTextWriterTests.cs
@@ -84,6 +84,28 @@ namespace Marten.Testing.Services
             writer.Size.ShouldBe(0);
         }
 
+        [Fact]
+        public void respects_pool_hierarchy()
+        {
+            var root = new CharArrayTextWriter.Pool();
+            CharArrayTextWriter writer1, writer2;
+            
+            using (var pool = new CharArrayTextWriter.Pool(root))
+            {
+                writer1 = pool.Lease();
+                pool.Release(writer1 );
+            }
+
+            using (var pool = new CharArrayTextWriter.Pool(root))
+            {
+                writer2 = pool.Lease();
+                pool.Release(writer2);
+            }
+
+            writer2.ShouldBe(writer1);
+        }
+
+
         static ArraySegment<char> ToCharSegment(CharArrayTextWriter writer)
         {
             return new ArraySegment<char>(writer.Buffer, 0, writer.Size);

--- a/src/Marten.Testing/Services/CharArrayTextWriterTests.cs
+++ b/src/Marten.Testing/Services/CharArrayTextWriterTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using Marten.Services;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Services
+{
+    public class CharArrayTextWriterTests
+    {
+        [Fact]
+        public void writes_single_char()
+        {
+            var writer = new CharArrayTextWriter();
+
+            writer.Write('z');
+
+            var written = writer.ToRawArraySegment();
+
+            written.ShouldBe('z'.ToString());
+        }
+
+        [Fact]
+        public void writes_char_array()
+        {
+            var writer = new CharArrayTextWriter();
+
+            var chars = new[] { 'a', 'b', 'c', 'd', 'e', 'f' };
+
+            const int offset = 5;
+            const int take = 1;
+            writer.Write(chars, offset, take);
+
+            var written = writer.ToRawArraySegment();
+
+            written.ShouldBe(chars.Skip(offset).Take(take));
+        }
+
+        [Fact]
+        public void writes_string()
+        {
+            var writer = new CharArrayTextWriter();
+
+            writer.Write("test");
+
+            var written = writer.ToRawArraySegment();
+
+            written.ShouldBe("test");
+        }
+
+        [Fact]
+        public void writes_characters_beyond_limit()
+        {
+            var writer = new CharArrayTextWriter();
+
+            var s = new string('a', CharArrayTextWriter.InitialSize) + "b";
+
+            writer.Write(s);
+
+            var written = writer.ToRawArraySegment();
+
+            written.ShouldBe(s);
+        }
+    }
+}

--- a/src/Marten.Testing/Services/CharArrayTextWriterTests.cs
+++ b/src/Marten.Testing/Services/CharArrayTextWriterTests.cs
@@ -62,9 +62,31 @@ namespace Marten.Testing.Services
             written.ShouldBe(s);
         }
 
+        [Fact]
+        public void has_offset_reset_when_returned_to_pool_via_single_release()
+        {
+            var pool = new CharArrayTextWriter.Pool();
+            var writer = pool.Lease();
+            writer.Write('a');
+            pool.Release(writer);
+
+            writer.Size.ShouldBe(0);
+        }
+
+        [Fact]
+        public void has_offset_reset_when_returned_to_pool_via_collection_release()
+        {
+            var pool = new CharArrayTextWriter.Pool();
+            var writer = pool.Lease();
+            writer.Write('a');
+            pool.Release(new[] { writer });
+
+            writer.Size.ShouldBe(0);
+        }
+
         static ArraySegment<char> ToCharSegment(CharArrayTextWriter writer)
         {
-            return new ArraySegment<char>(writer.Buffer,0,writer.Size);
+            return new ArraySegment<char>(writer.Buffer, 0, writer.Size);
         }
     }
 }

--- a/src/Marten.Testing/UnitOfWorkTests.cs
+++ b/src/Marten.Testing/UnitOfWorkTests.cs
@@ -38,7 +38,7 @@ namespace Marten.Testing
 
             using (var connection = theStore.Advanced.OpenConnection())
             {
-                var batch = new UpdateBatch(theStore.Advanced.Options, new JsonNetSerializer(), connection, new VersionTracker());
+                var batch = new UpdateBatch(theStore.Advanced.Options, new JsonNetSerializer(), connection, new VersionTracker(), null);
 
                 uow.ApplyChanges(batch);
             }

--- a/src/Marten.Testing/document_session_persist_and_load_single_documents_Tests.cs
+++ b/src/Marten.Testing/document_session_persist_and_load_single_documents_Tests.cs
@@ -63,6 +63,30 @@ namespace Marten.Testing
         }
 
         [Fact]
+        public void persist_and_reload_a_document_using_buffers()
+        {
+            var user = new User { FirstName = "James", LastName = "Worthy" };
+
+            using (var store = TestingDocumentStore.For(_ => { _.UseCharBufferPooling = true; }))
+            {
+                using (var session1 = store.OpenSession())
+                {
+                    session1.Store(user);
+                    session1.SaveChanges();
+                }
+
+                using (var session2 = store.OpenSession())
+                {
+                    var user2 = session2.Load<User>(user.Id);
+
+                    user.ShouldNotBeSameAs(user2);
+                    user2.FirstName.ShouldBe(user.FirstName);
+                    user2.LastName.ShouldBe(user.LastName);
+                }
+            }
+        }
+
+        [Fact]
         public async Task persist_and_reload_a_document_async()
         {
             var user = new User { FirstName = "James", LastName = "Worthy" };
@@ -80,6 +104,30 @@ namespace Marten.Testing
                 user.ShouldNotBeSameAs(user2);
                 user2.FirstName.ShouldBe(user.FirstName);
                 user2.LastName.ShouldBe(user.LastName);
+            }
+        }
+
+        [Fact]
+        public async Task persist_and_reload_a_document_async_using_buffers()
+        {
+            var user = new User { FirstName = "James", LastName = "Worthy" };
+
+            using (var store = TestingDocumentStore.For(_ => { _.UseCharBufferPooling = true; }))
+            {
+                using (var session1 = store.OpenSession())
+                {
+                    session1.Store(user);
+                    await session1.SaveChangesAsync().ConfigureAwait(false);
+                }
+
+                using (var session2 = store.OpenSession())
+                {
+                    var user2 = await session2.LoadAsync<User>(user.Id).ConfigureAwait(false);
+
+                    user.ShouldNotBeSameAs(user2);
+                    user2.FirstName.ShouldBe(user.FirstName);
+                    user2.LastName.ShouldBe(user.LastName);
+                }
             }
         }
 

--- a/src/Marten.Testing/performance_tuning.cs
+++ b/src/Marten.Testing/performance_tuning.cs
@@ -22,6 +22,11 @@ namespace Marten.Testing
         private readonly Options _options 
             = new Options(dateFormat: DateTimeFormat.ISO8601, includeInherited:true);
 
+        public void ToJson(object document, TextWriter writer)
+        {
+            JSON.Serialize(document, writer, _options);
+        }
+
         public string ToJson(object document)
         {
             return JSON.Serialize(document, _options);

--- a/src/Marten/AdvancedOptions.cs
+++ b/src/Marten/AdvancedOptions.cs
@@ -17,9 +17,9 @@ namespace Marten
     public class AdvancedOptions
     {
         private readonly IDocumentSchema _schema;
-        private readonly CharArrayTextWriter.Pool _writerPool;
+        private readonly CharArrayTextWriter.IPool _writerPool;
 
-        public AdvancedOptions(IDocumentCleaner cleaner, StoreOptions options, ISerializer serializer, IDocumentSchema schema, CharArrayTextWriter.Pool writerPool)
+        public AdvancedOptions(IDocumentCleaner cleaner, StoreOptions options, ISerializer serializer, IDocumentSchema schema, CharArrayTextWriter.IPool writerPool)
         {
             Serializer = serializer;
             _schema = schema;

--- a/src/Marten/AdvancedOptions.cs
+++ b/src/Marten/AdvancedOptions.cs
@@ -17,12 +17,13 @@ namespace Marten
     public class AdvancedOptions
     {
         private readonly IDocumentSchema _schema;
+        private readonly CharArrayTextWriter.Pool _writerPool;
 
-        public AdvancedOptions(IDocumentCleaner cleaner, StoreOptions options, ISerializer serializer,
-            IDocumentSchema schema)
+        public AdvancedOptions(IDocumentCleaner cleaner, StoreOptions options, ISerializer serializer, IDocumentSchema schema, CharArrayTextWriter.Pool writerPool)
         {
             Serializer = serializer;
             _schema = schema;
+            _writerPool = writerPool;
             Options = options;
             Clean = cleaner;
         }
@@ -58,7 +59,7 @@ namespace Marten
         /// <returns></returns>
         public UpdateBatch CreateUpdateBatch()
         {
-            return new UpdateBatch(Options, Serializer, OpenConnection(), new VersionTracker());
+            return new UpdateBatch(Options, Serializer, OpenConnection(), new VersionTracker(), _writerPool);
         }
 
         /// <summary>

--- a/src/Marten/DocumentSession.cs
+++ b/src/Marten/DocumentSession.cs
@@ -17,21 +17,19 @@ namespace Marten
     public class DocumentSession : QuerySession, IDocumentSession
     {
         private readonly IManagedConnection _connection;
-        private readonly CharArrayTextWriter.IPool _writerPool;
         private readonly StoreOptions _options;
         private readonly IDocumentSchema _schema;
         private readonly ISerializer _serializer;
         private readonly UnitOfWork _unitOfWork;
 
         public DocumentSession(IDocumentStore store, StoreOptions options, IDocumentSchema schema,
-            ISerializer serializer, IManagedConnection connection, IQueryParser parser, IIdentityMap identityMap, CharArrayTextWriter.IPool writerPool)
-            : base(store, schema, serializer, connection, parser, identityMap)
+            ISerializer serializer, IManagedConnection connection, IQueryParser parser, IIdentityMap identityMap, CharArrayTextWriter.Pool writerPool)
+            : base(store, schema, serializer, connection, parser, identityMap, writerPool)
         {
             _options = options;
             _schema = schema;
             _serializer = serializer;
             _connection = connection;
-            _writerPool = writerPool;
 
             IdentityMap = identityMap;
 
@@ -185,7 +183,7 @@ namespace Marten
 
             _options.Listeners.Each(x => x.BeforeSaveChanges(this));
 
-            var batch = new UpdateBatch(_options, _serializer, _connection, IdentityMap.Versions, _writerPool);
+            var batch = new UpdateBatch(_options, _serializer, _connection, IdentityMap.Versions, WriterPool);
             var changes = _unitOfWork.ApplyChanges(batch);
 
             try
@@ -221,7 +219,7 @@ namespace Marten
                 await listener.BeforeSaveChangesAsync(this, token).ConfigureAwait(false);
             }
 
-            var batch = new UpdateBatch(_options, _serializer, _connection, IdentityMap.Versions, _writerPool);
+            var batch = new UpdateBatch(_options, _serializer, _connection, IdentityMap.Versions, WriterPool);
             var changes = await _unitOfWork.ApplyChangesAsync(batch, token).ConfigureAwait(false);
 
 
@@ -297,7 +295,7 @@ namespace Marten
             assertNotDisposed();
             _unitOfWork.Add(storageOperation);
         }
-
+        
         private void applyProjections()
         {
             var streams = PendingChanges.Streams().ToArray();

--- a/src/Marten/DocumentSession.cs
+++ b/src/Marten/DocumentSession.cs
@@ -17,14 +17,14 @@ namespace Marten
     public class DocumentSession : QuerySession, IDocumentSession
     {
         private readonly IManagedConnection _connection;
-        private readonly CharArrayTextWriter.Pool _writerPool;
+        private readonly CharArrayTextWriter.IPool _writerPool;
         private readonly StoreOptions _options;
         private readonly IDocumentSchema _schema;
         private readonly ISerializer _serializer;
         private readonly UnitOfWork _unitOfWork;
 
         public DocumentSession(IDocumentStore store, StoreOptions options, IDocumentSchema schema,
-            ISerializer serializer, IManagedConnection connection, IQueryParser parser, IIdentityMap identityMap, CharArrayTextWriter.Pool writerPool)
+            ISerializer serializer, IManagedConnection connection, IQueryParser parser, IIdentityMap identityMap, CharArrayTextWriter.IPool writerPool)
             : base(store, schema, serializer, connection, parser, identityMap)
         {
             _options = options;

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -101,14 +101,14 @@ namespace Marten
 
             if (options.UseCharBufferPooling)
             {
-                _writerPool = CharArrayTextWriter.Pool.Instance;
+                _writerPool = CharArrayTextWriter.DefaultPool;
             }
         }
 
         private readonly StoreOptions _options;
         private readonly IConnectionFactory _connectionFactory;
         private readonly IMartenLogger _logger;
-        private readonly CharArrayTextWriter.Pool _writerPool;
+        private readonly CharArrayTextWriter.IPool _writerPool;
 
         public virtual void Dispose()
         {

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -82,7 +82,7 @@ namespace Marten
             _serializer = options.Serializer();
 
             var cleaner = new DocumentCleaner(_connectionFactory, Schema.As<DocumentSchema>());
-            Advanced = new AdvancedOptions(cleaner, options, _serializer, Schema);
+            Advanced = new AdvancedOptions(cleaner, options, _serializer, Schema, _writerPool);
 
             Diagnostics = new Diagnostics(Schema);
 
@@ -98,11 +98,17 @@ namespace Marten
             {
                 Schema.As<DocumentSchema>().RebuildSystemFunctions();
             }
+
+            if (options.UseCharBufferPooling)
+            {
+                _writerPool = CharArrayTextWriter.Pool.Instance;
+            }
         }
 
         private readonly StoreOptions _options;
         private readonly IConnectionFactory _connectionFactory;
         private readonly IMartenLogger _logger;
+        private readonly CharArrayTextWriter.Pool _writerPool;
 
         public virtual void Dispose()
         {
@@ -277,7 +283,7 @@ namespace Marten
         private IDocumentSession openSession(DocumentTracking tracking, ManagedConnection connection)
         {
             var map = createMap(tracking);
-            var session = new DocumentSession(this, _options, Schema, _serializer, connection, _parser, map);
+            var session = new DocumentSession(this, _options, Schema, _serializer, connection, _parser, map, _writerPool);
 
             connection.BeginSession();
 

--- a/src/Marten/ISerializer.cs
+++ b/src/Marten/ISerializer.cs
@@ -7,6 +7,13 @@ namespace Marten
     public interface ISerializer
     {
         /// <summary>
+        /// Serialize the document object into <paramref name="writer"/>.
+        /// </summary>
+        /// <param name="document"></param>
+        /// <param name="writer"></param>
+        void ToJson(object document, TextWriter writer);
+
+        /// <summary>
         /// Serialize the document object into a JSON string
         /// </summary>
         /// <param name="document"></param>

--- a/src/Marten/QuerySession.cs
+++ b/src/Marten/QuerySession.cs
@@ -27,9 +27,10 @@ namespace Marten
         private readonly IManagedConnection _connection;
         private readonly IQueryParser _parser;
         private readonly IIdentityMap _identityMap;
+        protected readonly CharArrayTextWriter.Pool WriterPool;
         private bool _disposed;
 
-        public QuerySession(IDocumentStore store, IDocumentSchema schema, ISerializer serializer, IManagedConnection connection, IQueryParser parser, IIdentityMap identityMap)
+        public QuerySession(IDocumentStore store, IDocumentSchema schema, ISerializer serializer, IManagedConnection connection, IQueryParser parser, IIdentityMap identityMap, CharArrayTextWriter.Pool writerPool)
         {
             DocumentStore = store;
             _schema = schema;
@@ -37,6 +38,7 @@ namespace Marten
             _connection = connection;
             _parser = parser;
             _identityMap = identityMap;
+            WriterPool = writerPool;
         }
 
         public IDocumentStore DocumentStore { get; }
@@ -54,7 +56,7 @@ namespace Marten
 
             var executor = new MartenQueryExecutor(_connection, _schema, _identityMap);
 
-            var queryProvider = new MartenQueryProvider(typeof (MartenQueryable<>), _parser, executor);
+            var queryProvider = new MartenQueryProvider(typeof(MartenQueryable<>), _parser, executor);
             return new MartenQueryable<T>(queryProvider);
         }
 
@@ -82,7 +84,7 @@ namespace Marten
 
         private IDocumentStorage storage<T>()
         {
-            return _schema.StorageFor(typeof (T));
+            return _schema.StorageFor(typeof(T));
         }
 
         public FetchResult<T> LoadDocument<T>(object id) where T : class
@@ -278,7 +280,7 @@ namespace Marten
 
             private IEnumerable<TDoc> fetchDocuments<TKey>(TKey[] keys)
             {
-                var storage = _parent._schema.StorageFor(typeof (TDoc));
+                var storage = _parent._schema.StorageFor(typeof(TDoc));
                 var resolver = storage.As<IResolver<TDoc>>();
                 var cmd = storage.LoadByArrayCommand(keys);
 
@@ -301,7 +303,7 @@ namespace Marten
 
             private async Task<IEnumerable<TDoc>> fetchDocumentsAsync<TKey>(TKey[] keys, CancellationToken token)
             {
-                var storage = _parent._schema.StorageFor(typeof (TDoc));
+                var storage = _parent._schema.StorageFor(typeof(TDoc));
                 var resolver = storage.As<IResolver<TDoc>>();
                 var cmd = storage.LoadByArrayCommand(keys);
 
@@ -363,6 +365,7 @@ namespace Marten
         {
             _disposed = true;
             _connection.Dispose();
+            WriterPool.Dispose();
         }
 
         public T Load<T>(int id)
@@ -375,7 +378,7 @@ namespace Marten
             return load<T>(id);
         }
 
-        public T Load<T>(Guid id) 
+        public T Load<T>(Guid id)
         {
             return load<T>(id);
         }

--- a/src/Marten/QuerySession.cs
+++ b/src/Marten/QuerySession.cs
@@ -365,7 +365,7 @@ namespace Marten
         {
             _disposed = true;
             _connection.Dispose();
-            WriterPool.Dispose();
+            WriterPool?.Dispose();
         }
 
         public T Load<T>(int id)

--- a/src/Marten/Schema/Arguments/CurrentVersionArgument.cs
+++ b/src/Marten/Schema/Arguments/CurrentVersionArgument.cs
@@ -14,14 +14,12 @@ namespace Marten.Schema.Arguments
             Column = null;
         }
 
-        public override Expression CompileBulkImporter(EnumStorage enumStorage, Expression writer,
-            ParameterExpression document,
-            ParameterExpression alias, ParameterExpression serializer)
+        public override Expression CompileBulkImporter(EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, bool useCharBufferPooling)
         {
             throw new NotSupportedException("This should not be used for CurrentVersionArgument");
         }
 
-        public override Expression CompileUpdateExpression(EnumStorage enumStorage, ParameterExpression call, ParameterExpression doc, ParameterExpression updateBatch, ParameterExpression mapping, ParameterExpression currentVersion, ParameterExpression newVersion)
+        public override Expression CompileUpdateExpression(EnumStorage enumStorage, ParameterExpression call, ParameterExpression doc, ParameterExpression updateBatch, ParameterExpression mapping, ParameterExpression currentVersion, ParameterExpression newVersion, bool useCharBufferPooling)
         {
             var argName = Expression.Constant(Arg);
 

--- a/src/Marten/Schema/Arguments/DocJsonBodyArgument.cs
+++ b/src/Marten/Schema/Arguments/DocJsonBodyArgument.cs
@@ -9,7 +9,7 @@ namespace Marten.Schema.Arguments
     public class DocJsonBodyArgument : UpsertArgument
     {
         private static readonly MethodInfo _serializer = ReflectionHelper.GetProperty<UpdateBatch>(x => x.Serializer).GetMethod;
-        private static readonly MethodInfo _tojson = typeof(ISerializer).GetMethod(nameof(ISerializer.ToJson));
+        private static readonly MethodInfo _tojson = typeof(ISerializer).GetMethod(nameof(ISerializer.ToJson), new[] { typeof(object) });
 
         public DocJsonBodyArgument()
         {

--- a/src/Marten/Schema/Arguments/DocJsonBodyArgument.cs
+++ b/src/Marten/Schema/Arguments/DocJsonBodyArgument.cs
@@ -19,7 +19,7 @@ namespace Marten.Schema.Arguments
             Column = "data";
         }
 
-        public override Expression CompileUpdateExpression(EnumStorage enumStorage, ParameterExpression call, ParameterExpression doc, ParameterExpression updateBatch, ParameterExpression mapping, ParameterExpression currentVersion, ParameterExpression newVersion)
+        public override Expression CompileUpdateExpression(EnumStorage enumStorage, ParameterExpression call, ParameterExpression doc, ParameterExpression updateBatch, ParameterExpression mapping, ParameterExpression currentVersion, ParameterExpression newVersion, bool useCharBufferPooling)
         {
             var argName = Expression.Constant(Arg);
 
@@ -29,7 +29,7 @@ namespace Marten.Schema.Arguments
             return Expression.Call(call, _paramMethod, argName, json, Expression.Constant(NpgsqlDbType.Jsonb));
         }
 
-        public override Expression CompileBulkImporter(EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer)
+        public override Expression CompileBulkImporter(EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, bool useCharBufferPooling)
         {
             var json = Expression.Call(serializer, _tojson, document);
             var method = writeMethod.MakeGenericMethod(typeof(string));

--- a/src/Marten/Schema/Arguments/DocJsonBodyArgument.cs
+++ b/src/Marten/Schema/Arguments/DocJsonBodyArgument.cs
@@ -9,7 +9,12 @@ namespace Marten.Schema.Arguments
     public class DocJsonBodyArgument : UpsertArgument
     {
         private static readonly MethodInfo _serializer = ReflectionHelper.GetProperty<UpdateBatch>(x => x.Serializer).GetMethod;
+        private static readonly MethodInfo _getWriter = typeof(UpdateBatch).GetMethod(nameof(UpdateBatch.GetWriter));
         private static readonly MethodInfo _tojson = typeof(ISerializer).GetMethod(nameof(ISerializer.ToJson), new[] { typeof(object) });
+        private static readonly MethodInfo _tojsonWithWriter = typeof(ISerializer).GetMethod(nameof(ISerializer.ToJson), new[] { typeof(object), typeof(CharArrayTextWriter) });
+
+        static readonly MethodInfo _writerBuffer = ReflectionHelper.GetProperty<CharArrayTextWriter>(x => x.Buffer).GetMethod;
+        static readonly MethodInfo _writerSize = ReflectionHelper.GetProperty<CharArrayTextWriter>(x => x.Size).GetMethod;
 
         public DocJsonBodyArgument()
         {
@@ -22,12 +27,27 @@ namespace Marten.Schema.Arguments
         public override Expression CompileUpdateExpression(EnumStorage enumStorage, ParameterExpression call, ParameterExpression doc, ParameterExpression updateBatch, ParameterExpression mapping, ParameterExpression currentVersion, ParameterExpression newVersion, bool useCharBufferPooling)
         {
             var argName = Expression.Constant(Arg);
-
             var serializer = Expression.Call(updateBatch, _serializer);
+            var jsonb = Expression.Constant(NpgsqlDbType.Jsonb);
 
+            if (useCharBufferPooling == false)
+            {
+                var json = Expression.Call(serializer, _tojson, doc);
+                return Expression.Call(call, _paramMethod, argName, json, jsonb);
+            }
+            else
+            {
+                var writer = Expression.Variable(typeof(CharArrayTextWriter), "writer");
 
-            var json = Expression.Call(serializer, _tojson, doc);
-            return Expression.Call(call, _paramMethod, argName, json, Expression.Constant(NpgsqlDbType.Jsonb));
+                var buffer = Expression.Call(writer, _writerBuffer);
+                var size = Expression.Call(writer, _writerSize);
+
+                return Expression.Block(new[] {writer},
+                    Expression.Assign(writer, Expression.Call(updateBatch, _getWriter)),
+                    Expression.Call(serializer, _tojsonWithWriter, doc, writer),
+                    Expression.Call(call, _paramWithSizeMethod, argName, buffer, jsonb, size)
+                );
+            }
         }
 
         public override Expression CompileBulkImporter(EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, bool useCharBufferPooling)

--- a/src/Marten/Schema/Arguments/DocJsonBodyArgument.cs
+++ b/src/Marten/Schema/Arguments/DocJsonBodyArgument.cs
@@ -24,8 +24,9 @@ namespace Marten.Schema.Arguments
             var argName = Expression.Constant(Arg);
 
             var serializer = Expression.Call(updateBatch, _serializer);
-            var json = Expression.Call(serializer, _tojson, doc);
 
+
+            var json = Expression.Call(serializer, _tojson, doc);
             return Expression.Call(call, _paramMethod, argName, json, Expression.Constant(NpgsqlDbType.Jsonb));
         }
 

--- a/src/Marten/Schema/Arguments/DocTypeArgument.cs
+++ b/src/Marten/Schema/Arguments/DocTypeArgument.cs
@@ -18,7 +18,7 @@ namespace Marten.Schema.Arguments
             PostgresType = "varchar";
         }
 
-        public override Expression CompileBulkImporter(EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer)
+        public override Expression CompileBulkImporter(EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, bool useCharBufferPooling)
         {
             var method = writeMethod.MakeGenericMethod(typeof(string));
             var dbType = Expression.Constant(DbType);
@@ -26,7 +26,7 @@ namespace Marten.Schema.Arguments
             return Expression.Call(writer, method, alias, dbType);
         }
 
-        public override Expression CompileUpdateExpression(EnumStorage enumStorage, ParameterExpression call, ParameterExpression doc, ParameterExpression updateBatch, ParameterExpression mapping, ParameterExpression currentVersion, ParameterExpression newVersion)
+        public override Expression CompileUpdateExpression(EnumStorage enumStorage, ParameterExpression call, ParameterExpression doc, ParameterExpression updateBatch, ParameterExpression mapping, ParameterExpression currentVersion, ParameterExpression newVersion, bool useCharBufferPooling)
         {
             var argName = Expression.Constant(Arg);
             var dbType = Expression.Constant(NpgsqlDbType.Varchar);

--- a/src/Marten/Schema/Arguments/DotNetTypeArgument.cs
+++ b/src/Marten/Schema/Arguments/DotNetTypeArgument.cs
@@ -22,7 +22,7 @@ namespace Marten.Schema.Arguments
             PostgresType = "varchar";
         }
 
-        public override Expression CompileBulkImporter(EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer)
+        public override Expression CompileBulkImporter(EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, bool useCharBufferPooling)
         {
             var getType = Expression.Call(document, _getType);
             var getName = Expression.Call(getType, _fullName);
@@ -34,7 +34,7 @@ namespace Marten.Schema.Arguments
             return Expression.Call(writer, method, getName, dbType);
         }
 
-        public override Expression CompileUpdateExpression(EnumStorage enumStorage, ParameterExpression call, ParameterExpression doc, ParameterExpression updateBatch, ParameterExpression mapping, ParameterExpression currentVersion, ParameterExpression newVersion)
+        public override Expression CompileUpdateExpression(EnumStorage enumStorage, ParameterExpression call, ParameterExpression doc, ParameterExpression updateBatch, ParameterExpression mapping, ParameterExpression currentVersion, ParameterExpression newVersion, bool useCharBufferPooling)
         {
             var getType = Expression.Call(doc, _getType);
             var getName = Expression.Call(getType, _fullName);

--- a/src/Marten/Schema/Arguments/UpsertArgument.cs
+++ b/src/Marten/Schema/Arguments/UpsertArgument.cs
@@ -17,6 +17,9 @@ namespace Marten.Schema.Arguments
         protected static readonly MethodInfo _paramMethod = typeof(SprocCall)
             .GetMethod("Param", new[] {typeof(string), typeof(object), typeof(NpgsqlDbType)});
 
+        protected static readonly MethodInfo _paramWithSizeMethod = typeof(SprocCall)
+            .GetMethod("Param", new[] { typeof(string), typeof(object), typeof(NpgsqlDbType), typeof(int) });
+
         private MemberInfo[] _members;
         private string _postgresType;
         public string Arg { get; set; }
@@ -61,7 +64,7 @@ namespace Marten.Schema.Arguments
             return $"{Arg} {PostgresType}";
         }
 
-        public virtual Expression CompileBulkImporter(EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer)
+        public virtual Expression CompileBulkImporter(EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, bool useCharBufferPooling)
         {
             var memberType = Members.Last().GetMemberType();
 
@@ -82,7 +85,7 @@ namespace Marten.Schema.Arguments
         }
 
 
-        public virtual Expression CompileUpdateExpression(EnumStorage enumStorage, ParameterExpression call, ParameterExpression doc, ParameterExpression updateBatch, ParameterExpression mapping, ParameterExpression currentVersion, ParameterExpression newVersion)
+        public virtual Expression CompileUpdateExpression(EnumStorage enumStorage, ParameterExpression call, ParameterExpression doc, ParameterExpression updateBatch, ParameterExpression mapping, ParameterExpression currentVersion, ParameterExpression newVersion, bool useCharBufferPooling)
         {
             var argName = Expression.Constant(Arg);
 

--- a/src/Marten/Schema/Arguments/VersionArgument.cs
+++ b/src/Marten/Schema/Arguments/VersionArgument.cs
@@ -20,7 +20,7 @@ namespace Marten.Schema.Arguments
             PostgresType = "uuid";
         }
 
-        public override Expression CompileBulkImporter(EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer)
+        public override Expression CompileBulkImporter(EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, bool useCharBufferPooling)
         {
             Expression value = Expression.Call(_newGuid);
 
@@ -31,7 +31,7 @@ namespace Marten.Schema.Arguments
             return Expression.Call(writer, method, value, dbType);
         }
 
-        public override Expression CompileUpdateExpression(EnumStorage enumStorage, ParameterExpression call, ParameterExpression doc, ParameterExpression updateBatch, ParameterExpression mapping, ParameterExpression currentVersion, ParameterExpression newVersion)
+        public override Expression CompileUpdateExpression(EnumStorage enumStorage, ParameterExpression call, ParameterExpression doc, ParameterExpression updateBatch, ParameterExpression mapping, ParameterExpression currentVersion, ParameterExpression newVersion, bool useCharBufferPooling)
         {
             var dbType = Expression.Constant(DbType);
             return Expression.Call(call, _paramMethod, Expression.Constant(Arg), Expression.Convert(newVersion, typeof(object)), dbType);

--- a/src/Marten/Schema/BulkLoading/BulkLoader.cs
+++ b/src/Marten/Schema/BulkLoading/BulkLoader.cs
@@ -22,7 +22,7 @@ namespace Marten.Schema.BulkLoading
         private readonly string _tempTableName;
 
 
-        public BulkLoader(ISerializer serializer, DocumentMapping mapping, IdAssignment<T> assignment)
+        public BulkLoader(ISerializer serializer, DocumentMapping mapping, IdAssignment<T> assignment, bool useCharBufferPooling)
         {
             _mapping = mapping;
             _assignment = assignment;
@@ -39,7 +39,7 @@ namespace Marten.Schema.BulkLoading
             var arguments = upsertFunction.OrderedArguments().Where(x => !(x is CurrentVersionArgument)).ToArray();
             var expressions =
                 arguments.Select(
-                    x => x.CompileBulkImporter(serializer.EnumStorage, writer, document, alias, serializerParam));
+                    x => x.CompileBulkImporter(serializer.EnumStorage, writer, document, alias, serializerParam, useCharBufferPooling));
 
             var columns = arguments.Select(x => $"\"{x.Column}\"").Join(", ");
             _baseSql = $"COPY %TABLE%({columns}) FROM STDIN BINARY";

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -124,7 +124,7 @@ namespace Marten.Schema
 
             var closedType = resolverType.MakeGenericType(DocumentType);
 
-            return Activator.CreateInstance(closedType, schema.StoreOptions.Serializer(), this)
+            return Activator.CreateInstance(closedType, schema.StoreOptions.Serializer(), this, schema.StoreOptions.UseCharBufferPooling)
                 .As<IDocumentStorage>();
         }
 

--- a/src/Marten/Schema/DocumentSchema.cs
+++ b/src/Marten/Schema/DocumentSchema.cs
@@ -143,7 +143,7 @@ namespace Marten.Schema
 
                 if (mapping is DocumentMapping)
                 {
-                    return new BulkLoader<T>(StoreOptions.Serializer(), mapping.As<DocumentMapping>(), assignment);
+                    return new BulkLoader<T>(StoreOptions.Serializer(), mapping.As<DocumentMapping>(), assignment, StoreOptions.UseCharBufferPooling);
                 }
 
                 

--- a/src/Marten/Schema/HierarchicalResolver.cs
+++ b/src/Marten/Schema/HierarchicalResolver.cs
@@ -10,8 +10,8 @@ namespace Marten.Schema
     {
         private readonly DocumentMapping _hierarchy;
 
-        public HierarchicalResolver(ISerializer serializer, DocumentMapping hierarchy)
-            : base(serializer, hierarchy)
+        public HierarchicalResolver(ISerializer serializer, DocumentMapping hierarchy, bool useCharBufferPooling)
+            : base(serializer, hierarchy, useCharBufferPooling)
         {
             _hierarchy = hierarchy;
         }

--- a/src/Marten/Schema/Resolver.cs
+++ b/src/Marten/Schema/Resolver.cs
@@ -23,13 +23,15 @@ namespace Marten.Schema
         private readonly string _loaderSql;
         private readonly ISerializer _serializer;
         private readonly DocumentMapping _mapping;
+        private readonly bool _useCharBufferPooling;
         private readonly FunctionName _upsertName;
         private readonly Action<SprocCall, T, UpdateBatch, DocumentMapping, Guid?, Guid> _sprocWriter;
 
-        public Resolver(ISerializer serializer, DocumentMapping mapping)
+        public Resolver(ISerializer serializer, DocumentMapping mapping, bool useCharBufferPooling)
         {
             _serializer = serializer;
             _mapping = mapping;
+            _useCharBufferPooling = useCharBufferPooling;
             IdType = TypeMappings.ToDbType(mapping.IdMember.GetMemberType());
 
 
@@ -75,7 +77,7 @@ namespace Marten.Schema
 
             var arguments = new UpsertFunction(mapping).OrderedArguments().Select(x =>
             {
-                return x.CompileUpdateExpression(_serializer.EnumStorage, call, doc, batch, mappingParam, currentVersion, newVersion);
+                return x.CompileUpdateExpression(_serializer.EnumStorage, call, doc, batch, mappingParam, currentVersion, newVersion, _useCharBufferPooling);
             });
 
             var block = Expression.Block(arguments);

--- a/src/Marten/Services/CharArrayTextWriter.cs
+++ b/src/Marten/Services/CharArrayTextWriter.cs
@@ -119,13 +119,21 @@ namespace Marten.Services
             public void Release(CharArrayTextWriter writer)
             {
                 // currently, all writers are cached. This might be changed to hold only N writers in the cache.
+
+                writer._next = 0;
                 _cache.Push(writer);
             }
 
             public void Release(IEnumerable<CharArrayTextWriter> writer)
             {
                 // currently, all writers are cached. This might be changed to hold only N writers in the cache.
-                _cache.PushRange(writer.ToArray());
+                var writers = writer.ToArray();
+                // ReSharper disable once ForCanBeConvertedToForeach
+                for (var i = 0; i < writers.Length; i++)
+                {
+                    writers[i]._next = 0;
+                }
+                _cache.PushRange(writers);
             }
         }
     }

--- a/src/Marten/Services/CharArrayTextWriter.cs
+++ b/src/Marten/Services/CharArrayTextWriter.cs
@@ -142,6 +142,11 @@ namespace Marten.Services
             {
                 // currently, all writers are cached. This might be changed to hold only N writers in the cache.
                 var writers = writer.ToArray();
+                if (writers.Length == 0)
+                {
+                    return;
+                }
+
                 // ReSharper disable once ForCanBeConvertedToForeach
                 for (var i = 0; i < writers.Length; i++)
                 {

--- a/src/Marten/Services/CharArrayTextWriter.cs
+++ b/src/Marten/Services/CharArrayTextWriter.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Marten.Services
+{
+    public sealed class CharArrayTextWriter : TextWriter
+    {
+        public const int InitialSize = 4096;
+        static readonly Encoding EncodingValue = new UnicodeEncoding(false, false);
+        char[] _chars = new char[InitialSize];
+        int _next;
+        int _length = InitialSize;
+
+        public override Encoding Encoding => EncodingValue;
+
+        public override void Write(char value)
+        {
+            Ensure(1);
+            _chars[_next] = value;
+            _next += 1;
+        }
+
+        void Ensure(int i)
+        {
+            if (_next + i >= _length)
+            {
+                _length *= 2;
+                Array.Resize(ref _chars, _length);
+            }
+        }
+
+        public override void Write(char[] buffer, int index, int count)
+        {
+            Ensure(count);
+            Array.Copy(buffer, index, _chars, _next, count);
+            _next += count;
+        }
+
+        public override void Write(string value)
+        {
+            var length = value.Length;
+            Ensure(length);
+            value.CopyTo(0, _chars, _next, length);
+            _next += length;
+        }
+
+        public override Task WriteAsync(char value)
+        {
+            Write(value);
+            return Task.CompletedTask;
+        }
+
+        public override Task WriteAsync(string value)
+        {
+            Write(value);
+            return Task.CompletedTask;
+        }
+
+        public override Task WriteAsync(char[] buffer, int index, int count)
+        {
+            Write(buffer, index, count);
+            return Task.CompletedTask;
+        }
+
+        public override Task WriteLineAsync(char value)
+        {
+            WriteLine(value);
+            return Task.CompletedTask;
+        }
+
+        public override Task WriteLineAsync(string value)
+        {
+            WriteLine(value);
+            return Task.CompletedTask;
+        }
+
+        public override Task WriteLineAsync(char[] buffer, int index, int count)
+        {
+            WriteLine(buffer, index, count);
+            return Task.CompletedTask;
+        }
+
+        public override Task FlushAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public ArraySegment<char> ToRawArraySegment()
+        {
+            return new ArraySegment<char>(_chars,0, _next);
+        }
+    }
+}

--- a/src/Marten/Services/DirtyTrackingIdentityMap.cs
+++ b/src/Marten/Services/DirtyTrackingIdentityMap.cs
@@ -6,9 +6,16 @@ namespace Marten.Services
 {
     public class DirtyTrackingIdentityMap : IdentityMap<TrackedEntity>, IDocumentTracker
     {
-        public DirtyTrackingIdentityMap(ISerializer serializer, IEnumerable<IDocumentSessionListener> listeners) : base(serializer, listeners)
+        readonly CharArrayTextWriter.IPool _pool;
+
+        public DirtyTrackingIdentityMap(ISerializer serializer, IEnumerable<IDocumentSessionListener> listeners, CharArrayTextWriter.IPool pool) : base(serializer, listeners)
         {
+            _pool = pool;
         }
+
+        // TEST PURPOSES ONLY
+        public DirtyTrackingIdentityMap(ISerializer serializer, IEnumerable<IDocumentSessionListener> listeners) : this(serializer, listeners, new CharArrayTextWriter.Pool())
+        {}
 
         protected override TrackedEntity ToCache(object id, Type concreteType, object document, string json)
         {

--- a/src/Marten/Services/JsonNetSerializer.cs
+++ b/src/Marten/Services/JsonNetSerializer.cs
@@ -37,6 +37,11 @@ namespace Marten.Services
             _clean.TypeNameHandling = TypeNameHandling.None;
         }
 
+        public void ToJson(object document, TextWriter writer)
+        {
+            _serializer.Serialize(writer, document);
+        }
+
         public string ToJson(object document)
         {
             var writer = new StringWriter();

--- a/src/Marten/Services/SprocCall.cs
+++ b/src/Marten/Services/SprocCall.cs
@@ -76,6 +76,16 @@ namespace Marten.Services
             return this;
         }
 
+        public SprocCall Param(string argName, object value, NpgsqlDbType dbType, int size)
+        {
+            var param = _parent.AddParameter(value, dbType);
+            param.Size = size;
+
+            _parameters.Add(new ParameterArg(argName, param));
+
+            return this;
+        }
+
         public struct ParameterArg
         {
             public string ArgName;

--- a/src/Marten/Services/UpdateBatch.cs
+++ b/src/Marten/Services/UpdateBatch.cs
@@ -14,14 +14,16 @@ namespace Marten.Services
         private readonly Stack<BatchCommand> _commands = new Stack<BatchCommand>();
         private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
         private readonly StoreOptions _options;
-
+        private readonly CharArrayTextWriter.Pool _writerPool;
+        private readonly List<CharArrayTextWriter> _writers = new List<CharArrayTextWriter>();
 
         public UpdateBatch(StoreOptions options, ISerializer serializer, IManagedConnection connection,
-            VersionTracker versions)
+            VersionTracker versions, CharArrayTextWriter.Pool writerPool)
         {
             if (versions == null) throw new ArgumentNullException(nameof(versions));
 
             _options = options;
+            _writerPool = writerPool;
             Serializer = serializer;
             Versions = versions;
 
@@ -34,6 +36,13 @@ namespace Marten.Services
         public VersionTracker Versions { get; }
 
         public IManagedConnection Connection { get; }
+
+        public CharArrayTextWriter GetWriter()
+        {
+            var writer = _writerPool.Lease();
+            _writers.Add(writer);
+            return writer;
+        }
 
         public void Dispose()
         {
@@ -70,24 +79,32 @@ namespace Marten.Services
         {
             var list = new List<Exception>();
 
-            foreach (var batch in _commands.ToArray())
+            try
             {
-                var cmd = batch.BuildCommand();
-                Connection.Execute(cmd, c =>
+                foreach (var batch in _commands.ToArray())
                 {
-                    if (batch.HasCallbacks())
+                    var cmd = batch.BuildCommand();
+                    Connection.Execute(cmd, c =>
                     {
-                        executeCallbacks(cmd, batch, list);
-                    }
-                    else
-                    {
-                        cmd.ExecuteNonQuery();
-                    }
-                });
-            }
+                        if (batch.HasCallbacks())
+                        {
+                            executeCallbacks(cmd, batch, list);
+                        }
+                        else
+                        {
+                            cmd.ExecuteNonQuery();
+                        }
+                    });
+                }
 
-            if (list.Any())
-                throw new AggregateException(list);
+                if (list.Any())
+                    throw new AggregateException(list);
+            }
+            finally
+            {
+                _writerPool.Release(_writers);
+                _writers.Clear();
+            }
         }
 
         private static void executeCallbacks(NpgsqlCommand cmd, BatchCommand batch, List<Exception> list)
@@ -113,25 +130,33 @@ namespace Marten.Services
 
         public async Task ExecuteAsync(CancellationToken token)
         {
-            var list = new List<Exception>();
-            foreach (var batch in _commands.ToArray())
+            try
             {
-                var cmd = batch.BuildCommand();
-                await Connection.ExecuteAsync(cmd, async (c, tkn) =>
+                var list = new List<Exception>();
+                foreach (var batch in _commands.ToArray())
                 {
-                    if (batch.HasCallbacks())
+                    var cmd = batch.BuildCommand();
+                    await Connection.ExecuteAsync(cmd, async (c, tkn) =>
                     {
-                        await executeCallbacksAsync(c, tkn, batch, list);
-                    }
-                    else
-                    {
-                        await c.ExecuteNonQueryAsync(tkn);
-                    }
-                }, token).ConfigureAwait(false);
-            }
+                        if (batch.HasCallbacks())
+                        {
+                            await executeCallbacksAsync(c, tkn, batch, list);
+                        }
+                        else
+                        {
+                            await c.ExecuteNonQueryAsync(tkn);
+                        }
+                    }, token).ConfigureAwait(false);
+                }
 
-            if (list.Any())
-                throw new AggregateException(list);
+                if (list.Any())
+                    throw new AggregateException(list);
+            }
+            finally
+            {
+                _writerPool.Release(_writers);
+                _writers.Clear();
+            }
         }
 
         private static async Task executeCallbacksAsync(NpgsqlCommand cmd, CancellationToken tkn, BatchCommand batch,
@@ -151,7 +176,7 @@ namespace Marten.Services
                             await reader.NextResultAsync(tkn).ConfigureAwait(false);
                         }
 
-                        
+
 
                         if (batch.Callbacks[i] != null)
                         {

--- a/src/Marten/Services/UpdateBatch.cs
+++ b/src/Marten/Services/UpdateBatch.cs
@@ -102,8 +102,11 @@ namespace Marten.Services
             }
             finally
             {
-                _writerPool.Release(_writers);
-                _writers.Clear();
+                if (_writerPool != null)
+                {
+                    _writerPool?.Release(_writers);
+                    _writers.Clear();
+                }
             }
         }
 
@@ -154,8 +157,11 @@ namespace Marten.Services
             }
             finally
             {
-                _writerPool.Release(_writers);
-                _writers.Clear();
+                if (_writerPool != null)
+                {
+                    _writerPool?.Release(_writers);
+                    _writers.Clear();
+                }
             }
         }
 

--- a/src/Marten/Services/UpdateBatch.cs
+++ b/src/Marten/Services/UpdateBatch.cs
@@ -11,14 +11,14 @@ namespace Marten.Services
 {
     public class UpdateBatch : IDisposable
     {
-        private readonly Stack<BatchCommand> _commands = new Stack<BatchCommand>();
-        private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
         private readonly StoreOptions _options;
-        private readonly CharArrayTextWriter.Pool _writerPool;
+        private readonly ISerializer _serializer;
+        private readonly CharArrayTextWriter.IPool _writerPool;
+        private readonly Stack<BatchCommand> _commands = new Stack<BatchCommand>(); 
+        private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
         private readonly List<CharArrayTextWriter> _writers = new List<CharArrayTextWriter>();
-
-        public UpdateBatch(StoreOptions options, ISerializer serializer, IManagedConnection connection,
-            VersionTracker versions, CharArrayTextWriter.Pool writerPool)
+        
+        public UpdateBatch(StoreOptions options, ISerializer serializer, IManagedConnection connection, VersionTracker versions, CharArrayTextWriter.IPool writerPool)
         {
             if (versions == null) throw new ArgumentNullException(nameof(versions));
 

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -95,6 +95,11 @@ namespace Marten
         public int UpdateBatchSize { get; set; } = 500;
 
         /// <summary>
+        /// Configures the store to use char buffer pooling, greatly reducing allocations for serializing documents and events.
+        /// </summary>
+        public bool UseCharBufferPooling { get; set; } = false;
+
+        /// <summary>
         ///     Set the default Id strategy for the document mapping.
         /// </summary>
         public Func<IDocumentMapping, StoreOptions, IIdGeneration> DefaultIdStrategy { get; set; }


### PR DESCRIPTION
**Work in progress**

Addresses #640 

This PR Introduces `CharArrayTextWriter` that by provides access to its `char[]`. Additionally changes the way that driver parameters are created, enables reusing memory and reducing allocations for serializing.

Plan
- [x] change `DocJsonBodyArgument` to use pooled writer
- [x] ~change `EventStreamAppender` to use pooled writers~
- [x] test buffering
- [x] decide what's the best buffering strategy: 
  - one pool per app (current approach) 
  - one per `DocumentStore`
  - additional pool for session to keep leased writers for reuse during the same session and return at the end of the session
  - another one?
- [x] decide should this be `opt-in` or `opt-out` behavior

**Notes:**
- The `EventStreamAppender` can't be changed now as Npgsql does not support writing `ArraySegment<char>` as `jsonb`, `json` nor `string`. I took a look at the implementation of the driver at it would require a lot of work as the [WriteBuffer](https://github.com/npgsql/npgsql/blob/dev/src/Npgsql/WriteBuffer.cs#L331-L33378) does not have overloads for this. If we had it, then appending events would be easy.