### PR TITLE
Last modified extensions

### DIFF
--- a/src/Marten.Testing/Acceptance/last_modified_queries.cs
+++ b/src/Marten.Testing/Acceptance/last_modified_queries.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using Marten.Linq.LastModified;
+using Marten.Testing.Documents;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Acceptance
+{
+    public class last_modified_queries : IntegratedFixture
+    {
+        [Fact]
+        public void query_modified_since_docs()
+        {
+            var user1 = new User { UserName = "foo" };
+            var user2 = new User { UserName = "bar" };
+            var user3 = new User { UserName = "baz" };
+            var user4 = new User { UserName = "jack" };
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(user1, user2, user3, user4);
+                session.SaveChanges();
+
+                var beforeChange = DateTimeOffset.UtcNow.DateTime;
+                session.Store(user3, user4);
+                session.SaveChanges();
+
+                // no where clause
+                session.Query<User>().Where(x => x.ModifiedSince(beforeChange)).OrderBy(x => x.UserName).Select(x => x.UserName)
+                    .ToList().ShouldHaveTheSameElementsAs("baz", "jack");
+
+                // with a where clause
+                session.Query<User>().Where(x => x.UserName != "baz" && x.ModifiedSince(beforeChange))
+                    .OrderBy(x => x.UserName)
+                    .ToList()
+                    .Select(x => x.UserName)
+                    .Single().ShouldBe("jack");
+            }
+        }
+
+        [Fact]
+        public void query_modified_before_docs()
+        {
+            var user1 = new User { UserName = "foo" };
+            var user2 = new User { UserName = "bar" };
+            var user3 = new User { UserName = "baz" };
+            var user4 = new User { UserName = "jack" };
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(user1, user2, user3, user4);
+                session.SaveChanges();
+
+                var epoch = DateTimeOffset.UtcNow;
+                session.Store(user3, user4);
+                session.SaveChanges();
+
+                // no where clause
+                session.Query<User>().Where(x => x.ModifiedBefore(epoch)).OrderBy(x => x.UserName).Select(x => x.UserName)
+                    .ToList().ShouldHaveTheSameElementsAs("bar", "foo");
+
+                // with a where clause
+                session.Query<User>().Where(x => x.UserName != "bar" && x.ModifiedBefore(epoch))
+                    .OrderBy(x => x.UserName)
+                    .ToList()
+                    .Select(x => x.UserName)
+                    .Single().ShouldBe("foo");
+            }
+        }
+    }
+}

--- a/src/Marten.Testing/MartenRegistryTests.cs
+++ b/src/Marten.Testing/MartenRegistryTests.cs
@@ -4,7 +4,6 @@ using Baseline;
 using Marten.Schema;
 using Marten.Testing.Documents;
 using Shouldly;
-using StructureMap;
 using Xunit;
 
 namespace Marten.Testing
@@ -82,6 +81,16 @@ namespace Marten.Testing
             mapping.PropertySearching.ShouldBe(PropertySearching.ContainmentOperator);
         }
 
+        [Fact]
+        public void mt_last_modified_index_is_added()
+        {
+            var mapping = theSchema.MappingFor(typeof(Organization)).As<DocumentMapping>();
+
+            var index = mapping.IndexesFor(DocumentMapping.LastModifiedColumn).Single();
+
+            index.IsConcurrent.ShouldBe(true);
+        }
+
         public class TestRegistry : MartenRegistry
         {
             public TestRegistry()
@@ -91,7 +100,8 @@ namespace Marten.Testing
                     {
                         x.IndexName = "mt_special";
                     })
-                    .GinIndexJsonData(x => x.IndexName = "my_gin_index");
+                    .GinIndexJsonData(x => x.IndexName = "my_gin_index")
+                    .IndexLastModified(x => x.IsConcurrent = true);
 
                 For<User>().PropertySearching(PropertySearching.JSON_Locator_Only);
             }

--- a/src/Marten.Testing/Schema/configuring_last_modified_index_Tests.cs
+++ b/src/Marten.Testing/Schema/configuring_last_modified_index_Tests.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+using Marten.Schema;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Schema
+{
+    public class configuring_last_modified_index_Tests
+    {
+        [Fact]
+        public void creates_btree_index_for_mt_last_modified()
+        {
+            var mapping = DocumentMapping.For<Customer>();
+            var indexDefinition = mapping.Indexes.Cast<IndexDefinition>().Single(x => x.Columns.First() == DocumentMapping.LastModifiedColumn);
+
+            indexDefinition.Method.ShouldBe(IndexMethod.btree);
+        }
+
+        [IndexedLastModified]
+        public class Customer
+        {
+        }
+    }
+}

--- a/src/Marten/Linq/LastModified/LastModifiedExtensions.cs
+++ b/src/Marten/Linq/LastModified/LastModifiedExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Marten.Linq.LastModified
+{
+    public static class LastModifiedExtensions
+    {
+        /// <summary>
+        /// The search results should include documents modified since given time (&gt;)
+        /// </summary>
+        /// <param name="doc"></param>
+        /// <param name="time"></param>
+        /// <returns></returns>
+        public static bool ModifiedSince(this object doc, DateTimeOffset time)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// The search results should include documents modified before given time (&lt;)
+        /// </summary>
+        /// <param name="doc"></param>
+        /// <param name="time"></param>
+        /// <returns></returns>
+        public static bool ModifiedBefore(this object doc, DateTimeOffset time)
+        {
+            return true;
+        }
+    }
+}

--- a/src/Marten/Linq/LastModified/ModifiedBeforeParser.cs
+++ b/src/Marten/Linq/LastModified/ModifiedBeforeParser.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Baseline;
+using Marten.Linq.Parsing;
+using Marten.Schema;
+
+namespace Marten.Linq.LastModified
+{
+    public class ModifiedBeforeParser : IMethodCallParser
+    {
+        private static readonly MethodInfo _method =
+            typeof(LastModifiedExtensions).GetMethod(nameof(LastModifiedExtensions.ModifiedBefore));
+
+        public bool Matches(MethodCallExpression expression)
+        {
+            return Equals(expression.Method, _method);
+        }
+
+        public IWhereFragment Parse(IQueryableDocument mapping, ISerializer serializer, MethodCallExpression expression)
+        {
+            var time = expression.Arguments.Last().Value().As<DateTimeOffset>();
+
+            return new WhereFragment($"d.{DocumentMapping.LastModifiedColumn} < ?", time);
+        }
+    }
+}

--- a/src/Marten/Linq/LastModified/ModifiedSinceParser.cs
+++ b/src/Marten/Linq/LastModified/ModifiedSinceParser.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Baseline;
+using Marten.Linq.Parsing;
+using Marten.Schema;
+
+namespace Marten.Linq.LastModified
+{
+    public class ModifiedSinceParser : IMethodCallParser
+    {
+        private static readonly MethodInfo _method =
+            typeof(LastModifiedExtensions).GetMethod(nameof(LastModifiedExtensions.ModifiedSince));
+
+        public bool Matches(MethodCallExpression expression)
+        {
+            return Equals(expression.Method, _method);
+        }
+
+        public IWhereFragment Parse(IQueryableDocument mapping, ISerializer serializer, MethodCallExpression expression)
+        {
+            var time = expression.Arguments.Last().Value().As<DateTimeOffset>();
+
+            return new WhereFragment($"d.{DocumentMapping.LastModifiedColumn} > ?", time);
+        }
+    }
+}

--- a/src/Marten/Linq/MartenExpressionParser.cs
+++ b/src/Marten/Linq/MartenExpressionParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Baseline;
+using Marten.Linq.LastModified;
 using Marten.Linq.Parsing;
 using Marten.Linq.SoftDeletes;
 using Marten.Schema;
@@ -74,6 +75,10 @@ namespace Marten.Linq
             // soft deletes
             new MaybeDeletedParser(),
             new IsDeletedParser(),
+
+            // last modified
+            new ModifiedSinceParser(),
+            new ModifiedBeforeParser(),
 
             // dictionaries
             new DictionaryExpressions()

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -158,6 +158,18 @@ namespace Marten
                 return this;
             }
 
+            /// <summary>
+            /// Creates an index on the predefined Last Modified column
+            /// </summary>
+            /// <param name="configure"></param>
+            /// <returns></returns>
+            public DocumentMappingExpression<T> IndexLastModified(Action<IndexDefinition> configure = null)
+            {
+                alter = m => m.AddLastModifiedIndex(configure);
+
+                return this;
+            }
+
             public DocumentMappingExpression<T> ForeignKey<TReference>(
                 Expression<Func<T, object>> expression,
                 Action<ForeignKeyDefinition> foreignKeyConfiguration = null,

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -290,6 +290,15 @@ namespace Marten.Schema
             return index;
         }
 
+        public IndexDefinition AddLastModifiedIndex(Action<IndexDefinition> configure = null)
+        {
+            var index = new IndexDefinition(this, LastModifiedColumn);
+            configure?.Invoke(index);
+            Indexes.Add(index);
+
+            return index;
+        }
+
         public IndexDefinition AddIndex(params string[] columns)
         {
             var existing = Indexes.OfType<IndexDefinition>().FirstOrDefault(x => x.Columns.SequenceEqual(columns));

--- a/src/Marten/Schema/IndexedLastModifiedAttribute.cs
+++ b/src/Marten/Schema/IndexedLastModifiedAttribute.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Marten.Schema
+{
+    /// <summary>
+    /// Creates an index on the predefined Last Modified column
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class IndexedLastModifiedAttribute : MartenAttribute
+    {
+        public override void Modify(DocumentMapping mapping)
+        {
+            mapping.AddLastModifiedIndex();
+        }
+    }
+}


### PR DESCRIPTION
Enable the use of the built in `mt_last_modified` column without dropping to raw queries.

Also adds mapping/registry/attribute option to configure index on the storage column.