### PR TITLE
[WIP] Buffer pooling for appending events.

### DIFF
--- a/src/Marten/Events/EventStreamAppender.cs
+++ b/src/Marten/Events/EventStreamAppender.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Baseline;
 using Marten.Schema;
@@ -25,16 +26,43 @@ namespace Marten.Events
 
             var streamTypeName = stream.AggregateType == null ? null : _graph.AggregateAliasFor(stream.AggregateType);
 
-            var eventTypes = stream.Events.Select(x => _graph.EventMappingFor(x.Data.GetType()).EventTypeName).ToArray();
-            var bodies = stream.Events.Select(x => batch.Serializer.ToJson(x.Data)).ToArray();
-            var ids = stream.Events.Select(x => x.Id).ToArray();
+            var events = stream.Events.ToArray();
+            var eventTypes = events.Select(x => _graph.EventMappingFor(x.Data.GetType()).EventTypeName).ToArray();
+            var ids = events.Select(x => x.Id).ToArray();
 
-            batch.Sproc(AppendEventFunction, new EventStreamVersioningCallback(stream))
+            var sprocCall = batch.Sproc(AppendEventFunction, new EventStreamVersioningCallback(stream))
                 .Param("stream", stream.Id)
                 .Param("stream_type", streamTypeName)
                 .Param("event_ids", ids)
-                .Param("event_types", eventTypes)
-                .JsonBodies("bodies", bodies);
+                .Param("event_types", eventTypes);
+
+            AddJsonBodies(batch, sprocCall, events);
+        }
+
+        static void AddJsonBodies(UpdateBatch batch, SprocCall sprocCall, IEvent[] events)
+        {
+            var serializer = batch.Serializer;
+
+            if (batch.UseCharBufferPooling)
+            {
+                var segments = new ArraySegment<char>[events.Length];
+                for (var i = 0; i < events.Length; i++)
+                {
+                    segments[i] = SerializeToCharArraySegment(batch, serializer, events[i].Data);
+                }
+                sprocCall.JsonBodies("bodies", segments);
+            }
+            else
+            {
+                sprocCall.JsonBodies("bodies", events.Select(x => serializer.ToJson(x.Data)).ToArray());
+            }
+        }
+
+        static ArraySegment<char> SerializeToCharArraySegment(UpdateBatch batch, ISerializer serializer, object data)
+        {
+            var writer = batch.GetWriter();
+            serializer.ToJson(data, writer);
+            return new ArraySegment<char>(writer.Buffer, 0, writer.Size);
         }
 
         public void RegisterUpdate(UpdateBatch batch, object entity, string json)

--- a/src/Marten/Services/SprocCall.cs
+++ b/src/Marten/Services/SprocCall.cs
@@ -67,6 +67,11 @@ namespace Marten.Services
             return Param(argName, bodies, NpgsqlDbType.Jsonb | NpgsqlDbType.Array);
         }
 
+        public SprocCall JsonBodies(string argName, ArraySegment<char>[] bodies)
+        {
+            return Param(argName, bodies, NpgsqlDbType.Jsonb | NpgsqlDbType.Array);
+        }
+
         public SprocCall Param(string argName, object value, NpgsqlDbType dbType)
         {
             var param = _parent.AddParameter(value, dbType);

--- a/src/Marten/Services/UpdateBatch.cs
+++ b/src/Marten/Services/UpdateBatch.cs
@@ -198,5 +198,7 @@ namespace Marten.Services
             foreach (var op in operations)
                 Add(op);
         }
+
+        public bool UseCharBufferPooling => _options.UseCharBufferPooling;
     }
 }


### PR DESCRIPTION
Events are appended using `ArraySegment<char>` from a pooled writer when `UseCharBufferPooling` is enabled.

This will work as soon as https://github.com/npgsql/npgsql/pull/1411 is released in [npgsql 3.2](https://github.com/npgsql/npgsql/milestone/24)