### PR TITLE
Support Parameterized Constructors in Select projections

### DIFF
--- a/src/Marten.Testing/Services/SelectTransformerTests.cs
+++ b/src/Marten.Testing/Services/SelectTransformerTests.cs
@@ -18,8 +18,8 @@ namespace Marten.Testing.Linq
         {
             theMapping = DocumentMapping.For<User>();
             theTarget = new TargetObject(typeof(invoking_query_with_select_Tests.User2));
-            theTarget.StartBinding(ReflectionHelper.GetProperty<User>(x => x.FirstName)).Members.Add(ReflectionHelper.GetProperty<User2>(x => x.First));
-            theTarget.StartBinding(ReflectionHelper.GetProperty<User>(x => x.LastName)).Members.Add(ReflectionHelper.GetProperty<User2>(x => x.Last));
+            theTarget.StartBinding(ReflectionHelper.GetProperty<User>(x => x.FirstName).Name).Add(ReflectionHelper.GetProperty<User2>(x => x.First));
+            theTarget.StartBinding(ReflectionHelper.GetProperty<User>(x => x.LastName).Name).Add(ReflectionHelper.GetProperty<User2>(x => x.Last));
 
             theSelector = new SelectTransformer<User2>(theMapping, theTarget);
         }

--- a/src/Marten/Linq/TargetObject.cs
+++ b/src/Marten/Linq/TargetObject.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -10,17 +11,17 @@ namespace Marten.Linq
     public class TargetObject
     {
         public Type Type { get; }
-        public readonly IList<SetterBinding> Setters = new List<SetterBinding>(); 
+        private readonly IList<SetterBinding> _setters = new List<SetterBinding>(); 
 
         public TargetObject(Type type)
         {
             Type = type;
         }
 
-        public SelectedField StartBinding(MemberInfo member)
+        public SelectedField StartBinding(string bindingName)
         {
-            var setter = new SetterBinding(member);
-            Setters.Add(setter);
+            var setter = new SetterBinding(bindingName);
+            _setters.Add(setter);
 
             return setter.Field;
         }
@@ -32,7 +33,7 @@ namespace Marten.Linq
 
         public string ToSelectField(IQueryableDocument mapping)
         {
-            var jsonBuildObjectArgs = Setters.Select(x => x.ToJsonBuildObjectPair(mapping)).Join(", ");
+            var jsonBuildObjectArgs = _setters.Select(x => x.ToJsonBuildObjectPair(mapping)).Join(", ");
             return  $"jsonb_build_object({jsonBuildObjectArgs}) as json";
         }
 
@@ -40,6 +41,45 @@ namespace Marten.Linq
         {
             var field = ToSelectField(mapping);
             return new JsonSelector(field).As<ISelector<T>>();
+        }
+
+        private class SetterBinding
+        {
+            public SetterBinding(string name)
+            {
+                Name = name;
+            }
+
+            private string Name { get; }
+            public SelectedField Field { get; } = new SelectedField();
+
+            public string ToJsonBuildObjectPair(IQueryableDocument mapping)
+            {
+                var field = mapping.FieldFor(Field.ToArray());
+                var locator = field.SelectionLocator ?? field.SqlLocator;
+
+                return $"'{Name}', {locator}";
+            }
+        }
+    }
+
+    public class SelectedField : IEnumerable<MemberInfo>
+    {
+        private readonly Stack<MemberInfo> _members = new Stack<MemberInfo>();
+
+        public void Add(MemberInfo member)
+        {
+            _members.Push(member);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public IEnumerator<MemberInfo> GetEnumerator()
+        {
+            return _members.GetEnumerator();
         }
     }
 }


### PR DESCRIPTION
Adds support for type constructors with parameters in Select.

This obviously also requires support from your serializer, Newtonsoft.Json is ok but JIL for instance does not support, but at least the `json_build_object()` call is generated correctly irrespective of whether the user has specified field selectors as constructor arguments or property setters.