### PR TITLE
GH-516 initial projection rebuild and async daemon running in Marten.CommandLine

### DIFF
--- a/src/Marten.CommandLine/Commands/ApplyCommand.cs
+++ b/src/Marten.CommandLine/Commands/ApplyCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Oakton;
 
-namespace Marten.CommandLine
+namespace Marten.CommandLine.Commands
 {
     [Description("Applies all outstanding changes to the database based on the current configuration")]
     public class ApplyCommand : MartenCommand<MartenInput>

--- a/src/Marten.CommandLine/Commands/AssertCommand.cs
+++ b/src/Marten.CommandLine/Commands/AssertCommand.cs
@@ -2,7 +2,7 @@
 using Marten.Schema;
 using Oakton;
 
-namespace Marten.CommandLine
+namespace Marten.CommandLine.Commands
 {
     [Description("Assert that the existing database matches the current Marten configuration")]
     public class AssertCommand : MartenCommand<MartenInput>

--- a/src/Marten.CommandLine/Commands/Dump/DumpCommand.cs
+++ b/src/Marten.CommandLine/Commands/Dump/DumpCommand.cs
@@ -2,7 +2,7 @@
 using Baseline;
 using Oakton;
 
-namespace Marten.CommandLine
+namespace Marten.CommandLine.Commands.Dump
 {
     [Description("Dumps the entire DDL for the configured Marten database")]
     public class DumpCommand : MartenCommand<DumpInput>

--- a/src/Marten.CommandLine/Commands/Dump/DumpInput.cs
+++ b/src/Marten.CommandLine/Commands/Dump/DumpInput.cs
@@ -1,6 +1,6 @@
 ﻿using Oakton;
 
-namespace Marten.CommandLine
+namespace Marten.CommandLine.Commands.Dump
 {
     public class DumpInput : MartenInput
     {

--- a/src/Marten.CommandLine/Commands/Patch/PatchCommand.cs
+++ b/src/Marten.CommandLine/Commands/Patch/PatchCommand.cs
@@ -2,7 +2,7 @@
 using Marten.Schema;
 using Oakton;
 
-namespace Marten.CommandLine
+namespace Marten.CommandLine.Commands.Patch
 {
     [Description(
          "Evaluates the current configuration against the database and writes a patch and drop file if there are any differences"

--- a/src/Marten.CommandLine/Commands/Patch/PatchInput.cs
+++ b/src/Marten.CommandLine/Commands/Patch/PatchInput.cs
@@ -1,6 +1,6 @@
 ﻿using Oakton;
 
-namespace Marten.CommandLine
+namespace Marten.CommandLine.Commands.Patch
 {
     public class PatchInput : MartenInput
     {

--- a/src/Marten.CommandLine/Commands/Projection/ProjectionCommand.cs
+++ b/src/Marten.CommandLine/Commands/Projection/ProjectionCommand.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Linq;
+using Marten.Events.Projections.Async;
+using Oakton;
+
+namespace Marten.CommandLine.Commands.Projection
+{
+    [Description("Rebuilds all projections of specified kind")]
+    public class ProjectionCommand : MartenCommand<ProjectionInput>
+    {
+        public ProjectionCommand()
+        {
+            Usage("Rebuilds a specified kind of projections, either async or inline")
+                .Arguments(x => x.Kind);
+        }
+
+        protected override bool execute(IDocumentStore store, ProjectionInput input)
+        {
+            var daemon = GetDaemon(input.Kind, store);
+            daemon.RebuildAll().Wait();
+            return true;
+        }
+
+        private IDaemon GetDaemon(ProjectionInput.ProjectionKind inputKind, IDocumentStore store)
+        {
+            var logger = GetDaemonLogger();
+            switch (inputKind)
+            {
+                case ProjectionInput.ProjectionKind.async:
+                    return store.BuildProjectionDaemon(logger: logger);
+                case ProjectionInput.ProjectionKind.inline:
+                    return store.BuildProjectionDaemon(projections: store.Schema.Events.InlineProjections.ToArray(),
+                        logger: GetDaemonLogger());
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(inputKind), inputKind, null);
+            }
+        }
+
+        private IDaemonLogger GetDaemonLogger() => new ConsoleDaemonLogger();
+    }
+}

--- a/src/Marten.CommandLine/Commands/Projection/ProjectionInput.cs
+++ b/src/Marten.CommandLine/Commands/Projection/ProjectionInput.cs
@@ -1,0 +1,16 @@
+﻿using Oakton;
+
+namespace Marten.CommandLine.Commands.Projection
+{
+    public class ProjectionInput: MartenInput
+    {
+        public enum ProjectionKind
+        {
+            async,
+            inline
+        };
+
+        [Description("Projections kind: Async or Inline")]
+        public ProjectionKind Kind { get; set; } = ProjectionKind.async;
+    }
+}

--- a/src/Marten.CommandLine/Commands/RunDaemon.cs
+++ b/src/Marten.CommandLine/Commands/RunDaemon.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Marten.Events.Projections.Async;
+using Oakton;
+
+namespace Marten.CommandLine.Commands
+{
+    [Description("Run the async projections daemon")]
+    public class RunDaemon: MartenCommand<MartenInput>
+    {
+        protected override bool execute(IDocumentStore store, MartenInput input)
+        {
+            var daemon = store.BuildProjectionDaemon(logger: new ConsoleDaemonLogger());
+            daemon.StartAll();
+            input.WriteLine(ConsoleColor.Green, "Daemon started. Press enter to stop.");
+            Console.ReadLine();
+            daemon.StopAll();
+            input.WriteLine(ConsoleColor.DarkCyan, "Daemon stopped");
+            return true;
+        }
+    }
+}

--- a/src/Marten.CommandLine/project.json
+++ b/src/Marten.CommandLine/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Command line tooling for managing Marten development",
   "authors": [
     "Jeremy D. Miller",


### PR DESCRIPTION
I've re-organized files layout to make it more readable, hope it's ok

this change introduces two new commands, 

* projection inline|async - which rebuilds either inline or async projections
* rundaemon which runs the async projection daemon

to be honest, I'm not fully convinced to using Daemon for rebuilding inline projections. It's very tempting because all the paging etc is already there, and therefore I've used it, at least for now.
On the other hand, I'm afraid of possible side effects, the tracking information being stored for inline projections - to name one. 
Maybe it'd be better to use Daemon (ProjectionTracks, in fact) in "no-tracking" mode, or even better - extract the paged fetching/applying out of the ProjectionTrack ?