### PR TITLE
Typename not getting properly written to mt_streams when using private apply strategy

### DIFF
--- a/src/Marten/Events/Projections/Aggregator.cs
+++ b/src/Marten/Events/Projections/Aggregator.cs
@@ -14,14 +14,11 @@ namespace Marten.Events.Projections
         private readonly IDictionary<Type, object> _aggregations = new Dictionary<Type, object>();
 
 
-        public Aggregator() : this(typeof(T).GetMethods()
-                .Where(x => x.Name == ApplyMethod && x.GetParameters().Length == 1))
-        {           
-            Alias = typeof(T).Name.ToTableAlias();
-        }
+        public Aggregator() : this(typeof(T).GetMethods().Where(x => x.Name == ApplyMethod && x.GetParameters().Length == 1)) { }
 
         protected Aggregator(IEnumerable<MethodInfo> overrideMethodLookup)
         {
+            Alias = typeof(T).Name.ToTableAlias();
             overrideMethodLookup
                 .Each(method =>
                 {

--- a/src/Marten/Events/StreamStateHandler.cs
+++ b/src/Marten/Events/StreamStateHandler.cs
@@ -67,7 +67,7 @@ namespace Marten.Events
         {
             var id = await reader.GetFieldValueAsync<Guid>(0, token).ConfigureAwait(false);
             var version = await reader.GetFieldValueAsync<int>(1, token).ConfigureAwait(false);
-            var typeName = await reader.IsDBNullAsync(2, token) ? null : await reader.GetFieldValueAsync<string>(2, token).ConfigureAwait(false);
+            var typeName = await reader.IsDBNullAsync(2, token).ConfigureAwait(false) ? null : await reader.GetFieldValueAsync<string>(2, token).ConfigureAwait(false);
             var timestamp = await reader.GetFieldValueAsync<DateTime>(3, token).ConfigureAwait(false);
 
             Type aggregateType = null;

--- a/src/Marten/Events/StreamStateHandler.cs
+++ b/src/Marten/Events/StreamStateHandler.cs
@@ -51,7 +51,7 @@ namespace Marten.Events
         {
             var id = reader.GetFieldValue<Guid>(0);
             var version = reader.GetFieldValue<int>(1);
-            var typeName = reader.GetFieldValue<string>(2);
+            var typeName = reader.IsDBNull(2) ? null : reader.GetFieldValue<string>(2);
             var timestamp = reader.GetFieldValue<DateTime>(3);
 
             Type aggregateType = null;
@@ -67,7 +67,7 @@ namespace Marten.Events
         {
             var id = await reader.GetFieldValueAsync<Guid>(0, token).ConfigureAwait(false);
             var version = await reader.GetFieldValueAsync<int>(1, token).ConfigureAwait(false);
-            var typeName = await reader.GetFieldValueAsync<string>(2, token).ConfigureAwait(false);
+            var typeName = await reader.IsDBNullAsync(2, token) ? null : await reader.GetFieldValueAsync<string>(2, token).ConfigureAwait(false);
             var timestamp = await reader.GetFieldValueAsync<DateTime>(3, token).ConfigureAwait(false);
 
             Type aggregateType = null;


### PR DESCRIPTION
When using the private apply strategy with the following configuration 

```
_.Events.UseAggregatorLookup(AggregationLookupStrategy.UsePrivateApply);
```

Then the type name of the aggregate type is not written in `mt_streams`. This causes any call to `FetchStreamState` or `FetchStreamStateAsync` to explode with an `InvalidCastException` since it doesnt check for nulls properly in that column.

This PR fixes both the null check on the way out and ensuring that typename is set properly on the way in when using the private apply lookup strategy.