### PR TITLE
CharArrayTextWriter adjusts size properly

### DIFF
--- a/src/Marten.Testing/Services/CharArrayTextWriterTests.cs
+++ b/src/Marten.Testing/Services/CharArrayTextWriterTests.cs
@@ -62,6 +62,21 @@ namespace Marten.Testing.Services
             written.ShouldBe(s);
         }
 
+
+        [Fact]
+        public void writes_characters_much_beyond_limit()
+        {
+            var writer = new CharArrayTextWriter();
+
+            var s = new string('a', CharArrayTextWriter.InitialSize * 8);
+
+            writer.Write(s);
+
+            var written = writer.ToCharSegment();
+
+            written.ShouldBe(s);
+        }
+
         [Fact]
         public void has_offset_reset_when_returned_to_pool_via_single_release()
         {
@@ -89,11 +104,11 @@ namespace Marten.Testing.Services
         {
             var root = new CharArrayTextWriter.Pool();
             CharArrayTextWriter writer1, writer2;
-            
+
             using (var pool = new CharArrayTextWriter.Pool(root))
             {
                 writer1 = pool.Lease();
-                pool.Release(writer1 );
+                pool.Release(writer1);
             }
 
             using (var pool = new CharArrayTextWriter.Pool(root))

--- a/src/Marten/Services/CharArrayTextWriter.cs
+++ b/src/Marten/Services/CharArrayTextWriter.cs
@@ -28,11 +28,17 @@ namespace Marten.Services
 
         void Ensure(int i)
         {
-            if (_next + i >= _length)
+            var required = _next + i;
+            if (required < _length)
+            {
+                return;
+            }
+
+            while (required >= _length)
             {
                 _length *= 2;
-                Array.Resize(ref _chars, _length);
             }
+            Array.Resize(ref _chars, _length);
         }
 
         public override void Write(char[] buffer, int index, int count)


### PR DESCRIPTION
Solves #680 

This PR fixes a bug in resizing `CharArrayTextWriter`. Previously, when big enough `string` was written the size was not adjusted properly (no enlarged to the required size).