### PR TITLE
Ensure event storage exists for all public methods in eventstore.

### DIFF
--- a/src/Marten/Events/EventStore.cs
+++ b/src/Marten/Events/EventStore.cs
@@ -1,14 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Baseline;
 using Marten.Linq;
 using Marten.Schema;
 using Marten.Services;
-using Marten.Services.Deletes;
 using Marten.Services.Events;
 
 namespace Marten.Events
@@ -93,6 +91,8 @@ namespace Marten.Events
 
         public IList<IEvent> FetchStream(Guid streamId, int version = 0, DateTime? timestamp = null)
         {
+            _schema.EnsureStorageExists(typeof(EventStream));
+
             var handler = new EventQueryHandler(_selector, streamId, version, timestamp);
             return _connection.Fetch(handler, null, null);
         }
@@ -100,12 +100,16 @@ namespace Marten.Events
         public Task<IList<IEvent>> FetchStreamAsync(Guid streamId, int version = 0, DateTime? timestamp = null,
             CancellationToken token = new CancellationToken())
         {
+            _schema.EnsureStorageExists(typeof(EventStream));
+
             var handler = new EventQueryHandler(_selector, streamId, version, timestamp);
             return _connection.FetchAsync(handler, null, null, token);
         }
 
         public T AggregateStream<T>(Guid streamId, int version = 0, DateTime? timestamp = null) where T : class, new()
         {
+            _schema.EnsureStorageExists(typeof(EventStream));
+
             var inner = new EventQueryHandler(_selector, streamId, version, timestamp);
             var aggregator = _schema.Events.AggregateFor<T>();
             var handler = new AggregationQueryHandler<T>(aggregator, inner, _session);
@@ -122,6 +126,8 @@ namespace Marten.Events
         public async Task<T> AggregateStreamAsync<T>(Guid streamId, int version = 0, DateTime? timestamp = null,
             CancellationToken token = new CancellationToken()) where T : class, new()
         {
+            _schema.EnsureStorageExists(typeof(EventStream));
+
             var inner = new EventQueryHandler(_selector, streamId, version, timestamp);
             var aggregator = _schema.Events.AggregateFor<T>();
             var handler = new AggregationQueryHandler<T>(aggregator, inner, _session);
@@ -138,6 +144,8 @@ namespace Marten.Events
 
         public IMartenQueryable<T> QueryRawEventDataOnly<T>()
         {
+            _schema.EnsureStorageExists(typeof(EventStream));
+
             if (_schema.Events.AllAggregates().Any(x => x.AggregateType == typeof(T)))
             {
                 return _session.Query<T>();
@@ -154,11 +162,15 @@ namespace Marten.Events
 
         public IMartenQueryable<IEvent> QueryAllRawEvents()
         {
+            _schema.EnsureStorageExists(typeof(EventStream));
+
             return _session.Query<IEvent>();
         }
 
         public Event<T> Load<T>(Guid id) where T : class
         {
+            _schema.EnsureStorageExists(typeof(EventStream));
+
             _schema.Events.AddEventType(typeof (T));
 
 
@@ -167,6 +179,8 @@ namespace Marten.Events
 
         public async Task<Event<T>> LoadAsync<T>(Guid id, CancellationToken token = default(CancellationToken)) where T : class
         {
+            _schema.EnsureStorageExists(typeof(EventStream));
+
             _schema.Events.AddEventType(typeof (T));
 
             return (await LoadAsync(id, token).ConfigureAwait(false)).As<Event<T>>();
@@ -174,24 +188,32 @@ namespace Marten.Events
 
         public IEvent Load(Guid id)
         {
+            _schema.EnsureStorageExists(typeof(EventStream));
+
             var handler = new SingleEventQueryHandler(id, _schema.Events, _serializer);
             return _connection.Fetch(handler, new NulloIdentityMap(_serializer), null);
         }
 
         public Task<IEvent> LoadAsync(Guid id, CancellationToken token = default(CancellationToken))
         {
+            _schema.EnsureStorageExists(typeof(EventStream));
+
             var handler = new SingleEventQueryHandler(id, _schema.Events, _serializer);
             return _connection.FetchAsync(handler, new NulloIdentityMap(_serializer), null, token);
         }
 
         public StreamState FetchStreamState(Guid streamId)
         {
+            _schema.EnsureStorageExists(typeof(EventStream));
+
             var handler = new StreamStateHandler(_schema.Events, streamId);
             return _connection.Fetch(handler, null, null);
         }
 
         public Task<StreamState> FetchStreamStateAsync(Guid streamId, CancellationToken token = new CancellationToken())
         {
+            _schema.EnsureStorageExists(typeof(EventStream));
+
             var handler = new StreamStateHandler(_schema.Events, streamId);
             return _connection.FetchAsync(handler, null, null, token);
         }


### PR DESCRIPTION
For #687 and #681, there are several methods in `EventStore` that doesnt verify that the eventstore tables exists before they use them. This should hopefully catch them all.