### PR TITLE
Fix issue with count throwing when no result value

### DIFF
--- a/src/Marten.Testing/Linq/query_with_select_many.cs
+++ b/src/Marten.Testing/Linq/query_with_select_many.cs
@@ -87,6 +87,29 @@ namespace Marten.Testing.Linq
         }
 
         [Fact]
+        public void select_many_with_count_when_none_match_does_not_throw()
+        {
+            var product1 = new Product { Tags = new[] { "a", "b", "c" } };
+            var product2 = new Product { Tags = new[] { "b", "c", "d" } };
+            var product3 = new Product { Tags = new[] { "d", "e", "f" } };
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(product1, product2, product3);
+                session.SaveChanges();
+            }
+
+            using (var query = theStore.QuerySession())
+            {
+                var queryable = query.Query<Product>()
+                    .Where(p => p.Tags.Length == 1)
+                    .SelectMany(x => x.Tags);
+                var ex = Record.Exception(() => queryable.Count());
+                ex.ShouldBeNull();
+            }
+        }
+
+        [Fact]
         public async Task select_many_against_complex_type_with_count_async()
         {
             var product1 = new Product {Tags = new[] {"a", "b", "c"}};
@@ -103,6 +126,29 @@ namespace Marten.Testing.Linq
             {
                 (await query.Query<Product>().SelectMany(x => x.Tags)
                     .CountAsync()).ShouldBe(9);
+            }
+        }
+
+        [Fact]
+        public async Task select_many_with_count_when_none_match_does_not_throw_async()
+        {
+            var product1 = new Product { Tags = new[] { "a", "b", "c" } };
+            var product2 = new Product { Tags = new[] { "b", "c", "d" } };
+            var product3 = new Product { Tags = new[] { "d", "e", "f" } };
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(product1, product2, product3);
+                session.SaveChanges();
+            }
+
+            using (var query = theStore.QuerySession())
+            {
+                var queryable = query.Query<Product>()
+                    .Where(p => p.Tags.Length == 1)
+                    .SelectMany(x => x.Tags);
+                var ex = await Record.ExceptionAsync(() => queryable.CountAsync());
+                ex.ShouldBeNull();
             }
         }
 

--- a/src/Marten/Linq/QueryHandlers/CountQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/CountQueryHandler.cs
@@ -27,13 +27,17 @@ namespace Marten.Linq.QueryHandlers
         public T Handle(DbDataReader reader, IIdentityMap map, QueryStatistics stats)
         {
             var hasNext = reader.Read();
-            return hasNext ? reader.GetFieldValue<T>(0) : default(T);
+            return hasNext && !reader.IsDBNull(0)
+                ? reader.GetFieldValue<T>(0)
+                : default(T);
         }
 
         public async Task<T> HandleAsync(DbDataReader reader, IIdentityMap map, QueryStatistics stats, CancellationToken token)
         {
             var hasNext = await reader.ReadAsync(token).ConfigureAwait(false);
-            return hasNext ? await reader.GetFieldValueAsync<T>(0, token).ConfigureAwait(false) : default(T);
+            return hasNext && !await reader.IsDBNullAsync(0, token).ConfigureAwait(false) 
+                ? await reader.GetFieldValueAsync<T>(0, token).ConfigureAwait(false) 
+                : default(T);
         }
     }
 }


### PR DESCRIPTION
Count used in combination with an aggregate function, e.g. when used in conjunction with `SelectMany`, will throw when no rows matched or when all collections are null.

Implemented a guard in `CountQueryHandler<T>`. 