### PR TITLE
Add AppendIfNotExists and InsertIfNotExists to patching API

### DIFF
--- a/documentation/documentation/documents/advanced/patch_api.md
+++ b/documentation/documentation/documents/advanced/patch_api.md
@@ -60,7 +60,7 @@ To increment a persisted value in the persisted document, use this operation:
 
 <[sample:increment_for_int]>
 
-By default, the `Increment()` operation will add 1 to the existing value. You can optionally override the increment:
+By default, the `Patch.Increment()` operation will add 1 to the existing value. You can optionally override the increment:
 
 <[sample:increment_for_int_with_explicit_increment]>
 
@@ -70,15 +70,19 @@ The `Patch.Append()` operation adds a new item to the end of a child collection:
 
 <[sample:append_complex_element]>
 
+The `Patch.AppendIfNotExists()` operation will treat the child collection as a set rather than a list and only append the element if it does not already exist within the collection
+
 Marten can append either complex, value object values or primitives like numbers or strings.
 
 ## Insert an Element into a Child Collection
 
-Instead of adding an item to the end of a child collection, the `Insert()` operation allows you
-to put a new item into a persisted collection with a given index -- with the default index
+Instead of appending an item to the end of a child collection, the `Patch.Insert()` operation allows you
+to insert a new item into a persisted collection with a given index -- with the default index
 being 0 so that a new item would be inserted at the beginning of the child collection.
 
 <[sample:insert_first_complex_element]>
+
+The `Patch.InsertIfNotExists()` operation will only insert the element if the element at the designated index does not already exist.  
 
 ## Remove an Element from a Child Collection
 

--- a/javascript/mt_patching.js
+++ b/javascript/mt_patching.js
@@ -103,7 +103,7 @@ function appendElementIfNotExists(doc, patch, location){
 
     var array = location.element[location.prop];
     var patchValueAsJSONString = JSON.stringify(patch.value);
-    for(i = 0; i < array.length; i++)
+    for(var i = 0; i < array.length; i++)
     {
         var elementAsJSONString = JSON.stringify(array[i])
         if (patchValueAsJSONString === elementAsJSONString)

--- a/javascript/mt_patching.js
+++ b/javascript/mt_patching.js
@@ -96,6 +96,25 @@ function appendElement(doc, patch, location){
     return doc;
 }
 
+function appendElementIfNotExists(doc, patch, location){
+     if (!location.element[location.prop]){
+        location.element[location.prop] = [];
+    }
+
+    var array = location.element[location.prop];
+    var patchValueAsJSONString = JSON.stringify(patch.value);
+    for(i = 0; i < array.length; i++)
+    {
+        var elementAsJSONString = JSON.stringify(array[i])
+        if (patchValueAsJSONString === elementAsJSONString)
+            return doc;
+    }
+
+    location.element[location.prop].push(patch.value);
+
+    return doc;
+}
+
 function insertElement(doc, patch, location){
     if (!location.element[location.prop]){
         location.element[location.prop] = [];
@@ -109,6 +128,27 @@ function insertElement(doc, patch, location){
     }
 
     array.splice(index, 0, patch.value);
+
+    return doc;
+}
+
+function insertElementIfNotExists(doc, patch, location){
+    if (!location.element[location.prop]){
+        location.element[location.prop] = [];
+    }
+
+    var array = location.element[location.prop];
+
+    var index = 0;
+    if (patch.index){
+        index = parseInt(patch.index);
+    }
+
+    var patchValueAsJSONString = JSON.stringify(patch.value);
+    var elementAsJSONString = JSON.stringify(array[index]);
+    if (elementAsJSONString !== patchValueAsJSONString){
+        array.splice(index, 0, patch.value);
+    }
 
     return doc;
 }
@@ -160,8 +200,10 @@ var ops = {
     'increment': incrementValue,
     'increment_float': incrementFloat,
     'append': appendElement,
+    'append_if_not_exists': appendElementIfNotExists,
     'rename': rename,
     'insert': insertElement,
+    'insert_if_not_exists' : insertElementIfNotExists,
     'remove': removeElement
 }
 

--- a/src/Marten.Testing/Acceptance/patching_api.cs
+++ b/src/Marten.Testing/Acceptance/patching_api.cs
@@ -306,8 +306,36 @@ namespace Marten.Testing.Acceptance
             }
         }
 
+        [Fact]
+        public void append_if_not_exists_to_a_primitive_array()
+        {
+            var target = Target.Random();
+            target.NumberArray = new[] { 1, 2, 3 };
+
+            theSession.Store(target);
+            theSession.SaveChanges();
+
+            theSession.Patch<Target>(target.Id).AppendIfNotExists(x => x.NumberArray, 3);
+            theSession.SaveChanges();
+
+            using (var query = theStore.QuerySession())
+            {
+                query.Load<Target>(target.Id).NumberArray
+                    .ShouldHaveTheSameElementsAs(1, 2, 3);
+            }
+
+            theSession.Patch<Target>(target.Id).AppendIfNotExists(x => x.NumberArray, 4);
+            theSession.SaveChanges();
+
+            using (var query = theStore.QuerySession())
+            {
+                query.Load<Target>(target.Id).NumberArray
+                    .ShouldHaveTheSameElementsAs(1, 2, 3, 4);
+            }
+        }
+
         // SAMPLE: append_complex_element
-    [Fact]
+        [Fact]
     public void append_complex_element()
     {
         var target = Target.Random(true);
@@ -332,6 +360,42 @@ namespace Marten.Testing.Acceptance
         // ENDSAMPLE
 
         [Fact]
+        public void append_if_not_exists_complex_element()
+        {
+            var target = Target.Random(true);
+            var initialCount = target.Children.Length;
+
+            var child = Target.Random();
+            var child2 = Target.Random();
+
+            theSession.Store(target);
+            theSession.SaveChanges();
+            theSession.Patch<Target>(target.Id).Append(x => x.Children, child);
+            theSession.SaveChanges();
+            theSession.Patch<Target>(target.Id).AppendIfNotExists(x => x.Children, child);
+            theSession.SaveChanges();
+
+            using (var query = theStore.QuerySession())
+            {
+                var target2 = query.Load<Target>(target.Id);
+                target2.Children.Length.ShouldBe(initialCount + 1);
+
+                target2.Children.Last().Id.ShouldBe(child.Id);
+            }
+
+            theSession.Patch<Target>(target.Id).AppendIfNotExists(x => x.Children, child2);
+            theSession.SaveChanges();
+
+            using (var query = theStore.QuerySession())
+            {
+                var target2 = query.Load<Target>(target.Id);
+                target2.Children.Length.ShouldBe(initialCount + 2);
+
+                target2.Children.Last().Id.ShouldBe(child2.Id);
+            }
+        }
+
+        [Fact]
         public void insert_first_to_a_primitive_array()
         {
             var target = Target.Random();
@@ -341,6 +405,34 @@ namespace Marten.Testing.Acceptance
             theSession.SaveChanges();
 
             theSession.Patch<Target>(target.Id).Insert(x => x.NumberArray, 4);
+            theSession.SaveChanges();
+
+            using (var query = theStore.QuerySession())
+            {
+                query.Load<Target>(target.Id).NumberArray
+                    .ShouldHaveTheSameElementsAs(4, 1, 2, 3);
+            }
+        }
+
+        [Fact]
+        public void insert_if_not_exists_first_to_a_primitive_array()
+        {
+            var target = Target.Random();
+            target.NumberArray = new[] { 1, 2, 3 };
+
+            theSession.Store(target);
+            theSession.SaveChanges();
+
+            theSession.Patch<Target>(target.Id).InsertIfNotExists(x => x.NumberArray, 1);
+            theSession.SaveChanges();
+
+            using (var query = theStore.QuerySession())
+            {
+                query.Load<Target>(target.Id).NumberArray
+                    .ShouldHaveTheSameElementsAs(1, 2, 3);
+            }
+
+            theSession.Patch<Target>(target.Id).InsertIfNotExists(x => x.NumberArray, 4);
             theSession.SaveChanges();
 
             using (var query = theStore.QuerySession())
@@ -369,8 +461,36 @@ namespace Marten.Testing.Acceptance
             }
         }
 
+        [Fact]
+        public void insert_if_not_exists_first_to_a_primitive_array_at_a_certain_position()
+        {
+            var target = Target.Random();
+            target.NumberArray = new[] { 1, 2, 3 };
+
+            theSession.Store(target);
+            theSession.SaveChanges();
+
+            theSession.Patch<Target>(target.Id).InsertIfNotExists(x => x.NumberArray, 3, 2);
+            theSession.SaveChanges();
+
+            using (var query = theStore.QuerySession())
+            {
+                query.Load<Target>(target.Id).NumberArray
+                    .ShouldHaveTheSameElementsAs(1, 2, 3);
+            }
+
+            theSession.Patch<Target>(target.Id).InsertIfNotExists(x => x.NumberArray, 4, 2);
+            theSession.SaveChanges();
+
+            using (var query = theStore.QuerySession())
+            {
+                query.Load<Target>(target.Id).NumberArray
+                    .ShouldHaveTheSameElementsAs(1, 2, 4, 3);
+            }
+        }
+
         // SAMPLE: insert_first_complex_element
-    [Fact]
+        [Fact]
     public void insert_first_complex_element()
     {
         var target = Target.Random(true);
@@ -393,6 +513,50 @@ namespace Marten.Testing.Acceptance
         }
     }
         // ENDSAMPLE
+
+        public void insert_if_not_exists_first_complex_element()
+        {
+            var target = Target.Random(true);
+            var initialCount = target.Children.Length;
+
+            var child = Target.Random();
+            var child2 = Target.Random();
+            theSession.Store(target);
+            theSession.SaveChanges();
+
+            theSession.Patch<Target>(target.Id).Insert(x => x.Children, child);
+            theSession.SaveChanges();
+
+            using (var query = theStore.QuerySession())
+            {
+                var target2 = query.Load<Target>(target.Id);
+                target2.Children.Length.ShouldBe(initialCount + 1);
+
+                target2.Children.First().Id.ShouldBe(child.Id);
+            }
+
+            theSession.Patch<Target>(target.Id).InsertIfNotExists(x => x.Children, child);
+            theSession.SaveChanges();
+
+            using (var query = theStore.QuerySession())
+            {
+                var target2 = query.Load<Target>(target.Id);
+                target2.Children.Length.ShouldBe(initialCount + 1);
+
+                target2.Children.First().Id.ShouldBe(child.Id);
+            }
+
+            theSession.Patch<Target>(target.Id).InsertIfNotExists(x => x.Children, child2);
+            theSession.SaveChanges();
+
+            using (var query = theStore.QuerySession())
+            {
+                var target2 = query.Load<Target>(target.Id);
+                target2.Children.Length.ShouldBe(initialCount + 2);
+
+                target2.Children.First().Id.ShouldBe(child2.Id);
+            }
+        }
 
         [Fact]
         public void rename_shallow_prop()

--- a/src/Marten.Testing/Patching/PatchExpressionTests.cs
+++ b/src/Marten.Testing/Patching/PatchExpressionTests.cs
@@ -208,12 +208,32 @@ namespace Marten.Testing.Patching
         }
 
         [Fact]
+        public void append_if_not_exists_shallow()
+        {
+            _expression.AppendIfNotExists(x => x.NumberArray, 5);
+
+            _expression.Patch["path"].ShouldBe("NumberArray");
+            _expression.Patch["type"].ShouldBe("append_if_not_exists");
+            _expression.Patch["value"].ShouldBe(5);
+        }
+
+        [Fact]
         public void append_deep()
         {
             _expression.Append(x => x.Inner.Inner.NumberArray, 5);
 
             _expression.Patch["path"].ShouldBe("Inner.Inner.NumberArray");
             _expression.Patch["type"].ShouldBe("append");
+            _expression.Patch["value"].ShouldBe(5);
+        }
+
+        [Fact]
+        public void append_if_not_exists_deep()
+        {
+            _expression.AppendIfNotExists(x => x.Inner.Inner.NumberArray, 5);
+
+            _expression.Patch["path"].ShouldBe("Inner.Inner.NumberArray");
+            _expression.Patch["type"].ShouldBe("append_if_not_exists");
             _expression.Patch["value"].ShouldBe(5);
         }
 
@@ -229,12 +249,34 @@ namespace Marten.Testing.Patching
         }
 
         [Fact]
+        public void insert_if_not_exists_shallow()
+        {
+            _expression.InsertIfNotExists(x => x.NumberArray, 5);
+
+            _expression.Patch["path"].ShouldBe("NumberArray");
+            _expression.Patch["type"].ShouldBe("insert_if_not_exists");
+            _expression.Patch["value"].ShouldBe(5);
+            _expression.Patch["index"].ShouldBe(0);
+        }
+
+        [Fact]
         public void insert_deep()
         {
             _expression.Insert(x => x.Inner.Inner.NumberArray, 5);
 
             _expression.Patch["path"].ShouldBe("Inner.Inner.NumberArray");
             _expression.Patch["type"].ShouldBe("insert");
+            _expression.Patch["value"].ShouldBe(5);
+            _expression.Patch["index"].ShouldBe(0);
+        }
+
+        [Fact]
+        public void insert_if_not_exists_deep()
+        {
+            _expression.InsertIfNotExists(x => x.Inner.Inner.NumberArray, 5);
+
+            _expression.Patch["path"].ShouldBe("Inner.Inner.NumberArray");
+            _expression.Patch["type"].ShouldBe("insert_if_not_exists");
             _expression.Patch["value"].ShouldBe(5);
             _expression.Patch["index"].ShouldBe(0);
         }

--- a/src/Marten/Patching/IPatchExpression.cs
+++ b/src/Marten/Patching/IPatchExpression.cs
@@ -82,6 +82,15 @@ namespace Marten.Patching
         void Append<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element);
 
         /// <summary>
+        /// Append an element to the end of a child collection on the persisted
+        /// document if the element does not already exist
+        /// </summary>
+        /// <typeparam name="TElement"></typeparam>
+        /// <param name="expression"></param>
+        /// <param name="element"></param>
+        void AppendIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element);
+
+        /// <summary>
         /// Insert an element at the designated index to a child collection on the persisted document
         /// </summary>
         /// <typeparam name="TElement"></typeparam>
@@ -89,6 +98,16 @@ namespace Marten.Patching
         /// <param name="element"></param>
         /// <param name="index"></param>
         void Insert<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, int index = 0);
+
+        /// <summary>
+        /// Insert an element at the designated index to a child collection on the persisted document 
+        /// if the value does not already exist at that index
+        /// </summary>
+        /// <typeparam name="TElement"></typeparam>
+        /// <param name="expression"></param>
+        /// <param name="element"></param>
+        /// <param name="index"></param>
+        void InsertIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, int index = 0);
 
         /// <summary>
         /// Remove element from a child collection on the persisted document

--- a/src/Marten/Patching/PatchExpression.cs
+++ b/src/Marten/Patching/PatchExpression.cs
@@ -104,10 +104,30 @@ namespace Marten.Patching
             apply();
         }
 
+        public void AppendIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element)
+        {
+            Patch.Add("type", "append_if_not_exists");
+            Patch.Add("value", element);
+            Patch.Add("path", toPath(expression));
+
+            apply();
+        }
+
         public void Insert<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element,
             int index = 0)
         {
             Patch.Add("type", "insert");
+            Patch.Add("value", element);
+            Patch.Add("path", toPath(expression));
+            Patch.Add("index", index);
+
+            apply();
+        }
+
+        public void InsertIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element,
+            int index = 0)
+        {
+            Patch.Add("type", "insert_if_not_exists");
             Patch.Add("value", element);
             Patch.Add("path", toPath(expression));
             Patch.Add("index", index);

--- a/test/test_mt_patching.js
+++ b/test/test_mt_patching.js
@@ -116,6 +116,14 @@ describe('Patching API', function() {
     expect(Patch(doc, patch)).to.deep.equal({numbers: [5]});
   });
 
+  it('can append if not exists to a first level array', function() {
+    var doc = {numbers: []};
+
+    var patch = {type: 'append_if_not_exists', path: 'numbers', value: 5};
+
+    expect(Patch(doc, patch)).to.deep.equal({numbers: [5]});
+  });
+
   it('can append to a first level array with existing elements', function() {
     var doc = {numbers: [3, 4]};
 
@@ -124,10 +132,34 @@ describe('Patching API', function() {
     expect(Patch(doc, patch)).to.deep.equal({numbers: [3, 4, 5]});
   });
 
+  it('can append if not exists to a first level array with existing elements', function() {
+    var doc = {numbers: [3, 4]};
+
+    var patch = {type: 'append_if_not_exists', path: 'numbers', value: 5};
+
+    expect(Patch(doc, patch)).to.deep.equal({numbers: [3, 4, 5]});
+  });  
+
+  it('can append if not exists to a first level array with existing element and element count stays the same', function() {
+    var doc = {numbers: [3, 4]};
+
+    var patch = {type: 'append_if_not_exists', path: 'numbers', value: 4};
+
+    expect(Patch(doc, patch)).to.deep.equal({numbers: [3, 4]});
+  });  
+
   it('can append to a first level array when the array does not already exist', function() {
     var doc = {};
 
     var patch = {type: 'append', path: 'numbers', value: 5};
+
+    expect(Patch(doc, patch)).to.deep.equal({numbers: [5]});
+  });
+
+  it('can append if not exists to a first level array when the array does not already exist', function() {
+    var doc = {};
+
+    var patch = {type: 'append_if_not_exists', path: 'numbers', value: 5};
 
     expect(Patch(doc, patch)).to.deep.equal({numbers: [5]});
   });
@@ -140,13 +172,58 @@ describe('Patching API', function() {
     expect(Patch(doc, patch)).to.deep.equal({region: {numbers: [5]}});
   });
 
-  it('can append to a 3rd level array when the array does not already exist', function() {
+  it('can append if not exists to a 2nd level array when the array does not already exist', function() {
+    var doc = {};
+
+    var patch = {type: 'append_if_not_exists', path: 'region.numbers', value: 5};
+
+    expect(Patch(doc, patch)).to.deep.equal({region: {numbers: [5]}});
+  });
+
+  it('can append to a 3rd level array with existing elements', function() {
     var doc = {division: {region: {numbers: [3, 4]}}};
 
     var patch = {type: 'append', path: 'division.region.numbers', value: 5};
 
     expect(Patch(doc, patch)).to.deep.equal({division: {region: {numbers: [3, 4, 5]}}});
   });
+
+  it('can append if not exists to a 3rd level array with existing elements', function() {
+    var doc = {division: {region: {numbers: [3, 4]}}};
+
+    var patch = {type: 'append_if_not_exists', path: 'division.region.numbers', value: 5};
+
+    expect(Patch(doc, patch)).to.deep.equal({division: {region: {numbers: [3, 4, 5]}}});
+  });  
+
+  it('can append if not exists to a 3rd level array with existing elements and the element count stays the same', function() {
+    var doc = {division: {region: {numbers: [3, 4]}}};
+
+    var patch = {type: 'append_if_not_exists', path: 'division.region.numbers', value: 4};
+
+    expect(Patch(doc, patch)).to.deep.equal({division: {region: {numbers: [3, 4]}}});
+  });   
+
+  it('can append if not exists to an array with complex element', function() {
+    var doc = {divisions: [{region: {numbers: [3, 4]}},{region: {numbers: [5, 6]}}]};
+
+    var element = {region: {numbers: [7,8]}}
+
+    var patch = {type: 'append_if_not_exists', path: 'divisions', value: element};
+
+    expect(Patch(doc, patch)).to.deep.equal({divisions: [{region: {numbers: [3, 4]}},{region: {numbers: [5, 6]}},{region: {numbers: [7, 8]}}]});
+  });     
+
+  it('can append if not exists to an array with complex existing element and element count stays the same', function() {
+    var doc = {divisions: [{region: {numbers: [3, 4]}},{region: {numbers: [5, 6]}}]};
+
+    var element = {region: {numbers: [5,6]}}
+
+    var patch = {type: 'append_if_not_exists', path: 'divisions', value: element};
+
+    expect(Patch(doc, patch)).to.deep.equal({divisions: [{region: {numbers: [3, 4]}},{region: {numbers: [5, 6]}}]});
+  });     
+  
 
   it('can rename a prop shallow', function() {
     var doc = {number: 1};
@@ -180,6 +257,22 @@ describe('Patching API', function() {
     expect(Patch(doc, patch)).to.deep.equal({numbers: [5, 3, 4]});
   });
 
+  it('can insert not exists into a child collection with default', function() {
+    var doc = {numbers: [3, 4]};
+
+    var patch = {type: 'insert_if_not_exists', path: 'numbers', value: 5};
+
+    expect(Patch(doc, patch)).to.deep.equal({numbers: [5, 3, 4]});
+  });
+
+  it('can insert not exists into a child collection with existing element', function() {
+    var doc = {numbers: [3, 4]};
+
+    var patch = {type: 'insert_if_not_exists', path: 'numbers', value: 3};
+
+    expect(Patch(doc, patch)).to.deep.equal({numbers: [3, 4]});
+  });  
+
   it('can insert into a child collection with designated index', function() {
     var doc = {numbers: [3, 4]};
 
@@ -188,6 +281,22 @@ describe('Patching API', function() {
     expect(Patch(doc, patch)).to.deep.equal({numbers: [3, 5, 4]});
   });
 
+  it('can insert not exists into a child collection with designated index', function() {
+    var doc = {numbers: [3, 4]};
+
+    var patch = {type: 'insert_if_not_exists', path: 'numbers', value: 5, index: 1};
+
+    expect(Patch(doc, patch)).to.deep.equal({numbers: [3, 5, 4]});
+  });  
+
+  it('can insert not exists into a child collection with designated index with existing element', function() {
+    var doc = {numbers: [3, 4]};
+
+    var patch = {type: 'insert_if_not_exists', path: 'numbers', value: 4, index: 1};
+
+    expect(Patch(doc, patch)).to.deep.equal({numbers: [3, 4]});
+  });    
+
   it('can insert into a 2 deep child collection with designated index', function() {
     var doc = {region: {numbers: [3, 4]}};
 
@@ -195,6 +304,42 @@ describe('Patching API', function() {
 
     expect(Patch(doc, patch)).to.deep.equal({region: {numbers: [3, 5, 4]}});
   });
+
+  it('can insert not exists into a 2 deep child collection with designated index', function() {
+    var doc = {region: {numbers: [3, 4]}};
+
+    var patch = {type: 'insert_if_not_exists', path: 'region.numbers', value: 5, index: 1};
+
+    expect(Patch(doc, patch)).to.deep.equal({region: {numbers: [3, 5, 4]}});
+  });  
+
+  it('can insert not exists into a 2 deep child collection with designated index with existing element', function() {
+    var doc = {region: {numbers: [3, 4]}};
+
+    var patch = {type: 'insert_if_not_exists', path: 'region.numbers', value: 4, index: 1};
+
+    expect(Patch(doc, patch)).to.deep.equal({region: {numbers: [3, 4]}});
+  });
+
+  it('can insert if not exists to an array with complex element', function() {
+    var doc = {divisions: [{region: {numbers: [3, 4]}},{region: {numbers: [5, 6]}}]};
+
+    var element = {region: {numbers: [7,8]}}
+
+    var patch = {type: 'insert_if_not_exists', path: 'divisions', value: element};
+
+    expect(Patch(doc, patch)).to.deep.equal({divisions: [{region: {numbers: [7, 8]}},{region: {numbers: [3, 4]}},{region: {numbers: [5, 6]}}]});
+  });     
+
+  it('can insert if not exists to an array with complex existing element and element count stays the same', function() {
+    var doc = {divisions: [{region: {numbers: [3, 4]}},{region: {numbers: [5, 6]}}]};
+
+    var element = {region: {numbers: [3, 4]}}
+
+    var patch = {type: 'insert_if_not_exists', path: 'divisions', value: element};
+
+    expect(Patch(doc, patch)).to.deep.equal({divisions: [{region: {numbers: [3, 4]}},{region: {numbers: [5, 6]}}]});
+  });           
 
   it('can remove from array', function() {
     var doc = {items: ['foo', 'bar']};


### PR DESCRIPTION
Resolves issue #629 

Add two new methods and associated JS functions
AppendIfNotExists
InsertIfNotExists

The premise behind both methods is to only apply the patch if the
element within the collection does not already exist.

In order to check for complex types, JSON.stringify is used, which does
mean the order of elements is important. Assume this is OK for now.