### PR TITLE
Fix System.Data.Common dependency downgrade

### DIFF
--- a/src/Marten/Schema/IndexDefinition.cs
+++ b/src/Marten/Schema/IndexDefinition.cs
@@ -88,7 +88,8 @@ namespace Marten.Schema
                 actual = actual.Replace("USING btree", "");
             }
 
-            var match = Regex.Match(actual, "\\((?<columns>.*(?:(?:[\\w.]+)\\s(?:[\\w_]+).*))\\)");
+            string columnsMatchPattern = "\\((?<columns>.*(?:(?:[\\w.]+)\\s(?:[\\w_]+).*))\\)";
+            var match = Regex.Match(actual, columnsMatchPattern);
             var replace = string.Empty;
             if (match.Success)
             {
@@ -98,7 +99,7 @@ namespace Marten.Schema
                     columns = Regex.Replace(columns, $"({col})\\s?([\\w_]+)?", "\"$1\" $2");
                 });
 
-                actual = Regex.Replace(actual, "\\((?<columns>.*(?:(?:[\\w.]+)\\s(?:[\\w_]+).*))\\)", $"({columns})");
+                actual = Regex.Replace(actual, columnsMatchPattern, $"({columns})");
             }
 
             if (!actual.Contains(_parent.Table.QualifiedName))

--- a/src/Marten/Schema/IndexDefinition.cs
+++ b/src/Marten/Schema/IndexDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Baseline;
+using System.Text.RegularExpressions;
 
 namespace Marten.Schema
 {
@@ -9,7 +10,6 @@ namespace Marten.Schema
         private readonly DocumentMapping _parent;
         private readonly string[] _columns;
         private string _indexName;
-
 
         public IndexDefinition(DocumentMapping parent, params string[] columns)
         {
@@ -89,7 +89,7 @@ namespace Marten.Schema
 
             _columns.Each(col =>
             {
-                actual = actual.Replace($"({col})", $"(\"{col}\")");
+                actual = Regex.Replace(actual, "\\((?<column>[\\w_]+) (?<operatorclass>[\\w_]+)\\)", "(\"${column}\" ${operatorclass})");
             });
 
             if (!actual.Contains(_parent.Table.QualifiedName))

--- a/src/Marten/Schema/IndexDefinition.cs
+++ b/src/Marten/Schema/IndexDefinition.cs
@@ -88,7 +88,7 @@ namespace Marten.Schema
                 actual = actual.Replace("USING btree", "");
             }
 
-            string columnsMatchPattern = "\\((?<columns>.*(?:(?:[\\w.]+)\\s(?:[\\w_]+).*))\\)";
+            string columnsMatchPattern = "\\((?<columns>.*(?:(?:[\\w.]+)\\s?(?:[\\w_]+).*))\\)";
             var match = Regex.Match(actual, columnsMatchPattern);
             var replace = string.Empty;
             if (match.Success)
@@ -99,7 +99,7 @@ namespace Marten.Schema
                     columns = Regex.Replace(columns, $"({col})\\s?([\\w_]+)?", "\"$1\" $2");
                 });
 
-                actual = Regex.Replace(actual, columnsMatchPattern, $"({columns})");
+                actual = Regex.Replace(actual, columnsMatchPattern, $"({columns.Trim()})");
             }
 
             if (!actual.Contains(_parent.Table.QualifiedName))

--- a/src/Marten/project.json
+++ b/src/Marten/project.json
@@ -41,7 +41,7 @@
         "NETStandard.Library": "1.6.0",
         "System.Reflection.TypeExtensions": "4.1.0",
         "System.Linq.Expressions": "4.1.0",
-        "System.Data.Common": "4.1.0"
+        "System.Data.Common": "4.3.0"
       }
     },
     "net46": {


### PR DESCRIPTION
Related to #722 

Fix warning : 

Detected package downgrade: System.Data.Common from 4.3.0 to 4.1.0
Marten (>= 1.5.0) -> Npgsql (>= 3.2.2) -> System.Data.Common (>= 4.3.0)
Marten (>= 1.5.0) -> System.Data.Common (>= 4.1.0)