### PR TITLE
Fix : Detected package downgrade: System.Data.Common from 4.3.0 to 4.1.0

### DIFF
--- a/src/Marten/project.json
+++ b/src/Marten/project.json
@@ -41,7 +41,7 @@
         "NETStandard.Library": "1.6.0",
         "System.Reflection.TypeExtensions": "4.1.0",
         "System.Linq.Expressions": "4.1.0",
-        "System.Data.Common": "4.1.0"
+        "System.Data.Common": "4.3.0"
       }
     },
     "net46": {


### PR DESCRIPTION
Related to #722 

Fix warning :

Detected package downgrade: System.Data.Common from 4.3.0 to 4.1.0
Marten (>= 1.5.0) -> Npgsql (>= 3.2.2) -> System.Data.Common (>= 4.3.0)
Marten (>= 1.5.0) -> System.Data.Common (>= 4.1.0)