### PR TITLE
delay document mapping validation until store construction - fixes #743

### DIFF
--- a/src/Marten.Testing/Acceptance/using_natural_identity_keys.cs
+++ b/src/Marten.Testing/Acceptance/using_natural_identity_keys.cs
@@ -68,8 +68,6 @@ namespace Marten.Testing.Acceptance
 
     public class OverriddenIdDoc
     {
-        public Guid Id { get; set; }
-
         public string Name { get; set; }
 
         public DateTime Date { get; set; }

--- a/src/Marten.Testing/document_types_must_have_an_id_member_Tests.cs
+++ b/src/Marten.Testing/document_types_must_have_an_id_member_Tests.cs
@@ -10,10 +10,25 @@ namespace Marten.Testing
         {
             Exception<InvalidDocumentException>.ShouldBeThrownBy(() =>
             {
-                var schema = new DocumentSchema(new StoreOptions(), null, null);
-                schema.MappingFor(typeof(BadDoc)).ShouldBeNull();
+                var options = new StoreOptions();
+                var schema = new DocumentSchema(options, null, null);
+                schema.MappingFor(typeof(BadDoc));
+                options.Validate();
             });
             
+        }
+
+        [Fact]
+        public void cannot_use_a_doc_type_with_no_id_with_store()
+        {
+            Exception<InvalidDocumentException>.ShouldBeThrownBy(() =>
+            {
+                DocumentStore.For(options =>
+                {
+                    options.MappingFor(typeof(BadDoc));
+                });
+            });
+
         }
     }
 

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -70,6 +70,7 @@ namespace Marten
         /// <param name="options"></param>
         public DocumentStore(StoreOptions options)
         {
+            options.Validate();
             options.CreatePatching();
 
             _options = options;

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -478,6 +478,15 @@ namespace Marten.Schema
             return Indexes.OfType<IndexDefinition>().Where(x => x.Columns.Contains(column));
         }
 
+        public void Validate()
+        {
+            if (IdMember == null)
+            {
+                throw new InvalidDocumentException(
+                    $"Could not determine an 'id/Id' field or property for requested document type {DocumentType.FullName}");
+            }
+        }
+
         public override string ToString()
         {
             return $"Storage for {DocumentType}, Table: {Table}";

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -117,18 +117,7 @@ namespace Marten
 
         public DocumentMapping MappingFor(Type documentType)
         {
-            return _documentMappings.GetOrAdd(documentType, type =>
-            {
-                var mapping = typeof(DocumentMapping<>).CloseAndBuildAs<DocumentMapping>(this, documentType);
-
-                if (mapping.IdMember == null)
-                {
-                    throw new InvalidDocumentException(
-                        $"Could not determine an 'id/Id' field or property for requested document type {documentType.FullName}");
-                }
-
-                return mapping;
-            });
+            return _documentMappings.GetOrAdd(documentType, type => typeof(DocumentMapping<>).CloseAndBuildAs<DocumentMapping>(this, documentType));
         }
 
         private readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, ChildDocument>> _childDocs 
@@ -274,6 +263,12 @@ namespace Marten
                 throw new PostgresqlIdentifierInvalidException(name);
             if (name.Length < NameDataLength) return;
             throw new PostgresqlIdentifierTooLongException(NameDataLength, name);
+        }
+
+        public void Validate()
+        {
+            foreach (var mapping in AllDocumentMappings)
+                mapping.Validate();
         }
 
         internal IDocumentMapping FindMapping(Type documentType)


### PR DESCRIPTION
Currently the IdMember is validated when the initial DocumentMapping is retrieved, but this means that the there has to be an existing IdMember before one can be added via the Fluent interface.   The idea behind the fix here is to delay validating the mappings until the DocumentStore is constructed.  I'm not sure if any other checks could or should be moved here. 

If there's any other part of configuration that would depend on IdMember not being null it would throw a null exception now, but nothing came up in the tests.  Conceptually, I was thinking that constructing the store is the gate after which everything should be configured.