### PR TITLE
#772 Index with Expression Should Match DDL

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_772_index_wrapping_column_does_not_match_DDL.cs
+++ b/src/Marten.Testing/Bugs/Bug_772_index_wrapping_column_does_not_match_DDL.cs
@@ -55,7 +55,7 @@ namespace Marten.Testing.Bugs
             theStore.Schema.AssertDatabaseMatchesConfiguration();
         }
 
-        //[Fact] // Experiment, failed
+        // [Fact] // Experiment, failed
         public void index_with_expression_wrapping_column_should_match_DDL()
         {
             StoreOptions(_ =>

--- a/src/Marten.Testing/Bugs/Bug_772_index_wrapping_column_does_not_match_DDL.cs
+++ b/src/Marten.Testing/Bugs/Bug_772_index_wrapping_column_does_not_match_DDL.cs
@@ -1,0 +1,78 @@
+﻿using Marten.Schema;
+using Marten.Testing.Documents;
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+    public class Bug_772_index_wrapping_column_does_not_match_DDL : IntegratedFixture
+    {
+        [Fact] // Control
+        public void index_with_no_expression_should_match_DDL()
+        {
+            StoreOptions(_ =>
+            {
+                _.Schema.For<Company>()
+                    .Duplicate(c => c.Name);
+            });
+
+            theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            theStore.Schema.AssertDatabaseMatchesConfiguration();
+        }
+
+        [Fact] // Control
+        public void index_with_expression_not_wrapping_column_should_match_DDL()
+        {
+            StoreOptions(_ =>
+            {
+                _.Schema.For<Company>()
+                    .Duplicate(c => c.Name, "jsonb", id =>
+                    {
+                        id.Method = IndexMethod.gin;
+                        id.Expression = "? jsonb_path_ops";
+                    });
+            });
+
+            theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            theStore.Schema.AssertDatabaseMatchesConfiguration();
+        }
+
+        [Fact] // Experiment, passed
+        public void index_with_expression_wrapping_column_should_match_DDL_if_DDL_not_reformatted()
+        {
+            StoreOptions(_ =>
+            {
+                _.Schema.For<Company>()
+                    .Duplicate(c => c.Name, configure: id =>
+                    {
+                        // The DDL for this expression is not reformatted,
+                        // and so the index definition matches the DDL.
+                        id.Expression = "lower((?)::text)";
+                        id.IndexName = id.IndexName + "_lower";
+                    });
+            });
+
+            theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            theStore.Schema.AssertDatabaseMatchesConfiguration();
+        }
+
+        //[Fact] // Experiment, failed
+        public void index_with_expression_wrapping_column_should_match_DDL()
+        {
+            StoreOptions(_ =>
+            {
+                _.Schema.For<Company>()
+                    .Duplicate(c => c.Name, configure: id =>
+                    {
+                        // The DDL for this expression is reformatted,
+                        // and so I'm not certain there is a simple
+                        // way to get the formats to match.
+                        id.Expression = "lower(?)";
+                        id.IndexName = id.IndexName + "_lower";
+                    });
+            });
+
+            theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            theStore.Schema.AssertDatabaseMatchesConfiguration();
+        }
+    }
+}

--- a/src/Marten.Testing/ConnectionSource.cs
+++ b/src/Marten.Testing/ConnectionSource.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Baseline;
 
 namespace Marten.Testing
 {
@@ -11,7 +10,7 @@ namespace Marten.Testing
         {
             if (ConnectionString.IsEmpty())
                 throw new Exception(
-                    "You need to set the connection string for your local Postgresql database in the environment variable 'marten-testing-database'");
+                    "You need to set the connection string for your local Postgresql database in the environment variable 'marten_testing_database'");
         }
 
 


### PR DESCRIPTION
See #772 

I wasn't able to universally match DDL from the database with DDL generated by code, but I was able to change the `Match` method on `IndexDefinition` to return a positive match if the `Expression` property is added in such a way as to minimize/eliminate reformatting by Postgres. This PR handles my use case, and I believe others, as long as `Expression` values are set appropriately.

I also corrected the error message in the testing `ConnectionSource`, since the environment variable in the exception message and the actual environment variable were different.