### PR TITLE
Scaled out ViewProjection functionality

### DIFF
--- a/src/Marten.Testing/Events/Projections/MonsterSlayed.cs
+++ b/src/Marten.Testing/Events/Projections/MonsterSlayed.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Marten.Testing.Events.Projections
 {
@@ -10,6 +11,24 @@ namespace Marten.Testing.Events.Projections
     public class MonsterSlayed
     {
         public Guid QuestId { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class MonsterDestroyed
+    {
+        public Guid QuestId { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class MonsterQuestsAdded
+    {
+        public List<Guid> QuestIds { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class MonsterQuestsRemoved
+    {
+        public List<Guid> QuestIds { get; set; }
         public string Name { get; set; }
     }
 }

--- a/src/Marten.Testing/Events/Projections/custom_transformation_of_events.cs
+++ b/src/Marten.Testing/Events/Projections/custom_transformation_of_events.cs
@@ -10,27 +10,34 @@ namespace Marten.Testing.Events.Projections
     public class project_events_from_multiple_streams_into_view : DocumentSessionFixture<IdentityMap>
     {
         static readonly Guid streamId = Guid.NewGuid();
+        static readonly Guid streamId2 = Guid.NewGuid();
 
         QuestStarted started = new QuestStarted { Id = streamId, Name = "Find the Orb" };
+        QuestStarted started2 = new QuestStarted { Id = streamId2, Name = "Find the Orb 2.0" };
+        MonsterQuestsAdded monsterQuestsAdded = new MonsterQuestsAdded { QuestIds = new List<Guid> { streamId, streamId2 }, Name = "Dragon" };
+        MonsterQuestsRemoved monsterQuestsRemoved = new MonsterQuestsRemoved { QuestIds = new List<Guid> { streamId, streamId2 }, Name = "Dragon" };
+        QuestEnded ended = new QuestEnded { Id = streamId, Name = "Find the Orb" };
         MembersJoined joined = new MembersJoined { QuestId = streamId, Day = 2, Location = "Faldor's Farm", Members = new[] { "Garion", "Polgara", "Belgarath" } };
         MonsterSlayed slayed1 = new MonsterSlayed { QuestId = streamId, Name = "Troll" };
         MonsterSlayed slayed2 = new MonsterSlayed { QuestId = streamId, Name = "Dragon" };
-
+        MonsterDestroyed destroyed = new MonsterDestroyed { QuestId = streamId, Name = "Troll" };
+        MembersDeparted departed = new MembersDeparted { QuestId = streamId, Day = 5, Location = "Sendaria", Members = new[] { "Silk", "Barak" } };
         MembersJoined joined2 = new MembersJoined { QuestId = streamId, Day = 5, Location = "Sendaria", Members = new[] { "Silk", "Barak" } };
 
         [Fact]
         public void from_configuration()
         {
-            var events = new List<object>();
-
             StoreOptions(_ =>
             {
                 _.AutoCreateSchemaObjects = AutoCreate.All;
                 _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
-                _.Events.ProjectView<PersistedView>()
-                    .ProjectEvent<QuestStarted>((view, @event) => events.Add(@event))
-                    .ProjectEvent<MembersJoined>(e => e.QuestId, (view, @event) => events.Add(@event))
-                    .ProjectEvent<MonsterSlayed>(e => e.QuestId, (view, @event) => events.Add(@event));
+                _.Events.ProjectView<PersistedView, Guid>()
+                    .ProjectEvent<QuestStarted>((view, @event) => view.Events.Add(@event))
+                    .ProjectEvent<MembersJoined>(e => e.QuestId, (view, @event) => view.Events.Add(@event))
+                    .ProjectEvent<MonsterSlayed>(e => e.QuestId, (view, @event) => view.Events.Add(@event))
+                    .DeleteEvent<QuestEnded>()
+                    .DeleteEvent<MembersDeparted>(e => e.QuestId)
+                    .DeleteEvent<MonsterDestroyed>((session, e) => session.Load<QuestParty>(e.QuestId).Id);
             });
 
             theSession.Events.StartStream<QuestParty>(streamId, started, joined);
@@ -42,23 +49,52 @@ namespace Marten.Testing.Events.Projections
             theSession.Events.Append(streamId, joined2);
             theSession.SaveChanges();
 
-            events.Count.ShouldBe(5);
-            events.ShouldHaveTheSameElementsAs(started, joined, slayed1, slayed2, joined2);
+            var document = theSession.Load<PersistedView>(streamId);
+            document.Events.Count.ShouldBe(5);
+            document.Events.ShouldHaveTheSameElementsAs(started, joined, slayed1, slayed2, joined2);
+
+            theSession.Events.Append(streamId, ended);
+            theSession.SaveChanges();
+            var nullDocument = theSession.Load<PersistedView>(streamId);
+            nullDocument.ShouldBeNull();
+
+            // Add document back to so we can delete it by selector
+            theSession.Events.Append(streamId, started);
+            theSession.SaveChanges();
+            var document2 = theSession.Load<PersistedView>(streamId);
+            document2.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, departed);
+            theSession.SaveChanges();
+            var nullDocument2 = theSession.Load<PersistedView>(streamId);
+            nullDocument2.ShouldBeNull();
+
+            // Add document back to so we can delete it by other selector type
+            theSession.Events.Append(streamId, started);
+            theSession.SaveChanges();
+            var document3 = theSession.Load<PersistedView>(streamId);
+            document3.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, destroyed);
+            theSession.SaveChanges();
+            var nullDocument3 = theSession.Load<PersistedView>(streamId);
+            nullDocument3.ShouldBeNull();
         }
 
         [Fact]
         public async void from_configuration_async()
         {
-            var events = new List<object>();
-
             StoreOptions(_ =>
             {
                 _.AutoCreateSchemaObjects = AutoCreate.All;
                 _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
-                _.Events.ProjectView<PersistedView>()
-                    .ProjectEvent<QuestStarted>((view, @event) => { events.Add(@event);})
-                    .ProjectEvent<MembersJoined>(e => e.QuestId, (view, @event) => { events.Add(@event); })
-                    .ProjectEvent<MonsterSlayed>(e => e.QuestId, (view, @event) => { events.Add(@event); });
+                _.Events.ProjectView<PersistedView, Guid>()
+                    .ProjectEvent<QuestStarted>((view, @event) => { view.Events.Add(@event); })
+                    .ProjectEvent<MembersJoined>(e => e.QuestId, (view, @event) => { view.Events.Add(@event); })
+                    .ProjectEvent<MonsterSlayed>(e => e.QuestId, (view, @event) => { view.Events.Add(@event); })
+                    .DeleteEvent<QuestEnded>()
+                    .DeleteEvent<MembersDeparted>(e => e.QuestId)
+                    .DeleteEvent<MonsterDestroyed>((session, e) => session.Load<QuestParty>(e.QuestId).Id);
             });
 
             theSession.Events.StartStream<QuestParty>(streamId, started, joined);
@@ -70,8 +106,36 @@ namespace Marten.Testing.Events.Projections
             theSession.Events.Append(streamId, joined2);
             await theSession.SaveChangesAsync();
 
-            events.Count.ShouldBe(5);
-            events.ShouldHaveTheSameElementsAs(started, joined, slayed1, slayed2, joined2);
+            var document = theSession.Load<PersistedView>(streamId);
+            document.Events.Count.ShouldBe(5);
+            document.Events.ShouldHaveTheSameElementsAs(started, joined, slayed1, slayed2, joined2);
+
+            theSession.Events.Append(streamId, ended);
+            await theSession.SaveChangesAsync();
+            var nullDocument = theSession.Load<PersistedView>(streamId);
+            nullDocument.ShouldBeNull();
+
+            // Add document back to so we can delete it by selector
+            theSession.Events.Append(streamId, started);
+            await theSession.SaveChangesAsync();
+            var document2 = theSession.Load<PersistedView>(streamId);
+            document2.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, departed);
+            await theSession.SaveChangesAsync();
+            var nullDocument2 = theSession.Load<PersistedView>(streamId);
+            nullDocument2.ShouldBeNull();
+
+            // Add document back to so we can delete it by other selector type
+            theSession.Events.Append(streamId, started);
+            await theSession.SaveChangesAsync();
+            var document3 = theSession.Load<PersistedView>(streamId);
+            document3.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, destroyed);
+            await theSession.SaveChangesAsync();
+            var nullDocument3 = theSession.Load<PersistedView>(streamId);
+            nullDocument3.ShouldBeNull();
         }
 
         [Fact]
@@ -96,6 +160,33 @@ namespace Marten.Testing.Events.Projections
             var document = theSession.Load<PersistedView>(streamId);
             document.Events.Count.ShouldBe(5);
             document.Events.ShouldHaveTheSameElementsAs(started, joined, slayed1, slayed2, joined2);
+
+            theSession.Events.Append(streamId, ended);
+            theSession.SaveChanges();
+            var nullDocument = theSession.Load<PersistedView>(streamId);
+            nullDocument.ShouldBeNull();
+
+            // Add document back to so we can delete it by selector
+            theSession.Events.Append(streamId, started);
+            theSession.SaveChanges();
+            var document2 = theSession.Load<PersistedView>(streamId);
+            document2.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, departed);
+            theSession.SaveChanges();
+            var nullDocument2 = theSession.Load<PersistedView>(streamId);
+            nullDocument2.ShouldBeNull();
+
+            // Add document back to so we can delete it by other selector type
+            theSession.Events.Append(streamId, started);
+            theSession.SaveChanges();
+            var document3 = theSession.Load<PersistedView>(streamId);
+            document3.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, destroyed);
+            theSession.SaveChanges();
+            var nullDocument3 = theSession.Load<PersistedView>(streamId);
+            nullDocument3.ShouldBeNull();
         }
 
         [Fact]
@@ -120,7 +211,108 @@ namespace Marten.Testing.Events.Projections
             var document = theSession.Load<PersistedView>(streamId);
             document.Events.Count.ShouldBe(5);
             document.Events.ShouldHaveTheSameElementsAs(started, joined, slayed1, slayed2, joined2);
+
+            theSession.Events.Append(streamId, ended);
+            await theSession.SaveChangesAsync();
+            var nullDocument = theSession.Load<PersistedView>(streamId);
+            nullDocument.ShouldBeNull();
+
+            // Add document back to so we can delete it by selector
+            theSession.Events.Append(streamId, started);
+            await theSession.SaveChangesAsync();
+            var document2 = theSession.Load<PersistedView>(streamId);
+            document2.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, departed);
+            await theSession.SaveChangesAsync();
+            var nullDocument2 = theSession.Load<PersistedView>(streamId);
+            nullDocument2.ShouldBeNull();
+
+            // Add document back to so we can delete it by other selector type
+            theSession.Events.Append(streamId, started);
+            await theSession.SaveChangesAsync();
+            var document3 = theSession.Load<PersistedView>(streamId);
+            document3.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, destroyed);
+            await theSession.SaveChangesAsync();
+            var nullDocument3 = theSession.Load<PersistedView>(streamId);
+            nullDocument3.ShouldBeNull();
         }
+
+        [Fact]
+        public void using_collection_of_ids()
+        {
+            StoreOptions(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
+                _.Events.ProjectView<QuestView, Guid>()
+                    .ProjectEvent<QuestStarted>((view, @event) => view.Name = @event.Name)
+                    .ProjectEvent<MonsterQuestsAdded>(e => e.QuestIds, (view, @event) => view.Name = view.Name.Insert(0, $"{@event.Name}: "))
+                    .DeleteEvent<MonsterQuestsRemoved>(e => e.QuestIds);
+            });
+
+            theSession.Events.StartStream<QuestParty>(streamId, started);
+            theSession.Events.StartStream<QuestParty>(streamId2, started2);
+            theSession.SaveChanges();
+
+            theSession.Events.StartStream<Monster>(monsterQuestsAdded);
+            theSession.SaveChanges();
+
+            var document = theSession.Load<QuestView>(streamId);
+            document.Name.ShouldStartWith(monsterQuestsAdded.Name);
+            var document2 = theSession.Load<QuestView>(streamId2);
+            document2.Name.ShouldStartWith(monsterQuestsAdded.Name);
+
+            theSession.Events.StartStream<Monster>(monsterQuestsRemoved);
+            theSession.SaveChanges();
+
+            var nullDocument = theSession.Load<QuestView>(streamId);
+            nullDocument.ShouldBeNull();
+            var nullDocument2 = theSession.Load<QuestView>(streamId2);
+            nullDocument2.ShouldBeNull();
+        }
+
+        [Fact]
+        public async void using_collection_of_ids_async()
+        {
+            StoreOptions(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
+                _.Events.ProjectView<QuestView, Guid>()
+                    .ProjectEvent<QuestStarted>((view, @event) => view.Name = @event.Name)
+                    .ProjectEvent<MonsterQuestsAdded>(e => e.QuestIds, (view, @event) => view.Name = view.Name.Insert(0, $"{@event.Name}: "))
+                    .DeleteEvent<MonsterQuestsRemoved>(e => e.QuestIds);
+            });
+
+            theSession.Events.StartStream<QuestParty>(streamId, started);
+            theSession.Events.StartStream<QuestParty>(streamId2, started2);
+            await theSession.SaveChangesAsync();
+
+            theSession.Events.StartStream<Monster>(monsterQuestsAdded);
+            await theSession.SaveChangesAsync();
+
+            var document = theSession.Load<QuestView>(streamId);
+            document.Name.ShouldStartWith(monsterQuestsAdded.Name);
+            var document2 = theSession.Load<QuestView>(streamId2);
+            document2.Name.ShouldStartWith(monsterQuestsAdded.Name);
+
+            theSession.Events.StartStream<Monster>(monsterQuestsRemoved);
+            await theSession.SaveChangesAsync();
+
+            var nullDocument = theSession.Load<QuestView>(streamId);
+            nullDocument.ShouldBeNull();
+            var nullDocument2 = theSession.Load<QuestView>(streamId2);
+            nullDocument2.ShouldBeNull();
+        }
+    }
+
+    public class QuestView
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
     }
 
     public class PersistedView
@@ -129,13 +321,16 @@ namespace Marten.Testing.Events.Projections
         public List<object> Events { get; } = new List<object>();
     }
 
-    public class PersistViewProjection : ViewProjection<PersistedView>
+    public class PersistViewProjection : ViewProjection<PersistedView, Guid>
     {
         public PersistViewProjection()
         {
             ProjectEvent<QuestStarted>(Persist);
             ProjectEvent<MembersJoined>(e => e.QuestId, Persist);
             ProjectEvent<MonsterSlayed>((session, e) => session.Load<QuestParty>(e.QuestId).Id, Persist);
+            DeleteEvent<QuestEnded>();
+            DeleteEvent<MembersDeparted>(e => e.QuestId);
+            DeleteEvent<MonsterDestroyed>((session, e) => session.Load<QuestParty>(e.QuestId).Id);
         }
 
         private void Persist<T>(PersistedView view, T @event)

--- a/src/Marten.Testing/Events/QuestTypes.cs
+++ b/src/Marten.Testing/Events/QuestTypes.cs
@@ -63,9 +63,22 @@ namespace Marten.Testing.Events
         }
     }
 
+    public class QuestEnded
+    {
+        public string Name { get; set; }
+        public Guid Id { get; set; }
+
+        public override string ToString()
+        {
+            return $"Quest {Name} ended";
+        }
+    }
+
     public class MembersDeparted
     {
         public Guid Id { get; set; }
+
+        public Guid QuestId { get; set; }
 
         public int Day { get; set; }
 

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -152,9 +152,9 @@ namespace Marten.Events
             return AsyncProjections.ForView(viewType) ?? InlineProjections.ForView(viewType);
         }
 
-        public ViewProjection<TView> ProjectView<TView>() where TView : class, new()
+        public ViewProjection<TView, TId> ProjectView<TView, TId>() where TView : class, new()
         {
-            var projection = new ViewProjection<TView>();
+            var projection = new ViewProjection<TView, TId>();
             InlineProjections.Add(projection);
             return projection;
         }

--- a/src/Marten/Events/Projections/ViewProjection.cs
+++ b/src/Marten/Events/Projections/ViewProjection.cs
@@ -2,38 +2,86 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Events.Projections.Async;
 using Marten.Schema.Identity;
+using System.Linq.Expressions;
 using Marten.Storage;
 
 namespace Marten.Events.Projections
 {
-    public class ViewProjection<TView> : DocumentProjection<TView>, IDocumentProjection where TView : class, new()
+    public class ViewProjection<TView, TId> : DocumentProjection<TView>, IDocumentProjection 
+        where TView : class, new()
     {
+        private readonly Func<DocumentSession, TId[], IList<TView>> _sessionLoadMany;
+
+        public ViewProjection()
+        {
+            var loadManyMethod = typeof(DocumentSession).GetMethods()
+                .Where(x => x.Name == "LoadMany" && x.GetParameters().Any(y => y.ParameterType == typeof(TId[])))
+                .FirstOrDefault();
+
+            if (loadManyMethod == null)
+            {
+                throw new ArgumentException($"{typeof(TId)} is not supported.");
+            }
+
+            var sessionParameter = Expression.Parameter(typeof(DocumentSession), "a");
+            var idParameter = Expression.Parameter(typeof(TId[]), "e");
+            var body = Expression.Call(sessionParameter, loadManyMethod.MakeGenericMethod(typeof(TView)), idParameter);
+            var lambda = Expression.Lambda<Func<DocumentSession, TId[], IList<TView>>>(body, sessionParameter, idParameter);
+            _sessionLoadMany = lambda.Compile();
+        }
+
         private class EventHandler
         {
-            public Func<IDocumentSession, object, Guid, Guid> IdSelector { get; }
+            public Func<IDocumentSession, object, Guid, TId> IdSelector { get; }
+            public Func<IDocumentSession, object, Guid, List<TId>> IdsSelector { get; }
             public Action<TView, object> Handler { get; }
+            public ProjectionEventType Type { get; set; }
 
-            public EventHandler(Func<IDocumentSession, object, Guid, Guid> idSelector, Action<TView, object> handler)
+            public EventHandler(
+                Func<IDocumentSession, object, Guid, TId> idSelector,
+                Func<IDocumentSession, object, Guid, List<TId>> idsSelector,
+                Action<TView, object> handler,
+                ProjectionEventType type)
             {
                 IdSelector = idSelector;
+                IdsSelector = idsSelector;
                 Handler = handler;
+                Type = type;
             }
         }
 
         private class EventProjection
         {
-            public Guid ViewId { get; }
+            public TId ViewId { get; }
             public Action<TView> ProjectTo { get; }
+            public ProjectionEventType Type { get; set; }
 
-            public EventProjection(EventHandler eventHandler, Guid viewId, IEvent @event)
+            public EventProjection(EventHandler eventHandler, TId viewId, IEvent @event, object projectionEvent)
             {
                 ViewId = viewId;
-                ProjectTo = view => eventHandler.Handler(view, @event.Data);
+                Type = eventHandler.Type;
+
+                if (projectionEvent != null)
+                {
+                    // Event handler uses ProjectionEvent generic
+                    ProjectTo = view => eventHandler.Handler(view, projectionEvent);
+                }
+                else
+                {
+                    ProjectTo = view => eventHandler.Handler(view, @event.Data);
+                }
             }
+        }
+
+        public enum ProjectionEventType
+        {
+            Modify,
+            Delete
         }
 
         private readonly IDictionary<Type, EventHandler> _handlers = new ConcurrentDictionary<Type, EventHandler>();
@@ -41,31 +89,94 @@ namespace Marten.Events.Projections
         public Type[] Consumes => getUniqueEventTypes();
         public AsyncOptions AsyncOptions { get; } = new AsyncOptions();
 
-        public ViewProjection<TView> ProjectEvent<TEvent>(Action<TView, TEvent> handler) where TEvent : class
-            => projectEvent((session, @event, streamId) => streamId, handler);
+        public ViewProjection<TView, TId> DeleteEvent<TEvent>() where TEvent : class
+            => projectEvent<TEvent>((session, @event, streamId) => convertToTId(streamId), null, null, ProjectionEventType.Delete);
 
-        public ViewProjection<TView> ProjectEvent<TEvent>(Func<IDocumentSession, TEvent, Guid> viewIdSelector, Action<TView, TEvent> handler) where TEvent : class
+        public ViewProjection<TView, TId> DeleteEvent<TEvent>(Func<TEvent, TId> viewIdSelector) where TEvent : class
         {
             if (viewIdSelector == null) throw new ArgumentNullException(nameof(viewIdSelector));
-            return projectEvent((session, @event, streamId) => viewIdSelector(session, @event as TEvent), handler);
+            return projectEvent<TEvent>((session, @event, streamId) => viewIdSelector(@event as TEvent), null, null, ProjectionEventType.Delete);
         }
 
-        public ViewProjection<TView> ProjectEvent<TEvent>(Func<TEvent, Guid> viewIdSelector, Action<TView, TEvent> handler) where TEvent : class
+        public ViewProjection<TView, TId> DeleteEvent<TEvent>(Func<IDocumentSession, TEvent, TId> viewIdSelector) where TEvent : class
         {
             if (viewIdSelector == null) throw new ArgumentNullException(nameof(viewIdSelector));
-            return projectEvent((session, @event, streamId) => viewIdSelector(@event as TEvent), handler);
+            return projectEvent<TEvent>((session, @event, streamId) => viewIdSelector(session, @event as TEvent), null, null, ProjectionEventType.Delete);
         }
 
-        private ViewProjection<TView> projectEvent<TEvent>(Func<IDocumentSession, object, Guid, Guid> viewIdSelector, Action<TView, TEvent> handler) where TEvent : class
+        public ViewProjection<TView, TId> DeleteEvent<TEvent>(Func<TEvent, List<TId>> viewIdsSelector) where TEvent : class
+        {
+            if (viewIdsSelector == null) throw new ArgumentNullException(nameof(viewIdsSelector));
+            return projectEvent<TEvent>(null, (session, @event, streamId) => viewIdsSelector(@event as TEvent), null, ProjectionEventType.Delete);
+        }
+
+        public ViewProjection<TView, TId> DeleteEvent<TEvent>(Func<IDocumentSession, TEvent, List<TId>> viewIdsSelector) where TEvent : class
+        {
+            if (viewIdsSelector == null) throw new ArgumentNullException(nameof(viewIdsSelector));
+            return projectEvent<TEvent>(null, (session, @event, streamId) => viewIdsSelector(session, @event as TEvent), null, ProjectionEventType.Delete);
+        }
+
+        public ViewProjection<TView, TId> ProjectEvent<TEvent>(Action<TView, TEvent> handler) where TEvent : class
+            => projectEvent((session, @event, streamId) => convertToTId(streamId), null, handler);
+
+        public ViewProjection<TView, TId> ProjectEvent<TEvent>(Func<IDocumentSession, TEvent, TId> viewIdSelector, Action<TView, TEvent> handler) where TEvent : class
         {
             if (viewIdSelector == null) throw new ArgumentNullException(nameof(viewIdSelector));
-            if (handler == null) throw new ArgumentNullException(nameof(handler));
+            return projectEvent((session, @event, streamId) => viewIdSelector(session, @event as TEvent), null, handler);
+        }
 
-            var eventHandler = new EventHandler(viewIdSelector, (view, @event) => handler(view, @event as TEvent));
+        public ViewProjection<TView, TId> ProjectEvent<TEvent>(Func<TEvent, TId> viewIdSelector, Action<TView, TEvent> handler) where TEvent : class
+        {
+            if (viewIdSelector == null) throw new ArgumentNullException(nameof(viewIdSelector));
+            return projectEvent((session, @event, streamId) => viewIdSelector(@event as TEvent), null, handler);
+        }
+
+        public ViewProjection<TView, TId> ProjectEvent<TEvent>(Func<IDocumentSession, TEvent, List<TId>> viewIdsSelector, Action<TView, TEvent> handler) where TEvent : class
+        {
+            if (viewIdsSelector == null) throw new ArgumentNullException(nameof(viewIdsSelector));
+            return projectEvent(null, (session, @event, streamId) => viewIdsSelector(session, @event as TEvent), handler);
+        }
+
+        public ViewProjection<TView, TId> ProjectEvent<TEvent>(Func<TEvent, List<TId>> viewIdsSelector, Action<TView, TEvent> handler) where TEvent : class
+        {
+            if (viewIdsSelector == null) throw new ArgumentNullException(nameof(viewIdsSelector));
+            return projectEvent(null, (session, @event, streamId) => viewIdsSelector(@event as TEvent), handler);
+        }
+
+        private ViewProjection<TView, TId> projectEvent<TEvent>(
+            Func<IDocumentSession, object, Guid, TId> viewIdSelector,
+            Func<IDocumentSession, object, Guid, List<TId>> viewIdsSelector,
+            Action<TView, TEvent> handler,
+            ProjectionEventType type = ProjectionEventType.Modify) where TEvent : class
+        {
+            if (viewIdSelector == null && viewIdsSelector == null) throw new ArgumentException($"{nameof(viewIdSelector)} or {nameof(viewIdsSelector)} must be provided.");
+            if (handler == null && type == ProjectionEventType.Modify) throw new ArgumentNullException(nameof(handler));
+
+            EventHandler eventHandler;
+            if (type == ProjectionEventType.Modify)
+            {
+                eventHandler = new EventHandler(viewIdSelector, viewIdsSelector, (view, @event) => handler(view, @event as TEvent), type);
+            }
+            else
+            {
+                eventHandler = new EventHandler(viewIdSelector, viewIdsSelector, null, type);
+            }
 
             _handlers.Add(typeof(TEvent), eventHandler);
 
             return this;
+        }
+
+        private TId convertToTId(Guid streamId)
+        {
+            if (streamId is TId)
+            {
+                return (TId)Convert.ChangeType(streamId, typeof(TId));
+            }
+            else
+            {
+                throw new InvalidOperationException("IdSelector must be used if Id type is different than Guid.");
+            }
         }
 
         void IProjection.Apply(IDocumentSession session, EventPage page)
@@ -73,19 +184,29 @@ namespace Marten.Events.Projections
             var projections = getEventProjections(session, page);
 
             var viewIds = projections.Select(projection => projection.ViewId).Distinct().ToArray();
-            var views = session.LoadMany<TView>(viewIds);
 
-            applyProjections(session, projections, views);
+            if (viewIds.Length > 0)
+            {
+                var views = _sessionLoadMany((DocumentSession)session, viewIds);
+
+                applyProjections(session, projections, views);
+            }
         }
 
-        async Task IProjection.ApplyAsync(IDocumentSession session, EventPage page, CancellationToken token)
+        Task IProjection.ApplyAsync(IDocumentSession session, EventPage page, CancellationToken token)
         {
             var projections = getEventProjections(session, page);
 
             var viewIds = projections.Select(projection => projection.ViewId).Distinct().ToArray();
-            var views = await session.LoadManyAsync<TView>(token, viewIds).ConfigureAwait(false);
 
-            applyProjections(session, projections, views);
+            if (viewIds.Length > 0)
+            {
+                var views = _sessionLoadMany((DocumentSession)session, viewIds);
+
+                applyProjections(session, projections, views);
+            }
+
+            return Task.CompletedTask;
         }
 
         private void applyProjections(IDocumentSession session, IList<EventProjection> projections, IList<TView> views)
@@ -96,16 +217,23 @@ namespace Marten.Events.Projections
             {
                 var view = viewMap[eventProjection.ViewId];
 
-                eventProjection.ProjectTo(view);
+                if (eventProjection.Type == ProjectionEventType.Delete)
+                {
+                    session.Delete(view);
+                }
+                else
+                {
+                    eventProjection.ProjectTo(view);
+                }
             }
         }
 
-        private IDictionary<Guid, TView> createViewMap(IDocumentSession session, IList<EventProjection> projections, IList<TView> views)
+        private IDictionary<TId, TView> createViewMap(IDocumentSession session, IList<EventProjection> projections, IList<TView> views)
         {
             var idAssigner = session.Tenant.IdAssignmentFor<TView>();
             var resolver = session.Tenant.StorageFor<TView>();
 
-            var viewMap =  views.ToDictionary(view => (Guid) resolver.Identity(view), view => view);
+            var viewMap = views.ToDictionary(view => (TId)resolver.Identity(view), view => view);
 
             foreach (var projection in projections)
             {
@@ -116,13 +244,17 @@ namespace Marten.Events.Projections
                     view = newView(session.Tenant, idAssigner, viewId);
                     viewMap.Add(viewId, view);
                 }
-                session.Store(view);
+
+                if (projection.Type == ProjectionEventType.Modify)
+                {
+                    session.Store(view);
+                }
             }
 
             return viewMap;
         }
 
-        private static TView newView(ITenant tenant, IdAssignment<TView> idAssigner, Guid id)
+        private static TView newView(ITenant tenant, IdAssignment<TView> idAssigner, TId id)
         {
             var view = new TView();
             idAssigner.Assign(tenant, view, id);
@@ -135,13 +267,50 @@ namespace Marten.Events.Projections
             foreach (var streamEvent in page.Events)
             {
                 EventHandler handler;
-                if (_handlers.TryGetValue(streamEvent.Data.GetType(), out handler))
+                var eventType = streamEvent.Data.GetType();
+                if (_handlers.TryGetValue(eventType, out handler))
                 {
-                    var viewId = handler.IdSelector(session, streamEvent.Data, streamEvent.StreamId);
-                    projections.Add(new EventProjection(handler, viewId, streamEvent));
+                    appendProjections(projections, handler, session, streamEvent, eventType, false);
+                }
+                else
+                {
+                    var genericEventType = typeof(ProjectionEvent<>).MakeGenericType(eventType);
+                    if (_handlers.TryGetValue(genericEventType, out handler))
+                    {
+                        appendProjections(projections, handler, session, streamEvent, genericEventType, true);
+                    }
                 }
             }
             return projections;
+        }
+
+        private void appendProjections(List<EventProjection> projections, EventHandler handler, IDocumentSession session, IEvent streamEvent, Type eventType, bool isProjectionEvent)
+        {
+            object projectionEvent = null;
+            if (isProjectionEvent)
+            {
+                var timestamp = streamEvent.Timestamp.UtcDateTime;
+                projectionEvent = Activator.CreateInstance(
+                    eventType,
+                    streamEvent.Id,
+                    streamEvent.Version,
+                    // Inline projections don't have the timestamp set, set it manually
+                    timestamp == default(DateTime) ? DateTime.UtcNow : timestamp,
+                    streamEvent.Data);
+            }
+
+            if (handler.IdSelector != null)
+            {
+                var viewId = handler.IdSelector(session, isProjectionEvent ? projectionEvent : streamEvent.Data, streamEvent.StreamId);
+                projections.Add(new EventProjection(handler, viewId, streamEvent, projectionEvent));
+            }
+            else
+            {
+                foreach (var viewId in handler.IdsSelector(session, isProjectionEvent ? projectionEvent : streamEvent.Data, streamEvent.StreamId))
+                {
+                    projections.Add(new EventProjection(handler, viewId, streamEvent, projectionEvent));
+                }
+            }
         }
 
         private Type[] getUniqueEventTypes()
@@ -150,6 +319,22 @@ namespace Marten.Events.Projections
                 .Union(_handlers.Keys)
                 .Distinct()
                 .ToArray();
+        }
+    }
+
+    public class ProjectionEvent<T>
+    {
+        public Guid Id { get; protected set; }
+        public int Version { get; protected set; }
+        public DateTime Timestamp { get; protected set; }
+        public T Data { get; protected set; }
+
+        public ProjectionEvent(Guid id, int version, DateTime timestamp, T data)
+        {
+            Id = id;
+            Version = version;
+            Timestamp = timestamp;
+            Data = data;
         }
     }
 }


### PR DESCRIPTION
- Added support for Id types other than `Guid` through a generic `TId` type.

```
StoreOptions(_ =>
{
    _.Events.ProjectView<PersistedView, Guid>();
});
```

OR

```
PersistViewProjection : ViewProjection<PersistedView, string>
```

- Added `DeleteEvent` for deleting a record from a document. This supports the same type of selectors that `ProjectEvent` does

```
DeleteEvent<QuestEnded>();
DeleteEvent<MembersDeparted>(e => e.QuestId);
DeleteEvent<MonsterDestroyed>((session, e) => session.Load<QuestParty>(e.QuestId).Id);
```

- Added support for passing a `List<TId>` as the selector of `ProjectEvent` and `DeleteEvent` to better support bulk events. The List will be broken into separate calls to the handler delegate.

```
public class PersistViewProjection : ViewProjection<PersistedView, Guid>
{
    public PersistViewProjection()
    {
        ProjectEvent<QuestsStarted>(e => e.QuestIds, Persist);
    }

    private void Persist(PersistedView view, QuestsStarted @event) { }
}
```