### PR TITLE
Cleanup unused Appveyor config items

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # set version as running build number for CI build use
-version: {build}
+version: Build {build}
 
 configuration: Release
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
-version: 2.0.0.{build}
+# set version as running build number for CI build use
+version: {build}
 
 configuration: Release
 
@@ -33,13 +34,6 @@ before_build:
   - psql -d %PG_DB% -c "create extension if not exists plv8;"
   - npm install
   - dotnet --info
-
-assembly_info:
-  patch: true
-  file: '**\CommonAssemblyInfo.cs'
-  assembly_version: '{version}'
-  assembly_file_version: '{version}'
-  assembly_informational_version: '{version}'
 
 build_script:
 - cmd: >-


### PR DESCRIPTION
- Changed version config entry to format "Build [version]" since it is not used anywhere else other than CI build label
- Removed assembly_info patching config since the rake script takes care of it