### PR TITLE
Convert public api to IReadOnlyList<T>

### DIFF
--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -45,7 +45,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="HtmlTags" Version="3.0.0.186" />
-    <PackageReference Include="Jil" Version="2.14.3" />
     <PackageReference Include="Storyteller" Version="3.0.0.329-rc" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.0.2" />
     <Reference Include="System.Web" />

--- a/src/Marten/Events/EventQueryHandler.cs
+++ b/src/Marten/Events/EventQueryHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
@@ -10,7 +10,7 @@ using Marten.Util;
 
 namespace Marten.Events
 {
-    internal interface IEventQueryHandler : IQueryHandler<IList<IEvent>>
+    internal interface IEventQueryHandler : IQueryHandler<IReadOnlyList<IEvent>>
     {
         
     }
@@ -63,12 +63,12 @@ namespace Marten.Events
             sql.Append(" order by version");
         }
 
-        public IList<IEvent> Handle(DbDataReader reader, IIdentityMap map, QueryStatistics stats)
+        public IReadOnlyList<IEvent> Handle(DbDataReader reader, IIdentityMap map, QueryStatistics stats)
         {
             return _selector.Read(reader, map, stats);
         }
 
-        public Task<IList<IEvent>> HandleAsync(DbDataReader reader, IIdentityMap map, QueryStatistics stats, CancellationToken token)
+        public Task<IReadOnlyList<IEvent>> HandleAsync(DbDataReader reader, IIdentityMap map, QueryStatistics stats, CancellationToken token)
         {
             return _selector.ReadAsync(reader, map, stats, token);
         }

--- a/src/Marten/Events/EventStore.cs
+++ b/src/Marten/Events/EventStore.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -172,7 +172,7 @@ namespace Marten.Events
             return StartStream(Guid.NewGuid(), events);
         }
 
-        public IList<IEvent> FetchStream(Guid streamId, int version = 0, DateTime? timestamp = null)
+        public IReadOnlyList<IEvent> FetchStream(Guid streamId, int version = 0, DateTime? timestamp = null)
         {
             ensureAsGuidStorage();
 
@@ -180,8 +180,7 @@ namespace Marten.Events
             return _connection.Fetch(handler, null, null, _tenant);
         }
 
-        public Task<IList<IEvent>> FetchStreamAsync(Guid streamId, int version = 0, DateTime? timestamp = null,
-            CancellationToken token = new CancellationToken())
+        public Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, int version = 0, DateTime? timestamp = null, CancellationToken token = default(CancellationToken))
         {
             ensureAsGuidStorage();
 
@@ -189,7 +188,7 @@ namespace Marten.Events
             return _connection.FetchAsync(handler, null, null, _tenant, token);
         }
 
-        public IList<IEvent> FetchStream(string streamKey, int version = 0, DateTime? timestamp = null)
+        public IReadOnlyList<IEvent> FetchStream(string streamKey, int version = 0, DateTime? timestamp = null)
         {
             ensureAsStringStorage();
 
@@ -197,8 +196,7 @@ namespace Marten.Events
             return _connection.Fetch(handler, null, null, _tenant);
         }
 
-        public Task<IList<IEvent>> FetchStreamAsync(string streamKey, int version = 0, DateTime? timestamp = null,
-            CancellationToken token = new CancellationToken())
+        public Task<IReadOnlyList<IEvent>> FetchStreamAsync(string streamKey, int version = 0, DateTime? timestamp = null, CancellationToken token = default(CancellationToken))
         {
             ensureAsStringStorage();
 

--- a/src/Marten/Events/IEventStore.cs
+++ b/src/Marten/Events/IEventStore.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -103,7 +103,7 @@ namespace Marten.Events
         /// <param name="version">If set, queries for events up to and including this version</param>
         /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
         /// <returns></returns>
-        IList<IEvent> FetchStream(Guid streamId, int version = 0, DateTime? timestamp = null);
+        IReadOnlyList<IEvent> FetchStream(Guid streamId, int version = 0, DateTime? timestamp = null);
 
         /// <summary>
         /// Synchronously fetches all of the events for the named stream
@@ -113,7 +113,7 @@ namespace Marten.Events
         /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<IList<IEvent>> FetchStreamAsync(Guid streamId, int version = 0, DateTime? timestamp = null, CancellationToken token = default(CancellationToken));
+        Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, int version = 0, DateTime? timestamp = null, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Synchronously fetches all of the events for the named stream
@@ -122,7 +122,7 @@ namespace Marten.Events
         /// <param name="version">If set, queries for events up to and including this version</param>
         /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
         /// <returns></returns>
-        IList<IEvent> FetchStream(string streamKey, int version = 0, DateTime? timestamp = null);
+        IReadOnlyList<IEvent> FetchStream(string streamKey, int version = 0, DateTime? timestamp = null);
 
         /// <summary>
         /// Synchronously fetches all of the events for the named stream
@@ -132,7 +132,7 @@ namespace Marten.Events
         /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<IList<IEvent>> FetchStreamAsync(string streamKey, int version = 0, DateTime? timestamp = null, CancellationToken token = default(CancellationToken));
+        Task<IReadOnlyList<IEvent>> FetchStreamAsync(string streamKey, int version = 0, DateTime? timestamp = null, CancellationToken token = default(CancellationToken));
 
 
         /// <summary>

--- a/src/Marten/Events/Projections/Async/EventPage.cs
+++ b/src/Marten/Events/Projections/Async/EventPage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace Marten.Events.Projections.Async
@@ -15,7 +14,7 @@ namespace Marten.Events.Projections.Async
     public class EventPage
     {
         private EventStream[] _streams;
-        private IList<IEvent> _events;
+        private IReadOnlyList<IEvent> _events;
 
         public static EventStream[] ToStreams(StreamIdentity streamIdentity, IEnumerable<IEvent> events)
         {
@@ -79,7 +78,7 @@ namespace Marten.Events.Projections.Async
             To = 0;
         }
 
-        public EventPage(long from, long to, IList<IEvent> events)
+        public EventPage(long from, long to, IReadOnlyList<IEvent> events)
         {
             _events = events;
             From = @from;
@@ -88,7 +87,7 @@ namespace Marten.Events.Projections.Async
 
         public StreamIdentity StreamIdentity { get; set; } = StreamIdentity.AsGuid;
 
-        public IList<IEvent> Events
+        public IReadOnlyList<IEvent> Events
         {
             get
             {
@@ -101,7 +100,7 @@ namespace Marten.Events.Projections.Async
             }
         }
 
-        public EventPage(long @from, IList<long> sequences, IList<IEvent> events)
+        public EventPage(long @from, IList<long> sequences, IReadOnlyList<IEvent> events)
         {
             _events = events;
             Sequences = sequences;

--- a/src/Marten/Events/Projections/Async/Fetcher.cs
+++ b/src/Marten/Events/Projections/Async/Fetcher.cs
@@ -182,13 +182,13 @@ select max(seq_id) from {_selector.Events.DatabaseSchemaName}.mt_events where se
             }
         }
 
-        private async Task<EventPage> buildEventPage(long @from, NpgsqlCommand cmd)
+        private async Task<EventPage> buildEventPage(long from, NpgsqlCommand cmd)
         {
-            IList<IEvent> events = null;
+            IReadOnlyList<IEvent> events;
             IList<long> sequences = new List<long>();
 
-            long nextKnown = 0;
-            long lastKnown = 0;
+            long nextKnown;
+            long lastKnown;
 
             using (var reader = await cmd.ExecuteReaderAsync(_token).ConfigureAwait(false))
             {
@@ -214,7 +214,7 @@ select max(seq_id) from {_selector.Events.DatabaseSchemaName}.mt_events where se
                 lastKnown = await getLong(reader).ConfigureAwait(false);
             }
 
-            return new EventPage(@from, sequences, events)
+            return new EventPage(from, sequences, events)
             {
                 NextKnownSequence = nextKnown,
                 LastKnownSequence = lastKnown,

--- a/src/Marten/Events/Projections/ViewProjection.cs
+++ b/src/Marten/Events/Projections/ViewProjection.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +15,7 @@ namespace Marten.Events.Projections
     public class ViewProjection<TView, TId> : DocumentProjection<TView>, IDocumentProjection 
         where TView : class, new()
     {
-        private readonly Func<DocumentSession, TId[], IList<TView>> _sessionLoadMany;
+        private readonly Func<DocumentSession, TId[], IReadOnlyList<TView>> _sessionLoadMany;
 
         public ViewProjection()
         {
@@ -31,7 +31,7 @@ namespace Marten.Events.Projections
             var sessionParameter = Expression.Parameter(typeof(DocumentSession), "a");
             var idParameter = Expression.Parameter(typeof(TId[]), "e");
             var body = Expression.Call(sessionParameter, loadManyMethod.MakeGenericMethod(typeof(TView)), idParameter);
-            var lambda = Expression.Lambda<Func<DocumentSession, TId[], IList<TView>>>(body, sessionParameter, idParameter);
+            var lambda = Expression.Lambda<Func<DocumentSession, TId[], IReadOnlyList<TView>>>(body, sessionParameter, idParameter);
             _sessionLoadMany = lambda.Compile();
         }
 
@@ -209,7 +209,7 @@ namespace Marten.Events.Projections
             return Task.CompletedTask;
         }
 
-        private void applyProjections(IDocumentSession session, IList<EventProjection> projections, IList<TView> views)
+        private void applyProjections(IDocumentSession session, ICollection<EventProjection> projections, IEnumerable<TView> views)
         {
             var viewMap = createViewMap(session, projections, views);
 
@@ -228,7 +228,7 @@ namespace Marten.Events.Projections
             }
         }
 
-        private IDictionary<TId, TView> createViewMap(IDocumentSession session, IList<EventProjection> projections, IList<TView> views)
+        private IDictionary<TId, TView> createViewMap(IDocumentSession session, IEnumerable<EventProjection> projections, IEnumerable<TView> views)
         {
             var idAssigner = session.Tenant.IdAssignmentFor<TView>();
             var resolver = session.Tenant.StorageFor<TView>();

--- a/src/Marten/IDocumentSession.cs
+++ b/src/Marten/IDocumentSession.cs
@@ -206,7 +206,7 @@ namespace Marten
         /// <typeparam name="TKey"></typeparam>
         /// <param name="keys"></param>
         /// <returns></returns>
-        IList<TDoc> ById<TKey>(params TKey[] keys);
+        IReadOnlyList<TDoc> ById<TKey>(params TKey[] keys);
 
         /// <summary>
         /// Supply the document id's to load asynchronously
@@ -214,7 +214,7 @@ namespace Marten
         /// <typeparam name="TKey"></typeparam>
         /// <param name="keys"></param>
         /// <returns></returns>
-        Task<IList<TDoc>> ByIdAsync<TKey>(params TKey[] keys);
+        Task<IReadOnlyList<TDoc>> ByIdAsync<TKey>(params TKey[] keys);
 
         /// <summary>
         /// Supply the document id's to load
@@ -222,7 +222,7 @@ namespace Marten
         /// <typeparam name="TKey"></typeparam>
         /// <param name="keys"></param>
         /// <returns></returns>
-        IList<TDoc> ById<TKey>(IEnumerable<TKey> keys);
+        IReadOnlyList<TDoc> ById<TKey>(IEnumerable<TKey> keys);
 
         /// <summary>
         /// Supply the document id's to load asynchronously
@@ -231,6 +231,6 @@ namespace Marten
         /// <param name="keys"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<IList<TDoc>> ByIdAsync<TKey>(IEnumerable<TKey> keys, CancellationToken token = default(CancellationToken));
+        Task<IReadOnlyList<TDoc>> ByIdAsync<TKey>(IEnumerable<TKey> keys, CancellationToken token = default(CancellationToken));
     }
 }

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -97,7 +97,7 @@ namespace Marten
         /// <param name="sql"></param>
         /// <param name="parameters"></param>
         /// <returns></returns>
-        IList<T> Query<T>(string sql, params object[] parameters);
+        IReadOnlyList<T> Query<T>(string sql, params object[] parameters);
 
         /// <summary>
         /// Asynchronously queries the document storage table for the document type T by supplied SQL. See http://jasperfx.github.io/marten/documentation/documents/querying/sql/ for more information on usage.
@@ -107,7 +107,7 @@ namespace Marten
         /// <param name="token"></param>
         /// <param name="parameters"></param>
         /// <returns></returns>
-        Task<IList<T>> QueryAsync<T>(string sql, CancellationToken token = default(CancellationToken), params object[] parameters);
+        Task<IReadOnlyList<T>> QueryAsync<T>(string sql, CancellationToken token = default(CancellationToken), params object[] parameters);
 
         /// <summary>
         /// Define a batch of deferred queries and load operations to be conducted in one asynchronous request to the 
@@ -164,84 +164,84 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        IList<T> LoadMany<T>(params string[] ids);
+        IReadOnlyList<T> LoadMany<T>(params string[] ids);
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        IList<T> LoadMany<T>(params Guid[] ids);
+        IReadOnlyList<T> LoadMany<T>(params Guid[] ids);
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        IList<T> LoadMany<T>(params int[] ids);
+        IReadOnlyList<T> LoadMany<T>(params int[] ids);
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        IList<T> LoadMany<T>(params long[] ids);
+        IReadOnlyList<T> LoadMany<T>(params long[] ids);
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IList<T>> LoadManyAsync<T>(params string[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(params string[] ids);
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IList<T>> LoadManyAsync<T>(params Guid[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(params Guid[] ids);
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IList<T>> LoadManyAsync<T>(params int[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(params int[] ids);
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IList<T>> LoadManyAsync<T>(params long[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(params long[] ids);
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IList<T>> LoadManyAsync<T>(CancellationToken token, params string[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params string[] ids);
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IList<T>> LoadManyAsync<T>(CancellationToken token, params Guid[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params Guid[] ids);
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IList<T>> LoadManyAsync<T>(CancellationToken token, params int[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params int[] ids);
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IList<T>> LoadManyAsync<T>(CancellationToken token, params long[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params long[] ids);
 
         /// <summary>
         /// Directly load the persisted JSON data for documents by Id

--- a/src/Marten/Linq/IMartenQueryable.cs
+++ b/src/Marten/Linq/IMartenQueryable.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -16,7 +16,7 @@ namespace Marten.Linq
         IEnumerable<IIncludeJoin> Includes { get; }
 
         QueryStatistics Statistics { get; }
-        Task<IList<TResult>> ToListAsync<TResult>(CancellationToken token);
+        Task<IReadOnlyList<TResult>> ToListAsync<TResult>(CancellationToken token);
         Task<bool> AnyAsync(CancellationToken token);
         Task<int> CountAsync(CancellationToken token);
         Task<long> CountLongAsync(CancellationToken token);
@@ -54,7 +54,6 @@ namespace Marten.Linq
 
         IMartenQueryable<T> Include<TInclude, TKey>(Expression<Func<T, object>> idSource,
             IDictionary<TKey, TInclude> dictionary, JoinType joinType = JoinType.Inner);
-
 
         IMartenQueryable<T> Stats(out QueryStatistics stats);
 

--- a/src/Marten/Linq/ISelector.cs
+++ b/src/Marten/Linq/ISelector.cs
@@ -51,7 +51,7 @@ namespace Marten.Linq
     public abstract class BasicSelector
     {
         private readonly string[] _selectFields;
-        private readonly bool _distinct = false;
+        private readonly bool _distinct;
 
         protected BasicSelector(params string[] selectFields)
         {
@@ -99,7 +99,7 @@ namespace Marten.Linq
             return builder.ToString();
         }
 
-        public static IList<T> Read<T>(this ISelector<T> selector, DbDataReader reader, IIdentityMap map, QueryStatistics stats)
+        public static IReadOnlyList<T> Read<T>(this ISelector<T> selector, DbDataReader reader, IIdentityMap map, QueryStatistics stats)
         {
             var list = new List<T>();
 
@@ -111,7 +111,7 @@ namespace Marten.Linq
             return list;
         }
 
-        public static async Task<IList<T>> ReadAsync<T>(this ISelector<T> selector, DbDataReader reader, IIdentityMap map, QueryStatistics stats, CancellationToken token)
+        public static async Task<IReadOnlyList<T>> ReadAsync<T>(this ISelector<T> selector, DbDataReader reader, IIdentityMap map, QueryStatistics stats, CancellationToken token)
         {
             var list = new List<T>();
 

--- a/src/Marten/Linq/MartenQueryable.cs
+++ b/src/Marten/Linq/MartenQueryable.cs
@@ -119,9 +119,9 @@ namespace Marten.Linq
             return this;
         }
 
-        public Task<IList<TResult>> ToListAsync<TResult>(CancellationToken token)
+        public Task<IReadOnlyList<TResult>> ToListAsync<TResult>(CancellationToken token)
         {
-            return executeAsync(q => q.ToList().As<IQueryHandler<IList<TResult>>>(), token);
+            return executeAsync(q => q.ToList().As<IQueryHandler<IReadOnlyList<TResult>>>(), token);
         }
 
         public Task<bool> AnyAsync(CancellationToken token)

--- a/src/Marten/Linq/Model/LinqQuery.cs
+++ b/src/Marten/Linq/Model/LinqQuery.cs
@@ -188,7 +188,7 @@ namespace Marten.Linq.Model
         }
 
 
-        public IQueryHandler<IList<T>> ToList()
+        public IQueryHandler<IReadOnlyList<T>> ToList()
         {
             return new ListQueryHandler<T>(this);
         }

--- a/src/Marten/Linq/QueryHandlers/EnumerableQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/EnumerableQueryHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
@@ -13,7 +13,7 @@ namespace Marten.Linq.QueryHandlers
 {
     public class EnumerableQueryHandler<T> : IQueryHandler<IEnumerable<T>>
     {
-        private readonly IQueryHandler<IList<T>> _inner;
+        private readonly IQueryHandler<IReadOnlyList<T>> _inner;
 
         public EnumerableQueryHandler(DocumentStore store, QueryModel query, IIncludeJoin[] joins, QueryStatistics stats)
         {

--- a/src/Marten/Linq/QueryHandlers/ListQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/ListQueryHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
@@ -6,11 +6,10 @@ using System.Threading.Tasks;
 using Marten.Linq.Model;
 using Marten.Services;
 using Marten.Util;
-using Npgsql;
 
 namespace Marten.Linq.QueryHandlers
 {
-    public class ListQueryHandler<T> : IQueryHandler<IList<T>>
+    public class ListQueryHandler<T> : IQueryHandler<IReadOnlyList<T>>
     {
         private readonly LinqQuery<T> _query;
 
@@ -19,12 +18,12 @@ namespace Marten.Linq.QueryHandlers
             _query = query;
         }
 
-        public IList<T> Handle(DbDataReader reader, IIdentityMap map, QueryStatistics stats)
+        public IReadOnlyList<T> Handle(DbDataReader reader, IIdentityMap map, QueryStatistics stats)
         {
             return _query.Selector.Read(reader, map, stats);
         }
 
-        public Task<IList<T>> HandleAsync(DbDataReader reader, IIdentityMap map, QueryStatistics stats, CancellationToken token)
+        public Task<IReadOnlyList<T>> HandleAsync(DbDataReader reader, IIdentityMap map, QueryStatistics stats, CancellationToken token)
         {
             return _query.Selector.ReadAsync(reader, map, stats, token);
         }

--- a/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
@@ -1,19 +1,16 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Baseline;
-using Marten.Schema;
 using Marten.Services;
 using Marten.Util;
-using Npgsql;
 
 namespace Marten.Linq.QueryHandlers
 {
-    public class UserSuppliedQueryHandler<T> : IQueryHandler<IList<T>>
+    public class UserSuppliedQueryHandler<T> : IQueryHandler<IReadOnlyList<T>>
     {
         private readonly DocumentStore _store;
         private readonly string _sql;
@@ -68,13 +65,13 @@ namespace Marten.Linq.QueryHandlers
             }
         }
 
-        public IList<T> Handle(DbDataReader reader, IIdentityMap map, QueryStatistics stats)
+        public IReadOnlyList<T> Handle(DbDataReader reader, IIdentityMap map, QueryStatistics stats)
         {
             var selector = new DeserializeSelector<T>(_store.Serializer);
             return selector.Read(reader, map, stats);
         }
 
-        public Task<IList<T>> HandleAsync(DbDataReader reader, IIdentityMap map, QueryStatistics stats, CancellationToken token)
+        public Task<IReadOnlyList<T>> HandleAsync(DbDataReader reader, IIdentityMap map, QueryStatistics stats, CancellationToken token)
         {
             var selector = new DeserializeSelector<T>(_store.Serializer);
 

--- a/src/Marten/QuerySession.cs
+++ b/src/Marten/QuerySession.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -59,7 +59,7 @@ namespace Marten
             return new MartenQueryable<T>(queryProvider);
         }
 
-        public IList<T> Query<T>(string sql, params object[] parameters)
+        public IReadOnlyList<T> Query<T>(string sql, params object[] parameters)
         {
             assertNotDisposed();
 
@@ -67,7 +67,7 @@ namespace Marten
             return _connection.Fetch(handler, _identityMap.ForQuery(), null, Tenant);
         }
 
-        public Task<IList<T>> QueryAsync<T>(string sql, CancellationToken token, params object[] parameters)
+        public Task<IReadOnlyList<T>> QueryAsync<T>(string sql, CancellationToken token = default(CancellationToken), params object[] parameters)
         {
             assertNotDisposed();
 
@@ -86,7 +86,6 @@ namespace Marten
             return Tenant.StorageFor<T>();
         }
 
-
         public T Load<T>(string id)
         {
             return load<T>(id);
@@ -95,11 +94,6 @@ namespace Marten
         public Task<T> LoadAsync<T>(string id, CancellationToken token)
         {
             return loadAsync<T>(id, token);
-        }
-
-        public T Load<T>(ValueType id)
-        {
-            return load<T>(id);
         }
 
         private T load<T>(object id)
@@ -132,79 +126,71 @@ namespace Marten
             return storage<T>().As<IDocumentStorage<T>>().ResolveAsync(_identityMap, this, token, id);
         }
 
-        public ILoadByKeys<T> LoadMany<T>()
+        private ILoadByKeys<T> LoadMany<T>()
         {
             assertNotDisposed();
             return new LoadByKeys<T>(this);
         }
 
-
-
-
-        public IList<T> LoadMany<T>(params string[] ids)
+        public IReadOnlyList<T> LoadMany<T>(params string[] ids)
         {
-            assertNotDisposed();
             return LoadMany<T>().ById(ids);
         }
 
-        public IList<T> LoadMany<T>(params Guid[] ids)
+        public IReadOnlyList<T> LoadMany<T>(params Guid[] ids)
         {
-            assertNotDisposed();
             return LoadMany<T>().ById(ids);
         }
 
-        public IList<T> LoadMany<T>(params int[] ids)
+        public IReadOnlyList<T> LoadMany<T>(params int[] ids)
         {
-            assertNotDisposed();
             return LoadMany<T>().ById(ids);
         }
 
-        public IList<T> LoadMany<T>(params long[] ids)
+        public IReadOnlyList<T> LoadMany<T>(params long[] ids)
         {
-            assertNotDisposed();
             return LoadMany<T>().ById(ids);
         }
 
-        public Task<IList<T>> LoadManyAsync<T>(params string[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(params string[] ids)
         {
             return LoadMany<T>().ByIdAsync(ids);
         }
 
-        public Task<IList<T>> LoadManyAsync<T>(params Guid[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(params Guid[] ids)
         {
             return LoadMany<T>().ByIdAsync(ids);
         }
 
-        public Task<IList<T>> LoadManyAsync<T>(params int[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(params int[] ids)
         {
             return LoadMany<T>().ByIdAsync(ids);
         }
 
-        public Task<IList<T>> LoadManyAsync<T>(params long[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(params long[] ids)
         {
             return LoadMany<T>().ByIdAsync(ids);
         }
 
-        public Task<IList<T>> LoadManyAsync<T>(CancellationToken token, params string[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params string[] ids)
         {
             return LoadMany<T>().ByIdAsync(ids, token);
         }
 
-        public Task<IList<T>> LoadManyAsync<T>(CancellationToken token, params Guid[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params Guid[] ids)
         {
             return LoadMany<T>().ByIdAsync(ids, token);
         }
 
-        public Task<IList<T>> LoadManyAsync<T>(CancellationToken token, params int[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params int[] ids)
         {
             return LoadMany<T>().ByIdAsync(ids, token);
         }
 
-        public Task<IList<T>> LoadManyAsync<T>(CancellationToken token, params long[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params long[] ids)
         {
             return LoadMany<T>().ByIdAsync(ids, token);
         }
-
 
         private class LoadByKeys<TDoc> : ILoadByKeys<TDoc>
         {
@@ -215,7 +201,7 @@ namespace Marten
                 _parent = parent;
             }
 
-            public IList<TDoc> ById<TKey>(params TKey[] keys)
+            public IReadOnlyList<TDoc> ById<TKey>(params TKey[] keys)
             {
                 assertCorrectIdType<TKey>();
 
@@ -239,18 +225,17 @@ namespace Marten
                 }
             }
 
-            public Task<IList<TDoc>> ByIdAsync<TKey>(params TKey[] keys)
+            public Task<IReadOnlyList<TDoc>> ByIdAsync<TKey>(params TKey[] keys)
             {
                 return ByIdAsync(keys, CancellationToken.None);
             }
 
-            public IList<TDoc> ById<TKey>(IEnumerable<TKey> keys)
+            public IReadOnlyList<TDoc> ById<TKey>(IEnumerable<TKey> keys)
             {
                 return ById(keys.ToArray());
             }
 
-            public async Task<IList<TDoc>> ByIdAsync<TKey>(IEnumerable<TKey> keys,
-                CancellationToken token = default(CancellationToken))
+            public async Task<IReadOnlyList<TDoc>> ByIdAsync<TKey>(IEnumerable<TKey> keys, CancellationToken token = default(CancellationToken))
             {
                 assertCorrectIdType<TKey>();
 
@@ -262,7 +247,7 @@ namespace Marten
                 return concatDocuments(hits, documents);
             }
 
-            private IList<TDoc> concatDocuments<TKey>(TKey[] hits, IEnumerable<TDoc> documents)
+            private IReadOnlyList<TDoc> concatDocuments<TKey>(TKey[] hits, IEnumerable<TDoc> documents)
             {
                 return
                     hits.Select(key => _parent._identityMap.Retrieve<TDoc>(key))
@@ -407,7 +392,5 @@ namespace Marten
         {
             return loadAsync<T>(id, token);
         }
-
-
     }
 }

--- a/src/Marten/QueryableExtensions.cs
+++ b/src/Marten/QueryableExtensions.cs
@@ -20,7 +20,7 @@ namespace Marten
 
         #region ToList
 
-        public static Task<IList<T>> ToListAsync<T>(this IQueryable<T> queryable,
+        public static Task<IReadOnlyList<T>> ToListAsync<T>(this IQueryable<T> queryable,
             CancellationToken token = default(CancellationToken))
         {
             return queryable.As<IMartenQueryable>().ToListAsync<T>(token);

--- a/src/Marten/Services/BatchQuerying/BatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQuery.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -8,7 +8,6 @@ using Marten.Events;
 using Marten.Linq;
 using Marten.Linq.Model;
 using Marten.Linq.QueryHandlers;
-using Marten.Schema;
 using Marten.Util;
 using Npgsql;
 
@@ -49,7 +48,7 @@ namespace Marten.Services.BatchQuerying
             return new BatchLoadByKeys<TDoc>(this);
         }
 
-        public Task<IList<T>> Query<T>(string sql, params object[] parameters) where T : class
+        public Task<IReadOnlyList<T>> Query<T>(string sql, params object[] parameters) where T : class
         {
             return AddItem(new UserSuppliedQueryHandler<T>(_store, sql, parameters), null);
         }
@@ -151,7 +150,7 @@ namespace Marten.Services.BatchQuerying
             return AddItem(handler, null);
         }
 
-        public Task<IList<IEvent>> FetchStream(Guid streamId, int version = 0, DateTime? timestamp = null)
+        public Task<IReadOnlyList<IEvent>> FetchStream(Guid streamId, int version = 0, DateTime? timestamp = null)
         {
             var selector = new EventSelector(_store.Events, _store.Serializer);
             var handler = new EventQueryHandler<Guid>(selector, streamId, version, timestamp);
@@ -189,7 +188,7 @@ namespace Marten.Services.BatchQuerying
             return AddItem(queryable.ToLinqQuery().ToCount<long>(), null);
         }
 
-        internal Task<IList<T>> Query<T>(IMartenQueryable<T> queryable)
+        internal Task<IReadOnlyList<T>> Query<T>(IMartenQueryable<T> queryable)
         {
             var expression = queryable.Expression;
 

--- a/src/Marten/Services/BatchQuerying/BatchedQueryable.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQueryable.cs
@@ -104,9 +104,9 @@ namespace Marten.Services.BatchQuerying
             return _parent.Any(_inner.Where(filter).As<IMartenQueryable<T>>());
         }
 
-        public Task<IList<T>> ToList()
+        public Task<IReadOnlyList<T>> ToList()
         {
-            return _parent.Query<T>(_inner);
+            return _parent.Query(_inner);
         }
 
         public Task<T> First()

--- a/src/Marten/Services/BatchQuerying/IBatchedFetcher.cs
+++ b/src/Marten/Services/BatchQuerying/IBatchedFetcher.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -34,7 +34,7 @@ namespace Marten.Services.BatchQuerying
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         Task<bool> Any(Expression<Func<T, bool>> filter);
-        Task<IList<T>> ToList();
+        Task<IReadOnlyList<T>> ToList();
         Task<T> First();
 
         /// <summary>

--- a/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,7 +43,7 @@ namespace Marten.Services.BatchQuerying
         /// <param name="version"></param>
         /// <param name="timestamp"></param>
         /// <returns></returns>
-        Task<IList<IEvent>> FetchStream(Guid streamId, int version = 0, DateTime? timestamp = null);
+        Task<IReadOnlyList<IEvent>> FetchStream(Guid streamId, int version = 0, DateTime? timestamp = null);
     }
 
     public interface IBatchedQuery
@@ -83,7 +83,7 @@ namespace Marten.Services.BatchQuerying
         /// <param name="sql"></param>
         /// <param name="parameters"></param>
         /// <returns></returns>
-        Task<IList<T>> Query<T>(string sql, params object[] parameters) where T : class;
+        Task<IReadOnlyList<T>> Query<T>(string sql, params object[] parameters) where T : class;
 
         /// <summary>
         /// Execute this batched query

--- a/src/Marten/Services/BatchQuerying/TransformedBatchQueryable.cs
+++ b/src/Marten/Services/BatchQuerying/TransformedBatchQueryable.cs
@@ -1,6 +1,5 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Marten.Linq;
@@ -9,7 +8,7 @@ namespace Marten.Services.BatchQuerying
 {
     public interface ITransformedBatchQueryable<TValue>
     {
-        Task<IList<TValue>> ToList();
+        Task<IReadOnlyList<TValue>> ToList();
         Task<TValue> First();
         Task<TValue> FirstOrDefault();
         Task<TValue> Single();
@@ -27,7 +26,7 @@ namespace Marten.Services.BatchQuerying
             _inner = inner;
         }
 
-        public Task<IList<TValue>> ToList()
+        public Task<IReadOnlyList<TValue>> ToList()
         {
             return _parent.Query<TValue>(_inner);
         }

--- a/src/Marten/Services/CommandRunnerExtensions.cs
+++ b/src/Marten/Services/CommandRunnerExtensions.cs
@@ -1,6 +1,5 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Baseline;

--- a/src/Marten/Services/IManagedConnection.cs
+++ b/src/Marten/Services/IManagedConnection.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Data;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;


### PR DESCRIPTION
Converts all `IList<T>` return types to `IReadOnlyList<T>` thereby dropping the inappropriate methods from the former's interface.