### PR TITLE
Not a pretty or complete commit (due to the .NET SDK issues discussed…

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -12,7 +12,7 @@ BUILD_NUMBER = build_number
 
 task :ci => [:connection, :version, :default, :storyteller, 'pack']
 
-task :default => [:mocha, :test, :storyteller]
+task :default => [:mocha, :tests, :storyteller]
 
 desc "Prepares the working directory for a new build"
 task :clean do
@@ -75,6 +75,19 @@ end
 desc 'Compile the code'
 task :compile => [:clean, :restore] do
   sh "dotnet build src/Marten.Testing/Marten.Testing.csproj --framework netcoreapp1.0 --configuration #{COMPILE_TARGET}"
+end
+
+desc 'Run the unit tests against all profiles'
+task :tests do
+  ["", "marten-testing-CamelCase"].each do |x|
+	begin
+		ENV[x]="true" unless x.empty?
+		Rake::Task["test"].invoke()
+		Rake::Task["test"].reenable
+	ensure
+		ENV.delete(x) unless x.empty?
+	end
+  end
 end
 
 desc 'Run the unit tests'

--- a/src/Marten.Testing/Acceptance/document_transforms.cs
+++ b/src/Marten.Testing/Acceptance/document_transforms.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using Marten.Testing.Documents;
 using Shouldly;
 using Xunit;
+using Xunit.Extensions;
 
 namespace Marten.Testing.Acceptance
 {
@@ -10,8 +12,14 @@ namespace Marten.Testing.Acceptance
         public document_transforms()
         {
             StoreOptions(_ =>
-            {
-                _.Transforms.LoadFile("default_username.js");
+            {                
+                this.InProfile(TestingContracts.CamelCase, () =>
+                {
+                    _.Transforms.LoadFile("default_username_camelCase.js", "default_username");
+                }).Otherwise(() =>
+                {
+                    _.Transforms.LoadFile("default_username.js", "default_username");
+                });                
             });
         }
 
@@ -57,9 +65,7 @@ namespace Marten.Testing.Acceptance
         }
         // ENDSAMPLE
 
-
-
-        [Fact] //-- Unreliable on CI
+        [Fact] //-- Unreliable on CI        
         public void use_transform_in_production_mode()
         {
             theStore.Tenancy.Default.EnsureStorageExists(typeof(User));
@@ -102,7 +108,13 @@ namespace Marten.Testing.Acceptance
             StoreOptions(_ =>
             {
                 _.Schema.For<User>().MultiTenanted();
-                _.Transforms.LoadFile("default_username.js");
+                this.InProfile(TestingContracts.CamelCase, () =>
+                {
+                    _.Transforms.LoadFile("default_username_camelCase.js", "default_username");
+                }).Otherwise(() =>
+                {
+                    _.Transforms.LoadFile("default_username.js", "default_username");
+                });
             });
 
             var user1 = new User { FirstName = "Jeremy", LastName = "Miller" };

--- a/src/Marten.Testing/Acceptance/select_with_transformation.cs
+++ b/src/Marten.Testing/Acceptance/select_with_transformation.cs
@@ -14,7 +14,16 @@ namespace Marten.Testing.Acceptance
     {
         public select_with_transformation()
         {
-            StoreOptions(_ => _.Transforms.LoadFile("get_fullname.js"));
+            StoreOptions(_ =>
+            {
+                this.InProfile(TestingContracts.CamelCase, () =>
+                {
+                    _.Transforms.LoadFile("get_fullname_camelCase.js", "get_fullname");
+                }).Otherwise(() =>
+                {
+                    _.Transforms.LoadFile("get_fullname.js", "get_fullname");
+                });
+            });
         }
 
         public void load_transformation()

--- a/src/Marten.Testing/Bugs/Bug_432_querying_with_UTC_times_with_offset.cs
+++ b/src/Marten.Testing/Bugs/Bug_432_querying_with_UTC_times_with_offset.cs
@@ -52,7 +52,7 @@ namespace Marten.Testing.Bugs
 
                 _output.WriteLine(cmd.CommandText);
 
-                var sql = "select public.mt_immutable_timestamp(d.data ->> \'DateTimeField\') as time from public.mt_doc_dateclass as d";
+                var sql = $"select public.mt_immutable_timestamp(d.data ->> '{session.ColumnName<DateClass>(t => t.DateTimeField)}') as time from public.mt_doc_dateclass as d";
 
                 using (var reader = session.Connection.CreateCommand().Sql(sql).ExecuteReader())
                 {

--- a/src/Marten.Testing/Documents/User.cs
+++ b/src/Marten.Testing/Documents/User.cs
@@ -27,6 +27,22 @@ namespace Marten.Testing.Documents
         {
             return $"{{\"Id\": \"{Id}\", \"Age\": {Age}, \"FullName\": \"{FullName}\", \"Internal\": {Internal.ToString().ToLowerInvariant()}, \"LastName\": \"{LastName}\", \"UserName\": \"{UserName}\", \"FirstName\": \"{FirstName}\"}}";
         }
+        
+        public string ToJson(Casing casing)
+        {
+            // puke
+            switch (casing)
+            {
+                case Casing.CamelCase:
+                {
+                    return $"{{\"id\": \"{Id}\", \"age\": {Age}, \"fullName\": \"{FullName}\", \"internal\": {Internal.ToString().ToLowerInvariant()}, \"lastName\": \"{LastName}\", \"userName\": \"{UserName}\", \"firstName\": \"{FirstName}\"}}";
+                }
+                default:
+                {
+                    return ToJson();
+                }
+            }            
+        }
 
         public void From(User user)
         {

--- a/src/Marten.Testing/Events/CustomAggregatorLookupTests.cs
+++ b/src/Marten.Testing/Events/CustomAggregatorLookupTests.cs
@@ -19,17 +19,32 @@ namespace Marten.Testing.Events
     public class CustomAggregatorLookupTests : DocumentSessionFixture<NulloIdentityMap>
     {        
         public CustomAggregatorLookupTests()
-        {            
-            StoreOptions(options =>
+        {    
+            this.InProfile(TestingContracts.CamelCase, () =>
             {
-                // SAMPLE: scenarios-immutableprojections-storesetup
-                var serializer = new JsonNetSerializer();
-                serializer.Customize(c => c.ContractResolver = new ResolvePrivateSetters());
-                options.Serializer(serializer);
-                options.Events.UseAggregatorLookup(AggregationLookupStrategy.UsePrivateApply);
-                options.Events.InlineProjections.AggregateStreamsWith<AggregateWithPrivateEventApply>();
-                // ENDSAMPLE
-            });
+                StoreOptions(options =>
+                {
+                    var serializer = new JsonNetSerializer();                    
+                    var resolver = new ResolvePrivateSetters {NamingStrategy = new CamelCaseNamingStrategy()};
+
+                    serializer.Customize(c => c.ContractResolver = resolver);
+                    options.Serializer(serializer);
+                    options.Events.UseAggregatorLookup(AggregationLookupStrategy.UsePrivateApply);
+                    options.Events.InlineProjections.AggregateStreamsWith<AggregateWithPrivateEventApply>();                    
+                });
+            }).Otherwise(() =>
+            {
+                StoreOptions(options =>
+                {
+                    // SAMPLE: scenarios-immutableprojections-storesetup
+                    var serializer = new JsonNetSerializer();
+                    serializer.Customize(c => c.ContractResolver = new ResolvePrivateSetters());
+                    options.Serializer(serializer);
+                    options.Events.UseAggregatorLookup(AggregationLookupStrategy.UsePrivateApply);
+                    options.Events.InlineProjections.AggregateStreamsWith<AggregateWithPrivateEventApply>();
+                    // ENDSAMPLE
+                });
+            });    
         }
 
         [Fact]

--- a/src/Marten.Testing/Linq/Compiled/compiled_query_Tests.cs
+++ b/src/Marten.Testing/Linq/Compiled/compiled_query_Tests.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Marten.Linq;
 using Marten.Services;
+using Marten.Storage;
 using Marten.Testing.Documents;
 using Shouldly;
 using Xunit;
@@ -33,7 +34,7 @@ namespace Marten.Testing.Linq.Compiled
         {
             var cmd = theStore.Diagnostics.PreviewCommand(new UserByUsername {UserName = "hank"});
 
-            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_user as d where d.data ->> 'UserName' = :arg0 LIMIT 1");
+            cmd.CommandText.ShouldBe($"select d.data, d.id, d.mt_version from public.mt_doc_user as d where d.data ->> '{theStore.Storage.ColumnName<UserByUsername>(t => t.UserName)}' = :arg0 LIMIT 1");
 
             cmd.Parameters.Single().Value.ShouldBe("hank");
         }
@@ -81,7 +82,7 @@ namespace Marten.Testing.Linq.Compiled
             var user = theSession.Query(new FindJsonUserByUsername() {Username = "jdm"});
 
             user.ShouldNotBeNull();
-            user.ShouldBe(_user1.ToJson());
+            user.ShouldBe(_user1.ToJson(theStore.Advanced.Serializer.Casing));
         }
         // ENDSAMPLE
 
@@ -92,7 +93,7 @@ namespace Marten.Testing.Linq.Compiled
             var user = theSession.Query(new FindJsonOrderedUsersByUsername() {FirstName = "Jeremy" });
 
             user.ShouldNotBeNull();
-            user.ShouldBe($"[{_user1.ToJson()},{_user5.ToJson()}]");
+            user.ShouldBe($"[{_user1.ToJson(theStore.Advanced.Serializer.Casing)},{_user5.ToJson(theStore.Advanced.Serializer.Casing)}]");
         }
         // ENDSAMPLE
 

--- a/src/Marten.Testing/Linq/explain_query.cs
+++ b/src/Marten.Testing/Linq/explain_query.cs
@@ -98,7 +98,7 @@ namespace Marten.Testing.Linq
             plan.ActualTotalTime.ShouldBeGreaterThan(0m);
             plan.PlanningTime.ShouldBeGreaterThan(0m);
             plan.ExecutionTime.ShouldBeGreaterThan(0m);
-            plan.SortKey.ShouldContain("(((d.data ->> 'Number'::text))::integer)");
+            plan.SortKey.ShouldContain($"(((d.data ->> '{theSession.ColumnName<SimpleUser>(u => u.Number)}'::text))::integer)");
             plan.Plans.ShouldNotBeEmpty();
         }
     }

--- a/src/Marten.Testing/Linq/previewing_the_command_from_a_queryable_Tests.cs
+++ b/src/Marten.Testing/Linq/previewing_the_command_from_a_queryable_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Marten.Linq;
 using Marten.Services;
+using Marten.Storage;
 using Shouldly;
 using Xunit;
 
@@ -23,7 +24,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().Where(x => x.Number == 3 && x.Double > 2).ToCommand(FetchType.FetchMany);
 
-            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d where (CAST(d.data ->> 'Number' as integer) = :arg0 and CAST(d.data ->> 'Double' as double precision) > :arg1)");
+            cmd.CommandText.ShouldBe($"select d.data, d.id, d.mt_version from public.mt_doc_target as d where ({theSession.Locator<Target>(t => t.Number)} = :arg0 and {theSession.Locator<Target>(t => t.Double)} > :arg1)");
 
             cmd.Parameters.Count.ShouldBe(2);
             cmd.Parameters["arg0"].Value.ShouldBe(3);
@@ -51,7 +52,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().OrderBy(x => x.Double).ToCommand(FetchType.FetchOne);
 
-            cmd.CommandText.Trim().ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d order by CAST(d.data ->> 'Double' as double precision) LIMIT 1");
+            cmd.CommandText.Trim().ShouldBe($"select d.data, d.id, d.mt_version from public.mt_doc_target as d order by {theSession.Locator<Target>(t => t.Double)} LIMIT 1");
         }
     }
 
@@ -76,7 +77,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().Where(x => x.Number == 3 && x.Double > 2).ToCommand(FetchType.FetchMany);
 
-            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version from other.mt_doc_target as d where (CAST(d.data ->> 'Number' as integer) = :arg0 and CAST(d.data ->> 'Double' as double precision) > :arg1)");
+            cmd.CommandText.ShouldBe($"select d.data, d.id, d.mt_version from other.mt_doc_target as d where ({theSession.Locator<Target>(t => t.Number)} = :arg0 and {theSession.Locator<Target>(t => t.Double)} > :arg1)");
 
             cmd.Parameters.Count.ShouldBe(2);
             cmd.Parameters["arg0"].Value.ShouldBe(3);
@@ -104,7 +105,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().OrderBy(x => x.Double).ToCommand(FetchType.FetchOne);
 
-            cmd.CommandText.Trim().ShouldBe("select d.data, d.id, d.mt_version from other.mt_doc_target as d order by CAST(d.data ->> 'Double' as double precision) LIMIT 1");
+            cmd.CommandText.Trim().ShouldBe($"select d.data, d.id, d.mt_version from other.mt_doc_target as d order by {theSession.Locator<Target>(t => t.Double)} LIMIT 1");
         }
     }
 }

--- a/src/Marten.Testing/Linq/query_against_child_collections_integrated_Tests.cs
+++ b/src/Marten.Testing/Linq/query_against_child_collections_integrated_Tests.cs
@@ -15,7 +15,13 @@ namespace Marten.Testing.Linq
     {
         public query_against_child_collections_integrated_Tests()
         {
-            StoreOptions(_ => _.UseDefaultSerialization(EnumStorage.AsString));
+            this.InProfile(TestingContracts.CamelCase, () =>
+            {
+                StoreOptions(_ => _.UseDefaultSerialization(EnumStorage.AsString, Casing.CamelCase));
+            }).Otherwise(() =>
+            {
+                StoreOptions(_ => _.UseDefaultSerialization(EnumStorage.AsString));
+            });                          
         }
 
         private Target[] targets;

--- a/src/Marten.Testing/Linq/query_for_json_format.cs
+++ b/src/Marten.Testing/Linq/query_for_json_format.cs
@@ -76,7 +76,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var listJson = theSession.Query<SimpleUser>().Where(x=>x.Number>=5).ToJsonArray();
-            listJson.ShouldBe($@"[{user1.ToJson()},{user2.ToJson()}]");
+            listJson.ShouldBe($@"[{user1.ToJson().CaseBy(theStore.Serializer.Casing)},{user2.ToJson().CaseBy(theStore.Serializer.Casing)}]");
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var listJson = await theSession.Query<SimpleUser>().Where(x=>x.Number>=5).ToJsonArrayAsync().ConfigureAwait(false);
-            listJson.ShouldBe($@"[{user1.ToJson()},{user2.ToJson()}]");
+            listJson.ShouldBe($@"[{user1.ToJson().CaseBy(theStore.Serializer.Casing)},{user2.ToJson().CaseBy(theStore.Serializer.Casing)}]");
         }
 
         [Fact]
@@ -138,7 +138,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().First();
-            userJson.ShouldBe($@"{user1.ToJson()}");
+            userJson.ShouldBe($@"{user1.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -169,7 +169,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = theSession.Query<SimpleUser>().AsJson().First();
-            userJson.ShouldBe($@"{user0.ToJson()}");
+            userJson.ShouldBe($@"{user0.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -224,7 +224,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().FirstAsync().ConfigureAwait(false);
-            userJson.ShouldBe($@"{user1.ToJson()}");
+            userJson.ShouldBe($@"{user1.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -255,7 +255,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = await theSession.Query<SimpleUser>().AsJson().FirstAsync().ConfigureAwait(false);
-            userJson.ShouldBe($@"{user0.ToJson()}");
+            userJson.ShouldBe($@"{user0.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -311,7 +311,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().FirstOrDefault();
-            userJson.ShouldBe($@"{user1.ToJson()}");
+            userJson.ShouldBe($@"{user1.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -342,7 +342,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = theSession.Query<SimpleUser>().AsJson().FirstOrDefault();
-            userJson.ShouldBe($@"{user0.ToJson()}");
+            userJson.ShouldBe($@"{user0.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -373,7 +373,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().FirstOrDefaultAsync().ConfigureAwait(false);
-            userJson.ShouldBe($@"{user1.ToJson()}");
+            userJson.ShouldBe($@"{user1.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -404,7 +404,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = await theSession.Query<SimpleUser>().AsJson().FirstOrDefaultAsync().ConfigureAwait(false);
-            userJson.ShouldBe($@"{user0.ToJson()}");
+            userJson.ShouldBe($@"{user0.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]

--- a/src/Marten.Testing/Linq/query_for_single_json.cs
+++ b/src/Marten.Testing/Linq/query_for_single_json.cs
@@ -38,7 +38,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().Single();
-            userJson.ShouldBe($@"{user1.ToJson()}");
+            userJson.ShouldBe($@"{user1.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = theSession.Query<SimpleUser>().AsJson().Single();
-            userJson.ShouldBe($@"{user1.ToJson()}");
+            userJson.ShouldBe($@"{user1.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -127,7 +127,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().SingleAsync().ConfigureAwait(false);
-            userJson.ShouldBe($@"{user1.ToJson()}");
+            userJson.ShouldBe($@"{user1.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -145,7 +145,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = await theSession.Query<SimpleUser>().AsJson().SingleAsync().ConfigureAwait(false);
-            userJson.ShouldBe($@"{user1.ToJson()}");
+            userJson.ShouldBe($@"{user1.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -219,7 +219,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().SingleOrDefault();
-            userJson.ShouldBe($@"{user1.ToJson()}");
+            userJson.ShouldBe($@"{user1.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -236,7 +236,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = theSession.Query<SimpleUser>().AsJson().SingleOrDefault();
-            userJson.ShouldBe($@"{user1.ToJson()}");
+            userJson.ShouldBe($@"{user1.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -267,7 +267,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().SingleOrDefaultAsync().ConfigureAwait(false);
-            userJson.ShouldBe($@"{user1.ToJson()}");
+            userJson.ShouldBe($@"{user1.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]
@@ -284,7 +284,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var userJson = await theSession.Query<SimpleUser>().AsJson().SingleOrDefaultAsync().ConfigureAwait(false);
-            userJson.ShouldBe($@"{user1.ToJson()}");
+            userJson.ShouldBe($@"{user1.ToJson()}".CaseBy(theStore.Serializer.Casing));
         }
 
         [Fact]

--- a/src/Marten.Testing/Linq/select_transformations_Tests.cs
+++ b/src/Marten.Testing/Linq/select_transformations_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Marten.Linq;
 using Marten.Services;
+using Marten.Storage;
 using Marten.Testing.Documents;
 using Shouldly;
 using Xunit;
@@ -17,7 +18,7 @@ namespace Marten.Testing.Linq
 
             var cmd = theSession.Query<User>().Select(x => x.UserName).ToCommand(FetchType.FetchMany);
 
-            cmd.CommandText.ShouldBe("select d.data ->> 'UserName' from public.mt_doc_user as d");
+            cmd.CommandText.ShouldBe($"select d.data ->> '{theStore.Storage.ColumnName<User>(u => u.UserName)}' from public.mt_doc_user as d");
         }
     }
 
@@ -33,7 +34,7 @@ namespace Marten.Testing.Linq
 
             var cmd = theSession.Query<User>().Select(x => x.UserName).ToCommand(FetchType.FetchMany);
 
-            cmd.CommandText.ShouldBe("select d.data ->> 'UserName' from other_select.mt_doc_user as d");
+            cmd.CommandText.ShouldBe($"select d.data ->> '{theStore.Storage.ColumnName<User>(u => u.UserName)}' from other_select.mt_doc_user as d");
         }
     }
 }

--- a/src/Marten.Testing/Linq/using_containment_operator_in_linq_Tests.cs
+++ b/src/Marten.Testing/Linq/using_containment_operator_in_linq_Tests.cs
@@ -9,7 +9,10 @@ namespace Marten.Testing.Linq
     {
         public using_containment_operator_in_linq_Tests()
         {
-            StoreOptions(_ => { _.Schema.For<Target>().GinIndexJsonData(); });
+            StoreOptions(_ =>
+            {
+                _.Schema.For<Target>().GinIndexJsonData();
+            });
         }
 
         [Fact]

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
     <AssemblyName>Marten.Testing</AssemblyName>
@@ -9,7 +8,6 @@
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
   </PropertyGroup>
-
   <ItemGroup>
     <None Update="**/*.js;connection.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -19,12 +17,10 @@
     </None>
     <None Include="App.config" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Marten\Marten.csproj" />
     <ProjectReference Include="..\Marten.Testing.OtherAssembly\Marten.Testing.OtherAssembly.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Jil" Version="2.15.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
@@ -34,15 +30,12 @@
     <PackageReference Include="Shouldly" Version="2.8.0" />
     <PackageReference Include="structuremap" Version="4.2.0.402" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <Compile Remove="**\Fixtures\**\*.cs;**\Github\**\*.cs;StorytellerHarness.cs" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="HtmlTags" Version="3.0.0.186" />
     <PackageReference Include="Jil" Version="2.14.3" />
@@ -52,9 +45,7 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
 </Project>

--- a/src/Marten.Testing/Session/document_session_find_json_Tests.cs
+++ b/src/Marten.Testing/Session/document_session_find_json_Tests.cs
@@ -16,9 +16,9 @@ namespace Marten.Testing.Session
 
             theSession.Store(issue);
             theSession.SaveChanges();
-
+            
             var json = theSession.Json.FindById<Issue>(issue.Id);
-            json.ShouldBe($"{{\"Id\": \"{issue.Id}\", \"Tags\": null, \"Title\": \"Issue 1\", \"Number\": 0, \"AssigneeId\": null, \"ReporterId\": null}}");
+            json.ShouldBe($"{{\"Id\": \"{issue.Id}\", \"Tags\": null, \"Title\": \"Issue 1\", \"Number\": 0, \"AssigneeId\": null, \"ReporterId\": null}}".CaseBy(theStore.Serializer.Casing));
         }
         // ENDSAMPLE
 

--- a/src/Marten.Testing/Session/document_session_find_json_async_Tests.cs
+++ b/src/Marten.Testing/Session/document_session_find_json_async_Tests.cs
@@ -19,7 +19,7 @@ namespace Marten.Testing.Session
             await theSession.SaveChangesAsync().ConfigureAwait(false);
 
             var json = await theSession.Json.FindByIdAsync<Issue>(issue.Id).ConfigureAwait(false);
-            json.ShouldBe($"{{\"Id\": \"{issue.Id}\", \"Tags\": null, \"Title\": \"Issue 2\", \"Number\": 0, \"AssigneeId\": null, \"ReporterId\": null}}");
+            json.ShouldBe($"{{\"Id\": \"{issue.Id}\", \"Tags\": null, \"Title\": \"Issue 2\", \"Number\": 0, \"AssigneeId\": null, \"ReporterId\": null}}".CaseBy(theStore.Serializer.Casing));
         }
         // ENDSAMPLE
 

--- a/src/Marten.Testing/Storage/when_generating_a_table_for_soft_deletes.cs
+++ b/src/Marten.Testing/Storage/when_generating_a_table_for_soft_deletes.cs
@@ -40,13 +40,16 @@ namespace Marten.Testing.Storage
         [Fact]
         public void can_generate_the_patch()
         {
+            ISerializer serializer;
             using (var store1 = TestingDocumentStore.Basic())
             {
+                serializer = store1.Serializer;
                 store1.BulkInsert(new User [] {new User {UserName = "foo"}, new User { UserName = "bar" } });
             }
 
             using (var store2 = DocumentStore.For(_ =>
             {
+                _.Serializer(serializer);
                 _.Connection(ConnectionSource.ConnectionString);
                 _.Schema.For<User>().SoftDeleted();
             }))

--- a/src/Marten.Testing/TestingDocumentStore.cs
+++ b/src/Marten.Testing/TestingDocumentStore.cs
@@ -1,12 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Dynamic;
+using System.IO;
 using Baseline;
 using Baseline.Dates;
+using Marten;
 using Marten.Schema;
 using Marten.Testing.Documents;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Marten.Testing
 {
@@ -16,24 +22,43 @@ namespace Marten.Testing
         public static int SchemaCount = 0;
         private static readonly object _locker = new object();
 
+        private static readonly Dictionary<string, Action<StoreOptions>>
+            CustomizationPerContract = new Dictionary<string, Action<StoreOptions>>
+            {
+                { TestingContracts.CamelCase, (options) =>
+                {
+                    var currentSerializer = options.Serializer();
+                    options.UseDefaultSerialization(currentSerializer.EnumStorage, Casing.CamelCase);
+                } }
+            };
+
         public new static DocumentStore For(Action<StoreOptions> configure)
         {
             var options = new StoreOptions();
             options.Connection(ConnectionSource.ConnectionString);
-            options.Serializer<TestsSerializer>();
-
-            options.NameDataLength = 100;
-
+            options.Serializer<TestsSerializer>();            
+            options.NameDataLength = 100;            
+            
             configure(options);
 
+            ContractsPerEnvironment(options);
             
-
             var store = new TestingDocumentStore(options);
             store.Advanced.Clean.CompletelyRemoveAll();
 
             return store;
         }
 
+        private static void ContractsPerEnvironment(StoreOptions options)
+        {
+            foreach (var c in CustomizationPerContract)
+            {
+                if (Environment.GetEnvironmentVariable(c.Key) != null)
+                {
+                    CustomizationPerContract[c.Key](options);
+                }
+            }
+        }
 
         public static DocumentStore Basic()
         {
@@ -68,10 +93,67 @@ namespace Marten.Testing
                 }
             }
 
-            
+
             base.Dispose();
 
 
+        }
+    }
+
+    internal static class TestHelperExtensions
+    {
+        public static string Locator<T>(this IQuerySession session, Expression<Func<T, object>> e)
+        {
+            return session.DocumentStore.Advanced.Storage
+                .MappingFor(typeof(T)).JsonLocator(e);                                        
+        }
+        
+        public static string ColumnName<T>(this IQuerySession session, Expression<Func<T, object>> e)
+        {
+            return session.DocumentStore.Advanced.Storage
+                .MappingFor(typeof(T)).FieldInfo(e).ColumnName;
+        }
+
+
+        public static string CaseBy(this string value, Casing casing)
+        {
+            var jsonSerializerSettings = new JsonSerializerSettings();
+
+            if (casing == Casing.CamelCase)
+            {
+                jsonSerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+
+            }
+
+            var jsonSerializer = JsonSerializer.CreateDefault(jsonSerializerSettings);
+            using (var sw = new StringWriter())
+            using (var jsonWriter = new JsonTextWriterEx(sw))
+            {                
+                var interimObject = JsonConvert.DeserializeObject<ExpandoObject>(value);
+                jsonSerializer.Serialize(jsonWriter, interimObject);
+                return sw.ToString();
+            }            
+        }
+
+        public class JsonTextWriterEx : JsonTextWriter
+        {
+            private readonly TextWriter _textWriter;            
+
+            public JsonTextWriterEx(TextWriter textWriter) : base(textWriter)
+            {
+                _textWriter = textWriter;                
+            }
+
+            protected override void WriteValueDelimiter()
+            {
+                this._textWriter.Write(", ");
+            }
+            
+            public override void WritePropertyName(string name, bool escape)
+            {
+                base.WritePropertyName(name, escape);
+                _textWriter.Write(" ");
+            }
         }
     }
 }

--- a/src/Marten.Testing/default_username_camelCase.js
+++ b/src/Marten.Testing/default_username_camelCase.js
@@ -1,0 +1,5 @@
+﻿module.exports = function (doc) {
+    doc.userName = (doc.firstName + '.' + doc.lastName).toLowerCase();
+
+    return doc;
+}

--- a/src/Marten.Testing/get_fullname_camelCase.js
+++ b/src/Marten.Testing/get_fullname_camelCase.js
@@ -1,0 +1,5 @@
+﻿// SAMPLE: get_fullname.js
+module.exports = function (doc) {
+    return {fullname: doc.firstName + ' ' + doc.lastName};
+}
+// ENDSAMPLE

--- a/src/Marten.Testing/query_by_sql_where_clause_Tests.cs
+++ b/src/Marten.Testing/query_by_sql_where_clause_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using Marten.Schema;
+using Marten.Storage;
 using Marten.Testing.Documents;
 using Shouldly;
 using Xunit;
@@ -23,7 +24,7 @@ namespace Marten.Testing
                 session.SaveChanges();
 
                 var firstnames =
-                    session.Query<User>("where data ->> 'LastName' = ?", "Miller").OrderBy(x => x.FirstName)
+                    session.Query<User>($"where data ->> '{session.ColumnName<User>(u => u.LastName)}' = ?", "Miller").OrderBy(x => x.FirstName)
                            .Select(x => x.FirstName).ToArray();
 
                 firstnames.Length.ShouldBe(3);
@@ -45,7 +46,7 @@ namespace Marten.Testing
                 session.SaveChanges();
 
                 var firstnames =
-                    session.Query<User>("where data ->> 'LastName' = :Name", new { Name = "Miller" }).OrderBy(x => x.FirstName)
+                    session.Query<User>($"where data ->> '{session.ColumnName<User>(u => u.LastName)}' = :Name", new { Name = "Miller" }).OrderBy(x => x.FirstName)
                            .Select(x => x.FirstName).ToArray();
 
                 firstnames.Length.ShouldBe(3);
@@ -67,7 +68,7 @@ namespace Marten.Testing
                 session.SaveChanges();
                 // SAMPLE: using_parameterized_sql
                 var user =
-                    session.Query<User>("where data ->> 'FirstName' = ? and data ->> 'LastName' = ?", "Jeremy",
+                    session.Query<User>($"where data ->> '{theStore.Storage.ColumnName<User>(u => u.FirstName)}' = ? and data ->> '{session.ColumnName<User>(u => u.LastName)}' = ?", "Jeremy",
                                "Miller")
                            .Single();
                 // ENDSAMPLE
@@ -90,7 +91,7 @@ namespace Marten.Testing
                 session.Store(new User { FirstName = "Frank", LastName = "Zombo" });
                 session.SaveChanges();
                 var user =
-                    session.Query<User>("where data ->> 'FirstName' = :FirstName and data ->> 'LastName' = :LastName", new { FirstName = "Jeremy", LastName = "Miller" })
+                    session.Query<User>($"where data ->> '{theStore.Storage.ColumnName<User>(u => u.FirstName)}' = :FirstName and data ->> '{session.ColumnName<User>(u => u.LastName)}' = :LastName", new { FirstName = "Jeremy", LastName = "Miller" })
                            .Single();
 
                 user.ShouldNotBeNull();
@@ -109,7 +110,7 @@ namespace Marten.Testing
                 session.Store(new User { FirstName = "Frank", LastName = "Zombo" });
                 session.SaveChanges();
                 var user =
-                    session.Query<User>("where data ->> 'FirstName' = :Name or data ->> 'LastName' = :Name", new { Name = "Jeremy" })
+                    session.Query<User>($"where data ->> '{session.ColumnName<User>(u => u.FirstName)}' = :Name or data ->> '{session.ColumnName<User>(u => u.LastName)}' = :Name", new { Name = "Jeremy" })
                            .Single();
 
                 user.ShouldNotBeNull();
@@ -128,7 +129,7 @@ namespace Marten.Testing
                 session.SaveChanges();
 
                 var firstnames =
-                    session.Query<User>("where data ->> 'LastName' = 'Miller'").OrderBy(x => x.FirstName)
+                    session.Query<User>($"where data ->> '{session.ColumnName<User>(u => u.LastName)}' = 'Miller'").OrderBy(x => x.FirstName)
                            .Select(x => x.FirstName).ToArray();
 
                 firstnames.Length.ShouldBe(3);
@@ -151,7 +152,7 @@ namespace Marten.Testing
                 session.SaveChanges();
 
                 var firstnames =
-                    session.Query<User>("where data ->> 'LastName' = 'Miller' order by data ->> 'FirstName'")
+                    session.Query<User>($"where data ->> '{session.ColumnName<User>(u => u.LastName)}' = 'Miller' order by data ->> '{session.ColumnName<User>(u => u.FirstName)}ttes'")
                            .Select(x => x.FirstName).ToArray();
 
                 firstnames.Length.ShouldBe(3);
@@ -172,7 +173,7 @@ namespace Marten.Testing
                 session.Store(u);
                 session.SaveChanges();
 
-                var user = session.Query<User>("where data ->> 'FirstName' = 'Jeremy'").Single();
+                var user = session.Query<User>($"where data ->> '{theStore.Storage.ColumnName<User>(z => z.FirstName)}' = 'Jeremy'").Single();
                 user.LastName.ShouldBe("Miller");
                 user.Id.ShouldBe(u.Id);
             }
@@ -190,7 +191,7 @@ namespace Marten.Testing
 
                 // SAMPLE: use_all_your_own_sql
                 var user =
-                    session.Query<User>("select data from mt_doc_user where data ->> 'FirstName' = 'Jeremy'")
+                    session.Query<User>($"select data from mt_doc_user where data ->> '{theStore.Storage.ColumnName<User>(z => z.FirstName)}' = 'Jeremy'")
                            .Single();
                 // ENDSAMPLE
                 user.LastName.ShouldBe("Miller");
@@ -210,7 +211,7 @@ namespace Marten.Testing
                 var users =
                     await
                         session.QueryAsync<User>(
-                                   "select data from mt_doc_user where data ->> 'FirstName' = 'Jeremy'")
+                                   $"select data from mt_doc_user where data ->> '{theStore.Storage.ColumnName<User>(z => z.FirstName)}' = 'Jeremy'")
                                .ConfigureAwait(false);
                 var user = users.Single();
 

--- a/src/Marten.Testing/query_scalar_values_with_select_in_query_async.cs
+++ b/src/Marten.Testing/query_scalar_values_with_select_in_query_async.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using Marten.Schema;
 using Marten.Services;
+using Marten.Testing.Documents;
 using Shouldly;
 using Xunit;
 
@@ -18,7 +20,7 @@ namespace Marten.Testing
             theSession.Store(new Target { Color = Colors.Blue, Number = 4 });
 
             theSession.SaveChanges();
-            var sumResults = await theSession.QueryAsync<int>("select sum(CAST(d.data ->> 'Number' as integer)) as number from mt_doc_target as d").ConfigureAwait(false);
+            var sumResults = await theSession.QueryAsync<int>($"select sum({theSession.Locator<Target>(u => u.Number)}) as number from mt_doc_target as d").ConfigureAwait(false);
             var sum = sumResults.Single();
             sum.ShouldBe(10);
         }

--- a/src/Marten/AdvancedOptions.cs
+++ b/src/Marten/AdvancedOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using Marten.Schema;
+using Marten.Storage;
 
 namespace Marten
 {
@@ -18,5 +19,7 @@ namespace Marten
 
 
         public ISerializer Serializer => _store.Serializer;
+
+        public StorageFeatures Storage => _store.Storage;
     }
 }

--- a/src/Marten/IDocumentStore.cs
+++ b/src/Marten/IDocumentStore.cs
@@ -158,6 +158,6 @@ namespace Marten
         ITenancy Tenancy { get; }
 
 
-        IDaemon BuildProjectionDaemon(Type[] viewTypes = null, IDaemonLogger logger = null, DaemonSettings settings = null, IProjection[] projections = null);
+        IDaemon BuildProjectionDaemon(Type[] viewTypes = null, IDaemonLogger logger = null, DaemonSettings settings = null, IProjection[] projections = null);               
     }
 }

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <Description>Postgresql as a Document Db and Event Store for .Net Development</Description>
-  <VersionPrefix>2.0.0</VersionPrefix>
-  <VersionSuffix>alpha-</VersionSuffix>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionSuffix>alpha-</VersionSuffix>
     <Authors>Jeremy D. Miller;Tim Cools;Jeff Doolittle</Authors>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <AssemblyName>Marten</AssemblyName>
@@ -20,7 +19,6 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
     <EmbeddedResource Include="Schema\SQL\mt_transforms.js" />
@@ -31,7 +29,6 @@
     <EmbeddedResource Include="Schema\SQL\mt_get_next_hi.sql" />
     <EmbeddedResource Include="Schema\SchemaObjects.sql" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="Remotion.Linq" Version="2.1.1" />
@@ -40,16 +37,13 @@
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
     <PackageReference Include="FastExpressionCompiler" Version="1.0.1" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="NETStandard.Library" Version="1.6.1" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Data" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
 </Project>

--- a/src/Marten/Schema/IDocumentMapping.cs
+++ b/src/Marten/Schema/IDocumentMapping.cs
@@ -26,6 +26,16 @@ namespace Marten.Schema
 
     public static class DocumentMappingExtensions
     {
+        public static string ColumnName(this IQueryableDocument mapping, Expression expression)
+        {
+            var visitor = new FindMembers();
+            visitor.Visit(expression);
+
+
+            var field = mapping.FieldFor(visitor.Members);
+
+            return field.ColumnName;
+        }
         public static string JsonLocator(this IQueryableDocument mapping, Expression expression)
         {
             var visitor = new FindMembers();
@@ -35,6 +45,16 @@ namespace Marten.Schema
             var field = mapping.FieldFor(visitor.Members);
 
             return field.SqlLocator;
+        }
+        public static IField FieldInfo(this IQueryableDocument mapping, Expression expression)
+        {
+            var visitor = new FindMembers();
+            visitor.Visit(expression);
+
+
+            var field = mapping.FieldFor(visitor.Members);
+
+            return field;
         }
     }
 }

--- a/src/Marten/Schema/JsonLocatorField.cs
+++ b/src/Marten/Schema/JsonLocatorField.cs
@@ -54,6 +54,8 @@ namespace Marten.Schema
                 };
             }
 
+            ColumnName = memberName;
+
             if (SelectionLocator.IsEmpty())
             {
                 SelectionLocator = SqlLocator;
@@ -91,7 +93,7 @@ namespace Marten.Schema
 
         public string SqlLocator { get; }
         public string SelectionLocator { get; }
-        public string ColumnName => String.Empty;
+        public string ColumnName { get; private set; }
         public void WritePatch(DocumentMapping mapping, SchemaPatch patch)
         {
             throw new NotSupportedException();

--- a/src/Marten/Services/JsonNetSerializer.cs
+++ b/src/Marten/Services/JsonNetSerializer.cs
@@ -122,10 +122,12 @@ namespace Marten.Services
                 if (value == Casing.Default)
                 {
                     _serializer.ContractResolver = new DefaultContractResolver();
+                    _clean.ContractResolver = new DefaultContractResolver();
                 }
                 else
                 {
                     _serializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
+                    _clean.ContractResolver = new CamelCasePropertyNamesContractResolver();
                 }
             }
         }

--- a/src/Marten/Storage/StorageFeaturesExtensions.cs
+++ b/src/Marten/Storage/StorageFeaturesExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Linq.Expressions;
+using Marten.Schema;
+
+namespace Marten.Storage
+{
+    public static class StorageFeaturesExtensions
+    {
+        public static string ColumnName<T>(this StorageFeatures storageFeatures, Expression<Func<T, object>> e)
+        {
+            return storageFeatures
+                .MappingFor(typeof(T)).FieldInfo(e).ColumnName;
+        }
+    }
+}


### PR DESCRIPTION
… in Gitter).

Bugs: "clean" serializer in the default serializer has to respect casing (otherwise e.g. contains queries [ContainmentWhereFragment] will result in unexpected matches, which is dangerous). This needs to be fixed prior to CamelCasing being pushed to production.

API Changes: lift StorageFeatures to AdvancedOptions.StorageFeatures. Rationale: Mappings, amonst other things, can be accessed this way.

The rest: Start fixing test cases not to assume casing. Notes:
*a subset of tests goes outside of the shared setup -> test session specific customizations need to be applied in these cases too
*a subset of tests assumes string formatting. Some of these are contained within docs -> resort to extensions that adjust expectations
*harness: changed harness to check env variables for customizations -> Rake build script currently runs harness twice: default & CamelCase. (not reflected in build.sh atm)

While I'm not happy with this commit (due to reasons above), at least the bug with containtment needs to be addressed before 2.0 is released.