### PR TITLE
fixed WhereClauseVisitor to handle constant booleans. Fixes #821

### DIFF
--- a/src/Marten.Testing/Linq/using_const_boolean_in_where_clause_Tests.cs
+++ b/src/Marten.Testing/Linq/using_const_boolean_in_where_clause_Tests.cs
@@ -1,0 +1,49 @@
+﻿using System.Linq;
+using Marten.Services;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Linq
+{
+    [ControlledQueryStoryteller]
+    public class using_const_boolean_in_where_clause_Tests : DocumentSessionFixture<NulloIdentityMap>
+    {
+        [Fact]
+        public void where_const_false()
+        {
+            var target1 = new Target { Number = 1, String = "Foo" };
+            var target2 = new Target { Number = 2, String = "Foo" };
+            var target3 = new Target { Number = 1, String = "Bar" };
+            var target4 = new Target { Number = 1, String = "Foo" };
+            var target5 = new Target { Number = 2, String = "Bar" };
+            theSession.Store(target1);
+            theSession.Store(target2);
+            theSession.Store(target3);
+            theSession.Store(target4);
+            theSession.Store(target5);
+            theSession.SaveChanges();
+
+            var q = Queryable.Where<Target>(theSession.Query<Target>(), x => false && x.Number == 1);
+            q.Count().ShouldBe(0);
+        }
+
+        [Fact]
+        public void where_const_true()
+        {
+            var target1 = new Target { Number = 1, String = "Foo" };
+            var target2 = new Target { Number = 2, String = "Foo" };
+            var target3 = new Target { Number = 1, String = "Bar" };
+            var target4 = new Target { Number = 1, String = "Foo" };
+            var target5 = new Target { Number = 2, String = "Bar" };
+            theSession.Store(target1);
+            theSession.Store(target2);
+            theSession.Store(target3);
+            theSession.Store(target4);
+            theSession.Store(target5);
+            theSession.SaveChanges();
+
+            var q = Queryable.Where<Target>(theSession.Query<Target>(), x => true && x.Number == 1);
+            q.Count().ShouldBe(3);
+        }
+    }
+}

--- a/src/Marten/Linq/WhereClauseVisitor.cs
+++ b/src/Marten/Linq/WhereClauseVisitor.cs
@@ -108,7 +108,8 @@ namespace Marten.Linq
 
             protected override Expression VisitConstant(ConstantExpression node)
             {
-                if ((node.Type == typeof(bool)) && (bool) node.Value) _top = new WhereFragment("true");
+                if ((node.Type == typeof(bool)))
+                    _register.Peek()(new WhereFragment(node.Value.ToString().ToLower()));
                 return base.VisitConstant(node);
             }
 


### PR DESCRIPTION
###  Please be careful 

I don't really know what I'm doing :)

I did a quick analysis of the behavior and fixed what seemed to be the problem in my case. I'm not however sure I completely understand the original idea, so I can't tell if the previous implementation was a mistake or had some purpose to behave like it did.

I ran all the tests, some of them failed but they did failed on the latest origin sources as well, so I suppose these are not because of my change. More likely the lack of v8 language and some system encoding problems, I can't investigate it right now
