### PR TITLE
Fixing #831

### DIFF
--- a/src/Marten.Testing/Session/query_session_Tests.cs
+++ b/src/Marten.Testing/Session/query_session_Tests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Data;
+using Marten.Services;
+using Marten.Testing.Documents;
+using Marten.Util;
+using Npgsql;
+using Xunit;
+
+namespace Marten.Testing.Session
+{
+	public class query_session_Tests : DocumentSessionFixture<NulloIdentityMap>
+	{
+		[Fact]
+		public void should_respect_command_timeout_options()
+		{
+			using (var session = theStore.QuerySession(new SessionOptions() { Timeout = -1 }))
+			{
+				var e = Assert.Throws<ArgumentOutOfRangeException>(() => session.Query<int>("select 1"));
+				Assert.StartsWith("CommandTimeout can't be less than zero", e.Message);
+			}
+		}
+
+		[Fact]
+		public void should_respect_isolationlevel_and_be_read_only_transaction_when_serializable_isolation()
+		{
+			var user = new User();
+
+			theStore.BulkInsertDocuments(new [] { user });
+			using (var session = theStore.QuerySession(new SessionOptions() { IsolationLevel = IsolationLevel.Serializable, Timeout = 1 }))
+			{
+				using (var cmd = session.Connection.CreateCommand("delete from mt_doc_user"))
+				{
+					var e = Assert.Throws<PostgresException>(() => cmd.ExecuteNonQuery());
+
+					// ERROR: cannot execute DELETE in a read-only transaction
+					// read_only_sql_transaction
+					Assert.Equal("25006", e.SqlState);
+				}
+			}
+		}
+
+	}
+}

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -258,13 +258,15 @@ namespace Marten
             var parser = new MartenQueryParser();
 
             var tenant = Tenancy[options.TenantId];
-            var connection = tenant.OpenConnection(CommandRunnerMode.ReadOnly);
+            var connection = tenant.OpenConnection(CommandRunnerMode.ReadOnly, options.IsolationLevel, options.Timeout);
 
             var session = new QuerySession(this,
                 connection, parser,
                 new NulloIdentityMap(Serializer), tenant);
 
-            session.Logger = _logger.StartSession(session);
+	        connection.BeginSession();
+
+			session.Logger = _logger.StartSession(session);
 
             return session;
         }
@@ -284,6 +286,8 @@ namespace Marten
             var session = new QuerySession(this,
                 connection, parser,
                 new NulloIdentityMap(Serializer), tenant);
+
+			connection.BeginSession();
 
             session.Logger = _logger.StartSession(session);
 


### PR DESCRIPTION
Ensure serializable query session is also read only.
Ensure query session respects command timeout & isolation from session options.
Unit tests to exercise expected behavior.