### PR TITLE
Add proper handling of async in ApplyAsync method for ViewProjection

### DIFF
--- a/src/Marten.Testing/Events/Projections/custom_async_transformation_of_events.cs
+++ b/src/Marten.Testing/Events/Projections/custom_async_transformation_of_events.cs
@@ -1,0 +1,335 @@
+﻿using System;
+using System.Collections.Generic;
+using Marten.Events.Projections;
+using Marten.Services;
+using Shouldly;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace Marten.Testing.Events.Projections
+{
+    public class project_events_async_from_multiple_streams_into_view : DocumentSessionFixture<IdentityMap>
+    {
+        static readonly Guid streamId = Guid.NewGuid();
+        static readonly Guid streamId2 = Guid.NewGuid();
+
+        QuestStarted started = new QuestStarted { Id = streamId, Name = "Find the Orb" };
+        QuestStarted started2 = new QuestStarted { Id = streamId2, Name = "Find the Orb 2.0" };
+        MonsterQuestsAdded monsterQuestsAdded = new MonsterQuestsAdded { QuestIds = new List<Guid> { streamId, streamId2 }, Name = "Dragon" };
+        MonsterQuestsRemoved monsterQuestsRemoved = new MonsterQuestsRemoved { QuestIds = new List<Guid> { streamId, streamId2 }, Name = "Dragon" };
+        QuestEnded ended = new QuestEnded { Id = streamId, Name = "Find the Orb" };
+        MembersJoined joined = new MembersJoined { QuestId = streamId, Day = 2, Location = "Faldor's Farm", Members = new[] { "Garion", "Polgara", "Belgarath" } };
+        MonsterSlayed slayed1 = new MonsterSlayed { QuestId = streamId, Name = "Troll" };
+        MonsterSlayed slayed2 = new MonsterSlayed { QuestId = streamId, Name = "Dragon" };
+        MonsterDestroyed destroyed = new MonsterDestroyed { QuestId = streamId, Name = "Troll" };
+        MembersDeparted departed = new MembersDeparted { QuestId = streamId, Day = 5, Location = "Sendaria", Members = new[] { "Silk", "Barak" } };
+        MembersJoined joined2 = new MembersJoined { QuestId = streamId, Day = 5, Location = "Sendaria", Members = new[] { "Silk", "Barak" } };
+
+        [Fact]
+        public void from_configuration()
+        {
+            StoreOptions(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
+                _.Events.ProjectView<PersistedView, Guid>()
+                    .ProjectEventAsync<QuestStarted>((view, @event) => { view.Events.Add(@event); return Task.CompletedTask; })
+                    .ProjectEventAsync<MembersJoined>(e => e.QuestId, (view, @event) => { view.Events.Add(@event); return Task.CompletedTask; })
+                    .ProjectEventAsync<MonsterSlayed>(e => e.QuestId, (view, @event) => { view.Events.Add(@event); return Task.CompletedTask; })
+                    .DeleteEvent<QuestEnded>()
+                    .DeleteEvent<MembersDeparted>(e => e.QuestId)
+                    .DeleteEvent<MonsterDestroyed>((session, e) => session.Load<QuestParty>(e.QuestId).Id);
+            });
+
+            theSession.Events.StartStream<QuestParty>(streamId, started, joined);
+            theSession.SaveChanges();
+
+            theSession.Events.StartStream<Monster>(slayed1, slayed2);
+            theSession.SaveChanges();
+
+            theSession.Events.Append(streamId, joined2);
+            theSession.SaveChanges();
+
+            var document = theSession.Load<PersistedView>(streamId);
+            document.Events.Count.ShouldBe(5);
+            document.Events.ShouldHaveTheSameElementsAs(started, joined, slayed1, slayed2, joined2);
+
+            theSession.Events.Append(streamId, ended);
+            theSession.SaveChanges();
+            var nullDocument = theSession.Load<PersistedView>(streamId);
+            nullDocument.ShouldBeNull();
+
+            // Add document back to so we can delete it by selector
+            theSession.Events.Append(streamId, started);
+            theSession.SaveChanges();
+            var document2 = theSession.Load<PersistedView>(streamId);
+            document2.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, departed);
+            theSession.SaveChanges();
+            var nullDocument2 = theSession.Load<PersistedView>(streamId);
+            nullDocument2.ShouldBeNull();
+
+            // Add document back to so we can delete it by other selector type
+            theSession.Events.Append(streamId, started);
+            theSession.SaveChanges();
+            var document3 = theSession.Load<PersistedView>(streamId);
+            document3.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, destroyed);
+            theSession.SaveChanges();
+            var nullDocument3 = theSession.Load<PersistedView>(streamId);
+            nullDocument3.ShouldBeNull();
+        }
+
+        [Fact]
+        public async void from_configuration_async()
+        {
+            // SAMPLE: viewprojection-from-configuration 
+            StoreOptions(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
+                _.Events.ProjectView<PersistedView, Guid>()
+                    .ProjectEventAsync<QuestStarted>((view, @event) => { view.Events.Add(@event); return Task.CompletedTask; })
+                    .ProjectEventAsync<MembersJoined>(e => e.QuestId, (view, @event) => { view.Events.Add(@event); return Task.CompletedTask; })
+                    .ProjectEventAsync<ProjectionEvent<MonsterSlayed>>(e => e.Data.QuestId, (view, @event) => { view.Events.Add(@event.Data); return Task.CompletedTask; })
+                    .DeleteEvent<QuestEnded>()
+                    .DeleteEvent<MembersDeparted>(e => e.QuestId)
+                    .DeleteEvent<MonsterDestroyed>((session, e) => session.Load<QuestParty>(e.QuestId).Id);
+            });
+            // ENDSAMPLE 
+
+            theSession.Events.StartStream<QuestParty>(streamId, started, joined);
+            await theSession.SaveChangesAsync();
+
+            theSession.Events.StartStream<Monster>(slayed1, slayed2);
+            await theSession.SaveChangesAsync();
+
+            theSession.Events.Append(streamId, joined2);
+            await theSession.SaveChangesAsync();
+
+            var document = theSession.Load<PersistedView>(streamId);
+            document.Events.Count.ShouldBe(5);
+            document.Events.ShouldHaveTheSameElementsAs(started, joined, slayed1, slayed2, joined2);
+
+            theSession.Events.Append(streamId, ended);
+            await theSession.SaveChangesAsync();
+            var nullDocument = theSession.Load<PersistedView>(streamId);
+            nullDocument.ShouldBeNull();
+
+            // Add document back to so we can delete it by selector
+            theSession.Events.Append(streamId, started);
+            await theSession.SaveChangesAsync();
+            var document2 = theSession.Load<PersistedView>(streamId);
+            document2.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, departed);
+            await theSession.SaveChangesAsync();
+            var nullDocument2 = theSession.Load<PersistedView>(streamId);
+            nullDocument2.ShouldBeNull();
+
+            // Add document back to so we can delete it by other selector type
+            theSession.Events.Append(streamId, started);
+            await theSession.SaveChangesAsync();
+            var document3 = theSession.Load<PersistedView>(streamId);
+            document3.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, destroyed);
+            await theSession.SaveChangesAsync();
+            var nullDocument3 = theSession.Load<PersistedView>(streamId);
+            nullDocument3.ShouldBeNull();
+        }
+
+        [Fact]
+        public void from_projection()
+        {
+            StoreOptions(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
+                _.Events.InlineProjections.Add(new PersistAsyncViewProjection());
+            });
+
+            theSession.Events.StartStream<QuestParty>(streamId, started, joined);
+            theSession.SaveChanges();
+
+            theSession.Events.StartStream<Monster>(slayed1, slayed2);
+            theSession.SaveChanges();
+
+            theSession.Events.Append(streamId, joined2);
+            theSession.SaveChanges();
+
+            var document = theSession.Load<PersistedView>(streamId);
+            document.Events.Count.ShouldBe(5);
+            document.Events.ShouldHaveTheSameElementsAs(started, joined, slayed1, slayed2, joined2);
+
+            theSession.Events.Append(streamId, ended);
+            theSession.SaveChanges();
+            var nullDocument = theSession.Load<PersistedView>(streamId);
+            nullDocument.ShouldBeNull();
+
+            // Add document back to so we can delete it by selector
+            theSession.Events.Append(streamId, started);
+            theSession.SaveChanges();
+            var document2 = theSession.Load<PersistedView>(streamId);
+            document2.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, departed);
+            theSession.SaveChanges();
+            var nullDocument2 = theSession.Load<PersistedView>(streamId);
+            nullDocument2.ShouldBeNull();
+
+            // Add document back to so we can delete it by other selector type
+            theSession.Events.Append(streamId, started);
+            theSession.SaveChanges();
+            var document3 = theSession.Load<PersistedView>(streamId);
+            document3.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, destroyed);
+            theSession.SaveChanges();
+            var nullDocument3 = theSession.Load<PersistedView>(streamId);
+            nullDocument3.ShouldBeNull();
+        }
+
+        [Fact]
+        public async void from_projection_async()
+        {
+            StoreOptions(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
+                _.Events.InlineProjections.Add(new PersistAsyncViewProjection());
+            });
+
+            theSession.Events.StartStream<QuestParty>(streamId, started, joined);
+            await theSession.SaveChangesAsync();
+
+            theSession.Events.StartStream<Monster>(slayed1, slayed2);
+            await theSession.SaveChangesAsync();
+
+            theSession.Events.Append(streamId, joined2);
+            await theSession.SaveChangesAsync();
+
+            var document = theSession.Load<PersistedView>(streamId);
+            document.Events.Count.ShouldBe(5);
+            document.Events.ShouldHaveTheSameElementsAs(started, joined, slayed1, slayed2, joined2);
+
+            theSession.Events.Append(streamId, ended);
+            await theSession.SaveChangesAsync();
+            var nullDocument = theSession.Load<PersistedView>(streamId);
+            nullDocument.ShouldBeNull();
+
+            // Add document back to so we can delete it by selector
+            theSession.Events.Append(streamId, started);
+            await theSession.SaveChangesAsync();
+            var document2 = theSession.Load<PersistedView>(streamId);
+            document2.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, departed);
+            await theSession.SaveChangesAsync();
+            var nullDocument2 = theSession.Load<PersistedView>(streamId);
+            nullDocument2.ShouldBeNull();
+
+            // Add document back to so we can delete it by other selector type
+            theSession.Events.Append(streamId, started);
+            await theSession.SaveChangesAsync();
+            var document3 = theSession.Load<PersistedView>(streamId);
+            document3.Events.Count.ShouldBe(1);
+
+            theSession.Events.Append(streamId, destroyed);
+            await theSession.SaveChangesAsync();
+            var nullDocument3 = theSession.Load<PersistedView>(streamId);
+            nullDocument3.ShouldBeNull();
+        }
+
+        [Fact]
+        public void using_collection_of_ids()
+        {
+            StoreOptions(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
+                _.Events.ProjectView<QuestView, Guid>()
+                    .ProjectEventAsync<QuestStarted>((view, @event) => { view.Name = @event.Name; return Task.CompletedTask; })
+                    .ProjectEventAsync<MonsterQuestsAdded>(e => e.QuestIds, (view, @event) => { view.Name = view.Name.Insert(0, $"{@event.Name}: "); return Task.CompletedTask; })
+                    .DeleteEvent<MonsterQuestsRemoved>(e => e.QuestIds);
+            });
+
+            theSession.Events.StartStream<QuestParty>(streamId, started);
+            theSession.Events.StartStream<QuestParty>(streamId2, started2);
+            theSession.SaveChanges();
+
+            theSession.Events.StartStream<Monster>(monsterQuestsAdded);
+            theSession.SaveChanges();
+
+            var document = theSession.Load<QuestView>(streamId);
+            document.Name.ShouldStartWith(monsterQuestsAdded.Name);
+            var document2 = theSession.Load<QuestView>(streamId2);
+            document2.Name.ShouldStartWith(monsterQuestsAdded.Name);
+
+            theSession.Events.StartStream<Monster>(monsterQuestsRemoved);
+            theSession.SaveChanges();
+
+            var nullDocument = theSession.Load<QuestView>(streamId);
+            nullDocument.ShouldBeNull();
+            var nullDocument2 = theSession.Load<QuestView>(streamId2);
+            nullDocument2.ShouldBeNull();
+        }
+
+        [Fact]
+        public async void using_collection_of_ids_async()
+        {
+            StoreOptions(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
+                _.Events.ProjectView<QuestView, Guid>()
+                    .ProjectEventAsync<QuestStarted>((view, @event) => { view.Name = @event.Name; return Task.CompletedTask; } )
+                    .ProjectEventAsync<MonsterQuestsAdded>(e => e.QuestIds, (view, @event) => { view.Name = view.Name.Insert(0, $"{@event.Name}: "); return Task.CompletedTask; })
+                    .DeleteEvent<MonsterQuestsRemoved>(e => e.QuestIds);
+            });
+
+            theSession.Events.StartStream<QuestParty>(streamId, started);
+            theSession.Events.StartStream<QuestParty>(streamId2, started2);
+            await theSession.SaveChangesAsync();
+
+            theSession.Events.StartStream<Monster>(monsterQuestsAdded);
+            await theSession.SaveChangesAsync();
+
+            var document = theSession.Load<QuestView>(streamId);
+            document.Name.ShouldStartWith(monsterQuestsAdded.Name);
+            var document2 = theSession.Load<QuestView>(streamId2);
+            document2.Name.ShouldStartWith(monsterQuestsAdded.Name);
+
+            theSession.Events.StartStream<Monster>(monsterQuestsRemoved);
+            await theSession.SaveChangesAsync();
+
+            var nullDocument = theSession.Load<QuestView>(streamId);
+            nullDocument.ShouldBeNull();
+            var nullDocument2 = theSession.Load<QuestView>(streamId2);
+            nullDocument2.ShouldBeNull();
+        }
+    }
+    
+    // SAMPLE: viewprojection-from-class 
+    public class PersistAsyncViewProjection : ViewProjection<PersistedView, Guid>
+    {
+        public PersistAsyncViewProjection()
+        {
+            ProjectEventAsync<QuestStarted>(PersistAsync);
+            ProjectEventAsync<MembersJoined>(e => e.QuestId, PersistAsync);
+            ProjectEventAsync<MonsterSlayed>((session, e) => session.Load<QuestParty>(e.QuestId).Id, PersistAsync);
+            DeleteEvent<QuestEnded>();
+            DeleteEvent<MembersDeparted>(e => e.QuestId);
+            DeleteEvent<MonsterDestroyed>((session, e) => session.Load<QuestParty>(e.QuestId).Id);
+        }
+
+        private Task PersistAsync<T>(PersistedView view, T @event)
+        {
+            view.Events.Add(@event);
+            return Task.CompletedTask;
+        }
+    }
+    // ENDSAMPLE 
+}

--- a/src/Marten/Events/Projections/ViewProjection.cs
+++ b/src/Marten/Events/Projections/ViewProjection.cs
@@ -248,7 +248,10 @@ namespace Marten.Events.Projections
                 }
                 else
                 {
-                    eventProjection.ProjectTo(view).Wait();
+                    using (Util.NoSynchronizationContextScope.Enter())
+                    {
+                        eventProjection.ProjectTo(view).Wait();
+                    }
                 }
             }
         }

--- a/src/Marten/Events/Projections/ViewProjection.cs
+++ b/src/Marten/Events/Projections/ViewProjection.cs
@@ -39,13 +39,13 @@ namespace Marten.Events.Projections
         {
             public Func<IDocumentSession, object, Guid, TId> IdSelector { get; }
             public Func<IDocumentSession, object, Guid, List<TId>> IdsSelector { get; }
-            public Action<TView, object> Handler { get; }
+            public Func<TView, object, Task> Handler { get; }
             public ProjectionEventType Type { get; set; }
 
             public EventHandler(
                 Func<IDocumentSession, object, Guid, TId> idSelector,
                 Func<IDocumentSession, object, Guid, List<TId>> idsSelector,
-                Action<TView, object> handler,
+                Func<TView, object, Task> handler,
                 ProjectionEventType type)
             {
                 IdSelector = idSelector;
@@ -58,7 +58,7 @@ namespace Marten.Events.Projections
         private class EventProjection
         {
             public TId ViewId { get; }
-            public Action<TView> ProjectTo { get; }
+            public Func<TView, Task> ProjectTo { get; }
             public ProjectionEventType Type { get; set; }
 
             public EventProjection(EventHandler eventHandler, TId viewId, IEvent @event, object projectionEvent)
@@ -117,27 +117,54 @@ namespace Marten.Events.Projections
         }
 
         public ViewProjection<TView, TId> ProjectEvent<TEvent>(Action<TView, TEvent> handler) where TEvent : class
-            => projectEvent((session, @event, streamId) => convertToTId(streamId), null, handler);
+            => projectEvent((session, @event, streamId) => convertToTId(streamId), null, (TView view, TEvent @event) => { handler(view, @event); return Task.CompletedTask; });
 
         public ViewProjection<TView, TId> ProjectEvent<TEvent>(Func<IDocumentSession, TEvent, TId> viewIdSelector, Action<TView, TEvent> handler) where TEvent : class
         {
             if (viewIdSelector == null) throw new ArgumentNullException(nameof(viewIdSelector));
-            return projectEvent((session, @event, streamId) => viewIdSelector(session, @event as TEvent), null, handler);
+            return projectEvent((session, @event, streamId) => viewIdSelector(session, @event as TEvent), null, (TView view, TEvent @event) => { handler(view, @event); return Task.CompletedTask; });
         }
 
         public ViewProjection<TView, TId> ProjectEvent<TEvent>(Func<TEvent, TId> viewIdSelector, Action<TView, TEvent> handler) where TEvent : class
         {
             if (viewIdSelector == null) throw new ArgumentNullException(nameof(viewIdSelector));
-            return projectEvent((session, @event, streamId) => viewIdSelector(@event as TEvent), null, handler);
+            return projectEvent((session, @event, streamId) => viewIdSelector(@event as TEvent), null, (TView view, TEvent @event) => { handler(view, @event); return Task.CompletedTask; });
         }
 
         public ViewProjection<TView, TId> ProjectEvent<TEvent>(Func<IDocumentSession, TEvent, List<TId>> viewIdsSelector, Action<TView, TEvent> handler) where TEvent : class
         {
             if (viewIdsSelector == null) throw new ArgumentNullException(nameof(viewIdsSelector));
-            return projectEvent(null, (session, @event, streamId) => viewIdsSelector(session, @event as TEvent), handler);
+            return projectEvent(null, (session, @event, streamId) => viewIdsSelector(session, @event as TEvent), (TView view, TEvent  @event) => { handler(view, @event); return Task.CompletedTask; });
         }
 
         public ViewProjection<TView, TId> ProjectEvent<TEvent>(Func<TEvent, List<TId>> viewIdsSelector, Action<TView, TEvent> handler) where TEvent : class
+        {
+            if (viewIdsSelector == null) throw new ArgumentNullException(nameof(viewIdsSelector));
+            return projectEvent(null, (session, @event, streamId) => viewIdsSelector(@event as TEvent), (TView view, TEvent @event) => { handler(view, @event); return Task.CompletedTask; });
+        }
+
+        public ViewProjection<TView, TId> ProjectEventAsync<TEvent>(Func<TView, TEvent, Task> handler) where TEvent : class
+            => projectEvent((session, @event, streamId) => convertToTId(streamId), null, handler);
+
+        public ViewProjection<TView, TId> ProjectEventAsync<TEvent>(Func<IDocumentSession, TEvent, TId> viewIdSelector, Func<TView, TEvent, Task> handler) where TEvent : class
+        {
+            if (viewIdSelector == null) throw new ArgumentNullException(nameof(viewIdSelector));
+            return projectEvent((session, @event, streamId) => viewIdSelector(session, @event as TEvent), null, handler);
+        }
+
+        public ViewProjection<TView, TId> ProjectEventAsync<TEvent>(Func<TEvent, TId> viewIdSelector, Func<TView, TEvent, Task> handler) where TEvent : class
+        {
+            if (viewIdSelector == null) throw new ArgumentNullException(nameof(viewIdSelector));
+            return projectEvent((session, @event, streamId) => viewIdSelector(@event as TEvent), null, handler);
+        }
+
+        public ViewProjection<TView, TId> ProjectEventAsync<TEvent>(Func<IDocumentSession, TEvent, List<TId>> viewIdsSelector, Func<TView, TEvent, Task> handler) where TEvent : class
+        {
+            if (viewIdsSelector == null) throw new ArgumentNullException(nameof(viewIdsSelector));
+            return projectEvent(null, (session, @event, streamId) => viewIdsSelector(session, @event as TEvent), handler);
+        }
+
+        public ViewProjection<TView, TId> ProjectEventAsync<TEvent>(Func<TEvent, List<TId>> viewIdsSelector, Func<TView, TEvent, Task> handler) where TEvent : class
         {
             if (viewIdsSelector == null) throw new ArgumentNullException(nameof(viewIdsSelector));
             return projectEvent(null, (session, @event, streamId) => viewIdsSelector(@event as TEvent), handler);
@@ -146,7 +173,7 @@ namespace Marten.Events.Projections
         private ViewProjection<TView, TId> projectEvent<TEvent>(
             Func<IDocumentSession, object, Guid, TId> viewIdSelector,
             Func<IDocumentSession, object, Guid, List<TId>> viewIdsSelector,
-            Action<TView, TEvent> handler,
+            Func<TView, TEvent, Task> handler,
             ProjectionEventType type = ProjectionEventType.Modify) where TEvent : class
         {
             if (viewIdSelector == null && viewIdsSelector == null) throw new ArgumentException($"{nameof(viewIdSelector)} or {nameof(viewIdsSelector)} must be provided.");
@@ -155,7 +182,7 @@ namespace Marten.Events.Projections
             EventHandler eventHandler;
             if (type == ProjectionEventType.Modify)
             {
-                eventHandler = new EventHandler(viewIdSelector, viewIdsSelector, (view, @event) => handler(view, @event as TEvent), type);
+                eventHandler = new EventHandler(viewIdSelector, viewIdsSelector, (view, @event) => { handler(view, @event as TEvent); return Task.CompletedTask; } , type);
             }
             else
             {
@@ -193,7 +220,7 @@ namespace Marten.Events.Projections
             }
         }
 
-        Task IProjection.ApplyAsync(IDocumentSession session, EventPage page, CancellationToken token)
+        async Task IProjection.ApplyAsync(IDocumentSession session, EventPage page, CancellationToken token)
         {
             var projections = getEventProjections(session, page);
 
@@ -203,10 +230,8 @@ namespace Marten.Events.Projections
             {
                 var views = _sessionLoadMany((DocumentSession)session, viewIds);
 
-                applyProjections(session, projections, views);
+                await applyProjectionsAsync(session, projections, views);
             }
-
-            return Task.CompletedTask;
         }
 
         private void applyProjections(IDocumentSession session, ICollection<EventProjection> projections, IEnumerable<TView> views)
@@ -223,7 +248,26 @@ namespace Marten.Events.Projections
                 }
                 else
                 {
-                    eventProjection.ProjectTo(view);
+                    eventProjection.ProjectTo(view).Wait();
+                }
+            }
+        }
+
+        private async Task applyProjectionsAsync(IDocumentSession session, ICollection<EventProjection> projections, IEnumerable<TView> views)
+        {
+            var viewMap = createViewMap(session, projections, views);
+
+            foreach (var eventProjection in projections)
+            {
+                var view = viewMap[eventProjection.ViewId];
+
+                if (eventProjection.Type == ProjectionEventType.Delete)
+                {
+                    session.Delete(view);
+                }
+                else
+                {
+                    await eventProjection.ProjectTo(view);
                 }
             }
         }

--- a/src/Marten/Util/NoSynchronizationContextScope.cs
+++ b/src/Marten/Util/NoSynchronizationContextScope.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading;
+
+namespace Marten.Util
+{
+    public static class NoSynchronizationContextScope
+    {
+        public static Disposable Enter()
+        {
+            var context = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
+            return new Disposable(context);
+        }
+
+        public struct Disposable : IDisposable
+        {
+            private readonly SynchronizationContext _synchronizationContext;
+
+            public Disposable(SynchronizationContext synchronizationContext)
+            {
+                _synchronizationContext = synchronizationContext;
+            }
+
+            public void Dispose() =>
+                SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
+        }
+    }
+}


### PR DESCRIPTION
Currently ViewProjection even though it has `async Task IProjection.ApplyAsync(IDocumentSession session, EventPage page, CancellationToken token)` method it's not doing any async code there - it doesn't await for applyProjections so it's not possible to use async code in the persisting event projection method.

I know that there is AsyncDaemon, that helps with some of the async cases, but it's complext in usage and sometimes there is a need to use the code that has only async API (like in my commercial project, most of the code doesn't support synchronous access). Imho it would be good from the performance  and consistency perspective to allow to use async code in the `ProjectEvent` persist method.

In my PR, I changed the `Handler` definition to always return Task. For the non async code it just returns `Task.Completed` (by convention found in other Marten classes). That gives the unified usage for both synchronous and asynchronous projection handling. If the async code is used in synchronous `applyProjections` then the `.Wait` method is being used.

I added also the tests, that mimics the original tests. I'm not 100% sure that it's the best way to do doubled code with that. The other possibility is to add additional 3 events, that we could use in `PersistViewProjection` class and check in same scenarios. But I wasn't sure if that won't break the convention of using same events in documentation and in the tests.