### PR TITLE
!Equals, null check depth improvements, fix #849

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_337_certain_boolean_searches_are_not_using_searchable_field.cs
+++ b/src/Marten.Testing/Bugs/Bug_337_certain_boolean_searches_are_not_using_searchable_field.cs
@@ -22,7 +22,7 @@ namespace Marten.Testing.Bugs
                 var cmd2 = session.Query<Target>().Where(x => !x.Flag).ToCommand();
 
                 cmd1.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d where d.flag = :arg0");
-                cmd2.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d where d.flag = False");
+                cmd2.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d where d.flag != :arg0");
             }
         }
 

--- a/src/Marten.Testing/Bugs/Bug_849_not_node_not_correctly_evaluated.cs
+++ b/src/Marten.Testing/Bugs/Bug_849_not_node_not_correctly_evaluated.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+using Marten.Linq;
+using Marten.Services;
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+    public class Bug_849_not_node_not_correctly_evaluated : DocumentSessionFixture<NulloIdentityMap>
+    {
+        public class TestClass
+        {
+	        public TestClass()
+	        {
+		        Id = Guid.NewGuid();
+	        }
+
+	        public Guid Id { get; set; }
+			public bool Flag { get; set; }
+        }
+
+        internal TestClass TestNullObject { get; set; }
+
+        [Fact]
+        public void When_Property_Is_Null_Exception_Should_Be_Null_Reference_Exception()
+        {
+	        var flagFalse = new TestClass { Flag = false };
+	        var flagTrue = new TestClass { Flag = true } ;
+
+			theSession.Store(flagFalse, flagTrue);
+			theSession.SaveChanges();
+
+	        using (var s = theStore.OpenSession())
+	        {
+		        var items = s.Query<TestClass>().Where(x => !x.Flag == false).ToList();
+				
+				Assert.Equal(1, items.Count);
+		        Assert.Equal(flagTrue.Id, items[0].Id);
+			}
+		}
+    }
+}

--- a/src/Marten.Testing/Linq/IsNullNotNullArbitraryDepthTests.cs
+++ b/src/Marten.Testing/Linq/IsNullNotNullArbitraryDepthTests.cs
@@ -1,0 +1,55 @@
+﻿using System.Linq;
+using Marten.Services;
+using Marten.Testing.Documents;
+using Marten.Util;
+using Xunit;
+
+namespace Marten.Testing.Linq
+{	
+	// Change type mapping to treat "unknown" PG types as jsonb -> null checks depths at arbitrary depths don't fail due to CAST
+	public class IsNullNotNullArbitraryDepthTests : DocumentSessionFixture<NulloIdentityMap>
+	{
+		class UserNested : User
+		{
+			public UserNested Nested { get; set; }
+		}
+
+		[Fact]
+		public void CanQueryNullNotNullAtArbitraryDepth()
+		{
+			var user = new UserNested
+			{
+				Nested = new UserNested
+				{
+					Nested = new UserNested
+					{
+						Nested = new UserNested()
+					}
+				}
+			};
+
+			theSession.Store(user);
+
+			theSession.SaveChanges();
+
+			using (var s = theStore.QuerySession())
+			{
+				var notNull = s.Query<UserNested>().FirstOrDefault(x => x.Nested.Nested.Nested != null);				
+				var notNullAlso = s.Query<UserNested>().FirstOrDefault(x => x.Nested.Nested.Nested.Nested.Nested == null);
+				var shouldBeNull = s.Query<UserNested>().FirstOrDefault(x => x.Nested.Nested.Nested == null);
+
+				Assert.Equal(user.Id, notNull.Id);
+				Assert.Equal(user.Id, notNullAlso.Id);
+				Assert.Null(shouldBeNull);
+			}
+		}
+
+		[Fact]
+		public void UnknownPGTypesMapToJsonb()
+		{
+			var cast = TypeMappings.ApplyCastToLocator("item", EnumStorage.AsInteger, typeof(UserNested));
+
+			Assert.Contains("as jsonb", cast);
+		}
+	}
+}

--- a/src/Marten.Testing/Linq/SimpleNotEqualsParserTests.cs
+++ b/src/Marten.Testing/Linq/SimpleNotEqualsParserTests.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+using System.Linq;
+using System.Linq.Expressions;
+using Marten.Services;
+using Marten.Linq;
+using Marten.Schema;
+
+namespace Marten.Testing.Linq
+{
+	public class SimpleNotEqualsParserTests : DocumentSessionFixture<NulloIdentityMap>
+	{		
+		class QueryTarget
+		{
+			public int IntProp { get; set; }
+			public long LongProp { get; set; }
+			public decimal DecimalProp { get; set; }
+			public bool BoolProp { get; set; }
+			public Guid Id { get; set; }
+			public DateTime DateTimeProp { get; set; }
+			public DateTimeOffset DateTimeOffsetProp { get; set; }
+		}		
+
+		[Fact]
+		public void CanTranslateNotEqualsToQueries()
+		{
+			var queryTarget = new QueryTarget
+			{
+				IntProp = 1,
+				LongProp = 2,
+				DecimalProp = 1.1m,
+				BoolProp = true,
+				Id = Guid.NewGuid(),
+				DateTimeProp = DateTime.UtcNow,
+				DateTimeOffsetProp = DateTimeOffset.UtcNow
+			};
+
+			theSession.Store(queryTarget);
+
+			theSession.SaveChanges();
+
+			var itemFromDb = theSession.Query<QueryTarget>()
+				.Where(x => !x.IntProp.Equals(queryTarget.IntProp))
+				.Where(x => !x.LongProp.Equals(queryTarget.LongProp))
+				.Where(x => !x.DecimalProp.Equals(queryTarget.DecimalProp))
+				.Where(x => !x.BoolProp.Equals(queryTarget.BoolProp))
+				.Where(x => !x.Id.Equals(queryTarget.Id))
+				.Where(x => !x.DateTimeProp.Equals(queryTarget.DateTimeProp))
+				.Where(x => !x.DateTimeOffsetProp.Equals(queryTarget.DateTimeOffsetProp))
+				.FirstOrDefault();
+
+			Assert.Null(itemFromDb);
+		}
+
+		[Fact]
+		public void ThrowsWhenValueNotConvertibleToComparandType()
+		{
+			var queryTarget = new QueryTarget
+			{
+				Id = System.Guid.NewGuid()
+			};
+			theSession.Store(queryTarget);
+
+			theSession.SaveChanges();
+
+			object notInt = "not int";
+
+			Assert.Throws<BadLinqExpressionException>(() =>
+			{
+				theSession.Query<QueryTarget>()
+					.Where(x => !x.IntProp.Equals(notInt))
+					.FirstOrDefault();
+			});
+		}
+
+
+		public class TestData : IEnumerable<object[]>
+		{
+			private readonly List<object[]> _data = new List<object[]>
+			{
+				new object[] { Guid.NewGuid() },
+				new object[] { 0 },
+				new object[] { null },
+				new object[] { false },
+				new object[] { 32m },
+				new object[] { 0L },
+				new object[] { DateTime.UtcNow },
+				new object[] { DateTimeOffset.UtcNow },
+			};
+
+			public IEnumerator<object[]> GetEnumerator()
+			{
+				return _data.GetEnumerator();
+			}
+
+			IEnumerator IEnumerable.GetEnumerator()
+			{
+				return GetEnumerator();
+			}
+		}
+
+		[Theory]
+		[InlineData(PropertySearching.ContainmentOperator)]
+		[InlineData(PropertySearching.JSON_Locator_Only)]
+		public void NotEqualsGeneratesSameSqlAsNotEqualityOperatorWhenRegardlessOfPropertySearching(PropertySearching search)
+		{
+			StoreOptions(options =>
+			{
+				options.Schema.For<QueryTarget>().PropertySearching(search);
+			});
+
+			var queryTarget = new QueryTarget
+			{
+				IntProp = 1,
+				LongProp = 2,
+				DecimalProp = 1.1m,
+				BoolProp = true,
+				Id = Guid.NewGuid(),
+				DateTimeProp = DateTime.UtcNow
+			};
+
+			var queryEquals = theSession.Query<QueryTarget>()
+				.Where(x => !x.IntProp.Equals(queryTarget.IntProp))
+				.Where(x => !x.LongProp.Equals(queryTarget.LongProp))
+				.Where(x => !x.DecimalProp.Equals(queryTarget.DecimalProp))
+				.Where(x => !x.BoolProp.Equals(queryTarget.BoolProp))
+				.Where(x => !x.Id.Equals(queryTarget.Id))
+				.Where(x => !x.DateTimeProp.Equals(queryTarget.DateTimeProp))
+				.Where(x => !x.DateTimeOffsetProp.Equals(queryTarget.DateTimeOffsetProp))
+				.ToCommand().CommandText;
+
+			var queryEqualOperator = theSession.Query<QueryTarget>()
+				.Where(x => x.IntProp != queryTarget.IntProp)
+				.Where(x => x.LongProp != queryTarget.LongProp)
+				.Where(x => x.DecimalProp != queryTarget.DecimalProp)
+				.Where(x => x.BoolProp != queryTarget.BoolProp)
+				.Where(x => x.Id != queryTarget.Id)
+				.Where(x => x.DateTimeProp != queryTarget.DateTimeProp)
+				.Where(x => x.DateTimeOffsetProp != queryTarget.DateTimeOffsetProp)
+				.ToCommand().CommandText;
+
+			Assert.Equal(queryEqualOperator, queryEquals);
+		}
+
+		[Theory]
+		[ClassData(typeof(TestData))]
+		public void NotEqualsGeneratesSameSqlAsNotEqualityOperator(object value)
+		{			
+			string queryEquals = null, queryEqualOperator = null;
+			switch (value)
+			{
+				case int intValue:
+					queryEquals = theSession.Query<QueryTarget>()
+						.Where(x => !x.IntProp.Equals(intValue)).ToCommand().CommandText;
+					queryEqualOperator = theSession.Query<QueryTarget>()
+						.Where(x => x.IntProp != intValue).ToCommand().CommandText;
+					break;
+				case Guid guidValue:
+					queryEquals = theSession.Query<QueryTarget>()
+						.Where(x => !x.Id.Equals(guidValue)).ToCommand().CommandText;
+					queryEqualOperator = theSession.Query<QueryTarget>()
+						.Where(x => x.Id != guidValue).ToCommand().CommandText;
+					break;
+				case decimal decimalValue:
+					queryEquals = theSession.Query<QueryTarget>()
+						.Where(x => !x.DecimalProp.Equals(decimalValue)).ToCommand().CommandText;
+					queryEqualOperator = theSession.Query<QueryTarget>()
+						.Where(x => x.DecimalProp != decimalValue).ToCommand().CommandText;
+					break;
+				case long longValue:
+					queryEquals = theSession.Query<QueryTarget>()
+						.Where(x => !x.LongProp.Equals(longValue)).ToCommand().CommandText;
+					queryEqualOperator = theSession.Query<QueryTarget>()
+						.Where(x => x.LongProp != longValue).ToCommand().CommandText;
+					break;
+				case DateTime dateTimeValue:
+					queryEquals = theSession.Query<QueryTarget>()
+						.Where(x => !x.DateTimeProp.Equals(dateTimeValue)).ToCommand().CommandText;
+					queryEqualOperator = theSession.Query<QueryTarget>()
+						.Where(x => x.DateTimeProp != dateTimeValue).ToCommand().CommandText;
+					break;
+				case DateTimeOffset dateTimeOffsetValue:
+					queryEquals = theSession.Query<QueryTarget>()
+						.Where(x => !x.DateTimeOffsetProp.Equals(dateTimeOffsetValue)).ToCommand().CommandText;
+					queryEqualOperator = theSession.Query<QueryTarget>()
+						.Where(x => x.DateTimeOffsetProp != dateTimeOffsetValue).ToCommand().CommandText;
+					break;
+				// Null
+				default:
+					queryEquals = theSession.Query<QueryTarget>()
+						.Where(x => !x.BoolProp.Equals(null)).ToCommand().CommandText;
+					queryEqualOperator = theSession.Query<QueryTarget>()
+#pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+						.Where(x => x.BoolProp != null).ToCommand().CommandText;
+#pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
+					break;
+			}
+			Assert.Equal(queryEqualOperator, queryEquals);
+		}		
+	}
+}

--- a/src/Marten/Linq/MartenExpressionParser.cs
+++ b/src/Marten/Linq/MartenExpressionParser.cs
@@ -148,6 +148,11 @@ namespace Marten.Linq
                 return new WhereFragment("{0} % {1} {2} ?".ToFormat(jsonLocator, moduloByValue, op), value);
             }
 
+			// ! == -> <>
+	        if (binary.Left.NodeType == ExpressionType.Not && binary.NodeType == ExpressionType.Equal)
+	        {
+		        op = _operators[ExpressionType.NotEqual];
+	        }
 
             return new WhereFragment("{0} {1} ?".ToFormat(jsonLocator, op), value);
         }

--- a/src/Marten/Linq/NotVisitor.cs
+++ b/src/Marten/Linq/NotVisitor.cs
@@ -15,6 +15,7 @@ namespace Marten.Linq
         private readonly IQueryableDocument _mapping;
         private readonly Action<IWhereFragment> _callback;
 	    private static readonly IMethodCallParser[] _parsers = {
+			new SimpleNotEqualsParser(),
 			new StringNotEquals(),
 			new StringNotContains(),
 		    new StringNotStartsWith(),
@@ -48,7 +49,7 @@ namespace Marten.Linq
             if (expression.Type == typeof (bool))
             {
                 var locator = _mapping.JsonLocator(expression);
-                var @where = new WhereFragment($"{locator} = False");
+                var @where = new WhereFragment($"{locator} != ?", true);
                 _callback(@where);
             }
 			

--- a/src/Marten/Linq/NotVisitor.cs
+++ b/src/Marten/Linq/NotVisitor.cs
@@ -38,7 +38,9 @@ namespace Marten.Linq
 			if (parser != null)
 			{
 				var where = parser.Parse(_mapping, _serializer, expression);
-				_callback(where);				
+				_callback(where);
+
+				return expression;
 			}
 	
 			return base.VisitMethodCall(expression);

--- a/src/Marten/Linq/Parsing/SimpleNotEqualsParser.cs
+++ b/src/Marten/Linq/Parsing/SimpleNotEqualsParser.cs
@@ -1,0 +1,14 @@
+﻿namespace Marten.Linq.Parsing
+{
+	/// <summary>
+	/// Implement !Equals for <see cref="int"/>, <see cref="long"/>, <see cref="decimal"/>, <see cref="Guid"/>, <see cref="bool"/>, <see cref="DateTime"/>, <see cref="DateTimeOffset"/>.
+	/// </summary>
+	/// <remarks>Equals(object) calls into <see cref="Convert.ChangeType(object, Type)"/>. Equals(null) is converted to "is null" query.</remarks>
+	public sealed class SimpleNotEqualsParser : SimpleEqualsParser
+	{
+		public SimpleNotEqualsParser() : base("!=", "is not", false)
+		{
+			
+		}
+	}
+}

--- a/src/Marten/Linq/Parsing/SimpleNotEqualsParser.cs
+++ b/src/Marten/Linq/Parsing/SimpleNotEqualsParser.cs
@@ -1,4 +1,6 @@
-﻿namespace Marten.Linq.Parsing
+﻿using System;
+
+namespace Marten.Linq.Parsing
 {
 	/// <summary>
 	/// Implement !Equals for <see cref="int"/>, <see cref="long"/>, <see cref="decimal"/>, <see cref="Guid"/>, <see cref="bool"/>, <see cref="DateTime"/>, <see cref="DateTimeOffset"/>.

--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -151,11 +151,8 @@ namespace Marten.Util
                 return enumStyle == EnumStorage.AsInteger ? "({0})::int".ToFormat(locator) : locator;
             }
 
-            if (!PgTypes.ContainsKey(memberType))
-                throw new ArgumentOutOfRangeException(nameof(memberType),
-                    "There is not a known Postgresql cast for member type " + memberType.FullName);
-
-            return "CAST({0} as {1})".ToFormat(locator, PgTypes[memberType]);
+			// Treat "unknown" PgTypes as jsonb (this way null checks of arbitary depth won't fail on cast).
+            return "CAST({0} as {1})".ToFormat(locator, GetPgType(memberType));
         }
 
         public static bool IsDate(this object value)


### PR DESCRIPTION
Changes:
* Parameterize NOT Equals (Value = False -> Value <> :arg, :arg = True). This aligns it with implementation of translation of equality & allows generalized implementation of !Equals.
   * Align compiled query compilation with the change.
* Introduce !Equals for int, long, decimal, Guid, bool, DateTime, DateTimeOffset.
* Treat unknown PG types as jsonb. This allows null & not null checks at arbitrary depths (whereby current implementation fails on CAST).
* Fix bug #849 whereby ! == is incorrectly translated.

