### PR TITLE
Fix missing sample in docs, Add non-generic Query extensions, Docs

### DIFF
--- a/documentation/documentation/documents/querying/sql.md
+++ b/documentation/documentation/documents/querying/sql.md
@@ -23,12 +23,17 @@ If you want to combine other Linq operations with your sql, you can use the `Mat
 
 The best resource for this topic might just be [the unit tests](https://github.com/JasperFx/Marten/blob/master/src/Marten.Testing/query_by_sql_where_clause_Tests.cs).
 
-
 ## Asynchronous Queries
 
 You can also query asynchronously with user supplied SQL:
 
 <[sample:using-queryasync]>
+
+### Non-generic Overloads
+
+The SQL queries described above can also be performed through the non-generic IQuerySession extensions, which allow for providing the document type during runtime. The sample below demonstrates this feature together with the C# `dynamic` type.
+
+<[sample:sample-query-type-parameter-overload]>
 
 ## Named Parameter Queries
 

--- a/src/Marten.Testing/Session/query_session_extension_Tests.cs
+++ b/src/Marten.Testing/Session/query_session_extension_Tests.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using System.Threading;
+using Marten.Services;
+using Marten.Testing.Documents;
+using Xunit;
+
+namespace Marten.Testing.Session
+{
+	public class query_session_extension_Tests : DocumentSessionFixture<NulloIdentityMap>
+	{
+		[Fact]
+		public async void CanQueryByRuntimeType()
+		{
+			var user = new User();
+			var company = new Company {Name = "Megadodo Publications"};
+			theSession.Store(user);
+			theSession.Store(company);
+			theSession.SaveChanges();
+			
+			using (var session = theStore.OpenSession())
+			{
+                // SAMPLE: sample-query-type-parameter-overload
+                dynamic userFromDb = session.Query(user.GetType(), "where id = ?", user.Id).FirstOrDefault();
+                dynamic companyFromDb = (await session.QueryAsync(typeof(Company), "where id = ?", CancellationToken.None, company.Id)).FirstOrDefault();
+                // ENDSAMPLE
+
+				Assert.Equal(user.Id, userFromDb.Id);
+				Assert.Equal(company.Name, companyFromDb.Name);
+			}
+		}
+	}
+}

--- a/src/Marten.Testing/query_by_sql_where_clause_Tests.cs
+++ b/src/Marten.Testing/query_by_sql_where_clause_Tests.cs
@@ -218,24 +218,25 @@ namespace Marten.Testing
 
         [Fact]
         public async Task query_with_select_in_query_async()
-        {
-            using (var session = theStore.OpenSession())
+        {	        
+			using (var session = theStore.OpenSession())
             {
                 var u = new User { FirstName = "Jeremy", LastName = "Miller" };
                 session.Store(u);
                 session.SaveChanges();
 
+                // SAMPLE: using-queryasync
                 var users =
                     await
                         session.QueryAsync<User>(
                                    "select data from mt_doc_user where data ->> 'FirstName' = 'Jeremy'")
                                .ConfigureAwait(false);
                 var user = users.Single();
+                // ENDSAMPLE
 
-                user.LastName.ShouldBe("Miller");
+				user.LastName.ShouldBe("Miller");
                 user.Id.ShouldBe(u.Id);
-            }
-            // ENDSAMPLE
+            }            
         }
     }
 }

--- a/src/Marten/QuerySessionExtensions.cs
+++ b/src/Marten/QuerySessionExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten
+{
+	public static class QuerySessionExtensions
+	{
+		private static readonly MethodInfo QueryMethod = typeof(IQuerySession).GetMethod(nameof(IQuerySession.Query), new[] { typeof(string), typeof(object[]) });
+		private static readonly MethodInfo QueryMethodAsync = typeof(IQuerySession).GetMethod(nameof(IQuerySession.QueryAsync), new[] { typeof(string), typeof(CancellationToken), typeof(object[]) });
+
+		public static IReadOnlyList<object> Query(this IQuerySession session, Type type, string sql, params object[] parameters)
+		{
+			return (IReadOnlyList<object>)QueryMethod.MakeGenericMethod(type).Invoke(session, new object[] { sql, parameters });
+		}
+
+		public static async Task<IReadOnlyList<object>> QueryAsync(this IQuerySession session, Type type, string sql, CancellationToken token = default(CancellationToken), params object[] parameters)
+		{
+			var task = (Task)QueryMethodAsync.MakeGenericMethod(type).Invoke(session, new object[] { sql, token, parameters });
+			await task.ConfigureAwait(false);
+			return (IReadOnlyList<object>)task.GetType().GetProperty("Result").GetValue(task);
+		}
+	}
+}


### PR DESCRIPTION
* Fix missing query SQL async sample in docs.
* Fix #836 - adds extension methods to IQuerySession to provide non-generic Query overloads.
	* Document said feature.