### PR TITLE
Bug fixes pertaining to GH-837 and GH-864

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_837_missing_func_mt_immutable_timestamp_when_initializing_with_new_Schema.cs
+++ b/src/Marten.Testing/Bugs/Bug_837_missing_func_mt_immutable_timestamp_when_initializing_with_new_Schema.cs
@@ -23,5 +23,20 @@ namespace Marten.Testing.Bugs
                 session.Query<Target>().FirstOrDefault(m => m.DateOffset > DateTimeOffset.Now);
             }
         }
+
+        [Fact]
+        public void test_func_mt_immutable_timestamp_when_initializing_with_default_Schema()
+        {
+            var store = DocumentStore.For(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.Connection(ConnectionSource.ConnectionString);
+            });
+
+            using (var session = store.OpenSession())
+            {
+                session.Query<Target>().FirstOrDefault(m => m.DateOffset > DateTimeOffset.Now);
+            }
+        }
     }
 }

--- a/src/Marten/Schema/JsonLocatorField.cs
+++ b/src/Marten/Schema/JsonLocatorField.cs
@@ -32,12 +32,12 @@ namespace Marten.Schema
             }
             else if (memberType == typeof(DateTime) || memberType == typeof(DateTime?))
             {
-                SqlLocator = $"public.mt_immutable_timestamp({dataLocator} ->> '{memberName}')";
+                SqlLocator = $"{options.DatabaseSchemaName}.mt_immutable_timestamp({dataLocator} ->> '{memberName}')";
                 SelectionLocator = $"CAST({dataLocator} ->> '{memberName}' as {PgType})";
             }
             else if (memberType == typeof(DateTimeOffset) || memberType == typeof(DateTimeOffset?))
             {
-                SqlLocator = $"public.mt_immutable_timestamp({dataLocator} ->> '{memberName}')";
+                SqlLocator = $"{options.DatabaseSchemaName}.mt_immutable_timestamp({dataLocator} ->> '{memberName}')";
                 SelectionLocator = $"CAST({dataLocator} ->> '{memberName}' as {PgType})";
             }
             else

--- a/src/Marten/Storage/StorageFeatures.cs
+++ b/src/Marten/Storage/StorageFeatures.cs
@@ -33,18 +33,8 @@ namespace Marten.Storage
             _options = options;
 
             SystemFunctions = new SystemFunctions(options);
-
-            store(SystemFunctions);
-            Transforms = options.Transforms.As<Transforms.Transforms>();
-            store(Transforms.As<IFeatureSchema>());
-
-            store(options.Events);
-            _features[typeof(StreamState)] = options.Events;
-            _features[typeof(EventStream)] = options.Events;
-            _features[typeof(IEvent)] = options.Events;
-
             
-           
+            Transforms = options.Transforms.As<Transforms.Transforms>();
         }
 
         public Transforms.Transforms Transforms { get; }
@@ -134,6 +124,17 @@ namespace Marten.Storage
 
         internal void PostProcessConfiguration()
         {
+            SystemFunctions.AddSystemFunction(_options, "mt_immutable_timestamp", "text");
+
+            store(SystemFunctions);
+
+            store(Transforms.As<IFeatureSchema>());
+
+            store(_options.Events);
+            _features[typeof(StreamState)] = _options.Events;
+            _features[typeof(EventStream)] = _options.Events;
+            _features[typeof(IEvent)] = _options.Events;
+
             _mappings[typeof(IEvent)] = new EventQueryMapping(_options);
 
             foreach (var mapping in _documentMappings.Values)

--- a/src/Marten/Storage/SystemFunctions.cs
+++ b/src/Marten/Storage/SystemFunctions.cs
@@ -15,8 +15,6 @@ namespace Marten.Storage
         public SystemFunctions(StoreOptions options)
         {
             _options = options;
-
-            AddSystemFunction(options, "mt_immutable_timestamp", "text");
         }
 
         public void AddSystemFunction(StoreOptions options, string name, string args)


### PR DESCRIPTION
Bug fixes pertaining to GH-837 and GH-864
1. Revert incorrect fix done earlier pertaining to GH-837
2. Fix storage logic to tweak the timing of use for db schema name
    - Moved the logic of adding mt_immutable_timestamp from SystemFunction constructor to StorageFeature.PostProcessConfiguration
    - Moved few initialization code from StorageFeature constructor into PostProcessConfiguration
3. Added an additional test for default db schema for 837.