### PR TITLE
Bug fix for query operand ordering

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_432_querying_with_UTC_times_with_offset.cs
+++ b/src/Marten.Testing/Bugs/Bug_432_querying_with_UTC_times_with_offset.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Baseline;
 using Baseline.Dates;
@@ -18,11 +18,9 @@ namespace Marten.Testing.Bugs
         [Fact]
         public void can_issue_queries_against_DateTime()
         {
-
-
             using (var session = theStore.LightweightSession())
             {
-                var now = DateTime.UtcNow.ToUniversalTime();
+                var now = GenerateTestDateTime();
                 _output.WriteLine("now: " + now.ToString("o"));
                 var testClass = new DateClass
                 {
@@ -78,7 +76,7 @@ namespace Marten.Testing.Bugs
 
             using (var session = theStore.LightweightSession())
             {
-                var now = DateTime.UtcNow.ToUniversalTime();
+                var now = GenerateTestDateTime();
                 _output.WriteLine("now: " + now.ToString("o"));
                 var testClass = new DateClass
                 {
@@ -134,7 +132,7 @@ namespace Marten.Testing.Bugs
 
             using (var session = theStore.LightweightSession())
             {
-                var now = DateTime.UtcNow.ToUniversalTime();
+                var now = GenerateTestDateTime();
                 _output.WriteLine("now: " + now.ToString("o"));
                 var testClass = new DateClass
                 {
@@ -190,7 +188,7 @@ namespace Marten.Testing.Bugs
 
             using (var session = theStore.LightweightSession())
             {
-                var now = DateTime.UtcNow;
+                var now = GenerateTestDateTime();
                 _output.WriteLine("now: " + now.ToString("o"));
                 var testClass = new DateClass
                 {
@@ -234,9 +232,9 @@ namespace Marten.Testing.Bugs
         {
             using (var session = theStore.LightweightSession())
             {
-                var now = DateTime.UtcNow;
+                var now = GenerateTestDateTime();
                 _output.WriteLine("now: " + now.ToString("o"));
-                var testClass = new DateOffsetClass()
+                var testClass = new DateOffsetClass
                 {
                     Id = Guid.NewGuid(),
                     DateTimeField = now
@@ -244,12 +242,12 @@ namespace Marten.Testing.Bugs
 
                 session.Store(testClass);
 
-                session.Store(new DateOffsetClass()
+                session.Store(new DateOffsetClass
                 {
                     DateTimeField = now.Add(5.Minutes())
                 });
 
-                session.Store(new DateOffsetClass()
+                session.Store(new DateOffsetClass
                 {
                     DateTimeField = now.Add(-5.Minutes())
                 });
@@ -280,9 +278,9 @@ namespace Marten.Testing.Bugs
 
             using (var session = theStore.LightweightSession())
             {
-                var now = DateTimeOffset.UtcNow;
+                var now = GenerateTestDateTime();
                 _output.WriteLine("now: " + now.ToString("o"));
-                var testClass = new DateOffsetClass()
+                var testClass = new DateOffsetClass
                 {
                     Id = Guid.NewGuid(),
                     DateTimeField = now
@@ -290,12 +288,12 @@ namespace Marten.Testing.Bugs
 
                 session.Store(testClass);
 
-                session.Store(new DateOffsetClass()
+                session.Store(new DateOffsetClass
                 {
                     DateTimeField = now.Add(5.Minutes())
                 });
 
-                session.Store(new DateOffsetClass()
+                session.Store(new DateOffsetClass
                 {
                     DateTimeField = now.Add(-5.Minutes())
                 });
@@ -319,7 +317,11 @@ namespace Marten.Testing.Bugs
             }
         }
 
-
+        private static DateTime GenerateTestDateTime()
+        {
+            var now = DateTime.UtcNow;
+            return now.AddTicks(-(now.Ticks % TimeSpan.TicksPerMillisecond));
+        }
     }
 
     public class DateClass

--- a/src/Marten.Testing/Linq/query_beginning_with_constant_Tests.cs
+++ b/src/Marten.Testing/Linq/query_beginning_with_constant_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Marten.Services;
 using Xunit;
 
@@ -28,7 +28,7 @@ namespace Marten.Testing.Linq
 
             theSession.SaveChanges();
 
-            theSession.Query<Target>().Where(x => 1 > x.Number).ToArray()
+            theSession.Query<Target>().Where(x => 1 < x.Number).ToArray()
                 .Select(x => x.Number)
                 .ShouldHaveTheSameElementsAs(2);
         }

--- a/src/Marten.Testing/Linq/query_with_modulo_Tests.cs
+++ b/src/Marten.Testing/Linq/query_with_modulo_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Marten.Services;
 using Xunit;
 
@@ -20,10 +20,27 @@ namespace Marten.Testing.Linq
 
             theSession.SaveChanges();
 
-            theSession.Query<Target>().Where(x => x.Number % 2 == 0 && x.Color == Colors.Blue).ToArray()
+            theSession.Query<Target>().Where(x => x.Number % 2 == 0 && x.Color < Colors.Green).ToArray()
                 .Select(x => x.Number)
                 .ShouldHaveTheSameElementsAs(2, 4);
         }
         // ENDSAMPLE
+
+        [Fact]
+        public void use_modulo_operands_reversed()
+        {
+            theSession.Store(new Target { Color = Colors.Blue, Number = 1 });
+            theSession.Store(new Target { Color = Colors.Blue, Number = 2 });
+            theSession.Store(new Target { Color = Colors.Blue, Number = 3 });
+            theSession.Store(new Target { Color = Colors.Blue, Number = 4 });
+            theSession.Store(new Target { Color = Colors.Blue, Number = 5 });
+            theSession.Store(new Target { Color = Colors.Green, Number = 6 });
+
+            theSession.SaveChanges();
+
+            theSession.Query<Target>().Where(x => 0 == x.Number % 2 && Colors.Green > x.Color).ToArray()
+                .Select(x => x.Number)
+                .ShouldHaveTheSameElementsAs(2, 4);
+        }
     }
 }

--- a/src/Marten/Linq/MartenExpressionParser.cs
+++ b/src/Marten/Linq/MartenExpressionParser.cs
@@ -144,8 +144,9 @@ namespace Marten.Linq
             }
             if (jsonLocatorExpression.NodeType == ExpressionType.Modulo)
             {
-                var moduloByValue = MartenExpressionParser.moduloByValue(binary);
-                return new WhereFragment("{0} % {1} {2} ?".ToFormat(jsonLocator, moduloByValue, op), value);
+                var byValue = moduloByValue((isValueExpressionOnRight ? binary.Left : binary.Right) as BinaryExpression);
+                var moduloFormat = isValueExpressionOnRight ? "{0} % {1} {2} ?" : "? {2} {0} % {1}";
+                return new WhereFragment(moduloFormat.ToFormat(jsonLocator, byValue, op), value);
             }
 
 			// ! == -> <>
@@ -154,7 +155,8 @@ namespace Marten.Linq
 		        op = _operators[ExpressionType.NotEqual];
 	        }
 
-            return new WhereFragment("{0} {1} ?".ToFormat(jsonLocator, op), value);
+            var whereFormat = isValueExpressionOnRight ? "{0} {1} ?" : "? {1} {0}";
+            return new WhereFragment(whereFormat.ToFormat(jsonLocator, op), value);
         }
 
         private IWhereFragment buildChildCollectionQuery(IQueryableDocument mapping, QueryModel query, Expression valueExpression, string op)
@@ -174,8 +176,7 @@ namespace Marten.Linq
 
         private static object moduloByValue(BinaryExpression binary)
         {
-            var moduloExpression = binary.Left as BinaryExpression;
-            var moduloValueExpression = moduloExpression?.Right as ConstantExpression;
+            var moduloValueExpression = binary?.Right as ConstantExpression;
             return moduloValueExpression != null ? moduloValueExpression.Value : 1;
         }
     }


### PR DESCRIPTION
Found an issue with operand ordering.

For example if you had 
```csharp
x => x.ValidFrom < now && now < x.ValidTo
```
as your query clause the generated SQL would be
```sql
where (public.mt_immutable_timestamp(d.data ->> 'ValidFrom') < $1)
and (public.mt_immutable_timestamp(d.data ->> 'ValidTo') < $2)
```
which would yield entirely incorrect results.

Simply reversing the operands in the second clause yields the correct results.
```csharp
x => x.ValidFrom < now && x.ValidTo > now
```
```sql
where (public.mt_immutable_timestamp(d.data ->> 'ValidFrom') < $1)
and (public.mt_immutable_timestamp(d.data ->> 'ValidTo') > $2)
```

Corrected some tests that were relying on the behaviour.