### PR TITLE
Compiled Queries - Adds support for fields in query filters

### DIFF
--- a/src/Marten.Testing/Linq/Compiled/compiled_query_Tests.cs
+++ b/src/Marten.Testing/Linq/Compiled/compiled_query_Tests.cs
@@ -60,6 +60,18 @@ namespace Marten.Testing.Linq.Compiled
             UserByUsername.Count.ShouldBe(1);
         }
 
+        [Fact]
+        public void a_single_item_compiled_query_with_fields()
+        {
+            UserByUsernameWithFields.Count = 0;
+
+            var user = theSession.Query(new UserByUsernameWithFields { UserName = "myusername" });
+            user.ShouldNotBeNull();
+            var differentUser = theSession.Query(new UserByUsernameWithFields { UserName = "jdm" });
+            differentUser.UserName.ShouldBe("jdm");
+            UserByUsernameWithFields.Count.ShouldBe(1);
+        }
+
 
         [Fact]
         public void a_single_item_compiled_query_SingleOrDefault()
@@ -150,6 +162,21 @@ namespace Marten.Testing.Linq.Compiled
             differentUsers.Count().ShouldBe(2);
             UsersByFirstName.Count.ShouldBe(1);
         }
+
+        [Fact]
+        public void a_list_query_with_fields_compiled()
+        {
+            UsersByFirstNameWithFields.Count = 0;
+
+            var users = theSession.Query(new UsersByFirstNameWithFields { FirstName = "Jeremy" }).ToList();
+            users.Count.ShouldBe(2);
+            users.ElementAt(0).UserName.ShouldBe("jdm");
+            users.ElementAt(1).UserName.ShouldBe("shadetreedev");
+            var differentUsers = theSession.Query(new UsersByFirstNameWithFields { FirstName = "Jeremy" });
+            differentUsers.Count().ShouldBe(2);
+            UsersByFirstNameWithFields.Count.ShouldBe(1);
+        }
+
 
         [Fact]
         public async Task a_list_query_compiled_async()
@@ -282,6 +309,19 @@ namespace Marten.Testing.Linq.Compiled
         }
     }
 
+    public class UserByUsernameWithFields : ICompiledQuery<User>
+    {
+        public static int Count;
+        public string UserName;
+
+        public Expression<Func<IQueryable<User>, User>> QueryIs()
+        {
+            Count++;
+            return query => query.Where(x => x.UserName == UserName)
+                .FirstOrDefault();
+        }
+    }
+
     public class UserByUsernameSingleOrDefault : ICompiledQuery<User>
     {
         public static int Count;
@@ -310,6 +350,18 @@ namespace Marten.Testing.Linq.Compiled
     }
     // ENDSAMPLE
 
+    public class UsersByFirstNameWithFields : ICompiledListQuery<User>
+    {
+        public static int Count;
+        public string FirstName;
+
+        public Expression<Func<IQueryable<User>, IEnumerable<User>>> QueryIs()
+        {
+            // Ignore this line, it's from a unit test;)
+            Count++;
+            return query => query.Where(x => x.FirstName == FirstName);
+        }
+    }
 
     // SAMPLE: UserNamesForFirstName
     public class UserNamesForFirstName : ICompiledListQuery<User, string>

--- a/src/Marten/Linq/Compiled/CompiledQueryMemberExpressionVisitor.cs
+++ b/src/Marten/Linq/Compiled/CompiledQueryMemberExpressionVisitor.cs
@@ -75,16 +75,27 @@ namespace Marten.Linq.Compiled
 
 	    protected override Expression VisitMember(MemberExpression node)
         {
-            _lastMember = _mapping.FieldFor(new MemberInfo[] { node.Member });
+            _lastMember = _mapping.FieldFor(new[] { node.Member });
 
-            if (node.NodeType == ExpressionType.MemberAccess && node.Member.DeclaringType == _queryType)
+            if (node.NodeType != ExpressionType.MemberAccess || node.Member.DeclaringType != _queryType)
+                return base.VisitMember(node);
+
+            string methodName;
+            switch (node.Member)
             {
-                var property = (PropertyInfo)node.Member;
-
-                var method = GetType().GetMethod(nameof(CreateParameterSetter), BindingFlags.Instance | BindingFlags.NonPublic).MakeGenericMethod(_queryType, property.PropertyType);
-                var result = (IDbParameterSetter)method.Invoke(this, new[] { property });
-                ParameterSetters.Add(result);
+                case PropertyInfo _:
+                    methodName = nameof(CreatePropertyParameterSetter);
+                    break;
+                case FieldInfo _:
+                    methodName = nameof(CreateFieldParameterSetter);
+                    break;
+                default:
+                    throw new NotSupportedException("Only Property or Field is supported for query parameter");
             }
+            var method = GetType()
+                .GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
+                .MakeGenericMethod(_queryType);
+            ParameterSetters.Add((IDbParameterSetter) method.Invoke(this, new[] {node.Member}));
 
             return base.VisitMember(node);
         }
@@ -127,15 +138,24 @@ namespace Marten.Linq.Compiled
             }
         }
 
-        private IDbParameterSetter CreateParameterSetter<TObject, TProperty>(PropertyInfo property)
+        private IDbParameterSetter CreatePropertyParameterSetter<TObject>(PropertyInfo property)
         {
-            var getter = LambdaBuilder.GetProperty<TObject, object>(property);
-            if (property.PropertyType.GetTypeInfo().IsEnum && _serializer.EnumStorage == EnumStorage.AsString)
+            return CreateParameterSetter(property.PropertyType, LambdaBuilder.GetProperty<TObject, object>(property));
+        }
+
+        private IDbParameterSetter CreateFieldParameterSetter<TObject>(FieldInfo field)
+        {
+            return CreateParameterSetter(field.FieldType, LambdaBuilder.GetField<TObject, object>(field));
+        }
+
+        private IDbParameterSetter CreateParameterSetter<TObject>(Type type, Func<TObject, object> getter)
+        {
+            if (type.GetTypeInfo().IsEnum && _serializer.EnumStorage == EnumStorage.AsString)
             {
                 getter = o =>
                 {
                     var number = getter(o);
-                    return Enum.GetName(property.PropertyType, number);
+                    return Enum.GetName(type, number);
                 };
             }
 


### PR DESCRIPTION
In the marten [docs for compiled queries](http://jasperfx.github.io/marten/documentation/documents/querying/compiled_queries/) it states that properties and fields can be used in the query filter.  This currently works fine for properties but when a field is used this exception is raised:
```
Exception has occurred: CLR/System.InvalidCastException
An unhandled exception of type 'System.InvalidCastException' occurred in Marten.dll: 'Unable to cast object of type 'System.Reflection.RtFieldInfo' to type 'System.Reflection.PropertyInfo'.'
   at Marten.Linq.Compiled.CompiledQueryMemberExpressionVisitor.VisitMember(MemberExpression node)
```
This is because the CompiledQueryMemberExpressionVisitor is expecting only properties. This PR adds support for fields as well as properties. I believe this is what is being referred to in issue #604 


