### PR TITLE
Test and possible fix for FK and sub-classes exception #877

### DIFF
--- a/src/Marten.Testing/Bugs/SubClassForeignKeyBugs.cs
+++ b/src/Marten.Testing/Bugs/SubClassForeignKeyBugs.cs
@@ -1,0 +1,51 @@
+﻿using Marten.Services;
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+    public class SubClassForeignKeyBugs : IntegratedFixture
+    {
+        public class Person
+        {
+            public int Id { get; set; }
+        }
+
+        public class Employee : Person
+        {
+        }
+
+        public class Address
+        {
+            public int Id { get; set; }
+            public int ParentId { get; set; }
+        }
+        
+        public SubClassForeignKeyBugs()
+        {
+            StoreOptions(_ =>
+            {
+                _.Schema.For<Person>()
+                    .AddSubClass<Employee>();
+
+                _.Schema.For<Address>()
+                    .ForeignKey<Person>(c => c.ParentId);
+            });
+        }
+
+        [Fact]
+        public void ForeignKeysOnDerivedClassesShouldBeInsertedFirst()
+        {
+            using (var session = theStore.OpenSession())
+            {
+                // Creating an employee with an address - the employee object should be
+                // inserted *before* the address object.
+                var employee = new Employee {Id = 222};
+                session.Store(employee);
+                var address = new Address {ParentId = 222, Id = 42};
+                session.Store(address);
+
+                session.SaveChanges();
+            }
+        }
+    }
+}

--- a/src/Marten.Testing/Bugs/SubClassForeignKeyBugs.cs
+++ b/src/Marten.Testing/Bugs/SubClassForeignKeyBugs.cs
@@ -8,6 +8,7 @@ namespace Marten.Testing.Bugs
         public class Person
         {
             public int Id { get; set; }
+            public int DepartmentId { get; set; }
         }
 
         public class Employee : Person
@@ -19,13 +20,19 @@ namespace Marten.Testing.Bugs
             public int Id { get; set; }
             public int ParentId { get; set; }
         }
+     
+        public class Department
+        {
+            public int Id { get; set; }
+        }
         
         public SubClassForeignKeyBugs()
         {
             StoreOptions(_ =>
             {
                 _.Schema.For<Person>()
-                    .AddSubClass<Employee>();
+                    .AddSubClass<Employee>()
+                    .ForeignKey<Department>(p => p.DepartmentId);
 
                 _.Schema.For<Address>()
                     .ForeignKey<Person>(c => c.ParentId);
@@ -33,17 +40,38 @@ namespace Marten.Testing.Bugs
         }
 
         [Fact]
-        public void ForeignKeysOnDerivedClassesShouldBeInsertedFirst()
+        public void ForeignKeyEntitiesToSubClassesShouldBeInsertedFirst()
         {
+            using (var session = theStore.OpenSession())
+            {
+                var department = new Department {Id = 37};
+                session.Store(department);
+                session.SaveChanges();
+            }
             using (var session = theStore.OpenSession())
             {
                 // Creating an employee with an address - the employee object should be
                 // inserted *before* the address object.
-                var employee = new Employee {Id = 222};
+                var employee = new Employee {Id = 222, DepartmentId = 37};
                 session.Store(employee);
                 var address = new Address {ParentId = 222, Id = 42};
                 session.Store(address);
 
+                session.SaveChanges();
+            }
+        }
+
+        [Fact]
+        public void ForeignKeysOnSubClassesShouldInsertedFirst()
+        {
+            using (var session = theStore.OpenSession())
+            {
+                var department = new Department {Id = 1};
+                session.Store(department);
+
+                var employee = new Employee {Id = 2, DepartmentId = 1};
+                session.Store(employee);
+                
                 session.SaveChanges();
             }
         }

--- a/src/Marten/Services/UnitOfWork.cs
+++ b/src/Marten/Services/UnitOfWork.cs
@@ -237,7 +237,8 @@ namespace Marten.Services
 
         private IEnumerable<Type> GetTypeDependencies(Type type)
         {
-            var documentMapping = _tenant.MappingFor(type) as DocumentMapping;
+            var mappingFor = _tenant.MappingFor(type);
+            var documentMapping = mappingFor as DocumentMapping ?? (mappingFor as SubClassMapping)?.Parent;
             if (documentMapping == null)
                 return Enumerable.Empty<Type>();
 


### PR DESCRIPTION
Comment copied from #877:

I've spotted an issue when an entity has a ForeignKey setup to an entity that defines SubClasses.  It's equally possible I am doing something wrong!

e.g.
Given this setup...
```
        public class Person
        {
            public int Id { get; set; }
        }

        public class Employee : Person
        {
        }

        public class Address
        {
            public int Id { get; set; }
            public int ParentId { get; set; }
        }

        // STORE OPTIONS
        _.Schema.For<Person>()
            .AddSubClass<Employee>();

        _.Schema.For<Address>()
            .ForeignKey<Person>(c => c.ParentId);
```
When executing this code....
```
        using (var session = theStore.OpenSession())
        {
           // Creating an employee with an address - the employee object should be
           // inserted *before* the address object.
           var employee = new Employee {Id = 222};
           session.Store(employee);
           var address = new Address {ParentId = 222, Id = 42};
           session.Store(address);
           session.SaveChanges();
       }
```
I get a FK exception raised when SaveChanges is called.
I've done a bit of debugging, and I think that the issue is in `UnitOfWork.GetTypeDependencies` function.  When the 'Address' mapping is examined, it see `Person` as a dependency, but not 'Employee', so it attempts to insert the address before the employee.

I've added an integration test for this and a possible fix, although it makes `GetTypeDependencies` more expensive, so it's possibly something that should be calculated when the store is setup.  It might be that a unit test would be better for this, although I don't think the dependency information is exposed from `UnitOfWork` at the moment.

Please let me know if you want/need more info, or anything changed in the commit.  More than happy to help if I can.
