### PR TITLE
Check existence of schemas only once per feature & storage given that…

### DIFF
--- a/src/Marten.Testing/Schema/auto_create_schema_should_ensure_storage_only_once.cs
+++ b/src/Marten.Testing/Schema/auto_create_schema_should_ensure_storage_only_once.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Linq;
+using Marten.Testing.Schema.Identity.Sequences;
+using Xunit;
+
+namespace Marten.Testing.Schema
+{
+    public class auto_create_schema_should_ensure_storage_only_once
+    {
+        // This test looks a bit funny, as the path that registeres a feature checked
+        // in case of no schema patches does not log anything. Exposing something in ITenant
+        // just for testing does not feel right either.
+        [Fact]
+        public void EnsureFeatureIsRecordedAsCheckedOnCreation()
+        {
+            var dllLog = new DdlLogger();
+            using (var store = DocumentStore.For(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.CreateOrUpdate;
+                _.Connection(ConnectionSource.ConnectionString);
+                _.Logger(dllLog);
+            }))
+            {
+                store.Advanced.Clean.CompletelyRemoveAll();
+
+                using (var store2 = DocumentStore.For(_ =>
+                {
+                    _.Connection(ConnectionSource.ConnectionString);
+                }))
+                {
+
+                    // Store issues a command to verify & create event store schemas
+                    using (var s = store.OpenSession())
+                    {
+                        s.Events.FetchStreamState(Guid.NewGuid());
+                    }
+
+                    // Second store clears schemas (needs the second store as cleanup clears schema checks too)
+                    store2.Advanced.Clean.CompletelyRemoveAll();
+
+                    // Path to check schemas should not be executed -> exception
+                    var e = Assert.Throws<MartenCommandException>(() =>
+                    {
+                        using (var s = store.OpenSession())
+                        {
+                            s.Events.FetchStreamState(Guid.NewGuid());
+                        }
+                    });
+
+                    Assert.Contains("relation \"public.mt_streams\" does not exist", e.Message);
+                    // We should have enabled the feature, i.e. also generated & executed DDL
+                    Assert.True(dllLog.Sql.Any(x => x.IndexOf("mt_append_event") > -1));
+                }
+            }
+        }
+
+        [Fact]
+        public void EnsureCheckCanBeRemoved()
+        {
+            var dllLog = new DdlLogger();
+            using (var store = DocumentStore.For(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.CreateOrUpdate;
+                _.Connection(ConnectionSource.ConnectionString);
+                _.Logger(dllLog);
+            }))
+            {
+                store.Advanced.Clean.CompletelyRemoveAll();
+
+                using (var s = store.OpenSession())
+                {
+                    s.Events.FetchStreamState(Guid.NewGuid());
+                }
+
+                using (var store2 = DocumentStore.For(_ =>
+                {
+                    _.Connection(ConnectionSource.ConnectionString);
+                }))
+                {
+
+                    store2.Advanced.Clean.CompletelyRemoveAll();
+                }
+
+                store.Tenancy.Default.ResetSchemaExistenceChecks();
+                using (var s = store.OpenSession())
+                {
+                    s.Events.FetchStreamState(Guid.NewGuid());
+                }
+
+                // We have created mt_append_event more than once
+                Assert.True(dllLog.Sql.Count(x => x.IndexOf("mt_append_event") > -1) > 1);
+            }
+        }
+    }
+}

--- a/src/Marten.Testing/StoreOptionsTests.cs
+++ b/src/Marten.Testing/StoreOptionsTests.cs
@@ -16,6 +16,14 @@ namespace Marten.Testing
     public class StoreOptionsTests
     {
         [Fact]
+        public void CannotBuildStoreWithoutConnection()
+        {
+            var e = Assert.Throws<InvalidOperationException>(() => DocumentStore.For(_ => { }));
+
+            Assert.Contains("Tenancy not specified", e.Message);
+        }
+
+        [Fact]
         public void PLV8Enabled_is_true_by_default()
         {
             new StoreOptions().PLV8Enabled.ShouldBeTrue();

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -68,10 +68,10 @@ namespace Marten
         /// </summary>
         /// <param name="options"></param>
         public DocumentStore(StoreOptions options)
-        {
+        {            
             options.ApplyConfiguration();
             options.CreatePatching();
-
+            options.Validate();
             Options = options;
 
             _logger = options.Logger();

--- a/src/Marten/Storage/Tenant.cs
+++ b/src/Marten/Storage/Tenant.cs
@@ -133,18 +133,27 @@ namespace Marten.Storage
                         {
                             cmd.ExecuteNonQuery();
                             _options.Logger().SchemaChange(ddl);
-                            _checks[featureType] = true;
-                            if (feature.StorageType != featureType)
-                            {
-                                _checks[feature.StorageType] = true;
-                            }
+                            RegisterCheck(featureType, feature);
                         }
                         catch (Exception e)
                         {
                             throw new MartenCommandException(cmd, e);
                         }
                     }
+                    else if (patch.Difference == SchemaPatchDifference.None)
+                    {
+                        RegisterCheck(featureType, feature);
+                    }
                 }
+            }
+        }
+
+        private void RegisterCheck(Type featureType, IFeatureSchema feature)
+        {
+            _checks[featureType] = true;
+            if (feature.StorageType != featureType)
+            {
+                _checks[feature.StorageType] = true;
             }
         }
 

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -288,6 +288,17 @@ namespace Marten
         }
 
         /// <summary>
+        /// Validate that minimal options to initialize a document store have been specified
+        /// </summary>
+        internal void Validate()
+        {
+            if (Tenancy == null)
+            {
+                throw new InvalidOperationException("Tenancy not specified - provide either connection string or connection factory through Connection(..)");
+            }
+        }
+
+        /// <summary>
         /// Apply conventional policies to how documents are mapped
         /// </summary>
         public PoliciesExpression Policies => new PoliciesExpression(this);


### PR DESCRIPTION
… they're found. Previously these checks were always run, at least for the event store, on all the operations that ensured storage existence (given that AutoCreate.None was not used). Now, if schema comparison results in SchemaPatchDifference.None, feature (and its storage) will be registered as checked and not subsequently checked unless schema checks are cleared.

Note that version <=2.2 had a bug, whereby mt_append_event schema comparison failed, resulting in the code path that registered EventGraph feature as checked to be executed. 2.3 fixed the said schema comparison bug with the side effect that EventGraph schema comparison would always be executed on the event store operations.

In short, this should have very positive performance impact.

Piggybacking tiny usability fix: if trying to instantiate store without cstring or connection factory, give a meaningful exception message, instead of NRE.