### PR TITLE
Add a step to validate document for identity field before storage

### DIFF
--- a/src/Marten.Testing/Documents/InvalidDocument.cs
+++ b/src/Marten.Testing/Documents/InvalidDocument.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Marten.Testing.Documents
+{
+    // this document does not have an identity field
+    public class InvalidDocument
+    {
+        public string Name { get; set; }
+    }
+}

--- a/src/Marten.Testing/Storage/DocumentTableTester.cs
+++ b/src/Marten.Testing/Storage/DocumentTableTester.cs
@@ -356,5 +356,16 @@ namespace Marten.Testing.Storage
             ddl.ShouldContain("DROP TABLE IF EXISTS public.mt_doc_user CASCADE;");
             ddl.ShouldContain("CREATE TABLE public.mt_doc_user");
         }
+
+        [Fact]
+        public void invalid_document_should_throw_exception()
+        {
+            var docs = DocumentMapping.For<InvalidDocument>();
+
+            var ex =
+                Exception<InvalidDocumentException>.ShouldBeThrownBy(
+                    () => new DocumentTable(docs));
+            ex.Message.ShouldContain($"Could not determine an 'id/Id' field or property for requested document type {typeof(InvalidDocument).FullName}");
+        }
     }
 }

--- a/src/Marten/Storage/DocumentTable.cs
+++ b/src/Marten/Storage/DocumentTable.cs
@@ -11,6 +11,9 @@ namespace Marten.Storage
     {
         public DocumentTable(DocumentMapping mapping) : base(mapping.Table)
         {
+            // validate to ensure document has an Identity field or property
+            mapping.Validate();
+
             var pgIdType = TypeMappings.GetPgType(mapping.IdMember.GetMemberType());
             var pgTextType = TypeMappings.GetPgType(string.Empty.GetType());
 


### PR DESCRIPTION
- Add logic to validate document to ensure identity field exists in the document table constructor before storage. This will throw an appropriate InvalidDocument exception rather than a cryptic ArgumentNullException
- Add unit test