### PR TITLE
Move most of BinaryExpression parsing out of MartenExpressionParser as…

### DIFF
--- a/src/Marten.Storyteller/Fixtures/LinqFixture.cs
+++ b/src/Marten.Storyteller/Fixtures/LinqFixture.cs
@@ -90,6 +90,12 @@ namespace Marten.Storyteller.Fixtures
             expression(x => x.Date >= today, "x.Date >= Today");
             expression(x => x.Date <= today, "x.Date <= Today");
 
+            expression(x => !(x.Number == 1));
+            expression(x => !(x.Number > 3));
+            expression(x => !(x.Number < 3));
+            expression(x => !(x.Number <= 3));
+            expression(x => !(x.Number >= 3));
+            expression(x => !(x.Number != 3));
 
             AddSelectionValues("Expressions", _wheres.Keys.ToArray());
 
@@ -102,7 +108,7 @@ namespace Marten.Storyteller.Fixtures
         {
             if (key.IsEmpty())
             {
-                key = @where.As<LambdaExpression>().Body.ToString().TrimStart('(').TrimEnd(')').Replace(") AndAlso (", " && ").Replace(") OrElse (", " || ");
+                key = @where.As<LambdaExpression>().Body.ToString().TrimStart('(').TrimEnd(')').Replace("Not((", "Not ").Replace(") AndAlso (", " && ").Replace(") OrElse (", " || ");
             }
             _wheres.Add(key, where);
         }

--- a/src/Marten.Storyteller/Specs/Linq Queries/Basic_NOT_node_comparisons_on_a_single_integer_property.md
+++ b/src/Marten.Storyteller/Specs/Linq Queries/Basic_NOT_node_comparisons_on_a_single_integer_property.md
@@ -1,0 +1,32 @@
+# Basic NOT node comparisons on a single integer property
+
+-> id = 4574a4a5-0ecc-4e20-a9b2-04339126a793
+-> lifecycle = Acceptance
+-> max-retries = 0
+-> last-updated = 2017-10-17T12:51:07.7426468Z
+-> tags = 
+
+[Linq]
+|> TheDocumentsAre
+    [Rows]
+    -> String = False
+    -> Long = False
+    |Name|Number|Flag |Double|Decimal|Date |InnerFlag|
+    |A   |1     |false|1     |1      |TODAY|False    |
+    |B   |2     |false|1     |1      |TODAY|False    |
+    |C   |3     |false|1     |1      |TODAY|False    |
+    |D   |4     |false|1     |1      |TODAY|False    |
+    |E   |5     |false|1     |1      |TODAY|False    |
+    |F   |6     |false|1     |1      |TODAY|False    |
+
+|> ExecutingQuery
+    [table]
+    |WhereClause      |Results      |
+    |Not x.Number == 1|B, C, D, E, F|
+    |Not x.Number > 3 |A, B, C      |
+    |Not x.Number < 3 |C, D, E, F   |
+    |Not x.Number <= 3|D, E, F      |
+    |Not x.Number >= 3|A, B         |
+    |Not x.Number != 3|C            |
+
+~~~

--- a/src/Marten/Linq/ContainmentWhereFragment.cs
+++ b/src/Marten/Linq/ContainmentWhereFragment.cs
@@ -13,17 +13,19 @@ namespace Marten.Linq
     public class ContainmentWhereFragment : IWhereFragment
     {
         private readonly IDictionary<string, object> _dictionary;
+        private readonly string _wherePrefix;
         private readonly ISerializer _serializer;
 
 
-        public ContainmentWhereFragment(ISerializer serializer, IDictionary<string, object> dictionary)
+        public ContainmentWhereFragment(ISerializer serializer, IDictionary<string, object> dictionary, string wherePrefix = null)
         {
             _serializer = serializer;
             _dictionary = dictionary;
+            _wherePrefix = wherePrefix;
         }
 
-        public ContainmentWhereFragment(ISerializer serializer, BinaryExpression binary)
-            : this(serializer, new Dictionary<string, object>())
+        public ContainmentWhereFragment(ISerializer serializer, BinaryExpression binary, string wherePrefix = null)
+            : this(serializer, new Dictionary<string, object>(), wherePrefix)
         {
             CreateDictionaryForSearch(binary, _dictionary);
         }
@@ -34,7 +36,7 @@ namespace Marten.Linq
             var param = builder.AddParameter(json);
             param.NpgsqlDbType = NpgsqlDbType.Jsonb;
 
-            builder.Append("d.data @> :");
+            builder.Append($"{_wherePrefix}d.data @> :");
             builder.Append(param.ParameterName);
         }
 

--- a/src/Marten/Linq/Parsing/IExpressionParser.cs
+++ b/src/Marten/Linq/Parsing/IExpressionParser.cs
@@ -1,0 +1,21 @@
+using System.Linq.Expressions;
+using Marten.Schema;
+
+namespace Marten.Linq.Parsing
+{
+    public interface IExpressionParser<in T> where T : Expression
+    {
+        /// <summary>
+        /// Can this parser create a Sql where clause
+        /// from part of a Linq expression
+        /// </summary>        
+        bool Matches(T expression);
+
+        /// <summary>
+        /// Creates an IWhereFragment object that Marten
+        /// uses to help construct the underlying Sql
+        /// command
+        /// </summary>
+        IWhereFragment Parse(IQueryableDocument mapping, ISerializer serializer, T expression);
+    }
+}

--- a/src/Marten/Linq/Parsing/SimpleBinaryComparisonExpressionParser.cs
+++ b/src/Marten/Linq/Parsing/SimpleBinaryComparisonExpressionParser.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Baseline;
+using Marten.Schema;
+
+namespace Marten.Linq.Parsing
+{
+    public class SimpleBinaryComparisonExpressionParser : IExpressionParser<BinaryExpression>
+    {
+        private readonly string _isOperator;
+        private readonly string _wherePrefix;
+
+        private static readonly IDictionary<ExpressionType, string> _operators = new Dictionary<ExpressionType, string>
+        {
+            {ExpressionType.Equal, "="},
+            {ExpressionType.NotEqual, "!="},
+            {ExpressionType.GreaterThan, ">"},
+            {ExpressionType.GreaterThanOrEqual, ">="},
+            {ExpressionType.LessThan, "<"},
+            {ExpressionType.LessThanOrEqual, "<="}
+        };
+
+        public SimpleBinaryComparisonExpressionParser(string isOperator = "is", string wherePrefix = null)
+        {
+            _isOperator = isOperator;
+            _wherePrefix = wherePrefix;
+        }
+
+        public bool Matches(BinaryExpression expression)
+        {
+            return expression.Type == typeof(bool) && _operators.ContainsKey(expression.NodeType);
+        }
+
+        public IWhereFragment Parse(IQueryableDocument mapping, ISerializer serializer, BinaryExpression expression)
+        {
+            var isValueExpressionOnRight = expression.Right.IsValueExpression();
+            var jsonLocatorExpression = isValueExpressionOnRight ? expression.Left : expression.Right;
+            var valueExpression = isValueExpressionOnRight ? expression.Right : expression.Left;
+
+            var members = FindMembers.Determine(jsonLocatorExpression);
+
+            var field = mapping.FieldFor(members);
+
+
+            var value = field.GetValue(valueExpression);
+            var jsonLocator = field.SqlLocator;
+
+            var useContainment = mapping.PropertySearching == PropertySearching.ContainmentOperator || field.ShouldUseContainmentOperator();
+
+            var isDuplicated = (mapping.FieldFor(members) is DuplicatedField);
+
+            if (useContainment &&
+                expression.NodeType == ExpressionType.Equal && value != null && !isDuplicated)
+            {
+                return new ContainmentWhereFragment(serializer, expression, _wherePrefix);
+            }
+
+
+            if (value == null)
+            {
+                var sql = expression.NodeType == ExpressionType.NotEqual
+                    ? $"({jsonLocator}) is not null"
+                    : $"({jsonLocator}) {_isOperator} null";
+
+                return new WhereFragment(sql);
+            }
+
+            var op = _operators[expression.NodeType];
+
+            if (jsonLocatorExpression.NodeType == ExpressionType.Modulo)
+            {
+                var byValue = moduloByValue((isValueExpressionOnRight ? expression.Left : expression.Right) as BinaryExpression);
+                var moduloFormat = isValueExpressionOnRight ? "{0} % {1} {2} ?" : "? {2} {0} % {1}";
+                return new WhereFragment(moduloFormat.ToFormat(jsonLocator, byValue, op), value);
+            }
+
+            // ! == -> <>
+            
+            if (expression.Left.NodeType == ExpressionType.Not && expression.NodeType == ExpressionType.Equal)
+            {
+                op = _operators[ExpressionType.NotEqual];
+            }
+
+            var whereFormat = isValueExpressionOnRight ? "{0} {1} ?" : "? {1} {0}";
+            return new WhereFragment($"{_wherePrefix}{whereFormat.ToFormat(jsonLocator, op)}", value);
+
+           
+            return value == null ? new WhereFragment($"({jsonLocator}) {_isOperator} null") : new WhereFragment($"{_wherePrefix}({jsonLocator}) {op} ?", value);
+        }
+        private static object moduloByValue(BinaryExpression binary)
+        {
+            var moduloValueExpression = binary?.Right as ConstantExpression;
+            return moduloValueExpression != null ? moduloValueExpression.Value : 1;
+        }
+    }
+}

--- a/src/Marten/Linq/Parsing/SimpleBinaryNotNodeComparisonExpressionParser.cs
+++ b/src/Marten/Linq/Parsing/SimpleBinaryNotNodeComparisonExpressionParser.cs
@@ -1,0 +1,9 @@
+namespace Marten.Linq.Parsing
+{
+    public class SimpleBinaryNotNodeComparisonExpressionParser : SimpleBinaryComparisonExpressionParser
+    {
+        public SimpleBinaryNotNodeComparisonExpressionParser() : base("is not", "not ")
+        {
+        }
+    }
+}


### PR DESCRIPTION
… per todo item.

Generalize that parsing to enable Linq support for binary comparison expressions on NOT nodes.
Storysteller spec to exercise said queries (!(x op value) for ==, >, >=, <, <=, !=).