### PR TITLE
Add possibility to inject classes to projection

### DIFF
--- a/documentation/documentation/events/projections/custom.md
+++ b/documentation/documentation/events/projections/custom.md
@@ -15,3 +15,12 @@ or through a class like:
 `ProjectEvent` and `DeleteEvent` can operate on events that need a single or multiple Ids operated on. With `ProjectEvent` if a `List<TId>` is passed, the handler method will be called for each Id in the collection. With `DeleteEvent` if a `List<TId>` is passed, then each document tied to the Id in the collection will be removed. Each of these methods take various overloads that allow selecting the Id field implicitly, through a property or through two different Funcs `Func<IDocumentSession, TEvent, TId>` and `Func<TEvent, TId>`. 
  
 If additional Marten event details are needed, then events can use the `ProjectionEvent<>` generic when setting them up with `ProjectEvent`. `ProjectionEvent` exposes the Marten Id, Version, Timestamp and Data.
+
+Projections are created during the DocumentStore creation by default. Marten gives also possible to register them with factory method. With such registration projections are created on runtime during the events application. Thanks to that it's possible to setup custom creation logic or event connect dependency injection mechanism.
+
+<[sample:viewprojection-from-class-with-injection-configuration]> 
+
+By convention it's needed to provide the default constructor with projections definition and other with code injection (that calls the default constructor).
+
+<[sample:viewprojection-from-class-with-injection]> 
+

--- a/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
+++ b/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
@@ -38,7 +38,7 @@ namespace Marten.Testing.Events.Projections
                 ProjectEvent<QuestPaused>(@event => @event.QuestId, LogAndPersist);
             }
 
-            public PersistViewProjectionWithInjection(Logger logger)
+            public PersistViewProjectionWithInjection(Logger logger) : this()
             {
                 this.logger = logger;
             }

--- a/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
+++ b/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using Marten.Services;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Events.Projections
+{
+    public class lazy_loaded_projection : DocumentSessionFixture<IdentityMap>
+    {
+        public class Logger
+        {
+            public List<string> Logs { get; } = new List<string>();
+
+            public void Log(string message)
+            {
+                Logs.Add(message);
+            }
+        }
+
+        public class QuestPaused
+        {
+            public string Name { get; set; }
+            public Guid Id { get; set; }
+
+            public override string ToString()
+            {
+                return $"Quest {Name} paused";
+            }
+        }
+
+        public class PersistViewProjectionWithInjection : PersistViewProjection
+        {
+            private readonly Logger logger;
+
+            public PersistViewProjectionWithInjection() : base()
+            {
+                ProjectEvent<QuestPaused>(@event => @event.Id, LogAndPersist);
+            }
+
+            public PersistViewProjectionWithInjection(Logger logger)
+            {
+            }
+
+            private void LogAndPersist<T>(PersistedView view, T @event)
+            {
+                logger.Log($"Handled {typeof(T).Name} event: {@event.ToString()}");
+                view.Events.Add(@event);
+            }
+        }
+
+        private static readonly Guid streamId = Guid.NewGuid();
+
+        private QuestStarted started = new QuestStarted { Id = streamId, Name = "Find the Orb" };
+        private MembersJoined joined = new MembersJoined { QuestId = streamId, Day = 2, Location = "Faldor's Farm", Members = new[] { "Garion", "Polgara", "Belgarath" } };
+        private QuestPaused paused = new QuestPaused { Id = streamId, Name = "Find the Orb" };
+
+        [Fact]
+        public async void from_projection()
+        {
+            var logger = new Logger();
+
+            StoreOptions(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
+                _.Events.InlineProjections.Add(() => new PersistViewProjectionWithInjection(logger));
+            });
+
+            theSession.Events.StartStream<QuestParty>(streamId, started, joined);
+            theSession.SaveChanges();
+
+            var document = theSession.Load<PersistedView>(streamId);
+            document.Events.Count.ShouldBe(2);
+            logger.Logs.Count.ShouldBe(0);
+
+            //check injection
+            theSession.Events.Append(streamId, paused);
+            theSession.SaveChanges();
+
+            var document2 = theSession.Load<PersistedView>(streamId);
+            document.Events.Count.ShouldBe(3);
+
+            logger.Logs.Count.ShouldBe(1);
+        }
+    }
+}

--- a/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
+++ b/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
@@ -21,7 +21,7 @@ namespace Marten.Testing.Events.Projections
         public class QuestPaused
         {
             public string Name { get; set; }
-            public Guid Id { get; set; }
+            public Guid QuestId { get; set; }
 
             public override string ToString()
             {
@@ -35,7 +35,7 @@ namespace Marten.Testing.Events.Projections
 
             public PersistViewProjectionWithInjection() : base()
             {
-                ProjectEvent<QuestPaused>(@event => @event.Id, LogAndPersist);
+                ProjectEvent<QuestPaused>(@event => @event.QuestId, LogAndPersist);
             }
 
             public PersistViewProjectionWithInjection(Logger logger)
@@ -53,7 +53,7 @@ namespace Marten.Testing.Events.Projections
 
         private QuestStarted started = new QuestStarted { Id = streamId, Name = "Find the Orb" };
         private MembersJoined joined = new MembersJoined { QuestId = streamId, Day = 2, Location = "Faldor's Farm", Members = new[] { "Garion", "Polgara", "Belgarath" } };
-        private QuestPaused paused = new QuestPaused { Id = streamId, Name = "Find the Orb" };
+        private QuestPaused paused = new QuestPaused { QuestId = streamId, Name = "Find the Orb" };
 
         [Fact]
         public async void from_projection()

--- a/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
+++ b/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
@@ -40,6 +40,7 @@ namespace Marten.Testing.Events.Projections
 
             public PersistViewProjectionWithInjection(Logger logger)
             {
+                this.logger = logger;
             }
 
             private void LogAndPersist<T>(PersistedView view, T @event)

--- a/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
+++ b/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
@@ -79,7 +79,7 @@ namespace Marten.Testing.Events.Projections
             theSession.SaveChanges();
 
             var document2 = theSession.Load<PersistedView>(streamId);
-            document.Events.Count.ShouldBe(3);
+            document2.Events.Count.ShouldBe(3);
 
             logger.Logs.Count.ShouldBe(1);
         }

--- a/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
+++ b/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
@@ -57,7 +57,7 @@ namespace Marten.Testing.Events.Projections
         private QuestPaused paused = new QuestPaused { QuestId = streamId, Name = "Find the Orb" };
 
         [Fact]
-        public async void from_projection()
+        public void from_projection()
         {
             var logger = new Logger();
 

--- a/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
+++ b/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
@@ -29,6 +29,7 @@ namespace Marten.Testing.Events.Projections
             }
         }
 
+        // SAMPLE: viewprojection-from-class-with-injection
         public class PersistViewProjectionWithInjection : PersistViewProjection
         {
             private readonly Logger logger;
@@ -49,6 +50,7 @@ namespace Marten.Testing.Events.Projections
                 view.Events.Add(@event);
             }
         }
+        // ENDSAMPLE
 
         private static readonly Guid streamId = Guid.NewGuid();
 
@@ -61,12 +63,14 @@ namespace Marten.Testing.Events.Projections
         {
             var logger = new Logger();
 
+            // SAMPLE: viewprojection-from-class-with-injection-configuration
             StoreOptions(_ =>
             {
                 _.AutoCreateSchemaObjects = AutoCreate.All;
                 _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
                 _.Events.InlineProjections.Add(() => new PersistViewProjectionWithInjection(logger));
             });
+            // ENDSAMPLE
 
             theSession.Events.StartStream<QuestParty>(streamId, started, joined);
             theSession.SaveChanges();

--- a/src/Marten/Events/Projections/LazyLoadedProjection.cs
+++ b/src/Marten/Events/Projections/LazyLoadedProjection.cs
@@ -29,9 +29,9 @@ namespace Marten.Events.Projections
             factory().Apply(session, page);
         }
 
-        public async Task ApplyAsync(IDocumentSession session, EventPage page, CancellationToken token)
+        public Task ApplyAsync(IDocumentSession session, EventPage page, CancellationToken token)
         {
-            await factory().ApplyAsync(session, page, token);
+            return factory().ApplyAsync(session, page, token);
         }
 
         public void EnsureStorageExists(ITenant tenant)

--- a/src/Marten/Events/Projections/LazyLoadedProjection.cs
+++ b/src/Marten/Events/Projections/LazyLoadedProjection.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Events.Projections.Async;
+using Marten.Storage;
+
+namespace Marten.Events.Projections
+{
+    public class LazyLoadedProjection<T> : IProjection
+        where T : IProjection, new()
+    {
+        private readonly Func<T> factory;
+
+        public LazyLoadedProjection(Func<T> factory)
+        {
+            this.factory = factory;
+            var definition = new T();
+
+            Consumes = definition.Consumes;
+            AsyncOptions = definition.AsyncOptions;
+        }
+
+        public Type[] Consumes { get; }
+
+        public AsyncOptions AsyncOptions { get; }
+
+        public void Apply(IDocumentSession session, EventPage page)
+        {
+            factory().Apply(session, page);
+        }
+
+        public async Task ApplyAsync(IDocumentSession session, EventPage page, CancellationToken token)
+        {
+            await factory().ApplyAsync(session, page, token);
+        }
+
+        public void EnsureStorageExists(ITenant tenant)
+        {
+            factory().EnsureStorageExists(tenant);
+        }
+    }
+}

--- a/src/Marten/Events/Projections/ProjectionCollection.cs
+++ b/src/Marten/Events/Projections/ProjectionCollection.cs
@@ -3,6 +3,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
+using System.Reflection;
+
 namespace Marten.Events.Projections
 {
     public class ProjectionCollection : IEnumerable<IProjection>
@@ -66,7 +68,7 @@ namespace Marten.Events.Projections
 
             if (lazyLoadedProjection == null) throw new ArgumentNullException(nameof(lazyLoadedProjection));
 
-            if (typeof(T).IsAssignableFrom(typeof(IDocumentProjection)))
+            if (typeof(T).GetTypeInfo().IsAssignableFrom(typeof(IDocumentProjection).GetTypeInfo()))
             {
                 _options.Storage.MappingFor(lazyLoadedProjection.ProjectedType());
             }

--- a/src/Marten/Events/Projections/ProjectionCollection.cs
+++ b/src/Marten/Events/Projections/ProjectionCollection.cs
@@ -26,9 +26,8 @@ namespace Marten.Events.Projections
         }
 
         public AggregationProjection<T> AggregateStreamsWith<T>() where T : class, new()
-        {            
+        {
             var aggregator = _options.Events.AggregateFor<T>();
-
 
             IAggregationFinder<T> finder = _options.Events.StreamIdentity == StreamIdentity.AsGuid
                 ? (IAggregationFinder<T>)new AggregateFinder<T>()
@@ -57,8 +56,22 @@ namespace Marten.Events.Projections
             {
                 _options.Storage.MappingFor(projection.ProjectedType());
             }
-            
+
             _projections.Add(projection);
+        }
+
+        public void Add<T>(Func<T> projectionFactory) where T : IProjection, new()
+        {
+            var lazyLoadedProjection = new LazyLoadedProjection<T>(projectionFactory);
+
+            if (lazyLoadedProjection == null) throw new ArgumentNullException(nameof(lazyLoadedProjection));
+
+            if (typeof(T) is IDocumentProjection)
+            {
+                _options.Storage.MappingFor(lazyLoadedProjection.ProjectedType());
+            }
+
+            _projections.Add(lazyLoadedProjection);
         }
 
         public IProjection ForView(Type viewType)

--- a/src/Marten/Events/Projections/ProjectionCollection.cs
+++ b/src/Marten/Events/Projections/ProjectionCollection.cs
@@ -66,7 +66,7 @@ namespace Marten.Events.Projections
 
             if (lazyLoadedProjection == null) throw new ArgumentNullException(nameof(lazyLoadedProjection));
 
-            if (typeof(T) is IDocumentProjection)
+            if (typeof(T).IsAssignableFrom(typeof(IDocumentProjection)))
             {
                 _options.Storage.MappingFor(lazyLoadedProjection.ProjectedType());
             }

--- a/src/Marten/Events/Projections/ProjectionCollection.cs
+++ b/src/Marten/Events/Projections/ProjectionCollection.cs
@@ -62,6 +62,11 @@ namespace Marten.Events.Projections
             _projections.Add(projection);
         }
 
+        public void Add<T>() where T : IProjection, new()
+        {
+            Add(new T());
+        }
+
         public void Add<T>(Func<T> projectionFactory) where T : IProjection, new()
         {
             var lazyLoadedProjection = new LazyLoadedProjection<T>(projectionFactory);


### PR DESCRIPTION
# Description
Currently it's impossible to inject classes to Projection. Although I understand that it's not be the indented usage, to use other classes in event handler, from pragmatic point it's sometimes needed (at least in my usage scenarios). Imho it would be nice to have possibility to add Projection that is not created immediately, but when the projection is being applied.

## Type of change

Added new method to [ProjectionCollection](https://github.com/JasperFx/marten/tree/master/src/Marten/Events/Projections/ProjectionCollection.cs) class:

```
public void Add<T>(Func<T> projectionFactory) where T : IProjection, new()
```
it allows to pass factory method for the projection. Having that it can be even reused to allow Dependency Injection eg. 

```
public static void Add<TProjection>(this ProjectionCollection projectionCollection, IServiceProvider serviceProvider) where TProjection : IProjection, new()
{
        projectionCollection.Add(new LazyLoadedViewProjection<TProjection>(() => serviceProvider.GetService<TProjection>()));
}
```

Added also new type of projection: `LazyLoadedProjection<T>`. It's just simple wrapper for the projection. It passes projection options and uses factory method to create instance of the wrapped Projection during the call of Apply Method.

 [x] New feature (non-breaking change)

# How Has This Been Tested?

Added new [test](src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs)

- [x] lazy_loaded_projection.from_projection
  
P.S
I'm using these classes in my commercial projects already
  