### PR TITLE
Fix casing of various words

### DIFF
--- a/documentation/splash.htm
+++ b/documentation/splash.htm
@@ -53,10 +53,10 @@
                 <a href="https://ci.appveyor.com/project/jasper-ci/marten/history" onclick = $("#menu-close").click(); >AppVeyor</a>
             </li>
             <li>
-                <a href="https://www.nuget.org/packages/Marten/" onclick = $("#menu-close").click(); >Nuget Downloads</a>
+                <a href="https://www.nuget.org/packages/Marten/" onclick = $("#menu-close").click(); >NuGet Downloads</a>
             </li>
             <li>
-              <a href="https://github.com/jasperfx/marten/blob/master/documentation/<[FilePath]>"  class="fa fa-github"> Edit on GitHub</a>
+              <a href="https://github.com/jasperfx/marten/blob/master/documentation/<[FilePath]>"  class="fa fa-github">Edit on GitHub</a>
             </li>
 
         </ul>
@@ -67,9 +67,9 @@
         <div class="text-vertical-center">
 			<img src="http://jasperfx.github.io/marten/content/images/banner.png" width="80%" align="middle"/>
             <h1 style="color:white">Marten</h1>
-            <h3>Postgresql as Document Db &amp; Event Store for .Net Development</h3>
+            <h3>PostgreSQL as Document Db &amp; Event Store for .NET Development</h3>
 
-                    <h2>Polyglot Persistence for .Net Systems using the Rock Solid Postgresql Database</h2>
+                    <h2>Polyglot Persistence for .NET Systems using the Rock Solid PostgreSQL Database</h2>
                     <p class="lead">
                         <a href="https://ci.appveyor.com/project/jasper-ci/marten/history"><img src="https://img.shields.io/appveyor/ci/jasper-ci/marten.svg"></img></a>
                         <a href="https://www.nuget.org/packages/Marten/"><img src="https://img.shields.io/nuget/v/Marten.svg"></img></a>
@@ -103,7 +103,7 @@
         <div class="col-md-1"></div>
         <div class="col-md-4">
           <h2>Document Database</h2>
-          <p>The Marten library provides .Net developers with the ability to easily use the proven <a href="http://www.postgresql.org">Postgresql database engine</a>
+          <p>The Marten library provides .NET developers with the ability to easily use the proven <a href="http://www.postgresql.org">PostgreSQL database engine</a>
 and its <a href="https://www.compose.io/articles/is-postgresql-your-next-json-database/">fantastic JSON support</a> as a fully fledged <a href="https://en.wikipedia.org/wiki/Document-oriented_database">document database</a>. The Marten team believes that a document database has far reaching benefits for developer productivity
 over relational databases with or without an ORM tool.
           </p>
@@ -112,8 +112,8 @@ over relational databases with or without an ORM tool.
         <div class="col-md-2"></div>
         <div class="col-md-4">
           <h2>Event Store</h2>
-          <p>Event Sourcing can be a powerful technique in applications that are workflow centric or have any need for historical queries. Marten utilizes the strong JSONB support to expose an ACID-compliant event store implementation over the Postgresql database. Even better yet, Marten
-            takes advantage of Postgresql's embedded Javascript support to enable effective user-defined projections against your event streams.</p>
+          <p>Event Sourcing can be a powerful technique in applications that are workflow centric or have any need for historical queries. Marten utilizes the strong JSONB support to expose an ACID-compliant event store implementation over the PostgreSQL database. Even better yet, Marten
+            takes advantage of PostgreSQL's embedded JavaScript support to enable effective user-defined projections against your event streams.</p>
           <p><a class="btn btn-default" href="<[linkto:documentation/events;{href}]>" role="button">View details &raquo;</a></p>
        </div>
       </div>


### PR DESCRIPTION
Javascript => JavaScript, .Net => .NET, Nuget => NuGet, Postgresql => PostgreSQL.