### PR TITLE
make LazyLoadedProjection play nicer with async daemon

### DIFF
--- a/src/Marten/Events/Projections/LazyLoadedProjection.cs
+++ b/src/Marten/Events/Projections/LazyLoadedProjection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Events.Projections.Async;
@@ -6,10 +7,10 @@ using Marten.Storage;
 
 namespace Marten.Events.Projections
 {
-    public class LazyLoadedProjection<T> : IProjection
+    public class LazyLoadedProjection<T> : IProjection, IDocumentsProjection
         where T : IProjection, new()
     {
-        private readonly Func<T> factory;
+        private readonly Func<T> factory;        
 
         public LazyLoadedProjection(Func<T> factory)
         {
@@ -18,6 +19,9 @@ namespace Marten.Events.Projections
 
             Consumes = definition.Consumes;
             AsyncOptions = definition.AsyncOptions;
+            Produces = (definition as IDocumentsProjection)?.Produces;
+            if (Produces?.Any() != true && definition is IDocumentProjection documentProjection)
+                Produces = new[] {documentProjection.Produces};
         }
 
         public Type[] Consumes { get; }
@@ -38,5 +42,8 @@ namespace Marten.Events.Projections
         {
             factory().EnsureStorageExists(tenant);
         }
+
+
+        public Type[] Produces { get; }        
     }
 }


### PR DESCRIPTION
before this change, the async daemon is not able to clear the storage before replaying all events.

it looks for storage table for the projection itself, not taking into consideration that the projection might not be an aggregate one. 

note: the test included proves it to some point only. 
before the change (when the LazyLoadedProjection didn't implemented `IDocumentsProjection`), the test runned forever instead of failing.

There seem to be some other issue making the `Daemon.RebuildAll` Task to never complete (instead of fail) when there's an exception in `DocumentMapping.Validate`. But this is kind of an async hell so I didn't manage to dig into it. the only way you can tell there was a problem is by intercepting async daemon messages (there'll be a message with a validation exception)