### PR TITLE
Added Conjoined tenancy style to event store

### DIFF
--- a/src/Marten.Testing/Events/Projections/Async/MultidocumentProjectionTests.cs
+++ b/src/Marten.Testing/Events/Projections/Async/MultidocumentProjectionTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Marten.Events.Projections;
 using Marten.Events.Projections.Async;
+using Marten.Storage;
 using Shouldly;
 using Xunit;
 
@@ -23,7 +24,7 @@ namespace Marten.Testing.Events.Projections.Async
         public class CompanyNameChanged
         {
             public Guid Id { get; set; }
-            public string NewName { get; set; }            
+            public string NewName { get; set; }
         }
 
         public class OrderPlaced
@@ -32,7 +33,7 @@ namespace Marten.Testing.Events.Projections.Async
             public Guid CompanyId { get; set; }
             public decimal TotalAmount { get; set; }
             public string[] Items { get; set; }
-        }        
+        }
     }
 
     public static class ReadModels
@@ -49,7 +50,7 @@ namespace Marten.Testing.Events.Projections.Async
     public static class Projections
     {
         /// <summary>
-        /// A projection which uses multiple streams and manages several document types: main Read Model it's builiding and 
+        /// A projection which uses multiple streams and manages several document types: main Read Model it's builiding and
         /// a side-readmodel used as a kind of helper
         /// </summary>
         public class OrderProjection : DocumentsProjection
@@ -69,11 +70,11 @@ namespace Marten.Testing.Events.Projections.Async
                     CompanyName = company?.Name,
                     TotalAmount = created.TotalAmount,
                     CompanyId = created.CompanyId
-                });             
+                });
             }
 
             private void When(IDocumentSession session, Events.CompanyCreated created)
-            {                
+            {
                 session.Store(new CompanySideReadModel()
                 {
                     Id = created.Id,
@@ -89,15 +90,16 @@ namespace Marten.Testing.Events.Projections.Async
                 session.Store(company);
 
                 session.Patch<ReadModels.Order>(x => x.CompanyId == changed.Id)
-                    .Set(x => x.CompanyName, changed.NewName);                
+                    .Set(x => x.CompanyName, changed.NewName);
             }
 
-            #region Infrastructure and dispatching                       
-            public override Type[] Consumes => new[] {typeof(Events.CompanyCreated), typeof(Events.OrderPlaced), typeof(Events.CompanyNameChanged)};
+            #region Infrastructure and dispatching
+
+            public override Type[] Consumes => new[] { typeof(Events.CompanyCreated), typeof(Events.OrderPlaced), typeof(Events.CompanyNameChanged) };
 
             public override Type[] Produces => new[] { typeof(ReadModels.Order), typeof(CompanySideReadModel) };
 
-            public override AsyncOptions AsyncOptions { get; } = new AsyncOptions();          
+            public override AsyncOptions AsyncOptions { get; } = new AsyncOptions();
 
             public override void Apply(IDocumentSession session, EventPage page)
             {
@@ -113,21 +115,24 @@ namespace Marten.Testing.Events.Projections.Async
                         case Events.CompanyCreated created:
                             When(session, created);
                             break;
+
                         case Events.OrderPlaced placed:
                             When(session, placed);
                             break;
+
                         case Events.CompanyNameChanged changed:
                             When(session, changed);
                             break;
                     }
                     await session.SaveChangesAsync(token).ConfigureAwait(false);
-                }                
+                }
             }
-            #endregion
-        }
-    }   
 
-    public class MultidocumentProjectionTests: IntegratedFixture
+            #endregion Infrastructure and dispatching
+        }
+    }
+
+    public class MultidocumentProjectionTests : IntegratedFixture
     {
         private static readonly Guid Company1Id = new Guid("5713D147-8D8E-499A-8CDF-ECEFF867D810");
         private static readonly Guid Company2Id = new Guid("18F5DE28-6027-4638-9D4F-496A5F29FB22");
@@ -135,13 +140,16 @@ namespace Marten.Testing.Events.Projections.Async
         private static readonly Guid Order1Id = new Guid("C7F3F4B6-EDA9-4C5B-A0CF-6AE15EB83DEA");
         private static readonly Guid Order2Id = new Guid("367C1343-3A03-4888-A706-CA237B3CA020");
         private static readonly Guid Order3Id = new Guid("C3B5A850-92A1-449C-8653-B51BB56C84A3");
-        
-        [Fact]
-        public async Task Build_Projection_From_Stream()
+
+        [Theory]
+        [InlineData(TenancyStyle.Single)]
+        [InlineData(TenancyStyle.Conjoined)]
+        public async Task Build_Projection_From_Stream(TenancyStyle tenancyStyle)
         {
-            StoreOptions(cfg =>
+            StoreOptions(_ =>
             {
-                cfg.Events.AsyncProjections.Add(new Projections.OrderProjection());
+                _.Events.AsyncProjections.Add(new Projections.OrderProjection());
+                _.Events.TenancyStyle = tenancyStyle;
             });
 
             var daemon = theStore.BuildProjectionDaemon(logger: new DebugDaemonLogger());
@@ -152,13 +160,13 @@ namespace Marten.Testing.Events.Projections.Async
 
             using (var session = theStore.OpenSession())
             {
-                var order1 = session.Load<ReadModels.Order>(Order1Id);                
+                var order1 = session.Load<ReadModels.Order>(Order1Id);
                 var order2 = session.Load<ReadModels.Order>(Order2Id);
-                var order3 = session.Load<ReadModels.Order>(Order3Id);                
+                var order3 = session.Load<ReadModels.Order>(Order3Id);
 
-                order1.CompanyName.ShouldBe("Mexico Railways");                
+                order1.CompanyName.ShouldBe("Mexico Railways");
                 order2.CompanyName.ShouldBe("Mexico Railways");
-                
+
                 order3.CompanyName.ShouldBe("Microsoft");
             }
         }
@@ -195,7 +203,7 @@ namespace Marten.Testing.Events.Projections.Async
             await daemon.WaitForNonStaleResults();
             using (var session = theStore.OpenSession())
             {
-                var order2 = session.Load<ReadModels.Order>(Order1Id);                
+                var order2 = session.Load<ReadModels.Order>(Order1Id);
                 order2.CompanyName.ShouldBe("Mexico Railways");
                 order2.ShouldNotBeTheSameAs(order1);
             }
@@ -207,7 +215,7 @@ namespace Marten.Testing.Events.Projections.Async
             {
                 foreach (var @event in GetEvents())
                 {
-                    var id = (Guid) @event.GetType() .GetTypeInfo().GetProperty("Id").GetValue(@event);
+                    var id = (Guid)@event.GetType().GetTypeInfo().GetProperty("Id").GetValue(@event);
                     sess.Events.Append(id, @event);
                     await sess.SaveChangesAsync();
                 }

--- a/src/Marten.Testing/Events/Projections/appending_events_and_storing.cs
+++ b/src/Marten.Testing/Events/Projections/appending_events_and_storing.cs
@@ -1,26 +1,27 @@
-using Shouldly;
-using Marten.Services;
-using Npgsql;
-using Xunit;
 using System;
-using Marten.Events.Projections;
-using Marten.Events;
-using System.Threading;
 using System.Linq;
-using Marten.Events.Projections.Async;
+using System.Threading;
 using System.Threading.Tasks;
+using Marten.Events.Projections;
+using Marten.Events.Projections.Async;
+using Marten.Services;
 using Marten.Storage;
+using Shouldly;
+using Xunit;
 
 namespace Marten.Testing.Events
 {
     public class appending_events_and_storing : DocumentSessionFixture<IdentityMap>
-    {    
-        [Fact]
-        public void patch_inside_inline_projection_does_not_error_during_savechanges()
+    {
+        [Theory]
+        [InlineData(TenancyStyle.Single)]
+        [InlineData(TenancyStyle.Conjoined)]
+        public void patch_inside_inline_projection_does_not_error_during_savechanges(TenancyStyle tenancyStyle)
         {
             StoreOptions(_ =>
             {
                 _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.Events.TenancyStyle = tenancyStyle;
                 _.Events.InlineProjections.Add(new QuestPatchTestProjection());
             });
 

--- a/src/Marten.Testing/Events/Projections/custom_transformation_of_events.cs
+++ b/src/Marten.Testing/Events/Projections/custom_transformation_of_events.cs
@@ -9,20 +9,20 @@ namespace Marten.Testing.Events.Projections
 {
     public class project_events_from_multiple_streams_into_view : DocumentSessionFixture<IdentityMap>
     {
-        static readonly Guid streamId = Guid.NewGuid();
-        static readonly Guid streamId2 = Guid.NewGuid();
+        private static readonly Guid streamId = Guid.NewGuid();
+        private static readonly Guid streamId2 = Guid.NewGuid();
 
-        QuestStarted started = new QuestStarted { Id = streamId, Name = "Find the Orb" };
-        QuestStarted started2 = new QuestStarted { Id = streamId2, Name = "Find the Orb 2.0" };
-        MonsterQuestsAdded monsterQuestsAdded = new MonsterQuestsAdded { QuestIds = new List<Guid> { streamId, streamId2 }, Name = "Dragon" };
-        MonsterQuestsRemoved monsterQuestsRemoved = new MonsterQuestsRemoved { QuestIds = new List<Guid> { streamId, streamId2 }, Name = "Dragon" };
-        QuestEnded ended = new QuestEnded { Id = streamId, Name = "Find the Orb" };
-        MembersJoined joined = new MembersJoined { QuestId = streamId, Day = 2, Location = "Faldor's Farm", Members = new[] { "Garion", "Polgara", "Belgarath" } };
-        MonsterSlayed slayed1 = new MonsterSlayed { QuestId = streamId, Name = "Troll" };
-        MonsterSlayed slayed2 = new MonsterSlayed { QuestId = streamId, Name = "Dragon" };
-        MonsterDestroyed destroyed = new MonsterDestroyed { QuestId = streamId, Name = "Troll" };
-        MembersDeparted departed = new MembersDeparted { QuestId = streamId, Day = 5, Location = "Sendaria", Members = new[] { "Silk", "Barak" } };
-        MembersJoined joined2 = new MembersJoined { QuestId = streamId, Day = 5, Location = "Sendaria", Members = new[] { "Silk", "Barak" } };
+        private QuestStarted started = new QuestStarted { Id = streamId, Name = "Find the Orb" };
+        private QuestStarted started2 = new QuestStarted { Id = streamId2, Name = "Find the Orb 2.0" };
+        private MonsterQuestsAdded monsterQuestsAdded = new MonsterQuestsAdded { QuestIds = new List<Guid> { streamId, streamId2 }, Name = "Dragon" };
+        private MonsterQuestsRemoved monsterQuestsRemoved = new MonsterQuestsRemoved { QuestIds = new List<Guid> { streamId, streamId2 }, Name = "Dragon" };
+        private QuestEnded ended = new QuestEnded { Id = streamId, Name = "Find the Orb" };
+        private MembersJoined joined = new MembersJoined { QuestId = streamId, Day = 2, Location = "Faldor's Farm", Members = new[] { "Garion", "Polgara", "Belgarath" } };
+        private MonsterSlayed slayed1 = new MonsterSlayed { QuestId = streamId, Name = "Troll" };
+        private MonsterSlayed slayed2 = new MonsterSlayed { QuestId = streamId, Name = "Dragon" };
+        private MonsterDestroyed destroyed = new MonsterDestroyed { QuestId = streamId, Name = "Troll" };
+        private MembersDeparted departed = new MembersDeparted { QuestId = streamId, Day = 5, Location = "Sendaria", Members = new[] { "Silk", "Barak" } };
+        private MembersJoined joined2 = new MembersJoined { QuestId = streamId, Day = 5, Location = "Sendaria", Members = new[] { "Silk", "Barak" } };
 
         [Fact]
         public void from_configuration()
@@ -30,6 +30,7 @@ namespace Marten.Testing.Events.Projections
             StoreOptions(_ =>
             {
                 _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.Events.TenancyStyle = Marten.Storage.TenancyStyle.Conjoined;
                 _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
                 _.Events.ProjectView<PersistedView, Guid>()
                     .ProjectEvent<QuestStarted>((view, @event) => view.Events.Add(@event))
@@ -84,7 +85,7 @@ namespace Marten.Testing.Events.Projections
         [Fact]
         public async void from_configuration_async()
         {
-            // SAMPLE: viewprojection-from-configuration 
+            // SAMPLE: viewprojection-from-configuration
             StoreOptions(_ =>
             {
                 _.AutoCreateSchemaObjects = AutoCreate.All;
@@ -97,7 +98,7 @@ namespace Marten.Testing.Events.Projections
                     .DeleteEvent<MembersDeparted>(e => e.QuestId)
                     .DeleteEvent<MonsterDestroyed>((session, e) => session.Load<QuestParty>(e.QuestId).Id);
             });
-            // ENDSAMPLE 
+            // ENDSAMPLE
 
             theSession.Events.StartStream<QuestParty>(streamId, started, joined);
             await theSession.SaveChangesAsync();
@@ -323,7 +324,7 @@ namespace Marten.Testing.Events.Projections
         public List<object> Events { get; } = new List<object>();
     }
 
-    // SAMPLE: viewprojection-from-class 
+    // SAMPLE: viewprojection-from-class
     public class PersistViewProjection : ViewProjection<PersistedView, Guid>
     {
         public PersistViewProjection()
@@ -341,5 +342,6 @@ namespace Marten.Testing.Events.Projections
             view.Events.Add(@event);
         }
     }
-    // ENDSAMPLE 
+
+    // ENDSAMPLE
 }

--- a/src/Marten.Testing/Events/Projections/inline_aggregation_by_stream_with_multiples.cs
+++ b/src/Marten.Testing/Events/Projections/inline_aggregation_by_stream_with_multiples.cs
@@ -4,31 +4,34 @@ using System.Linq;
 using System.Threading.Tasks;
 using Baseline;
 using Marten.Services;
+using Marten.Storage;
 using Xunit;
 
 namespace Marten.Testing.Events.Projections
 {
     public class inline_aggregation_by_stream_with_multiples : DocumentSessionFixture<NulloIdentityMap>
     {
-        QuestStarted started = new QuestStarted {Name = "Find the Orb"};
-        MembersJoined joined = new MembersJoined {Day = 2, Location = "Faldor's Farm", Members = new string[] {"Garion", "Polgara", "Belgarath"}};
-        MonsterSlayed slayed1 = new MonsterSlayed {Name = "Troll"};        
-        MonsterSlayed slayed2 = new MonsterSlayed {Name = "Dragon"};  
-        
-        MembersJoined joined2 = new MembersJoined {Day = 5, Location = "Sendaria", Members = new string[] {"Silk", "Barak"}};
+        private QuestStarted started = new QuestStarted { Name = "Find the Orb" };
+        private MembersJoined joined = new MembersJoined { Day = 2, Location = "Faldor's Farm", Members = new string[] { "Garion", "Polgara", "Belgarath" } };
+        private MonsterSlayed slayed1 = new MonsterSlayed { Name = "Troll" };
+        private MonsterSlayed slayed2 = new MonsterSlayed { Name = "Dragon" };
+
+        private MembersJoined joined2 = new MembersJoined { Day = 5, Location = "Sendaria", Members = new string[] { "Silk", "Barak" } };
 
         public inline_aggregation_by_stream_with_multiples()
         {
-
         }
 
-        [Fact]
-        public void run_multiple_aggregates_sync()
+        [Theory]
+        [InlineData(TenancyStyle.Single)]
+        [InlineData(TenancyStyle.Conjoined)]
+        public void run_multiple_aggregates_sync(TenancyStyle tenancyStyle)
         {
             // SAMPLE: registering-quest-party
             var store = DocumentStore.For(_ =>
             {
                 _.Connection(ConnectionSource.ConnectionString);
+                _.Events.TenancyStyle = tenancyStyle;
 
                 // This is all you need to create the QuestParty projected
                 // view

--- a/src/Marten.Testing/Events/Projections/inline_transformation_of_events.cs
+++ b/src/Marten.Testing/Events/Projections/inline_transformation_of_events.cs
@@ -5,6 +5,7 @@ using Baseline;
 using Marten.Events;
 using Marten.Events.Projections;
 using Marten.Services;
+using Marten.Storage;
 using Shouldly;
 using Xunit;
 
@@ -12,20 +13,22 @@ namespace Marten.Testing.Events.Projections
 {
     public class inline_transformation_of_events : DocumentSessionFixture<NulloIdentityMap>
     {
-        QuestStarted started = new QuestStarted { Name = "Find the Orb" };
-        MembersJoined joined = new MembersJoined { Day = 2, Location = "Faldor's Farm", Members = new string[] { "Garion", "Polgara", "Belgarath" } };
-        MonsterSlayed slayed1 = new MonsterSlayed { Name = "Troll" };
-        MonsterSlayed slayed2 = new MonsterSlayed { Name = "Dragon" };
+        private QuestStarted started = new QuestStarted { Name = "Find the Orb" };
+        private MembersJoined joined = new MembersJoined { Day = 2, Location = "Faldor's Farm", Members = new string[] { "Garion", "Polgara", "Belgarath" } };
+        private MonsterSlayed slayed1 = new MonsterSlayed { Name = "Troll" };
+        private MonsterSlayed slayed2 = new MonsterSlayed { Name = "Dragon" };
 
-        MembersJoined joined2 = new MembersJoined { Day = 5, Location = "Sendaria", Members = new string[] { "Silk", "Barak" } };
+        private MembersJoined joined2 = new MembersJoined { Day = 5, Location = "Sendaria", Members = new string[] { "Silk", "Barak" } };
 
-        [Fact]
-        public void sync_projection_of_events()
+        [Theory]
+        [InlineData(TenancyStyle.Single)]
+        [InlineData(TenancyStyle.Conjoined)]
+        public void sync_projection_of_events(TenancyStyle tenancyStyle)
         {
             StoreOptions(_ =>
             {
                 _.AutoCreateSchemaObjects = AutoCreate.All;
-
+                _.Events.TenancyStyle = tenancyStyle;
                 _.Events.InlineProjections.TransformEvents(new MonsterDefeatedTransform());
             });
 
@@ -70,7 +73,6 @@ namespace Marten.Testing.Events.Projections
             });
         }
 
-
         [Fact]
         public async Task async_projection_of_events()
         {
@@ -82,8 +84,6 @@ namespace Marten.Testing.Events.Projections
                 _.Events.InlineProjections.TransformEvents(new MonsterDefeatedTransform());
             });
             // ENDSAMPLE
-
-
 
             // The code below is just customizing the document store
             // used in the tests
@@ -108,7 +108,6 @@ namespace Marten.Testing.Events.Projections
                 doc.Monster.ShouldBe(e.Data.Name);
             }
         }
-
     }
 
     // SAMPLE: MonsterDefeatedTransform
@@ -129,5 +128,6 @@ namespace Marten.Testing.Events.Projections
         public Guid Id { get; set; }
         public string Monster { get; set; }
     }
+
     // ENDSAMPLE
 }

--- a/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
+++ b/src/Marten.Testing/Events/Projections/lazy_loaded_projection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Marten.Services;
+using Marten.Storage;
 using Shouldly;
 using Xunit;
 
@@ -50,6 +51,7 @@ namespace Marten.Testing.Events.Projections
                 view.Events.Add(@event);
             }
         }
+
         // ENDSAMPLE
 
         private static readonly Guid streamId = Guid.NewGuid();
@@ -58,8 +60,10 @@ namespace Marten.Testing.Events.Projections
         private MembersJoined joined = new MembersJoined { QuestId = streamId, Day = 2, Location = "Faldor's Farm", Members = new[] { "Garion", "Polgara", "Belgarath" } };
         private QuestPaused paused = new QuestPaused { QuestId = streamId, Name = "Find the Orb" };
 
-        [Fact]
-        public void from_projection()
+        [Theory]
+        [InlineData(TenancyStyle.Single)]
+        [InlineData(TenancyStyle.Conjoined)]
+        public void from_projection(TenancyStyle tenancyStyle)
         {
             var logger = new Logger();
 
@@ -67,6 +71,7 @@ namespace Marten.Testing.Events.Projections
             StoreOptions(_ =>
             {
                 _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.Events.TenancyStyle = tenancyStyle;
                 _.Events.InlineProjections.AggregateStreamsWith<QuestParty>();
                 _.Events.InlineProjections.Add(() => new PersistViewProjectionWithInjection(logger));
             });

--- a/src/Marten.Testing/Events/Utils/MultipleActionCheck.cs
+++ b/src/Marten.Testing/Events/Utils/MultipleActionCheck.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+
+namespace Marten.Testing.Events.Utils
+{
+    internal static class When
+    {
+        public static MultipleActionCheck<T> CalledForEach<T>(IEnumerable<T> elements, Action<T, int> action)
+        {
+            return new MultipleActionCheck<T>(elements, action);
+        }
+
+        public static MultipleActionCheck<T> CalledForEachAsync<T>(IEnumerable<T> elements, Func<T, int, Task> action)
+        {
+            return new MultipleActionCheck<T>(elements, action);
+        }
+    }
+
+    internal class MultipleActionCheck<T>
+    {
+        private readonly T[] elements;
+        private readonly Action<T, int> action;
+        private readonly Func<T, int, Task> asyncAction;
+
+        internal MultipleActionCheck(IEnumerable<T> elements, Action<T, int> action)
+        {
+            this.elements = elements.ToArray();
+            this.action = action;
+        }
+
+        internal MultipleActionCheck(IEnumerable<T> elements, Func<T, int, Task> asyncAction)
+        {
+            this.elements = elements.ToArray();
+            this.asyncAction = asyncAction;
+        }
+
+        public void ShouldSucceed()
+        {
+            Should.NotThrow(() => PerformAction());
+        }
+
+        public Task ShouldSucceedAsync()
+        {
+            return PerformActionAsync();
+        }
+
+        public Exception ShouldThrowIf(bool check)
+        {
+            if (!check)
+            {
+                ShouldSucceed();
+                return null;
+            }
+
+            return Should.Throw<Exception>(() => PerformAction());
+        }
+
+        public async Task<Exception> ShouldThrowIfAsync(bool check)
+        {
+            if (!check)
+            {
+                await ShouldSucceedAsync();
+                return null;
+            }
+
+            return await Should.ThrowAsync<Exception>(PerformActionAsync());
+        }
+
+        private void PerformAction()
+        {
+            for (var i = 0; i < elements.Length; i++)
+            {
+                action(elements[i], i);
+            }
+        }
+
+        private async Task PerformActionAsync()
+        {
+            for (var i = 0; i < elements.Length; i++)
+            {
+                await asyncAction(elements[i], i);
+            }
+        }
+    }
+}

--- a/src/Marten.Testing/Events/delete_single_event_stream.cs
+++ b/src/Marten.Testing/Events/delete_single_event_stream.cs
@@ -1,15 +1,20 @@
 ﻿using System;
 using System.Linq;
 using Marten.Events;
+using Marten.Storage;
 using Xunit;
 
 namespace Marten.Testing.Events
 {
     public class delete_single_event_stream : IntegratedFixture
     {
-        [Fact]
-        public void delete_stream_by_guid_id()
+        [Theory]
+        [InlineData(TenancyStyle.Single)]
+        [InlineData(TenancyStyle.Conjoined)]
+        public void delete_stream_by_guid_id(TenancyStyle tenancyStyle)
         {
+            StoreOptions(_ => _.Events.TenancyStyle = tenancyStyle);
+
             var stream1 = Guid.NewGuid();
             var stream2 = Guid.NewGuid();
 
@@ -30,7 +35,6 @@ namespace Marten.Testing.Events
 
             theStore.Advanced.Clean.DeleteSingleEventStream(stream1);
 
-
             using (var session = theStore.LightweightSession())
             {
                 session.Events.QueryAllRawEvents().ToList().All(x => x.StreamId == stream2)
@@ -38,10 +42,16 @@ namespace Marten.Testing.Events
             }
         }
 
-        [Fact]
-        public void delete_stream_by_string_key()
+        [Theory]
+        [InlineData(TenancyStyle.Single)]
+        [InlineData(TenancyStyle.Conjoined)]
+        public void delete_stream_by_string_key(TenancyStyle tenancyStyle)
         {
-            StoreOptions(_ => _.Events.StreamIdentity = StreamIdentity.AsString);
+            StoreOptions(_ =>
+            {
+                _.Events.StreamIdentity = StreamIdentity.AsString;
+                _.Events.TenancyStyle = tenancyStyle;
+            });
 
             var stream1 = "one";
             var stream2 = "two";
@@ -62,7 +72,6 @@ namespace Marten.Testing.Events
             }
 
             theStore.Advanced.Clean.DeleteSingleEventStream(stream1);
-
 
             using (var session = theStore.LightweightSession())
             {

--- a/src/Marten.Testing/Events/end_to_end_event_capture_and_fetching_the_stream_Tests.cs
+++ b/src/Marten.Testing/Events/end_to_end_event_capture_and_fetching_the_stream_Tests.cs
@@ -2,7 +2,9 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Baseline;
+using Marten.Storage;
 using Marten.Testing.Events.Projections;
+using Marten.Testing.Events.Utils;
 using Shouldly;
 using Xunit;
 
@@ -10,571 +12,650 @@ namespace Marten.Testing.Events
 {
     public class end_to_end_event_capture_and_fetching_the_stream_Tests
     {
-        public static TheoryData<DocumentTracking> SessionTypes = new TheoryData<DocumentTracking>
+        private static readonly string[] SameTenants = { "tenant", "tenant" };
+        private static readonly string[] DiffetentTenants = { "tenant", "differentTenant" };
+        private static readonly string[] DefaultTenant = { Tenancy.DefaultTenantId };
+
+        public static TheoryData<DocumentTracking, TenancyStyle, string[]> SessionParams = new TheoryData<DocumentTracking, TenancyStyle, string[]>
         {
-            DocumentTracking.IdentityOnly,
-            DocumentTracking.DirtyTracking
+            { DocumentTracking.IdentityOnly, TenancyStyle.Conjoined, SameTenants },
+            { DocumentTracking.DirtyTracking, TenancyStyle.Conjoined, DiffetentTenants },
+
+            { DocumentTracking.IdentityOnly, TenancyStyle.Conjoined, SameTenants },
+            { DocumentTracking.DirtyTracking, TenancyStyle.Conjoined, DiffetentTenants },
+
+            { DocumentTracking.IdentityOnly, TenancyStyle.Single, DefaultTenant },
+            { DocumentTracking.DirtyTracking, TenancyStyle.Single, DefaultTenant },
+
+            { DocumentTracking.IdentityOnly, TenancyStyle.Single, DiffetentTenants },
+            { DocumentTracking.DirtyTracking, TenancyStyle.Single, DiffetentTenants },
+
+            { DocumentTracking.IdentityOnly, TenancyStyle.Single, SameTenants },
+            { DocumentTracking.DirtyTracking, TenancyStyle.Single, SameTenants },
         };
 
-
         [Theory]
-        [MemberData("SessionTypes")]
-        public void capture_events_to_a_new_stream_and_fetch_the_events_back(DocumentTracking sessionType)
+        [MemberData("SessionParams")]
+        public void capture_events_to_a_new_stream_and_fetch_the_events_back(DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
         {
-            var store = InitStore();
+            var store = InitStore(tenancyStyle);
 
-
-            using (var session = store.OpenSession(sessionType))
+            When.CalledForEach(tenants, (tenantId, index) =>
             {
-                // SAMPLE: start-stream-with-aggregate-type
-                var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-                var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-                var id = session.Events.StartStream<Quest>(joined, departed).Id;
-                session.SaveChanges();
-                // ENDSAMPLE
-
-                var streamEvents = session.Events.FetchStream(id);
-
-                streamEvents.Count().ShouldBe(2);
-                streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
-                streamEvents.ElementAt(0).Version.ShouldBe(1);
-                streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
-                streamEvents.ElementAt(1).Version.ShouldBe(2);
-
-                streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
-            }
-        }
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public async Task capture_events_to_a_new_stream_and_fetch_the_events_back_async(DocumentTracking sessionType)
-        {
-            var store = InitStore();
-
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                // SAMPLE: start-stream-with-aggregate-type
-                var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-                var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-                var id = session.Events.StartStream<Quest>(joined, departed).Id;
-                await session.SaveChangesAsync();
-                // ENDSAMPLE
-
-                var streamEvents = await session.Events.FetchStreamAsync(id);
-
-                streamEvents.Count().ShouldBe(2);
-                streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
-                streamEvents.ElementAt(0).Version.ShouldBe(1);
-                streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
-                streamEvents.ElementAt(1).Version.ShouldBe(2);
-
-                streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
-            }
-        }
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public async Task capture_events_to_a_new_stream_and_fetch_the_events_back_async_with_linq(DocumentTracking sessionType)
-        {
-            var store = InitStore();
-
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                // SAMPLE: start-stream-with-aggregate-type
-                var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-                var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-                var id = session.Events.StartStream<Quest>(joined, departed).Id;
-                await session.SaveChangesAsync();
-                // ENDSAMPLE
-
-                var streamEvents = await session.Events.QueryAllRawEvents()
-                    .Where(x => x.StreamId == id).OrderBy(x => x.Version).ToListAsync();
-                    
-
-                streamEvents.Count().ShouldBe(2);
-                streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
-                streamEvents.ElementAt(0).Version.ShouldBe(1);
-                streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
-                streamEvents.ElementAt(1).Version.ShouldBe(2);
-
-                streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
-            }
-        }
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public void capture_events_to_a_new_stream_and_fetch_the_events_back_sync_with_linq(DocumentTracking sessionType)
-        {
-            var store = InitStore();
-
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                // SAMPLE: start-stream-with-aggregate-type
-                var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-                var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-                var id = session.Events.StartStream<Quest>(joined, departed).Id;
-                session.SaveChanges();
-                // ENDSAMPLE
-
-                var streamEvents = session.Events.QueryAllRawEvents()
-                    .Where(x => x.StreamId == id).OrderBy(x => x.Version).ToList();
-
-
-                streamEvents.Count().ShouldBe(2);
-                streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
-                streamEvents.ElementAt(0).Version.ShouldBe(1);
-                streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
-                streamEvents.ElementAt(1).Version.ShouldBe(2);
-
-                streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
-            }
-        }
-
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public void live_aggregate_equals_inlined_aggregate_without_hidden_contracts(DocumentTracking sessionType)
-        {
-            var store = InitStore("event_store");
-            var questId = Guid.NewGuid();
-
-            using (var session = store.OpenSession())
-            {
-                //Note Id = questId, is we remove it from first message then AggregateStream will return party.Id=default(Guid) that is not equals to Load<QuestParty> result
-                var started = new QuestStarted { /*Id = questId,*/ Name = "Destroy the One Ring" };
-                var joined1 = new MembersJoined(1, "Hobbiton", "Frodo", "Merry");
-
-                session.Events.StartStream<Quest>(questId, started, joined1);
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession())
-            {
-                var liveAggregate = session.Events.AggregateStream<QuestParty>(questId);
-                var inlinedAggregate = session.Load<QuestParty>(questId);
-                liveAggregate.Id.ShouldBe(inlinedAggregate.Id);
-                inlinedAggregate.ToString().ShouldBe(liveAggregate.ToString());
-            }
-        }
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public void open_persisted_stream_in_new_store_with_same_settings(DocumentTracking sessionType)
-        {
-            var store = InitStore("event_store");
-            var questId = Guid.NewGuid();
-
-            using (var session = store.OpenSession())
-            {
-                //Note "Id = questId" @see live_aggregate_equals_inlined_aggregate...
-                var started = new QuestStarted { Id = questId, Name = "Destroy the One Ring" };
-                var joined1 = new MembersJoined(1, "Hobbiton", "Frodo", "Merry");
-
-                session.Events.StartStream<Quest>(questId, started, joined1);
-                session.SaveChanges();
-            }
-
-            // events-aggregate-on-the-fly - works with same store
-            using (var session = store.OpenSession())
-            {
-                // questId is the id of the stream
-                var party = session.Events.AggregateStream<QuestParty>(questId);
-
-                party.Id.ShouldBe(questId);
-                party.ShouldNotBeNull();
-
-                var party_at_version_3 = session.Events
-                    .AggregateStream<QuestParty>(questId, 3);
-
-                party_at_version_3.ShouldNotBeNull();
-
-                var party_yesterday = session.Events
-                    .AggregateStream<QuestParty>(questId, timestamp: DateTime.UtcNow.AddDays(-1));
-                party_yesterday.ShouldNotBeNull();
-            }
-
-            using (var session = store.OpenSession())
-            {
-                var party = session.Load<QuestParty>(questId);
-                party.Id.ShouldBe(questId);
-            }
-
-            var newStore = InitStore("event_store", false);
-
-            //Inline is working
-            using (var session = store.OpenSession())
-            {
-                var party = session.Load<QuestParty>(questId);
-                party.ShouldNotBeNull();
-            }
-            //GetAll
-            using (var session = store.OpenSession())
-            {
-                var parties = session.Events.QueryRawEventDataOnly<QuestParty>().ToArray();
-                foreach (var party in parties)
+                using (var session = store.OpenSession(tenantId, sessionType))
                 {
+                    // SAMPLE: start-stream-with-aggregate-type
+                    var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+                    var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+                    var id = session.Events.StartStream<Quest>(joined, departed).Id;
+                    session.SaveChanges();
+                    // ENDSAMPLE
+
+                    var streamEvents = session.Events.FetchStream(id);
+
+                    streamEvents.Count().ShouldBe(2);
+                    streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
+                    streamEvents.ElementAt(0).Version.ShouldBe(1);
+                    streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
+                    streamEvents.ElementAt(1).Version.ShouldBe(2);
+
+                    streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
+                }
+            }).ShouldSucceed();
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public Task capture_events_to_a_new_stream_and_fetch_the_events_back_async(DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+
+            return When.CalledForEachAsync(tenants, async (tenantId, index) =>
+            {
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    // SAMPLE: start-stream-with-aggregate-type
+                    var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+                    var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+                    var id = session.Events.StartStream<Quest>(joined, departed).Id;
+                    await session.SaveChangesAsync();
+                    // ENDSAMPLE
+
+                    var streamEvents = await session.Events.FetchStreamAsync(id);
+
+                    streamEvents.Count().ShouldBe(2);
+                    streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
+                    streamEvents.ElementAt(0).Version.ShouldBe(1);
+                    streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
+                    streamEvents.ElementAt(1).Version.ShouldBe(2);
+
+                    streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
+                }
+            }).ShouldSucceedAsync();
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public Task capture_events_to_a_new_stream_and_fetch_the_events_back_async_with_linq(DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+
+            return When.CalledForEachAsync(tenants, async (tenantId, index) =>
+            {
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    // SAMPLE: start-stream-with-aggregate-type
+                    var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+                    var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+                    var id = session.Events.StartStream<Quest>(joined, departed).Id;
+                    await session.SaveChangesAsync();
+                    // ENDSAMPLE
+
+                    var streamEvents = await session.Events.QueryAllRawEvents()
+                        .Where(x => x.StreamId == id).OrderBy(x => x.Version).ToListAsync();
+
+                    streamEvents.Count().ShouldBe(2);
+                    streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
+                    streamEvents.ElementAt(0).Version.ShouldBe(1);
+                    streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
+                    streamEvents.ElementAt(1).Version.ShouldBe(2);
+
+                    streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
+                }
+            }).ShouldSucceedAsync();
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public void capture_events_to_a_new_stream_and_fetch_the_events_back_sync_with_linq(DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+
+            When.CalledForEach(tenants, (tenantId, index) =>
+            {
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    // SAMPLE: start-stream-with-aggregate-type
+                    var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+                    var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+                    var id = session.Events.StartStream<Quest>(joined, departed).Id;
+                    session.SaveChanges();
+                    // ENDSAMPLE
+
+                    var streamEvents = session.Events.QueryAllRawEvents()
+                        .Where(x => x.StreamId == id).OrderBy(x => x.Version).ToList();
+
+                    streamEvents.Count().ShouldBe(2);
+                    streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
+                    streamEvents.ElementAt(0).Version.ShouldBe(1);
+                    streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
+                    streamEvents.ElementAt(1).Version.ShouldBe(2);
+
+                    streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
+                }
+            }).ShouldSucceed();
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public void live_aggregate_equals_inlined_aggregate_without_hidden_contracts(DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+            var questId = Guid.NewGuid();
+
+            When.CalledForEach(tenants, (tenantId, index) =>
+            {
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    //Note Id = questId, is we remove it from first message then AggregateStream will return party.Id=default(Guid) that is not equals to Load<QuestParty> result
+                    var started = new QuestStarted { /*Id = questId,*/ Name = "Destroy the One Ring" };
+                    var joined1 = new MembersJoined(1, "Hobbiton", "Frodo", "Merry");
+
+                    session.Events.StartStream<Quest>(questId, started, joined1);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    var liveAggregate = session.Events.AggregateStream<QuestParty>(questId);
+                    var inlinedAggregate = session.Load<QuestParty>(questId);
+                    liveAggregate.Id.ShouldBe(inlinedAggregate.Id);
+                    inlinedAggregate.ToString().ShouldBe(liveAggregate.ToString());
+                }
+            }).ShouldThrowIf(
+                (tenancyStyle == TenancyStyle.Single && tenants.Length > 1) || (tenancyStyle == TenancyStyle.Conjoined && tenants.SequenceEqual(SameTenants))
+            );
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public void open_persisted_stream_in_new_store_with_same_settings(DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+            var questId = Guid.NewGuid();
+
+            When.CalledForEach(tenants, (tenantId, index) =>
+            {
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    //Note "Id = questId" @see live_aggregate_equals_inlined_aggregate...
+                    var started = new QuestStarted { Id = questId, Name = "Destroy the One Ring" };
+                    var joined1 = new MembersJoined(1, "Hobbiton", "Frodo", "Merry");
+
+                    session.Events.StartStream<Quest>(questId, started, joined1);
+                    session.SaveChanges();
+                }
+
+                // events-aggregate-on-the-fly - works with same store
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    // questId is the id of the stream
+                    var party = session.Events.AggregateStream<QuestParty>(questId);
+
+                    party.Id.ShouldBe(questId);
+                    party.ShouldNotBeNull();
+
+                    var party_at_version_3 = session.Events
+                        .AggregateStream<QuestParty>(questId, 3);
+
+                    party_at_version_3.ShouldNotBeNull();
+
+                    var party_yesterday = session.Events
+                        .AggregateStream<QuestParty>(questId, timestamp: DateTime.UtcNow.AddDays(-1));
+                    party_yesterday.ShouldNotBeNull();
+                }
+
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    var party = session.Load<QuestParty>(questId);
+                    party.Id.ShouldBe(questId);
+                }
+
+                var newStore = InitStore(tenancyStyle, false);
+
+                //Inline is working
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    var party = session.Load<QuestParty>(questId);
                     party.ShouldNotBeNull();
                 }
-            }
-            //This AggregateStream fail with NPE
-            using (var session = newStore.OpenSession())
-            {
-                // questId is the id of the stream
-                var party = session.Events.AggregateStream<QuestParty>(questId);//Here we get NPE
-                party.Id.ShouldBe(questId);
-
-                var party_at_version_3 = session.Events
-                    .AggregateStream<QuestParty>(questId, 3);
-                party_at_version_3.Id.ShouldBe(questId);
-
-                var party_yesterday = session.Events
-                    .AggregateStream<QuestParty>(questId, timestamp: DateTime.UtcNow.AddDays(-1));
-                party_yesterday.Id.ShouldBe(questId);
-            }
-        }
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public void query_before_saving(DocumentTracking sessionType)
-        {
-            var store = InitStore("event_store");
-            var questId = Guid.NewGuid();
-
-            using (var session = store.OpenSession())
-            {
-                var parties = session.Query<QuestParty>().ToArray();
-                parties.Length.ShouldBeLessThanOrEqualTo(0);
-            }
-
-            //This SaveChanges will fail with missing method (ro collection configured?)
-            using (var session = store.OpenSession())
-            {
-                var started = new QuestStarted { Name = "Destroy the One Ring" };
-                var joined1 = new MembersJoined(1, "Hobbiton", "Frodo", "Merry");
-
-                session.Events.StartStream<Quest>(questId, started, joined1);
-                session.SaveChanges();
-
-                var party = session.Events.AggregateStream<QuestParty>(questId);
-                party.Id.ShouldBe(questId);
-            }
-        }
-
-        [Fact]
-        public async Task aggregate_stream_async_has_the_id()
-        {
-            var store = InitStore("event_store");
-            var questId = Guid.NewGuid();
-
-            using (var session = store.OpenSession())
-            {
-                var parties = await session.Query<QuestParty>().ToListAsync();
-                parties.Count.ShouldBeLessThanOrEqualTo(0);
-            }
-
-            //This SaveChanges will fail with missing method (ro collection configured?)
-            using (var session = store.OpenSession())
-            {
-                var started = new QuestStarted { Name = "Destroy the One Ring" };
-                var joined1 = new MembersJoined(1, "Hobbiton", "Frodo", "Merry");
-
-                session.Events.StartStream<Quest>(questId, started, joined1);
-                await session.SaveChangesAsync();
-
-                var party = await session.Events.AggregateStreamAsync<QuestParty>(questId);
-                party.Id.ShouldBe(questId);
-            }
-        }
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public void capture_events_to_a_new_stream_and_fetch_the_events_back_with_stream_id_provided(
-            DocumentTracking sessionType)
-        {
-            var store = InitStore();
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                // SAMPLE: start-stream-with-existing-guid
-                var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-                var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-                var id = Guid.NewGuid();
-                session.Events.StartStream<Quest>(id, joined, departed);
-                session.SaveChanges();
-                // ENDSAMPLE
-
-                var streamEvents = session.Events.FetchStream(id);
-
-                streamEvents.Count().ShouldBe(2);
-                streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
-                streamEvents.ElementAt(0).Version.ShouldBe(1);
-                streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
-                streamEvents.ElementAt(1).Version.ShouldBe(2);
-            }
-        }
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public void capture_events_to_a_non_existing_stream_and_fetch_the_events_back(DocumentTracking sessionType)
-        {
-            var store = InitStore();
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-                var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-                var id = Guid.NewGuid();
-                session.Events.StartStream<Quest>(id, joined);
-                session.Events.Append(id, departed);
-
-                session.SaveChanges();
-
-                var streamEvents = session.Events.FetchStream(id);
-
-                streamEvents.Count().ShouldBe(2);
-                streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
-                streamEvents.ElementAt(0).Version.ShouldBe(1);
-                streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
-                streamEvents.ElementAt(1).Version.ShouldBe(2);
-            }
-        }
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public void capture_events_to_an_existing_stream_and_fetch_the_events_back(DocumentTracking sessionType)
-        {
-            var store = InitStore();
-
-            var id = Guid.NewGuid();
-            var started = new QuestStarted();
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                session.Events.StartStream<Quest>(id, started);
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-                var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-                session.Events.Append(id, joined);
-                session.Events.Append(id, departed);
-
-                session.SaveChanges();
-
-                var streamEvents = session.Events.FetchStream(id);
-
-                streamEvents.Count().ShouldBe(3);
-                streamEvents.ElementAt(0).Data.ShouldBeOfType<QuestStarted>();
-                streamEvents.ElementAt(0).Version.ShouldBe(1);
-                streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersJoined>();
-                streamEvents.ElementAt(1).Version.ShouldBe(2);
-                streamEvents.ElementAt(2).Data.ShouldBeOfType<MembersDeparted>();
-                streamEvents.ElementAt(2).Version.ShouldBe(3);
-            }
-        }
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public void capture_events_to_a_new_stream_and_fetch_the_events_back_in_another_database_schema(
-            DocumentTracking sessionType)
-        {
-            var store = InitStore("event_store");
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-                var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-                var id = session.Events.StartStream<Quest>(joined, departed).Id;
-                session.SaveChanges();
-
-                var streamEvents = session.Events.FetchStream(id);
-
-                streamEvents.Count().ShouldBe(2);
-                streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
-                streamEvents.ElementAt(0).Version.ShouldBe(1);
-                streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
-                streamEvents.ElementAt(1).Version.ShouldBe(2);
-            }
-        }
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public void
-            capture_events_to_a_new_stream_and_fetch_the_events_back_with_stream_id_provided_in_another_database_schema(
-            DocumentTracking sessionType)
-        {
-            var store = InitStore("event_store");
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-                var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-                var id = Guid.NewGuid();
-                session.Events.StartStream<Quest>(id, joined, departed);
-                session.SaveChanges();
-
-                var streamEvents = session.Events.FetchStream(id);
-
-                streamEvents.Count().ShouldBe(2);
-                streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
-                streamEvents.ElementAt(0).Version.ShouldBe(1);
-                streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
-                streamEvents.ElementAt(1).Version.ShouldBe(2);
-
-                streamEvents.Each(x => x.Sequence.ShouldBeGreaterThan(0L));
-            }
-        }
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public void capture_events_to_a_non_existing_stream_and_fetch_the_events_back_in_another_database_schema(
-            DocumentTracking sessionType)
-        {
-            var store = InitStore("event_store");
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-                var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-                var id = Guid.NewGuid();
-                session.Events.StartStream<Quest>(id, joined);
-                session.Events.Append(id, departed);
-
-                session.SaveChanges();
-
-                var streamEvents = session.Events.FetchStream(id);
-
-                streamEvents.Count().ShouldBe(2);
-                streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
-                streamEvents.ElementAt(0).Version.ShouldBe(1);
-                streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
-                streamEvents.ElementAt(1).Version.ShouldBe(2);
-            }
-        }
-
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public void capture_events_to_an_existing_stream_and_fetch_the_events_back_in_another_database_schema(
-            DocumentTracking sessionType)
-        {
-            var store = InitStore("event_store");
-
-            var id = Guid.NewGuid();
-            var started = new QuestStarted();
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                session.Events.StartStream<Quest>(id, started);
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                // SAMPLE: append-events
-                var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-                var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-                session.Events.Append(id, joined, departed);
-
-                session.SaveChanges();
-                // ENDSAMPLE
-
-                var streamEvents = session.Events.FetchStream(id);
-
-                streamEvents.Count().ShouldBe(3);
-                streamEvents.ElementAt(0).Data.ShouldBeOfType<QuestStarted>();
-                streamEvents.ElementAt(0).Version.ShouldBe(1);
-                streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersJoined>();
-                streamEvents.ElementAt(1).Version.ShouldBe(2);
-                streamEvents.ElementAt(2).Data.ShouldBeOfType<MembersDeparted>();
-                streamEvents.ElementAt(2).Version.ShouldBe(3);
-            }
-        }
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public void assert_on_max_event_id_on_event_stream_append(
-            DocumentTracking sessionType)
-        {
-            var store = InitStore("event_store");
-
-            var id = Guid.NewGuid();
-            var started = new QuestStarted();
-            
-            using (var session = store.OpenSession(sessionType))
-            {
-                // SAMPLE: append-events-assert-on-eventid
-                session.Events.StartStream<Quest>(id, started);
-                session.SaveChanges();
-
-                var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-                var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-                // Events are appended into the stream only if the maximum event id for the stream
-                // would be 3 after the append operation.
-                session.Events.Append(id, 3, joined, departed);
-
-                session.SaveChanges();
-                // ENDSAMPLE
-            }
-        }
-
-
-        [Theory]
-        [MemberData("SessionTypes")]
-        public void capture_immutable_events(DocumentTracking sessionType)
-        {
-            var store = InitStore();
-
-            var id = Guid.NewGuid();
-            var immutableEvent = new ImmutableEvent(id, "some-name");
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                session.Events.Append(id, immutableEvent);
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession(sessionType))
-            {
-                var streamEvents = session.Events.FetchStream(id);
-
-                streamEvents.Count.ShouldBe(1);
-                var @event = streamEvents.ElementAt(0).Data.ShouldBeOfType<ImmutableEvent>();
-
-                @event.Id.ShouldBe(id);
-                @event.Name.ShouldBe("some-name");
-            }
-        }
-
-
-
-        private static DocumentStore InitStore(string databascSchema = null, bool cleanShema = true)
-        {
-            var store = DocumentStore.For(_ =>
-            {
-                if (databascSchema != null)
+                //GetAll
+                using (var session = store.OpenSession(tenantId, sessionType))
                 {
-                    _.Events.DatabaseSchemaName = databascSchema;
+                    var parties = session.Events.QueryRawEventDataOnly<QuestParty>().ToArray();
+                    foreach (var party in parties)
+                    {
+                        party.ShouldNotBeNull();
+                    }
+                }
+                //This AggregateStream fail with NPE
+                using (var session = newStore.OpenSession(tenantId, sessionType))
+                {
+                    // questId is the id of the stream
+                    var party = session.Events.AggregateStream<QuestParty>(questId);//Here we get NPE
+                    party.Id.ShouldBe(questId);
+
+                    var party_at_version_3 = session.Events
+                        .AggregateStream<QuestParty>(questId, 3);
+                    party_at_version_3.Id.ShouldBe(questId);
+
+                    var party_yesterday = session.Events
+                        .AggregateStream<QuestParty>(questId, timestamp: DateTime.UtcNow.AddDays(-1));
+                    party_yesterday.Id.ShouldBe(questId);
+                }
+            }).ShouldThrowIf(
+                (tenancyStyle == TenancyStyle.Single && tenants.Length > 1) || (tenancyStyle == TenancyStyle.Conjoined && tenants.SequenceEqual(SameTenants))
+            );
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public void query_before_saving(DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+            var questId = Guid.NewGuid();
+
+            When.CalledForEach(tenants, (tenantId, index) =>
+            {
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    var parties = session.Query<QuestParty>().ToArray();
+                    parties.Length.ShouldBeLessThanOrEqualTo(index);
                 }
 
+                //This SaveChanges will fail with missing method (ro collection configured?)
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    var started = new QuestStarted { Name = "Destroy the One Ring" };
+                    var joined1 = new MembersJoined(1, "Hobbiton", "Frodo", "Merry");
+
+                    session.Events.StartStream<Quest>(questId, started, joined1);
+                    session.SaveChanges();
+
+                    var party = session.Events.AggregateStream<QuestParty>(questId);
+                    party.Id.ShouldBe(questId);
+                }
+            }).ShouldThrowIf(
+                (tenancyStyle == TenancyStyle.Single && tenants.Length > 1) || (tenancyStyle == TenancyStyle.Conjoined && tenants.SequenceEqual(SameTenants))
+            );
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public Task aggregate_stream_async_has_the_id(DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+            var questId = Guid.NewGuid();
+
+            return When.CalledForEachAsync(tenants, async (tenantId, index) =>
+            {
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    var parties = await session.Query<QuestParty>().ToListAsync();
+                    parties.Count.ShouldBeLessThanOrEqualTo(index);
+                }
+
+                //This SaveChanges will fail with missing method (ro collection configured?)
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    var started = new QuestStarted { Name = "Destroy the One Ring" };
+                    var joined1 = new MembersJoined(1, "Hobbiton", "Frodo", "Merry");
+
+                    session.Events.StartStream<Quest>(questId, started, joined1);
+                    await session.SaveChangesAsync();
+
+                    var party = await session.Events.AggregateStreamAsync<QuestParty>(questId);
+                    party.Id.ShouldBe(questId);
+                }
+            }).ShouldThrowIfAsync(
+                (tenancyStyle == TenancyStyle.Single && tenants.Length > 1) || (tenancyStyle == TenancyStyle.Conjoined && tenants.SequenceEqual(SameTenants))
+            );
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public void capture_events_to_a_new_stream_and_fetch_the_events_back_with_stream_id_provided(
+            DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+
+            When.CalledForEach(tenants, (tenantId, index) =>
+            {
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    // SAMPLE: start-stream-with-existing-guid
+                    var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+                    var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+                    var id = Guid.NewGuid();
+                    session.Events.StartStream<Quest>(id, joined, departed);
+                    session.SaveChanges();
+                    // ENDSAMPLE
+
+                    var streamEvents = session.Events.FetchStream(id);
+
+                    streamEvents.Count().ShouldBe(2);
+                    streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
+                    streamEvents.ElementAt(0).Version.ShouldBe(1);
+                    streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
+                    streamEvents.ElementAt(1).Version.ShouldBe(2);
+                }
+            }).ShouldSucceed();
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public void capture_events_to_a_non_existing_stream_and_fetch_the_events_back(DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+
+            When.CalledForEach(tenants, (tenantId, index) =>
+            {
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+                    var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+                    var id = Guid.NewGuid();
+                    session.Events.StartStream<Quest>(id, joined);
+                    session.Events.Append(id, departed);
+
+                    session.SaveChanges();
+
+                    var streamEvents = session.Events.FetchStream(id);
+
+                    streamEvents.Count().ShouldBe(2);
+                    streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
+                    streamEvents.ElementAt(0).Version.ShouldBe(1);
+                    streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
+                    streamEvents.ElementAt(1).Version.ShouldBe(2);
+                }
+            }).ShouldSucceed();
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public void capture_events_to_an_existing_stream_and_fetch_the_events_back(DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+
+            var id = Guid.NewGuid();
+
+            When.CalledForEach(tenants, (tenantId, index) =>
+            {
+                var started = new QuestStarted();
+
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    session.Events.StartStream<Quest>(id, started);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+                    var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+                    session.Events.Append(id, joined);
+                    session.Events.Append(id, departed);
+
+                    session.SaveChanges();
+
+                    var streamEvents = session.Events.FetchStream(id);
+
+                    streamEvents.Count().ShouldBe(3);
+                    streamEvents.ElementAt(0).Data.ShouldBeOfType<QuestStarted>();
+                    streamEvents.ElementAt(0).Version.ShouldBe(1);
+                    streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersJoined>();
+                    streamEvents.ElementAt(1).Version.ShouldBe(2);
+                    streamEvents.ElementAt(2).Data.ShouldBeOfType<MembersDeparted>();
+                    streamEvents.ElementAt(2).Version.ShouldBe(3);
+                }
+            }).ShouldThrowIf(
+                (tenancyStyle == TenancyStyle.Single && tenants.Length > 1) || (tenancyStyle == TenancyStyle.Conjoined && tenants.SequenceEqual(SameTenants))
+            );
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public void capture_events_to_a_new_stream_and_fetch_the_events_back_in_another_database_schema(
+            DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+
+            When.CalledForEach(tenants, (tenantId, index) =>
+            {
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+                    var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+                    var id = session.Events.StartStream<Quest>(joined, departed).Id;
+                    session.SaveChanges();
+
+                    var streamEvents = session.Events.FetchStream(id);
+
+                    streamEvents.Count().ShouldBe(2);
+                    streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
+                    streamEvents.ElementAt(0).Version.ShouldBe(1);
+                    streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
+                    streamEvents.ElementAt(1).Version.ShouldBe(2);
+                }
+            }).ShouldSucceed();
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public void
+            capture_events_to_a_new_stream_and_fetch_the_events_back_with_stream_id_provided_in_another_database_schema(
+            DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+
+            When.CalledForEach(tenants, (tenantId, index) =>
+            {
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+                    var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+                    var id = Guid.NewGuid();
+                    session.Events.StartStream<Quest>(id, joined, departed);
+                    session.SaveChanges();
+
+                    var streamEvents = session.Events.FetchStream(id);
+
+                    streamEvents.Count().ShouldBe(2);
+                    streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
+                    streamEvents.ElementAt(0).Version.ShouldBe(1);
+                    streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
+                    streamEvents.ElementAt(1).Version.ShouldBe(2);
+
+                    streamEvents.Each(x => x.Sequence.ShouldBeGreaterThan(0L));
+                }
+            }).ShouldSucceed();
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public void capture_events_to_a_non_existing_stream_and_fetch_the_events_back_in_another_database_schema(
+            DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+
+            When.CalledForEach(tenants, (tenantId, index) =>
+            {
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+                    var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+                    var id = Guid.NewGuid();
+                    session.Events.StartStream<Quest>(id, joined);
+                    session.Events.Append(id, departed);
+
+                    session.SaveChanges();
+
+                    var streamEvents = session.Events.FetchStream(id);
+
+                    streamEvents.Count().ShouldBe(2);
+                    streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
+                    streamEvents.ElementAt(0).Version.ShouldBe(1);
+                    streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
+                    streamEvents.ElementAt(1).Version.ShouldBe(2);
+                }
+            }).ShouldSucceed();
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public void capture_events_to_an_existing_stream_and_fetch_the_events_back_in_another_database_schema(
+            DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+
+            var id = Guid.NewGuid();
+
+            When.CalledForEach(tenants, (tenantId, index) =>
+            {
+                var started = new QuestStarted();
+
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    session.Events.StartStream<Quest>(id, started);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    // SAMPLE: append-events
+                    var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+                    var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+                    session.Events.Append(id, joined, departed);
+
+                    session.SaveChanges();
+                    // ENDSAMPLE
+
+                    var streamEvents = session.Events.FetchStream(id);
+
+                    streamEvents.Count().ShouldBe(3);
+                    streamEvents.ElementAt(0).Data.ShouldBeOfType<QuestStarted>();
+                    streamEvents.ElementAt(0).Version.ShouldBe(1);
+                    streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersJoined>();
+                    streamEvents.ElementAt(1).Version.ShouldBe(2);
+                    streamEvents.ElementAt(2).Data.ShouldBeOfType<MembersDeparted>();
+                    streamEvents.ElementAt(2).Version.ShouldBe(3);
+                }
+            }).ShouldThrowIf(
+                (tenancyStyle == TenancyStyle.Single && tenants.Length > 1) || (tenancyStyle == TenancyStyle.Conjoined && tenants.SequenceEqual(SameTenants))
+            );
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public void assert_on_max_event_id_on_event_stream_append(
+            DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+
+            var id = Guid.NewGuid();
+
+            When.CalledForEach(tenants, (tenantId, index) =>
+            {
+                var started = new QuestStarted();
+
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    // SAMPLE: append-events-assert-on-eventid
+                    session.Events.StartStream<Quest>(id, started);
+                    session.SaveChanges();
+
+                    var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+                    var departed = new MembersDeparted { Members = new[] { "Thom" } };
+
+                    // Events are appended into the stream only if the maximum event id for the stream
+                    // would be 3 after the append operation.
+                    session.Events.Append(id, 3, joined, departed);
+
+                    session.SaveChanges();
+                    // ENDSAMPLE
+                }
+            }).ShouldThrowIf(
+                (tenancyStyle == TenancyStyle.Single && tenants.Length > 1) || (tenancyStyle == TenancyStyle.Conjoined && tenants.SequenceEqual(SameTenants))
+            );
+        }
+
+        [Theory]
+        [MemberData("SessionParams")]
+        public void capture_immutable_events(DocumentTracking sessionType, TenancyStyle tenancyStyle, string[] tenants)
+        {
+            var store = InitStore(tenancyStyle);
+
+            var id = Guid.NewGuid();
+
+            When.CalledForEach(tenants, (tenantId, index) =>
+            {
+                var immutableEvent = new ImmutableEvent(id, "some-name");
+
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    session.Events.Append(id, immutableEvent);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(tenantId, sessionType))
+                {
+                    var streamEvents = session.Events.FetchStream(id);
+
+                    streamEvents.Count.ShouldBe(1);
+                    var @event = streamEvents.ElementAt(0).Data.ShouldBeOfType<ImmutableEvent>();
+
+                    @event.Id.ShouldBe(id);
+                    @event.Name.ShouldBe("some-name");
+                }
+            }).ShouldThrowIf(
+                (tenancyStyle == TenancyStyle.Single && tenants.Length > 1) || (tenancyStyle == TenancyStyle.Conjoined && tenants.SequenceEqual(SameTenants))
+            );
+        }
+
+        private static DocumentStore InitStore(TenancyStyle tenancyStyle, bool cleanShema = true)
+        {
+            var databaseSchema = $"end_to_end_event_capture_{tenancyStyle.ToString().ToLower()}";
+
+            var store = DocumentStore.For(_ =>
+            {
+                _.Events.DatabaseSchemaName = databaseSchema;
+                _.Events.TenancyStyle = tenancyStyle;
+
                 _.AutoCreateSchemaObjects = AutoCreate.All;
+
+                if (tenancyStyle == TenancyStyle.Conjoined)
+                    _.Policies.AllDocumentsAreMultiTenanted();
 
                 _.Connection(ConnectionSource.ConnectionString);
 

--- a/src/Marten.Testing/Events/start_stream_should_enforce_that_it_is_a_new_stream.cs
+++ b/src/Marten.Testing/Events/start_stream_should_enforce_that_it_is_a_new_stream.cs
@@ -26,5 +26,71 @@ namespace Marten.Testing.Events
                 });
             }
         }
+
+        [Fact]
+        public void throw_exception_if_start_stream_is_called_on_existing_stream_with_the_same_tenant()
+        {
+            var stream = Guid.NewGuid();
+            const string tenantName = "Tenant";
+
+            using (var session = theStore.OpenSession(tenantName))
+            {
+                session.Events.StartStream(stream, new MembersJoined());
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession("Tenant"))
+            {
+                session.Events.StartStream(stream, new MembersJoined());
+                Exception<ExistingStreamIdCollisionException>.ShouldBeThrownBy(() =>
+                {
+                    session.SaveChanges();
+                });
+            }
+        }
+
+        [Fact]
+        public void does_not_throw_exception_if_start_stream_is_called_on_existing_stream_with_the_same_tenant_and_tenancy_style_conjoined()
+        {
+            StoreOptions(_ => _.Events.TenancyStyle = Marten.Storage.TenancyStyle.Conjoined);
+
+            var stream = Guid.NewGuid();
+            const string tenantName = "Tenant";
+
+            using (var session = theStore.OpenSession(tenantName))
+            {
+                session.Events.StartStream(stream, new MembersJoined());
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession(tenantName))
+            {
+                session.Events.StartStream(stream, new MembersJoined());
+                Exception<ExistingStreamIdCollisionException>.ShouldBeThrownBy(() =>
+                {
+                    session.SaveChanges();
+                });
+            }
+        }
+
+        [Fact]
+        public void does_not_throw_exception_if_start_stream_is_called_on_existing_stream_with_different_tenant_and_tenancy_style_conjoined()
+        {
+            StoreOptions(_ => _.Events.TenancyStyle = Marten.Storage.TenancyStyle.Conjoined);
+
+            var stream = Guid.NewGuid();
+
+            using (var session = theStore.OpenSession("Tenant"))
+            {
+                session.Events.StartStream(stream, new MembersJoined());
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession("OtherTenant"))
+            {
+                session.Events.StartStream(stream, new MembersJoined());
+                session.SaveChanges();
+            }
+        }
     }
 }

--- a/src/Marten/Events/AppendEventFunction.cs
+++ b/src/Marten/Events/AppendEventFunction.cs
@@ -4,7 +4,7 @@ using Marten.Storage;
 
 namespace Marten.Events
 {
-	// SAMPLE: AppendEventFunction
+    // SAMPLE: AppendEventFunction
     public class AppendEventFunction : Function
     {
         private readonly EventGraph _events;
@@ -16,8 +16,17 @@ namespace Marten.Events
 
         public override void Write(DdlRules rules, StringWriter writer)
         {
-            var streamIdType = _events.GetStreamIdType();
+            var streamIdType = _events.GetStreamIdDBType();
             var databaseSchema = _events.DatabaseSchemaName;
+
+            var tenancyStyle = _events.TenancyStyle;
+
+            var streamsWhere = "id = stream";
+
+            if (tenancyStyle == TenancyStyle.Conjoined)
+            {
+                streamsWhere += " AND tenant_id = tenantid";
+            }
 
             writer.WriteLine($@"
 CREATE OR REPLACE FUNCTION {Identifier}(stream {streamIdType}, stream_type varchar, tenantid varchar, event_ids uuid[], event_types varchar[], dotnet_types varchar[], bodies jsonb[]) RETURNS int[] AS $$
@@ -31,19 +40,18 @@ DECLARE
     actual_tenant varchar;
 	return_value int[];
 BEGIN
-	select version into event_version from {databaseSchema}.mt_streams where id = stream;
+	select version into event_version from {databaseSchema}.mt_streams where {streamsWhere};
 	if event_version IS NULL then
 		event_version = 0;
 		insert into {databaseSchema}.mt_streams (id, type, version, timestamp, tenant_id) values (stream, stream_type, 0, now(), tenantid);
     else
         if tenantid IS NOT NULL then
-            select tenant_id into actual_tenant from {databaseSchema}.mt_streams where id = stream;
+            select tenant_id into actual_tenant from {databaseSchema}.mt_streams where {streamsWhere};
             if actual_tenant != tenantid then
                 RAISE EXCEPTION 'The tenantid does not match the existing stream';
             end if;
         end if;
 	end if;
-
 
 	index := 1;
 	return_value := ARRAY[event_version + array_length(event_ids, 1)];
@@ -57,16 +65,15 @@ BEGIN
 		event_type = event_types[index];
 		body = bodies[index];
 
-		insert into {databaseSchema}.mt_events 
-			(seq_id, id, stream_id, version, data, type, tenant_id, {DocumentMapping.DotNetTypeColumn}) 
-		values 
+		insert into {databaseSchema}.mt_events
+			(seq_id, id, stream_id, version, data, type, tenant_id, {DocumentMapping.DotNetTypeColumn})
+		values
 			(seq, event_id, stream, event_version, body, event_type, tenantid, dotnet_types[index]);
 
-		
 		index := index + 1;
 	end loop;
 
-	update {databaseSchema}.mt_streams set version = event_version, timestamp = now() where id = stream;
+	update {databaseSchema}.mt_streams set version = event_version, timestamp = now() where {streamsWhere};
 
 	return return_value;
 END
@@ -76,9 +83,10 @@ $$ LANGUAGE plpgsql;
 
         protected override string toDropSql()
         {
-            var streamIdType = _events.GetStreamIdType();
+            var streamIdType = _events.GetStreamIdDBType();
             return $"drop function if exists {Identifier} ({streamIdType}, varchar, varchar, uuid[], varchar[], jsonb[])";
         }
     }
-	// ENDSAMPLE
+
+    // ENDSAMPLE
 }

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -11,7 +11,6 @@ using Marten.Storage;
 
 namespace Marten.Events
 {
-
     public enum StreamIdentity
     {
         AsGuid,
@@ -47,15 +46,16 @@ namespace Marten.Events
             _byEventName.OnMissing = name => { return AllEvents().FirstOrDefault(x => x.EventTypeName == name); };
 
             InlineProjections = new ProjectionCollection(options);
-            AsyncProjections = new ProjectionCollection(options);            
+            AsyncProjections = new ProjectionCollection(options);
         }
 
         public StreamIdentity StreamIdentity { get; set; } = StreamIdentity.AsGuid;
 
+        public TenancyStyle TenancyStyle { get; set; } = TenancyStyle.Single;
+
         internal StoreOptions Options { get; }
 
         internal DbObjectName Table => new DbObjectName(DatabaseSchemaName, "mt_events");
-
 
         public EventMapping EventMappingFor(Type eventType)
         {
@@ -92,7 +92,6 @@ namespace Marten.Events
             types.Each(AddEventType);
         }
 
-
         public bool IsActive(StoreOptions options) => _events.Any() || _aggregates.Any();
 
         public string DatabaseSchemaName
@@ -100,7 +99,6 @@ namespace Marten.Events
             get { return _databaseSchemaName ?? Options.DatabaseSchemaName; }
             set { _databaseSchemaName = value; }
         }
-
 
         public void AddAggregator<T>(IAggregator<T> aggregator) where T : class, new()
         {
@@ -118,7 +116,6 @@ namespace Marten.Events
                 })
                 .As<IAggregator<T>>();
         }
-
 
         public Type AggregateTypeFor(string aggregateTypeName)
         {
@@ -161,7 +158,7 @@ namespace Marten.Events
         }
 
         /// <summary>
-        /// Set default strategy to lookup IAggregator when no explicit IAggregator registration exists. 
+        /// Set default strategy to lookup IAggregator when no explicit IAggregator registration exists.
         /// </summary>
         /// <remarks>Unless called, <see cref="AggregatorLookup"/> is used</remarks>
         public void UseAggregatorLookup(IAggregatorLookup aggregatorLookup)
@@ -179,7 +176,7 @@ namespace Marten.Events
             get
             {
                 var eventsTable = new EventsTable(this);
-                
+
                 // SAMPLE: using-sequence
                 var sequence = new Sequence(new DbObjectName(DatabaseSchemaName, "mt_events_sequence"))
                 {
@@ -192,25 +189,31 @@ namespace Marten.Events
                 {
                     new StreamsTable(this),
                     eventsTable,
-                    new EventProgressionTable(DatabaseSchemaName), 
-                    sequence,  
-                    
-                    new AppendEventFunction(this), 
-                    new SystemFunction(DatabaseSchemaName, "mt_mark_event_progression", "varchar, bigint"), 
+                    new EventProgressionTable(DatabaseSchemaName),
+                    sequence,
+
+                    new AppendEventFunction(this),
+                    new SystemFunction(DatabaseSchemaName, "mt_mark_event_progression", "varchar, bigint"),
                 };
             }
         }
 
         Type IFeatureSchema.StorageType => typeof(EventGraph);
         public string Identifier { get; } = "eventstore";
+
         public void WritePermissions(DdlRules rules, StringWriter writer)
         {
             // Nothing
         }
 
-        internal string GetStreamIdType()
+        internal string GetStreamIdDBType()
         {
             return StreamIdentity == StreamIdentity.AsGuid ? "uuid" : "varchar";
+        }
+
+        internal Type GetStreamIdType()
+        {
+            return StreamIdentity == StreamIdentity.AsGuid ? typeof(Guid) : typeof(string);
         }
 
         private readonly ConcurrentDictionary<Type, string> _dotnetTypeNames = new ConcurrentDictionary<Type, string>();

--- a/src/Marten/Events/EventQueryHandler.cs
+++ b/src/Marten/Events/EventQueryHandler.cs
@@ -6,13 +6,13 @@ using System.Threading.Tasks;
 using Marten.Linq;
 using Marten.Linq.QueryHandlers;
 using Marten.Services;
+using Marten.Storage;
 using Marten.Util;
 
 namespace Marten.Events
 {
     internal interface IEventQueryHandler : IQueryHandler<IReadOnlyList<IEvent>>
     {
-        
     }
 
     internal class EventQueryHandler<TIdentity> : IEventQueryHandler
@@ -21,18 +21,27 @@ namespace Marten.Events
         private readonly TIdentity _streamId;
         private readonly DateTime? _timestamp;
         private readonly int _version;
+        private readonly TenancyStyle _tenancyStyle;
+        private readonly string _tenantId;
 
-        public EventQueryHandler(ISelector<IEvent> selector, TIdentity streamId, int version = 0, DateTime? timestamp = null)
+        public EventQueryHandler(ISelector<IEvent> selector, TIdentity streamId, int version = 0, DateTime? timestamp = null, TenancyStyle tenancyStyle = TenancyStyle.Single, string tenantId = null)
         {
             if (timestamp != null && timestamp.Value.Kind != DateTimeKind.Utc)
             {
                 throw new ArgumentOutOfRangeException(nameof(timestamp), "This method only accepts UTC dates");
             }
 
+            if (_tenancyStyle == TenancyStyle.Conjoined && tenantId == null)
+            {
+                throw new ArgumentNullException(nameof(tenantId), $"{nameof(tenantId)} cannot be null for {TenancyStyle.Conjoined}");
+            }
+
             _selector = selector;
             _streamId = streamId;
             _version = version;
             _timestamp = timestamp;
+            _tenancyStyle = tenancyStyle;
+            _tenantId = tenantId;
         }
 
         public Type SourceType => typeof(IEvent);
@@ -41,7 +50,6 @@ namespace Marten.Events
         {
             _selector.WriteSelectClause(sql, null);
 
- 
             var param = sql.AddParameter(_streamId);
             sql.Append(" where stream_id = :");
             sql.Append(param.ParameterName);
@@ -60,6 +68,13 @@ namespace Marten.Events
                 sql.Append(timestampParam.ParameterName);
             }
 
+            if (_tenancyStyle == TenancyStyle.Conjoined)
+            {
+                var tenantIdParam = sql.AddParameter(_tenantId);
+                sql.Append(" and tenant_id = :");
+                sql.Append(tenantIdParam.ParameterName);
+            }
+
             sql.Append(" order by version");
         }
 
@@ -72,6 +87,5 @@ namespace Marten.Events
         {
             return _selector.ReadAsync(reader, map, stats, token);
         }
-
     }
 }

--- a/src/Marten/Events/EventStore.cs
+++ b/src/Marten/Events/EventStore.cs
@@ -19,12 +19,11 @@ namespace Marten.Events
         private readonly ISelector<IEvent> _selector;
         private readonly DocumentStore _store;
 
-
         public EventStore(IDocumentSession session, DocumentStore store, IManagedConnection connection, UnitOfWork unitOfWork, ITenant tenant)
         {
             _session = session;
             _store = store;
-            
+
             _connection = connection;
             _unitOfWork = unitOfWork;
             _tenant = tenant;
@@ -39,7 +38,6 @@ namespace Marten.Events
             {
                 _selector = new StringIdentifiedEventSelector(_store.Events, _store.Serializer);
             }
-
         }
 
         private void ensureAsStringStorage()
@@ -118,7 +116,7 @@ namespace Marten.Events
 
             var stream = new EventStream(id, events.Select(EventStream.ToEvent).ToArray(), true)
             {
-                AggregateType = typeof (T)
+                AggregateType = typeof(T)
             };
 
             _unitOfWork.StoreStream(stream);
@@ -176,7 +174,7 @@ namespace Marten.Events
         {
             ensureAsGuidStorage();
 
-            var handler = new EventQueryHandler<Guid>(_selector, streamId, version, timestamp);
+            var handler = new EventQueryHandler<Guid>(_selector, streamId, version, timestamp, _store.Events.TenancyStyle, _tenant.TenantId);
             return _connection.Fetch(handler, null, null, _tenant);
         }
 
@@ -184,7 +182,7 @@ namespace Marten.Events
         {
             ensureAsGuidStorage();
 
-            var handler = new EventQueryHandler<Guid>(_selector, streamId, version, timestamp);
+            var handler = new EventQueryHandler<Guid>(_selector, streamId, version, timestamp, _store.Events.TenancyStyle, _tenant.TenantId);
             return _connection.FetchAsync(handler, null, null, _tenant, token);
         }
 
@@ -192,7 +190,7 @@ namespace Marten.Events
         {
             ensureAsStringStorage();
 
-            var handler = new EventQueryHandler<string>(_selector, streamKey, version, timestamp);
+            var handler = new EventQueryHandler<string>(_selector, streamKey, version, timestamp, _store.Events.TenancyStyle, _tenant.TenantId);
             return _connection.Fetch(handler, null, null, _tenant);
         }
 
@@ -200,7 +198,7 @@ namespace Marten.Events
         {
             ensureAsStringStorage();
 
-            var handler = new EventQueryHandler<string>(_selector, streamKey, version, timestamp);
+            var handler = new EventQueryHandler<string>(_selector, streamKey, version, timestamp, _store.Events.TenancyStyle, _tenant.TenantId);
             return _connection.FetchAsync(handler, null, null, _tenant, token);
         }
 
@@ -208,7 +206,7 @@ namespace Marten.Events
         {
             ensureAsGuidStorage();
 
-            var inner = new EventQueryHandler<Guid>(_selector, streamId, version, timestamp);
+            var inner = new EventQueryHandler<Guid>(_selector, streamId, version, timestamp, _store.Events.TenancyStyle, _tenant.TenantId);
             var aggregator = _store.Events.AggregateFor<T>();
             var handler = new AggregationQueryHandler<T>(aggregator, inner, _session, state);
 
@@ -216,7 +214,6 @@ namespace Marten.Events
 
             var assignment = _tenant.IdAssignmentFor<T>();
             assignment.Assign(_tenant, aggregate, streamId);
-
 
             return aggregate;
         }
@@ -226,7 +223,7 @@ namespace Marten.Events
         {
             ensureAsGuidStorage();
 
-            var inner = new EventQueryHandler<Guid>(_selector, streamId, version, timestamp);
+            var inner = new EventQueryHandler<Guid>(_selector, streamId, version, timestamp, _store.Events.TenancyStyle, _tenant.TenantId);
             var aggregator = _store.Events.AggregateFor<T>();
             var handler = new AggregationQueryHandler<T>(aggregator, inner, _session, state);
 
@@ -235,7 +232,6 @@ namespace Marten.Events
             var assignment = _tenant.IdAssignmentFor<T>();
             assignment.Assign(_tenant, aggregate, streamId);
 
-
             return aggregate;
         }
 
@@ -243,7 +239,7 @@ namespace Marten.Events
         {
             ensureAsStringStorage();
 
-            var inner = new EventQueryHandler<string>(_selector, streamKey, version, timestamp);
+            var inner = new EventQueryHandler<string>(_selector, streamKey, version, timestamp, _store.Events.TenancyStyle, _tenant.TenantId);
             var aggregator = _store.Events.AggregateFor<T>();
             var handler = new AggregationQueryHandler<T>(aggregator, inner, _session, state);
 
@@ -251,7 +247,6 @@ namespace Marten.Events
 
             var assignment = _tenant.IdAssignmentFor<T>();
             assignment.Assign(_tenant, aggregate, streamKey);
-
 
             return aggregate;
         }
@@ -261,7 +256,7 @@ namespace Marten.Events
         {
             ensureAsStringStorage();
 
-            var inner = new EventQueryHandler<string>(_selector, streamKey, version, timestamp);
+            var inner = new EventQueryHandler<string>(_selector, streamKey, version, timestamp, _store.Events.TenancyStyle, _tenant.TenantId);
             var aggregator = _store.Events.AggregateFor<T>();
             var handler = new AggregationQueryHandler<T>(aggregator, inner, _session, state);
 
@@ -270,10 +265,8 @@ namespace Marten.Events
             var assignment = _tenant.IdAssignmentFor<T>();
             assignment.Assign(_tenant, aggregate, streamKey);
 
-
             return aggregate;
         }
-
 
         public IMartenQueryable<T> QueryRawEventDataOnly<T>()
         {
@@ -285,7 +278,6 @@ namespace Marten.Events
             }
 
             _store.Events.AddEventType(typeof(T));
-
 
             return _session.Query<T>();
         }
@@ -301,8 +293,7 @@ namespace Marten.Events
         {
             _tenant.EnsureStorageExists(typeof(EventStream));
 
-            _store.Events.AddEventType(typeof (T));
-
+            _store.Events.AddEventType(typeof(T));
 
             return Load(id).As<Event<T>>();
         }
@@ -311,7 +302,7 @@ namespace Marten.Events
         {
             _tenant.EnsureStorageExists(typeof(EventStream));
 
-            _store.Events.AddEventType(typeof (T));
+            _store.Events.AddEventType(typeof(T));
 
             return (await LoadAsync(id, token).ConfigureAwait(false)).As<Event<T>>();
         }
@@ -336,7 +327,7 @@ namespace Marten.Events
         {
             _tenant.EnsureStorageExists(typeof(EventStream));
 
-            var handler = new StreamStateByGuidHandler(_store.Events, streamId);
+            var handler = new StreamStateByGuidHandler(_store.Events, streamId, _tenant.TenantId);
             return _connection.Fetch(handler, null, null, _tenant);
         }
 
@@ -344,7 +335,7 @@ namespace Marten.Events
         {
             _tenant.EnsureStorageExists(typeof(EventStream));
 
-            var handler = new StreamStateByGuidHandler(_store.Events, streamId);
+            var handler = new StreamStateByGuidHandler(_store.Events, streamId, _tenant.TenantId);
             return _connection.FetchAsync(handler, null, null, _tenant, token);
         }
 
@@ -352,7 +343,7 @@ namespace Marten.Events
         {
             _tenant.EnsureStorageExists(typeof(EventStream));
 
-            var handler = new StreamStateByStringHandler(_store.Events, streamKey);
+            var handler = new StreamStateByStringHandler(_store.Events, streamKey, _tenant.TenantId);
             return _connection.Fetch(handler, null, null, _tenant);
         }
 
@@ -360,7 +351,7 @@ namespace Marten.Events
         {
             _tenant.EnsureStorageExists(typeof(EventStream));
 
-            var handler = new StreamStateByStringHandler(_store.Events, streamKey);
+            var handler = new StreamStateByStringHandler(_store.Events, streamKey, _tenant.TenantId);
             return _connection.FetchAsync(handler, null, null, _tenant, token);
         }
     }

--- a/src/Marten/Events/EventsTable.cs
+++ b/src/Marten/Events/EventsTable.cs
@@ -8,21 +8,31 @@ namespace Marten.Events
     {
         public EventsTable(EventGraph events) : base(new DbObjectName(events.DatabaseSchemaName, "mt_events"))
         {
-            var stringIdType = events.GetStreamIdType();
+            var stringIdType = events.GetStreamIdDBType();
 
             AddPrimaryKey(new TableColumn("seq_id", "bigint"));
             AddColumn("id", "uuid", "NOT NULL");
-            AddColumn("stream_id", stringIdType, $"REFERENCES {events.DatabaseSchemaName}.mt_streams ON DELETE CASCADE");
+            AddColumn("stream_id", stringIdType, (events.TenancyStyle != TenancyStyle.Conjoined) ? $"REFERENCES {events.DatabaseSchemaName}.mt_streams ON DELETE CASCADE" : null);
             AddColumn("version", "integer", "NOT NULL");
             AddColumn("data", "jsonb", "NOT NULL");
             AddColumn("type", "varchar(100)", "NOT NULL");
             AddColumn("timestamp", "timestamptz", "default (now()) NOT NULL");
             AddColumn<TenantIdColumn>();
-            AddColumn(new DotNetTypeColumn {Directive = "NULL"});
+            AddColumn(new DotNetTypeColumn { Directive = "NULL" });
 
-            Constraints.Add("CONSTRAINT pk_mt_events_stream_and_version UNIQUE(stream_id, version)");
+            if (events.TenancyStyle == TenancyStyle.Conjoined)
+            {
+                Constraints.Add($"FOREIGN KEY(stream_id, {TenantIdColumn.Name}) REFERENCES {events.DatabaseSchemaName}.mt_streams(id, {TenantIdColumn.Name})");
+                Constraints.Add($"CONSTRAINT pk_mt_events_stream_and_version UNIQUE(stream_id, {TenantIdColumn.Name}, version)");
+            }
+            else
+            {
+                Constraints.Add("CONSTRAINT pk_mt_events_stream_and_version UNIQUE(stream_id, version)");
+            }
+
             Constraints.Add("CONSTRAINT pk_mt_events_id_unique UNIQUE(id)");
         }
     }
+
     // ENDSAMPLE
 }

--- a/src/Marten/Events/StreamState.cs
+++ b/src/Marten/Events/StreamState.cs
@@ -29,5 +29,22 @@ namespace Marten.Events
             LastTimestamp = lastTimestamp;
             Created = created;
         }
+
+        internal static StreamState Create(object identifier, int version, Type aggregateType, DateTime lastTimestamp, DateTime created)
+        {
+            if (!(identifier is string) && !(identifier is Guid))
+            {
+                throw new ArgumentException("Stream identifier needs to be string or Guid type", nameof(identifier));
+            }
+
+            if (identifier is string)
+            {
+                return new StreamState((string)identifier, version, aggregateType, lastTimestamp, created);
+            }
+            else
+            {
+                return new StreamState((Guid)identifier, version, aggregateType, lastTimestamp, created);
+            }
+        }
     }
 }

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Postgresql as a Document Db and Event Store for .Net Development</Description>
-    <VersionPrefix>2.7.1-beta1</VersionPrefix>
+    <VersionPrefix>2.7.1</VersionPrefix>
     <Authors>Jeremy D. Miller;Tim Cools;Jeff Doolittle;James Hopper</Authors>
     <TargetFrameworks>net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Marten</AssemblyName>

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Postgresql as a Document Db and Event Store for .Net Development</Description>
-    <VersionPrefix>2.7.1</VersionPrefix>
+    <VersionPrefix>2.7.1-beta1</VersionPrefix>
     <Authors>Jeremy D. Miller;Tim Cools;Jeff Doolittle;James Hopper</Authors>
     <TargetFrameworks>net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Marten</AssemblyName>


### PR DESCRIPTION
# Description
Currently Marten only supports Conjoined multitenancy on Document database. Event Store supports only Single tenancy style. Currently it's not possible to eg. add streams with same id for multiple tenants. This PR adds support for that. I did my best to not introduce breaking changes to current code. This PR does not contain changes for Async Daemon.

## Type of change

Updated all Event Store query handlers and stream, events append mechanisms. Updated also database functions.

 [x] New feature (non-breaking change)

# How Has This Been Tested?

* Extended current Event Store tests with Theory Data to check backward compatibility and behaviour with new tenancy style (I recommend to especially have a look on `end_to_end_event_capture_and_fetching_the_stream_Tests.cs` tests
* Added new tests to classes like `multi_tenancy_and_event_capture.cs` and `start_stream_should_enforce_that_it_is_a_new_stream.cs` to check specific Conjoined tenancy streams behaviour
* Added `MultipleActionCheck` class to make easier testing multitenancy behaviour (eg. calling same actions for same stream id with multiple tenants)