### PR TITLE
fix for optimistic concurrency with multitenancy (use tenant_id when …

### DIFF
--- a/src/Marten.Testing/MultiTenancy/with_optimistic_concurrency.cs
+++ b/src/Marten.Testing/MultiTenancy/with_optimistic_concurrency.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using StructureMap.Building;
+using Xunit;
+
+namespace Marten.Testing.MultiTenancy
+{
+    public class with_optimistic_concurrency : IntegratedFixture
+    {
+        private Target target = Target.Random();
+
+        public with_optimistic_concurrency()
+        {
+            StoreOptions(_ =>
+            {
+                _.Connection(ConnectionSource.ConnectionString);
+                _.Policies.AllDocumentsAreMultiTenanted();
+                _.Schema.For<Target>().UseOptimisticConcurrency(enabled: true);
+            });
+        }
+
+        [Fact]
+        public async Task composite_key_correctly_used_for_upsert_concurrency_check()
+        {
+            using (var session = theStore.OpenSession("Red"))
+            {
+                session.Store(target);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = theStore.OpenSession("Blue"))
+            {
+                session.Store(target);
+                await session.SaveChangesAsync();
+            }
+        }       
+    }
+}

--- a/src/Marten/Storage/OverwriteFunction.cs
+++ b/src/Marten/Storage/OverwriteFunction.cs
@@ -23,7 +23,7 @@ INSERT INTO {_tableName.QualifiedName} ({inserts}) VALUES ({valueList})
   ON CONFLICT ON CONSTRAINT {_primaryKeyConstraintName}
   DO UPDATE SET {updates};
 
-  SELECT mt_version FROM {_tableName.QualifiedName} into final_version WHERE id = docId;
+  SELECT mt_version FROM {_tableName.QualifiedName} into final_version WHERE id = docId {_andTenantWhereClause };
   RETURN final_version;
 END;
 $function$;

--- a/src/Marten/Storage/UpdateFunction.cs
+++ b/src/Marten/Storage/UpdateFunction.cs
@@ -25,7 +25,7 @@ DECLARE
 BEGIN
   {statement}
 
-  SELECT mt_version FROM {_tableName} into final_version WHERE id = docId;
+  SELECT mt_version FROM {_tableName} into final_version WHERE id = docId {_andTenantWhereClause};
   RETURN final_version;
 END;
 $function$;


### PR DESCRIPTION
…selecting final_version)
