### PR TITLE
Issue 1007 - Unclear Exception when EventType not recognized.

### DIFF
--- a/src/Marten/Events/EventSelector.cs
+++ b/src/Marten/Events/EventSelector.cs
@@ -81,8 +81,15 @@ namespace Marten.Events
                 {
                     throw new UnknownEventTypeException(eventTypeName);
                 }
-
-                var type = Events.TypeForDotNetName(dotnetTypeName);
+                Type type;
+                try 
+                {
+                    type = Events.TypeForDotNetName(dotnetTypeName);
+                }
+                catch (ArgumentNullException)
+                {
+                    throw new UnknownEventTypeException(dotnetTypeName);
+                }
                 mapping = Events.EventMappingFor(type);
             }
 


### PR DESCRIPTION
Added better error handling for cases where an event type cannot be found to match what types are currently in the database.
Fixes #1007