### PR TITLE
#1003 - Add documentation for unique indexes

### DIFF
--- a/documentation/documentation/documents/configuration/unique.md
+++ b/documentation/documentation/documents/configuration/unique.md
@@ -1,2 +1,75 @@
 <!--title:Unique Indexes-->
 
+[Unique Indexes](https://www.postgresql.org/docs/current/static/indexes-unique.html) are used to enforce uniqueness of property value. They can be combined to handle also uniqueness of multiple properties.
+
+Marten supports both <[linkto:documentation/documents/configuration/duplicated_fields]> and <[linkto:documentation/documents/configuration/computed_indexes]> uniqueness. Using Duplicated Field brings benefits to queries but brings additional complexity, while Computed Index reuses current JSON structure without adding additional db column.
+
+## Definining Unique Index through Store options
+
+Unique Indexes can be created using the fluent interface off of `StoreOptions` like this: 
+
+1. **Computed**:
+* single property
+
+<[sample:using_a_single_property_computed_unique_index_through_store_options]>
+
+* multiple properties
+
+<[sample:using_a_multiple_properties_computed_unique_index_through_store_options]>
+
+<div class="alert alert-info">
+If you don't specify first parameter (index type) - by default it will be created as computed index.
+</div>
+
+2. **Duplicated field**:
+* single property
+
+<[sample:using_a_single_property_duplicate_field_unique_index_through_store_options]>
+
+* multiple properties
+
+<[sample:using_a_multiple_properties_duplicate_field_unique_index_through_store_options]>
+
+## Defining Unique Index through Attribute
+
+Unique Indexes can be created using the `[UniqueIndex]` attribute like this: 
+
+1. **Computed**:
+* single property
+
+<[sample:using_a_single_property_computed_unique_index_through_attribute]>
+
+* multiple properties
+
+<[sample:using_a_multiple_properties_computed_unique_inde_through_attributex]>
+
+
+<div class="alert alert-info">
+If you don't specify IndexType parameter - by default it will be created as computed index.
+</div>
+
+
+2. **Duplicated field**:
+* single property
+
+<[sample:using_a_single_property_duplicate_field_unique_index_through_attribute]>
+
+* multiple properties
+
+<[sample:using_a_multiple_properties_duplicate_field_unique_index_through_attribute]>
+
+<div class="alert alert-info">
+To group multiple properties into single index you need to specify the same values in `IndexName` parameters.
+</div>
+
+
+## Defining Unique Index through Index customization
+
+You have some ability to extend to Computed Index definition to be unique index  by passing a second Lambda `Action` into
+the `Index()` method and definining `IsUnique` property as `true` as shown below:
+
+<[sample:customizing-calculated-index]>
+
+Same can be configured for Duplicated Field:
+
+<[sample:IndexExamples]>

--- a/src/Marten.Testing/Acceptance/unique_indexes.cs
+++ b/src/Marten.Testing/Acceptance/unique_indexes.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using Marten.Schema;
+using Marten.Testing.Documents;
+using Xunit;
+
+namespace Marten.Testing.Acceptance
+{
+    public class unique_indexes : IntegratedFixture
+    {
+        // SAMPLE: using_a_single_property_computed_unique_index_through_attribute
+        public class Account
+        {
+            public Guid Id { get; set; }
+
+            [UniqueIndex(IndexType = UniqueIndexType.Computed)]
+            public string Number { get; set; }
+        }
+
+        // ENDSAMPLE
+
+        // SAMPLE: using_a_single_property_duplicate_field_unique_index_through_store_attribute
+        public class Client
+        {
+            public Guid Id { get; set; }
+
+            [UniqueIndex(IndexType = UniqueIndexType.DuplicatedField)]
+            public string Name { get; set; }
+        }
+
+        // ENDSAMPLE
+
+        // SAMPLE: using_a_multiple_properties_computed_unique_index_through_store_attribute
+        public class Address
+        {
+            private const string UniqueIndexName = "sample_uidx_person";
+
+            public Guid Id { get; set; }
+
+            [UniqueIndex(IndexType = UniqueIndexType.Computed, IndexName = UniqueIndexName)]
+            public string Street { get; set; }
+
+            [UniqueIndex(IndexType = UniqueIndexType.Computed, IndexName = UniqueIndexName)]
+            public string Number { get; set; }
+        }
+
+        // ENDSAMPLE
+
+        // SAMPLE: using_a_multiple_properties_duplicate_field_unique_index_through_attribute
+        public class Person
+        {
+            private const string UniqueIndexName = "sample_uidx_person";
+
+            public Guid Id { get; set; }
+
+            [UniqueIndex(IndexType = UniqueIndexType.DuplicatedField, IndexName = UniqueIndexName)]
+            public string FirstName { get; set; }
+
+            [UniqueIndex(IndexType = UniqueIndexType.DuplicatedField, IndexName = UniqueIndexName)]
+            public string SecondName { get; set; }
+        }
+
+        // ENDSAMPLE
+
+        [Fact]
+        public void example_using_a_single_property_computed_unique_index()
+        {
+            // SAMPLE: using_a_single_property_computed_unique_index_through_store_options
+            var store = DocumentStore.For(_ =>
+            {
+                _.Connection(ConnectionSource.ConnectionString);
+
+                // This creates
+                _.Schema.For<User>().UniqueIndex(UniqueIndexType.Computed, x => x.UserName);
+            });
+        }
+
+        [Fact]
+        public void example_using_a_single_property_duplicate_field_unique_index()
+        {
+            // SAMPLE: using_a_single_property_duplicate_field_unique_index_through_store_options
+            var store = DocumentStore.For(_ =>
+            {
+                _.Connection(ConnectionSource.ConnectionString);
+
+                // This creates
+                _.Schema.For<User>().UniqueIndex(UniqueIndexType.DuplicatedField, x => x.UserName);
+            });
+        }
+
+        [Fact]
+        public void example_using_a_multiple_properties_computed_unique_index()
+        {
+            // SAMPLE: using_a_multiple_properties_computed_unique_index_through_store_options
+            var store = DocumentStore.For(_ =>
+            {
+                _.Connection(ConnectionSource.ConnectionString);
+
+                // This creates
+                _.Schema.For<User>().UniqueIndex(UniqueIndexType.Computed, x => x.FirstName, x => x.FullName);
+            });
+        }
+
+        [Fact]
+        public void example_using_a_multiple_properties_duplicate_field_unique_index()
+        {
+            // SAMPLE: using_a_multiple_properties_duplicate_field_unique_index_through_store_options
+            var store = DocumentStore.For(_ =>
+            {
+                _.Connection(ConnectionSource.ConnectionString);
+
+                // This creates
+                _.Schema.For<User>().UniqueIndex(UniqueIndexType.DuplicatedField, x => x.FirstName, x => x.FullName);
+            });
+        }
+    }
+}

--- a/src/Marten.Testing/Acceptance/unique_indexes.cs
+++ b/src/Marten.Testing/Acceptance/unique_indexes.cs
@@ -15,7 +15,6 @@ namespace Marten.Testing.Acceptance
             [UniqueIndex(IndexType = UniqueIndexType.Computed)]
             public string Number { get; set; }
         }
-
         // ENDSAMPLE
 
         // SAMPLE: using_a_single_property_duplicate_field_unique_index_through_store_attribute
@@ -26,7 +25,6 @@ namespace Marten.Testing.Acceptance
             [UniqueIndex(IndexType = UniqueIndexType.DuplicatedField)]
             public string Name { get; set; }
         }
-
         // ENDSAMPLE
 
         // SAMPLE: using_a_multiple_properties_computed_unique_index_through_store_attribute
@@ -42,7 +40,6 @@ namespace Marten.Testing.Acceptance
             [UniqueIndex(IndexType = UniqueIndexType.Computed, IndexName = UniqueIndexName)]
             public string Number { get; set; }
         }
-
         // ENDSAMPLE
 
         // SAMPLE: using_a_multiple_properties_duplicate_field_unique_index_through_attribute
@@ -58,7 +55,6 @@ namespace Marten.Testing.Acceptance
             [UniqueIndex(IndexType = UniqueIndexType.DuplicatedField, IndexName = UniqueIndexName)]
             public string SecondName { get; set; }
         }
-
         // ENDSAMPLE
 
         [Fact]

--- a/src/Marten.Testing/Examples/MartenRegistryExamples.cs
+++ b/src/Marten.Testing/Examples/MartenRegistryExamples.cs
@@ -30,15 +30,15 @@ namespace Marten.Testing.Examples
         public MyMartenRegistry()
         {
             // I'm going to search for user by UserName
-            // pretty frequently, so I want that to be 
+            // pretty frequently, so I want that to be
             // a duplicated, searchable field
             For<User>().Duplicate(x => x.UserName);
-
 
             // Add a gin index to Company's json data storage
             For<Company>().GinIndexJsonData();
         }
     }
+
     // ENDSAMPLE
 
     // SAMPLE: using_attributes_on_document
@@ -53,6 +53,7 @@ namespace Marten.Testing.Examples
         [DuplicateField(PgType = "text")]
         public string Category;
     }
+
     // ENDSAMPLE
 
     // SAMPLE: IndexExamples
@@ -69,14 +70,21 @@ namespace Marten.Testing.Examples
             For<User>().Duplicate(x => x.FirstName, pgType: "varchar(50)");
 
             // Customize the index on the duplicated field
-            // for FirstName 
-            For<User>().Duplicate(x => x.FirstName, configure:idx =>
+            // for FirstName
+            For<User>().Duplicate(x => x.FirstName, configure: idx =>
             {
                 idx.IndexName = "idx_special";
                 idx.Method = IndexMethod.hash;
             });
 
+            // Customize the index on the duplicated field
+            // for UserName to be unique
+            For<User>().Duplicate(x => x.UserName, configure: idx =>
+            {
+                idx.IsUnique = true;
+            });
         }
     }
+
     // ENDSAMPLE
 }

--- a/src/Marten.Testing/Schema/UniqueIndexTests.cs
+++ b/src/Marten.Testing/Schema/UniqueIndexTests.cs
@@ -23,7 +23,7 @@ namespace Marten.Testing.Schema
 
             public string UserName { get; set; }
 
-            [UniqueIndex(IsComputed = false)]
+            [UniqueIndex(IndexType = UniqueIndexType.DuplicatedField)]
             public string Email { get; set; }
 
             [UniqueIndex(IndexName = "fullname")]

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -2,9 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
-using Baseline;
-using Baseline.Reflection;
 using Marten.Linq;
 using Marten.Schema;
 using Marten.Schema.Identity;
@@ -88,7 +85,7 @@ namespace Marten
             {
                 _parent = parent;
 
-                _parent.alter = options => options.Storage.MappingFor(typeof (T));
+                _parent.alter = options => options.Storage.MappingFor(typeof(T));
             }
 
             /// <summary>
@@ -99,7 +96,7 @@ namespace Marten
             /// <returns></returns>
             public DocumentMappingExpression<T> PropertySearching(PropertySearching searching)
             {
-                alter = m => m.PropertySearching = searching; 
+                alter = m => m.PropertySearching = searching;
                 return this;
             }
 
@@ -114,10 +111,10 @@ namespace Marten
             {
                 alter = m => m.Alias = alias;
                 return this;
-            }  
+            }
 
             /// <summary>
-            /// Marks a property or field on this document type as a searchable field that is also duplicated in the 
+            /// Marks a property or field on this document type as a searchable field that is also duplicated in the
             /// database document table
             /// </summary>
             /// <param name="expression"></param>
@@ -131,7 +128,7 @@ namespace Marten
             }
 
             /// <summary>
-            /// Marks a property or field on this document type as a searchable field that is also duplicated in the 
+            /// Marks a property or field on this document type as a searchable field that is also duplicated in the
             /// database document table
             /// </summary>
             /// <param name="expression"></param>
@@ -153,6 +150,31 @@ namespace Marten
             public DocumentMappingExpression<T> Index(Expression<Func<T, object>> expression, Action<ComputedIndex> configure = null)
             {
                 alter = m => m.Index(expression, configure);
+
+                return this;
+            }
+
+            /// <summary>
+            /// Creates a unique index on this data member within the JSON data storage
+            /// </summary>
+            /// <param name="expressions"></param>
+            /// <returns></returns>
+            public DocumentMappingExpression<T> UniqueIndex(params Expression<Func<T, object>>[] expressions)
+            {
+                alter = m => m.UniqueIndex(expressions);
+
+                return this;
+            }
+
+            /// <summary>
+            /// Creates a unique index on this data member within the JSON data storage
+            /// </summary>
+            /// <param name="isComputed"></param>
+            /// <param name="expressions"></param>
+            /// <returns></returns>
+            public DocumentMappingExpression<T> UniqueIndex(UniqueIndexType indexType, params Expression<Func<T, object>>[] expressions)
+            {
+                alter = m => m.UniqueIndex(indexType, expressions);
 
                 return this;
             }
@@ -231,12 +253,10 @@ namespace Marten
                 {
                     Action<StoreOptions> alteration = o =>
                     {
-                        value((DocumentMapping<T>) o.Storage.MappingFor(typeof (T)));
+                        value((DocumentMapping<T>)o.Storage.MappingFor(typeof(T)));
                     };
 
-
                     _parent.alter = alteration;
-                   
                 }
             }
 
@@ -273,7 +293,7 @@ namespace Marten
             /// <summary>
             /// Programmatically directs Marten to map all the subclasses of <cref name="T"/> to a hierarchy of types
             /// </summary>
-            /// <param name="allSubclassTypes">All the subclass types of <cref name="T"/> that you wish to map. 
+            /// <param name="allSubclassTypes">All the subclass types of <cref name="T"/> that you wish to map.
             /// You can use either params of <see cref="Type"/> or <see cref="MappedType"/> or a mix, since Type can implicitly convert to MappedType (without an alias)</param>
             /// <returns></returns>
             public DocumentMappingExpression<T> AddSubClassHierarchy(params MappedType[] allSubclassTypes)
@@ -292,7 +312,6 @@ namespace Marten
 
                 return this;
             }
-
 
             public DocumentMappingExpression<T> AddSubClass<TSubclass>(string alias = null) where TSubclass : T
             {
@@ -359,7 +378,6 @@ namespace Marten
                 return this;
             }
 
-
             public DocumentMappingExpression<T> VersionedWith(Expression<Func<T, Guid>> memberExpression)
             {
                 alter = m => m.VersionMember = FindMembers.Determine(memberExpression).Single();
@@ -375,10 +393,11 @@ namespace Marten
             Type = type;
             Alias = alias;
         }
+
         public Type Type { get; set; }
         public string Alias { get; set; }
 
-        public static implicit operator MappedType (Type type)
+        public static implicit operator MappedType(Type type)
         {
             return new MappedType(type);
         }

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -399,9 +399,9 @@ namespace Marten.Schema
             return index;
         }
 
-        public IIndexDefinition AddUniqueIndex(MemberInfo[][] members, bool isComputed = true, string indexName = null, IndexMethod indexMethod = IndexMethod.btree)
+        public IIndexDefinition AddUniqueIndex(MemberInfo[][] members, UniqueIndexType indexType = UniqueIndexType.Computed, string indexName = null, IndexMethod indexMethod = IndexMethod.btree)
         {
-            if (!isComputed)
+            if (indexType == UniqueIndexType.DuplicatedField)
             {
                 var fields = members.Select(memberPath => DuplicateField(memberPath)).ToList();
 
@@ -711,10 +711,10 @@ namespace Marten.Schema
 
         public void UniqueIndex(params Expression<Func<T, object>>[] expressions)
         {
-            UniqueIndex(true, expressions);
+            UniqueIndex(UniqueIndexType.Computed, expressions);
         }
 
-        public void UniqueIndex(bool isComputed, params Expression<Func<T, object>>[] expressions)
+        public void UniqueIndex(UniqueIndexType indexType, params Expression<Func<T, object>>[] expressions)
         {
             AddUniqueIndex(
                 expressions
@@ -725,7 +725,7 @@ namespace Marten.Schema
                     return visitor.Members.ToArray();
                 })
                 .ToArray(),
-                isComputed);
+                indexType);
         }
 
         public void ForeignKey<TReference>(

--- a/src/Marten/Schema/UniqueIndexType.cs
+++ b/src/Marten/Schema/UniqueIndexType.cs
@@ -1,0 +1,8 @@
+﻿namespace Marten.Schema
+{
+    public enum UniqueIndexType
+    {
+        DuplicatedField,
+        Computed
+    }
+}

--- a/src/Marten/UniqueIndexAttribute.cs
+++ b/src/Marten/UniqueIndexAttribute.cs
@@ -22,7 +22,7 @@ namespace Marten.Schema
 
             mapping.AddUniqueIndex(
                 membersGroupedByIndexName.Select(mg => new[] { mg.Member }).ToArray(),
-                IsComputed,
+                IndexType,
                 IndexName,
                 IndexMethod);
         }
@@ -43,8 +43,8 @@ namespace Marten.Schema
         public string IndexName { get; set; } = null;
 
         /// <summary>
-        /// Specify if Index is computed
+        /// Specify Index type
         /// </summary>
-        public bool IsComputed = true;
+        public UniqueIndexType IndexType = UniqueIndexType.Computed;
     }
 }


### PR DESCRIPTION
# Description
Currently there is no documentation for setting up unique indexes.

## Type of change

Added:
- Documentation for unique indexes
- Created samples of unique indexes definition
- Added `UniqueIndexType` enum to make Unique Index api more descriptive. After rethinking I didn't like `bool` parameter, that I initially introduced - it's too enigmatic... So having the chance to make it better before offical `2.8.0` release - I changed that.

 [x] New feature (non-breaking change)