### PR TITLE
more informative exception for unknown event types

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_1019_event_type_not_found_bad_exception_message.cs
+++ b/src/Marten.Testing/Bugs/Bug_1019_event_type_not_found_bad_exception_message.cs
@@ -1,0 +1,55 @@
+using System;
+using Marten.Events;
+using Marten.Schema;
+using Marten.Util;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+	public class Bug_1019_event_type_not_found_bad_exception_message : IntegratedFixture
+	{
+		[Fact]
+		public void unknown_type_should_report_type_name()
+		{
+			var streamGuid = Guid.Parse("378b8405-8cdc-40ef-bafa-2033cd3c43c3");
+			var typeName = "Marten.Testing.Bugs.Bug1019.Product, Marten.Testing";
+			var newTypeName = "Foo, Bar";
+			using (var session = theStore.OpenSession())
+			{
+				var product = new Bug1019.Product {Id = 1, Name = "prod1", Price = 108};
+				session.Events.Append(streamGuid, product);
+				session.SaveChanges();
+				var command = session.Connection.CreateCommand();
+				command.CommandText = @"
+update 
+	public.mt_events 
+set 
+	mt_dotnet_type = :newDotnetTypeName
+	, type = :newTypeName
+where
+	mt_dotnet_type = :originalTypeName
+";
+				command.AddNamedParameter("newDotnetTypeName", newTypeName);
+				command.AddNamedParameter("newTypeName", "foo");
+				command.AddNamedParameter("originalTypeName", typeName);
+				command.ExecuteNonQuery();
+				Assert.Throws<UnknownEventTypeException>(() => session.Events.FetchStream(streamGuid)).Message.ShouldContain(newTypeName);
+			}
+
+		}
+	}
+
+	namespace Bug1019
+	{
+		public class Product
+		{
+			public int Id { get; set; }
+
+			public string Name { get; set; }
+
+			public decimal Price { get; set; }
+		}
+	}
+
+}

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -234,7 +234,12 @@ namespace Marten.Events
         {
             if (!_nameToType.ContainsKey(assemblyQualifiedName))
             {
-                _nameToType[assemblyQualifiedName] = Type.GetType(assemblyQualifiedName);
+                var runtimeType = Type.GetType(assemblyQualifiedName);
+                if(runtimeType == null)
+                {
+                    throw new Exception($"Unable to load event type '{assemblyQualifiedName}'.");
+                }
+                _nameToType[assemblyQualifiedName] = runtimeType;
             }
 
             return _nameToType[assemblyQualifiedName];

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -237,7 +237,7 @@ namespace Marten.Events
                 var runtimeType = Type.GetType(assemblyQualifiedName);
                 if(runtimeType == null)
                 {
-                    throw new Exception($"Unable to load event type '{assemblyQualifiedName}'.");
+                    throw new UnknownEventTypeException($"Unable to load event type '{assemblyQualifiedName}'.");
                 }
                 _nameToType[assemblyQualifiedName] = runtimeType;
             }


### PR DESCRIPTION
Note: bear with me, this is all done in github editor.

I'm facing issue trying to retrieve events that I defined in a F# script (evaluating/running the script again results in potentially different assembly name):

```fsharp
let store = DocumentStore.For(fun o ->
  o.Connection(connectionString)
  o.Events.set_StreamIdentity Marten.Events.StreamIdentity.AsString
)
```

When I run this code:

```fsharp
let stream = session.Events.FetchStream streamId
```

I'm getting this exception, which doesn't help troubleshooting the origin of the issue:

```
System.ArgumentNullException: Value cannot be null.
Parameter name: key
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at Baseline.ConcurrentCache`2.Fill(TKey key, Func`2 onMissing)
   at Marten.Events.StringIdentifiedEventSelector.Resolve(DbDataReader reader, IIdentityMap map, QueryStatistics stats)
   at Marten.Linq.SelectorExtensions.Read[T](ISelector`1 selector, DbDataReader reader, IIdentityMap map, QueryStatistics stats)
   at Marten.Events.EventQueryHandler`1.Handle(DbDataReader reader, IIdentityMap map, QueryStatistics stats)
   at Marten.Services.CommandRunnerExtensions.<>c__DisplayClass2_0`1.<Fetch>b__0(NpgsqlCommand c)
   at Marten.Services.ManagedConnection.Execute[T](NpgsqlCommand cmd, Func`2 func)
   at Marten.Events.EventStore.FetchStream(String streamKey, Int32 version, Nullable`1 timestamp)
   at <StartupCode$FSI_0015>.$FSI_0015.main@()
```

If there is a way to override how the event type is retrieved at runtime, it would be a good idea to point to it in the exception message, but I'm just learning about Marten so haven't yet figured that out.