### PR TITLE
[wip] Allow event type name to be defined manually as part of StoreOptions customization

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_1019_event_type_not_found_bad_exception_message.cs
+++ b/src/Marten.Testing/Bugs/Bug_1019_event_type_not_found_bad_exception_message.cs
@@ -1,0 +1,55 @@
+using System;
+using Marten.Events;
+using Marten.Schema;
+using Marten.Util;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+	public class Bug_1019_event_type_not_found_bad_exception_message : IntegratedFixture
+	{
+		[Fact]
+		public void unknown_type_should_report_type_name()
+		{
+			var streamGuid = Guid.Parse("378b8405-8cdc-40ef-bafa-2033cd3c43c3");
+			var typeName = "Marten.Testing.Bugs.Bug1019.Product, Marten.Testing";
+			var newTypeName = "Foo, Bar";
+			using (var session = theStore.OpenSession())
+			{
+				var product = new Bug1019.Product {Id = 1, Name = "prod1", Price = 108};
+				session.Events.Append(streamGuid, product);
+				session.SaveChanges();
+				var command = session.Connection.CreateCommand();
+				command.CommandText = @"
+update 
+	public.mt_events 
+set 
+	mt_dotnet_type = :newDotnetTypeName
+	, type = :newTypeName
+where
+	mt_dotnet_type = :originalTypeName
+";
+				command.AddNamedParameter("newDotnetTypeName", newTypeName);
+				command.AddNamedParameter("newTypeName", "foo");
+				command.AddNamedParameter("originalTypeName", typeName);
+				command.ExecuteNonQuery();
+				Assert.Throws<UnknownEventTypeException>(() => session.Events.FetchStream(streamGuid)).Message.ShouldContain(newTypeName);
+			}
+
+		}
+	}
+
+	namespace Bug1019
+	{
+		public class Product
+		{
+			public int Id { get; set; }
+
+			public string Name { get; set; }
+
+			public decimal Price { get; set; }
+		}
+	}
+
+}

--- a/src/Marten.Testing/Bugs/Bug_1019_event_type_not_found_bad_exception_message.cs
+++ b/src/Marten.Testing/Bugs/Bug_1019_event_type_not_found_bad_exception_message.cs
@@ -44,19 +44,18 @@ where
         public void eventmapping_for_type_can_be_obtiained_via_event_type_name()
         {
             var customEventTypeName = "foo";
-            var eventType = typeof(Bug1019.Product);
             StoreOptions(options =>
             {
-                var eventMapping = options.Storage.EventMappingFor(eventType);
+                var eventMapping = options.Storage.EventMappingFor<Bug1019.Product>();
                 eventMapping.EventTypeName = customEventTypeName;
             });
             using (var session = theStore.OpenSession())
             {
                 var eventGraph = session.DocumentStore.Events;
-                eventGraph.EventMappingFor(eventType).ShouldBeTheSameAs(eventGraph.EventMappingFor(customEventTypeName));
+                eventGraph.EventMappingFor<Bug1019.Product>().ShouldBeTheSameAs(eventGraph.EventMappingFor(customEventTypeName));
 
                 // note doing the following first would not work
-                eventGraph.EventMappingFor(customEventTypeName).ShouldBeTheSameAs(eventGraph.EventMappingFor(eventType));
+                eventGraph.EventMappingFor(customEventTypeName).ShouldBeTheSameAs(eventGraph.EventMappingFor<Bug1019.Product>());
             }
 
         }

--- a/src/Marten.Testing/Bugs/Bug_1019_event_type_not_found_bad_exception_message.cs
+++ b/src/Marten.Testing/Bugs/Bug_1019_event_type_not_found_bad_exception_message.cs
@@ -1,55 +1,77 @@
 using System;
 using Marten.Events;
 using Marten.Schema;
+using Marten.Services;
 using Marten.Util;
 using Shouldly;
 using Xunit;
 
 namespace Marten.Testing.Bugs
 {
-	public class Bug_1019_event_type_not_found_bad_exception_message : IntegratedFixture
-	{
-		[Fact]
-		public void unknown_type_should_report_type_name()
-		{
-			var streamGuid = Guid.Parse("378b8405-8cdc-40ef-bafa-2033cd3c43c3");
-			var typeName = "Marten.Testing.Bugs.Bug1019.Product, Marten.Testing";
-			var newTypeName = "Foo, Bar";
-			using (var session = theStore.OpenSession())
-			{
-				var product = new Bug1019.Product {Id = 1, Name = "prod1", Price = 108};
-				session.Events.Append(streamGuid, product);
-				session.SaveChanges();
-				var command = session.Connection.CreateCommand();
-				command.CommandText = @"
+    public class Bug_1019_event_type_not_found_bad_exception_message : IntegratedFixture
+    {
+        [Fact]
+        public void unknown_type_should_report_type_name()
+        {
+            var streamGuid = Guid.Parse("378b8405-8cdc-40ef-bafa-2033cd3c43c3");
+            var typeName = "Marten.Testing.Bugs.Bug1019.Product, Marten.Testing";
+            var newTypeName = "Foo, Bar";
+            using (var session = theStore.OpenSession())
+            {
+                var product = new Bug1019.Product {Id = 1, Name = "prod1", Price = 108};
+                session.Events.Append(streamGuid, product);
+                session.SaveChanges();
+                var command = session.Connection.CreateCommand();
+                command.CommandText = @"
 update 
-	public.mt_events 
+    public.mt_events 
 set 
-	mt_dotnet_type = :newDotnetTypeName
-	, type = :newTypeName
+    mt_dotnet_type = :newDotnetTypeName
+    , type = :newTypeName
 where
-	mt_dotnet_type = :originalTypeName
+    mt_dotnet_type = :originalTypeName
 ";
-				command.AddNamedParameter("newDotnetTypeName", newTypeName);
-				command.AddNamedParameter("newTypeName", "foo");
-				command.AddNamedParameter("originalTypeName", typeName);
-				command.ExecuteNonQuery();
-				Assert.Throws<UnknownEventTypeException>(() => session.Events.FetchStream(streamGuid)).Message.ShouldContain(newTypeName);
-			}
+                command.AddNamedParameter("newDotnetTypeName", newTypeName);
+                command.AddNamedParameter("newTypeName", "foo");
+                command.AddNamedParameter("originalTypeName", typeName);
+                command.ExecuteNonQuery();
+                Assert.Throws<UnknownEventTypeException>(() => session.Events.FetchStream(streamGuid)).Message.ShouldContain(newTypeName);
+            }
 
-		}
-	}
+        }
 
-	namespace Bug1019
-	{
-		public class Product
-		{
-			public int Id { get; set; }
+        [Fact]
+        public void eventmapping_for_type_can_be_obtiained_via_event_type_name()
+        {
+            var customEventTypeName = "foo";
+            var eventType = typeof(Bug1019.Product);
+            StoreOptions(options =>
+            {
+                var eventMapping = options.Storage.EventMappingFor(eventType);
+                eventMapping.EventTypeName = customEventTypeName;
+            });
+            using (var session = theStore.OpenSession())
+            {
+                var eventGraph = session.DocumentStore.Events;
+                eventGraph.EventMappingFor(eventType).ShouldBeTheSameAs(eventGraph.EventMappingFor(customEventTypeName));
 
-			public string Name { get; set; }
+                // note doing the following first would not work
+                eventGraph.EventMappingFor(customEventTypeName).ShouldBeTheSameAs(eventGraph.EventMappingFor(eventType));
+            }
 
-			public decimal Price { get; set; }
-		}
-	}
+        }
+    }
+
+    namespace Bug1019
+    {
+        public class Product
+        {
+            public int Id { get; set; }
+
+            public string Name { get; set; }
+
+            public decimal Price { get; set; }
+        }
+    }
 
 }

--- a/src/Marten.Testing/Events/EventMappingTests.cs
+++ b/src/Marten.Testing/Events/EventMappingTests.cs
@@ -14,5 +14,14 @@ namespace Marten.Testing.Events
 
             mapping.EventTypeName.ShouldBe("members_joined");
         }
+
+        [Fact]
+        public void arbitrary_event_name_for_event_type()
+        {
+            var options = new StoreOptions();
+            var mapping = new EventMapping<MembersJoined>(new EventGraph(options), "special_members_joined");
+
+            mapping.EventTypeName.ShouldBe("special_members_joined");
+        }
     }
 }

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -38,7 +38,7 @@ namespace Marten.Events
             _events.OnMissing = eventType =>
             {
                 var mapping = typeof(EventMapping<>).CloseAndBuildAs<EventMapping>(this, eventType);
-                Options.Storage.AddMapping(mapping);
+                Options.Storage.AddDocumentMapping(mapping);
 
                 return mapping;
             };

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -37,9 +37,10 @@ namespace Marten.Events
             _aggregatorLookup = new AggregatorLookup();
             _events.OnMissing = eventType =>
             {
-                var mapping = typeof(EventMapping<>).CloseAndBuildAs<EventMapping>(this, eventType);
-                Options.Storage.AddDocumentMapping(mapping);
+                var mapping = options.Storage.EventMappingFor(eventType);
 
+                Options.Storage.AddDocumentMapping(mapping);
+                _byEventName.Fill(mapping.EventTypeName, mapping);
                 return mapping;
             };
 

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -234,7 +234,12 @@ namespace Marten.Events
         {
             if (!_nameToType.ContainsKey(assemblyQualifiedName))
             {
-                _nameToType[assemblyQualifiedName] = Type.GetType(assemblyQualifiedName);
+                var runtimeType = Type.GetType(assemblyQualifiedName);
+                if(runtimeType == null)
+                {
+                    throw new Exception($"Unable to load event type '{assemblyQualifiedName}'.");
+                }
+                _nameToType[assemblyQualifiedName] = runtimeType;
             }
 
             return _nameToType[assemblyQualifiedName];

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -237,7 +237,7 @@ namespace Marten.Events
                 var runtimeType = Type.GetType(assemblyQualifiedName);
                 if(runtimeType == null)
                 {
-                    throw new Exception($"Unable to load event type '{assemblyQualifiedName}'.");
+                    throw new UnknownEventTypeException($"Unable to load event type '{assemblyQualifiedName}'.");
                 }
                 _nameToType[assemblyQualifiedName] = runtimeType;
             }

--- a/src/Marten/Schema/DocumentCleaner.cs
+++ b/src/Marten/Schema/DocumentCleaner.cs
@@ -54,7 +54,7 @@ AND    n.nspname = '{1}';";
 
         public void DeleteDocumentsFor(Type documentType)
         {
-            var mapping = _options.Storage.FindMapping(documentType);
+            var mapping = _options.Storage.FindDocumentMapping(documentType);
             mapping.DeleteAllDocuments(_tenant);
         }
 

--- a/src/Marten/Storage/DocumentStorageFeatures.cs
+++ b/src/Marten/Storage/DocumentStorageFeatures.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Baseline;
+using Marten.Events;
+using Marten.Schema;
+using Marten.Schema.BulkLoading;
+using Marten.Schema.Identity;
+using Marten.Schema.Identity.Sequences;
+using Marten.Util;
+
+namespace Marten.Storage
+{
+    internal class DocumentStorageFeatures
+    {
+        private readonly ConcurrentDictionary<Type, DocumentMapping> _documentMappings =
+            new ConcurrentDictionary<Type, DocumentMapping>();
+
+        private readonly ConcurrentDictionary<Type, IDocumentMapping> _mappings =
+            new ConcurrentDictionary<Type, IDocumentMapping>();
+
+        private readonly ConcurrentDictionary<Type, IDocumentStorage> _documentTypes =
+            new ConcurrentDictionary<Type, IDocumentStorage>();
+
+        internal IEnumerable<DocumentMapping> AllDocumentMappings => _documentMappings.Values;
+        internal IEnumerable<IDocumentMapping> AllMappings => _documentMappings.Values.Union(_mappings.Values);
+
+        internal bool SequenceIsRequired()
+        {
+            return _documentMappings.Values.Any(x => x.IdStrategy.RequiresSequences);
+        }
+        internal DocumentMapping MappingFor(Type documentType, StoreOptions options)
+        {
+            return _documentMappings.GetOrAdd(documentType, type => typeof(DocumentMapping<>).CloseAndBuildAs<DocumentMapping>(options, documentType));
+        }
+
+        internal void AddMapping(IDocumentMapping mapping)
+        {
+            _mappings[mapping.DocumentType] = mapping;
+        }
+
+        internal IDocumentMapping FindMapping(Type documentType, StoreOptions options)
+        {
+
+            return _mappings.GetOrAdd(documentType, type =>
+            {
+                var subclass = AllDocumentMappings.SelectMany(x => x.SubClasses)
+                    .FirstOrDefault(x => x.DocumentType == type) as IDocumentMapping;
+
+                return subclass ?? MappingFor(documentType, options);
+            });
+        }
+
+        public IDocumentStorage StorageFor(Type documentType, StoreOptions options) {
+            return _documentTypes.GetOrAdd(documentType, type =>
+            {
+                var mapping = FindMapping(documentType, options);
+
+                assertNoDuplicateDocumentAliases();
+
+                return mapping.BuildStorage(options);
+            });
+        }
+
+        private void assertNoDuplicateDocumentAliases()
+        {
+            var duplicates =
+                AllDocumentMappings.Where(x => !x.StructuralTyped)
+                    .GroupBy(x => x.Alias)
+                    .Where(x => x.Count() > 1)
+                    .ToArray();
+            if (duplicates.Any())
+            {
+                var message = duplicates.Select(group =>
+                {
+                    return
+                        $"Document types {group.Select(x => x.DocumentType.Name).Join(", ")} all have the same document alias '{group.Key}'. You must explicitly make document type aliases to disambiguate the database schema objects";
+                }).Join("\n");
+
+                throw new AmbiguousDocumentTypeAliasesException(message);
+            }
+        }
+
+        public void HoldEventQueryMapping(StoreOptions options)
+        {
+            _mappings[typeof(IEvent)] = new EventQueryMapping(options);
+        }
+
+        public void HoldSubClassMapping(Type subClassDocumentType, SubClassMapping subClass)
+        {
+            _mappings[subClass.DocumentType] = subClass;
+        }
+    }
+}

--- a/src/Marten/Storage/EventStorageFeature.cs
+++ b/src/Marten/Storage/EventStorageFeature.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Concurrent;
+using Baseline;
+using Marten.Events;
+
+namespace Marten.Storage {
+    internal class EventStorageFeatures
+    {
+        private readonly ConcurrentDictionary<Type, EventMapping> _eventMappings = new ConcurrentDictionary<Type, EventMapping>();
+        internal EventMapping MappingFor(Type eventType, StoreOptions options)
+        {
+            return _eventMappings.GetOrAdd(eventType, type => typeof(EventMapping<>).CloseAndBuildAs<EventMapping>(options.Events, eventType));
+        }
+    }
+}

--- a/src/Marten/Storage/StorageFeatures.cs
+++ b/src/Marten/Storage/StorageFeatures.cs
@@ -98,6 +98,7 @@ namespace Marten.Storage
         }
 
         public EventMapping EventMappingFor(Type eventType) => _eventStorageFeatures.MappingFor(eventType, _options);
+        public EventMapping EventMappingFor<T>() => EventMappingFor(typeof(T));
 
         internal void PostProcessConfiguration()
         {

--- a/src/Marten/Storage/StorageFeatures.cs
+++ b/src/Marten/Storage/StorageFeatures.cs
@@ -17,6 +17,7 @@ namespace Marten.Storage
     {
         private readonly StoreOptions _options;
         private readonly DocumentStorageFeatures _documentStorageFeatures = new DocumentStorageFeatures();
+        private readonly EventStorageFeatures _eventStorageFeatures = new EventStorageFeatures();
         private readonly Dictionary<Type, IFeatureSchema> _features = new Dictionary<Type, IFeatureSchema>();
 
         public StorageFeatures(StoreOptions options)
@@ -96,6 +97,7 @@ namespace Marten.Storage
             return MappingFor(featureType);
         }
 
+        public EventMapping EventMappingFor(Type eventType) => _eventStorageFeatures.MappingFor(eventType, _options);
 
         internal void PostProcessConfiguration()
         {

--- a/src/Marten/Storage/Tenant.cs
+++ b/src/Marten/Storage/Tenant.cs
@@ -169,7 +169,7 @@ namespace Marten.Storage
         public IDocumentMapping MappingFor(Type documentType)
         {
             EnsureStorageExists(documentType);
-            return _features.FindMapping(documentType);
+            return _features.FindDocumentMapping(documentType);
         }
 
         public ISequences Sequences => _sequences.Value;


### PR DESCRIPTION
This allow to work around the problem I face in #1019.

```csharp
DocumentStore.For(o => 
  o.Connection(connectionString);
  var mapping = o.Storage.EventMappingFor<MyEvent>();
  mapping.EventTypeName = "my_custom_event";
);
```

```fsharp
DocumentStore.For(fun o -> 
  o.Connection(connectionString)
  o.Storage.EventMappingFor<MyEvent>(EventTypeName = "my_custom_event")
)
```