### PR TITLE
Factorize EventMappingFor related duplicated logic in event selectors

### DIFF
--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -67,6 +67,29 @@ namespace Marten.Events
             return EventMappingFor(typeof(T));
         }
 
+        public EventMapping EventMappingFor(string eventType)
+        {
+            return _byEventName[eventType];
+        }
+
+        public EventMapping EventMappingFor(string eventTypeName, string dotnetTypeName)
+        {
+            var mapping = EventMappingFor(eventTypeName);
+
+            if (mapping == null)
+            {
+                if (dotnetTypeName.IsEmpty())
+                {
+                    throw new UnknownEventTypeException(eventTypeName);
+                }
+
+                var type = TypeForDotNetName(dotnetTypeName);
+                mapping = EventMappingFor(type);
+            }
+
+            return mapping;
+        }
+
         public IEnumerable<EventMapping> AllEvents()
         {
             return _events;
@@ -75,11 +98,6 @@ namespace Marten.Events
         public IEnumerable<IAggregator> AllAggregates()
         {
             return _aggregates.Values;
-        }
-
-        public EventMapping EventMappingFor(string eventType)
-        {
-            return _byEventName[eventType];
         }
 
         public void AddEventType(Type eventType)

--- a/src/Marten/Events/EventSelector.cs
+++ b/src/Marten/Events/EventSelector.cs
@@ -30,21 +30,9 @@ namespace Marten.Events
             var eventTypeName = reader.GetString(1);
             var version = reader.GetInt32(2);
             var dataJson = reader.GetTextReader(3);
+            var dotnetTypeName = reader.GetFieldValue<string>(8);
 
-
-            var mapping = Events.EventMappingFor(eventTypeName);
-
-            if (mapping == null)
-            {
-                var dotnetTypeName = reader.GetFieldValue<string>(8);
-                if (dotnetTypeName.IsEmpty())
-                {
-                    throw new UnknownEventTypeException(eventTypeName);
-                }
-
-                var type = Events.TypeForDotNetName(dotnetTypeName);
-                mapping = Events.EventMappingFor(type);
-            }
+            var mapping = Events.EventMappingFor(eventTypeName, dotnetTypeName);
 
             var data = _serializer.FromJson(mapping.DocumentType, dataJson).As<object>();
 
@@ -71,27 +59,9 @@ namespace Marten.Events
             var eventTypeName = await reader.GetFieldValueAsync<string>(1, token).ConfigureAwait(false);
             var version = await reader.GetFieldValueAsync<int>(2, token).ConfigureAwait(false);
             var dataJson = await reader.As<NpgsqlDataReader>().GetTextReaderAsync(3).ConfigureAwait(false);
+            var dotnetTypeName = await reader.GetFieldValueAsync<string>(8, token).ConfigureAwait(false);
 
-            var mapping = Events.EventMappingFor(eventTypeName);
-
-            if (mapping == null)
-            {
-                var dotnetTypeName = await reader.GetFieldValueAsync<string>(8, token).ConfigureAwait(false);
-                if (dotnetTypeName.IsEmpty())
-                {
-                    throw new UnknownEventTypeException(eventTypeName);
-                }
-                Type type;
-                try 
-                {
-                    type = Events.TypeForDotNetName(dotnetTypeName);
-                }
-                catch (ArgumentNullException)
-                {
-                    throw new UnknownEventTypeException(dotnetTypeName);
-                }
-                mapping = Events.EventMappingFor(type);
-            }
+            var mapping = Events.EventMappingFor(eventTypeName, dotnetTypeName);
 
             var data = _serializer.FromJson(mapping.DocumentType, dataJson).As<object>();
 

--- a/src/Marten/Events/StringIdentifiedEventSelector.cs
+++ b/src/Marten/Events/StringIdentifiedEventSelector.cs
@@ -29,21 +29,9 @@ namespace Marten.Events
             var eventTypeName = reader.GetString(1);
             var version = reader.GetInt32(2);
             var dataJson = reader.GetTextReader(3);
+            var dotnetTypeName = reader.GetFieldValue<string>(8);
 
-
-            var mapping = Events.EventMappingFor(eventTypeName);
-
-            if (mapping == null)
-            {
-                var dotnetTypeName = reader.GetFieldValue<string>(8);
-                if (dotnetTypeName.IsEmpty())
-                {
-                    throw new UnknownEventTypeException(eventTypeName);
-                }
-
-                var type = Events.TypeForDotNetName(dotnetTypeName);
-                mapping = Events.EventMappingFor(type);
-            }
+            var mapping = Events.EventMappingFor(eventTypeName, dotnetTypeName);
 
             var data = _serializer.FromJson(mapping.DocumentType, dataJson).As<object>();
 
@@ -70,20 +58,9 @@ namespace Marten.Events
             var eventTypeName = await reader.GetFieldValueAsync<string>(1, token).ConfigureAwait(false);
             var version = await reader.GetFieldValueAsync<int>(2, token).ConfigureAwait(false);
             var dataJson = await reader.As<NpgsqlDataReader>().GetTextReaderAsync(3).ConfigureAwait(false);
+            var dotnetTypeName = await reader.GetFieldValueAsync<string>(8, token).ConfigureAwait(false);
 
-            var mapping = Events.EventMappingFor(eventTypeName);
-
-            if (mapping == null)
-            {
-                var dotnetTypeName = await reader.GetFieldValueAsync<string>(8, token).ConfigureAwait(false);
-                if (dotnetTypeName.IsEmpty())
-                {
-                    throw new UnknownEventTypeException(eventTypeName);
-                }
-
-                var type = Events.TypeForDotNetName(dotnetTypeName);
-                mapping = Events.EventMappingFor(type);
-            }
+            var mapping = Events.EventMappingFor(eventTypeName, dotnetTypeName);
 
             var data = TypeExtensions.As<object>(_serializer.FromJson(mapping.DocumentType, dataJson));
 


### PR DESCRIPTION
This factorizes the event mapping resolution which was duplicated 4 times in the code with two variants.

Slight drawback is that we pull dotnettypename from reader upfront.