### PR TITLE
Fix for netcore 2.1 Linq support

### DIFF
--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <AssemblyName>Marten.Testing</AssemblyName>
     <PackageId>Marten.Testing</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -33,11 +33,11 @@
     <PackageReference Include="structuremap" Version="4.5.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' or '$(TargetFramework)' == 'netcoreapp2.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' or '$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' or '$(TargetFramework)' == 'netcoreapp2.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' or '$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetFramework)' == 'netcoreapp2.1'">
     <Compile Remove="**\Fixtures\**\*.cs;**\Github\**\*.cs;StorytellerHarness.cs" />
   </ItemGroup>
 

--- a/src/Marten/Linq/Parsing/StringContains.cs
+++ b/src/Marten/Linq/Parsing/StringContains.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 using Baseline.Reflection;
 using Marten.Util;
@@ -7,15 +8,26 @@ namespace Marten.Linq.Parsing
 {
     public class StringContains : StringComparisonParser
     {
-        public StringContains() : base(
-            ReflectionHelper.GetMethod<string>(s => s.Contains(null)),
-            ReflectionHelper.GetMethod<string>(s => s.Contains(null, StringComparison.CurrentCulture)))
+        public StringContains() : base(GetContainsMethods())
         {
         }
 
         public override string FormatValue(MethodInfo method, string value)
         {
             return "%" + value + "%";
+        }
+
+        private static MethodInfo[] GetContainsMethods()
+        {
+            return new []
+            {
+                typeof(string).GetMethod("Contains", new Type[] { typeof(string), typeof(StringComparison)}),
+                ReflectionHelper.GetMethod<string>(s => s.Contains(null)),
+                ReflectionHelper.GetMethod<string>(s => s.Contains(null, StringComparison.CurrentCulture))
+            }
+            .Where(m => m != null)
+            .Distinct()
+            .ToArray();
         }
     }
 }


### PR DESCRIPTION
This is the best we could come up with for a fix for this.  Reflection will have to try to get the overloads for `String.Contains` at runtime, and what it gets will vary depending on whether its running on 2.0 or 2.1. 