### PR TITLE
[WIP] npgsql upgrade to 2.0

### DIFF
--- a/src/Marten.CommandLine/Marten.CommandLine.csproj
+++ b/src/Marten.CommandLine/Marten.CommandLine.csproj
@@ -4,7 +4,7 @@
     <Description>Command line tooling for managing Marten development</Description>
     <VersionPrefix>2.8.0</VersionPrefix>
     <Authors>Jeremy D. Miller;Tim Cools;Jeff Doolittle</Authors>
-    <TargetFrameworks>net46;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <AssemblyName>Marten.CommandLine</AssemblyName>
     <PackageId>Marten.CommandLine</PackageId>
     <PackageIconUrl>http://jasperfx.github.io/marten/content/images/emblem.png</PackageIconUrl>

--- a/src/Marten.Storyteller/Marten.Storyteller.csproj
+++ b/src/Marten.Storyteller/Marten.Storyteller.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Marten.Storyteller</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Marten.Storyteller</PackageId>

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <AssemblyName>Marten.Testing</AssemblyName>
     <PackageId>Marten.Testing</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -33,11 +33,11 @@
     <PackageReference Include="structuremap" Version="4.5.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' or '$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' or '$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetFramework)' == 'netcoreapp2.1'">
     <Compile Remove="**\Fixtures\**\*.cs;**\Github\**\*.cs;StorytellerHarness.cs" />
   </ItemGroup>
 

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -3,7 +3,7 @@
     <Description>Postgresql as a Document Db and Event Store for .Net Development</Description>
     <VersionPrefix>2.8.0</VersionPrefix>
     <Authors>Jeremy D. Miller;Tim Cools;Jeff Doolittle;James Hopper</Authors>
-    <TargetFrameworks>net46;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <AssemblyName>Marten</AssemblyName>
     <PackageId>Marten</PackageId>
     <PackageIconUrl>http://jasperfx.github.io/marten/content/images/emblem.png</PackageIconUrl>
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Remotion.Linq" Version="2.1.1" />
-    <PackageReference Include="Npgsql" Version="3.2.5" />
+    <PackageReference Include="Npgsql" Version="4.0.0" />
     <PackageReference Include="Baseline" Version="1.3.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />

--- a/src/SampleConsoleApp/SampleConsoleApp.csproj
+++ b/src/SampleConsoleApp/SampleConsoleApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>SampleConsoleApp</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>SampleConsoleApp</PackageId>


### PR DESCRIPTION
* Removes netstandard1.3 support (npgsql targets netstandard2.0 now)
* Updated `TypeMapping` to use the new `GlobalTypeMapper`.

__Please steal this code__ 😄 to move forward as I may not be able to get back to it for a week or so, but I wanted to know what was blowing up.

I was not able to get plv8 working properly in my docker instance, so that still needs to be tested (in the event CI fails here).

