### PR TITLE
BulkInsertion optimization

### DIFF
--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -134,7 +134,7 @@ namespace Marten
         public IDocumentSchema Schema { get; }
         public AdvancedOptions Advanced { get; }
 
-        public void BulkInsert<T>(T[] documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly, int batchSize = 1000)
+        public void BulkInsert<T>(IReadOnlyCollection<T> documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly, int batchSize = 1000)
         {
             var bulkInsertion = new BulkInsertion(Tenancy.Default, Options, _writerPool);
             bulkInsertion.BulkInsert(documents, mode, batchSize);
@@ -146,7 +146,7 @@ namespace Marten
             bulkInsertion.BulkInsertDocuments(documents, mode, batchSize);
         }
 
-        public void BulkInsert<T>(string tenantId, T[] documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly,
+        public void BulkInsert<T>(string tenantId, IReadOnlyCollection<T> documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly,
             int batchSize = 1000)
         {
             var bulkInsertion = new BulkInsertion(Tenancy[tenantId], Options, _writerPool);

--- a/src/Marten/IDocumentStore.cs
+++ b/src/Marten/IDocumentStore.cs
@@ -37,7 +37,7 @@ namespace Marten
         /// <param name="documents"></param>
         /// <param name="mode"></param>
         /// <param name="batchSize"></param>
-        void BulkInsert<T>(T[] documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly, int batchSize = 1000);
+        void BulkInsert<T>(IReadOnlyCollection<T> documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly, int batchSize = 1000);
 
         /// <summary>
         ///     Uses Postgresql's COPY ... FROM STDIN BINARY feature to efficiently store
@@ -48,7 +48,7 @@ namespace Marten
         /// <param name="documents"></param>
         /// <param name="mode"></param>
         /// <param name="batchSize"></param>
-        void BulkInsert<T>(string tenantId, T[] documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly, int batchSize = 1000);
+        void BulkInsert<T>(string tenantId, IReadOnlyCollection<T> documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly, int batchSize = 1000);
 
 
         /// <summary>

--- a/src/Marten/Storage/BulkInsertion.cs
+++ b/src/Marten/Storage/BulkInsertion.cs
@@ -22,7 +22,7 @@ namespace Marten.Storage
 
         public ISerializer Serializer { get;}
 
-        public void BulkInsert<T>(T[] documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly, int batchSize = 1000)
+        public void BulkInsert<T>(IReadOnlyCollection<T> documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly, int batchSize = 1000)
         {
             if (typeof(T) == typeof(object))
             {
@@ -101,7 +101,7 @@ namespace Marten.Storage
             }
         }
 
-        private void bulkInsertDocuments<T>(T[] documents, int batchSize, NpgsqlConnection conn, BulkInsertMode mode)
+        private void bulkInsertDocuments<T>(IReadOnlyCollection<T> documents, int batchSize, NpgsqlConnection conn, BulkInsertMode mode)
         {
             var loader = _tenant.BulkLoaderFor<T>();
 
@@ -114,7 +114,7 @@ namespace Marten.Storage
             var writer = _writerPool.Lease();
             try
             {
-                if (documents.Length <= batchSize)
+                if (documents.Count <= batchSize)
                 {
                     if (mode == BulkInsertMode.InsertsOnly)
                     {
@@ -131,7 +131,7 @@ namespace Marten.Storage
                     var total = 0;
                     var page = 0;
 
-                    while (total < documents.Length)
+                    while (total < documents.Count)
                     {
                         var batch = documents.Skip(page * batchSize).Take(batchSize).ToArray();
 


### PR DESCRIPTION
1. BulkInsert method now accept not only arrays, but also lists and hashsets.
2. Reduce GC memory pressure on batch gathering