### PR TITLE
Fix travis ci build file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -ev
 
-dotnet restore ./src/Marten.sln --runtime netstandard1.3
 dotnet build ./src/Marten.Testing/Marten.Testing.csproj --framework netcoreapp2.0 --configuration Release
 npm run test
 dotnet test ./src/Marten.Testing/Marten.Testing.csproj --framework netcoreapp2.0 --configuration Release 


### PR DESCRIPTION
- Remove restore step targeting netstandard1.3
- Keep tests targeting netcoreapp2.0

This is also the fix for travis ci build failing for #1038.

