### PR TITLE
Fix GH-1018

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_1018_multi_key_unique_index_schema_update_assert_failure.cs
+++ b/src/Marten.Testing/Bugs/Bug_1018_multi_key_unique_index_schema_update_assert_failure.cs
@@ -1,0 +1,34 @@
+﻿using Marten.Schema;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+    public class Doc_1018
+    {
+        public Guid Id { get; set; }
+        public string Field1 { get; set; }
+        public string Field2 { get; set; }
+    }
+
+    public class Bug_1018_multi_key_unique_index_schema_update_assert_failure : IntegratedFixture
+    {
+        [Fact]
+        public void check_database_matches_configuration_with_multi_key_unique_index()
+        {
+            var store = DocumentStore.For(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.CreateOrUpdate;
+                _.Connection(ConnectionSource.ConnectionString);
+                _.Schema.For<Doc_1018>()
+                    .Duplicate(x => x.Field1)
+                    .Duplicate(x => x.Field2)
+                    .UniqueIndex(UniqueIndexType.DuplicatedField, x => x.Field1, x => x.Field2);
+            });
+
+            store.Schema.ApplyAllConfiguredChangesToDatabase();
+            store.Schema.AssertDatabaseMatchesConfiguration();
+        }
+    }
+}

--- a/src/Marten/Schema/IndexDefinition.cs
+++ b/src/Marten/Schema/IndexDefinition.cs
@@ -105,7 +105,7 @@ namespace Marten.Schema
                 var columns = match.Groups["columns"].Value;
                 _columns.Each(col =>
                 {
-                    columns = Regex.Replace(columns, $"({col})\\s?([\\w_]+)?", "\"$1\" $2");
+                    columns = Regex.Replace(columns, $"({col})\\s?([\\w_]+)?", "\"$1\"$2");
                 });
 
                 var replacement = Expression.IsEmpty() ?


### PR DESCRIPTION
- Fix bug GH-1018 to remove extra space between index keys from actual DDL statament for multi key indices
in Matches function which results in mismatch
- Add unit test