### PR TITLE
Only check table indices against the configured schema. This

### DIFF
--- a/src/Marten.Testing/Schema/DbObjectsTests.cs
+++ b/src/Marten.Testing/Schema/DbObjectsTests.cs
@@ -31,7 +31,7 @@ namespace Marten.Testing.Schema
             var indices = store2.Tenancy.Default.DbObjects.AllIndexes();
 
             indices.Any(x => Equals(x.Table, store1.Storage.MappingFor(typeof(User)).ToQueryableDocument().Table))
-                .ShouldBeTrue();
+                .ShouldBeFalse();
 
             indices.Any(x => Equals(x.Table, store2.Storage.MappingFor(typeof(User)).ToQueryableDocument().Table))
                 .ShouldBeTrue();

--- a/src/Marten/Storage/Table.cs
+++ b/src/Marten/Storage/Table.cs
@@ -210,7 +210,8 @@ FROM pg_index AS idx
     ON i.relam = am.oid
   JOIN pg_namespace AS NS ON i.relnamespace = NS.OID
   JOIN pg_user AS U ON i.relowner = U.usesysid
-WHERE 
+WHERE
+  nspname = :{schemaParam} AND
   NOT nspname LIKE 'pg%' AND 
   i.relname like 'mt_%';
 


### PR DESCRIPTION
* Makes `IDbObjects.AllIndexes` implementation respect the documented behavior (get indices for the current tenant)
* Allows indice check not to fail in PG with `XX000: could not open relation with OID ..` when changes happen in unrelated schemas (e.g. schema is dropped so that an OID no longer exists when `pg_get_indexdef` executes)
  * Concurrent test scenarios where schemas are treated as "disposable", e.g. only created for the duration of tests, won't sporadically fail in schema checks & patch generation