### PR TITLE
Add option to create transactional or non transactional script for patch and dump

### DIFF
--- a/src/Marten.CommandLine/Commands/Dump/DumpCommand.cs
+++ b/src/Marten.CommandLine/Commands/Dump/DumpCommand.cs
@@ -18,7 +18,7 @@ namespace Marten.CommandLine.Commands.Dump
             if (input.ByTypeFlag)
             {
                 input.WriteLine("Writing DDL files to " + input.FileName);
-                store.Schema.WriteDDLByType(input.FileName);
+                store.Schema.WriteDDLByType(input.FileName, input.TransactionalScriptFlag);
             }
             else
             {
@@ -35,7 +35,7 @@ namespace Marten.CommandLine.Commands.Dump
                     input.WriteLine(ConsoleColor.Yellow, $"Unable to clean the directory at {input.FileName} before writing new files");
                 }
 
-                store.Schema.WriteDDL(input.FileName);
+                store.Schema.WriteDDL(input.FileName, input.TransactionalScriptFlag);
             }
 
             return true;

--- a/src/Marten.CommandLine/Commands/Dump/DumpInput.cs
+++ b/src/Marten.CommandLine/Commands/Dump/DumpInput.cs
@@ -10,5 +10,9 @@ namespace Marten.CommandLine.Commands.Dump
         [Description("Opt into writing the DDL split out by file")]
         [FlagAlias("by-type")]
         public bool ByTypeFlag { get; set; }
+
+        [Description("Option to create patch and rollup scripts as transactional script")]
+        [FlagAlias("transactional-script")]
+        public bool TransactionalScriptFlag { get; set; }
     }
 }

--- a/src/Marten.CommandLine/Commands/Dump/DumpInput.cs
+++ b/src/Marten.CommandLine/Commands/Dump/DumpInput.cs
@@ -11,7 +11,7 @@ namespace Marten.CommandLine.Commands.Dump
         [FlagAlias("by-type")]
         public bool ByTypeFlag { get; set; }
 
-        [Description("Option to create patch and rollup scripts as transactional script")]
+        [Description("Option to create scripts as transactional script")]
         [FlagAlias("transactional-script")]
         public bool TransactionalScriptFlag { get; set; }
     }

--- a/src/Marten.CommandLine/Commands/Patch/PatchCommand.cs
+++ b/src/Marten.CommandLine/Commands/Patch/PatchCommand.cs
@@ -30,13 +30,13 @@ namespace Marten.CommandLine.Commands.Patch
                 var patch = store.Schema.ToPatch(input.SchemaFlag, withAutoCreateAll: true);
 
                 input.WriteLine(ConsoleColor.Green, "Wrote a patch file to " + input.FileName);
-                patch.WriteUpdateFile(input.FileName);
+                patch.WriteUpdateFile(input.FileName, input.TransactionalScriptFlag);
 
 
                 var dropFile = input.DropFlag ?? SchemaPatch.ToDropFileName(input.FileName);
 
                 input.WriteLine(ConsoleColor.Green, "Wrote the drop file to " + dropFile);
-                patch.WriteRollbackFile(dropFile);
+                patch.WriteRollbackFile(dropFile, input.TransactionalScriptFlag);
 
                 return true;
             }

--- a/src/Marten.CommandLine/Commands/Patch/PatchInput.cs
+++ b/src/Marten.CommandLine/Commands/Patch/PatchInput.cs
@@ -13,5 +13,9 @@ namespace Marten.CommandLine.Commands.Patch
 
         [Description("Override the location of the drop file")]
         public string DropFlag { get; set; }
+
+        [Description("Option to create patch and rollup scripts as transactional script")]
+        [FlagAlias("transactional-script")]
+        public bool TransactionalScriptFlag { get; set; }
     }
 }

--- a/src/Marten.CommandLine/Commands/Patch/PatchInput.cs
+++ b/src/Marten.CommandLine/Commands/Patch/PatchInput.cs
@@ -14,7 +14,7 @@ namespace Marten.CommandLine.Commands.Patch
         [Description("Override the location of the drop file")]
         public string DropFlag { get; set; }
 
-        [Description("Option to create patch and rollup scripts as transactional script")]
+        [Description("Option to create scripts as transactional script")]
         [FlagAlias("transactional-script")]
         public bool TransactionalScriptFlag { get; set; }
     }

--- a/src/Marten.CommandLine/MartenInput.cs
+++ b/src/Marten.CommandLine/MartenInput.cs
@@ -13,10 +13,6 @@ namespace Marten.CommandLine
         [Description("Option to store all output into a log file")]
         public string LogFlag { get; set; }
 
-        [Description("Option to create patch and rollup scripts as transactional or not")]
-        [FlagAlias("transactional-script")]
-        public bool TransactionalScriptFlag { get; set; }
-
         [IgnoreOnCommandLine]
         public IDocumentStore Store { get; set; }
 

--- a/src/Marten.CommandLine/MartenInput.cs
+++ b/src/Marten.CommandLine/MartenInput.cs
@@ -15,7 +15,7 @@ namespace Marten.CommandLine
 
         [Description("Option to create patch and rollup scripts as transactional or not")]
         [FlagAlias("transactional-script")]
-        public bool TransactionalScriptFlag { get; set; } = true;
+        public bool TransactionalScriptFlag { get; set; }
 
         [IgnoreOnCommandLine]
         public IDocumentStore Store { get; set; }

--- a/src/Marten.CommandLine/MartenInput.cs
+++ b/src/Marten.CommandLine/MartenInput.cs
@@ -13,6 +13,10 @@ namespace Marten.CommandLine
         [Description("Option to store all output into a log file")]
         public string LogFlag { get; set; }
 
+        [Description("Option to create patch and rollup scripts as transactional or not")]
+        [FlagAlias("transactional-script")]
+        public bool TransactionalScriptFlag { get; set; } = true;
+
         [IgnoreOnCommandLine]
         public IDocumentStore Store { get; set; }
 

--- a/src/Marten.Testing/Schema/SchemaPatchTester.cs
+++ b/src/Marten.Testing/Schema/SchemaPatchTester.cs
@@ -27,7 +27,7 @@ namespace Marten.Testing.Schema
 
             var writer = new StringWriter();
 
-            patch.WriteTransactionalScript(writer, w =>
+            patch.WriteScript(writer, w =>
             {
                 w.WriteLine("Hello.");
             });
@@ -46,7 +46,7 @@ namespace Marten.Testing.Schema
 
             var writer = new StringWriter();
 
-            patch.WriteTransactionalScript(writer, w =>
+            patch.WriteScript(writer, w =>
             {
                 w.WriteLine("Hello.");
             });

--- a/src/Marten/Schema/IDocumentSchema.cs
+++ b/src/Marten/Schema/IDocumentSchema.cs
@@ -11,7 +11,7 @@ namespace Marten.Schema
         ///     objects to a file
         /// </summary>
         /// <param name="filename"></param>
-        void WriteDDL(string filename);
+        void WriteDDL(string filename, bool transactionalScript = true);
 
 
         /// <summary>
@@ -19,14 +19,14 @@ namespace Marten.Schema
         ///     split by document type
         /// </summary>
         /// <param name="directory"></param>
-        void WriteDDLByType(string directory);
+        void WriteDDLByType(string directory, bool transactionalScript = true);
 
         /// <summary>
         ///     Creates all the SQL script that would build all the database
         ///     schema objects for the configured schema
         /// </summary>
         /// <returns></returns>
-        string ToDDL();
+        string ToDDL(bool transactionalScript = true);
 
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Marten.Schema
         /// </summary>
         /// <param name="filename"></param>
         /// <param name="withSchemas"></param>
-        void WritePatch(string filename, bool withSchemas = true);
+        void WritePatch(string filename, bool withSchemas = true, bool transactionalScript = true);
 
         /// <summary>
         ///     Tries to write a "patch" SQL text to upgrade the database
@@ -66,6 +66,6 @@ namespace Marten.Schema
         /// <returns></returns>
         SchemaPatch ToPatch(Type documentType);
 
-        void WritePatchByType(string directory);
+        void WritePatchByType(string directory, bool transactionalScript = true);
     }
 }

--- a/src/Marten/Storage/TenantSchema.cs
+++ b/src/Marten/Storage/TenantSchema.cs
@@ -23,13 +23,13 @@ namespace Marten.Storage
 
         public DdlRules DdlRules { get; }
 
-        public void WriteDDL(string filename)
+        public void WriteDDL(string filename, bool transactionalScript = true)
         {
-            var sql = ToDDL();
+            var sql = ToDDL(transactionalScript);
             new FileSystem().WriteStringToFile(filename, sql);
         }
 
-        public void WriteDDLByType(string directory)
+        public void WriteDDLByType(string directory, bool transactionalScript=true)
         {
             var system = new FileSystem();
 
@@ -47,7 +47,7 @@ namespace Marten.Storage
 
                 var file = directory.AppendPath(feature.Identifier + ".sql");
 
-                new SchemaPatch(StoreOptions.DdlRules).WriteTransactionalFile(file, writer.ToString());
+                new SchemaPatch(StoreOptions.DdlRules).WriteFile(file, writer.ToString(), transactionalScript);
             }
         }
 
@@ -74,11 +74,11 @@ namespace Marten.Storage
             system.WriteStringToFile(filename, writer.ToString());
         }
 
-        public string ToDDL()
+        public string ToDDL(bool transactionalScript = true)
         {
             var writer = new StringWriter();
 
-            new SchemaPatch(StoreOptions.DdlRules).WriteTransactionalScript(writer, w =>
+            new SchemaPatch(StoreOptions.DdlRules).WriteScript(writer, w =>
             {
                 var allSchemaNames = StoreOptions.Storage.AllSchemaNames();
                 DatabaseSchemaGenerator.WriteSql(StoreOptions, allSchemaNames, w);
@@ -87,13 +87,13 @@ namespace Marten.Storage
                 {
                     feature.Write(StoreOptions.DdlRules, writer);
                 }
-            });
+            }, transactionalScript);
 
             return writer.ToString();
         }
 
 
-        public void WritePatch(string filename, bool withSchemas = true)
+        public void WritePatch(string filename, bool withSchemas = true, bool transactionalScript = true)
         {
             if (!Path.IsPathRooted(filename))
             {
@@ -102,10 +102,10 @@ namespace Marten.Storage
 
             var patch = ToPatch(withSchemas, withAutoCreateAll: true);
 
-            patch.WriteUpdateFile(filename);
+            patch.WriteUpdateFile(filename, transactionalScript);
 
             var dropFile = SchemaPatch.ToDropFileName(filename);
-            patch.WriteRollbackFile(dropFile);
+            patch.WriteRollbackFile(dropFile, transactionalScript);
         }
 
         public SchemaPatch ToPatch(bool withSchemas = true, bool withAutoCreateAll = false)
@@ -176,7 +176,7 @@ namespace Marten.Storage
             return patch;
         }
 
-        public void WritePatchByType(string directory)
+        public void WritePatchByType(string directory, bool transactionalScript = true)
         {
             var system = new FileSystem();
 
@@ -198,7 +198,7 @@ namespace Marten.Storage
                     if (patch.UpdateDDL.IsNotEmpty())
                     {
                         var file = directory.AppendPath(feature.Identifier + ".sql");
-                        patch.WriteUpdateFile(file);
+                        patch.WriteUpdateFile(file, transactionalScript);
                     }
                 }
 


### PR DESCRIPTION
By default Marten always creates transactional script for patch and dump. When user choose to add indexes with `IsConcurrency=True`, create or drop index concurrently with a transaction block results in a script error as raised in #1042. 

This PR adds functionality to create transactional or non-transactional script using flag `[-t, --transactional-script]` passed to patch or dump. This way, user can choose to wrap a transaction or not.

With introduction of these changes, by default patch and dump will produce non-transactional script. Only with the flag passed, it produces transactional script. This changes the current default behaviour.

