### PR TITLE
Add space below previous and next links

### DIFF
--- a/documentation/content/theme.css
+++ b/documentation/content/theme.css
@@ -47,3 +47,7 @@ i.command-description {
 .navbar-inverse {
      background-color: transparent;
 }
+
+nav.related-links {
+    margin-bottom: 21px;
+}

--- a/documentation/layout.htm
+++ b/documentation/layout.htm
@@ -95,7 +95,7 @@
 
 			      	<hr />
 
-			      	<nav>
+			      	<nav class="related-links">
 				        <span>
 				        	<[linkto:{previous};<strong>Previous: </strong><a href="{href}">{title}</a>]>
 


### PR DESCRIPTION
Hi 👋,

I ❤ the extensive docs but I find it hard to see and click the previous and next links at the bottom of the pages.
This PR adds some space below them; I picked 21px because that's the margin defined by the `<hr>` just above the `<nav>`.

### Before

![before-adding-space-below](https://user-images.githubusercontent.com/6102639/43504787-fa8fdbae-95a7-11e8-88d4-b4851725f09b.png)

### After

![after-adding-space-below](https://user-images.githubusercontent.com/6102639/43504796-ff289890-95a7-11e8-90e3-8c1111267d0c.png)

