### PR TITLE
Update nuget badge to use badgen.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Join the chat at https://gitter.im/JasperFx/Marten](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JasperFx/Marten?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/jasperfx/marten?svg=true)](https://ci.appveyor.com/project/jasper-ci/marten)
 [![Linux Build status](https://api.travis-ci.org/JasperFx/marten.svg)](https://travis-ci.org/JasperFx/marten)
-[![Nuget Package](https://img.shields.io/nuget/v/Marten.svg?style=flat)](https://www.nuget.org/packages/Marten/)
+[![Nuget Package](https://badgen.net/nuget/v/marten)](https://www.nuget.org/packages/Marten/)
 
 ![marten logo](http://jasperfx.github.io/marten/content/images/banner.png)
 

--- a/documentation/splash.htm
+++ b/documentation/splash.htm
@@ -71,7 +71,7 @@
 
                     <h2>Polyglot Persistence for .NET Systems using the Rock Solid PostgreSQL Database</h2>
                     <p class="lead">
-                        <a href="https://ci.appveyor.com/project/jasper-ci/marten/history"><img src="https://img.shields.io/appveyor/ci/jasper-ci/marten.svg"></img></a>
+                        <a href="https://ci.appveyor.com/project/jasper-ci/marten/history"><img src="https://ci.appveyor.com/api/projects/status/github/jasperfx/marten?svg=true"></img></a>
                         <a href="https://www.nuget.org/packages/Marten/"><img src="https://badgen.net/nuget/v/marten"></img></a>
 
 

--- a/documentation/splash.htm
+++ b/documentation/splash.htm
@@ -72,7 +72,7 @@
                     <h2>Polyglot Persistence for .NET Systems using the Rock Solid PostgreSQL Database</h2>
                     <p class="lead">
                         <a href="https://ci.appveyor.com/project/jasper-ci/marten/history"><img src="https://img.shields.io/appveyor/ci/jasper-ci/marten.svg"></img></a>
-                        <a href="https://www.nuget.org/packages/Marten/"><img src="https://img.shields.io/nuget/v/Marten.svg"></img></a>
+                        <a href="https://www.nuget.org/packages/Marten/"><img src="https://badgen.net/nuget/v/marten"></img></a>
 
 
 <a href="https://gitter.im/jasperfx/marten?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img src="https://camo.githubusercontent.com/da2edb525cde1455a622c58c0effc3a90b9a181c/68747470733a2f2f6261646765732e6769747465722e696d2f4a6f696e253230436861742e737667" alt="Join the chat at https://gitter.im/jasperfx/marten" data-canonical-src="https://badges.gitter.im/Join%20Chat.svg" style="max-width:100%;"></a>


### PR DESCRIPTION
Update nuget badge to use badgen.net which is faster and reliable to load than shields.io. Many a times, shields.io badge just does not load at all.

Also updated appveyor badge to use the appveyor url rather than shields.io