### PR TITLE
Update event documentation

### DIFF
--- a/documentation/documentation/events/appending.md
+++ b/documentation/documentation/events/appending.md
@@ -17,22 +17,15 @@ but for production usage when you may be querying event data before you append a
 
 <[sample:registering-event-types]>
 
-
 ## Stream or Aggregate Types
 
-At this point there are no specific requirements about stream aggregate types as they are purely marker types for now. In the future we will probably support
-aggregating events via snapshot caching using the aggregate type.
-
+At this point there are no specific requirements about stream aggregate types as they are purely marker types. In the future we will probably support aggregating events via snapshot caching using the aggregate type.
 
 ## Starting a new Stream
 
-As of Marten v0.9, you can **optionally** start a new event stream against some kind of .Net type that theoretically marks the type of stream your capturing. 
-Marten does not yet use this type as anything more than metadata, but our thought is that some projections would key off this information and that in a 
-future version use that aggregate type to perform versioned snapshots of the entire stream. We may also make the aggregate type optional so that
-you could just supply either a string to mark the "stream type" or work without a stream type.
+As of Marten v0.9, you can **optionally** start a new event stream against some kind of .Net type that theoretically marks the type of stream you're capturing. Marten does not yet use this type as anything more than metadata, but our thought is that some projections would key off this information and in a future version use that aggregate type to perform versioned snapshots of the entire stream. We may also make the aggregate type optional so that you could just supply either a string to mark the "stream type" or work without a stream type.
 
-As usual, our sample problem domain is the Lord of the Rings style "Quest." For now, you can either start a new stream and let Marten assign the Guid
-id for the stream:
+As usual, our sample problem domain is the Lord of the Rings style "Quest." For now, you can either start a new stream and let Marten assign the Guid id for the stream:
 
 <[sample:start-stream-with-aggregate-type]>
 
@@ -42,7 +35,7 @@ Or have Marten use a Guid value that you provide yourself:
 
 For stream identity (strings vs. Guids), see <[linkto:documentation/events/identity]>.
 
-Note that `StartStream` checks for existing stream and throws `ExistingStreamIdCollisionException` in case stream already exists.
+Note that `StartStream` checks for and existing stream and throws `ExistingStreamIdCollisionException` if a matching stream already exists.
 
 ## Appending Events
 
@@ -52,12 +45,10 @@ If you have an existing stream, you can later append additional events with `IEv
 
 ### Appending & Assertions ###
 
-`IEventStore.Append()` supports an overload taking in a parameter `int expectedVersion` that can be used to assert that events are inserted into the
-event stream if and only if the maximum event id for the stream matches the expected version after event insertions. Otherwise the transaction is aborted
-and a `EventStreamUnexpectedMaxEventIdException` exception is thrown.
+`IEventStore.Append()` supports an overload taking in a parameter `int expectedVersion` that can be used to assert that events are inserted into the event stream if and only if the maximum event id for the stream matches the expected version after event insertions. Otherwise the transaction is aborted and an `EventStreamUnexpectedMaxEventIdException` exception is thrown.
 
 <[sample:append-events-assert-on-eventid]> 
 
 ### CreateStream vs. Append
 
-Both, `StartStream` and `Append` can be used to start a new event stream. The difference with the methods is that `StartStream` always checks for existing stream and throws `ExistingStreamIdCollisionException` in case stream already exists.
+Both `StartStream` and `Append` can be used to start a new event stream. The difference with the methods is that `StartStream` always checks for existing stream and throws `ExistingStreamIdCollisionException` in case the stream already exists.

--- a/documentation/documentation/events/identity.md
+++ b/documentation/documentation/events/identity.md
@@ -1,6 +1,6 @@
 <!--Title:Stream Identity-->
 
-The Event Store in Marten can identify and index streams either as GUIDs (`System.Guid`) or strings (`System.String`). This is reflected in the overloads of `IEventStore` such as `IEventStore.StartStream`, `IEventStore.Append` and `IEventStore.AggregateStream` that accept either `string` or `Guid` as the stream identifier.
+The Event Store in Marten can identify and index streams either as Guids (`System.Guid`) or strings (`System.String`). This is reflected in the overloads of `IEventStore` such as `IEventStore.StartStream`, `IEventStore.Append` and `IEventStore.AggregateStream` that accept either `string` or `Guid` as the stream identifier.
 
 ## Configuring Event Stream Identity
  

--- a/documentation/documentation/events/index.md
+++ b/documentation/documentation/events/index.md
@@ -13,12 +13,12 @@ stream data, Marten also helps you create "read side" views of the raw event dat
 There is not anything special you need to do to enable the event store functionality in Marten, and it obeys the same rules about automatic schema generation described in <[linkto:documentation/schema]>. Marten is just a client library,
 and there's nothing to install other than the Marten nuget.
 
-Because I’ve read way too much epic fantasy series, my sample problem domain is an application that records, analyses, and visualizes the status of quests. During a quest,  you may want to record events like:
+Because I’ve read way too much epic fantasy fiction, my sample problem domain is an application that records, analyses, and visualizes the status of quests. During a quest, you may want to record events like:
 
 <[sample:sample-events]>
 
-Now, let's say that we're starting a new "quest" with the first couple events, then appending a couple more as other quest party members join up:
+Now, let's say that we're starting a new "quest" with the first couple of events, then appending a couple more as other quest party members join up:
 
 <[sample:event-store-quickstart]>
 
-In addition to generic `StartStream<T>`, `IEventStore` has non-generic `StartStream` overload to create streams without associating them with aggregate type (stored in `mt_streams` table).
+In addition to generic `StartStream<T>`, `IEventStore` has a non-generic `StartStream` overload to create streams without associating them with aggregate type (stored in `mt_streams` table).

--- a/documentation/documentation/events/projections/async_daemon.md
+++ b/documentation/documentation/events/projections/async_daemon.md
@@ -1,9 +1,3 @@
 <!--Title: Async Projections Daemon-->
 
-For the most information, see Jeremy's blog post on [Offline Event Processing in Marten with the new “Async Daemon”](https://jeremydmiller.com/2016/08/04/offline-event-processing-in-marten-with-the-new-async-daemon/).
-
-## Rebuilding Projections
-
-Projections need to be rebuilt when the code that defines them changes in a way that requires events to be reapplied in order to maintain correct state. Using an `IDaemon` this is easy to execute on-demand:
-
-<[sample:rebuild-single-projection]>
+For most information, see Jeremy's blog post on [Offline Event Processing in Marten with the new “Async Daemon”](https://jeremydmiller.com/2016/08/04/offline-event-processing-in-marten-with-the-new-async-daemon/).

--- a/documentation/documentation/events/projections/async_daemon.md
+++ b/documentation/documentation/events/projections/async_daemon.md
@@ -1,3 +1,9 @@
 <!--Title: Async Projections Daemon-->
 
-For the moment, see Jeremy's blog post on [Offline Event Processing in Marten with the new “Async Daemon”](https://jeremydmiller.com/2016/08/04/offline-event-processing-in-marten-with-the-new-async-daemon/).
+For the most information, see Jeremy's blog post on [Offline Event Processing in Marten with the new “Async Daemon”](https://jeremydmiller.com/2016/08/04/offline-event-processing-in-marten-with-the-new-async-daemon/).
+
+## Rebuilding Projections
+
+Projections need to be rebuilt when the code that defines them changes in a way that requires events to be reapplied in order to maintain correct state. Using an `IDaemon` this is easy to execute on-demand:
+
+<[sample:rebuild-single-projection]>

--- a/documentation/documentation/events/projections/index.md
+++ b/documentation/documentation/events/projections/index.md
@@ -2,8 +2,7 @@
 <!--Url:projections-->
 
 <div class="alert alert-info">
-The Marten community is working to create more samples of event store projections. Check this page again soon. In the meantime,
-don't forget to just look through the code and our unit tests.
+The Marten community is working to create more samples of event store projections. Check this page again soon. In the meantime, don't forget to just look through the code and our unit tests.
 </div>
 
 First, some terminology that we're going to use throughout this section:
@@ -11,14 +10,13 @@ First, some terminology that we're going to use throughout this section:
 * _Projection_ - any strategy for generating "read side" views from the raw event streams
 * _Transformation_ - a type of projection that generates or updates a single read side view for a single event
 * _Aggregate_ - a type of projection that "aggregates" data from multiple events to create a single readside view document
-* _Inline Projections_ - projection's that are executed as part of any event capture transaction
-* _Async Projections_ - projection's that run in some kind of background process using an [eventual consistency](https://en.wikipedia.org/wiki/Eventual_consistency) strategy
-* _Live Projections_ - evaluating a projected view from the raw event data on demand within Marten
+* _Inline Projections_ - a type of projection that executes as part of any event capture transaction and is stored as a document
+* _Async Projections_ - a type of projection that runs in a background process using an [eventual consistency](https://en.wikipedia.org/wiki/Eventual_consistency) strategy, and is stored as a document
+* _Live Projections_ - evaluates a projected view from the raw event data on demand within Marten
 
 ## Event Metadata in Projections
 
-First off, please be aware that **event metadata like stream version and sequence number are not available duing the execution of
-inline projections.** If you need to use event metadata in your projections, please use asynchronous or live projections.
+First off, please be aware that **event metadata like stream version and sequence number are not available duing the execution of inline projections.** If you need to use event metadata in your projections, please use asynchronous or live projections.
 
 ## Projecting from One Event to One Document    
 
@@ -26,7 +24,7 @@ If you want to have certain events projected to a readside document and the rela
 
 <[sample:ITransform]>
 
-As a sample problem, let's say that we're constantly capturing `MonsterSlayed` events and our system needs to query just this data. You could query directly against the big ol' `mt_events` table with 
+As a sample problem, let's say that we're constantly capturing `MonsterSlayed` events and our system needs to query just this data. You could query directly against the large `mt_events` table with 
 `IEventStore.Query<MonsterSlayed>()`, but it would be more efficient to keep a separate "read side" copy of this data in a new data collection. We could build a new transform class and readside document like this:
 
 <[sample:MonsterDefeatedTransform]>
@@ -39,17 +37,16 @@ Now, we can plug our new transform type above as a projection when we configure 
 
 ## Aggregated Views Across a Single Stream
 
-As of now (v1.0), Marten is only supporting aggregation via .Net classes. The out of the box convention is to expose `public Apply([Event Type])` methods
-on your aggregate class to do all incremental updates to an aggregate object.  This can be customised using [AggregatorLookup](#aggregator-lookup).
+As of v1.0, Marten only supports aggregation via .Net classes. The out of the box convention is to expose `public Apply([Event Type])` methods on your aggregate class to do all incremental updates to an aggregate object.  This can be customised using [AggregatorLookup](#aggregator-lookup).
 
 Sticking with the fantasy theme, the `QuestParty` class shown below could be used to aggregate streams of quest data:
 
 <[sample:QuestParty]>
 
-New in Marten 1.2 is the ability to use `Event<T>` metadata within your projections -- assuming that you're not trying to run the aggregations inline.
+New in Marten 1.2 is the ability to use `Event<T>` metadata within your projections, assuming that you're not trying to run the aggregations inline.
 
 The syntax using the built in aggregation technique is to take in `Event<T>` as the argument to your `Apply(event)` methods,
-where "T" is the event type you're interested in:
+where `T` is the event type you're interested in:
 
 <[sample:QuestPartyWithEvents]>
 
@@ -57,11 +54,8 @@ where "T" is the event type you're interested in:
 
 Example coming soon, and check [Jeremy's blog](http://jeremydmiller.com) for a sample soon.
 
-It's possible today by using either a custom `IProjection` or using the existing aggregation capabilities with a
-custom `IAggregateFinder<T>`, where "T" is the projected view document type.
-
-
-
+It's possible currently by using either a custom `IProjection` or using the existing aggregation capabilities with a
+custom `IAggregateFinder<T>`, where `T` is the projected view document type.
 
 ## Live Aggregation via .Net
 
@@ -72,26 +66,19 @@ You can always fetch a stream of events and build an aggregate completely live f
 There is also a matching asynchronous `AggregateStreamAsync()` mechanism as well. Additionally, you can do stream aggregations in batch queries with
 `IBatchQuery.Events.AggregateStream<T>(streamId)`.
 
-
-
-
 ## Inline Aggregation
 
-If you would prefer that the projected aggregate document be updated _inline_ with the events being appended, you simply need to register
-the aggregation type in the `StoreOptions` upfront when you build up your document store like this:
+If you would prefer that the projected aggregate document be updated _inline_ with the events being appended, you simply need to register the aggregation type in the `StoreOptions` upfront when you build up your document store like this:
 
 <[sample:registering-quest-party]>
 
 At this point, you would be able to query against `QuestParty` as just another document type.
 
-
 ## Aggregator Lookup
 
+`EventGraph.UseAggregatorLookup(IAggregatorLookup aggregatorLookup)` can be used to register an `IAggregatorLookup` that is used to look up `IAggregator<T>` for aggregations. This allows a generic aggregation strategy to be used, rather than registering aggregators case-by-case through `EventGraphAddAggregator<T>(IAggregator<T> aggregator)`.
 
-`EventGraph.UseAggregatorLookup(IAggregatorLookup aggregatorLookup)` can be used to register an `IAggregatorLookup` that is used to look up `IAggregator<T>` for aggregations. This allows e.g. for generic aggregation strategy to be used, rathen than registering aggregators 
-case-by-case through `EventGraphAddAggregator<T>(IAggregator<T> aggregator)`. 
-
-A shorthand extension method `EventGraph.UseAggregatorLookup(this EventGraph eventGraph, AggregationLookupStrategy strategy)` can be used to set default aggregation lookup, whereby 
+A shorthand extension method `EventGraph.UseAggregatorLookup(this EventGraph eventGraph, AggregationLookupStrategy strategy)` can be used to set default aggregation lookup, whereby
 
 - `AggregationLookupStrategy.UsePublicApply` resolves aggregators that use public Apply
 - `AggregationLookupStrategy.UsePrivateApply` resolves aggregators that use private Apply  

--- a/documentation/documentation/events/projections/projectionbyeventtype.md
+++ b/documentation/documentation/events/projections/projectionbyeventtype.md
@@ -3,15 +3,18 @@
 While projections can target specific stream or streams, it is also possible to project by event types. The following sample demonstrates this with the `CandleProjection` that implements the `ViewProjection` interface to build `Candle` projections from events of type `Tick`.
 
 Introduce a type to hold candle data:
+
 <[sample:sample-type-candle]>
 
 This data will then be populated and updated from observing ticks:
+
 <[sample:sample-type-tick]>
 
 We then introduce a projection that subscribes to the 'Tick' event:
+
 <[sample:sample-candleprojection]>
 
 Lastly, we configure the Event Store to use the newly introduced projection:
-<[sample:sample-project-by-event-type]> 
 
+<[sample:sample-project-by-event-type]> 
  

--- a/documentation/documentation/events/schema.md
+++ b/documentation/documentation/events/schema.md
@@ -1,6 +1,5 @@
 <!--Title:Event Store Schema Objects-->
 
-
 ## Overriding the Schema
 
 By default, the event store database objects are created in the default schema for the active `IDocumentStore`. If you wish,
@@ -23,8 +22,7 @@ The events are stored in the `mt_events` table, with these columns:
 * `tenant_id` - Identifies the tenancy of the event
 * `mt_dotnet_type` - The full name of the underlying event type, including assembly name, e.g. "Marten.Testing.Events.IssueResolved, Marten.Testing"
 
-The "Async Daemon" projection support keys off of the sequential id, but we retained the Guid id field for backward compatibility
-and to retain a potential way to uniquely identify events across databases.
+The "Async Daemon" projection supports keys off of the sequential id, but we retained the Guid id field for backward compatibility and to retain a potential way to uniquely identify events across databases.
 
 In addition, there are a couple other metadata tables you'll see in your schema:
 
@@ -36,14 +34,10 @@ And finally, a couple functions that Marten uses internally:
 * `mt_append_event` - Writes event data to the `mt_events` and `mt_streams` tables
 * `mt_mark_event_progression` - Updates the `mt_event_progression` table
 
-
 ## Event Metadata in Code
 
-Hopefully, it's relatively clear how the fields in `mt_events` maps to the `IEvent` interface in Marten: 
+Hopefully, it's relatively clear how the fields in `mt_events` map to the `IEvent` interface in Marten: 
 
 <[sample:event_metadata]>
 
-The full event data is available on `EventStream` and `IEvent` objects immediately after committing a transaction that involves
-event capture. See <[linkto:documentation/documents/diagnostics]> for more information on capturing event data in the instrumentation
-hooks.
-
+The full event data is available on `EventStream` and `IEvent` objects immediately after committing a transaction that involves event capture. See <[linkto:documentation/documents/diagnostics]> for more information on capturing event data in the instrumentation hooks.

--- a/documentation/documentation/events/streams.md
+++ b/documentation/documentation/events/streams.md
@@ -1,21 +1,19 @@
 <!--Title:Querying Event and Stream Data-->
 <!--Url:streams-->
 
-
 ## Fetch Events for a Stream
 
 You can retrieve the events for a single stream at any time with the `IEventStore.FetchStream()` methods shown below:
 
 <[sample:using-fetch-stream]>
 
-The data returned is a list of `IEvent` objects, where each is a strong typed `Event<T>` object shown below:
+The data returned is a list of `IEvent` objects, where each is a strongly-typed `Event<T>` object shown below:
 
 <[sample:IEvent]>
 
 ## Stream State
 
-If you just need to check on the state of an event stream - what version (effectively the number of events in the stream) it is and what if any aggregate type it represents - you can use the 
-`IEventStore.FetchStreamState()/FetchStreamStateAsync()` methods or through `IBatchQuery.Events.FetchStreamState()` shown below:
+If you just need to check on the state of an event stream - what version (effectively the number of events in the stream) it is and what, if any, aggregate type it represents - you can use the `IEventStore.FetchStreamState()/FetchStreamStateAsync()` methods or `IBatchQuery.Events.FetchStreamState()`, as shown below:
 
 <[sample:fetching_stream_state]>
 
@@ -27,18 +25,15 @@ You can fetch the information for a single event by id, including its version nu
 
 <[sample:load-a-single-event]>
 
-
 ## Querying Directly Against Event Data
 
-We have to urge some caution about this functionality because it requires a search against the entire `mt_events` table. To issue Linq queries against
-any specific event type, use the method shown below:
+We urge caution about this functionality because it requires a search against the entire `mt_events` table. To issue Linq queries against any specific event type, use the method shown below:
 
 <[sample:query-against-event-data]>
 
-You can use any Linq operator that Marten supports to query against event data. We think that this functionality is probably more useful for diagnostics or troubleshooting
-rather than something you would routinely use to support your application. We recommend that you favor event projection views over querying within the raw event table.
+You can use any Linq operator that Marten supports to query against event data. We think that this functionality is probably more useful for diagnostics or troubleshooting rather than something you would routinely use to support your application. We recommend that you favor event projection views over querying within the raw event table.
 
-Just in time for Marten 1.0, you can issue queries with Marten's full Linq support against the raw event data with this method:
+With Marten 1.0, you can issue queries with Marten's full Linq support against the raw event data with this method:
 
 <[sample:example_of_querying_for_event_data]>
 

--- a/src/Marten.Testing/AsyncDaemon/async_daemon_end_to_end.cs
+++ b/src/Marten.Testing/AsyncDaemon/async_daemon_end_to_end.cs
@@ -48,9 +48,7 @@ namespace Marten.Testing.AsyncDaemon
 
             _testHelper.PublishAllProjectEvents(theStore, true);
 
-
-            
-
+            // SAMPLE: rebuild-single-projection
             using (var daemon = theStore.BuildProjectionDaemon(logger: _logger, settings: new DaemonSettings
             {
                 LeadingEdgeBuffer = 0.Seconds()
@@ -58,6 +56,7 @@ namespace Marten.Testing.AsyncDaemon
             {
                 await daemon.Rebuild<ActiveProject>().ConfigureAwait(false);
             }
+            // ENDSAMPLE
 
             _testHelper.CompareActiveProjects(theStore);
             

--- a/src/Marten.Testing/Events/Projections/QuestParty.cs
+++ b/src/Marten.Testing/Events/Projections/QuestParty.cs
@@ -27,33 +27,33 @@ namespace Marten.Testing.Events.Projections
         public IList<string> Slayed { get; } = new List<string>();
 
 
-    public void Apply(MembersJoined joined)
-    {
-        _members.Fill(joined.Members);
+        public void Apply(MembersJoined joined)
+        {
+            _members.Fill(joined.Members);
+        }
+
+        public void Apply(MembersDeparted departed)
+        {
+            _members.RemoveAll(x => departed.Members.Contains(x));
+        }
+
+        public void Apply(QuestStarted started)
+        {
+            Name = started.Name;
+        }
+
+
+        public string Key { get; set; }
+
+        public string Name { get; set; }
+
+        public Guid Id { get; set; }
+
+        public override string ToString()
+        {
+            return $"Quest party '{Name}' is {Members.Join(", ")}";
+        }
     }
-
-    public void Apply(MembersDeparted departed)
-    {
-        _members.RemoveAll(x => departed.Members.Contains(x));
-    }
-
-    public void Apply(QuestStarted started)
-    {
-        Name = started.Name;
-    }
-
-
-    public string Key { get; set; }
-
-    public string Name { get; set; }
-
-    public Guid Id { get; set; }
-
-    public override string ToString()
-    {
-        return $"Quest party '{Name}' is {Members.Join(", ")}";
-    }
-}
 
     public class QuestFinishingParty : QuestParty
     {


### PR DESCRIPTION
The documentation on events (and particularly projections) is a bit confusing, and lacks a key concept or two. I fixed typos all across the event documentation and focused heavily on the projections index page, to make it easier to differentiate aggregate types and details of each. This should help people who are new to Marten get started a lot more quickly.

Code changes are indentation or sample marking only.