### PR TITLE
using Streams during an inline projection overrides event ids with Guid for string based events

### DIFF
--- a/src/Marten/Events/EventStream.cs
+++ b/src/Marten/Events/EventStream.cs
@@ -42,7 +42,6 @@ namespace Marten.Events
 
         public EventStream(string stream, IEvent[] events, bool isNew)
         {
-            Id = Guid.NewGuid();
             Key = stream;
             AddEvents(events);
             IsNew = isNew;
@@ -59,7 +58,10 @@ namespace Marten.Events
             _events.AddRange(events);
             _events.Where(x => x.Id == Guid.Empty).Each(x => x.Id = CombGuidIdGeneration.NewGuid());
 
-            _events.Each(x => x.StreamId = Id);
+            if (string.IsNullOrEmpty(Key))
+                _events.Each(x => x.StreamId = Id);
+            else
+                _events.Each(x => x.StreamKey = Key);
 
             return this;
         }


### PR DESCRIPTION
This is a very subtle bug that I'm not 100% sure the best way to add a proper unit test for. 

Basically if you use `EventPage.Streams` during an inline projection, when using `StreamIdentity.AsString` the underlying events get updated to have both an `StreamId` Guid and a `StreamKey` which causes some strange issues later down the road.

I should have more details in a day or two, when I can get back to the problem and try to get a good repro around it.