### PR TITLE
Restrict Npgsql version >=3.2.5 and <4.0

### DIFF
--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Remotion.Linq" Version="2.1.1" />
-    <PackageReference Include="Npgsql" Version="3.2.5" />
+    <PackageReference Include="Npgsql" Version="[3.2.5,4.0)" />
     <PackageReference Include="Baseline" Version="1.3.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />


### PR DESCRIPTION
This would allow nuget package that is published to limit the version of npgsql, this way we can enforce the version during package installation of Marten without waiting for runtime errors to occur
Related to #1081 