### PR TITLE
Fixes duplicate "where" bug in Query/QueryAsync with sql text

### DIFF
--- a/src/Marten.Testing/query_by_sql_where_clause_Tests.cs
+++ b/src/Marten.Testing/query_by_sql_where_clause_Tests.cs
@@ -202,6 +202,22 @@ namespace Marten.Testing
         }
         // ENDSAMPLE
 
+        [Fact]
+        public void query_for_single_document_where_clause_trimmed()
+        {
+            using (var session = theStore.OpenSession())
+            {
+                var u = new User { FirstName = "Jeremy", LastName = "Miller" };
+                session.Store(u);
+                session.SaveChanges();
+
+                var user = session.Query<User>(@"
+where data ->> 'FirstName' = 'Jeremy'").Single();
+                user.LastName.ShouldBe("Miller");
+                user.Id.ShouldBe(u.Id);
+            }
+        }
+
         // SAMPLE: query_with_matches_sql
         [Fact]
         public void query_with_matches_sql()

--- a/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
@@ -35,7 +35,7 @@ namespace Marten.Linq.QueryHandlers
                 builder.Append("select data from ");
                 builder.Append(tableName);
 
-                if (_sql.StartsWith("where", StringComparison.OrdinalIgnoreCase))
+                if (_sql.TrimStart().StartsWith("where", StringComparison.OrdinalIgnoreCase))
                 {
                     builder.Append(" ");
                 }


### PR DESCRIPTION
If Query/QueryAsync was started with a "where" clause but there was a space or new line before the "where", a duplicate "where" would be inserted because the start was not trimmed. Passing test included.