### PR TITLE
Reimplementing full text search on top of the latest code

### DIFF
--- a/src/Marten.Testing/Acceptance/full_text_index.cs
+++ b/src/Marten.Testing/Acceptance/full_text_index.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Marten.Schema;
 using Marten.Testing.Documents;
 using Shouldly;
 using Xunit;
@@ -20,8 +21,15 @@ namespace Marten.Testing.Acceptance
                                               _.Schema.For<User>().FullTextIndex();
                                           });
 
-            using(var session = store.QuerySession())
+            using(var session = store.OpenSession())
             {
+                session.Store(new User { FirstName = "Jeremy", LastName = "Miller", UserName = "jmiller"});
+                session.Store(new User { FirstName = "Lindsey", LastName = "Miller", UserName = "lmiller"});
+                session.Store(new User { FirstName = "Max", LastName = "Miller", UserName = "mmiller"});
+                session.Store(new User { FirstName = "Frank", LastName = "Zombo", UserName = "fzombo"});
+                session.Store(new User { FirstName = "Somebody", LastName = "Somewher", UserName = "somebody"});
+                session.SaveChanges();
+                
                 var somebody = session.Search<User>("somebody");
             }
 
@@ -39,11 +47,84 @@ namespace Marten.Testing.Acceptance
             theStore.BulkInsert(data);
 
             var ddl = theStore.Tenancy.Default.DbObjects.AllIndexes()
-                              .Where(x => x.Name == "mt_target_idx_fts")
+                              .Where(x => x.Name == "mt_doc_target_idx_fts")
                               .Select(x => x.DDL.ToLower())
                               .First();
 
-            ddl.ShouldBe("CREATE INDEX mt_target_idx_fts ON mt_doc_target USING gin (( to_tsvector('english', data) ));");
+            ddl.ShouldContain("create index mt_doc_target_idx_fts");
+            ddl.ShouldContain("on public.mt_doc_target");
+            ddl.ShouldContain("to_tsvector");
+        }
+
+        [Fact]
+        public void not_specifying_an_index_name_should_generate_default_index_name()
+        {
+            StoreOptions(_ => _.Schema.For<Target>().FullTextIndex());
+            var data = Target.GenerateRandomData(100).ToArray();
+            theStore.BulkInsert(data);
+
+            var ddl = theStore.Tenancy.Default.DbObjects.AllIndexes()
+                              .Select(x => x.DDL.ToLower())
+                              .First();
+
+            ddl.ShouldContain("mt_doc_target_idx_fts");
+        }
+
+        [Fact]
+        public void specifying_an_index_name_without_marten_prefix_should_prepend_prefix()
+        {
+            StoreOptions(_ => _.Schema.For<Target>().FullTextIndex(configure: x=>x.IndexName = "doesnt_have_prefix"));
+            var data = Target.GenerateRandomData(100).ToArray();
+            theStore.BulkInsert(data);
+
+            var ddl = theStore.Tenancy.Default.DbObjects.AllIndexes()
+                              .Select(x => x.DDL)
+                              .First();
+
+            ddl.ShouldContain("mt_doesnt_have_prefix");
+        }
+
+        [Fact]
+        public void specifying_an_index_name_with_mixed_case_should_result_in_lower_case_name()
+        {
+            StoreOptions(_ => _.Schema.For<Target>().FullTextIndex(configure: x=>x.IndexName = "Doesnt_Have_PreFix"));
+            var data = Target.GenerateRandomData(100).ToArray();
+            theStore.BulkInsert(data);
+
+            var ddl = theStore.Tenancy.Default.DbObjects.AllIndexes()
+                              .Select(x => x.DDL)
+                              .First();
+
+            ddl.ShouldContain("mt_doesnt_have_prefix");
+        }
+
+        [Fact]
+        public void specifying_an_index_name_with_marten_prefix_remains_unchanged()
+        {
+            StoreOptions(_ => _.Schema.For<Target>().FullTextIndex(configure: x=>x.IndexName = "mt_i_have_prefix"));
+            var data = Target.GenerateRandomData(100).ToArray();
+            theStore.BulkInsert(data);
+
+            var ddl = theStore.Tenancy.Default.DbObjects.AllIndexes()
+                              .Select(x => x.DDL)
+                              .First();
+
+            ddl.ShouldContain("mt_i_have_prefix");
+        }
+
+
+        [Fact]
+        public void specifying_an_index_name_with_marten_prefix_and_mixed_case_results_in_lowercase_name()
+        {
+            StoreOptions(_ => _.Schema.For<Target>().FullTextIndex(configure: x=>x.IndexName = "mT_I_hAve_preFIX"));
+            var data = Target.GenerateRandomData(100).ToArray();
+            theStore.BulkInsert(data);
+
+            var ddl = theStore.Tenancy.Default.DbObjects.AllIndexes()
+                              .Select(x => x.DDL)
+                              .First();
+
+            ddl.ShouldContain("mt_i_have_prefix");
         }
     }
 }

--- a/src/Marten.Testing/Acceptance/full_text_index.cs
+++ b/src/Marten.Testing/Acceptance/full_text_index.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Linq;
+using Marten.Testing.Documents;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Acceptance
+{
+    public class full_text_index : IntegratedFixture
+    {
+        [Fact]
+        public void example()
+        {
+            // SAMPLE: using-a-full-text-index
+            var store = DocumentStore.For(_ =>
+                                          {
+                                              _.Connection(ConnectionSource.ConnectionString);
+
+                                              // Create the full text index
+                                              _.Schema.For<User>().FullTextIndex();
+                                          });
+
+            using(var session = store.QuerySession())
+            {
+                var somebody = session.Search<User>("somebody");
+            }
+
+            store.Dispose();
+
+            // ENDSAMPLE
+        }
+
+        [Fact]
+        public void creating_a_full_text_index_should_create_the_index_on_the_table()
+        {
+            StoreOptions(_=>_.Schema.For<Target>().FullTextIndex());
+
+            var data = Target.GenerateRandomData(100).ToArray();
+            theStore.BulkInsert(data);
+
+            var ddl = theStore.Tenancy.Default.DbObjects.AllIndexes()
+                              .Where(x => x.Name == "mt_target_idx_fts")
+                              .Select(x => x.DDL.ToLower())
+                              .First();
+
+            ddl.ShouldBe("CREATE INDEX mt_target_idx_fts ON mt_doc_target USING gin (( to_tsvector('english', data) ));");
+        }
+    }
+}

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -259,5 +259,65 @@ namespace Marten
         /// <param name="entity"></param>
         /// <returns></returns>
         Guid? VersionFor<TDoc>(TDoc entity);
+
+        /// <summary>
+        /// Performs a full text search against <typeparamref name="TDoc"/>
+        /// </summary>
+        /// <param name="queryText">The text to search for.  May contain lexeme patterns used by PostgreSQL for full text searching</param>
+        /// <param name="config">The dictionary config passed to the 'to_tsquery' function, must match the config parameter used by <seealso cref="DocumentMapping.AddFullTextIndex(string)"/></param>
+        /// <remarks>
+        /// See: https://www.postgresql.org/docs/10/static/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
+        /// </remarks>
+        IReadOnlyList<TDoc> Search<TDoc>(string queryText, string config = "english");
+
+        /// <summary>
+        /// Performs an asynchronous full text search against <typeparamref name="TDoc"/>
+        /// </summary>
+        /// <param name="queryText">The text to search for.  May contain lexeme patterns used by PostgreSQL for full text searching</param>
+        /// <param name="config">The dictionary config passed to the 'to_tsquery' function, must match the config parameter used by <seealso cref="DocumentMapping.AddFullTextIndex(string)"/></param>
+        /// <remarks>
+        /// See: https://www.postgresql.org/docs/10/static/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
+        /// </remarks>
+        Task<IReadOnlyList<TDoc>> SearchAsync<TDoc>(string queryText, string config = "english", CancellationToken token = default);
+
+        /// <summary>
+        /// Performs a full text search against <typeparamref name="TDoc"/> using the 'plainto_tsquery' search function
+        /// </summary>
+        /// <param name="queryText">The text to search for.  May contain lexeme patterns used by PostgreSQL for full text searching</param>
+        /// <param name="config">The dictionary config passed to the 'to_tsquery' function, must match the config parameter used by <seealso cref="DocumentMapping.AddFullTextIndex(string)"/></param>
+        /// <remarks>
+        /// See: https://www.postgresql.org/docs/10/static/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
+        /// </remarks>
+        IReadOnlyList<TDoc> PlainTextSearch<TDoc>(string searchTerm, string config = "english");
+
+        /// <summary>
+        /// Performs an asynchronous full text search against <typeparamref name="TDoc"/> using the 'plainto_tsquery' function
+        /// </summary>
+        /// <param name="queryText">The text to search for.  May contain lexeme patterns used by PostgreSQL for full text searching</param>
+        /// <param name="config">The dictionary config passed to the 'to_tsquery' function, must match the config parameter used by <seealso cref="DocumentMapping.AddFullTextIndex(string)"/></param>
+        /// <remarks>
+        /// See: https://www.postgresql.org/docs/10/static/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
+        /// </remarks>
+        Task<IReadOnlyList<TDoc>> PlainTextSearchAsync<TDoc>(string searchTerm, string config = "english", CancellationToken token = default);
+
+        /// <summary>
+        /// Performs a full text search against <typeparamref name="TDoc"/> using the 'phraseto_tsquery' search function
+        /// </summary>
+        /// <param name="queryText">The text to search for.  May contain lexeme patterns used by PostgreSQL for full text searching</param>
+        /// <param name="config">The dictionary config passed to the 'to_tsquery' function, must match the config parameter used by <seealso cref="DocumentMapping.AddFullTextIndex(string)"/></param>
+        /// <remarks>
+        /// See: https://www.postgresql.org/docs/10/static/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
+        /// </remarks>
+        IReadOnlyList<TDoc> PhraseSearch<TDoc>(string searchTerm, string config = "english");
+
+        /// <summary>
+        /// Performs an asynchronous full text search against <typeparamref name="TDoc"/> using the 'phraseto_tsquery' search function
+        /// </summary>
+        /// <param name="queryText">The text to search for.  May contain lexeme patterns used by PostgreSQL for full text searching</param>
+        /// <param name="config">The dictionary config passed to the 'to_tsquery' function, must match the config parameter used by <seealso cref="DocumentMapping.AddFullTextIndex(string)"/></param>
+        /// <remarks>
+        /// See: https://www.postgresql.org/docs/10/static/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
+        /// </remarks>
+        Task<IReadOnlyList<TDoc>> PhraseSearchAsync<TDoc>(string searchTerm, string config = "english", CancellationToken token = default);
     }
 }

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -57,7 +57,6 @@
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' != 'Windows_NT' AND '$(TargetFramework)'== 'net46'">
-    <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.6"
-                      Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.6" Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -209,6 +209,12 @@ namespace Marten
                 return this;
             }
 
+            public DocumentMappingExpression<T> FullTextIndex(string config = "english", Action<FullTextIndex> configure = null)
+            {
+                alter = m => m.AddFullTextIndex(config, configure);
+                return this;
+            }
+
             public DocumentMappingExpression<T> ForeignKey<TReference>(
                 Expression<Func<T, object>> expression,
                 Action<ForeignKeyDefinition> foreignKeyConfiguration = null,

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -440,6 +440,21 @@ namespace Marten.Schema
             }
         }
 
+        /// <summary>
+        /// Adds a full text index
+        /// </summary>
+        /// <param name="config">The dictionary to used by the 'to_tsvector' function, defaults to 'english'.</param>
+        /// <param name="configure">Optional action to further configure the full text index</param>
+        /// <remarks>
+        /// See: https://www.postgresql.org/docs/10/static/textsearch-controls.html#TEXTSEARCH-PARSING-DOCUMENTS
+        /// </remarks>
+        public void AddFullTextIndex(string config = "english", Action<FullTextIndex> configure = null)
+        {
+            var index = new FullTextIndex(this, config);
+            configure?.Invoke(index);
+            Indexes.Add(index);
+        }
+
         public ForeignKeyDefinition AddForeignKey(string memberName, Type referenceType)
         {
             var field = FieldFor(memberName);

--- a/src/Marten/Schema/FullTextIndex.cs
+++ b/src/Marten/Schema/FullTextIndex.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Baseline;
+using Marten.Storage;
+
+namespace Marten.Schema
+{
+    public class FullTextIndex : IIndexDefinition
+    {
+        private readonly string _config;
+        private readonly DbObjectName _table;
+        private string _indexName;
+
+        public FullTextIndex(DocumentMapping parent, string config)
+        {
+            _table = parent.Table;
+            _config = config;
+        }
+
+        public string IndexName
+        {
+            get
+            {
+                if(_indexName.IsNotEmpty())
+                {
+                    return _indexName.StartsWith(DocumentMapping.MartenPrefix)
+                        ? _indexName
+                        : DocumentMapping.MartenPrefix + _indexName;
+                }
+
+                return $"mt_{_table.Name}_idx_fts";
+            }
+            set => _indexName = value;
+        }        
+        public string ToDDL()
+        {
+            return $"CREATE INDEX {IndexName} ON {_table.QualifiedName} USING gin (( to_tsvector('{_config}', data) ));";
+        }
+
+        public bool Matches(ActualIndex index)
+        {
+            var ddl = index?.DDL.ToLowerInvariant();
+            // Check for the existence of the 'to_tsvector' function, the correct table name, and the use of the data column
+            return ddl?.Contains("to_tsvector") == true && ddl.Contains(_table.QualifiedName) && ddl.Contains("data");
+        }
+    }
+}

--- a/src/Marten/Schema/FullTextIndex.cs
+++ b/src/Marten/Schema/FullTextIndex.cs
@@ -14,22 +14,22 @@ namespace Marten.Schema
         {
             _table = parent.Table;
             _config = config;
+            _indexName = $"{_table.Name}_idx_fts";
         }
 
         public string IndexName
         {
-            get
+            get => _indexName;
+            set
             {
-                if(_indexName.IsNotEmpty())
-                {
-                    return _indexName.StartsWith(DocumentMapping.MartenPrefix)
-                        ? _indexName
-                        : DocumentMapping.MartenPrefix + _indexName;
-                }
-
-                return $"mt_{_table.Name}_idx_fts";
+                var lowerValue = value.ToLowerInvariant();
+                if(value.IsNotEmpty() && lowerValue.StartsWith(DocumentMapping.MartenPrefix))
+                    _indexName = lowerValue.ToLowerInvariant();
+                else if(lowerValue.IsNotEmpty())
+                    _indexName = DocumentMapping.MartenPrefix + lowerValue.ToLowerInvariant();
+                else
+                    _indexName = $"{_table.Name}_idx_fts";
             }
-            set => _indexName = value;
         }        
         public string ToDDL()
         {


### PR DESCRIPTION
This adds an implementation of full text searching on top of the latest Marten code base.  Replacing #945 .