### PR TITLE
avoid redundant build

### DIFF
--- a/martenbuild.cs
+++ b/martenbuild.cs
@@ -63,7 +63,7 @@ namespace martenbuild
 
             Target("test", DependsOn("compile"), () =>
             {
-                Run("dotnet", $"test src/Marten.Testing/Marten.Testing.csproj --framework netcoreapp2.1 --configuration {configuration}");
+                Run("dotnet", $"test src/Marten.Testing/Marten.Testing.csproj --framework netcoreapp2.1 --configuration {configuration} --no-build");
             });
 
             Target("storyteller", DependsOn("compile"), () =>


### PR DESCRIPTION
Building is taken care of by the `compile` target, which is a dependency.