### PR TITLE
 fixes #1109 async batch updates sent fifo

### DIFF
--- a/src/Marten.Testing/Util/update_batch_Tests.cs
+++ b/src/Marten.Testing/Util/update_batch_Tests.cs
@@ -71,5 +71,23 @@ namespace Marten.Testing.Util
                 session.Query<Target>().Count().ShouldBe(100);
             }
         }
+
+        [Fact]
+        public async Task can_delete_and_make_updates_with_more_than_one_batch_async()
+        {
+            var targets = Target.GenerateRandomData(100).ToArray();
+            StoreOptions(_ => _.UpdateBatchSize = 10);
+
+            using (var session = theStore.LightweightSession())
+            {
+                session.DeleteWhere<Target>(x => x.Id != null);
+                targets.Each(x => session.Store(x));
+
+                await session.SaveChangesAsync().ConfigureAwait(false);
+
+                var t = await session.Query<Target>().CountAsync().ConfigureAwait(false);
+                t.ShouldBe(100);
+            }
+        }
     }
 }

--- a/src/Marten/Services/UpdateBatch.cs
+++ b/src/Marten/Services/UpdateBatch.cs
@@ -151,7 +151,9 @@ namespace Marten.Services
             try
             {
                 var list = new List<Exception>();
-                foreach (var batch in _commands.ToArray())
+
+                var commandsFifo = _commands.Reverse().ToArray();
+                foreach (var batch in commandsFifo)
                 {
                     var cmd = batch.BuildCommand();
                     await Connection.ExecuteAsync(cmd, async (c, tkn) =>


### PR DESCRIPTION
The PR is off of master (3.0) but I _really_ would like this fixed for 2.10.  What would make that easier to do - should I make a PR off of that branch?  I'd rather not go through regression testing for npgsql 4 on my app at the moment if I don't have to. 