### PR TITLE
Eliminate usage of reflection in TypeMappings - fixes 1049

### DIFF
--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -16,7 +16,7 @@ namespace Marten.Util
 
         static TypeMappings()
         {
-            // Create the CLR type type to NpgsqlDbType and PgTypeName mapping from exposed INpgsqlTypeMapper.Mappings
+            // Create the CLR type to NpgsqlDbType and PgTypeName mapping from exposed INpgsqlTypeMapper.Mappings
             PgTypes = new Dictionary<Type, string>();
             TypeToNpgsqlDbType = new Dictionary<Type, NpgsqlDbType?>();
 

--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -30,11 +30,11 @@ namespace Marten.Util
             }
 
             // Update or add the following PgTypes mappings to be inline with what we had earlier
-            // This not available in Npgsql mappings
+            // This is not available in Npgsql mappings
             PgTypes[typeof(long)] = "bigint";
-            // This not available in Npgsql mappings
+            // This is not available in Npgsql mappings
             PgTypes[typeof(string)] = "varchar";
-            // This not available in Npgsql mappings
+            // This is not available in Npgsql mappings
             PgTypes[typeof(float)] = "decimal";
 
             // Default Npgsql mapping is 'numeric' but we are using 'decimal'


### PR DESCRIPTION
- Eliminate usage of reflection in TypeMappings by using INpgsqlTypeMapper.Mappings - fixes #1049
- Update logic of PgTypes to use type mappings from INpgsqlTypeMapper.Mappings

Note: With the above fix, we don't need any change from Npgsql folks. @oskardudycz you can review and close the issue raised in Npgsql repo.