### PR TITLE
Implement RetryPolicy extension point feature to handle transient errors - fixes #1119

### DIFF
--- a/src/Marten.Testing/Services/ManagedConnectionTests.cs
+++ b/src/Marten.Testing/Services/ManagedConnectionTests.cs
@@ -12,7 +12,7 @@ namespace Marten.Testing.Services
         [Fact]
         public async Task increments_the_request_count()
         {
-            using (var connection = new ManagedConnection(new ConnectionSource()))
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()))
             {
                 connection.RequestCount.ShouldBe(0);
 
@@ -56,7 +56,7 @@ namespace Marten.Testing.Services
         {
             var ex = new DivideByZeroException();
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 Exception<DivideByZeroException>.ShouldBeThrownBy(() =>
                 {
@@ -78,7 +78,7 @@ namespace Marten.Testing.Services
         {
             var ex = new DivideByZeroException();
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 await Exception<DivideByZeroException>.ShouldBeThrownByAsync(async () =>
                 {
@@ -102,7 +102,7 @@ namespace Marten.Testing.Services
         {
             var ex = new DivideByZeroException();
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 var cmd = new NpgsqlCommand();
 
@@ -121,7 +121,7 @@ namespace Marten.Testing.Services
         {
             var ex = new DivideByZeroException();
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 var cmd = new NpgsqlCommand();
 
@@ -144,7 +144,7 @@ namespace Marten.Testing.Services
         public void log_execute_success_1()
         {
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 connection.Execute(c => c.CommandText = "do something");
 
@@ -157,7 +157,7 @@ namespace Marten.Testing.Services
         public async Task log_execute_success_1_async()
         {
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 await connection.ExecuteAsync(async (c, tkn) =>
                 {
@@ -174,7 +174,7 @@ namespace Marten.Testing.Services
         public void log_execute_success_2()
         {
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 var cmd = new NpgsqlCommand();
                 connection.Execute(cmd, c => c.CommandText = "do something");
@@ -188,7 +188,7 @@ namespace Marten.Testing.Services
         public async Task log_execute_success_2_async()
         {
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 var cmd = new NpgsqlCommand();
                 await connection.ExecuteAsync(cmd, async (c, tkn) =>
@@ -206,7 +206,7 @@ namespace Marten.Testing.Services
         public void log_execute_success_with_answer_1()
         {
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 connection.Execute(c =>
                 {
@@ -223,7 +223,7 @@ namespace Marten.Testing.Services
         public async Task log_execute_success_with_answer_1_async()
         {
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 await connection.Execute(async c =>
                 {
@@ -241,7 +241,7 @@ namespace Marten.Testing.Services
         public void log_execute_success_with_answer_2()
         {
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 var cmd = new NpgsqlCommand();
                 connection.Execute(cmd, c => "something");
@@ -255,7 +255,7 @@ namespace Marten.Testing.Services
         public async Task log_execute_success_with_answer_2_async()
         {
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 var cmd = new NpgsqlCommand();
                 await connection.ExecuteAsync(cmd, async (c, tkn) =>
@@ -273,7 +273,7 @@ namespace Marten.Testing.Services
         {
             var ex = new DivideByZeroException();
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 Exception<DivideByZeroException>.ShouldBeThrownBy(() =>
                 {
@@ -295,7 +295,7 @@ namespace Marten.Testing.Services
         {
             var ex = new DivideByZeroException();
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 await Exception<DivideByZeroException>.ShouldBeThrownByAsync(async () =>
                 {
@@ -319,7 +319,7 @@ namespace Marten.Testing.Services
         {
             var ex = new DivideByZeroException();
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 var cmd = new NpgsqlCommand();
 
@@ -340,7 +340,7 @@ namespace Marten.Testing.Services
         {
             var ex = new DivideByZeroException();
             var logger = new RecordingLogger();
-            using (var connection = new ManagedConnection(new ConnectionSource()) {Logger = logger})
+            using (var connection = new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
                 var cmd = new NpgsqlCommand();
 

--- a/src/Marten/IRetryPolicy.cs
+++ b/src/Marten/IRetryPolicy.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten
+{
+    /// <summary>
+    /// Interface defining the retry policy for handling NpgqlException with git statustransient failures
+    /// </summary>
+    public interface IRetryPolicy
+    {
+        /// <summary>
+        /// Execute operation with the relevant retry policy
+        /// </summary>
+        /// <param name="operation"></param>
+        void Execute(Action operation);
+
+        /// <summary>
+        /// Execute operation with the relevant retry policy and return result
+        /// </summary>
+        /// <param name="operation"></param>
+        /// <typeparam name="TResult"></typeparam>
+        /// <returns></returns>
+        TResult Execute<TResult>(Func<TResult> operation);
+
+        /// <summary>
+        /// Async execute operation with the relevant retry policy
+        /// </summary>
+        /// <param name="operation"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task ExecuteAsync(Func<Task> operation, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Async Execute operation with the relevant retry policy and return result
+        /// </summary>
+        /// <param name="operation"></param>
+        /// <param name="cancellationToken"></param>
+        /// <typeparam name="TResult"></typeparam>
+        /// <returns></returns>
+        Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> operation, CancellationToken cancellationToken);
+    }
+    
+    /// <summary>
+    /// Default implementation of IRetryPolicy
+    /// </summary>
+    public class NulloRetryPolicy : IRetryPolicy
+    {
+        public void Execute(Action operation)
+        {
+            operation();
+        }
+
+        public TResult Execute<TResult>(Func<TResult> operation)
+        {
+            return operation();
+        }
+
+        public Task ExecuteAsync(Func<Task> operation, CancellationToken cancellationToken)
+        {
+            return operation();
+        }
+
+        public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> operation, CancellationToken cancellationToken)
+        {
+            return operation();
+        }
+    }
+}
+

--- a/src/Marten/Services/ManagedConnection.cs
+++ b/src/Marten/Services/ManagedConnection.cs
@@ -18,7 +18,19 @@ namespace Marten.Services
         private bool _ownsConnection;
         private IRetryPolicy _retryPolicy;
 
+        // keeping this for binary compatibility (but not used)
+        [Obsolete("Use the method which includes IRetryPolicy instead")]
+        public ManagedConnection(IConnectionFactory factory) : this(factory, new NulloRetryPolicy())
+        {
+        }
+
         public ManagedConnection(IConnectionFactory factory, IRetryPolicy retryPolicy) : this(factory, CommandRunnerMode.AutoCommit, retryPolicy)
+        {
+        }
+
+        // keeping this for binary compatibility (but not used)
+        [Obsolete("Use the method which includes IRetryPolicy instead")]
+        public ManagedConnection(SessionOptions options, CommandRunnerMode mode) : this(options, mode, new NulloRetryPolicy())
         {
         }
 
@@ -33,6 +45,14 @@ namespace Marten.Services
 
             _connection = new TransactionState(_mode, _isolationLevel, _commandTimeout, conn, options.OwnsConnection, options.Transaction);
             _retryPolicy = retryPolicy;
+        }
+
+        // keeping this for binary compatibility (but not used)
+        [Obsolete("Use the method which includes IRetryPolicy instead")]
+        public ManagedConnection(IConnectionFactory factory, CommandRunnerMode mode,
+            IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, int commandTimeout = 30) : this(factory, mode,
+            new NulloRetryPolicy(), isolationLevel, commandTimeout)
+        {
         }
 
 

--- a/src/Marten/Storage/DefaultTenancy.cs
+++ b/src/Marten/Storage/DefaultTenancy.cs
@@ -22,7 +22,7 @@ namespace Marten.Storage
             Schema = new TenantSchema(options, Default.As<Tenant>());
         }
 
-        public ITenant this[string tenantId] => new LightweightTenant(tenantId, Default);
+        public ITenant this[string tenantId] => new LightweightTenant(tenantId, Default, Options.RetryPolicy());
 
         public ITenant Default { get; }
 
@@ -39,11 +39,13 @@ namespace Marten.Storage
     public class LightweightTenant : ITenant
     {
         private readonly ITenant _inner;
+        private readonly IRetryPolicy _retryPolicy;
 
-        public LightweightTenant(string tenantId, ITenant inner)
+        public LightweightTenant(string tenantId, ITenant inner, IRetryPolicy retryPolicy)
         {
             _inner = inner;
             TenantId = tenantId;
+            _retryPolicy = retryPolicy;
         }
 
         public IDbObjects DbObjects => _inner.DbObjects;

--- a/src/Marten/Storage/Tenant.cs
+++ b/src/Marten/Storage/Tenant.cs
@@ -235,7 +235,7 @@ namespace Marten.Storage
         /// <returns></returns>
         public IManagedConnection OpenConnection(CommandRunnerMode mode = CommandRunnerMode.AutoCommit, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, int timeout = 30)
         {
-            return new ManagedConnection(_factory, mode, isolationLevel, timeout);
+            return new ManagedConnection(_factory, mode, _options.RetryPolicy(), isolationLevel, timeout);
         }
 
         /// <summary>

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -50,6 +50,7 @@ namespace Marten
 
         private IMartenLogger _logger = new NulloMartenLogger();
         private ISerializer _serializer;
+        private IRetryPolicy _retryPolicy = new NulloRetryPolicy();
 
         /// <summary>
         ///     Whether or Marten should attempt to create any missing database schema objects at runtime. This
@@ -224,6 +225,16 @@ namespace Marten
         public void Logger(IMartenLogger logger)
         {
             _logger = logger;
+        }
+
+        public IRetryPolicy RetryPolicy()
+        {
+            return _retryPolicy ?? new NulloRetryPolicy();
+        }
+
+        public void RetryPolicy(IRetryPolicy retryPolicy)
+        {
+            _retryPolicy = retryPolicy;
         }
 
         /// <summary>


### PR DESCRIPTION
- Add `IRetryPolicy` and `NulloRetryPolicy`
- Implemement RetryPolicy to configure the same via `StoreOptions` and wrap the Npgsql calls in `ManagedConnection` using retry policy - fixes #1119
- Update `ManagedConnection` unit tests to retrofit retry policy changes.