### PR TITLE
Remove space before semicolon in CanonicizeSql

### DIFF
--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -89,6 +89,7 @@ namespace Marten.Util
                 .Replace('\r', ' ')
                 .Replace('\t', ' ')
                 .ReplaceMultiSpace(" ")
+                .Replace(" ;", ";")
                 .Replace("SECURITY INVOKER", "")
                 .Replace("  ", " ")
                 .Replace("LANGUAGE plpgsql AS $function$", "")


### PR DESCRIPTION
A space before a semi colon is a useless space, but it is considered a difference when comparing schemas and creating patches.

Added `.Replace(" ;", ";")` to remove spaces before semi-colons after squashing all multi spaces with `ReplaceMultiSpace`