### PR TITLE
Fix GH-1151 AssertDatabaseMatchesConfiguration throws exception 

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_1151_assert_database_matches_configuration_exception.cs
+++ b/src/Marten.Testing/Bugs/Bug_1151_assert_database_matches_configuration_exception.cs
@@ -1,0 +1,28 @@
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+    public class Bug_1151_assert_db_matches_config_exception : IntegratedFixture
+    {
+        [Fact]
+        public void check_assert_db_matches_config_for_doc_with_pg_keyword_prop()
+        {
+            StoreOptions(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.CreateOrUpdate;
+                _.Schema.For<Bug1151>()
+                    .Duplicate(c => c.Trim);
+            });
+            
+            theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            theStore.Schema.AssertDatabaseMatchesConfiguration();
+        }
+    }
+    
+    class Bug1151
+    {
+        public string Id { get; set; }
+        // trim is a PostgreSQL keyword
+        public string Trim { get; set; }
+    }
+}

--- a/src/Marten.Testing/duplicate_fields_in_table_and_upsert_Tests.cs
+++ b/src/Marten.Testing/duplicate_fields_in_table_and_upsert_Tests.cs
@@ -14,16 +14,6 @@ namespace Marten.Testing
         {
             theStore.Storage.MappingFor(typeof(User)).As<DocumentMapping>().DuplicateField("FirstName");
             
-            
-            var store = DocumentStore.For(_ =>
-            {
-                _.Connection("host=localhost;database=test;password=password1;username=postgres");
-                _.AutoCreateSchemaObjects = AutoCreate.CreateOrUpdate;
-                _.Schema.For<User>()
-                    .Duplicate(u => u.FirstName);
-            });
-
-
             var user1 = new User { FirstName = "Byron", LastName = "Scott" };
             using (var session = theStore.OpenSession())
             {

--- a/src/Marten.Testing/duplicate_fields_in_table_and_upsert_Tests.cs
+++ b/src/Marten.Testing/duplicate_fields_in_table_and_upsert_Tests.cs
@@ -13,6 +13,15 @@ namespace Marten.Testing
         public void end_to_end()
         {
             theStore.Storage.MappingFor(typeof(User)).As<DocumentMapping>().DuplicateField("FirstName");
+            
+            
+            var store = DocumentStore.For(_ =>
+            {
+                _.Connection("host=localhost;database=test;password=password1;username=postgres");
+                _.AutoCreateSchemaObjects = AutoCreate.CreateOrUpdate;
+                _.Schema.For<User>()
+                    .Duplicate(u => u.FirstName);
+            });
 
 
             var user1 = new User { FirstName = "Byron", LastName = "Scott" };

--- a/src/Marten/Schema/IndexDefinition.cs
+++ b/src/Marten/Schema/IndexDefinition.cs
@@ -122,6 +122,10 @@ namespace Marten.Schema
 
             actual = actual.Replace("  ", " ") + ";";
 
+            // if column name being a PostgreSQL keyword, column is already wrapped with double quotes
+            // above regex and replace logic will result in additional double quotes, remove the same
+            actual = actual.Replace("\"\"", "\"");
+
             return ToDDL().EqualsIgnoreCase(actual);
         }
     }


### PR DESCRIPTION
- Fix to remove duplicated double quotes for column names same as PostgreSQL keyword in actual sql statement in index definition matches logic
- Add unit test