### PR TITLE
Fix duplicate field null scenarios

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_1155_null_duplicate_fields.cs
+++ b/src/Marten.Testing/Bugs/Bug_1155_null_duplicate_fields.cs
@@ -1,0 +1,198 @@
+﻿using System.Linq;
+using Marten.Services;
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+    public class Bug_1155_null_duplicate_fields : IntegratedFixture
+    {
+        [Fact]
+        public void when_enum_is_null_due_to_nullable_type()
+        {
+            StoreOptions(_ =>
+            {
+                _.Serializer(new JsonNetSerializer {EnumStorage = EnumStorage.AsInteger});
+                _.Schema.For<Target>().Duplicate(t => t.NullableColor);
+            });
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(new Target
+                {
+                    Number = 1,
+                    NullableColor = null
+                });
+
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Query<Target>().Where(x => x.Number == 1)
+                    .ToArray()
+                    .Select(x => x.Number)
+                    .ShouldHaveTheSameElementsAs(1);
+            }
+        }
+
+        [Fact]
+        public void when_enum_is_null_due_to_nesting()
+        {
+            StoreOptions(_ =>
+            {
+                _.Serializer(new JsonNetSerializer {EnumStorage = EnumStorage.AsInteger});
+                _.Schema.For<Target>().Duplicate(t => t.Inner.Color);
+            });
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(new Target
+                {
+                    Number = 1,
+                    Inner = null
+                });
+
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Query<Target>().Where(x => x.Number == 1)
+                    .ToArray()
+                    .Select(x => x.Number)
+                    .ShouldHaveTheSameElementsAs(1);
+            }
+        }
+
+        [Fact]
+        public void when_string_enum_is_null_due_to_nullable_type()
+        {
+            StoreOptions(_ =>
+            {
+                _.Serializer(new JsonNetSerializer {EnumStorage = EnumStorage.AsString});
+                _.Schema.For<Target>().Duplicate(t => t.NullableColor);
+            });
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(new Target
+                {
+                    Number = 1,
+                    NullableColor = null
+                });
+
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Query<Target>().Where(x => x.Number == 1)
+                    .ToArray()
+                    .Select(x => x.Number)
+                    .ShouldHaveTheSameElementsAs(1);
+            }
+        }
+
+        [Fact]
+        public void when_string_enum_is_null_due_to_nesting()
+        {
+            StoreOptions(_ =>
+            {
+                _.Serializer(new JsonNetSerializer {EnumStorage = EnumStorage.AsString});
+                _.Schema.For<Target>().Duplicate(t => t.Inner.Color);
+            });
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(new Target
+                {
+                    Number = 1,
+                    Inner = null
+                });
+
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Query<Target>().Where(x => x.Number == 1)
+                    .ToArray()
+                    .Select(x => x.Number)
+                    .ShouldHaveTheSameElementsAs(1);
+            }
+        }
+
+        [Fact]
+        public void when_field_is_not_null_due_to_nesting()
+        {
+            StoreOptions(_ => _.Schema.For<Target>().Duplicate(t => t.Inner.Number));
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(new Target
+                {
+                    Number = 1,
+                    Inner = new Target {Number = 2}
+                });
+
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Query<Target>().Where(x => x.Number == 1)
+                    .ToArray()
+                    .Select(x => x.Number)
+                    .ShouldHaveTheSameElementsAs(1);
+            }
+        }
+
+        [Fact]
+        public void when_field_is_null_due_to_nesting()
+        {
+            StoreOptions(_ => _.Schema.For<Target>().Duplicate(t => t.Inner.Number));
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(new Target
+                {
+                    Number = 1,
+                    Inner = null
+                });
+
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Query<Target>().Where(x => x.Number == 1)
+                    .ToArray()
+                    .Select(x => x.Number)
+                    .ShouldHaveTheSameElementsAs(1);
+            }
+        }
+
+        [Fact]
+        public void when_bulk_inserting_and_field_is_null_due_to_nesting()
+        {
+            StoreOptions(_ => _.Schema.For<Target>().Duplicate(t => t.Inner.Number));
+
+            theStore.BulkInsertDocuments(new[]
+            {
+                new Target
+                {
+                    Number = 1,
+                    Inner = null
+                }
+            });
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Query<Target>().Where(x => x.Number == 1)
+                    .ToArray()
+                    .Select(x => x.Number)
+                    .ShouldHaveTheSameElementsAs(1);
+            }
+        }
+    }
+}

--- a/src/Marten.Testing/Target.cs
+++ b/src/Marten.Testing/Target.cs
@@ -133,6 +133,7 @@ namespace Marten.Testing
         public int? NullableNumber { get; set; }
         public DateTime? NullableDateTime { get; set; }
         public bool? NullableBoolean { get; set; }
+        public Colors? NullableColor { get; set; }
 
         public IDictionary<string,string> StringDict { get; set; }
 

--- a/src/Marten.Testing/Util/LambdaBuilderTester.cs
+++ b/src/Marten.Testing/Util/LambdaBuilderTester.cs
@@ -129,6 +129,23 @@ namespace Marten.Testing.Util
         }
 
         [Fact]
+        public void can_build_getter_for_null_deep_expression()
+        {
+            Expression<Func<Target, int>> expression = t => t.Inner.Number;
+
+            var visitor = new FindMembers();
+            visitor.Visit(expression);
+
+            var members = visitor.Members.ToArray();
+
+            var getter = LambdaBuilder.Getter<Target, int>(EnumStorage.AsInteger, members);
+
+            var target = Target.Random(false);
+
+            getter(target).ShouldBe(default(int));
+        }
+
+        [Fact]
         public void can_get_the_Enum_GetName_method()
         {
             typeof(Enum).GetMethod(nameof(Enum.GetName), BindingFlags.Static | BindingFlags.Public).ShouldNotBeNull();

--- a/src/Marten/Util/LambdaBuilder.cs
+++ b/src/Marten/Util/LambdaBuilder.cs
@@ -97,40 +97,64 @@ namespace Marten.Util
 
         private static readonly MethodInfo _getEnumStringValue = typeof(Enum).GetMethod(nameof(Enum.GetName), BindingFlags.Static | BindingFlags.Public);
         private static readonly MethodInfo _getEnumIntValue = typeof(Convert).GetMethods(BindingFlags.Static | BindingFlags.Public).Single(mi => mi.Name == nameof(Convert.ToInt32) && mi.GetParameters().Count() == 1 && mi.GetParameters().Single().ParameterType == typeof(object));
+        private static readonly Expression _trueConstant = Expression.Constant(true);
 
         public static Expression ToExpression(EnumStorage enumStorage, MemberInfo[] members, ParameterExpression target)
         {
-            Expression body = target;
-            foreach (var member in members)
-            {
-                if (member is PropertyInfo)
-                {
-                    var propertyInfo = member.As<PropertyInfo>();
-                    var getMethod = propertyInfo.GetGetMethod();
+            // Builds expression to retrieve value including enum conversion and null checks:
+            // Simple property/field                 target => target.Property
+            // Enum conversion to int                target => Convert.ToInt32(target.EnumProperty)
+            // Enum conversion to string             target => Enum.GetName(type, target.EnumProperty)
+            // Nested property/field null checks     target => target.Inner != null ? target.Inner.Property : default()
 
-                    body = Expression.Call(body, getMethod);
-                }
-                else
-                {
-                    var field = member.As<FieldInfo>();
-                    body = Expression.Field(body, field);
-                }
+            Expression NullCheck(Expression accessor)
+            {
+                return accessor.Type.IsValueType && !accessor.Type.IsNullableOfT()
+                    ? _trueConstant
+                    : Expression.NotEqual(accessor, Expression.Constant(null, accessor.Type));
             }
 
-            var memberType = members.Last().GetMemberType();
-            if (memberType.GetTypeInfo().IsEnum)
+            Expression AddToNullChecks(Expression nullChecks, Expression accessor)
             {
-                if (enumStorage == EnumStorage.AsString)
-                {
-                    body = Expression.Call(_getEnumStringValue, Expression.Constant(memberType), Expression.Convert(body, typeof(object)));
-                }
-                else
-                {
-                    body = Expression.Call(_getEnumIntValue, Expression.Convert(body, typeof(object)));
-                }
+                var check = NullCheck(accessor);
+                return check == _trueConstant
+                    ? nullChecks
+                    : Expression.AndAlso(nullChecks, check);
             }
 
-            return body;
+            Expression ConvertEnumExpression(Type type, Expression accessor)
+            {
+                return enumStorage == EnumStorage.AsString
+                    ? Expression.Call(_getEnumStringValue, Expression.Constant(type),
+                        Expression.Convert(accessor, typeof(object)))
+                    : Expression.Call(_getEnumIntValue,
+                        Expression.Convert(accessor, typeof(object)));
+            }
+
+            // Build accessor and null checks expressions.
+            var aggregatedExpressions = members.Aggregate(new
+                {
+                    Accessor = (Expression) target,
+                    NullChecks = NullCheck(target)
+                },
+                (acc, member) =>
+                {
+                    var memberType = member.GetMemberType();
+                    var accessor = (Expression) Expression.PropertyOrField(acc.Accessor, member.Name);
+                    return new
+                    {
+                        Accessor = memberType.GetTypeInfo().IsEnum
+                            ? ConvertEnumExpression(memberType, accessor)
+                            : accessor,
+                        NullChecks = AddToNullChecks(acc.NullChecks, accessor)
+                    };
+                });
+
+            // If there are potential nulls add condition.
+            return aggregatedExpressions.NullChecks == _trueConstant
+                ? aggregatedExpressions.Accessor
+                : Expression.Condition(aggregatedExpressions.NullChecks, aggregatedExpressions.Accessor,
+                    Expression.Default(aggregatedExpressions.Accessor.Type));
         }
     }
 }


### PR DESCRIPTION
Fixes #1155 scenarios where duplicate fields or their ancestors can be null.
When this is the case the default value will be stored to the duplicate field.

I've extended the expression generation logic to add null checks when getting values for duplicate fields and compiled queries. 

Excerpt from comments below:
```
            // Builds expression to retrieve value including enum conversion and null checks:
            // Simple property/field                 target => target.Property
            // Enum conversion to int                target => Convert.ToInt32(target.EnumProperty)
            // Enum conversion to string             target => Enum.GetName(type, target.EnumProperty)
            // Nested property/field null checks     target => target.Inner != null ? target.Inner.Property : default()
```

I've added tests scenarios specific the the use cases I came across the issue in Bug_1155_null_duplicate_fields.cs. I'm not sure if you'd prefer these to be move into a more suitable location? The code path is also used by compiled queries, all the existing tests pass but I haven't added any additional tests for them.

Let me know what else you'd like adding/changing/thinking about.