### PR TITLE
Respect custom mappings in NPGSQL's GlobalTypeMapper

### DIFF
--- a/src/Marten.Testing/TypeMappingsTests.cs
+++ b/src/Marten.Testing/TypeMappingsTests.cs
@@ -34,6 +34,14 @@ namespace Marten.Testing
             ShouldThrowExtensions.ShouldThrow<Exception>(() => TypeMappings.ToDbType(typeof(UnmappedTarget)));
         }
 
+
+        [Fact]
+        public void execute_get_pg_type_default_mappings_resolve()
+        {
+            TypeMappings.GetPgType(typeof(long), EnumStorage.AsString).ShouldBe("bigint");
+            TypeMappings.GetPgType(typeof(DateTime), EnumStorage.AsString).ShouldBe("timestamp without time zone");
+        }
+
         [Fact]
         public void execute_get_pg_type_custom_mappings_resolve_or_default_to_jsonb()
         {
@@ -74,12 +82,6 @@ namespace Marten.Testing
             var inputString = "Darth        Maroon the   First";
             var expectedString = "Darth Maroon the First";
             inputString.ReplaceMultiSpace(" ").ShouldBe(expectedString);
-        }
-
-        [Fact]
-        public void pull_default_clr_types_for_npgsql_type()
-        {
-            var npgsql = TypeMappings.ToDbType(typeof(string));
         }
     }
 }

--- a/src/Marten.Testing/TypeMappingsTests.cs
+++ b/src/Marten.Testing/TypeMappingsTests.cs
@@ -1,4 +1,6 @@
 ﻿using Marten.Util;
+using Npgsql;
+using Npgsql.TypeMapping;
 using NpgsqlTypes;
 using Shouldly;
 using Xunit;
@@ -32,8 +34,21 @@ namespace Marten.Testing
             var inputString = "Darth        Maroon the   First";
             var expectedString = "Darth Maroon the First";
             inputString.ReplaceMultiSpace(" ").ShouldBe(expectedString);
-
-
         }
+
+        [Fact]
+        public void recalculates_mappings_when_asked()
+        {
+            var originalMapping = TypeMappings.GetPgType(typeof(MappingTarget), EnumStorage.AsString);
+            originalMapping.ShouldBe("jsonb");
+
+            NpgsqlConnection.GlobalTypeMapper.MapComposite<MappingTarget>("nvarchar");
+            TypeMappings.RecalculateTypeMappings();
+
+            var updatedMapping = TypeMappings.GetPgType(typeof(MappingTarget), EnumStorage.AsString);
+            updatedMapping.ShouldBe("nvarchar");
+        }
+
+        public class MappingTarget { }
     }
 }

--- a/src/Marten.Testing/TypeMappingsTests.cs
+++ b/src/Marten.Testing/TypeMappingsTests.cs
@@ -48,7 +48,6 @@ namespace Marten.Testing
             NpgsqlConnection.GlobalTypeMapper.MapComposite<MappedTarget>("varchar");
 
             TypeMappings.GetPgType(typeof(MappedTarget), EnumStorage.AsString).ShouldBe("varchar");
-            TypeMappings.GetPgType(typeof(MappedTarget), EnumStorage.AsString).ShouldBe("varchar");
             TypeMappings.GetPgType(typeof(UnmappedTarget), EnumStorage.AsString).ShouldBe("jsonb");
         }
 

--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -20,6 +20,19 @@ namespace Marten.Util
             PgTypes = new Dictionary<Type, string>();
             TypeToNpgsqlDbType = new Dictionary<Type, NpgsqlDbType?>();
 
+            PopulateTypeMappings();
+        }
+
+        public static void RecalculateTypeMappings()
+        {
+            PgTypes.Clear();
+            TypeToNpgsqlDbType.Clear();
+
+            PopulateTypeMappings();
+        }
+
+        private static void PopulateTypeMappings()
+        {
             foreach (var mapping in NpgsqlConnection.GlobalTypeMapper.Mappings)
             {
                 foreach (var t in mapping.ClrTypes)
@@ -40,7 +53,7 @@ namespace Marten.Util
             // Default Npgsql mapping is 'numeric' but we are using 'decimal'
             PgTypes[typeof(decimal)] = "decimal";
             // Default Npgsql mappings is 'timestamp' but we are using 'timestamp without time zone'
-            PgTypes[typeof (DateTime)] = "timestamp without time zone";
+            PgTypes[typeof(DateTime)] = "timestamp without time zone";
         }
 
         public static string ConvertSynonyms(string type)


### PR DESCRIPTION
`Marten.Util.TypeMappings` pre-caches Type mappings in a static constructor, using the Npgsql registry. If client code depends on any custom mappings which are registered with Npgsql, they will not be picked up, since static constructors execute very early. (There may be a way to sneak a value into Npgsql before Marten gets initialized, but I was unable to find a way to make it happen.)

This change (or one like it) would allow those type mappings to be re-executed after any other custom mappings are added.

Thoughts?