### PR TITLE
Update run dependency docs and add link to automated docker solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,25 @@ Marten also provides .NET developers with an ACID-compliant event store with use
 
 Before getting started you will need the following in your environment:
 
-* Access to a PostgreSQL **9.5+** database.
-* An environment variable of `marten_testing_database` set to the connection string for the database you want to use as a testbed. (See the [Npgsql documentation](http://www.npgsql.org/doc/connection-string-parameters.html) for more information about PostgreSQL connection strings )
-* You will also need to enable the PLV8 extension inside of PostgreSQL for running JavaScript stored procedures for the nascent projection support. See
-[this link](http://www.postgresonline.com/journal/archives/360-PLV8-binaries-for-PostgreSQL-9.5-windows-both-32-bit-and-64-bit.html) for pre-built binaries for PLV8 running on Windows
-* You will also need to make sure that the login you are using to connect to your databasee is a member of the `postgres` role
-* Ensure you have installed [.NET Core SDK 2.0](https://www.microsoft.com/net/download/core)
-* Once you have the codebase and the connection string file, run the rake script or use the dotnet CLI to restore and build the solution.
+**1. .NET Core SDK 2.0+**
+
+Available [here](https://www.microsoft.com/net/download/core)
+
+**2. PostgreSQL **9.5+** database with PLV8**
+
+You need to enable the PLV8 extension inside of PostgreSQL for running JavaScript stored procedures for the nascent projection support.
+
+Ensure the following:
+
+- The login you are using to connect to your databasee is a member of the `postgres` role
+- An environment variable of `marten_testing_database` is set to the connection string for the database you want to use as a testbed. (See the [Npgsql documentation](http://www.npgsql.org/doc/connection-string-parameters.html) for more information about PostgreSQL connection strings ).
+
+_Help with PSQL/PLV8_
+
+- On Windows, see [this link](http://www.postgresonline.com/journal/archives/360-PLV8-binaries-for-PostgreSQL-9.5-windows-both-32-bit-and-64-bit.html) for pre-built binaries of PLV8
+- On unix, see [marten-local-db](https://github.com/eouw0o83hf/marten-local-db) for an automated Docker solution
+
+Once you have the codebase and the connection string file, run the rake script or use the dotnet CLI to restore and build the solution.
 
 You are now ready to contribute to Marten.
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ You need to enable the PLV8 extension inside of PostgreSQL for running JavaScrip
 
 Ensure the following:
 
-- The login you are using to connect to your databasee is a member of the `postgres` role
+- The login you are using to connect to your database is a member of the `postgres` role
 - An environment variable of `marten_testing_database` is set to the connection string for the database you want to use as a testbed. (See the [Npgsql documentation](http://www.npgsql.org/doc/connection-string-parameters.html) for more information about PostgreSQL connection strings ).
 
 _Help with PSQL/PLV8_
 
 - On Windows, see [this link](http://www.postgresonline.com/journal/archives/360-PLV8-binaries-for-PostgreSQL-9.5-windows-both-32-bit-and-64-bit.html) for pre-built binaries of PLV8
-- On unix, see [marten-local-db](https://github.com/eouw0o83hf/marten-local-db) for an automated Docker solution
+- On *nix, check [marten-local-db](https://github.com/eouw0o83hf/marten-local-db) for a Docker based PostgreSQL instance including PLV8.
 
 Once you have the codebase and the connection string file, run the rake script or use the dotnet CLI to restore and build the solution.
 


### PR DESCRIPTION
`README.md` contains a link for getting started with PLV8 on windows, but nothing for non-windows systems. I wrote an [automated Docker solution](https://github.com/eouw0o83hf/marten-local-db) to get testing up and running with one script call, and wanted to share it with other prospective contributors.

If it would be more useful to just add that container system to this repository, I'm glad to do that.