### PR TITLE
On the ViewProjection, if the Id selector returns the default of the projection type Id, then do not add that viewId as a new projection.

### DIFF
--- a/src/Marten/Events/Projections/ViewProjection.cs
+++ b/src/Marten/Events/Projections/ViewProjection.cs
@@ -839,7 +839,7 @@ namespace Marten.Events.Projections
                     streamEvent.Id,
                     streamEvent.Version,
                     // Inline projections don't have the timestamp set, set it manually
-                    timestamp == default(DateTime) ? DateTime.UtcNow : timestamp,
+                    timestamp == default ? DateTime.UtcNow : timestamp,
                     streamEvent.Sequence, 
                     streamEvent.StreamId, 
                     streamEvent.StreamKey, 
@@ -851,13 +851,19 @@ namespace Marten.Events.Projections
             if (handler.IdSelector != null)
             {
                 var viewId = handler.IdSelector(session, isProjectionEvent ? projectionEvent : streamEvent.Data, streamEvent.StreamId);
-                projections.Add(new EventProjection(handler, viewId, streamEvent, projectionEvent));
+                if (!EqualityComparer<TId>.Default.Equals(viewId, default))
+                {
+                    projections.Add(new EventProjection(handler, viewId, streamEvent, projectionEvent));
+                }
             }
             else
             {
                 foreach (var viewId in handler.IdsSelector(session, isProjectionEvent ? projectionEvent : streamEvent.Data, streamEvent.StreamId))
                 {
-                    projections.Add(new EventProjection(handler, viewId, streamEvent, projectionEvent));
+                    if (!EqualityComparer<TId>.Default.Equals(viewId, default))
+                    {
+                        projections.Add(new EventProjection(handler, viewId, streamEvent, projectionEvent));
+                    }
                 }
             }
         }


### PR DESCRIPTION
This prevents default type ids from creating new erroneous documents.