### PR TITLE
Fix small spelling mistake in Documentation

### DIFF
--- a/documentation/documentation/events/appending.md
+++ b/documentation/documentation/events/appending.md
@@ -35,7 +35,7 @@ Or have Marten use a Guid value that you provide yourself:
 
 For stream identity (strings vs. Guids), see <[linkto:documentation/events/identity]>.
 
-Note that `StartStream` checks for and existing stream and throws `ExistingStreamIdCollisionException` if a matching stream already exists.
+Note that `StartStream` checks for an existing stream and throws `ExistingStreamIdCollisionException` if a matching stream already exists.
 
 ## Appending Events
 


### PR DESCRIPTION
Dear Marten Team,

I recently startet experimenting with Marten DB as an event store. I found a mistake in the appending.md file of the events documentation.

This is my first pull request on a public project, but I hope it is helpful. 

Best regards,

Felix 