### PR TITLE
Adding the ability to create a foreign key from a marten document to non-marten table

### DIFF
--- a/src/Marten.Testing/Schema/ForeignKeyDefinitionTests.cs
+++ b/src/Marten.Testing/Schema/ForeignKeyDefinitionTests.cs
@@ -14,7 +14,7 @@ namespace Marten.Testing.Schema
         [Fact]
         public void default_key_name()
         {
-            new ForeignKeyDefinition("user_id", _issueMapping, _userMapping).KeyName.ShouldBe("mt_doc_issue_user_id_fkey");
+            new DocumentReferenceForeignKeyDefinition("user_id", _issueMapping, _userMapping).KeyName.ShouldBe("mt_doc_issue_user_id_fkey");
         }
 
         [Fact]
@@ -25,7 +25,7 @@ namespace Marten.Testing.Schema
                 "ADD CONSTRAINT mt_doc_issue_user_id_fkey FOREIGN KEY (user_id)",
                 "REFERENCES public.mt_doc_user (id);");
 
-            new ForeignKeyDefinition("user_id", _issueMapping, _userMapping).ToDDL()
+            new DocumentReferenceForeignKeyDefinition("user_id", _issueMapping, _userMapping).ToDDL()
                 .ShouldBe(expected);
         }
 
@@ -40,7 +40,7 @@ namespace Marten.Testing.Schema
                 "ADD CONSTRAINT mt_doc_issue_user_id_fkey FOREIGN KEY (user_id)",
                 "REFERENCES schema2.mt_doc_user (id);");
 
-            new ForeignKeyDefinition("user_id", issueMappingOtherSchema, userMappingOtherSchema).ToDDL()
+            new DocumentReferenceForeignKeyDefinition("user_id", issueMappingOtherSchema, userMappingOtherSchema).ToDDL()
                 .ShouldBe(expected);
         }
     }

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -513,7 +513,7 @@ namespace Marten.Schema
 
             var duplicateField = DuplicateField(members);
 
-            var foreignKey = new ForeignKeyDefinition(duplicateField.ColumnName, this, referenceMapping);
+            var foreignKey = new DocumentReferenceForeignKeyDefinition(duplicateField.ColumnName, this, referenceMapping);
             ForeignKeys.Add(foreignKey);
 
             return foreignKey;
@@ -892,6 +892,17 @@ namespace Marten.Schema
 
             var indexDefinition = AddIndex(foreignKeyDefinition.ColumnName);
             indexConfiguration?.Invoke(indexDefinition);
+        }
+
+        public void ForeignKey(Expression<Func<T, object>> expression, string schemaName, string tableName, string columnName)
+        {
+            var visitor = new FindMembers();
+            visitor.Visit(expression);
+
+            var duplicateField = DuplicateField(visitor.Members.ToArray());
+
+            var foreignKey = new ForeignReferenceForeignKeyDefinition(duplicateField.ColumnName, this, schemaName, tableName, columnName);
+            ForeignKeys.Add(foreignKey);
         }
     }
 }

--- a/src/Marten/Schema/ForeignKeyDefinition.cs
+++ b/src/Marten/Schema/ForeignKeyDefinition.cs
@@ -3,36 +3,77 @@ using System.Text;
 
 namespace Marten.Schema
 {
-    public class ForeignKeyDefinition
+    public abstract class ForeignKeyDefinition
     {
-        private readonly DocumentMapping _parent;
-        private readonly DocumentMapping _reference;
         private string _keyName;
 
-        public ForeignKeyDefinition(string columnName, DocumentMapping parent, DocumentMapping reference)
+        protected ForeignKeyDefinition(string columnName, DocumentMapping parent)
         {
             ColumnName = columnName;
-            _parent = parent;
-            _reference = reference;
+            Parent = parent;
         }
+
+        protected DocumentMapping Parent { get; }
 
         public string KeyName
         {
-            get => _keyName ?? $"{_parent.Table.Name}_{ColumnName}_fkey";
+            get => _keyName ?? $"{Parent.Table.Name}_{ColumnName}_fkey";
             set => _keyName = value;
         }
 
         public string ColumnName { get; }
 
-        public Type ReferenceDocumentType => _reference.DocumentType;
+        public abstract Type ReferenceDocumentType { get; }
 
-        public string ToDDL()
+        public abstract string ToDDL();
+    }
+
+    public class DocumentReferenceForeignKeyDefinition : ForeignKeyDefinition
+    {
+        private readonly DocumentMapping _reference;
+
+        public DocumentReferenceForeignKeyDefinition(string columnName, DocumentMapping parent, DocumentMapping reference) : base(columnName, parent)
+        {
+            _reference = reference;
+        }
+
+        public override Type ReferenceDocumentType => _reference.DocumentType;
+
+        public override string ToDDL()
         {
             var sb = new StringBuilder();
 
-            sb.AppendLine($"ALTER TABLE {_parent.Table.QualifiedName}");
+            sb.AppendLine($"ALTER TABLE {Parent.Table.QualifiedName}");
             sb.AppendLine($"ADD CONSTRAINT {KeyName} FOREIGN KEY ({ColumnName})");
             sb.Append($"REFERENCES {_reference.Table.QualifiedName} (id);");
+
+            return sb.ToString();
+        }
+    }
+
+    public class ForeignReferenceForeignKeyDefinition : ForeignKeyDefinition
+    {
+        private readonly string _foreignSchemaName;
+        private readonly string _foreignTableName;
+        private readonly string _foreignColumnName;
+
+        public ForeignReferenceForeignKeyDefinition(string columnName, DocumentMapping parent, string foreignSchemaName, string foreignTableName,
+                                                    string foreignColumnName) : base(columnName, parent)
+        {
+            _foreignSchemaName = foreignSchemaName;
+            _foreignTableName = foreignTableName;
+            _foreignColumnName = foreignColumnName;
+        }
+
+        public override Type ReferenceDocumentType => Parent.DocumentType;
+
+        public override string ToDDL()
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine($"ALTER TABLE {Parent.Table.QualifiedName}");
+            sb.AppendLine($"ADD CONSTRAINT {KeyName} FOREIGN KEY ({ColumnName})");
+            sb.Append($"REFERENCES {_foreignSchemaName}.{_foreignTableName} ({_foreignColumnName});");
 
             return sb.ToString();
         }


### PR DESCRIPTION
This is obviously not complete, but I wanted to get this request started to get some feedback on the idea and the implementaion.  The first big thing is that I made the `ForeignKeyDefinition` an abstract class, I think this is a breaking change since the `DocumentMapping.ForeignKeys` property is public so people could potentially create their own `ForeignKeyDefinition`s and add them manually.  I considered keeping the class non-abstract and instead making the `ReferenceType` and `ToDDL()` virtual, but I'm not a big fan of virtual members.