### PR TITLE
Would fix #1178:

### DIFF
--- a/src/Marten.Testing/SessionOptionsTests.cs
+++ b/src/Marten.Testing/SessionOptionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Baseline;
 using Marten.Services;
 using Npgsql;
@@ -47,27 +48,74 @@ public void ConfigureCommandTimeout(IDocumentStore store)
         }
 
         [Fact]
-        public void can_define_custom_timeout()
+        public void default_timeout_should_be_npgsql_default_ie_30()
         {
-            var guy1 = new FryGuy();
-            var guy2 = new FryGuy();
-            var guy3 = new FryGuy();
+	        var options = new SessionOptions();
 
-            using (var session = theStore.OpenSession())
-            {
-                session.Store(guy1, guy2, guy3);
-                session.SaveChanges();
-            }
+	        using (var query = theStore.QuerySession(options).As<QuerySession>())
+	        {
+		        var cmd = query.Query<FryGuy>().Explain();
+		        Assert.Equal(30, cmd.Command.CommandTimeout);
+	        }
+        }
 
+
+		// Remarks: this test was basically asserting nothing related before.
+		[Fact]		
+        public void can_define_custom_timeout()
+        {            
             var options = new SessionOptions() { Timeout = 15 };
 
             using (var query = theStore.QuerySession(options).As<QuerySession>())
             {
-                query.Load<FryGuy>(guy2.Id).ShouldNotBeNull();
+	            var cmd = query.Query<FryGuy>().Explain();
+				Assert.Equal(15, cmd.Command.CommandTimeout);
             }
         }
 
-        public class FryGuy
+        [Fact]
+        public void can_define_custom_timeout_via_pgcstring()
+        {
+	        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString);
+
+	        connectionStringBuilder.CommandTimeout = 1;
+
+	        var documentStore = DocumentStore.For(c =>
+	        {
+		        c.Connection(connectionStringBuilder.ToString());
+	        });
+
+	        using (var query = documentStore.OpenSession())
+	        {
+				var cmd = query.Query<FryGuy>().Explain();
+				Assert.Equal(1, cmd.Command.CommandTimeout);
+				Assert.Equal(1, query.Connection.CommandTimeout);
+	        }
+        }
+
+        [Fact]
+        public void can_override_pgcstring_timeout_in_sessionoptions()
+        {
+	        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString);
+
+	        connectionStringBuilder.CommandTimeout = 1;
+
+	        var documentStore = DocumentStore.For(c =>
+	        {
+		        c.Connection(connectionStringBuilder.ToString());
+	        });
+
+	        var options = new SessionOptions() { Timeout = 60 };
+
+			using (var query = documentStore.OpenSession(options))
+	        {
+		        var cmd = query.Query<FryGuy>().Explain();
+		        Assert.Equal(60, cmd.Command.CommandTimeout);
+		        Assert.Equal(1, query.Connection.CommandTimeout);
+	        }
+        }
+
+		public class FryGuy
         {
             public Guid Id;
         }

--- a/src/Marten.Testing/SessionOptionsTests.cs
+++ b/src/Marten.Testing/SessionOptionsTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Baseline;
 using Marten.Services;
 using Npgsql;
@@ -50,72 +49,72 @@ public void ConfigureCommandTimeout(IDocumentStore store)
         [Fact]
         public void default_timeout_should_be_npgsql_default_ie_30()
         {
-	        var options = new SessionOptions();
+            var options = new SessionOptions();
 
-	        using (var query = theStore.QuerySession(options).As<QuerySession>())
-	        {
-		        var cmd = query.Query<FryGuy>().Explain();
-		        Assert.Equal(30, cmd.Command.CommandTimeout);
-	        }
+            using (var query = theStore.QuerySession(options).As<QuerySession>())
+            {
+                var cmd = query.Query<FryGuy>().Explain();
+                Assert.Equal(30, cmd.Command.CommandTimeout);
+            }
         }
 
 
-		// Remarks: this test was basically asserting nothing related before.
-		[Fact]		
+        // Remarks: this test was basically asserting nothing related before.
+        [Fact]		
         public void can_define_custom_timeout()
         {            
             var options = new SessionOptions() { Timeout = 15 };
 
             using (var query = theStore.QuerySession(options).As<QuerySession>())
             {
-	            var cmd = query.Query<FryGuy>().Explain();
-				Assert.Equal(15, cmd.Command.CommandTimeout);
+                var cmd = query.Query<FryGuy>().Explain();
+                Assert.Equal(15, cmd.Command.CommandTimeout);
             }
         }
 
         [Fact]
         public void can_define_custom_timeout_via_pgcstring()
         {
-	        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString);
+            var connectionStringBuilder = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString);
 
-	        connectionStringBuilder.CommandTimeout = 1;
+            connectionStringBuilder.CommandTimeout = 1;
 
-	        var documentStore = DocumentStore.For(c =>
-	        {
-		        c.Connection(connectionStringBuilder.ToString());
-	        });
+            var documentStore = DocumentStore.For(c =>
+            {
+                c.Connection(connectionStringBuilder.ToString());
+            });
 
-	        using (var query = documentStore.OpenSession())
-	        {
-				var cmd = query.Query<FryGuy>().Explain();
-				Assert.Equal(1, cmd.Command.CommandTimeout);
-				Assert.Equal(1, query.Connection.CommandTimeout);
-	        }
+            using (var query = documentStore.OpenSession())
+            {
+                var cmd = query.Query<FryGuy>().Explain();
+                Assert.Equal(1, cmd.Command.CommandTimeout);
+                Assert.Equal(1, query.Connection.CommandTimeout);
+            }
         }
 
         [Fact]
         public void can_override_pgcstring_timeout_in_sessionoptions()
         {
-	        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString);
+            var connectionStringBuilder = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString);
 
-	        connectionStringBuilder.CommandTimeout = 1;
+            connectionStringBuilder.CommandTimeout = 1;
 
-	        var documentStore = DocumentStore.For(c =>
-	        {
-		        c.Connection(connectionStringBuilder.ToString());
-	        });
+            var documentStore = DocumentStore.For(c =>
+            {
+                c.Connection(connectionStringBuilder.ToString());
+            });
 
-	        var options = new SessionOptions() { Timeout = 60 };
+            var options = new SessionOptions() { Timeout = 60 };
 
-			using (var query = documentStore.OpenSession(options))
-	        {
-		        var cmd = query.Query<FryGuy>().Explain();
-		        Assert.Equal(60, cmd.Command.CommandTimeout);
-		        Assert.Equal(1, query.Connection.CommandTimeout);
-	        }
+            using (var query = documentStore.OpenSession(options))
+            {
+                var cmd = query.Query<FryGuy>().Explain();
+                Assert.Equal(60, cmd.Command.CommandTimeout);
+                Assert.Equal(1, query.Connection.CommandTimeout);
+            }
         }
 
-		public class FryGuy
+        public class FryGuy
         {
             public Guid Id;
         }

--- a/src/Marten/Linq/QueryPlan.cs
+++ b/src/Marten/Linq/QueryPlan.cs
@@ -89,11 +89,11 @@ namespace Marten.Linq
         // Lifted these from QueryPlanContainer so as not to change the returned type alltogether :|
         public decimal PlanningTime { get; set; }        
         public decimal ExecutionTime { get; set; }
-		
-		/// <summary>
-		/// The command executed by Marten
-		/// </summary>
-		public NpgsqlCommand Command { get; set; }
+        
+        /// <summary>
+        /// The command executed by Marten
+        /// </summary>
+        public NpgsqlCommand Command { get; set; }
     }
 
     class QueryPlanContainer

--- a/src/Marten/Linq/QueryPlan.cs
+++ b/src/Marten/Linq/QueryPlan.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using Npgsql;
 
 namespace Marten.Linq
 {
@@ -88,6 +89,11 @@ namespace Marten.Linq
         // Lifted these from QueryPlanContainer so as not to change the returned type alltogether :|
         public decimal PlanningTime { get; set; }        
         public decimal ExecutionTime { get; set; }
+		
+		/// <summary>
+		/// The command executed by Marten
+		/// </summary>
+		public NpgsqlCommand Command { get; set; }
     }
 
     class QueryPlanContainer

--- a/src/Marten/Services/CommandRunnerExtensions.cs
+++ b/src/Marten/Services/CommandRunnerExtensions.cs
@@ -36,6 +36,7 @@ namespace Marten.Services
                     {
                         planToReturn.PlanningTime = queryPlans[0].PlanningTime;
                         planToReturn.ExecutionTime = queryPlans[0].ExecutionTime;
+                        planToReturn.Command = cmd;
                     }
                     return planToReturn;
                 }

--- a/src/Marten/Services/ManagedConnection.cs
+++ b/src/Marten/Services/ManagedConnection.cs
@@ -44,7 +44,7 @@ namespace Marten.Services
 
             _commandTimeout = options.Timeout ?? conn?.CommandTimeout;
 
-			_connection = new TransactionState(_mode, _isolationLevel, _commandTimeout, conn, options.OwnsConnection, options.Transaction);
+            _connection = new TransactionState(_mode, _isolationLevel, _commandTimeout, conn, options.OwnsConnection, options.Transaction);
             _retryPolicy = retryPolicy;
         }
 

--- a/src/Marten/Services/ManagedConnection.cs
+++ b/src/Marten/Services/ManagedConnection.cs
@@ -13,7 +13,7 @@ namespace Marten.Services
         private readonly IConnectionFactory _factory;
         private readonly CommandRunnerMode _mode;
         private readonly IsolationLevel _isolationLevel;
-        private readonly int _commandTimeout;
+        private readonly int? _commandTimeout;
         private TransactionState _connection;
         private bool _ownsConnection;
         private IRetryPolicy _retryPolicy;
@@ -38,12 +38,13 @@ namespace Marten.Services
         {
             _ownsConnection = options.OwnsConnection;
             _mode = options.OwnsTransactionLifecycle ? mode : CommandRunnerMode.External;
-            _isolationLevel = options.IsolationLevel;
-            _commandTimeout = options.Timeout;
+            _isolationLevel = options.IsolationLevel;            
 
             var conn = options.Connection ?? options.Transaction?.Connection;
 
-            _connection = new TransactionState(_mode, _isolationLevel, _commandTimeout, conn, options.OwnsConnection, options.Transaction);
+            _commandTimeout = options.Timeout ?? conn?.CommandTimeout;
+
+			_connection = new TransactionState(_mode, _isolationLevel, _commandTimeout, conn, options.OwnsConnection, options.Transaction);
             _retryPolicy = retryPolicy;
         }
 
@@ -58,7 +59,7 @@ namespace Marten.Services
 
         // 30 is NpgsqlCommand.DefaultTimeout - ok to burn it to the call site?
         public ManagedConnection(IConnectionFactory factory, CommandRunnerMode mode, IRetryPolicy retryPolicy,
-            IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, int commandTimeout = 30)
+            IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, int? commandTimeout = null)
         {
             _factory = factory;
             _mode = mode;

--- a/src/Marten/Services/SessionOptions.cs
+++ b/src/Marten/Services/SessionOptions.cs
@@ -14,9 +14,9 @@ namespace Marten.Services
         public DocumentTracking Tracking { get; set; } = DocumentTracking.IdentityOnly;
 
         /// <summary>
-        /// Default to 30 seconds
+        /// If not specified, sessions default to Npgsql command timeout (30 seconds)
         /// </summary>
-        public int Timeout { get; set; } = 30;
+        public int? Timeout { get; set; }
 
         /// <summary>
         /// Default to IsolationLevel.ReadCommitted

--- a/src/Marten/Services/TransactionState.cs
+++ b/src/Marten/Services/TransactionState.cs
@@ -13,23 +13,23 @@ namespace Marten.Services
         private readonly int _commandTimeout;
         private readonly bool _ownsConnection;
 
-        public TransactionState(CommandRunnerMode mode, IsolationLevel isolationLevel, int commandTimeout, NpgsqlConnection connection, bool ownsConnection, NpgsqlTransaction transaction = null)
+        public TransactionState(CommandRunnerMode mode, IsolationLevel isolationLevel, int? commandTimeout, NpgsqlConnection connection, bool ownsConnection, NpgsqlTransaction transaction = null)
         {
             _mode = mode;
-            _isolationLevel = isolationLevel;
-            _commandTimeout = commandTimeout;
+            _isolationLevel = isolationLevel;            
             _ownsConnection = ownsConnection;
             Transaction = transaction;
             Connection = connection;
+            _commandTimeout = commandTimeout ?? Connection.CommandTimeout;
         }
 
-        public TransactionState(IConnectionFactory factory, CommandRunnerMode mode, IsolationLevel isolationLevel, int commandTimeout, bool ownsConnection)
+        public TransactionState(IConnectionFactory factory, CommandRunnerMode mode, IsolationLevel isolationLevel, int? commandTimeout, bool ownsConnection)
         {
             _mode = mode;
-            _isolationLevel = isolationLevel;
-            this._commandTimeout = commandTimeout;
+            _isolationLevel = isolationLevel;            
             _ownsConnection = ownsConnection;
             Connection = factory.Create();
+            _commandTimeout = commandTimeout ?? Connection.CommandTimeout;
         }
 
         public bool IsOpen => Connection.State != ConnectionState.Closed;

--- a/src/Marten/Storage/DefaultTenancy.cs
+++ b/src/Marten/Storage/DefaultTenancy.cs
@@ -94,7 +94,7 @@ namespace Marten.Storage
         }
 
         public IManagedConnection OpenConnection(CommandRunnerMode mode = CommandRunnerMode.AutoCommit,
-            IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, int timeout = 30)
+            IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, int? timeout = null)
         {
             return _inner.OpenConnection(mode, isolationLevel, timeout);
         }

--- a/src/Marten/Storage/ITenant.cs
+++ b/src/Marten/Storage/ITenant.cs
@@ -74,7 +74,7 @@ namespace Marten.Storage
         /// <param name="isolationLevel"></param>
         /// <param name="timeout"></param>
         /// <returns></returns>
-        IManagedConnection OpenConnection(CommandRunnerMode mode = CommandRunnerMode.AutoCommit, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, int timeout = 30);
+        IManagedConnection OpenConnection(CommandRunnerMode mode = CommandRunnerMode.AutoCommit, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, int? timeout = null);
 
         /// <summary>
         ///     Set the minimum sequence number for a Hilo sequence for a specific document type

--- a/src/Marten/Storage/Tenant.cs
+++ b/src/Marten/Storage/Tenant.cs
@@ -233,7 +233,7 @@ namespace Marten.Storage
         /// <param name="isolationLevel"></param>
         /// <param name="timeout"></param>
         /// <returns></returns>
-        public IManagedConnection OpenConnection(CommandRunnerMode mode = CommandRunnerMode.AutoCommit, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, int timeout = 30)
+        public IManagedConnection OpenConnection(CommandRunnerMode mode = CommandRunnerMode.AutoCommit, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, int? timeout = null)
         {
             return new ManagedConnection(_factory, mode, _options.RetryPolicy(), isolationLevel, timeout);
         }


### PR DESCRIPTION
* Default command timeout can be passed via Npgsql cstring & it is actually respected
* Default command timeout can be overriden with SessionOptions
* If not provided, commands default to Npgsql command timeout (currently 30 sec)

And obviously this commit would break some of the existing signatures. Other options would be to keep & pass around some internal state... Gets a bit nasty, since e.g. ConnectionFactory has lazy connectionString (and the only place where the cstring is contained) that can be resolved at a very late state on first command execution.