### PR TITLE
Add missing semicolons when dropping system functions

### DIFF
--- a/src/Marten/Events/AppendEventFunction.cs
+++ b/src/Marten/Events/AppendEventFunction.cs
@@ -84,7 +84,7 @@ $$ LANGUAGE plpgsql;
         protected override string toDropSql()
         {
             var streamIdType = _events.GetStreamIdDBType();
-            return $"drop function if exists {Identifier} ({streamIdType}, varchar, varchar, uuid[], varchar[], jsonb[])";
+            return $"drop function if exists {Identifier} ({streamIdType}, varchar, varchar, uuid[], varchar[], jsonb[]);";
         }
     }
 

--- a/src/Marten/Schema/SystemFunction.cs
+++ b/src/Marten/Schema/SystemFunction.cs
@@ -19,7 +19,7 @@ namespace Marten.Schema
         {
             _args = args;
             _function = new DbObjectName(schema, functionName);
-            _dropSql = $"drop function if exists {schema}.{functionName}({args}) cascade";
+            _dropSql = $"drop function if exists {schema}.{functionName}({args}) cascade;";
 
             Name = functionName;
         }


### PR DESCRIPTION
Hi all, we came across a minor issue when generating a patch rollback script for a new marten database, where the drop function statements for a few of the system functions didn't have semicolons following them. The affecting functions are mt_immutable_timestamp, mt_immutable_timestamptz, and mt_append_event. This PR fixes them and adds a test for it.

The whitespace changes in AppendEventFunction.cs are replacing all tabs with spaces as the file was mixed. Let me know if you'd rather not have the whitespace changes included and i'll remove them.

As always let me know if anything else is required.

I found a couple other issues related to patch rollback scripts that i'll create issues for as they likely require a bit more discussion than this.