### PR TITLE
Expose IStorageOperations on IUnitOfWork

### DIFF
--- a/src/Marten.Testing/UnitOfWork_PendingChanges_Functionality_Tests.cs
+++ b/src/Marten.Testing/UnitOfWork_PendingChanges_Functionality_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Baseline;
+using Marten.Services;
 using Marten.Services.Deletes;
 using Marten.Testing.Documents;
 using Shouldly;
@@ -31,6 +32,124 @@ namespace Marten.Testing
                 session.PendingChanges.Updates().ShouldContain(user2);
                 session.PendingChanges.Updates().ShouldContain(target1);
                 session.PendingChanges.Updates().ShouldContain(target2);
+            }
+        }
+
+        [Fact]
+        public void pending_changes_operations_from_store()
+        {
+            using (var session = theStore.LightweightSession())
+            {
+                var user1 = new User();
+                var user2 = new User();
+                var user3 = new User();
+                var user4 = new User();
+
+                session.Store(user1);
+                session.Insert(user2);
+                session.Update(user3);
+                session.Delete(user4);
+
+                var target1 = new Target();
+                var target2 = new Target();
+                var target3 = new Target();
+                var target4 = new Target();
+
+                session.Store(target1);
+                session.Insert(target2);
+                session.Update(target3);
+                session.Delete(target4);
+
+                session.PendingChanges.Operations().Count().ShouldBe(8);
+
+                session.PendingChanges.Operations().ShouldContain(o => o is UpsertDocument doc && doc.Document == user1);
+                session.PendingChanges.Operations().ShouldContain(o => o is InsertDocument doc && doc.Document == user2);
+                session.PendingChanges.Operations().ShouldContain(o => o is UpdateDocument doc && doc.Document == user3);
+                session.PendingChanges.Operations().ShouldContain(o => o is DeleteById doc && doc.Document == user4);
+
+                session.PendingChanges.Operations().ShouldContain(o => o is UpsertDocument doc && doc.Document == target1);
+                session.PendingChanges.Operations().ShouldContain(o => o is InsertDocument doc && doc.Document == target2);
+                session.PendingChanges.Operations().ShouldContain(o => o is UpdateDocument doc && doc.Document == target3);
+                session.PendingChanges.Operations().ShouldContain(o => o is DeleteById doc && doc.Document == target4);
+            }
+        }
+
+        [Fact]
+        public void pending_changes_operations_by_generic_type()
+        {
+            using (var session = theStore.LightweightSession())
+            {
+                var user1 = new User();
+                var user2 = new User();
+                var user3 = new User();
+                var user4 = new User();
+
+                session.Store(user1);
+                session.Insert(user2);
+                session.Update(user3);
+                session.Delete(user4);
+
+                var target1 = new Target();
+                var target2 = new Target();
+                var target3 = new Target();
+                var target4 = new Target();
+
+                session.Store(target1);
+                session.Insert(target2);
+                session.Update(target3);
+                session.Delete(target4);
+
+                session.PendingChanges.OperationsFor<User>().Count().ShouldBe(4);
+                session.PendingChanges.OperationsFor<User>().ShouldContain(o => o is UpsertDocument doc && doc.Document == user1);
+                session.PendingChanges.OperationsFor<User>().ShouldContain(o => o is InsertDocument doc && doc.Document == user2);
+                session.PendingChanges.OperationsFor<User>().ShouldContain(o => o is UpdateDocument doc && doc.Document == user3);
+                session.PendingChanges.OperationsFor<User>().ShouldContain(o => o is DeleteById doc && doc.Document == user4);
+
+                session.PendingChanges.OperationsFor<Target>().Count().ShouldBe(4);
+                session.PendingChanges.OperationsFor<Target>().ShouldContain(o => o is UpsertDocument doc && doc.Document == target1);
+                session.PendingChanges.OperationsFor<Target>().ShouldContain(o => o is InsertDocument doc && doc.Document == target2);
+                session.PendingChanges.OperationsFor<Target>().ShouldContain(o => o is UpdateDocument doc && doc.Document == target3);
+                session.PendingChanges.OperationsFor<Target>().ShouldContain(o => o is DeleteById doc && doc.Document == target4);
+            }
+        }
+
+
+        [Fact]
+        public void pending_changes_operations_by_type()
+        {
+            using (var session = theStore.LightweightSession())
+            {
+                var user1 = new User();
+                var user2 = new User();
+                var user3 = new User();
+                var user4 = new User();
+
+                session.Store(user1);
+                session.Insert(user2);
+                session.Update(user3);
+                session.Delete(user4);
+
+                var target1 = new Target();
+                var target2 = new Target();
+                var target3 = new Target();
+                var target4 = new Target();
+
+                session.Store(target1);
+                session.Insert(target2);
+                session.Update(target3);
+                session.Delete(target4);
+
+                session.PendingChanges.OperationsFor(typeof(User)).Count().ShouldBe(4);
+                session.PendingChanges.OperationsFor(typeof(User)).ShouldContain(o => o is UpsertDocument doc && doc.Document == user1);
+                session.PendingChanges.OperationsFor(typeof(User)).ShouldContain(o => o is InsertDocument doc && doc.Document == user2);
+                session.PendingChanges.OperationsFor(typeof(User)).ShouldContain(o => o is UpdateDocument doc && doc.Document == user3);
+                session.PendingChanges.OperationsFor(typeof(User)).ShouldContain(o => o is DeleteById doc && doc.Document == user4);
+
+                session.PendingChanges.OperationsFor(typeof(Target)).Count().ShouldBe(4);
+                session.PendingChanges.OperationsFor(typeof(Target)).ShouldContain(o => o is UpsertDocument doc && doc.Document == target1);
+                session.PendingChanges.OperationsFor(typeof(Target)).ShouldContain(o => o is InsertDocument doc && doc.Document == target2);
+                session.PendingChanges.OperationsFor(typeof(Target)).ShouldContain(o => o is UpdateDocument doc && doc.Document == target3);
+                session.PendingChanges.OperationsFor(typeof(Target)).ShouldContain(o => o is DeleteById doc && doc.Document == target4);
             }
         }
 

--- a/src/Marten/Services/IUnitOfWork.cs
+++ b/src/Marten/Services/IUnitOfWork.cs
@@ -75,6 +75,27 @@ namespace Marten.Services
         /// </summary>
         /// <returns></returns>
         IEnumerable<PatchOperation> Patches();
+
+        /// <summary>
+        /// All the storage operations that will be executed when this session is committed
+        /// </summary>
+        /// <returns></returns>
+        IEnumerable<IStorageOperation> Operations();
+
+        /// <summary>
+        /// All the storage operations that will be executed for documents of type T when this
+        /// session is committed
+        /// </summary>
+        /// <returns></returns>
+        IEnumerable<IStorageOperation> OperationsFor<T>();
+
+        /// <summary>
+        /// All the storage operations that will be executed for documents of type T when this
+        /// session is committed
+        /// </summary>
+        /// <param name="documentType"></param>
+        /// <returns></returns>
+        IEnumerable<IStorageOperation> OperationsFor(Type documentType);
     
     }
 }

--- a/src/Marten/Services/UnitOfWork.cs
+++ b/src/Marten/Services/UnitOfWork.cs
@@ -84,6 +84,21 @@ namespace Marten.Services
             return _operations.Value.Enumerate().SelectMany(x => x.Value).OfType<PatchOperation>();
         }
 
+        public IEnumerable<IStorageOperation> Operations()
+        {
+            return _operations.Value.Enumerate().SelectMany(x => x.Value);
+        }
+
+        public IEnumerable<IStorageOperation> OperationsFor<T>()
+        {
+            return operationsFor(typeof(T));
+        }
+
+        public IEnumerable<IStorageOperation> OperationsFor(Type documentType)
+        {
+            return operationsFor(documentType);
+        }
+
         public void AddTracker(IDocumentTracker tracker)
         {
             _trackers.Fill(tracker);


### PR DESCRIPTION
Exposes the `IStorageOperations` that will be executed by `IUnitOfWork`, as discussed in issue #1209 

The related issue discusses better support for multi-tenancy. This change does not tackle that. This PR allows for modification of existing operations that gives me the hooks to do more automatic handling for multi-tenancy (I can automatically set `TenantOverride` for operations).

I can envision other potential usages like all-encompassing logging, or even performance tracking related usages to check how many operations are being executed and alerting.