### PR TITLE
added type mappings for serial and text/varchar arrays

### DIFF
--- a/src/Marten.Testing/Storage/TableTester.cs
+++ b/src/Marten.Testing/Storage/TableTester.cs
@@ -30,7 +30,8 @@ namespace Marten.Testing.Storage
 
             theTable.AddColumn("name", "text");
             theTable.AddColumn("number", "int");
-        }
+            theTable.AddColumn("rownum", "serial");
+        }    
 
         public void Dispose()
         {
@@ -97,7 +98,7 @@ namespace Marten.Testing.Storage
             existing.ShouldNotBeNull();
 
             existing.PrimaryKey.Name.ShouldBe("id");
-            existing.Select(x => x.Name).ShouldHaveTheSameElementsAs("id", "name", "number");
+            existing.Select(x => x.Name).ShouldHaveTheSameElementsAs("id", "name", "number", "rownum");
         }
 
 
@@ -109,7 +110,7 @@ namespace Marten.Testing.Storage
 
             var diff = theTable.FetchDelta(_conn);
             diff.ShouldNotBeNull();
-            diff.Matched.Select(x => x.Name).ShouldHaveTheSameElementsAs("id", "name", "number");
+            diff.Matched.Select(x => x.Name).ShouldHaveTheSameElementsAs("id", "name", "number", "rownum");
             diff.Missing.Length.ShouldBe(0);
             diff.Extras.Length.ShouldBe(0);
             diff.Different.Length.ShouldBe(0);
@@ -159,6 +160,19 @@ namespace Marten.Testing.Storage
             diff.Matches.ShouldBeFalse();
 
             diff.Different.Single().Name.ShouldBe("id");
+        }
+
+        [Fact]
+        public void matching_with_columns_same_name_and_synonymn_of_type()
+        {
+            //e.g. serial is an int
+            writeTable();
+
+            var existing = theTable.FetchExisting(_conn);
+            existing._columns.First(c => c.Name == "rownum").Type.ShouldBe("integer");
+
+            var diff = theTable.FetchDelta(_conn);
+            diff.Matches.ShouldBeTrue();
         }
 
        

--- a/src/Marten.Testing/TypeMappingsTests.cs
+++ b/src/Marten.Testing/TypeMappingsTests.cs
@@ -82,5 +82,21 @@ namespace Marten.Testing
             var expectedString = "Darth Maroon the First";
             inputString.ReplaceMultiSpace(" ").ShouldBe(expectedString);
         }
+
+        [Fact]
+        public void table_columns_should_match_raw_types()
+        {
+            var serialAsInt = new Marten.Storage.TableColumn("id", "serial");
+            serialAsInt.Equals(new Marten.Storage.TableColumn("id", "int"));
+
+            var varchararrAsArray = new Marten.Storage.TableColumn("comments", "varchar[]");
+            varchararrAsArray.Equals(new Marten.Storage.TableColumn("comments", "array"));
+
+            var charactervaryingAsArray = new Marten.Storage.TableColumn("comments", "character varying[]");
+            charactervaryingAsArray.Equals(new Marten.Storage.TableColumn("comments", "array"));
+
+            var textarrayAsArray = new Marten.Storage.TableColumn("comments", "text[]");
+            charactervaryingAsArray.Equals(new Marten.Storage.TableColumn("comments", "array"));
+        }
     }
 }

--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -110,6 +110,7 @@ namespace Marten.Util
                     return "boolean";
 
                 case "integer":
+                case "serial":
                     return "int";
 
                 case "integer[]":
@@ -124,6 +125,12 @@ namespace Marten.Util
 
                 case "timestamp with time zone":
                     return "timestamptz";
+
+                case "array":
+                case "character varying[]":
+                case "varchar[]":
+                case "text[]":
+                    return "array";
             }
 
             return type;


### PR DESCRIPTION
I was working on a project and encountered the error "Marten cannot derive updates for objects" when creating a document store for tables with a "serial" column and text array columns (varchar[], text[], etc). I think the issue is related to TypeMappings.cs and can be resolved with this PR.  

Path to repo to reproduce error: https://github.com/egiraffe/Marten-Serial
in the repo, everything runs correctly on create, but creating the store after the initial run fails.