### PR TITLE
Added Auto LF and .editorconfig settings for aligning formatting rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,22 +12,6 @@ trim_trailing_whitespace = true
 max_line_length = off
 trim_trailing_whitespace = false
 
-[*.cs]
-csharp_indent_case_contents = true:warning
-csharp_indent_switch_labels = true:warning
-csharp_space_after_cast = false:warning
-csharp_space_after_keywords_in_control_flow_statements = true:warning
-csharp_space_between_method_declaration_parameter_list_parentheses = false:warning
-csharp_space_between_method_call_parameter_list_parentheses = false:warning
-csharp_space_before_colon_in_inheritance_clause = false:warning
-csharp_space_after_colon_in_inheritance_clause = true:warning
-csharp_space_around_binary_operators = before_and_after:warning
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false:warning
-csharp_space_between_method_call_name_and_opening_parenthesis = false:warning
-csharp_space_between_method_call_empty_parameter_list_parentheses = false:warning
-csharp_preserve_single_line_statements = false:warning
-csharp_preserve_single_line_blocks = true:warning
-
 ###############################
 # .NET Coding Conventions     #
 ###############################

--- a/.editorconfig
+++ b/.editorconfig
@@ -61,7 +61,7 @@ dotnet_style_readonly_field = true:warning
 dotnet_style_object_initializer = true:warning
 dotnet_style_collection_initializer = true:warning
 dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_null_propagation = true:warning
+dotnet_style_null_propagation = true
 dotnet_style_coalesce_expression = true:warning
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
@@ -75,7 +75,7 @@ dotnet_style_prefer_conditional_expression_over_return = true:silent
 ###############################
 
 # Style Definitions
-dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+dotnet_naming_style.pascal_case_style.capitalization              = pascal_case
 
 # Use PascalCase for constant fields
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
@@ -126,13 +126,13 @@ csharp_style_inlined_variable_declaration = true:warning
 ###############################
 
 # New line preferences
-csharp_new_line_before_open_brace = all:warning
-csharp_new_line_before_else = true:warning
-csharp_new_line_before_catch = true:warning
-csharp_new_line_before_finally = true:warning
-csharp_new_line_before_members_in_object_initializers = true:warning
-csharp_new_line_before_members_in_anonymous_types = true:warning
-csharp_new_line_between_query_expression_clauses = true:warning
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
 
 # Indentation preferences
 csharp_indent_case_contents = true:warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -135,24 +135,24 @@ csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
 # Indentation preferences
-csharp_indent_case_contents = true:warning
-csharp_indent_switch_labels = true:warning
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
 csharp_indent_labels = flush_left
 
 # Space preferences
-csharp_space_after_cast = false:warning
-csharp_space_after_keywords_in_control_flow_statements = true:warning
-csharp_space_between_method_declaration_parameter_list_parentheses = false:warning
-csharp_space_between_method_call_parameter_list_parentheses = false:warning
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
-csharp_space_before_colon_in_inheritance_clause = false:warning
-csharp_space_after_colon_in_inheritance_clause = true:warning
+csharp_space_before_colon_in_inheritance_clause = false
+csharp_space_after_colon_in_inheritance_clause = true
 
-csharp_space_around_binary_operators = before_and_after:warning
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false:warning
-csharp_space_between_method_call_name_and_opening_parenthesis = false:warning
-csharp_space_between_method_call_empty_parameter_list_parentheses = false:warning
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
 
 # Wrapping preferences
-csharp_preserve_single_line_statements = false:warning
-csharp_preserve_single_line_blocks = true:warning
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,158 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false
+
+[*.cs]
+csharp_indent_case_contents = true:warning
+csharp_indent_switch_labels = true:warning
+csharp_space_after_cast = false:warning
+csharp_space_after_keywords_in_control_flow_statements = true:warning
+csharp_space_between_method_declaration_parameter_list_parentheses = false:warning
+csharp_space_between_method_call_parameter_list_parentheses = false:warning
+csharp_space_before_colon_in_inheritance_clause = false:warning
+csharp_space_after_colon_in_inheritance_clause = true:warning
+csharp_space_around_binary_operators = before_and_after:warning
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false:warning
+csharp_space_between_method_call_name_and_opening_parenthesis = false:warning
+csharp_space_between_method_call_empty_parameter_list_parentheses = false:warning
+csharp_preserve_single_line_statements = false:warning
+csharp_preserve_single_line_blocks = true:warning
+
+###############################
+# .NET Coding Conventions     #
+###############################
+
+[*.cs]
+# Organize usings
+dotnet_sort_system_directives_first = true:warning
+dotnet_separate_import_directive_groups = false:warning
+
+# this. preferences
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = always:warning
+dotnet_style_readonly_field = true:warning
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:warning
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment = true:warning
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+
+###############################
+# Naming Conventions          #
+###############################
+
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+
+# Use PascalCase for constant fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+
+###############################
+# C# Code Style Rules         #
+###############################
+
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+
+# Pattern-matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+
+# Null-checking preferences
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# Expression-level preferences
+csharp_prefer_braces = true:information
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:warning
+csharp_style_pattern_local_over_anonymous_function = true:warning
+csharp_style_inlined_variable_declaration = true:warning
+
+###############################
+# C# Formatting Rules         #
+###############################
+
+# New line preferences
+csharp_new_line_before_open_brace = all:warning
+csharp_new_line_before_else = true:warning
+csharp_new_line_before_catch = true:warning
+csharp_new_line_before_finally = true:warning
+csharp_new_line_before_members_in_object_initializers = true:warning
+csharp_new_line_before_members_in_anonymous_types = true:warning
+csharp_new_line_between_query_expression_clauses = true:warning
+
+# Indentation preferences
+csharp_indent_case_contents = true:warning
+csharp_indent_switch_labels = true:warning
+csharp_indent_labels = flush_left
+
+# Space preferences
+csharp_space_after_cast = false:warning
+csharp_space_after_keywords_in_control_flow_statements = true:warning
+csharp_space_between_method_declaration_parameter_list_parentheses = false:warning
+csharp_space_between_method_call_parameter_list_parentheses = false:warning
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = false:warning
+csharp_space_after_colon_in_inheritance_clause = true:warning
+
+csharp_space_around_binary_operators = before_and_after:warning
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false:warning
+csharp_space_between_method_call_name_and_opening_parenthesis = false:warning
+csharp_space_between_method_call_empty_parameter_list_parentheses = false:warning
+
+# Wrapping preferences
+csharp_preserve_single_line_statements = false:warning
+csharp_preserve_single_line_blocks = true:warning

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 * text=auto *.sh eol=lf
+*.png binary
+*.ttf binary
+*.jpg binary
+*.jpeg binary
+*.pdf binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
-* text=auto *.sh eol=lf
+* text=auto 
+*.sh eol=lf
 *.png binary
 *.ttf binary
 *.jpg binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto *. sh eol=lf
+* text=auto *.sh eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto *. sh eol=lf

--- a/src/Marten.sln
+++ b/src/Marten.sln
@@ -17,7 +17,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten.Storyteller", "Marte
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten.NodaTime", "Marten.NodaTime\Marten.NodaTime.csproj", "{7B9552F4-9102-4A89-A150-C2F916CFF11E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marten.NodaTime.Testing", "Marten.NodaTime.Testing\Marten.NodaTime.Testing.csproj", "{1B5F9030-63ED-49B2-B001-F58E899CCA5F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten.NodaTime.Testing", "Marten.NodaTime.Testing\Marten.NodaTime.Testing.csproj", "{1B5F9030-63ED-49B2-B001-F58E899CCA5F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5A91B8F9-52F8-4322-BE34-E3A281902BEC}"
+	ProjectSection(SolutionItems) = preProject
+		..\.editorconfig = ..\.editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
@jeremydmiller @mysticmind @jokokko if you're fine with this `.editorsettings` then I'll do code clean up and change warnings settings into errors.

See rules explanation: https://docs.microsoft.com/en-US/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2017