### PR TITLE
Support sequences with custom start value.

### DIFF
--- a/src/Marten.Testing/Storage/SequenceCustomization.cs
+++ b/src/Marten.Testing/Storage/SequenceCustomization.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+using Marten.Schema;
+using Marten.Storage;
+using Xunit;
+
+namespace Marten.Testing.Storage
+{
+    public class SequenceCustomization : IntegratedFixture
+    {
+        public class SequenceWithStart : FeatureSchemaBase
+        {
+            private readonly string schema;
+
+            public SequenceWithStart(StoreOptions options) : base(nameof(SequenceWithStart), options)
+            {
+                schema = options.DatabaseSchemaName;
+            }
+
+            protected override IEnumerable<ISchemaObject> schemaObjects()
+            {
+                yield return new Sequence(new DbObjectName(schema, $"mt_{nameof(SequenceWithStart).ToLowerInvariant()}"), 1337);
+            }
+        }
+
+        [Fact]
+        public void CanRegisterSequenceWithStartAttribute()
+        {
+            StoreOptions(_ =>
+            {
+                _.Storage.Add<SequenceWithStart>();
+            });
+
+            theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+
+            using (var session = theStore.OpenSession())
+            {
+                var value = session.Query<int>("select nextval(?)",
+                    $"{theStore.Options.DatabaseSchemaName}.mt_{nameof(SequenceWithStart).ToLowerInvariant()}").First();
+
+                Assert.Equal(1337, value);
+            }
+        }
+    }
+}

--- a/src/Marten/Storage/Sequence.cs
+++ b/src/Marten/Storage/Sequence.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.IO;
 using Marten.Schema;
@@ -10,9 +10,17 @@ namespace Marten.Storage
     {
         public DbObjectName Identifier { get; }
 
+        private long? _startWith;
+
         public Sequence(DbObjectName identifier)
         {
             Identifier = identifier;
+        }
+
+        public Sequence(DbObjectName identifier, long startWith)
+        {
+            Identifier = identifier;
+            _startWith = startWith;
         }
 
         public DbObjectName Owner { get; set; }
@@ -25,7 +33,7 @@ namespace Marten.Storage
 
         public void Write(DdlRules rules, StringWriter writer)
         {
-            writer.WriteLine($"CREATE SEQUENCE {Identifier};");
+            writer.WriteLine($"CREATE SEQUENCE {Identifier}{(_startWith.HasValue ? $" START {_startWith.Value}" : string.Empty)};");
 
             if (Owner != null)
             {


### PR DESCRIPTION
Make `IDocumentCleaner.CompletelyRemoveAll` also drop _mt__ prefixed sequences (so it matches the method desc "Remove all Marten-related schema objects").

Additional _ctor_ in `Sequence` for binary compatibility.