### PR TITLE
Fix `pg_sequences` related failures in PG9.6 tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ resources:
       ports:
         - 5432:5432
     - container: pg9.6
-      image: clkao/postgres-plv8:9.6
+      image: clkao/postgres-plv8:9.6-1.4
       ports:
         - 5432:5432
 
@@ -55,7 +55,7 @@ jobs:
           versionSpec: $(node_version)
       - script: |
           PG_CONTAINER_NAME=$(docker ps --filter expose=5432/tcp --format {{.Names}})
-          docker exec $PG_CONTAINER_NAME psql -U postgres -c 'create database $(pg_db);'
+          docker exec $PG_CONTAINER_NAME psql -U postgres -c "create database $(pg_db);"
           docker exec $PG_CONTAINER_NAME psql -U postgres -d $(pg_db) -c "create extension if not exists plv8;"
         displayName: Create db and add plv8 extension
       - script: ./build.sh ci

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ resources:
       ports:
         - 5432:5432
     - container: pg9.6
-      image: clkao/postgres-plv8:9.6-1.4
+      image: mysticmind/postgres-plv8:9.6-1.4
       ports:
         - 5432:5432
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,7 @@ jobs:
           PG_CONTAINER_NAME=$(docker ps --filter expose=5432/tcp --format {{.Names}})
           docker exec $PG_CONTAINER_NAME psql -U postgres -c "create database $(pg_db);"
           docker exec $PG_CONTAINER_NAME psql -U postgres -d $(pg_db) -c "create extension if not exists plv8;"
+          docker exec $PG_CONTAINER_NAME psql -U postgres -c "DO 'plv8.elog(NOTICE, plv8.version);' LANGUAGE plv8;"
         displayName: Create db and add plv8 extension
       - script: ./build.sh ci
         displayName: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ variables:
 
 jobs:
   - job: Build
-    timeoutInMinutes: 20
+    # timeoutInMinutes: 20
     pool:
       vmImage: 'ubuntu-latest'
     strategy:

--- a/src/Marten/Schema/DocumentCleaner.cs
+++ b/src/Marten/Schema/DocumentCleaner.cs
@@ -97,8 +97,14 @@ WHERE  s.sequencename like 'mt_%' and s.schemaname = ANY(?);";
 
                 var allSchemas = new object[] {_options.Storage.AllSchemaNames()};
 
-                var drops = connection.GetStringList(DropAllFunctionSql, allSchemas)
-                    .Concat(connection.GetStringList(DropAllSequencesSql, allSchemas));
+                var drops = connection.GetStringList(DropAllFunctionSql, allSchemas);
+
+                // pg_sequences only available from 10 and above
+                if (connection.Connection.PostgreSqlVersion.Major >= 10)
+                {
+                    drops.Append(connection.GetStringList(DropAllSequencesSql, allSchemas));
+                }
+
                 drops.Each(drop => connection.Execute(drop));
                 connection.Commit();
 


### PR DESCRIPTION
Fix to run drop sequences using `pg_sequences` only for PG ver 10 or above