### PR TITLE
Fixes concurrency bug on mt_append_event function when processing the same stream.

### DIFF
--- a/src/Marten/Events/AppendEventFunction.cs
+++ b/src/Marten/Events/AppendEventFunction.cs
@@ -10,7 +10,7 @@ namespace Marten.Events
         private readonly EventGraph _events;
         private readonly bool _useAppendEventForUpdateLock;
 
-        public AppendEventFunction(EventGraph events, bool useAppendEventForUpdateLock) : base(new DbObjectName(events.DatabaseSchemaName, "mt_append_event"))
+        public AppendEventFunction(EventGraph events, bool useAppendEventForUpdateLock = false) : base(new DbObjectName(events.DatabaseSchemaName, "mt_append_event"))
         {
             _events = events;
             _useAppendEventForUpdateLock = useAppendEventForUpdateLock;

--- a/src/Marten/Events/AppendEventFunction.cs
+++ b/src/Marten/Events/AppendEventFunction.cs
@@ -8,10 +8,12 @@ namespace Marten.Events
     public class AppendEventFunction : Function
     {
         private readonly EventGraph _events;
+        private readonly bool _useAppendEventForUpdateLock;
 
-        public AppendEventFunction(EventGraph events) : base(new DbObjectName(events.DatabaseSchemaName, "mt_append_event"))
+        public AppendEventFunction(EventGraph events, bool useAppendEventForUpdateLock) : base(new DbObjectName(events.DatabaseSchemaName, "mt_append_event"))
         {
             _events = events;
+            _useAppendEventForUpdateLock = useAppendEventForUpdateLock;
         }
 
         public override void Write(DdlRules rules, StringWriter writer)
@@ -40,7 +42,7 @@ DECLARE
     actual_tenant varchar;
 	return_value int[];
 BEGIN
-	select version into event_version from {databaseSchema}.mt_streams where {streamsWhere};
+	select version into event_version from {databaseSchema}.mt_streams where {streamsWhere}{(_useAppendEventForUpdateLock ? " for update" : string.Empty)};
 	if event_version IS NULL then
 		event_version = 0;
 		insert into {databaseSchema}.mt_streams (id, type, version, timestamp, tenant_id) values (stream, stream_type, 0, now(), tenantid);

--- a/src/Marten/Events/AppendEventFunction.cs
+++ b/src/Marten/Events/AppendEventFunction.cs
@@ -8,12 +8,10 @@ namespace Marten.Events
     public class AppendEventFunction : Function
     {
         private readonly EventGraph _events;
-        private readonly bool _useAppendEventForUpdateLock;
 
-        public AppendEventFunction(EventGraph events, bool useAppendEventForUpdateLock = false) : base(new DbObjectName(events.DatabaseSchemaName, "mt_append_event"))
+        public AppendEventFunction(EventGraph events) : base(new DbObjectName(events.DatabaseSchemaName, "mt_append_event"))
         {
             _events = events;
-            _useAppendEventForUpdateLock = useAppendEventForUpdateLock;
         }
 
         public override void Write(DdlRules rules, StringWriter writer)
@@ -42,7 +40,7 @@ DECLARE
     actual_tenant varchar;
 	return_value int[];
 BEGIN
-	select version into event_version from {databaseSchema}.mt_streams where {streamsWhere}{(_useAppendEventForUpdateLock ? " for update" : string.Empty)};
+	select version into event_version from {databaseSchema}.mt_streams where {streamsWhere}{(_events.UseAppendEventForUpdateLock ? " for update" : string.Empty)};
 	if event_version IS NULL then
 		event_version = 0;
 		insert into {databaseSchema}.mt_streams (id, type, version, timestamp, tenant_id) values (stream, stream_type, 0, now(), tenantid);

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -206,7 +206,7 @@ namespace Marten.Events
                     new EventProgressionTable(DatabaseSchemaName),
                     sequence,
 
-                    new AppendEventFunction(this, UseAppendEventForUpdateLock),
+                    new AppendEventFunction(this),
                     new SystemFunction(DatabaseSchemaName, "mt_mark_event_progression", "varchar, bigint"),
                 };
             }

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -53,6 +53,15 @@ namespace Marten.Events
 
         public TenancyStyle TenancyStyle { get; set; } = TenancyStyle.Single;
 
+        /// <summary>
+        ///     Whether a "for update" (row exclusive lock) should be used when selecting out the event version to use from the streams table
+        /// </summary>
+        /// <remkarks>
+        ///     Not using this can result in race conditions in a concurrent environment that lead to
+        ///       event version mismatches between the event and stream version numbers
+        /// </remkarks>
+        public bool UseAppendEventForUpdateLock { get; set; } = false;
+
         internal StoreOptions Options { get; }
 
         internal DbObjectName Table => new DbObjectName(DatabaseSchemaName, "mt_events");
@@ -197,7 +206,7 @@ namespace Marten.Events
                     new EventProgressionTable(DatabaseSchemaName),
                     sequence,
 
-                    new AppendEventFunction(this),
+                    new AppendEventFunction(this, UseAppendEventForUpdateLock),
                     new SystemFunction(DatabaseSchemaName, "mt_mark_event_progression", "varchar, bigint"),
                 };
             }

--- a/src/Marten/Schema/SQL/mt_stream.sql
+++ b/src/Marten/Schema/SQL/mt_stream.sql
@@ -1,4 +1,4 @@
-﻿
+
 
 DROP TABLE IF EXISTS {databaseSchema}.mt_streams CASCADE;
 CREATE TABLE {databaseSchema}.mt_streams (
@@ -39,7 +39,7 @@ DECLARE
 	seq int;
 	return_value int[];
 BEGIN
-	select version into event_version from {databaseSchema}.mt_streams where id = stream;
+	select version into event_version from {databaseSchema}.mt_streams where id = stream for update;
 	if event_version IS NULL then
 		event_version = 0;
 		insert into {databaseSchema}.mt_streams (id, type, version, timestamp) values (stream, stream_type, 0, now());

--- a/src/Marten/Schema/SQL/mt_stream.sql
+++ b/src/Marten/Schema/SQL/mt_stream.sql
@@ -39,7 +39,7 @@ DECLARE
 	seq int;
 	return_value int[];
 BEGIN
-	select version into event_version from {databaseSchema}.mt_streams where id = stream for update;
+	select version into event_version from {databaseSchema}.mt_streams where id = stream;
 	if event_version IS NULL then
 		event_version = 0;
 		insert into {databaseSchema}.mt_streams (id, type, version, timestamp) values (stream, stream_type, 0, now());


### PR DESCRIPTION
Currently, if you have a concurrent calls from different processes appending events to the same stream id, it can lead to a mismatch in the `version` stored in the `mt_streams` table and the `version` stored in the `mt_events` table. This is due to the fact that the selection and updating of the event version on the `mt_streams` table is not placing any type of lock on the row after selecting out the version before updating. This creates a race condition in the `mt_append_event` function. Which then leads to a duplicate version key constraint error.

This change puts a `FOR UPDATE` lock on the event version `SELECT` from the `mt_streams` table. This puts a `ROW EXCLUSIVE` lock on the that given streams row, causing any other concurrent calls on the same stream id to wait on that lock, resolving the concurrency issue.