### PR TITLE
update SimpleExec to 6.0.0-beta.1

### DIFF
--- a/martenbuild.cs
+++ b/martenbuild.cs
@@ -125,17 +125,8 @@ namespace martenbuild
             baseDir.Delete(true);
         }
 
-        private static void RunNpm(string args)
-        {
-            if (Environment.OSVersion.Platform != PlatformID.Unix && Environment.OSVersion.Platform != PlatformID.MacOSX)
-            {
-                Run("cmd.exe", $"/c npm {args}");
-            }
-            else
-            {
-                Run("npm", args);
-            }
-        }
+        private static void RunNpm(string args) =>
+            Run("npm", args, windowsName: "cmd.exe", windowsArgs: $"/c npm {args}");
 
         private static void RunStoryTellerDocs(string args)
         {

--- a/martenbuild.csproj
+++ b/martenbuild.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bullseye" Version="2.3.0-rc.1" />
-    <PackageReference Include="SimpleExec" Version="4.2.0" />
+    <PackageReference Include="SimpleExec" Version="6.0.0-beta.1" />
     <PackageReference Include="Westwind.Utilities" Version="3.0.20.4" />
   </ItemGroup>
 


### PR DESCRIPTION
6.0.0 introduces [this feature](https://github.com/adamralph/simple-exec/pull/128), which means you no longer have to inspect the OS platform yourself.