### PR TITLE
Fixes #1276 - fixed nodaTime instant deserialization

### DIFF
--- a/src/Marten.CommandLine/Marten.CommandLine.csproj
+++ b/src/Marten.CommandLine/Marten.CommandLine.csproj
@@ -1,74 +1,73 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Description>Command line tooling for managing Marten development</Description>
-    <VersionPrefix>3.5.0</VersionPrefix>
-    <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz</Authors>
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
-    <AssemblyName>Marten.CommandLine</AssemblyName>
-    <PackageId>Marten.CommandLine</PackageId>
-    <PackageIconUrl>http://jasperfx.github.io/marten/content/images/emblem.png</PackageIconUrl>
-    <PackageProjectUrl>http://jasperfx.github.io/marten</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Description>Command line tooling for managing Marten development</Description>
+        <VersionPrefix>3.6.0</VersionPrefix>
+        <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
+        <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+        <AssemblyName>Marten.CommandLine</AssemblyName>
+        <PackageId>Marten.CommandLine</PackageId>
+        <PackageIconUrl>http://jasperfx.github.io/marten/content/images/emblem.png</PackageIconUrl>
+        <PackageProjectUrl>http://jasperfx.github.io/marten</PackageProjectUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+        <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+        <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+        <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    </PropertyGroup>
 
-  <PropertyGroup Condition="'$(OS)' != 'Windows_NT' AND '$(TargetFramework)'== 'net46'">
-    <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.6/1.0.1/lib/net46/</FrameworkPathOverride>
-    <RestoreAdditionalProjectSources>https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreAdditionalProjectSources>
-  </PropertyGroup>
+    <PropertyGroup Condition="'$(OS)' != 'Windows_NT' AND '$(TargetFramework)'== 'net46'">
+        <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.6/1.0.1/lib/net46/</FrameworkPathOverride>
+        <RestoreAdditionalProjectSources>https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreAdditionalProjectSources>
+    </PropertyGroup>
 
-  <ItemGroup Condition="'$(OS)' != 'Windows_NT' AND '$(TargetFramework)'== 'net46'">
-      <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.6" Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
-  </ItemGroup>
-  
+    <ItemGroup Condition="'$(OS)' != 'Windows_NT' AND '$(TargetFramework)'== 'net46'">
+        <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.6" Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="..\CommonAssemblyInfo.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="..\CommonAssemblyInfo.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Marten\Marten.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Marten\Marten.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Oakton" Version="1.5.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Oakton" Version="1.5.0" />
+    </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+        <Reference Include="System" />
+        <Reference Include="System.Runtime" />
+        <Reference Include="Microsoft.CSharp" />
+    </ItemGroup>
 
-  <PropertyGroup>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
 
-  <!--SourceLink specific settings-->
-  <PropertyGroup>
-    <RepositoryUrl>https://github.com/JasperFx/marten.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-  <PropertyGroup>
-    <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
-    <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <NoWarn>1591;1701;1702</NoWarn>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
-  </ItemGroup>
+    <!--SourceLink specific settings-->
+    <PropertyGroup>
+        <RepositoryUrl>https://github.com/JasperFx/marten.git</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+    <PropertyGroup>
+        <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
+        <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <NoWarn>1591;1701;1702</NoWarn>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
+    </ItemGroup>
 </Project>

--- a/src/Marten.NodaTime/InstantJsonConverter.cs
+++ b/src/Marten.NodaTime/InstantJsonConverter.cs
@@ -1,0 +1,45 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NodaTime;
+using NodaTime.Serialization.JsonNet;
+using NodaTime.Text;
+
+namespace Marten.NodaTime
+{
+    /// <summary>
+    /// Class used to properly deserialize Instants when db won't return data in TZ format.
+    /// The need come up with https://github.com/JasperFx/marten/issues/1276.
+    /// This is workaround for NodaTime issues https://github.com/nodatime/nodatime/issues/154 and https://github.com/nodatime/nodatime/pull/1237.
+    /// Revisit this when NodaTime 3.0.0 will be officialy released - then this class might be not needed anymore
+    /// </summary>
+    internal class InstantJsonConverter: JsonConverter
+    {
+        public static InstantJsonConverter Instance = new InstantJsonConverter();
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            NodaConverters.InstantConverter.WriteJson(writer, value, serializer);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return NodaConverters.InstantConverter.ReadJson(reader, objectType, existingValue, serializer);
+
+            var token = JToken.Load(reader);
+            var stringValue = token.ToObject<string>();
+            var parseResult = InstantPattern.ExtendedIso.Parse(stringValue);
+
+            if (parseResult.Success)
+                return parseResult.Value;
+
+            return Instant.FromDateTimeUtc(DateTime.SpecifyKind(DateTime.Parse(stringValue), DateTimeKind.Utc));
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(Instant) == objectType;
+        }
+    }
+}

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -1,46 +1,46 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <Description>Postgresql as a Document Db and Event Store for .Net Development</Description>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>Marten.NodaTime</AssemblyName>
-    <PackageId>Marten.NodaTime</PackageId>
-    <PackageIconUrl>http://jasperfx.github.io/marten/content/images/emblem.png</PackageIconUrl>
-    <PackageProjectUrl>http://jasperfx.github.io/marten</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/JasperFX/marten/blob/master/LICENSE.txt</PackageLicenseUrl>
-    <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyProductAttribute>true</GenerateAssemblyProductAttribute>
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>7.2</LangVersion>
-  </PropertyGroup>
-  
-  <!--SourceLink specific settings-->
-  <PropertyGroup>
-    <RepositoryUrl>https://github.com/JasperFx/marten.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-  <PropertyGroup>
-    <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
-    <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <NoWarn>1591;1701;1702</NoWarn>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="NodaTime.Serialization.JsonNet" Version="2.2.0" />
-    <PackageReference Include="Npgsql.NodaTime" Version="4.0.7" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Marten\Marten.csproj" />
-  </ItemGroup>
+    <PropertyGroup>
+        <Description>Postgresql as a Document Db and Event Store for .Net Development</Description>
+        <VersionPrefix>1.1.0</VersionPrefix>
+        <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <AssemblyName>Marten.NodaTime</AssemblyName>
+        <PackageId>Marten.NodaTime</PackageId>
+        <PackageIconUrl>http://jasperfx.github.io/marten/content/images/emblem.png</PackageIconUrl>
+        <PackageProjectUrl>http://jasperfx.github.io/marten</PackageProjectUrl>
+        <PackageLicenseUrl>https://github.com/JasperFX/marten/blob/master/LICENSE.txt</PackageLicenseUrl>
+        <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
+        <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>
+        <GenerateAssemblyProductAttribute>true</GenerateAssemblyProductAttribute>
+        <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+        <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <LangVersion>7.2</LangVersion>
+    </PropertyGroup>
+
+    <!--SourceLink specific settings-->
+    <PropertyGroup>
+        <RepositoryUrl>https://github.com/JasperFx/marten.git</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+    <PropertyGroup>
+        <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
+        <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <NoWarn>1591;1701;1702</NoWarn>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="NodaTime.Serialization.JsonNet" Version="2.2.0" />
+        <PackageReference Include="Npgsql.NodaTime" Version="4.0.7" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Marten\Marten.csproj" />
+    </ItemGroup>
 </Project>

--- a/src/Marten.NodaTime/NodaTimeExtensions.cs
+++ b/src/Marten.NodaTime/NodaTimeExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Marten.Services;
 using Marten.Util;
 using NodaTime;
@@ -27,7 +27,11 @@ namespace Marten.NodaTime
             if (shouldConfigureJsonNetSerializer)
             {
                 var serializer = storeOptions.Serializer();
-                (serializer as JsonNetSerializer)?.Customize(s => s.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb));
+                (serializer as JsonNetSerializer)?.Customize(s =>
+                {
+                    s.Converters.Add(InstantJsonConverter.Instance);
+                    s.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
+                });
                 storeOptions.Serializer(serializer);
             }
         }

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Postgresql as a Document Db and Event Store for .Net Development</Description>
-        <VersionPrefix>3.5.0</VersionPrefix>
-        <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz</Authors>
+        <VersionPrefix>3.6.0</VersionPrefix>
+        <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
         <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
         <AssemblyName>Marten</AssemblyName>
         <PackageId>Marten</PackageId>


### PR DESCRIPTION
Added InstantJsonConverter to properly deserialize Instants when db won't return data in TZ format.
The need come up with https://github.com/JasperFx/marten/issues/1276.
This is workaround for NodaTime issues https://github.com/nodatime/nodatime/issues/154 and https://github.com/nodatime/nodatime/pull/1237.

Revisit this when NodaTime 3.0.0 will be officialy released - then this class might be not needed anymore.

Upgraded Packages for `3.6.0` release.