### PR TITLE
Fix to use Bullseye --no-color for Azure Pipelines

### DIFF
--- a/azure-pipelines-benchmarks.yml
+++ b/azure-pipelines-benchmarks.yml
@@ -55,8 +55,8 @@ jobs:
           docker exec $PG_CONTAINER_NAME psql -U postgres -d $(pg_db) -c "create extension if not exists plv8;"
           docker exec $PG_CONTAINER_NAME psql -U postgres -c "DO 'plv8.elog(NOTICE, plv8.version);' LANGUAGE plv8;"
         displayName: Create db and add plv8 extension
-      - script: ./build.sh ci      
-      - script: ./build.sh benchmarks
+      - script: ./build.sh --no-color ci
+      - script: ./build.sh --no-color benchmarks
         displayName: BuildAndBenchmark
       - task: CopyFiles@2
         displayName: Copy Benchmark results

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ jobs:
           docker exec $PG_CONTAINER_NAME psql -U postgres -d $(pg_db) -c "create extension if not exists plv8;"
           docker exec $PG_CONTAINER_NAME psql -U postgres -c "DO 'plv8.elog(NOTICE, plv8.version);' LANGUAGE plv8;"
         displayName: Create db and add plv8 extension
-      - script: ./build.sh ci
+      - script: ./build.sh --no-color ci
         displayName: Build
   # Publish job will be enabled later
   # - job: Publish
@@ -73,7 +73,7 @@ jobs:
   #       displayName: Install .Net Core
   #       inputs:
   #         version: $(dotnet_core_version)
-  #     - script: ./build.sh pack
+  #     - script: ./build.sh --no-color pack
   #       displayName: Create NuGet Packages
   #     - task: NuGetCommand@2
   #       displayName: Publish packages to NuGet


### PR DESCRIPTION
Log messages on Azure Pipelines are showing character escapes due to ANSI code support issue - refer to https://github.com/microsoft/azure-pipelines-agent/issues/2140. 

Update Bullseye to use `--no-color` in the interim to resolve the issue at hand.