### PR TITLE
Fix #1296. Return updates AND upserts in `IUnitOfWork.Updates` and `I…

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_1296_sessionlistener_updates.cs
+++ b/src/Marten.Testing/Bugs/Bug_1296_sessionlistener_updates.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using Marten.Services;
+using Marten.Testing.Documents;
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+    public class Bug_1296_sessionlistener_updates : IntegratedFixture
+    {
+        [Fact]
+        public void bug()
+        {
+            var user = new User();
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Insert(user);
+                session.SaveChanges();
+            }
+
+            var updates = 0;
+
+            using (var session = theStore.OpenSession(new SessionOptions()
+            {
+                Listeners = { new CustomDocumentSessionListener(work =>
+                {
+                    updates = work.UpdatesFor<User>().Count();
+                }) }
+            }))
+            {
+                var u = session.Load<User>(user.Id);
+                u.FirstName = "updated";
+                session.Update(u);
+                session.SaveChanges();
+            }
+
+            Assert.Equal(1, updates);
+        }
+
+        public class CustomDocumentSessionListener: DocumentSessionListenerBase
+        {
+            private readonly Action<IUnitOfWork> onUpdate;
+
+            public CustomDocumentSessionListener(Action<IUnitOfWork> onUpdate)
+            {
+                this.onUpdate = onUpdate;
+            }
+
+            public override void BeforeSaveChanges(IDocumentSession session)
+            {
+                onUpdate(session.PendingChanges);
+            }
+        }
+    }
+}

--- a/src/Marten/Services/UnitOfWork.cs
+++ b/src/Marten/Services/UnitOfWork.cs
@@ -51,7 +51,7 @@ namespace Marten.Services
 
         public IEnumerable<object> Updates()
         {
-            return _operations.Value.Enumerate().SelectMany(x => x.Value.OfType<UpsertDocument>().Select(u => u.Document))
+            return _operations.Value.Enumerate().SelectMany(x => x.Value.Where(t => t is UpsertDocument || t is UpdateDocument).OfType<DocumentStorageOperation>().Select(u => u.Document))
                 .Union(detectTrackerChanges().Select(x => x.Document));
         }
 


### PR DESCRIPTION
…UnitOfWork.UpdatesFor`.