### PR TITLE
Updated Scenario `Aggregates, Events, Repositories` to be simplified to not provide additional infrastructure wrapping around Marten

### DIFF
--- a/src/Marten.Testing/Events/ScenarioAggregateAndRepository.cs
+++ b/src/Marten.Testing/Events/ScenarioAggregateAndRepository.cs
@@ -123,7 +123,7 @@ namespace Marten.Testing.Events
 
             var @event = new InvoiceCreated(invoiceNumber);
             // Instantiation creates our initial event, capturing the invoice number
-            RaiseEvent(@event);
+            Enqueue(@event);
             Apply(@event);
         }
 
@@ -141,7 +141,7 @@ namespace Marten.Testing.Events
             }
 
             var @event = new LineItemAdded(price, vat, description);
-            RaiseEvent(@event);
+            Enqueue(@event);
             Apply(@event);
         }
 
@@ -231,7 +231,7 @@ namespace Marten.Testing.Events
             uncommittedEvents.Clear();
         }
 
-        protected void RaiseEvent(object @event)
+        protected void Enqueue(object @event)
         {
             Version++;
             if (@event is IVersionedEvent versionedEvent)

--- a/src/Marten.Testing/Events/ScenarioAggregateAndRepository.cs
+++ b/src/Marten.Testing/Events/ScenarioAggregateAndRepository.cs
@@ -121,7 +121,7 @@ namespace Marten.Testing.Events
                 throw new ArgumentException("Invoice number needs to be positive", nameof(invoiceNumber));
             }
 
-            var @event = new InvoiceCreated(invoiceNumber);
+            var @event = new InvoiceCreated(invoiceNumber, ++Version);
             // Instantiation creates our initial event, capturing the invoice number
             Enqueue(@event);
             Apply(@event);
@@ -140,7 +140,7 @@ namespace Marten.Testing.Events
                 throw new ArgumentException("Description cannot be empty", nameof(description));
             }
 
-            var @event = new LineItemAdded(price, vat, description);
+            var @event = new LineItemAdded(price, vat, description, ++Version);
             Enqueue(@event);
             Apply(@event);
         }
@@ -171,35 +171,33 @@ namespace Marten.Testing.Events
     // ENDSAMPLE
 
     // SAMPLE: scenario-aggregate-events
-    public interface IVersionedEvent
-    {
-        int Version { get; set; }
-    }
 
-    public sealed class InvoiceCreated: IVersionedEvent
+    public sealed class InvoiceCreated
     {
         public int InvoiceNumber { get; }
 
-        public int Version { get; set; }
+        public int Version { get; }
 
-        public InvoiceCreated(int invoiceNumber)
+        public InvoiceCreated(int invoiceNumber, int version)
         {
             InvoiceNumber = invoiceNumber;
+            Version = version;
         }
     }
 
-    public sealed class LineItemAdded: IVersionedEvent
+    public sealed class LineItemAdded
     {
         public decimal Price { get; }
         public decimal Vat { get; }
         public string Description { get; }
-        public int Version { get; set; }
+        public int Version { get; }
 
-        public LineItemAdded(decimal price, decimal vat, string description)
+        public LineItemAdded(decimal price, decimal vat, string description, int version)
         {
             Price = price;
             Vat = vat;
             Description = description;
+            Version = version;
         }
     }
 
@@ -233,11 +231,6 @@ namespace Marten.Testing.Events
 
         protected void Enqueue(object @event)
         {
-            Version++;
-            if (@event is IVersionedEvent versionedEvent)
-            {
-                versionedEvent.Version = Version;
-            }
             uncommittedEvents.Add(@event);
         }
     }


### PR DESCRIPTION
Based on the Discussion on Gitter Updated Scenario `Aggregates, Events, Repositories` to be simplified to not provide additional infrastructure wrapping around Marten. That will make it more straightforward for new users (eg. to not think why did we used custom aggregation instead of the default one. 

Fixed also version handling for the optimistic concurrency.

Question raised on Gitter:
```
ddivita
@ddivita
Jun 24 21:39
Int the repository example here: http://jasperfx.github.io/marten/documentation/scenarios/aggregates_events_repositories/ The method : protected void Register<T>(Action<T> handle) is manually setting the handlers as opposed to Marten automatically registering the Applymethods on the Aggregate Root?
```

@ddivita fyi