### PR TITLE
Bug 1308

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_1308_get_dependent_types_should_not_return_null.cs
+++ b/src/Marten.Testing/Bugs/Bug_1308_get_dependent_types_should_not_return_null.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using Marten.Schema;
+using Marten.Storage;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+    public class Bug_1308_get_dependent_types_should_not_return_null
+    {
+        [Fact]
+        public void documentmapping_dependenttypes_should_not_include_nulls()
+        {
+            var docMap = new DocumentMapping(typeof(BugTestClass), new StoreOptions());
+            docMap.ForeignKeys.Add(new ExternalForeignKeyDefinition("test_column", docMap, "test_schema", "test_table", "test_column_2"));
+
+            var featureSchema = (IFeatureSchema)docMap;
+
+            featureSchema.DependentTypes().Any(t => t == null).ShouldBeFalse();
+        }
+
+        public class BugTestClass
+        {
+        }
+    }
+}

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -669,6 +669,10 @@ namespace Marten.Schema
 
             foreach (var foreignKey in ForeignKeys)
             {
+                // ExternalForeignKeyDefinition's will have a null ReferenceDocumentType, so we can skip it
+                if (foreignKey.ReferenceDocumentType == null)
+                    continue;
+
                 yield return foreignKey.ReferenceDocumentType;
             }
         }


### PR DESCRIPTION
Addresses #1308 by skipping `null` values in the `DocumentMapping`'s `IFeatureSchema.DependentTypes()` implementation.