### PR TITLE
Update dev dependency lodash to use version >=4.17.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,6 @@
 {
-  "name": "marten",
-  "version": "0.5.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "assertion-error": {
       "version": "1.0.2",
@@ -148,9 +146,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
     "minimatch": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "mocha": "^5.2.0"
   }
 }


### PR DESCRIPTION
The prior version of lodash had security vulnerability so updated it to use version >=4.17.13 (Github notification highlighted this issue)