### PR TITLE
Short circuit applying empty streams to all Inline projections when saving if there are no streams

### DIFF
--- a/src/Marten/DocumentSession.cs
+++ b/src/Marten/DocumentSession.cs
@@ -456,19 +456,29 @@ namespace Marten
 
         private void applyProjections()
         {
-            var eventPage = new EventPage(PendingChanges.Streams().ToArray());
-            foreach (var projection in _store.Events.InlineProjections)
+            var streams = PendingChanges.Streams().ToArray();
+
+            if (streams.Length > 0)
             {
-                projection.Apply(this, eventPage);
+                var eventPage = new EventPage(streams);
+                foreach (var projection in _store.Events.InlineProjections)
+                {
+                    projection.Apply(this, eventPage);
+                }
             }
         }
 
         private async Task applyProjectionsAsync(CancellationToken token)
         {
-            var eventPage = new EventPage(PendingChanges.Streams().ToArray());
-            foreach (var projection in _store.Events.InlineProjections)
+            var streams = PendingChanges.Streams().ToArray();
+
+            if (streams.Length > 0)
             {
-                await projection.ApplyAsync(this, eventPage, token).ConfigureAwait(false);
+                var eventPage = new EventPage(streams);
+                foreach (var projection in _store.Events.InlineProjections)
+                {
+                    await projection.ApplyAsync(this, eventPage, token).ConfigureAwait(false);
+                }
             }
         }
 

--- a/src/Marten/Events/Projections/AggregateFinder.cs
+++ b/src/Marten/Events/Projections/AggregateFinder.cs
@@ -50,7 +50,10 @@ namespace Marten.Events.Projections
 
         public async Task FetchAllAggregates(IDocumentSession session, EventStream[] streams, CancellationToken token)
         {
-            await session.LoadManyAsync<T>(token, streams.Select(x => x.Id).ToArray()).ConfigureAwait(false);
+            if (streams.Length > 0)
+            {
+                await session.LoadManyAsync<T>(token, streams.Select(x => x.Id).ToArray()).ConfigureAwait(false);
+            }
         }
     }
 }


### PR DESCRIPTION
Also don’t try to load an empty array of stream ids in the AggregateFinder.

These two changes provide a decent performance boost when there are no streams when saving, by eliminating erroneous DB queries and not looping inline projections, as explained below. 

Prior to this change `applyProjections` would loop every inline projection trying to apply an empty array of streams. If one of the projections used the `AggregateFinder` (like AggregateStreamsWith<>), then it would be querying the database to load an empty array of ids for every inline projection that uses it.

This issue was especially visible when rebuilding a projection in the Async Daemon 