### PR TITLE
Add functionality to run `ApplyAllConfiguredChangesToDatabase` independent of StoreOptions AutoCreate

### DIFF
--- a/src/Marten.Testing/Schema/ApplyAllConfiguredChangesToDatabaseTests.cs
+++ b/src/Marten.Testing/Schema/ApplyAllConfiguredChangesToDatabaseTests.cs
@@ -1,0 +1,45 @@
+using Marten.Testing.Documents;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Schema
+{
+    public class ApplyAllConfiguredChangesToDatabaseTests : IntegratedFixture
+    {
+        [Fact]
+        public void can_apply_schema_changes_independent_of_store_options_auto_create()
+        {
+            StoreOptions(_ =>
+            {
+                _.DatabaseSchemaName = "apply_all_config_changes_to_db_0";
+                _.Schema.For<User>();
+                _.AutoCreateSchemaObjects = AutoCreate.None;
+            });
+
+            // should not throw SchemaValidationException
+            Should.NotThrow(() =>
+            {
+                theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+                theStore.Schema.AssertDatabaseMatchesConfiguration();
+            });
+        }
+
+        [Fact]
+        public void can_apply_schema_changes_with_create_options_independent_of_store_options_auto_create()
+        {
+            StoreOptions(_ =>
+            {
+                _.DatabaseSchemaName = "apply_all_config_changes_to_db_1";
+                _.Schema.For<User>();
+                _.AutoCreateSchemaObjects = AutoCreate.None;
+            });
+
+            // should not throw SchemaValidationException
+            Should.NotThrow(() =>
+            {
+                theStore.Schema.ApplyAllConfiguredChangesToDatabase(AutoCreate.All);
+                theStore.Schema.AssertDatabaseMatchesConfiguration();
+            });
+        }
+    }
+}

--- a/src/Marten/Schema/IDocumentSchema.cs
+++ b/src/Marten/Schema/IDocumentSchema.cs
@@ -54,7 +54,7 @@ namespace Marten.Schema
         ///     Executes all detected DDL patches to the schema based on current configuration
         ///     upfront at one time
         /// </summary>
-        void ApplyAllConfiguredChangesToDatabase();
+        void ApplyAllConfiguredChangesToDatabase(AutoCreate? withAutoCreate = null);
 
         /// <summary>
         ///     Generate a DDL patch for one specific document type


### PR DESCRIPTION
- Add functionality to run `ApplyAllConfiguredChangesToDatabase` independent of StoreOptions AutoCreate
- Add unit tests
- Fixes #1324