### PR TITLE
Issue #1190 -  ensure the locator for a CollectionAnyContainment query matches the field's index

### DIFF
--- a/src/Marten.Testing/Linq/IsNullNotNullArbitraryDepthTests.cs
+++ b/src/Marten.Testing/Linq/IsNullNotNullArbitraryDepthTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+using System.Linq;
+using Marten.Schema;
 using Marten.Services;
 using Marten.Testing.Documents;
 using Marten.Util;
@@ -44,12 +45,11 @@ namespace Marten.Testing.Linq
 			}
 		}
 
-		[Fact]
-		public void UnknownPGTypesMapToJsonb()
-		{
-			var cast = TypeMappings.ApplyCastToLocator("item", EnumStorage.AsInteger, typeof(UserNested));
-
-			Assert.Contains("as jsonb", cast);
-		}
+        [Fact]
+        public void UnknownPGTypesMapToJsonb()
+        {
+            var locator = JsonLocatorField.For<UserNested>(EnumStorage.AsInteger, Casing.Default, x => x.Nested);
+            Assert.Equal("CAST(d.data ->> 'Nested' as jsonb)", locator.SqlLocator);
+        }
 	}
 }

--- a/src/Marten.Testing/Linq/previewing_the_command_from_a_queryable_Tests.cs
+++ b/src/Marten.Testing/Linq/previewing_the_command_from_a_queryable_Tests.cs
@@ -53,6 +53,26 @@ namespace Marten.Testing.Linq
 
             cmd.CommandText.Trim().ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d order by CAST(d.data ->> 'Double' as double precision) LIMIT 1");
         }
+
+        [Fact]
+        public void preview_collection_any_containment_command()
+        {
+            var tags = new[] { "ONE", "TWO" };
+            var cmd = theSession.Query<Target>().Where(x => x.TagsArray.Any(t => tags.Contains(t))).ToCommand(FetchType.FetchMany);
+
+            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d where CAST(d.data ->> 'TagsArray' as jsonb) ?| :arg0");
+            cmd.Parameters["arg0"].Value.ShouldBe(tags);
+        }
+
+        [Fact]
+        public void preview_deep_collection_any_containment_command()
+        {
+            var tags = new[] { "ONE", "TWO" };
+            var cmd = theSession.Query<Target>().Where(x => x.Inner.TagsArray.Any(t => tags.Contains(t))).ToCommand(FetchType.FetchMany);
+
+            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d where CAST(d.data -> 'Inner' ->> 'TagsArray' as jsonb) ?| :arg0");
+            cmd.Parameters["arg0"].Value.ShouldBe(tags);
+        }
     }
 
     public class previewing_the_command_from_a_queryable_inb_different_schema_Tests : DocumentSessionFixture<NulloIdentityMap>

--- a/src/Marten.Testing/Schema/DuplicatedFieldTests.cs
+++ b/src/Marten.Testing/Schema/DuplicatedFieldTests.cs
@@ -81,7 +81,9 @@ namespace Marten.Testing.Schema
             field.PgType = pgType ?? field.PgType;
 
             field.UpdateSqlFragment().ShouldBe(expectedUpdateFragment);
-            field.PgType.ShouldBe(pgType ?? "varchar");
+            var expectedPgType = pgType ?? "varchar";
+            field.PgType.ShouldBe(expectedPgType);
+            field.UpsertArgument.PostgresType.ShouldBe(expectedPgType);           
             field.DbType.ShouldBe(NpgsqlDbType.Text);
         }
 
@@ -95,7 +97,9 @@ namespace Marten.Testing.Schema
             field.PgType = pgType ?? field.PgType;
 
             field.UpdateSqlFragment().ShouldBe(expectedUpdateFragment);
-            field.PgType.ShouldBe(pgType ?? "uuid");
+            var expectedPgType = pgType ?? "uuid";
+            field.PgType.ShouldBe(expectedPgType);
+            field.UpsertArgument.PostgresType.ShouldBe(expectedPgType);
             field.DbType.ShouldBe(NpgsqlDbType.Uuid);
         }
 
@@ -109,7 +113,9 @@ namespace Marten.Testing.Schema
             field.PgType = pgType ?? field.PgType;
 
             field.UpdateSqlFragment().ShouldBe(expectedUpdateFragment);
-            field.PgType.ShouldBe(pgType ?? "varchar[]");
+            var expectedPgType = pgType ?? "varchar[]";
+            field.PgType.ShouldBe(expectedPgType);
+            field.UpsertArgument.PostgresType.ShouldBe(expectedPgType);
             field.DbType.ShouldBe(NpgsqlDbType.Array | NpgsqlDbType.Text);
         }
 
@@ -123,7 +129,9 @@ namespace Marten.Testing.Schema
             field.PgType = pgType ?? field.PgType;
 
             field.UpdateSqlFragment().ShouldBe(expectedUpdateFragment);
-            field.PgType.ShouldBe(pgType ?? "jsonb");
+            var expectedPgType = pgType ?? "jsonb";
+            field.PgType.ShouldBe(expectedPgType);
+            field.UpsertArgument.PostgresType.ShouldBe(expectedPgType);
             field.DbType.ShouldBe(NpgsqlDbType.Array | NpgsqlDbType.Text);
         }
 

--- a/src/Marten.Testing/Schema/JsonLocatorFieldTests.cs
+++ b/src/Marten.Testing/Schema/JsonLocatorFieldTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using Baseline.Reflection;
@@ -108,7 +108,7 @@ namespace Marten.Testing.Schema
             var inner = ReflectionHelper.GetProperty<Target>(x => x.Inner);
             var number = ReflectionHelper.GetProperty<Target>(x => x.Number);
 
-            var twodeep = new JsonLocatorField("d.data", EnumStorage.AsInteger, casing, new MemberInfo[] {inner, number});
+            var twodeep = new JsonLocatorField("d.data", null, EnumStorage.AsInteger, casing, new MemberInfo[] {inner, number});
 
             twodeep.SqlLocator.ShouldBe($"CAST(d.data -> '{innerName}' ->> '{numberName}' as integer)");
         }
@@ -123,7 +123,7 @@ namespace Marten.Testing.Schema
             var inner = ReflectionHelper.GetProperty<Target>(x => x.Inner);
             var number = ReflectionHelper.GetProperty<Target>(x => x.Number);
 
-            var deep = new JsonLocatorField("d.data", EnumStorage.AsInteger, casing, new MemberInfo[] { inner, inner, number });
+            var deep = new JsonLocatorField("d.data", null, EnumStorage.AsInteger, casing, new MemberInfo[] { inner, inner, number });
 
             deep.SqlLocator.ShouldBe($"CAST(d.data -> '{innerName}' -> '{innerName}' ->> '{numberName}' as integer)");
         }
@@ -137,7 +137,7 @@ namespace Marten.Testing.Schema
             var inner = ReflectionHelper.GetProperty<Target>(x => x.Inner);
             var stringProp = ReflectionHelper.GetProperty<Target>(x => x.String);
 
-            var deep = new JsonLocatorField("d.data", EnumStorage.AsInteger, casing, new MemberInfo[] { inner, inner, stringProp });
+            var deep = new JsonLocatorField("d.data", null, EnumStorage.AsInteger, casing, new MemberInfo[] { inner, inner, stringProp });
 
             deep.SqlLocator.ShouldBe($"d.data -> '{innerName}' -> '{innerName}' ->> '{stringName}'");
         }

--- a/src/Marten.Testing/Schema/JsonLocatorFieldTests.cs
+++ b/src/Marten.Testing/Schema/JsonLocatorFieldTests.cs
@@ -108,7 +108,7 @@ namespace Marten.Testing.Schema
             var inner = ReflectionHelper.GetProperty<Target>(x => x.Inner);
             var number = ReflectionHelper.GetProperty<Target>(x => x.Number);
 
-            var twodeep = new JsonLocatorField("d.data", null, EnumStorage.AsInteger, casing, new MemberInfo[] {inner, number});
+            var twodeep = new JsonLocatorField("d.data", new StoreOptions(), EnumStorage.AsInteger, casing, new MemberInfo[] {inner, number});
 
             twodeep.SqlLocator.ShouldBe($"CAST(d.data -> '{innerName}' ->> '{numberName}' as integer)");
         }
@@ -123,7 +123,7 @@ namespace Marten.Testing.Schema
             var inner = ReflectionHelper.GetProperty<Target>(x => x.Inner);
             var number = ReflectionHelper.GetProperty<Target>(x => x.Number);
 
-            var deep = new JsonLocatorField("d.data", null, EnumStorage.AsInteger, casing, new MemberInfo[] { inner, inner, number });
+            var deep = new JsonLocatorField("d.data", new StoreOptions(), EnumStorage.AsInteger, casing, new MemberInfo[] { inner, inner, number });
 
             deep.SqlLocator.ShouldBe($"CAST(d.data -> '{innerName}' -> '{innerName}' ->> '{numberName}' as integer)");
         }
@@ -137,7 +137,7 @@ namespace Marten.Testing.Schema
             var inner = ReflectionHelper.GetProperty<Target>(x => x.Inner);
             var stringProp = ReflectionHelper.GetProperty<Target>(x => x.String);
 
-            var deep = new JsonLocatorField("d.data", null, EnumStorage.AsInteger, casing, new MemberInfo[] { inner, inner, stringProp });
+            var deep = new JsonLocatorField("d.data", new StoreOptions(), EnumStorage.AsInteger, casing, new MemberInfo[] { inner, inner, stringProp });
 
             deep.SqlLocator.ShouldBe($"d.data -> '{innerName}' -> '{innerName}' ->> '{stringName}'");
         }

--- a/src/Marten.Testing/Util/CommandBuilderTests.cs
+++ b/src/Marten.Testing/Util/CommandBuilderTests.cs
@@ -1,0 +1,36 @@
+using Baseline.Reflection;
+using Marten.Util;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace Marten.Testing.Util
+{
+    public class CommandBuilderTests
+    {
+        [Theory]
+        [InlineData("data", Casing.Default, "data -> 'Inner' ->> 'AnotherString'")]
+        [InlineData("d.data", Casing.CamelCase, "d.data -> 'inner' ->> 'anotherString'")]
+        [InlineData("string", Casing.SnakeCase, "string -> 'inner' ->> 'another_string'")]
+        public void build_json_string_locator(string column, Casing casing, string expected)
+        {
+            var members = new MemberInfo[] { ReflectionHelper.GetProperty<Target>(x => x.Inner), ReflectionHelper.GetProperty<Target>(x => x.AnotherString) };
+            var locator = CommandBuilder.BuildJsonStringLocator(column, members, casing);
+            locator.ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("data", Casing.Default, "data -> 'Inner' -> 'AnotherString'")]
+        [InlineData("d.data", Casing.CamelCase, "d.data -> 'inner' -> 'anotherString'")]
+        [InlineData("string", Casing.SnakeCase, "string -> 'inner' -> 'another_string'")]
+        public void build_json_object_locator(string column, Casing casing, string expected)
+        {
+            var members = new MemberInfo[] { ReflectionHelper.GetProperty<Target>(x => x.Inner), ReflectionHelper.GetProperty<Target>(x => x.AnotherString) };
+            var locator = CommandBuilder.BuildJsonObjectLocator(column, members, casing);
+            locator.ShouldBe(expected);
+        }
+    }
+}

--- a/src/Marten/Linq/ChildCollectionWhereVisitor.cs
+++ b/src/Marten/Linq/ChildCollectionWhereVisitor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using Baseline;
+using Marten.Schema;
 using Marten.Util;
 using Remotion.Linq;
 using Remotion.Linq.Clauses.Expressions;
@@ -18,13 +19,15 @@ namespace Marten.Linq
         private readonly SubQueryExpression _expression;
         private readonly Action<IWhereFragment> _registerFilter;
         private readonly QueryModel _query;
+        private readonly IQueryableDocument _mapping;
 
-        public ChildCollectionWhereVisitor(ISerializer serializer, SubQueryExpression expression, Action<IWhereFragment> registerFilter)
+        public ChildCollectionWhereVisitor(ISerializer serializer, SubQueryExpression expression, Action<IWhereFragment> registerFilter, IQueryableDocument mapping)
         {
             _serializer = serializer;
             _expression = expression;
             _query = expression.QueryModel;
             _registerFilter = registerFilter;
+            _mapping = mapping;
         }
 
         public void Parse()
@@ -70,7 +73,7 @@ namespace Marten.Linq
                     return;
                 }
 
-                var @where = new CollectionAnyContainmentWhereFragment(members, _serializer, _expression);
+                var @where = new CollectionAnyContainmentWhereFragment(members, _serializer, _expression, _mapping);
                 _registerFilter(@where);
             }
         }

--- a/src/Marten/Linq/ChildCollectionWhereVisitor.cs
+++ b/src/Marten/Linq/ChildCollectionWhereVisitor.cs
@@ -21,6 +21,7 @@ namespace Marten.Linq
         private readonly QueryModel _query;
         private readonly IQueryableDocument _mapping;
 
+        [Obsolete("Use the constructor that takes IQueryableDocument instead. This might be removed in v4.0.")]
         public ChildCollectionWhereVisitor(ISerializer serializer, SubQueryExpression expression, Action<IWhereFragment> registerFilter) : this(serializer, expression, registerFilter, null)
         {
         }

--- a/src/Marten/Linq/ChildCollectionWhereVisitor.cs
+++ b/src/Marten/Linq/ChildCollectionWhereVisitor.cs
@@ -21,6 +21,10 @@ namespace Marten.Linq
         private readonly QueryModel _query;
         private readonly IQueryableDocument _mapping;
 
+        public ChildCollectionWhereVisitor(ISerializer serializer, SubQueryExpression expression, Action<IWhereFragment> registerFilter) : this(serializer, expression, registerFilter, null)
+        {
+        }
+
         public ChildCollectionWhereVisitor(ISerializer serializer, SubQueryExpression expression, Action<IWhereFragment> registerFilter, IQueryableDocument mapping)
         {
             _serializer = serializer;

--- a/src/Marten/Linq/CollectionAnyContainmentWhereFragment.cs
+++ b/src/Marten/Linq/CollectionAnyContainmentWhereFragment.cs
@@ -22,6 +22,7 @@ namespace Marten.Linq
         private readonly SubQueryExpression _expression;
         private readonly IQueryableDocument _mapping;
 
+        [Obsolete("Use the constructor that takes IQueryableDocument instead. This might be removed in v4.0.")]
         public CollectionAnyContainmentWhereFragment(MemberInfo[] members, ISerializer serializer, SubQueryExpression expression) : this(members, serializer, expression, null)
         {
         }
@@ -203,7 +204,7 @@ namespace Marten.Linq
             var members = visitor.Members;
             if (!members.Any())
                 throwNotSupportedContains();
-            var path = _mapping?.FieldFor(members).SqlLocator ?? CommandBuilder.BuildJsonStringLocator("d.data", members.ToArray(), _serializer.Casing);
+            var path = _mapping?.FieldFor(members).SqlLocator ?? $"CAST ({CommandBuilder.BuildJsonStringLocator("d.data", members.ToArray(), _serializer.Casing)} as jsonb)";
             return $"{path} ?| :{fromParam.ParameterName}";
         }
 

--- a/src/Marten/Linq/CollectionAnyContainmentWhereFragment.cs
+++ b/src/Marten/Linq/CollectionAnyContainmentWhereFragment.cs
@@ -22,6 +22,10 @@ namespace Marten.Linq
         private readonly SubQueryExpression _expression;
         private readonly IQueryableDocument _mapping;
 
+        public CollectionAnyContainmentWhereFragment(MemberInfo[] members, ISerializer serializer, SubQueryExpression expression) : this(members, serializer, expression, null)
+        {
+        }
+
         public CollectionAnyContainmentWhereFragment(MemberInfo[] members, ISerializer serializer, SubQueryExpression expression, IQueryableDocument mapping)
         {
             _members = members;
@@ -199,7 +203,8 @@ namespace Marten.Linq
             var members = visitor.Members;
             if (!members.Any())
                 throwNotSupportedContains();
-            return $"{_mapping.FieldFor(members).SqlLocator} ?| :{fromParam.ParameterName}";
+            var path = _mapping?.FieldFor(members).SqlLocator ?? CommandBuilder.BuildJsonStringLocator("d.data", members.ToArray(), _serializer.Casing);
+            return $"{path} ?| :{fromParam.ParameterName}";
         }
 
         private void throwNotSupportedContains()

--- a/src/Marten/Linq/WhereClauseVisitor.cs
+++ b/src/Marten/Linq/WhereClauseVisitor.cs
@@ -114,7 +114,7 @@ namespace Marten.Linq
             {
                 Action<IWhereFragment> register = w => _register.Peek()(w);
 
-                var visitor = new ChildCollectionWhereVisitor(_parent._serializer, expression, register);
+                var visitor = new ChildCollectionWhereVisitor(_parent._serializer, expression, register, _mapping);
                 visitor.Parse();
 
                 return null;

--- a/src/Marten/Schema/DuplicatedField.cs
+++ b/src/Marten/Schema/DuplicatedField.cs
@@ -98,12 +98,12 @@ namespace Marten.Schema
         {
             if ((DbType & NpgsqlDbType.Array) == NpgsqlDbType.Array && PgType != "jsonb")
             {
-                var jsonField = new JsonLocatorField("data", null, _enumStorage, Casing.Default, Members, "jsonb");
+                var jsonField = new JsonLocatorField("data", new StoreOptions(), _enumStorage, Casing.Default, Members, "jsonb");
                 return $"{ColumnName} = CAST(ARRAY(SELECT jsonb_array_elements_text({jsonField.SqlLocator})) as {PgType})";
             }
             else
             {
-                var jsonField = new JsonLocatorField("data", null, _enumStorage, Casing.Default, Members, PgType);
+                var jsonField = new JsonLocatorField("data", new StoreOptions(), _enumStorage, Casing.Default, Members, PgType);
                 return $"{ColumnName} = {jsonField.SqlLocator}";
             }
         }

--- a/src/Marten/Schema/FieldCollection.cs
+++ b/src/Marten/Schema/FieldCollection.cs
@@ -52,7 +52,7 @@ namespace Marten.Schema
             var serializer = _options.Serializer();
 
             return _fields.GetOrAdd(key,
-                _ => new JsonLocatorField(_dataLocator, serializer.EnumStorage, serializer.Casing, members.ToArray()));
+                _ => new JsonLocatorField(_dataLocator, _options.DatabaseSchemaName, serializer.EnumStorage, serializer.Casing, members.ToArray()));
         }
 
         public IField FieldFor(MemberInfo member)
@@ -60,7 +60,7 @@ namespace Marten.Schema
             var serializer = _options.Serializer();
 
             return _fields.GetOrAdd(member.Name,
-                name => new JsonLocatorField(_dataLocator, _options, serializer.EnumStorage, serializer.Casing, member));
+                name => new JsonLocatorField(_dataLocator, _options.DatabaseSchemaName, serializer.EnumStorage, serializer.Casing, member));
         }
 
         public IField FieldFor(string memberName)
@@ -75,7 +75,7 @@ namespace Marten.Schema
 
                 var serializer = _options.Serializer();
 
-                return new JsonLocatorField(_dataLocator, _options, serializer.EnumStorage, serializer.Casing, member);
+                return new JsonLocatorField(_dataLocator, _options.DatabaseSchemaName, serializer.EnumStorage, serializer.Casing, member);
             });
         }
 

--- a/src/Marten/Schema/FieldCollection.cs
+++ b/src/Marten/Schema/FieldCollection.cs
@@ -52,7 +52,7 @@ namespace Marten.Schema
             var serializer = _options.Serializer();
 
             return _fields.GetOrAdd(key,
-                _ => new JsonLocatorField(_dataLocator, _options.DatabaseSchemaName, serializer.EnumStorage, serializer.Casing, members.ToArray()));
+                _ => new JsonLocatorField(_dataLocator, _options, serializer.EnumStorage, serializer.Casing, members.ToArray()));
         }
 
         public IField FieldFor(MemberInfo member)
@@ -60,7 +60,7 @@ namespace Marten.Schema
             var serializer = _options.Serializer();
 
             return _fields.GetOrAdd(member.Name,
-                name => new JsonLocatorField(_dataLocator, _options.DatabaseSchemaName, serializer.EnumStorage, serializer.Casing, member));
+                name => new JsonLocatorField(_dataLocator, _options, serializer.EnumStorage, serializer.Casing, member));
         }
 
         public IField FieldFor(string memberName)
@@ -75,7 +75,7 @@ namespace Marten.Schema
 
                 var serializer = _options.Serializer();
 
-                return new JsonLocatorField(_dataLocator, _options.DatabaseSchemaName, serializer.EnumStorage, serializer.Casing, member);
+                return new JsonLocatorField(_dataLocator, _options, serializer.EnumStorage, serializer.Casing, member);
             });
         }
 

--- a/src/Marten/Schema/JsonLocatorField.cs
+++ b/src/Marten/Schema/JsonLocatorField.cs
@@ -74,8 +74,9 @@ namespace Marten.Schema
             }
         }
 
+        [Obsolete("Use a constructor that takes StoreOptions instead. This might be removed in v4.0.")]
         public JsonLocatorField(string dataLocator, EnumStorage enumStyle, Casing casing, MemberInfo[] members) :
-            this(dataLocator, new StoreOptions(), enumStyle, casing, members, null)
+            this(dataLocator, null, enumStyle, casing, members, null)
         {
         }
 

--- a/src/Marten/Util/CommandBuilder.cs
+++ b/src/Marten/Util/CommandBuilder.cs
@@ -16,6 +16,29 @@ namespace Marten.Util
     {
         public static readonly string TenantIdArg = ":" + TenantIdArgument.ArgName;
 
+        public static string BuildJsonStringLocator(string column, MemberInfo[] members, Casing casing = Casing.Default)
+        {
+            var locator = new StringBuilder(column);
+            var depth = 1;
+            foreach (var memberInfo in members)
+            {
+                locator.Append(depth == members.Length ? " ->> " : " -> ");
+                locator.Append($"'{memberInfo.Name.FormatCase(casing)}'");
+                depth++;
+            }
+            return locator.ToString();
+        }
+
+        public static string BuildJsonObjectLocator(string column, MemberInfo[] members, Casing casing = Casing.Default)
+        {
+            var locator = new StringBuilder(column);
+            foreach (var memberInfo in members)
+            {
+                locator.Append($" -> '{memberInfo.Name.FormatCase(casing)}'");
+            }
+            return locator.ToString();
+        }
+
         public static NpgsqlCommand BuildCommand(Action<CommandBuilder> configure)
         {
             var cmd = new NpgsqlCommand();
@@ -99,28 +122,12 @@ namespace Marten.Util
 
         public void AppendPathToObject(MemberInfo[] members, string column)
         {
-            _sql.Append(column);
-            _sql.Append(" -> ");
-
-            _sql.Append($"{ members.Select(x => $"'{x.Name}'").Join(" -> ")}");
+            _sql.Append(BuildJsonObjectLocator(column, members));
         }
 
         public void AppendPathToValue(MemberInfo[] members, string column)
         {
-            _sql.Append(column);
-            if (members.Length == 1)
-            {
-                _sql.Append($" ->> '{members.Single().Name}'");
-            }
-            else
-            {
-                for (int i = 0; i < members.Length - 1; i++)
-                {
-                    _sql.Append($" -> '{members[i].Name}'");
-                }
-
-                _sql.Append($" ->> '{members.Last().Name}'");
-            }
+            _sql.Append(BuildJsonStringLocator(column, members));
         }
 
         public override string ToString()

--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -310,6 +310,18 @@ namespace Marten.Util
             return ResolvePgType(memberType) != null || memberType.IsEnum;
         }
 
+        [Obsolete("Use JsonLocatorField to build locators with appropriate casting.  This might be removed in v4.0.")]
+        public static string ApplyCastToLocator(this string locator, EnumStorage enumStyle, Type memberType)
+        {
+            if (memberType.IsEnum)
+            {
+                return enumStyle == EnumStorage.AsInteger ? "({0})::int".ToFormat(locator) : locator;
+            }
+
+            // Treat "unknown" PgTypes as jsonb (this way null checks of arbitary depth won't fail on cast).
+            return "CAST({0} as {1})".ToFormat(locator, GetPgType(memberType, enumStyle));
+        }
+
         private static Type GetNullableType(Type type)
         {
             type = Nullable.GetUnderlyingType(type) ?? type;

--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -310,17 +310,6 @@ namespace Marten.Util
             return ResolvePgType(memberType) != null || memberType.IsEnum;
         }
 
-        public static string ApplyCastToLocator(this string locator, EnumStorage enumStyle, Type memberType)
-        {
-            if (memberType.IsEnum)
-            {
-                return enumStyle == EnumStorage.AsInteger ? "({0})::int".ToFormat(locator) : locator;
-            }
-
-            // Treat "unknown" PgTypes as jsonb (this way null checks of arbitary depth won't fail on cast).
-            return "CAST({0} as {1})".ToFormat(locator, GetPgType(memberType, enumStyle));
-        }
-
         private static Type GetNullableType(Type type)
         {
             type = Nullable.GetUnderlyingType(type) ?? type;


### PR DESCRIPTION
This required changes the JsonLocatorField constructors so the generated locators were consistent regardless of field depth.

Before this change, an array would change casting behavior depending on depth: 

```
public class T
{
    public String[] MyArray { get; set; }
    public T Inner { get; set; }
}
```
 `CAST(d.data ->> 'MyArray' as jsonb)`
vs
 `CAST(d.data -> 'Inner' ->> 'MyArray' as varchar[])`
 
I'm still unclear why arrays as top level properties were always being cast to jsonb, but I left it that way. 