### PR TITLE
Updated minimum version of Npgsql to 4.0.9 based on the users feedback

### DIFF
--- a/martenbuild.cs
+++ b/martenbuild.cs
@@ -8,7 +8,7 @@ namespace martenbuild
 {
     internal class MartenBuild
     {
-        private const string BUILD_VERSION = "3.8.1";
+        private const string BUILD_VERSION = "3.8.2";
 
         private static void Main(string[] args)
         {

--- a/src/Marten.CommandLine/Marten.CommandLine.csproj
+++ b/src/Marten.CommandLine/Marten.CommandLine.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Description>Command line tooling for managing Marten development</Description>
-        <VersionPrefix>3.8.1</VersionPrefix>
+        <VersionPrefix>3.8.2</VersionPrefix>
         <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
         <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
         <AssemblyName>Marten.CommandLine</AssemblyName>

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Postgresql as a Document Db and Event Store for .Net Development</Description>
-        <VersionPrefix>1.3.1</VersionPrefix>
+        <VersionPrefix>1.3.2</VersionPrefix>
         <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
         <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>Marten.NodaTime</AssemblyName>
@@ -37,7 +37,11 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="2.2.0" />
+<<<<<<< .mine
+        <PackageReference Include="Npgsql.NodaTime" Version="[4.0.9,4.1)" />
+=======
         <PackageReference Include="Npgsql.NodaTime" Version="[4.0.4,4.1)" />
+>>>>>>> .theirs
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -37,11 +37,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="2.2.0" />
-<<<<<<< .mine
         <PackageReference Include="Npgsql.NodaTime" Version="[4.0.9,4.1)" />
-=======
-        <PackageReference Include="Npgsql.NodaTime" Version="[4.0.4,4.1)" />
->>>>>>> .theirs
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -37,8 +37,8 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-        <PackageReference Include="Npgsql" Version="[4.0.4,4.1)" />
-        <PackageReference Include="Npgsql.Json.NET" Version="[4.0.4,4.1)" />
+        <PackageReference Include="Npgsql" Version="[4.0.9,4.1)" />
+        <PackageReference Include="Npgsql.Json.NET" Version="[4.0.9,4.1)" />
         <PackageReference Include="Remotion.Linq" Version="2.2.0" />
         <PackageReference Include="Baseline" Version="1.5.0" />
         <PackageReference Include="System.Memory" Version="4.5.3" />


### PR DESCRIPTION
Because the version of the Npgsql was lowered to `4.0.4` then users without doing a cleanup might have failed first build with cached nugets.
Raised the version to limit such issues.