### PR TITLE
Allow case invariance for netcore apps

### DIFF
--- a/src/Marten.Testing/Linq/InvariantCultureIgnoreCase_filtering.cs
+++ b/src/Marten.Testing/Linq/InvariantCultureIgnoreCase_filtering.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+using Marten.Testing.Documents;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Linq
+{
+    public class InvariantCultureIgnoreCase_filtering: IntegratedFixture
+    {
+        [Fact]
+        public void can_search_case_insensitive()
+        {
+            var user = new User {UserName = "TEST_USER"};
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(user);
+                session.SaveChanges();
+            }
+
+            using (var query = theStore.QuerySession())
+            {
+                query.Query<User>().Single(x => x.UserName.Equals("test_user", StringComparison.InvariantCultureIgnoreCase)).Id.ShouldBe(user.Id);
+            }
+        }
+    }
+}

--- a/src/Marten/Linq/Parsing/StringComparisonParser.cs
+++ b/src/Marten/Linq/Parsing/StringComparisonParser.cs
@@ -52,7 +52,7 @@ namespace Marten.Linq.Parsing
             var comparison = expression.Arguments.OfType<ConstantExpression>().Where(a => a.Type == typeof(StringComparison)).Select(c => (StringComparison)c.Value).FirstOrDefault();
 
             var ignoreCaseComparisons = new[] { StringComparison.CurrentCultureIgnoreCase,
-#if NET46
+#if (NET46 || NETCOREAPP)
                 StringComparison.InvariantCultureIgnoreCase,
 #endif
                 StringComparison.OrdinalIgnoreCase };

--- a/src/Marten/Linq/Parsing/StringComparisonParser.cs
+++ b/src/Marten/Linq/Parsing/StringComparisonParser.cs
@@ -52,9 +52,7 @@ namespace Marten.Linq.Parsing
             var comparison = expression.Arguments.OfType<ConstantExpression>().Where(a => a.Type == typeof(StringComparison)).Select(c => (StringComparison)c.Value).FirstOrDefault();
 
             var ignoreCaseComparisons = new[] { StringComparison.CurrentCultureIgnoreCase,
-#if (NET46 || NETCOREAPP)
                 StringComparison.InvariantCultureIgnoreCase,
-#endif
                 StringComparison.OrdinalIgnoreCase };
             if (ignoreCaseComparisons.Contains(comparison))
                 return true;


### PR DESCRIPTION
We just ran into an issue where `StringComparison.InvariantCultureIgnoreCase` was not being applied to queries in our netcore 2.2 app. This should make query case invariance work as expected for netcore apps.

I was unable to divine the intend behind the `#if NET46` directive - I really wanted to just delete it entirely, but I'm sure it's allowing for some other edge case somewhere.