### PR TITLE
Issue #1346 - Add ability to project document metadata to document properties

### DIFF
--- a/src/Marten.Testing/Acceptance/assigning_versions_to_documents.cs
+++ b/src/Marten.Testing/Acceptance/assigning_versions_to_documents.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Marten.Schema;
 using Marten.Services;
@@ -261,6 +262,11 @@ namespace Marten.Testing.Acceptance
             {
                 doc.Version.ShouldNotBe(Guid.Empty);
             }
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Query<AttVersionedDoc>().Where(d => d.Version != Guid.Empty).Count().ShouldBe(100);
+            }
         }
 
         [Fact]
@@ -277,6 +283,11 @@ namespace Marten.Testing.Acceptance
             foreach (var doc in docs)
             {
                 doc.Version.ShouldNotBe(Guid.Empty);
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Query<PropVersionedDoc>().Where(d => d.Version != Guid.Empty).Count().ShouldBe(100);
             }
         }
     }

--- a/src/Marten.Testing/Acceptance/projecting_metadata_to_documents.cs
+++ b/src/Marten.Testing/Acceptance/projecting_metadata_to_documents.cs
@@ -1,0 +1,420 @@
+using Marten.Schema;
+using Marten.Linq.SoftDeletes;
+using Shouldly;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Marten.Testing.Acceptance
+{
+    public class projecting_metadata_to_documents_schema_tests
+    {
+        [Fact]
+        public void set_the_metadata_projections_through_the_fluent_interface()
+        {
+            using (var store = TestingDocumentStore.For(_ =>
+            {
+                _.Schema.For<DocWithMeta>().VersionedWith(x => x.Version);
+                _.Schema.For<DocWithMeta>().MapLastModifiedTo(x => x.LastModified);
+                _.Schema.For<DocWithMeta>().MapIsSoftDeletedTo(x => x.Deleted);
+                _.Schema.For<DocWithMeta>().MapSoftDeletedAtTo(x => x.DeletedAt);
+                _.Schema.For<DocWithMeta>().MapDotNetTypeTo(x => x.DotNetType);
+                _.Schema.For<DocWithMeta>().SoftDeleted();
+            }))
+            {
+                store.Storage.MappingFor(typeof(DocWithMeta))
+                    .VersionMember.Name.ShouldBe(nameof(DocWithMeta.Version));
+
+                store.Storage.MappingFor(typeof(DocWithMeta))
+                    .LastModifiedMember.Name.ShouldBe(nameof(DocWithMeta.LastModified));
+
+                store.Storage.MappingFor(typeof(DocWithMeta))
+                    .IsSoftDeletedMember.Name.ShouldBe(nameof(DocWithMeta.Deleted));
+
+                store.Storage.MappingFor(typeof(DocWithMeta))
+                    .SoftDeletedAtMember.Name.ShouldBe(nameof(DocWithMeta.DeletedAt));
+
+                store.Storage.MappingFor(typeof(DocWithMeta))
+                    .DotNetTypeMember.Name.ShouldBe(nameof(DocWithMeta.DotNetType));
+            }
+        }
+
+        [Fact]
+        public void set_the_metadata_projections_via_attributes()
+        {
+            using (var store = TestingDocumentStore.For(_ =>
+            {
+
+            }))
+            {
+                store.Storage.MappingFor(typeof(DocWithAttributeMeta))
+                    .VersionMember.Name.ShouldBe(nameof(DocWithAttributeMeta.Version));
+
+                store.Storage.MappingFor(typeof(DocWithAttributeMeta))
+                    .LastModifiedMember.Name.ShouldBe(nameof(DocWithAttributeMeta.LastModified));
+
+                store.Storage.MappingFor(typeof(DocWithAttributeMeta))
+                    .DotNetTypeMember.Name.ShouldBe(nameof(DocWithAttributeMeta.DotNetType));
+            }
+
+        }
+    }
+
+    public class projecting_metadata_end_to_end_tests: IntegratedFixture
+    {
+        [Fact]
+        public void doc_has_projected_data_after_storage()
+        {
+            StoreOptions(c =>
+            {
+                c.Schema.For<DocWithMeta>()
+                .MapDotNetTypeTo(x => x.DotNetType)
+                .MapLastModifiedTo(x => x.LastModified);
+            });
+
+            var doc = new DocWithMeta();
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(doc);
+                session.MetadataFor(doc).ShouldBeNull();
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                var loaded = session.Load<DocWithMeta>(doc.Id);
+                loaded.LastModified.ShouldNotBe(DateTime.MinValue);
+                loaded.DotNetType.ShouldBe(typeof(DocWithMeta).FullName);
+            }
+        }
+
+        [Fact]
+        public void doc_metadata_is_read_only_on_store()
+        {
+            var doc = new DocWithAttributeMeta();
+
+            using (var session = theStore.OpenSession())
+            {
+                doc.DotNetType = "my dotnet type";
+                doc.LastModified = DateTime.UtcNow.AddYears(-1);
+                doc.Version = Guid.Empty;
+                session.Store(doc);
+                session.MetadataFor(doc).ShouldBeNull();
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                var loaded = session.Load<DocWithAttributeMeta>(doc.Id);
+                loaded.DotNetType.ShouldBe(typeof(DocWithAttributeMeta).FullName);
+                loaded.DocType.ShouldBeNull();
+                loaded.TenantId.ShouldBeNull();
+                (DateTime.UtcNow - loaded.LastModified.ToUniversalTime()).ShouldBeLessThan(TimeSpan.FromMinutes(1));
+                loaded.Deleted.ShouldBeFalse();
+                loaded.DeletedAt.ShouldBeNull();
+                loaded.Version.ShouldNotBe(Guid.Empty);
+            }
+        }
+
+        [Fact]
+        public void doc_metadata_is_read_only_on_update()
+        {
+            var doc = new DocWithAttributeMeta();
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(doc);
+                session.MetadataFor(doc).ShouldBeNull();
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                var loaded = session.Load<DocWithAttributeMeta>(doc.Id);
+                loaded.DotNetType = "my type, not yours";
+                session.Store(loaded);
+                Should.Throw<InvalidOperationException>(() => session.SaveChanges());
+            }
+        }
+
+        [Fact]
+        public void doc_metadata_is_mapped_for_query_includes()
+        {
+            StoreOptions(c =>
+            {
+                c.Schema.For<DocWithMeta>()
+                .MapDotNetTypeTo(x => x.DotNetType)
+                .MapLastModifiedTo(x => x.LastModified);
+            });
+
+            var include = new IncludedDocWithMeta();
+            var doc = new DocWithMeta();
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(include);
+                doc.IncludedDocId = include.Id;
+                session.Store(doc);
+                session.MetadataFor(include).ShouldBeNull();
+                session.MetadataFor(doc).ShouldBeNull();
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                IncludedDocWithMeta loadedInclude = null;
+                var loaded = session.Query<DocWithMeta>().Include<IncludedDocWithMeta>(d => d.IncludedDocId, i => loadedInclude = i).Single(d => d.Id == doc.Id);
+
+                loaded.ShouldNotBeNull();
+                loaded.DotNetType.ShouldBe(typeof(DocWithMeta).FullName);
+
+                loadedInclude.ShouldNotBeNull();
+                loadedInclude.DotNetType.ShouldBe(typeof(IncludedDocWithMeta).FullName);
+                loadedInclude.Version.ShouldNotBe(Guid.Empty);
+            }
+        }
+
+        [Fact]
+        public void doc_metadata_is_updated_for_user_supplied_query()
+        {
+            StoreOptions(c =>
+            {
+                c.Schema.For<DocWithMeta>()
+                .MapDotNetTypeTo(x => x.DotNetType)
+                .MapLastModifiedTo(x => x.LastModified);
+            });
+
+            var doc = new DocWithMeta();
+            var lastMod = DateTime.UtcNow;
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(doc);
+                session.MetadataFor(doc).ShouldBeNull();
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                var userQuery = session.Query<DocWithMeta>($"where data ->> 'Id' = '{doc.Id.ToString()}'").Single();
+                userQuery.Description = "updated via a user SQL query";
+                userQuery.LastModified.ShouldBeGreaterThanOrEqualTo(lastMod);
+                lastMod = userQuery.LastModified;
+                session.Store(userQuery);
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                var userQuery = session.Query<DocWithMeta>($"where data ->> 'Id' = '{doc.Id.ToString()}'").Single();
+                userQuery.LastModified.ShouldBeGreaterThanOrEqualTo(lastMod);
+            }
+        }
+
+        [Fact]
+        public async Task doc_metadata_is_mapped_for_conjoined_tenant()
+        {
+            StoreOptions(c =>
+            {
+                c.Schema.For<DocWithMeta>()
+                .MultiTenanted()
+                .MapTenantIdTo(x => x.TenantId)
+                .MapDotNetTypeTo(x => x.DotNetType)
+                .MapLastModifiedTo(x => x.LastModified);
+            });
+
+            var doc = new DocWithMeta();
+            var tenant = "TENANT_A";
+
+            using (var session = theStore.OpenSession(tenant))
+            {
+                doc.DotNetType = "my dotnet type";
+                doc.LastModified = DateTime.UtcNow.AddYears(-1);
+                session.Store(doc);
+                session.MetadataFor(doc).ShouldBeNull();
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession(tenant))
+            {
+                session.Query<DocWithMeta>().Where(d => d.TenantId == tenant).Count().ShouldBe(1);
+
+                var loaded = await session.Query<DocWithMeta>().Where(d => d.Id == doc.Id).FirstOrDefaultAsync();
+                loaded.DotNetType.ShouldBe(typeof(DocWithMeta).FullName);
+                loaded.TenantId.ShouldBe(tenant);
+                (DateTime.UtcNow - loaded.LastModified.ToUniversalTime()).ShouldBeLessThan(TimeSpan.FromMinutes(1));
+            }
+        }
+
+        [Fact]
+        public void doc_metadata_is_mapped_for_structural_typed_docs()
+        {
+            StoreOptions(c =>
+            {
+                c.Schema.For<DocWithMeta>()
+                .MapDotNetTypeTo(x => x.DotNetType)
+                .MapLastModifiedTo(x => x.LastModified);
+            });
+
+            var bigDoc = new DocWithMeta();
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Store(bigDoc);
+                session.SaveChanges();
+
+                var slimDoc = session.Load<StructuralTypes.DocWithMeta>(bigDoc.Id);
+                slimDoc.DotNetType.ShouldBe(bigDoc.DotNetType);
+                slimDoc.LastModified.ShouldNotBe(default(DateTime));
+                slimDoc.LastModified.ShouldBe(bigDoc.LastModified);
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Query<DocWithMeta>().Where(d => d.DotNetType == typeof(DocWithMeta).FullName).Count().ShouldBe(1);
+
+                var slimDoc = session.Load<StructuralTypes.DocWithMeta>(bigDoc.Id);
+                slimDoc.DotNetType.ShouldBe(bigDoc.DotNetType);
+                slimDoc.LastModified.ShouldNotBe(default(DateTime));
+                slimDoc.LastModified.ShouldBe(bigDoc.LastModified);
+            }
+        }
+
+        [Fact]
+        public void doc_metadata_is_mapped_for_doc_hierarchies()
+        {
+            StoreOptions(c =>
+            {
+                c.Schema.For<DocWithMeta>()
+                .AddSubClassHierarchy(typeof(RedDocWithMeta), typeof(BlueDocWithMeta), typeof(GreenDocWithMeta), typeof(EmeraldGreenDocWithMeta))
+                .SoftDeleted()
+                .MapIsSoftDeletedTo(x => x.Deleted)
+                .MapSoftDeletedAtTo(x => x.DeletedAt)
+                .MapDocumentTypeTo(x => x.DocType)
+                .MapDotNetTypeTo(x => x.DotNetType);
+            });
+
+            using (var session = theStore.OpenSession())
+            {
+                var doc = new DocWithMeta { Description = "transparent" };
+                var red = new RedDocWithMeta { Description = "red doc" };
+                var green = new GreenDocWithMeta { Description = "green doc" };
+                var blue = new BlueDocWithMeta { Description = "blue doc" };
+                var emerald = new EmeraldGreenDocWithMeta { Description = "emerald doc" };
+
+                session.Store(doc, red, green, blue, emerald);
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Query<DocWithMeta>().Count(d => d.DocType == "BASE").ShouldBe(1);
+                session.Query<DocWithMeta>().Count(d => d.DocType == "blue_doc_with_meta").ShouldBe(1);
+                session.Query<DocWithMeta>().Count(d => d.DocType == "red_doc_with_meta").ShouldBe(1);
+                session.Query<DocWithMeta>().Count(d => d.DocType == "green_doc_with_meta").ShouldBe(1);
+                session.Query<DocWithMeta>().Count(d => d.DocType == "emerald_green_doc_with_meta").ShouldBe(1);
+
+                var docs = session.Query<DocWithMeta>().ToList();
+                docs.Count.ShouldBe(5);
+                docs.Count(d => d.DotNetType == typeof(BlueDocWithMeta).FullName).ShouldBe(1);
+                docs.Count(d => d.DotNetType == typeof(GreenDocWithMeta).FullName).ShouldBe(1);
+                docs.Count(d => d.DotNetType == typeof(EmeraldGreenDocWithMeta).FullName).ShouldBe(1);
+
+                var redDocs = session.Query<RedDocWithMeta>().ToList();
+                redDocs.Count.ShouldBe(1);
+                redDocs.First().DocType.ShouldBe("red_doc_with_meta");
+                session.Delete(redDocs.First());
+
+                var baseName = typeof(DocWithMeta).FullName;
+                var baseDoc = session.Query<DocWithMeta>().Where(d => d.DotNetType == baseName).Single();
+                session.Delete(baseDoc);
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Query<DocWithMeta>().Count(d => d.Deleted && d.MaybeDeleted()).ShouldBe(2);
+                session.Query<RedDocWithMeta>().Count(d => d.Deleted && d.MaybeDeleted()).ShouldBe(1);
+
+                var allDocs = session.Query<DocWithMeta>().Where(x => x.MaybeDeleted()).ToList();
+                allDocs.Count.ShouldBe(5);
+                allDocs.Count(d => d.Deleted).ShouldBe(2);
+                var deletedDocs = session.Query<DocWithMeta>().Where(x => x.IsDeleted()).ToList();
+                deletedDocs.ShouldAllBe(d => d.Deleted);
+                deletedDocs.ShouldAllBe(d => d.DeletedAt != null);
+            }
+        }
+    }
+    internal class DocWithMeta
+    {
+        public Guid Id { get; set; }
+        public string Description { get; set; }
+        public Guid Version { get; set; }
+        public DateTime LastModified { get; set; }
+        public string TenantId { get; private set; }
+        public bool Deleted { get; private set; }
+        public DateTime? DeletedAt { get; private set; }
+        public string DocType { get; private set; }
+        public string DotNetType { get; set; }
+        public Guid IncludedDocId { get; set; }
+    }
+
+    internal class RedDocWithMeta: DocWithMeta
+    {
+        public int RedHue { get; set; }
+    }
+
+    internal class BlueDocWithMeta: DocWithMeta
+    {
+        public int BlueHue { get; set; }
+    }
+
+    internal class GreenDocWithMeta: DocWithMeta
+    {
+        public int GreenHue { get; set; }
+    }
+
+    internal class EmeraldGreenDocWithMeta: GreenDocWithMeta
+    {
+        public string Label { get; set; }
+    }
+
+    internal class IncludedDocWithMeta
+    {
+        public Guid Id { get; set; }
+        [Version]
+        public Guid Version { get; private set; }
+        public DateTime LastModified { get; private set; }
+        [DotNetTypeMetadata]
+        public string DotNetType { get; private set; }
+    }
+
+    internal class DocWithAttributeMeta
+    {
+        public Guid Id { get; set; }
+        public string TenantId { get; private set; }
+        public string DocType { get; private set; }
+        public bool Deleted { get; private set; }
+        public DateTime? DeletedAt { get; private set; }
+        [Version]
+        public Guid Version { get; set; }
+        [LastModifiedMetadata]
+        public DateTime LastModified { get; set; }
+        [DotNetTypeMetadata]
+        public string DotNetType { get; set; }
+    }
+}
+
+namespace Marten.Testing.Acceptance.StructuralTypes
+{
+    [StructuralTyped]
+    internal class DocWithMeta
+    {
+        public Guid Id { get; set; }
+        public DateTime LastModified { get; set; }
+        public string DocType { get; private set; }
+        public string DotNetType { get; set; }
+    }
+}

--- a/src/Marten.Testing/Acceptance/soft_deletes.cs
+++ b/src/Marten.Testing/Acceptance/soft_deletes.cs
@@ -16,7 +16,7 @@ namespace Marten.Testing.Acceptance
             StoreOptions(_ =>
             {
                 _.Schema.For<User>().SoftDeletedWithIndex();
-                _.Schema.For<File>().SoftDeleted();
+                _.Schema.For<File>().SoftDeleted().MapIsSoftDeletedTo(x => x.Deleted).MapSoftDeletedAtTo(x => x.DeletedAt);
             });
         }
 
@@ -425,6 +425,8 @@ namespace Marten.Testing.Acceptance
             public Guid Id { get; set; } = Guid.NewGuid();
             public Guid UserId { get; set; }
             public string Path { get; set; }
+            public bool Deleted { get; set; }
+            public DateTime? DeletedAt { get; set; }
         }
     }
 }

--- a/src/Marten.Testing/Bugs/Bug_337_certain_boolean_searches_are_not_using_searchable_field.cs
+++ b/src/Marten.Testing/Bugs/Bug_337_certain_boolean_searches_are_not_using_searchable_field.cs
@@ -20,8 +20,8 @@ namespace Marten.Testing.Bugs
 
                 var cmd2 = session.Query<Target>().Where(x => !x.Flag).ToCommand();
 
-                cmd1.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d where d.flag = :arg0");
-                cmd2.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d where (d.flag IS NULL or d.flag != :arg0)");
+                cmd1.CommandText.ShouldBe("select d.data, d.id, d.mt_version, d.mt_last_modified, d.mt_dotnet_type from public.mt_doc_target as d where d.flag = :arg0");
+                cmd2.CommandText.ShouldBe("select d.data, d.id, d.mt_version, d.mt_last_modified, d.mt_dotnet_type from public.mt_doc_target as d where (d.flag IS NULL or d.flag != :arg0)");
             }
         }
 
@@ -38,7 +38,7 @@ namespace Marten.Testing.Bugs
             {
                 var cmd1 = session.Query<Target>().Where(x => x.Flag == false).ToCommand();
 
-                cmd1.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d where d.data @> :arg0");
+                cmd1.CommandText.ShouldBe("select d.data, d.id, d.mt_version, d.mt_last_modified, d.mt_dotnet_type from public.mt_doc_target as d where d.data @> :arg0");
             }
         }
     }

--- a/src/Marten.Testing/Linq/Compiled/compiled_query_Tests.cs
+++ b/src/Marten.Testing/Linq/Compiled/compiled_query_Tests.cs
@@ -33,7 +33,7 @@ namespace Marten.Testing.Linq.Compiled
         {
             var cmd = theStore.Diagnostics.PreviewCommand(new UserByUsername { UserName = "hank" });
 
-            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_user as d where d.data ->> 'UserName' = :arg0 LIMIT 1");
+            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version, d.mt_last_modified, d.mt_dotnet_type from public.mt_doc_user as d where d.data ->> 'UserName' = :arg0 LIMIT 1");
 
             cmd.Parameters.Single().Value.ShouldBe("hank");
         }

--- a/src/Marten.Testing/Linq/WholeDocumentSelectorTests.cs
+++ b/src/Marten.Testing/Linq/WholeDocumentSelectorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data.Common;
 using System.Diagnostics;
 using Marten.Linq;
@@ -26,7 +26,7 @@ namespace Marten.Testing.Linq
         [Fact]
         public void the_selected_fields()
         {
-            theSelector.SelectFields().ShouldHaveTheSameElementsAs("d.data", "d.id", "d.mt_version");
+            theSelector.SelectFields().ShouldHaveTheSameElementsAs("d.data", "d.id", "d.mt_version", "d.mt_last_modified", "d.mt_dotnet_type");
         }
 
         [Fact]

--- a/src/Marten.Testing/Linq/previewing_the_command_from_a_queryable_Tests.cs
+++ b/src/Marten.Testing/Linq/previewing_the_command_from_a_queryable_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Marten.Linq;
 using Marten.Services;
 using Shouldly;
@@ -14,7 +14,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().ToCommand(FetchType.FetchMany);
 
-            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d");
+            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version, d.mt_last_modified, d.mt_dotnet_type from public.mt_doc_target as d");
             cmd.Parameters.Any().ShouldBeFalse();
         }
 
@@ -23,7 +23,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().Where(x => x.Number == 3 && x.Double > 2).ToCommand(FetchType.FetchMany);
 
-            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d where (CAST(d.data ->> 'Number' as integer) = :arg0 and CAST(d.data ->> 'Double' as double precision) > :arg1)");
+            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version, d.mt_last_modified, d.mt_dotnet_type from public.mt_doc_target as d where (CAST(d.data ->> 'Number' as integer) = :arg0 and CAST(d.data ->> 'Double' as double precision) > :arg1)");
 
             cmd.Parameters.Count.ShouldBe(2);
             cmd.Parameters["arg0"].Value.ShouldBe(3);
@@ -51,7 +51,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().OrderBy(x => x.Double).ToCommand(FetchType.FetchOne);
 
-            cmd.CommandText.Trim().ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d order by CAST(d.data ->> 'Double' as double precision) LIMIT 1");
+            cmd.CommandText.Trim().ShouldBe("select d.data, d.id, d.mt_version, d.mt_last_modified, d.mt_dotnet_type from public.mt_doc_target as d order by CAST(d.data ->> 'Double' as double precision) LIMIT 1");
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace Marten.Testing.Linq
             var tags = new[] { "ONE", "TWO" };
             var cmd = theSession.Query<Target>().Where(x => x.TagsArray.Any(t => tags.Contains(t))).ToCommand(FetchType.FetchMany);
 
-            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d where CAST(d.data ->> 'TagsArray' as jsonb) ?| :arg0");
+            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version, d.mt_last_modified, d.mt_dotnet_type from public.mt_doc_target as d where CAST(d.data ->> 'TagsArray' as jsonb) ?| :arg0");
             cmd.Parameters["arg0"].Value.ShouldBe(tags);
         }
 
@@ -70,7 +70,7 @@ namespace Marten.Testing.Linq
             var tags = new[] { "ONE", "TWO" };
             var cmd = theSession.Query<Target>().Where(x => x.Inner.TagsArray.Any(t => tags.Contains(t))).ToCommand(FetchType.FetchMany);
 
-            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version from public.mt_doc_target as d where CAST(d.data -> 'Inner' ->> 'TagsArray' as jsonb) ?| :arg0");
+            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version, d.mt_last_modified, d.mt_dotnet_type from public.mt_doc_target as d where CAST(d.data -> 'Inner' ->> 'TagsArray' as jsonb) ?| :arg0");
             cmd.Parameters["arg0"].Value.ShouldBe(tags);
         }
     }
@@ -87,7 +87,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().ToCommand(FetchType.FetchMany);
 
-            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version from other.mt_doc_target as d");
+            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version, d.mt_last_modified, d.mt_dotnet_type from other.mt_doc_target as d");
             cmd.Parameters.Any().ShouldBeFalse();
         }
 
@@ -96,7 +96,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().Where(x => x.Number == 3 && x.Double > 2).ToCommand(FetchType.FetchMany);
 
-            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version from other.mt_doc_target as d where (CAST(d.data ->> 'Number' as integer) = :arg0 and CAST(d.data ->> 'Double' as double precision) > :arg1)");
+            cmd.CommandText.ShouldBe("select d.data, d.id, d.mt_version, d.mt_last_modified, d.mt_dotnet_type from other.mt_doc_target as d where (CAST(d.data ->> 'Number' as integer) = :arg0 and CAST(d.data ->> 'Double' as double precision) > :arg1)");
 
             cmd.Parameters.Count.ShouldBe(2);
             cmd.Parameters["arg0"].Value.ShouldBe(3);
@@ -124,7 +124,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().OrderBy(x => x.Double).ToCommand(FetchType.FetchOne);
 
-            cmd.CommandText.Trim().ShouldBe("select d.data, d.id, d.mt_version from other.mt_doc_target as d order by CAST(d.data ->> 'Double' as double precision) LIMIT 1");
+            cmd.CommandText.Trim().ShouldBe("select d.data, d.id, d.mt_version, d.mt_last_modified, d.mt_dotnet_type from other.mt_doc_target as d order by CAST(d.data ->> 'Double' as double precision) LIMIT 1");
         }
     }
 }

--- a/src/Marten.Testing/Schema/DocumentMappingTests.cs
+++ b/src/Marten.Testing/Schema/DocumentMappingTests.cs
@@ -511,7 +511,7 @@ namespace Marten.Testing.Schema
         public void select_fields_for_non_hierarchy_mapping()
         {
             var mapping = DocumentMapping.For<User>();
-            mapping.SelectFields().ShouldHaveTheSameElementsAs("data", "id", DocumentMapping.VersionColumn);
+            mapping.SelectFields().ShouldHaveTheSameElementsAs("data", "id", DocumentMapping.VersionColumn, DocumentMapping.LastModifiedColumn, DocumentMapping.DotNetTypeColumn);
         }
 
         [Fact]
@@ -522,14 +522,14 @@ namespace Marten.Testing.Schema
 
             mapping.SelectFields()
                 .ShouldHaveTheSameElementsAs("data", "id", DocumentMapping.DocumentTypeColumn,
-                    DocumentMapping.VersionColumn);
+                    DocumentMapping.VersionColumn, DocumentMapping.LastModifiedColumn, DocumentMapping.DotNetTypeColumn);
         }
 
         [Fact]
         public void select_fields_without_subclasses()
         {
             var mapping = DocumentMapping.For<User>();
-            mapping.SelectFields().ShouldHaveTheSameElementsAs("data", "id", DocumentMapping.VersionColumn);
+            mapping.SelectFields().ShouldHaveTheSameElementsAs("data", "id", DocumentMapping.VersionColumn, DocumentMapping.LastModifiedColumn, DocumentMapping.DotNetTypeColumn);
         }
 
         [Fact]

--- a/src/Marten.Testing/Services/Includes/IncludeSelectorTests.cs
+++ b/src/Marten.Testing/Services/Includes/IncludeSelectorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data.Common;
 using Marten.Linq;
 using Marten.Schema;
@@ -38,7 +38,7 @@ namespace Marten.Testing.Services.Includes
         [Fact]
         public void select_fields_has_both_the_inner_and_outer_fields()
         {
-            theSelector.SelectFields().ShouldHaveTheSameElementsAs("a", "b", "c", "foo.data", "foo.id", "foo.mt_version");
+            theSelector.SelectFields().ShouldHaveTheSameElementsAs("a", "b", "c", "foo.data", "foo.id", "foo.mt_version", "foo.mt_last_modified", "foo.mt_dotnet_type");
         }
 
         [Fact]

--- a/src/Marten.Testing/StoreOptionsTests.cs
+++ b/src/Marten.Testing/StoreOptionsTests.cs
@@ -149,6 +149,11 @@ namespace Marten.Testing
                 throw new NotImplementedException();
             }
 
+            public void RegisterUpdate(string tenantIdOverride, UpdateStyle updateStyle, UpdateBatch batch, object entity, Type entityType)
+            {
+                throw new NotImplementedException();
+            }
+
             public void Remove(IIdentityMap map, object entity)
             {
                 throw new NotImplementedException();
@@ -218,6 +223,11 @@ namespace Marten.Testing
             }
 
             public void RegisterUpdate(string tenantIdOverride, UpdateStyle updateStyle, UpdateBatch batch, object entity, string json)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void RegisterUpdate(string tenantIdOverride, UpdateStyle updateStyle, UpdateBatch batch, object entity, Type entityType)
             {
                 throw new NotImplementedException();
             }

--- a/src/Marten/DocumentSession.cs
+++ b/src/Marten/DocumentSession.cs
@@ -308,7 +308,7 @@ namespace Marten
                 listener.BeforeSaveChanges(this);
             }
 
-            var batch = new UpdateBatch(_store, _connection, IdentityMap.Versions, WriterPool, Tenant, Concurrency);
+            var batch = new UpdateBatch(_store, _connection, IdentityMap.Versions, WriterPool, Tenant, Concurrency, IdentityMap.MetadataCache);
             var changes = _unitOfWork.ApplyChanges(batch);
             EjectPatchedTypes(changes);
 
@@ -350,7 +350,7 @@ namespace Marten
                 await listener.BeforeSaveChangesAsync(this, token).ConfigureAwait(false);
             }
 
-            var batch = new UpdateBatch(_store, _connection, IdentityMap.Versions, WriterPool, Tenant, Concurrency);
+            var batch = new UpdateBatch(_store, _connection, IdentityMap.Versions, WriterPool, Tenant, Concurrency, IdentityMap.MetadataCache);
             var changes = await _unitOfWork.ApplyChangesAsync(batch, token).ConfigureAwait(false);
             EjectPatchedTypes(changes);
 

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -135,6 +135,11 @@ namespace Marten.Events
             // Do nothing
         }
 
+        public void RegisterUpdate(string tenantIdOverride, UpdateStyle updateStyle, UpdateBatch batch, object entity, Type entityType)
+        {
+            // Do nothing
+        }
+
         public void Remove(IIdentityMap map, object entity)
         {
             throw new InvalidOperationException("Use IDocumentSession.Events for all persistence of IEvent objects");

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -258,6 +258,16 @@ namespace Marten
         /// <returns></returns>
         Guid? VersionFor<TDoc>(TDoc entity);
 
+
+        /// <summary>
+        /// Retrieve the current metadata for the given document using
+        /// the cached value in the IIdentityMap if available.
+        /// </summary>
+        /// <typeparam name="TDoc"></typeparam>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        DocumentMetadata MetadataFor<TDoc>(TDoc entity);
+
         /// <summary>
         /// Performs a full text search against <typeparamref name="TDoc"/>
         /// </summary>

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -478,9 +478,115 @@ namespace Marten
                 return this;
             }
 
+            /// <summary>
+            /// Copy the document version metadata to the selected member
+            /// </summary>
+            /// <param name="memberExpression"></param>
+            /// <returns></returns>
             public DocumentMappingExpression<T> VersionedWith(Expression<Func<T, Guid>> memberExpression)
             {
-                alter = m => m.VersionMember = FindMembers.Determine(memberExpression).Single();
+                var members = FindMembers.Determine(memberExpression);
+                if (members.Length > 1)
+                {
+                    throw new ArgumentException($"The {nameof(VersionedWith)} member cannot be a nested property.", nameof(memberExpression));
+                }
+                alter = m => m.VersionMember = members.First();
+                return this;
+            }
+
+            /// <summary>
+            /// Copy the last modification date metadata to the selected member 
+            /// </summary>
+            /// <param name="memberExpression"></param>
+            /// <returns></returns>
+            public DocumentMappingExpression<T> MapLastModifiedTo(Expression<Func<T, DateTime>> memberExpression)
+            {
+                var members = FindMembers.Determine(memberExpression);
+                if (members.Length > 1)
+                {
+                    throw new ArgumentException($"The {nameof(MapLastModifiedTo)} member cannot be a nested property.", nameof(memberExpression));
+                }
+                alter = m => m.LastModifiedMember = members.First();
+                return this;
+            }
+
+            /// <summary>
+            /// Copy the tenant id metadata to the selected member
+            /// </summary>
+            /// <param name="memberExpression"></param>
+            /// <returns></returns>
+            public DocumentMappingExpression<T> MapTenantIdTo(Expression<Func<T, string>> memberExpression)
+            {
+                var members = FindMembers.Determine(memberExpression);
+                if (members.Length > 1)
+                {
+                    throw new ArgumentException($"The {nameof(MapTenantIdTo)} member cannot be a nested property.", nameof(memberExpression));
+                }
+                alter = m => m.TenantIdMember = members.First();
+                return this;
+            }
+
+            /// <summary>
+            /// Copy the is soft deleted metadata to the selected member
+            /// </summary>
+            /// <param name="memberExpression"></param>
+            /// <returns></returns>
+            public DocumentMappingExpression<T> MapIsSoftDeletedTo(Expression<Func<T, bool>> memberExpression)
+            {
+                var members = FindMembers.Determine(memberExpression);
+                if (members.Length > 1)
+                {
+                    throw new ArgumentException($"The {nameof(MapIsSoftDeletedTo)} member cannot be a nested property.", nameof(memberExpression));
+                }
+                alter = m => m.IsSoftDeletedMember = members.First();
+                return this;
+            }
+
+            /// <summary>
+            /// Copy the soft deleted timestamp to the selected member
+            /// </summary>
+            /// <param name="memberExpression"></param>
+            /// <returns></returns>
+            public DocumentMappingExpression<T> MapSoftDeletedAtTo(Expression<Func<T, DateTime?>> memberExpression)
+            {
+                var members = FindMembers.Determine(memberExpression);
+                if (members.Length > 1)
+                {
+                    throw new ArgumentException($"The {nameof(MapSoftDeletedAtTo)} member cannot be a nested property.", nameof(memberExpression));
+                }
+                alter = m => m.SoftDeletedAtMember = members.First();
+                return this;
+            }
+
+            /// <summary>
+            /// Copy the hierarchical document type to the selected member
+            /// </summary>
+            /// <param name="memberExpression"></param>
+            /// <returns></returns>
+            public DocumentMappingExpression<T> MapDocumentTypeTo(Expression<Func<T, string>> memberExpression)
+            {
+                var members = FindMembers.Determine(memberExpression);
+                if (members.Length > 1)
+                {
+                    throw new ArgumentException($"The {nameof(MapDocumentTypeTo)} member cannot be a nested property.", nameof(memberExpression));
+                }
+                alter = m => m.DocumentTypeMember = members.First();
+                return this;
+            }
+
+            /// <summary>
+            /// Copy the document's qualified class name to the selected member
+            /// </summary>
+            /// <param name="memberExpression"></param>
+            /// <returns></returns>
+            public DocumentMappingExpression<T> MapDotNetTypeTo(Expression<Func<T, string>> memberExpression)
+            {
+                var members = FindMembers.Determine(memberExpression);
+                if (members.Length > 1)
+                {
+                    throw new ArgumentException($"The {nameof(MapDocumentTypeTo)} member cannot be a nested property.", nameof(memberExpression));
+                }
+                alter = m => m.DotNetTypeMember = members.First();
                 return this;
             }
         }

--- a/src/Marten/QuerySession.cs
+++ b/src/Marten/QuerySession.cs
@@ -47,6 +47,12 @@ namespace Marten
             return _identityMap.Versions.Version<TDoc>(id);
         }
 
+        public DocumentMetadata MetadataFor<TDoc>(TDoc entity)
+        {
+            var id = _store.Storage.StorageFor(typeof(TDoc)).Identity(entity);
+            return _identityMap.MetadataCache?.MetadataFor(typeof(TDoc), id) ?? Tenant.MetadataFor(entity);
+        }
+
         public IDocumentStore DocumentStore => _store;
 
         public IJsonLoader Json => new JsonLoader(_connection, Tenant);

--- a/src/Marten/Schema/Arguments/CurrentVersionArgument.cs
+++ b/src/Marten/Schema/Arguments/CurrentVersionArgument.cs
@@ -14,7 +14,7 @@ namespace Marten.Schema.Arguments
             Column = null;
         }
 
-        public override Expression CompileBulkImporter(DocumentMapping mapping, EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, ParameterExpression textWriter, ParameterExpression tenantId)
+        public override Expression CompileBulkImporter(DocumentMapping mapping, EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, ParameterExpression textWriter, ParameterExpression version, ParameterExpression tenantId)
         {
             throw new NotSupportedException("This should not be used for CurrentVersionArgument");
         }

--- a/src/Marten/Schema/Arguments/DocJsonBodyArgument.cs
+++ b/src/Marten/Schema/Arguments/DocJsonBodyArgument.cs
@@ -50,7 +50,7 @@ namespace Marten.Schema.Arguments
             }
         }
 
-        public override Expression CompileBulkImporter(DocumentMapping mapping, EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, ParameterExpression textWriter, ParameterExpression tenantId)
+        public override Expression CompileBulkImporter(DocumentMapping mapping, EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, ParameterExpression textWriter, ParameterExpression version, ParameterExpression tenantId)
         {
             var method = writeMethod.MakeGenericMethod(typeof(ArraySegment<char>));
             var dbType = Expression.Constant(DbType);

--- a/src/Marten/Schema/Arguments/DocTypeArgument.cs
+++ b/src/Marten/Schema/Arguments/DocTypeArgument.cs
@@ -18,7 +18,7 @@ namespace Marten.Schema.Arguments
             PostgresType = "varchar";
         }
 
-        public override Expression CompileBulkImporter(DocumentMapping mapping, EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, ParameterExpression textWriter, ParameterExpression tenantId)
+        public override Expression CompileBulkImporter(DocumentMapping mapping, EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, ParameterExpression textWriter, ParameterExpression version, ParameterExpression tenantId)
         {
             var method = writeMethod.MakeGenericMethod(typeof(string));
             var dbType = Expression.Constant(DbType);

--- a/src/Marten/Schema/Arguments/DotNetTypeArgument.cs
+++ b/src/Marten/Schema/Arguments/DotNetTypeArgument.cs
@@ -21,7 +21,7 @@ namespace Marten.Schema.Arguments
             PostgresType = "varchar";
         }
 
-        public override Expression CompileBulkImporter(DocumentMapping mapping, EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, ParameterExpression textWriter, ParameterExpression tenantId)
+        public override Expression CompileBulkImporter(DocumentMapping mapping, EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, ParameterExpression textWriter, ParameterExpression version, ParameterExpression tenantId)
         {
             var getType = Expression.Call(document, _getType);
             var getName = Expression.Call(getType, _fullName);

--- a/src/Marten/Schema/Arguments/TenantIdArgument.cs
+++ b/src/Marten/Schema/Arguments/TenantIdArgument.cs
@@ -16,7 +16,7 @@ namespace Marten.Schema.Arguments
             Column = TenantIdColumn.Name;
         }
 
-        public override Expression CompileBulkImporter(DocumentMapping mapping, EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, ParameterExpression textWriter, ParameterExpression tenantId)
+        public override Expression CompileBulkImporter(DocumentMapping mapping, EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, ParameterExpression textWriter, ParameterExpression version, ParameterExpression tenantId)
         {
             var method = writeMethod.MakeGenericMethod(typeof(string));
             var dbType = Expression.Constant(DbType);

--- a/src/Marten/Schema/Arguments/UpsertArgument.cs
+++ b/src/Marten/Schema/Arguments/UpsertArgument.cs
@@ -60,7 +60,7 @@ namespace Marten.Schema.Arguments
             return $"{Arg} {PostgresType}";
         }
 
-        public virtual Expression CompileBulkImporter(DocumentMapping mapping, EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, ParameterExpression textWriter, ParameterExpression tenantId)
+        public virtual Expression CompileBulkImporter(DocumentMapping mapping, EnumStorage enumStorage, Expression writer, ParameterExpression document, ParameterExpression alias, ParameterExpression serializer, ParameterExpression textWriter, ParameterExpression version, ParameterExpression tenantId)
         {
             var memberType = Members.Last().GetMemberType();
 

--- a/src/Marten/Schema/HierarchicalResolver.cs
+++ b/src/Marten/Schema/HierarchicalResolver.cs
@@ -4,6 +4,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Baseline;
 using Marten.Services;
+using Marten.Storage;
+using Marten.Util;
 using Npgsql;
 
 namespace Marten.Schema
@@ -23,13 +25,38 @@ namespace Marten.Schema
             if (reader.IsDBNull(startingIndex))
                 return null;
 
-            var id = reader[startingIndex + 1];
-            var typeAlias = reader.GetFieldValue<string>(startingIndex + 2);
+            var offset = 0;
+            var id = reader[startingIndex + ++offset];
+            var typeAlias = reader.GetFieldValue<string>(startingIndex + ++offset);
 
-            var version = reader.GetFieldValue<Guid>(startingIndex + 3);
+            var version = reader.GetFieldValue<Guid>(startingIndex + ++offset);
+            var lastMod = reader.GetValue(startingIndex + ++offset).MapToDateTime();
+            var dotNetType = reader.GetFieldValue<string>(startingIndex + ++offset);
+            
+            var deleted = false;
+            DateTime? deletedAt = null;
+            if (_hierarchy.DeleteStyle == DeleteStyle.SoftDelete)
+            {
+                deleted = reader.GetFieldValue<bool>(startingIndex + ++offset);
+                if (!reader.IsDBNull(startingIndex + ++offset))
+                {
+                    deletedAt = reader.GetValue(startingIndex + offset).MapToDateTime();
+                }
+            }
+
+            string tenantId = null;
+            if (_hierarchy.TenancyStyle == TenancyStyle.Conjoined)
+            {
+                tenantId = reader.GetFieldValue<string>(startingIndex + ++offset);
+            }
+
+            var metadata = new DocumentMetadata(lastMod, version, dotNetType, typeAlias, deleted, deletedAt)
+            {
+                TenantId = tenantId
+            };
 
             var json = reader.GetTextReader(startingIndex);
-            return map.Get<T>(id, _hierarchy.TypeFor(typeAlias), json, version);
+            return map.Get<T>(id, _hierarchy.TypeFor(typeAlias), json, version, t => MetadataProjector.ProjectTo(t, metadata));
         }
 
         public override async Task<T> ResolveAsync(int startingIndex, DbDataReader reader, IIdentityMap map, CancellationToken token)
@@ -37,15 +64,40 @@ namespace Marten.Schema
             if (await reader.IsDBNullAsync(startingIndex, token).ConfigureAwait(false))
                 return null;
 
-            var id = await reader.GetFieldValueAsync<object>(startingIndex + 1, token).ConfigureAwait(false);
+            var offset = 0;
+            var id = await reader.GetFieldValueAsync<object>(startingIndex + ++offset, token).ConfigureAwait(false);
 
-            var typeAlias = await reader.GetFieldValueAsync<string>(startingIndex + 2, token).ConfigureAwait(false);
+            var typeAlias = await reader.GetFieldValueAsync<string>(startingIndex + ++offset, token).ConfigureAwait(false);
 
-            var version = await reader.GetFieldValueAsync<Guid>(startingIndex + 3, token).ConfigureAwait(false);
+            var version = await reader.GetFieldValueAsync<Guid>(startingIndex + ++offset, token).ConfigureAwait(false);
+            var lastMod = (await reader.GetFieldValueAsync<object>(startingIndex + ++offset, token).ConfigureAwait(false)).MapToDateTime();
+            var dotNetType = await reader.GetFieldValueAsync<string>(startingIndex + ++offset, token).ConfigureAwait(false);
+
+            var deleted = false;
+            DateTime? deletedAt = null;
+            if (_hierarchy.DeleteStyle == DeleteStyle.SoftDelete)
+            {
+                deleted = await reader.GetFieldValueAsync<bool>(startingIndex + ++offset, token).ConfigureAwait(false);
+                if (!await reader.IsDBNullAsync(startingIndex + ++offset, token).ConfigureAwait(false))
+                {
+                    deletedAt = (await reader.GetFieldValueAsync<object>(startingIndex + offset, token).ConfigureAwait(false)).MapToDateTime();
+                }
+            }
+
+            string tenantId = null;
+            if (_hierarchy.TenancyStyle == TenancyStyle.Conjoined)
+            {
+                tenantId = await reader.GetFieldValueAsync<string>(startingIndex + ++offset, token).ConfigureAwait(false);
+            }
+
+            var metadata = new DocumentMetadata(lastMod, version, dotNetType, typeAlias, deleted, deletedAt)
+            {
+                TenantId = tenantId
+            };
 
             var json = await reader.As<NpgsqlDataReader>().GetTextReaderAsync(startingIndex).ConfigureAwait(false);
 
-            return map.Get<T>(id, _hierarchy.TypeFor(typeAlias), json, version);
+            return map.Get<T>(id, _hierarchy.TypeFor(typeAlias), json, version, t => MetadataProjector.ProjectTo(t, metadata));
         }
 
         public override T Fetch(object id, DbDataReader reader, IIdentityMap map)
@@ -53,15 +105,7 @@ namespace Marten.Schema
             if (!reader.Read())
                 return null;
 
-            var typeAlias = reader.GetString(2);
-
-            var actualType = _hierarchy.TypeFor(typeAlias);
-
-            var version = reader.GetFieldValue<Guid>(3);
-
-            var json = reader.GetTextReader(0);
-
-            return map.Get<T>(id, actualType, json, version);
+            return Resolve(0, reader, map);
         }
 
         public override async Task<T> FetchAsync(object id, DbDataReader reader, IIdentityMap map, CancellationToken token)
@@ -71,15 +115,7 @@ namespace Marten.Schema
             if (!found)
                 return null;
 
-            var typeAlias = await reader.GetFieldValueAsync<string>(2, token).ConfigureAwait(false);
-
-            var actualType = _hierarchy.TypeFor(typeAlias);
-
-            var version = await reader.GetFieldValueAsync<Guid>(3, token).ConfigureAwait(false);
-
-            var json = await reader.As<NpgsqlDataReader>().GetTextReaderAsync(0).ConfigureAwait(false);
-
-            return map.Get<T>(id, actualType, json, version);
+            return await ResolveAsync(0, reader, map, token).ConfigureAwait(false);
         }
     }
 }

--- a/src/Marten/Schema/IDocumentStorage.cs
+++ b/src/Marten/Schema/IDocumentStorage.cs
@@ -47,7 +47,10 @@ namespace Marten.Schema
 
         void RegisterUpdate(string tenantIdOverride, UpdateStyle updateStyle, UpdateBatch batch, object entity);
 
+        [Obsolete]
         void RegisterUpdate(string tenantIdOverride, UpdateStyle updateStyle, UpdateBatch batch, object entity, string json);
+
+        void RegisterUpdate(string tenantIdOverride, UpdateStyle updateStyle, UpdateBatch batch, object entity, Type entityType);
     }
 
     public interface IDocumentStorage<T>: IDocumentStorage

--- a/src/Marten/Schema/MetadataAttributes.cs
+++ b/src/Marten/Schema/MetadataAttributes.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Reflection;
+
+namespace Marten.Schema
+{
+    /// <summary>
+    /// Direct Marten to copy the last modified metadata to this member
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class LastModifiedMetadataAttribute: MartenAttribute
+    {
+        public override void Modify(DocumentMapping mapping, MemberInfo member)
+        {
+            mapping.LastModifiedMember = member;
+        }
+    }
+
+    /// <summary>
+    /// Direct Marten to copy the tenant id metadata to this member
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class TenantIdMetadataAttribute: MartenAttribute
+    {
+        public override void Modify(DocumentMapping mapping, MemberInfo member)
+        {
+            mapping.TenantIdMember = member;
+        }
+    }
+
+    /// <summary>
+    /// Direct Marten to copy the is soft deleted metadata to this member
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class IsSoftDeletedMetadataAttributeAttribute: MartenAttribute
+    {
+        public override void Modify(DocumentMapping mapping, MemberInfo member)
+        {
+            mapping.IsSoftDeletedMember = member;
+        }
+    }
+
+    /// <summary>
+    /// Direct Marten to copy the soft deleted timestamp metadata to this member
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class SoftDeletedAtMetadataAttribute: MartenAttribute
+    {
+        public override void Modify(DocumentMapping mapping, MemberInfo member)
+        {
+            mapping.SoftDeletedAtMember = member;
+        }
+    }
+
+    /// <summary>
+    /// Direct Marten to copy the hierarchical document type metadata to this member
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class DocumentTypeMetadataAttribute: MartenAttribute
+    {
+        public override void Modify(DocumentMapping mapping, MemberInfo member)
+        {
+            mapping.DocumentTypeMember = member;
+        }
+    }
+
+    /// <summary>
+    /// Direct Marten to copy the qualified class name metadata to this member
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class DotNetTypeMetadataAttribute: MartenAttribute
+    {
+        public override void Modify(DocumentMapping mapping, MemberInfo member)
+        {
+            mapping.DotNetTypeMember = member;
+        }
+    }
+
+}

--- a/src/Marten/Schema/MetadataProjector.cs
+++ b/src/Marten/Schema/MetadataProjector.cs
@@ -1,0 +1,120 @@
+using Marten.Storage;
+using Marten.Util;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Marten.Schema
+{
+    public class MetadataProjector<T>
+    {
+        private readonly Dictionary<string, dynamic> _memberSetters = new Dictionary<string, dynamic>();
+        private readonly Dictionary<string, dynamic> _memberGetters = new Dictionary<string, dynamic>();
+
+        public bool HasMappings => _memberSetters.Count > 0;
+
+        public MetadataProjector(DocumentMapping mapping)
+        {
+            CreateMemberGetterSetters(mapping);
+        }
+
+        public DocumentMetadata ProjectTo(T entity, DocumentMetadata metadata)
+        {
+            if (!HasMappings)
+            {
+                return metadata;
+            }
+
+            ProjectMemberValue(DocumentMapping.VersionColumn, entity, metadata.CurrentVersion);
+            ProjectMemberValue(DocumentMapping.LastModifiedColumn, entity, metadata.LastModified);
+            ProjectMemberValue(TenantIdColumn.Name, entity, metadata.TenantId);
+            ProjectMemberValue(DocumentMapping.DocumentTypeColumn, entity, metadata.DocumentType);
+            ProjectMemberValue(DocumentMapping.DotNetTypeColumn, entity, metadata.DotNetType);
+            ProjectMemberValue(DocumentMapping.DeletedColumn, entity, metadata.Deleted);
+            ProjectMemberValue(DocumentMapping.DeletedAtColumn, entity, metadata.DeletedAt);
+
+            return metadata;
+        }
+
+        public void Update(T entity, DocumentMetadata metadata)
+        {
+            if (!HasMappings)
+            {
+                return;
+            }
+
+            ValidateReadOnlyMetadata(entity, metadata);
+            ProjectTo(entity, metadata);
+        }
+
+        public void UpdateVersion(T entity, Guid newVersion)
+        {
+            ProjectMemberValue(DocumentMapping.VersionColumn, entity, newVersion);
+        }
+
+        private void CreateMemberGetterSetters(DocumentMapping mapping)
+        {
+            CreateSetter<Guid>(DocumentMapping.VersionColumn, mapping.VersionMember);
+            CreateSetter<DateTime>(DocumentMapping.LastModifiedColumn, mapping.LastModifiedMember);
+
+            CreateSetter<string>(TenantIdColumn.Name, mapping.TenantIdMember);
+            CreateGetter<string>(TenantIdColumn.Name, mapping.TenantIdMember);
+
+            CreateSetter<string>(DocumentMapping.DocumentTypeColumn, mapping.DocumentTypeMember);
+            CreateGetter<string>(DocumentMapping.DocumentTypeColumn, mapping.DocumentTypeMember);
+
+            CreateSetter<string>(DocumentMapping.DotNetTypeColumn, mapping.DotNetTypeMember);
+            CreateGetter<string>(DocumentMapping.DotNetTypeColumn, mapping.DotNetTypeMember);
+
+            CreateSetter<bool>(DocumentMapping.DeletedColumn, mapping.IsSoftDeletedMember);
+            CreateGetter<bool>(DocumentMapping.DeletedColumn, mapping.IsSoftDeletedMember);
+
+            CreateSetter<DateTime?>(DocumentMapping.DeletedAtColumn, mapping.SoftDeletedAtMember);
+            CreateGetter<DateTime?>(DocumentMapping.DeletedAtColumn, mapping.SoftDeletedAtMember);
+        }
+
+        private void CreateSetter<TMember>(string memberKey, MemberInfo memberInfo)
+        {
+            if (memberInfo != null)
+            {
+                _memberSetters.Add(memberKey, LambdaBuilder.Setter<T, TMember>(memberInfo));
+            }
+        }
+
+        private void CreateGetter<TMember>(string memberKey, MemberInfo memberInfo)
+        {
+            if (memberInfo != null)
+            {
+                _memberGetters.Add(memberKey, LambdaBuilder.Getter<T, TMember>(memberInfo));
+            }
+        }
+
+        private void ProjectMemberValue<TMember>(string memberKey, T entity, TMember value)
+        {
+            if (_memberSetters.TryGetValue(memberKey, out var setter))
+            {
+                (setter as Action<T, TMember>)(entity, value);
+            }
+        }
+
+        private void ValidateReadOnlyMetadata(T entity, DocumentMetadata metadata)
+        {
+            ValidateReadOnlyMetadataField(DocumentMapping.DeletedColumn, entity, metadata.Deleted);
+            ValidateReadOnlyMetadataField(DocumentMapping.DeletedAtColumn, entity, metadata.DeletedAt);
+            ValidateReadOnlyMetadataField(DocumentMapping.DotNetTypeColumn, entity, metadata.DotNetType);
+            ValidateReadOnlyMetadataField(DocumentMapping.DocumentTypeColumn, entity, metadata.DocumentType);
+            ValidateReadOnlyMetadataField(TenantIdColumn.Name, entity, metadata.TenantId);
+        }
+
+        private void ValidateReadOnlyMetadataField<TMember>(string memberKey, T entity, TMember expectedValue)
+        {
+            if (_memberGetters.TryGetValue(memberKey, out var getter))
+            {
+                if (!expectedValue.Equals((getter as Func<T, TMember>)(entity)))
+                {
+                    throw new InvalidOperationException($"The mapped {memberKey} metadata member is read-only.");
+                }
+            }
+        }
+    }
+}

--- a/src/Marten/Schema/SubClassMapping.cs
+++ b/src/Marten/Schema/SubClassMapping.cs
@@ -75,7 +75,19 @@ namespace Marten.Schema
 
         public string[] SelectFields()
         {
-            return new[] { "data", "id", DocumentMapping.DocumentTypeColumn, DocumentMapping.VersionColumn };
+            var fields = new List<string> { "data", "id", DocumentMapping.DocumentTypeColumn, DocumentMapping.VersionColumn, DocumentMapping.LastModifiedColumn, DocumentMapping.DotNetTypeColumn };
+
+            if (DeleteStyle == DeleteStyle.SoftDelete)
+            {
+                fields.AddRange(new[] { DocumentMapping.DeletedColumn, DocumentMapping.DeletedAtColumn });
+            }
+
+            if (TenancyStyle == TenancyStyle.Conjoined)
+            {
+                fields.Add(TenantIdColumn.Name);
+            }
+
+            return fields.ToArray();
         }
 
         public IField FieldFor(IEnumerable<MemberInfo> members)

--- a/src/Marten/Services/IIdentityMap.cs
+++ b/src/Marten/Services/IIdentityMap.cs
@@ -1,3 +1,4 @@
+using Marten.Storage;
 using System;
 using System.IO;
 
@@ -9,9 +10,13 @@ namespace Marten.Services
 
         VersionTracker Versions { get; }
 
+        MetadataCache MetadataCache { get; }
+
         T Get<T>(object id, TextReader json, Guid? version);
 
         T Get<T>(object id, Type concreteType, TextReader json, Guid? version);
+
+        T Get<T>(object id, Type concreteType, TextReader json, Guid? version, Func<T, DocumentMetadata> applyMetadata);
 
         void Remove<T>(object id);
 

--- a/src/Marten/Services/MetadataCache.cs
+++ b/src/Marten/Services/MetadataCache.cs
@@ -1,0 +1,58 @@
+using Marten.Storage;
+using Marten.Util;
+using System;
+
+namespace Marten.Services
+{
+    public class MetadataCache
+    {
+        protected Ref<ImHashMap<Type, ImHashMap<object, DocumentMetadata>>> Cache { get; } = Ref.Of(ImHashMap<Type, ImHashMap<object, DocumentMetadata>>.Empty);
+
+        public DocumentMetadata MetadataFor<T>(object id)
+        {
+            return MetadataFor(typeof(T), id);
+        }
+
+        public DocumentMetadata MetadataFor(Type documentType, object id)
+        {
+            if (Cache.Value.TryFind(documentType, out var t) && t.TryFind(id, out var value))
+            {
+                return value;
+            }
+
+            return null;
+        }
+
+        public void Store<T>(object id, DocumentMetadata metadata)
+        {
+            if (metadata == null)
+            {
+                return;
+            }
+
+            Store(typeof(T), id, metadata);
+        }
+
+        public void Store(Type documentType, object id, DocumentMetadata metadata)
+        {
+            Cache.Swap(c => c.AddOrUpdate(documentType,
+                (c.GetValueOrDefault(documentType) ?? ImHashMap<object, DocumentMetadata>.Empty).AddOrUpdate(id, metadata)));
+        }
+
+        public void Remove<T>(object id)
+        {
+            Remove(typeof(T), id);
+        }
+
+        public void Remove(Type documentType, object id)
+        {
+            Cache.Swap(c => c.AddOrUpdate(documentType,
+                (c.GetValueOrDefault(documentType) ?? ImHashMap<object, DocumentMetadata>.Empty).Remove(id)));
+        }
+
+        public void RemoveAllOfType(Type documentType)
+        {
+            Cache.Swap(c => c.AddOrUpdate(documentType, ImHashMap<object, DocumentMetadata>.Empty));
+        }
+    }
+}

--- a/src/Marten/Services/UnitOfWork.cs
+++ b/src/Marten/Services/UnitOfWork.cs
@@ -256,7 +256,7 @@ namespace Marten.Services
             {
                 var upsert = _tenant.StorageFor(group.Key);
 
-                group.Each(c => { upsert.RegisterUpdate(null, UpdateStyle.Upsert, batch, c.Document, c.Json); });
+                group.Each(c => { upsert.RegisterUpdate(null, UpdateStyle.Upsert, batch, c.Document, c.DocumentType); });
             });
 
             return changes;

--- a/src/Marten/Services/UpdateBatch.cs
+++ b/src/Marten/Services/UpdateBatch.cs
@@ -21,6 +21,11 @@ namespace Marten.Services
         private BatchCommand _current;
 
         public UpdateBatch(DocumentStore store, IManagedConnection connection, VersionTracker versions, MemoryPool<char> writerPool, ITenant tenant, ConcurrencyChecks concurrency)
+            : this(store, connection, versions, writerPool, tenant, concurrency, new MetadataCache())
+        {
+        }
+
+        public UpdateBatch(DocumentStore store, IManagedConnection connection, VersionTracker versions, MemoryPool<char> writerPool, ITenant tenant, ConcurrencyChecks concurrency, MetadataCache metadataCache)
         {
             _store = store;
             _writerPool = writerPool;
@@ -35,11 +40,14 @@ namespace Marten.Services
             Concurrency = concurrency;
             TenantId = tenant.TenantId;
             _tenant = tenant;
+            MetadataCache = metadataCache;
         }
 
         public ISerializer Serializer => _store.Serializer;
 
         public VersionTracker Versions { get; }
+
+        public MetadataCache MetadataCache { get; }
 
         public IManagedConnection Connection { get; }
         public ConcurrencyChecks Concurrency { get; }

--- a/src/MartenBenchmarks/BenchAgainst/UnitOfWorkBaseline.cs
+++ b/src/MartenBenchmarks/BenchAgainst/UnitOfWorkBaseline.cs
@@ -218,7 +218,7 @@ namespace MartenBenchmarks.BenchAgainst
             {
                 var upsert = _tenant.StorageFor(group.Key);
 
-                group.Each(c => { upsert.RegisterUpdate(null, UpdateStyle.Upsert, batch, c.Document, c.Json); });
+                group.Each(c => { upsert.RegisterUpdate(null, UpdateStyle.Upsert, batch, c.Document, c.DocumentType); });
             });
 
             return changes;


### PR DESCRIPTION
These changes are somewhat involved in order to ensure that the projected metadata fields in the jsonb match the actual metadata columns as best as possible.

- The metadata projector runs when saving documents in both unit of work and bulk insert scenarios.
- The metadata projector also runs when the IIdentityMap maps a document on read.  This should guarantee read-side consistency if you enable the feature on existing data.
- The read-only metadata projected onto document properties is validated when saving and will throw if the metadata does not match what was loaded in the session.

In order to do the read-only validation, the metadata of a document is always stored in the IIdentityMap rather than making another db call.  This also makes it possible to used cached metadata when calling `MetadataFor<T>` in an IQuerySession.   It should only be required to go to the database for metadata if the doc wasn't already loaded in session (or loaded by a user defined query).

**Performance considerations:**
- Additional metadata columns will be retrieved from the database for all queries to project and cache the DocumentMetadata
- DocumentMetadata objects are stored in all implementations of IIdentityMap to perform read-only validations and support session based `MetadataFor<T>`.

**Public API breaking changes:**
The only potential breaking change is adding a parameter to `Marten.Schema.Arguments.UpsertArgument.CompileBulkImporter()` and its overrides.   This seemed like something that should be internal anyway, but it could be adjusted if necessary to prevent a binary break on these public methods.

**API surface change report:**
https://github.com/barryhagan/marten/commit/236e1f312cf114556debaa3354e27b1cad484e3b/checks?check_suite_id=250920331#step:6:6

In a perfect world:
- DocumentMetadata would have its own jsonb column in the db instead of being a combination of individual columns to make it easier to add arbitrary metadata going forward.
