### PR TITLE
Removed redundant null conditional method calls

### DIFF
--- a/src/Marten/Services/TransactionState.cs
+++ b/src/Marten/Services/TransactionState.cs
@@ -124,8 +124,8 @@ namespace Marten.Services
             {
                 try
                 {
-                    Transaction?.Rollback();
-                    Transaction?.Dispose();
+                    Transaction.Rollback();
+                    Transaction.Dispose();
                     Transaction = null;
                 }
                 catch (Exception e)


### PR DESCRIPTION
Since `Rollback` checks the current transaction for null, there is no need in conditional invocations.