### PR TITLE
Use async versions of dispose and close methods

### DIFF
--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -37,8 +37,8 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-        <PackageReference Include="Npgsql" Version="[4.1.1,4.2.0)" />
-        <PackageReference Include="Npgsql.Json.NET" Version="[4.1.1,4.2.0)" />
+        <PackageReference Include="Npgsql" Version="[4.1.2,4.2.0)" />
+        <PackageReference Include="Npgsql.Json.NET" Version="[4.1.2,4.2.0)" />
         <PackageReference Include="Remotion.Linq" Version="2.2.0" />
         <PackageReference Include="Baseline" Version="1.5.0" />
         <PackageReference Include="System.Memory" Version="4.5.3" />

--- a/src/Marten/Services/TransactionState.cs
+++ b/src/Marten/Services/TransactionState.cs
@@ -107,14 +107,13 @@ namespace Marten.Services
             if (Transaction != null && _mode != CommandRunnerMode.External)
             {
                 await Transaction.CommitAsync(token).ConfigureAwait(false);
-
-                Transaction.Dispose();
+                await Transaction.DisposeAsync().ConfigureAwait(false);
                 Transaction = null;
             }
 
             if (_ownsConnection)
             {
-                Connection.Close();
+                await Connection.CloseAsync().ConfigureAwait(false);
             }
         }
 
@@ -146,7 +145,7 @@ namespace Marten.Services
                 try
                 {
                     await Transaction.RollbackAsync(token).ConfigureAwait(false);
-                    Transaction.Dispose();
+                    await Transaction.DisposeAsync().ConfigureAwait(false);
                     Transaction = null;
                 }
                 catch (Exception e)
@@ -155,7 +154,7 @@ namespace Marten.Services
                 }
                 finally
                 {
-                    Connection.Close();
+                    await Connection.CloseAsync().ConfigureAwait(false);
                 }
             }
         }


### PR DESCRIPTION
Npgsql starting version 4.1 supports async versions of `Close` and `Dispose` methods.