### PR TITLE
Fixes #1372 -  thread safety of storage setup

### DIFF
--- a/src/Marten/Storage/IFeatureSchema.cs
+++ b/src/Marten/Storage/IFeatureSchema.cs
@@ -97,7 +97,12 @@ namespace Marten.Storage
     {
         public static void AssertValidNames(this IFeatureSchema schema, StoreOptions options)
         {
-            foreach (var objectName in schema.Objects.SelectMany(x => x.AllNames()))
+            AssertValidNames(schema.Objects, options);
+        }
+
+        public static void AssertValidNames(this ISchemaObject[] schemaObjects, StoreOptions options)
+        {
+            foreach (var objectName in schemaObjects.SelectMany(x => x.AllNames()))
             {
                 options.AssertValidIdentifier(objectName.Name);
             }


### PR DESCRIPTION
- move name check inside the lock,
- only load the schema objects once to do this, 
- don't re-run checks on race conditions