### PR TITLE
QuerySession implements finalizer, but Dispose does not call into `GC…

### DIFF
--- a/src/Marten/QuerySession.cs
+++ b/src/Marten/QuerySession.cs
@@ -370,6 +370,7 @@ namespace Marten
             _disposed = true;
             _connection?.Dispose();
             WriterPool?.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         public T Load<T>(int id)


### PR DESCRIPTION
….SuppressFinalize` -> our connections needlessly always end up in the finalizer queue.

Fixed by calling into `GC.SuppressFinalize`. Now, do we want the finalizer in the first place? By quick look, Npgsql has no finalizers (though
they call into `GC.SuppressFinalize` in a few ctors where they derive from `Component` or other types with finalizers). Noticed by incident when going over a mem dump...