### PR TITLE
Fixes #1386 - not being able to serialize IReadonlyCollection<int> while using CollectionStorage.AsArray

### DIFF
--- a/src/Marten.Testing/Documents/User.cs
+++ b/src/Marten.Testing/Documents/User.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Baseline;
 
 namespace Marten.Testing.Documents
@@ -75,6 +77,20 @@ namespace Marten.Testing.Documents
     public class UserWithNicknames
     {
         public string[] Nicknames { get; set; }
+    }
+
+    public class UserWithReadonlyCollectionWithPrivateSetter
+    {
+        public Guid Id { get; private set; }
+        public string Name { get; private set; }
+        public IReadOnlyCollection<int> Collection { get; private set; }
+
+        public UserWithReadonlyCollectionWithPrivateSetter(Guid id, string name, IEnumerable<int> collection)
+        {
+            Id = id;
+            Name = name;
+            Collection = collection.ToList();
+        }
     }
 
     public class Post

--- a/src/Marten.Testing/Linq/query_with_inner_query_with_global_CollectionStorage_WithArray.cs
+++ b/src/Marten.Testing/Linq/query_with_inner_query_with_global_CollectionStorage_WithArray.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -25,37 +25,67 @@ namespace Marten.Testing.Linq
         public ICollection<string> ICollection { get; set; }
 
         public IReadOnlyCollection<string> IReadonlyCollection { get; set; }
+        public int[] ArrayWithInt { get; set; }
+        public List<int> ListWithInt { get; set; }
+        public IList<int> IListWithInt { get; set; }
+
+        public IEnumerable<int> EnumerableWithInt { get; set; }
+
+        public IEnumerable<int> IEnumerableWithIntFromArray { get; set; }
+
+        public IEnumerable<int> IEnumerbaleWithIntFromList { get; set; }
+
+        public ICollection<int> ICollectionWithInt { get; set; }
+
+        public IReadOnlyCollection<int> IReadonlyCollectionWithInt { get; set; }
 
         public IReadOnlyCollection<TypeWithInnerCollections> IReadonlyCollectionOfInnerClasses { get; set; }
 
-        public static TypeWithInnerCollections Create(params string[] array)
+        public static TypeWithInnerCollections Create(params int[] array)
         {
+            var stringArray = array.Select(x => x.ToString()).ToArray();
             return new TypeWithInnerCollections()
             {
                 Id = Guid.NewGuid(),
-                Flatten = array.Aggregate((i, j) => i + j),
-                Array = array,
-                List = array.ToList(),
-                IList = array.ToList(),
-                Enumerable = array.AsEnumerable(),
-                IEnumerableFromArray = array,
-                IEnumerbaleFromList = array.ToList(),
-                ICollection = array.ToList(),
-                IReadonlyCollection = array.ToList(),
+                Flatten = stringArray.Aggregate((i, j) => i + j),
+                Array = stringArray,
+                List = stringArray.ToList(),
+                IList = stringArray.ToList(),
+                Enumerable = stringArray.AsEnumerable(),
+                IEnumerableFromArray = stringArray,
+                IEnumerbaleFromList = stringArray.ToList(),
+                ICollection = stringArray.ToList(),
+                IReadonlyCollection = stringArray.ToList(),
+                ArrayWithInt = array,
+                ListWithInt = array.ToList(),
+                IListWithInt = array.ToList(),
+                EnumerableWithInt = array.AsEnumerable(),
+                IEnumerableWithIntFromArray = array,
+                IEnumerbaleWithIntFromList = array.ToList(),
+                ICollectionWithInt = array.ToList(),
+                IReadonlyCollectionWithInt = array.ToList(),
                 IReadonlyCollectionOfInnerClasses = new List<TypeWithInnerCollections>
                     {
                         new TypeWithInnerCollections()
                         {
                             Id = Guid.NewGuid(),
-                            Flatten = array.Aggregate((i, j) => i + j),
-                            Array = array,
-                            List = array.ToList(),
-                            IList = array.ToList(),
-                            Enumerable = array.AsEnumerable(),
-                            IEnumerableFromArray = array,
-                            ICollection = array.ToList(),
-                            IEnumerbaleFromList = array.ToList(),
-                            IReadonlyCollection = array.ToList(),
+                            Flatten = stringArray.Aggregate((i, j) => i + j),
+                            Array = stringArray,
+                            List = stringArray.ToList(),
+                            IList = stringArray.ToList(),
+                            Enumerable = stringArray.AsEnumerable(),
+                            IEnumerableFromArray = stringArray,
+                            IEnumerbaleFromList = stringArray.ToList(),
+                            ICollection = stringArray.ToList(),
+                            IReadonlyCollection = stringArray.ToList(),
+                            ArrayWithInt = array,
+                            ListWithInt = array.ToList(),
+                            IListWithInt = array.ToList(),
+                            EnumerableWithInt = array.AsEnumerable(),
+                            IEnumerableWithIntFromArray = array,
+                            IEnumerbaleWithIntFromList = array.ToList(),
+                            ICollectionWithInt = array.ToList(),
+                            IReadonlyCollectionWithInt = array.ToList(),
                         }
                     }
             };
@@ -63,16 +93,17 @@ namespace Marten.Testing.Linq
     }
 
     [ControlledQueryStoryteller]
-    public class query_with_inner_query_with_global_CollectionStorage_WithArray : IntegratedFixture
+    public class query_with_inner_query_with_global_CollectionStorage_WithArray: IntegratedFixture
     {
         private static readonly TypeWithInnerCollections[] TestData = new TypeWithInnerCollections[]
         {
-            TypeWithInnerCollections.Create("one", "two"),
-            TypeWithInnerCollections.Create("two", "three"),
-            TypeWithInnerCollections.Create("four", "five"),
+            TypeWithInnerCollections.Create(1, 2),
+            TypeWithInnerCollections.Create(2, 3),
+            TypeWithInnerCollections.Create(4, 5),
         };
 
-        private const string SearchPhrase = "two";
+        private const string SearchPhrase = "2";
+        private const int IntSearchPhrase = 2;
 
         public static readonly TheoryData<Expression<Func<TypeWithInnerCollections, bool>>> Predicates = new TheoryData<Expression<Func<TypeWithInnerCollections, bool>>>
         {
@@ -85,7 +116,16 @@ namespace Marten.Testing.Linq
             x => x.ICollection.Contains(SearchPhrase),
             x => x.IReadonlyCollection.Contains(SearchPhrase),
             x => x.IReadonlyCollection.Where(e => e == SearchPhrase).Any(),
-            x => x.IReadonlyCollectionOfInnerClasses.Where(e => e.Flatten == "onetwo").Any() || x.IReadonlyCollectionOfInnerClasses.Where(e => e.Flatten == "twothree").Any()
+            x => x.IReadonlyCollectionOfInnerClasses.Where(e => e.Flatten == "12").Any() || x.IReadonlyCollectionOfInnerClasses.Where(e => e.Flatten == "23").Any(),
+            x => x.ArrayWithInt.Contains(IntSearchPhrase),
+            x => x.EnumerableWithInt.Contains(IntSearchPhrase),
+            x => x.IEnumerableWithIntFromArray.Contains(IntSearchPhrase),
+            x => x.IEnumerbaleWithIntFromList.Contains(IntSearchPhrase),
+            x => x.ListWithInt.Contains(IntSearchPhrase),
+            x => x.IListWithInt.Contains(IntSearchPhrase),
+            x => x.ICollectionWithInt.Contains(IntSearchPhrase),
+            x => x.IReadonlyCollectionWithInt.Contains(IntSearchPhrase),
+            x => x.IReadonlyCollectionWithInt.Where(e => e == IntSearchPhrase).Any(),
         };
 
         [Theory]

--- a/src/Marten.Testing/Session/document_session_load_document.cs
+++ b/src/Marten.Testing/Session/document_session_load_document.cs
@@ -34,7 +34,7 @@ namespace Marten.Testing.Session
         }
 
         [Fact]
-        public void when_collection_with_no_setter()
+        public void when_collectionstorage_asarray_and_with_readonlycollection_with_integers_and_private_setter()
         {
             StoreOptions(_ =>
             {

--- a/src/Marten/Services/Json/JsonNetCollectionToArrayJsonConverter.cs
+++ b/src/Marten/Services/Json/JsonNetCollectionToArrayJsonConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
@@ -24,8 +25,8 @@ namespace Marten.Services.Json
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            var o = value as IEnumerable<object>;
-            serializer.Serialize(writer, o?.ToArray());
+            var o = value as IEnumerable;
+            serializer.Serialize(writer, o?.Cast<object>().ToArray());
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)


### PR DESCRIPTION
As in the description - see more details in #1386 

Besides providing the fix and adding test for the described case, I updated inner collection queries tests to be sure that this case won't be missed again.