### PR TITLE
Fix patch expression to use right property name casing

### DIFF
--- a/src/Marten.Testing/Patching/PatchExpressionTests.cs
+++ b/src/Marten.Testing/Patching/PatchExpressionTests.cs
@@ -3,6 +3,7 @@ using Marten.Patching;
 using Marten.Schema;
 using Marten.Services;
 using Marten.Storage;
+using Marten.Testing.Documents;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -13,7 +14,7 @@ namespace Marten.Testing.Patching
     {
         private readonly PatchExpression<Target> _expression;
         private readonly ITenant _schema = Substitute.For<ITenant>();
-        
+
 
         public PatchExpressionTests()
         {
@@ -399,6 +400,23 @@ namespace Marten.Testing.Patching
         {
             Assert.Throws<ArgumentException>(() => _expression.Duplicate(x => x.String))
                 .Message.ShouldContain("At least one destination must be given");
+        }
+
+        [Fact]
+        public void check_camel_case_serialized_property()
+        {
+            var store = TestingDocumentStore.For(_ =>
+            {
+                _.UseDefaultSerialization(casing: Casing.CamelCase);
+            });
+
+            var expr1 = new PatchExpression<Target>(null, _schema, new UnitOfWork(store, store.Tenancy.Default), store.Serializer);
+            expr1.Set(x => x.Color, Colors.Blue);
+            expr1.Patch["path"].ShouldBe("color");
+
+            var expr2 = new PatchExpression<Target>(null, _schema, new UnitOfWork(store, store.Tenancy.Default), store.Serializer);
+            expr2.Delete(x => x.Inner.AnotherString);
+            expr2.Patch["path"].ShouldBe("inner.anotherString");
         }
     }
 }

--- a/src/Marten.Testing/Patching/PatchExpressionTests.cs
+++ b/src/Marten.Testing/Patching/PatchExpressionTests.cs
@@ -410,13 +410,13 @@ namespace Marten.Testing.Patching
                 _.UseDefaultSerialization(casing: Casing.CamelCase);
             });
 
-            var expr1 = new PatchExpression<Target>(null, _schema, new UnitOfWork(store, store.Tenancy.Default), store.Serializer);
-            expr1.Set(x => x.Color, Colors.Blue);
-            expr1.Patch["path"].ShouldBe("color");
+            var expressionWithSimpleProperty = new PatchExpression<Target>(null, _schema, new UnitOfWork(store, store.Tenancy.Default), store.Serializer);
+            expressionWithSimpleProperty.Set(x => x.Color, Colors.Blue);
+            expressionWithSimpleProperty.Patch["path"].ShouldBe("color");
 
-            var expr2 = new PatchExpression<Target>(null, _schema, new UnitOfWork(store, store.Tenancy.Default), store.Serializer);
-            expr2.Delete(x => x.Inner.AnotherString);
-            expr2.Patch["path"].ShouldBe("inner.anotherString");
+            var expressionWithNestedProperty = new PatchExpression<Target>(null, _schema, new UnitOfWork(store, store.Tenancy.Default), store.Serializer);
+            expressionWithNestedProperty.Delete(x => x.Inner.AnotherString);
+            expressionWithNestedProperty.Patch["path"].ShouldBe("inner.anotherString");
         }
     }
 }

--- a/src/Marten/Patching/PatchExpression.cs
+++ b/src/Marten/Patching/PatchExpression.cs
@@ -6,6 +6,7 @@ using Baseline;
 using Marten.Linq;
 using Marten.Services;
 using Marten.Storage;
+using Marten.Util;
 
 namespace Marten.Patching
 {
@@ -194,7 +195,7 @@ namespace Marten.Patching
             var visitor = new FindMembers();
             visitor.Visit(expression);
 
-            return visitor.Members.Select(x => x.Name).Join(".");
+            return visitor.Members.Select(x => x.Name.FormatCase(_serializer.Casing)).Join(".");
         }
 
         private void apply()


### PR DESCRIPTION
- Fix patch expression to use right property name casing based on serializer settings
- Add unit test

fixes GH-1385