### PR TITLE
Fix mixed content and links in docs

### DIFF
--- a/documentation/documentation/cli.md
+++ b/documentation/documentation/cli.md
@@ -64,7 +64,7 @@ and the database
 In all cases, the commands expose usage help through "marten help [command]." Each of the commands also exposes a "--conn" (or "-c" if you prefer) flag to override the database connection string and a "--log" flag to record all the command output to a file.
 
 ### Current Thinking about Marten + Sqitch
-Our team doing the RavenDB-to-Marten transition work has turned us on to using [Sqitch](http://sqitch.org/) for database migrations. From my point of view, I like this choice because Sqitch just uses script files in whatever the underlying database's SQL dialect is. That means that Marten can use our [existing `WritePatch()` schema management](http://jasperfx.github.io/marten/documentation/schema/migrations/) to tie into Sqitch's migration scheme.
+Our team doing the RavenDB-to-Marten transition work has turned us on to using [Sqitch](http://sqitch.org/) for database migrations. From my point of view, I like this choice because Sqitch just uses script files in whatever the underlying database's SQL dialect is. That means that Marten can use our existing `WritePatch()` <[linkto:documentation/schema/migrations;title=schema management]> to tie into Sqitch's migration scheme.
 
 The way that I think this could work for us is first to have a Sqitch project established in our codebase with its folders for updates, rollbacks, and verify's. In our build script that runs in our master continuous integration (CI) build, we would:
 

--- a/documentation/documentation/documents/configuration/unique.md
+++ b/documentation/documentation/documents/configuration/unique.md
@@ -77,6 +77,6 @@ Same can be configured for Duplicated Field:
 
 ## Unique Index per Tenant
 
-For tables which have been configured for <[linkto:/documentation/documents/tenancy/]>, index definitions may also be scoped per tenant.
+For tables which have been configured for <[linkto:documentation/documents/tenancy]>, index definitions may also be scoped per tenant.
 
 <[sample:per-tenant-unique-index]>

--- a/documentation/documentation/postgres/naming.md
+++ b/documentation/documentation/postgres/naming.md
@@ -50,4 +50,4 @@ When we query the table definition:
 
 You can see from the screen grab that the table and columns are stored lowercase.
 
-![](/documentation/content/images/postgres-table-definition.png)
+![](/content/images/postgres-table-definition.png)

--- a/documentation/documentation/postgres/types.md
+++ b/documentation/documentation/postgres/types.md
@@ -36,7 +36,7 @@ You can then query for sequences in Postgres by selecting from the `information_
 
 There will be an entry for the sequence created by the table definition above.
 
-![](/documentation/content/images/postgres-sequence.png)
+![](/content/images/postgres-sequence.png)
 
 The naming is: table_column_seq
 

--- a/documentation/layout.htm
+++ b/documentation/layout.htm
@@ -70,7 +70,7 @@
 
             <div class="col-md-3" id="leftCol">
 
-                <img src="http://jasperfx.github.io/marten/content/images/emblem.png" width="80%" align="middle" />
+                <img src="/content/images/emblem.png" width="80%" align="middle" />
                 <br />
                 <ul class="nav nav-stacked affix" id="sidebar"></ul>
                 <[linkto:{next};<h3 class="no-margin">Next</h3><p><a href="{href}">{title}</a></p>]>
@@ -100,8 +100,8 @@
 </body>
 
 <foot>
-    <script type='text/javascript' src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-    <script type='text/javascript' src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+    <script type='text/javascript' src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script type='text/javascript' src="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
     <[script:content/prism.js]>
     <[script:content/sidebar.js]>
     <[script:content/affix.js]>

--- a/documentation/splash.htm
+++ b/documentation/splash.htm
@@ -53,7 +53,7 @@
     <!-- Header -->
     <header id="top" class="header">
         <div class="text-vertical-center">
-            <img src="https://jasperfx.github.io/marten/content/images/banner.png" width="80%" align="middle" />
+            <img src="/content/images/banner.png" width="80%" align="middle" />
             <h1 style="color:white">Marten</h1>
             <h3>PostgreSQL as Document Db &amp; Event Store for .NET Development</h3>
             <h2>Polyglot Persistence for .NET Systems using the Rock Solid PostgreSQL Database</h2>


### PR DESCRIPTION
- Fix js files to use https served via CDN
- Remove url prefixe jasperfx.github.io/marten in links or images
- Fix url for image resources
- Fix broken link references added via `linkto:`