### PR TITLE
Another `IQuerySession.QueryAsync` method

### DIFF
--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Linq;
+using Marten.Linq.QueryHandlers;
 using Marten.Schema;
 using Marten.Services.BatchQuerying;
 using Marten.Storage;
@@ -109,6 +110,16 @@ namespace Marten
         /// <param name="parameters"></param>
         /// <returns></returns>
         Task<IReadOnlyList<T>> QueryAsync<T>(string sql, CancellationToken token = default(CancellationToken), params object[] parameters);
+
+        /// <summary>
+        /// Asynchronously queries the document storage table for the document type T by supplied handler. See http://jasperfx.github.io/marten/documentation/documents/querying/sql/ for more information on usage.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="sql"></param>
+        /// <param name="token"></param>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        Task<T> QueryAsync<T>(IQueryHandler<T> handler, CancellationToken token = default(CancellationToken));
 
         /// <summary>
         /// Define a batch of deferred queries and load operations to be conducted in one asynchronous request to the

--- a/src/Marten/QuerySession.cs
+++ b/src/Marten/QuerySession.cs
@@ -76,10 +76,12 @@ namespace Marten
         }
 
         public Task<IReadOnlyList<T>> QueryAsync<T>(string sql, CancellationToken token = default(CancellationToken), params object[] parameters)
+            => QueryAsync(new UserSuppliedQueryHandler<T>(_store, sql, parameters));
+
+        public Task<T> QueryAsync<T>(IQueryHandler<T> handler, CancellationToken token = default(CancellationToken))
         {
             assertNotDisposed();
 
-            var handler = new UserSuppliedQueryHandler<T>(_store, sql, parameters);
             return _connection.FetchAsync(handler, _identityMap.ForQuery(), null, Tenant, token);
         }
 


### PR DESCRIPTION
Hi. 

I'm trying to extend my awesome `DocumentStore` with custom db function based on `UpsertFunction` logic. I've found how you use `SprocCall` to fill `NpgsqlCommand`'s argument list during Insert/Update/... documents. Looks pretty reusable... 

But for now there is no way to invoke custom `IQueryHandler<T>` from the user code (https://github.com/JasperFx/marten/blob/master/src/Marten/QuerySession.cs#L78).

So it might be extreamly usefult to extend `IQuerySession.QueryAsync` api which acceps 'IQueryHandler<IReadOnlyList<T>>' as paramters. No sooner said than done ^____^
