### PR TITLE
Bug#1404 fixed Hilo concurrency error

### DIFF
--- a/src/Marten.Testing/Schema/Identity/Sequences/Bug_1404_Hilo_concurrent_update_failure.cs
+++ b/src/Marten.Testing/Schema/Identity/Sequences/Bug_1404_Hilo_concurrent_update_failure.cs
@@ -13,9 +13,9 @@ namespace Marten.Testing.Schema.Identity.Sequences
     public class Bug_1404_Hilo_concurrent_update_failure
     {
         [Fact]
-        public async void only_generated_once_default_connection_string_schema()
+        public void only_generated_once_default_connection_string_schema()
         {
-            await Task.WhenAll(new Task[]
+            Task.WaitAll(new Task[]
             {
                 Task.Run(()=> Hammertime()),
                 Task.Run(()=> Hammertime()),

--- a/src/Marten.Testing/Schema/Identity/Sequences/Bug_1404_Hilo_concurrent_update_failure.cs
+++ b/src/Marten.Testing/Schema/Identity/Sequences/Bug_1404_Hilo_concurrent_update_failure.cs
@@ -51,7 +51,7 @@ namespace Marten.Testing.Schema.Identity.Sequences
         {
             return DocumentStore.For(_ =>
             {
-                _.HiloSequenceDefaults.MaxLo = 1;
+                _.HiloSequenceDefaults.MaxLo = 3;
                 _.Connection(ConnectionSource.ConnectionString);
                 _.AutoCreateSchemaObjects = AutoCreate.All;
             });

--- a/src/Marten.Testing/Schema/Identity/Sequences/Bug_1404_Hilo_concurrent_update_failure.cs
+++ b/src/Marten.Testing/Schema/Identity/Sequences/Bug_1404_Hilo_concurrent_update_failure.cs
@@ -51,7 +51,7 @@ namespace Marten.Testing.Schema.Identity.Sequences
         {
             return DocumentStore.For(_ =>
             {
-                _.HiloSequenceDefaults.MaxLo = 3;
+                _.HiloSequenceDefaults.MaxLo = 5;
                 _.Connection(ConnectionSource.ConnectionString);
                 _.AutoCreateSchemaObjects = AutoCreate.All;
             });

--- a/src/Marten.Testing/Schema/Identity/Sequences/Bug_1404_Hilo_concurrent_update_failure.cs
+++ b/src/Marten.Testing/Schema/Identity/Sequences/Bug_1404_Hilo_concurrent_update_failure.cs
@@ -13,7 +13,7 @@ namespace Marten.Testing.Schema.Identity.Sequences
     public class Bug_1404_Hilo_concurrent_update_failure
     {
         [Fact]
-        public void only_generated_once_default_connection_string_schema()
+        public void generate_hilo_in_highly_concurrent_scenarios()
         {
             Task.WaitAll(new Task[]
             {

--- a/src/Marten.Testing/Schema/Identity/Sequences/Bug_1404_Hilo_concurrent_update_failure.cs
+++ b/src/Marten.Testing/Schema/Identity/Sequences/Bug_1404_Hilo_concurrent_update_failure.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Baseline;
+using Marten;
+using Marten.Testing;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Schema.Identity.Sequences
+{
+    public class Bug_1404_Hilo_concurrent_update_failure
+    {
+        [Fact]
+        public async void only_generated_once_default_connection_string_schema()
+        {
+            await Task.WhenAll(new Task[]
+            {
+                Task.Run(()=> Hammertime()),
+                Task.Run(()=> Hammertime()),
+                Task.Run(()=> Hammertime()),
+                Task.Run(()=> Hammertime())
+            });
+        }
+
+        private void Hammertime()
+        {
+            using (var store = DocumentStore.For(_ =>
+            {
+                 _.HiloSequenceDefaults.MaxLo = 1;
+                 _.Connection(ConnectionSource.ConnectionString);
+                 _.AutoCreateSchemaObjects = AutoCreate.All;
+             }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    var targets = TargetIntId.GenerateRandomData(100);
+                    session.InsertObjects(targets);
+                    session.SaveChanges();
+                }
+                
+            }
+        }
+    }
+}

--- a/src/Marten.Testing/TargetIntId.cs
+++ b/src/Marten.Testing/TargetIntId.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Baseline;
+
+namespace Marten.Testing
+{
+    public class TargetIntId
+    {
+        private static readonly Random _random = new Random(67);
+
+        private static readonly string[] _strings =
+        {
+            "Red", "Orange", "Yellow", "Green", "Blue", "Purple", "Violet",
+            "Pink", "Gray", "Black"
+        };
+
+        private static readonly string[] _otherStrings =
+        {
+            "one", "two", "three", "four", "five", "six", "seven", "eight",
+            "nine", "ten"
+        };
+
+        public static IEnumerable<TargetIntId> GenerateRandomData(int number)
+        {
+            var i = 0;
+            while (i < number)
+            {
+                yield return Random(true);
+
+                i++;
+            }
+        }
+
+        public static TargetIntId Random(bool deep = false)
+        {
+            var target = new TargetIntId();
+            target.String = _strings[_random.Next(0, 10)];
+            target.AnotherString = _otherStrings[_random.Next(0, 10)];
+            target.Number = _random.Next();
+            target.AnotherNumber = _random.Next();
+
+            target.Flag = _random.Next(0, 10) > 5;
+
+            target.Float = float.Parse(_random.NextDouble().ToString());
+
+            target.NumberArray = new[] { _random.Next(0, 10), _random.Next(0, 10), _random.Next(0, 10) };
+
+            target.NumberArray = target.NumberArray.Distinct().ToArray();
+
+            switch (_random.Next(0, 2))
+            {
+                case 0:
+                    target.Color = Colors.Blue;
+                    break;
+
+                case 1:
+                    target.Color = Colors.Green;
+                    break;
+
+                default:
+                    target.Color = Colors.Red;
+                    break;
+            }
+
+            target.Long = 100 * _random.Next();
+            target.Double = _random.NextDouble();
+            target.Long = _random.Next() * 10000;
+
+            target.Date = DateTime.Today.AddDays(_random.Next(-10000, 10000)).ToUniversalTime();
+
+            if (deep)
+            {
+                target.Inner = Random();
+
+                var number = _random.Next(1, 10);
+                target.Children = new TargetIntId[number];
+                for (int i = 0; i < number; i++)
+                {
+                    target.Children[i] = Random();
+                }
+
+                target.StringDict = Enumerable.Range(0, _random.Next(1, 10)).ToDictionary(i => $"key{i}", i => $"value{i}");
+            }
+
+            return target;
+        }
+
+        public TargetIntId()
+        {
+            StringDict = new Dictionary<string, string>();
+        }
+
+        public int Id { get; set; }
+
+        public int Number { get; set; }
+
+        public int AnotherNumber { get; set; }
+
+        public long Long { get; set; }
+        public string String { get; set; }
+        public string AnotherString { get; set; }
+
+        public Guid OtherGuid { get; set; }
+
+        public TargetIntId Inner { get; set; }
+
+        public Colors Color { get; set; }
+
+        public Colors? NullableEnum { get; set; }
+
+        public bool Flag { get; set; }
+
+        public string StringField;
+
+        public double Double { get; set; }
+        public decimal Decimal { get; set; }
+        public DateTime Date { get; set; }
+        public DateTimeOffset DateOffset { get; set; }
+
+        public float Float;
+
+        public int[] NumberArray { get; set; }
+
+        public string[] TagsArray { get; set; }
+
+        public HashSet<string> TagsHashSet { get; set; }
+
+        public TargetIntId[] Children { get; set; }
+
+        public int? NullableNumber { get; set; }
+        public DateTime? NullableDateTime { get; set; }
+        public bool? NullableBoolean { get; set; }
+        public Colors? NullableColor { get; set; }
+
+        public IDictionary<string, string> StringDict { get; set; }
+
+        public Guid UserId { get; set; }
+
+        public class Address
+        {
+            public Address()
+            {
+            }
+
+            public Address(string text)
+            {
+                var parts = text.ToDelimitedArray();
+                Address1 = parts[0];
+                City = parts[1];
+                StateOrProvince = parts[2];
+            }
+
+            public string Address1 { get; set; }
+            public string Address2 { get; set; }
+            public string City { get; set; }
+            public string StateOrProvince { get; set; }
+            public string Country { get; set; }
+            public string PostalCode { get; set; }
+
+            public bool Primary { get; set; }
+        }
+    }    
+}

--- a/src/Marten/Schema/Identity/Sequences/HiLoSequence.cs
+++ b/src/Marten/Schema/Identity/Sequences/HiLoSequence.cs
@@ -94,12 +94,12 @@ namespace Marten.Schema.Identity.Sequences
 
                         CurrentHi = Convert.ToInt64(raw);
 
-                    } while (CurrentHi < 0 && attempts < 30);
+                    } while (CurrentHi < 0 && attempts < _options.HiloSequenceDefaults.MaxAdvanceToNextHiAttempts);
 
                     // if CurrentHi is still less than 0 at this point, then throw exception
                     if (CurrentHi < 0)
                     {
-                        throw new Exception("Unable to advance hi sequence");
+                        throw new HiloSequenceAdvanceToNextHiAttemptsExceededException();
                     }
                 }
                 finally

--- a/src/Marten/Schema/Identity/Sequences/HiLoSequence.cs
+++ b/src/Marten/Schema/Identity/Sequences/HiLoSequence.cs
@@ -86,7 +86,7 @@ namespace Marten.Schema.Identity.Sequences
                     {
                         attempts++;
 
-                        // GetNextFunction is expected to return -1 if it's unable to
+                        // Sproc is expected to return -1 if it's unable to
                         // atomically secure the next hi
                         var raw = conn.CreateCommand().CallsSproc(GetNextFunction)
                             .With("entity", _entityName)
@@ -96,7 +96,7 @@ namespace Marten.Schema.Identity.Sequences
 
                     } while (CurrentHi < 0 && attempts < 30);
 
-                    // if CurrentHi is still less than 1 at this point, then throw exception
+                    // if CurrentHi is still less than 0 at this point, then throw exception
                     if (CurrentHi < 0)
                     {
                         throw new Exception("Unable to advance hi sequence");

--- a/src/Marten/Schema/Identity/Sequences/HiLoSequence.cs
+++ b/src/Marten/Schema/Identity/Sequences/HiLoSequence.cs
@@ -94,7 +94,7 @@ namespace Marten.Schema.Identity.Sequences
 
                         CurrentHi = Convert.ToInt64(raw);
 
-                    } while (CurrentHi < 0 && attempts < 20);
+                    } while (CurrentHi < 0 && attempts < 30);
 
                     // if CurrentHi is still less than 1 at this point, then throw exception
                     if (CurrentHi < 0)

--- a/src/Marten/Schema/Identity/Sequences/HiloSequenceAdvanceToNextHiAttemptsExceededException.cs
+++ b/src/Marten/Schema/Identity/Sequences/HiloSequenceAdvanceToNextHiAttemptsExceededException.cs
@@ -1,0 +1,10 @@
+using System;
+namespace Marten.Schema.Identity.Sequences
+{
+    public class HiloSequenceAdvanceToNextHiAttemptsExceededException : Exception
+    {
+        private const string message = "Advance to next hilo sequence retry limit exceeded. Unable to secure next hi sequence";
+        public HiloSequenceAdvanceToNextHiAttemptsExceededException() : base(message)
+        { }
+    }
+}

--- a/src/Marten/Schema/Identity/Sequences/HiloSettings.cs
+++ b/src/Marten/Schema/Identity/Sequences/HiloSettings.cs
@@ -4,5 +4,6 @@ namespace Marten.Schema.Identity.Sequences
     {
         public int MaxLo = 1000;
         public string SequenceName = null;
+        public int MaxAdvanceToNextHiAttempts = 30;
     }
 }

--- a/src/Marten/Schema/SQL/mt_get_next_hi.sql
+++ b/src/Marten/Schema/SQL/mt_get_next_hi.sql
@@ -9,7 +9,12 @@ BEGIN
 		next_value := 0;
 	ELSE
 		next_value := current_value + 1;
-		update {databaseSchema}.mt_hilo set hi_value = next_value where entity_name = entity;
+		update {databaseSchema}.mt_hilo set hi_value = next_value where entity_name = entity and hi_value = current_value;
+
+        IF NOT FOUND THEN
+            next_value := -1;
+        END IF;
+
 	END IF;
 
 	return next_value;


### PR DESCRIPTION
Fixes concurrency error with HiloSequence generator in high concurrency case.

1. Added test that consistently reproduces the problem

2. Updated `get_next_hi` sproc update condition to include check that the current hilo value hasn't changed since the last select. If it did, then return -1

3. Updated transaction isolation to read committed.  We do not need to run in serialization isolation now because of #2. 

4. Removed `try..catch` block surrounding sproc call. It's put in place before to address exceptions regarding concurrency issues in serialization isolation mode, hence no longer necessary.


Things for reviewer to look at
1. I'm not sure about is whether those who already have Marten running live would get the updated sproc (e.g. AutoCreate option is set to none).  How do we force sproc update?

2. It might be a better idea to retry getting next hi within the sproc.  Depends on maintainers' stance on this and sproc updates to deployments, we can implement it in this way instead

2. Throwing type `Exception`.  Should I create a new exception type for HiloSequence?