### PR TITLE
Removed the requirement for having the default constructor in the aggregation process and projections

### DIFF
--- a/documentation/documentation/events/projections/custom.md
+++ b/documentation/documentation/events/projections/custom.md
@@ -37,7 +37,7 @@ It comes of the way how Marten handles projection mechanism:
 <li>
     If such document exists, then new record needs to be created. Marten by default tries to use <b>default constructor</b>. <br />
     Default constructor doesn't have to be public, might be also private or protected. <br />
-    If class does not have the default constructor then it creates unitialized object (see <a href="https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatterservices.getuninitializedobject?view=netframework-4.8" target="_parent">more</a>).<br />
+    If class does not have the default constructor then it creates an uninitialized object (see <a href="https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatterservices.getuninitializedobject?view=netframework-4.8" target="_parent">more</a>).<br />
     Because of that, no member initializers will be run so all of them need to be initialized in the event handler methods.
 </li>
 <li>If document with such <b>Id</b> was found then it's being loaded from database.</li>

--- a/documentation/documentation/events/projections/custom.md
+++ b/documentation/documentation/events/projections/custom.md
@@ -28,16 +28,18 @@ Each of these methods take various overloads that allow selecting the Id field i
 <div class="alert alert-warning">
 <b><u>Warning:</u></b>
 <br />
-Projection class needs to have:
-<ul>
-<li>public default constructor,</li>
-<li><b>Id</b> property with public getter or setter.</li>
-</ul>
+Projection class needs to have <b>Id</b> property with public getter or property marked with <b>Identity</b> attribute.
+<br /><br />
 It comes of the way how Marten handles projection mechanism:
 <br />
 <ol>
 <li>Try to find document that has the same <b>Id</b> as the value of the property selected from event (so eg. for <b>UserCreated</b> event it will be <b>UserId</b>).</li>
-<li>If such document exists, then new record needs to be created. It's done using <b>default constructor</b>.</li>
+<li>
+    If such document exists, then new record needs to be created. Marten by default tries to use <b>default constructor</b>. <br />
+    Default constructor doesn't have to be public, might be also private or protected. <br />
+    If class does not have the default constructor then it creates unitialized object (see <a href="https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatterservices.getuninitializedobject?view=netframework-4.8" target="_parent">more</a>).<br />
+    Because of that, no member initializers will be run so all of them need to be initialized in the event handler methods.
+</li>
 <li>If document with such <b>Id</b> was found then it's being loaded from database.</li>
 <li>Document is updated with the defined in <b>ViewProjection</b> logic (using expression from second <b>ProjectEvent</b> parameter).</li>
 <li>Created or updated document is upserted to database.</li>

--- a/documentation/documentation/events/projections/index.md
+++ b/documentation/documentation/events/projections/index.md
@@ -93,3 +93,12 @@ At this point, you would be able to query against `QuestParty` as just another d
 Projections need to be rebuilt when the code that defines them changes in a way that requires events to be reapplied in order to maintain correct state. Using an `IDaemon` this is easy to execute on-demand:
 
 <[sample:rebuild-single-projection]>
+
+<div class="alert alert-warning">
+<b><u>Warning:</u></b>
+<br />
+Marten by default while creating new object tries to use <b>default constructor</b>. <br />
+Default constructor doesn't have to be public, might be also private or protected. <br />
+If class does not have the default constructor then it creates an uninitialized object (see <a href="https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatterservices.getuninitializedobject?view=netframework-4.8" target="_parent">more</a>).<br />
+Because of that, no member initializers will be run so all of them need to be initialized in the event handler methods.
+</div>

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,143 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false
+
+###############################
+# .NET Coding Conventions     #
+###############################
+
+[*.cs]
+# Organize usings
+dotnet_sort_system_directives_first = true:warning
+dotnet_separate_import_directive_groups = false:warning
+
+# this. preferences
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = always:warning
+dotnet_style_readonly_field = true:warning
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment = true:warning
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+
+###############################
+# Naming Conventions          #
+###############################
+
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization              = pascal_case
+
+# Use PascalCase for constant fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+
+###############################
+# C# Code Style Rules         #
+###############################
+
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+
+# Pattern-matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+
+# Null-checking preferences
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# Expression-level preferences
+csharp_prefer_braces = true:information
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:warning
+csharp_style_pattern_local_over_anonymous_function = true:warning
+csharp_style_inlined_variable_declaration = true:warning
+
+###############################
+# C# Formatting Rules         #
+###############################
+
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = false
+csharp_space_after_colon_in_inheritance_clause = true
+
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+
+# Wrapping preferences
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true

--- a/src/Marten.Testing/Events/Projections/QuestMonsters.cs
+++ b/src/Marten.Testing/Events/Projections/QuestMonsters.cs
@@ -145,4 +145,57 @@ namespace Marten.Testing.Events.Projections
             }
         }
     }
+
+    public class QuestMonstersWithNonDefaultPublicConstructor: IMonstersView
+    {
+        public Guid Id { get; private set; }
+
+        public IList<string> Monsters { get; private set; }
+
+        string[] IMonstersView.Monsters => Monsters.ToArray();
+
+        public QuestMonstersWithNonDefaultPublicConstructor(
+            Guid id,
+            string[] monsters
+        )
+        {
+            Id = id;
+            Monsters = monsters;
+        }
+
+        public void Apply(MonsterSlayed slayed)
+        {
+            if (Monsters == null)
+                Monsters = new List<string>();
+
+            Monsters.Fill(slayed.Name);
+        }
+    }
+
+    public class QuestMonstersWithDefaultPrivateConstructorAndNonDefaultPublicConstructor: IMonstersView
+    {
+        public Guid Id { get; private set; }
+
+        public IList<string> Monsters { get; private set; } = new List<string>();
+
+        string[] IMonstersView.Monsters => Monsters.ToArray();
+
+        public QuestMonstersWithDefaultPrivateConstructorAndNonDefaultPublicConstructor(
+            Guid id,
+            string[] monsters
+        )
+        {
+            Id = id;
+            Monsters = monsters;
+        }
+
+        private QuestMonstersWithDefaultPrivateConstructorAndNonDefaultPublicConstructor()
+        {
+        }
+
+        public void Apply(MonsterSlayed slayed)
+        {
+            Monsters.Fill(slayed.Name);
+        }
+    }
 }

--- a/src/Marten.Testing/Events/Projections/view_projection_for_view_with_base_class .cs
+++ b/src/Marten.Testing/Events/Projections/view_projection_for_view_with_base_class .cs
@@ -21,6 +21,8 @@ namespace Marten.Testing.Events.Projections
                 _.Events.InlineProjections.Add<ViewProjectionForViewWithBaseClass>();
                 _.Events.InlineProjections.Add<ViewProjectionForViewWithBaseClassAndIdOverloaded>();
                 _.Events.InlineProjections.Add<ViewProjectionForViewWithBaseClassAndIdOverloadedWithNew>();
+                _.Events.InlineProjections.Add<ViewProjectionForViewWithNonDefaultPublicConstructor>();
+                _.Events.InlineProjections.Add<ViewProjectionForViewWithDefaultPrivateConstructorAndNonDefaultPublicConstructor>();
             });
 
             streamId = theSession.Events
@@ -45,6 +47,18 @@ namespace Marten.Testing.Events.Projections
         public void run_view_projection_with_base_class_and_id_overloaded_with_new()
         {
             VerifyProjection<QuestMonstersWithBaseClassAndIdOverloadedWithNew>();
+        }
+
+        [Fact]
+        public void run_view_projection_with_non_default_public_constructor()
+        {
+            VerifyProjection<QuestMonstersWithNonDefaultPublicConstructor>();
+        }
+
+        [Fact]
+        public void run_view_projection_with_default_private_constructor_and_non_default_public_constructor()
+        {
+            VerifyProjection<QuestMonstersWithDefaultPrivateConstructorAndNonDefaultPublicConstructor>();
         }
 
         private void VerifyProjection<T>() where T : IMonstersView
@@ -95,6 +109,33 @@ namespace Marten.Testing.Events.Projections
             }
 
             private void Project(QuestMonstersWithBaseClassAndIdOverloadedWithNew view, MonsterSlayed @event)
+            {
+                view.Apply(@event);
+            }
+        }
+
+        public class ViewProjectionForViewWithNonDefaultPublicConstructor: ViewProjection<QuestMonstersWithNonDefaultPublicConstructor, Guid>
+        {
+            public ViewProjectionForViewWithNonDefaultPublicConstructor()
+            {
+                ProjectEvent<MonsterSlayed>(Project);
+            }
+
+            private void Project(QuestMonstersWithNonDefaultPublicConstructor view, MonsterSlayed @event)
+            {
+                view.Apply(@event);
+            }
+        }
+
+        public class ViewProjectionForViewWithDefaultPrivateConstructorAndNonDefaultPublicConstructor
+            : ViewProjection<QuestMonstersWithDefaultPrivateConstructorAndNonDefaultPublicConstructor, Guid>
+        {
+            public ViewProjectionForViewWithDefaultPrivateConstructorAndNonDefaultPublicConstructor()
+            {
+                ProjectEvent<MonsterSlayed>(Project);
+            }
+
+            private void Project(QuestMonstersWithDefaultPrivateConstructorAndNonDefaultPublicConstructor view, MonsterSlayed @event)
             {
                 view.Apply(@event);
             }

--- a/src/Marten.Testing/Events/ScenarioAggregateAndRepository.cs
+++ b/src/Marten.Testing/Events/ScenarioAggregateAndRepository.cs
@@ -111,10 +111,6 @@ namespace Marten.Testing.Events
     // SAMPLE: scenario-aggregate-invoice
     public sealed class Invoice: AggregateBase
     {
-        public Invoice()
-        {
-        }
-
         public Invoice(int invoiceNumber)
         {
             if (invoiceNumber <= 0)
@@ -130,6 +126,10 @@ namespace Marten.Testing.Events
 
             // Add the event to uncommitted events to use it while persisting the events to Marten events store
             AddUncommittedEvent(@event);
+        }
+
+        private Invoice()
+        {
         }
 
         // Enforce any contracts on input, then raise event capturing the data
@@ -156,6 +156,7 @@ namespace Marten.Testing.Events
         }
 
         public decimal Total { get; private set; }
+
         private readonly List<Tuple<string, decimal, decimal>> lines = new List<Tuple<string, decimal, decimal>>();
 
         // Apply the deltas to mutate our state
@@ -184,7 +185,7 @@ namespace Marten.Testing.Events
     // SAMPLE: scenario-aggregate-events
     public sealed class InvoiceCreated
     {
-        public readonly int InvoiceNumber;
+        public int InvoiceNumber { get; }
 
         public InvoiceCreated(int invoiceNumber)
         {
@@ -194,9 +195,9 @@ namespace Marten.Testing.Events
 
     public sealed class LineItemAdded
     {
-        public readonly decimal Price;
-        public readonly decimal Vat;
-        public readonly string Description;
+        public decimal Price { get; }
+        public decimal Vat { get; }
+        public string Description { get; }
 
         public LineItemAdded(decimal price, decimal vat, string description)
         {

--- a/src/Marten.Testing/Events/ScenarioAggregateAndRepository.cs
+++ b/src/Marten.Testing/Events/ScenarioAggregateAndRepository.cs
@@ -266,7 +266,7 @@ namespace Marten.Testing.Events
             aggregate.ClearUncommittedEvents();
         }
 
-        public T Load<T>(string id, int? version = null) where T : AggregateBase, new()
+        public T Load<T>(string id, int? version = null) where T : AggregateBase
         {
             using (var session = store.LightweightSession())
             {

--- a/src/Marten.Testing/Util/NewTests.cs
+++ b/src/Marten.Testing/Util/NewTests.cs
@@ -57,6 +57,16 @@ namespace Marten.Testing.Util
         }
 
         [Fact]
+        public void can_create_not_intialized_instance_of_class_with_no_default_constructor()
+        {
+            var instance = New<ClassWithNoDefaultConstructor>.Instance();
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeOfType<ClassWithNoDefaultConstructor>();
+            instance.IsInitialized.ShouldBeFalse();
+        }
+
+        [Fact]
         public void can_create_intialized_instance_of_class_with_private_default_constructor_and_public_non_default_constructor()
         {
             var instance = New<ClassWithPrivateDefaultConstructorAndPublicNonDefaultConstructor>.Instance();
@@ -150,6 +160,16 @@ namespace Marten.Testing.Util
 
         private ClassWithProtectedDefaultConstructor()
         {
+        }
+    }
+
+    internal class ClassWithNoDefaultConstructor
+    {
+        public bool IsInitialized = false;
+
+        public ClassWithNoDefaultConstructor(string stringParam)
+        {
+            IsInitialized = true;
         }
     }
 

--- a/src/Marten.Testing/Util/NewTests.cs
+++ b/src/Marten.Testing/Util/NewTests.cs
@@ -1,0 +1,243 @@
+using Marten.Util;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Util
+{
+    public class NewTests
+    {
+        [Fact]
+        public void can_create_intialized_instance_of_class_with_public_default_constructor()
+        {
+            var instance = New<ClassWithPublicDefaultConstructor>.Instance();
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeOfType<ClassWithPublicDefaultConstructor>();
+            instance.IsInitialized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void can_create_intialized_instance_of_class_with_public_default_constructor_and_public_non_default_constructor()
+        {
+            var instance = New<ClassWithPublicDefaultConstructorAndPublicNonDefaultConstructor>.Instance();
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeOfType<ClassWithPublicDefaultConstructorAndPublicNonDefaultConstructor>();
+            instance.IsInitialized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void can_create_intialized_instance_of_class_with_protected_default_constructor()
+        {
+            var instance = New<ClassWithProtectedDefaultConstructor>.Instance();
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeOfType<ClassWithProtectedDefaultConstructor>();
+            instance.IsInitialized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void can_create_intialized_instance_of_class_with_protected_default_constructor_and_public_non_default_constructor()
+        {
+            var instance = New<ClassWithProtectedDefaultConstructorAndPublicNonDefaultConstructor>.Instance();
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeOfType<ClassWithProtectedDefaultConstructorAndPublicNonDefaultConstructor>();
+            instance.IsInitialized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void can_create_intialized_instance_of_class_with_private_default_constructor()
+        {
+            var instance = New<ClassWithPrivateDefaultConstructor>.Instance();
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeOfType<ClassWithPrivateDefaultConstructor>();
+            instance.IsInitialized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void can_create_intialized_instance_of_class_with_private_default_constructor_and_public_non_default_constructor()
+        {
+            var instance = New<ClassWithPrivateDefaultConstructorAndPublicNonDefaultConstructor>.Instance();
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeOfType<ClassWithPrivateDefaultConstructorAndPublicNonDefaultConstructor>();
+            instance.IsInitialized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void can_create_intialized_instance_of_class_with_public_default_constructor_and_base_class_with_public_default_constructor()
+        {
+            var instance = New<DerivedClassWithPublicDefaultConstructor>.Instance();
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeOfType<DerivedClassWithPublicDefaultConstructor>();
+            instance.IsInitialized.ShouldBeTrue();
+            instance.IsInitializedInBaseClass.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void can_create_intialized_instance_of_class_with_protected_default_constructor_and_base_class_with_public_default_constructor()
+        {
+            var instance = New<DerivedClassWithProtectedDefaultConstructor>.Instance();
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeOfType<DerivedClassWithProtectedDefaultConstructor>();
+            instance.IsInitialized.ShouldBeTrue();
+            instance.IsInitializedInBaseClass.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void can_create_intialized_instance_of_class_with_private_default_constructor_and_base_class_with_public_default_constructor()
+        {
+            var instance = New<DerivedClassWithPrivateDefaultConstructor>.Instance();
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeOfType<DerivedClassWithPrivateDefaultConstructor>();
+            instance.IsInitialized.ShouldBeTrue();
+            instance.IsInitializedInBaseClass.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void can_create__not_intialized_instance_of_class_with_no_default_constructor_and_base_class_with_public_default_constructor()
+        {
+            var instance = New<DerivedClassWithNoDefaultConstructor>.Instance();
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeOfType<DerivedClassWithNoDefaultConstructor>();
+            instance.IsInitialized.ShouldBeFalse();
+            instance.IsInitializedInBaseClass.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void can_create_intialized_instance_of_string_and_returns_empty_string()
+        {
+            var instance = New<string>.Instance();
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeEmpty();
+        }
+    }
+
+    internal class ClassWithPublicDefaultConstructor
+    {
+        public bool IsInitialized = false;
+
+        public ClassWithPublicDefaultConstructor()
+        {
+            IsInitialized = true;
+        }
+    }
+
+    internal class ClassWithPublicDefaultConstructorAndPublicNonDefaultConstructor
+    {
+        public bool IsInitialized = false;
+
+        public ClassWithPublicDefaultConstructorAndPublicNonDefaultConstructor()
+        {
+            IsInitialized = true;
+        }
+
+        public ClassWithPublicDefaultConstructorAndPublicNonDefaultConstructor(string stringParam)
+        {
+        }
+    }
+
+    internal class ClassWithProtectedDefaultConstructor
+    {
+        public bool IsInitialized = true;
+
+        private ClassWithProtectedDefaultConstructor()
+        {
+        }
+    }
+
+    internal class ClassWithProtectedDefaultConstructorAndPublicNonDefaultConstructor
+    {
+        public bool IsInitialized = false;
+
+        private ClassWithProtectedDefaultConstructorAndPublicNonDefaultConstructor()
+        {
+            IsInitialized = true;
+        }
+
+        public ClassWithProtectedDefaultConstructorAndPublicNonDefaultConstructor(string stringParam)
+        {
+        }
+    }
+
+    internal class ClassWithPrivateDefaultConstructor
+    {
+        public bool IsInitialized = false;
+
+        private ClassWithPrivateDefaultConstructor()
+        {
+            IsInitialized = true;
+        }
+    }
+
+    internal class ClassWithPrivateDefaultConstructorAndPublicNonDefaultConstructor
+    {
+        public bool IsInitialized = false;
+
+        private ClassWithPrivateDefaultConstructorAndPublicNonDefaultConstructor()
+        {
+            IsInitialized = true;
+        }
+
+        public ClassWithPrivateDefaultConstructorAndPublicNonDefaultConstructor(string stringParam)
+        {
+        }
+    }
+
+    internal class BaseClassWithPublicDefaultConstructor
+    {
+        public bool IsInitializedInBaseClass = false;
+
+        public BaseClassWithPublicDefaultConstructor()
+        {
+            IsInitializedInBaseClass = true;
+        }
+    }
+
+    internal class DerivedClassWithPublicDefaultConstructor: BaseClassWithPublicDefaultConstructor
+    {
+        public bool IsInitialized = false;
+
+        public DerivedClassWithPublicDefaultConstructor()
+        {
+            IsInitialized = true;
+        }
+    }
+
+    internal class DerivedClassWithProtectedDefaultConstructor: BaseClassWithPublicDefaultConstructor
+    {
+        public bool IsInitialized = false;
+
+        private DerivedClassWithProtectedDefaultConstructor()
+        {
+            IsInitialized = true;
+        }
+    }
+
+    internal class DerivedClassWithPrivateDefaultConstructor: BaseClassWithPublicDefaultConstructor
+    {
+        public bool IsInitialized = false;
+
+        private DerivedClassWithPrivateDefaultConstructor()
+        {
+            IsInitialized = true;
+        }
+    }
+
+    internal class DerivedClassWithNoDefaultConstructor: BaseClassWithPublicDefaultConstructor
+    {
+        public bool IsInitialized = false;
+
+        private DerivedClassWithNoDefaultConstructor(string stringParam)
+        {
+            IsInitialized = true;
+        }
+    }
+}

--- a/src/Marten/Events/AggregationQueryHandler.cs
+++ b/src/Marten/Events/AggregationQueryHandler.cs
@@ -10,7 +10,7 @@ using Marten.Util;
 
 namespace Marten.Events
 {
-    internal class AggregationQueryHandler<T>: IQueryHandler<T> where T : class, new()
+    internal class AggregationQueryHandler<T>: IQueryHandler<T> where T : class
     {
         private readonly IAggregator<T> _aggregator;
         private readonly IEventQueryHandler _inner;

--- a/src/Marten/Events/Event.cs
+++ b/src/Marten/Events/Event.cs
@@ -40,7 +40,7 @@ namespace Marten.Events
         string TenantId { get; set; }
 
         void Apply<TAggregate>(TAggregate state, IAggregator<TAggregate> aggregator)
-            where TAggregate : class, new();
+            where TAggregate : class;
     }
 
     // ENDSAMPLE
@@ -97,7 +97,7 @@ namespace Marten.Events
         object IEvent.Data => Data;
 
         public virtual void Apply<TAggregate>(TAggregate state, IAggregator<TAggregate> aggregator)
-            where TAggregate : class, new()
+            where TAggregate : class
         {
             var step = aggregator.AggregatorFor<T>();
             if (step is IAggregationWithMetadata<TAggregate, T>)

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -71,7 +71,7 @@ namespace Marten.Events
             return _events[eventType];
         }
 
-        public EventMapping EventMappingFor<T>() where T : class, new()
+        public EventMapping EventMappingFor<T>() where T : class
         {
             return EventMappingFor(typeof(T));
         }
@@ -109,13 +109,13 @@ namespace Marten.Events
             set { _databaseSchemaName = value; }
         }
 
-        public void AddAggregator<T>(IAggregator<T> aggregator) where T : class, new()
+        public void AddAggregator<T>(IAggregator<T> aggregator) where T : class
         {
             Options.Storage.MappingFor(typeof(T));
             _aggregates.Swap(a => a.AddOrUpdate(typeof(T), aggregator));
         }
 
-        public IAggregator<T> AggregateFor<T>() where T : class, new()
+        public IAggregator<T> AggregateFor<T>() where T : class
         {
             if (!_aggregates.Value.TryFind(typeof(T), out var aggregator))
             {
@@ -164,7 +164,7 @@ namespace Marten.Events
             return AsyncProjections.ForView(viewType) ?? InlineProjections.ForView(viewType);
         }
 
-        public ViewProjection<TView, TId> ProjectView<TView, TId>() where TView : class, new()
+        public ViewProjection<TView, TId> ProjectView<TView, TId>() where TView : class
         {
             var projection = new ViewProjection<TView, TId>();
             InlineProjections.Add(projection);

--- a/src/Marten/Events/EventStore.cs
+++ b/src/Marten/Events/EventStore.cs
@@ -112,7 +112,7 @@ namespace Marten.Events
             return eventStream;
         }
 
-        public EventStream StartStream<T>(Guid id, params object[] events) where T : class, new()
+        public EventStream StartStream<T>(Guid id, params object[] events) where T : class
         {
             ensureAsGuidStorage();
 
@@ -126,7 +126,7 @@ namespace Marten.Events
             return stream;
         }
 
-        public EventStream StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class, new()
+        public EventStream StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class
         {
             ensureAsStringStorage();
 
@@ -162,7 +162,7 @@ namespace Marten.Events
             return stream;
         }
 
-        public EventStream StartStream<TAggregate>(params object[] events) where TAggregate : class, new()
+        public EventStream StartStream<TAggregate>(params object[] events) where TAggregate : class
         {
             return StartStream<TAggregate>(Guid.NewGuid(), events);
         }
@@ -204,7 +204,7 @@ namespace Marten.Events
             return _connection.FetchAsync(handler, null, null, _tenant, token);
         }
 
-        public T AggregateStream<T>(Guid streamId, int version = 0, DateTime? timestamp = null, T state = null) where T : class, new()
+        public T AggregateStream<T>(Guid streamId, int version = 0, DateTime? timestamp = null, T state = null) where T : class
         {
             ensureAsGuidStorage();
 
@@ -221,7 +221,7 @@ namespace Marten.Events
         }
 
         public async Task<T> AggregateStreamAsync<T>(Guid streamId, int version = 0, DateTime? timestamp = null,
-            T state = null, CancellationToken token = new CancellationToken()) where T : class, new()
+            T state = null, CancellationToken token = new CancellationToken()) where T : class
         {
             ensureAsGuidStorage();
 
@@ -237,7 +237,7 @@ namespace Marten.Events
             return aggregate;
         }
 
-        public T AggregateStream<T>(string streamKey, int version = 0, DateTime? timestamp = null, T state = null) where T : class, new()
+        public T AggregateStream<T>(string streamKey, int version = 0, DateTime? timestamp = null, T state = null) where T : class
         {
             ensureAsStringStorage();
 
@@ -254,7 +254,7 @@ namespace Marten.Events
         }
 
         public async Task<T> AggregateStreamAsync<T>(string streamKey, int version = 0, DateTime? timestamp = null,
-            T state = null, CancellationToken token = new CancellationToken()) where T : class, new()
+            T state = null, CancellationToken token = new CancellationToken()) where T : class
         {
             ensureAsStringStorage();
 

--- a/src/Marten/Events/IEventStore.cs
+++ b/src/Marten/Events/IEventStore.cs
@@ -47,7 +47,7 @@ namespace Marten.Events
         /// <param name="id"></param>
         /// <param name="events"></param>
         /// <returns></returns>
-        EventStream StartStream<TAggregate>(Guid id, params object[] events) where TAggregate : class, new();
+        EventStream StartStream<TAggregate>(Guid id, params object[] events) where TAggregate : class;
 
         /// <summary>
         /// Creates a new event stream based on a user-supplied Guid and appends the events in order to the new stream
@@ -57,7 +57,7 @@ namespace Marten.Events
         /// <param name="streamKey">String identifier of this stream</param>
         /// <param name="events"></param>
         /// <returns></returns>
-        EventStream StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class, new();
+        EventStream StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class;
 
         /// <summary>
         /// Creates a new event stream based on a user-supplied Guid and appends the events in order to the new stream - WILL THROW AN EXCEPTION IF THE STREAM ALREADY EXISTS
@@ -83,7 +83,7 @@ namespace Marten.Events
         /// <typeparam name="TAggregate"></typeparam>
         /// <param name="events"></param>
         /// <returns></returns>
-        EventStream StartStream<TAggregate>(params object[] events) where TAggregate : class, new();
+        EventStream StartStream<TAggregate>(params object[] events) where TAggregate : class;
 
         /// <summary>
         /// Creates a new event stream, assigns a new Guid id, and appends the events in order to the new stream
@@ -141,7 +141,7 @@ namespace Marten.Events
         /// <param name="timestamp"></param>
         /// <param name="state">Instance of T to apply events to</param>
         /// <returns></returns>
-        T AggregateStream<T>(Guid streamId, int version = 0, DateTime? timestamp = null, T state = null) where T : class, new();
+        T AggregateStream<T>(Guid streamId, int version = 0, DateTime? timestamp = null, T state = null) where T : class;
 
         /// <summary>
         /// Perform a live aggregation of the raw events in this stream to a T object
@@ -153,7 +153,7 @@ namespace Marten.Events
         /// <param name="state">Instance of T to apply events to</param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T> AggregateStreamAsync<T>(Guid streamId, int version = 0, DateTime? timestamp = null, T state = null, CancellationToken token = default(CancellationToken)) where T : class, new();
+        Task<T> AggregateStreamAsync<T>(Guid streamId, int version = 0, DateTime? timestamp = null, T state = null, CancellationToken token = default(CancellationToken)) where T : class;
 
         /// <summary>
         /// Perform a live aggregation of the raw events in this stream to a T object
@@ -164,7 +164,7 @@ namespace Marten.Events
         /// <param name="timestamp"></param>
         /// <param name="state">Instance of T to apply events to</param>
         /// <returns></returns>
-        T AggregateStream<T>(string streamKey, int version = 0, DateTime? timestamp = null, T state = null) where T : class, new();
+        T AggregateStream<T>(string streamKey, int version = 0, DateTime? timestamp = null, T state = null) where T : class;
 
         /// <summary>
         /// Perform a live aggregation of the raw events in this stream to a T object
@@ -176,7 +176,7 @@ namespace Marten.Events
         /// <param name="state">Instance of T to apply events to</param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T> AggregateStreamAsync<T>(string streamKey, int version = 0, DateTime? timestamp = null, T state = null, CancellationToken token = default(CancellationToken)) where T : class, new();
+        Task<T> AggregateStreamAsync<T>(string streamKey, int version = 0, DateTime? timestamp = null, T state = null, CancellationToken token = default(CancellationToken)) where T : class;
 
         /// <summary>
         /// Query directly against ONLY the raw event data. Use IQuerySession.Query() for aggregated documents!

--- a/src/Marten/Events/Projections/AggregateFinder.cs
+++ b/src/Marten/Events/Projections/AggregateFinder.cs
@@ -12,7 +12,7 @@ namespace Marten.Events.Projections
     /// Simple aggregation finder that looks for an aggregate document based on the stream id
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class AggregateFinder<T>: IAggregationFinder<T> where T : class, new()
+    public class AggregateFinder<T>: IAggregationFinder<T> where T : class
     {
         private readonly Action<T, Guid> _setId;
 
@@ -33,7 +33,7 @@ namespace Marten.Events.Projections
 
         public T Find(EventStream stream, IDocumentSession session)
         {
-            var returnValue = stream.IsNew ? new T() : session.Load<T>(stream.Id) ?? new T();
+            var returnValue = stream.IsNew ? New<T>.Instance() : session.Load<T>(stream.Id) ?? New<T>.Instance();
             _setId(returnValue, stream.Id);
 
             return returnValue;
@@ -41,7 +41,7 @@ namespace Marten.Events.Projections
 
         public async Task<T> FindAsync(EventStream stream, IDocumentSession session, CancellationToken token)
         {
-            var returnValue = stream.IsNew ? new T() : await session.LoadAsync<T>(stream.Id, token).ConfigureAwait(false) ?? new T();
+            var returnValue = stream.IsNew ? New<T>.Instance() : await session.LoadAsync<T>(stream.Id, token).ConfigureAwait(false) ?? New<T>.Instance();
 
             _setId(returnValue, stream.Id);
 

--- a/src/Marten/Events/Projections/AggregationProjection.cs
+++ b/src/Marten/Events/Projections/AggregationProjection.cs
@@ -4,11 +4,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Baseline;
 using Marten.Events.Projections.Async;
+using Marten.Util;
 
 namespace Marten.Events.Projections
 {
     // This is mostly tested through integration tests and in the Storyteller suite
-    public class AggregationProjection<T>: DocumentProjection<T>, IDocumentProjection where T : class, new()
+    public class AggregationProjection<T>: DocumentProjection<T>, IDocumentProjection where T : class
     {
         private readonly IAggregationFinder<T> _finder;
         private readonly IAggregator<T> _aggregator;
@@ -44,7 +45,7 @@ namespace Marten.Events.Projections
 
             foreach (var stream in matchingStreams)
             {
-                var state = await _finder.FindAsync(stream, session, token).ConfigureAwait(false) ?? new T();
+                var state = await _finder.FindAsync(stream, session, token).ConfigureAwait(false) ?? New<T>.Instance();
                 update(state, stream);
 
                 session.Store(state);

--- a/src/Marten/Events/Projections/Aggregator.cs
+++ b/src/Marten/Events/Projections/Aggregator.cs
@@ -7,7 +7,7 @@ using Marten.Util;
 
 namespace Marten.Events.Projections
 {
-    public class Aggregator<T>: IAggregator<T> where T : class, new()
+    public class Aggregator<T>: IAggregator<T> where T : class
     {
         public static readonly string ApplyMethod = "Apply";
 
@@ -47,7 +47,7 @@ namespace Marten.Events.Projections
 
         public T Build(IEnumerable<IEvent> events, IDocumentSession session)
         {
-            return Build(events, session, new T());
+            return Build(events, session, New<T>.Instance());
         }
 
         public T Build(IEnumerable<IEvent> events, IDocumentSession session, T state)

--- a/src/Marten/Events/Projections/AggregatorApplyPrivate.cs
+++ b/src/Marten/Events/Projections/AggregatorApplyPrivate.cs
@@ -6,7 +6,7 @@ namespace Marten.Events.Projections
     /// <summary>
     /// Customize behaviour of <see cref="Aggregator{T}" /> by using private Apply methods in aggregation.
     /// </summary>
-    public class AggregatorApplyPrivate<T>: Aggregator<T> where T : class, new()
+    public class AggregatorApplyPrivate<T>: Aggregator<T> where T : class
     {
         public AggregatorApplyPrivate() : base(typeof(T).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
             .Where(x => x.Name == ApplyMethod && x.GetParameters().Length == 1))

--- a/src/Marten/Events/Projections/AggregatorApplyPublicAndPrivate.cs
+++ b/src/Marten/Events/Projections/AggregatorApplyPublicAndPrivate.cs
@@ -6,7 +6,7 @@ namespace Marten.Events.Projections
     /// <summary>
     /// Customize behaviour of <see cref="Aggregator{T}" /> by using private Apply methods in aggregation.
     /// </summary>
-    public class AggregatorApplyPublicAndPrivate<T>: Aggregator<T> where T : class, new()
+    public class AggregatorApplyPublicAndPrivate<T>: Aggregator<T> where T : class
     {
         public AggregatorApplyPublicAndPrivate() : base(typeof(T).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
             .Where(x => x.Name == ApplyMethod && x.GetParameters().Length == 1))

--- a/src/Marten/Events/Projections/AggregatorLookup.cs
+++ b/src/Marten/Events/Projections/AggregatorLookup.cs
@@ -16,7 +16,7 @@ namespace Marten.Events.Projections
             this.factory = factory;
         }
 
-        public IAggregator<T> Lookup<T>() where T : class, new()
+        public IAggregator<T> Lookup<T>() where T : class
         {
             // trade null check for the cost of using default factory with Activator.CreateInstance
             return (IAggregator<T>)factory?.Invoke(typeof(T)) ?? new Aggregator<T>();

--- a/src/Marten/Events/Projections/IAggregatorLookup.cs
+++ b/src/Marten/Events/Projections/IAggregatorLookup.cs
@@ -10,7 +10,7 @@ namespace Marten.Events.Projections
         /// <summary>
         /// Resolve aggregator for T
         /// </summary>
-        IAggregator<T> Lookup<T>() where T : class, new();
+        IAggregator<T> Lookup<T>() where T : class;
 
         /// <summary>
         /// Resolve aggregator for aggregateType

--- a/src/Marten/Events/Projections/LazyLoadedProjection.cs
+++ b/src/Marten/Events/Projections/LazyLoadedProjection.cs
@@ -4,18 +4,19 @@ using System.Threading;
 using System.Threading.Tasks;
 using Marten.Events.Projections.Async;
 using Marten.Storage;
+using Marten.Util;
 
 namespace Marten.Events.Projections
 {
     public class LazyLoadedProjection<T>: IProjection, IDocumentsProjection
-        where T : IProjection, new()
+        where T : IProjection
     {
         private readonly Func<T> factory;
 
         public LazyLoadedProjection(Func<T> factory)
         {
             this.factory = factory;
-            var definition = new T();
+            var definition = New<T>.Instance();
 
             Consumes = definition.Consumes;
             AsyncOptions = definition.AsyncOptions;

--- a/src/Marten/Events/Projections/ProjectionCollection.cs
+++ b/src/Marten/Events/Projections/ProjectionCollection.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using System.Reflection;
+using Marten.Util;
 
 namespace Marten.Events.Projections
 {
@@ -27,7 +28,7 @@ namespace Marten.Events.Projections
             return GetEnumerator();
         }
 
-        public AggregationProjection<T> AggregateStreamsWith<T>() where T : class, new()
+        public AggregationProjection<T> AggregateStreamsWith<T>() where T : class
         {
             var aggregator = _options.Events.AggregateFor<T>();
 
@@ -63,12 +64,12 @@ namespace Marten.Events.Projections
             _projections.Add(projection);
         }
 
-        public void Add<T>() where T : IProjection, new()
+        public void Add<T>() where T : IProjection
         {
-            Add(new T());
+            Add(New<T>.Instance());
         }
 
-        public void Add<T>(Func<T> projectionFactory) where T : IProjection, new()
+        public void Add<T>(Func<T> projectionFactory) where T : IProjection
         {
             var lazyLoadedProjection = new LazyLoadedProjection<T>(projectionFactory);
 

--- a/src/Marten/Events/Projections/StringIdentifiedAggregateFinder.cs
+++ b/src/Marten/Events/Projections/StringIdentifiedAggregateFinder.cs
@@ -12,7 +12,7 @@ namespace Marten.Events.Projections
     /// Simple aggregation finder that looks for an aggregate document based on the stream key
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class StringIdentifiedAggregateFinder<T>: IAggregationFinder<T> where T : class, new()
+    public class StringIdentifiedAggregateFinder<T>: IAggregationFinder<T> where T : class
     {
         private readonly Action<T, string> _setId;
 
@@ -33,7 +33,7 @@ namespace Marten.Events.Projections
 
         public T Find(EventStream stream, IDocumentSession session)
         {
-            var returnValue = stream.IsNew ? new T() : session.Load<T>(stream.Key) ?? new T();
+            var returnValue = stream.IsNew ? New<T>.Instance() : session.Load<T>(stream.Key) ?? New<T>.Instance();
             _setId(returnValue, stream.Key);
 
             return returnValue;
@@ -41,7 +41,7 @@ namespace Marten.Events.Projections
 
         public async Task<T> FindAsync(EventStream stream, IDocumentSession session, CancellationToken token)
         {
-            var returnValue = stream.IsNew ? new T() : await session.LoadAsync<T>(stream.Key, token).ConfigureAwait(false) ?? new T();
+            var returnValue = stream.IsNew ? New<T>.Instance() : await session.LoadAsync<T>(stream.Key, token).ConfigureAwait(false) ?? New<T>.Instance();
 
             _setId(returnValue, stream.Key);
 

--- a/src/Marten/Events/Projections/ViewProjection.cs
+++ b/src/Marten/Events/Projections/ViewProjection.cs
@@ -13,7 +13,7 @@ using Marten.Util;
 namespace Marten.Events.Projections
 {
     public class ViewProjection<TView, TId>: DocumentProjection<TView>, IDocumentProjection
-        where TView : class, new()
+        where TView : class
     {
         private readonly Func<IQuerySession, TId[], IReadOnlyList<TView>> _sessionLoadMany;
 
@@ -828,7 +828,7 @@ namespace Marten.Events.Projections
 
         private static TView newView(ITenant tenant, IdAssignment<TView> idAssigner, TId id)
         {
-            var view = new TView();
+            var view = New<TView>.Instance();
             idAssigner.Assign(tenant, view, id);
             return view;
         }

--- a/src/Marten/Services/BatchQuerying/BatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQuery.cs
@@ -128,7 +128,7 @@ namespace Marten.Services.BatchQuerying
         }
 
         public Task<T> AggregateStream<T>(Guid streamId, int version = 0, DateTime? timestamp = null)
-            where T : class, new()
+            where T : class
         {
             var inner = new EventQueryHandler<Guid>(new EventSelector(_store.Events, _store.Serializer), streamId, version,
                 timestamp, _store.Events.TenancyStyle, _parent.Tenant.TenantId);

--- a/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
@@ -17,7 +17,7 @@ namespace Marten.Services.BatchQuerying
         /// <param name="version"></param>
         /// <param name="timestamp"></param>
         /// <returns></returns>
-        Task<T> AggregateStream<T>(Guid streamId, int version = 0, DateTime? timestamp = null) where T : class, new();
+        Task<T> AggregateStream<T>(Guid streamId, int version = 0, DateTime? timestamp = null) where T : class;
 
         /// <summary>
         /// Load a single event with all of its metadata

--- a/src/Marten/Util/New.cs
+++ b/src/Marten/Util/New.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Runtime.Serialization;
 
 namespace Marten.Util
@@ -25,7 +26,17 @@ namespace Marten.Util
     {
         public static bool HasDefaultConstructor(this Type t)
         {
-            return t.IsValueType || t.GetConstructor(Type.EmptyTypes) != null;
+            return t.IsValueType || t.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, Type.EmptyTypes, null) != null;
         }
+    }
+
+    public enum ConstructorHandling
+    {
+        DefaultPublic = 1,
+        DefaultProtected = 2,
+        DefaultPrivate = 4,
+        NotInitialized = 8,
+        AnyDefault = DefaultPublic | DefaultProtected | DefaultPrivate,
+        All = AnyDefault | NotInitialized
     }
 }

--- a/src/Marten/Util/New.cs
+++ b/src/Marten/Util/New.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq.Expressions;
+using System.Runtime.Serialization;
+
+namespace Marten.Util
+{
+    public static class New<T>
+    {
+        public static readonly Func<T> Instance = Creator();
+
+        private static Func<T> Creator()
+        {
+            var t = typeof(T);
+            if (t == typeof(string))
+                return Expression.Lambda<Func<T>>(Expression.Constant(string.Empty)).Compile();
+
+            if (t.HasDefaultConstructor())
+                return Expression.Lambda<Func<T>>(Expression.New(t)).Compile();
+
+            return () => (T)FormatterServices.GetUninitializedObject(t);
+        }
+    }
+
+    public static class New
+    {
+        public static bool HasDefaultConstructor(this Type t)
+        {
+            return t.IsValueType || t.GetConstructor(Type.EmptyTypes) != null;
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Currently, Marten forces in many places `new ()` constructor. This is not a huge issue, but a bit painful and sometimes too big restriction. For most of the guides of how to construct proper aggregates (and classes in general), it stated that they should only expose what's needed. Usually, it's good to not expose the public default constructor but use the dedicated factory method.

Especially for the event-sourced aggregates, it's important, as the state should be rebuilt from the events. 

## Details of changed

Introduced new object factory called (surprise!) [New](https://github.com/JasperFx/marten/pull/1447/files#diff-7d3a0e04c31307b447489d682c01847aR8). This solution is taken from https://stackoverflow.com/a/16162475/10966454.

See also more benchmarks and discussion about object creation from lambda (with expression caching):
- http://grantbyrne.com/post/activatorcreateinstancealternativetesting/
- https://codereview.stackexchange.com/questions/151167/accessing-properties-by-name

The solution tries to find the default public constructor, if it's not able then it's searching for non-public and this is also not found then it creates an uninitialized object (see  https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatterservices.getuninitializedobject?view=netframework-4.8). 

Besides that:
- added necessary tests,
- updated aggregate & repository case study,
- updated documentation with information about object creation,
- copied .editorconfig file to be located in the same folder as marten solution file (this is required to have rules properly applied).