### PR TITLE
Add possibility to start typed event streams with non-generic StartStream

### DIFF
--- a/documentation/documentation/events/index.md
+++ b/documentation/documentation/events/index.md
@@ -19,6 +19,12 @@ Because I’ve read way too much epic fantasy fiction, my sample problem domain 
 
 Now, let's say that we're starting a new "quest" with the first couple of events, then appending a couple more as other quest party members join up:
 
-<[sample:event-store-quickstart]>
+<[sample:event-store-start-stream-with-explicit-type]>
 
-In addition to generic `StartStream<T>`, `IEventStore` has a non-generic `StartStream` overload to create streams without associating them with aggregate type (stored in `mt_streams` table).
+In addition to generic `StartStream<T>`, `IEventStore` has a non-generic `StartStream` overload that let you pass explicit type.
+
+<[sample:event-store-quickstart]>
+ 
+It has also overload to create streams without associating them with aggregate type (stored in `mt_streams` table).
+
+<[sample:event-store-start-stream-with-explicit-type]>

--- a/src/Marten.Testing/Examples/event_store_quickstart.cs
+++ b/src/Marten.Testing/Examples/event_store_quickstart.cs
@@ -41,6 +41,32 @@ namespace Marten.Testing.Examples
             }
             // ENDSAMPLE
 
+
+            // SAMPLE: event-store-start-stream-with-explicit-type
+            using (var session = store.OpenSession())
+            {
+                var started = new QuestStarted { Name = "Destroy the One Ring" };
+                var joined1 = new MembersJoined(1, "Hobbiton", "Frodo", "Sam");
+
+                // Start a brand new stream and commit the new events as
+                // part of a transaction
+                // no stream type will be stored in database
+                session.Events.StartStream(typeof(Quest), questId, started, joined1);
+            }
+
+            // SAMPLE: event-store-start-stream-with-no-type
+            using (var session = store.OpenSession())
+            {
+                var started = new QuestStarted { Name = "Destroy the One Ring" };
+                var joined1 = new MembersJoined(1, "Hobbiton", "Frodo", "Sam");
+
+                // Start a brand new stream and commit the new events as
+                // part of a transaction
+                // no stream type will be stored in database
+                session.Events.StartStream(questId, started, joined1);
+            }
+            // ENDSAMPLE
+
             // SAMPLE: events-fetching-stream
             using (var session = store.OpenSession())
             {

--- a/src/Marten/Events/EventStore.cs
+++ b/src/Marten/Events/EventStore.cs
@@ -175,7 +175,12 @@ namespace Marten.Events
 
         public EventStream StartStream<TAggregate>(params object[] events) where TAggregate : class
         {
-            return StartStream<TAggregate>(CombGuidIdGeneration.NewGuid(), events);
+            return StartStream(typeof(TAggregate), events);
+        }
+
+        public EventStream StartStream(Type aggregateType, params object[] events)
+        {
+            return StartStream(aggregateType, CombGuidIdGeneration.NewGuid(), events);
         }
 
         public EventStream StartStream(params object[] events)

--- a/src/Marten/Events/EventStore.cs
+++ b/src/Marten/Events/EventStore.cs
@@ -115,11 +115,16 @@ namespace Marten.Events
 
         public EventStream StartStream<T>(Guid id, params object[] events) where T : class
         {
+            return StartStream(typeof(T), id, events);
+        }
+
+        public EventStream StartStream(Type aggregateType, Guid id, params object[] events)
+        {
             ensureAsGuidStorage();
 
             var stream = new EventStream(id, events.Select(EventStream.ToEvent).ToArray(), true)
             {
-                AggregateType = typeof(T)
+                AggregateType = aggregateType
             };
 
             _unitOfWork.StoreStream(stream);
@@ -129,11 +134,16 @@ namespace Marten.Events
 
         public EventStream StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class
         {
+            return StartStream(typeof(TAggregate), streamKey, events);
+        }
+
+        public EventStream StartStream(Type aggregateType, string streamKey, params object[] events)
+        {
             ensureAsStringStorage();
 
             var stream = new EventStream(streamKey, events.Select(EventStream.ToEvent).ToArray(), true)
             {
-                AggregateType = typeof(TAggregate)
+                AggregateType = aggregateType
             };
 
             _unitOfWork.StoreStream(stream);

--- a/src/Marten/Events/IEventStore.cs
+++ b/src/Marten/Events/IEventStore.cs
@@ -104,6 +104,16 @@ namespace Marten.Events
         /// <returns></returns>
         EventStream StartStream<TAggregate>(params object[] events) where TAggregate : class;
 
+
+        /// <summary>
+        /// Creates a new event stream, assigns a new Guid id, and appends the events in order to the new stream
+        ///  - WILL THROW AN EXCEPTION IF THE STREAM ALREADY EXISTS
+        /// </summary>
+        /// <typeparam name="TAggregate"></typeparam>
+        /// <param name="events"></param>
+        /// <returns></returns>
+        EventStream StartStream(Type aggregateType, params object[] events);
+
         /// <summary>
         /// Creates a new event stream, assigns a new Guid id, and appends the events in order to the new stream
         ///  - WILL THROW AN EXCEPTION IF THE STREAM ALREADY EXISTS

--- a/src/Marten/Events/IEventStore.cs
+++ b/src/Marten/Events/IEventStore.cs
@@ -51,6 +51,15 @@ namespace Marten.Events
 
         /// <summary>
         /// Creates a new event stream based on a user-supplied Guid and appends the events in order to the new stream
+        /// </summary>
+        /// <param name="aggregateType"></param>
+        /// <param name="id"></param>
+        /// <param name="events"></param>
+        /// <returns></returns>
+        EventStream StartStream(Type aggregateType, Guid id, params object[] events);
+
+        /// <summary>
+        /// Creates a new event stream based on a user-supplied Guid and appends the events in order to the new stream
         ///  - WILL THROW AN EXCEPTION IF THE STREAM ALREADY EXISTS
         /// </summary>
         /// <typeparam name="TAggregate"></typeparam>
@@ -58,6 +67,16 @@ namespace Marten.Events
         /// <param name="events"></param>
         /// <returns></returns>
         EventStream StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class;
+
+        /// <summary>
+        /// Creates a new event stream based on a user-supplied Guid and appends the events in order to the new stream
+        ///  - WILL THROW AN EXCEPTION IF THE STREAM ALREADY EXISTS
+        /// </summary>
+        /// <param name="aggregateType"></param>
+        /// <param name="streamKey">String identifier of this stream</param>
+        /// <param name="events"></param>
+        /// <returns></returns>
+        EventStream StartStream(Type aggregateType, string streamKey, params object[] events);
 
         /// <summary>
         /// Creates a new event stream based on a user-supplied Guid and appends the events in order to the new stream - WILL THROW AN EXCEPTION IF THE STREAM ALREADY EXISTS


### PR DESCRIPTION
I have a use case where I'm starting new event streams without knowing the type at compile time. It's essential for me that the stream type info gets persisted. This change declares two new StartStream methods on the IEventStore interface which allows you to pass the the aggregate type as a parameter. 