### PR TITLE
Failing test for alternate nullable syntax

### DIFF
--- a/src/Marten.Testing/Linq/query_with_nullable_types_Tests.cs
+++ b/src/Marten.Testing/Linq/query_with_nullable_types_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Marten.Services;
 using Shouldly;
@@ -80,6 +80,18 @@ namespace Marten.Testing.Linq
 
             theSession.Query<Target>().Where(x => !x.NullableDateTime.HasValue || x.NullableDateTime > new DateTime(2525,1,1)).Count()
                 .ShouldBe(4);
+        }
+
+        [Fact]
+        public void query_against_null_6()
+        {
+            theSession.Store(new Target { NullableBoolean = null });
+            theSession.Store(new Target { NullableBoolean = true });
+
+            theSession.SaveChanges();
+
+            theSession.Query<Target>().Where(x => x.NullableBoolean.HasValue == false).Count()
+                .ShouldBe(1);
         }
 
         [Fact]


### PR DESCRIPTION
Example for https://github.com/JasperFx/marten/issues/1458

I wanted to start by showing a failing test. Is this a good candidate for a fix, assuming I could figure out where to patch the LINQ parser?