### PR TITLE
#1431 - Added tests for the case when there is a session having deletions to two or more document types, where those documents have the same types of primary keys

### DIFF
--- a/src/Marten.Testing/CoreFunctionality/document_session_delete_a_single_document_Tests.cs
+++ b/src/Marten.Testing/CoreFunctionality/document_session_delete_a_single_document_Tests.cs
@@ -1,13 +1,18 @@
-﻿using Marten.Services;
+﻿using System;
+using Marten.Services;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Xunit;
 
 namespace Marten.Testing.CoreFunctionality
 {
-    public abstract class document_session_delete_a_single_document_Tests<T> : IntegrationContextWithIdentityMap<T>
+    public abstract class document_session_delete_a_single_document_Tests<T>: IntegrationContextWithIdentityMap<T>
         where T : IIdentityMap
     {
+        protected document_session_delete_a_single_document_Tests(DefaultStoreFixture fixture): base(fixture)
+        {
+        }
+
         [Fact]
         public void persist_and_delete_a_document_by_entity()
         {
@@ -47,29 +52,56 @@ namespace Marten.Testing.CoreFunctionality
             }
         }
 
-        protected document_session_delete_a_single_document_Tests(DefaultStoreFixture fixture) : base(fixture)
+
+        [Fact]
+        public void persist_and_delete_by_id_documents_with_the_same_id()
         {
+            var id = Guid.NewGuid();
+            using (var session = theStore.OpenSession())
+            {
+                var user = new User { Id = id, FirstName = "Mychal", LastName = "Thompson"};
+                session.Store(user);
+                session.SaveChanges();
+
+                var target = new Target {Id = id};
+                session.Store(target);
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Delete<User>(id);
+                session.Delete<Target>(id);
+
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Load<User>(id).ShouldBeNull();
+                session.Load<Target>(id).ShouldBeNull();
+            }
         }
     }
 
-    public class delete_with_nullo_Tests : document_session_delete_a_single_document_Tests<NulloIdentityMap>
+    public class delete_with_nullo_Tests: document_session_delete_a_single_document_Tests<NulloIdentityMap>
     {
-        public delete_with_nullo_Tests(DefaultStoreFixture fixture) : base(fixture)
+        public delete_with_nullo_Tests(DefaultStoreFixture fixture): base(fixture)
         {
         }
     }
 
-    public class delete_with_identity_map_Tests : document_session_delete_a_single_document_Tests<IdentityMap>
+    public class delete_with_identity_map_Tests: document_session_delete_a_single_document_Tests<IdentityMap>
     {
-        public delete_with_identity_map_Tests(DefaultStoreFixture fixture) : base(fixture)
+        public delete_with_identity_map_Tests(DefaultStoreFixture fixture): base(fixture)
         {
         }
     }
 
-    public class delete_with_dirty_tracking_identity_map_Tests :
+    public class delete_with_dirty_tracking_identity_map_Tests:
         document_session_delete_a_single_document_Tests<DirtyTrackingIdentityMap>
     {
-        public delete_with_dirty_tracking_identity_map_Tests(DefaultStoreFixture fixture) : base(fixture)
+        public delete_with_dirty_tracking_identity_map_Tests(DefaultStoreFixture fixture): base(fixture)
         {
         }
     }


### PR DESCRIPTION
Added tests for the case when there is a session having deletions to two or more document types, where those documents have the same types of primary keys

It seems that they're passing and I cannot reproduce the #1431 issue. @malclear could you verify if I'm doing the same case like yours?