### PR TITLE
Event Store uses sequential guids for the stream ids. Closes GH-1432

### DIFF
--- a/src/Marten/Events/EventStore.cs
+++ b/src/Marten/Events/EventStore.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Baseline;
 using Marten.Linq;
+using Marten.Schema.Identity;
 using Marten.Services;
 using Marten.Storage;
 
@@ -164,12 +165,12 @@ namespace Marten.Events
 
         public EventStream StartStream<TAggregate>(params object[] events) where TAggregate : class
         {
-            return StartStream<TAggregate>(Guid.NewGuid(), events);
+            return StartStream<TAggregate>(CombGuidIdGeneration.NewGuid(), events);
         }
 
         public EventStream StartStream(params object[] events)
         {
-            return StartStream(Guid.NewGuid(), events);
+            return StartStream(CombGuidIdGeneration.NewGuid(), events);
         }
 
         public IReadOnlyList<IEvent> FetchStream(Guid streamId, int version = 0, DateTime? timestamp = null)

--- a/src/Marten/Events/EventStream.cs
+++ b/src/Marten/Events/EventStream.cs
@@ -42,7 +42,7 @@ namespace Marten.Events
 
         public EventStream(string stream, IEvent[] events, bool isNew)
         {
-            Id = Guid.NewGuid();
+            Id = CombGuidIdGeneration.NewGuid();
             Key = stream;
             AddEvents(events);
             IsNew = isNew;

--- a/src/Marten/Events/StreamState.cs
+++ b/src/Marten/Events/StreamState.cs
@@ -1,10 +1,11 @@
 using System;
+using Marten.Schema.Identity;
 
 namespace Marten.Events
 {
     public class StreamState
     {
-        public Guid Id { get; } = Guid.NewGuid();
+        public Guid Id { get; } = CombGuidIdGeneration.NewGuid();
         public int Version { get; }
         public Type AggregateType { get; }
 


### PR DESCRIPTION
I think this was mostly an oversight on my part to begin with