### PR TITLE
#1302 - Fixed the ProjectView / DeleteEvent and rebuilding projections

### DIFF
--- a/src/Marten.Testing/Events/Projections/custom_transformation_of_events.cs
+++ b/src/Marten.Testing/Events/Projections/custom_transformation_of_events.cs
@@ -6,7 +6,6 @@ using Baseline.Dates;
 using Marten.Events.Projections;
 using Marten.Events.Projections.Async;
 using Marten.Services;
-using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -357,7 +357,7 @@ namespace Marten
 
             if (projections == null)
             {
-                projections = viewTypes?.Select(x => Events.ProjectionFor(x)).Where(x => x != null).ToArray() ?? Events.AsyncProjections.ToArray();
+                projections = viewTypes?.SelectMany(x => Events.AllProjectionFor(x)).Where(x => x != null).ToArray() ?? Events.AsyncProjections.ToArray();
             }
 
             return new Daemon(this, Tenancy.Default, settings ?? new DaemonSettings(), logger ?? new NulloDaemonLogger(), projections);

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -357,7 +357,7 @@ namespace Marten
 
             if (projections == null)
             {
-                projections = viewTypes?.SelectMany(x => Events.AllProjectionFor(x)).Where(x => x != null).ToArray() ?? Events.AsyncProjections.ToArray();
+                projections = viewTypes?.SelectMany(x => Events.AllProjectionsFor(x)).Where(x => x != null).ToArray() ?? Events.AsyncProjections.ToArray();
             }
 
             return new Daemon(this, Tenancy.Default, settings ?? new DaemonSettings(), logger ?? new NulloDaemonLogger(), projections);

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -159,9 +159,15 @@ namespace Marten.Events
             return aggregator.Alias;
         }
 
+        //TODO: This should be merged in V4 with AllForView method to return IEnumerable
         public IProjection ProjectionFor(Type viewType)
         {
             return AsyncProjections.ForView(viewType) ?? InlineProjections.ForView(viewType);
+        }
+
+        public IEnumerable<IProjection> AllProjectionFor(Type viewType)
+        {
+            return AsyncProjections.AllForView(viewType) ?? InlineProjections.AllForView(viewType);
         }
 
         public ViewProjection<TView, TId> ProjectView<TView, TId>() where TView : class

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -165,7 +165,7 @@ namespace Marten.Events
             return AsyncProjections.ForView(viewType) ?? InlineProjections.ForView(viewType);
         }
 
-        public IEnumerable<IProjection> AllProjectionFor(Type viewType)
+        public IEnumerable<IProjection> AllProjectionsFor(Type viewType)
         {
             return AsyncProjections.AllForView(viewType) ?? InlineProjections.AllForView(viewType);
         }

--- a/src/Marten/Events/Projections/ProjectionCollection.cs
+++ b/src/Marten/Events/Projections/ProjectionCollection.cs
@@ -84,9 +84,16 @@ namespace Marten.Events.Projections
             _projections.Add(lazyLoadedProjection);
         }
 
+
+        //TODO: This should be merged in V4 with AllForView method to return IEnumerable
         public IProjection ForView(Type viewType)
         {
             return _projections.FirstOrDefault(x => x.ProjectedType() == viewType);
+        }
+        
+        public IEnumerable<IProjection> AllForView(Type viewType)
+        {
+            return _projections.Where(x => x.ProjectedType() == viewType).ToList();
         }
     }
 }


### PR DESCRIPTION
Fixes #1302 

@sturatcliffe @ericgreenmix it seems that the issue was fixed in one of the previous releases. I copied the repro from the linked project https://github.com/sturatcliffe/MartenProjectViewIssue.

Could you confirm

**EDIT:**
After a nice catch from @mysticmind I was able to reproduce and fix the issue.

The problem was that for such case we had more than one inline projection defined for the specific projection type. In the AsyncDaemon we were always getting `FirstOrDefault` projection instead of a list of the projections for the selected view type.

Fixed that with adding overload for the ForView method that's returning Enumerable instead of single Projection. 

Note in V4 this method should be merged into the ForView methods so it returns the IEnumerable properly. Added overload to not provide unexpected breaking changes.