### PR TITLE
Index should not lower/uppercase non-strings

### DIFF
--- a/src/Marten/Schema/ComputedIndex.cs
+++ b/src/Marten/Schema/ComputedIndex.cs
@@ -95,8 +95,16 @@ namespace Marten.Schema
             var membersLocator = _members
                 .Select(m =>
                 {
-                    var sql = _mapping.FieldFor(m).SqlLocator.Replace("d.", "");
-                    switch (Casing)
+                    var field = _mapping.FieldFor(m);
+                    var casing = Casing;
+                    if (field.MemberType != typeof(string))
+                    {
+                        // doesn't make sense to lower-case this particular member
+                        casing = Casings.Default;
+                    }
+
+                    var sql = field.SqlLocator.Replace("d.", "");
+                    switch (casing)
                     {
                         case Casings.Upper:
                             return $" upper({sql})";


### PR DESCRIPTION
Index definition tries to call lower and upper for members that are not strings, this ends badly when I want to have an index composed of multiple fields which of all are not of string type.