### PR TITLE
Call the correct TransactionState constructor

### DIFF
--- a/src/Marten.Testing/CoreFunctionality/SessionOptionsTests.cs
+++ b/src/Marten.Testing/CoreFunctionality/SessionOptionsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Baseline;
 using Marten.Services;
 using Marten.Testing.Harness;
@@ -130,18 +131,18 @@ public void ConfigureCommandTimeout(IDocumentStore store)
 
             var options = new SessionOptions() { Connection = connection };
 
-            var testobject = new FryGuy();
+            var testObject = new FryGuy();
 
             using (var session = documentStore.OpenSession(options))
             {
-                session.Store(testobject);
+                session.Store(testObject);
                 session.SaveChanges();
-                session.Load<FryGuy>(testobject.Id).ShouldNotBeNull();
+                session.Load<FryGuy>(testObject.Id).ShouldNotBeNull();
             }
         }
 
         [Fact]
-        public void session_with_custom_connection_reusable_after_saveChangesAsync()
+        public async Task session_with_custom_connection_reusable_after_saveChangesAsync()
         {
             var connectionStringBuilder = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString);
 
@@ -155,13 +156,14 @@ public void ConfigureCommandTimeout(IDocumentStore store)
 
             var options = new SessionOptions() { Connection = connection };
 
-            var testobject = new FryGuy();
+            var testObject = new FryGuy();
 
             using (var query = documentStore.OpenSession(options))
             {
-                query.Store(testobject);
-                query.SaveChangesAsync().Wait();
-                query.LoadAsync<FryGuy>(testobject.Id).GetAwaiter().GetResult().ShouldNotBeNull();
+                query.Store(testObject);
+                await query.SaveChangesAsync();
+                var loadedObject = await query.LoadAsync<FryGuy>(testObject.Id);
+                loadedObject.ShouldNotBeNull();
             }
         }
 


### PR DESCRIPTION
The session raised a NullReferenceException on usage after a SaveAsync call when constructed with Session options.

The problem can be found in the ManagedConnection when constructed with SessionOptions.
After a dispose of the TransactionState the ManagedConnection will try to rebuild it on further usage in the buildConnection method, The TransactionState constructor used relies on, that the factory has been set before.

This behaviour has been fixed by using the correct constructor and providing the fields needed.

The following test replicates the behaviour:
```C#
  class TestObject
{
    public Guid Id { get; set; }
    public string Name { get; set; }
}

[Test]
public void Inject_Connection()
{
    var connectionString = $"host=host;database=db;password=pw;username=un;";
    var store = DocumentStore.For(connectionString);

    var connection = new NpgsqlConnection(connectionString);
    connection.Open();
    var session = store.OpenSession(new SessionOptions { Connection = connection });

    var testObject = new TestObject{Id = new Guid(), Name = "testObject"};

    session.Store(testObject);
    session.SaveChanges();

    // The following call will throw a NullReferenceException without this patch
    session.Query<TestObject>().Any(t => t.Id == testObject.Id);
}
```

fixes #1507 