### PR TITLE
Sample showing how Marten handles Event type namespace or name migration

### DIFF
--- a/documentation/documentation/events/order.txt
+++ b/documentation/documentation/events/order.txt
@@ -3,3 +3,4 @@ identity
 appending
 streams
 projections
+versioning

--- a/documentation/documentation/events/versioning/index.md
+++ b/documentation/documentation/events/versioning/index.md
@@ -22,7 +22,7 @@ Such mapping needs to be defined manually:
 - either by registering events with store options `Events.AddEventTypes` method,
 - or by defining custom mapping with `Events.EventMappingFor` method.
 
-For the case of namespace migration, it's enough to use `AddEventTypes` method as it's generating mapping based on the event type. So eg. having `OrderStatusChanged` event changed from:
+For the case of namespace migration, it's enough to use `AddEventTypes` method as it's generating mapping based on the event type. As an example, change `OrderStatusChanged` event from:
 
 <[sample:old_event_namespace]> 
 
@@ -34,11 +34,11 @@ It's enough to register new event type as follows:
 
 <[sample:event_namespace_migration_options]>
 
-After that Marten will automatically perform a matching based on the type name (that didn't change) - so. `order_status_changed`.
+After that Marten will automatically perform a matching based on the type name (that didn't change) - `order_status_changed`.
 
 ## Event type name migration
 
-For the case when event class type name changed Marten is unable to perform the automatic mapping. However, it allows to define a custom one.
+When the event class type name has changed, Marten does not perform automatic mapping but allows to define a custom one.
 
 To do that you need to use `Events.EventMappingFor` method to define the type name for the new event.
 
@@ -54,5 +54,5 @@ it's needed to register mapping using old event type name (`order_status_changed
 <div class="alert alert-warning">
 <b><u>Warning:</u></b>
 <br />
-In this case old event type name will be also used when publishing events of the new type name - so both `OrderStatusChanged` and `ConfirmedOrderStatusChanged` will be published with the same `order_status_changed` event type.
+In this case, both old `OrderStatusChanged` and new `ConfirmedOrderStatusChanged` event type names will get published with the same `order_status_changed` event type.
 </div>

--- a/documentation/documentation/events/versioning/index.md
+++ b/documentation/documentation/events/versioning/index.md
@@ -1,0 +1,58 @@
+<!--Title:Events Versioning-->
+<!--Url:versioning-->
+
+Events by their nature represent facts that happened in the past. They should be immutable even if they had wrong values (as we can only roughly guess what should be the missing property value).
+
+However, in practice, it's unavoidable in the living system to not have the event schema migrations. They might come from:
+
+- bug - eg. typo in the property name, missing event data, 
+- new business requirements - eg. besides storing the user email we'd like to be also storing its full name,
+- refactorings - eg. renaming event class, moving to different namespace or assembly,
+- etc.
+
+Depending on the concrete business case we may use a different technique for handling such event migrations.
+
+## Namespace migration
+
+Marten by default tries to find the event class based on the fully qualified assembly name (it's stored in `mt_dotnet_type` column of `mt_events` table, read more in <[linkto:documentation/events/schema;title=events schema documentation]>). 
+When it is not able to find event type with the same assembly, namespace and type name then it tries to make a lookup for mapping on the event type name (stored in `type` column of `mt_events` table).
+
+Such mapping needs to be defined manually:
+
+- either by registering events with store options `Events.AddEventTypes` method,
+- or by defining custom mapping with `Events.EventMappingFor` method.
+
+For the case of namespace migration, it's enough to use `AddEventTypes` method as it's generating mapping based on the event type. So eg. having `OrderStatusChanged` event changed from:
+
+<[sample:old_event_namespace]> 
+
+to:
+
+<[sample:new_event_namespace]> 
+
+It's enough to register new event type as follows:
+
+<[sample:event_namespace_migration_options]>
+
+After that Marten will automatically perform a matching based on the type name (that didn't change) - so. `order_status_changed`.
+
+## Event type name migration
+
+For the case when event class type name changed Marten is unable to perform the automatic mapping. However, it allows to define a custom one.
+
+To do that you need to use `Events.EventMappingFor` method to define the type name for the new event.
+
+Eg. for migrating `OrderStatusChanged` event into `ConfirmedOrderStatusChanged` 
+
+<[sample:new_event_type_name]>
+
+it's needed to register mapping using old event type name (`order_status_changed`) as follows:
+
+<[sample:event_type_name_migration_options]>
+
+<br />
+<div class="alert alert-warning">
+<b><u>Warning:</u></b>
+<br />
+In this case old event type name will be also used when publishing events of the new type name - so both `OrderStatusChanged` and `ConfirmedOrderStatusChanged` will be published with the same `order_status_changed` event type.
+</div>

--- a/src/Marten.Testing/Events/SchemaChange/NamespaceChange.cs
+++ b/src/Marten.Testing/Events/SchemaChange/NamespaceChange.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Threading.Tasks;
+using Marten.Events;
+using Marten.Services;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Events.SchemaChange
+{
+    // Different namespace - event will be stored with "Old"
+    namespace New
+    {
+        public class TaskCreated
+        {
+            public Guid TaskId { get; }
+            public string Description { get; }
+
+            public TaskCreated(Guid taskId, string description)
+            {
+                TaskId = taskId;
+                Description = description;
+            }
+        }
+
+        // Type name has changed - Event will be stored with `TaskDescriptionUpdated`
+        public class TaskDescriptionUpdatedNewName
+        {
+            public Guid TaskId { get; }
+            public string Description { get; }
+
+            public TaskDescriptionUpdatedNewName(Guid taskId, string description)
+            {
+                TaskId = taskId;
+                Description = description;
+            }
+        }
+
+
+        public class Task
+        {
+            public Guid Id { get; private set; }
+            public string Description { get; private set; }
+
+            public void Apply(TaskCreated @event)
+            {
+                Id = @event.TaskId;
+                Description = @event.Description;
+            }
+
+            public void Apply(TaskDescriptionUpdatedNewName @event)
+            {
+                Description = @event.Description;
+            }
+        }
+    }
+
+    [Collection("events_namespace_migration")]
+    public class EventsNamespaceChange: OneOffConfigurationsContext
+    {
+        [Fact]
+        public async Task HavingEvents_WithSchemaChange_AggregationShouldWork()
+        {
+            // test events data
+            var taskId = Guid.NewGuid();
+            const string initialDescription = "initial description";
+            const string updatedDescription = "updated description";
+
+            // events types
+            const string taskCreatedType = "task_created";
+            const string taskDescriptionUpdatedType = "task_description_updated";
+
+            // simulate namespace change from `Old` to `New`
+            const string oldTaskCreatedClrType = "Marten.Testing.Events.SchemaChange.Old.TaskCreated, Marten.Testing";
+            // simulate namespace change from `TaskDescriptionUpdated` to `TaskDescriptionUpdatedNewName`
+            const string oldTaskUpdatedClrType = "Marten.Testing.Events.SchemaChange.Old.TaskDescriptionUpdated, Marten.Testing";
+
+            using (var session = theStore.OpenSession())
+            {
+                // ensure events tables already exists
+                session.Tenant.EnsureStorageExists(typeof(EventStream));
+
+                using (var conn = session.Tenant.OpenConnection())
+                {
+                    // we need to insert data manually, as if we keep old type in assembly then Marten would use it.
+                    // Marten at first tries to find concrete type based on the `mt_dotnet_type` column value.
+                    // When Marten cannot find concrete CLR type then it searches it by `type` column value
+                    conn.Execute(
+                        $@"INSERT INTO events_namespace_migration.mt_streams (id, type, version, timestamp, snapshot, snapshot_version, created, tenant_id)
+                        VALUES ('{taskId}', null, 2, '2020-07-16 19:32:43.912171', null, null, '2020-07-16 19:32:43.912171', '*DEFAULT*');");
+                    conn.Execute("INSERT INTO events_namespace_migration.mt_events (seq_id, id, stream_id, version, data, type, timestamp, tenant_id, mt_dotnet_type) " +
+                        $"VALUES (1, '{Guid.NewGuid()}', '{taskId}', 1, '{{\"TaskId\": \"{taskId}\", \"Description\": \"{initialDescription}\"}}', '{taskCreatedType}', '2020-07-16 19:32:43.912171', '*DEFAULT*', '{oldTaskCreatedClrType}');");
+                    conn.Execute("INSERT INTO events_namespace_migration.mt_events (seq_id, id, stream_id, version, data, type, timestamp, tenant_id, mt_dotnet_type)" +
+                        $"VALUES (2, '{Guid.NewGuid()}', '{taskId}', 2, '{{\"TaskId\": \"{taskId}\", \"Description\": \"{updatedDescription}\"}}', '{taskDescriptionUpdatedType}', '2020-07-16 19:32:43.912171', '*DEFAULT*', '{oldTaskUpdatedClrType}');");
+                }
+
+                await session.SaveChangesAsync();
+            }
+
+            using (var store = SeparateStore(_ =>
+            {
+                // Add new Event types, if type names won't change then the same type name will be generated
+                // and we don't need additional config
+                _.Events.AddEventTypes(new []{typeof(New.TaskCreated), typeof(New.TaskDescriptionUpdatedNewName)});
+
+                // When type name has changed we need to define custom mapping
+                _.Events.EventMappingFor<New.TaskDescriptionUpdatedNewName>()
+                        .EventTypeName = taskDescriptionUpdatedType;
+            }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    var taskNew = await session.Events.AggregateStreamAsync<New.Task>(taskId);
+
+                    taskNew.Id.ShouldBe(taskId);
+                    taskNew.Description.ShouldBe(updatedDescription);
+                }
+            }
+        }
+
+        public EventsNamespaceChange() : base("events_namespace_migration")
+        {
+        }
+    }
+}

--- a/src/Marten.Testing/Events/SchemaChange/NamespaceChange.cs
+++ b/src/Marten.Testing/Events/SchemaChange/NamespaceChange.cs
@@ -10,6 +10,84 @@ using Xunit;
 
 namespace Marten.Testing.Events.SchemaChange
 {
+    // SAMPLE: old_event_namespace
+    namespace OldEventNamespace
+    {
+        public class OrderStatusChanged
+        {
+            public Guid OrderId { get; }
+            public int Status { get; }
+
+            public OrderStatusChanged(Guid orderId, int status)
+            {
+                OrderId = orderId;
+                Status = status;
+            }
+        }
+    }
+    // ENDSAMPLE
+
+    // SAMPLE: new_event_namespace
+    namespace NewEventNamespace
+    {
+        public class OrderStatusChanged
+        {
+            public Guid OrderId { get; }
+            public int Status { get; }
+
+            public OrderStatusChanged(Guid orderId, int status)
+            {
+                OrderId = orderId;
+                Status = status;
+            }
+        }
+    }
+    // ENDSAMPLE
+
+
+    // SAMPLE: new_event_type_name
+    namespace OldEventNamespace
+    {
+        public class ConfirmedOrderStatusChanged
+        {
+            public Guid OrderId { get; }
+            public int Status { get; }
+
+            public ConfirmedOrderStatusChanged(Guid orderId, int status)
+            {
+                OrderId = orderId;
+                Status = status;
+            }
+        }
+    }
+    // ENDSAMPLE
+
+    public static class SampleEventsSchemaMigration
+    {
+        public static void SampleAddEventsRegistration()
+        {
+            // SAMPLE: event_namespace_migration_options
+            var options = new StoreOptions();
+
+            options.Events.AddEventTypes(new[] {typeof(NewEventNamespace.OrderStatusChanged)});
+
+            var store = new DocumentStore(options);
+            // ENDSAMPLE
+        }
+
+        public static void SampleEventMappingRegistration()
+        {
+            // SAMPLE: event_type_name_migration_options
+            var options = new StoreOptions();
+
+            var orderStatusChangedMapping = options.Events.EventMappingFor<OldEventNamespace.ConfirmedOrderStatusChanged>();
+            orderStatusChangedMapping.EventTypeName = "order_status_changed";
+
+            var store = new DocumentStore(options);
+            // ENDSAMPLE
+        }
+    }
+
     // Different namespace - event will be stored with "Old"
     namespace New
     {


### PR DESCRIPTION
Added sample and documentation showing how event type namespace or name migration can be handled by Marten. 

More advanced scenarios or guidelines will come in follow up PRs.