### PR TITLE
Support case-insensitive order by for strings

### DIFF
--- a/src/Marten.Testing/Examples/LinqExamples.cs
+++ b/src/Marten.Testing/Examples/LinqExamples.cs
@@ -91,6 +91,12 @@ namespace Marten.Testing.Examples
 
             // You can use multiple order by's
             session.Query<Target>().OrderBy(x => x.Date).ThenBy(x => x.Number);
+
+            // Sort case-insensitively, Postgres is case-sensitive by default
+            session.Query<Target>().OrderBy(x => x.String, StringComparer.OrdinalIgnoreCase);
+
+            // If you want to sort by multiple fields case-insensitive, you need to supply StringComparer for each sort
+            session.Query<Target>().OrderBy(x => x.String, StringComparer.OrdinalIgnoreCase).ThenBy(x => x.AnotherString, StringComparer.Ordinal);
         }
 
         // ENDSAMPLE

--- a/src/Marten.Testing/Linq/Compatibility/simple_order_by_clauses.cs
+++ b/src/Marten.Testing/Linq/Compatibility/simple_order_by_clauses.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using Marten.Testing.Documents;
 using Marten.Testing.Linq.Compatibility.Support;
+using Xunit;
 
 namespace Marten.Testing.Linq.Compatibility
 {
@@ -14,6 +18,9 @@ namespace Marten.Testing.Linq.Compatibility
             ordered(t => t.OrderBy(x => x.String));
             ordered(t => t.OrderByDescending(x => x.String));
 
+            ordered(t => t.OrderBy(x => x.String, StringComparer.OrdinalIgnoreCase));
+            ordered(t => t.OrderByDescending(x => x.String, StringComparer.OrdinalIgnoreCase));
+
             ordered(t => t.OrderBy(x => x.Number).ThenBy(x => x.String));
             ordered(t => t.OrderBy(x => x.Number).ThenByDescending(x => x.String));
             ordered(t => t.OrderByDescending(x => x.Number).ThenBy(x => x.String));
@@ -21,6 +28,89 @@ namespace Marten.Testing.Linq.Compatibility
             ordered(t => t.OrderBy(x => x.String).Take(2));
             ordered(t => t.OrderBy(x => x.String).Skip(2));
             ordered(t => t.OrderBy(x => x.String).Take(2).Skip(2));
+        }
+
+        [Fact]
+        public void order_by_query_format()
+        {
+            using var session = Fixture.Store.QuerySession();
+            Assert.EndsWith(" order by d.data ->> 'String'", session.Query<Target>().OrderBy(x => x.String).ToCommand().CommandText);
+            Assert.EndsWith(" order by lower(d.data ->> 'String')", session.Query<Target>().OrderBy(x => x.String, StringComparer.OrdinalIgnoreCase).ToCommand().CommandText);
+            Assert.EndsWith(" order by lower(d.data ->> 'String'), lower(d.data ->> 'AnotherString') desc", session.Query<Target>().OrderBy(x => x.String, StringComparer.OrdinalIgnoreCase).ThenByDescending(x => x.AnotherString, StringComparer.OrdinalIgnoreCase).ToCommand().CommandText);
+
+            Assert.EndsWith(" order by d.data ->> 'String' desc", session.Query<Target>().OrderByDescending(x => x.String).ToCommand().CommandText);
+            Assert.EndsWith(" order by lower(d.data ->> 'String') desc", session.Query<Target>().OrderByDescending(x => x.String, StringComparer.OrdinalIgnoreCase).ToCommand().CommandText);
+
+            Assert.EndsWith(" order by d.data ->> 'String', d.data ->> 'AnotherString'", session.Query<Target>().OrderBy(x => x.String).ThenBy(x => x.AnotherString).ToCommand().CommandText);
+            Assert.EndsWith(" order by lower(d.data ->> 'String') desc, lower(d.data ->> 'AnotherString') desc", session.Query<Target>().OrderByDescending(x => x.String, StringComparer.OrdinalIgnoreCase).ThenByDescending(x => x.AnotherString, StringComparer.OrdinalIgnoreCase).ToCommand().CommandText);
+        }
+
+        [Fact]
+        public void order_by_query_results()
+        {
+            Fixture.Store.Advanced.Clean.CompletelyRemoveAll();
+
+            using var session = Fixture.Store.OpenSession();
+
+            var objects = new[]
+            {
+                new Target
+                {
+                    String = "Andreas", AnotherString = "a"
+                },
+                new Target
+                {
+                    String = "adam", AnotherString = "b"
+                },
+                new Target
+                {
+                    String = "Bertha", AnotherString = "c"
+                },
+                new Target
+                {
+                    String = "Bob", AnotherString = "e"
+                },
+                new Target
+                {
+                    String = "Bob", AnotherString = "f"
+                },
+                new Target
+                {
+                    String = "bertil", AnotherString = "e"
+                }
+            };
+            session.StoreObjects(objects);
+            session.SaveChanges();
+
+            var ids = objects.Select(x => x.Id).ToArray();
+
+            Assert.Equal(
+                objects.OrderBy(x => x.String, StringComparer.OrdinalIgnoreCase).ThenBy(x => x.AnotherString, StringComparer.Ordinal).Select(x => new { x = x.String, y = x.AnotherString }).ToList(),
+                session.Query<Target>().Where(x => x.Id.In(ids)).OrderBy(x => x.String, StringComparer.OrdinalIgnoreCase).ThenBy(x => x.AnotherString, StringComparer.Ordinal).Select(x => new { x = x.String, y = x.AnotherString }).ToList());
+
+            Assert.Equal(
+                objects.OrderBy(x => x.String, StringComparer.OrdinalIgnoreCase).ThenBy(x => x.AnotherString, StringComparer.Ordinal).Select(x => new { x = x.String, y = x.AnotherString }).ToList(),
+                session.Query<Target>().Where(x => x.Id.In(ids)).OrderBy(x => x.String, StringComparer.OrdinalIgnoreCase).ThenBy(x => x.AnotherString, StringComparer.Ordinal).Select(x => new { x = x.String, y = x.AnotherString }).ToList());
+
+            Assert.Equal(
+                objects.OrderByDescending(x => x.String, StringComparer.OrdinalIgnoreCase).ThenBy(x => x.AnotherString).Select(x => new { x = x.String, y = x.AnotherString }).ToList(),
+                session.Query<Target>().Where(x => x.Id.In(ids)).OrderByDescending(x => x.String, StringComparer.OrdinalIgnoreCase).ThenBy(x => x.AnotherString, StringComparer.InvariantCulture).Select(x => new { x = x.String, y = x.AnotherString }).ToList());
+        }
+
+        [Fact]
+        public void order_by_with_non_string()
+        {
+            using var session = Fixture.Store.QuerySession();
+            var ex = Assert.Throws<ArgumentException>(() => session.Query<Target>().OrderBy(x => x.Number, Comparer<int>.Default).ToCommand());
+            Assert.Equal("Only strings are supported when providing order comparer", ex.Message);
+        }
+
+        [Fact]
+        public void order_by_with_custom_comparer()
+        {
+            using var session = Fixture.Store.QuerySession();
+            var ex = Assert.Throws<ArgumentException>(() => session.Query<Target>().OrderBy(x => x.String, Comparer<string>.Create((s, s1) => 0)).ToCommand());
+            Assert.Equal("Only standard StringComparer static comparer members are allowed as comparer", ex.Message);
         }
     }
 }

--- a/src/Marten/Linq/MartenQueryParser.cs
+++ b/src/Marten/Linq/MartenQueryParser.cs
@@ -33,6 +33,8 @@ namespace Marten.Linq
             var nodeTypeRegistry = MethodInfoBasedNodeTypeRegistry.CreateFromRelinqAssembly();
             registerNodeTypes?.Invoke(nodeTypeRegistry);
 
+            nodeTypeRegistry.Register(OrderByComparerExpressionNode.SupportedMethods, typeof(OrderByComparerExpressionNode));
+
             var expressionTreeParser =
                 new ExpressionTreeParser(nodeTypeRegistry, processor);
             _parser = new QueryParser(expressionTreeParser);

--- a/src/Marten/Linq/Model/LinqQuery.cs
+++ b/src/Marten/Linq/Model/LinqQuery.cs
@@ -193,20 +193,7 @@ namespace Marten.Linq.Model
 
         private void writeOrderClause(CommandBuilder sql)
         {
-            var orders = bodyClauses()
-                .SelectMany<IBodyClause, (Ordering Clause, bool CaseSensitive)>(x =>
-                {
-                    switch (x)
-                    {
-                        case OrderByClause orderByClause:
-                            return orderByClause.Orderings.Select(o => (o, true));
-                        case OrderByComparerClause orderByComparerClause:
-                            return orderByComparerClause.Orderings.Select(o => (o, orderByComparerClause.CaseSensitive));
-                        default:
-                            return Enumerable.Empty<(Ordering, bool)>();
-                    }
-                })
-                .ToArray();
+            var orders = bodyClauses().GetStringOrderingClauses();
 
             if (!orders.Any())
                 return;

--- a/src/Marten/Linq/Model/SelectManyQuery.cs
+++ b/src/Marten/Linq/Model/SelectManyQuery.cs
@@ -171,20 +171,7 @@ namespace Marten.Linq.Model
 
         private string determineOrderClause(ChildDocument document)
         {
-            var orders = bodyClauses()
-                .SelectMany<IBodyClause, (Ordering Clause, bool CaseSensitive)>(x =>
-                {
-                    switch (x)
-                    {
-                        case OrderByClause orderByClause:
-                            return orderByClause.Orderings.Select(o => (o, true));
-                        case OrderByComparerClause orderByComparerClause:
-                            return orderByComparerClause.Orderings.Select(o => (o, orderByComparerClause.CaseSensitive));
-                        default:
-                            return Enumerable.Empty<(Ordering, bool)>();
-                    }
-                })
-                .ToArray();
+            var orders = bodyClauses().GetStringOrderingClauses();
 
             if (!orders.Any())
                 return string.Empty;

--- a/src/Marten/Linq/OrderByComparerClause.cs
+++ b/src/Marten/Linq/OrderByComparerClause.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Marten.Linq
+{
+    internal class OrderByComparerClause: IBodyClause
+    {
+        public OrderByComparerClause(bool caseSensitive, Ordering ordering)
+        {
+            CaseSensitive = caseSensitive;
+            Orderings.Add(ordering);
+        }
+
+        public bool CaseSensitive { get; }
+
+        public readonly List<Ordering> Orderings = new List<Ordering>();
+
+        public void TransformExpressions(Func<Expression, Expression> transformation) => throw new NotImplementedException();
+
+        public void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index) => throw new NotImplementedException();
+
+        public IBodyClause Clone(CloneContext cloneContext) => throw new NotImplementedException();
+    }
+}

--- a/src/Marten/Linq/OrderByComparerExpressionNode.cs
+++ b/src/Marten/Linq/OrderByComparerExpressionNode.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Marten.Linq
+{
+    internal class OrderByComparerExpressionNode: ResultOperatorExpressionNodeBase
+    {
+        private readonly ResolvedExpressionCache<Expression> cachedSelector;
+        private readonly LambdaExpression keySelector;
+
+        public static readonly MethodInfo[] SupportedMethods =
+            typeof(Queryable).GetMethods()
+                .Where(m => m.Name == nameof(Queryable.OrderBy) || m.Name == nameof(Queryable.OrderByDescending) || m.Name == nameof(Queryable.ThenBy) || m.Name == nameof(Queryable.ThenByDescending))
+                .Where(x => x.GetParameters().Length == 3)
+                .ToArray();
+
+        private readonly OrderingDirection orderingDirection;
+
+        public OrderByComparerExpressionNode(
+            MethodCallExpressionParseInfo parseInfo,
+            LambdaExpression keySelector,
+            ConstantExpression constantExpression)
+            : base(parseInfo, null, null)
+        {
+            ConstantExpression = constantExpression;
+            this.keySelector = keySelector;
+            cachedSelector = new ResolvedExpressionCache<Expression>(this);
+
+            orderingDirection = parseInfo.ParsedExpression.Method.Name == nameof(Queryable.OrderBy) || parseInfo.ParsedExpression.Method.Name == nameof(Queryable.ThenBy)
+                ? OrderingDirection.Asc
+                : OrderingDirection.Desc;
+        }
+
+        public ConstantExpression ConstantExpression { get; }
+
+        protected override ResultOperatorBase CreateResultOperator(
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return new OrderByComparerOperator(null, ConstantExpression);
+        }
+
+        public override Expression Resolve(
+            ParameterExpression inputParameter,
+            Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(
+                inputParameter,
+                expressionToBeResolved,
+                clauseGenerationContext);
+        }
+
+        protected override void ApplyNodeSpecificSemantics(
+            QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            if (keySelector.ReturnType != typeof(string))
+            {
+                throw new ArgumentException("Only strings are supported when providing order comparer");
+            }
+
+            bool caseSensitive;
+            if (ReferenceEquals(ConstantExpression.Value, StringComparer.OrdinalIgnoreCase)
+                || ReferenceEquals(ConstantExpression.Value, StringComparer.InvariantCultureIgnoreCase)
+                || ReferenceEquals(ConstantExpression.Value, StringComparer.OrdinalIgnoreCase))
+            {
+                caseSensitive = false;
+            }
+            else if (ReferenceEquals(ConstantExpression.Value, StringComparer.Ordinal)
+                     || ReferenceEquals(ConstantExpression.Value, StringComparer.InvariantCulture)
+                     || ReferenceEquals(ConstantExpression.Value, StringComparer.Ordinal))
+            {
+                caseSensitive = false;
+            }
+            else
+            {
+                throw new ArgumentException("Only standard StringComparer static comparer members are allowed as comparer");
+            }
+
+            var orderByClause = new OrderByComparerClause(caseSensitive, new Ordering(GetResolvedKeySelector(clauseGenerationContext), orderingDirection));
+            queryModel.BodyClauses.Add(orderByClause);
+        }
+
+        private Expression GetResolvedKeySelector(
+            ClauseGenerationContext clauseGenerationContext) => cachedSelector.GetOrCreate(r => r.GetResolvedExpression(keySelector.Body, keySelector.Parameters[0], clauseGenerationContext));
+
+    }
+}

--- a/src/Marten/Linq/OrderByComparerOperator.cs
+++ b/src/Marten/Linq/OrderByComparerOperator.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq.Expressions;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Marten.Linq
+{
+    public class OrderByComparerOperator
+        : OrderByOperator
+    {
+        public OrderByComparerOperator(
+            Expression parameter,
+            ConstantExpression comparerExpression): base(parameter)
+        {
+            ComparerExpression = comparerExpression;
+        }
+
+        public ConstantExpression ComparerExpression { get; }
+
+        public override ResultOperatorBase Clone(CloneContext cloneContext)
+        {
+            return new OrderByComparerOperator(Parameter, ComparerExpression);
+        }
+
+        public override StreamedSequence ExecuteInMemory<T>(StreamedSequence input)
+        {
+            return input;
+        }
+    }
+}

--- a/src/Marten/Linq/OrderByOperator.cs
+++ b/src/Marten/Linq/OrderByOperator.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq.Expressions;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Marten.Linq
+{
+    public class OrderByOperator
+        : SequenceTypePreservingResultOperatorBase
+    {
+        public OrderByOperator(Expression parameter)
+        {
+            Parameter = parameter;
+        }
+
+        public Expression Parameter { get; private set; }
+
+        public override ResultOperatorBase Clone(CloneContext cloneContext)
+        {
+            return new OrderByOperator(Parameter);
+        }
+
+        public override void TransformExpressions(
+            Func<Expression, Expression> transformation)
+        {
+            Parameter = transformation(Parameter);
+        }
+
+        public override StreamedSequence ExecuteInMemory<T>(StreamedSequence input)
+        {
+            return input;
+        }
+    }
+}

--- a/src/Marten/Util/OrderingExtensions.cs
+++ b/src/Marten/Util/OrderingExtensions.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using Marten.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Marten.Util
+{
+    internal static class OrderingExtensions
+    {
+        internal static (Ordering Clause, bool CaseSensitive)[] GetStringOrderingClauses(
+            this IEnumerable<IBodyClause> bodyClauses)
+        {
+            return bodyClauses
+                .SelectMany<IBodyClause, (Ordering Clause, bool CaseSensitive)>(x =>
+                {
+                    switch (x)
+                    {
+                        case OrderByClause orderByClause:
+                            return orderByClause.Orderings.Select(o => (o, true));
+                        case OrderByComparerClause orderByComparerClause:
+                            return orderByComparerClause.Orderings.Select(o => (o, orderByComparerClause.CaseSensitive));
+                        default:
+                            return Enumerable.Empty<(Ordering, bool)>();
+                    }
+                })
+                .ToArray();
+        }
+    }
+}


### PR DESCRIPTION
I asked about this on Gitter with little feedback, it seemed to be missing so I decided to try how one could implement order by semantics case-insensitively. Some remarks:

* To order normal column one would use `citext` type or in Postgres v12 there's new collation support, either of if these are not available on Marten context
* This solution uses `lower(field)` which should work for most use cases, with slight performance penalty
* Because Remotion.Linq doesn't support the comparer parameter, a new code path needs to be taken
    * This is why you cannot combine "regular" OrderBy and OrderBy that has comparer

This was my first try against Remotion.Linq so not sure if the approach is ideal.

I did this against 3.12 as I would need this feature, if you find this reasonable addition. Otherwise it would be nice to find a way to plug this in on consumer side. Basically the `writeOrderClause` and friends should somehow be virtual.