### PR TITLE
Introduce DefaultRetryPolicy

### DIFF
--- a/documentation/documentation/documents/advanced/retrypolicy.md
+++ b/documentation/documentation/documents/advanced/retrypolicy.md
@@ -10,6 +10,10 @@ The policy is then plugged into the `StoreOptions` via the `RetryPolicy` method:
 
 <[sample:retrypolicy-samplepolicy-pluggingin]>
 
-Lastly, the filter is configured to retry failing operations twice, given they throw a `NpgsqlException` that is non-transient (for the sake of demonstrability).
+Lastly, the filter is configured to retry failing operations twice, given they throw a `NpgsqlException` that is transient and thus might succeed later.
+
+There's also a built-in `DefaultRetryPolicy` that has sane defaults for transient error handling. Like any custom policy, you can plug it into into the `StoreOptions` via the `RetryPolicy` method:
+
+<[sample:retrypolicy-samplepolicy-default]>
 
 Also you could use the fantastic [Polly](https://www.nuget.org/packages/polly) library to easily build more resilient and expressive retry policies by implementing `IRetryPolicy`.

--- a/src/Marten.Testing/Examples/RetryPolicyTests.cs
+++ b/src/Marten.Testing/Examples/RetryPolicyTests.cs
@@ -99,10 +99,19 @@ namespace Marten.Testing.Examples
             {
                 // SAMPLE: retrypolicy-samplepolicy-pluggingin
                 // Plug in our custom retry policy via StoreOptions
-                // We retry operations twice if they yield and NpgsqlException that is not transient (for the sake of easier demonstrability)
-                c.RetryPolicy(ExceptionFilteringRetryPolicy.Twice(e => e is NpgsqlException ne && !ne.IsTransient));
+                // We retry operations twice if they yield and NpgsqlException that is transient
+                c.RetryPolicy(ExceptionFilteringRetryPolicy.Twice(e => e is NpgsqlException ne && ne.IsTransient));
                 // ENDSAMPLE
 
+                // SAMPLE: retrypolicy-samplepolicy-default
+                // Use DefaultRetryPolicy which handles Postgres's transient errors by default with sane defaults
+                // We retry operations twice if they yield and NpgsqlException that is transient
+                // Each error will cause sleep of N seconds where N is the current retry number
+                c.RetryPolicy(DefaultRetryPolicy.Twice());
+                // ENDSAMPLE
+
+                // For unit test, use one that checks that exception is not transient
+                c.RetryPolicy(ExceptionFilteringRetryPolicy.Twice(e => e is NpgsqlException ne && !ne.IsTransient));
                 // For unit test, override the policy with one that captures messages
                 c.RetryPolicy(ExceptionFilteringRetryPolicy.Twice(e =>
                 {

--- a/src/Marten.Testing/Services/DefaultRetryPolicyTests.cs
+++ b/src/Marten.Testing/Services/DefaultRetryPolicyTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Marten.Services;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Services
+{
+    public class DefaultRetryPolicyTests
+    {
+        [Fact]
+        public async Task transient_exception_is_retried()
+        {
+            var runNumber = 0;
+            using var connection = setUpManagedConnectionWithRetry(retryTimes: 1);
+            var cmd = new NpgsqlCommand();
+
+            await connection.ExecuteAsync(cmd, (c, tkn) =>
+                {
+                    if (runNumber++ == 0)
+                    {
+                        throw createNpgsqlException(true);
+                    }
+
+                    return Task.FromResult("");
+                }
+            );
+
+            runNumber.ShouldBe(2);
+            cmd.Dispose();
+            connection.Dispose();
+        }
+
+        [Fact]
+        public void transient_exception_is_retried_but_throws_eventually()
+        {
+            var runNumber = 0;
+            var retryNumbers = new List<int>();
+            var retryPolicy = DefaultRetryPolicy.Twice(sleep: x =>
+            {
+                retryNumbers.Add(x);
+                return TimeSpan.FromMilliseconds(20);
+            });
+
+            using var connection = new ManagedConnection(new ConnectionSource(), retryPolicy);
+            var cmd = new NpgsqlCommand();
+
+            Exception<Marten.Exceptions.MartenCommandException>.ShouldBeThrownBy(() =>
+            {
+                connection.Execute(cmd, c =>
+                    {
+                        runNumber++;
+                        throw createNpgsqlException(true);
+                    }
+                );
+            });
+
+            runNumber.ShouldBe(3);
+            retryNumbers.ShouldBe(new [] { 1, 2 });
+
+            cmd.Dispose();
+            connection.Dispose();
+        }
+
+        [Fact]
+        public async Task non_transient_exception_is_not_retried()
+        {
+            var runNumber = 0;
+            using var connection = setUpManagedConnectionWithRetry(retryTimes: 1);
+            var cmd = new NpgsqlCommand();
+
+            Exception<Marten.Exceptions.MartenCommandException>.ShouldBeThrownBy(() =>
+            {
+                connection.Execute(cmd, c =>
+                    {
+                        runNumber++;
+                        throw createNpgsqlException(false);
+                    }
+                );
+            });
+
+            runNumber.ShouldBe(1);
+            cmd.Dispose();
+            connection.Dispose();
+        }
+
+        private static NpgsqlException createNpgsqlException(bool transient)
+        {
+            var innerException = transient ? (Exception)new TimeoutException() : new DivideByZeroException();
+            var ex = new NpgsqlException("exception occurred", innerException);
+            return ex;
+        }
+
+        private static ManagedConnection setUpManagedConnectionWithRetry(int retryTimes)
+        {
+            // minimal sleep not to cause slowness
+            var retryPolicy = DefaultRetryPolicy.Times(retryTimes, sleep: x => TimeSpan.FromMilliseconds(20));
+            using var connection = new ManagedConnection(new ConnectionSource(), retryPolicy);
+            return connection;
+        }
+    }
+}

--- a/src/Marten/IRetryPolicy.cs
+++ b/src/Marten/IRetryPolicy.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Npgsql;
 
 namespace Marten
 {
@@ -64,6 +65,109 @@ namespace Marten
         public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> operation, CancellationToken cancellationToken)
         {
             return operation();
+        }
+    }
+
+    /// <summary>
+    /// Default retry policy, which accounts for <see cref="NpgsqlException.IsTransient"/>.
+    /// </summary>
+    /// <remarks>
+    /// Based on example https://martendb.io/documentation/documents/advanced/retrypolicy/ by Joona-Pekka Kokko.
+    /// </remarks>
+    public sealed class DefaultRetryPolicy: IRetryPolicy
+    {
+        private readonly int _maxTries;
+        private readonly Func<Exception, bool> _filter;
+
+        private static readonly Func<Exception, bool> DefaultFilter = x => x is NpgsqlException npgsqlException && npgsqlException.IsTransient;
+
+        private DefaultRetryPolicy(int maxTries, Func<Exception, bool> filter)
+        {
+            _maxTries = maxTries;
+            _filter = filter;
+        }
+
+        /// <summary>
+        /// Initializes a retry policy that will retry once after failure.
+        /// </summary>
+        /// <param name="filter">Optional filter, default to checking for <see cref="NpgsqlException.IsTransient"/></param>
+        /// <returns>The configured retry policy.</returns>
+        public static IRetryPolicy Once(Func<Exception, bool> filter)
+        {
+            return new DefaultRetryPolicy(2, filter ?? DefaultFilter);
+        }
+
+        /// <summary>
+        /// Initializes a retry policy that will retry twice after failure.
+        /// </summary>
+        /// <param name="filter">Optional filter, default to checking for <see cref="NpgsqlException.IsTransient"/></param>
+        /// <returns>The configured retry policy.</returns>
+        public static IRetryPolicy Twice(Func<Exception, bool> filter = null)
+        {
+            return new DefaultRetryPolicy(3, filter ?? DefaultFilter);
+        }
+
+        /// <summary>
+        /// Initializes a retry policy that will retry given amount of times after failure.
+        /// </summary>
+        /// <param name="filter">Optional filter, default to checking for <see cref="NpgsqlException.IsTransient"/></param>
+        /// <returns>The configured retry policy.</returns>
+        public static IRetryPolicy Times(int times, Func<Exception, bool> filter = null)
+        {
+            return new DefaultRetryPolicy(times + 1, filter ?? DefaultFilter);
+        }
+
+        void IRetryPolicy.Execute(Action operation)
+        {
+            Try(() =>
+            {
+                operation();
+                return Task.CompletedTask;
+            }, CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        TResult IRetryPolicy.Execute<TResult>(Func<TResult> operation)
+        {
+            return Try(() => Task.FromResult(operation()), CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        Task IRetryPolicy.ExecuteAsync(Func<Task> operation, CancellationToken cancellationToken)
+        {
+            return Try(operation, cancellationToken);
+        }
+
+        Task<TResult> IRetryPolicy.ExecuteAsync<TResult>(Func<Task<TResult>> operation, CancellationToken cancellationToken)
+        {
+            return Try(operation, cancellationToken);
+        }
+
+        private async Task Try(Func<Task> operation, CancellationToken token)
+        {
+            for (var tries = 0;; token.ThrowIfCancellationRequested())
+            {
+                try
+                {
+                    await operation().ConfigureAwait(false);
+                    return;
+                }
+                catch (Exception e) when (++tries < _maxTries && _filter(e))
+                {
+                }
+            }
+        }
+
+        private async Task<T> Try<T>(Func<Task<T>> operation, CancellationToken token)
+        {
+            for (var tries = 0;; token.ThrowIfCancellationRequested())
+            {
+                try
+                {
+                    return await operation().ConfigureAwait(false);
+                }
+                catch (Exception e) when (++tries < _maxTries && _filter(e))
+                {
+                }
+            }
         }
     }
 }

--- a/src/Marten/IRetryPolicy.cs
+++ b/src/Marten/IRetryPolicy.cs
@@ -43,7 +43,7 @@ namespace Marten
     }
 
     /// <summary>
-    /// Default implementation of IRetryPolicy
+    /// No-op implementation of IRetryPolicy
     /// </summary>
     public class NulloRetryPolicy: IRetryPolicy
     {

--- a/src/Marten/IRetryPolicy.cs
+++ b/src/Marten/IRetryPolicy.cs
@@ -125,16 +125,22 @@ namespace Marten
 
         void IRetryPolicy.Execute(Action operation)
         {
-            Try(() =>
+            using (Util.NoSynchronizationContextScope.Enter())
             {
-                operation();
-                return Task.CompletedTask;
-            }, CancellationToken.None).GetAwaiter().GetResult();
+                Try(() =>
+                {
+                    operation();
+                    return Task.CompletedTask;
+                }, CancellationToken.None).GetAwaiter().GetResult();
+            }
         }
 
         TResult IRetryPolicy.Execute<TResult>(Func<TResult> operation)
         {
-            return Try(() => Task.FromResult(operation()), CancellationToken.None).GetAwaiter().GetResult();
+            using (Util.NoSynchronizationContextScope.Enter())
+            {
+                return Try(() => Task.FromResult(operation()), CancellationToken.None).GetAwaiter().GetResult();
+            }
         }
 
         Task IRetryPolicy.ExecuteAsync(Func<Task> operation, CancellationToken cancellationToken)


### PR DESCRIPTION
Per Gitter discussion, this is the [documentation sample retry policy](https://martendb.io/documentation/documents/advanced/retrypolicy/) with some tweaks.

* filter defaults to checking for `x is NpgsqlException npgsqlException && npgsqlException.IsTransient`
* renamed `NTimes` to just `Times`
* new parameter `sleep` that allows to return `TimeSpan` to sleep given current retry number, defaults to retry number as seconds
* made `IRetryPolicy` interface implementation explicit to hide members not relevant for public API