### PR TITLE
Fix projecting nullable Instant

### DIFF
--- a/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
+++ b/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
@@ -185,12 +185,13 @@ namespace Marten.NodaTime.Testing.Acceptance
 
                 var result = query.Query<TargetWithDates>()
                     .Where(c => c.Id == testDoc.Id)
-                    .Select(c => new { c.Id, c.InstantUTC })
+                    .Select(c => new { c.Id, c.InstantUTC, c.NullableInstantUTC })
                     .Single();
 
                 result.ShouldNotBeNull();
                 result.Id.ShouldBe(testDoc.Id);
                 ShouldBeEqualWithDbPrecision(result.InstantUTC, instantUTC);
+                ShouldBeEqualWithDbPrecision(result.NullableInstantUTC.GetValueOrDefault(), instantUTC);
             }
         }
 

--- a/src/Marten.NodaTime/InstantJsonConverter.cs
+++ b/src/Marten.NodaTime/InstantJsonConverter.cs
@@ -15,7 +15,7 @@ namespace Marten.NodaTime
     /// </summary>
     internal class InstantJsonConverter: JsonConverter
     {
-        public static InstantJsonConverter Instance = new InstantJsonConverter();
+        public static readonly InstantJsonConverter Instance = new InstantJsonConverter();
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
@@ -39,7 +39,7 @@ namespace Marten.NodaTime
 
         public override bool CanConvert(Type objectType)
         {
-            return typeof(Instant) == objectType;
+            return typeof(Instant) == objectType || typeof(Instant?) == objectType;
         }
     }
 }


### PR DESCRIPTION
This adds upon earlier fix https://github.com/JasperFx/marten/pull/1290 for https://github.com/JasperFx/marten/issues/1276 , unfortunately the converter didn't check for Nullable<Instant> and projecting such non-null value from database fails with error: 

```
Newtonsoft.Json.JsonSerializationException: Cannot convert value to System.Nullable`1[NodaTime.Instant]
 ---> NodaTime.Text.UnparsableValueException: The value string does not match a quoted string in the pattern. Value being parsed: '2020-08-20T11:11:32.467173^'. (^ indicates error position.)
```

I extended the earlier test case a bit and added missing type check. Hoping to get this to next servicing release 🙏 

/cc @oskardudycz 