### PR TITLE
Fix enum reflection for .NET 5

### DIFF
--- a/src/Marten/Util/LambdaBuilder.cs
+++ b/src/Marten/Util/LambdaBuilder.cs
@@ -95,8 +95,8 @@ namespace Marten.Util
 
             return ExpressionCompiler.Compile<Func<TTarget, TValue>>(lambda);
         }
-
-        private static readonly MethodInfo _getEnumStringValue = typeof(Enum).GetMethod(nameof(Enum.GetName), BindingFlags.Static | BindingFlags.Public);
+        
+        private static readonly MethodInfo _getEnumStringValue = typeof(Enum).GetMethods(BindingFlags.Static | BindingFlags.Public).Single(x=> x.Name == nameof(Enum.GetName) && !x.IsGenericMethod);
         private static readonly MethodInfo _getEnumIntValue = typeof(Convert).GetMethods(BindingFlags.Static | BindingFlags.Public).Single(mi => mi.Name == nameof(Convert.ToInt32) && mi.GetParameters().Count() == 1 && mi.GetParameters().Single().ParameterType == typeof(object));
         private static readonly Expression _trueConstant = Expression.Constant(true);
 

--- a/src/Marten/Util/LambdaBuilder.cs
+++ b/src/Marten/Util/LambdaBuilder.cs
@@ -96,7 +96,7 @@ namespace Marten.Util
             return ExpressionCompiler.Compile<Func<TTarget, TValue>>(lambda);
         }
         
-        private static readonly MethodInfo _getEnumStringValue = typeof(Enum).GetMethods(BindingFlags.Static | BindingFlags.Public).Single(x=> x.Name == nameof(Enum.GetName) && !x.IsGenericMethod);
+        private static readonly MethodInfo _getEnumStringValue = typeof(Enum).GetMethods(BindingFlags.Static | BindingFlags.Public).Single(mi => mi.Name == nameof(Enum.GetName) && !mi.IsGenericMethod);
         private static readonly MethodInfo _getEnumIntValue = typeof(Convert).GetMethods(BindingFlags.Static | BindingFlags.Public).Single(mi => mi.Name == nameof(Convert.ToInt32) && mi.GetParameters().Count() == 1 && mi.GetParameters().Single().ParameterType == typeof(object));
         private static readonly Expression _trueConstant = Expression.Constant(true);
 


### PR DESCRIPTION
.NET 5 Preview 8 added a generic overload for `GetName`, thus breaking the previous reflection.


.NET Core 3.1:
![image](https://user-images.githubusercontent.com/975824/91263398-e9b6a200-e7a2-11ea-8153-15f5ff3855be.png)


.NET 5 Preview 8:
![image](https://user-images.githubusercontent.com/975824/91263081-d1df1e00-e7a2-11ea-9788-96b50e783d77.png)
