### PR TITLE
Update minimum npgsql to 4.1.5

### DIFF
--- a/documentation/documentation/documents/configuration/noda_time.md
+++ b/documentation/documentation/documents/configuration/noda_time.md
@@ -26,7 +26,3 @@ By default it also sets up the `JsonNetSerializer` options (see more details in 
 If you're using custom Json serializer or you'd like to maintain fully its configuration then you can set disable default configuration by setting `shouldConfigureJsonNetSerializer` parameter to `false`. By changing this setting you need to configure NodaTime Json serialization by yourself.
 
 <[sample:noda_time_setup_without_json_net_serializer_configuration]>
-
-<div class="alert alert-warning">
-By using NodaTime plugin - you're opting out of DateTime type handling. Using DateTime in your Document will end up getting NotSupportedException exception.
-</div>

--- a/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
+++ b/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
@@ -66,7 +66,7 @@ namespace Marten.NodaTime.Testing.Acceptance
         }
 
         [Fact]
-        public void can_query_document_with_noda_time_types()
+        public void can_query_document_with_noda_time_types_and_bcl_types()
         {
             StoreOptions(_ =>
             {
@@ -75,6 +75,7 @@ namespace Marten.NodaTime.Testing.Acceptance
             });
 
             var dateTime = DateTime.UtcNow;
+            var dateTimeOffset = new DateTimeOffset(dateTime);
             var localDateTime = LocalDateTime.FromDateTime(dateTime);
             var instantUTC = Instant.FromDateTimeUtc(dateTime.ToUniversalTime());
             var testDoc = TargetWithDates.Generate(dateTime);
@@ -129,7 +130,35 @@ namespace Marten.NodaTime.Testing.Acceptance
                     query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableInstantUTC < instantUTC.PlusTicks(1000)),
                     query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableInstantUTC <= instantUTC.PlusTicks(1000)),
                     query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableInstantUTC > instantUTC.PlusTicks(-1000)),
-                    query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableInstantUTC >= instantUTC.PlusTicks(-1000))
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableInstantUTC >= instantUTC.PlusTicks(-1000)),
+
+                    // BCL DateTime
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.DateTime == dateTime),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.DateTime < dateTime.AddTicks(1000)),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.DateTime <= dateTime.AddTicks(1000)),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.DateTime > dateTime.AddTicks(-1000)),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.DateTime >= dateTime.AddTicks(-1000)),
+
+                    // BCL Nullable DateTime
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableDateTime == dateTime),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableDateTime < dateTime.AddTicks(1000)),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableDateTime <= dateTime.AddTicks(1000)),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableDateTime > dateTime.AddTicks(-1000)),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableDateTime >= dateTime.AddTicks(-1000)),
+
+                    // BCL DateTimeOffset
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.DateTimeOffset == dateTimeOffset),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.DateTimeOffset < dateTimeOffset.AddTicks(1000)),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.DateTimeOffset <= dateTimeOffset.AddTicks(1000)),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.DateTimeOffset > dateTimeOffset.AddTicks(-1000)),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.DateTimeOffset >= dateTimeOffset.AddTicks(-1000)),
+
+                    // BCL Nullable DateTimeOffset
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableDateTimeOffset == dateTimeOffset),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableDateTimeOffset < dateTimeOffset.AddTicks(1000)),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableDateTimeOffset <= dateTimeOffset.AddTicks(1000)),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableDateTimeOffset > dateTimeOffset.AddTicks(-1000)),
+                    query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableDateTimeOffset >= dateTimeOffset.AddTicks(-1000)),
                 };
 
                 results.ShouldAllBe(x => x.Equals(testDoc));

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>NodaTime extension for Marten</Description>
         <VersionPrefix>1.8.1</VersionPrefix>
@@ -36,8 +36,8 @@
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735</NoWarn>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="NodaTime.Serialization.JsonNet" Version="2.2.0" />
-        <PackageReference Include="Npgsql.NodaTime" Version="[4.1.4,4.2.0)" />
+        <PackageReference Include="NodaTime.Serialization.JsonNet" Version="2.3.0" />
+        <PackageReference Include="Npgsql.NodaTime" Version="[4.1.5,4.2.0)" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -37,8 +37,8 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-        <PackageReference Include="Npgsql" Version="[4.1.4,4.2.0)" />
-        <PackageReference Include="Npgsql.Json.NET" Version="[4.1.4,4.2.0)" />
+        <PackageReference Include="Npgsql" Version="[4.1.5,4.2.0)" />
+        <PackageReference Include="Npgsql.Json.NET" Version="[4.1.5,4.2.0)" />
         <PackageReference Include="Remotion.Linq" Version="2.2.0" />
         <PackageReference Include="Baseline" Version="1.5.0" />
         <PackageReference Include="System.Memory" Version="4.5.3" />


### PR DESCRIPTION
Changes: https://github.com/npgsql/npgsql/milestone/70?closed=1

Most importantly, this fixes the long-running problem of combining NodaTime with BCL DateTime types.