### PR TITLE
Allow null enum values to be parsed in duplicated field resolution

### DIFF
--- a/src/Marten.Testing/Linq/Fields/DuplicatedFieldTests.cs
+++ b/src/Marten.Testing/Linq/Fields/DuplicatedFieldTests.cs
@@ -62,6 +62,25 @@ namespace Marten.Testing.Linq.Fields
             field.GetValueForCompiledQueryParameter(constant).ShouldBe(Colors.Blue.ToString());
         }
 
+
+        [Fact]
+        public void enum_field_allows_null()
+        {
+            var options = new StoreOptions();
+            options.Serializer(new JsonNetSerializer
+            {
+                EnumStorage = EnumStorage.AsString
+            });
+
+            var field = DuplicatedField.For<Target>(options, x => x.Color);
+            field.UpsertArgument.DbType.ShouldBe(NpgsqlDbType.Varchar);
+            field.UpsertArgument.PostgresType.ShouldBe("varchar");
+
+            var constant = Expression.Constant(null);
+
+            field.GetValueForCompiledQueryParameter(constant).ShouldBe(null);
+        }
+
         [Theory]
         [InlineData(EnumStorage.AsInteger, "color = CAST(data ->> 'Color' as integer)")]
         [InlineData(EnumStorage.AsString, "color = data ->> 'Color'")]

--- a/src/Marten/Linq/Fields/DuplicatedField.cs
+++ b/src/Marten/Linq/Fields/DuplicatedField.cs
@@ -41,6 +41,10 @@ namespace Marten.Linq.Fields
                     _parseObject = expression =>
                     {
                         var raw = expression.Value();
+                        if (raw == null)
+                        {
+                            return null;
+                        }
                         return Enum.GetName(FieldType, raw);
                     };
                 }


### PR DESCRIPTION
This caused a nasty production bug for me when constructing a query against duplicated columns using optional args. For instance, given the document setup:

```
class ExampleDocument
{
    Colors Color { get; set; }
    string Name { get; set; }
}
```

I had a method which was something to the tune of:

```
IEnumerable<ExampleDocument> ListDocuments(Colors? color, string? name)
    =>  _querySession
        .Query<ExampleDocument>()
        .Where(a => (color != null && a.Color == color)
                 && (name == null || a.Name == name))
        .ToList();
```

That caused a hard error because a `null` value for `color` was causing the duplicated field handler to error out, despite the fact that it would never be evaluated against the column itself due to the OR evaluation.