### PR TITLE
Strongly typed custom ids

### DIFF
--- a/src/Marten.Schema.Testing/Identity/StronglyTyped/DefaultPrimitiveTypeFinderTests.cs
+++ b/src/Marten.Schema.Testing/Identity/StronglyTyped/DefaultPrimitiveTypeFinderTests.cs
@@ -1,0 +1,55 @@
+using Marten.Schema.Identity.StronglyTyped;
+using System;
+using Xunit;
+
+namespace Marten.Schema.Testing.Identity.StronglyTyped
+{
+    public class DefaultPrimitiveTypeFinderTests
+    {
+        [Fact]
+        public void SingleParamConstructor()
+        {
+            var type = DefaultPrimitiveTypeFinder.FindPrimitiveType(typeof(FieldWrapper));
+            Assert.Equal(typeof(Guid), type);
+        }
+
+        [Fact]
+        public void DefaultConstructor()
+        {
+            var type = DefaultPrimitiveTypeFinder.FindPrimitiveType(typeof(DefaultWrapper));
+            Assert.Equal(typeof(Guid), type);
+        }
+
+        [Fact]
+        public void SingleParamPropConstructor()
+        {
+            var type = DefaultPrimitiveTypeFinder.FindPrimitiveType(typeof(PropertyWrapper));
+            Assert.Equal(typeof(Guid), type);
+        }
+
+        public class FieldWrapper
+        {
+            private Guid id;
+
+            public FieldWrapper(Guid id)
+            {
+                this.id = id;
+            }
+        }
+
+        public class PropertyWrapper
+        {
+            public Guid Id { get; }
+
+            public PropertyWrapper(Guid id)
+            {
+                this.Id = id;
+            }
+        }
+
+        public class DefaultWrapper
+        {
+            public Guid Id { get; set; }
+        }
+    }
+}

--- a/src/Marten.Schema.Testing/Identity/StronglyTyped/Model/Blog.cs
+++ b/src/Marten.Schema.Testing/Identity/StronglyTyped/Model/Blog.cs
@@ -1,0 +1,15 @@
+namespace Marten.Schema.Testing.Identity.StronglyTyped.Model
+{
+    public class Blog
+    {
+        public Blog(BlogId id, string name)
+        {
+            this.Id = id;
+            this.Name = name;
+        }
+
+        public BlogId Id { get; }
+
+        public string Name { get; }
+    }
+}

--- a/src/Marten.Schema.Testing/Identity/StronglyTyped/Model/BlogId.cs
+++ b/src/Marten.Schema.Testing/Identity/StronglyTyped/Model/BlogId.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Marten.Schema.Testing.Identity.StronglyTyped.Model
+{
+    public struct BlogId
+    {
+        public Guid Id { get; }
+
+        public BlogId(Guid id)
+        {
+            Id = id;
+        }
+        public bool Equals(BlogId other)
+        {
+            return Id.Equals(other.Id);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is BlogId other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+
+        public static bool operator ==(BlogId a, BlogId b)
+        {
+            return a.Id == b.Id;
+        }
+
+        public static bool operator !=(BlogId a, BlogId b)
+        {
+            return !(a == b);
+        }
+    }
+}

--- a/src/Marten.Schema.Testing/Identity/StronglyTyped/Model/Post.cs
+++ b/src/Marten.Schema.Testing/Identity/StronglyTyped/Model/Post.cs
@@ -1,0 +1,16 @@
+namespace Marten.Schema.Testing.Identity.StronglyTyped.Model
+{
+    public class Post
+    {
+        public Post(PostId id, BlogId blogId, string name)
+        {
+            this.Id = id;
+            this.BlogId = blogId;
+            this.Name = name;
+        }
+
+        public PostId Id { get; }
+        public BlogId BlogId { get; }
+        public string Name { get; }
+    }
+}

--- a/src/Marten.Schema.Testing/Identity/StronglyTyped/Model/PostId.cs
+++ b/src/Marten.Schema.Testing/Identity/StronglyTyped/Model/PostId.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace Marten.Schema.Testing.Identity.StronglyTyped.Model
+{
+    public struct PostId
+    {
+        public Guid Id { get; }
+
+        public PostId(Guid id)
+        {
+            Id = id;
+        }
+        public bool Equals(PostId other)
+        {
+            return Id.Equals(other.Id);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is PostId other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+
+        public static bool operator ==(PostId a, PostId b)
+        {
+            return a.Id == b.Id;
+        }
+
+        public static bool operator !=(PostId a, PostId b)
+        {
+            return !(a == b);
+        }
+    }
+}

--- a/src/Marten.Schema.Testing/Identity/StronglyTyped/WrappedPrimitiveAccessorTests.cs
+++ b/src/Marten.Schema.Testing/Identity/StronglyTyped/WrappedPrimitiveAccessorTests.cs
@@ -1,0 +1,113 @@
+using System;
+using Marten.Schema.Identity.StronglyTyped;
+using Xunit;
+
+namespace Marten.Schema.Testing.Identity.StronglyTyped
+{
+    public class WrappedPrimitiveAccessorTests
+    {
+        [Fact]
+        public void GetCastableId()
+        {
+            var wrappedPrimitiveAccessor = new DefaultWrappedPrimitiveAccessor<ImplicitWrapper, Guid>();
+            var id = Guid.NewGuid();
+            var wrapper = new ImplicitWrapper(id);
+            var extractedId = wrappedPrimitiveAccessor.GetId(wrapper);
+            Assert.Equal(id, extractedId);
+        }
+
+        [Fact]
+        public void GetWrapperWithIdField()
+        {
+            var wrappedPrimitiveAccessor = new DefaultWrappedPrimitiveAccessor<FieldWrapper, Guid>();
+            var id = Guid.NewGuid();
+            var wrapper = new FieldWrapper(id);
+            var extractedId = wrappedPrimitiveAccessor.GetId(wrapper);
+            Assert.Equal(id, extractedId);
+        }
+
+        [Fact]
+        public void GetWrapperWithIdProperty()
+        {
+            var wrappedPrimitiveAccessor = new DefaultWrappedPrimitiveAccessor<PropertyWrapper, Guid>();
+            var id = Guid.NewGuid();
+            var wrapper = new PropertyWrapper(id);
+            var extractedId = wrappedPrimitiveAccessor.GetId(wrapper);
+            Assert.Equal(id, extractedId);
+        }
+
+        [Fact]
+        public void NewSameType()
+        {
+            var wrappedPrimitiveAccessor = new DefaultWrappedPrimitiveAccessor<Guid, Guid>();
+            var id = Guid.NewGuid();
+            var wrapped = wrappedPrimitiveAccessor.NewId(id);
+            Assert.Equal(id, wrapped);
+        }
+
+        [Fact]
+        public void NewCastable()
+        {
+            var wrappedPrimitiveAccessor = new DefaultWrappedPrimitiveAccessor<ImplicitWrapper, Guid>();
+            var id = Guid.NewGuid();
+            var wrapped = wrappedPrimitiveAccessor.NewId(id);
+            Assert.Equal(id, (Guid)wrapped);
+        }
+
+        [Fact]
+        public void NewSingleParamConstructor()
+        {
+            var wrappedPrimitiveAccessor = new DefaultWrappedPrimitiveAccessor<PropertyWrapper, Guid>();
+            var id = Guid.NewGuid();
+            var wrapped = wrappedPrimitiveAccessor.NewId(id);
+            Assert.Equal(id, wrapped.Id);
+        }
+
+        [Fact]
+        public void NewDefaultConstructor()
+        {
+            var wrappedPrimitiveAccessor = new DefaultWrappedPrimitiveAccessor<DefaultWrapper, Guid>();
+            var id = Guid.NewGuid();
+            var wrapped = wrappedPrimitiveAccessor.NewId(id);
+            Assert.Equal(id, wrapped.Id);
+        }
+
+        public class ImplicitWrapper
+        {
+            private Guid theWrappedId;
+
+            public ImplicitWrapper(Guid id)
+            {
+                theWrappedId = id;
+            }
+
+            public static explicit operator Guid(ImplicitWrapper w) => w.theWrappedId;
+            public static explicit operator ImplicitWrapper(Guid g) => new ImplicitWrapper(g);
+        }
+
+        public class FieldWrapper
+        {
+            private Guid id;
+
+            public FieldWrapper(Guid id)
+            {
+                this.id = id;
+            }
+        }
+
+        public class PropertyWrapper
+        {
+            public Guid Id { get; }
+
+            public PropertyWrapper(Guid id)
+            {
+                this.Id = id;
+            }
+        }
+
+        public class DefaultWrapper
+        {
+            public Guid Id { get; set; }
+        }
+    }
+}

--- a/src/Marten.Schema.Testing/Identity/StronglyTyped/load_and_store_strongly_typed_ids.cs
+++ b/src/Marten.Schema.Testing/Identity/StronglyTyped/load_and_store_strongly_typed_ids.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Linq;
+using Marten.Schema.Identity.StronglyTyped;
+using Marten.Schema.Testing.Identity.StronglyTyped.Model;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Marten.Schema.Testing.Identity.StronglyTyped
+{
+    public class load_and_store_strongly_typed_ids : IntegrationContext
+    {
+        private readonly ITestOutputHelper _outputHelper;
+
+        public load_and_store_strongly_typed_ids(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+
+        [Fact]
+        public void custom_id_type()
+        {
+            StoreOptions(s =>
+            {
+                s.Logger(new TestOutputMartenLogger(this._outputHelper));
+                s.UseStronglyTypedId<BlogId>();
+            });
+
+            var blog = new Blog(new BlogId(Guid.NewGuid()), "Marten Blog");
+            theSession.Store(blog);
+            theSession.SaveChanges();
+
+            var loadedBlog = theSession.Load<Blog, BlogId>(blog.Id);
+            loadedBlog.ShouldNotBeNull();
+            Assert.NotSame(blog, loadedBlog);
+
+            var loadedThroughLinq = theSession.Query<Blog>().Single(b => b.Id == blog.Id);
+            loadedThroughLinq.ShouldNotBeNull();
+            Assert.NotSame(loadedBlog, loadedThroughLinq);
+            Assert.Equal(blog.Id, loadedThroughLinq.Id);
+        }
+
+        [Fact]
+        public void when_loading_then_a_different_document_should_be_returned()
+        {
+            StoreOptions(s =>
+            {
+                s.Logger(new TestOutputMartenLogger(this._outputHelper));
+                s.UseStronglyTypedId<BlogId>();
+            });
+
+            var blog = new Blog(new BlogId(Guid.NewGuid()), "Marten Blog 2");
+            theSession.Store(blog);
+            theSession.SaveChanges();
+
+            using (var session = theStore.OpenSession())
+            {
+                var first = session.Load<Blog, BlogId>(blog.Id);
+                var second = session.Load<Blog, BlogId>(blog.Id);
+                first.ShouldBeSameAs(second);
+            }
+        }
+
+        [Fact]
+        public void when_filtered_by_foreign_id()
+        {
+            StoreOptions(s =>
+            {
+                s.Logger(new TestOutputMartenLogger(this._outputHelper));
+                s.UseStronglyTypedId<PostId>();
+                s.UseStronglyTypedId<BlogId>();
+            });
+
+            var blogId = new BlogId(Guid.NewGuid());
+            var firstPost = new Post(new PostId(Guid.NewGuid()), blogId, "First post");
+            var secondPost = new Post(new PostId(Guid.NewGuid()), blogId, "Second post");
+            var otherPost = new Post(new PostId(Guid.NewGuid()), new BlogId(Guid.NewGuid()), "Other post");
+            theSession.Store(firstPost, secondPost, otherPost);
+            theSession.SaveChanges();
+
+            using (var session = theStore.OpenSession())
+            {
+                var posts = session.Query<Post>().Where(p => p.BlogId == blogId).ToArray();
+                Assert.Equal(2, posts.Length);
+                Assert.All(posts, p => {
+                    Assert.Equal(p.BlogId, blogId);
+                    });
+            }
+        }
+    }
+}

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -55,6 +55,25 @@ namespace Marten
         T Load<T>(Guid id);
 
         /// <summary>
+        /// Load or find a single document of type T with an id of type TId
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TId"></typeparam>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        T Load<T, TId>(TId id);
+
+        /// <summary>
+        /// Asynchronously load or find a single document of type T with an id of type TId
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TId"></typeparam>
+        /// <param name="id"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task<T> LoadAsync<T, TId>(TId id, CancellationToken token = default(CancellationToken));
+
+        /// <summary>
         /// Asynchronously load or find a single document of type T with either a numeric or Guid id
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -218,6 +237,22 @@ namespace Marten
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TId"></typeparam>
+        /// <returns></returns>
+        IReadOnlyList<T> LoadMany<T, TId>(params TId[] ids);
+
+        /// <summary>
+        /// Load or find multiple documents by id
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TId"></typeparam>
+        /// <returns></returns>
+        IReadOnlyList<T> LoadMany<T, TId>(IEnumerable<TId> ids);
+
+        /// <summary>
+        /// Load or find multiple documents by id
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         Task<IReadOnlyList<T>> LoadManyAsync<T>(params string[] ids);
 
@@ -274,6 +309,22 @@ namespace Marten
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TId"></typeparam>
+        /// <returns></returns>
+        Task<IReadOnlyList<T>> LoadManyAsync<T, TId>(params TId[] ids);
+
+        /// <summary>
+        /// Load or find multiple documents by id
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TId"></typeparam>
+        /// <returns></returns>
+        Task<IReadOnlyList<T>> LoadManyAsync<T, TId>(IEnumerable<TId> ids);
+
+        /// <summary>
+        /// Load or find multiple documents by id
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params string[] ids);
 
@@ -325,6 +376,22 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<long> ids);
+
+        /// <summary>
+        /// Load or find multiple documents by id
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TId"></typeparam>
+        /// <returns></returns>
+        Task<IReadOnlyList<T>> LoadManyAsync<T, TId>(CancellationToken token, params TId[] ids);
+
+        /// <summary>
+        /// Load or find multiple documents by id
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TId"></typeparam>
+        /// <returns></returns>
+        Task<IReadOnlyList<T>> LoadManyAsync<T, TId>(CancellationToken token, IEnumerable<TId> ids);
 
         /// <summary>
         /// Directly load the persisted JSON data for documents by Id

--- a/src/Marten/Internal/Sessions/QuerySession.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.cs
@@ -189,6 +189,22 @@ namespace Marten.Internal.Sessions
             return document;
         }
 
+        public T Load<T, TId>(TId id)
+        {
+            assertNotDisposed();
+
+            var document = storageFor<T, TId>().Load(id, this);
+            return document;
+        }
+
+        public async Task<T> LoadAsync<T, TId>(TId id, CancellationToken token = default(CancellationToken))
+        {
+            assertNotDisposed();
+
+            var document = await storageFor<T, TId>().LoadAsync(id, this, token).ConfigureAwait(false);
+            return document;
+        }
+
         public async Task<T> LoadAsync<T>(int id, CancellationToken token = default(CancellationToken))
         {
             assertNotDisposed();
@@ -318,6 +334,12 @@ namespace Marten.Internal.Sessions
 
         }
 
+        public IReadOnlyList<T> LoadMany<T, TId>(IEnumerable<TId> ids)
+        {
+            assertNotDisposed();
+            return storageFor<T, TId>().LoadMany(ids.ToArray(), this);
+        }
+
         public Task<IReadOnlyList<T>> LoadManyAsync<T>(params string[] ids)
         {
             assertNotDisposed();
@@ -329,6 +351,12 @@ namespace Marten.Internal.Sessions
         {
             assertNotDisposed();
             return storageFor<T, string>().LoadManyAsync(ids.ToArray(), this, default(CancellationToken));
+        }
+
+        public Task<IReadOnlyList<T>> LoadManyAsync<T, TId>(IEnumerable<TId> ids)
+        {
+            assertNotDisposed();
+            return storageFor<T, TId>().LoadManyAsync(ids.ToArray(), this, default(CancellationToken));
         }
 
         public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params string[] ids)
@@ -417,6 +445,12 @@ namespace Marten.Internal.Sessions
 
         }
 
+        public IReadOnlyList<T> LoadMany<T, TId>(params TId[] ids)
+        {
+            assertNotDisposed();
+            return storageFor<T, TId>().LoadMany(ids, this);
+        }
+
         public Task<IReadOnlyList<T>> LoadManyAsync<T>(params long[] ids)
         {
             assertNotDisposed();
@@ -428,6 +462,12 @@ namespace Marten.Internal.Sessions
         {
             assertNotDisposed();
             return storageFor<T, long>().LoadManyAsync(ids.ToArray(), this, default(CancellationToken));
+        }
+
+        public Task<IReadOnlyList<T>> LoadManyAsync<T, TId>(params TId[] ids)
+        {
+            assertNotDisposed();
+            return storageFor<T, TId>().LoadManyAsync(ids, this, default(CancellationToken));
         }
 
         public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params long[] ids)
@@ -442,7 +482,17 @@ namespace Marten.Internal.Sessions
             return storageFor<T, long>().LoadManyAsync(ids.ToArray(), this, token);
         }
 
+        public Task<IReadOnlyList<T>> LoadManyAsync<T, TId>(CancellationToken token, params TId[] ids)
+        {
+            assertNotDisposed();
+            return storageFor<T, TId>().LoadManyAsync(ids, this, token);
+        }
 
+        public Task<IReadOnlyList<T>> LoadManyAsync<T, TId>(CancellationToken token, IEnumerable<TId> ids)
+        {
+            assertNotDisposed();
+            return storageFor<T, TId>().LoadManyAsync(ids.ToArray(), this, token);
+        }
 
 
         public IReadOnlyList<T> LoadMany<T>(params Guid[] ids)

--- a/src/Marten/Schema/Identity/PrimitiveIdTypes.cs
+++ b/src/Marten/Schema/Identity/PrimitiveIdTypes.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Marten.Schema.Identity
+{
+    public static class PrimitiveIdTypes
+    {
+        public static readonly Type[] Supported = new[] {typeof(int), typeof(Guid), typeof(long), typeof(string)};
+    }
+}

--- a/src/Marten/Schema/Identity/StronglyTyped/DefaultPrimitiveTypeFinder.cs
+++ b/src/Marten/Schema/Identity/StronglyTyped/DefaultPrimitiveTypeFinder.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Marten.Schema.Identity.StronglyTyped
+{
+    internal static class DefaultPrimitiveTypeFinder
+    {
+        public static Type FindPrimitiveType(Type idType)
+        {
+            // try to find a single parameter constructor that takes one of our supported primitive types
+            // that will probably be the primitive type for the id
+            var constructors = idType.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+            var singleParameterPrimitiveConstructor = constructors
+                .Where(ci =>
+                {
+                    var parameters = ci.GetParameters();
+                    return parameters.Length == 1 && parameters[0].ParameterType
+                        .IsOneOf(PrimitiveIdTypes.Supported);
+                }).ToArray();
+            if (singleParameterPrimitiveConstructor.Length == 1)
+            {
+                return singleParameterPrimitiveConstructor[0].GetParameters()[0].ParameterType;
+            }
+
+            // try to find a public property of one of our supported primitive types
+            // matching our naming convention
+            var publicProperties = idType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(pi => (string.Equals(pi.Name, "id", StringComparison.OrdinalIgnoreCase)
+                              || string.Equals(pi.Name, "value",
+                                  StringComparison.OrdinalIgnoreCase) // https://github.com/andrewlock/StronglyTypedId
+                    ) && pi.PropertyType.IsOneOf(PrimitiveIdTypes.Supported)).ToArray();
+            if (publicProperties.Length == 1)
+            {
+                return publicProperties[0].PropertyType;
+            }
+
+            throw new InvalidOperationException($"Unable to determine the underlying primitive type for the id of type {idType.FullName}");
+        }
+    }
+}

--- a/src/Marten/Schema/Identity/StronglyTyped/DefaultWrappedPrimitiveAccessor.cs
+++ b/src/Marten/Schema/Identity/StronglyTyped/DefaultWrappedPrimitiveAccessor.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CSharp.RuntimeBinder;
+
+namespace Marten.Schema.Identity.StronglyTyped
+{
+    /// <summary>
+    /// The DefaultWrappedPrimitiveAccessor uses a variety of strategies for implementation:
+    ///  - attempted casts
+    ///  - reflection over fields or properties
+    /// </summary>
+    /// <typeparam name="TId"></typeparam>
+    /// <typeparam name="TPrimitive"></typeparam>
+    internal class DefaultWrappedPrimitiveAccessor<TId, TPrimitive>: IWrappedPrimitiveAccessor<TId, TPrimitive>
+    {
+        // if it fails once it will probably fail every time so we don't
+        // waste time catching exceptions once it fails the first time
+        private static bool typeCastMaySucceed = true;
+
+        public TPrimitive GetId(TId obj)
+        {
+            if (TryCast(obj, out TPrimitive castPrimitive))
+            {
+                return castPrimitive;
+            }
+
+            var idMember = GetIdMember();
+            if (idMember != null)
+            {
+                if (TryGetFieldValue(idMember, obj, out var fieldPrimitiveId))
+                {
+                    return fieldPrimitiveId;
+                }
+
+                if (TryGetPropertyValue(idMember, obj, out var propertyPrimitiveId))
+                {
+                    return propertyPrimitiveId;
+                }
+
+                throw new Exception($"Unable to get underlying id on type {typeof(TId)} from member {idMember.Name}");
+            }
+
+            throw new Exception($"Unable to find id on type {typeof(TId)}");
+        }
+
+        private static bool TryGetPropertyValue(MemberInfo memberInfo, TId obj, out TPrimitive primitiveId)
+        {
+            if (memberInfo is PropertyInfo property)
+            {
+                var idValue = property.GetValue(obj);
+                if (idValue is TPrimitive primitiveIdValue)
+                {
+                    primitiveId = primitiveIdValue;
+                    return true;
+                }
+            }
+
+            primitiveId = default;
+            return false;
+        }
+
+        private static bool TryGetFieldValue(MemberInfo memberInfo, TId obj, out TPrimitive primitiveId)
+        {
+            if (memberInfo is FieldInfo field)
+            {
+                var idValue = field.GetValue(obj);
+                if (idValue is TPrimitive primitiveIdValue)
+                {
+                    primitiveId = primitiveIdValue;
+                    return true;
+                }
+            }
+
+            primitiveId = default;
+            return false;
+        }
+
+        private static bool TryCast<TFrom, TTo>(TFrom from, out TTo to)
+        {
+            if (!typeCastMaySucceed)
+            {
+                to = default;
+                return false;
+            }
+            
+            try
+            {
+                dynamic dynamicFrom = from;
+                to = (TTo)dynamicFrom;
+                return true;
+            }
+            catch (InvalidCastException)
+            {
+                typeCastMaySucceed = false;
+            }
+            catch (RuntimeBinderException)
+            {
+                typeCastMaySucceed = false;
+            }
+
+            to = default;
+            return false;
+        }
+
+        private static MemberInfo GetIdMember()
+        {
+            var idMember = typeof(TId).GetMembers(BindingFlags.GetField | BindingFlags.GetProperty | BindingFlags.Public |
+                                                  BindingFlags.NonPublic | BindingFlags.Instance)
+                .SingleOrDefault(m => string.Equals("id", m.Name, StringComparison.InvariantCultureIgnoreCase));
+            return idMember;
+        }
+
+        public TId NewId(TPrimitive primitiveId)
+        {
+            if (typeof(TId) == typeof(TPrimitive))
+            {
+                return (TId)(object)primitiveId;
+            }
+
+            if (TryCast(primitiveId, out TId castWrapper))
+            {
+                return castWrapper;
+            }
+
+            var constructors = typeof(TId).GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+            if (TryActivateUsingSingleParameterConstructor(constructors, primitiveId, out var id1))
+            {
+                return id1;
+            }
+
+            if (TryActivateUsingDefaultConstructor(constructors, primitiveId, out var id2))
+            {
+                return id2;
+            }
+
+            throw new Exception($"Unable to create a new {typeof(TId)}");
+        }
+
+        private static bool TryActivateUsingDefaultConstructor(ConstructorInfo[] constructors, TPrimitive primitiveId, out TId id)
+        {
+            var parameterlessConstructor = constructors.SingleOrDefault(ci => ci.GetParameters().Length == 0);
+            if (parameterlessConstructor != null)
+            {
+                id = Activator.CreateInstance<TId>();
+                var idMember = GetIdMember();
+                if (idMember == null)
+                {
+                    throw new Exception($"Unable to find id on type {typeof(TId)}");
+                }
+
+                if (idMember is FieldInfo field)
+                {
+                    field.SetValue(id, primitiveId);
+                }
+                else if (idMember is PropertyInfo property)
+                {
+                    property.SetValue(id, primitiveId);
+                }
+                else
+                {
+                    throw new Exception($"id member is neither field nor property");
+                }
+
+                return true;
+            }
+
+            id = default;
+            return false;
+        }
+
+        private static bool TryActivateUsingSingleParameterConstructor(ConstructorInfo[] constructors, TPrimitive primitiveId, out TId id)
+        {
+            var singleMatchingParameterConstructor = constructors.SingleOrDefault(ci =>
+            {
+                var parameters = ci.GetParameters();
+                return parameters.Length == 1 && parameters[0].ParameterType == typeof(TPrimitive);
+            });
+            if (singleMatchingParameterConstructor != null)
+            {
+                id = (TId)Activator.CreateInstance(typeof(TId), primitiveId);
+                return true;
+            }
+
+            id = default;
+            return false;
+        }
+    }
+}

--- a/src/Marten/Schema/Identity/StronglyTyped/IWrappedPrimitiveAccessor.cs
+++ b/src/Marten/Schema/Identity/StronglyTyped/IWrappedPrimitiveAccessor.cs
@@ -1,0 +1,25 @@
+namespace Marten.Schema.Identity.StronglyTyped
+{
+    /// <summary>
+    /// Class enables the extraction of an underlying primitive type from a strongly typed id
+    /// as well as the creation of a strongly typed id from a primitive type
+    /// </summary>
+    /// <typeparam name="TId"></typeparam>
+    /// <typeparam name="TPrimitive"></typeparam>
+    public interface IWrappedPrimitiveAccessor<TId, TPrimitive>
+    {
+        /// <summary>
+        /// Gets the primitive id value from the strongly typed id
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        TPrimitive GetId(TId obj);
+
+        /// <summary>
+        /// Creates a new strongly typed id from a primitive id value
+        /// </summary>
+        /// <param name="primitiveId"></param>
+        /// <returns></returns>
+        TId NewId(TPrimitive primitiveId);
+    }
+}

--- a/src/Marten/Schema/Identity/StronglyTyped/NpgsqlTypeHandlerFactoryExtensions.cs
+++ b/src/Marten/Schema/Identity/StronglyTyped/NpgsqlTypeHandlerFactoryExtensions.cs
@@ -1,0 +1,14 @@
+using System;
+using Npgsql.TypeHandling;
+
+namespace Marten.Schema.Identity.StronglyTyped
+{
+    internal static class NpgsqlTypeHandlerFactoryExtensions
+    {
+        public static NpgsqlTypeHandlerFactory ToWrappedPrimitiveHandlerFactory(this NpgsqlTypeHandlerFactory primitiveTypeHandlerFactory, Type primitiveType)
+        {
+            return (NpgsqlTypeHandlerFactory) Activator.CreateInstance(typeof(WrappedPrimitiveTypeHandlerFactory<>).MakeGenericType(primitiveType),
+                primitiveTypeHandlerFactory);
+        }
+    }
+}

--- a/src/Marten/Schema/Identity/StronglyTyped/StronglyTypedIdExtensions.cs
+++ b/src/Marten/Schema/Identity/StronglyTyped/StronglyTypedIdExtensions.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Marten.Services;
+using Marten.Util;
+using Npgsql;
+using Npgsql.TypeMapping;
+
+namespace Marten.Schema.Identity.StronglyTyped
+{
+    public static class StronglyTypedIdExtensions
+    {
+        private static Func<Type, Type> primitiveTypeFinder;
+
+        public static Func<Type, Type> PrimitiveTypeFinder
+        {
+            get
+            {
+                return primitiveTypeFinder ?? DefaultPrimitiveTypeFinder.FindPrimitiveType;
+            }
+            set
+            {
+                primitiveTypeFinder = value;
+            }
+        }
+
+        private static readonly HashSet<Type> seenPrimitives = new HashSet<Type>();
+
+        private static object mapLock = new object();
+
+        public static void UseStronglyTypedId<TId>(this StoreOptions storeOptions,
+            bool shouldConfigureJsonNetSerializer = true)
+        {
+            storeOptions.UseStronglyTypedId(typeof(TId), shouldConfigureJsonNetSerializer);
+        }
+
+        public static void UseStronglyTypedId<TId, TPrimitive>(this StoreOptions storeOptions,
+            bool shouldConfigureJsonNetSerializer = true)
+        {
+            storeOptions.UseStronglyTypedId(typeof(TId), typeof(TPrimitive), shouldConfigureJsonNetSerializer);
+        }
+
+        public static void UseStronglyTypedId(this StoreOptions storeOptions, Type idType,
+            bool shouldConfigureJsonNetSerializer = true)
+        {
+            var primitiveType = PrimitiveTypeFinder(idType);
+            storeOptions.UseStronglyTypedId(idType, primitiveType, shouldConfigureJsonNetSerializer);
+        }
+
+        public static void UseStronglyTypedId(this StoreOptions storeOptions, Type idType, Type primitiveType,
+            bool shouldConfigureJsonNetSerializer = true)
+        {
+            // simple locking strategy as this should be called upon store configuration
+            lock (mapLock)
+            {
+                if (!AlreadyMapped(idType))
+                {
+                    var pgTypeMapping = GetTypeMapping(primitiveType);
+                    if (pgTypeMapping == null)
+                    {
+                        throw new InvalidOperationException(
+                            $"Unable to find NpgsqlTypeMapping for {primitiveType.FullName}");
+                    }
+
+                    var mappingBuilder = new NpgsqlTypeMappingBuilder
+                    {
+                        PgTypeName = pgTypeMapping.PgTypeName,
+                        NpgsqlDbType = pgTypeMapping.NpgsqlDbType,
+                        DbTypes = pgTypeMapping.DbTypes,
+                        ClrTypes = pgTypeMapping.ClrTypes.Union(new[] {idType}).ToArray(),
+                        InferredDbType = pgTypeMapping.InferredDbType,
+                        TypeHandlerFactory = seenPrimitives.Contains(primitiveType)
+                            ? pgTypeMapping
+                                .TypeHandlerFactory // the existing one will handle the new type automatically
+                            : pgTypeMapping.TypeHandlerFactory.ToWrappedPrimitiveHandlerFactory(primitiveType)
+                    };
+                    NpgsqlConnection.GlobalTypeMapper.AddMapping(mappingBuilder.Build());
+                    TypeMappings.RegisterMapping(idType, pgTypeMapping.PgTypeName, pgTypeMapping.NpgsqlDbType);
+                    seenPrimitives.Add(primitiveType);
+                }
+
+                if (shouldConfigureJsonNetSerializer)
+                {
+                    var serializer = storeOptions.Serializer();
+                    (serializer as JsonNetSerializer)?.Customize(s =>
+                    {
+                        if (s.Converters.All(jc => jc.GetType() != typeof(StronglyTypedIdJsonNetConverter<,>).MakeGenericType(idType, primitiveType)))
+                        {
+                            s.Converters.Add(StronglyTypedIdJsonNetConverterFactory.Create(idType, primitiveType));
+                        }
+                    });
+                    storeOptions.Serializer(serializer);
+                }
+            }
+        }
+
+        public static void UseStronglyTypedIds(this StoreOptions storeOptions,
+            bool shouldConfigureJsonNetSerializer = true, params Type[] idTypes)
+        {
+            storeOptions.UseStronglyTypedIds(idTypes, shouldConfigureJsonNetSerializer);
+        }
+
+        public static void UseStronglyTypedIds(this StoreOptions storeOptions, IEnumerable<Type> idTypes,
+            bool shouldConfigureJsonNetSerializer = true)
+        {
+            foreach (var idType in idTypes)
+            {
+                storeOptions.UseStronglyTypedId(idType, shouldConfigureJsonNetSerializer);
+            }
+        }
+
+        public static void UseStronglyTypedIds(this StoreOptions storeOptions, IDictionary<Type, Type> idTypes,
+            bool shouldConfigureJsonNetSerializer = true)
+        {
+            foreach (var idTypePair in idTypes)
+            {
+                storeOptions.UseStronglyTypedId(idTypePair.Key, idTypePair.Value, shouldConfigureJsonNetSerializer);
+            }
+        }
+
+        private static bool AlreadyMapped(Type idType)
+        {
+            return idType.IsOneOf(typeof(int), typeof(Guid), typeof(long), typeof(string))
+                   || TypeMappings.HasTypeMapping(idType);
+        }
+
+        private static NpgsqlTypeMapping GetTypeMapping(Type type)
+        {
+            return NpgsqlConnection
+                .GlobalTypeMapper
+                .Mappings
+                .FirstOrDefault(mapping => mapping.ClrTypes.Contains(type));
+        }
+    }
+}

--- a/src/Marten/Schema/Identity/StronglyTyped/StronglyTypedIdJsonNetConverter.cs
+++ b/src/Marten/Schema/Identity/StronglyTyped/StronglyTypedIdJsonNetConverter.cs
@@ -1,0 +1,27 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Marten.Schema.Identity.StronglyTyped
+{
+    internal class StronglyTypedIdJsonNetConverter<TId, TPrimitive>: Newtonsoft.Json.JsonConverter<TId>
+    {
+        private DefaultWrappedPrimitiveAccessor<TId, TPrimitive> wrappedPrimitiveAccessor;
+
+        public StronglyTypedIdJsonNetConverter()
+        {
+            this.wrappedPrimitiveAccessor = new DefaultWrappedPrimitiveAccessor<TId, TPrimitive>();
+        }
+
+        public override void WriteJson(JsonWriter writer, TId value, JsonSerializer serializer)
+        {
+            var primitiveId = this.wrappedPrimitiveAccessor.GetId(value);
+            serializer.Serialize(writer, primitiveId);
+        }
+
+        public override TId ReadJson(JsonReader reader, Type objectType, TId existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var id = serializer.Deserialize<TPrimitive>(reader);
+            return this.wrappedPrimitiveAccessor.NewId(id);
+        }
+    }
+}

--- a/src/Marten/Schema/Identity/StronglyTyped/StronglyTypedIdJsonNetConverterFactory.cs
+++ b/src/Marten/Schema/Identity/StronglyTyped/StronglyTypedIdJsonNetConverterFactory.cs
@@ -1,0 +1,14 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Marten.Schema.Identity.StronglyTyped
+{
+    internal static class StronglyTypedIdJsonNetConverterFactory
+    {
+        public static JsonConverter Create(Type idType, Type primitiveType)
+        {
+            return (JsonConverter)Activator.CreateInstance(
+                typeof(StronglyTypedIdJsonNetConverter<,>).MakeGenericType(idType, primitiveType));
+        }
+    }
+}

--- a/src/Marten/Schema/Identity/StronglyTyped/WrappedPrimitiveHandler.cs
+++ b/src/Marten/Schema/Identity/StronglyTyped/WrappedPrimitiveHandler.cs
@@ -1,0 +1,137 @@
+using System.Reflection;
+using System.Threading.Tasks;
+using Npgsql;
+using Npgsql.BackendMessages;
+using Npgsql.PostgresTypes;
+using Npgsql.TypeHandling;
+
+namespace Marten.Schema.Identity.StronglyTyped
+{
+    /// <summary>
+    /// This class is used by npgsql to read and write parameters that are strongly type ids. That is, it wraps the behaviour of the
+    /// handler that would be used for the primitive type that the strongly typed id is "wrapping". 
+    /// </summary>
+    /// <remarks>
+    /// Inspiration taken from the JsonHandler (in npgsql) as well as looking at the NpgsqlSimpleTypeHandler class, the implementation
+    /// of which is not straight forward and the reason for why this code is not a simple forward of method calls to the underlying
+    /// handler.
+    ///
+    /// We basically make use of the fact that the interface provides Read<TAny> and WriteWithLength<TAny> methods to enable
+    /// mapping to any type
+    /// </remarks>
+    /// <typeparam name="TPrimitive"></typeparam>
+    internal class WrappedPrimitiveHandler<TPrimitive>: NpgsqlTypeHandler<TPrimitive>
+    {
+        private readonly INpgsqlTypeHandler<TPrimitive> _primitiveTypeHandler;
+
+        public WrappedPrimitiveHandler(PostgresType postgresType, INpgsqlTypeHandler<TPrimitive> primitiveTypeHandler) : base(postgresType)
+        {
+            _primitiveTypeHandler = primitiveTypeHandler;
+        }
+
+        public override ValueTask<TPrimitive> Read(NpgsqlReadBuffer buf, int len, bool async,
+            FieldDescription? fieldDescription = null)
+        {
+            return this._primitiveTypeHandler.Read(buf, len, async, fieldDescription);
+        }
+
+        protected override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        {
+            var primitive = await this.Read(buf, len, async, fieldDescription);
+            var primitiveAccessor = new DefaultWrappedPrimitiveAccessor<TAny, TPrimitive>();
+            return primitiveAccessor.NewId(primitive);
+        }
+
+        public override Task Write(TPrimitive value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter,
+            bool async)
+        {
+            return this.WriteUsingPrimitiveHandler(value, buf, lengthCache, parameter, async);
+        }
+
+        protected override Task WriteWithLength<TAny>(TAny value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache,
+            NpgsqlParameter? parameter, bool async)
+        {
+            if (typeof(TAny) == typeof(TPrimitive))
+            {
+                return this.WriteUsingPrimitiveHandler((TPrimitive)(object)value, buf, lengthCache, parameter, async);
+            }
+
+            var primitiveAccessor = new DefaultWrappedPrimitiveAccessor<TAny, TPrimitive>();
+            var primitive = primitiveAccessor.GetId(value);
+            return this.WriteUsingPrimitiveHandler(primitive, buf, lengthCache, parameter, async);
+        }
+
+        protected override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache,
+            NpgsqlParameter? parameter, bool async)
+        {
+            return (Task)this.GetType().GetMethod(nameof(WriteWithLength), BindingFlags.FlattenHierarchy | BindingFlags.Instance | BindingFlags.NonPublic)
+                .MakeGenericMethod(value.GetType()).Invoke(this, new[] { value, buf, lengthCache, parameter, async });
+        }
+
+        private Task WriteUsingPrimitiveHandler(TPrimitive value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache,
+            NpgsqlParameter? parameter,
+            bool async)
+        {
+            if (this._primitiveTypeHandler is INpgsqlSimpleTypeHandler<TPrimitive> primitiveTypeHandler)
+            {
+                // see NpgsqlSimpleTypeHandler.WriteWithLengthInternal
+                var elementLen = ValidateAndGetLength(value, ref lengthCache, parameter);
+                if (buf.WriteSpaceLeft < 4 + elementLen)
+                    return WriteWithLengthLong();
+                buf.WriteInt32(elementLen);
+                primitiveTypeHandler.Write(value, buf, parameter);
+                return Task.CompletedTask;
+
+                async Task WriteWithLengthLong()
+                {
+                    elementLen = ValidateAndGetLength(value, ref lengthCache, parameter);
+                    if (buf.WriteSpaceLeft < 4 + elementLen)
+                        await buf.Flush(async);
+                    buf.WriteInt32(elementLen);
+                    primitiveTypeHandler.Write(value, buf, parameter);
+                }
+            }
+
+            return this._primitiveTypeHandler.Write(value, buf, lengthCache, parameter, async);
+        }
+
+        public override int ValidateAndGetLength(TPrimitive value, ref NpgsqlLengthCache? lengthCache,
+            NpgsqlParameter? parameter)
+            => this.ValidateAndGetLengthFromPrimitiveHandler(value, ref lengthCache, parameter);
+
+        protected override int ValidateAndGetLength<TAny>(TAny value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        {
+            if (value is TPrimitive primitive)
+            {
+                return this.ValidateAndGetLengthFromPrimitiveHandler(primitive, ref lengthCache, parameter);
+            }
+
+            var primitiveAccessor = new DefaultWrappedPrimitiveAccessor<TAny, TPrimitive>();
+            var wrappedPrimitive = primitiveAccessor.GetId(value);
+            return this.ValidateAndGetLengthFromPrimitiveHandler(wrappedPrimitive, ref lengthCache, parameter);
+        }
+
+        protected override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache,
+            NpgsqlParameter? parameter)
+        {
+            return (int)this.GetType().GetMethod(nameof(ValidateAndGetLength), BindingFlags.NonPublic | BindingFlags.Instance).MakeGenericMethod(value.GetType())
+                .Invoke(this, new[]
+                {
+                    value, lengthCache, parameter
+                });
+        }
+
+        private int ValidateAndGetLengthFromPrimitiveHandler(TPrimitive value, ref NpgsqlLengthCache? lengthCache,
+            NpgsqlParameter? parameter)
+        {
+            // Simple type handlers throw NotSupportedException for the interface method and provide a different public method instead!!!
+            // Breaks Liskov substitution principle if you ask me
+            if (this._primitiveTypeHandler is INpgsqlSimpleTypeHandler<TPrimitive> simpleTypeHandler)
+            {
+                return simpleTypeHandler.ValidateAndGetLength(value, parameter);
+            }
+
+            return this._primitiveTypeHandler.ValidateAndGetLength(value, ref lengthCache, parameter);
+        }
+    }
+}

--- a/src/Marten/Schema/Identity/StronglyTyped/WrappedPrimitiveTypeHandlerFactory.cs
+++ b/src/Marten/Schema/Identity/StronglyTyped/WrappedPrimitiveTypeHandlerFactory.cs
@@ -1,0 +1,31 @@
+using System;
+using Npgsql;
+using Npgsql.PostgresTypes;
+using Npgsql.TypeHandlers;
+using Npgsql.TypeHandling;
+
+namespace Marten.Schema.Identity.StronglyTyped
+{
+    internal class WrappedPrimitiveTypeHandlerFactory<TPrimitive> : NpgsqlTypeHandlerFactory
+    {
+        private readonly NpgsqlTypeHandlerFactory primitiveTypeHandlerFactory;
+
+        public WrappedPrimitiveTypeHandlerFactory(NpgsqlTypeHandlerFactory primitiveTypeHandlerFactory)
+        {
+            this.primitiveTypeHandlerFactory = primitiveTypeHandlerFactory;
+        }
+
+        public override NpgsqlTypeHandler CreateNonGeneric(PostgresType pgType, NpgsqlConnection conn)
+        {
+            var primitiveTypeHandler = this.primitiveTypeHandlerFactory.CreateNonGeneric(pgType, conn);
+            if (primitiveTypeHandler is INpgsqlTypeHandler<TPrimitive> typedPrimitiveTypeHandler)
+            {
+                return new WrappedPrimitiveHandler<TPrimitive>(pgType, typedPrimitiveTypeHandler);
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public override Type DefaultValueType => typeof(TPrimitive);
+    }
+}


### PR DESCRIPTION
Enables the use of strongly type ids (see https://andrewlock.net/using-strongly-typed-entity-ids-to-avoid-primitive-obsession-part-1/ for details).

Provides npgsql type handlers for conversion to underlying primitive type as well as json converters for document serialization to primitive type.

Strongly typed ids are registered through various StoreOptions extension methods named UseStronglyTypedId(s)

For understanding what the calling code looks like see src/Marten.Schema.Testing/Identity/StronglyTyped/load_and_store_strongly_typed_ids.cs Hopefully everything flows from there.

Accompanying issue is here: https://github.com/JasperFx/marten/issues/1582

As a first time contributor, and someone who's not actually used marten in anger (although I want to!), I imagine I've missed a bunch of use-cases. So please let me know of anything that you might be aware of as a possible issue and I'll be sure to add extra tests/code. I was pleasantly surprised at how little change I actually had to make to the core library - well done!

At the moment, there's no documentation. Feels like something that can wait until the PR is in a decent state?