### PR TITLE
Update to use Npgsql 5.0.0

### DIFF
--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -37,7 +37,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="2.3.0" />
-        <PackageReference Include="Npgsql.NodaTime" Version="[4.1.5,4.2.0)" />
+        <PackageReference Include="Npgsql.NodaTime" Version="5.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Marten.Schema.Testing/Storage/DocumentTableTester.cs
+++ b/src/Marten.Schema.Testing/Storage/DocumentTableTester.cs
@@ -83,7 +83,12 @@ namespace Marten.Schema.Testing.Storage
 
             patch.Apply(_conn, autoCreate, new ISchemaObject[] {table});
 
-            _conn.CreateCommand(patch.UpdateDDL).ExecuteNonQuery();
+            var updateDDL = patch.UpdateDDL;
+
+            if (!string.IsNullOrEmpty(updateDDL))
+            {
+                _conn.CreateCommand().ExecuteNonQuery();
+            }
         }
 
         [Theory]

--- a/src/Marten.Schema.Testing/Storage/DocumentTableTester.cs
+++ b/src/Marten.Schema.Testing/Storage/DocumentTableTester.cs
@@ -87,7 +87,7 @@ namespace Marten.Schema.Testing.Storage
 
             if (!string.IsNullOrEmpty(updateDDL))
             {
-                _conn.CreateCommand().ExecuteNonQuery();
+                _conn.CreateCommand(updateDDL).ExecuteNonQuery();
             }
         }
 

--- a/src/Marten.Testing/Services/DefaultRetryPolicyTests.cs
+++ b/src/Marten.Testing/Services/DefaultRetryPolicyTests.cs
@@ -23,7 +23,7 @@ namespace Marten.Testing.Services
                 }
             });
             using var connection = new ManagedConnection(new ConnectionSource(), retryPolicyDecorator);
-            var cmd = new NpgsqlCommand();
+            var cmd = new NpgsqlCommand("select 1");
 
             await connection.ExecuteAsync(cmd);
 

--- a/src/Marten.Testing/Services/ManagedConnectionTests.cs
+++ b/src/Marten.Testing/Services/ManagedConnectionTests.cs
@@ -107,7 +107,7 @@ namespace Marten.Testing.Services
             using (var connection =
                 new ManagedConnection(new ConnectionSource(), new NulloRetryPolicy()) {Logger = logger})
             {
-                var cmd = new NpgsqlCommand();
+                var cmd = new NpgsqlCommand("select 1");
                 connection.Execute(cmd);
 
                 logger.LastCommand.ShouldBeSameAs(cmd);

--- a/src/Marten.Testing/Services/ManagedConnectionTests.cs
+++ b/src/Marten.Testing/Services/ManagedConnectionTests.cs
@@ -20,17 +20,16 @@ namespace Marten.Testing.Services
                 connection.Execute(new NpgsqlCommand("select 1"));
                 connection.RequestCount.ShouldBe(1);
 
-                connection.Execute(new NpgsqlCommand());
+                connection.Execute(new NpgsqlCommand("select 2"));
                 connection.RequestCount.ShouldBe(2);
 
-                connection.Execute(new NpgsqlCommand());
+                connection.Execute(new NpgsqlCommand("select 3"));
                 connection.RequestCount.ShouldBe(3);
 
-                connection.Execute(new NpgsqlCommand());
+                connection.Execute(new NpgsqlCommand("select 4"));
                 connection.RequestCount.ShouldBe(4);
 
-
-                await connection.ExecuteAsync(new NpgsqlCommand());
+                await connection.ExecuteAsync(new NpgsqlCommand("select 5"));
                 connection.RequestCount.ShouldBe(5);
 
             }

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -35,9 +35,9 @@
         <PackageReference Include="BaselineTypeDiscovery" Version="1.1.0" />
         <PackageReference Include="LamarCodeGeneration" Version="2.4.0" />
         <PackageReference Include="LamarCompiler" Version="2.3.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-        <PackageReference Include="Npgsql" Version="[4.1.5,4.2.0)" />
-        <PackageReference Include="Npgsql.Json.NET" Version="[4.1.5,4.2.0)" />
+        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+        <PackageReference Include="Npgsql" Version="5.0.0" />
+        <PackageReference Include="Npgsql.Json.NET" Version="5.0.0" />
         <PackageReference Include="Remotion.Linq" Version="2.2.0" />
         <PackageReference Include="Baseline" Version="2.1.0" />
         <PackageReference Include="System.Memory" Version="4.5.4" />


### PR DESCRIPTION
- Update `Npgsql`, `Npgsql.Json.NET`, `Npgsql.NodaTime` to v5.0.0
- Fix and handle a Npgsql breaking change of `NpgsqlTransaction.IsCompleted` not
available in public API. Refer to https://github.com/npgsql/npgsql/blob/d5aee643792fad71b9220d06c16a3612ccc10e0d/src/Npgsql/NpgsqlTransaction.cs#L412 based on which the fix is added
- Update `Newtonsoft.Json` to  12.0.3 (12.0.2 is the minimum requirement for
`Npgsql.Json.NET 5.0.0`)