### PR TITLE
Swap samples in customizing_linq.md

### DIFF
--- a/documentation/documentation/documents/advanced/customizing_linq.md
+++ b/documentation/documentation/documents/advanced/customizing_linq.md
@@ -9,7 +9,7 @@ Marten allows you to add Linq parsing and querying support for your own custom m
 Using the (admittedly contrived) example from Marten's tests, say that you want to reuse a small part of a `Where()` clause across
 different queries for "IsBlue()." First, write the method you want to be recognized by Marten's Linq support:
 
- <[sample:IsBlue]>
+<[sample:custom-extension-for-linq]>
 
  Note a couple things here:
 
@@ -19,12 +19,12 @@ different queries for "IsBlue()." First, write the method you want to be recogni
  Now, to create a custom Linq parser for the `IsBlue()` method, you need to create a custom implementation of the `IMethodCallParser`
  interface shown below:
 
- <[sample:IMethodCallParser]>
+<[sample:IMethodCallParser]>
 
  The `IMethodCallParser` interface needs to match on method expressions that it could parse, and be able to turn the Linq expression into
  part of a Postgresql "where" clause. The custom Linq parser for `IsBlue()` is shown below:
 
-<[sample:custom-extension-for-linq]>
+<[sample:IsBlue]>
 
 Lastly, to plug in our new parser, we can add that to the `StoreOptions` object that we use to bootstrap a new `DocumentStore` as shown below:
 


### PR DESCRIPTION
For documentation on [Customizing Linq](https://martendb.io/documentation/documents/advanced/customizing_linq/)

The first sample should be the extension method and the third should be the implementation of `IMethodCallParser`

