### PR TITLE
Remove type mappers from nodatime implementation on 3.x

### DIFF
--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -37,7 +37,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="2.3.0" />
-        <PackageReference Include="Npgsql.NodaTime" Version="[4.1.5,4.2.0)" />
+        <PackageReference Include="Npgsql.NodaTime" Version="[4.1.6,4.2.0)" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Marten.NodaTime/NodaTimeExtensions.cs
+++ b/src/Marten.NodaTime/NodaTimeExtensions.cs
@@ -1,6 +1,4 @@
-using System;
 using Marten.Services;
-using Marten.Util;
 using NodaTime;
 using NodaTime.Serialization.JsonNet;
 using Npgsql;
@@ -19,10 +17,6 @@ namespace Marten.NodaTime
         public static void UseNodaTime(this StoreOptions storeOptions, bool shouldConfigureJsonNetSerializer = true)
         {
             NpgsqlConnection.GlobalTypeMapper.UseNodaTime();
-            TypeMappings.CustomMappingToDateTime = MapToDateTime;
-            TypeMappings.CustomMappingToDateTimeOffset = MapToDateTimeOffset;
-            TypeMappings.CustomMappingFromDateTime = MapFromDateTime;
-            TypeMappings.CustomMappingFromDateTimeOffset = MapFromDateTimeOffset;
 
             if (shouldConfigureJsonNetSerializer)
             {
@@ -34,74 +28,6 @@ namespace Marten.NodaTime
                 });
                 storeOptions.Serializer(serializer);
             }
-        }
-
-        private static DateTime MapToDateTime(object value)
-        {
-            switch (value)
-            {
-                case null:
-                    throw new ArgumentNullException(nameof(value));
-                case DateTime time:
-                    return time;
-
-                case Instant instant:
-                    return instant.ToDateTimeUtc();
-
-                case LocalDate localDate:
-                    return localDate.AtMidnight().InUtc().ToDateTimeUtc();
-
-                case LocalDateTime localDateTime:
-                    return localDateTime.InUtc().ToDateTimeUtc();
-
-                case OffsetDateTime offsetDateTime:
-                    return offsetDateTime.ToInstant().InUtc().ToDateTimeUtc();
-
-                case ZonedDateTime zonedDateTime:
-                    return zonedDateTime.ToDateTimeUtc();
-
-                default:
-                    throw new ArgumentException($"Cannot convert type {value.GetType()} to DateTime", nameof(value));
-            }
-        }
-
-        private static DateTimeOffset MapToDateTimeOffset(object value)
-        {
-            switch (value)
-            {
-                case null:
-                    throw new ArgumentNullException(nameof(value));
-                case DateTimeOffset offset:
-                    return offset;
-
-                case Instant instant:
-                    return instant.ToDateTimeOffset();
-
-                case LocalDate localDate:
-                    return localDate.AtMidnight().InUtc().ToDateTimeOffset();
-
-                case LocalDateTime localDateTime:
-                    return localDateTime.InUtc().ToDateTimeOffset();
-
-                case OffsetDateTime offsetDateTime:
-                    return offsetDateTime.ToDateTimeOffset();
-
-                case ZonedDateTime zonedDateTime:
-                    return zonedDateTime.ToDateTimeOffset();
-
-                default:
-                    throw new ArgumentException($"Cannot convert type {value.GetType()} to DateTimeOffset", nameof(value));
-            }
-        }
-
-        private static object MapFromDateTime(this DateTime value)
-        {
-            return Instant.FromDateTimeUtc(value);
-        }
-
-        private static object MapFromDateTimeOffset(this DateTimeOffset value)
-        {
-            return Instant.FromDateTimeOffset(value);
         }
     }
 }

--- a/src/Marten/Events/EventQueryHandler.cs
+++ b/src/Marten/Events/EventQueryHandler.cs
@@ -63,7 +63,7 @@ namespace Marten.Events
 
             if (_timestamp.HasValue)
             {
-                var timestampParam = sql.AddParameter(_timestamp.Value.MapFromDateTime());
+                var timestampParam = sql.AddParameter(_timestamp.Value);
                 sql.Append(" and timestamp <= :");
                 sql.Append(timestampParam.ParameterName);
             }

--- a/src/Marten/Events/EventSelector.cs
+++ b/src/Marten/Events/EventSelector.cs
@@ -48,7 +48,7 @@ namespace Marten.Events
 
             var sequence = reader.GetFieldValue<long>(4);
             var stream = reader.GetFieldValue<Guid>(5);
-            var timestamp = reader.GetValue(6).MapToDateTimeOffset();
+            var timestamp = reader.GetFieldValue<DateTimeOffset>(6);
             var tenantId = reader.GetFieldValue<string>(7);
 
             var @event = EventStream.ToEvent(data);
@@ -94,7 +94,7 @@ namespace Marten.Events
 
             var sequence = await reader.GetFieldValueAsync<long>(4, token).ConfigureAwait(false);
             var stream = await reader.GetFieldValueAsync<Guid>(5, token).ConfigureAwait(false);
-            var timestamp = (await reader.GetFieldValueAsync<object>(6, token).ConfigureAwait(false)).MapToDateTimeOffset();
+            var timestamp = await reader.GetFieldValueAsync<DateTimeOffset>(6, token).ConfigureAwait(false);
             var tenantId = await reader.GetFieldValueAsync<string>(7, token).ConfigureAwait(false);
 
             var @event = EventStream.ToEvent(data);

--- a/src/Marten/Events/StreamStateByGuidHandler.cs
+++ b/src/Marten/Events/StreamStateByGuidHandler.cs
@@ -78,8 +78,8 @@ namespace Marten.Events
             var id = reader.GetFieldValue<T>(0);
             var version = reader.GetFieldValue<int>(1);
             var typeName = reader.IsDBNull(2) ? null : reader.GetFieldValue<string>(2);
-            var timestamp = reader.GetValue(3).MapToDateTime();
-            var created = reader.GetValue(4).MapToDateTime();
+            var timestamp = reader.GetFieldValue<DateTime>(3);
+            var created = reader.GetFieldValue<DateTime>(4);
 
             Type aggregateType = null;
             if (typeName.IsNotEmpty())
@@ -95,8 +95,8 @@ namespace Marten.Events
             var id = await reader.GetFieldValueAsync<T>(0, token).ConfigureAwait(false);
             var version = await reader.GetFieldValueAsync<int>(1, token).ConfigureAwait(false);
             var typeName = await reader.IsDBNullAsync(2, token).ConfigureAwait(false) ? null : await reader.GetFieldValueAsync<string>(2, token).ConfigureAwait(false);
-            var timestamp = await reader.GetFieldValueAsync<object>(3, token).ConfigureAwait(false);
-            var created = await reader.GetFieldValueAsync<object>(4, token).ConfigureAwait(false);
+            var timestamp = await reader.GetFieldValueAsync<DateTime>(3, token).ConfigureAwait(false);
+            var created = await reader.GetFieldValueAsync<DateTime>(4, token).ConfigureAwait(false);
 
             Type aggregateType = null;
             if (typeName.IsNotEmpty())
@@ -104,7 +104,7 @@ namespace Marten.Events
                 aggregateType = _events.AggregateTypeFor(typeName);
             }
 
-            return StreamState.Create(id, version, aggregateType, timestamp.MapToDateTime().ToUniversalTime(), created.MapToDateTime());
+            return StreamState.Create(id, version, aggregateType, timestamp.ToUniversalTime(), created);
         }
 
         public string[] SelectFields()

--- a/src/Marten/Events/StringIdentifiedEventSelector.cs
+++ b/src/Marten/Events/StringIdentifiedEventSelector.cs
@@ -48,7 +48,7 @@ namespace Marten.Events
 
             var sequence = reader.GetFieldValue<long>(4);
             var stream = reader.GetFieldValue<string>(5);
-            var timestamp = reader.GetValue(6).MapToDateTimeOffset();
+            var timestamp = reader.GetFieldValue<DateTimeOffset>(6);
             var tenantId = reader.GetFieldValue<string>(7);
 
             var @event = EventStream.ToEvent(data);
@@ -87,7 +87,7 @@ namespace Marten.Events
 
             var sequence = await reader.GetFieldValueAsync<long>(4, token).ConfigureAwait(false);
             var stream = await reader.GetFieldValueAsync<string>(5, token).ConfigureAwait(false);
-            var timestamp = await reader.GetFieldValueAsync<object>(6, token).ConfigureAwait(false);
+            var timestamp = await reader.GetFieldValueAsync<DateTimeOffset>(6, token).ConfigureAwait(false);
             var tenantId = await reader.GetFieldValueAsync<string>(7, token).ConfigureAwait(false);
 
             var @event = EventStream.ToEvent(data);
@@ -95,7 +95,7 @@ namespace Marten.Events
             @event.Id = id;
             @event.Sequence = sequence;
             @event.StreamKey = stream;
-            @event.Timestamp = timestamp.MapToDateTimeOffset();
+            @event.Timestamp = timestamp;
             @event.TenantId = tenantId;
 
             return @event;

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -37,8 +37,8 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-        <PackageReference Include="Npgsql" Version="[4.1.5,4.2.0)" />
-        <PackageReference Include="Npgsql.Json.NET" Version="[4.1.5,4.2.0)" />
+        <PackageReference Include="Npgsql" Version="[4.1.6,4.2.0)" />
+        <PackageReference Include="Npgsql.Json.NET" Version="[4.1.6,4.2.0)" />
         <PackageReference Include="Remotion.Linq" Version="2.2.0" />
         <PackageReference Include="Baseline" Version="1.5.0" />
         <PackageReference Include="System.Memory" Version="4.5.3" />

--- a/src/Marten/Storage/EntityMetadataQueryHandler.cs
+++ b/src/Marten/Storage/EntityMetadataQueryHandler.cs
@@ -80,7 +80,7 @@ namespace Marten.Storage
             var dotNetType = reader.GetFieldValue<string>(2);
             var docType = GetOptionalFieldValue<string>(reader, DocumentMapping.DocumentTypeColumn);
             var deleted = GetOptionalFieldValue<bool>(reader, DocumentMapping.DeletedColumn);
-            var deletedAt = GetOptionalFieldValue<DateTime>(reader, DocumentMapping.DeletedAtColumn);
+            var deletedAt = GetOptionalFieldValue<DateTime?>(reader, DocumentMapping.DeletedAtColumn);
             var tenantId = GetOptionalFieldValue<string>(reader, TenantIdColumn.Name);
 
             var metadata = new DocumentMetadata(timestamp, version, dotNetType, docType, deleted, deletedAt)
@@ -106,7 +106,7 @@ namespace Marten.Storage
             var deleted = await GetOptionalFieldValueAsync<bool>(reader, DocumentMapping.DeletedColumn, token)
                 .ConfigureAwait(false);
             var deletedAt =
-                await GetOptionalFieldValueAsync<DateTime>(reader, DocumentMapping.DeletedAtColumn, token)
+                await GetOptionalFieldValueAsync<DateTime?>(reader, DocumentMapping.DeletedAtColumn, token)
                     .ConfigureAwait(false);
 
             var metadata = new DocumentMetadata(timestamp, version, dotNetType, docType, deleted, deletedAt);

--- a/src/Marten/Storage/EntityMetadataQueryHandler.cs
+++ b/src/Marten/Storage/EntityMetadataQueryHandler.cs
@@ -76,14 +76,14 @@ namespace Marten.Storage
                 return null;
 
             var version = reader.GetFieldValue<Guid>(0);
-            var timestamp = reader.GetValue(1).MapToDateTime();
+            var timestamp = reader.GetFieldValue<DateTime>(1);
             var dotNetType = reader.GetFieldValue<string>(2);
             var docType = GetOptionalFieldValue<string>(reader, DocumentMapping.DocumentTypeColumn);
             var deleted = GetOptionalFieldValue<bool>(reader, DocumentMapping.DeletedColumn);
-            var deletedAt = GetOptionalFieldValue<object>(reader, DocumentMapping.DeletedAtColumn);
+            var deletedAt = GetOptionalFieldValue<DateTime>(reader, DocumentMapping.DeletedAtColumn);
             var tenantId = GetOptionalFieldValue<string>(reader, TenantIdColumn.Name);
 
-            var metadata = new DocumentMetadata(timestamp, version, dotNetType, docType, deleted, deletedAt?.MapToDateTime())
+            var metadata = new DocumentMetadata(timestamp, version, dotNetType, docType, deleted, deletedAt)
             {
                 TenantId = tenantId ?? Tenancy.DefaultTenantId
             };
@@ -99,17 +99,17 @@ namespace Marten.Storage
                 return null;
 
             var version = await reader.GetFieldValueAsync<Guid>(0, token).ConfigureAwait(false);
-            var timestamp = await reader.GetFieldValueAsync<object>(1, token).ConfigureAwait(false);
+            var timestamp = await reader.GetFieldValueAsync<DateTime>(1, token).ConfigureAwait(false);
             var dotNetType = await reader.GetFieldValueAsync<string>(2, token).ConfigureAwait(false);
             var docType = await GetOptionalFieldValueAsync<string>(reader, DocumentMapping.DocumentTypeColumn, token)
                 .ConfigureAwait(false);
             var deleted = await GetOptionalFieldValueAsync<bool>(reader, DocumentMapping.DeletedColumn, token)
                 .ConfigureAwait(false);
             var deletedAt =
-                await GetOptionalFieldValueAsync<object>(reader, DocumentMapping.DeletedAtColumn, token)
+                await GetOptionalFieldValueAsync<DateTime>(reader, DocumentMapping.DeletedAtColumn, token)
                     .ConfigureAwait(false);
 
-            var metadata = new DocumentMetadata(timestamp.MapToDateTime(), version, dotNetType, docType, deleted, deletedAt?.MapToDateTime());
+            var metadata = new DocumentMetadata(timestamp, version, dotNetType, docType, deleted, deletedAt);
             if (_mapping.TenancyStyle == TenancyStyle.Conjoined)
             {
                 metadata.TenantId = await GetOptionalFieldValueAsync<string>(reader, TenantIdColumn.Name, token)

--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -16,11 +16,6 @@ namespace Marten.Util
         private static readonly Ref<ImHashMap<Type, NpgsqlDbType?>> NpgsqlDbTypeMemo;
         private static readonly Ref<ImHashMap<NpgsqlDbType, Type[]>> TypeMemo;
 
-        public static Func<object, DateTime> CustomMappingToDateTime = null;
-        public static Func<object, DateTimeOffset> CustomMappingToDateTimeOffset = null;
-        public static Func<DateTime, object> CustomMappingFromDateTime = null;
-        public static Func<DateTimeOffset, object> CustomMappingFromDateTimeOffset = null;
-
         public static List<Type> ContainmentOperatorTypes { get; } = new List<Type>();
         public static List<Type> TimespanTypes { get; } = new List<Type>();
         public static List<Type> TimespanZTypes { get; } = new List<Type>();
@@ -339,56 +334,6 @@ namespace Marten.Util
             timespanTypesList.AddRange(typesWithNullables);
 
             ContainmentOperatorTypes.AddRange(typesWithNullables);
-        }
-
-        internal static DateTime MapToDateTime(this object value)
-        {
-            if (value == null)
-                throw new ArgumentNullException(nameof(value));
-
-            if (CustomMappingToDateTime != null)
-                return CustomMappingToDateTime(value);
-
-            if (value is DateTimeOffset offset)
-                return offset.DateTime;
-
-            if (value is DateTime dateTime)
-                return dateTime;
-
-            throw new ArgumentException($"Cannot convert type {value.GetType()} to DateTime", nameof(value));
-        }
-
-        internal static DateTimeOffset MapToDateTimeOffset(this object value)
-        {
-            if (value == null)
-                throw new ArgumentNullException(nameof(value));
-
-            if (CustomMappingToDateTimeOffset != null)
-                return CustomMappingToDateTimeOffset(value);
-
-            if (value is DateTimeOffset offset)
-                return offset;
-
-            if (value is DateTime dateTime)
-                return dateTime;
-
-            throw new ArgumentException($"Cannot convert type {value.GetType()} to DateTimeOffset", nameof(value));
-        }
-
-        internal static object MapFromDateTime(this DateTime value)
-        {
-            if (CustomMappingFromDateTime != null)
-                return CustomMappingFromDateTime(value);
-
-            return value;
-        }
-
-        internal static object MapFromDateTimeOffset(this DateTimeOffset value)
-        {
-            if (CustomMappingFromDateTimeOffset != null)
-                return CustomMappingFromDateTimeOffset(value);
-
-            return value;
         }
     }
 }


### PR DESCRIPTION
- Remove type mappers from NodaTime implementation (retrofit changes
from master/ PR https://github.com/JasperFx/marten/pull/1604)
- Update Npgsql, Npgsql.Json.NET, Npgsql.NodaTime min dependency to 4.1.6