### PR TITLE
Consolidate csproj settings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>4.0.0-alpha.4</VersionPrefix>
+    <LangVersion>9.0</LangVersion>
+    <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
+    <PackageIconUrl>http://jasperfx.github.io/marten/content/images/emblem.png</PackageIconUrl>
+    <PackageProjectUrl>http://jasperfx.github.io/marten</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/src/Marten.CommandLine.Testing/Marten.CommandLine.Testing.csproj
+++ b/src/Marten.CommandLine.Testing/Marten.CommandLine.Testing.csproj
@@ -1,8 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Marten.CommandLine/Marten.CommandLine.csproj
+++ b/src/Marten.CommandLine/Marten.CommandLine.csproj
@@ -2,14 +2,7 @@
 
     <PropertyGroup>
         <Description>Command line tooling for Marten</Description>
-        <VersionPrefix>4.0.0-alpha.4</VersionPrefix>
-        <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
         <TargetFramework>netstandard2.1</TargetFramework>
-        <AssemblyName>Marten.CommandLine</AssemblyName>
-        <PackageId>Marten.CommandLine</PackageId>
-        <PackageIconUrl>http://jasperfx.github.io/marten/content/images/emblem.png</PackageIconUrl>
-        <PackageProjectUrl>http://jasperfx.github.io/marten</PackageProjectUrl>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
         <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
         <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -18,6 +11,7 @@
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -27,10 +21,6 @@
     <ItemGroup>
         <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
-
-    <PropertyGroup>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    </PropertyGroup>
 
     <!--SourceLink specific settings-->
     <PropertyGroup>
@@ -43,10 +33,6 @@
     <PropertyGroup>
         <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
         <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
+++ b/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
@@ -21,6 +21,6 @@
     <PackageReference Include="Shouldly" Version="4.0.1" />
   </ItemGroup>
   <PropertyGroup>
-    <NoWarn>xUnit1013;CS0618</NoWarn>
+    <NoWarn>xUnit1013</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -2,13 +2,7 @@
     <PropertyGroup>
         <Description>NodaTime extension for Marten</Description>
         <VersionPrefix>2.0.0-alpha.4</VersionPrefix>
-        <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
         <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
-        <AssemblyName>Marten.NodaTime</AssemblyName>
-        <PackageId>Marten.NodaTime</PackageId>
-        <PackageIconUrl>http://jasperfx.github.io/marten/content/images/emblem.png</PackageIconUrl>
-        <PackageProjectUrl>http://jasperfx.github.io/marten</PackageProjectUrl>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>
         <GenerateAssemblyProductAttribute>true</GenerateAssemblyProductAttribute>
@@ -17,7 +11,6 @@
         <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <LangVersion>8</LangVersion>
         <nullable>enable</nullable>
     </PropertyGroup>
 
@@ -32,9 +25,6 @@
     <PropertyGroup>
         <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
         <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
-    </PropertyGroup>
-    <PropertyGroup>
-        <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />

--- a/src/Marten.Schema.Testing/Marten.Schema.Testing.csproj
+++ b/src/Marten.Schema.Testing/Marten.Schema.Testing.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
@@ -40,6 +39,6 @@
       </None>
     </ItemGroup>
     <PropertyGroup>
-        <NoWarn>xUnit1013;CS0618</NoWarn>
+        <NoWarn>xUnit1013</NoWarn>
     </PropertyGroup>
 </Project>

--- a/src/Marten.Storyteller/Marten.Storyteller.csproj
+++ b/src/Marten.Storyteller/Marten.Storyteller.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-        <AssemblyName>Marten.Storyteller</AssemblyName>
         <OutputType>Exe</OutputType>
-        <PackageId>Marten.Storyteller</PackageId>
         <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
         <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
         <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Marten.Testing.OtherAssembly/Marten.Testing.OtherAssembly.csproj
+++ b/src/Marten.Testing.OtherAssembly/Marten.Testing.OtherAssembly.csproj
@@ -2,10 +2,7 @@
 
     <PropertyGroup>
         <Description>Dummy project for test scenario</Description>
-        <Authors>Jeremy D. Miller;Tim Cools;Jeff Doolittle</Authors>
         <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
-        <AssemblyName>Marten.Testing.OtherAssembly</AssemblyName>
-        <PackageId>Marten.Testing.OtherAssembly</PackageId>
         <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
         <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-    <AssemblyName>Marten.Testing</AssemblyName>
-    <PackageId>Marten.Testing</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,6 +35,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <PropertyGroup>
-    <NoWarn>xUnit1013;CS0618</NoWarn>
+    <NoWarn>xUnit1013</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/Marten.sln
+++ b/src/Marten.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30709.64
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten", "Marten\Marten.csproj", "{FCCA5D3A-B632-4D81-B839-F6344FDD01F1}"
 EndProject
@@ -22,15 +22,16 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5A91B8F9-52F8-4322-BE34-E3A281902BEC}"
 	ProjectSection(SolutionItems) = preProject
 		..\.editorconfig = ..\.editorconfig
+		..\Directory.Build.props = ..\Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marten.Schema.Testing", "Marten.Schema.Testing\Marten.Schema.Testing.csproj", "{3B5EFB35-DEA7-48C5-B9A0-CD16A7F272A5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten.Schema.Testing", "Marten.Schema.Testing\Marten.Schema.Testing.csproj", "{3B5EFB35-DEA7-48C5-B9A0-CD16A7F272A5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCoreWithMarten", "AspNetCoreWithMarten\AspNetCoreWithMarten.csproj", "{739B657C-4E0D-40E8-853E-ADF5C2D3D89D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreWithMarten", "AspNetCoreWithMarten\AspNetCoreWithMarten.csproj", "{739B657C-4E0D-40E8-853E-ADF5C2D3D89D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marten.CommandLine.Testing", "Marten.CommandLine.Testing\Marten.CommandLine.Testing.csproj", "{D1D4DF75-17B4-4FFD-82DC-1137112AA340}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten.CommandLine.Testing", "Marten.CommandLine.Testing\Marten.CommandLine.Testing.csproj", "{D1D4DF75-17B4-4FFD-82DC-1137112AA340}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StorytellerRunner", "StorytellerRunner\StorytellerRunner.csproj", "{B921A5AB-3A70-4F12-9ABD-EA7B772DFA4D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StorytellerRunner", "StorytellerRunner\StorytellerRunner.csproj", "{B921A5AB-3A70-4F12-9ABD-EA7B772DFA4D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -15,13 +15,7 @@
         <None Remove="Schema\SQL\mt_immutable_timestamptz.sql" />
     </ItemGroup>
     <ItemGroup>
-        <EmbeddedResource Include="Schema\SQL\mt_immutable_timestamptz.sql" />
-        <EmbeddedResource Include="Schema\SQL\mt_transforms.js" />
-        <EmbeddedResource Include="Schema\SQL\mt_patching.js" />
-        <EmbeddedResource Include="Schema\SQL\mt_mark_event_progression.sql" />
-        <EmbeddedResource Include="Schema\SQL\mt_immutable_timestamp.sql" />
-        <EmbeddedResource Include="Schema\SQL\mt_stream.sql" />
-        <EmbeddedResource Include="Schema\SQL\mt_get_next_hi.sql" />
+        <EmbeddedResource Include="Schema\SQL\*.*" />
         <EmbeddedResource Include="Schema\SchemaObjects.sql" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -1,14 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>.NET Transactional Document DB and Event Store on PostgreSQL</Description>
-        <VersionPrefix>4.0.0-alpha.4</VersionPrefix>
-        <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
         <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
-        <AssemblyName>Marten</AssemblyName>
-        <PackageId>Marten</PackageId>
-        <PackageIconUrl>http://jasperfx.github.io/marten/content/images/emblem.png</PackageIconUrl>
-        <PackageProjectUrl>http://jasperfx.github.io/marten</PackageProjectUrl>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>
         <GenerateAssemblyProductAttribute>true</GenerateAssemblyProductAttribute>
@@ -16,7 +9,7 @@
         <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
         <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
         <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
-        <LangVersion>8</LangVersion>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
         <None Remove="Schema\SQL\mt_immutable_timestamptz.sql" />
@@ -46,9 +39,6 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[2.1.0, 6.0.0]" />
     </ItemGroup>
 
-    <PropertyGroup>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    </PropertyGroup>
     <!--SourceLink specific settings-->
     <PropertyGroup>
         <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
@@ -60,9 +50,6 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    </PropertyGroup>
-    <PropertyGroup>
-        <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/src/MartenBenchmarks/MartenBenchmarks.csproj
+++ b/src/MartenBenchmarks/MartenBenchmarks.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-    <AssemblyName>MartenBenchmarks</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>MartenBenchmarks</PackageId>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/StorytellerRunner/StorytellerRunner.csproj
+++ b/src/StorytellerRunner/StorytellerRunner.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
 * use dir props to share common settings
 * remove default csproj values. `IsPackable>false`, AssemblyName and PackageId default to the csproj file name,
 * moved to c# 9. i am assuming u will eventually want to use some of those features