### PR TITLE
check for ViewProjection.projectEvent.handler null when UpdateOnly

### DIFF
--- a/src/Marten/Events/Projections/ViewProjection.cs
+++ b/src/Marten/Events/Projections/ViewProjection.cs
@@ -680,12 +680,12 @@ namespace Marten.Events.Projections
         {
             if (viewIdSelector == null && viewIdsSelector == null)
                 throw new ArgumentException($"{nameof(viewIdSelector)} or {nameof(viewIdsSelector)} must be provided.");
-            if (handler == null && type == ProjectionEventType.CreateAndUpdate)
-                throw new ArgumentNullException(nameof(handler));
 
             EventHandler eventHandler;
             if (type == ProjectionEventType.CreateAndUpdate || type == ProjectionEventType.UpdateOnly)
             {
+                if (handler == null)
+                   throw new ArgumentNullException(nameof(handler));
                 eventHandler = new EventHandler(
                     viewIdSelector,
                     viewIdsSelector,


### PR DESCRIPTION
will prevent a null ref when UpdateOnly and handler=null

given handler is assumed to not be null when ProjectionEventType.UpdateOnly. then null check should be inside the 

    type == ProjectionEventType.CreateAndUpdate || type == ProjectionEventType.UpdateOnly

also better perf by removing a redundant check if a different ProjectionEventType