### PR TITLE
use direct cast to ConstantExpression in QueryFromICollectionContains

### DIFF
--- a/src/Marten/Linq/Parsing/DictionaryExpressions.cs
+++ b/src/Marten/Linq/Parsing/DictionaryExpressions.cs
@@ -56,7 +56,7 @@ namespace Marten.Linq.Parsing
 
         private static ISqlFragment QueryFromICollectionContains(MethodCallExpression expression, string fieldPath, ISerializer serializer)
         {
-            var constant = expression.Arguments[0] as ConstantExpression;
+            var constant = (ConstantExpression)expression.Arguments[0];
             var kvp = constant.Value; // is kvp<string, unknown>
             var kvpType = kvp.GetType();
             var key = kvpType.GetProperty("Key").GetValue(kvp);


### PR DESCRIPTION
the code assumes that the argument is a ConstantExpression, so may as well use a cast. if this assumption is wrong, it is better to get a cast exception (with the associated type info) than a null reff