### PR TITLE
use First when result is assumed to exist

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_1495_initial_data_populate_with_query_causing_null_ref_ex.cs
+++ b/src/Marten.Testing/Bugs/Bug_1495_initial_data_populate_with_query_causing_null_ref_ex.cs
@@ -26,7 +26,7 @@ namespace Marten.Testing.Bugs
             {
                 foreach (var initialAggregate in InitialWithQueryDatasets.Aggregates)
                 {
-                    var aggregate = session.Query<Aggregate1495>().FirstOrDefault(x => x.Name == initialAggregate.Name);
+                    var aggregate = session.Query<Aggregate1495>().First(x => x.Name == initialAggregate.Name);
                     aggregate.Name.ShouldBe(initialAggregate.Name);
                 }
             }

--- a/src/Marten.Testing/CoreFunctionality/query_session_extension_Tests.cs
+++ b/src/Marten.Testing/CoreFunctionality/query_session_extension_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading;
 using Marten.Services;
 using Marten.Testing.Documents;
@@ -21,8 +21,8 @@ namespace Marten.Testing.CoreFunctionality
 			using (var session = theStore.OpenSession())
 			{
                 // SAMPLE: sample-query-type-parameter-overload
-                dynamic userFromDb = session.Query(user.GetType(), "where id = ?", user.Id).FirstOrDefault();
-                dynamic companyFromDb = (await session.QueryAsync(typeof(Company), "where id = ?", CancellationToken.None, company.Id)).FirstOrDefault();
+                dynamic userFromDb = session.Query(user.GetType(), "where id = ?", user.Id).First();
+                dynamic companyFromDb = (await session.QueryAsync(typeof(Company), "where id = ?", CancellationToken.None, company.Id)).First();
                 // ENDSAMPLE
 
 				Assert.Equal(user.Id, userFromDb.Id);

--- a/src/Marten.Testing/Linq/IsNullNotNullArbitraryDepthTests.cs
+++ b/src/Marten.Testing/Linq/IsNullNotNullArbitraryDepthTests.cs
@@ -36,9 +36,9 @@ namespace Marten.Testing.Linq
 
 			using (var s = theStore.QuerySession())
 			{
-				var notNull = s.Query<UserNested>().FirstOrDefault(x => x.Nested.Nested.Nested != null);
-				var notNullAlso = s.Query<UserNested>().FirstOrDefault(x => x.Nested.Nested.Nested.Nested.Nested == null);
-				var shouldBeNull = s.Query<UserNested>().FirstOrDefault(x => x.Nested.Nested.Nested == null);
+				var notNull = s.Query<UserNested>().First(x => x.Nested.Nested.Nested != null);
+				var notNullAlso = s.Query<UserNested>().First(x => x.Nested.Nested.Nested.Nested.Nested == null);
+				var shouldBeNull = s.Query<UserNested>().First(x => x.Nested.Nested.Nested == null);
 
 				Assert.Equal(user.Id, notNull.Id);
 				Assert.Equal(user.Id, notNullAlso.Id);

--- a/src/Marten.Testing/Linq/invoking_queryable_through_first_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_through_first_Tests.cs
@@ -69,7 +69,7 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 4 });
             theSession.SaveChanges();
 
-            theSession.Query<Target>().Where(x => x.Number == 2).FirstOrDefault().Flag
+            theSession.Query<Target>().Where(x => x.Number == 2).First().Flag
                 .ShouldBeTrue();
         }
 

--- a/src/Marten.Testing/Linq/query_against_child_collections_integrated_Tests.cs
+++ b/src/Marten.Testing/Linq/query_against_child_collections_integrated_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -156,7 +156,7 @@ namespace Marten.Testing.Linq
             using (var session2 = theStore.OpenSession())
             {
                 // This works
-                var o1 = session2.Query<Outer>().FirstOrDefault(o => o.Inners.Any(i => i.Type == "T1" && i.Value == "V12"));
+                var o1 = session2.Query<Outer>().First(o => o.Inners.Any(i => i.Type == "T1" && i.Value == "V12"));
                 SpecificationExtensions.ShouldNotBeNull(o1);
 
                 var o2 = session2.Query(new FindOuterByInner("T1", "V12"));


### PR DESCRIPTION
in these scenarios First is more correct than FirstOrDefault since the result is assumed not to be null