### PR TITLE
Fix to close connection on rollback only if it owns the connection

### DIFF
--- a/src/Marten/Services/TransactionState.cs
+++ b/src/Marten/Services/TransactionState.cs
@@ -133,7 +133,10 @@ namespace Marten.Services
                 }
                 finally
                 {
-                    Connection.Close();
+                    if (_ownsConnection)
+                    {
+                        Connection.Close();
+                    }
                 }
             }
         }
@@ -154,7 +157,10 @@ namespace Marten.Services
                 }
                 finally
                 {
-                    await Connection.CloseAsync().ConfigureAwait(false);
+                    if (_ownsConnection)
+                    {
+                        await Connection.CloseAsync().ConfigureAwait(false);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix to close connection on rollback only if it owns the connection
fixes #1620 