### PR TITLE
Fix to throw an exception for unique index without any properties on 3.x

### DIFF
--- a/src/Marten.Testing/Acceptance/unique_indexes.cs
+++ b/src/Marten.Testing/Acceptance/unique_indexes.cs
@@ -3,6 +3,7 @@ using Marten.Schema;
 using Marten.Schema.Indexing.Unique;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
+using Shouldly;
 using Xunit;
 
 namespace Marten.Testing.Acceptance
@@ -139,6 +140,21 @@ namespace Marten.Testing.Acceptance
                 _.Schema.For<Client>().MultiTenanted().UniqueIndex(UniqueIndexType.Computed, "index_name", TenancyScope.PerTenant, x => x.Name);
             });
             // ENDSAMPLE
+        }
+
+        [Fact]
+        public void unique_index_without_any_property_should_not_add_unique_index()
+        {
+            Should.Throw<InvalidOperationException>(() =>
+            {
+                var store = DocumentStore.For(_ =>
+                {
+                    _.Connection(ConnectionSource.ConnectionString);
+                    _.DatabaseSchemaName = "unique_text";
+                    // unique index without any property
+                    _.Schema.For<User>().UniqueIndex();
+                });
+            }).Message.ShouldBe($"Unique index on {typeof(User)} requires at least one property/field");
         }
 
         public unique_indexes(DefaultStoreFixture fixture) : base(fixture)

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -828,15 +828,22 @@ namespace Marten.Schema
 
         public void UniqueIndex(UniqueIndexType indexType, string indexName, TenancyScope tenancyScope = TenancyScope.Global, params Expression<Func<T, object>>[] expressions)
         {
+            var members = expressions
+                .Select(e =>
+                {
+                    var visitor = new FindMembers();
+                    visitor.Visit(e);
+                    return visitor.Members.ToArray();
+                })
+                .ToArray();
+
+            if (members.Length == 0)
+            {
+                throw new InvalidOperationException($"Unique index on {typeof(T)} requires at least one property/field");
+            }
+
             AddUniqueIndex(
-                expressions
-                    .Select(e =>
-                    {
-                        var visitor = new FindMembers();
-                        visitor.Visit(e);
-                        return visitor.Members.ToArray();
-                    })
-                    .ToArray(),
+                members,
                 indexType,
                 indexName,
                 IndexMethod.btree,


### PR DESCRIPTION
Fix to throw an exception for unique index without any properties
fixes #1581 