### PR TITLE
Bugfix/symmetric equality (for objects)

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_1703_Equality_Not_Symmetric.cs
+++ b/src/Marten.Testing/Bugs/Bug_1703_Equality_Not_Symmetric.cs
@@ -8,14 +8,14 @@ using Xunit;
 
 namespace Marten.Testing.Bugs
 {
-    public sealed class equality_not_symmetric: IntegrationContext
+    public sealed class Bug_1703_Equality_Not_Symmetric: IntegrationContext
     {
-        public equality_not_symmetric(DefaultStoreFixture fixture) : base(fixture)
+        public Bug_1703_Equality_Not_Symmetric(DefaultStoreFixture fixture) : base(fixture)
         {
         }
         
         [Fact]
-        public void equality_equals_operator_should_be_symmetric()
+        public void string_equality_equals_operator_should_be_symmetric()
         {
             var random = Target.Random();
             var theString = random.String;
@@ -43,7 +43,7 @@ namespace Marten.Testing.Bugs
         }
 
         [Fact]
-        public async Task equality_equals_should_be_symmetric()
+        public async Task string_equality_equals_should_be_symmetric()
         {
             var random = Target.Random();
             var theString = random.String;
@@ -69,9 +69,11 @@ namespace Marten.Testing.Bugs
                     .ShouldBe(1);
             }
         }
+
+        
         
         [Fact]
-        public async Task equality_equals_ignoring_case_should_be_symmetric()
+        public async Task string_equality_equals_ignoring_case_should_be_symmetric()
         {
             var random = Target.Random();
             var theString = random.String;
@@ -96,6 +98,62 @@ namespace Marten.Testing.Bugs
                     .Count
                     .ShouldBe(1);
                 
+            }
+        }
+        
+        [Fact]
+        public async Task object_equality_equals_should_be_symmetric()
+        {
+            var random = Target.Random();
+            var theNumber = random.Number;
+            using (var session = theStore.OpenSession())
+            {
+                session.Insert(random);
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.QuerySession())
+            {
+
+                session.Query<Target>()
+                    .Where(x => x.Number.Equals(theNumber))
+                    .ToList()
+                    .Count
+                    .ShouldBe(1);
+                
+                session.Query<Target>()
+                    .Where(x => theNumber.Equals(x.Number))
+                    .ToList()
+                    .Count
+                    .ShouldBe(1);
+            }
+        }
+        
+        [Fact]
+        public async Task object_equality_equals_operator_should_be_symmetric()
+        {
+            var random = Target.Random();
+            var theNumber = random.Number;
+            using (var session = theStore.OpenSession())
+            {
+                session.Insert(random);
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.QuerySession())
+            {
+
+                session.Query<Target>()
+                    .Where(x => x.Number == theNumber )
+                    .ToList()
+                    .Count
+                    .ShouldBe(1);
+                
+                session.Query<Target>()
+                    .Where(x => theNumber == x.Number)
+                    .ToList()
+                    .Count
+                    .ShouldBe(1);
             }
         }
     }

--- a/src/Marten.Testing/Bugs/equality_not_symmetric.cs
+++ b/src/Marten.Testing/Bugs/equality_not_symmetric.cs
@@ -95,6 +95,7 @@ namespace Marten.Testing.Bugs
                     .ToList()
                     .Count
                     .ShouldBe(1);
+                
             }
         }
     }

--- a/src/Marten.Testing/Bugs/equality_not_symmetric.cs
+++ b/src/Marten.Testing/Bugs/equality_not_symmetric.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+    public sealed class equality_not_symmetric: IntegrationContext
+    {
+        public equality_not_symmetric(DefaultStoreFixture fixture) : base(fixture)
+        {
+        }
+        
+        [Fact]
+        public void equality_equals_operator_should_be_symmetric()
+        {
+            var random = Target.Random();
+            var theString = random.String;
+            using (var session = theStore.OpenSession())
+            {
+                session.Insert(random);
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.QuerySession())
+            {
+
+                session.Query<Target>()
+                    .Where(x => x.String == (theString))
+                    .ToList()
+                    .Count
+                    .ShouldBe(1);
+                
+                session.Query<Target>()
+                    .Where(x => theString == x.String )
+                    .ToList()
+                    .Count
+                    .ShouldBe(1);
+            }
+        }
+
+        [Fact]
+        public async Task equality_equals_should_be_symmetric()
+        {
+            var random = Target.Random();
+            var theString = random.String;
+            using (var session = theStore.OpenSession())
+            {
+                session.Insert(random);
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.QuerySession())
+            {
+
+                session.Query<Target>()
+                    .Where(x => x.String.Equals(theString))
+                    .ToList()
+                    .Count
+                    .ShouldBe(1);
+                
+                session.Query<Target>()
+                    .Where(x => theString.Equals(x.String))
+                    .ToList()
+                    .Count
+                    .ShouldBe(1);
+            }
+        }
+        
+        [Fact]
+        public async Task equality_equals_ignoring_case_should_be_symmetric()
+        {
+            var random = Target.Random();
+            var theString = random.String;
+            using (var session = theStore.OpenSession())
+            {
+                session.Insert(random);
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.QuerySession())
+            {
+                
+                session.Query<Target>()
+                    .Where(x => x.String.Equals(theString, StringComparison.InvariantCultureIgnoreCase))
+                    .ToList()
+                    .Count
+                    .ShouldBe(1);
+
+                session.Query<Target>()
+                    .Where(x => theString.Equals(x.String, StringComparison.InvariantCultureIgnoreCase))
+                    .ToList()
+                    .Count
+                    .ShouldBe(1);
+            }
+        }
+    }
+}

--- a/src/Marten/Linq/Parsing/Methods/SimpleEqualsParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/SimpleEqualsParser.cs
@@ -51,7 +51,15 @@ namespace Marten.Linq.Parsing.Methods
             var field = GetField(mapping, expression);
             var locator = field.TypedLocator;
 
-            var value = expression.Arguments.OfType<ConstantExpression>().FirstOrDefault();
+            ConstantExpression value;
+            if (expression.Object?.NodeType == ExpressionType.Constant)
+            {
+                value = (ConstantExpression) expression.Object;
+            }
+            else
+            {
+                value =  expression.Arguments.OfType<ConstantExpression>().FirstOrDefault();
+            }
             if (value == null)
                 throw new BadLinqExpressionException("Could not extract value from {0}.".ToFormat(expression), null);
 

--- a/src/Marten/Linq/Parsing/Methods/StringComparisonParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/StringComparisonParser.cs
@@ -28,9 +28,20 @@ namespace Marten.Linq.Parsing.Methods
         {
             var locator = GetLocator(mapping, expression);
 
-            var value = expression.Arguments.OfType<ConstantExpression>().FirstOrDefault();
+            ConstantExpression value;
+            if (expression.Object.NodeType == ExpressionType.Constant)
+            {
+                value = (ConstantExpression) expression.Object;   
+            }
+            else
+            {
+                value = expression.Arguments.OfType<ConstantExpression>().FirstOrDefault();    
+            }
+
             if (value == null)
+            {
                 throw new BadLinqExpressionException("Could not extract string value from {0}.".ToFormat(expression), null);
+            }
 
             var stringOperator = GetOperator(expression);
             return new WhereFragment("{0} {1} ?".ToFormat(locator, stringOperator), FormatValue(expression.Method, value.Value as string));

--- a/src/Marten/Linq/Parsing/Methods/StringComparisonParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/StringComparisonParser.cs
@@ -31,7 +31,7 @@ namespace Marten.Linq.Parsing.Methods
             ConstantExpression value;
             if (expression.Object?.NodeType == ExpressionType.Constant)
             {
-             value = (ConstantExpression) expression.Object;   
+                value = (ConstantExpression) expression.Object;   
             }
             else
             {

--- a/src/Marten/Linq/Parsing/Methods/StringComparisonParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/StringComparisonParser.cs
@@ -29,9 +29,9 @@ namespace Marten.Linq.Parsing.Methods
             var locator = GetLocator(mapping, expression);
 
             ConstantExpression value;
-            if (expression.Object.NodeType == ExpressionType.Constant)
+            if (expression.Object?.NodeType == ExpressionType.Constant)
             {
-                value = (ConstantExpression) expression.Object;   
+             value = (ConstantExpression) expression.Object;   
             }
             else
             {


### PR DESCRIPTION
Fixes #1703, but for objects

As noted by @jeremydmiller, the previous fix (#1706) only  applied to strings. This change adds the same fix to the generic Equals method of System.Object. 
I've also moved the test class to better fit the naming scheme.

If there are other places where this issue occurs, I'd be happy to take a look. 