### PR TITLE
Add missing 'no', fix some readability issues.

### DIFF
--- a/documentation/documentation/events/projections/custom.md
+++ b/documentation/documentation/events/projections/custom.md
@@ -36,7 +36,7 @@ It comes of the way how Marten handles projection mechanism:
 <li>Try to find document that has the same <b>Id</b> as the value of the property selected from event (so eg. for <b>UserCreated</b> event it will be <b>UserId</b>).</li>
 <li>
     If no such document exists, then a new record needs to be created. Marten by default tries to use the <b>default constructor</b>. <br />
-    The default constructor doesn't have to be public, it can also private or protected. <br />
+    The default constructor doesn't have to be public, it can also be private or protected. <br />
     If the class does not have a default constructor then it creates an uninitialized object (see <a href="https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatterservices.getuninitializedobject?view=netframework-4.8" target="_parent">more</a>).<br />
     Because of that, no member initializers will be run so all of them need to be initialized in the event handler methods.
 </li>

--- a/documentation/documentation/events/projections/custom.md
+++ b/documentation/documentation/events/projections/custom.md
@@ -35,13 +35,13 @@ It comes of the way how Marten handles projection mechanism:
 <ol>
 <li>Try to find document that has the same <b>Id</b> as the value of the property selected from event (so eg. for <b>UserCreated</b> event it will be <b>UserId</b>).</li>
 <li>
-    If such document exists, then new record needs to be created. Marten by default tries to use <b>default constructor</b>. <br />
-    Default constructor doesn't have to be public, might be also private or protected. <br />
-    If class does not have the default constructor then it creates an uninitialized object (see <a href="https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatterservices.getuninitializedobject?view=netframework-4.8" target="_parent">more</a>).<br />
+    If no such document exists, then a new record needs to be created. Marten by default tries to use the <b>default constructor</b>. <br />
+    The default constructor doesn't have to be public, it can also private or protected. <br />
+    If the class does not have a default constructor then it creates an uninitialized object (see <a href="https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatterservices.getuninitializedobject?view=netframework-4.8" target="_parent">more</a>).<br />
     Because of that, no member initializers will be run so all of them need to be initialized in the event handler methods.
 </li>
-<li>If document with such <b>Id</b> was found then it's being loaded from database.</li>
-<li>Document is updated with the defined in <b>ViewProjection</b> logic (using expression from second <b>ProjectEvent</b> parameter).</li>
+<li>If a document with such <b>Id</b> was found then it's being loaded from database.</li>
+<li>Document is updated with logic defined in the <b>ViewProjection</b> (using expression from second <b>ProjectEvent</b> parameter).</li>
 <li>Created or updated document is upserted to database.</li>
 </div>
 


### PR DESCRIPTION
I think the change to L38 is correct - there's a missing 'no' that suggests that if no document is found for an Id, then a new one is created. Also adjusted some grammar to make it a little easier to read.