### PR TITLE
Add IEvent + ProjectEvent codegen failure scenario

### DIFF
--- a/src/Marten.Testing/Bugs/codegen_issue_with_IEvent.cs
+++ b/src/Marten.Testing/Bugs/codegen_issue_with_IEvent.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using Marten.Events;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+    public class CodeGenIEventIssue : BugIntegrationContext
+    {
+        [Fact]
+        public void TestAggregation()
+        {
+            var store = StoreOptions(_ =>
+            {
+                _.Events.Projections.Add(new FooProjection());
+            });
+
+            using var session = store.OpenSession();
+            session.Events.Append(Guid.NewGuid(), new FooCreated { Id = Guid.NewGuid() });
+            session.SaveChanges();
+        }
+    }
+    public class FooCreated
+    {
+        public Guid Id { get; set; }
+    }
+
+
+    public class Foo
+    {
+        public Guid Id { get; set; }
+    }
+
+    public class FooAuditLog
+    {
+        public Guid Id { get; set; }
+        public List<string> Changes { get; set; } = new List<string>();
+
+    }
+
+    public class FooProjection: ViewProjection<FooAuditLog, Guid>
+    {
+        public FooProjection()
+        {
+            ProjectionName = nameof(FooAuditLog);
+            Lifecycle = ProjectionLifecycle.Inline;
+
+            Identity<FooCreated>(x => x.Id);
+
+            ProjectEvent<IEvent<FooCreated>>((state, ev) => state.Changes.Add($"Foo was updated at {ev.Timestamp}"));
+        }
+    }
+
+}


### PR DESCRIPTION
Trace:

```
System.InvalidOperationException
Compilation failures!

CS1003: Syntax error, ':' expected
CS1010: Newline in constant
CS1002: ; expected
CS1003: Syntax error, ',' expected
CS1010: Newline in constant
CS1026: ) expected
CS1002: ; expected
CS1003: Syntax error, ':' expected
CS1010: Newline in constant
CS1002: ; expected
CS1003: Syntax error, ',' expected
CS1010: Newline in constant
CS1026: ) expected
CS1002: ; expected

Code:

using Marten;
using Marten.Events.Aggregation;
using Marten.Internal.Storage;
using Marten.Storage;
using Marten.Testing.Bugs;
using System.Linq;

namespace Marten.Generated
{
    // START: FooProjectionLiveAggregation
    public class FooProjectionLiveAggregation : Marten.Events.Aggregation.SyncLiveAggregatorBase<Marten.Testing.Bugs.FooAuditLog>
    {
        private readonly Marten.Testing.Bugs.FooProjection _fooProjection;

        public FooProjectionLiveAggregation(Marten.Testing.Bugs.FooProjection fooProjection)
        {
            _fooProjection = fooProjection;
        }


        public System.Action<Marten.Testing.Bugs.FooAuditLog, Marten.Events.IEvent<Marten.Testing.Bugs.FooCreated>> ProjectEvent1 {get; set;}


        public override Marten.Testing.Bugs.FooAuditLog Build(System.Collections.Generic.IReadOnlyList<Marten.Events.IEvent> events, Marten.IQuerySession session, Marten.Testing.Bugs.FooAuditLog snapshot)
        {
            if (!events.Any()) return null;
            Marten.Testing.Bugs.FooAuditLog fooAuditLog = null;
            snapshot ??= Create(events[0], session);
            foreach (var @event in events)
            {
                snapshot = Apply(@event, snapshot, session);
            }

            return snapshot;
        }


        public Marten.Testing.Bugs.FooAuditLog Create(Marten.Events.IEvent @event, Marten.IQuerySession session)
        {
            return new Marten.Testing.Bugs.FooAuditLog();
        }


        public Marten.Testing.Bugs.FooAuditLog Apply(Marten.Events.IEvent @event, Marten.Testing.Bugs.FooAuditLog aggregate, Marten.IQuerySession session)
        {
            switch (@event)
            {
                case Marten.Events.IEvent<Marten.Events.IEvent<Marten.Testing.Bugs.FooCreated>> event_IEvent"11:
                    ProjectEvent1.Invoke(aggregate, event_IEvent"11.GetData());
                    break;
            }

            return aggregate;
        }

    }

    // END: FooProjectionLiveAggregation
    
    
    // START: FooProjectionInlineHandler
    public class FooProjectionInlineHandler : Marten.Events.Aggregation.AggregationRuntime<Marten.Testing.Bugs.FooAuditLog, System.Guid>
    {
        private readonly Marten.IDocumentStore _store;
        private readonly Marten.Events.Aggregation.IAggregateProjection _projection;
        private readonly Marten.Events.Aggregation.IEventSlicer<Marten.Testing.Bugs.FooAuditLog, System.Guid> _slicer;
        private readonly Marten.Storage.ITenancy _tenancy;
        private readonly Marten.Internal.Storage.IDocumentStorage<Marten.Testing.Bugs.FooAuditLog, System.Guid> _storage;
        private readonly Marten.Testing.Bugs.FooProjection _fooProjection;

        public FooProjectionInlineHandler(Marten.IDocumentStore store, Marten.Events.Aggregation.IAggregateProjection projection, Marten.Events.Aggregation.IEventSlicer<Marten.Testing.Bugs.FooAuditLog, System.Guid> slicer, Marten.Storage.ITenancy tenancy, Marten.Internal.Storage.IDocumentStorage<Marten.Testing.Bugs.FooAuditLog, System.Guid> storage, Marten.Testing.Bugs.FooProjection fooProjection) : base(store, projection, slicer, tenancy, storage)
        {
            _store = store;
            _projection = projection;
            _slicer = slicer;
            _tenancy = tenancy;
            _storage = storage;
            _fooProjection = fooProjection;
        }


        public System.Action<Marten.Testing.Bugs.FooAuditLog, Marten.Events.IEvent<Marten.Testing.Bugs.FooCreated>> ProjectEvent1 {get; set;}


        public override async System.Threading.Tasks.ValueTask<Marten.Testing.Bugs.FooAuditLog> ApplyEvent(Marten.IQuerySession session, Marten.Events.Projections.EventSlice<Marten.Testing.Bugs.FooAuditLog, System.Guid> slice, Marten.Events.IEvent evt, Marten.Testing.Bugs.FooAuditLog aggregate, System.Threading.CancellationToken cancellationToken)
        {
            switch (evt)
            {
                case Marten.Events.IEvent<Marten.Events.IEvent<Marten.Testing.Bugs.FooCreated>> event_IEvent"12:
                    aggregate ??= new Marten.Testing.Bugs.FooAuditLog();
                    ProjectEvent1.Invoke(aggregate, event_IEvent"12.GetData());
                    return aggregate;
            }

            return aggregate;
        }


        public Marten.Testing.Bugs.FooAuditLog Create(Marten.Events.IEvent @event, Marten.IQuerySession session)
        {
            return new Marten.Testing.Bugs.FooAuditLog();
        }

    }

    // END: FooProjectionInlineHandler
    
    
}```