### PR TITLE
Hook up projection daemon in marten extensions

### DIFF
--- a/src/Marten.AsyncDaemon.Testing/DaemonServiceRegistrationTests.cs
+++ b/src/Marten.AsyncDaemon.Testing/DaemonServiceRegistrationTests.cs
@@ -48,13 +48,18 @@ namespace Marten.AsyncDaemon.Testing
                 });
             });
 
-            // No hosted service
+            // Hosted service
             container.Model.For<IHostedService>().Instances
                 .ShouldContain(x => x.ImplementationType == typeof(AsyncProjectionHostedService));
 
-            // No Node coordinator
+            // Node coordinator
             container.Model.For<INodeCoordinator>().Instances.Single()
                 .ImplementationType.ShouldBe(typeof(SoloCoordinator));
+
+            // Projection Daemon
+            container.Model.For<IProjectionDaemon>().Instances.Single()
+                .ServiceType.ShouldBe(typeof(IProjectionDaemon));
+
         }
 
         [Fact]
@@ -68,13 +73,17 @@ namespace Marten.AsyncDaemon.Testing
                 });
             });
 
-            // No hosted service
+            // hosted service
             container.Model.For<IHostedService>().Instances
                 .ShouldContain(x => x.ImplementationType == typeof(AsyncProjectionHostedService));
 
-            // No Node coordinator
+            // Node coordinator
             container.Model.For<INodeCoordinator>().Instances.Single()
                 .ImplementationType.ShouldBe(typeof(HotColdCoordinator));
+
+            // Projection Daemon
+            container.Model.For<IProjectionDaemon>().Instances.Single()
+                .ServiceType.ShouldBe(typeof(IProjectionDaemon));
         }
 
     }

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -57,14 +57,16 @@ namespace Marten
                 case DaemonMode.Solo:
                     services.AddSingleton<INodeCoordinator, SoloCoordinator>();
                     services.AddSingleton(x=>
-                        x.GetRequiredService<IDocumentStore>().BuildProjectionDaemon(x.GetRequiredService<ILogger<IProjectionDaemon>>()));
+                        x.GetRequiredService<IDocumentStore>()
+                            .BuildProjectionDaemon(x.GetRequiredService<ILogger<IProjectionDaemon>>()));
                     services.AddHostedService<AsyncProjectionHostedService>();
                     break;
 
                 case DaemonMode.HotCold:
                     services.AddSingleton<INodeCoordinator, HotColdCoordinator>();
                     services.AddSingleton(x =>
-                        x.GetRequiredService<IDocumentStore>().BuildProjectionDaemon(x.GetRequiredService<ILogger<IProjectionDaemon>>()));
+                        x.GetRequiredService<IDocumentStore>()
+                            .BuildProjectionDaemon(x.GetRequiredService<ILogger<IProjectionDaemon>>()));
                     services.AddHostedService<AsyncProjectionHostedService>();
                     break;
 

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -58,11 +58,16 @@ namespace Marten
 
                 case DaemonMode.Solo:
                     services.AddSingleton<INodeCoordinator, SoloCoordinator>();
+                    // Projection Daemon takes an ILogger instead of ILogger<T>, so factory wire-up is required for compatibility.
+                    services.AddSingleton<IProjectionDaemon, ProjectionDaemon>(x=>
+                        new ProjectionDaemon(x.GetRequiredService<DocumentStore>(), x.GetRequiredService<ILogger<ProjectionDaemon>>()));
                     services.AddHostedService<AsyncProjectionHostedService>();
                     break;
 
                 case DaemonMode.HotCold:
                     services.AddSingleton<INodeCoordinator, HotColdCoordinator>();
+                    services.AddSingleton<IProjectionDaemon, ProjectionDaemon>(x =>
+                        new ProjectionDaemon(x.GetRequiredService<DocumentStore>(), x.GetRequiredService<ILogger<ProjectionDaemon>>()));
                     services.AddHostedService<AsyncProjectionHostedService>();
                     break;
 

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Data;
 using Marten.Events.Daemon;
 using Marten.Events.Daemon.Resiliency;
-using Marten.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -58,16 +56,15 @@ namespace Marten
 
                 case DaemonMode.Solo:
                     services.AddSingleton<INodeCoordinator, SoloCoordinator>();
-                    // Projection Daemon takes an ILogger instead of ILogger<T>, so factory wire-up is required for compatibility.
-                    services.AddSingleton<IProjectionDaemon, ProjectionDaemon>(x=>
-                        new ProjectionDaemon(x.GetRequiredService<DocumentStore>(), x.GetRequiredService<ILogger<ProjectionDaemon>>()));
+                    services.AddSingleton(x=>
+                        x.GetRequiredService<IDocumentStore>().BuildProjectionDaemon(x.GetRequiredService<ILogger<IProjectionDaemon>>()));
                     services.AddHostedService<AsyncProjectionHostedService>();
                     break;
 
                 case DaemonMode.HotCold:
                     services.AddSingleton<INodeCoordinator, HotColdCoordinator>();
-                    services.AddSingleton<IProjectionDaemon, ProjectionDaemon>(x =>
-                        new ProjectionDaemon(x.GetRequiredService<DocumentStore>(), x.GetRequiredService<ILogger<ProjectionDaemon>>()));
+                    services.AddSingleton(x =>
+                        x.GetRequiredService<IDocumentStore>().BuildProjectionDaemon(x.GetRequiredService<ILogger<IProjectionDaemon>>()));
                     services.AddHostedService<AsyncProjectionHostedService>();
                     break;
 


### PR DESCRIPTION
This was missing and causing any daemon setting to throw on application startup when the hosted service attempted to resolve.

Due to the constructor on the projection daemon, building the instance via the store appears to be the simplest option.