### PR TITLE
Nullability - Public surface

### DIFF
--- a/.github/workflows/on-push-do-ci-build-pg10.yml
+++ b/.github/workflows/on-push-do-ci-build-pg10.yml
@@ -17,7 +17,7 @@ env:
   disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  dotnet_core_version: 3.1.x
+  dotnet_core_version: 5.0.x
   node_version: 10.x
   pg_db: marten_testing
   pg_user: postgres
@@ -71,5 +71,5 @@ jobs:
       - name: Build
         env:
           marten_testing_database: "Host=localhost;Port=5432;Database=${{ env.pg_db }};Username=${{ env.pg_user }}"
-        run: ./build.sh ci
+        run: dotnet run -p martenbuild.csproj -f netcoreapp3.1 -c Release -- ci
         shell: bash

--- a/.github/workflows/on-push-do-ci-build-pg10.yml
+++ b/.github/workflows/on-push-do-ci-build-pg10.yml
@@ -17,7 +17,6 @@ env:
   disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  dotnet_core_version: 5.0.x
   node_version: 10.x
   pg_db: marten_testing
   pg_user: postgres
@@ -44,10 +43,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install .NET Core
+      - name: Install .NET Core 3.1.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ env.dotnet_core_version }}
+          dotnet-version: 3.1.x
+
+      - name: Install .NET Core 5.0.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
 
       - name: Install Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/on-push-do-ci-build-pg11.yml
+++ b/.github/workflows/on-push-do-ci-build-pg11.yml
@@ -17,7 +17,7 @@ env:
   disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  dotnet_core_version: 3.1.x
+  dotnet_core_version: 5.0.x
   node_version: 10.x
   pg_db: marten_testing
   pg_user: postgres
@@ -71,5 +71,5 @@ jobs:
       - name: Build
         env:
           marten_testing_database: "Host=localhost;Port=5432;Database=${{ env.pg_db }};Username=${{ env.pg_user }}"
-        run: ./build.sh ci
+        run: dotnet run -p martenbuild.csproj -f netcoreapp3.1 -c Release -- ci
         shell: bash

--- a/.github/workflows/on-push-do-ci-build-pg11.yml
+++ b/.github/workflows/on-push-do-ci-build-pg11.yml
@@ -17,7 +17,6 @@ env:
   disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  dotnet_core_version: 5.0.x
   node_version: 10.x
   pg_db: marten_testing
   pg_user: postgres
@@ -44,10 +43,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install .NET Core
+      - name: Install .NET Core 3.1.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ env.dotnet_core_version }}
+          dotnet-version: 3.1.x
+
+      - name: Install .NET Core 5.0.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
 
       - name: Install Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/on-push-do-ci-build-pg12.yml
+++ b/.github/workflows/on-push-do-ci-build-pg12.yml
@@ -17,7 +17,6 @@ env:
   disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  dotnet_core_version: 5.0.x
   node_version: 10.x
   pg_db: marten_testing
   pg_user: postgres
@@ -44,15 +43,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install .NET Core
+      - name: Install .NET Core 3.1.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ env.dotnet_core_version }}
+          dotnet-version: 3.1.x
 
-      - name: Install Node.js
+      - name: Install Node.js 5.0.x
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ env.node_version }}
+          node-version: 5.0.x
 
       - name: Check and install plv8 extension
         run: |

--- a/.github/workflows/on-push-do-ci-build-pg12.yml
+++ b/.github/workflows/on-push-do-ci-build-pg12.yml
@@ -17,7 +17,7 @@ env:
   disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  dotnet_core_version: 3.1.x
+  dotnet_core_version: 5.0.x
   node_version: 10.x
   pg_db: marten_testing
   pg_user: postgres
@@ -71,5 +71,5 @@ jobs:
       - name: Build
         env:
           marten_testing_database: "Host=localhost;Port=5432;Database=${{ env.pg_db }};Username=${{ env.pg_user }}"
-        run: ./build.sh ci
+        run: dotnet run -p martenbuild.csproj -f netcoreapp3.1 -c Release -- ci
         shell: bash

--- a/.github/workflows/on-push-do-ci-build-pg12.yml
+++ b/.github/workflows/on-push-do-ci-build-pg12.yml
@@ -48,10 +48,15 @@ jobs:
         with:
           dotnet-version: 3.1.x
 
-      - name: Install Node.js 5.0.x
+      - name: Install .NET Core 5.0.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+
+      - name: Install Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 5.0.x
+          node-version: ${{ env.node_version }}
 
       - name: Check and install plv8 extension
         run: |

--- a/.github/workflows/on-push-do-ci-build-pg9.6.yml
+++ b/.github/workflows/on-push-do-ci-build-pg9.6.yml
@@ -17,7 +17,7 @@ env:
   disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  dotnet_core_version: 3.1.x
+  dotnet_core_version: 5.0.x
   node_version: 10.x
   pg_db: marten_testing
   pg_user: postgres
@@ -71,5 +71,5 @@ jobs:
       - name: Build
         env:
           marten_testing_database: "Host=localhost;Port=5432;Database=${{ env.pg_db }};Username=${{ env.pg_user }}"
-        run: ./build.sh ci
+        run: dotnet run -p martenbuild.csproj -f netcoreapp3.1 -c Release -- ci
         shell: bash

--- a/.github/workflows/on-push-do-ci-build-pg9.6.yml
+++ b/.github/workflows/on-push-do-ci-build-pg9.6.yml
@@ -17,7 +17,6 @@ env:
   disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  dotnet_core_version: 5.0.x
   node_version: 10.x
   pg_db: marten_testing
   pg_user: postgres
@@ -44,10 +43,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install .NET Core
+      - name: Install .NET Core 3.1.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ env.dotnet_core_version }}
+          dotnet-version: 3.1.x
+
+      - name: Install .NET Core 5.0.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
 
       - name: Install Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/on-push-do-ci-build-systemtextjson.yml
+++ b/.github/workflows/on-push-do-ci-build-systemtextjson.yml
@@ -17,7 +17,6 @@ env:
   disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  dotnet_core_version: 5.0.x
   node_version: 10.x
   pg_db: marten_testing
   pg_user: postgres
@@ -44,10 +43,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install .NET Core 3.1.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x
+
       - name: Install .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ env.dotnet_core_version }}
+          dotnet-version: 5.0.x
 
       - name: Install Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/on-push-do-ci-build-systemtextjson.yml
+++ b/.github/workflows/on-push-do-ci-build-systemtextjson.yml
@@ -17,7 +17,7 @@ env:
   disable_test_parallelization: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  dotnet_core_version: 3.1.x
+  dotnet_core_version: 5.0.x
   node_version: 10.x
   pg_db: marten_testing
   pg_user: postgres
@@ -72,5 +72,5 @@ jobs:
         env:
           DEFAULT_SERIALIZER: "SystemTextJson"
           marten_testing_database: "Host=localhost;Port=5432;Database=${{ env.pg_db }};Username=${{ env.pg_user }}"
-        run: ./build.sh ci
+        run: dotnet run -p martenbuild.csproj -f netcoreapp3.1 -c Release -- ci
         shell: bash

--- a/src/CommandLineRunner/CommandLineRunner.csproj
+++ b/src/CommandLineRunner/CommandLineRunner.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <UserSecretsId>dotnet-CommandLineRunner-144A5847-CAC2-4DF8-A6D4-C4150BB90A23</UserSecretsId>
+        <nullable>enable</nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EventPublisher/EventPublisher.csproj
+++ b/src/EventPublisher/EventPublisher.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net5.0</TargetFramework>
+        <nullable>enable</nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EventPublisher/Program.cs
+++ b/src/EventPublisher/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/EventSourceWorker/EventSourceWorker.csproj
+++ b/src/EventSourceWorker/EventSourceWorker.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <UserSecretsId>dotnet-EventSourceWorker-01BE20B5-3C2D-434B-8822-823B56E3F401</UserSecretsId>
+        <nullable>enable</nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EventSourceWorker/NewTripHandler.cs
+++ b/src/EventSourceWorker/NewTripHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Marten;
 using Marten.AsyncDaemon.Testing.TestingSupport;
+using Marten.Events;
 using Marten.Testing.Linq;
 
 namespace EventSourceWorker
@@ -10,8 +11,8 @@ namespace EventSourceWorker
     public class CreateNewTrip
     {
         public int Day { get; set; }
-        public string State { get; set; }
-        public Movement[] Movements { get; set; }
+        public string State { get; set; } = null!;
+        public Movement[] Movements { get; set; } = null!;
     }
 
     public class NewTripHandler
@@ -62,7 +63,7 @@ namespace EventSourceWorker
     {
         public Guid TripId { get; set; }
         public bool Successful { get; set; }
-        public string State { get; set; }
+        public string State { get; set; } = null!;
         public int Day { get; set; }
     }
 

--- a/src/Marten.Schema.Testing/Marten.Schema.Testing.csproj
+++ b/src/Marten.Schema.Testing/Marten.Schema.Testing.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
@@ -23,12 +23,6 @@
       <ProjectReference Include="..\Marten.Testing.OtherAssembly\Marten.Testing.OtherAssembly.csproj" />
       <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj" />
       <ProjectReference Include="..\Marten\Marten.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Compile Include="..\Marten.Testing\Harness\ConnectionSource.cs">
-        <Link>ConnectionSource.cs</Link>
-      </Compile>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Marten.Testing/Services/Includes/end_to_end_query_with_include_Tests.cs
+++ b/src/Marten.Testing/Services/Includes/end_to_end_query_with_include_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -329,7 +329,7 @@ namespace Marten.Testing.Services.Includes
             IncludeGeneric<UserWithInterface>(user);
         }
 
-        private void IncludeGeneric<T>(UserWithInterface userToCompareAgainst) where T : IUserWithInterface
+        private void IncludeGeneric<T>(UserWithInterface userToCompareAgainst) where T : class, IUserWithInterface
         {
             using (var query = theStore.QuerySession())
             {

--- a/src/Marten/AdvancedOperations.cs
+++ b/src/Marten/AdvancedOperations.cs
@@ -12,7 +12,7 @@ using Marten.Internal.Sessions;
 using Marten.Linq.QueryHandlers;
 using Marten.Schema;
 using Marten.Util;
-
+#nullable enable
 namespace Marten
 {
     /// <summary>

--- a/src/Marten/AdvancedOperations.cs
+++ b/src/Marten/AdvancedOperations.cs
@@ -174,7 +174,7 @@ select last_value from {_store.Events.DatabaseSchemaName}.mt_events_sequence;
             IDocumentSourceCode Load(IProviderGraph providers);
         }
 
-        internal class DocumentSourceCodeLoader<T>: IDocumentSourceCodeLoader
+        internal class DocumentSourceCodeLoader<T>: IDocumentSourceCodeLoader where T : notnull
         {
             public IDocumentSourceCode Load(IProviderGraph providers)
             {

--- a/src/Marten/CompiledQueryExtensions.cs
+++ b/src/Marten/CompiledQueryExtensions.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Baseline;
 using Marten.Linq;
-
+#nullable enable
 namespace Marten
 {
     public static class CompiledQueryExtensions

--- a/src/Marten/ConnectionFactory.cs
+++ b/src/Marten/ConnectionFactory.cs
@@ -1,6 +1,6 @@
 using System;
 using Npgsql;
-
+#nullable enable
 namespace Marten
 {
     /// <summary>

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -17,7 +17,7 @@ using Marten.Storage;
 using Marten.Transforms;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-
+#nullable enable
 namespace Marten
 {
     /// <summary>
@@ -232,7 +232,7 @@ namespace Marten
         }
 
         public IDocumentTransforms Transform { get; }
-        public IProjectionDaemon BuildProjectionDaemon(ILogger logger = null)
+        public IProjectionDaemon BuildProjectionDaemon(ILogger? logger = null)
         {
             logger ??= new NulloLogger();
 
@@ -341,7 +341,7 @@ namespace Marten
 
             if (options.DotNetTransaction != null)
             {
-                options.Connection.EnlistTransaction(options.DotNetTransaction);
+                options.Connection!.EnlistTransaction(options.DotNetTransaction);
                 options.OwnsTransactionLifecycle = false;
             }
 

--- a/src/Marten/Events/Aggregation/AggregateProjection.cs
+++ b/src/Marten/Events/Aggregation/AggregateProjection.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten.Events.Projections;
-
+#nullable enable
 namespace Marten.Events.Aggregation
 {
     public partial class AggregateProjection<T>: IAggregateProjection

--- a/src/Marten/Events/Aggregation/AggregationRuntime.cs
+++ b/src/Marten/Events/Aggregation/AggregationRuntime.cs
@@ -11,7 +11,7 @@ using Marten.Internal.Sessions;
 using Marten.Internal.Storage;
 using Marten.Storage;
 using Npgsql;
-
+#nullable enable
 namespace Marten.Events.Aggregation
 {
     public interface IAggregationRuntime : IProjection
@@ -19,7 +19,7 @@ namespace Marten.Events.Aggregation
         EventRangeGroup GroupEvents(DocumentStore store, EventRange range, CancellationToken cancellationToken);
     }
 
-    public abstract class AggregationRuntime<TDoc, TId> : IAggregationRuntime
+    public abstract class AggregationRuntime<TDoc, TId> : IAggregationRuntime where TDoc : notnull where TId : notnull
     {
         private readonly IDocumentStore _store;
         public IDocumentStorage<TDoc, TId> Storage { get; }
@@ -37,7 +37,7 @@ namespace Marten.Events.Aggregation
             _store = store;
         }
 
-        public async Task<IStorageOperation> DetermineOperation(DocumentSessionBase session,
+        public async Task<IStorageOperation?> DetermineOperation(DocumentSessionBase session,
             EventSlice<TDoc, TId> slice, CancellationToken cancellation, ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline)
         {
             var aggregate = slice.Aggregate;
@@ -83,7 +83,7 @@ namespace Marten.Events.Aggregation
         }
 
         public abstract ValueTask<TDoc> ApplyEvent(IQuerySession session, EventSlice<TDoc, TId> slice,
-            IEvent evt, TDoc aggregate,
+            IEvent evt, TDoc? aggregate,
             CancellationToken cancellationToken);
 
 
@@ -111,7 +111,7 @@ namespace Marten.Events.Aggregation
             var martenSession = (DocumentSessionBase)operations;
             foreach (var slice in slices)
             {
-                IStorageOperation operation = null;
+                IStorageOperation? operation;
 
                 // TODO -- this can only apply to the last event
                 if (Projection.MatchesAnyDeleteType(slice))

--- a/src/Marten/Events/Aggregation/AsyncLiveAggregatorBase.cs
+++ b/src/Marten/Events/Aggregation/AsyncLiveAggregatorBase.cs
@@ -2,16 +2,16 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Events.Projections;
-
+#nullable enable
 namespace Marten.Events.Aggregation
 {
 
     public abstract class AsyncLiveAggregatorBase<T> : ILiveAggregator<T> where T : class
     {
-        public abstract ValueTask<T> BuildAsync(IReadOnlyList<IEvent> events, IQuerySession session, T snapshot,
+        public abstract ValueTask<T> BuildAsync(IReadOnlyList<IEvent> events, IQuerySession session, T? snapshot,
             CancellationToken cancellation);
 
-        public T Build(IReadOnlyList<IEvent> events, IQuerySession session, T snapshot)
+        public T Build(IReadOnlyList<IEvent> events, IQuerySession session, T? snapshot)
         {
             return BuildAsync(events, session, snapshot, CancellationToken.None).GetAwaiter().GetResult();
         }

--- a/src/Marten/Events/Aggregation/ByStreamId.cs
+++ b/src/Marten/Events/Aggregation/ByStreamId.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Marten.Events.Projections;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Events.Aggregation
 {
     public class ByStreamId<TDoc>: IEventSlicer<TDoc, Guid>

--- a/src/Marten/Events/Aggregation/ByStreamKey.cs
+++ b/src/Marten/Events/Aggregation/ByStreamKey.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Marten.Events.Projections;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Events.Aggregation
 {
     public class ByStreamKey<TDoc>: IEventSlicer<TDoc, string>
@@ -12,7 +12,7 @@ namespace Marten.Events.Aggregation
             return streams.Select(s =>
             {
                 var tenant = tenancy[s.TenantId];
-                return new EventSlice<TDoc, string>(s.Key, tenant, s.Events);
+                return new EventSlice<TDoc, string>(s.Key!, tenant, s.Events);
             }).ToList();
         }
 

--- a/src/Marten/Events/Aggregation/ByStreamKey.cs
+++ b/src/Marten/Events/Aggregation/ByStreamKey.cs
@@ -27,7 +27,7 @@ namespace Marten.Events.Aggregation
 
                 var slices = tenantGroup
                     .GroupBy(x => x.StreamKey)
-                    .Select(x => new EventSlice<TDoc, string>(x.Key, tenant, x));
+                    .Select(x => new EventSlice<TDoc, string>(x.Key!, tenant, x));
 
                 var group = new TenantSliceGroup<TDoc, string>(tenant, slices);
 

--- a/src/Marten/Events/Aggregation/IAggregateProjection.cs
+++ b/src/Marten/Events/Aggregation/IAggregateProjection.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Marten.Events.Projections;
-
+#nullable enable
 namespace Marten.Events.Aggregation
 {
     public interface IAggregateProjection

--- a/src/Marten/Events/Aggregation/IEventSlicer.cs
+++ b/src/Marten/Events/Aggregation/IEventSlicer.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Marten.Events.Projections;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Events.Aggregation
 {
     public interface IEventSlicer<TDoc, TId>

--- a/src/Marten/Events/Aggregation/SyncLiveAggregatorBase.cs
+++ b/src/Marten/Events/Aggregation/SyncLiveAggregatorBase.cs
@@ -2,14 +2,14 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Events.Projections;
-
+#nullable enable
 namespace Marten.Events.Aggregation
 {
     public abstract class SyncLiveAggregatorBase<T> : ILiveAggregator<T> where T : class
     {
-        public abstract T Build(IReadOnlyList<IEvent> events, IQuerySession session, T snapshot);
+        public abstract T Build(IReadOnlyList<IEvent> events, IQuerySession session, T? snapshot);
 
-        public ValueTask<T> BuildAsync(IReadOnlyList<IEvent> events, IQuerySession session, T snapshot, CancellationToken cancellation)
+        public ValueTask<T> BuildAsync(IReadOnlyList<IEvent> events, IQuerySession session, T? snapshot, CancellationToken cancellation)
         {
             return new(Build(events, session, snapshot));
         }

--- a/src/Marten/Events/Event.cs
+++ b/src/Marten/Events/Event.cs
@@ -1,5 +1,4 @@
 using System;
-using Baseline;
 
 namespace Marten.Events
 {

--- a/src/Marten/Events/Event.cs
+++ b/src/Marten/Events/Event.cs
@@ -1,5 +1,5 @@
 using System;
-
+#nullable enable
 namespace Marten.Events
 {
     // TODO -- make the properties on the interface all be get only?
@@ -37,7 +37,7 @@ namespace Marten.Events
         ///     If using strings as the stream identifier, this will refer
         ///     to the containing Stream's Id
         /// </summary>
-        string StreamKey { get; set; }
+        string? StreamKey { get; set; }
 
         /// <summary>
         ///     The UTC time that this event was originally captured
@@ -47,7 +47,7 @@ namespace Marten.Events
         /// <summary>
         ///     If using multi-tenancy by tenant id
         /// </summary>
-        string TenantId { get; set; }
+        string? TenantId { get; set; }
 
         /// <summary>
         /// The .Net type of the event body
@@ -69,12 +69,12 @@ namespace Marten.Events
 
     #endregion sample_IEvent
 
-    public interface IEvent<out T> : IEvent
+    public interface IEvent<out T> : IEvent where T : notnull
     {
         new T Data { get; }
     }
 
-    internal class Event<T>: IEvent<T>
+    internal class Event<T>: IEvent<T> where T: notnull
     {
         public Event(T data)
         {
@@ -95,9 +95,9 @@ namespace Marten.Events
 
         /// <summary>
         ///     A reference to the stream if the stream
-        ///     identier mode is AsString
+        ///     identifier mode is AsString
         /// </summary>
-        public string StreamKey { get; set; }
+        public string? StreamKey { get; set; }
 
         /// <summary>
         ///     An alternative Guid identifier to identify
@@ -120,21 +120,21 @@ namespace Marten.Events
         /// </summary>
         public DateTimeOffset Timestamp { get; set; }
 
-        public string TenantId { get; set; }
+        public string? TenantId { get; set; }
         #endregion sample_event_metadata
 
         object IEvent.Data => Data;
 
         public Type EventType => typeof(T);
-        public string EventTypeName { get; set; }
-        public string DotNetTypeName { get; set; }
+        public string EventTypeName { get; set; } = null!;
+        public string DotNetTypeName { get; set; } = null!;
 
         protected bool Equals(Event<T> other)
         {
             return Id.Equals(other.Id);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
                 return false;

--- a/src/Marten/Events/EventStore.cs
+++ b/src/Marten/Events/EventStore.cs
@@ -15,7 +15,7 @@ using Marten.Schema.Identity;
 using Marten.Storage;
 using Marten.Util;
 using Npgsql;
-
+#nullable enable
 namespace Marten.Events
 {
     internal class EventStore: IEventStore
@@ -33,7 +33,8 @@ namespace Marten.Events
 
         public StreamAction Append(Guid stream, IEnumerable<object> events)
         {
-            return Append(stream, events?.ToArray());
+            // NRT: We're ignoring null here as to not unintentionally change any downstream behaviour - Replace with null guards in the future.
+            return Append(stream, events?.ToArray()!);
         }
 
         public StreamAction Append(Guid stream, params object[] events)
@@ -43,7 +44,7 @@ namespace Marten.Events
 
         public StreamAction Append(string stream, IEnumerable<object> events)
         {
-            return Append(stream, events?.ToArray());
+            return Append(stream, events?.ToArray()!);
         }
 
         public StreamAction Append(string stream, params object[] events)
@@ -53,7 +54,7 @@ namespace Marten.Events
 
         public StreamAction Append(Guid stream, long expectedVersion, IEnumerable<object> events)
         {
-            return Append(stream, expectedVersion, events?.ToArray());
+            return Append(stream, expectedVersion, events?.ToArray()!);
         }
 
         public StreamAction Append(Guid stream, long expectedVersion, params object[] events)
@@ -66,7 +67,7 @@ namespace Marten.Events
 
         public StreamAction Append(string stream, long expectedVersion, IEnumerable<object> events)
         {
-            return Append(stream, expectedVersion, events?.ToArray());
+            return Append(stream, expectedVersion, events?.ToArray()!);
         }
 
         public StreamAction Append(string stream, long expectedVersion, params object[] events)
@@ -79,7 +80,7 @@ namespace Marten.Events
 
         public StreamAction StartStream<TAggregate>(Guid id, IEnumerable<object> events) where TAggregate : class
         {
-            return StartStream<TAggregate>(id, events?.ToArray());
+            return StartStream<TAggregate>(id, events?.ToArray()!);
         }
 
         public StreamAction StartStream<T>(Guid id, params object[] events) where T : class
@@ -89,7 +90,7 @@ namespace Marten.Events
 
         public StreamAction StartStream(Type aggregateType, Guid id, IEnumerable<object> events)
         {
-            return StartStream(aggregateType, id, events?.ToArray());
+            return StartStream(aggregateType, id, events?.ToArray()!);
         }
 
         public StreamAction StartStream(Type aggregateType, Guid id, params object[] events)
@@ -102,7 +103,7 @@ namespace Marten.Events
 
         public StreamAction StartStream<TAggregate>(string streamKey, IEnumerable<object> events) where TAggregate : class
         {
-            return StartStream<TAggregate>(streamKey, events?.ToArray());
+            return StartStream<TAggregate>(streamKey, events?.ToArray()!);
         }
 
         public StreamAction StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class
@@ -112,7 +113,7 @@ namespace Marten.Events
 
         public StreamAction StartStream(Type aggregateType, string streamKey, IEnumerable<object> events)
         {
-            return StartStream(aggregateType, streamKey, events?.ToArray());
+            return StartStream(aggregateType, streamKey, events?.ToArray()!);
         }
 
         public StreamAction StartStream(Type aggregateType, string streamKey, params object[] events)
@@ -125,7 +126,7 @@ namespace Marten.Events
 
         public StreamAction StartStream(Guid id, IEnumerable<object> events)
         {
-            return StartStream(id, events?.ToArray());
+            return StartStream(id, events?.ToArray()!);
         }
 
         public StreamAction StartStream(Guid id, params object[] events)
@@ -135,7 +136,7 @@ namespace Marten.Events
 
         public StreamAction StartStream(string streamKey, IEnumerable<object> events)
         {
-            return StartStream(streamKey, events?.ToArray());
+            return StartStream(streamKey, events?.ToArray()!);
         }
 
         public StreamAction StartStream(string streamKey, params object[] events)
@@ -145,7 +146,7 @@ namespace Marten.Events
 
         public StreamAction StartStream<TAggregate>(IEnumerable<object> events) where TAggregate : class
         {
-            return StartStream<TAggregate>(events?.ToArray());
+            return StartStream<TAggregate>(events?.ToArray()!);
         }
 
         public StreamAction StartStream<TAggregate>(params object[] events) where TAggregate : class
@@ -155,7 +156,7 @@ namespace Marten.Events
 
         public StreamAction StartStream(Type aggregateType, IEnumerable<object> events)
         {
-            return StartStream(aggregateType, events?.ToArray());
+            return StartStream(aggregateType, events?.ToArray()!);
         }
 
         public StreamAction StartStream(Type aggregateType, params object[] events)
@@ -165,7 +166,7 @@ namespace Marten.Events
 
         public StreamAction StartStream(IEnumerable<object> events)
         {
-            return StartStream(events?.ToArray());
+            return StartStream(events?.ToArray()!);
         }
 
         public StreamAction StartStream(params object[] events)
@@ -188,7 +189,7 @@ namespace Marten.Events
             return _session.ExecuteHandler(handler);
         }
 
-        public Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0, DateTime? timestamp = null, CancellationToken token = default(CancellationToken))
+        public Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0, DateTime? timestamp = null, CancellationToken token = default)
         {
             var selector = _store.Events.EnsureAsGuidStorage(_session);
 
@@ -216,7 +217,7 @@ namespace Marten.Events
             return _session.ExecuteHandler(handler);
         }
 
-        public Task<IReadOnlyList<IEvent>> FetchStreamAsync(string streamKey, long version = 0, DateTime? timestamp = null, CancellationToken token = default(CancellationToken))
+        public Task<IReadOnlyList<IEvent>> FetchStreamAsync(string streamKey, long version = 0, DateTime? timestamp = null, CancellationToken token = default)
         {
             var selector = _store.Events.EnsureAsStringStorage(_session);
 
@@ -230,7 +231,7 @@ namespace Marten.Events
             return _session.ExecuteHandlerAsync(handler, token);
         }
 
-        public T AggregateStream<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T state = null) where T : class
+        public T? AggregateStream<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T? state = null) where T : class
         {
             var events = FetchStream(streamId, version, timestamp);
 
@@ -246,8 +247,8 @@ namespace Marten.Events
             return aggregate;
         }
 
-        public async Task<T> AggregateStreamAsync<T>(Guid streamId, long version = 0, DateTime? timestamp = null,
-            T state = null, CancellationToken token = new CancellationToken()) where T : class
+        public async Task<T?> AggregateStreamAsync<T>(Guid streamId, long version = 0, DateTime? timestamp = null,
+            T? state = null, CancellationToken token = default) where T : class
         {
             var events = await FetchStreamAsync(streamId, version, timestamp, token);
             if (!events.Any()) return null;
@@ -263,7 +264,7 @@ namespace Marten.Events
             return aggregate;
         }
 
-        public T AggregateStream<T>(string streamKey, long version = 0, DateTime? timestamp = null, T state = null) where T : class
+        public T? AggregateStream<T>(string streamKey, long version = 0, DateTime? timestamp = null, T? state = null) where T : class
         {
             var events = FetchStream(streamKey, version, timestamp);
             if (!events.Any())
@@ -280,8 +281,8 @@ namespace Marten.Events
             return aggregate;
         }
 
-        public async Task<T> AggregateStreamAsync<T>(string streamKey, long version = 0, DateTime? timestamp = null,
-            T state = null, CancellationToken token = new CancellationToken()) where T : class
+        public async Task<T?> AggregateStreamAsync<T>(string streamKey, long version = 0, DateTime? timestamp = null,
+            T? state = null, CancellationToken token = default) where T : class
         {
             var events = await FetchStreamAsync(streamKey, version, timestamp, token);
             if (!events.Any())
@@ -324,7 +325,7 @@ namespace Marten.Events
             return Load(id).As<Event<T>>();
         }
 
-        public async Task<IEvent<T>> LoadAsync<T>(Guid id, CancellationToken token = default(CancellationToken)) where T : class
+        public async Task<IEvent<T>> LoadAsync<T>(Guid id, CancellationToken token = default) where T : class
         {
             _tenant.EnsureStorageExists(typeof(StreamAction));
 
@@ -339,7 +340,7 @@ namespace Marten.Events
             return _session.ExecuteHandler(handler);
         }
 
-        public Task<IEvent> LoadAsync(Guid id, CancellationToken token = default(CancellationToken))
+        public Task<IEvent> LoadAsync(Guid id, CancellationToken token = default)
         {
             _tenant.EnsureStorageExists(typeof(StreamAction));
 
@@ -353,7 +354,7 @@ namespace Marten.Events
             return _session.ExecuteHandler(handler);
         }
 
-        public Task<StreamState> FetchStreamStateAsync(Guid streamId, CancellationToken token = new CancellationToken())
+        public Task<StreamState> FetchStreamStateAsync(Guid streamId, CancellationToken token = default)
         {
             var handler = _tenant.EventStorage().QueryForStream(StreamAction.ForReference(streamId, _tenant));
             return _session.ExecuteHandlerAsync(handler, token);
@@ -365,7 +366,7 @@ namespace Marten.Events
             return _session.ExecuteHandler(handler);
         }
 
-        public Task<StreamState> FetchStreamStateAsync(string streamKey, CancellationToken token = new CancellationToken())
+        public Task<StreamState> FetchStreamStateAsync(string streamKey, CancellationToken token = default)
         {
             var handler = _tenant.EventStorage().QueryForStream(StreamAction.ForReference(streamKey, _tenant));
             return _session.ExecuteHandlerAsync(handler, token);

--- a/src/Marten/Events/EventStoreStatistics.cs
+++ b/src/Marten/Events/EventStoreStatistics.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Events
 {
     public class EventStoreStatistics

--- a/src/Marten/Events/IEventStore.cs
+++ b/src/Marten/Events/IEventStore.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Linq;
-
+#nullable enable
 namespace Marten.Events
 {
     public interface IEventOperations
@@ -287,7 +287,7 @@ namespace Marten.Events
         /// <param name="timestamp"></param>
         /// <param name="state">Instance of T to apply events to</param>
         /// <returns></returns>
-        T AggregateStream<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T state = null) where T : class;
+        T? AggregateStream<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T? state = null) where T : class;
 
         /// <summary>
         /// Perform a live aggregation of the raw events in this stream to a T object
@@ -299,7 +299,7 @@ namespace Marten.Events
         /// <param name="state">Instance of T to apply events to</param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T> AggregateStreamAsync<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T state = null, CancellationToken token = default) where T : class;
+        Task<T?> AggregateStreamAsync<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T? state = null, CancellationToken token = default) where T : class;
 
         /// <summary>
         /// Perform a live aggregation of the raw events in this stream to a T object
@@ -310,7 +310,7 @@ namespace Marten.Events
         /// <param name="timestamp"></param>
         /// <param name="state">Instance of T to apply events to</param>
         /// <returns></returns>
-        T AggregateStream<T>(string streamKey, long version = 0, DateTime? timestamp = null, T state = null) where T : class;
+        T? AggregateStream<T>(string streamKey, long version = 0, DateTime? timestamp = null, T? state = null) where T : class;
 
         /// <summary>
         /// Perform a live aggregation of the raw events in this stream to a T object
@@ -322,7 +322,7 @@ namespace Marten.Events
         /// <param name="state">Instance of T to apply events to</param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T> AggregateStreamAsync<T>(string streamKey, long version = 0, DateTime? timestamp = null, T state = null, CancellationToken token = default) where T : class;
+        Task<T?> AggregateStreamAsync<T>(string streamKey, long version = 0, DateTime? timestamp = null, T? state = null, CancellationToken token = default) where T : class;
 
         /// <summary>
         /// Query directly against ONLY the raw event data. Use IQuerySession.Query() for aggregated documents!

--- a/src/Marten/Events/Projections/EventSlice.cs
+++ b/src/Marten/Events/Projections/EventSlice.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Events.Projections
 {
     public interface IEventSlice
@@ -13,7 +13,7 @@ namespace Marten.Events.Projections
     {
         private readonly List<IEvent> _events = new List<IEvent>();
 
-        public EventSlice(TId id, ITenant tenant, IEnumerable<IEvent> events = null)
+        public EventSlice(TId id, ITenant tenant, IEnumerable<IEvent>? events = null)
         {
             Id = id;
             Tenant = tenant;
@@ -33,7 +33,7 @@ namespace Marten.Events.Projections
         public TId Id { get; }
         public ITenant Tenant { get; }
 
-        public TDoc Aggregate { get; set; }
+        public TDoc? Aggregate { get; set; }
 
         public void AddEvent(IEvent e)
         {

--- a/src/Marten/Events/Projections/ILiveAggregator.cs
+++ b/src/Marten/Events/Projections/ILiveAggregator.cs
@@ -1,16 +1,16 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-
+#nullable enable
 namespace Marten.Events.Projections
 {
     public interface ILiveAggregator<T>
     {
-        T Build(IReadOnlyList<IEvent> events, IQuerySession session, T snapshot);
+        T Build(IReadOnlyList<IEvent> events, IQuerySession session, T? snapshot);
         ValueTask<T> BuildAsync(
             IReadOnlyList<IEvent> events,
             IQuerySession session,
-            T snapshot,
+            T? snapshot,
             CancellationToken cancellation);
 
     }

--- a/src/Marten/Events/Projections/IProjection.cs
+++ b/src/Marten/Events/Projections/IProjection.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Marten.Events.Daemon;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Events.Projections
 {
     public interface IProjection

--- a/src/Marten/Events/Projections/ProjectionSource.cs
+++ b/src/Marten/Events/Projections/ProjectionSource.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Marten.Events.Daemon;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Events.Projections
 {
     public enum ProjectionLifecycle
@@ -76,7 +76,7 @@ namespace Marten.Events.Projections
             yield break;
         }
 
-        private IProjection _projection;
+        private IProjection? _projection;
 
         internal virtual EventRangeGroup GroupEvents(
             DocumentStore store,

--- a/src/Marten/Events/Projections/ViewProjection.cs
+++ b/src/Marten/Events/Projections/ViewProjection.cs
@@ -1,14 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using Baseline;
 using LamarCodeGeneration;
 using Marten.Events.Aggregation;
 using Marten.Exceptions;
 using Marten.Schema;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Events.Projections
 {
     /// <summary>

--- a/src/Marten/Events/StreamAction.cs
+++ b/src/Marten/Events/StreamAction.cs
@@ -6,7 +6,7 @@ using Marten.Exceptions;
 using Marten.Internal;
 using Marten.Schema.Identity;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Events
 {
     public enum StreamActionType
@@ -39,7 +39,7 @@ namespace Marten.Events
         /// The identity of this stream if using strings as the stream
         /// identity
         /// </summary>
-        public string Key { get; }
+        public string? Key { get; }
 
         /// <summary>
         /// Is this action the start of a new stream or appending
@@ -51,22 +51,22 @@ namespace Marten.Events
         /// If the stream was started as tagged to an aggregate type, that will
         /// be reflected in this property. May be null
         /// </summary>
-        public Type AggregateType { get; internal set; }
+        public Type? AggregateType { get; internal set; }
 
         /// <summary>
         /// Marten's name for the aggregate type that will be persisted
         /// to the streams table
         /// </summary>
-        public string AggregateTypeName { get; internal set; }
+        public string? AggregateTypeName { get; internal set; }
 
         /// <summary>
         /// The Id of the current tenant
         /// </summary>
-        public string TenantId { get; internal set; }
+        public string? TenantId { get; internal set; }
 
 
 
-        private readonly List<IEvent> _events = new List<IEvent>();
+        private readonly List<IEvent> _events = new();
 
         private StreamAction(Guid stream, StreamActionType actionType)
         {
@@ -247,7 +247,7 @@ namespace Marten.Events
                 {
                     if (currentVersion != ExpectedVersionOnServer.Value)
                     {
-                        throw new EventStreamUnexpectedMaxEventIdException((object) Key ?? Id, AggregateType, ExpectedVersionOnServer.Value, currentVersion);
+                        throw new EventStreamUnexpectedMaxEventIdException((object?) Key ?? Id, AggregateType, ExpectedVersionOnServer.Value, currentVersion);
                     }
                 }
 

--- a/src/Marten/Events/StreamIdentity.cs
+++ b/src/Marten/Events/StreamIdentity.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Events
 {
     public enum StreamIdentity

--- a/src/Marten/Events/StreamState.cs
+++ b/src/Marten/Events/StreamState.cs
@@ -1,6 +1,5 @@
 using System;
-using Marten.Schema.Identity;
-
+#nullable enable
 namespace Marten.Events
 {
     public class StreamState
@@ -36,12 +35,14 @@ namespace Marten.Events
         /// The identity of this stream if using strings as the stream
         /// identity
         /// </summary>
-        public string Key { get; set;}
+        public string? Key { get; set;}
 
         // This needs to stay public
+#nullable disable
         public StreamState()
         {
         }
+#nullable enable
 
         public StreamState(Guid id, long version, Type aggregateType, DateTime lastTimestamp, DateTime created)
         {

--- a/src/Marten/IConnectionFactory.cs
+++ b/src/Marten/IConnectionFactory.cs
@@ -1,5 +1,5 @@
 using Npgsql;
-
+#nullable enable
 namespace Marten
 {
     /// <summary>

--- a/src/Marten/IDiagnostics.cs
+++ b/src/Marten/IDiagnostics.cs
@@ -1,7 +1,7 @@
 using System;
 using Marten.Linq;
 using Npgsql;
-
+#nullable enable
 namespace Marten
 {
     /// <summary>

--- a/src/Marten/IDocumentOperations.cs
+++ b/src/Marten/IDocumentOperations.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 using Marten.Internal.Operations;
 using Marten.Linq.SqlGeneration;
 using Marten.Patching;
-
+#nullable enable
 namespace Marten
 {
     /// <summary>

--- a/src/Marten/IDocumentOperations.cs
+++ b/src/Marten/IDocumentOperations.cs
@@ -17,56 +17,56 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="entity"></param>
-        void Delete<T>(T entity);
+        void Delete<T>(T entity) where T : notnull;
 
         /// <summary>
         /// Mark an entity of type T with either a numeric or Guid id for deletion upon the next call to SaveChanges()
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
-        void Delete<T>(int id);
+        void Delete<T>(int id) where T : notnull;
 
         /// <summary>
         /// Mark an entity of type T with either a numeric or Guid id for deletion upon the next call to SaveChanges()
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
-        void Delete<T>(long id);
+        void Delete<T>(long id) where T : notnull;
 
         /// <summary>
         /// Mark an entity of type T with either a numeric or Guid id for deletion upon the next call to SaveChanges()
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
-        void Delete<T>(Guid id);
+        void Delete<T>(Guid id) where T : notnull;
 
         /// <summary>
         /// Mark an entity of type T with a string id for deletion upon the next call to SaveChanges()
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
-        void Delete<T>(string id);
+        void Delete<T>(string id) where T : notnull;
 
         /// <summary>
         /// Bulk delete all documents of type T matching the expression condition
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="expression"></param>
-        void DeleteWhere<T>(Expression<Func<T, bool>> expression);
+        void DeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull;
 
         /// <summary>
         /// Explicitly marks multiple documents as needing to be inserted or updated upon the next call to SaveChanges()
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="entity"></param>
-        void Store<T>(IEnumerable<T> entities);
+        void Store<T>(IEnumerable<T> entities) where T : notnull;
 
         /// <summary>
         /// Explicitly marks one or more documents as needing to be inserted or updated upon the next call to SaveChanges()
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="entity"></param>
-        void Store<T>(params T[] entities);
+        void Store<T>(params T[] entities) where T : notnull;
 
         /// <summary>
         /// Explicitly marks a document as needing to be updated and supplies the
@@ -75,7 +75,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="entity"></param>
         /// <param name="version"></param>
-        void Store<T>(T entity, Guid version);
+        void Store<T>(T entity, Guid version) where T : notnull;
 
         /// <summary>
         /// DocumentStore an enumerable of potentially mixed documents
@@ -89,7 +89,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        IPatchExpression<T> Patch<T>(int id);
+        IPatchExpression<T> Patch<T>(int id) where T : notnull;
 
         /// <summary>
         /// Patch a single document of type T with the given id
@@ -97,7 +97,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        IPatchExpression<T> Patch<T>(long id);
+        IPatchExpression<T> Patch<T>(long id) where T : notnull;
 
         /// <summary>
         /// Patch a single document of type T with the given id
@@ -105,7 +105,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        IPatchExpression<T> Patch<T>(string id);
+        IPatchExpression<T> Patch<T>(string id) where T : notnull;
 
         /// <summary>
         /// Patch a single document of type T with the given id
@@ -113,7 +113,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        IPatchExpression<T> Patch<T>(Guid id);
+        IPatchExpression<T> Patch<T>(Guid id) where T : notnull;
 
         /// <summary>
         /// Patch a single document of type T with the given id
@@ -122,7 +122,7 @@ namespace Marten
         /// <param name="id"></param>
         /// <param name="where"></param>
         /// <returns></returns>
-        IPatchExpression<T> Patch<T>(Expression<Func<T, bool>> where);
+        IPatchExpression<T> Patch<T>(Expression<Func<T, bool>> where) where T : notnull;
 
         /// <summary>
         /// Patch multiple documents matching the supplied where fragment
@@ -130,7 +130,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="fragment"></param>
         /// <returns></returns>
-        IPatchExpression<T> Patch<T>(ISqlFragment fragment);
+        IPatchExpression<T> Patch<T>(ISqlFragment fragment) where T : notnull;
 
         /// <summary>
         /// Catch all mechanism to add additional database calls to the batched
@@ -145,7 +145,7 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="entity"></param>
-        void Insert<T>(IEnumerable<T> entities);
+        void Insert<T>(IEnumerable<T> entities) where T : notnull;
 
         /// <summary>
         /// Explicitly marks a document as needing to be inserted upon the next call to SaveChanges().
@@ -153,7 +153,7 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="entity"></param>
-        void Insert<T>(params T[] entities);
+        void Insert<T>(params T[] entities) where T : notnull;
 
         /// <summary>
         /// Explicitly marks a document as needing to be updated upon the next call to SaveChanges().
@@ -161,7 +161,7 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="entity"></param>
-        void Update<T>(IEnumerable<T> entities);
+        void Update<T>(IEnumerable<T> entities) where T : notnull;
 
         /// <summary>
         /// Explicitly marks a document as needing to be updated upon the next call to SaveChanges().
@@ -169,7 +169,7 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="entity"></param>
-        void Update<T>(params T[] entities);
+        void Update<T>(params T[] entities) where T : notnull;
 
         /// <summary>
         /// Insert an enumerable of potentially mixed documents. Will throw exceptions
@@ -184,7 +184,7 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="entity"></param>
-        void HardDelete<T>(T entity);
+        void HardDelete<T>(T entity) where T : notnull;
 
         /// <summary>
         /// Mark an entity of type T with either a numeric or Guid id for "hard" deletion upon the next call to SaveChanges()
@@ -192,7 +192,7 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
-        void HardDelete<T>(int id);
+        void HardDelete<T>(int id) where T : notnull;
 
         /// <summary>
         /// Mark an entity of type T with either a numeric or Guid id for hard deletion upon the next call to SaveChanges()
@@ -200,7 +200,7 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
-        void HardDelete<T>(long id);
+        void HardDelete<T>(long id) where T : notnull;
 
         /// <summary>
         /// Mark an entity of type T with either a numeric or Guid id for hard deletion upon the next call to SaveChanges()
@@ -208,7 +208,7 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
-        void HardDelete<T>(Guid id);
+        void HardDelete<T>(Guid id) where T : notnull;
 
         /// <summary>
         /// Mark an entity of type T with a string id for hard deletion upon the next call to SaveChanges()
@@ -216,7 +216,7 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
-        void HardDelete<T>(string id);
+        void HardDelete<T>(string id) where T : notnull;
 
         /// <summary>
         /// Bulk hard delete all documents of type T matching the expression condition
@@ -224,7 +224,7 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="expression"></param>
-        void HardDeleteWhere<T>(Expression<Func<T, bool>> expression);
+        void HardDeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull;
 
         /// <summary>
         /// For soft-deleted document types, this is a one sized fits all mechanism to reverse the
@@ -233,6 +233,6 @@ namespace Marten
         /// <param name="expression"></param>
         /// <typeparam name="T"></typeparam>
         /// <exception cref="InvalidOperationException"></exception>
-        void UndoDeleteWhere<T>(Expression<Func<T, bool>> expression);
+        void UndoDeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull;
     }
 }

--- a/src/Marten/IDocumentSession.cs
+++ b/src/Marten/IDocumentSession.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Marten.Events;
 using Marten.Services;
-
+#nullable enable
 namespace Marten
 {
     /// <summary>
@@ -63,7 +63,7 @@ namespace Marten
         /// Optional metadata describing the user name or
         /// process name for this unit of work
         /// </summary>
-        string LastModifiedBy { get; set; }
+        string? LastModifiedBy { get; set; }
 
         /// <summary>
         /// Set an optional user defined metadata value by key
@@ -77,7 +77,7 @@ namespace Marten
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
-        object GetHeader(string key);
+        object? GetHeader(string key);
 
         /// <summary>
         /// Access data from another tenant and apply document or event updates to this

--- a/src/Marten/IDocumentSession.cs
+++ b/src/Marten/IDocumentSession.cs
@@ -50,7 +50,7 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="document"></param>
-        void Eject<T>(T document);
+        void Eject<T>(T document) where T : notnull;
 
         /// <summary>
         /// Completely remove all the documents of given type from this session's unit of work tracking and identity map caching

--- a/src/Marten/IDocumentSessionListener.cs
+++ b/src/Marten/IDocumentSessionListener.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Services;
-
+#nullable enable
 namespace Marten
 {
     #region sample_IDocumentSessionListener

--- a/src/Marten/IDocumentStore.cs
+++ b/src/Marten/IDocumentStore.cs
@@ -9,7 +9,7 @@ using Marten.Services;
 using Marten.Transforms;
 using Microsoft.Extensions.Logging;
 using IsolationLevel = System.Data.IsolationLevel;
-
+#nullable enable
 namespace Marten
 {
     /// <summary>
@@ -67,7 +67,7 @@ namespace Marten
         /// <param name="documents"></param>
         /// <param name="mode"></param>
         /// <param name="batchSize"></param>
-        Task BulkInsertAsync<T>(IReadOnlyCollection<T> documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly, int batchSize = 1000, CancellationToken cancellation = default(CancellationToken));
+        Task BulkInsertAsync<T>(IReadOnlyCollection<T> documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly, int batchSize = 1000, CancellationToken cancellation = default);
 
         /// <summary>
         ///     Uses Postgresql's COPY ... FROM STDIN BINARY feature to efficiently store
@@ -78,7 +78,7 @@ namespace Marten
         /// <param name="documents"></param>
         /// <param name="mode"></param>
         /// <param name="batchSize"></param>
-        Task BulkInsertAsync<T>(string tenantId, IReadOnlyCollection<T> documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly, int batchSize = 1000, CancellationToken cancellation = default(CancellationToken));
+        Task BulkInsertAsync<T>(string tenantId, IReadOnlyCollection<T> documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly, int batchSize = 1000, CancellationToken cancellation = default);
 
 
 
@@ -184,7 +184,7 @@ namespace Marten
         /// <param name="mode"></param>
         /// <param name="batchSize"></param>
         Task BulkInsertDocumentsAsync(IEnumerable<object> documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly,
-            int batchSize = 1000, CancellationToken cancellation = default(CancellationToken));
+            int batchSize = 1000, CancellationToken cancellation = default);
 
         /// <summary>
         ///     Bulk insert a potentially mixed enumerable of document types
@@ -193,7 +193,7 @@ namespace Marten
         /// <param name="mode"></param>
         /// <param name="batchSize"></param>
         Task BulkInsertDocumentsAsync(string tenantId, IEnumerable<object> documents, BulkInsertMode mode = BulkInsertMode.InsertsOnly,
-            int batchSize = 1000, CancellationToken cancellation = default(CancellationToken));
+            int batchSize = 1000, CancellationToken cancellation = default);
 
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace Marten
         /// </summary>
         /// <param name="logger">Override the logger inside this instance of the async daemon</param>
         /// <returns></returns>
-        IProjectionDaemon BuildProjectionDaemon(ILogger logger = null);
+        IProjectionDaemon BuildProjectionDaemon(ILogger? logger = null);
 
 
     }

--- a/src/Marten/IJsonLoader.cs
+++ b/src/Marten/IJsonLoader.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-
+#nullable enable
 namespace Marten
 {
 
@@ -14,7 +14,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        string FindById<T>(string id) where T : class;
+        string? FindById<T>(string id) where T : class;
 
         /// <summary>
         /// Load or find only the document json by numeric or Guid id for a document of type T
@@ -22,7 +22,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        string FindById<T>(int id) where T : class;
+        string? FindById<T>(int id) where T : class;
 
         /// <summary>
         /// Load or find only the document json by numeric or Guid id for a document of type T
@@ -30,7 +30,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        string FindById<T>(long id) where T : class;
+        string? FindById<T>(long id) where T : class;
 
         /// <summary>
         /// Load or find only the document json by numeric or Guid id for a document of type T
@@ -38,7 +38,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        string FindById<T>(Guid id) where T : class;
+        string? FindById<T>(Guid id) where T : class;
 
         /// <summary>
         /// Asynchronously load or find only the document json by string id for a document of type T
@@ -47,7 +47,7 @@ namespace Marten
         /// <param name="id"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<string> FindByIdAsync<T>(string id, CancellationToken token = default(CancellationToken)) where T : class;
+        Task<string?> FindByIdAsync<T>(string id, CancellationToken token = default(CancellationToken)) where T : class;
 
         /// <summary>
         /// Asynchronously load or find only the document json by numeric or Guid id for a document of type T
@@ -56,7 +56,7 @@ namespace Marten
         /// <param name="id"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<string> FindByIdAsync<T>(int id, CancellationToken token = default(CancellationToken)) where T : class;
+        Task<string?> FindByIdAsync<T>(int id, CancellationToken token = default(CancellationToken)) where T : class;
 
         /// <summary>
         /// Asynchronously load or find only the document json by numeric or Guid id for a document of type T
@@ -65,7 +65,7 @@ namespace Marten
         /// <param name="id"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<string> FindByIdAsync<T>(long id, CancellationToken token = default(CancellationToken)) where T : class;
+        Task<string?> FindByIdAsync<T>(long id, CancellationToken token = default(CancellationToken)) where T : class;
 
         /// <summary>
         /// Asynchronously load or find only the document json by numeric or Guid id for a document of type T
@@ -74,7 +74,7 @@ namespace Marten
         /// <param name="id"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<string> FindByIdAsync<T>(Guid id, CancellationToken token = default(CancellationToken)) where T : class;
+        Task<string?> FindByIdAsync<T>(Guid id, CancellationToken token = default(CancellationToken)) where T : class;
 
 
 

--- a/src/Marten/IMartenLogger.cs
+++ b/src/Marten/IMartenLogger.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System.Linq;
 using Marten.Services;
 using Npgsql;
-
+#nullable enable
 namespace Marten
 {
     #region sample_IMartenLogger
@@ -68,7 +68,7 @@ namespace Marten
     #region sample_ConsoleMartenLogger
     public class ConsoleMartenLogger: IMartenLogger, IMartenSessionLogger
     {
-        private Stopwatch _stopwatch;
+        private Stopwatch? _stopwatch;
 
         public IMartenSessionLogger StartSession(IQuerySession session)
         {

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -8,7 +8,7 @@ using Marten.Services.BatchQuerying;
 using Marten.Storage;
 using Marten.Storage.Metadata;
 using Npgsql;
-
+#nullable enable
 namespace Marten
 {
     public interface IQuerySession: IDisposable, IAsyncDisposable
@@ -19,7 +19,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        T Load<T>(string id);
+        T? Load<T>(string id);
 
         /// <summary>
         /// Asynchronously find or load a single document of type T by a string id
@@ -28,7 +28,7 @@ namespace Marten
         /// <param name="id"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T> LoadAsync<T>(string id, CancellationToken token = default(CancellationToken));
+        Task<T?> LoadAsync<T>(string id, CancellationToken token = default);
 
         /// <summary>
         /// Load or find a single document of type T with either a numeric or Guid id
@@ -36,7 +36,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        T Load<T>(int id);
+        T? Load<T>(int id);
 
         /// <summary>
         /// Load or find a single document of type T with either a numeric or Guid id
@@ -44,7 +44,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        T Load<T>(long id);
+        T? Load<T>(long id);
 
         /// <summary>
         /// Load or find a single document of type T with either a numeric or Guid id
@@ -52,7 +52,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        T Load<T>(Guid id);
+        T? Load<T>(Guid id);
 
         /// <summary>
         /// Asynchronously load or find a single document of type T with either a numeric or Guid id
@@ -61,7 +61,7 @@ namespace Marten
         /// <param name="id"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T> LoadAsync<T>(int id, CancellationToken token = default(CancellationToken));
+        Task<T?> LoadAsync<T>(int id, CancellationToken token = default);
 
         /// <summary>
         /// Asynchronously load or find a single document of type T with either a numeric or Guid id
@@ -70,7 +70,7 @@ namespace Marten
         /// <param name="id"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T> LoadAsync<T>(long id, CancellationToken token = default(CancellationToken));
+        Task<T?> LoadAsync<T>(long id, CancellationToken token = default);
 
         /// <summary>
         /// Asynchronously load or find a single document of type T with either a numeric or Guid id
@@ -79,7 +79,7 @@ namespace Marten
         /// <param name="id"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T> LoadAsync<T>(Guid id, CancellationToken token = default(CancellationToken));
+        Task<T?> LoadAsync<T>(Guid id, CancellationToken token = default);
 
         #region sample_querying_with_linq
         /// <summary>
@@ -109,7 +109,7 @@ namespace Marten
         /// <param name="token"></param>
         /// <param name="parameters"></param>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> QueryAsync<T>(string sql, CancellationToken token = default(CancellationToken), params object[] parameters);
+        Task<IReadOnlyList<T>> QueryAsync<T>(string sql, CancellationToken token = default, params object[] parameters);
 
         /// <summary>
         /// Define a batch of deferred queries and load operations to be conducted in one asynchronous request to the
@@ -156,7 +156,7 @@ namespace Marten
         /// <param name="query">The instance of a compiled query</param>
         /// <param name="token">A cancellation token</param>
         /// <returns>A task for a single item query result</returns>
-        Task<TOut> QueryAsync<TDoc, TOut>(ICompiledQuery<TDoc, TOut> query, CancellationToken token = default(CancellationToken));
+        Task<TOut> QueryAsync<TDoc, TOut>(ICompiledQuery<TDoc, TOut> query, CancellationToken token = default);
 
         /// <summary>
         /// Load or find multiple documents by id
@@ -335,13 +335,13 @@ namespace Marten
         /// Optional metadata describing the causation id for this
         /// unit of work
         /// </summary>
-        string CausationId { get; set; }
+        string? CausationId { get; set; }
 
         /// <summary>
         /// Optional metadata describing the correlation id for this
         /// unit of work
         /// </summary>
-        string CorrelationId { get; set; }
+        string? CorrelationId { get; set; }
 
         /// <summary>
         /// Retrieve the current known version of the given document
@@ -450,6 +450,6 @@ namespace Marten
         /// <param name="token"></param>
         /// <returns></returns>
         Task<DocumentMetadata> MetadataForAsync<T>(T entity,
-            CancellationToken token = default(CancellationToken));
+            CancellationToken token = default);
     }
 }

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -19,7 +19,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        T? Load<T>(string id);
+        T? Load<T>(string id) where T : notnull;
 
         /// <summary>
         /// Asynchronously find or load a single document of type T by a string id
@@ -28,7 +28,7 @@ namespace Marten
         /// <param name="id"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T?> LoadAsync<T>(string id, CancellationToken token = default);
+        Task<T?> LoadAsync<T>(string id, CancellationToken token = default) where T : notnull;
 
         /// <summary>
         /// Load or find a single document of type T with either a numeric or Guid id
@@ -36,7 +36,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        T? Load<T>(int id);
+        T? Load<T>(int id) where T : notnull;
 
         /// <summary>
         /// Load or find a single document of type T with either a numeric or Guid id
@@ -44,7 +44,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        T? Load<T>(long id);
+        T? Load<T>(long id) where T : notnull;
 
         /// <summary>
         /// Load or find a single document of type T with either a numeric or Guid id
@@ -52,7 +52,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="id"></param>
         /// <returns></returns>
-        T? Load<T>(Guid id);
+        T? Load<T>(Guid id) where T : notnull;
 
         /// <summary>
         /// Asynchronously load or find a single document of type T with either a numeric or Guid id
@@ -61,7 +61,7 @@ namespace Marten
         /// <param name="id"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T?> LoadAsync<T>(int id, CancellationToken token = default);
+        Task<T?> LoadAsync<T>(int id, CancellationToken token = default) where T : notnull;
 
         /// <summary>
         /// Asynchronously load or find a single document of type T with either a numeric or Guid id
@@ -70,7 +70,7 @@ namespace Marten
         /// <param name="id"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T?> LoadAsync<T>(long id, CancellationToken token = default);
+        Task<T?> LoadAsync<T>(long id, CancellationToken token = default) where T : notnull;
 
         /// <summary>
         /// Asynchronously load or find a single document of type T with either a numeric or Guid id
@@ -79,7 +79,7 @@ namespace Marten
         /// <param name="id"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T?> LoadAsync<T>(Guid id, CancellationToken token = default);
+        Task<T?> LoadAsync<T>(Guid id, CancellationToken token = default) where T : notnull;
 
         #region sample_querying_with_linq
         /// <summary>
@@ -163,168 +163,168 @@ namespace Marten
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        IReadOnlyList<T> LoadMany<T>(params string[] ids);
+        IReadOnlyList<T> LoadMany<T>(params string[] ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        IReadOnlyList<T> LoadMany<T>(IEnumerable<string> ids);
+        IReadOnlyList<T> LoadMany<T>(IEnumerable<string> ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        IReadOnlyList<T> LoadMany<T>(params Guid[] ids);
+        IReadOnlyList<T> LoadMany<T>(params Guid[] ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        IReadOnlyList<T> LoadMany<T>(IEnumerable<Guid> ids);
+        IReadOnlyList<T> LoadMany<T>(IEnumerable<Guid> ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        IReadOnlyList<T> LoadMany<T>(params int[] ids);
+        IReadOnlyList<T> LoadMany<T>(params int[] ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        IReadOnlyList<T> LoadMany<T>(IEnumerable<int> ids);
+        IReadOnlyList<T> LoadMany<T>(IEnumerable<int> ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        IReadOnlyList<T> LoadMany<T>(params long[] ids);
+        IReadOnlyList<T> LoadMany<T>(params long[] ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        IReadOnlyList<T> LoadMany<T>(IEnumerable<long> ids);
+        IReadOnlyList<T> LoadMany<T>(IEnumerable<long> ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(params string[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(params string[] ids) where T : notnull; 
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<string> ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<string> ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(params Guid[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(params Guid[] ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<Guid> ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<Guid> ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(params int[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(params int[] ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<int> ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<int> ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(params long[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(params long[] ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<long> ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<long> ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params string[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params string[] ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<string> ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<string> ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params Guid[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params Guid[] ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<Guid> ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<Guid> ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params int[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params int[] ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<int> ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<int> ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params long[] ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params long[] ids) where T : notnull;
 
         /// <summary>
         /// Load or find multiple documents by id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<long> ids);
+        Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<long> ids) where T : notnull;
 
         /// <summary>
         /// Directly load the persisted JSON data for documents by Id
@@ -350,7 +350,7 @@ namespace Marten
         /// </summary>
         /// <param name="entity"></param>
         /// <returns></returns>
-        Guid? VersionFor<TDoc>(TDoc entity);
+        Guid? VersionFor<TDoc>(TDoc entity) where TDoc : notnull;
 
         /// <summary>
         /// Performs a full text search against <typeparamref name="TDoc"/>
@@ -441,7 +441,7 @@ namespace Marten
         /// </summary>
         /// <param name="entity"></param>
         /// <returns></returns>
-        DocumentMetadata MetadataFor<T>(T entity);
+        DocumentMetadata MetadataFor<T>(T entity) where T : notnull;
 
         /// <summary>
         ///     Fetch the entity version and last modified time from the database
@@ -450,6 +450,6 @@ namespace Marten
         /// <param name="token"></param>
         /// <returns></returns>
         Task<DocumentMetadata> MetadataForAsync<T>(T entity,
-            CancellationToken token = default);
+            CancellationToken token = default) where T : notnull;
     }
 }

--- a/src/Marten/IReadOnlyStoreOptions.cs
+++ b/src/Marten/IReadOnlyStoreOptions.cs
@@ -4,7 +4,7 @@ using Marten.Events;
 using Marten.Schema;
 using Marten.Storage;
 using Marten.Transforms;
-
+#nullable enable
 namespace Marten
 {
     public interface IReadOnlyStoreOptions

--- a/src/Marten/IRetryPolicy.cs
+++ b/src/Marten/IRetryPolicy.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-
+#nullable enable
 namespace Marten
 {
     /// <summary>

--- a/src/Marten/ISerializer.cs
+++ b/src/Marten/ISerializer.cs
@@ -3,7 +3,7 @@ using System.Data.Common;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-
+#nullable enable
 namespace Marten
 {
     #region sample_ISerializer

--- a/src/Marten/ITenantOperations.cs
+++ b/src/Marten/ITenantOperations.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten
 {
     /// <summary>

--- a/src/Marten/Internal/IMartenSession.cs
+++ b/src/Marten/Internal/IMartenSession.cs
@@ -5,7 +5,7 @@ using Marten.Internal.DirtyTracking;
 using Marten.Internal.Storage;
 using Marten.Services;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Internal
 {
     public interface IMartenSession: IDisposable, IAsyncDisposable
@@ -42,23 +42,23 @@ namespace Marten.Internal
         /// Optional metadata describing the causation id for this
         /// unit of work
         /// </summary>
-        string CausationId { get; set; }
+        string? CausationId { get; set; }
 
         /// <summary>
         /// Optional metadata describing the correlation id for this
         /// unit of work
         /// </summary>
-        string CorrelationId { get; set; }
+        string? CorrelationId { get; set; }
 
         /// <summary>
         /// Optional metadata describing the user name or
         /// process name for this unit of work
         /// </summary>
-        string LastModifiedBy { get; set; }
+        string? LastModifiedBy { get; set; }
 
         /// <summary>
         /// Optional metadata values. This may be null.
         /// </summary>
-        Dictionary<string, object> Headers { get; }
+        Dictionary<string, object>? Headers { get; }
     }
 }

--- a/src/Marten/Internal/IMartenSession.cs
+++ b/src/Marten/Internal/IMartenSession.cs
@@ -27,7 +27,7 @@ namespace Marten.Internal
         void MarkAsAddedForStorage(object id, object document);
 
         void MarkAsDocumentLoaded(object id, object document);
-        IDocumentStorage<T> StorageFor<T>();
+        IDocumentStorage<T> StorageFor<T>() where T : notnull; 
 
         IEventStorage EventStorage();
 

--- a/src/Marten/Internal/IProviderGraph.cs
+++ b/src/Marten/Internal/IProviderGraph.cs
@@ -2,7 +2,7 @@ using System;
 using Baseline;
 using Marten.Internal.CodeGeneration;
 using Marten.Internal.Storage;
-
+#nullable enable
 namespace Marten.Internal
 {
     public interface IProviderGraph

--- a/src/Marten/Internal/IProviderGraph.cs
+++ b/src/Marten/Internal/IProviderGraph.cs
@@ -7,7 +7,7 @@ namespace Marten.Internal
 {
     public interface IProviderGraph
     {
-        DocumentProvider<T> StorageFor<T>();
+        DocumentProvider<T> StorageFor<T>() where T : notnull;
     }
 
     internal static class ProviderGraphExtensions
@@ -22,7 +22,7 @@ namespace Marten.Internal
             IDocumentStorage Find(IProviderGraph providers);
         }
 
-        private class StorageFinder<T>: IStorageFinder
+        private class StorageFinder<T>: IStorageFinder where T : notnull
         {
             public IDocumentStorage Find(IProviderGraph providers)
             {

--- a/src/Marten/Internal/IUpdateBatch.cs
+++ b/src/Marten/Internal/IUpdateBatch.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-
+#nullable enable
 namespace Marten.Internal
 {
     public interface IUpdateBatch

--- a/src/Marten/Internal/Operations/IDocumentStorageOperation.cs
+++ b/src/Marten/Internal/Operations/IDocumentStorageOperation.cs
@@ -1,5 +1,5 @@
 using Marten.Internal.DirtyTracking;
-
+#nullable enable
 namespace Marten.Internal.Operations
 {
     public interface IDocumentStorageOperation : IStorageOperation

--- a/src/Marten/Internal/Operations/IStorageOperation.cs
+++ b/src/Marten/Internal/Operations/IStorageOperation.cs
@@ -4,7 +4,7 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Linq.QueryHandlers;
-
+#nullable enable
 namespace Marten.Internal.Operations
 {
     public interface IStorageOperation : IQueryHandler

--- a/src/Marten/Internal/ProviderGraph.cs
+++ b/src/Marten/Internal/ProviderGraph.cs
@@ -7,7 +7,9 @@ using Marten.Internal.CodeGeneration;
 using Marten.Internal.Storage;
 using Marten.Schema;
 using Marten.Util;
+using Remotion.Linq.Clauses;
 
+#nullable enable
 namespace Marten.Internal
 {
     public class ProviderGraph: IProviderGraph
@@ -20,7 +22,7 @@ namespace Marten.Internal
             _options = options;
         }
 
-        public DocumentProvider<T> StorageFor<T>()
+        public DocumentProvider<T> StorageFor<T>() where T : notnull
         {
             var documentType = typeof(T);
 
@@ -88,7 +90,7 @@ namespace Marten.Internal
             DocumentProvider<T> BuildPersistence(IProviderGraph graph, SubClassMapping mapping);
         }
 
-        private class SubClassLoader<TRoot, T, TId> : ISubClassLoader<T> where T : TRoot
+        private class SubClassLoader<TRoot, T, TId>: ISubClassLoader<T> where T : TRoot where TId : notnull where TRoot: notnull
         {
             public DocumentProvider<T> BuildPersistence(IProviderGraph graph, SubClassMapping mapping)
             {

--- a/src/Marten/Internal/Sessions/DirtyCheckingDocumentSession.cs
+++ b/src/Marten/Internal/Sessions/DirtyCheckingDocumentSession.cs
@@ -59,14 +59,14 @@ namespace Marten.Internal.Sessions
 
         // NEED TO REMOVE TRACKER TOO!
 
-        protected internal override void ejectById<T>(long id)
+        protected internal override void ejectById<T>(long id) 
         {
             var documentStorage = StorageFor<T>();
             documentStorage.EjectById(this, id);
             documentStorage.RemoveDirtyTracker(this, id);
         }
 
-        protected internal override void ejectById<T>(int id)
+        protected internal override void ejectById<T>(int id) 
         {
             var documentStorage = StorageFor<T>();
             documentStorage.EjectById(this, id);
@@ -80,7 +80,7 @@ namespace Marten.Internal.Sessions
             documentStorage.RemoveDirtyTracker(this, id);
         }
 
-        protected internal override void ejectById<T>(string id)
+        protected internal override void ejectById<T>(string id) 
         {
             var documentStorage = StorageFor<T>();
             documentStorage.EjectById(this, id);

--- a/src/Marten/Internal/Sessions/DirtyCheckingDocumentSession.cs
+++ b/src/Marten/Internal/Sessions/DirtyCheckingDocumentSession.cs
@@ -6,7 +6,7 @@ using Marten.Internal.Operations;
 using Marten.Internal.Storage;
 using Marten.Services;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Internal.Sessions
 {
     public class DirtyCheckingDocumentSession: DocumentSessionBase

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.Deletes.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.Deletes.cs
@@ -9,7 +9,7 @@ namespace Marten.Internal.Sessions
 {
     public abstract partial class DocumentSessionBase
     {
-        public void Delete<T>(T entity)
+        public void Delete<T>(T entity) where T: notnull
         {
             assertNotDisposed();
             var documentStorage = StorageFor<T>();
@@ -20,7 +20,7 @@ namespace Marten.Internal.Sessions
             documentStorage.Eject(this, entity);
         }
 
-        public void Delete<T>(int id)
+        public void Delete<T>(int id) where T : notnull
         {
             assertNotDisposed();
 
@@ -44,7 +44,7 @@ namespace Marten.Internal.Sessions
             }
         }
 
-        public void Delete<T>(long id)
+        public void Delete<T>(long id) where T : notnull
         {
             assertNotDisposed();
             var deletion = StorageFor<T, long>().DeleteForId(id, Tenant);
@@ -53,7 +53,7 @@ namespace Marten.Internal.Sessions
             ejectById<T>(id);
         }
 
-        public void Delete<T>(Guid id)
+        public void Delete<T>(Guid id) where T : notnull
         {
             assertNotDisposed();
             var deletion = StorageFor<T, Guid>().DeleteForId(id, Tenant);
@@ -62,7 +62,7 @@ namespace Marten.Internal.Sessions
             ejectById<T>(id);
         }
 
-        public void Delete<T>(string id)
+        public void Delete<T>(string id) where T : notnull
         {
             assertNotDisposed();
 
@@ -72,7 +72,7 @@ namespace Marten.Internal.Sessions
             ejectById<T>(id);
         }
 
-        public void DeleteWhere<T>(Expression<Func<T, bool>> expression)
+        public void DeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull
         {
             assertNotDisposed();
 

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.Deletes.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.Deletes.cs
@@ -4,6 +4,7 @@ using Marten.Exceptions;
 using Marten.Internal.Storage;
 using Marten.Linq.SqlGeneration;
 
+#nullable enable
 namespace Marten.Internal.Sessions
 {
     public abstract partial class DocumentSessionBase

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.HardDeletes.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.HardDeletes.cs
@@ -12,7 +12,7 @@ namespace Marten.Internal.Sessions
 {
     public abstract partial class DocumentSessionBase
     {
-        public void HardDelete<T>(T entity)
+        public void HardDelete<T>(T entity) where T : notnull
         {
             assertNotDisposed();
             var documentStorage = StorageFor<T>();
@@ -23,7 +23,7 @@ namespace Marten.Internal.Sessions
             documentStorage.Eject(this, entity);
         }
 
-        public void HardDelete<T>(int id)
+        public void HardDelete<T>(int id) where T : notnull
         {
             assertNotDisposed();
 
@@ -47,7 +47,7 @@ namespace Marten.Internal.Sessions
             }
         }
 
-        public void HardDelete<T>(long id)
+        public void HardDelete<T>(long id) where T : notnull
         {
             assertNotDisposed();
             var deletion = StorageFor<T, long>().HardDeleteForId(id, Tenant);
@@ -56,7 +56,7 @@ namespace Marten.Internal.Sessions
             ejectById<T>(id);
         }
 
-        public void HardDelete<T>(Guid id)
+        public void HardDelete<T>(Guid id) where T : notnull
         {
             assertNotDisposed();
             var deletion = StorageFor<T, Guid>().HardDeleteForId(id, Tenant);
@@ -65,7 +65,7 @@ namespace Marten.Internal.Sessions
             ejectById<T>(id);
         }
 
-        public void HardDelete<T>(string id)
+        public void HardDelete<T>(string id) where T : notnull
         {
             assertNotDisposed();
 
@@ -75,7 +75,7 @@ namespace Marten.Internal.Sessions
             ejectById<T>(id);
         }
 
-        public void HardDeleteWhere<T>(Expression<Func<T, bool>> expression)
+        public void HardDeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull
         {
             assertNotDisposed();
 
@@ -93,7 +93,7 @@ namespace Marten.Internal.Sessions
         /// <param name="expression"></param>
         /// <typeparam name="T"></typeparam>
         /// <exception cref="InvalidOperationException"></exception>
-        public void UndoDeleteWhere<T>(Expression<Func<T, bool>> expression)
+        public void UndoDeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull
         {
             assertNotDisposed();
 

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.HardDeletes.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.HardDeletes.cs
@@ -7,6 +7,7 @@ using Marten.Internal.Storage;
 using Marten.Linq.Filters;
 using Marten.Linq.SqlGeneration;
 
+#nullable enable
 namespace Marten.Internal.Sessions
 {
     public abstract partial class DocumentSessionBase

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace Marten.Internal.Sessions
 {
     public abstract partial class DocumentSessionBase

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -47,12 +47,12 @@ namespace Marten.Internal.Sessions
         internal ISessionWorkTracker WorkTracker => _workTracker;
 
 
-        public void Store<T>(IEnumerable<T> entities)
+        public void Store<T>(IEnumerable<T> entities) where T : notnull
         {
             Store(entities?.ToArray()!);
         }
 
-        public void Store<T>(params T[] entities)
+        public void Store<T>(params T[] entities) where T : notnull
         {
             if (entities == null)
                 throw new ArgumentNullException(nameof(entities));
@@ -64,7 +64,7 @@ namespace Marten.Internal.Sessions
             store(entities);
         }
 
-        public void Store<T>(T entity, Guid version)
+        public void Store<T>(T entity, Guid version) where T : notnull
         {
             assertNotDisposed();
 
@@ -74,12 +74,12 @@ namespace Marten.Internal.Sessions
             _workTracker.Add(op);
         }
 
-        public void Insert<T>(IEnumerable<T> entities)
+        public void Insert<T>(IEnumerable<T> entities) where T : notnull
         {
             Insert(entities.ToArray());
         }
 
-        public void Insert<T>(params T[] entities)
+        public void Insert<T>(params T[] entities) where T : notnull
         {
             assertNotDisposed();
 
@@ -106,12 +106,12 @@ namespace Marten.Internal.Sessions
             }
         }
 
-        public void Update<T>(IEnumerable<T> entities)
+        public void Update<T>(IEnumerable<T> entities) where T : notnull
         {
             Update(entities.ToArray());
         }
 
-        public void Update<T>(params T[] entities)
+        public void Update<T>(params T[] entities) where T : notnull
         {
             assertNotDisposed();
 
@@ -169,34 +169,34 @@ namespace Marten.Internal.Sessions
 
         public IEventStore Events { get; }
 
-        public IPatchExpression<T> Patch<T>(int id)
+        public IPatchExpression<T> Patch<T>(int id) where T : notnull
         {
             return patchById<T>(id);
         }
 
-        public IPatchExpression<T> Patch<T>(long id)
+        public IPatchExpression<T> Patch<T>(long id) where T : notnull
         {
             return patchById<T>(id);
         }
 
-        public IPatchExpression<T> Patch<T>(string id)
+        public IPatchExpression<T> Patch<T>(string id) where T : notnull
         {
             return patchById<T>(id);
         }
 
-        public IPatchExpression<T> Patch<T>(Guid id)
+        public IPatchExpression<T> Patch<T>(Guid id) where T : notnull
         {
             return patchById<T>(id);
         }
 
-        public IPatchExpression<T> Patch<T>(Expression<Func<T, bool>> filter)
+        public IPatchExpression<T> Patch<T>(Expression<Func<T, bool>> filter) where T : notnull
         {
             assertNotDisposed();
 
             return new PatchExpression<T>(filter, this);
         }
 
-        public IPatchExpression<T> Patch<T>(ISqlFragment fragment)
+        public IPatchExpression<T> Patch<T>(ISqlFragment fragment) where T : notnull
         {
             assertNotDisposed();
 
@@ -209,7 +209,7 @@ namespace Marten.Internal.Sessions
             _workTracker.Add(storageOperation);
         }
 
-        public virtual void Eject<T>(T document)
+        public virtual void Eject<T>(T document) where T : notnull
         {
             StorageFor<T>().Eject(this, document);
             _workTracker.Eject(document);
@@ -259,10 +259,10 @@ namespace Marten.Internal.Sessions
             return tenantSession;
         }
 
-        protected internal abstract void ejectById<T>(long id);
-        protected internal abstract void ejectById<T>(int id);
-        protected internal abstract void ejectById<T>(Guid id);
-        protected internal abstract void ejectById<T>(string id);
+        protected internal abstract void ejectById<T>(long id) where T : notnull;
+        protected internal abstract void ejectById<T>(int id) where T : notnull;
+        protected internal abstract void ejectById<T>(Guid id) where T : notnull;
+        protected internal abstract void ejectById<T>(string id) where T : notnull;
 
         protected internal virtual void processChangeTrackers()
         {
@@ -275,7 +275,7 @@ namespace Marten.Internal.Sessions
         }
 
 
-        private void store<T>(IEnumerable<T> entities)
+        private void store<T>(IEnumerable<T> entities) where T : notnull
         {
             assertNotDisposed();
 
@@ -333,7 +333,7 @@ namespace Marten.Internal.Sessions
             void Store(IDocumentSession session, IEnumerable<object> objects);
         }
 
-        internal class Handler<T>: IHandler
+        internal class Handler<T>: IHandler where T : notnull
         {
             public void Store(IDocumentSession session, IEnumerable<object> objects)
             {
@@ -342,7 +342,7 @@ namespace Marten.Internal.Sessions
             }
         }
 
-        internal class InsertHandler<T>: IHandler
+        internal class InsertHandler<T>: IHandler where T : notnull
         {
             public void Store(IDocumentSession session, IEnumerable<object> objects)
             {

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -13,6 +13,7 @@ using Marten.Patching;
 using Marten.Services;
 using Marten.Storage;
 
+#nullable enable
 namespace Marten.Internal.Sessions
 {
     public abstract partial class DocumentSessionBase: QuerySession, IDocumentSession
@@ -48,7 +49,7 @@ namespace Marten.Internal.Sessions
 
         public void Store<T>(IEnumerable<T> entities)
         {
-            Store(entities?.ToArray());
+            Store(entities?.ToArray()!);
         }
 
         public void Store<T>(params T[] entities)
@@ -229,12 +230,12 @@ namespace Marten.Internal.Sessions
             Headers[key] = value;
         }
 
-        public object GetHeader(string key)
+        public object? GetHeader(string key)
         {
             return Headers?[key];
         }
 
-        private Dictionary<string, NestedTenantSession> _byTenant;
+        private Dictionary<string, NestedTenantSession>? _byTenant;
 
         /// <summary>
         /// Access data from another tenant and apply document or event updates to this
@@ -244,10 +245,7 @@ namespace Marten.Internal.Sessions
         /// <returns></returns>
         public ITenantOperations ForTenant(string tenantId)
         {
-            if (_byTenant == null)
-            {
-                _byTenant = new Dictionary<string, NestedTenantSession>();
-            }
+            _byTenant ??= new Dictionary<string, NestedTenantSession>();
 
             if (_byTenant.TryGetValue(tenantId, out var tenantSession))
             {

--- a/src/Marten/Internal/Sessions/IdentityMapDocumentSession.cs
+++ b/src/Marten/Internal/Sessions/IdentityMapDocumentSession.cs
@@ -3,7 +3,7 @@ using Marten.Internal.CodeGeneration;
 using Marten.Internal.Storage;
 using Marten.Services;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Internal.Sessions
 {
     public class IdentityMapDocumentSession: DocumentSessionBase

--- a/src/Marten/Internal/Sessions/LightweightSession.cs
+++ b/src/Marten/Internal/Sessions/LightweightSession.cs
@@ -4,6 +4,7 @@ using Marten.Internal.Storage;
 using Marten.Services;
 using Marten.Storage;
 
+#nullable enable
 namespace Marten.Internal.Sessions
 {
     public class LightweightSession: DocumentSessionBase

--- a/src/Marten/Internal/Sessions/NestedTenantSession.cs
+++ b/src/Marten/Internal/Sessions/NestedTenantSession.cs
@@ -3,14 +3,14 @@ using Baseline;
 using Marten.Internal.CodeGeneration;
 using Marten.Internal.Storage;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Internal.Sessions
 {
     internal class NestedTenantSession : DocumentSessionBase, ITenantOperations
     {
         private readonly DocumentSessionBase _parent;
 
-        internal NestedTenantSession(DocumentSessionBase parent, ITenant tenant) : base((DocumentStore) parent.DocumentStore, parent.SessionOptions, parent.Database, tenant, parent._workTracker)
+        internal NestedTenantSession(DocumentSessionBase parent, ITenant tenant) : base((DocumentStore) parent.DocumentStore, parent.SessionOptions!, parent.Database, tenant, parent._workTracker)
         {
             Listeners.AddRange(parent.Listeners);
             _parent = parent;

--- a/src/Marten/Internal/Sessions/QuerySession.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.cs
@@ -84,7 +84,7 @@ namespace Marten.Internal.Sessions
             Options = store.Options;
         }
 
-        protected internal virtual IDocumentStorage<T> selectStorage<T>(DocumentProvider<T> provider)
+        protected internal virtual IDocumentStorage<T> selectStorage<T>(DocumentProvider<T> provider) where T : notnull
         {
             return provider.QueryOnly;
         }
@@ -100,7 +100,7 @@ namespace Marten.Internal.Sessions
             IDocumentStorage Find(QuerySession session);
         }
 
-        private class StorageFinder<T>: IStorageFinder
+        private class StorageFinder<T>: IStorageFinder where T : notnull
         {
             public IDocumentStorage Find(QuerySession session)
             {
@@ -108,7 +108,7 @@ namespace Marten.Internal.Sessions
             }
         }
 
-        internal IDocumentStorage<T, TId> StorageFor<T, TId>()
+        internal IDocumentStorage<T, TId> StorageFor<T, TId>() where T : notnull where TId : notnull
         {
             var storage = StorageFor<T>();
             if (storage is IDocumentStorage<T, TId> s) return s;
@@ -124,7 +124,7 @@ namespace Marten.Internal.Sessions
         /// <typeparam name="TId"></typeparam>
         /// <returns></returns>
         /// <exception cref="DocumentIdTypeMismatchException"></exception>
-        internal IDocumentStorage<T, TId> QueryStorageFor<T, TId>()
+        internal IDocumentStorage<T, TId> QueryStorageFor<T, TId>() where T : notnull where TId : notnull
         {
             var storage = _providers.StorageFor<T>().QueryOnly;
             if (storage is IDocumentStorage<T, TId> s) return s;
@@ -133,7 +133,7 @@ namespace Marten.Internal.Sessions
             throw new DocumentIdTypeMismatchException(storage, typeof(TId));
         }
 
-        public IDocumentStorage<T> StorageFor<T>()
+        public IDocumentStorage<T> StorageFor<T>() where T : notnull
         {
             return selectStorage(_providers.StorageFor<T>());
         }
@@ -189,7 +189,7 @@ namespace Marten.Internal.Sessions
                 throw new ObjectDisposedException("This session has been disposed");
         }
 
-        public T? Load<T>(string id)
+        public T? Load<T>(string id) where T : notnull
         {
             assertNotDisposed();
             var document = StorageFor<T, string>().Load(id, this);
@@ -197,7 +197,7 @@ namespace Marten.Internal.Sessions
             return document;
         }
 
-        public async Task<T?> LoadAsync<T>(string id, CancellationToken token = default)
+        public async Task<T?> LoadAsync<T>(string id, CancellationToken token = default) where T : notnull
         {
             assertNotDisposed();
             var document = await StorageFor<T, string>().LoadAsync(id, this, token).ConfigureAwait(false);
@@ -205,7 +205,7 @@ namespace Marten.Internal.Sessions
             return document;
         }
 
-        public T? Load<T>(int id)
+        public T? Load<T>(int id) where T : notnull
         {
             assertNotDisposed();
 
@@ -222,7 +222,7 @@ namespace Marten.Internal.Sessions
             return document;
         }
 
-        public async Task<T?> LoadAsync<T>(int id, CancellationToken token = default)
+        public async Task<T?> LoadAsync<T>(int id, CancellationToken token = default) where T : notnull
         {
             assertNotDisposed();
 
@@ -239,7 +239,7 @@ namespace Marten.Internal.Sessions
             return document;
         }
 
-        public T? Load<T>(long id)
+        public T? Load<T>(long id) where T : notnull
         {
             assertNotDisposed();
             var document = StorageFor<T, long>().Load(id, this);
@@ -247,7 +247,7 @@ namespace Marten.Internal.Sessions
             return document;
         }
 
-        public async Task<T?> LoadAsync<T>(long id, CancellationToken token = default)
+        public async Task<T?> LoadAsync<T>(long id, CancellationToken token = default) where T : notnull
         {
             assertNotDisposed();
             var document = await StorageFor<T, long>().LoadAsync(id, this, token).ConfigureAwait(false);
@@ -255,7 +255,7 @@ namespace Marten.Internal.Sessions
             return document;
         }
 
-        public T? Load<T>(Guid id)
+        public T? Load<T>(Guid id) where T : notnull
         {
             assertNotDisposed();
             var document = StorageFor<T, Guid>().Load(id, this);
@@ -263,7 +263,7 @@ namespace Marten.Internal.Sessions
             return document;
         }
 
-        public async Task<T?> LoadAsync<T>(Guid id, CancellationToken token = default)
+        public async Task<T?> LoadAsync<T>(Guid id, CancellationToken token = default) where T : notnull
         {
             assertNotDisposed();
             var document = await StorageFor<T, Guid>().LoadAsync(id, this, token).ConfigureAwait(false);
@@ -331,39 +331,39 @@ namespace Marten.Internal.Sessions
             return ExecuteHandlerAsync(handler, token);
         }
 
-        public IReadOnlyList<T> LoadMany<T>(params string[] ids)
+        public IReadOnlyList<T> LoadMany<T>(params string[] ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, string>().LoadMany(ids, this);
         }
 
-        public IReadOnlyList<T> LoadMany<T>(IEnumerable<string> ids)
-        {
+        public IReadOnlyList<T> LoadMany<T>(IEnumerable<string> ids) where T : notnull
+        { 
             assertNotDisposed();
             return StorageFor<T, string>().LoadMany(ids.ToArray(), this);
 
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(params string[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(params string[] ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, string>().LoadManyAsync(ids, this, default);
 
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<string> ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<string> ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, string>().LoadManyAsync(ids.ToArray(), this, default);
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params string[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params string[] ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, string>().LoadManyAsync(ids, this, token);
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<string> ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<string> ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, string>().LoadManyAsync(ids.ToArray(), this, token);
@@ -371,7 +371,7 @@ namespace Marten.Internal.Sessions
 
 
 
-        public IReadOnlyList<T> LoadMany<T>(params int[] ids)
+        public IReadOnlyList<T> LoadMany<T>(params int[] ids) where T : notnull
         {
             assertNotDisposed();
 
@@ -389,22 +389,22 @@ namespace Marten.Internal.Sessions
             throw new DocumentIdTypeMismatchException($"The identity type for document type {typeof(T).FullNameInCode()} is not numeric");
         }
 
-        public IReadOnlyList<T> LoadMany<T>(IEnumerable<int> ids)
+        public IReadOnlyList<T> LoadMany<T>(IEnumerable<int> ids) where T : notnull
         {
             return LoadMany<T>(ids.ToArray());
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(params int[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(params int[] ids) where T : notnull
         {
             return LoadManyAsync<T>(CancellationToken.None, ids);
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<int> ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<int> ids) where T : notnull
         {
             return LoadManyAsync<T>(ids.ToArray());
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params int[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params int[] ids) where T : notnull
         {
             assertNotDisposed();
 
@@ -422,47 +422,44 @@ namespace Marten.Internal.Sessions
             throw new DocumentIdTypeMismatchException($"The identity type for document type {typeof(T).FullNameInCode()} is not numeric");
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<int> ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<int> ids) where T : notnull
         {
             return LoadManyAsync<T>(token, ids.ToArray());
         }
 
-
-
-
-        public IReadOnlyList<T> LoadMany<T>(params long[] ids)
+        public IReadOnlyList<T> LoadMany<T>(params long[] ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, long>().LoadMany(ids, this);
         }
 
-        public IReadOnlyList<T> LoadMany<T>(IEnumerable<long> ids)
+        public IReadOnlyList<T> LoadMany<T>(IEnumerable<long> ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, long>().LoadMany(ids.ToArray(), this);
 
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(params long[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(params long[] ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, long>().LoadManyAsync(ids, this, default);
 
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<long> ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<long> ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, long>().LoadManyAsync(ids.ToArray(), this, default);
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params long[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params long[] ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, long>().LoadManyAsync(ids, this, token);
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<long> ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<long> ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, long>().LoadManyAsync(ids.ToArray(), this, token);
@@ -471,39 +468,39 @@ namespace Marten.Internal.Sessions
 
 
 
-        public IReadOnlyList<T> LoadMany<T>(params Guid[] ids)
+        public IReadOnlyList<T> LoadMany<T>(params Guid[] ids) where T: notnull 
         {
             assertNotDisposed();
             return StorageFor<T, Guid>().LoadMany(ids, this);
         }
 
-        public IReadOnlyList<T> LoadMany<T>(IEnumerable<Guid> ids)
+        public IReadOnlyList<T> LoadMany<T>(IEnumerable<Guid> ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, Guid>().LoadMany(ids.ToArray(), this);
 
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(params Guid[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(params Guid[] ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, Guid>().LoadManyAsync(ids, this, default);
 
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<Guid> ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(IEnumerable<Guid> ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, Guid>().LoadManyAsync(ids.ToArray(), this, default);
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params Guid[] ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, params Guid[] ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, Guid>().LoadManyAsync(ids, this, token);
         }
 
-        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<Guid> ids)
+        public Task<IReadOnlyList<T>> LoadManyAsync<T>(CancellationToken token, IEnumerable<Guid> ids) where T : notnull
         {
             assertNotDisposed();
             return StorageFor<T, Guid>().LoadManyAsync(ids.ToArray(), this, token);
@@ -514,7 +511,7 @@ namespace Marten.Internal.Sessions
 
 
         public IJsonLoader Json => new JsonLoader(this);
-        public Guid? VersionFor<TDoc>(TDoc entity)
+        public Guid? VersionFor<TDoc>(TDoc entity) where TDoc : notnull
         {
             return StorageFor<TDoc>().VersionFor(entity, this);
         }
@@ -559,7 +556,7 @@ namespace Marten.Internal.Sessions
             return Query<TDoc>().Where(d => d.WebStyleSearch(searchTerm, regConfig)).ToListAsync(token: token);
         }
 
-        public DocumentMetadata MetadataFor<T>(T entity)
+        public DocumentMetadata MetadataFor<T>(T entity) where T: notnull
         {
             assertNotDisposed();
             if (entity == null) throw new ArgumentNullException(nameof(entity));
@@ -571,7 +568,7 @@ namespace Marten.Internal.Sessions
             return ExecuteHandler(handler);
         }
 
-        public Task<DocumentMetadata> MetadataForAsync<T>(T entity, CancellationToken token = default)
+        public Task<DocumentMetadata> MetadataForAsync<T>(T entity, CancellationToken token = default) where T : notnull
         {
             assertNotDisposed();
             if (entity == null) throw new ArgumentNullException(nameof(entity));

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -22,13 +22,13 @@ using Npgsql;
 using NpgsqlTypes;
 using Remotion.Linq;
 using LambdaBuilder = Baseline.Expressions.LambdaBuilder;
-
+#nullable enable
 namespace Marten.Internal.Storage
 {
 
-    public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>
+    public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId> where T: notnull where TId: notnull
     {
-        private ISqlFragment _defaultWhere;
+        private ISqlFragment? _defaultWhere;
         private readonly string _selectClause;
 
         protected readonly string _loadArraySql;
@@ -261,7 +261,7 @@ namespace Marten.Internal.Storage
 
         public IOperationFragment HardDeleteFragment { get; }
 
-        public ISqlFragment FilterDocuments(QueryModel model, ISqlFragment query)
+        public ISqlFragment FilterDocuments(QueryModel? model, ISqlFragment query)
         {
             var extras = extraFilters(query).ToList();
 
@@ -274,7 +274,7 @@ namespace Marten.Internal.Storage
             return query;
         }
 
-        public ISqlFragment DefaultWhereFragment()
+        public ISqlFragment? DefaultWhereFragment()
         {
             return _defaultWhere;
         }
@@ -282,11 +282,11 @@ namespace Marten.Internal.Storage
         public IFieldMapping Fields { get; }
 
 
-        public abstract T Load(TId id, IMartenSession session);
-        public abstract Task<T> LoadAsync(TId id, IMartenSession session, CancellationToken token);
+        public abstract T? Load(TId id, IMartenSession session);
+        public abstract Task<T?> LoadAsync(TId id, IMartenSession session, CancellationToken token);
 
 
-        protected T load(TId id, IMartenSession session)
+        protected T? load(TId id, IMartenSession session)
         {
             var command = BuildLoadCommand(id, session.Tenant);
             var selector = (ISelector<T>)BuildSelector(session);
@@ -294,7 +294,7 @@ namespace Marten.Internal.Storage
             return session.Database.LoadOne(command, selector);
         }
 
-        protected Task<T> loadAsync(TId id, IMartenSession session, CancellationToken token)
+        protected Task<T?> loadAsync(TId id, IMartenSession session, CancellationToken token)
         {
             var command = BuildLoadCommand(id, session.Tenant);
             var selector = (ISelector<T>)BuildSelector(session);

--- a/src/Marten/Internal/Storage/IDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IDocumentStorage.cs
@@ -25,7 +25,7 @@ namespace Marten.Internal.Storage
 
         ISqlFragment FilterDocuments(QueryModel? model, ISqlFragment query);
 
-        ISqlFragment DefaultWhereFragment();
+        ISqlFragment? DefaultWhereFragment();
 
         bool UseOptimisticConcurrency { get; }
         IOperationFragment DeleteFragment { get; }

--- a/src/Marten/Internal/Storage/IDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IDocumentStorage.cs
@@ -10,7 +10,7 @@ using Marten.Services;
 using Marten.Storage;
 using Npgsql;
 using Remotion.Linq;
-
+#nullable enable
 namespace Marten.Internal.Storage
 {
     public interface IDocumentStorage : ISelectClause
@@ -23,7 +23,7 @@ namespace Marten.Internal.Storage
 
         IFieldMapping Fields { get; }
 
-        ISqlFragment FilterDocuments(QueryModel model, ISqlFragment query);
+        ISqlFragment FilterDocuments(QueryModel? model, ISqlFragment query);
 
         ISqlFragment DefaultWhereFragment();
 
@@ -37,7 +37,7 @@ namespace Marten.Internal.Storage
         TenancyStyle TenancyStyle { get; }
     }
 
-    public interface IDocumentStorage<T> : IDocumentStorage
+    public interface IDocumentStorage<T> : IDocumentStorage where T : notnull
     {
         object IdentityFor(T document);
 
@@ -63,7 +63,7 @@ namespace Marten.Internal.Storage
         IDeletion HardDeleteForDocument(T document, ITenant tenant);
     }
 
-    public interface IDocumentStorage<T, TId> : IDocumentStorage<T>
+    public interface IDocumentStorage<T, TId> : IDocumentStorage<T> where T : notnull where TId : notnull
     {
         /// <summary>
         /// Assign the given identity to the document
@@ -74,8 +74,8 @@ namespace Marten.Internal.Storage
 
         IDeletion DeleteForId(TId id, ITenant tenant);
 
-        T Load(TId id, IMartenSession session);
-        Task<T> LoadAsync(TId id, IMartenSession session, CancellationToken token);
+        T? Load(TId id, IMartenSession session);
+        Task<T?> LoadAsync(TId id, IMartenSession session, CancellationToken token);
 
         IReadOnlyList<T> LoadMany(TId[] ids, IMartenSession session);
         Task<IReadOnlyList<T>> LoadManyAsync(TId[] ids, IMartenSession session, CancellationToken token);

--- a/src/Marten/Internal/StorageCheckingProviderGraph.cs
+++ b/src/Marten/Internal/StorageCheckingProviderGraph.cs
@@ -19,7 +19,7 @@ namespace Marten.Internal
 
         public ITenantStorage Tenant { get; }
 
-        public DocumentProvider<T> StorageFor<T>()
+        public DocumentProvider<T> StorageFor<T>() where T : notnull
         {
             if (_storage.TryFind(typeof(T), out var stored))
             {

--- a/src/Marten/Internal/StorageCheckingProviderGraph.cs
+++ b/src/Marten/Internal/StorageCheckingProviderGraph.cs
@@ -3,7 +3,7 @@ using Baseline;
 using Marten.Internal.CodeGeneration;
 using Marten.Storage;
 using Marten.Util;
-
+#nullable enable
 namespace Marten.Internal
 {
     public class StorageCheckingProviderGraph: IProviderGraph

--- a/src/Marten/JsonLoader.cs
+++ b/src/Marten/JsonLoader.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Marten.Internal.Sessions;
 using Marten.Linq.QueryHandlers;
 using Marten.Services;
-
+#nullable enable
 namespace Marten
 {
     internal class JsonLoader: IJsonLoader
@@ -17,22 +17,22 @@ namespace Marten
             _session = session;
         }
 
-        public string FindById<T>(string id) where T : class
+        public string? FindById<T>(string id) where T : class
         {
             return findJsonById<T, string>(id);
         }
 
-        public Task<string> FindByIdAsync<T>(string id, CancellationToken token) where T : class
+        public Task<string?> FindByIdAsync<T>(string id, CancellationToken token) where T : class
         {
             return findJsonByIdAsync<T, string>(id, token);
         }
 
-        public Task<string> FindJsonByIdAsync<T>(int id, CancellationToken token) where T : class
+        public Task<string?> FindJsonByIdAsync<T>(int id, CancellationToken token) where T : class
         {
             return findJsonByIdAsync<T, int>(id, token);
         }
 
-        private string findJsonById<T, TId>(TId id)
+        private string? findJsonById<T, TId>(TId id) where TId : notnull
         {
             var storage = _session.QueryStorageFor<T, TId>();
             var command = storage.BuildLoadCommand(id, _session.Tenant);
@@ -40,7 +40,7 @@ namespace Marten
             return _session.Database.LoadOne(command, LinqConstants.StringValueSelector);
         }
 
-        private Task<string> findJsonByIdAsync<T, TId>(TId id, CancellationToken token)
+        private Task<string?> findJsonByIdAsync<T, TId>(TId id, CancellationToken token) where TId : notnull
         {
             var storage = _session.QueryStorageFor<T, TId>();
             var command = storage.BuildLoadCommand(id, _session.Tenant);
@@ -48,32 +48,32 @@ namespace Marten
             return _session.Database.LoadOneAsync(command, LinqConstants.StringValueSelector, token);
         }
 
-        public string FindById<T>(int id) where T : class
+        public string? FindById<T>(int id) where T : class
         {
             return findJsonById<T, int>(id);
         }
 
-        public string FindById<T>(long id) where T : class
+        public string? FindById<T>(long id) where T : class
         {
             return findJsonById<T, long>(id);
         }
 
-        public string FindById<T>(Guid id) where T : class
+        public string? FindById<T>(Guid id) where T : class
         {
             return findJsonById<T, Guid>(id);
         }
 
-        public Task<string> FindByIdAsync<T>(int id, CancellationToken token = new CancellationToken()) where T : class
+        public Task<string?> FindByIdAsync<T>(int id, CancellationToken token = new CancellationToken()) where T : class
         {
             return findJsonByIdAsync<T, int>(id, token);
         }
 
-        public Task<string> FindByIdAsync<T>(long id, CancellationToken token = new CancellationToken()) where T : class
+        public Task<string?> FindByIdAsync<T>(long id, CancellationToken token = new CancellationToken()) where T : class
         {
             return findJsonByIdAsync<T, long>(id, token);
         }
 
-        public Task<string> FindByIdAsync<T>(Guid id, CancellationToken token = new CancellationToken()) where T : class
+        public Task<string?> FindByIdAsync<T>(Guid id, CancellationToken token = new CancellationToken()) where T : class
         {
             return findJsonByIdAsync<T, Guid>(id, token);
         }
@@ -83,7 +83,7 @@ namespace Marten
             return streamJsonById<T, int>(id, destination, token);
         }
 
-        private Task<bool> streamJsonById<T, TId>(TId id, Stream destination, CancellationToken token) where T : class
+        private Task<bool> streamJsonById<T, TId>(TId id, Stream destination, CancellationToken token) where T : class where TId : notnull
         {
             var storage = _session.QueryStorageFor<T, TId>();
             var command = storage.BuildLoadCommand(id, _session.Tenant);

--- a/src/Marten/JsonLoader.cs
+++ b/src/Marten/JsonLoader.cs
@@ -32,7 +32,7 @@ namespace Marten
             return findJsonByIdAsync<T, int>(id, token);
         }
 
-        private string? findJsonById<T, TId>(TId id) where TId : notnull
+        private string? findJsonById<T, TId>(TId id) where T : notnull where TId : notnull
         {
             var storage = _session.QueryStorageFor<T, TId>();
             var command = storage.BuildLoadCommand(id, _session.Tenant);
@@ -40,7 +40,7 @@ namespace Marten
             return _session.Database.LoadOne(command, LinqConstants.StringValueSelector);
         }
 
-        private Task<string?> findJsonByIdAsync<T, TId>(TId id, CancellationToken token) where TId : notnull
+        private Task<string?> findJsonByIdAsync<T, TId>(TId id, CancellationToken token) where T : notnull where TId : notnull
         {
             var storage = _session.QueryStorageFor<T, TId>();
             var command = storage.BuildLoadCommand(id, _session.Tenant);

--- a/src/Marten/LambdaConnectionFactory.cs
+++ b/src/Marten/LambdaConnectionFactory.cs
@@ -1,6 +1,6 @@
 using System;
 using Npgsql;
-
+#nullable enable
 namespace Marten
 {
     internal class LambdaConnectionFactory: IConnectionFactory

--- a/src/Marten/Linq/ICompiledQuery.cs
+++ b/src/Marten/Linq/ICompiledQuery.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-
+#nullable enable
 namespace Marten.Linq
 {
     /// <summary>

--- a/src/Marten/Linq/IConfigureExplainExpressions.cs
+++ b/src/Marten/Linq/IConfigureExplainExpressions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Linq
 {
     public interface IConfigureExplainExpressions

--- a/src/Marten/Linq/IMartenQueryable.cs
+++ b/src/Marten/Linq/IMartenQueryable.cs
@@ -70,12 +70,12 @@ namespace Marten.Linq
 
     public interface IMartenQueryable<T>: IQueryable<T>, IMartenQueryable
     {
-        IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback);
+        IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : notnull;
 
-        IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, IList<TInclude> list);
+        IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, IList<TInclude> list) where TInclude : notnull;
 
         IMartenQueryable<T> Include<TInclude, TKey>(Expression<Func<T, object>> idSource,
-            IDictionary<TKey, TInclude> dictionary);
+            IDictionary<TKey, TInclude> dictionary) where TInclude : notnull where TKey : notnull;
 
         IMartenQueryable<T> Stats(out QueryStatistics stats);
 

--- a/src/Marten/Linq/IMartenQueryable.cs
+++ b/src/Marten/Linq/IMartenQueryable.cs
@@ -70,12 +70,12 @@ namespace Marten.Linq
 
     public interface IMartenQueryable<T>: IQueryable<T>, IMartenQueryable
     {
-        IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : notnull;
+        IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : class;
 
-        IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, IList<TInclude> list) where TInclude : notnull;
+        IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, IList<TInclude> list) where TInclude : class;
 
         IMartenQueryable<T> Include<TInclude, TKey>(Expression<Func<T, object>> idSource,
-            IDictionary<TKey, TInclude> dictionary) where TInclude : notnull where TKey : notnull;
+            IDictionary<TKey, TInclude> dictionary) where TInclude : class where TKey : notnull;
 
         IMartenQueryable<T> Stats(out QueryStatistics stats);
 

--- a/src/Marten/Linq/IMartenQueryable.cs
+++ b/src/Marten/Linq/IMartenQueryable.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace Marten.Linq
 {
     public interface IMartenQueryable
@@ -22,11 +23,11 @@ namespace Marten.Linq
 
         Task<TResult> FirstAsync<TResult>(CancellationToken token);
 
-        Task<TResult> FirstOrDefaultAsync<TResult>(CancellationToken token);
+        Task<TResult?> FirstOrDefaultAsync<TResult>(CancellationToken token);
 
         Task<TResult> SingleAsync<TResult>(CancellationToken token);
 
-        Task<TResult> SingleOrDefaultAsync<TResult>(CancellationToken token);
+        Task<TResult?> SingleOrDefaultAsync<TResult>(CancellationToken token);
 
         Task<TResult> SumAsync<TResult>(CancellationToken token);
 
@@ -37,7 +38,7 @@ namespace Marten.Linq
         Task<double> AverageAsync(CancellationToken token);
 
         /// <param name="configureExplain">Configure EXPLAIN options as documented in <see href="https://www.postgresql.org/docs/9.6/static/sql-explain.html">EXPLAIN documentation</see></param>
-        QueryPlan Explain(FetchType fetchType = FetchType.FetchMany, Action<IConfigureExplainExpressions> configureExplain = null);
+        QueryPlan Explain(FetchType fetchType = FetchType.FetchMany, Action<IConfigureExplainExpressions>? configureExplain = null);
 
         /// <summary>
         ///     Applies a pre-loaded Javascript transformation to the documents

--- a/src/Marten/Linq/IMartenQueryable.cs
+++ b/src/Marten/Linq/IMartenQueryable.cs
@@ -70,12 +70,12 @@ namespace Marten.Linq
 
     public interface IMartenQueryable<T>: IQueryable<T>, IMartenQueryable
     {
-        IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : class;
+        IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : notnull;
 
-        IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, IList<TInclude> list) where TInclude : class;
+        IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, IList<TInclude> list) where TInclude : notnull;
 
         IMartenQueryable<T> Include<TInclude, TKey>(Expression<Func<T, object>> idSource,
-            IDictionary<TKey, TInclude> dictionary) where TInclude : class where TKey : notnull;
+            IDictionary<TKey, TInclude> dictionary) where TInclude : notnull where TKey : notnull;
 
         IMartenQueryable<T> Stats(out QueryStatistics stats);
 

--- a/src/Marten/Linq/LastModified/LastModifiedExtensions.cs
+++ b/src/Marten/Linq/LastModified/LastModifiedExtensions.cs
@@ -1,5 +1,5 @@
 using System;
-
+#nullable enable
 namespace Marten.Linq.LastModified
 {
     public static class LastModifiedExtensions

--- a/src/Marten/Linq/MartenLinqQueryProvider.cs
+++ b/src/Marten/Linq/MartenLinqQueryProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Internal;
@@ -93,7 +94,7 @@ namespace Marten.Linq
         }
 
 
-        public async IAsyncEnumerable<T> ExecuteAsyncEnumerable<T>(Expression expression, CancellationToken token)
+        public async IAsyncEnumerable<T> ExecuteAsyncEnumerable<T>(Expression expression, [EnumeratorCancellation]CancellationToken token)
         {
             var builder = new LinqHandlerBuilder(this, _session, expression);
             builder.BuildDatabaseStatement();

--- a/src/Marten/Linq/MartenLinqQueryable.cs
+++ b/src/Marten/Linq/MartenLinqQueryable.cs
@@ -155,7 +155,7 @@ namespace Marten.Linq
         {
             var command = ToPreviewCommand(fetchType);
 
-            return _session.Database.ExplainQuery(_session.Serializer, command, configureExplain);
+            return _session.Database.ExplainQuery(_session.Serializer, command, configureExplain)!;
         }
 
         public IQueryable<TDoc> TransformTo<TDoc>(string transformName)
@@ -163,14 +163,14 @@ namespace Marten.Linq
             return this.Select(x => x.TransformTo<T, TDoc>(transformName));
         }
 
-       public IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback)
+       public IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : notnull
         {
             var include = BuildInclude(idSource, callback);
             MartenProvider.AllIncludes.Add(include);
             return this;
         }
 
-        internal IIncludePlan BuildInclude<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback)
+        internal IIncludePlan BuildInclude<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : notnull
         {
             var storage = (IDocumentStorage<TInclude>) _session.StorageFor(typeof(TInclude));
             var identityField = _session.StorageFor(typeof(T)).Fields.FieldFor(idSource);
@@ -179,13 +179,13 @@ namespace Marten.Linq
             return include;
         }
 
-        public IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, IList<TInclude> list)
+        public IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, IList<TInclude> list) where TInclude : notnull
         {
             return Include<TInclude>(idSource, list.Add);
         }
 
         internal IIncludePlan BuildInclude<TInclude, TKey>(Expression<Func<T, object>> idSource,
-            IDictionary<TKey, TInclude> dictionary)
+            IDictionary<TKey, TInclude> dictionary) where TInclude : notnull where TKey: notnull
         {
             var storage = (IDocumentStorage<TInclude>)_session.StorageFor(typeof(TInclude));
 
@@ -208,7 +208,7 @@ namespace Marten.Linq
         }
 
         public IMartenQueryable<T> Include<TInclude, TKey>(Expression<Func<T, object>> idSource,
-            IDictionary<TKey, TInclude> dictionary)
+            IDictionary<TKey, TInclude> dictionary) where TInclude : notnull where TKey : notnull
         {
             var include = BuildInclude(idSource, dictionary);
             MartenProvider.AllIncludes.Add(include);

--- a/src/Marten/Linq/MartenLinqQueryable.cs
+++ b/src/Marten/Linq/MartenLinqQueryable.cs
@@ -163,14 +163,14 @@ namespace Marten.Linq
             return this.Select(x => x.TransformTo<T, TDoc>(transformName));
         }
 
-       public IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : class
+       public IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : notnull
         {
             var include = BuildInclude(idSource, callback);
             MartenProvider.AllIncludes.Add(include);
             return this;
         }
 
-        internal IIncludePlan BuildInclude<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : class
+        internal IIncludePlan BuildInclude<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : notnull
         {
             var storage = (IDocumentStorage<TInclude>) _session.StorageFor(typeof(TInclude));
             var identityField = _session.StorageFor(typeof(T)).Fields.FieldFor(idSource);
@@ -179,13 +179,13 @@ namespace Marten.Linq
             return include;
         }
 
-        public IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, IList<TInclude> list) where TInclude : class
+        public IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, IList<TInclude> list) where TInclude : notnull
         {
             return Include<TInclude>(idSource, list.Add);
         }
 
         internal IIncludePlan BuildInclude<TInclude, TKey>(Expression<Func<T, object>> idSource,
-            IDictionary<TKey, TInclude> dictionary) where TInclude : class where TKey: notnull
+            IDictionary<TKey, TInclude> dictionary) where TInclude : notnull where TKey: notnull
         {
             var storage = (IDocumentStorage<TInclude>)_session.StorageFor(typeof(TInclude));
 
@@ -208,7 +208,7 @@ namespace Marten.Linq
         }
 
         public IMartenQueryable<T> Include<TInclude, TKey>(Expression<Func<T, object>> idSource,
-            IDictionary<TKey, TInclude> dictionary) where TInclude : class where TKey : notnull
+            IDictionary<TKey, TInclude> dictionary) where TInclude : notnull where TKey : notnull
         {
             var include = BuildInclude(idSource, dictionary);
             MartenProvider.AllIncludes.Add(include);

--- a/src/Marten/Linq/MartenLinqQueryable.cs
+++ b/src/Marten/Linq/MartenLinqQueryable.cs
@@ -163,14 +163,14 @@ namespace Marten.Linq
             return this.Select(x => x.TransformTo<T, TDoc>(transformName));
         }
 
-       public IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : notnull
+       public IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : class
         {
             var include = BuildInclude(idSource, callback);
             MartenProvider.AllIncludes.Add(include);
             return this;
         }
 
-        internal IIncludePlan BuildInclude<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : notnull
+        internal IIncludePlan BuildInclude<TInclude>(Expression<Func<T, object>> idSource, Action<TInclude> callback) where TInclude : class
         {
             var storage = (IDocumentStorage<TInclude>) _session.StorageFor(typeof(TInclude));
             var identityField = _session.StorageFor(typeof(T)).Fields.FieldFor(idSource);
@@ -179,13 +179,13 @@ namespace Marten.Linq
             return include;
         }
 
-        public IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, IList<TInclude> list) where TInclude : notnull
+        public IMartenQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, IList<TInclude> list) where TInclude : class
         {
             return Include<TInclude>(idSource, list.Add);
         }
 
         internal IIncludePlan BuildInclude<TInclude, TKey>(Expression<Func<T, object>> idSource,
-            IDictionary<TKey, TInclude> dictionary) where TInclude : notnull where TKey: notnull
+            IDictionary<TKey, TInclude> dictionary) where TInclude : class where TKey: notnull
         {
             var storage = (IDocumentStorage<TInclude>)_session.StorageFor(typeof(TInclude));
 
@@ -208,7 +208,7 @@ namespace Marten.Linq
         }
 
         public IMartenQueryable<T> Include<TInclude, TKey>(Expression<Func<T, object>> idSource,
-            IDictionary<TKey, TInclude> dictionary) where TInclude : notnull where TKey : notnull
+            IDictionary<TKey, TInclude> dictionary) where TInclude : class where TKey : notnull
         {
             var include = BuildInclude(idSource, dictionary);
             MartenProvider.AllIncludes.Add(include);

--- a/src/Marten/Linq/MartenLinqQueryable.cs
+++ b/src/Marten/Linq/MartenLinqQueryable.cs
@@ -19,6 +19,7 @@ using Npgsql;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 
+#nullable enable
 namespace Marten.Linq
 {
     internal class MartenLinqQueryable<T>: QueryableBase<T>, IMartenQueryable<T>
@@ -47,7 +48,7 @@ namespace Marten.Linq
 
         public MartenLinqQueryProvider MartenProvider { get; }
 
-        internal IQueryHandler<TResult> BuildHandler<TResult>(ResultOperatorBase op = null)
+        internal IQueryHandler<TResult> BuildHandler<TResult>(ResultOperatorBase? op = null)
         {
             var builder = new LinqHandlerBuilder(MartenProvider, _session, Expression, op);
             return builder.BuildHandler<TResult>();
@@ -99,9 +100,9 @@ namespace Marten.Linq
             return MartenProvider.ExecuteAsync<TResult>(Expression, token, LinqConstants.FirstOperator);
         }
 
-        public Task<TResult> FirstOrDefaultAsync<TResult>(CancellationToken token)
+        public Task<TResult?> FirstOrDefaultAsync<TResult>(CancellationToken token)
         {
-            return MartenProvider.ExecuteAsync<TResult>(Expression, token, LinqConstants.FirstOrDefaultOperator);
+            return MartenProvider.ExecuteAsync<TResult>(Expression, token, LinqConstants.FirstOrDefaultOperator)!;
         }
 
         public Task<TResult> SingleAsync<TResult>(CancellationToken token)
@@ -109,9 +110,9 @@ namespace Marten.Linq
             return MartenProvider.ExecuteAsync<TResult>(Expression, token, LinqConstants.SingleOperator);
         }
 
-        public Task<TResult> SingleOrDefaultAsync<TResult>(CancellationToken token)
+        public Task<TResult?> SingleOrDefaultAsync<TResult>(CancellationToken token)
         {
-            return MartenProvider.ExecuteAsync<TResult>(Expression, token, LinqConstants.SingleOrDefaultOperator);
+            return MartenProvider.ExecuteAsync<TResult>(Expression, token, LinqConstants.SingleOrDefaultOperator)!;
         }
 
         public Task<TResult> SumAsync<TResult>(CancellationToken token)
@@ -150,7 +151,7 @@ namespace Marten.Linq
         }
 
         public QueryPlan Explain(FetchType fetchType = FetchType.FetchMany,
-            Action<IConfigureExplainExpressions> configureExplain = null)
+            Action<IConfigureExplainExpressions>? configureExplain = null)
         {
             var command = ToPreviewCommand(fetchType);
 

--- a/src/Marten/Linq/MatchesSql/MatchesSqlExtensions.cs
+++ b/src/Marten/Linq/MatchesSql/MatchesSqlExtensions.cs
@@ -1,6 +1,6 @@
 using System;
 using Marten.Linq.SqlGeneration;
-
+#nullable enable
 namespace Marten.Linq.MatchesSql
 {
     public static class MatchesSqlExtensions

--- a/src/Marten/Linq/QueryHandlers/IQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/IQueryHandler.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Marten.Internal;
 using Marten.Util;
-
+#nullable enable
 namespace Marten.Linq.QueryHandlers
 {
     public interface IQueryHandler

--- a/src/Marten/Linq/QueryHandlers/LoadByIdArrayHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/LoadByIdArrayHandler.cs
@@ -8,10 +8,10 @@ using Marten.Linq.Filters;
 using Marten.Linq.Selectors;
 using Marten.Storage;
 using Marten.Util;
-
+#nullable enable
 namespace Marten.Linq.QueryHandlers
 {
-    public class LoadByIdArrayHandler<T, TKey>: IQueryHandler<IReadOnlyList<T>>
+    public class LoadByIdArrayHandler<T, TKey>: IQueryHandler<IReadOnlyList<T>> where T: notnull
     {
         private readonly IDocumentStorage<T> storage;
         private readonly TKey[] _ids;

--- a/src/Marten/Linq/SqlGeneration/ISelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/ISelectClause.cs
@@ -3,7 +3,7 @@ using Marten.Internal;
 using Marten.Linq.QueryHandlers;
 using Marten.Linq.Selectors;
 using Marten.Util;
-
+#nullable enable
 namespace Marten.Linq.SqlGeneration
 {
     public interface ISelectClause

--- a/src/Marten/LinqExtensions.cs
+++ b/src/Marten/LinqExtensions.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Baseline;
 using Marten.Schema;
-
+#nullable enable
 namespace Marten
 {
     public static class LinqExtensions
@@ -115,7 +115,7 @@ namespace Marten
         /// <typeparam name="T"></typeparam>
         /// <param name="enumerable"></param>
         /// <returns></returns>
-        public static bool IsEmpty<T>(this IEnumerable<T> enumerable)
+        public static bool IsEmpty<T>(this IEnumerable<T>? enumerable)
         {
             if (enumerable == null)
                 return true;

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -10,7 +10,7 @@ using Marten.Schema.Indexing.Unique;
 using Marten.Storage;
 using Marten.Storage.Metadata;
 using NpgsqlTypes;
-
+#nullable enable
 namespace Marten
 {
     internal interface IDocumentMappingBuilder
@@ -107,8 +107,8 @@ namespace Marten
             /// <returns></returns>
             [Obsolete(
                 "Prefer Index() if you just want to optimize querying, or choose Duplicate() if you really want a duplicated field")]
-            public DocumentMappingExpression<T> Searchable(Expression<Func<T, object>> expression, string pgType = null,
-                NpgsqlDbType? dbType = null, Action<IndexDefinition> configure = null)
+            public DocumentMappingExpression<T> Searchable(Expression<Func<T, object>> expression, string? pgType = null,
+                NpgsqlDbType? dbType = null, Action<IndexDefinition>? configure = null)
             {
                 return Duplicate(expression, pgType, dbType, configure);
             }
@@ -125,8 +125,8 @@ namespace Marten
             /// </param>
             /// <param name="dbType">Optional, overrides the Npgsql DbType for any parameter usage of this property</param>
             /// <returns></returns>
-            public DocumentMappingExpression<T> Duplicate(Expression<Func<T, object>> expression, string pgType = null,
-                NpgsqlDbType? dbType = null, Action<IndexDefinition> configure = null, bool notNull = false)
+            public DocumentMappingExpression<T> Duplicate(Expression<Func<T, object>> expression, string? pgType = null,
+                NpgsqlDbType? dbType = null, Action<IndexDefinition>? configure = null, bool notNull = false)
             {
                 _builder.Alter = mapping =>
                 {
@@ -142,7 +142,7 @@ namespace Marten
             /// <param name="configure"></param>
             /// <returns></returns>
             public DocumentMappingExpression<T> Index(Expression<Func<T, object>> expression,
-                Action<ComputedIndex> configure = null)
+                Action<ComputedIndex>? configure = null)
             {
                 _builder.Alter = m => m.Index(expression, configure);
 
@@ -156,7 +156,7 @@ namespace Marten
             /// <param name="configure"></param>
             /// <returns></returns>
             public DocumentMappingExpression<T> Index(IReadOnlyCollection<Expression<Func<T, object>>> expressions,
-                Action<ComputedIndex> configure = null)
+                Action<ComputedIndex>? configure = null)
             {
                 _builder.Alter = m => m.Index(expressions, configure);
 
@@ -240,7 +240,7 @@ namespace Marten
             /// </summary>
             /// <param name="configure"></param>
             /// <returns></returns>
-            public DocumentMappingExpression<T> IndexLastModified(Action<IndexDefinition> configure = null)
+            public DocumentMappingExpression<T> IndexLastModified(Action<IndexDefinition>? configure = null)
             {
                 _builder.Alter = m => m.AddLastModifiedIndex(configure);
 
@@ -248,7 +248,7 @@ namespace Marten
             }
 
             public DocumentMappingExpression<T> FullTextIndex(string regConfig = Schema.FullTextIndex.DefaultRegConfig,
-                Action<FullTextIndex> configure = null)
+                Action<FullTextIndex>? configure = null)
             {
                 _builder.Alter = m => m.AddFullTextIndex(regConfig, configure);
                 return this;
@@ -295,8 +295,8 @@ namespace Marten
             /// <returns></returns>
             public DocumentMappingExpression<T> ForeignKey<TReference>(
                 Expression<Func<T, object>> expression,
-                Action<ForeignKeyDefinition> foreignKeyConfiguration = null,
-                Action<IndexDefinition> indexConfiguration = null)
+                Action<ForeignKeyDefinition>? foreignKeyConfiguration = null,
+                Action<IndexDefinition>? indexConfiguration = null)
             {
                 _builder.Alter = m =>
                 {
@@ -315,7 +315,7 @@ namespace Marten
 
             public DocumentMappingExpression<T> ForeignKey(Expression<Func<T, object>> expression, string schemaName,
                 string tableName, string columnName,
-                Action<ExternalForeignKeyDefinition> foreignKeyConfiguration = null)
+                Action<ExternalForeignKeyDefinition>? foreignKeyConfiguration = null)
             {
                 _builder.Alter = m =>
                 {
@@ -388,7 +388,7 @@ namespace Marten
             /// </summary>
             /// <param name="configureIndex"></param>
             /// <returns></returns>
-            public DocumentMappingExpression<T> GinIndexJsonData(Action<IndexDefinition> configureIndex = null)
+            public DocumentMappingExpression<T> GinIndexJsonData(Action<IndexDefinition>? configureIndex = null)
             {
                 _builder.Alter = mapping =>
                 {
@@ -406,7 +406,7 @@ namespace Marten
             /// <param name="subclassType"></param>
             /// <param name="alias"></param>
             /// <returns></returns>
-            public DocumentMappingExpression<T> AddSubClass(Type subclassType, string alias = null)
+            public DocumentMappingExpression<T> AddSubClass(Type subclassType, string? alias = null)
             {
                 _builder.Alter = mapping => mapping.SubClasses.Add(subclassType, alias);
                 return this;
@@ -439,7 +439,7 @@ namespace Marten
                 return this;
             }
 
-            public DocumentMappingExpression<T> AddSubClass<TSubclass>(string alias = null) where TSubclass : T
+            public DocumentMappingExpression<T> AddSubClass<TSubclass>(string? alias = null) where TSubclass : T
             {
                 return AddSubClass(typeof(TSubclass), alias);
             }
@@ -472,7 +472,7 @@ namespace Marten
                 return this;
             }
 
-            public DocumentMappingExpression<T> SoftDeletedWithIndex(Action<IndexDefinition> configure = null)
+            public DocumentMappingExpression<T> SoftDeletedWithIndex(Action<IndexDefinition>? configure = null)
             {
                 SoftDeleted();
                 _builder.Alter = m => m.AddDeletedAtIndex(configure);
@@ -521,7 +521,7 @@ namespace Marten
 
             public class MetadataConfig
             {
-                private readonly DocumentMapping _mapping;
+                private readonly DocumentMapping? _mapping;
                 private readonly DocumentMappingExpression<T> _parent;
 
                 public MetadataConfig(DocumentMapping mapping)
@@ -657,7 +657,7 @@ namespace Marten
     /// </summary>
     public class MappedType
     {
-        public MappedType(Type type, string alias = null)
+        public MappedType(Type type, string? alias = null)
         {
             Type = type;
             Alias = alias;
@@ -672,7 +672,7 @@ namespace Marten
         /// String alias that will be used to persist or load the documents
         /// from the underlying database
         /// </summary>
-        public string Alias { get; set; }
+        public string? Alias { get; set; }
 
         public static implicit operator MappedType(Type type)
         {

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -88,9 +88,9 @@ namespace Marten
         public class MartenConfigurationExpression
         {
             private readonly IServiceCollection _services;
-            private readonly StoreOptions _options;
+            private readonly StoreOptions? _options;
 
-            internal MartenConfigurationExpression(IServiceCollection services, StoreOptions options)
+            internal MartenConfigurationExpression(IServiceCollection services, StoreOptions? options)
             {
                 _services = services;
                 _options = options;

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -5,7 +5,7 @@ using Marten.Events.Daemon.Resiliency;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-
+#nullable enable
 namespace Marten
 {
     public static class MartenServiceCollectionExtensions

--- a/src/Marten/Metadata/ISoftDeleted.cs
+++ b/src/Marten/Metadata/ISoftDeleted.cs
@@ -1,5 +1,5 @@
 using System;
-
+#nullable enable
 namespace Marten.Metadata
 {
     /// <summary>

--- a/src/Marten/Metadata/ITenanted.cs
+++ b/src/Marten/Metadata/ITenanted.cs
@@ -1,7 +1,9 @@
+
+#nullable enable
 namespace Marten.Metadata
 {
     /// <summary>
-    /// Optionally implement thi interface on your Marten document
+    /// Optionally implement this interface on your Marten document
     /// types to opt into conjoined tenancy and track the tenant id
     /// on the document itself
     /// </summary>

--- a/src/Marten/Metadata/ITracked.cs
+++ b/src/Marten/Metadata/ITracked.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Metadata
 {
     /// <summary>

--- a/src/Marten/Metadata/IVersioned.cs
+++ b/src/Marten/Metadata/IVersioned.cs
@@ -1,5 +1,5 @@
 using System;
-
+#nullable enable
 namespace Marten.Metadata
 {
     /// <summary>

--- a/src/Marten/Metadata/SoftDeletedPolicy.cs
+++ b/src/Marten/Metadata/SoftDeletedPolicy.cs
@@ -1,6 +1,6 @@
 using Baseline;
 using Marten.Schema;
-
+#nullable enable
 namespace Marten.Metadata
 {
     internal class SoftDeletedPolicy: IDocumentPolicy

--- a/src/Marten/Metadata/TenancyPolicy.cs
+++ b/src/Marten/Metadata/TenancyPolicy.cs
@@ -1,7 +1,7 @@
 using Baseline;
 using Marten.Schema;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Metadata
 {
     internal class TenancyPolicy: IDocumentPolicy

--- a/src/Marten/Metadata/TrackedPolicy.cs
+++ b/src/Marten/Metadata/TrackedPolicy.cs
@@ -1,6 +1,6 @@
 using Baseline;
 using Marten.Schema;
-
+#nullable enable
 namespace Marten.Metadata
 {
     internal class TrackedPolicy: IDocumentPolicy

--- a/src/Marten/Metadata/VersionedPolicy.cs
+++ b/src/Marten/Metadata/VersionedPolicy.cs
@@ -1,6 +1,6 @@
 using Baseline;
 using Marten.Schema;
-
+#nullable enable
 namespace Marten.Metadata
 {
     internal class VersionedPolicy: IDocumentPolicy

--- a/src/Marten/Pagination/IPagedList.cs
+++ b/src/Marten/Pagination/IPagedList.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-
+#nullable enable
 namespace Marten.Pagination
 {
     /// <summary>

--- a/src/Marten/Pagination/PagedList.cs
+++ b/src/Marten/Pagination/PagedList.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Baseline;
 using Marten.Linq;
-
+#nullable enable
 namespace Marten.Pagination
 {
     /// <summary>
@@ -143,7 +143,7 @@ namespace Marten.Pagination
             PageNumber = pageNumber;
             PageSize = pageSize;
 
-            QueryStatistics queryStats = null;
+            QueryStatistics? queryStats;
 
             if (pageNumber == 1)
             {

--- a/src/Marten/Pagination/PagedListQueryableExtensions.cs
+++ b/src/Marten/Pagination/PagedListQueryableExtensions.cs
@@ -2,7 +2,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Linq;
-
+#nullable enable
 namespace Marten.Pagination
 {
     /// <summary>

--- a/src/Marten/Patching/IPatchExpression.cs
+++ b/src/Marten/Patching/IPatchExpression.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-
+#nullable enable
 namespace Marten.Patching
 {
     public interface IPatchExpression<T>
@@ -12,7 +12,7 @@ namespace Marten.Patching
         /// <typeparam name="TValue"></typeparam>
         /// <param name="name"></param>
         /// <param name="value"></param>
-        void Set<TValue>(string name, TValue value);
+        void Set<TValue>(string name, TValue value) where TValue : notnull;
 
         /// <summary>
         /// Set a single field or property value within the persisted JSON data
@@ -22,7 +22,7 @@ namespace Marten.Patching
         /// <param name="name"></param>
         /// <param name="expression">Path to the parent location</param>
         /// <param name="value"></param>
-        void Set<TParent, TValue>(string name, Expression<Func<T, TParent>> expression, TValue value);
+        void Set<TParent, TValue>(string name, Expression<Func<T, TParent>> expression, TValue value) where TValue : notnull;
 
         /// <summary>
         /// Set a single field or property value within the persisted JSON data
@@ -30,7 +30,7 @@ namespace Marten.Patching
         /// <typeparam name="TValue"></typeparam>
         /// <param name="expression"></param>
         /// <param name="value"></param>
-        void Set<TValue>(Expression<Func<T, TValue>> expression, TValue value);
+        void Set<TValue>(Expression<Func<T, TValue>> expression, TValue value) where TValue : notnull;
 
         /// <summary>
         /// Copy a single field or property value within the persisted JSON data to one or more destinations
@@ -79,7 +79,7 @@ namespace Marten.Patching
         /// <typeparam name="TElement"></typeparam>
         /// <param name="expression"></param>
         /// <param name="element"></param>
-        void Append<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element);
+        void Append<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element) where TElement : notnull;
 
         /// <summary>
         /// Append an element to the end of a child collection on the persisted
@@ -88,7 +88,7 @@ namespace Marten.Patching
         /// <typeparam name="TElement"></typeparam>
         /// <param name="expression"></param>
         /// <param name="element"></param>
-        void AppendIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element);
+        void AppendIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element) where TElement : notnull;
 
         /// <summary>
         /// Insert an element at the designated index to a child collection on the persisted document
@@ -97,7 +97,8 @@ namespace Marten.Patching
         /// <param name="expression"></param>
         /// <param name="element"></param>
         /// <param name="index"></param>
-        void Insert<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, int index = 0);
+        void Insert<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, int index = 0)
+            where TElement : notnull;
 
         /// <summary>
         /// Insert an element at the designated index to a child collection on the persisted document
@@ -107,7 +108,7 @@ namespace Marten.Patching
         /// <param name="expression"></param>
         /// <param name="element"></param>
         /// <param name="index"></param>
-        void InsertIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, int index = 0);
+        void InsertIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, int index = 0) where TElement : notnull;
 
         /// <summary>
         /// Remove element from a child collection on the persisted document
@@ -116,7 +117,7 @@ namespace Marten.Patching
         /// <param name="expression"></param>
         /// <param name="element"></param>
         /// <param name="action"></param>
-        void Remove<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, RemoveAction action = RemoveAction.RemoveFirst);
+        void Remove<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, RemoveAction action = RemoveAction.RemoveFirst) where TElement : notnull;
 
         /// <summary>
         /// Rename a property or field in the persisted JSON document

--- a/src/Marten/Patching/PatchExpression.cs
+++ b/src/Marten/Patching/PatchExpression.cs
@@ -8,13 +8,13 @@ using Marten.Linq;
 using Marten.Linq.Parsing;
 using Marten.Linq.SqlGeneration;
 using Marten.Util;
-
+#nullable enable
 namespace Marten.Patching
 {
     public class PatchExpression<T>: IPatchExpression<T>
     {
-        private readonly ISqlFragment _filter;
-        private readonly Expression<Func<T, bool>> _filterExpression;
+        private readonly ISqlFragment? _filter;
+        private readonly Expression<Func<T, bool>>? _filterExpression;
         private readonly DocumentSessionBase _session;
         public readonly IDictionary<string, object> Patch = new Dictionary<string, object>();
 
@@ -30,17 +30,17 @@ namespace Marten.Patching
             _session = session;
         }
 
-        public void Set<TValue>(string name, TValue value)
+        public void Set<TValue>(string name, TValue value) where TValue : notnull
         {
             set(name, value);
         }
 
-        public void Set<TParent, TValue>(string name, Expression<Func<T, TParent>> expression, TValue value)
+        public void Set<TParent, TValue>(string name, Expression<Func<T, TParent>> expression, TValue value) where TValue : notnull
         {
             set(toPath(expression) + $".{name}", value);
         }
 
-        public void Set<TValue>(Expression<Func<T, TValue>> expression, TValue value)
+        public void Set<TValue>(Expression<Func<T, TValue>> expression, TValue value) where TValue : notnull
         {
             set(toPath(expression), value);
         }
@@ -94,7 +94,7 @@ namespace Marten.Patching
             apply();
         }
 
-        public void Append<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element)
+        public void Append<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element) where TElement : notnull
         {
             Patch.Add("type", "append");
             Patch.Add("value", element);
@@ -105,7 +105,7 @@ namespace Marten.Patching
             apply();
         }
 
-        public void AppendIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element)
+        public void AppendIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element) where TElement : notnull
         {
             Patch.Add("type", "append_if_not_exists");
             Patch.Add("value", element);
@@ -117,7 +117,7 @@ namespace Marten.Patching
         }
 
         public void Insert<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element,
-            int index = 0)
+            int index = 0) where TElement : notnull
         {
             Patch.Add("type", "insert");
             Patch.Add("value", element);
@@ -130,7 +130,7 @@ namespace Marten.Patching
         }
 
         public void InsertIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element,
-            int index = 0)
+            int index = 0) where TElement : notnull
         {
             Patch.Add("type", "insert_if_not_exists");
             Patch.Add("value", element);
@@ -143,7 +143,7 @@ namespace Marten.Patching
         }
 
         public void Remove<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element,
-            RemoveAction action = RemoveAction.RemoveFirst)
+            RemoveAction action = RemoveAction.RemoveFirst) where TElement : notnull
         {
             Patch.Add("type", "remove");
             Patch.Add("value", element);
@@ -188,7 +188,7 @@ namespace Marten.Patching
             delete(toPath(expression));
         }
 
-        private void set<TValue>(string path, TValue value)
+        private void set<TValue>(string path, TValue value) where TValue : notnull
         {
             Patch.Add("type", "set");
             Patch.Add("value", value);

--- a/src/Marten/QueryableExtensions.cs
+++ b/src/Marten/QueryableExtensions.cs
@@ -7,9 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Baseline;
 using Marten.Linq;
-using Marten.Linq.Includes;
 using Npgsql;
-
+#nullable enable
 namespace Marten
 {
     public static class QueryableExtensions
@@ -22,7 +21,7 @@ namespace Marten
         /// <param name="configureExplain"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static QueryPlan Explain<T>(this IQueryable<T> queryable, Action<IConfigureExplainExpressions> configureExplain = null)
+        public static QueryPlan Explain<T>(this IQueryable<T> queryable, Action<IConfigureExplainExpressions>? configureExplain = null)
         {
             return queryable.As<IMartenQueryable<T>>().Explain(configureExplain: configureExplain);
         }
@@ -191,7 +190,7 @@ namespace Marten
             return source.Where(predicate).FirstAsync(token);
         }
 
-        public static Task<TSource> FirstOrDefaultAsync<TSource>(
+        public static Task<TSource?> FirstOrDefaultAsync<TSource>(
             this IQueryable<TSource> source,
             CancellationToken token = default(CancellationToken))
         {
@@ -201,7 +200,7 @@ namespace Marten
             return source.As<IMartenQueryable>().FirstOrDefaultAsync<TSource>(token);
         }
 
-        public static Task<TSource> FirstOrDefaultAsync<TSource>(
+        public static Task<TSource?> FirstOrDefaultAsync<TSource>(
             this IQueryable<TSource> source,
             Expression<Func<TSource, bool>> predicate,
             CancellationToken token = default(CancellationToken))
@@ -241,7 +240,7 @@ namespace Marten
             return source.Where(predicate).SingleAsync(token);
         }
 
-        public static Task<TSource> SingleOrDefaultAsync<TSource>(
+        public static Task<TSource?> SingleOrDefaultAsync<TSource>(
             this IQueryable<TSource> source,
             CancellationToken token = default(CancellationToken))
         {
@@ -251,7 +250,7 @@ namespace Marten
             return source.As<IMartenQueryable>().SingleOrDefaultAsync<TSource>(token);
         }
 
-        public static Task<TSource> SingleOrDefaultAsync<TSource>(
+        public static Task<TSource?> SingleOrDefaultAsync<TSource>(
             this IQueryable<TSource> source,
             Expression<Func<TSource, bool>> predicate,
             CancellationToken token = default(CancellationToken))

--- a/src/Marten/QueryableExtensions.cs
+++ b/src/Marten/QueryableExtensions.cs
@@ -295,7 +295,7 @@ namespace Marten
         /// <returns></returns>
         public static IMartenQueryable<T> Include<T, TInclude>(this IQueryable<T> queryable,
             Expression<Func<T, object>> idSource,
-            Action<TInclude> callback)
+            Action<TInclude> callback) where TInclude : notnull
         {
             return queryable.As<MartenLinqQueryable<T>>().Include(idSource, callback);
         }
@@ -312,7 +312,7 @@ namespace Marten
         /// <returns></returns>
         public static IMartenQueryable<T> Include<T, TInclude>(this IQueryable<T> queryable,
             Expression<Func<T, object>> idSource,
-            IList<TInclude> list)
+            IList<TInclude> list) where TInclude : notnull
         {
             return queryable.As<MartenLinqQueryable<T>>().Include(idSource, list);
         }
@@ -330,7 +330,7 @@ namespace Marten
         /// <returns></returns>
         public static IMartenQueryable<T> Include<T, TKey, TInclude>(this IQueryable<T> queryable,
             Expression<Func<T, object>> idSource,
-            IDictionary<TKey, TInclude> dictionary)
+            IDictionary<TKey, TInclude> dictionary) where TInclude : notnull where TKey : notnull
         {
             return queryable.As<MartenLinqQueryable<T>>()
                 .Include(idSource, dictionary);

--- a/src/Marten/Schema/DuplicateFieldAttribute.cs
+++ b/src/Marten/Schema/DuplicateFieldAttribute.cs
@@ -2,7 +2,7 @@ using System;
 using System.Reflection;
 using Baseline;
 using NpgsqlTypes;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>
@@ -32,7 +32,7 @@ namespace Marten.Schema
         /// <summary>
         /// Use to override the Postgresql database column type of this searchable field
         /// </summary>
-        public string PgType { get; set; } = null;
+        public string? PgType { get; set; } = null;
 
         /// <summary>
         /// Use to override the NpgsqlDbType used when querying with a parameter
@@ -48,7 +48,7 @@ namespace Marten.Schema
         /// <summary>
         /// Specify the name of the index explicity
         /// </summary>
-        public string IndexName { get; set; } = null;
+        public string? IndexName { get; set; } = null;
 
         /// <summary>
         /// Specifies the sort order of the index (only applicable to B-tree indexes)

--- a/src/Marten/Schema/ForeignKeyAttribute.cs
+++ b/src/Marten/Schema/ForeignKeyAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Reflection;
-
+#nullable enable
 namespace Marten.Schema
 {
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]

--- a/src/Marten/Schema/GinIndexedAttribute.cs
+++ b/src/Marten/Schema/GinIndexedAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Reflection;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>

--- a/src/Marten/Schema/HiLoSequenceAttribute.cs
+++ b/src/Marten/Schema/HiLoSequenceAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 using Marten.Schema.Identity.Sequences;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>
@@ -17,7 +17,7 @@ namespace Marten.Schema
             get { return _settings.MaxLo; }
         }
 
-        public string SequenceName
+        public string? SequenceName
         {
             set { _settings.SequenceName = value; }
             get { return _settings.SequenceName; }

--- a/src/Marten/Schema/IDatabaseCreationExpressions.cs
+++ b/src/Marten/Schema/IDatabaseCreationExpressions.cs
@@ -1,5 +1,5 @@
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Schema
 {
     public interface IDatabaseCreationExpressions

--- a/src/Marten/Schema/IDatabaseGenerator.cs
+++ b/src/Marten/Schema/IDatabaseGenerator.cs
@@ -1,6 +1,6 @@
 using System;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Schema
 {
     public interface IDatabaseGenerator

--- a/src/Marten/Schema/IDbObjects.cs
+++ b/src/Marten/Schema/IDbObjects.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Schema
 {
     public interface IDbObjects

--- a/src/Marten/Schema/IDocumentCleaner.cs
+++ b/src/Marten/Schema/IDocumentCleaner.cs
@@ -1,5 +1,5 @@
 using System;
-
+#nullable enable
 namespace Marten.Schema
 {
     public interface IDocumentCleaner

--- a/src/Marten/Schema/IDocumentSchema.cs
+++ b/src/Marten/Schema/IDocumentSchema.cs
@@ -1,5 +1,5 @@
 using System;
-
+#nullable enable
 namespace Marten.Schema
 {
     public interface IDocumentSchema

--- a/src/Marten/Schema/IInitialData.cs
+++ b/src/Marten/Schema/IInitialData.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Schema
 {
     public interface IInitialData

--- a/src/Marten/Schema/ITenantDatabaseCreationExpressions.cs
+++ b/src/Marten/Schema/ITenantDatabaseCreationExpressions.cs
@@ -1,6 +1,6 @@
 using System;
 using Npgsql;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>

--- a/src/Marten/Schema/Identity/CombGuidIdGeneration.cs
+++ b/src/Marten/Schema/Identity/CombGuidIdGeneration.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using LamarCodeGeneration;
 using LamarCodeGeneration.Frames;
-
+#nullable enable
 namespace Marten.Schema.Identity
 {
     /// <summary>

--- a/src/Marten/Schema/Identity/GuidIdGeneration.cs
+++ b/src/Marten/Schema/Identity/GuidIdGeneration.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using LamarCodeGeneration;
 using LamarCodeGeneration.Frames;
-
+#nullable enable
 namespace Marten.Schema.Identity
 {
     public class GuidIdGeneration: IIdGeneration

--- a/src/Marten/Schema/Identity/IIdGeneration.cs
+++ b/src/Marten/Schema/Identity/IIdGeneration.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using LamarCodeGeneration;
-
+#nullable enable
 namespace Marten.Schema.Identity
 {
     public interface IIdGeneration

--- a/src/Marten/Schema/Identity/NoOpIdGeneration.cs
+++ b/src/Marten/Schema/Identity/NoOpIdGeneration.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using LamarCodeGeneration;
 using LamarCodeGeneration.Frames;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Schema.Identity
 {
     public class NoOpIdGeneration: IIdGeneration

--- a/src/Marten/Schema/Identity/Sequences/HiLoSequence.cs
+++ b/src/Marten/Schema/Identity/Sequences/HiLoSequence.cs
@@ -5,7 +5,7 @@ using Marten.Exceptions;
 using Marten.Storage;
 using Marten.Util;
 using NpgsqlTypes;
-
+#nullable enable
 namespace Marten.Schema.Identity.Sequences
 {
     public class HiloSequence: ISequence

--- a/src/Marten/Schema/Identity/Sequences/HiloIdGeneration.cs
+++ b/src/Marten/Schema/Identity/Sequences/HiloIdGeneration.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using LamarCodeGeneration;
 using LamarCodeGeneration.Frames;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Schema.Identity.Sequences
 {
     public class HiloIdGeneration: IIdGeneration

--- a/src/Marten/Schema/Identity/Sequences/HiloSettings.cs
+++ b/src/Marten/Schema/Identity/Sequences/HiloSettings.cs
@@ -1,16 +1,17 @@
+#nullable enable
 namespace Marten.Schema.Identity.Sequences
 {
     public interface IReadOnlyHiloSettings
     {
         int MaxLo { get; }
-        string SequenceName { get; }
+        string? SequenceName { get; }
         int MaxAdvanceToNextHiAttempts { get; }
     }
 
     public class HiloSettings: IReadOnlyHiloSettings
     {
         public int MaxLo { get; set; } = 1000;
-        public string SequenceName { get; set; } = null;
+        public string? SequenceName { get; set; } = null;
         public int MaxAdvanceToNextHiAttempts { get; set; } = 30;
     }
 }

--- a/src/Marten/Schema/Identity/Sequences/ISequence.cs
+++ b/src/Marten/Schema/Identity/Sequences/ISequence.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Schema.Identity.Sequences
 {
     public interface ISequence

--- a/src/Marten/Schema/Identity/Sequences/ISequences.cs
+++ b/src/Marten/Schema/Identity/Sequences/ISequences.cs
@@ -1,6 +1,6 @@
 using System;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Schema.Identity.Sequences
 {
     public interface ISequences: IFeatureSchema

--- a/src/Marten/Schema/Identity/Sequences/IdentityKeyGeneration.cs
+++ b/src/Marten/Schema/Identity/Sequences/IdentityKeyGeneration.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using LamarCodeGeneration;
 using LamarCodeGeneration.Frames;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Schema.Identity.Sequences
 {
     public class IdentityKeyGeneration: IIdGeneration

--- a/src/Marten/Schema/Identity/Sequences/SequenceFactory.cs
+++ b/src/Marten/Schema/Identity/Sequences/SequenceFactory.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Schema.Identity.Sequences
 {
     public class SequenceFactory: ISequences

--- a/src/Marten/Schema/Identity/Sequences/SequenceFactory.cs
+++ b/src/Marten/Schema/Identity/Sequences/SequenceFactory.cs
@@ -67,7 +67,7 @@ namespace Marten.Schema.Identity.Sequences
         private string GetSequenceName(Type documentType, HiloSettings settings)
         {
             if (!string.IsNullOrEmpty(settings.SequenceName))
-                return settings.SequenceName;
+                return settings.SequenceName!;
             return documentType.Name;
         }
 

--- a/src/Marten/Schema/Identity/StringIdGeneration.cs
+++ b/src/Marten/Schema/Identity/StringIdGeneration.cs
@@ -4,7 +4,7 @@ using Baseline;
 using LamarCodeGeneration;
 using LamarCodeGeneration.Frames;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Schema.Identity
 {
     public class StringIdGeneration: IIdGeneration

--- a/src/Marten/Schema/IdentityAttribute.cs
+++ b/src/Marten/Schema/IdentityAttribute.cs
@@ -1,5 +1,5 @@
 using System;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>

--- a/src/Marten/Schema/IndexedLastModifiedAttribute.cs
+++ b/src/Marten/Schema/IndexedLastModifiedAttribute.cs
@@ -1,5 +1,5 @@
 using System;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>

--- a/src/Marten/Schema/Indexing/Unique/TenancyScope.cs
+++ b/src/Marten/Schema/Indexing/Unique/TenancyScope.cs
@@ -1,4 +1,5 @@
-﻿namespace Marten.Schema.Indexing.Unique
+#nullable enable
+namespace Marten.Schema.Indexing.Unique
 {
     public enum TenancyScope
     {

--- a/src/Marten/Schema/MartenAttribute.cs
+++ b/src/Marten/Schema/MartenAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Reflection;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>

--- a/src/Marten/Schema/MetadataAttributes.cs
+++ b/src/Marten/Schema/MetadataAttributes.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Reflection;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>

--- a/src/Marten/Schema/MultiTenantedAttribute.cs
+++ b/src/Marten/Schema/MultiTenantedAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 using Marten.Storage;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>

--- a/src/Marten/Schema/PropertySearching.cs
+++ b/src/Marten/Schema/PropertySearching.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Schema
 {
     public enum PropertySearching

--- a/src/Marten/Schema/PropertySearchingAttribute.cs
+++ b/src/Marten/Schema/PropertySearchingAttribute.cs
@@ -1,5 +1,5 @@
 using System;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>

--- a/src/Marten/Schema/SoftDeletedAttribute.cs
+++ b/src/Marten/Schema/SoftDeletedAttribute.cs
@@ -1,5 +1,5 @@
 using System;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>

--- a/src/Marten/Schema/StructuralTypedAttribute.cs
+++ b/src/Marten/Schema/StructuralTypedAttribute.cs
@@ -1,5 +1,5 @@
 using System;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>

--- a/src/Marten/Schema/UniqueIndexType.cs
+++ b/src/Marten/Schema/UniqueIndexType.cs
@@ -1,4 +1,5 @@
-﻿namespace Marten.Schema
+#nullable enable
+namespace Marten.Schema
 {
     public enum UniqueIndexType
     {

--- a/src/Marten/Schema/UseOptimisticConcurrencyAttribute.cs
+++ b/src/Marten/Schema/UseOptimisticConcurrencyAttribute.cs
@@ -1,5 +1,5 @@
 using System;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>

--- a/src/Marten/Schema/VersionAttribute.cs
+++ b/src/Marten/Schema/VersionAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Reflection;
-
+#nullable enable
 namespace Marten.Schema
 {
     /// <summary>

--- a/src/Marten/Services/BatchQuerying/BatchQueryItem.cs
+++ b/src/Marten/Services/BatchQuerying/BatchQueryItem.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Marten.Internal;
 using Marten.Linq;
 using Marten.Linq.QueryHandlers;
-
+#nullable enable
 namespace Marten.Services.BatchQuerying
 {
     public class BatchQueryItem<T>: IBatchQueryItem

--- a/src/Marten/Services/BatchQuerying/BatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQuery.cs
@@ -16,10 +16,8 @@ using Marten.Linq.QueryHandlers;
 using Marten.Schema.Arguments;
 using Marten.Storage;
 using Marten.Util;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
-using Npgsql;
 using Remotion.Linq.Clauses;
-
+#nullable enable
 namespace Marten.Services.BatchQuerying
 {
     public class BatchedQuery: IBatchedQuery, IBatchEvents
@@ -165,7 +163,7 @@ namespace Marten.Services.BatchQuerying
             return item.Result;
         }
 
-        private Task<T> load<T, TId>(TId id) where T : class
+        private Task<T> load<T, TId>(TId id) where T : class where TId : notnull
         {
             var storage = _parent.StorageFor<T>();
             if (storage is IDocumentStorage<T, TId> s)

--- a/src/Marten/Services/BatchQuerying/BatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQuery.cs
@@ -70,7 +70,7 @@ namespace Marten.Services.BatchQuerying
             return new BatchedQueryable<T>(this, _parent.Query<T>());
         }
 
-        public async Task Execute(CancellationToken token = default(CancellationToken))
+        public async Task Execute(CancellationToken token = default)
         {
             if (!_items.Any())
                 return;
@@ -204,9 +204,9 @@ namespace Marten.Services.BatchQuerying
             return addItem<T, T>(queryable, LinqConstants.FirstOperator);
         }
 
-        public Task<T> FirstOrDefault<T>(IMartenQueryable<T> queryable)
+        public Task<T?> FirstOrDefault<T>(IMartenQueryable<T> queryable)
         {
-            return addItem<T, T>(queryable, LinqConstants.FirstOrDefaultOperator);
+            return addItem<T, T?>(queryable, LinqConstants.FirstOrDefaultOperator);
         }
 
         public Task<T> Single<T>(IMartenQueryable<T> queryable)
@@ -214,9 +214,9 @@ namespace Marten.Services.BatchQuerying
             return addItem<T, T>(queryable, LinqConstants.SingleOperator);
         }
 
-        public Task<T> SingleOrDefault<T>(IMartenQueryable<T> queryable)
+        public Task<T?> SingleOrDefault<T>(IMartenQueryable<T> queryable)
         {
-            return addItem<T, T>(queryable, LinqConstants.SingleOrDefaultOperator);
+            return addItem<T, T?>(queryable, LinqConstants.SingleOrDefaultOperator);
         }
 
         public Task<TResult> Min<TResult>(IQueryable<TResult> queryable)

--- a/src/Marten/Services/BatchQuerying/BatchedQueryable.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQueryable.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Baseline;
 using Marten.Linq;
-
+#nullable enable
 namespace Marten.Services.BatchQuerying
 {
     public class BatchedQueryable<T>: IBatchedQueryable<T> where T : class
@@ -73,7 +73,7 @@ namespace Marten.Services.BatchQuerying
         }
 
         public IBatchedQueryable<T> Include<TInclude, TKey>(Expression<Func<T, object>> idSource,
-            IDictionary<TKey, TInclude> dictionary) where TInclude : class
+            IDictionary<TKey, TInclude> dictionary) where TKey: notnull where TInclude : class
         {
             _inner = _inner.Include(idSource, dictionary);
             return this;
@@ -115,12 +115,12 @@ namespace Marten.Services.BatchQuerying
             return _parent.First<T>(_inner.Where(filter).As<IMartenQueryable<T>>());
         }
 
-        public Task<T> FirstOrDefault()
+        public Task<T?> FirstOrDefault()
         {
             return _parent.FirstOrDefault<T>(_inner);
         }
 
-        public Task<T> FirstOrDefault(Expression<Func<T, bool>> filter)
+        public Task<T?> FirstOrDefault(Expression<Func<T, bool>> filter)
         {
             return _parent.FirstOrDefault<T>(_inner.Where(filter).As<IMartenQueryable<T>>());
         }
@@ -135,12 +135,12 @@ namespace Marten.Services.BatchQuerying
             return _parent.Single<T>(_inner.Where(filter).As<IMartenQueryable<T>>());
         }
 
-        public Task<T> SingleOrDefault()
+        public Task<T?> SingleOrDefault()
         {
             return _parent.SingleOrDefault<T>(_inner);
         }
 
-        public Task<T> SingleOrDefault(Expression<Func<T, bool>> filter)
+        public Task<T?> SingleOrDefault(Expression<Func<T, bool>> filter)
         {
             return _parent.SingleOrDefault<T>(_inner.Where(filter).As<IMartenQueryable<T>>());
         }

--- a/src/Marten/Services/BatchQuerying/IBatchLoadByKeys.cs
+++ b/src/Marten/Services/BatchQuerying/IBatchLoadByKeys.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-
+#nullable enable
 namespace Marten.Services.BatchQuerying
 {
     public interface IBatchLoadByKeys<TDoc> where TDoc : class

--- a/src/Marten/Services/BatchQuerying/IBatchQueryItem.cs
+++ b/src/Marten/Services/BatchQuerying/IBatchQueryItem.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Marten.Internal;
 using Marten.Linq;
 using Marten.Linq.QueryHandlers;
-
+#nullable enable
 namespace Marten.Services.BatchQuerying
 {
     public interface IBatchQueryItem

--- a/src/Marten/Services/BatchQuerying/IBatchedFetcher.cs
+++ b/src/Marten/Services/BatchQuerying/IBatchedFetcher.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
-
+#nullable enable
 namespace Marten.Services.BatchQuerying
 {
     public interface IBatchedFetcher<T>
@@ -51,9 +51,9 @@ namespace Marten.Services.BatchQuerying
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<T> FirstOrDefault();
+        Task<T?> FirstOrDefault();
 
-        Task<T> FirstOrDefault(Expression<Func<T, bool>> filter);
+        Task<T?> FirstOrDefault(Expression<Func<T, bool>> filter);
 
         /// <summary>
         /// Returns the single document of type "T" matching this query. Will
@@ -80,7 +80,7 @@ namespace Marten.Services.BatchQuerying
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<T> SingleOrDefault();
+        Task<T?> SingleOrDefault();
 
         /// <summary>
         /// Returns the single document of type "T" matching this query or null. Will
@@ -89,6 +89,6 @@ namespace Marten.Services.BatchQuerying
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<T> SingleOrDefault(Expression<Func<T, bool>> filter);
+        Task<T?> SingleOrDefault(Expression<Func<T, bool>> filter);
     }
 }

--- a/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Marten.Events;
 using Marten.Linq;
-
+#nullable enable
 namespace Marten.Services.BatchQuerying
 {
     public interface IBatchEvents

--- a/src/Marten/Services/BatchQuerying/IBatchedQueryable.cs
+++ b/src/Marten/Services/BatchQuerying/IBatchedQueryable.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Marten.Linq;
-
+#nullable enable
 namespace Marten.Services.BatchQuerying
 {
     public interface IBatchedQueryable<T>: IBatchedFetcher<T>
@@ -27,7 +27,7 @@ namespace Marten.Services.BatchQuerying
         IBatchedQueryable<T> Include<TInclude>(Expression<Func<T, object>> idSource, IList<TInclude> list) where TInclude : class;
 
         IBatchedQueryable<T> Include<TInclude, TKey>(Expression<Func<T, object>> idSource,
-            IDictionary<TKey, TInclude> dictionary) where TInclude : class;
+            IDictionary<TKey, TInclude> dictionary) where TInclude : class where TKey: notnull;
 
         Task<TResult> Min<TResult>(Expression<Func<T, TResult>> expression);
 

--- a/src/Marten/Services/BatchQuerying/TransformedBatchQueryable.cs
+++ b/src/Marten/Services/BatchQuerying/TransformedBatchQueryable.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Marten.Linq;
-
+#nullable enable
 namespace Marten.Services.BatchQuerying
 {
     public interface ITransformedBatchQueryable<TValue>
@@ -12,11 +12,11 @@ namespace Marten.Services.BatchQuerying
 
         Task<TValue> First();
 
-        Task<TValue> FirstOrDefault();
+        Task<TValue?> FirstOrDefault();
 
         Task<TValue> Single();
 
-        Task<TValue> SingleOrDefault();
+        Task<TValue?> SingleOrDefault();
     }
 
     public class TransformedBatchQueryable<TValue>: ITransformedBatchQueryable<TValue>
@@ -45,7 +45,7 @@ namespace Marten.Services.BatchQuerying
             throw new NotSupportedException();
         }
 
-        public Task<TValue> FirstOrDefault()
+        public Task<TValue?> FirstOrDefault()
         {
             return _parent.FirstOrDefault<TValue>(_inner);
         }
@@ -55,7 +55,7 @@ namespace Marten.Services.BatchQuerying
             return _parent.Single<TValue>(_inner);
         }
 
-        public Task<TValue> SingleOrDefault()
+        public Task<TValue?> SingleOrDefault()
         {
             return _parent.SingleOrDefault<TValue>(_inner);
         }

--- a/src/Marten/Services/CommandRunnerExtensions.cs
+++ b/src/Marten/Services/CommandRunnerExtensions.cs
@@ -1,11 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Baseline;
 using Marten.Linq;
-using Marten.Services.Json;
 using Marten.Util;
 using Npgsql;
-
+#nullable enable
 namespace Marten.Services
 {
     public static class CommandRunnerExtensions
@@ -16,7 +15,7 @@ namespace Marten.Services
             return runner.Execute(cmd);
         }
 
-        public static QueryPlan ExplainQuery(this IManagedConnection runner, ISerializer serializer, NpgsqlCommand cmd, Action<IConfigureExplainExpressions> configureExplain = null)
+        public static QueryPlan? ExplainQuery(this IManagedConnection runner, ISerializer serializer, NpgsqlCommand cmd, Action<IConfigureExplainExpressions>? configureExplain = null)
         {
             var config = new ConfigureExplainExpressions();
             configureExplain?.Invoke(config);
@@ -31,7 +30,7 @@ namespace Marten.Services
             if (planToReturn == null)
                 return null;
 
-            planToReturn.PlanningTime = queryPlans[0].PlanningTime;
+            planToReturn.PlanningTime = queryPlans![0].PlanningTime;
             planToReturn.ExecutionTime = queryPlans[0].ExecutionTime;
             planToReturn.Command = cmd;
 
@@ -63,13 +62,13 @@ namespace Marten.Services
             return list;
         }
 
-        public static T QueryScalar<T>(this IManagedConnection runner, string sql)
+        public static T? QueryScalar<T>(this IManagedConnection runner, string sql)
         {
             var cmd = new NpgsqlCommand(sql);
             return runner.QueryScalar<T>(cmd);
         }
 
-        public static T QueryScalar<T>(this IManagedConnection runner, NpgsqlCommand cmd)
+        public static T? QueryScalar<T>(this IManagedConnection runner, NpgsqlCommand cmd)
         {
             using var reader = runner.ExecuteReader(cmd);
 

--- a/src/Marten/Services/Diagnostics.cs
+++ b/src/Marten/Services/Diagnostics.cs
@@ -4,13 +4,13 @@ using Marten.Internal;
 using Marten.Linq;
 using Marten.Util;
 using Npgsql;
-
+#nullable enable
 namespace Marten.Services
 {
     public class Diagnostics: IDiagnostics
     {
         private readonly DocumentStore _store;
-        private Version _postgreSqlVersion;
+        private Version? _postgreSqlVersion;
 
         public Diagnostics(DocumentStore store)
         {
@@ -52,7 +52,7 @@ namespace Marten.Services
             var cmd = PreviewCommand(query);
 
             using var conn = _store.Tenancy.Default.OpenConnection();
-            return conn.ExplainQuery(_store.Serializer, cmd);
+            return conn.ExplainQuery(_store.Serializer, cmd)!;
         }
 
         /// <summary>

--- a/src/Marten/Services/IChangeSet.cs
+++ b/src/Marten/Services/IChangeSet.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Marten.Events;
 using Marten.Patching;
-
+#nullable enable
 namespace Marten.Services
 {
     public interface IChangeSet

--- a/src/Marten/Services/IDeletion.cs
+++ b/src/Marten/Services/IDeletion.cs
@@ -1,9 +1,7 @@
 using Marten.Internal.Operations;
-
+#nullable enable
 namespace Marten.Services
 {
-
-
     public interface IDeletion: IStorageOperation, NoDataReturnedCall
     {
         object Document { get; set; }

--- a/src/Marten/Services/IManagedConnection.cs
+++ b/src/Marten/Services/IManagedConnection.cs
@@ -3,7 +3,7 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
-
+#nullable enable
 namespace Marten.Services
 {
     public interface IManagedConnection: IDisposable, IAsyncDisposable

--- a/src/Marten/Services/IUnitOfWork.cs
+++ b/src/Marten/Services/IUnitOfWork.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Marten.Events;
 using Marten.Internal.Operations;
 using Marten.Patching;
-
+#nullable enable
 namespace Marten.Services
 {
     public interface IUnitOfWork

--- a/src/Marten/Services/Json/SerializerOptions.cs
+++ b/src/Marten/Services/Json/SerializerOptions.cs
@@ -1,4 +1,5 @@
-﻿namespace Marten.Services.Json
+#nullable enable
+namespace Marten.Services.Json
 {
     public class SerializerOptions
     {

--- a/src/Marten/Services/Json/SerializerType.cs
+++ b/src/Marten/Services/Json/SerializerType.cs
@@ -1,4 +1,5 @@
-﻿namespace Marten.Services.Json
+#nullable enable
+namespace Marten.Services.Json
 {
     public enum SerializerType
     {

--- a/src/Marten/Services/ManagedConnectionExtensions.cs
+++ b/src/Marten/Services/ManagedConnectionExtensions.cs
@@ -6,26 +6,26 @@ using System.Threading.Tasks;
 using Marten.Linq.Selectors;
 using Marten.Util;
 using Npgsql;
-
+#nullable enable
 namespace Marten.Services
 {
     internal static class ManagedConnectionExtensions
     {
-        internal static T LoadOne<T>(this IManagedConnection connection, NpgsqlCommand command, ISelector<T> selector)
+        internal static T? LoadOne<T>(this IManagedConnection connection, NpgsqlCommand command, ISelector<T> selector)
         {
             using (var reader = connection.ExecuteReader(command))
             {
-                if (!reader.Read()) return default(T);
+                if (!reader.Read()) return default;
 
                 return selector.Resolve(reader);
             }
         }
 
-        internal static async Task<T> LoadOneAsync<T>(this IManagedConnection connection, NpgsqlCommand command, ISelector<T> selector, CancellationToken token)
+        internal static async Task<T?> LoadOneAsync<T>(this IManagedConnection connection, NpgsqlCommand command, ISelector<T> selector, CancellationToken token)
         {
             using (var reader = await connection.ExecuteReaderAsync(command, token))
             {
-                if (!(await reader.ReadAsync(token))) return default(T);
+                if (!await reader.ReadAsync(token)) return default;
 
                 return await selector.ResolveAsync(reader, token);
             }
@@ -35,7 +35,7 @@ namespace Marten.Services
         {
             using (var reader = (NpgsqlDataReader)await connection.ExecuteReaderAsync(command, token))
             {
-                if (!(await reader.ReadAsync(token))) return false;
+                if (!await reader.ReadAsync(token)) return false;
 
                 var ordinal = reader.FieldCount == 1 ? 0 : reader.GetOrdinal("data");
 
@@ -65,7 +65,7 @@ namespace Marten.Services
 
         internal static async Task StreamMany(this IManagedConnection connection, NpgsqlCommand command, Stream stream, CancellationToken token)
         {
-            using (var reader = (NpgsqlDataReader)await connection.ExecuteReaderAsync(command, token))
+            await using (var reader = (NpgsqlDataReader)await connection.ExecuteReaderAsync(command, token))
             {
                 var ordinal = reader.FieldCount == 1 ? 0 : reader.GetOrdinal("data");
 

--- a/src/Marten/Services/SessionOptions.cs
+++ b/src/Marten/Services/SessionOptions.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Marten.Storage;
 using Npgsql;
-
+#nullable enable
 namespace Marten.Services
 {
     public sealed class SessionOptions
@@ -39,12 +39,12 @@ namespace Marten.Services
         /// <summary>
         /// Optional mechanism to open a session with an existing connection
         /// </summary>
-        public NpgsqlConnection Connection { get; set; }
+        public NpgsqlConnection? Connection { get; set; }
 
         /// <summary>
         /// Optional mechanism to open a session with an existing transaction
         /// </summary>
-        public NpgsqlTransaction Transaction { get; set; }
+        public NpgsqlTransaction? Transaction { get; set; }
 
         /// <summary>
         /// Default is true. If false, Marten will issue commands on IDocumentSession.SaveChanges/SaveChangesAsync,
@@ -80,7 +80,7 @@ namespace Marten.Services
                 if (value)
                 {
                     OwnsTransactionLifecycle = false;
-                    DotNetTransaction = System.Transactions.Transaction.Current;
+                    DotNetTransaction = System.Transactions.Transaction.Current!;
                 }
 
                 _enlistInAmbientTransactionScope = value;
@@ -90,7 +90,7 @@ namespace Marten.Services
         /// <summary>
         /// Enlist the session in this transaction
         /// </summary>
-        public System.Transactions.Transaction DotNetTransaction { get; set; }
+        public System.Transactions.Transaction? DotNetTransaction { get; set; }
 
         /// <summary>
         /// Open a session that enlists in the current, ambient TransactionScope

--- a/src/Marten/Storage/DefaultTenancy.cs
+++ b/src/Marten/Storage/DefaultTenancy.cs
@@ -53,7 +53,7 @@ namespace Marten.Storage
 
         public string TenantId { get; }
 
-        public IDocumentStorage<T> StorageFor<T>()
+        public IDocumentStorage<T> StorageFor<T>() where T : notnull
         {
             return _inner.StorageFor<T>();
         }

--- a/src/Marten/Storage/DefaultTenancy.cs
+++ b/src/Marten/Storage/DefaultTenancy.cs
@@ -11,7 +11,7 @@ using Marten.Schema.Identity.Sequences;
 using Marten.Services;
 using Marten.Transforms;
 using Npgsql;
-
+#nullable enable
 namespace Marten.Storage
 {
     public class DefaultTenancy: Tenancy, ITenancy

--- a/src/Marten/Storage/IFeatureSchema.cs
+++ b/src/Marten/Storage/IFeatureSchema.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using Marten.Exceptions;
 using Marten.Util;
 using Npgsql;
-
+#nullable enable
 namespace Marten.Storage
 {
     #region sample_IFeatureSchema

--- a/src/Marten/Storage/ITenant.cs
+++ b/src/Marten/Storage/ITenant.cs
@@ -10,7 +10,7 @@ using Marten.Schema.Identity.Sequences;
 using Marten.Services;
 using Marten.Transforms;
 using Npgsql;
-
+#nullable enable
 namespace Marten.Storage
 {
     public interface ITenantStorage
@@ -47,7 +47,7 @@ namespace Marten.Storage
         /// </summary>
         /// <param name="documentType"></param>
         /// <returns></returns>
-        IDocumentStorage<T> StorageFor<T>();
+        IDocumentStorage<T> StorageFor<T>() where T : notnull;
 
         /// <summary>
         /// Used to create new Hilo sequences

--- a/src/Marten/Storage/StorageFeatures.cs
+++ b/src/Marten/Storage/StorageFeatures.cs
@@ -8,7 +8,7 @@ using Marten.Events;
 using Marten.Exceptions;
 using Marten.Schema;
 using Marten.Util;
-
+#nullable enable
 namespace Marten.Storage
 {
     public class StorageFeatures

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -20,7 +20,7 @@ using Marten.Storage;
 using Marten.Transforms;
 using Marten.Util;
 using Npgsql;
-
+#nullable enable
 namespace Marten
 {
     /// <summary>
@@ -56,7 +56,7 @@ namespace Marten
         private string _databaseSchemaName = DefaultDatabaseSchemaName;
 
         private IMartenLogger _logger = new NulloMartenLogger();
-        private ISerializer _serializer;
+        private ISerializer? _serializer;
 
 
         private IRetryPolicy _retryPolicy = new NulloRetryPolicy();
@@ -76,7 +76,7 @@ namespace Marten
             CreateDatabases = configure ?? throw new ArgumentNullException(nameof(configure));
         }
 
-        internal Action<IDatabaseCreationExpressions> CreateDatabases { get; set; }
+        internal Action<IDatabaseCreationExpressions>? CreateDatabases { get; set; }
 
         internal IProviderGraph Providers { get; }
 
@@ -103,7 +103,7 @@ namespace Marten
         public string DatabaseSchemaName
         {
             get { return _databaseSchemaName; }
-            set { _databaseSchemaName = value?.ToLowerInvariant(); }
+            set { _databaseSchemaName = value.ToLowerInvariant(); }
         }
 
         /// <summary>
@@ -258,7 +258,7 @@ namespace Marten
 
         public IDocumentType FindOrResolveDocumentType(Type documentType)
         {
-            return Storage.FindMapping(documentType).Root as IDocumentType;
+            return (Storage.FindMapping(documentType).Root as IDocumentType)!;
         }
 
         public void RetryPolicy(IRetryPolicy retryPolicy)
@@ -316,7 +316,7 @@ namespace Marten
             }
         }
 
-        public ITenancy Tenancy { get; set; }
+        public ITenancy Tenancy { get; set; } = null!;
 
         private readonly IList<IDocumentPolicy> _policies = new List<IDocumentPolicy>
         {

--- a/src/Marten/Util/CommandBuilder.cs
+++ b/src/Marten/Util/CommandBuilder.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Text;
 using Npgsql;
 using NpgsqlTypes;
-
+#nullable enable
 namespace Marten.Util
 {
     public class CommandBuilder: IDisposable

--- a/src/Marten/Util/CommandExtensions.cs
+++ b/src/Marten/Util/CommandExtensions.cs
@@ -11,7 +11,7 @@ using Marten.Schema;
 using Marten.Schema.Arguments;
 using Npgsql;
 using NpgsqlTypes;
-
+#nullable enable
 namespace Marten.Util
 {
     public static class CommandExtensions
@@ -105,7 +105,7 @@ namespace Marten.Util
             return list;
         }
 
-        public static void AddParameters(this NpgsqlCommand command, object parameters)
+        public static void AddParameters(this NpgsqlCommand command, object? parameters)
         {
             if (parameters == null)
                 return;
@@ -165,7 +165,7 @@ namespace Marten.Util
             return command;
         }
 
-        public static NpgsqlCommand With(this NpgsqlCommand command, string name, string value)
+        public static NpgsqlCommand With(this NpgsqlCommand command, string name, string? value)
         {
             var parameter = command.CreateParameter();
             parameter.ParameterName = name;

--- a/src/Marten/Util/New.cs
+++ b/src/Marten/Util/New.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Serialization;
-
+#nullable enable
 namespace Marten.Util
 {
     public static class New<T>

--- a/src/Marten/Util/StreamExtensions.cs
+++ b/src/Marten/Util/StreamExtensions.cs
@@ -1,9 +1,9 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
+#nullable enable
 namespace Marten.Util
 {
     public static class StreamExtensions

--- a/src/Marten/Util/StringExtensions.cs
+++ b/src/Marten/Util/StringExtensions.cs
@@ -1,7 +1,7 @@
 using System;
 using Newtonsoft.Json.Serialization;
 using Npgsql;
-
+#nullable enable
 namespace Marten.Util
 {
     public static class StringExtensionMethods

--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -7,7 +7,7 @@ using Baseline;
 using Npgsql;
 using Npgsql.TypeMapping;
 using NpgsqlTypes;
-
+#nullable enable
 namespace Marten.Util
 {
     public static class TypeMappings
@@ -55,7 +55,7 @@ namespace Marten.Util
         // Lazily retrieve the CLR type to NpgsqlDbType and PgTypeName mapping from exposed INpgsqlTypeMapper.Mappings.
         // This is lazily calculated instead of precached because it allows consuming code to register
         // custom npgsql mappings prior to execution.
-        private static string ResolvePgType(Type type)
+        private static string? ResolvePgType(Type type)
         {
             if (PgTypeMemo.Value.TryFind(type, out var value))
                 return value;
@@ -91,13 +91,13 @@ namespace Marten.Util
             return values;
         }
 
-        private static NpgsqlTypeMapping GetTypeMapping(Type type)
+        private static NpgsqlTypeMapping? GetTypeMapping(Type type)
             => NpgsqlConnection
                 .GlobalTypeMapper
                 .Mappings
                 .FirstOrDefault(mapping => mapping.ClrTypes.Contains(type));
 
-        private static NpgsqlTypeMapping GetTypeMapping(NpgsqlDbType type)
+        private static NpgsqlTypeMapping? GetTypeMapping(NpgsqlDbType type)
             => NpgsqlConnection
                 .GlobalTypeMapper
                 .Mappings
@@ -210,7 +210,7 @@ namespace Marten.Util
             throw new NotSupportedException("Can't infer NpgsqlDbType for type " + type);
         }
 
-        public static NpgsqlDbType? TryGetDbType(Type type)
+        public static NpgsqlDbType? TryGetDbType(Type? type)
         {
             if (type == null || !determineNpgsqlDbType(type, out var dbType))
                 return null;

--- a/src/Marten/Util/TypeMappings.cs
+++ b/src/Marten/Util/TypeMappings.cs
@@ -86,9 +86,9 @@ namespace Marten.Util
 
             values = GetTypeMapping(npgsqlDbType)?.ClrTypes;
 
-            TypeMemo.Swap(d => d.AddOrUpdate(npgsqlDbType, values));
+            TypeMemo.Swap(d => d.AddOrUpdate(npgsqlDbType, values!));
 
-            return values;
+            return values!;
         }
 
         private static NpgsqlTypeMapping? GetTypeMapping(Type type)
@@ -290,7 +290,7 @@ namespace Marten.Util
 
             if (memberType.IsArray)
             {
-                return GetPgType(memberType.GetElementType(), enumStyle) + "[]";
+                return GetPgType(memberType.GetElementType()!, enumStyle) + "[]";
             }
 
             if (memberType.IsNullable())


### PR DESCRIPTION
This first PR mostly targets DocumentSession + Queryable extensions, as well as few spots that were simple to annotate. If the Marten maintainers are fine with this direction I'll continue into further areas. It might be valuable to consider any additional generic constraints that could be added as part of this work.

Some example projects have had NRTs enabled in order to serve as a test bed when required.

The build will fail for the 3.1 tests until the pipeline is updated to build with the .NET 5 SDK, as unconstrained nullable generics from C# 9 are required.

