### PR TITLE
Fixed Inline Projection for type with a private constructor

### DIFF
--- a/src/Marten.Testing/Events/Projections/QuestMonsters.cs
+++ b/src/Marten.Testing/Events/Projections/QuestMonsters.cs
@@ -82,6 +82,35 @@ namespace Marten.Testing.Events.Projections
         }
     }
 
+    public class QuestMonstersWithPrivateConstructor: IMonstersView
+    {
+        public Guid Id { get; protected set; }
+
+        private readonly IList<string> _monsters = new List<string>();
+
+        private QuestMonstersWithPrivateConstructor()
+        {
+
+        }
+
+        public static QuestMonstersWithPrivateConstructor Init() => new QuestMonstersWithPrivateConstructor();
+
+        public void Apply(MonsterSlayed slayed)
+        {
+            _monsters.Fill(slayed.Name);
+        }
+
+        public string[] Monsters
+        {
+            get { return _monsters.ToArray(); }
+            set
+            {
+                _monsters.Clear();
+                _monsters.AddRange(value);
+            }
+        }
+    }
+
     public class QuestMonstersWithBaseClass: Root, IMonstersView
     {
         private readonly IList<string> _monsters = new List<string>();

--- a/src/Marten.Testing/Events/Projections/inline_aggregation_with_private_constructor.cs
+++ b/src/Marten.Testing/Events/Projections/inline_aggregation_with_private_constructor.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using Marten.Services;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Events.Projections
+{
+    public class inline_aggregation_with_private_constructor: IntegrationContext
+    {
+        public inline_aggregation_with_private_constructor(DefaultStoreFixture fixture) : base(fixture)
+        {
+            StoreOptions(_ =>
+            {
+                _.AutoCreateSchemaObjects = AutoCreate.All;
+                _.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.NonPublicSetters);
+                _.Events.Projections.SelfAggregate<QuestMonstersWithPrivateConstructor>();
+            });
+        }
+
+        [Fact]
+        public void run_inline_aggregation_with_private_constructor()
+        {
+            var slayed1 = new MonsterSlayed { Name = "Troll" };
+            var slayed2 = new MonsterSlayed { Name = "Dragon" };
+            var streamId = theSession.Events
+                .StartStream<QuestMonstersWithPrivateConstructor>(slayed1, slayed2).Id;
+
+            theSession.SaveChanges();
+
+            var loadedView = theSession.Load<QuestMonstersWithPrivateConstructor>(streamId);
+
+            loadedView.Id.ShouldBe(streamId);
+            loadedView.Monsters.ShouldHaveTheSameElementsAs("Troll", "Dragon");
+
+            var queriedView = theSession.Query<QuestMonstersWithPrivateConstructor>()
+                .Single(x => x.Id == streamId);
+
+            queriedView.Id.ShouldBe(streamId);
+            queriedView.Monsters.ShouldHaveTheSameElementsAs("Troll", "Dragon");
+        }
+    }
+}

--- a/src/Marten/Events/CodeGeneration/AggregateEventProcessingFrame.cs
+++ b/src/Marten/Events/CodeGeneration/AggregateEventProcessingFrame.cs
@@ -74,15 +74,18 @@ namespace Marten.Events.CodeGeneration
                 writer.Write("return null;");
             }
 
-            CreationFrame?.GenerateCode(method, writer);
+
+            if (CreationFrame != null)
+            {
+                CreationFrame.GenerateCode(method, writer);
+            }
+            else
+            {
+                writer.Write($"{Aggregate.Usage} ??= Create({SpecificEvent.Usage}, session);");
+            }
 
             if (Apply != null)
             {
-                if (AggregateType.GetConstructors().Any(x => !x.GetParameters().Any()))
-                {
-                    writer.Write($"{Aggregate.Usage} ??= new {AggregateType.FullNameInCode()}();");
-                }
-
                 Apply.GenerateCode(method, writer);
             }
 

--- a/src/Marten/Events/CodeGeneration/AggregateEventProcessingFrame.cs
+++ b/src/Marten/Events/CodeGeneration/AggregateEventProcessingFrame.cs
@@ -79,14 +79,20 @@ namespace Marten.Events.CodeGeneration
 
             if (Apply != null)
             {
-                var defaultConstructor = AggregateType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic).SingleOrDefault(x => !x.GetParameters().Any());
-                if (defaultConstructor?.IsPublic == true)
+                if (CreationFrame == null)
                 {
-                    writer.Write($"{Aggregate.Usage} ??= new {AggregateType.FullNameInCode()}();");
-                }
-                else if (defaultConstructor?.IsPublic == false)
-                {
-                    writer.Write($"{Aggregate.Usage} ??= AggregateBuilder();");
+                    var defaultConstructor = AggregateType.GetConstructor(
+                        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, Type.EmptyTypes,
+                        null);
+
+                    if (defaultConstructor?.IsPublic == true)
+                    {
+                        writer.Write($"{Aggregate.Usage} ??= new {AggregateType.FullNameInCode()}();");
+                    }
+                    else if (defaultConstructor?.IsPublic == false)
+                    {
+                        writer.Write($"{Aggregate.Usage} ??= AggregateBuilder();");
+                    }
                 }
 
                 Apply.GenerateCode(method, writer);

--- a/src/Marten/Events/CodeGeneration/AggregateEventProcessingFrame.cs
+++ b/src/Marten/Events/CodeGeneration/AggregateEventProcessingFrame.cs
@@ -93,6 +93,12 @@ namespace Marten.Events.CodeGeneration
                     {
                         writer.Write($"{Aggregate.Usage} ??= AggregateBuilder();");
                     }
+                    else
+                    {
+                        var errorMessage = $"Projection for {AggregateType.FullName} should either have the Create Method or Constructor for event of type {SpecificEvent.VariableType.FullName}, or {AggregateType.FullName} should have a Default Constructor.";
+
+                        writer.Write($"if({Aggregate.Usage} == default) throw new ArgumentException(\"{errorMessage}\");");
+                    }
                 }
 
                 Apply.GenerateCode(method, writer);

--- a/src/Marten/Events/CodeGeneration/CreateMethodCollection.cs
+++ b/src/Marten/Events/CodeGeneration/CreateMethodCollection.cs
@@ -26,7 +26,6 @@ namespace Marten.Events.CodeGeneration
             _validReturnTypes.Fill(aggregateType);
             _validReturnTypes.Add(typeof(Task<>).MakeGenericType(aggregateType));
 
-
             var constructors = aggregateType
                 .GetConstructors()
                 .Where(x => x.GetParameters().Length == 1);
@@ -66,7 +65,6 @@ namespace Marten.Events.CodeGeneration
                 {IfStyle = IfStyle.None});
 
         }
-
 
         public override IEventHandlingFrame CreateEventTypeHandler(Type aggregateType,
             DocumentMapping aggregateMapping, MethodSlot slot)


### PR DESCRIPTION
The inline projection was generating the proper Create method, but this method was not used at all. It was working fine for the case with a public constructor, as it was used directly instead of the Create method. 

Fixed by using the create method.