### PR TITLE
Cleanup `ConfigureAwait(false)` from unit tests

### DIFF
--- a/src/Marten.Schema.Testing/Hierarchies/end_to_end_document_hierarchy_usage_Tests.cs
+++ b/src/Marten.Schema.Testing/Hierarchies/end_to_end_document_hierarchy_usage_Tests.cs
@@ -145,14 +145,14 @@ namespace Marten.Schema.Testing.Hierarchies
             theSession.Store(admin1);
             theSession.SaveChanges();
 
-            (await theSession.LoadAsync<User>(admin1.Id).ConfigureAwait(false)).ShouldBeTheSameAs(admin1);
-            (await theSession.LoadAsync<AdminUser>(admin1.Id).ConfigureAwait(false)).ShouldBeTheSameAs(admin1);
+            (await theSession.LoadAsync<User>(admin1.Id)).ShouldBeTheSameAs(admin1);
+            (await theSession.LoadAsync<AdminUser>(admin1.Id)).ShouldBeTheSameAs(admin1);
 
             using (var session = theStore.QuerySession())
             {
-                (await session.LoadAsync<AdminUser>(admin1.Id).ConfigureAwait(false)).ShouldNotBeTheSameAs(admin1)
+                (await session.LoadAsync<AdminUser>(admin1.Id)).ShouldNotBeTheSameAs(admin1)
                     .ShouldNotBeNull();
-                (await session.LoadAsync<User>(admin1.Id).ConfigureAwait(false)).ShouldNotBeTheSameAs(admin1)
+                (await session.LoadAsync<User>(admin1.Id)).ShouldNotBeTheSameAs(admin1)
                     .ShouldNotBeNull();
             }
         }
@@ -224,7 +224,7 @@ namespace Marten.Schema.Testing.Hierarchies
         [Fact]
         public async Task load_by_id_keys_from_base_class_resolved_from_identity_map_async()
         {
-            var users = await theSession.LoadManyAsync<AdminUser>(admin1.Id, admin2.Id).ConfigureAwait(false);
+            var users = await theSession.LoadManyAsync<AdminUser>(admin1.Id, admin2.Id);
             users.ShouldHaveTheSameElementsAs(admin1, admin2);
         }
 
@@ -246,7 +246,7 @@ namespace Marten.Schema.Testing.Hierarchies
         {
             using (var session = theStore.QuerySession())
             {
-                var users = await session.LoadManyAsync<User>(admin1.Id, super1.Id, user1.Id).ConfigureAwait(false);
+                var users = await session.LoadManyAsync<User>(admin1.Id, super1.Id, user1.Id);
 
                 users.OrderBy(x => x.FirstName)
                     .Select(x => x.Id)
@@ -264,7 +264,7 @@ namespace Marten.Schema.Testing.Hierarchies
         [Fact]
         public async Task load_by_id_with_mixed_results_from_identity_map_async()
         {
-            var users = await theSession.LoadManyAsync<User>(admin1.Id, super1.Id, user1.Id).ConfigureAwait(false);
+            var users = await theSession.LoadManyAsync<User>(admin1.Id, super1.Id, user1.Id);
             users.OrderBy(x => x.FirstName).ShouldHaveTheSameElementsAs(admin1, super1, user1);
         }
 

--- a/src/Marten.Testing/Acceptance/optimistic_concurrency.cs
+++ b/src/Marten.Testing/Acceptance/optimistic_concurrency.cs
@@ -58,9 +58,9 @@ namespace Marten.Testing.Acceptance
             {
                 var coffeeShop = new CoffeeShop();
                 session.Store(coffeeShop);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
 
-                SpecificationExtensions.ShouldNotBeNull((await session.LoadAsync<CoffeeShop>(coffeeShop.Id).ConfigureAwait(false)));
+                SpecificationExtensions.ShouldNotBeNull((await session.LoadAsync<CoffeeShop>(coffeeShop.Id)));
             }
         }
 
@@ -109,21 +109,21 @@ namespace Marten.Testing.Acceptance
             using (var session = theStore.OpenSession())
             {
                 session.Store(doc1);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             using (var session = theStore.OpenSession())
             {
-                var doc2 = await session.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false);
+                var doc2 = await session.LoadAsync<CoffeeShop>(doc1.Id);
                 doc2.Name = "Mozart's";
 
                 session.Store(doc2);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             using (var session = theStore.QuerySession())
             {
-                (await session.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false)).Name.ShouldBe("Mozart's");
+                (await session.LoadAsync<CoffeeShop>(doc1.Id)).Name.ShouldBe("Mozart's");
             }
         }
 
@@ -224,14 +224,14 @@ namespace Marten.Testing.Acceptance
             using (var session = theStore.OpenSession())
             {
                 session.Store(doc1);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             var session1 = theStore.DirtyTrackedSession();
             var session2 = theStore.DirtyTrackedSession();
 
-            var session1Copy = await session1.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false);
-            var session2Copy = await session2.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false);
+            var session1Copy = await session1.LoadAsync<CoffeeShop>(doc1.Id);
+            var session2Copy = await session2.LoadAsync<CoffeeShop>(doc1.Id);
 
             try
             {
@@ -239,11 +239,11 @@ namespace Marten.Testing.Acceptance
                 session2Copy.Name = "Dominican Joe's";
 
                 // Should go through just fine
-                await session2.SaveChangesAsync().ConfigureAwait(false);
+                await session2.SaveChangesAsync();
 
                 var ex = await Exception<ConcurrencyException>.ShouldBeThrownByAsync(async () =>
                 {
-                    await session1.SaveChangesAsync().ConfigureAwait(false);
+                    await session1.SaveChangesAsync();
                 });
 
                 ex.Message.ShouldBe($"Optimistic concurrency check failed for {typeof(CoffeeShop).FullName} #{doc1.Id}");
@@ -256,7 +256,7 @@ namespace Marten.Testing.Acceptance
 
             using (var query = theStore.QuerySession())
             {
-                (await query.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false)).Name.ShouldBe("Dominican Joe's");
+                (await query.LoadAsync<CoffeeShop>(doc1.Id)).Name.ShouldBe("Dominican Joe's");
             }
         }
 
@@ -295,24 +295,24 @@ namespace Marten.Testing.Acceptance
             using (var session = theStore.OpenSession())
             {
                 session.Store(doc1);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             using (var session = theStore.DirtyTrackedSession())
             {
-                var doc2 = await session.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false);
+                var doc2 = await session.LoadAsync<CoffeeShop>(doc1.Id);
                 doc2.Name = "Mozart's";
 
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
 
                 doc2.Name = "Cafe Medici";
 
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             using (var query = theStore.QuerySession())
             {
-                (await query.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false)).Name.ShouldBe("Cafe Medici");
+                (await query.LoadAsync<CoffeeShop>(doc1.Id)).Name.ShouldBe("Cafe Medici");
             }
         }
 
@@ -355,24 +355,24 @@ namespace Marten.Testing.Acceptance
             using (var session = theStore.OpenSession())
             {
                 session.Store(doc1, doc2);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             using (var session = theStore.DirtyTrackedSession())
             {
-                var doc12 = await session.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false);
+                var doc12 = await session.LoadAsync<CoffeeShop>(doc1.Id);
                 doc12.Name = "Mozart's";
 
-                var doc22 = await session.LoadAsync<CoffeeShop>(doc2.Id).ConfigureAwait(false);
+                var doc22 = await session.LoadAsync<CoffeeShop>(doc2.Id);
                 doc22.Name = "Dominican Joe's";
 
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             using (var query = theStore.QuerySession())
             {
-                (await query.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false)).Name.ShouldBe("Mozart's");
-                (await query.LoadAsync<CoffeeShop>(doc2.Id).ConfigureAwait(false)).Name.ShouldBe("Dominican Joe's");
+                (await query.LoadAsync<CoffeeShop>(doc1.Id)).Name.ShouldBe("Mozart's");
+                (await query.LoadAsync<CoffeeShop>(doc2.Id)).Name.ShouldBe("Dominican Joe's");
             }
         }
 
@@ -422,28 +422,28 @@ namespace Marten.Testing.Acceptance
             using (var session = theStore.OpenSession())
             {
                 session.Store(doc1, doc2);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             using (var session = theStore.DirtyTrackedSession())
             {
-                var doc12 = await session.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false);
+                var doc12 = await session.LoadAsync<CoffeeShop>(doc1.Id);
                 doc12.Name = "Mozart's";
 
-                var doc22 = await session.LoadAsync<CoffeeShop>(doc2.Id).ConfigureAwait(false);
+                var doc22 = await session.LoadAsync<CoffeeShop>(doc2.Id);
                 doc22.Name = "Dominican Joe's";
 
                 using (var other = theStore.DirtyTrackedSession())
                 {
-                    (await other.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false)).Name = "Genuine Joe's";
-                    (await other.LoadAsync<CoffeeShop>(doc2.Id).ConfigureAwait(false)).Name = "Cafe Medici";
+                    (await other.LoadAsync<CoffeeShop>(doc1.Id)).Name = "Genuine Joe's";
+                    (await other.LoadAsync<CoffeeShop>(doc2.Id)).Name = "Cafe Medici";
 
-                    await other.SaveChangesAsync().ConfigureAwait(false);
+                    await other.SaveChangesAsync();
                 }
 
                 var ex = await Exception<AggregateException>.ShouldBeThrownByAsync(async () =>
                 {
-                    await session.SaveChangesAsync().ConfigureAwait(false);
+                    await session.SaveChangesAsync();
                 });
 
                 ex.InnerExceptions.OfType<ConcurrencyException>().Count().ShouldBe(2);
@@ -491,13 +491,13 @@ namespace Marten.Testing.Acceptance
             using (var session = theStore.OpenSession())
             {
                 session.Store(doc1);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             DocumentMetadata metadata;
             using (var session = theStore.QuerySession())
             {
-                metadata = await session.MetadataForAsync(doc1).ConfigureAwait(false);
+                metadata = await session.MetadataForAsync(doc1);
             }
 
             using (var session = theStore.OpenSession())
@@ -505,12 +505,12 @@ namespace Marten.Testing.Acceptance
                 doc1.Name = "Mozart's";
                 session.Store(doc1, metadata.CurrentVersion);
 
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             using (var query = theStore.QuerySession())
             {
-                (await query.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false)).Name
+                (await query.LoadAsync<CoffeeShop>(doc1.Id)).Name
                     .ShouldBe("Mozart's");
             }
         }
@@ -546,7 +546,7 @@ namespace Marten.Testing.Acceptance
             using (var session = theStore.OpenSession())
             {
                 session.Store(doc1);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             using (var session = theStore.OpenSession())
@@ -558,7 +558,7 @@ namespace Marten.Testing.Acceptance
 
                 await Exception<ConcurrencyException>.ShouldBeThrownByAsync(async () =>
                 {
-                    await session.SaveChangesAsync().ConfigureAwait(false);
+                    await session.SaveChangesAsync();
                 });
             }
         }
@@ -574,7 +574,7 @@ namespace Marten.Testing.Acceptance
             {
                 session.Store(emp1);
                 session.Store(doc1);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             using (var session = theStore.OpenSession(tracking: DocumentTracking.DirtyTracking))
@@ -585,7 +585,7 @@ namespace Marten.Testing.Acceptance
                 doc.Employees.Remove(emp.Id);
                 session.Delete(emp);
 
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
         }
 

--- a/src/Marten.Testing/Acceptance/optimistic_concurrency_with_subclass_hierarchies.cs
+++ b/src/Marten.Testing/Acceptance/optimistic_concurrency_with_subclass_hierarchies.cs
@@ -40,9 +40,9 @@ namespace Marten.Testing.Acceptance
             {
                 var coffeeShop = new CoffeeShop();
                 session.Store(coffeeShop);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
 
-                SpecificationExtensions.ShouldNotBeNull((await session.LoadAsync<CoffeeShop>(coffeeShop.Id).ConfigureAwait(false)));
+                SpecificationExtensions.ShouldNotBeNull((await session.LoadAsync<CoffeeShop>(coffeeShop.Id)));
             }
         }
 
@@ -78,21 +78,21 @@ namespace Marten.Testing.Acceptance
             using (var session = theStore.OpenSession())
             {
                 session.Store(doc1);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             using (var session = theStore.OpenSession())
             {
-                var doc2 = await session.LoadAsync<Shop>(doc1.Id).ConfigureAwait(false);
+                var doc2 = await session.LoadAsync<Shop>(doc1.Id);
                 doc2.As<CoffeeShop>().Name = "Mozart's";
 
                 session.Store(doc2);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             using (var session = theStore.QuerySession())
             {
-                (await session.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false)).Name.ShouldBe("Mozart's");
+                (await session.LoadAsync<CoffeeShop>(doc1.Id)).Name.ShouldBe("Mozart's");
             }
         }
 
@@ -147,14 +147,14 @@ namespace Marten.Testing.Acceptance
             using (var session = theStore.OpenSession())
             {
                 session.Store(doc1);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             var session1 = theStore.DirtyTrackedSession();
             var session2 = theStore.DirtyTrackedSession();
 
-            var session1Copy = await session1.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false);
-            var session2Copy = await session2.LoadAsync<CoffeeShop>(doc1.Id).ConfigureAwait(false);
+            var session1Copy = await session1.LoadAsync<CoffeeShop>(doc1.Id);
+            var session2Copy = await session2.LoadAsync<CoffeeShop>(doc1.Id);
 
             try
             {
@@ -162,11 +162,11 @@ namespace Marten.Testing.Acceptance
                 session2Copy.Name = "Dominican Joe's";
 
                 // Should go through just fine
-                await session2.SaveChangesAsync().ConfigureAwait(false);
+                await session2.SaveChangesAsync();
 
                 var ex = await Exception<ConcurrencyException>.ShouldBeThrownByAsync(async () =>
                 {
-                    await session1.SaveChangesAsync().ConfigureAwait(false);
+                    await session1.SaveChangesAsync();
                 });
 
                 ex.Message.ShouldBe($"Optimistic concurrency check failed for {typeof(Shop).FullName} #{doc1.Id}");

--- a/src/Marten.Testing/Acceptance/select_with_transformation.cs
+++ b/src/Marten.Testing/Acceptance/select_with_transformation.cs
@@ -96,11 +96,11 @@ namespace Marten.Testing.Acceptance
             using (var session = theStore.OpenSession())
             {
                 session.Store(user);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
 
                 var json = await session.Query<User>()
                     .Where(x => x.Id == user.Id)
-                    .TransformToJson("get_fullname").SingleAsync().ConfigureAwait(false);
+                    .TransformToJson("get_fullname").SingleAsync();
 
                 json.ShouldBe("{\"fullname\": \"Eric Berry\"}");
             }
@@ -140,11 +140,11 @@ namespace Marten.Testing.Acceptance
             using (var session = theStore.OpenSession())
             {
                 session.Store(user);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
 
                 var view = await session.Query<User>()
                     .Where(x => x.Id == user.Id)
-                    .TransformTo<FullNameView>("get_fullname").SingleAsync().ConfigureAwait(false);
+                    .TransformTo<FullNameView>("get_fullname").SingleAsync();
 
                 view.fullname.ShouldBe("Eric Berry");
             }

--- a/src/Marten.Testing/Bugs/Bug_339_async_cache_problem.cs
+++ b/src/Marten.Testing/Bugs/Bug_339_async_cache_problem.cs
@@ -21,8 +21,8 @@ namespace Marten.Testing.Bugs
 
             using (var session2 = theStore.DirtyTrackedSession())
             {
-                var user12 = await session2.LoadAsync<User>(user1.Id).ConfigureAwait(false);
-                var breakThings = await session2.LoadAsync<User>(user1.Id).ConfigureAwait(false);
+                var user12 = await session2.LoadAsync<User>(user1.Id);
+                var breakThings = await session2.LoadAsync<User>(user1.Id);
             }
         }
 

--- a/src/Marten.Testing/Bugs/Bug_504_Take_Skip_before_Select_not_applying_sort_or_where_clause.cs
+++ b/src/Marten.Testing/Bugs/Bug_504_Take_Skip_before_Select_not_applying_sort_or_where_clause.cs
@@ -36,7 +36,7 @@ namespace Marten.Testing.Bugs
 
             theSession.Store(targets);
 
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             QueryStatistics stats;
 
@@ -60,7 +60,7 @@ namespace Marten.Testing.Bugs
 
             theSession.Store(targets);
 
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             QueryStatistics stats;
 

--- a/src/Marten.Testing/CodeTracker/GithubDataRecorder.cs
+++ b/src/Marten.Testing/CodeTracker/GithubDataRecorder.cs
@@ -18,11 +18,11 @@ namespace Marten.Testing.CodeTracker
         {
             Debug.WriteLine($"Starting to fetch {organization}/{projectName}");
 
-            var repository = await _client.Repository.Get(organization, projectName).ConfigureAwait(false);
+            var repository = await _client.Repository.Get(organization, projectName);
 
             var project = new GithubProject(organization, projectName, repository.CreatedAt);
 
-            var issues = await _client.Issue.GetAllForRepository(organization, projectName).ConfigureAwait(false);
+            var issues = await _client.Issue.GetAllForRepository(organization, projectName);
 
             foreach (var issue in issues)
             {
@@ -31,12 +31,12 @@ namespace Marten.Testing.CodeTracker
 
             Debug.WriteLine($"Done with issues for {organization}/{projectName}");
 
-            var commits = await _client.Repository.Commit.GetAll(organization, projectName, new ApiOptions {PageSize = 100, PageCount = 10}).ConfigureAwait(false);
+            var commits = await _client.Repository.Commit.GetAll(organization, projectName, new ApiOptions {PageSize = 100, PageCount = 10});
 
             foreach (var commit in commits)
             {
                 var full =
-                    await _client.Repository.Commit.Get(organization, projectName, commit.Sha).ConfigureAwait(false);
+                    await _client.Repository.Commit.Get(organization, projectName, commit.Sha);
 
                 project.RecordCommit(commit, full.Stats);
             }

--- a/src/Marten.Testing/CodeTracker/GithubProject.cs
+++ b/src/Marten.Testing/CodeTracker/GithubProject.cs
@@ -154,7 +154,7 @@ namespace Marten.Testing.CodeTracker
                         }
                     }
 
-                    await session.SaveChangesAsync().ConfigureAwait(false);
+                    await session.SaveChangesAsync();
                 }
 
                 index += 10;

--- a/src/Marten.Testing/CoreFunctionality/Using_Global_DocumentSessionListener_Tests.cs
+++ b/src/Marten.Testing/CoreFunctionality/Using_Global_DocumentSessionListener_Tests.cs
@@ -74,7 +74,7 @@ namespace Marten.Testing.CoreFunctionality
                 {
                     session.Store(new User(), new User());
 
-                    await session.SaveChangesAsync().ConfigureAwait(false);
+                    await session.SaveChangesAsync();
 
                     stub1.SaveChangesSession.ShouldBeTheSameAs(session);
                     stub1.AfterCommitSession.ShouldBeTheSameAs(session);

--- a/src/Marten.Testing/CoreFunctionality/Using_Local_DocumentSessionListener_Tests.cs
+++ b/src/Marten.Testing/CoreFunctionality/Using_Local_DocumentSessionListener_Tests.cs
@@ -66,7 +66,7 @@ namespace Marten.Testing.CoreFunctionality
                 {
                     session.Store(new User(), new User());
 
-                    await session.SaveChangesAsync().ConfigureAwait(false);
+                    await session.SaveChangesAsync();
 
                     stub1.SaveChangesSession.ShouldBeTheSameAs(session);
                     stub1.AfterCommitSession.ShouldBeTheSameAs(session);

--- a/src/Marten.Testing/CoreFunctionality/document_session_find_json_async_Tests.cs
+++ b/src/Marten.Testing/CoreFunctionality/document_session_find_json_async_Tests.cs
@@ -17,9 +17,9 @@ namespace Marten.Testing.CoreFunctionality
             var issue = new Issue { Title = "Issue 2" };
 
             theSession.Store(issue);
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var json = await theSession.Json.FindByIdAsync<Issue>(issue.Id).ConfigureAwait(false);
+            var json = await theSession.Json.FindByIdAsync<Issue>(issue.Id);
             json.ShouldBe($"{{\"Id\": \"{issue.Id}\", \"Tags\": null, \"BugId\": null, \"Title\": \"Issue 2\", \"Number\": 0, \"AssigneeId\": null, \"ReporterId\": null}}");
         }
 
@@ -28,7 +28,7 @@ namespace Marten.Testing.CoreFunctionality
         [Fact]
         public async Task when_find_then_a_null_should_be_returned()
         {
-            var json = await theSession.Json.FindByIdAsync<Issue>(Guid.NewGuid()).ConfigureAwait(false);
+            var json = await theSession.Json.FindByIdAsync<Issue>(Guid.NewGuid());
             json.ShouldBeNull();
         }
 

--- a/src/Marten.Testing/CoreFunctionality/document_session_logs_SaveChanges_Tests.cs
+++ b/src/Marten.Testing/CoreFunctionality/document_session_logs_SaveChanges_Tests.cs
@@ -35,7 +35,7 @@ namespace Marten.Testing.CoreFunctionality
 
             theSession.Store(Target.Random());
 
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             logger.LastSession.ShouldBe(theSession);
         }

--- a/src/Marten.Testing/CoreFunctionality/document_session_persist_and_load_single_documents_Tests.cs
+++ b/src/Marten.Testing/CoreFunctionality/document_session_persist_and_load_single_documents_Tests.cs
@@ -82,13 +82,13 @@ namespace Marten.Testing.CoreFunctionality
 
             // theSession is Marten's IDocumentSession service
             theSession.Store(user);
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             using (var session2 = theStore.OpenSession())
             {
                 session2.ShouldNotBeSameAs(theSession);
 
-                var user2 = await session2.LoadAsync<User>(user.Id).ConfigureAwait(false);
+                var user2 = await session2.LoadAsync<User>(user.Id);
 
                 user.ShouldNotBeSameAs(user2);
                 user2.FirstName.ShouldBe(user.FirstName);
@@ -149,7 +149,7 @@ namespace Marten.Testing.CoreFunctionality
             theSession.Store(user4);
             theSession.Store(user5);
 
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
             #endregion sample_saving-changes-async
 
             var store = theStore;
@@ -157,7 +157,7 @@ namespace Marten.Testing.CoreFunctionality
             #region sample_load_by_id_array_async
             using (var session = store.OpenSession())
             {
-                var users = await session.LoadManyAsync<User>(user2.Id, user3.Id, user4.Id).ConfigureAwait(false);
+                var users = await session.LoadManyAsync<User>(user2.Id, user3.Id, user4.Id);
                 users.Count().ShouldBe(3);
             }
             #endregion sample_load_by_id_array_async

--- a/src/Marten.Testing/CoreFunctionality/get_raw_json_Tests.cs
+++ b/src/Marten.Testing/CoreFunctionality/get_raw_json_Tests.cs
@@ -37,13 +37,13 @@ namespace Marten.Testing.CoreFunctionality
             theSession.Store(issue);
             theSession.SaveChanges();
 
-            var json = await theSession.Query<Issue>().Where(x => x.Title == "Issue 1").ToJsonArrayAsync().ConfigureAwait(false);
+            var json = await theSession.Query<Issue>().Where(x => x.Title == "Issue 1").ToJsonArrayAsync();
             json.ShouldBe($"[{{\"Id\": \"{issue.Id}\", \"Tags\": null, \"Title\": \"Issue 1\", \"AssigneeId\": null, \"ReporterId\": null}}]");
-            json = await theSession.Query<Issue>().AsJson().FirstAsync().ConfigureAwait(false);
+            json = await theSession.Query<Issue>().AsJson().FirstAsync();
             json.ShouldBe($"{{\"Id\": \"{issue.Id}\", \"Tags\": null, \"Title\": \"Issue 1\", \"AssigneeId\": null, \"ReporterId\": null}}");
-            json = await theSession.Query<Issue>().AsJson().FirstOrDefaultAsync().ConfigureAwait(false);
-            json = await theSession.Query<Issue>().AsJson().SingleAsync().ConfigureAwait(false);
-            json = await theSession.Query<Issue>().AsJson().SingleOrDefaultAsync().ConfigureAwait(false);
+            json = await theSession.Query<Issue>().AsJson().FirstOrDefaultAsync();
+            json = await theSession.Query<Issue>().AsJson().SingleAsync();
+            json = await theSession.Query<Issue>().AsJson().SingleOrDefaultAsync();
         }
         #endregion sample_get-raw-json-async
         public get_raw_json_Tests(DefaultStoreFixture fixture) : base(fixture)

--- a/src/Marten.Testing/CoreFunctionality/persisting_document_with_string_id_Tests.cs
+++ b/src/Marten.Testing/CoreFunctionality/persisting_document_with_string_id_Tests.cs
@@ -35,13 +35,13 @@ namespace Marten.Testing.CoreFunctionality
             var account = new Account { Id = "email@server.com" };
 
             theSession.Store(account);
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             using (var session = theStore.OpenSession())
             {
-                SpecificationExtensions.ShouldNotBeNull((await session.LoadAsync<Account>("email@server.com").ConfigureAwait(false)));
+                SpecificationExtensions.ShouldNotBeNull((await session.LoadAsync<Account>("email@server.com")));
 
-                SpecificationExtensions.ShouldBeNull((await session.LoadAsync<Account>("nonexistent@server.com").ConfigureAwait(false)));
+                SpecificationExtensions.ShouldBeNull((await session.LoadAsync<Account>("nonexistent@server.com")));
             }
         }
         #endregion sample_persist_and_load_async

--- a/src/Marten.Testing/CoreFunctionality/query_by_sql_where_clause_Tests.cs
+++ b/src/Marten.Testing/CoreFunctionality/query_by_sql_where_clause_Tests.cs
@@ -270,8 +270,7 @@ where data ->> 'FirstName' = 'Jeremy'").Single();
                 var users =
                     await
                         session.QueryAsync<User>(
-                                   "select data from mt_doc_user where data ->> 'FirstName' = 'Jeremy'")
-                               .ConfigureAwait(false);
+                                   "select data from mt_doc_user where data ->> 'FirstName' = 'Jeremy'");
                 var user = users.Single();
                 #endregion sample_using-queryasync
 

--- a/src/Marten.Testing/CoreFunctionality/query_scalar_values_with_select_in_query_async.cs
+++ b/src/Marten.Testing/CoreFunctionality/query_scalar_values_with_select_in_query_async.cs
@@ -19,7 +19,7 @@ namespace Marten.Testing.CoreFunctionality
             theSession.Store(new Target { Color = Colors.Blue, Number = 4 });
 
             theSession.SaveChanges();
-            var sumResults = await theSession.QueryAsync<int>("select sum(CAST(d.data ->> 'Number' as integer)) as number from mt_doc_target as d").ConfigureAwait(false);
+            var sumResults = await theSession.QueryAsync<int>("select sum(CAST(d.data ->> 'Number' as integer)) as number from mt_doc_target as d");
             var sum = sumResults.Single();
             sum.ShouldBe(10);
         }
@@ -33,7 +33,7 @@ namespace Marten.Testing.CoreFunctionality
             theSession.Store(new Target { Color = Colors.Blue, Number = 4 });
 
             theSession.SaveChanges();
-            var sumResults = await theSession.QueryAsync<int>("select count(*) from mt_doc_target").ConfigureAwait(false);
+            var sumResults = await theSession.QueryAsync<int>("select count(*) from mt_doc_target");
             var sum = sumResults.Single();
             sum.ShouldBe(4);
         }

--- a/src/Marten.Testing/Events/Projections/inline_aggregation_by_stream_with_multiples.cs
+++ b/src/Marten.Testing/Events/Projections/inline_aggregation_by_stream_with_multiples.cs
@@ -67,11 +67,11 @@ namespace Marten.Testing.Events.Projections
 
             var streamId = theSession.Events
                 .StartStream<QuestParty>(started, joined, slayed1, slayed2, joined2).Id;
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            (await theSession.LoadAsync<QuestMonsters>(streamId).ConfigureAwait(false)).Monsters.ShouldHaveTheSameElementsAs("Troll", "Dragon");
+            (await theSession.LoadAsync<QuestMonsters>(streamId)).Monsters.ShouldHaveTheSameElementsAs("Troll", "Dragon");
 
-            (await theSession.LoadAsync<QuestParty>(streamId).ConfigureAwait(false)).Members
+            (await theSession.LoadAsync<QuestParty>(streamId)).Members
                 .ShouldHaveTheSameElementsAs("Garion", "Polgara", "Belgarath", "Silk", "Barak");
         }
 

--- a/src/Marten.Testing/Events/capturing_event_versions_on_existing_streams_after_append.cs
+++ b/src/Marten.Testing/Events/capturing_event_versions_on_existing_streams_after_append.cs
@@ -104,7 +104,7 @@ namespace Marten.Testing.Events
                 var departed = new MembersDeparted { Members = new[] { "Thom" } };
 
                 session.Events.StartStream<Quest>(streamId, joined, departed);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
 
                 logger.LastCommit.GetEvents().Select(x => x.Version)
                     .ShouldHaveTheSameElementsAs(1, 2);
@@ -118,7 +118,7 @@ namespace Marten.Testing.Events
                 var departed2 = new MembersDeparted { Members = new[] { "Perrin" } };
 
                 session.Events.Append(streamId, joined2, departed2);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
 
                 logger.LastCommit.GetEvents().Select(x => x.Version)
                     .ShouldHaveTheSameElementsAs(3, 4);
@@ -132,7 +132,7 @@ namespace Marten.Testing.Events
                 var departed3 = new MembersDeparted { Members = new[] { "Perrin" } };
 
                 session.Events.Append(streamId, joined3, departed3);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
 
                 var events = logger.LastCommit.GetEvents().ToArray();
                 events.Select(x => x.Version)

--- a/src/Marten.Testing/Events/fetch_a_single_event_with_metadata.cs
+++ b/src/Marten.Testing/Events/fetch_a_single_event_with_metadata.cs
@@ -45,20 +45,20 @@ namespace Marten.Testing.Events
         {
             var streamId = theSession.Events
                 .StartStream<QuestParty>(started, joined, slayed1, slayed2, joined2).Id;
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             var events = await theSession.Events.FetchStreamAsync(streamId);
 
-            SpecificationExtensions.ShouldBeNull((await theSession.Events.LoadAsync(Guid.NewGuid()).ConfigureAwait(false)));
-            SpecificationExtensions.ShouldBeNull((await theSession.Events.LoadAsync<MonsterSlayed>(Guid.NewGuid()).ConfigureAwait(false)));
+            SpecificationExtensions.ShouldBeNull((await theSession.Events.LoadAsync(Guid.NewGuid())));
+            SpecificationExtensions.ShouldBeNull((await theSession.Events.LoadAsync<MonsterSlayed>(Guid.NewGuid())));
 
             // Knowing the event type
-            var slayed1_2 = await theSession.Events.LoadAsync<MonsterSlayed>(events[2].Id).ConfigureAwait(false);
+            var slayed1_2 = await theSession.Events.LoadAsync<MonsterSlayed>(events[2].Id);
             slayed1_2.Version.ShouldBe(3);
             slayed1_2.Data.Name.ShouldBe("Troll");
 
             // Not knowing the event type
-            var slayed1_3 = (await theSession.Events.LoadAsync<MonsterSlayed>(events[2].Id).ConfigureAwait(false)).ShouldBeOfType<Event<MonsterSlayed>>();
+            var slayed1_3 = (await theSession.Events.LoadAsync<MonsterSlayed>(events[2].Id)).ShouldBeOfType<Event<MonsterSlayed>>();
             slayed1_3.Version.ShouldBe(3);
             slayed1_3.Data.Name.ShouldBe("Troll");
         }
@@ -68,7 +68,7 @@ namespace Marten.Testing.Events
         {
             var streamId = theSession.Events
                 .StartStream<QuestParty>(started, joined, slayed1, slayed2, joined2).Id;
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             var events = await theSession.Events.FetchStreamAsync(streamId);
 
@@ -80,13 +80,13 @@ namespace Marten.Testing.Events
 
             await batch.Execute();
 
-            (await slayed1_2.ConfigureAwait(false)).ShouldBeOfType<Event<MonsterSlayed>>()
+            (await slayed1_2).ShouldBeOfType<Event<MonsterSlayed>>()
                 .Data.Name.ShouldBe("Troll");
 
-            (await slayed2_2.ConfigureAwait(false)).ShouldBeOfType<Event<MonsterSlayed>>()
+            (await slayed2_2).ShouldBeOfType<Event<MonsterSlayed>>()
                 .Data.Name.ShouldBe("Dragon");
 
-            SpecificationExtensions.ShouldBeNull((await missing.ConfigureAwait(false)));
+            SpecificationExtensions.ShouldBeNull((await missing));
         }
 
         public fetch_a_single_event_with_metadata(DefaultStoreFixture fixture) : base(fixture)

--- a/src/Marten.Testing/Events/fetching_stream_state.cs
+++ b/src/Marten.Testing/Events/fetching_stream_state.cs
@@ -110,7 +110,7 @@ namespace Marten.Testing.Events
         [Fact]
         public async Task can_fetch_the_stream_version_and_aggregate_type_async()
         {
-            var state = await theSession.Events.FetchStreamStateAsync(theStreamId).ConfigureAwait(false);
+            var state = await theSession.Events.FetchStreamStateAsync(theStreamId);
 
             state.Id.ShouldBe(theStreamId);
             state.Version.ShouldBe(2);
@@ -126,9 +126,9 @@ namespace Marten.Testing.Events
 
             var stateTask = batch.Events.FetchStreamState(theStreamId);
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
-            var state = await stateTask.ConfigureAwait(false);
+            var state = await stateTask;
 
             state.Id.ShouldBe(theStreamId);
             state.Version.ShouldBe(2);
@@ -143,9 +143,9 @@ namespace Marten.Testing.Events
 
             var eventsTask = batch.Events.FetchStream(theStreamId);
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
-            var events = await eventsTask.ConfigureAwait(false);
+            var events = await eventsTask;
 
             events.Count.ShouldBe(2);
         }

--- a/src/Marten.Testing/Examples/RetryPolicyTests.cs
+++ b/src/Marten.Testing/Examples/RetryPolicyTests.cs
@@ -63,7 +63,7 @@ namespace Marten.Testing.Examples
             {
                 try
                 {
-                    await operation().ConfigureAwait(false);
+                    await operation();
                     return;
                 }
                 catch (Exception e) when (++tries < maxTries && filter(e))
@@ -78,7 +78,7 @@ namespace Marten.Testing.Examples
             {
                 try
                 {
-                    return await operation().ConfigureAwait(false);
+                    return await operation();
                 }
                 catch (Exception e) when (++tries < maxTries && filter(e))
                 {

--- a/src/Marten.Testing/Examples/event_store_quickstart.cs
+++ b/src/Marten.Testing/Examples/event_store_quickstart.cs
@@ -142,12 +142,10 @@ namespace Marten.Testing.Examples
         public async Task load_a_single_event_asynchronously(IDocumentSession session, Guid eventId)
         {
             // If you know what the event type is already
-            var event1 = await session.Events.LoadAsync<MembersJoined>(eventId)
-                .ConfigureAwait(false);
+            var event1 = await session.Events.LoadAsync<MembersJoined>(eventId);
 
             // If you do not know what the event type is
-            var event2 = await session.Events.LoadAsync(eventId)
-                .ConfigureAwait(false);
+            var event2 = await session.Events.LoadAsync(eventId);
         }
 
         #endregion sample_load-a-single-event

--- a/src/Marten.Testing/Linq/Compiled/compiled_query_Tests.cs
+++ b/src/Marten.Testing/Linq/Compiled/compiled_query_Tests.cs
@@ -114,7 +114,7 @@ namespace Marten.Testing.Linq.Compiled
         [Fact]
         public async Task a_filtered_list_compiled_query_AsJson_async()
         {
-            var user = await theSession.QueryAsync(new FindJsonUsersByUsername() { FirstName = "Jeremy" }).ConfigureAwait(false);
+            var user = await theSession.QueryAsync(new FindJsonUsersByUsername() { FirstName = "Jeremy" });
 
             SpecificationExtensions.ShouldNotBeNull(user);
             user.ShouldNotBeEmpty();
@@ -134,7 +134,7 @@ namespace Marten.Testing.Linq.Compiled
         [Fact]
         public async Task a_single_item_compiled_query_async()
         {
-            var user = await theSession.QueryAsync(new UserByUsername { UserName = "myusername" }).ConfigureAwait(false);
+            var user = await theSession.QueryAsync(new UserByUsername { UserName = "myusername" });
             SpecificationExtensions.ShouldNotBeNull(user);
             var differentUser = await theSession.QueryAsync(new UserByUsername { UserName = "jdm" });
             differentUser.UserName.ShouldBe("jdm");
@@ -166,7 +166,7 @@ namespace Marten.Testing.Linq.Compiled
         [Fact]
         public async Task a_list_query_compiled_async()
         {
-            var users = await theSession.QueryAsync(new UsersByFirstName { FirstName = "Jeremy" }).ConfigureAwait(false);
+            var users = await theSession.QueryAsync(new UsersByFirstName { FirstName = "Jeremy" });
             users.Count().ShouldBe(2);
             users.ElementAt(0).UserName.ShouldBe("jdm");
             users.ElementAt(1).UserName.ShouldBe("shadetreedev");

--- a/src/Marten.Testing/Linq/invoking_query_with_select_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_query_with_select_Tests.cs
@@ -54,7 +54,7 @@ namespace Marten.Testing.Linq
 
             theSession.SaveChanges();
 
-            var names = await theSession.Query<User>().OrderBy(x => x.FirstName).Select(x => x.FirstName).ToListAsync().ConfigureAwait(false);
+            var names = await theSession.Query<User>().OrderBy(x => x.FirstName).Select(x => x.FirstName).ToListAsync();
             names.ShouldHaveTheSameElementsAs("Bill", "Hank", "Sam", "Tom");
         }
 
@@ -171,7 +171,7 @@ namespace Marten.Testing.Linq
                 .Query<User>()
                 .OrderBy(x => x.FirstName)
                 .Select(x => new UserName { Name = x.FirstName })
-                .ToListAsync().ConfigureAwait(false);
+                .ToListAsync();
 
             users.Select(x => x.Name)
                 .ShouldHaveTheSameElementsAs("Bill", "Hank", "Sam", "Tom");
@@ -341,7 +341,7 @@ namespace Marten.Testing.Linq
                 .Query<User>()
                 .OrderBy(x => x.FirstName)
                 .Select(x => new { Name = x.FirstName })
-                .ToListAsync().ConfigureAwait(false);
+                .ToListAsync();
 
             users
                 .Select(x => x.Name)

--- a/src/Marten.Testing/Linq/invoking_query_with_statistics.cs
+++ b/src/Marten.Testing/Linq/invoking_query_with_statistics.cs
@@ -63,7 +63,7 @@ namespace Marten.Testing.Linq
         [Fact]
         public async Task can_get_the_total_from_a_compiled_query_running_in_a_batch()
         {
-            var count = await theSession.Query<Target>().Where(x => x.Number > 10).CountAsync().ConfigureAwait(false);
+            var count = await theSession.Query<Target>().Where(x => x.Number > 10).CountAsync();
             SpecificationExtensions.ShouldBeGreaterThan(count, 0);
 
             var query = new TargetPaginationQuery(2, 5);
@@ -72,9 +72,9 @@ namespace Marten.Testing.Linq
 
             var targets = batch.Query(query);
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
-            (await targets.ConfigureAwait(false))
+            (await targets)
                 .Any().ShouldBeTrue();
 
             query.Stats.TotalResults.ShouldBe(count);
@@ -103,7 +103,7 @@ namespace Marten.Testing.Linq
         [Fact]
         public async Task can_get_the_total_in_batch_query()
         {
-            var count = await theSession.Query<Target>().Where(x => x.Number > 10).CountAsync().ConfigureAwait(false);
+            var count = await theSession.Query<Target>().Where(x => x.Number > 10).CountAsync();
             SpecificationExtensions.ShouldBeGreaterThan(count, 0);
 
             QueryStatistics stats = null;
@@ -113,9 +113,9 @@ namespace Marten.Testing.Linq
             var list = batch.Query<Target>().Stats(out stats).Where(x => x.Number > 10).Take(5)
                 .ToList();
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
-            (await list.ConfigureAwait(false)).Any().ShouldBeTrue();
+            (await list).Any().ShouldBeTrue();
 
             stats.TotalResults.ShouldBe(count);
         }
@@ -171,13 +171,13 @@ namespace Marten.Testing.Linq
         [Fact]
         public async Task can_get_the_total_in_results_async()
         {
-            var count = await theSession.Query<Target>().Where(x => x.Number > 10).CountAsync().ConfigureAwait(false);
+            var count = await theSession.Query<Target>().Where(x => x.Number > 10).CountAsync();
             SpecificationExtensions.ShouldBeGreaterThan(count, 0);
 
             QueryStatistics stats = null;
 
             var list = await theSession.Query<Target>().Stats(out stats).Where(x => x.Number > 10).Take(5)
-                .ToListAsync().ConfigureAwait(false);
+                .ToListAsync();
 
             list.Any().ShouldBeTrue();
 

--- a/src/Marten.Testing/Linq/invoking_queryable_any_async_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_any_async_Tests.cs
@@ -17,16 +17,16 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 3 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var result = await theSession.Query<Target>().AnyAsync(x => x.Number == 11).ConfigureAwait(false);
+            var result = await theSession.Query<Target>().AnyAsync(x => x.Number == 11);
             result.ShouldBeFalse();
         }
 
         [Fact]
         public async Task naked_any_miss()
         {
-            var result = await theSession.Query<Target>().AnyAsync().ConfigureAwait(false);
+            var result = await theSession.Query<Target>().AnyAsync();
             result.ShouldBeFalse();
         }
 
@@ -39,7 +39,7 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 4 });
             theSession.SaveChanges();
 
-            var result = await theSession.Query<Target>().AnyAsync().ConfigureAwait(false);
+            var result = await theSession.Query<Target>().AnyAsync();
             result.ShouldBeTrue();
         }
 
@@ -52,7 +52,7 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 4 });
             theSession.SaveChanges();
 
-            var result = await theSession.Query<Target>().AnyAsync(x => x.Number == 3).ConfigureAwait(false);
+            var result = await theSession.Query<Target>().AnyAsync(x => x.Number == 3);
             result.ShouldBeTrue();
         }
 
@@ -65,7 +65,7 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 4 });
             theSession.SaveChanges();
 
-            var result = await theSession.Query<Target>().Where(x => x.Number == 2).AnyAsync().ConfigureAwait(false);
+            var result = await theSession.Query<Target>().Where(x => x.Number == 2).AnyAsync();
             result.ShouldBeTrue();
         }
 

--- a/src/Marten.Testing/Linq/invoking_queryable_count_async_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_count_async_Tests.cs
@@ -16,9 +16,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 3 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var result = await theSession.Query<Target>().CountAsync().ConfigureAwait(false);
+            var result = await theSession.Query<Target>().CountAsync();
             result.ShouldBe(4);
         }
 
@@ -29,9 +29,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 3 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var result = await theSession.Query<Target>().LongCountAsync().ConfigureAwait(false);
+            var result = await theSession.Query<Target>().LongCountAsync();
             result.ShouldBe(4);
         }
 
@@ -44,9 +44,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 4 });
             theSession.Store(new Target { Number = 5 });
             theSession.Store(new Target { Number = 6 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var result = await theSession.Query<Target>().CountAsync(x => x.Number > 3).ConfigureAwait(false);
+            var result = await theSession.Query<Target>().CountAsync(x => x.Number > 3);
             result.ShouldBe(3);
         }
 
@@ -59,9 +59,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 4 });
             theSession.Store(new Target { Number = 5 });
             theSession.Store(new Target { Number = 6 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var result = await theSession.Query<Target>().LongCountAsync(x => x.Number > 3).ConfigureAwait(false);
+            var result = await theSession.Query<Target>().LongCountAsync(x => x.Number > 3);
             result.ShouldBe(3);
         }
 
@@ -72,9 +72,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 3 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var result = await theSession.Query<Target>().SumAsync(x => x.Number).ConfigureAwait(false);
+            var result = await theSession.Query<Target>().SumAsync(x => x.Number);
             result.ShouldBe(10);
         }
 
@@ -85,9 +85,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { NullableNumber = 2 });
             theSession.Store(new Target { NullableNumber = 3 });
             theSession.Store(new Target { NullableNumber = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var result = await theSession.Query<Target>().SumAsync(x => x.NullableNumber).ConfigureAwait(false);
+            var result = await theSession.Query<Target>().SumAsync(x => x.NullableNumber);
             result.ShouldBe(10);
         }
 

--- a/src/Marten.Testing/Linq/invoking_queryable_through_first_async_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_through_first_async_Tests.cs
@@ -19,9 +19,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 3 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var target = await theSession.Query<Target>().FirstAsync(x => x.Number == 3).ConfigureAwait(false);
+            var target = await theSession.Query<Target>().FirstAsync(x => x.Number == 3);
             SpecificationExtensions.ShouldNotBeNull(target);
         }
 
@@ -32,9 +32,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 3 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var target = await theSession.Query<Target>().FirstOrDefaultAsync(x => x.Number == 3).ConfigureAwait(false);
+            var target = await theSession.Query<Target>().FirstOrDefaultAsync(x => x.Number == 3);
             SpecificationExtensions.ShouldNotBeNull(target);
         }
 
@@ -45,9 +45,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 3 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var target = await theSession.Query<Target>().FirstOrDefaultAsync(x => x.Number == 11).ConfigureAwait(false);
+            var target = await theSession.Query<Target>().FirstOrDefaultAsync(x => x.Number == 11);
             SpecificationExtensions.ShouldBeNull(target);
         }
 
@@ -58,9 +58,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2, Flag = true });
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var target = await theSession.Query<Target>().Where(x => x.Number == 2).FirstAsync().ConfigureAwait(false);
+            var target = await theSession.Query<Target>().Where(x => x.Number == 2).FirstAsync();
             target.Flag.ShouldBeTrue();
         }
 
@@ -71,9 +71,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2, Flag = true });
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var target = await theSession.Query<Target>().Where(x => x.Number == 2).FirstOrDefaultAsync().ConfigureAwait(false);
+            var target = await theSession.Query<Target>().Where(x => x.Number == 2).FirstOrDefaultAsync();
             target.Flag.ShouldBeTrue();
         }
 
@@ -84,11 +84,11 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 3 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             await Exception<InvalidOperationException>.ShouldBeThrownByAsync(async () =>
             {
-                await theSession.Query<Target>().Where(x => x.Number == 11).FirstAsync().ConfigureAwait(false);
+                await theSession.Query<Target>().Where(x => x.Number == 11).FirstAsync();
             });
         }
 

--- a/src/Marten.Testing/Linq/invoking_queryable_through_single_async_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_through_single_async_Tests.cs
@@ -18,9 +18,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 3 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var target = await theSession.Query<Target>().SingleAsync(x => x.Number == 3).ConfigureAwait(false);
+            var target = await theSession.Query<Target>().SingleAsync(x => x.Number == 3);
             target.ShouldNotBeNull();
         }
 
@@ -31,9 +31,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 3 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var target = await theSession.Query<Target>().SingleOrDefaultAsync(x => x.Number == 3).ConfigureAwait(false);
+            var target = await theSession.Query<Target>().SingleOrDefaultAsync(x => x.Number == 3);
             target.ShouldNotBeNull();
         }
 
@@ -44,9 +44,9 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 3 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var target = await theSession.Query<Target>().SingleOrDefaultAsync(x => x.Number == 11).ConfigureAwait(false);
+            var target = await theSession.Query<Target>().SingleOrDefaultAsync(x => x.Number == 11);
             target.ShouldBeNull();
         }
 
@@ -57,11 +57,11 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             await Exception<InvalidOperationException>.ShouldBeThrownByAsync(async () =>
             {
-                await theSession.Query<Target>().Where(x => x.Number == 2).SingleAsync().ConfigureAwait(false);
+                await theSession.Query<Target>().Where(x => x.Number == 2).SingleAsync();
             });
         }
 
@@ -72,11 +72,11 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             await Exception<InvalidOperationException>.ShouldBeThrownByAsync(async () =>
             {
-                await theSession.Query<Target>().Where(x => x.Number == 2).SingleOrDefaultAsync().ConfigureAwait(false);
+                await theSession.Query<Target>().Where(x => x.Number == 2).SingleOrDefaultAsync();
             });
         }
 
@@ -87,11 +87,11 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Number = 2 });
             theSession.Store(new Target { Number = 3 });
             theSession.Store(new Target { Number = 4 });
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             await Exception<InvalidOperationException>.ShouldBeThrownByAsync(async () =>
             {
-                await theSession.Query<Target>().Where(x => x.Number == 11).SingleAsync().ConfigureAwait(false);
+                await theSession.Query<Target>().Where(x => x.Number == 11).SingleAsync();
             });
         }
 

--- a/src/Marten.Testing/Linq/invoking_queryable_through_to_list_async_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_through_to_list_async_Tests.cs
@@ -21,12 +21,12 @@ namespace Marten.Testing.Linq
             theSession.Store(new User { FirstName = "Sam" });
             theSession.Store(new User { FirstName = "Tom" });
 
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             var users = await theSession
                 .Query<User>()
                 .Where(x => x.FirstName == "Sam")
-                .ToListAsync().ConfigureAwait(false);
+                .ToListAsync();
 
             users.Single().FirstName.ShouldBe("Sam");
         }
@@ -38,7 +38,7 @@ namespace Marten.Testing.Linq
             var users = await theSession
                 .Query<User>()
                 .Where(x => x.FirstName == "Sam")
-                .ToListAsync().ConfigureAwait(false);
+                .ToListAsync();
             users.ShouldBeEmpty();
         }
 

--- a/src/Marten.Testing/Linq/query_for_json_format.cs
+++ b/src/Marten.Testing/Linq/query_for_json_format.cs
@@ -104,7 +104,7 @@ namespace Marten.Testing.Linq
             theSession.Store(user0,user1,user2);
             theSession.SaveChanges();
 
-            var listJson = await theSession.Query<SimpleUser>().Where(x=>x.Number>=5).ToJsonArrayAsync().ConfigureAwait(false);
+            var listJson = await theSession.Query<SimpleUser>().Where(x=>x.Number>=5).ToJsonArrayAsync();
             listJson.ShouldBeSemanticallySameJsonAs($@"[{user1.ToJson()},{user2.ToJson()}]");
         }
 
@@ -221,7 +221,7 @@ namespace Marten.Testing.Linq
             theSession.Store(user0,user1,user2);
             await theSession.SaveChangesAsync();
 
-            var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().FirstAsync().ConfigureAwait(false);
+            var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().FirstAsync();
             userJson.ShouldBeSemanticallySameJsonAs($@"{user1.ToJson()}");
         }
 
@@ -252,7 +252,7 @@ namespace Marten.Testing.Linq
             theSession.Store(user0,user1,user2);
             theSession.SaveChanges();
 
-            var userJson = await theSession.Query<SimpleUser>().AsJson().FirstAsync().ConfigureAwait(false);
+            var userJson = await theSession.Query<SimpleUser>().AsJson().FirstAsync();
             userJson.ShouldBeSemanticallySameJsonAs($@"{user0.ToJson()}");
         }
 
@@ -277,7 +277,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var ex = await Exception<InvalidOperationException>.ShouldBeThrownByAsync(() =>
-                theSession.Query<SimpleUser>().Where(x => x.Number != 5).AsJson().FirstAsync()).ConfigureAwait(false);
+                theSession.Query<SimpleUser>().Where(x => x.Number != 5).AsJson().FirstAsync());
             ex.Message.ShouldBe("Sequence contains no elements");
         }
 
@@ -370,7 +370,7 @@ namespace Marten.Testing.Linq
             theSession.Store(user0,user1,user2);
             theSession.SaveChanges();
 
-            var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().FirstOrDefaultAsync().ConfigureAwait(false);
+            var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().FirstOrDefaultAsync();
             userJson.ShouldBeSemanticallySameJsonAs($@"{user1.ToJson()}");
         }
 
@@ -401,7 +401,7 @@ namespace Marten.Testing.Linq
             theSession.Store(user0,user1,user2);
             theSession.SaveChanges();
 
-            var userJson = await theSession.Query<SimpleUser>().AsJson().FirstOrDefaultAsync().ConfigureAwait(false);
+            var userJson = await theSession.Query<SimpleUser>().AsJson().FirstOrDefaultAsync();
             userJson.ShouldBeSemanticallySameJsonAs($@"{user0.ToJson()}");
         }
 
@@ -449,7 +449,7 @@ namespace Marten.Testing.Linq
             theSession.Store(user1,user2);
             theSession.SaveChanges();
 
-            var userJson = await theSession.Query<SimpleUser>().Where(x=>x.Number != 5).AsJson().FirstOrDefaultAsync().ConfigureAwait(false);
+            var userJson = await theSession.Query<SimpleUser>().Where(x=>x.Number != 5).AsJson().FirstOrDefaultAsync();
             SpecificationExtensions.ShouldBeNull(userJson);
         }
 

--- a/src/Marten.Testing/Linq/query_for_single_json.cs
+++ b/src/Marten.Testing/Linq/query_for_single_json.cs
@@ -122,7 +122,7 @@ namespace Marten.Testing.Linq
             theSession.Store(user0, user1);
             theSession.SaveChanges();
 
-            var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().SingleAsync().ConfigureAwait(false);
+            var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().SingleAsync();
             userJson.ShouldBeSemanticallySameJsonAs($@"{user1.ToJson()}");
         }
 
@@ -140,7 +140,7 @@ namespace Marten.Testing.Linq
             theSession.Store(user1);
             theSession.SaveChanges();
 
-            var userJson = await theSession.Query<SimpleUser>().AsJson().SingleAsync().ConfigureAwait(false);
+            var userJson = await theSession.Query<SimpleUser>().AsJson().SingleAsync();
             userJson.ShouldBeSemanticallySameJsonAs($@"{user1.ToJson()}");
         }
 
@@ -165,7 +165,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var ex = await Exception<InvalidOperationException>.ShouldBeThrownByAsync(() =>
-                theSession.Query<SimpleUser>().Where(x => x.Number != 5).AsJson().SingleAsync()).ConfigureAwait(false);
+                theSession.Query<SimpleUser>().Where(x => x.Number != 5).AsJson().SingleAsync());
             ex.Message.ShouldBe("Sequence contains no elements");
         }
 
@@ -190,7 +190,7 @@ namespace Marten.Testing.Linq
             theSession.SaveChanges();
 
             var ex = await Exception<InvalidOperationException>.ShouldBeThrownByAsync(() =>
-                theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().SingleAsync()).ConfigureAwait(false);
+                theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().SingleAsync());
             ex.Message.ShouldBe("Sequence contains more than one element");
         }
 
@@ -262,7 +262,7 @@ namespace Marten.Testing.Linq
             theSession.Store(user0, user1, user2);
             theSession.SaveChanges();
 
-            var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().SingleOrDefaultAsync().ConfigureAwait(false);
+            var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number == 5).AsJson().SingleOrDefaultAsync();
             userJson.ShouldBeSemanticallySameJsonAs($@"{user1.ToJson()}");
         }
 
@@ -279,7 +279,7 @@ namespace Marten.Testing.Linq
             theSession.Store(user1);
             theSession.SaveChanges();
 
-            var userJson = await theSession.Query<SimpleUser>().AsJson().SingleOrDefaultAsync().ConfigureAwait(false);
+            var userJson = await theSession.Query<SimpleUser>().AsJson().SingleOrDefaultAsync();
             userJson.ShouldBeSemanticallySameJsonAs($@"{user1.ToJson()}");
         }
 
@@ -351,7 +351,7 @@ namespace Marten.Testing.Linq
             theSession.Store(user1, user2);
             theSession.SaveChanges();
 
-            var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number != 5).AsJson().SingleOrDefaultAsync().ConfigureAwait(false);
+            var userJson = await theSession.Query<SimpleUser>().Where(x => x.Number != 5).AsJson().SingleOrDefaultAsync();
             userJson.ShouldBeNull();
         }
 

--- a/src/Marten.Testing/Linq/query_running_through_the_IdentityMap_Tests.cs
+++ b/src/Marten.Testing/Linq/query_running_through_the_IdentityMap_Tests.cs
@@ -76,12 +76,12 @@ namespace Marten.Testing.Linq
         public async Task single_runs_through_the_identity_map_async()
         {
             var u1 = await theSession.Query<User>().Where(x => x.FirstName == "Jeremy")
-                .SingleAsync().ConfigureAwait(false);
+                .SingleAsync();
 
             u1.ShouldBeTheSameAs(user1);
 
             var u2 = await theSession.Query<User>().Where(x => x.FirstName == user4.FirstName)
-                .SingleOrDefaultAsync().ConfigureAwait(false);
+                .SingleOrDefaultAsync();
 
             u2.ShouldBeTheSameAs(user4);
 
@@ -94,13 +94,13 @@ namespace Marten.Testing.Linq
         public async Task first_runs_through_the_identity_map_async()
         {
             var u1 = await theSession.Query<User>().Where(x => x.FirstName.StartsWith("J")).OrderBy(x => x.FirstName)
-                .FirstAsync().ConfigureAwait(false);
+                .FirstAsync();
 
             u1.ShouldBeTheSameAs(user3);
 
 
             var u2 = await theSession.Query<User>().Where(x => x.FirstName.StartsWith("J")).OrderBy(x => x.FirstName)
-                .FirstOrDefaultAsync().ConfigureAwait(false);
+                .FirstOrDefaultAsync();
 
             u2.ShouldBeTheSameAs(user3);
 
@@ -111,7 +111,7 @@ namespace Marten.Testing.Linq
         public async Task query_runs_through_identity_map_async()
         {
             var users = await theSession.Query<User>().Where(x => x.FirstName.StartsWith("J")).OrderBy(x => x.FirstName)
-                .ToListAsync().ConfigureAwait(false);
+                .ToListAsync();
 
             users[0].ShouldBeTheSameAs(user3);
             users[1].ShouldBeTheSameAs(user2);

--- a/src/Marten.Testing/Linq/query_with_aggregate_functions.cs
+++ b/src/Marten.Testing/Linq/query_with_aggregate_functions.cs
@@ -37,7 +37,7 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Color = Colors.Blue, Number = 4 });
 
             theSession.SaveChanges();
-            var maxNumber = await theSession.Query<Target>().MaxAsync(t => t.Number).ConfigureAwait(false);
+            var maxNumber = await theSession.Query<Target>().MaxAsync(t => t.Number);
             maxNumber.ShouldBe(42);
         }
 
@@ -65,7 +65,7 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Color = Colors.Blue, Number = 4 });
 
             await theSession.SaveChangesAsync();
-            var maxNumber = await theSession.Query<Target>().MinAsync(t => t.Number).ConfigureAwait(false);
+            var maxNumber = await theSession.Query<Target>().MinAsync(t => t.Number);
             maxNumber.ShouldBe(-5);
         }
 
@@ -93,7 +93,7 @@ namespace Marten.Testing.Linq
             theSession.Store(new Target { Color = Colors.Blue, Number = 2 });
 
             await theSession.SaveChangesAsync();
-            var maxNumber = await theSession.Query<Target>().AverageAsync(t => t.Number).ConfigureAwait(false);
+            var maxNumber = await theSession.Query<Target>().AverageAsync(t => t.Number);
             maxNumber.ShouldBe(10);
         }
 

--- a/src/Marten.Testing/Linq/query_with_inheritance.cs
+++ b/src/Marten.Testing/Linq/query_with_inheritance.cs
@@ -204,9 +204,9 @@ namespace Marten.Testing.Linq
             var brainy = new BrainySmurf { Ability = "Invent" };
             theSession.Store(smurf, papa, brainy, papy);
 
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
-            var list = await theSession.Query<IPapaSmurf>().ToListAsync().ConfigureAwait(false);
+            var list = await theSession.Query<IPapaSmurf>().ToListAsync();
             list.Count().ShouldBe(3);
             list.Count(s => s.Ability == "Invent").ShouldBe(1);
         }

--- a/src/Marten.Testing/Linq/query_with_select_many.cs
+++ b/src/Marten.Testing/Linq/query_with_select_many.cs
@@ -324,7 +324,7 @@ namespace Marten.Testing.Linq
                 // Some Target docs w/ no children
                 session.Store(Target.Random(), Target.Random(), Target.Random());
 
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
             }
 
             using (var query = theStore.QuerySession())

--- a/src/Marten.Testing/Pagination/pagedlist_queryable_extension_Tests.cs
+++ b/src/Marten.Testing/Pagination/pagedlist_queryable_extension_Tests.cs
@@ -76,8 +76,7 @@ namespace Marten.Testing.Pagination
             var pageNumber = 2;
             var pageSize = 10;
 
-            var pagedList = await theSession.Query<Target>().ToPagedListAsync(pageNumber, pageSize)
-                .ConfigureAwait(false);
+            var pagedList = await theSession.Query<Target>().ToPagedListAsync(pageNumber, pageSize);
             #endregion sample_to_paged_list_async
 
             pagedList.Count.ShouldBe(pageSize);

--- a/src/Marten.Testing/Services/BatchedQuerying/batched_querying_acceptance_Tests.cs
+++ b/src/Marten.Testing/Services/BatchedQuerying/batched_querying_acceptance_Tests.cs
@@ -22,7 +22,7 @@ namespace Marten.Testing.Services.BatchedQuerying
         public async Task can_run_aggregate_functions()
         {
             theSession.Store(new IntDoc(1), new IntDoc(3), new IntDoc(5), new IntDoc(6));
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             var batch = theSession.CreateBatchQuery();
 
@@ -31,7 +31,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var sum = batch.Query<IntDoc>().Sum(x => x.Id);
             var average = batch.Query<IntDoc>().Average(x => x.Id);
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
             (await min).ShouldBe(1);
             (await max).ShouldBe(6);
@@ -152,7 +152,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var justin = batch.Query(new FindByFirstName {FirstName = "Justin"});
             var tamba = batch.Query(new FindByFirstName {FirstName = "Tamba"});
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
             (await justin).Id.ShouldBe(user1.Id);
             (await tamba).Id.ShouldBe(user2.Id);
@@ -181,7 +181,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             #region sample_using-compiled-query
             var justin = theSession.Query(new FindByFirstName {FirstName = "Justin"});
 
-            var tamba = await theSession.QueryAsync(new FindByFirstName {FirstName = "Tamba"}).ConfigureAwait(false);
+            var tamba = await theSession.QueryAsync(new FindByFirstName {FirstName = "Tamba"});
             #endregion sample_using-compiled-query
         }
 
@@ -193,7 +193,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var justin = batch.Query<User>("where first_name = ?", "Justin");
             var tamba = batch.Query<User>("where first_name = ? and last_name = ?", "Tamba", "Hali");
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
             (await justin).Single().Id.ShouldBe(user1.Id);
             (await tamba).Single().Id.ShouldBe(user2.Id);
@@ -207,7 +207,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var firstUser = batch.Query<User>().OrderBy(_ => _.FirstName).First();
             var firstAdmin = batch.Query<SuperUser>().OrderBy(_ => _.FirstName).First();
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
             (await firstUser).UserName.ShouldBe("A2");
             (await firstAdmin).UserName.ShouldBe("A3");
@@ -222,7 +222,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var firstAdmin = batch.Query<SuperUser>().OrderBy(_ => _.FirstName).FirstOrDefault();
             var noneUser = batch.Query<User>().FirstOrDefault(_ => _.FirstName == "not me");
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
             (await firstUser).UserName.ShouldBe("A2");
             (await firstAdmin).UserName.ShouldBe("A3");
@@ -239,7 +239,7 @@ namespace Marten.Testing.Services.BatchedQuerying
 
             var noneUser = batch.Query<User>().SingleOrDefault(_ => _.FirstName == "not me");
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
             (await tamba).FirstName.ShouldBe("Tamba");
             (await justin).FirstName.ShouldBe("Justin");
@@ -258,7 +258,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var aUsers = batch.Query<User>().Where(_ => _.UserName.StartsWith("A")).ToList();
             var cUsers = batch.Query<User>().Where(_ => _.UserName.StartsWith("C")).ToList();
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
             (await anyUsers).OrderBy(x => x.FirstName).Select(x => x.Id)
                 .ShouldHaveTheSameElementsAs(admin1.Id, super1.Id, admin2.Id, user1.Id, super2.Id, user2.Id);
@@ -285,7 +285,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var aUsers = batch.Query<User>().Where(_ => _.UserName.StartsWith("A")).ToList();
             var cUsers = batch.Query<User>().Where(_ => _.UserName.StartsWith("C")).ToList();
 
-            batch.Execute().ConfigureAwait(false);
+            batch.Execute();
 
             anyUsers.Result.OrderBy(x => x.FirstName).Select(x => x.Id)
                 .ShouldHaveTheSameElementsAs(admin1.Id, super1.Id, admin2.Id, user1.Id, super2.Id, user2.Id);
@@ -313,7 +313,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var aUsers = batch.Query<User>().Any(_ => _.UserName.StartsWith("A"));
             var cUsers = batch.Query<User>().Any(_ => _.UserName.StartsWith("C"));
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
             (await anyUsers).ShouldBeTrue();
             (await anyAdmins).ShouldBeTrue();
@@ -333,7 +333,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var aUsers = batch.Query<User>().Count(_ => _.UserName.StartsWith("A"));
             var cUsers = batch.Query<User>().Count(_ => _.UserName.StartsWith("C"));
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
             (await anyUsers).ShouldBe(6);
             (await anyAdmins).ShouldBe(2);
@@ -349,7 +349,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var task1 = batch.Load<Target>(target1.Id);
             var task3 = batch.Load<Target>(target3.Id);
 
-            await batch.Execute().ConfigureAwait(false);
+            await batch.Execute();
 
             SpecificationExtensions.ShouldNotBeNull((await task1).ShouldBeOfType<Target>());
             SpecificationExtensions.ShouldNotBeNull((await task3).ShouldBeOfType<Target>());
@@ -364,7 +364,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var task1 = batch1.Load<Target>(target1.Id);
             var task3 = batch1.Load<Target>(target3.Id);
 
-            await batch1.Execute().ConfigureAwait(false);
+            await batch1.Execute();
 
             var batch2 = theSession.CreateBatchQuery();
             var task21 = batch2.Load<Target>(target1.Id);
@@ -382,7 +382,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var batch1 = theSession.CreateBatchQuery();
             var task = batch1.LoadMany<Target>().ById(target1.Id, target3.Id);
 
-            await batch1.Execute().ConfigureAwait(false);
+            await batch1.Execute();
 
             var list = await task;
 
@@ -399,7 +399,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var batch1 = theSession.CreateBatchQuery();
             var task1 = batch1.LoadMany<Target>().ById(target1.Id, target3.Id);
 
-            await batch1.Execute().ConfigureAwait(false);
+            await batch1.Execute();
 
             var batch2 = theSession.CreateBatchQuery();
             var task2 = batch2.LoadMany<Target>().ById(target1.Id, target3.Id);
@@ -415,7 +415,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var batch1 = theSession.CreateBatchQuery();
             var task = batch1.LoadMany<Target>().ByIdList(new List<Guid> {target1.Id, target3.Id});
 
-            await batch1.Execute().ConfigureAwait(false);
+            await batch1.Execute();
 
             var list = await task;
 
@@ -432,7 +432,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var batch1 = theSession.CreateBatchQuery();
             var task1 = batch1.LoadMany<Target>().ByIdList(new List<Guid> {target1.Id, target3.Id});
 
-            await batch1.Execute().ConfigureAwait(false);
+            await batch1.Execute();
 
             var batch2 = theSession.CreateBatchQuery();
             var task2 = batch2.LoadMany<Target>().ByIdList(new List<Guid> {target1.Id, target3.Id});
@@ -460,7 +460,7 @@ namespace Marten.Testing.Services.BatchedQuerying
             var singleOrDefault =
                 batch1.Query<User>().Where(x => x.FirstName == "nobody").Select(x => x.FirstName).SingleOrDefault();
 
-            await batch1.Execute().ConfigureAwait(false);
+            await batch1.Execute();
 
             (await toList).ShouldHaveTheSameElementsAs("Derrick", "Dontari", "Eric", "Justin", "Sean", "Tamba");
             (await first).ShouldBe("Derrick");
@@ -490,7 +490,7 @@ namespace Marten.Testing.Services.BatchedQuerying
                     .Select(x => new {Name = x.FirstName})
                     .SingleOrDefault();
 
-            await batch1.Execute().ConfigureAwait(false);
+            await batch1.Execute();
 
             (await toList).Select(x => x.Name)
                 .ShouldHaveTheSameElementsAs("Derrick", "Dontari", "Eric", "Justin", "Sean", "Tamba");
@@ -527,7 +527,7 @@ namespace Marten.Testing.Services.BatchedQuerying
                     .Select(x => new UserName {Name = x.FirstName})
                     .SingleOrDefault();
 
-            await batch1.Execute().ConfigureAwait(false);
+            await batch1.Execute();
 
             (await toList).Select(x => x.Name)
                 .ShouldHaveTheSameElementsAs("Derrick", "Dontari", "Eric", "Justin", "Sean", "Tamba");

--- a/src/Marten.Testing/Services/Includes/end_to_end_query_with_include_Tests.cs
+++ b/src/Marten.Testing/Services/Includes/end_to_end_query_with_include_Tests.cs
@@ -58,7 +58,7 @@ namespace Marten.Testing.Services.Includes
                 var toDict = batch.Query<Issue>()
                     .Include(x => x.AssigneeId, dict).ToList();
 
-                await batch.Execute().ConfigureAwait(false);
+                await batch.Execute();
 
 
                 (await found).Id.ShouldBe(issue1.Id);
@@ -581,7 +581,7 @@ namespace Marten.Testing.Services.Includes
             var issue = new Issue { AssigneeId = user.Id, Title = "Garage Door is busted" };
 
             theSession.Store<object>(user, issue);
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             using (var query = theStore.QuerySession())
             {
@@ -589,7 +589,7 @@ namespace Marten.Testing.Services.Includes
                 var issue2 = await query.Query<Issue>()
                     .Include<User>(x => x.AssigneeId, x => included = x)
                     .Where(x => x.Title == issue.Title)
-                    .SingleAsync().ConfigureAwait(false);
+                    .SingleAsync();
 
                 SpecificationExtensions.ShouldNotBeNull(included);
                 included.Id.ShouldBe(user.Id);
@@ -610,13 +610,13 @@ namespace Marten.Testing.Services.Includes
 
             theSession.Store(user1, user2);
             theSession.Store(issue1, issue2, issue3);
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             using (var query = theStore.QuerySession())
             {
                 var list = new List<User>();
 
-                await query.Query<Issue>().Include(x => x.AssigneeId, list).ToListAsync().ConfigureAwait(false);
+                await query.Query<Issue>().Include(x => x.AssigneeId, list).ToListAsync();
 
                 list.Count.ShouldBe(2);
 
@@ -637,7 +637,7 @@ namespace Marten.Testing.Services.Includes
 
             theSession.Store(user1, user2);
             theSession.Store(issue1, issue2, issue3);
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             using (var query = theStore.QuerySession())
             {
@@ -645,7 +645,7 @@ namespace Marten.Testing.Services.Includes
 
                 await query.Query<Issue>().Include(x => x.AssigneeId, list)
                            .OrderByDescending(x => x.Id)
-                           .ToListAsync().ConfigureAwait(false);
+                           .ToListAsync();
 
                 list.Count.ShouldBe(2);
 
@@ -666,7 +666,7 @@ namespace Marten.Testing.Services.Includes
 
             theSession.Store(user1, user2);
             theSession.Store(issue1, issue2, issue3);
-            await theSession.SaveChangesAsync().ConfigureAwait(false);
+            await theSession.SaveChangesAsync();
 
             using (var query = theStore.QuerySession())
             {
@@ -674,7 +674,7 @@ namespace Marten.Testing.Services.Includes
 
                 await query.Query<Issue>().Include(x => x.AssigneeId, list)
                            .OrderBy(x => x.Id)
-                           .ToListAsync().ConfigureAwait(false);
+                           .ToListAsync();
 
                 list.Count.ShouldBe(2);
 
@@ -701,7 +701,7 @@ namespace Marten.Testing.Services.Includes
 
             var dict = new Dictionary<Guid, User>();
 
-            await query.Query<Issue>().Include(x => x.AssigneeId, dict).ToListAsync().ConfigureAwait(false);
+            await query.Query<Issue>().Include(x => x.AssigneeId, dict).ToListAsync();
 
             dict.Count.ShouldBe(2);
             dict.ContainsKey(user1.Id).ShouldBeTrue();

--- a/src/Marten.Testing/Util/update_batch_Tests.cs
+++ b/src/Marten.Testing/Util/update_batch_Tests.cs
@@ -49,9 +49,9 @@ namespace Marten.Testing.Util
             using (var session = theStore.LightweightSession())
             {
                 session.Store(targets);
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
 
-                var t = await session.Query<Target>().CountAsync().ConfigureAwait(false);
+                var t = await session.Query<Target>().CountAsync();
                 t.ShouldBe(100);
             }
         }
@@ -85,9 +85,9 @@ namespace Marten.Testing.Util
                 session.DeleteWhere<Target>(x => x.Id != Guid.Empty);
                 targets.Each(x => session.Store(x));
 
-                await session.SaveChangesAsync().ConfigureAwait(false);
+                await session.SaveChangesAsync();
 
-                var t = await session.Query<Target>().CountAsync().ConfigureAwait(false);
+                var t = await session.Query<Target>().CountAsync();
                 t.ShouldBe(100);
             }
         }


### PR DESCRIPTION
- Cleanup `ConfigureAwait(false)` from unit tests
- fixes #1698