### PR TITLE
Event Projection testing helper

### DIFF
--- a/src/Marten.Testing/Events/event_projection_scenario_tests.cs
+++ b/src/Marten.Testing/Events/event_projection_scenario_tests.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Threading.Tasks;
+using Marten.Events.Projections;
+using Marten.Events.TestSupport;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Events
+{
+    [Collection("projection_scenario")]
+    public class event_projection_scenario_tests : OneOffConfigurationsContext
+    {
+        public event_projection_scenario_tests() : base("projection_scenario")
+        {
+        }
+
+        [Fact]
+        public async Task happy_path_test_with_inline_projection()
+        {
+            StoreOptions(opts =>
+            {
+                opts.Events.Projections.Add(new UserProjection(), ProjectionLifecycle.Inline);
+            });
+
+            await theStore.Advanced.EventProjectionScenario(scenario =>
+            {
+                var id1 = Guid.NewGuid();
+                var id2 = Guid.NewGuid();
+                var id3 = Guid.NewGuid();
+
+                scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id1, UserName = "Kareem"});
+                scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id2, UserName = "Magic"});
+                scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id3, UserName = "James"});
+
+                scenario.DocumentShouldExist<User>(id1);
+                scenario.DocumentShouldExist<User>(id2);
+                scenario.DocumentShouldExist<User>(id3, user => user.UserName.ShouldBe("James"));
+
+                scenario.Append(Guid.NewGuid(), new DeleteUser {UserId = id2});
+
+                scenario.DocumentShouldExist<User>(id1);
+                scenario.DocumentShouldNotExist<User>(id2);
+                scenario.DocumentShouldExist<User>(id3);
+
+            });
+        }
+
+        [Fact]
+        public async Task sad_path_test_with_inline_projection()
+        {
+            StoreOptions(opts =>
+            {
+                opts.Events.Projections.Add(new UserProjection(), ProjectionLifecycle.Inline);
+            });
+
+            await Exception<ProjectionScenarioException>.ShouldBeThrownByAsync(async () =>
+            {
+                await theStore.Advanced.EventProjectionScenario(scenario =>
+                {
+                    var id1 = Guid.NewGuid();
+                    var id2 = Guid.NewGuid();
+                    var id3 = Guid.NewGuid();
+
+                    scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id1, UserName = "Kareem"});
+                    scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id2, UserName = "Magic"});
+                    scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id3, UserName = "James"});
+
+                    scenario.DocumentShouldExist<User>(id1);
+                    scenario.DocumentShouldExist<User>(id2);
+                    scenario.DocumentShouldExist<User>(id3, user => user.UserName.ShouldBe("James"));
+
+                    scenario.Append(Guid.NewGuid(), new DeleteUser {UserId = id2});
+
+                    // This should have been deleted
+                    scenario.DocumentShouldExist<User>(id2);
+
+                });
+            });
+
+
+        }
+
+        [Fact]
+        public async Task sad_path_test_with_inline_projection_with_document_assertion()
+        {
+            StoreOptions(opts =>
+            {
+                opts.Events.Projections.Add(new UserProjection(), ProjectionLifecycle.Inline);
+            });
+
+            await Exception<ProjectionScenarioException>.ShouldBeThrownByAsync(async () =>
+            {
+                await theStore.Advanced.EventProjectionScenario(scenario =>
+                {
+                    var id1 = Guid.NewGuid();
+                    var id2 = Guid.NewGuid();
+                    var id3 = Guid.NewGuid();
+
+                    scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id1, UserName = "Kareem"});
+                    scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id2, UserName = "Magic"});
+                    scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id3, UserName = "James"});
+
+                    scenario.DocumentShouldExist<User>(id1, u => u.FirstName.ShouldBe("WRONG"));
+                    scenario.DocumentShouldExist<User>(id2);
+                    scenario.DocumentShouldExist<User>(id3, user => user.UserName.ShouldBe("James"));
+
+
+                });
+            });
+
+
+        }
+
+
+
+
+
+
+        [Fact]
+        public async Task happy_path_test_with_inline_projection_async()
+        {
+            StoreOptions(opts =>
+            {
+                opts.Events.Projections.Add(new UserProjection(), ProjectionLifecycle.Async);
+            });
+
+            await theStore.Advanced.EventProjectionScenario(scenario =>
+            {
+                var id1 = Guid.NewGuid();
+                var id2 = Guid.NewGuid();
+                var id3 = Guid.NewGuid();
+
+                scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id1, UserName = "Kareem"});
+                scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id2, UserName = "Magic"});
+                scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id3, UserName = "James"});
+
+                scenario.DocumentShouldExist<User>(id1);
+                scenario.DocumentShouldExist<User>(id2);
+                scenario.DocumentShouldExist<User>(id3, user => user.UserName.ShouldBe("James"));
+
+                scenario.Append(Guid.NewGuid(), new DeleteUser {UserId = id2});
+
+                scenario.DocumentShouldExist<User>(id1);
+                scenario.DocumentShouldNotExist<User>(id2);
+                scenario.DocumentShouldExist<User>(id3);
+
+            });
+        }
+
+        [Fact]
+        public async Task sad_path_test_with_inline_projection_async()
+        {
+            StoreOptions(opts =>
+            {
+                opts.Events.Projections.Add(new UserProjection(), ProjectionLifecycle.Async);
+            });
+
+            await Exception<ProjectionScenarioException>.ShouldBeThrownByAsync(async () =>
+            {
+                await theStore.Advanced.EventProjectionScenario(scenario =>
+                {
+                    var id1 = Guid.NewGuid();
+                    var id2 = Guid.NewGuid();
+                    var id3 = Guid.NewGuid();
+
+                    scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id1, UserName = "Kareem"});
+                    scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id2, UserName = "Magic"});
+                    scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id3, UserName = "James"});
+
+                    scenario.DocumentShouldExist<User>(id1);
+                    scenario.DocumentShouldExist<User>(id2);
+                    scenario.DocumentShouldExist<User>(id3, user => user.UserName.ShouldBe("James"));
+
+                    scenario.Append(Guid.NewGuid(), new DeleteUser {UserId = id2});
+
+                    // This should have been deleted
+                    scenario.DocumentShouldExist<User>(id2);
+
+                });
+            });
+
+
+        }
+
+        [Fact]
+        public async Task sad_path_test_with_inline_projection_with_document_assertion_async()
+        {
+            StoreOptions(opts =>
+            {
+                opts.Events.Projections.Add(new UserProjection(), ProjectionLifecycle.Async);
+            });
+
+            await Exception<ProjectionScenarioException>.ShouldBeThrownByAsync(async () =>
+            {
+                await theStore.Advanced.EventProjectionScenario(scenario =>
+                {
+                    var id1 = Guid.NewGuid();
+                    var id2 = Guid.NewGuid();
+                    var id3 = Guid.NewGuid();
+
+                    scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id1, UserName = "Kareem"});
+                    scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id2, UserName = "Magic"});
+                    scenario.Append(Guid.NewGuid(), new CreateUser {UserId = id3, UserName = "James"});
+
+                    scenario.DocumentShouldExist<User>(id1, u => u.FirstName.ShouldBe("WRONG"));
+                    scenario.DocumentShouldExist<User>(id2);
+                    scenario.DocumentShouldExist<User>(id3, user => user.UserName.ShouldBe("James"));
+
+
+                });
+            });
+
+
+        }
+
+
+
+
+    }
+
+    public class CreateUser
+    {
+        public Guid UserId { get; set; }
+        public string UserName { get; set; }
+    }
+
+    public class DeleteUser
+    {
+        public Guid UserId { get; set; }
+    }
+
+    public class UserProjection: EventProjection
+    {
+        public User Create(CreateUser create)
+        {
+            return new User
+            {
+                Id = create.UserId, UserName = create.UserName
+            };
+        }
+
+        public void Project(DeleteUser deletion, IDocumentOperations operations)
+        {
+            operations.Delete<User>(deletion.UserId);
+        }
+    }
+}

--- a/src/Marten/AdvancedOperations.cs
+++ b/src/Marten/AdvancedOperations.cs
@@ -6,6 +6,7 @@ using Baseline;
 using Marten.Events;
 using Marten.Events.Daemon;
 using Marten.Events.Daemon.Progress;
+using Marten.Events.TestSupport;
 using Marten.Internal;
 using Marten.Internal.Sessions;
 using Marten.Linq.QueryHandlers;
@@ -180,5 +181,21 @@ select last_value from {_store.Events.DatabaseSchemaName}.mt_events_sequence;
                 return providers.StorageFor<T>();
             }
         }
+
+
+        /// <summary>
+        /// Marten's built in test support for event projections. Only use this in testing as
+        /// it will delete existing event and projected aggregate data
+        /// </summary>
+        /// <param name="configuration"></param>
+        /// <returns></returns>
+        public Task EventProjectionScenario(Action<ProjectionScenario> configuration)
+        {
+            var scenario = new ProjectionScenario(_store);
+            configuration(scenario);
+
+            return scenario.Execute();
+        }
+
     }
 }

--- a/src/Marten/Events/Daemon/IProjectionDaemon.cs
+++ b/src/Marten/Events/Daemon/IProjectionDaemon.cs
@@ -74,5 +74,14 @@ namespace Marten.Events.Daemon
         /// </summary>
         /// <returns></returns>
         Task StartDaemon();
+
+
+        /// <summary>
+        /// Use with caution! This will try to wait for all projections to "catch up" to the currently
+        /// known farthest known sequence of the event store
+        /// </summary>
+        /// <param name="timeout"></param>
+        /// <returns></returns>
+        Task WaitForNonStaleData(TimeSpan timeout);
     }
 }

--- a/src/Marten/Events/IEventStore.cs
+++ b/src/Marten/Events/IEventStore.cs
@@ -7,7 +7,7 @@ using Marten.Linq;
 
 namespace Marten.Events
 {
-    public interface IEventStore
+    public interface IEventOperations
     {
         /// <summary>
         /// Append one or more events in order to an existing stream
@@ -44,15 +44,6 @@ namespace Marten.Events
         /// <param name="stream"></param>
         /// <param name="expectedVersion">Expected maximum event version after append</param>
         /// <param name="events"></param>
-        StreamAction Append(Guid stream, long expectedVersion, IEnumerable<object> events);
-
-        /// <summary>
-        /// Append one or more events in order to an existing stream and verify that maximum event id for the stream
-        /// matches supplied expected version or transaction is aborted.
-        /// </summary>
-        /// <param name="stream"></param>
-        /// <param name="expectedVersion">Expected maximum event version after append</param>
-        /// <param name="events"></param>
         StreamAction Append(Guid stream, long expectedVersion, params object[] events);
 
         /// <summary>
@@ -72,15 +63,6 @@ namespace Marten.Events
         /// <param name="expectedVersion">Expected maximum event version after append</param>
         /// <param name="events"></param>
         StreamAction Append(string stream, long expectedVersion, params object[] events);
-
-        /// <summary>
-        /// Creates a new event stream based on a user-supplied Guid and appends the events in order to the new stream
-        /// </summary>
-        /// <typeparam name="TAggregate"></typeparam>
-        /// <param name="id"></param>
-        /// <param name="events"></param>
-        /// <returns></returns>
-        StreamAction StartStream<TAggregate>(Guid id, IEnumerable<object> events) where TAggregate : class;
 
         /// <summary>
         /// Creates a new event stream based on a user-supplied Guid and appends the events in order to the new stream
@@ -236,6 +218,27 @@ namespace Marten.Events
         /// <param name="events"></param>
         /// <returns></returns>
         StreamAction StartStream(params object[] events);
+    }
+
+    public interface IEventStore: IEventOperations
+    {
+        /// <summary>
+        /// Append one or more events in order to an existing stream and verify that maximum event id for the stream
+        /// matches supplied expected version or transaction is aborted.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="expectedVersion">Expected maximum event version after append</param>
+        /// <param name="events"></param>
+        StreamAction Append(Guid stream, long expectedVersion, IEnumerable<object> events);
+
+        /// <summary>
+        /// Creates a new event stream based on a user-supplied Guid and appends the events in order to the new stream
+        /// </summary>
+        /// <typeparam name="TAggregate"></typeparam>
+        /// <param name="id"></param>
+        /// <param name="events"></param>
+        /// <returns></returns>
+        StreamAction StartStream<TAggregate>(Guid id, IEnumerable<object> events) where TAggregate : class;
 
         /// <summary>
         /// Synchronously fetches all of the events for the named stream

--- a/src/Marten/Events/Projections/ProjectionCollection.cs
+++ b/src/Marten/Events/Projections/ProjectionCollection.cs
@@ -32,6 +32,11 @@ namespace Marten.Events.Projections
             return Projections.SelectMany(x => x.AsyncProjectionShards(store)).ToList();
         }
 
+        internal bool HasAnyAsyncProjections()
+        {
+            return Projections.Any(x => x.Lifecycle == ProjectionLifecycle.Async);
+        }
+
         internal IEnumerable<Type> AllAggregateTypes()
         {
             foreach (var kv in _liveAggregators.Enumerate())

--- a/src/Marten/Events/TestSupport/ProjectionScenario.Assertions.cs
+++ b/src/Marten/Events/TestSupport/ProjectionScenario.Assertions.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Threading.Tasks;
+using LamarCodeGeneration;
+
+namespace Marten.Events.TestSupport
+{
+    public partial class ProjectionScenario
+    {
+        /// <summary>
+        /// General hook to run
+        /// </summary>
+        /// <param name="description"></param>
+        /// <param name="assertions"></param>
+        public void AssertAgainstProjectedData(string description, Func<IQuerySession, Task> assertions)
+        {
+            assertion(assertions).Description = description;
+        }
+
+        /// <summary>
+        ///     Verify that a document with the supplied id exists
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="assertions">Optional lambda to make additional assertions about the document state</param>
+        /// <typeparam name="T">The document type</typeparam>
+        public void DocumentShouldExist<T>(string id, Action<T> assertions = null)
+        {
+            assertion(async session =>
+            {
+                var document = await session.LoadAsync<T>(id);
+                if (document == null)
+                {
+                    throw new Exception($"Document {typeof(T).FullNameInCode()} with id '{id}' does not exist");
+                }
+
+                assertions?.Invoke(document);
+            }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should exist";
+        }
+
+        /// <summary>
+        ///     Verify that a document with the supplied id exists
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="assertions">Optional lambda to make additional assertions about the document state</param>
+        /// <typeparam name="T">The document type</typeparam>
+        public void DocumentShouldExist<T>(long id, Action<T> assertions = null)
+        {
+            assertion(async session =>
+            {
+                var document = await session.LoadAsync<T>(id);
+                if (document == null)
+                {
+                    throw new Exception($"Document {typeof(T).FullNameInCode()} with id '{id}' does not exist");
+                }
+
+                assertions?.Invoke(document);
+            }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should exist";
+        }
+
+        /// <summary>
+        ///     Verify that a document with the supplied id exists
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="assertions">Optional lambda to make additional assertions about the document state</param>
+        /// <typeparam name="T">The document type</typeparam>
+        public void DocumentShouldExist<T>(int id, Action<T> assertions = null)
+        {
+            assertion(async session =>
+            {
+                var document = await session.LoadAsync<T>(id);
+                if (document == null)
+                {
+                    throw new Exception($"Document {typeof(T).FullNameInCode()} with id '{id}' does not exist");
+                }
+
+                assertions?.Invoke(document);
+            }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should exist";
+        }
+
+        /// <summary>
+        ///     Verify that a document with the supplied id exists
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="assertions">Optional lambda to make additional assertions about the document state</param>
+        /// <typeparam name="T">The document type</typeparam>
+        public void DocumentShouldExist<T>(Guid id, Action<T> assertions = null)
+        {
+            assertion(async session =>
+            {
+                var document = await session.LoadAsync<T>(id);
+                if (document == null)
+                {
+                    throw new Exception($"Document {typeof(T).FullNameInCode()} with id '{id}' does not exist");
+                }
+
+                assertions?.Invoke(document);
+            }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should exist";
+        }
+
+        /// <summary>
+        ///     Asserts that a document with a given id has been deleted or does not exist
+        /// </summary>
+        /// <param name="id">The identity of the document</param>
+        /// <typeparam name="T">The document type</typeparam>
+        public void DocumentShouldNotExist<T>(string id)
+        {
+            assertion(async session =>
+            {
+                var document = await session.LoadAsync<T>(id);
+                if (document != null)
+                {
+                    throw new Exception(
+                        $"Document {typeof(T).FullNameInCode()} with id '{id}' exists, but should not.");
+                }
+            }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should not exist or be deleted";
+        }
+
+        /// <summary>
+        ///     Asserts that a document with a given id has been deleted or does not exist
+        /// </summary>
+        /// <param name="id">The identity of the document</param>
+        /// <typeparam name="T">The document type</typeparam>
+        public void DocumentShouldNotExist<T>(long id)
+        {
+            assertion(async session =>
+            {
+                var document = await session.LoadAsync<T>(id);
+                if (document != null)
+                {
+                    throw new Exception(
+                        $"Document {typeof(T).FullNameInCode()} with id '{id}' exists, but should not.");
+                }
+            }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should not exist or be deleted";
+        }
+
+        /// <summary>
+        ///     Asserts that a document with a given id has been deleted or does not exist
+        /// </summary>
+        /// <param name="id">The identity of the document</param>
+        /// <typeparam name="T">The document type</typeparam>
+        public void DocumentShouldNotExist<T>(int id)
+        {
+            assertion(async session =>
+            {
+                var document = await session.LoadAsync<T>(id);
+                if (document != null)
+                {
+                    throw new Exception(
+                        $"Document {typeof(T).FullNameInCode()} with id '{id}' exists, but should not.");
+                }
+            }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should not exist or be deleted";
+        }
+
+        /// <summary>
+        ///     Asserts that a document with a given id has been deleted or does not exist
+        /// </summary>
+        /// <param name="id">The identity of the document</param>
+        /// <typeparam name="T">The document type</typeparam>
+        public void DocumentShouldNotExist<T>(Guid id)
+        {
+            assertion(async session =>
+            {
+                var document = await session.LoadAsync<T>(id);
+                if (document != null)
+                {
+                    throw new Exception(
+                        $"Document {typeof(T).FullNameInCode()} with id '{id}' exists, but should not.");
+                }
+            }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should not exist or be deleted";
+        }
+    }
+}

--- a/src/Marten/Events/TestSupport/ProjectionScenario.EventOperations.cs
+++ b/src/Marten/Events/TestSupport/ProjectionScenario.EventOperations.cs
@@ -1,0 +1,411 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Baseline;
+using LamarCodeGeneration;
+
+namespace Marten.Events.TestSupport
+{
+    public partial class ProjectionScenario
+    {
+        /// <summary>
+        /// Make any number of append event operations in the scenario sequence
+        /// </summary>
+        /// <param name="description">Descriptive explanation of the action in case of failures</param>
+        /// <param name="appendAction"></param>
+        public void AppendEvents(string description, Action<IEventOperations> appendAction)
+        {
+            action(appendAction).Description = description;
+        }
+
+        /// <summary>
+        /// Make any number of append event operations in the scenario sequence
+        /// </summary>
+        /// <param name="appendAction"></param>
+        public void AppendEvents(Action<IEventOperations> appendAction)
+        {
+            AppendEvents("Appending events...", appendAction);
+        }
+
+        public StreamAction Append(Guid stream, IEnumerable<object> events)
+        {
+            var step = action(e => e.Append(stream, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"Append({stream}, events)";
+            }
+            else
+            {
+                step.Description = $"Append({stream}, {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Append(_store.Events, stream, events);
+        }
+
+        public StreamAction Append(Guid stream, params object[] events)
+        {
+            var step = action(e => e.Append(stream, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"Append({stream}, events)";
+            }
+            else
+            {
+                step.Description = $"Append({stream}, {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Append(_store.Events, stream, events);
+        }
+
+        public StreamAction Append(string stream, IEnumerable<object> events)
+        {
+            var step = action(e => e.Append(stream, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"Append('{stream}', events)";
+            }
+            else
+            {
+                step.Description = $"Append('{stream}', {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Append(_store.Events, stream, events);
+        }
+
+        public StreamAction Append(string stream, params object[] events)
+        {
+            var step = action(e => e.Append(stream, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"Append('{stream}', events)";
+            }
+            else
+            {
+                step.Description = $"Append('{stream}', {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Append(_store.Events, stream, events);
+        }
+
+        public StreamAction Append(Guid stream, long expectedVersion, params object[] events)
+        {
+            var step = action(e => e.Append(stream, expectedVersion, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"Append({stream}, {expectedVersion}, events)";
+            }
+            else
+            {
+                step.Description =
+                    $"Append({stream}, {expectedVersion}, {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Append(_store.Events, stream, events);
+        }
+
+        public StreamAction Append(string stream, long expectedVersion, IEnumerable<object> events)
+        {
+            var step = action(e => e.Append(stream, expectedVersion, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"Append(\"{stream}\", {expectedVersion}, events)";
+            }
+            else
+            {
+                step.Description =
+                    $"Append(\"{stream}\", {expectedVersion}, {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Append(_store.Events, stream, events);
+        }
+
+        public StreamAction Append(string stream, long expectedVersion, params object[] events)
+        {
+            var step = action(e => e.Append(stream, expectedVersion, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"Append(\"{stream}\", {expectedVersion}, events)";
+            }
+            else
+            {
+                step.Description =
+                    $"Append(\"{stream}\", {expectedVersion}, {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Append(_store.Events, stream, events);
+        }
+
+        public StreamAction StartStream<TAggregate>(Guid id, params object[] events) where TAggregate : class
+        {
+            var step = action(e => e.StartStream<TAggregate>(id, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream<{typeof(TAggregate).FullNameInCode()}>({id}, events)";
+            }
+            else
+            {
+                step.Description =
+                    $"StartStream<{typeof(TAggregate).FullNameInCode()}>({id}, {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, id, events);
+        }
+
+        public StreamAction StartStream(Type aggregateType, Guid id, IEnumerable<object> events)
+        {
+            var step = action(e => e.StartStream(aggregateType, id, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream({aggregateType.FullNameInCode()}>({id}, events)";
+            }
+            else
+            {
+                step.Description =
+                    $"StartStream({aggregateType.FullNameInCode()}, {id}, {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, id, events);
+        }
+
+        public StreamAction StartStream(Type aggregateType, Guid id, params object[] events)
+        {
+            var step = action(e => e.StartStream(aggregateType, id, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream({aggregateType.FullNameInCode()}>({id}, events)";
+            }
+            else
+            {
+                step.Description =
+                    $"StartStream({aggregateType.FullNameInCode()}, {id}, {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, id, events);
+        }
+
+        public StreamAction StartStream<TAggregate>(string streamKey, IEnumerable<object> events)
+            where TAggregate : class
+        {
+            var step = action(e => e.StartStream<TAggregate>(streamKey, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream<{typeof(TAggregate).FullNameInCode()}>(\"{streamKey}\", events)";
+            }
+            else
+            {
+                step.Description =
+                    $"StartStream<{typeof(TAggregate).FullNameInCode()}>(\"{streamKey}\", {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, streamKey, events);
+        }
+
+        public StreamAction StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class
+        {
+            var step = action(e => e.StartStream<TAggregate>(streamKey, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream<{typeof(TAggregate).FullNameInCode()}>(\"{streamKey}\", events)";
+            }
+            else
+            {
+                step.Description =
+                    $"StartStream<{typeof(TAggregate).FullNameInCode()}>(\"{streamKey}\", {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, streamKey, events);
+        }
+
+        public StreamAction StartStream(Type aggregateType, string streamKey, IEnumerable<object> events)
+        {
+            var step = action(e => e.StartStream(aggregateType, streamKey, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream({aggregateType.FullNameInCode()}>(\"{streamKey}\", events)";
+            }
+            else
+            {
+                step.Description =
+                    $"StartStream({aggregateType.FullNameInCode()}, \"{streamKey}\", {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, streamKey, events);
+        }
+
+        public StreamAction StartStream(Type aggregateType, string streamKey, params object[] events)
+        {
+            var step = action(e => e.StartStream(aggregateType, streamKey, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream({aggregateType.FullNameInCode()}>(\"{streamKey}\", events)";
+            }
+            else
+            {
+                step.Description =
+                    $"StartStream({aggregateType.FullNameInCode()}, \"{streamKey}\", {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, streamKey, events);
+        }
+
+        public StreamAction StartStream(Guid id, IEnumerable<object> events)
+        {
+            var step = action(e => e.StartStream(id, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream({id}, events)";
+            }
+            else
+            {
+                step.Description = $"StartStream({id}, {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, id, events);
+        }
+
+        public StreamAction StartStream(Guid id, params object[] events)
+        {
+            var step = action(e => e.StartStream(id, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream({id}, events)";
+            }
+            else
+            {
+                step.Description = $"StartStream({id}, {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, id, events);
+        }
+
+        public StreamAction StartStream(string streamKey, IEnumerable<object> events)
+        {
+            var step = action(e => e.StartStream(streamKey, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream(\"{streamKey}\", events)";
+            }
+            else
+            {
+                step.Description = $"StartStream(\"{streamKey}\", {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, streamKey, events);
+        }
+
+        public StreamAction StartStream(string streamKey, params object[] events)
+        {
+            var step = action(e => e.StartStream(streamKey, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream(\"{streamKey}\", events)";
+            }
+            else
+            {
+                step.Description = $"StartStream(\"{streamKey}\", {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, streamKey, events);
+        }
+
+        public StreamAction StartStream<TAggregate>(IEnumerable<object> events) where TAggregate : class
+        {
+            var streamId = Guid.NewGuid();
+            var step = action(e => e.StartStream<TAggregate>(streamId, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream<{typeof(TAggregate).FullNameInCode()}>(events)";
+            }
+            else
+            {
+                step.Description =
+                    $"StartStream<{typeof(TAggregate).FullNameInCode()}>({events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, streamId, events);
+        }
+
+        public StreamAction StartStream<TAggregate>(params object[] events) where TAggregate : class
+        {
+            var streamId = Guid.NewGuid();
+            var step = action(e => e.StartStream<TAggregate>(streamId, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream<{typeof(TAggregate).FullNameInCode()}>(events)";
+            }
+            else
+            {
+                step.Description =
+                    $"StartStream<{typeof(TAggregate).FullNameInCode()}>({events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, streamId, events);
+        }
+
+        public StreamAction StartStream(Type aggregateType, IEnumerable<object> events)
+        {
+            var streamId = Guid.NewGuid();
+            var step = action(e => e.StartStream(aggregateType, streamId, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream({aggregateType.FullNameInCode()}>(events)";
+            }
+            else
+            {
+                step.Description =
+                    $"StartStream({aggregateType.FullNameInCode()}, {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, streamId, events);
+        }
+
+        public StreamAction StartStream(Type aggregateType, params object[] events)
+        {
+            var streamId = Guid.NewGuid();
+            var step = action(e => e.StartStream(aggregateType, streamId, events));
+            if (events.Count() > 3)
+            {
+                step.Description = $"StartStream({aggregateType.FullNameInCode()}>(events)";
+            }
+            else
+            {
+                step.Description =
+                    $"StartStream({aggregateType.FullNameInCode()}, {events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, streamId, events);
+        }
+
+        public StreamAction StartStream(IEnumerable<object> events)
+        {
+            var streamId = Guid.NewGuid();
+            var step = action(e => e.StartStream(streamId, events));
+            if (events.Count() > 3)
+            {
+                step.Description = "StartStream(events)";
+            }
+            else
+            {
+                step.Description = $"StartStream({events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, streamId, events);
+        }
+
+        public StreamAction StartStream(params object[] events)
+        {
+            var streamId = Guid.NewGuid();
+            var step = action(e => e.StartStream(streamId, events));
+            if (events.Count() > 3)
+            {
+                step.Description = "StartStream(events)";
+            }
+            else
+            {
+                step.Description = $"StartStream({events.Select(x => x.ToString()).Join(", ")})";
+            }
+
+            return StreamAction.Start(_store.Events, streamId, events);
+        }
+    }
+}

--- a/src/Marten/Events/TestSupport/ProjectionScenario.cs
+++ b/src/Marten/Events/TestSupport/ProjectionScenario.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Baseline;
+using Baseline.Dates;
+using Marten.Events.Daemon;
+
+namespace Marten.Events.TestSupport
+{
+    public partial class ProjectionScenario: IEventOperations
+    {
+        private readonly Queue<ScenarioStep> _steps = new();
+        private readonly DocumentStore _store;
+
+
+        public ProjectionScenario(DocumentStore store)
+        {
+            _store = store;
+        }
+
+        internal IProjectionDaemon Daemon { get; private set; }
+
+        internal ScenarioStep NextStep => _steps.Any() ? _steps.Peek() : null;
+
+        internal IDocumentSession Session { get; private set; }
+
+        /// <summary>
+        ///     Disable the scenario from "cleaning" out any existing
+        ///     event and projected document data before running the scenario
+        /// </summary>
+        public bool DoNotDeleteExistingData { get; set; }
+
+
+
+        internal Task WaitForNonStaleData()
+        {
+            if (Daemon == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            return Daemon.WaitForNonStaleData(30.Seconds());
+        }
+
+
+        private ScenarioStep action(Action<IEventOperations> action)
+        {
+            var step = new ScenarioAction(action);
+            _steps.Enqueue(step);
+
+            return step;
+        }
+
+        private ScenarioStep assertion(Func<IQuerySession, Task> check)
+        {
+            var step = new ScenarioAssertion(check);
+            _steps.Enqueue(step);
+
+            return step;
+        }
+
+        internal async Task Execute()
+        {
+            if (!DoNotDeleteExistingData)
+            {
+                _store.Advanced.Clean.DeleteAllEventData();
+                foreach (var storageType in
+                    _store.Events.Projections.Projections.SelectMany(x => x.Options.StorageTypes))
+                    _store.Advanced.Clean.DeleteDocumentsFor(storageType);
+            }
+
+            if (_store.Events.Projections.HasAnyAsyncProjections())
+            {
+                Daemon = _store.BuildProjectionDaemon();
+                await Daemon.StartAll();
+            }
+
+            Session = _store.LightweightSession();
+
+            try
+            {
+                var exceptions = new List<Exception>();
+                var number = 0;
+                var descriptions = new List<string>();
+
+                while (_steps.Any())
+                {
+                    number++;
+                    var step = _steps.Dequeue();
+
+                    try
+                    {
+                        await step.Execute(this);
+                        descriptions.Add($"{number.ToString().PadLeft(3)}. {step.Description}");
+                    }
+                    catch (Exception e)
+                    {
+                        descriptions.Add($"FAILED: {number.ToString().PadLeft(3)}. {step.Description}");
+                        descriptions.Add(e.ToString());
+                        exceptions.Add(e);
+                    }
+                }
+
+                if (exceptions.Any())
+                {
+                    throw new ProjectionScenarioException(descriptions, exceptions);
+                }
+            }
+            finally
+            {
+                if (Daemon != null)
+                {
+                    await Daemon.StopAll();
+                    Daemon.SafeDispose();
+                }
+
+                Session?.SafeDispose();
+            }
+        }
+    }
+}

--- a/src/Marten/Events/TestSupport/ProjectionScenarioException.cs
+++ b/src/Marten/Events/TestSupport/ProjectionScenarioException.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using Baseline;
+
+namespace Marten.Events.TestSupport
+{
+    /// <summary>
+    ///     Thrown when a ProjectionScenario fails
+    /// </summary>
+    public class ProjectionScenarioException: AggregateException
+    {
+        public ProjectionScenarioException(List<string> descriptions, List<Exception> exceptions): base(
+            $"Event Projection Scenario Failure{Environment.NewLine}{descriptions.Join(Environment.NewLine)}",
+            exceptions)
+        {
+        }
+    }
+}

--- a/src/Marten/Events/TestSupport/ScenarioAction.cs
+++ b/src/Marten/Events/TestSupport/ScenarioAction.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Marten.Events.TestSupport
+{
+    internal class ScenarioAction: ScenarioStep
+    {
+        private readonly Action<IEventOperations> _action;
+
+        public ScenarioAction(Action<IEventOperations> action)
+        {
+            _action = action;
+        }
+
+        public override async Task Execute(ProjectionScenario scenario)
+        {
+            _action(scenario.Session.Events);
+
+            if (scenario.NextStep is ScenarioAssertion)
+            {
+                await scenario.Session.SaveChangesAsync();
+                await scenario.WaitForNonStaleData();
+            }
+        }
+    }
+}

--- a/src/Marten/Events/TestSupport/ScenarioAssertion.cs
+++ b/src/Marten/Events/TestSupport/ScenarioAssertion.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Marten.Events.TestSupport
+{
+    internal class ScenarioAssertion: ScenarioStep
+    {
+        private readonly Func<IQuerySession, Task> _check;
+
+        public ScenarioAssertion(Func<IQuerySession, Task> check)
+        {
+            _check = check;
+        }
+
+        public override Task Execute(ProjectionScenario scenario)
+        {
+            return _check(scenario.Session);
+        }
+    }
+}

--- a/src/Marten/Events/TestSupport/ScenarioStep.cs
+++ b/src/Marten/Events/TestSupport/ScenarioStep.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace Marten.Events.TestSupport
+{
+    internal abstract class ScenarioStep
+    {
+        public string Description { get; set; }
+
+        public abstract Task Execute(ProjectionScenario scenario);
+    }
+}

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Baseline;
 using Marten.Events;
 using Marten.Events.Daemon;
+using Marten.Events.TestSupport;
 using Marten.Exceptions;
 using Marten.Internal;
 using Marten.Internal.CompiledQueries;
@@ -562,5 +563,7 @@ namespace Marten
         /// </summary>
         public DdlRules DdlRules { get; } = new DdlRules();
 
+
     }
+
 }


### PR DESCRIPTION
It admittedly doesn't do a lot, but it does help with clearing out existing data and coordinating the test with the async daemon process *if* there are async projections