### PR TITLE
Use pg_roles instead of pg_user in Storage.Table schema object indexes query

### DIFF
--- a/src/Marten/Storage/Table.cs
+++ b/src/Marten/Storage/Table.cs
@@ -184,7 +184,7 @@ where attrelid = (select pg_class.oid
 and i.indisprimary;
 
 SELECT
-  U.usename                AS user_name,
+  R.rolname                AS user_name,
   ns.nspname               AS schema_name,
   pg_catalog.textin(pg_catalog.regclassout(idx.indrelid :: REGCLASS)) AS table_name,
   i.relname                AS index_name,
@@ -207,7 +207,7 @@ FROM pg_index AS idx
   JOIN pg_am AS am
     ON i.relam = am.oid
   JOIN pg_namespace AS NS ON i.relnamespace = NS.OID
-  JOIN pg_user AS U ON i.relowner = U.usesysid
+  JOIN pg_roles AS R ON i.relowner = r.oid
 WHERE
   nspname = :{schemaParam} AND
   NOT nspname LIKE 'pg%' AND


### PR DESCRIPTION
The change causes marten not to miss indexes in Storage.Table metadata queries.

Before the change, Marten would not return indexes that are owned by a role that cannot log in, which causes Marten to try to generate a patch creating existing indexes. 

Having roles that cannot log in is a common scenario in Postgres world, that allows easy password rotation without downtimes.