### PR TITLE
Fix codegen failure for aggregate types with no default constructor

### DIFF
--- a/src/Marten/Events/Aggregation/AggregateProjection.CodeGen.cs
+++ b/src/Marten/Events/Aggregation/AggregateProjection.CodeGen.cs
@@ -158,6 +158,7 @@ namespace Marten.Events.Aggregation
             _assembly.Generation.Assemblies.AddRange(_createMethods.ReferencedAssemblies());
             _assembly.Generation.Assemblies.AddRange(_shouldDeleteMethods.ReferencedAssemblies());
 
+            _assembly.Namespaces.Add("System");
             _assembly.Namespaces.Add("System.Linq");
 
             _isAsync = _createMethods.IsAsync || _applyMethods.IsAsync;

--- a/src/Marten/Events/CodeGeneration/AggregateEventProcessingFrame.cs
+++ b/src/Marten/Events/CodeGeneration/AggregateEventProcessingFrame.cs
@@ -95,7 +95,7 @@ namespace Marten.Events.CodeGeneration
                     }
                     else
                     {
-                        var errorMessage = $"Projection for {AggregateType.FullName} should either have the Create Method or Constructor for event of type {SpecificEvent.VariableType.FullName}, or {AggregateType.FullName} should have a Default Constructor.";
+                        var errorMessage = $"Projection for {AggregateType.FullName} should either have the Create Method or Constructor for event of type {SpecificEvent.VariableType.FullNameInCode()}, or {AggregateType.FullName} should have a Default Constructor.";
 
                         writer.Write($"if({Aggregate.Usage} == default) throw new ArgumentException(\"{errorMessage}\");");
                     }


### PR DESCRIPTION
Discovered this today whilst attempting to update to alpha.9. `FullName` spits out spaghetti and the exception was missing an import. Not exclusive to records, but very likely to encounter the issue.