### PR TITLE
Fix event querying with correlation and causation ids

### DIFF
--- a/src/Marten.Testing/Events/flexible_event_metadata.cs
+++ b/src/Marten.Testing/Events/flexible_event_metadata.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Events.Projections;
 using Marten.Testing.Harness;
@@ -29,6 +30,26 @@ namespace Marten.Testing.Events
             {
                 @event.CorrelationId.ShouldBe(correlationId);
             }
+        }
+
+        [Fact]
+        public async Task check_search_with_correlation_id()
+        {
+            StoreOptions(_ => _.Events.MetadataConfig.CorrelationIdEnabled = true);
+            const string correlationId = "test-correlation-id";
+            theSession.CorrelationId = correlationId;
+
+            var streamId = theSession.Events.StartStream<QuestParty>(started, joined, slayed).Id;
+            await theSession.SaveChangesAsync();
+
+            var events = await theSession.Events.QueryAllRawEvents()
+                .Where(x => x.CorrelationId == correlationId)
+                .ToListAsync();
+
+            events.Count.ShouldBe(3);
+            events[0].StreamId.ShouldBe(streamId);
+            events[1].StreamId.ShouldBe(streamId);
+            events[2].StreamId.ShouldBe(streamId);
         }
 
         [Fact]
@@ -65,6 +86,26 @@ namespace Marten.Testing.Events
             {
                 @event.CausationId.ShouldBe(causationId);
             }
+        }
+
+        [Fact]
+        public async Task check_search_with_causation_id()
+        {
+            StoreOptions(_ => _.Events.MetadataConfig.CausationIdEnabled = true);
+            const string causationId = "test-causation-id";
+            theSession.CausationId = causationId;
+
+            var streamId = theSession.Events.StartStream<QuestParty>(started, joined, slayed).Id;
+            await theSession.SaveChangesAsync();
+
+            var events = await theSession.Events.QueryAllRawEvents()
+                .Where(x => x.CausationId == causationId)
+                .ToListAsync();
+
+            events.Count.ShouldBe(3);
+            events[0].StreamId.ShouldBe(streamId);
+            events[1].StreamId.ShouldBe(streamId);
+            events[2].StreamId.ShouldBe(streamId);
         }
 
         [Fact]

--- a/src/Marten/Events/EventQueryMapping.cs
+++ b/src/Marten/Events/EventQueryMapping.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
-using Marten.Linq;
 using Marten.Linq.Fields;
 using Marten.Linq.Parsing;
 using Marten.Schema;
@@ -30,6 +29,16 @@ namespace Marten.Events
 
             duplicateField(x => x.Version, "version");
             duplicateField(x => x.Timestamp, "timestamp");
+
+            if (storeOptions.EventGraph.Metadata.CorrelationId.Enabled)
+            {
+                duplicateField(x => x.CorrelationId, storeOptions.EventGraph.Metadata.CorrelationId.Name);
+            }
+
+            if (storeOptions.EventGraph.Metadata.CausationId.Enabled)
+            {
+                duplicateField(x => x.CausationId, storeOptions.EventGraph.Metadata.CausationId.Name);
+            }
         }
 
         public override DbObjectName TableName { get; }
@@ -41,6 +50,5 @@ namespace Marten.Events
 
             return DuplicateField(finder.Members.ToArray(), columnName: columnName);
         }
-
     }
 }


### PR DESCRIPTION
When I was trying out the new event metadata support, I came across a bug when querying events with `session.Events.QueryAllRawEvents()`.

When querying events with correlation or causation ids, no events were returned. The generated SQL filtered causation/correlation id from event data (`d.data ->> 'CorrelationId' = :p0`) instead of the correlation/causation id columns. This PR hopefully fixes this issue.