### PR TITLE
Fix null value handling in DuplicatedField.CreateComparison

### DIFF
--- a/src/Marten/Linq/Fields/DuplicatedField.cs
+++ b/src/Marten/Linq/Fields/DuplicatedField.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Baseline;
+using Marten.Exceptions;
 using Marten.Linq.Filters;
 using Marten.Linq.Parsing;
 using Marten.Linq.SqlGeneration;
@@ -128,7 +129,12 @@ namespace Marten.Linq.Fields
         {
             if (value.Value == null)
             {
-                return new IsNullFilter(this);
+                return op switch
+                {
+                    "=" => new IsNullFilter(this),
+                    "!=" => new IsNotNullFilter(this),
+                    _ => throw new BadLinqExpressionException($"Can only compare property {MemberName} by '=' or '!=' with null value")
+                };
             }
 
             return new ComparisonFilter(this, new CommandParameter(_parseObject(value), DbType), op);


### PR DESCRIPTION
Currently `DuplicatedField.CreateComparison` always generates `is null` sql for null value and ignores the operator. Added check for the operator and support for using != to create `is not null`.