### PR TITLE
Failing select scenario reproduction

### DIFF
--- a/src/Marten.Testing/Linq/invoking_query_with_select_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_query_with_select_Tests.cs
@@ -353,6 +353,24 @@ namespace Marten.Testing.Linq
             actual.InnerNumber.ShouldBe(target.Inner.Number);
         }
 
+        [Fact]
+        public void use_select_in_query_for_one_object_property()
+        {
+            var target = Target.Random(true);
+
+            theSession.Store(target);
+            theSession.SaveChanges();
+
+            var actual = theSession.Query<Target>()
+                .Where(x => x.Id == target.Id)
+                .Select(x => x.Inner)
+                .First();
+
+            actual.Id.ShouldBe(target.Inner.Id);
+            actual.Number.ShouldBe(target.Inner.Number);
+        }
+
+
         public class FlatTarget
         {
             public FlatTarget(Guid id, int number, int innerNumber)


### PR DESCRIPTION
Results in:
```csharp


System.ArgumentException
GenericArguments[0], 'Marten.Testing.Documents.Target', on 'Marten.Linq.SqlGeneration.ScalarSelectClause`1[T]' violates the constraint of type 'T'.
   at System.RuntimeType.ValidateGenericArguments(MemberInfo definition, RuntimeType[] genericArguments, Exception e)
   at System.RuntimeType.MakeGenericType(Type[] instantiation)
   at Baseline.TypeExtensions.CloseAndBuildAs[T](Type openType, Object ctorArgument1, Object ctorArgument2, Type[] parameterTypes)
   at Marten.Linq.SqlGeneration.SelectorStatement.ToScalar(Expression selectClauseSelector) in C:\Source\marten\src\Marten\Linq\SqlGeneration\SelectorStatement.cs:line 74
   at Marten.Linq.Parsing.LinqHandlerBuilder.SelectorVisitor.VisitMember(MemberExpression node) in C:\Source\marten\src\Marten\Linq\Parsing\SelectorVisitor.cs:line 28
   at System.Linq.Expressions.MemberExpression.Accept(ExpressionVisitor visitor)
   at System.Linq.Expressions.ExpressionVisitor.Visit(Expression node)
   at Marten.Linq.Parsing.LinqHandlerBuilder.readQueryModel(QueryModel queryModel, IDocumentStorage storage, Boolean considerSelectors, IFieldMapping fields) in C:\Source\marten\src\Marten\Linq\Parsing\LinqHandlerBuilder.cs:line 71
   at Marten.Linq.Parsing.LinqHandlerBuilder..ctor(MartenLinqQueryProvider provider, IMartenSession session, Expression expression, ResultOperatorBase additionalOperator, Boolean forCompiled) in C:\Source\marten\src\Marten\Linq\Parsing\LinqHandlerBuilder.cs:line 56
   at Marten.Linq.MartenLinqQueryProvider.Execute[TResult](Expression expression) in C:\Source\marten\src\Marten\Linq\MartenLinqQueryProvider.cs:line 50
   at System.Linq.Queryable.First[TSource](IQueryable`1 source)
   at Marten.Testing.Linq.invoking_query_with_select_Tests.use_select_in_query_for_one_object_property() in C:\Source\marten\src\Marten.Testing\Linq\invoking_query_with_select_Tests.cs:line 364

System.TypeLoadException
GenericArguments[0], 'Marten.Testing.Documents.Target', on 'System.Nullable`1[T]' violates the constraint of type parameter 'T'.
   at System.RuntimeTypeHandle.Instantiate(Type[] inst)
   at System.RuntimeType.MakeGenericType(Type[] instantiation)