### PR TITLE
Fix for loading multi tenant documents with batch query

### DIFF
--- a/src/Marten.Testing/Bugs/Batch_query_load_fails_with_multi_tenant_document.cs
+++ b/src/Marten.Testing/Bugs/Batch_query_load_fails_with_multi_tenant_document.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+
+using Shouldly;
+
+using Weasel.Postgresql;
+
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+    public class Batch_query_load_fails_with_multi_tenant_document: BugIntegrationContext
+    {
+        [Fact]
+        public async Task load_with_batch_query_should_work_for_multi_tenanted_document()
+        {
+            using var documentStore = SeparateStore(x =>
+            {
+                x.AutoCreateSchemaObjects = AutoCreate.All;
+                x.Schema.For<User>().MultiTenanted();
+            });
+
+            await documentStore.Advanced.Clean.CompletelyRemoveAllAsync();
+            await documentStore.Schema.ApplyAllConfiguredChangesToDatabase(AutoCreate.All);
+
+            var testDocument = new User {Id = Guid.NewGuid(), UserName = "Test name"};
+
+            await using var tenantASession = documentStore.OpenSession("tenant_a");
+            tenantASession.Insert(testDocument);
+            await tenantASession.SaveChangesAsync();
+
+            await using var tenantAQuerySession = documentStore.OpenSession("tenant_a");
+
+            var batchQuery = tenantAQuerySession.CreateBatchQuery();
+            var testDocumentWithBatchLoad = batchQuery.Load<User>(testDocument.Id);
+            await batchQuery.Execute();
+
+            testDocumentWithBatchLoad.Result.ShouldNotBeNull();
+            testDocumentWithBatchLoad.Result.UserName.ShouldBe(testDocument.UserName);
+        }
+
+        [Fact]
+        public async Task load_with_batch_query_should_not_return_document_from_other_tenant()
+        {
+            using var documentStore = SeparateStore(x =>
+            {
+                x.AutoCreateSchemaObjects = AutoCreate.All;
+                x.Schema.For<User>().MultiTenanted();
+            });
+
+            await documentStore.Advanced.Clean.CompletelyRemoveAllAsync();
+            await documentStore.Schema.ApplyAllConfiguredChangesToDatabase(AutoCreate.All);
+
+            var testDocument = new User {Id = Guid.NewGuid(), UserName = "Test name"};
+
+            await using var tenantASession = documentStore.OpenSession("tenant_a");
+            tenantASession.Insert(testDocument);
+            await tenantASession.SaveChangesAsync();
+
+            await using var tenantBQuerySession = documentStore.OpenSession("tenant_b");
+
+            var batchQuery = tenantBQuerySession.CreateBatchQuery();
+            var testDocumentWithBatchLoad = batchQuery.Load<User>(testDocument.Id);
+            await batchQuery.Execute();
+
+            testDocumentWithBatchLoad.Result.ShouldBeNull();
+        }
+    }
+}

--- a/src/Marten/Internal/Storage/IDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IDocumentStorage.cs
@@ -7,6 +7,7 @@ using Marten.Linq.Fields;
 using Marten.Linq.Filters;
 using Marten.Linq.SqlGeneration;
 using Marten.Schema;
+using Marten.Schema.Arguments;
 using Weasel.Postgresql;
 using Marten.Services;
 using Marten.Storage;
@@ -102,6 +103,7 @@ namespace Marten.Internal.Storage
             if (storage.TenancyStyle == TenancyStyle.Conjoined)
             {
                 sql.Append($" and {CurrentTenantFilter.Filter}");
+                sql.AddNamedParameter(TenantIdArgument.ArgName, "");
             }
         }
 


### PR DESCRIPTION
When loading multi tenanted documents with batch query, following exception is thrown. Using v4 rc2.

```Marten.Testing.Bugs.Batch_query_load_fails_with_multi_tenant_document.load_with_batch_query_should_work_for_multi_tenanted_document

Marten.Exceptions.MartenCommandException: Marten Command Failure:$

Marten.Exceptions.MartenCommandException
Marten Command Failure:$
select d.id, d.data from bugs.mt_doc_user as d where id = :p0 and d.tenant_id = :tenantid;$
$
42601: syntax error at or near ":"
   at Baseline.Exceptions.ExceptionTransformExtensions.TransformAndThrow(IEnumerable`1 transforms, Exception ex)
   at Baseline.Exceptions.ExceptionTransforms.TransformAndThrow(Exception ex)
   at Marten.Exceptions.MartenExceptionTransformer.WrapAndThrow(NpgsqlCommand command, Exception exception) in C:\marten\src\Marten\Exceptions\MartenExceptionTransformer.cs:line 43
   at Marten.Services.ManagedConnection.handleCommandException(NpgsqlCommand cmd, Exception e) in C:\marten\src\Marten\Services\ManagedConnection.cs:line 210
   at Marten.Services.ManagedConnection.ExecuteReaderAsync(NpgsqlCommand command, CancellationToken token) in C:\marten\src\Marten\Services\ManagedConnection.cs:line 275
   at Marten.Services.BatchQuerying.BatchedQuery.Execute(CancellationToken token) in C:\marten\src\Marten\Services\BatchQuerying\BatchedQuery.cs:line 79
   at Marten.Testing.Bugs.Batch_query_load_fails_with_multi_tenant_document.load_with_batch_query_should_work_for_multi_tenanted_document() in C:\marten\src\Marten.Testing\Bugs\Batch_query_load_fails_with_multi_tenant_document.cs:line 43
   at Marten.Testing.Bugs.Batch_query_load_fails_with_multi_tenant_document.load_with_batch_query_should_work_for_multi_tenanted_document() in C:\marten\src\Marten.Testing\Bugs\Batch_query_load_fails_with_multi_tenant_document.cs:line 46
   at Marten.Testing.Bugs.Batch_query_load_fails_with_multi_tenant_document.load_with_batch_query_should_work_for_multi_tenanted_document() in C:\marten\src\Marten.Testing\Bugs\Batch_query_load_fails_with_multi_tenant_document.cs:line 46
   at Xunit.Sdk.TestInvoker`1.<>c__DisplayClass48_1.<<InvokeTestMethodAsync>b__1>d.MoveNext() in C:\Dev\xunit\xunit\src\xunit.execution\Sdk\Frameworks\Runners\TestInvoker.cs:line 264
--- End of stack trace from previous location where exception was thrown ---
   at Xunit.Sdk.ExecutionTimer.AggregateAsync(Func`1 asyncAction) in C:\Dev\xunit\xunit\src\xunit.execution\Sdk\Frameworks\ExecutionTimer.cs:line 48
   at Xunit.Sdk.ExceptionAggregator.RunAsync(Func`1 code) in C:\Dev\xunit\xunit\src\xunit.core\Sdk\ExceptionAggregator.cs:line 90

Npgsql.PostgresException
42601: syntax error at or near ":"
   at Npgsql.NpgsqlConnector.<ReadMessage>g__ReadMessageLong|194_0(NpgsqlConnector connector, Boolean async, DataRowLoadingMode dataRowLoadingMode, Boolean readingNotifications, Boolean isReadingPrependedMessage)
   at Npgsql.NpgsqlDataReader.NextResult(Boolean async, Boolean isConsuming, CancellationToken cancellationToken)
   at Npgsql.NpgsqlCommand.ExecuteReader(CommandBehavior behavior, Boolean async, CancellationToken cancellationToken)
   at Npgsql.NpgsqlCommand.ExecuteReader(CommandBehavior behavior, Boolean async, CancellationToken cancellationToken)
   at Marten.Services.ManagedConnection.ExecuteReaderAsync(NpgsqlCommand command, CancellationToken token) in C:\marten\src\Marten\Services\ManagedConnection.cs:line 268
```