### PR TITLE
Don't call Stop on daemon if projections are disabled

### DIFF
--- a/src/Marten/Events/Daemon/AsyncProjectionHostedService.cs
+++ b/src/Marten/Events/Daemon/AsyncProjectionHostedService.cs
@@ -54,8 +54,14 @@ namespace Marten.Events.Daemon
 
         public async Task StopAsync(CancellationToken cancellationToken)
         {
+            if (_store.Options.Events.Daemon.AsyncMode == DaemonMode.Disabled)
+            {
+                return;
+            }
+
             try
             {
+                _logger.LogDebug("Stopping the asynchronous projection agent");
                 await Coordinator.Stop();
                 await Agent.StopAll();
             }


### PR DESCRIPTION
I have seen the daemon trying to stop when using Marten as document store, using 4.0.0-rc.2
This PR covers a first attempt to try to stop the error message (I know this is not a real issue since is just the log so the code will continue just fine until the end of my app)
I added the debug just for the sake of testing, but open to change this.
![image](https://user-images.githubusercontent.com/3247183/121860584-e6b87e00-ccf0-11eb-954e-13414551368b.png)
