### PR TITLE
Fix bug #1851 - recursively walk referenced assemblies.

### DIFF
--- a/src/Marten.Testing.OtherAssembly/Bug1851/GenericOuter.cs
+++ b/src/Marten.Testing.OtherAssembly/Bug1851/GenericOuter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Marten.Linq;
+
+namespace Marten.Testing.OtherAssembly.Bug1851
+{
+    public class GenericOuter<TInOtherAssembly> where TInOtherAssembly : StoredObjectInOtherAssembly
+    {
+        public class FindByNameQuery: ICompiledQuery<TInOtherAssembly, string>
+        {
+            public string Name { get; set; } = string.Empty;
+
+            public Expression<Func<IMartenQueryable<TInOtherAssembly>, string>> QueryIs()
+            {
+                return q => q.Where(x => x.Name == Name).Select(x => x.Name).FirstOrDefault();
+            }
+        }
+    }
+}

--- a/src/Marten.Testing.OtherAssembly/Bug1851/StoredObjectInOtherAssembly.cs
+++ b/src/Marten.Testing.OtherAssembly/Bug1851/StoredObjectInOtherAssembly.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Marten.Testing.OtherAssembly.Bug1851
+{
+    public class StoredObjectInOtherAssembly
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/src/Marten.Testing.OtherAssembly/Marten.Testing.OtherAssembly.csproj
+++ b/src/Marten.Testing.OtherAssembly/Marten.Testing.OtherAssembly.csproj
@@ -13,4 +13,8 @@
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     </PropertyGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\Marten\Marten.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/src/Marten.Testing/Bugs/Bug_1851_need_to_recursively_reference_assemblies_in_generic_type_parameters_of_compiled_queries.cs
+++ b/src/Marten.Testing/Bugs/Bug_1851_need_to_recursively_reference_assemblies_in_generic_type_parameters_of_compiled_queries.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using Marten.Testing.Harness;
+using Marten.Testing.OtherAssembly.Bug1851;
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+    public class Bug_1851_need_to_recursively_reference_assemblies_in_generic_type_parameters_of_compiled_queries : BugIntegrationContext
+    {
+        [Fact]
+        public async Task Should_be_able_execute_query()
+        {
+            _ = await theSession
+                .QueryAsync(
+                    new GenericOuter<StoredObjectInThisAssembly>.FindByNameQuery { Name = "random" })
+                .ConfigureAwait(false);
+        }
+    }
+
+    public class StoredObjectInThisAssembly: StoredObjectInOtherAssembly
+    {
+
+    }
+}


### PR DESCRIPTION
This fixes bug #1851. Unit test enclosed.

Care was taken to make the walking process use a stack instead of recursion to avoid stack overflows.