### PR TITLE
Added Async suffix to Marten.Schema methods

### DIFF
--- a/docs/guide/documents/advanced/extensions.md
+++ b/docs/guide/documents/advanced/extensions.md
@@ -72,7 +72,7 @@ public class FakeStorage : FeatureSchemaBase
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/CoreFunctionality/ability_to_add_custom_storage_features.cs#L49-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_creating-a-fake-schema-feature' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/CoreFunctionality/ability_to_add_custom_storage_features.cs#L50-L69' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_creating-a-fake-schema-feature' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Now, to actually apply this feature to your Marten applications, use this syntax:
@@ -91,7 +91,7 @@ var store = DocumentStore.For(_ =>
     _.Storage.Add(new FakeStorage(_));
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/CoreFunctionality/ability_to_add_custom_storage_features.cs#L30-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_adding-schema-feature' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/CoreFunctionality/ability_to_add_custom_storage_features.cs#L31-L42' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_adding-schema-feature' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Do note that when you use the `Add<T>()` syntax, Marten will pass along the current `StoreOptions` to the constructor function if there is a constructor with that signature. Otherwise, it uses the no-arg constructor.
@@ -200,7 +200,7 @@ internal class EventsTable: Table
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Schema/EventsTable.cs#L12-L106' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_eventstable' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Schema/EventsTable.cs#L13-L107' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_eventstable' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Function
@@ -222,5 +222,5 @@ var sequence = new Sequence(new DbObjectName(DatabaseSchemaName, "mt_events_sequ
     OwnerColumn = "seq_id"
 };
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/EventGraph.FeatureSchema.cs#L31-L37' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using-sequence' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/EventGraph.FeatureSchema.cs#L32-L38' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using-sequence' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/guide/documents/advanced/hierarchies.md
+++ b/docs/guide/documents/advanced/hierarchies.md
@@ -89,7 +89,7 @@ public class BrainySmurf: PapaSmurf
 {
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_with_inheritance.cs#L11-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_smurfs-hierarchy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_with_inheritance.cs#L12-L42' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_smurfs-hierarchy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If you wish to query over one of hierarchy classes and be able to get all of its documents as well as its subclasses,
@@ -119,7 +119,7 @@ public query_with_inheritance(DefaultStoreFixture fixture): base(fixture)
     });
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_with_inheritance.cs#L85-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_add-subclass-hierarchy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_with_inheritance.cs#L86-L110' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_add-subclass-hierarchy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note that if you wish to use aliases on certain subclasses, you could pass a `MappedType`, which contains the type to map
@@ -138,7 +138,7 @@ _.Schema.For<ISmurf>()
         typeof(BrainySmurf)
     );
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_with_inheritance.cs#L49-L60' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_add-subclass-hierarchy-with-aliases' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_with_inheritance.cs#L50-L61' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_add-subclass-hierarchy-with-aliases' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Now you can query the "complex" hierarchy in the following ways:
@@ -232,5 +232,5 @@ public void get_all_subclasses_of_an_interface()
     theSession.Query<IPapaSmurf>().Count().ShouldBe(3);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_with_inheritance.cs#L143-L233' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query-subclass-hierarchy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_with_inheritance.cs#L144-L234' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query-subclass-hierarchy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/guide/documents/advanced/patch-api.md
+++ b/docs/guide/documents/advanced/patch-api.md
@@ -33,7 +33,7 @@ To apply a patch to all documents matching a given criteria, use the following s
 // Change every Target document where the Color is Blue
 theSession.Patch<Target>(x => x.Color == Colors.Blue).Set(x => x.Number, 2);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L130-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_set_an_immediate_property_by_where_clause' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L131-L134' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_set_an_immediate_property_by_where_clause' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Setting a single Property/Field
@@ -62,7 +62,7 @@ public void set_an_immediate_property_by_id()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L58-L78' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_set_an_immediate_property_by_id' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L59-L79' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_set_an_immediate_property_by_id' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Initialize a new Property/Field
@@ -82,7 +82,7 @@ using (var query = theStore.QuerySession())
     query.Query<Target>(where).Count.ShouldBe(0);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L86-L96' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_initialise_a_new_property_by_expression' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L87-L97' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_initialise_a_new_property_by_expression' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Duplicating an existing Property/Field
@@ -106,7 +106,7 @@ using (var query = theStore.QuerySession())
     result.AnotherString.ShouldBe(target.String);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L154-L168' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_duplicate_to_new_field' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L155-L169' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_duplicate_to_new_field' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The same value can be copied to multiple new locations:
@@ -119,7 +119,7 @@ theSession.Patch<Target>(target.Id).Duplicate(t => t.String,
     t => t.Inner.String,
     t => t.Inner.AnotherString);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L180-L185' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_duplicate_to_multiple_new_fields' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L181-L186' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_duplicate_to_multiple_new_fields' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The new locations need not exist in the persisted document, null or absent parents will be initialized
@@ -149,7 +149,7 @@ public void increment_for_int()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L199-L218' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_increment_for_int' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L200-L219' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_increment_for_int' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 By default, the `Patch.Increment()` operation will add 1 to the existing value. You can optionally override the increment:
@@ -175,7 +175,7 @@ public void increment_for_int_with_explicit_increment()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L220-L239' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_increment_for_int_with_explicit_increment' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L221-L240' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_increment_for_int_with_explicit_increment' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Append an Element to a Child Collection
@@ -212,7 +212,7 @@ public void append_complex_element()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L342-L366' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_append_complex_element' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L343-L367' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_append_complex_element' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `Patch.AppendIfNotExists()` operation will treat the child collection as a set rather than a list and only append the element if it does not already exist within the collection
@@ -251,7 +251,7 @@ public void insert_first_complex_element()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L498-L522' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_insert_first_complex_element' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L499-L523' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_insert_first_complex_element' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `Patch.InsertIfNotExists()` operation will only insert the element if the element at the designated index does not already exist.
@@ -287,7 +287,7 @@ public void remove_primitive_element()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L614-L639' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_remove_primitive_element' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L615-L640' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_remove_primitive_element' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Removing complex items can also be accomplished, matching is performed on all fields:
@@ -319,7 +319,7 @@ public void remove_complex_element()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L675-L700' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_remove_complex_element' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L676-L701' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_remove_complex_element' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To remove reoccurring values from a collection specify `RemoveAction.RemoveAll`:
@@ -358,7 +358,7 @@ public void remove_repeated_primitive_elements()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L641-L673' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_remove_repeated_primitive_element' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L642-L674' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_remove_repeated_primitive_element' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Rename a Property/Field
@@ -391,7 +391,7 @@ public void rename_deep_prop()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L590-L612' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_rename_deep_prop' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L591-L613' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_rename_deep_prop' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Renaming can be used on nested values.
@@ -408,7 +408,7 @@ To delete a redundant property no longer available on the class use the string o
 ```cs
 theSession.Patch<Target>(target.Id).Delete("String");
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L709-L711' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_delete_redundant_property' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L710-L712' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_delete_redundant_property' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To delete a redundant property nested on a child class specify a location lambda:
@@ -418,7 +418,7 @@ To delete a redundant property nested on a child class specify a location lambda
 ```cs
 theSession.Patch<Target>(target.Id).Delete("String", t => t.Inner);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L729-L731' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_delete_redundant_nested_property' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L730-L732' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_delete_redundant_nested_property' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 A current property may be erased simply with a lambda:
@@ -428,7 +428,7 @@ A current property may be erased simply with a lambda:
 ```cs
 theSession.Patch<Target>(target.Id).Delete(t => t.Inner);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L749-L751' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_delete_existing_property' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L750-L752' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_delete_existing_property' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Many documents may be patched using a where expressions:
@@ -446,5 +446,5 @@ using (var query = theStore.QuerySession())
     query.Query<Target>(where).Count(t => t.String != null).ShouldBe(0);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L771-L781' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_delete_property_from_many_documents' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.PLv8.Testing/Patching/patching_api.cs#L772-L782' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_delete_property_from_many_documents' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/guide/documents/advanced/soft-deletes.md
+++ b/docs/guide/documents/advanced/soft-deletes.md
@@ -69,7 +69,7 @@ public void query_soft_deleted_docs()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/soft_deletes.cs#L286-L314' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_soft_deleted_docs' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/soft_deletes.cs#L285-L313' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_soft_deleted_docs' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The SQL generated for the first call to `Query<User>()` above would be:
@@ -115,7 +115,7 @@ public void query_maybe_soft_deleted_docs()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/soft_deletes.cs#L316-L346' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_maybe_soft_deleted_docs' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/soft_deletes.cs#L315-L345' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_maybe_soft_deleted_docs' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Fetching Only Deleted Documents
@@ -155,7 +155,7 @@ public void query_is_soft_deleted_docs()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/soft_deletes.cs#L348-L378' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_is_soft_deleted_docs' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/soft_deletes.cs#L347-L377' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_is_soft_deleted_docs' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Fetching Documents Deleted before or after a specific time
@@ -191,7 +191,7 @@ public void query_is_soft_deleted_since_docs()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/soft_deletes.cs#L380-L406' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_soft_deleted_since' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/soft_deletes.cs#L379-L405' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_soft_deleted_since' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 _Neither `DeletedSince` nor `DeletedBefore` are inclusive searches as shown_

--- a/docs/guide/documents/basics/bulk-insert.md
+++ b/docs/guide/documents/basics/bulk-insert.md
@@ -15,7 +15,7 @@ theStore.BulkInsert(data, batchSize: 500);
 // And just checking that the data is actually there;)
 theSession.Query<Target>().Count().ShouldBe(data.Length);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/CoreFunctionality/bulk_loading_Tests.cs#L94-L104' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_bulk_insert' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/CoreFunctionality/bulk_loading_Tests.cs#L95-L105' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_bulk_insert' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The bulk insert is done with a single transaction. For really large document collections, you may need to page the calls to `IDocumentStore.BulkInsert()`.
@@ -37,7 +37,7 @@ var data = Target.GenerateRandomData(100).ToArray();
 
 theStore.BulkInsert(data, BulkInsertMode.IgnoreDuplicates);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/CoreFunctionality/bulk_loading_Tests.cs#L147-L151' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bulk_insert_with_ignoreduplicates' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/CoreFunctionality/bulk_loading_Tests.cs#L148-L152' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bulk_insert_with_ignoreduplicates' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Internally, Marten creates a temporary table matching the targeted document table and inserts the new values into that table. After writing those documents, Marten issues
@@ -54,7 +54,7 @@ var data = Target.GenerateRandomData(100).ToArray();
 
 theStore.BulkInsert(data, BulkInsertMode.OverwriteExisting);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/CoreFunctionality/bulk_loading_Tests.cs#L167-L171' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bulk_insert_with_overwriteexisting' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/CoreFunctionality/bulk_loading_Tests.cs#L168-L172' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bulk_insert_with_overwriteexisting' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Internally, Marten creates a temporary table matching the targeted document table and inserts the new values into that table. After writing those documents, Marten issues

--- a/docs/guide/documents/configuration/index.md
+++ b/docs/guide/documents/configuration/index.md
@@ -40,7 +40,7 @@ var store = DocumentStore.For(_ =>
     _.NameDataLength = 100;
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/CoreFunctionality/StoreOptionsTests.cs#L278-L287' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_setting-name-data-length' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/CoreFunctionality/StoreOptionsTests.cs#L279-L288' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_setting-name-data-length' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Custom StoreOptions
@@ -67,7 +67,7 @@ public class MyStoreOptions: StoreOptions
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L209-L227' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_custom-store-options' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L210-L228' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_custom-store-options' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This strategy might be beneficial if you need to share Marten configuration across different applications
@@ -171,7 +171,7 @@ public class ConfiguresItself
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/DocumentMappingTests.cs#L122-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuremarten-generic' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/DocumentMappingTests.cs#L123-L134' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuremarten-generic' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `DocumentMapping` type is the core configuration class representing how a document type is persisted or
@@ -195,5 +195,5 @@ public class ConfiguresItselfSpecifically
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/DocumentMappingTests.cs#L135-L147' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuremarten-specifically' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/DocumentMappingTests.cs#L136-L148' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuremarten-specifically' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/guide/documents/configuration/noda-time.md
+++ b/docs/guide/documents/configuration/noda-time.md
@@ -31,7 +31,7 @@ var store = DocumentStore.For(_ =>
     _.UseNodaTime();
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs#L23-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_noda_time_default_setup' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs#L24-L32' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_noda_time_default_setup' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 By default it also sets up the `JsonNetSerializer` options (see more details in [NodaTime documentation](https://nodatime.org/2.4.x/api/NodaTime.Serialization.JsonNet.Extensions.html)).
@@ -51,7 +51,7 @@ var store = DocumentStore.For(_ =>
     _.UseNodaTime(shouldConfigureJsonNetSerializer: false);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs#L36-L46' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_noda_time_setup_without_json_net_serializer_configuration' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs#L37-L47' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_noda_time_setup_without_json_net_serializer_configuration' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: warning

--- a/docs/guide/documents/index.md
+++ b/docs/guide/documents/index.md
@@ -14,7 +14,7 @@ with Marten can be as simple as opening a `DocumentStore` to your new Postgresql
 var store = DocumentStore
     .For("host=localhost;database=marten_testing;password=mypassword;username=someuser");
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L33-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_start_a_store' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L34-L37' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_start_a_store' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The code sample above sets up document storage against the Postgresql at the connection string you supplied. In this "quickstart" configuration,
@@ -41,7 +41,7 @@ var store = DocumentStore.For(_ =>
     _.Serializer<TestsSerializer>();
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L78-L90' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_start_a_complex_store' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L79-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_start_a_complex_store' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 For more information on using the `IDocumentStore` and configuring document storage, see:
@@ -68,7 +68,7 @@ using (var session = store.QuerySession())
         .Query<User>().Where(x => x.Internal).ToArray();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L38-L44' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_start_a_query_session' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L39-L45' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_start_a_query_session' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 For more information on the query support within Marten, check [document querying](/guide/documents/querying/)
@@ -108,7 +108,7 @@ using (var session = store.DirtyTrackedSession())
 {
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L46-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_opening_sessions' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L47-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_opening_sessions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In all cases, `IDocumentSession` has the same query and loading functions as the read only `IQuerySession`.

--- a/docs/guide/documents/json/index.md
+++ b/docs/guide/documents/json/index.md
@@ -112,7 +112,7 @@ public interface ISerializer
     ValueCasting ValueCasting { get; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/ISerializer.cs#L13-L118' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iserializer' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/ISerializer.cs#L14-L119' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iserializer' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To support a new serialization library or customize the JSON serialization options, you can write a new version of `ISerializer` and plug it

--- a/docs/guide/documents/json/jil.md
+++ b/docs/guide/documents/json/jil.md
@@ -75,7 +75,7 @@ public class JilSerializer : ISerializer
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/performance_tuning.cs#L13-L80' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_jilserializer' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/performance_tuning.cs#L14-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_jilserializer' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Next, replace the default `ISerializer` when you bootstrap your `DocumentStore` as in this example below:
@@ -91,7 +91,7 @@ var store = DocumentStore.For(_ =>
     _.Serializer<TestsSerializer>();
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/performance_tuning.cs#L91-L99' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_replacing_serializer_with_jil' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/performance_tuning.cs#L92-L100' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_replacing_serializer_with_jil' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 See [Optimizing for Performance in Marten](http://jeremydmiller.com/2015/11/09/optimizing-for-performance-in-marten/) 

--- a/docs/guide/documents/json/newtonsoft.md
+++ b/docs/guide/documents/json/newtonsoft.md
@@ -18,7 +18,7 @@ private readonly JsonSerializer _serializer = new()
     ContractResolver = new JsonNetContractResolver()
 };
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Services/JsonNetSerializer.cs#L39-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_newtonsoft-configuration' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Services/JsonNetSerializer.cs#L40-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_newtonsoft-configuration' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To customize the Newtonsoft.Json serialization, you need to explicitly supply an instance of Marten's `JsonNetSerializer` as shown below:
@@ -48,7 +48,7 @@ var store = DocumentStore.For(_ =>
     _.Serializer(serializer);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L95-L117' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_serialization' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L96-L118' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_serialization' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: tip INFO
@@ -76,7 +76,7 @@ var store = DocumentStore.For(_ =>
     _.UseDefaultSerialization(enumStorage: EnumStorage.AsString);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L122-L132' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_enum_storage_serialization' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L123-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_enum_storage_serialization' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Fields Names Casing
@@ -102,7 +102,7 @@ var store = DocumentStore.For(_ =>
     _.UseDefaultSerialization(casing: Casing.CamelCase);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L137-L147' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_camelcase_casing_serialization' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L138-L148' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_camelcase_casing_serialization' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 <!-- snippet: sample_customize_json_net_snakecase_casing_serialization -->
@@ -117,7 +117,7 @@ var store = DocumentStore.For(_ =>
     _.UseDefaultSerialization(casing: Casing.SnakeCase);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L152-L162' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_snakecase_casing_serialization' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L153-L163' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_snakecase_casing_serialization' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Collection Storage
@@ -147,7 +147,7 @@ var store = DocumentStore.For(_ =>
     _.UseDefaultSerialization(collectionStorage: CollectionStorage.AsArray);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L167-L177' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_snakecase_collectionstorage' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L168-L178' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_snakecase_collectionstorage' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Non Public Members Storage
@@ -168,5 +168,5 @@ var store = DocumentStore.For(_ =>
     _.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.NonPublicSetters);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L182-L192' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_snakecase_nonpublicmembersstorage_nonpublicsetters' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L183-L193' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_snakecase_nonpublicmembersstorage_nonpublicsetters' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/guide/documents/querying/include.md
+++ b/docs/guide/documents/querying/include.md
@@ -31,7 +31,7 @@ public void simple_include_for_a_single_document()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Services/Includes/end_to_end_query_with_include_Tests.cs#L85-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_simple_include' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Services/Includes/end_to_end_query_with_include_Tests.cs#L86-L110' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_simple_include' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The first parameter of the `Include()` method takes an expression that specifies the document properties on which the join will be done (`AssigneeId` in this case). The second parameter is the expression that will assign the fetched related document to a previously declared variable (`included` in our case). By default, Marten will use an inner join. This means that any `Issue` with no corresponding `User` (or no `AssigneeId`), will not be fetched. If you wish to override this behaviour, you can add as a third parameter the enum `JoinType.LeftOuter`.
@@ -71,7 +71,7 @@ public void include_to_dictionary()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Services/Includes/end_to_end_query_with_include_Tests.cs#L489-L515' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_dictionary_include' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Services/Includes/end_to_end_query_with_include_Tests.cs#L490-L516' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_dictionary_include' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Include Multiple Document Types
@@ -111,7 +111,7 @@ public void multiple_includes()
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Services/Includes/end_to_end_query_with_include_Tests.cs#L712-L742' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_multiple_include' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Services/Includes/end_to_end_query_with_include_Tests.cs#L713-L743' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_multiple_include' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Chaining other Linq Methods
@@ -143,5 +143,5 @@ var found = batch.Query<Issue>()
     .Where(x => x.Title == issue1.Title)
     .Single();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Services/Includes/end_to_end_query_with_include_Tests.cs#L47-L54' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_batch_include' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Services/Includes/end_to_end_query_with_include_Tests.cs#L48-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_batch_include' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/guide/documents/querying/linq.md
+++ b/docs/guide/documents/querying/linq.md
@@ -143,7 +143,7 @@ var results = theSession
     .Where(x => x.Children.Any(_ => _.Number == 6 && _.Double == -1))
     .ToArray();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_against_child_collections_integrated_Tests.cs#L94-L99' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_any-query-through-child-collection-with-and' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_against_child_collections_integrated_Tests.cs#L95-L100' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_any-query-through-child-collection-with-and' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Finally, you can query for child collections that do **not** contain a value:
@@ -362,7 +362,7 @@ public void get_sum_of_integers()
         .ShouldBe(10);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_for_sum_Tests.cs#L13-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_sum' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_for_sum_Tests.cs#L14-L28' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_sum' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Ordering Results
@@ -453,7 +453,7 @@ public void query_against_string_array()
         .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc1.Id, doc2.Id);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_against_child_collections_integrated_Tests.cs#L418-L435' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_against_string_array' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_against_child_collections_integrated_Tests.cs#L419-L436' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_against_string_array' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Marten also allows you to query over IEnumerables using the Any method for equality (similar to Contains):
@@ -481,7 +481,7 @@ public void query_against_number_list_with_any()
         .Count(x => x.Numbers.Any()).ShouldBe(3);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_against_child_collections_integrated_Tests.cs#L522-L543' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_any_string_array' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_against_child_collections_integrated_Tests.cs#L523-L544' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_any_string_array' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 As of 1.2, you can also query against the `Count()` or `Length` of a child collection with the normal comparison
@@ -507,7 +507,7 @@ public void query_against_number_list_with_count_method()
         .Single(x => x.Numbers.Count() == 4).Id.ShouldBe(doc3.Id);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_against_child_collections_integrated_Tests.cs#L545-L563' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_against_number_list_with_count_method' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Linq/query_against_child_collections_integrated_Tests.cs#L546-L564' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_against_number_list_with_count_method' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## SelectMany()

--- a/docs/guide/events/schema.md
+++ b/docs/guide/events/schema.md
@@ -17,7 +17,7 @@ var store = DocumentStore.For(_ =>
     _.Events.DatabaseSchemaName = "events";
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L197-L206' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_setting_event_schema' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L198-L207' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_setting_event_schema' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Configuration

--- a/docs/guide/events/streams.md
+++ b/docs/guide/events/streams.md
@@ -273,7 +273,7 @@ public void can_query_against_event_type()
         .Single(x => x.Members.Contains("Matt")).Id.ShouldBe(departed2.Id);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Events/query_against_event_documents_Tests.cs#L22-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query-against-event-data' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Events/query_against_event_documents_Tests.cs#L23-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query-against-event-data' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can use any Linq operator that Marten supports to query against event data. We think that this functionality is probably more useful for diagnostics or troubleshooting rather than something you would routinely use to support your application. We recommend that you favor event projection views over querying within the raw event table.
@@ -291,7 +291,7 @@ public void example_of_querying_for_event_data(IDocumentSession session, Guid st
         .ToList();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Events/query_against_event_documents_Tests.cs#L157-L166' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_example_of_querying_for_event_data' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Events/query_against_event_documents_Tests.cs#L158-L167' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_example_of_querying_for_event_data' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This mechanism will allow you to query by any property of the `IEvent` interface shown above.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -102,7 +102,7 @@ all the default behavior and a connection string:
 var store = DocumentStore
     .For("host=localhost;database=marten_testing;password=mypassword;username=someuser");
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L33-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_start_a_store' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L34-L37' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_start_a_store' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Now, for your first document type, let's represent the users in our system:
@@ -120,7 +120,7 @@ public class User
     public string Department { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L14-L25' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_user_document' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L15-L26' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_user_document' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 _For more information on document id's, see [identity](/guide/documents/identity/)._
@@ -157,7 +157,7 @@ using (var session = store.DirtyTrackedSession())
 {
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L46-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_opening_sessions' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L47-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_opening_sessions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## IoC container integration

--- a/docs/guide/scenarios/using-sequence-for-unique-id.md
+++ b/docs/guide/scenarios/using-sequence-for-unique-id.md
@@ -30,7 +30,7 @@ public class MatterId: FeatureSchemaBase
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs#L13-L32' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-usingsequenceforuniqueid-setup' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs#L14-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-usingsequenceforuniqueid-setup' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This sequence yielding customization will be plugged into Marten via the store configuration
@@ -40,7 +40,7 @@ This sequence yielding customization will be plugged into Marten via the store c
 ```cs
 storeOptions.Storage.Add(new MatterId(storeOptions, 10000));
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs#L39-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-usingsequenceforuniqueid-storesetup-1' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs#L40-L42' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-usingsequenceforuniqueid-storesetup-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 and then executed against the database (generating & executing the DDL statements that create the required database objects):
@@ -48,9 +48,9 @@ and then executed against the database (generating & executing the DDL statement
 <!-- snippet: sample_scenario-usingsequenceforuniqueid-storesetup-2 -->
 <a id='snippet-sample_scenario-usingsequenceforuniqueid-storesetup-2'></a>
 ```cs
-await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs#L44-L46' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-usingsequenceforuniqueid-storesetup-2' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs#L45-L47' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-usingsequenceforuniqueid-storesetup-2' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 We introduce a few types with `Guid` identifiers, whom we reference to our end users by numbers, encapsulated in the `Matter` field:
@@ -71,7 +71,7 @@ public class Inquiry
     // Other fields...
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs#L76-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-usingsequenceforuniqueid-setup-types' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs#L77-L90' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-usingsequenceforuniqueid-setup-types' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Now, when creating and persisting such types, we first query the database for a new and unique running number. While we generate (or if wanted, let Marten generate) non-human-readable, system-internal identifiers for the created instances, we assign to them the newly generated and unique human-readable identifier:
@@ -104,7 +104,7 @@ using (var session = theStore.OpenSession())
     session.SaveChanges();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs#L48-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-usingsequenceforuniqueid-querymatter' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs#L49-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-usingsequenceforuniqueid-querymatter' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Lastly, we have an extension method (used above) as a shorthand for generating the SQL statement for a sequence value query:
@@ -121,5 +121,5 @@ public static class SessionExtensions
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs#L92-L101' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-usingsequenceforuniqueid-setup-extensions' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs#L93-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-usingsequenceforuniqueid-setup-extensions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/guide/schema/index.md
+++ b/docs/guide/schema/index.md
@@ -60,7 +60,7 @@ By default marten will use the default `public` database scheme to create the do
 ```cs
 _.DatabaseSchemaName = "other";
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/DocumentSchemaTests.cs#L495-L499' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_override_schema_name' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/DocumentSchemaTests.cs#L496-L500' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_override_schema_name' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `Hilo` sequence table is always created in this document store database schema.
@@ -78,10 +78,10 @@ StoreOptions(_ =>
     _.Storage.MappingFor(typeof(IntDoc));
 
     // this will tell marten to use the default 'public' schema name.
-    _.DatabaseSchemaName = DbObjectName.DefaultDatabaseSchemaName;
+    _.DatabaseSchemaName = SchemaConstants.DefaultSchema;
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/DocumentSchemaTests.cs#L334-L347' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_override_schema_per_table' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/DocumentSchemaTests.cs#L335-L348' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_override_schema_per_table' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This will create the following tables in your database: `other.mt_doc_user`, `overriden.mt_doc_issue` and `public.mt_doc_company`. When a schema doesn't exist it will be generated in the database.

--- a/docs/guide/schema/migrations.md
+++ b/docs/guide/schema/migrations.md
@@ -74,7 +74,7 @@ want to update, and use:
 <!-- snippet: sample_WritePatch -->
 <a id='snippet-sample_writepatch'></a>
 ```cs
-await store.Schema.WriteMigrationFile("1.initial.sql");
+await store.Schema.WriteMigrationFileAsync("1.initial.sql");
 ```
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/WritePatch_smoke_tests.cs#L28-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_writepatch' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -97,7 +97,7 @@ bootstrapped, you can use this mechanism:
 <!-- snippet: sample_ApplyAllConfiguredChangesToDatabase -->
 <a id='snippet-sample_applyallconfiguredchangestodatabase'></a>
 ```cs
-await store.Schema.ApplyAllConfiguredChangesToDatabase();
+await store.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 ```
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/WritePatch_smoke_tests.cs#L32-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_applyallconfiguredchangestodatabase' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -110,7 +110,7 @@ by throwing an exception:
 <!-- snippet: sample_AssertDatabaseMatchesConfiguration -->
 <a id='snippet-sample_assertdatabasematchesconfiguration'></a>
 ```cs
-await store.Schema.AssertDatabaseMatchesConfiguration();
+await store.Schema.AssertDatabaseMatchesConfigurationAsync();
 ```
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/WritePatch_smoke_tests.cs#L36-L38' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_assertdatabasematchesconfiguration' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/guide/schema/schema.md
+++ b/docs/guide/schema/schema.md
@@ -14,10 +14,10 @@ StoreOptions(_ =>
     _.Storage.MappingFor(typeof(IntDoc));
 
     // this will tell marten to use the default 'public' schema name.
-    _.DatabaseSchemaName = DbObjectName.DefaultDatabaseSchemaName;
+    _.DatabaseSchemaName = SchemaConstants.DefaultSchema;
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/DocumentSchemaTests.cs#L334-L347' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_override_schema_per_table' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Schema.Testing/DocumentSchemaTests.cs#L335-L348' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_override_schema_per_table' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 As you can see, you can also choose to configure the schema storage for each document type individually.

--- a/src/CommandLineRunner/TestCommand.cs
+++ b/src/CommandLineRunner/TestCommand.cs
@@ -21,7 +21,7 @@ namespace CommandLineRunner
             var store = host.Services.GetRequiredService<IDocumentStore>();
             await store.Advanced.Clean.DeleteAllDocumentsAsync();
 
-            await store.Schema.ApplyAllConfiguredChangesToDatabase();
+            await store.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             var targets = Target.GenerateRandomData(1000).ToArray();
 

--- a/src/Marten.CommandLine/Commands/ApplyCommand.cs
+++ b/src/Marten.CommandLine/Commands/ApplyCommand.cs
@@ -11,7 +11,7 @@ namespace Marten.CommandLine.Commands
         {
             try
             {
-                await store.Schema.ApplyAllConfiguredChangesToDatabase();
+                await store.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
                 input.WriteLine(ConsoleColor.Green, "Successfully applied outstanding database changes");
                 return true;

--- a/src/Marten.CommandLine/Commands/AssertCommand.cs
+++ b/src/Marten.CommandLine/Commands/AssertCommand.cs
@@ -13,7 +13,7 @@ namespace Marten.CommandLine.Commands
         {
             try
             {
-                await store.Schema.AssertDatabaseMatchesConfiguration();
+                await store.Schema.AssertDatabaseMatchesConfigurationAsync();
 
                 input.WriteLine(ConsoleColor.Green, "No database differences detected.");
 

--- a/src/Marten.CommandLine/Commands/Patch/PatchCommand.cs
+++ b/src/Marten.CommandLine/Commands/Patch/PatchCommand.cs
@@ -21,7 +21,7 @@ namespace Marten.CommandLine.Commands.Patch
         {
             try
             {
-                await store.Schema.AssertDatabaseMatchesConfiguration();
+                await store.Schema.AssertDatabaseMatchesConfigurationAsync();
 
                 input.WriteLine(ConsoleColor.Green, "No differences were detected between the Marten configuration and the database");
 
@@ -29,7 +29,7 @@ namespace Marten.CommandLine.Commands.Patch
             }
             catch (SchemaValidationException)
             {
-                var patch = await store.Schema.CreateMigration();
+                var patch = await store.Schema.CreateMigrationAsync();
 
                 input.WriteLine(ConsoleColor.Green, "Wrote a patch file to " + input.FileName);
 

--- a/src/Marten.PLv8.Testing/Patching/Bug_593_patch_doc_function_should_be_built_in_designated_schema.cs
+++ b/src/Marten.PLv8.Testing/Patching/Bug_593_patch_doc_function_should_be_built_in_designated_schema.cs
@@ -20,7 +20,7 @@ namespace Marten.PLv8.Testing.Patching
                 _.UseJavascriptTransformsAndPatching();
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             var expected = new DbObjectName("other", "mt_transform_patch_doc");
             (await theStore.Tenancy.Default.Functions()).Contains(expected).ShouldBeTrue();

--- a/src/Marten.PLv8.Testing/Patching/patching_api.cs
+++ b/src/Marten.PLv8.Testing/Patching/patching_api.cs
@@ -33,7 +33,7 @@ namespace Marten.PLv8.Testing.Patching
         [Fact]
         public async Task can_use_patch_api_when_autocreate_is_none()
         {
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             var entity = Target.Random();
             theSession.Store(entity);
@@ -787,7 +787,7 @@ namespace Marten.PLv8.Testing.Patching
         {
             var mapping = theStore.Storage.MappingFor(typeof(Target));
             var field = mapping.DuplicateField("String");
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             var entity = Target.Random();
             theSession.Store(entity);
@@ -810,7 +810,7 @@ namespace Marten.PLv8.Testing.Patching
             var mapping = theStore.Storage.MappingFor(typeof(Target));
             var field = mapping.DuplicateField("String");
             var field2 = mapping.DuplicateField(nameof(Target.Number));
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             var entity = Target.Random();
             theSession.Store(entity);
@@ -842,7 +842,7 @@ namespace Marten.PLv8.Testing.Patching
                 _.UseJavascriptTransformsAndPatching();
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             var aggregateId = Guid.NewGuid();
             var quest = new Quest

--- a/src/Marten.PLv8.Testing/Transforms/document_transforms.cs
+++ b/src/Marten.PLv8.Testing/Transforms/document_transforms.cs
@@ -86,7 +86,7 @@ namespace Marten.PLv8.Testing.Transforms
         public async Task use_transform_in_production_mode()
         {
             theStore.Tenancy.Default.EnsureStorageExists(typeof(User));
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             await theStore.TransformAsync(x => x.All<User>("default_username"));
 

--- a/src/Marten.Schema.Testing/ApplyAllConfiguredChangesToDatabaseTests.cs
+++ b/src/Marten.Schema.Testing/ApplyAllConfiguredChangesToDatabaseTests.cs
@@ -21,8 +21,8 @@ namespace Marten.Schema.Testing
 
             await Should.NotThrowAsync(async () =>
             {
-                await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
-                await theStore.Schema.AssertDatabaseMatchesConfiguration();
+                await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+                await theStore.Schema.AssertDatabaseMatchesConfigurationAsync();
             });
         }
 
@@ -38,8 +38,8 @@ namespace Marten.Schema.Testing
 
             await Should.NotThrowAsync(async () =>
             {
-                await theStore.Schema.ApplyAllConfiguredChangesToDatabase(AutoCreate.All);
-                await theStore.Schema.AssertDatabaseMatchesConfiguration();
+                await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.All);
+                await theStore.Schema.AssertDatabaseMatchesConfigurationAsync();
             });
         }
 

--- a/src/Marten.Schema.Testing/DocumentCleanerTests.cs
+++ b/src/Marten.Schema.Testing/DocumentCleanerTests.cs
@@ -211,7 +211,7 @@ namespace Marten.Schema.Testing
                 opts.Events.AddEventType(typeof(MembersJoined));
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             var allSchemas = theStore.Storage.AllSchemaNames();
 

--- a/src/Marten.Schema.Testing/DocumentSchemaTests.cs
+++ b/src/Marten.Schema.Testing/DocumentSchemaTests.cs
@@ -195,7 +195,7 @@ namespace Marten.Schema.Testing
                 store.Advanced.Clean.CompletelyRemoveAll();
 
 
-                await store.Schema.WriteMigrationFileByType(_binAllsql2);
+                await store.Schema.WriteMigrationFileByTypeAsync(_binAllsql2);
             }
 
             var fileSystem = new FileSystem();

--- a/src/Marten.Schema.Testing/EventStoreSchemaV3ToV4Tests.cs
+++ b/src/Marten.Schema.Testing/EventStoreSchemaV3ToV4Tests.cs
@@ -23,7 +23,7 @@ namespace Marten.Schema.Testing
             // create another store and check if the schema can be be auto updated
             using var store2 = Store(AutoCreate.CreateOrUpdate);
 
-            var sql = (await store2.Schema.CreateMigration()).UpdateSql;
+            var sql = (await store2.Schema.CreateMigrationAsync()).UpdateSql;
             sql.ShouldContain($"alter table {_schemaName}.mt_events alter column version type bigint", Case.Insensitive);
             sql.ShouldContain($"alter table {_schemaName}.mt_streams alter column version type bigint", Case.Insensitive);
             sql.ShouldContain($"drop function if exists {_schemaName}.mt_append_event", Case.Insensitive);
@@ -33,7 +33,7 @@ namespace Marten.Schema.Testing
         public async Task can_auto_update_event_store_schema_changes()
         {
             using var store1 = Store(AutoCreate.All);
-            await store1.Schema.ApplyAllConfiguredChangesToDatabase();
+            await store1.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             SimulateEventStoreV3Schema();
 
@@ -42,13 +42,13 @@ namespace Marten.Schema.Testing
 
             await Should.ThrowAsync<SchemaValidationException>(async () =>
             {
-                await store2.Schema.AssertDatabaseMatchesConfiguration();
+                await store2.Schema.AssertDatabaseMatchesConfigurationAsync();
             });
 
             await Should.NotThrowAsync(async () =>
             {
-                await store2.Schema.ApplyAllConfiguredChangesToDatabase();
-                await store2.Schema.AssertDatabaseMatchesConfiguration();
+                await store2.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+                await store2.Schema.AssertDatabaseMatchesConfigurationAsync();
             });
         }
 
@@ -61,7 +61,7 @@ namespace Marten.Schema.Testing
             // create another store and check if no v3 to v4 patches are generated
             using var store2 = Store(AutoCreate.CreateOrUpdate);
 
-            var sql = (await store2.Schema.CreateMigration()).UpdateSql;
+            var sql = (await store2.Schema.CreateMigrationAsync()).UpdateSql;
             sql.ShouldNotContain($"alter table {_schemaName}.mt_events alter column version type bigint", Case.Insensitive);
             sql.ShouldNotContain($"alter table {_schemaName}.mt_streams alter column version type bigint", Case.Insensitive);
             sql.ShouldNotContain($"drop function if exists {_schemaName}.mt_append_event", Case.Insensitive);

--- a/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs
+++ b/src/Marten.Schema.Testing/Storage/ScenarioUsingSequenceForUniqueId.cs
@@ -43,7 +43,7 @@ namespace Marten.Schema.Testing.Storage
             });
 
             #region sample_scenario-usingsequenceforuniqueid-storesetup-2
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
             #endregion sample_scenario-usingsequenceforuniqueid-storesetup-2
 
             #region sample_scenario-usingsequenceforuniqueid-querymatter

--- a/src/Marten.Schema.Testing/WritePatch_smoke_tests.cs
+++ b/src/Marten.Schema.Testing/WritePatch_smoke_tests.cs
@@ -26,15 +26,15 @@ namespace Marten.Schema.Testing
             #endregion sample_configure-document-types-upfront
 
             #region sample_WritePatch
-            await store.Schema.WriteMigrationFile("1.initial.sql");
+            await store.Schema.WriteMigrationFileAsync("1.initial.sql");
             #endregion sample_WritePatch
 
             #region sample_ApplyAllConfiguredChangesToDatabase
-            await store.Schema.ApplyAllConfiguredChangesToDatabase();
+            await store.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
             #endregion sample_ApplyAllConfiguredChangesToDatabase
 
             #region sample_AssertDatabaseMatchesConfiguration
-            await store.Schema.AssertDatabaseMatchesConfiguration();
+            await store.Schema.AssertDatabaseMatchesConfigurationAsync();
             #endregion sample_AssertDatabaseMatchesConfiguration
             store.Dispose();
         }
@@ -49,7 +49,7 @@ namespace Marten.Schema.Testing
                 _.Schema.For<User>();
             });
 
-            var patch = await theStore.Schema.CreateMigration(typeof(User));
+            var patch = await theStore.Schema.CreateMigrationAsync(typeof(User));
 
             patch.UpdateSql.ShouldContain("CREATE OR REPLACE FUNCTION public.mt_upsert_user");
             patch.UpdateSql.ShouldContain("CREATE TABLE public.mt_doc_user");
@@ -70,7 +70,7 @@ namespace Marten.Schema.Testing
             theStore.Tenancy.Default.EnsureStorageExists(typeof(User));
             theStore.Tenancy.Default.EnsureStorageExists(typeof(Target));
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             using (var store = DocumentStore.For(_ =>
             {
@@ -82,7 +82,7 @@ namespace Marten.Schema.Testing
                 var ex = await Exception<SchemaValidationException>.ShouldBeThrownByAsync(async
                     () =>
                 {
-                    await store.Schema.AssertDatabaseMatchesConfiguration();
+                    await store.Schema.AssertDatabaseMatchesConfigurationAsync();
                 });
 
 
@@ -97,7 +97,7 @@ namespace Marten.Schema.Testing
             theStore.Tenancy.Default.EnsureStorageExists(typeof(User));
             theStore.Tenancy.Default.EnsureStorageExists(typeof(Target));
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             using var store = DocumentStore.For(_ =>
             {
@@ -105,7 +105,7 @@ namespace Marten.Schema.Testing
                 _.Schema.For<User>();
                 _.Schema.For<Target>();
             });
-            await store.Schema.AssertDatabaseMatchesConfiguration();
+            await store.Schema.AssertDatabaseMatchesConfigurationAsync();
         }
 
         [Fact] // -- flakey on ci
@@ -132,7 +132,7 @@ namespace Marten.Schema.Testing
                 _.Events.AddEventType(typeof(MembersJoined));
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
 
             using var store = DocumentStore.For(_ =>
@@ -141,7 +141,7 @@ namespace Marten.Schema.Testing
                 _.Events.AddEventType(typeof(MembersJoined));
             });
 
-            await store.Schema.AssertDatabaseMatchesConfiguration();
+            await store.Schema.AssertDatabaseMatchesConfigurationAsync();
         }
 
         [Fact(Skip = "flakey on ci")]
@@ -167,7 +167,7 @@ namespace Marten.Schema.Testing
 
             #region sample_write-patch
             // Write the patch SQL file to the @"bin\patches" directory
-            await theStore.Schema.WriteMigrationFile(directory.AppendPath("1.initial.sql"));
+            await theStore.Schema.WriteMigrationFileAsync(directory.AppendPath("1.initial.sql"));
             #endregion sample_write-patch
 
             fileSystem.FileExists(directory.AppendPath("1.initial.sql"));
@@ -191,7 +191,7 @@ namespace Marten.Schema.Testing
 
             #region sample_write-patch
             // Write the patch SQL file to the @"bin\patches" directory
-            await theStore.Schema.WriteMigrationFile(directory.AppendPath("1.initial.sql"));
+            await theStore.Schema.WriteMigrationFileAsync(directory.AppendPath("1.initial.sql"));
             #endregion sample_write-patch
 
             fileSystem.FileExists(directory.AppendPath("1.initial.sql"));

--- a/src/Marten.Schema.Testing/create_database_Tests.cs
+++ b/src/Marten.Schema.Testing/create_database_Tests.cs
@@ -26,7 +26,7 @@ namespace Marten.Schema.Testing
             {
                 await Should.ThrowAsync<PostgresException>(async () =>
                 {
-                    await store1.Schema.ApplyAllConfiguredChangesToDatabase();
+                    await store1.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
                 });
             }
 
@@ -56,8 +56,8 @@ namespace Marten.Schema.Testing
             {
                 await store.Advanced.Clean.CompletelyRemoveAllAsync();
 
-                await store.Schema.ApplyAllConfiguredChangesToDatabase();
-                await store.Schema.AssertDatabaseMatchesConfiguration();
+                await store.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+                await store.Schema.AssertDatabaseMatchesConfigurationAsync();
                 Assert.True(dbCreated);
             }
         }

--- a/src/Marten.Schema.Testing/creating_a_full_patch.cs
+++ b/src/Marten.Schema.Testing/creating_a_full_patch.cs
@@ -25,7 +25,7 @@ namespace Marten.Schema.Testing
                 _.AutoCreateSchemaObjects = AutoCreate.CreateOrUpdate;
             }))
             {
-                var patch = (await store2.Schema.CreateMigration()).UpdateSql;
+                var patch = (await store2.Schema.CreateMigrationAsync()).UpdateSql;
 
                 // don't patch Target and Company because they don't change
                 patch.ShouldNotContain("mt_doc_company");

--- a/src/Marten.Testing/Acceptance/computed_indexes.cs
+++ b/src/Marten.Testing/Acceptance/computed_indexes.cs
@@ -228,7 +228,7 @@ namespace Marten.Testing.Acceptance
                 _.Schema.For<Target>().Index(x => x.Number);
             }))
             {
-                var patch = await store2.Schema.CreateMigration();
+                var patch = await store2.Schema.CreateMigrationAsync();
 
                 patch.UpdateSql.ShouldContain( "mt_doc_target_idx_number", Case.Insensitive);
             }

--- a/src/Marten.Testing/Acceptance/full_text_index.cs
+++ b/src/Marten.Testing/Acceptance/full_text_index.cs
@@ -774,10 +774,10 @@ namespace Marten.Testing.Acceptance
             });
 
             // Apply changes
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             // Look at updates after that
-            var patch = await theStore.Schema.CreateMigration();
+            var patch = await theStore.Schema.CreateMigrationAsync();
 
             Assert.DoesNotContain("drop index fulltext.mt_doc_user_idx_fts", patch.UpdateSql);
         }
@@ -792,10 +792,10 @@ namespace Marten.Testing.Acceptance
             });
 
             // Apply changes
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             // Look at updates after that
-            var patch = await theStore.Schema.CreateMigration();
+            var patch = await theStore.Schema.CreateMigrationAsync();
 
             Assert.DoesNotContain("drop index fulltext.mt_doc_company_idx_fts", patch.UpdateSql);
         }
@@ -810,10 +810,10 @@ namespace Marten.Testing.Acceptance
             });
 
             // Apply changes
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             // Look at updates after that
-            var patch = await theStore.Schema.CreateMigration();
+            var patch = await theStore.Schema.CreateMigrationAsync();
 
             Assert.DoesNotContain("drop index fulltext.mt_doc_user_idx_fts", patch.UpdateSql);
         }
@@ -828,7 +828,7 @@ namespace Marten.Testing.Acceptance
             });
 
             // Apply changes
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             // Change indexed fields
             var store = DocumentStore.For(_ =>
@@ -841,7 +841,7 @@ namespace Marten.Testing.Acceptance
             });
 
             // Look at updates after that
-            var patch = await store.Schema.CreateMigration();
+            var patch = await store.Schema.CreateMigrationAsync();
 
             Assert.Contains("drop index concurrently if exists fulltext.mt_doc_user_idx_fts", patch.UpdateSql);
         }

--- a/src/Marten.Testing/Bugs/Batch_query_load_fails_with_multi_tenant_document.cs
+++ b/src/Marten.Testing/Bugs/Batch_query_load_fails_with_multi_tenant_document.cs
@@ -24,7 +24,7 @@ namespace Marten.Testing.Bugs
             });
 
             await documentStore.Advanced.Clean.CompletelyRemoveAllAsync();
-            await documentStore.Schema.ApplyAllConfiguredChangesToDatabase(AutoCreate.All);
+            await documentStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.All);
 
             var testDocument = new User {Id = Guid.NewGuid(), UserName = "Test name"};
 
@@ -52,7 +52,7 @@ namespace Marten.Testing.Bugs
             });
 
             await documentStore.Advanced.Clean.CompletelyRemoveAllAsync();
-            await documentStore.Schema.ApplyAllConfiguredChangesToDatabase(AutoCreate.All);
+            await documentStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.All);
 
             var testDocument = new User {Id = Guid.NewGuid(), UserName = "Test name"};
 

--- a/src/Marten.Testing/Bugs/Bug_1002_new_duplicate_field_write_patch_syntax_error.cs
+++ b/src/Marten.Testing/Bugs/Bug_1002_new_duplicate_field_write_patch_syntax_error.cs
@@ -17,7 +17,7 @@ namespace Marten.Testing.Bugs
                 _.Schema.For<Bug_1002>();
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             var store = SeparateStore(_ =>
             {
@@ -26,7 +26,7 @@ namespace Marten.Testing.Bugs
                     .Duplicate(x => x.Name); // add a new duplicate column
             });
 
-            (await store.Schema.CreateMigration()).UpdateSql.ShouldNotContain(";;");
+            (await store.Schema.CreateMigrationAsync()).UpdateSql.ShouldNotContain(";;");
         }
 
     }

--- a/src/Marten.Testing/Bugs/Bug_1018_multi_key_unique_index_schema_update_assert_failure.cs
+++ b/src/Marten.Testing/Bugs/Bug_1018_multi_key_unique_index_schema_update_assert_failure.cs
@@ -28,8 +28,8 @@ namespace Marten.Testing.Bugs
                     .UniqueIndex(UniqueIndexType.DuplicatedField, x => x.Field1, x => x.Field2);
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
-            await theStore.Schema.AssertDatabaseMatchesConfiguration();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+            await theStore.Schema.AssertDatabaseMatchesConfigurationAsync();
         }
 
     }

--- a/src/Marten.Testing/Bugs/Bug_1151_assert_database_matches_configuration_exception.cs
+++ b/src/Marten.Testing/Bugs/Bug_1151_assert_database_matches_configuration_exception.cs
@@ -17,8 +17,8 @@ namespace Marten.Testing.Bugs
                     .Duplicate(c => c.Trim);
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
-            await theStore.Schema.AssertDatabaseMatchesConfiguration();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+            await theStore.Schema.AssertDatabaseMatchesConfigurationAsync();
         }
 
     }

--- a/src/Marten.Testing/Bugs/Bug_1821_schema_validation_fails_if_document_has_indexes_or_foreign_keys.cs
+++ b/src/Marten.Testing/Bugs/Bug_1821_schema_validation_fails_if_document_has_indexes_or_foreign_keys.cs
@@ -24,9 +24,9 @@ namespace Marten.Testing.Bugs
             });
 
             await documentStore.Advanced.Clean.CompletelyRemoveAllAsync();
-            await documentStore.Schema.ApplyAllConfiguredChangesToDatabase(AutoCreate.All);
+            await documentStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.All);
 
-            await documentStore.Schema.AssertDatabaseMatchesConfiguration();
+            await documentStore.Schema.AssertDatabaseMatchesConfigurationAsync();
         }
 
         [Fact]
@@ -40,9 +40,9 @@ namespace Marten.Testing.Bugs
             });
 
             await documentStore.Advanced.Clean.CompletelyRemoveAllAsync();
-            await documentStore.Schema.ApplyAllConfiguredChangesToDatabase(AutoCreate.All);
+            await documentStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.All);
 
-            await documentStore.Schema.AssertDatabaseMatchesConfiguration();
+            await documentStore.Schema.AssertDatabaseMatchesConfigurationAsync();
         }
 
         [Fact]
@@ -56,9 +56,9 @@ namespace Marten.Testing.Bugs
             });
 
             await documentStore.Advanced.Clean.CompletelyRemoveAllAsync();
-            await documentStore.Schema.ApplyAllConfiguredChangesToDatabase(AutoCreate.All);
+            await documentStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.All);
 
-            await documentStore.Schema.AssertDatabaseMatchesConfiguration();
+            await documentStore.Schema.AssertDatabaseMatchesConfigurationAsync();
         }
 
         [Fact]
@@ -72,9 +72,9 @@ namespace Marten.Testing.Bugs
             });
 
             await documentStore.Advanced.Clean.CompletelyRemoveAllAsync();
-            await documentStore.Schema.ApplyAllConfiguredChangesToDatabase(AutoCreate.All);
+            await documentStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.All);
 
-            await documentStore.Schema.AssertDatabaseMatchesConfiguration();
+            await documentStore.Schema.AssertDatabaseMatchesConfigurationAsync();
         }
     }
 }

--- a/src/Marten.Testing/Bugs/Bug_1822_recreating_index_fails_if_there_are_more_than_one_change.cs
+++ b/src/Marten.Testing/Bugs/Bug_1822_recreating_index_fails_if_there_are_more_than_one_change.cs
@@ -26,7 +26,7 @@ namespace Marten.Testing.Bugs
             });
 
             await documentStore.Advanced.Clean.CompletelyRemoveAllAsync();
-            await documentStore.Schema.ApplyAllConfiguredChangesToDatabase(AutoCreate.All);
+            await documentStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.All);
 
             using var secondDocumentStore = SeparateStore(x =>
             {
@@ -36,7 +36,7 @@ namespace Marten.Testing.Bugs
                     .Index(y => y.LastName, index => index.Casing = ComputedIndex.Casings.Upper);
             });
 
-            await documentStore.Schema.ApplyAllConfiguredChangesToDatabase(AutoCreate.All);
+            await documentStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.All);
         }
     }
 }

--- a/src/Marten.Testing/Bugs/Bug_431_not_patching_with_the_doc_type_column.cs
+++ b/src/Marten.Testing/Bugs/Bug_431_not_patching_with_the_doc_type_column.cs
@@ -28,8 +28,8 @@ namespace Marten.Testing.Bugs
                 _.Schema.For<User>().AddSubClass<SuperUser>();
             });
 
-            await store2.Schema.ApplyAllConfiguredChangesToDatabase();
-            await store2.Schema.AssertDatabaseMatchesConfiguration();
+            await store2.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+            await store2.Schema.AssertDatabaseMatchesConfigurationAsync();
 
 
 

--- a/src/Marten.Testing/Bugs/Bug_550_schema_diff_with_precision.cs
+++ b/src/Marten.Testing/Bugs/Bug_550_schema_diff_with_precision.cs
@@ -19,7 +19,7 @@ namespace Marten.Testing.Bugs
                 _.Schema.For<DocWithPrecision>().Duplicate(x => x.Name, "character varying (100)");
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             var store = SeparateStore(_ =>
             {
@@ -27,7 +27,7 @@ namespace Marten.Testing.Bugs
                 _.Schema.For<DocWithPrecision>().Duplicate(x => x.Name, "character varying (100)");
             });
 
-            var patch = await store.Schema.CreateMigration(typeof(DocWithPrecision));
+            var patch = await store.Schema.CreateMigrationAsync(typeof(DocWithPrecision));
             patch.Difference.ShouldBe(SchemaPatchDifference.None);
         }
 

--- a/src/Marten.Testing/Bugs/Bug_620_alias_bool.cs
+++ b/src/Marten.Testing/Bugs/Bug_620_alias_bool.cs
@@ -16,7 +16,7 @@ namespace Marten.Testing.Bugs
             {
                 store1.Tenancy.Default.EnsureStorageExists(typeof(DocWithBool));
 
-                await store1.Schema.ApplyAllConfiguredChangesToDatabase();
+                await store1.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
             }
 
             using (var store2 = SeparateStore(_ =>
@@ -24,7 +24,7 @@ namespace Marten.Testing.Bugs
                 _.Schema.For<DocWithBool>();
             }))
             {
-                await store2.Schema.AssertDatabaseMatchesConfiguration();
+                await store2.Schema.AssertDatabaseMatchesConfigurationAsync();
             }
         }
     }

--- a/src/Marten.Testing/Bugs/Bug_628_fk_from_doc_to_itself.cs
+++ b/src/Marten.Testing/Bugs/Bug_628_fk_from_doc_to_itself.cs
@@ -22,7 +22,7 @@ namespace Marten.Testing.Bugs
                 _.Schema.For<Category>().ForeignKey<Category>(x => x.ParentId);
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
         }
 
     }

--- a/src/Marten.Testing/Bugs/Bug_772_index_wrapping_column_does_not_match_DDL.cs
+++ b/src/Marten.Testing/Bugs/Bug_772_index_wrapping_column_does_not_match_DDL.cs
@@ -18,8 +18,8 @@ namespace Marten.Testing.Bugs
                     .Duplicate(c => c.Name);
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
-            await theStore.Schema.AssertDatabaseMatchesConfiguration();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+            await theStore.Schema.AssertDatabaseMatchesConfigurationAsync();
         }
 
         [Fact] // Control
@@ -34,8 +34,8 @@ namespace Marten.Testing.Bugs
                       });
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
-            await theStore.Schema.AssertDatabaseMatchesConfiguration();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+            await theStore.Schema.AssertDatabaseMatchesConfigurationAsync();
         }
 
         [Fact] // Experiment, passed
@@ -53,8 +53,8 @@ namespace Marten.Testing.Bugs
                     });
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
-            await theStore.Schema.AssertDatabaseMatchesConfiguration();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+            await theStore.Schema.AssertDatabaseMatchesConfigurationAsync();
         }
 
 

--- a/src/Marten.Testing/Bugs/Bug_961_custom_identity_field_with_fk.cs
+++ b/src/Marten.Testing/Bugs/Bug_961_custom_identity_field_with_fk.cs
@@ -28,7 +28,7 @@ namespace Marten.Testing.Bugs
                 _.Schema.For<Document>().ForeignKey<FkTarget>(a => a.TargetId);
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
         }
 
     }

--- a/src/Marten.Testing/Bugs/Bug_983_autocreate_none_is_disabling_schema_validation.cs
+++ b/src/Marten.Testing/Bugs/Bug_983_autocreate_none_is_disabling_schema_validation.cs
@@ -25,7 +25,7 @@ namespace Marten.Testing.Bugs
 
             await Exception<SchemaValidationException>.ShouldBeThrownByAsync(() =>
             {
-                return theStore.Schema.AssertDatabaseMatchesConfiguration();
+                return theStore.Schema.AssertDatabaseMatchesConfigurationAsync();
             });
         }
 

--- a/src/Marten.Testing/Bugs/Bug_PR_1412_spaces_in_table_name_cause_schema_patch_to_fail.cs
+++ b/src/Marten.Testing/Bugs/Bug_PR_1412_spaces_in_table_name_cause_schema_patch_to_fail.cs
@@ -26,8 +26,8 @@ namespace Marten.Testing.Bugs
             });
             await Should.NotThrowAsync(async () =>
             {
-                await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
-                await theStore.Schema.AssertDatabaseMatchesConfiguration();
+                await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+                await theStore.Schema.AssertDatabaseMatchesConfigurationAsync();
             });
         }
 
@@ -41,8 +41,8 @@ namespace Marten.Testing.Bugs
             });
             await Should.NotThrowAsync(async () =>
             {
-                await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
-                await theStore.Schema.AssertDatabaseMatchesConfiguration();
+                await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+                await theStore.Schema.AssertDatabaseMatchesConfigurationAsync();
             });
         }
 
@@ -56,8 +56,8 @@ namespace Marten.Testing.Bugs
             });
             await Should.NotThrowAsync(async () =>
             {
-                await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
-                await theStore.Schema.AssertDatabaseMatchesConfiguration();
+                await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+                await theStore.Schema.AssertDatabaseMatchesConfigurationAsync();
             });
         }
 

--- a/src/Marten.Testing/CoreFunctionality/ability_to_add_custom_storage_features.cs
+++ b/src/Marten.Testing/CoreFunctionality/ability_to_add_custom_storage_features.cs
@@ -21,7 +21,7 @@ namespace Marten.Testing.CoreFunctionality
                 _.Storage.Add<FakeStorage>();
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
             (await theStore.Tenancy.Default.SchemaTables()).Any(x => x.Name == "mt_fake_table")
                 .ShouldBeTrue();
         }

--- a/src/Marten.Testing/Events/Bugs/Bug_443_erroneously_creating_the_event_tables_when_unnecessary.cs
+++ b/src/Marten.Testing/Events/Bugs/Bug_443_erroneously_creating_the_event_tables_when_unnecessary.cs
@@ -16,7 +16,7 @@ namespace Marten.Testing.Events.Bugs
         {
             theStore.Tenancy.Default.EnsureStorageExists(typeof(User));
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             var tables = await theStore.Tenancy.Default.SchemaTables();
 
@@ -36,7 +36,7 @@ namespace Marten.Testing.Events.Bugs
         [Fact]
         public async Task not_part_of_the_patch()
         {
-            var patch = await theStore.Schema.CreateMigration();
+            var patch = await theStore.Schema.CreateMigrationAsync();
 
             SpecificationExtensions.ShouldNotContain(patch.UpdateSql, "mt_events");
             SpecificationExtensions.ShouldNotContain(patch.UpdateSql, "mt_streams");

--- a/src/Marten.Testing/Events/Bugs/Bug_499_event_store_objects_should_not_be_erroneously_in_the_patch.cs
+++ b/src/Marten.Testing/Events/Bugs/Bug_499_event_store_objects_should_not_be_erroneously_in_the_patch.cs
@@ -12,7 +12,7 @@ namespace Marten.Testing.Events.Bugs
         {
             StoreOptions(_ => _.Schema.For<User>());
 
-            var patch = await theStore.Schema.CreateMigration();
+            var patch = await theStore.Schema.CreateMigrationAsync();
 
             patch.UpdateSql.ShouldNotContain("mt_events");
             patch.UpdateSql.ShouldNotContain("mt_streams");

--- a/src/Marten.Testing/Linq/Bug_1061_string_enum_serialization_does_not_work_with_ginindexjsondata.cs
+++ b/src/Marten.Testing/Linq/Bug_1061_string_enum_serialization_does_not_work_with_ginindexjsondata.cs
@@ -36,7 +36,7 @@ namespace Marten.Testing.Linq
                 });
             });
 
-            await theStore.Schema.ApplyAllConfiguredChangesToDatabase();
+            await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
 
             using var store = DocumentStore.For(_ =>
             {

--- a/src/Marten/Schema/IDocumentSchema.cs
+++ b/src/Marten/Schema/IDocumentSchema.cs
@@ -37,40 +37,40 @@ namespace Marten.Schema
         ///     rollback file as well.
         /// </summary>
         /// <param name="filename"></param>
-        Task WriteMigrationFile(string filename);
+        Task WriteMigrationFileAsync(string filename);
 
         /// <summary>
         ///     Tries to write a "patch" SQL text to upgrade the database
         ///     to the current Marten schema configuration
         /// </summary>
         /// <returns></returns>
-        Task<SchemaMigration> CreateMigration();
+        Task<SchemaMigration> CreateMigrationAsync();
 
         /// <summary>
         ///     Validates the Marten configuration of documents and transforms against
         ///     the current database schema. Will throw an exception if any differences are
         ///     detected. Useful for "environment tests"
         /// </summary>
-        Task AssertDatabaseMatchesConfiguration();
+        Task AssertDatabaseMatchesConfigurationAsync();
 
         /// <summary>
         ///     Executes all detected DDL patches to the schema based on current configuration
         ///     upfront at one time
         /// </summary>
-        Task ApplyAllConfiguredChangesToDatabase(AutoCreate? withAutoCreate = null);
+        Task ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate? withAutoCreate = null);
 
         /// <summary>
         ///     Generate a DDL patch for one specific document type
         /// </summary>
         /// <param name="documentType"></param>
         /// <returns></returns>
-        Task<SchemaMigration> CreateMigration(Type documentType);
+        Task<SchemaMigration> CreateMigrationAsync(Type documentType);
 
         /// <summary>
         /// Write a migration file for a single document type to the supplied file name
         /// </summary>
         /// <param name="directory"></param>
         /// <returns></returns>
-        Task WriteMigrationFileByType(string directory);
+        Task WriteMigrationFileByTypeAsync(string directory);
     }
 }

--- a/src/Marten/Storage/TenantSchema.cs
+++ b/src/Marten/Storage/TenantSchema.cs
@@ -76,7 +76,7 @@ namespace Marten.Storage
             system.WriteStringToFile(filename, writer.ToString());
         }
 
-        public async Task<SchemaMigration> CreateMigration()
+        public async Task<SchemaMigration> CreateMigrationAsync()
         {
             var @objects = _features.AllActiveFeatures(_tenant).SelectMany(x => x.Objects).ToArray();
 
@@ -104,14 +104,14 @@ namespace Marten.Storage
             return writer.ToString();
         }
 
-        public async Task WriteMigrationFile(string filename)
+        public async Task WriteMigrationFileAsync(string filename)
         {
             if (!Path.IsPathRooted(filename))
             {
                 filename = AppContext.BaseDirectory.AppendPath(filename);
             }
 
-            var patch = await CreateMigration();
+            var patch = await CreateMigrationAsync();
 
             DdlRules.WriteTemplatedFile(filename, (r, w) =>
             {
@@ -125,22 +125,22 @@ namespace Marten.Storage
             });
         }
 
-        public async Task AssertDatabaseMatchesConfiguration()
+        public async Task AssertDatabaseMatchesConfigurationAsync()
         {
-            var patch = await CreateMigration();
+            var patch = await CreateMigrationAsync();
             if (patch.Difference != SchemaPatchDifference.None)
             {
                 throw new SchemaValidationException(patch.UpdateSql);
             }
         }
 
-        public async Task ApplyAllConfiguredChangesToDatabase(AutoCreate? withCreateSchemaObjects = null)
+        public async Task ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate? withCreateSchemaObjects = null)
         {
             var defaultAutoCreate = StoreOptions.AutoCreateSchemaObjects != AutoCreate.None
                 ? StoreOptions.AutoCreateSchemaObjects
                 : AutoCreate.CreateOrUpdate;
 
-            var patch = await CreateMigration();
+            var patch = await CreateMigrationAsync();
 
             if (patch.Difference == SchemaPatchDifference.None) return;
 
@@ -160,7 +160,7 @@ namespace Marten.Storage
             }
         }
 
-        public async Task<SchemaMigration> CreateMigration(Type documentType)
+        public async Task<SchemaMigration> CreateMigrationAsync(Type documentType)
         {
             var mapping = _features.MappingFor(documentType);
 
@@ -172,7 +172,7 @@ namespace Marten.Storage
             return migration;
         }
 
-        public async Task WriteMigrationFileByType(string directory)
+        public async Task WriteMigrationFileByTypeAsync(string directory)
         {
             var system = new FileSystem();
 

--- a/src/MartenBenchmarks/BenchmarkStore.cs
+++ b/src/MartenBenchmarks/BenchmarkStore.cs
@@ -20,7 +20,7 @@ namespace MartenBenchmarks
             });
 
             Store.Advanced.Clean.CompletelyRemoveAll();
-            Store.Schema.ApplyAllConfiguredChangesToDatabase().GetAwaiter().GetResult();
+            Store.Schema.ApplyAllConfiguredChangesToDatabaseAsync().GetAwaiter().GetResult();
         }
     }
 }


### PR DESCRIPTION
Added Async suffix to Marten.Schema methods (e.g., ApplyAllConfiguredChangesToDatabase`) as they do not follow the convention method (e.g. SaveChangesAsync, RunSqlAsync etc.) which may be dangerous for the database setup if someone skips await. I personally stumbled on that.

I would be all for removing the suffix in all places if we were all async.