### PR TITLE
Fix run_specification for Inline_Aggregation_by_Stream.md

### DIFF
--- a/src/Marten.Storyteller/Fixtures/EventStore/InlineAggregationFixture.cs
+++ b/src/Marten.Storyteller/Fixtures/EventStore/InlineAggregationFixture.cs
@@ -75,9 +75,9 @@ namespace Marten.Storyteller.Fixtures.EventStore
         }
 
         [FormatAs("Members should be {Members}")]
-        public List<string> Members()
+        public string[] Members()
         {
-            return CurrentObject.As<QuestParty>().Members;
+            return CurrentObject.As<QuestParty>().Members.ToArray();
         }
     }
 }


### PR DESCRIPTION
Before this commit:
❌ run_specification(path: "Event Store/Projections/Inline_Aggregation_by_Stream.md") would fail with the following error:
> System.Exception: Rights: 2, Wrongs: 0, Exceptions: 2, SyntaxErrors: 0

And this is what was displayed in the html result file:
> Cell Error in 'Members'
```
No converter found for type System.Collections.Generic.List`1[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
```

After this commit:
✅ All StorytellerRunner.Runner.run_specification theories pass

Note: this looks like a limitation of Storyteller.