### PR TITLE
Make MartenIgnore public

### DIFF
--- a/src/Marten/Events/CodeGeneration/MartenIgnoreAttribute.cs
+++ b/src/Marten/Events/CodeGeneration/MartenIgnoreAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Marten.Events.CodeGeneration
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
-    internal class MartenIgnoreAttribute: Attribute
+    public class MartenIgnoreAttribute: Attribute
     {
 
     }


### PR DESCRIPTION
Can't use this handy attribute when it's marked `internal`.