### PR TITLE
Added readonly event store methods to IQuerySession

### DIFF
--- a/docs/guide/documents/querying/linq/index.md
+++ b/docs/guide/documents/querying/linq/index.md
@@ -16,7 +16,7 @@ implements the traditional [IQueryable](https://msdn.microsoft.com/en-us/library
 /// <returns></returns>
 IMartenQueryable<T> Query<T>();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/IQuerySession.cs#L84-L93' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_querying_with_linq' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/IQuerySession.cs#L85-L94' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_querying_with_linq' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To query for all documents of a type - not that you would do this very often outside of testing - use the `Query<T>()` method like this:

--- a/src/Marten/Events/IEventStore.cs
+++ b/src/Marten/Events/IEventStore.cs
@@ -1,10 +1,9 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.Linq;
 #nullable enable
+
 namespace Marten.Events
 {
     public interface IEventOperations
@@ -220,7 +219,7 @@ namespace Marten.Events
         StreamAction StartStream(params object[] events);
     }
 
-    public interface IEventStore: IEventOperations
+    public interface IEventStore: IEventOperations, IQueryEventStore
     {
         /// <summary>
         /// Append one or more events in order to an existing stream and verify that maximum event id for the stream
@@ -239,167 +238,6 @@ namespace Marten.Events
         /// <param name="events"></param>
         /// <returns></returns>
         StreamAction StartStream<TAggregate>(Guid id, IEnumerable<object> events) where TAggregate : class;
-
-        /// <summary>
-        /// Synchronously fetches all of the events for the named stream
-        /// </summary>
-        /// <param name="streamId"></param>
-        /// <param name="version">If set, queries for events up to and including this version</param>
-        /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
-        /// <returns></returns>
-        IReadOnlyList<IEvent> FetchStream(Guid streamId, long version = 0, DateTime? timestamp = null);
-
-        /// <summary>
-        /// Synchronously fetches all of the events for the named stream
-        /// </summary>
-        /// <param name="streamId"></param>
-        /// <param name="version">If set, queries for events up to and including this version</param>
-        /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0, DateTime? timestamp = null, CancellationToken token = default);
-
-        /// <summary>
-        /// Synchronously fetches all of the events for the named stream
-        /// </summary>
-        /// <param name="streamKey"></param>
-        /// <param name="version">If set, queries for events up to and including this version</param>
-        /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
-        /// <returns></returns>
-        IReadOnlyList<IEvent> FetchStream(string streamKey, long version = 0, DateTime? timestamp = null);
-
-        /// <summary>
-        /// Synchronously fetches all of the events for the named stream
-        /// </summary>
-        /// <param name="streamKey"></param>
-        /// <param name="version">If set, queries for events up to and including this version</param>
-        /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        Task<IReadOnlyList<IEvent>> FetchStreamAsync(string streamKey, long version = 0, DateTime? timestamp = null, CancellationToken token = default);
-
-        /// <summary>
-        /// Perform a live aggregation of the raw events in this stream to a T object
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="streamId"></param>
-        /// <param name="version"></param>
-        /// <param name="timestamp"></param>
-        /// <param name="state">Instance of T to apply events to</param>
-        /// <returns></returns>
-        T? AggregateStream<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T? state = null) where T : class;
-
-        /// <summary>
-        /// Perform a live aggregation of the raw events in this stream to a T object
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="streamId"></param>
-        /// <param name="version"></param>
-        /// <param name="timestamp"></param>
-        /// <param name="state">Instance of T to apply events to</param>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        Task<T?> AggregateStreamAsync<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T? state = null, CancellationToken token = default) where T : class;
-
-        /// <summary>
-        /// Perform a live aggregation of the raw events in this stream to a T object
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="streamKey"></param>
-        /// <param name="version"></param>
-        /// <param name="timestamp"></param>
-        /// <param name="state">Instance of T to apply events to</param>
-        /// <returns></returns>
-        T? AggregateStream<T>(string streamKey, long version = 0, DateTime? timestamp = null, T? state = null) where T : class;
-
-        /// <summary>
-        /// Perform a live aggregation of the raw events in this stream to a T object
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="streamKey"></param>
-        /// <param name="version"></param>
-        /// <param name="timestamp"></param>
-        /// <param name="state">Instance of T to apply events to</param>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        Task<T?> AggregateStreamAsync<T>(string streamKey, long version = 0, DateTime? timestamp = null, T? state = null, CancellationToken token = default) where T : class;
-
-        /// <summary>
-        /// Query directly against ONLY the raw event data. Use IQuerySession.Query() for aggregated documents!
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        IMartenQueryable<T> QueryRawEventDataOnly<T>();
-
-        /// <summary>
-        /// Query directly against the raw event data across all event types
-        /// </summary>
-        /// <returns></returns>
-        IMartenQueryable<IEvent> QueryAllRawEvents();
-
-        /// <summary>
-        /// Load a single event by its id knowing the event type upfront
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="id"></param>
-        /// <returns></returns>
-        IEvent<T> Load<T>(Guid id) where T : class;
-
-        /// <summary>
-        /// Load a single event by its id knowing the event type upfront
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="id"></param>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        Task<IEvent<T>> LoadAsync<T>(Guid id, CancellationToken token = default) where T : class;
-
-        /// <summary>
-        /// Load a single event by its id
-        /// </summary>
-        /// <param name="id"></param>
-        /// <returns></returns>
-        IEvent Load(Guid id);
-
-        /// <summary>
-        /// Load a single event by its id
-        /// </summary>
-        /// <param name="id"></param>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        Task<IEvent> LoadAsync(Guid id, CancellationToken token = default);
-
-        /// <summary>
-        /// Fetches only the metadata about a stream by id
-        /// </summary>
-        /// <param name="streamId"></param>
-        /// <returns></returns>
-        StreamState FetchStreamState(Guid streamId);
-
-        /// <summary>
-        /// Fetches only the metadata about a stream by id
-        /// </summary>
-        /// <param name="streamId"></param>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        Task<StreamState> FetchStreamStateAsync(Guid streamId, CancellationToken token = default);
-
-        /// <summary>
-        /// Fetches only the metadata about a stream by id
-        /// </summary>
-        /// <param name="streamKey"></param>
-        /// <returns></returns>
-        StreamState FetchStreamState(string streamKey);
-
-        /// <summary>
-        /// Fetches only the metadata about a stream by id
-        /// </summary>
-        /// <param name="streamKey"></param>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        Task<StreamState> FetchStreamStateAsync(string streamKey, CancellationToken token = default);
-
-
 
         /// <summary>
         /// Append events to an existing stream with optimistic concurrency checks against the

--- a/src/Marten/Events/IQueryEventStore.cs
+++ b/src/Marten/Events/IQueryEventStore.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Linq;
+#nullable enable
+
+namespace Marten.Events
+{
+    public interface IQueryEventStore
+    {
+        /// <summary>
+        /// Synchronously fetches all of the events for the named stream
+        /// </summary>
+        /// <param name="streamId"></param>
+        /// <param name="version">If set, queries for events up to and including this version</param>
+        /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
+        /// <returns></returns>
+        IReadOnlyList<IEvent> FetchStream(Guid streamId, long version = 0, DateTime? timestamp = null);
+
+        /// <summary>
+        /// Synchronously fetches all of the events for the named stream
+        /// </summary>
+        /// <param name="streamId"></param>
+        /// <param name="version">If set, queries for events up to and including this version</param>
+        /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0, DateTime? timestamp = null, CancellationToken token = default);
+
+        /// <summary>
+        /// Synchronously fetches all of the events for the named stream
+        /// </summary>
+        /// <param name="streamKey"></param>
+        /// <param name="version">If set, queries for events up to and including this version</param>
+        /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
+        /// <returns></returns>
+        IReadOnlyList<IEvent> FetchStream(string streamKey, long version = 0, DateTime? timestamp = null);
+
+        /// <summary>
+        /// Synchronously fetches all of the events for the named stream
+        /// </summary>
+        /// <param name="streamKey"></param>
+        /// <param name="version">If set, queries for events up to and including this version</param>
+        /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task<IReadOnlyList<IEvent>> FetchStreamAsync(string streamKey, long version = 0, DateTime? timestamp = null, CancellationToken token = default);
+
+        /// <summary>
+        /// Perform a live aggregation of the raw events in this stream to a T object
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="streamId"></param>
+        /// <param name="version"></param>
+        /// <param name="timestamp"></param>
+        /// <param name="state">Instance of T to apply events to</param>
+        /// <returns></returns>
+        T? AggregateStream<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T? state = null) where T : class;
+
+        /// <summary>
+        /// Perform a live aggregation of the raw events in this stream to a T object
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="streamId"></param>
+        /// <param name="version"></param>
+        /// <param name="timestamp"></param>
+        /// <param name="state">Instance of T to apply events to</param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task<T?> AggregateStreamAsync<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T? state = null, CancellationToken token = default) where T : class;
+
+        /// <summary>
+        /// Perform a live aggregation of the raw events in this stream to a T object
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="streamKey"></param>
+        /// <param name="version"></param>
+        /// <param name="timestamp"></param>
+        /// <param name="state">Instance of T to apply events to</param>
+        /// <returns></returns>
+        T? AggregateStream<T>(string streamKey, long version = 0, DateTime? timestamp = null, T? state = null) where T : class;
+
+        /// <summary>
+        /// Perform a live aggregation of the raw events in this stream to a T object
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="streamKey"></param>
+        /// <param name="version"></param>
+        /// <param name="timestamp"></param>
+        /// <param name="state">Instance of T to apply events to</param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task<T?> AggregateStreamAsync<T>(string streamKey, long version = 0, DateTime? timestamp = null, T? state = null, CancellationToken token = default) where T : class;
+
+        /// <summary>
+        /// Query directly against ONLY the raw event data. Use IQuerySession.Query() for aggregated documents!
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        IMartenQueryable<T> QueryRawEventDataOnly<T>();
+
+        /// <summary>
+        /// Query directly against the raw event data across all event types
+        /// </summary>
+        /// <returns></returns>
+        IMartenQueryable<IEvent> QueryAllRawEvents();
+
+        /// <summary>
+        /// Load a single event by its id knowing the event type upfront
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        IEvent<T> Load<T>(Guid id) where T : class;
+
+        /// <summary>
+        /// Load a single event by its id knowing the event type upfront
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="id"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task<IEvent<T>> LoadAsync<T>(Guid id, CancellationToken token = default) where T : class;
+
+        /// <summary>
+        /// Load a single event by its id
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        IEvent Load(Guid id);
+
+        /// <summary>
+        /// Load a single event by its id
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task<IEvent> LoadAsync(Guid id, CancellationToken token = default);
+
+        /// <summary>
+        /// Fetches only the metadata about a stream by id
+        /// </summary>
+        /// <param name="streamId"></param>
+        /// <returns></returns>
+        StreamState FetchStreamState(Guid streamId);
+
+        /// <summary>
+        /// Fetches only the metadata about a stream by id
+        /// </summary>
+        /// <param name="streamId"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task<StreamState> FetchStreamStateAsync(Guid streamId, CancellationToken token = default);
+
+        /// <summary>
+        /// Fetches only the metadata about a stream by id
+        /// </summary>
+        /// <param name="streamKey"></param>
+        /// <returns></returns>
+        StreamState FetchStreamState(string streamKey);
+
+        /// <summary>
+        /// Fetches only the metadata about a stream by id
+        /// </summary>
+        /// <param name="streamKey"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task<StreamState> FetchStreamStateAsync(string streamKey, CancellationToken token = default);
+    }
+}

--- a/src/Marten/Events/QueryEventStore.cs
+++ b/src/Marten/Events/QueryEventStore.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Baseline;
+using Marten.Events.Archiving;
+using Marten.Events.Querying;
+using Marten.Exceptions;
+using Marten.Internal.Sessions;
+using Marten.Internal.Storage;
+using Marten.Linq;
+using Marten.Linq.QueryHandlers;
+using Weasel.Postgresql;
+using Marten.Schema.Identity;
+using Marten.Storage;
+using Marten.Util;
+using Npgsql;
+using Weasel.Core;
+
+#nullable enable
+namespace Marten.Events
+{
+    internal class QueryEventStore: IQueryEventStore
+    {
+        private readonly QuerySession _session;
+        private readonly ITenant _tenant;
+        private readonly DocumentStore _store;
+
+        public QueryEventStore(QuerySession session, DocumentStore store, ITenant tenant)
+        {
+            _session = session;
+            _store = store;
+            _tenant = tenant;
+        }
+
+        public IReadOnlyList<IEvent> FetchStream(Guid streamId, long version = 0, DateTime? timestamp = null)
+        {
+            var selector = _store.Events.EnsureAsGuidStorage(_session);
+
+            var statement = new EventStatement(selector)
+            {
+                StreamId = streamId, Version = version, Timestamp = timestamp, TenantId = _tenant.TenantId
+            };
+
+            IQueryHandler<IReadOnlyList<IEvent>> handler = new ListQueryHandler<IEvent>(statement, selector);
+
+            return _session.ExecuteHandler(handler);
+        }
+
+        public Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0, DateTime? timestamp = null, CancellationToken token = default)
+        {
+            var selector = _store.Events.EnsureAsGuidStorage(_session);
+
+            var statement = new EventStatement(selector)
+            {
+                StreamId = streamId, Version = version, Timestamp = timestamp, TenantId = _tenant.TenantId
+            };
+
+            IQueryHandler<IReadOnlyList<IEvent>> handler = new ListQueryHandler<IEvent>(statement, selector);
+
+            return _session.ExecuteHandlerAsync(handler, token);
+        }
+
+        public IReadOnlyList<IEvent> FetchStream(string streamKey, long version = 0, DateTime? timestamp = null)
+        {
+            var selector = _store.Events.EnsureAsStringStorage(_session);
+
+            var statement = new EventStatement(selector)
+            {
+                StreamKey = streamKey, Version = version, Timestamp = timestamp, TenantId = _tenant.TenantId
+            };
+
+            IQueryHandler<IReadOnlyList<IEvent>> handler = new ListQueryHandler<IEvent>(statement, selector);
+
+            return _session.ExecuteHandler(handler);
+        }
+
+        public Task<IReadOnlyList<IEvent>> FetchStreamAsync(string streamKey, long version = 0, DateTime? timestamp = null, CancellationToken token = default)
+        {
+            var selector = _store.Events.EnsureAsStringStorage(_session);
+
+            var statement = new EventStatement(selector)
+            {
+                StreamKey = streamKey, Version = version, Timestamp = timestamp, TenantId = _tenant.TenantId
+            };
+
+            IQueryHandler<IReadOnlyList<IEvent>> handler = new ListQueryHandler<IEvent>(statement, selector);
+
+            return _session.ExecuteHandlerAsync(handler, token);
+        }
+
+        public T? AggregateStream<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T? state = null) where T : class
+        {
+            var events = FetchStream(streamId, version, timestamp);
+
+            var aggregator = _store.Options.Projections.AggregatorFor<T>();
+
+            if (!events.Any()) return null;
+
+            var aggregate = aggregator.Build(events, _session, state);
+
+            var storage = _session.StorageFor<T>();
+            if (storage is IDocumentStorage<T, Guid> s) s.SetIdentity(aggregate, streamId);
+
+            return aggregate;
+        }
+
+        public async Task<T?> AggregateStreamAsync<T>(Guid streamId, long version = 0, DateTime? timestamp = null,
+            T? state = null, CancellationToken token = default) where T : class
+        {
+            var events = await FetchStreamAsync(streamId, version, timestamp, token);
+            if (!events.Any()) return null;
+
+            var aggregator = _store.Options.Projections.AggregatorFor<T>();
+            var aggregate = await aggregator.BuildAsync(events, _session, state, token);
+
+            if (aggregate == null) return null;
+
+            var storage = _session.StorageFor<T>();
+            if (storage is IDocumentStorage<T, Guid> s) s.SetIdentity(aggregate, streamId);
+
+            return aggregate;
+        }
+
+        public T? AggregateStream<T>(string streamKey, long version = 0, DateTime? timestamp = null, T? state = null) where T : class
+        {
+            var events = FetchStream(streamKey, version, timestamp);
+            if (!events.Any())
+            {
+                return null;
+            }
+
+            var aggregator = _store.Options.Projections.AggregatorFor<T>();
+            var aggregate = aggregator.Build(events, _session, state);
+
+            var storage = _session.StorageFor<T>();
+            if (storage is IDocumentStorage<T, string> s) s.SetIdentity(aggregate, streamKey);
+
+            return aggregate;
+        }
+
+        public async Task<T?> AggregateStreamAsync<T>(string streamKey, long version = 0, DateTime? timestamp = null,
+            T? state = null, CancellationToken token = default) where T : class
+        {
+            var events = await FetchStreamAsync(streamKey, version, timestamp, token);
+            if (!events.Any())
+            {
+                return null;
+            }
+
+            var aggregator = _store.Options.Projections.AggregatorFor<T>();
+
+            var aggregate = await aggregator.BuildAsync(events, _session, state, token);
+
+            var storage = _session.StorageFor<T>();
+            if (storage is IDocumentStorage<T, string> s) s.SetIdentity(aggregate, streamKey);
+
+            return aggregate;
+        }
+
+        public IMartenQueryable<T> QueryRawEventDataOnly<T>()
+        {
+            _tenant.EnsureStorageExists(typeof(StreamAction));
+
+            _store.Events.AddEventType(typeof(T));
+
+            return _session.Query<T>();
+        }
+
+        public IMartenQueryable<IEvent> QueryAllRawEvents()
+        {
+            _tenant.EnsureStorageExists(typeof(StreamAction));
+
+            return _session.Query<IEvent>();
+        }
+
+        public IEvent<T> Load<T>(Guid id) where T : class
+        {
+            _tenant.EnsureStorageExists(typeof(StreamAction));
+
+            _store.Events.AddEventType(typeof(T));
+
+            return Load(id).As<Event<T>>();
+        }
+
+        public async Task<IEvent<T>> LoadAsync<T>(Guid id, CancellationToken token = default) where T : class
+        {
+            await _tenant.EnsureStorageExistsAsync(typeof(StreamAction), token);
+
+            _store.Events.AddEventType(typeof(T));
+
+            return (await LoadAsync(id, token)).As<Event<T>>();
+        }
+
+        public IEvent Load(Guid id)
+        {
+            var handler = new SingleEventQueryHandler(id, _session.EventStorage());
+            return _session.ExecuteHandler(handler);
+        }
+
+        public Task<IEvent> LoadAsync(Guid id, CancellationToken token = default)
+        {
+            _tenant.EnsureStorageExists(typeof(StreamAction));
+
+            var handler = new SingleEventQueryHandler(id, _session.EventStorage());
+            return _session.ExecuteHandlerAsync(handler, token);
+        }
+
+        public StreamState FetchStreamState(Guid streamId)
+        {
+            var handler = _tenant.EventStorage().QueryForStream(StreamAction.ForReference(streamId, _tenant));
+            return _session.ExecuteHandler(handler);
+        }
+
+        public Task<StreamState> FetchStreamStateAsync(Guid streamId, CancellationToken token = default)
+        {
+            var handler = _tenant.EventStorage().QueryForStream(StreamAction.ForReference(streamId, _tenant));
+            return _session.ExecuteHandlerAsync(handler, token);
+        }
+
+        public StreamState FetchStreamState(string streamKey)
+        {
+            var handler = _tenant.EventStorage().QueryForStream(StreamAction.ForReference(streamKey, _tenant));
+            return _session.ExecuteHandler(handler);
+        }
+
+        public Task<StreamState> FetchStreamStateAsync(string streamKey, CancellationToken token = default)
+        {
+            var handler = _tenant.EventStorage().QueryForStream(StreamAction.ForReference(streamKey, _tenant));
+            return _session.ExecuteHandlerAsync(handler, token);
+        }
+    }
+}

--- a/src/Marten/IDocumentSession.cs
+++ b/src/Marten/IDocumentSession.cs
@@ -32,7 +32,7 @@ namespace Marten
         /// <summary>
         /// Access to the event store functionality
         /// </summary>
-        IEventStore Events { get; }
+        new IEventStore Events { get; }
 
         /// <summary>
         /// Override whether or not this session honors optimistic concurrency checks

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Marten.Events;
 using Marten.Linq;
 using Marten.Schema;
 using Marten.Services.BatchQuerying;
@@ -143,7 +144,6 @@ namespace Marten
         /// <returns></returns>
         Task<IReadOnlyList<T>> QueryAsync<T>(string sql, params object[] parameters);
 
-
         /// <summary>
         /// Define a batch of deferred queries and load operations to be conducted in one asynchronous request to the
         /// database for potentially performance
@@ -173,6 +173,11 @@ namespace Marten
         IDocumentStore DocumentStore { get; }
 
         /// <summary>
+        /// Access to the event store functionality
+        /// </summary>
+        IQueryEventStore Events { get; }
+
+        /// <summary>
         /// A query that is compiled so a copy of the DbCommand can be used directly in subsequent requests.
         /// </summary>
         /// <typeparam name="TDoc">The document</typeparam>
@@ -191,7 +196,6 @@ namespace Marten
         /// <returns>A task for a single item query result</returns>
         Task<TOut> QueryAsync<TDoc, TOut>(ICompiledQuery<TDoc, TOut> query, CancellationToken token = default);
 
-
         /// <summary>
         /// Stream a single JSON document to the destination using a compiled query
         /// </summary>
@@ -202,7 +206,6 @@ namespace Marten
         /// <typeparam name="TOut"></typeparam>
         /// <returns></returns>
         Task<bool> StreamJsonOne<TDoc, TOut>(ICompiledQuery<TDoc, TOut> query, Stream destination, CancellationToken token = default);
-
 
         /// <summary>
         /// Stream many documents as a JSON array to the destination using a compiled query
@@ -215,7 +218,6 @@ namespace Marten
         /// <returns></returns>
         Task<int> StreamJsonMany<TDoc, TOut>(ICompiledQuery<TDoc, TOut> query, Stream destination,
             CancellationToken token = default);
-
 
         /// <summary>
         /// Fetch the JSON representation of a single document using a compiled query
@@ -236,8 +238,6 @@ namespace Marten
         /// <typeparam name="TOut"></typeparam>
         /// <returns></returns>
         Task<string> ToJsonMany<TDoc, TOut>(ICompiledQuery<TDoc, TOut> query, CancellationToken token = default);
-
-
 
         /// <summary>
         /// Load or find multiple documents by id

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Baseline;
-using Baseline.ImTools;
 using Marten.Events;
 using Marten.Internal.Operations;
 using Marten.Services;
@@ -27,19 +26,12 @@ namespace Marten.Internal.Sessions
         {
             Concurrency = sessionOptions.ConcurrencyChecks;
             _workTracker = new UnitOfWork(this);
-
-            Events = new EventStore(this, store, tenant);
-            _workTracker = new UnitOfWork(this);
         }
 
         internal DocumentSessionBase(DocumentStore store, SessionOptions sessionOptions, IManagedConnection database,
             ITenant tenant, ISessionWorkTracker workTracker): base(store, sessionOptions, database, tenant)
         {
             Concurrency = sessionOptions.ConcurrencyChecks;
-            _workTracker = new UnitOfWork(this);
-
-            Events = new EventStore(this, store, tenant);
-
             _workTracker = workTracker;
         }
 
@@ -182,7 +174,10 @@ namespace Marten.Internal.Sessions
             }
         }
 
-        public IEventStore Events { get; }
+        public new IEventStore Events => (IEventStore)base.Events;
+
+        protected override IQueryEventStore CreateEventStore(DocumentStore store, ITenant tenant)
+            => new EventStore(this, store, tenant);
 
 
         public void QueueOperation(IStorageOperation storageOperation)


### PR DESCRIPTION
I achieved that by adding the `IQueryEventStore` interface and `QueryEventStore` implementation.

I'm not entirely proud with the [CreateEventStore](https://github.com/JasperFx/marten/pull/1904/files#diff-629665ba21293b01ff2d61f05c14faeb4da6cc434d3baaa436520fd9ca8ab9beR41) virtual method, but I haven't found a better (less invasive) option, as creating `EventStore` requires passing to-be-created session with `this`. Another alternative would be to have a public setter for the session, but that's even more ugly...

@jeremydmiller, if you have better suggestions, I'm open to updating PR.