### PR TITLE
Fix for GH-1888 to prevent DefaultMartenLogger throwing exception 

### DIFF
--- a/src/Marten.Testing/Logging/DefaultMartenLoggerTests.cs
+++ b/src/Marten.Testing/Logging/DefaultMartenLoggerTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Xunit;
+
+namespace Marten.Testing.Logging
+{
+    public class DefaultMartenLoggerTests
+    {
+        [Fact]
+        public void log_failure_should_not_throw()
+        {
+            var sb = new StringBuilder();
+            var logger = new DefaultMartenLogger(new XunitLogger(sb));
+            var command = new NpgsqlCommand()
+            {
+                CommandText = "select * from users where id = @id",
+                Parameters =
+                {
+                        new NpgsqlParameter("id", "{1}")
+                }
+            };
+            logger.LogFailure(command, new Exception());
+            Assert.Equal("Marten encountered an exception executing \nselect * from users where id = @id\n  id: {1}\n", sb.ToString());
+        }
+    }
+
+    internal class XunitLogger : ILogger
+    {
+        private readonly StringBuilder _sb;
+        public XunitLogger(StringBuilder sb) => _sb = sb;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            var message = formatter(state, exception);
+            _sb.AppendLine(message);
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable BeginScope<TState>(TState state) => throw new NotImplementedException();
+    }
+}

--- a/src/Marten/DefaultMartenLogger.cs
+++ b/src/Marten/DefaultMartenLogger.cs
@@ -50,11 +50,11 @@ namespace Marten
         {
             _stopwatch?.Stop();
 
-            var message = "Marten encountered an exception executing \n{SQL}\n" + command.Parameters
-                .OfType<NpgsqlParameter>()
+            var message = "Marten encountered an exception executing \n{SQL}\n{PARAMS}";
+            var parameters = command.Parameters.OfType<NpgsqlParameter>()
                 .Select(p => $"  {p.ParameterName}: {p.Value}")
                 .Join(Environment.NewLine);
-            _logger.LogError(ex, message, command.CommandText);
+            _logger.LogError(ex, message, command.CommandText, parameters);
 
         }
 


### PR DESCRIPTION
Fix for GH-1888 to prevent DefaultMartenLogger throwing exception when parameter nam and/or value includes {