### PR TITLE
Adjust wording on quickstart and configuration pages

### DIFF
--- a/docs/configuration/hostbuilder.md
+++ b/docs/configuration/hostbuilder.md
@@ -1,55 +1,37 @@
 # Bootstrapping with HostBuilder
 
-::: tip INFO
-The built in DI service registration helpers were introduced in Marten v3.12.
-:::
-
 As briefly shown in the [getting started](/) page, Marten comes with extension methods
 for the .Net Core standard `IServiceCollection` to quickly add Marten services to any .Net application that is bootstrapped by
-either the [Generic IHostBuilder abstraction](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-3.1) or the [ASP.Net Core IWebHostBuilder](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.hosting.iwebhostbuilder?view=aspnetcore-3.1)
+either the [Generic IHostBuilder abstraction](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host) or the [ASP.Net Core IWebHostBuilder](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.hosting.iwebhostbuilder)
 hosting models.
 
-Jumping right into a basic ASP.Net Core application using the out of the box Web API template, you'd have a class called `Startup` that holds most of the configuration for your application including
+Jumping right into a basic ASP&#46;NET Core application using the out of the box Web API template, you'd have a class called `Startup` that holds most of the configuration for your application including
 the IoC service registrations for your application in the `Startup.ConfigureServices()` method. To add Marten
 to your application, use the `AddMarten()` method as shown below:
 
 <!-- snippet: sample_StartupConfigureServices -->
 <a id='snippet-sample_startupconfigureservices'></a>
 ```cs
-public class Startup
+public void ConfigureServices(IServiceCollection services)
 {
-    public IConfiguration Configuration { get; }
-    public IHostEnvironment Environment { get; }
-
-    public Startup(IConfiguration configuration, IHostEnvironment environment)
+    // This is the absolute, simplest way to integrate Marten into your
+    // .Net Core application with Marten's default configuration
+    services.AddMarten(options =>
     {
-        Configuration = configuration;
-        Environment = environment;
-    }
+        // Establish the connection string to your Marten database
+        options.Connection(Configuration.GetConnectionString("Marten"));
 
-    // This method gets called by the runtime. Use this method to add services to the container.
-    // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
-    public void ConfigureServices(IServiceCollection services)
-    {
-        // This is the absolute, simplest way to integrate Marten into your
-        // .Net Core application with Marten's default configuration
-        services.AddMarten(options =>
+        // If we're running in development mode, let Marten just take care
+        // of all necessary schema building and patching behind the scenes
+        if (Environment.IsDevelopment())
         {
-            // Establish the connection string to your Marten database
-            options.Connection(Configuration.GetConnectionString("Marten"));
-
-            // If we're running in development mode, let Marten just take care
-            // of all necessary schema building and patching behind the scenes
-            if (Environment.IsDevelopment())
-            {
-                options.AutoCreateSchemaObjects = AutoCreate.All;
-            }
-        });
-    }
-
-    // and other methods we don't care about right now...
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+        }
+    });
+}
+// and other methods we don't care about right now...
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Startup.cs#L13-L48' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_startupconfigureservices' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Startup.cs#L23-L44' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_startupconfigureservices' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `AddMarten()` method will add these service registrations to your application:
@@ -67,8 +49,7 @@ For more information, see:
 ## AddMarten() Options
 
 ::: tip INFO
-All the examples in this page are assuming the usage of the `IServiceCollection` interface for service
-registrations within a `Startup` class, but Marten can be used with any IoC container or with no IoC container whatsoever.
+All the examples in this page are assuming the usage of the default IoC container `Microsoft.Extensions.DependencyInjection`, but Marten can be used with any IoC container or with no IoC container whatsoever.
 :::
 
 First, if you are using Marten completely out of the box with no customizations (besides attributes on your documents), you can just supply a connection string to the underlying Postgresql database like this:
@@ -192,7 +173,7 @@ The last option may be best for more complicated Marten configuration just to ke
 ## Using Lightweight Sessions
 
 ::: tip
-Most new usages of Marten should default to the lightweight sessions for better performance
+Most usages of Marten should default to the lightweight sessions for better performance
 :::
 
 The default registration for `IDocumentSession` added by `AddMarten()` is a session with
@@ -324,7 +305,7 @@ See [diagnostics and instrumentation](/diagnostics) for more information.
 From a recent user request to Marten, what if you want to log the database statement activity in Marten with some kind of correlation to the active HTTP request or service bus message or some other logical
 session identification in your application? That's now possible by using a custom `ISessionFactory`.
 
-Taking the example of an ASP.Net Core application, let's say that you have a small service scoped to an HTTP request that tracks a correlation identifier for the request like this:
+Taking the example of an ASP&#46;NET Core application, let's say that you have a small service scoped to an HTTP request that tracks a correlation identifier for the request like this:
 
 <!-- snippet: sample_CorrelationIdWithISession -->
 <a id='snippet-sample_correlationidwithisession'></a>

--- a/docs/configuration/ioc.md
+++ b/docs/configuration/ioc.md
@@ -2,7 +2,7 @@
 
 ::: tip
 The Marten team recommends using the `IServiceCollection.AddMarten()` extension method
-for IoC integration out of the box, but Marten is usable without that.
+for IoC integration out of the box.
 :::
 
 The Marten team has striven to make the library perfectly usable without the usage of an IoC container, but you may still want to

--- a/docs/configuration/json.md
+++ b/docs/configuration/json.md
@@ -323,6 +323,9 @@ var store = DocumentStore.For(opts =>
     opts.Connection("some connection string");
 
     // Opt into System.Text.Json serialization
+    opts.UseDefaultSerialization(serializerType: SerializerType.SystemTextJson);
+
+    // Optionally add the serializer directly
     opts.Serializer(new SystemTextJsonSerializer
     {
         // Optionally override the enum storage
@@ -333,7 +336,7 @@ var store = DocumentStore.For(opts =>
     });
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/UsingSystemTextJsonSerializer.cs#L10-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_stj_serialization' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/UsingSystemTextJsonSerializer.cs#L11-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_stj_serialization' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Serializing with Jil

--- a/docs/configuration/storeoptions.md
+++ b/docs/configuration/storeoptions.md
@@ -313,11 +313,9 @@ var store = DocumentStore.For(opts =>
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDatabaseSchemaName.cs#L22-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configure_schema_by_document_type' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-
-
 ## Postgres Limits on Naming
 
-Postgresql out of the box has a limitation on the length of database object names to 64. This can be overridden in a
+Postgresql has a default limitation on the length of database object names (64). This can be overridden in a
 Postgresql database by [setting the NAMEDATALEN property](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS).
 
 This can unfortunately have a negative impact on Marten's ability to detect changes to the schema configuration when Postgresql quietly

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -4,92 +4,76 @@ Click this [link](https://sec.ch9.ms/ch9/2d29/a281311a-76bb-4573-a2a0-2dd7affc2d
 
 ## What is Marten?
 
-Marten is a library distributed by Nuget that allows .Net developers to use the Postgresql database as both a
-[document database](https://en.wikipedia.org/wiki/Document-oriented_database) and a full-featured [event store](https://martinfowler.com/eaaDev/EventSourcing.html) -- with the document database features being the out of the box
-mechanism for projected "read side" views of your events. There is absolutely nothing else to install in your application
-other than the Nuget or process to run other than Postgresql itself. Marten was made possible by the unique [JSONB](https://www.postgresql.org/docs/current/datatype-json.html) support
-first introduced in Postgresql 9.4.
+Marten is a .NET library that allows developers to use the Postgresql database as both a
+[document database](https://en.wikipedia.org/wiki/Document-oriented_database) and a fully-featured [event store](https://martinfowler.com/eaaDev/EventSourcing.html) -- with the document features serving as the out-of-the-box
+mechanism for projected "read side" views of your events. There is absolutely nothing else to install or run, outside of the Nuget package and Postgresql itself. Marten was made possible by the unique [JSONB](https://www.postgresql.org/docs/current/datatype-json.html) support first introduced in Postgresql 9.4.
 
-Marten was originally built to replace Raven Db inside a very large web application that was suffering stability and performance issues.
+Marten was originally built to replace RavenDB inside a very large web application that was suffering stability and performance issues.
 The project name *Marten* came from a quick Google search one day for "what are the natural predators of ravens?" -- which led to us to
 use the [marten](https://en.wikipedia.org/wiki/Marten) as our project codename and avatar.
 
 ![A Marten](/images/marten.jpeg)
 
 The Marten project was publicly announced in late 2015 and quickly gained a solid community of interested developers. An event sourcing feature set was
-added early on, which helped Marten attract much more interest. Marten first went into a production system in 2016 and has been going strong ever since. The V4
-release in 2021 marks a massive overhaul of Marten's internals and new functionality requested by our users to better position Marten for the future.
+added, which proved popular with our users. Marten first went into a production system in 2016 and has been going strong ever since. The v4
+release in 2021 marks a massive overhaul of Marten's internals, and introduces new functionality requested by our users to better position Marten for the future.
 
 
-## .NET version compatibility
+## .NET Version Compatibility
 
 Marten aligns with the [.NET Core Support Lifecycle](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) to determine platform compatibility.
 
-4.xx targets `netstandard2.0` & `net5.0` and is compatible with `.NET Core 2.x`, `.NET Core 3.x` and `.NET 5+`.
+Marten v4 targets `netstandard2.0` & `net5.0` and is compatible with `.NET Core 3.1` & `.NET 5+`. `.NET Core 2.1` may work but is out of support and thus untested.
 
-::: tip INFO
-.NET Framework support was dropped as part of the v4 release, if you require .NET Framework support, please use the latest Marten 3.xx release.
-:::
+.NET Framework support was dropped as part of the v4 release. If you require .NET Framework support, please use the latest Marten v3 release.
+
+#### Nullable Reference Types
+
+For enhanced developer ergonomics, Marten [supports NRTs](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references). For users of `.NET 6` or later, this is automatically enabled in new projects. In previous versions of .NET, this can be opted-into via `<Nullable>enable</Nullable>` within your `.csproj`.
 
 ## Marten Quickstart
 
-::: tip INFO
-There's a very small [sample project in the Marten codebase](https://github.com/JasperFx/marten/tree/master/src/AspNetCoreWithMarten) that shows the mechanics for wiring
-Marten into a .Net Core application.
-:::
+Following the common .Net idiom, Marten supplies extension methods to quickly integrate Marten into any .Net application that uses the `IServiceCollection` abstractions to register IoC services.
 
-Following the common .Net idiom, Marten supplies extension methods to quickly integrate Marten into any .Net Core application that uses the `IServiceCollection` abstractions to register IoC services.
-
-In the `Startup.ConfigureServices()` method of your .Net Core application (or you can use `IHostBuilder.ConfigureServices()` as well) make a call to `AddMarten()` to register Marten services like so:
+In the `ConfigureServices()` method of your ASP&#46;NET Core or Generic Host application, make a call to `AddMarten()` to register Marten services like so:
 
 <!-- snippet: sample_StartupConfigureServices -->
 <a id='snippet-sample_startupconfigureservices'></a>
 ```cs
-public class Startup
+public void ConfigureServices(IServiceCollection services)
 {
-    public IConfiguration Configuration { get; }
-    public IHostEnvironment Environment { get; }
-
-    public Startup(IConfiguration configuration, IHostEnvironment environment)
+    // This is the absolute, simplest way to integrate Marten into your
+    // .Net Core application with Marten's default configuration
+    services.AddMarten(options =>
     {
-        Configuration = configuration;
-        Environment = environment;
-    }
+        // Establish the connection string to your Marten database
+        options.Connection(Configuration.GetConnectionString("Marten"));
 
-    // This method gets called by the runtime. Use this method to add services to the container.
-    // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
-    public void ConfigureServices(IServiceCollection services)
-    {
-        // This is the absolute, simplest way to integrate Marten into your
-        // .Net Core application with Marten's default configuration
-        services.AddMarten(options =>
+        // If we're running in development mode, let Marten just take care
+        // of all necessary schema building and patching behind the scenes
+        if (Environment.IsDevelopment())
         {
-            // Establish the connection string to your Marten database
-            options.Connection(Configuration.GetConnectionString("Marten"));
-
-            // If we're running in development mode, let Marten just take care
-            // of all necessary schema building and patching behind the scenes
-            if (Environment.IsDevelopment())
-            {
-                options.AutoCreateSchemaObjects = AutoCreate.All;
-            }
-        });
-    }
-
-    // and other methods we don't care about right now...
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+        }
+    });
+}
+// and other methods we don't care about right now...
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Startup.cs#L13-L48' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_startupconfigureservices' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Startup.cs#L23-L44' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_startupconfigureservices' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-See [integrating Marten in .NET Core applications](/configuration/) for more information and options about this integration.
+See [Bootstrapping with HostBuilder](/configuration/hostbuilder) for more information and options about this integration.
 
 Also see the blog post [Marten, the Generic Host Builder in .Net Core, and why this could be the golden age for OSS in .Net](https://jeremydmiller.com/2021/07/29/marten-the-generic-host-builder-in-net-core-and-why-this-could-be-the-golden-age-for-oss-in-net/) for more background about how Marten is fully embracing
 the generic host in .Net. 
 
+::: tip INFO
+The complete ASP<span/>.NET Core sample project is [available in the Marten codebase](https://github.com/JasperFx/marten/tree/master/src/AspNetCoreWithMarten)
+:::
 
 ## Working with Documents
 
-Now, for your first document type, let's represent the users in our system:
+Now, for your first document type, we'll represent the users in our system:
 
 <!-- snippet: sample_user_document -->
 <a id='snippet-sample_user_document'></a>
@@ -136,7 +120,7 @@ using (var session = store.QuerySession())
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L49-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_opening_sessions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Now that we've got a document store, we can use that to create a new `IQuerySession` object just for querying or loading documents from the database:
+We can use our document store to create a new `IQuerySession` object just for querying or loading documents from the database:
 
 <!-- snippet: sample_start_a_query_session -->
 <a id='snippet-sample_start_a_query_session'></a>

--- a/src/AspNetCoreWithMarten/Startup.cs
+++ b/src/AspNetCoreWithMarten/Startup.cs
@@ -9,9 +9,7 @@ using Microsoft.Extensions.Hosting;
 using Weasel.Postgresql;
 
 namespace AspNetCoreWithMarten
-{
-    #region sample_StartupConfigureServices
-
+{    
     public class Startup
     {
         public IConfiguration Configuration { get; }
@@ -22,9 +20,8 @@ namespace AspNetCoreWithMarten
             Configuration = configuration;
             Environment = environment;
         }
+      #region sample_StartupConfigureServices
 
-        // This method gets called by the runtime. Use this method to add services to the container.
-        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
             // This is the absolute, simplest way to integrate Marten into your
@@ -42,12 +39,11 @@ namespace AspNetCoreWithMarten
                 }
             });
         }
-
         // and other methods we don't care about right now...
 
         #endregion
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+      
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())

--- a/src/Marten.Testing/Examples/UsingSystemTextJsonSerializer.cs
+++ b/src/Marten.Testing/Examples/UsingSystemTextJsonSerializer.cs
@@ -1,4 +1,5 @@
 using Marten.Services;
+using Marten.Services.Json;
 using Weasel.Core;
 
 namespace Marten.Testing.Examples
@@ -14,6 +15,9 @@ namespace Marten.Testing.Examples
                 opts.Connection("some connection string");
 
                 // Opt into System.Text.Json serialization
+                opts.UseDefaultSerialization(serializerType: SerializerType.SystemTextJson);
+
+                // Optionally configure the serializer directly
                 opts.Serializer(new SystemTextJsonSerializer
                 {
                     // Optionally override the enum storage


### PR DESCRIPTION
Adjustments to wording/examples within initial sections so they flow together a bit better. 