### PR TITLE
Fix some exception logging

### DIFF
--- a/src/Marten/Events/Daemon/HotColdCoordinator.cs
+++ b/src/Marten/Events/Daemon/HotColdCoordinator.cs
@@ -74,7 +74,7 @@ namespace Marten.Events.Daemon
             {
                 conn?.SafeDispose();
 
-                _logger.LogError("Error trying to attain the async daemon lock", e);
+                _logger.LogError(e, "Error trying to attain the async daemon lock");
                 return false;
             }
 
@@ -91,7 +91,7 @@ namespace Marten.Events.Daemon
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError("Failure while trying to start all async projection shards", ex);
+                    _logger.LogError(ex, "Failure while trying to start all async projection shards");
                 }
             }
             else


### PR DESCRIPTION
Some log messages are currently using this overload:

`void LogError(this ILogger logger, string message, params object[] args)`

But in order to correctly capture and enrich the log event with the exception, the following overload should be used:

`void LogError(this ILogger logger, Exception exception, string message, params object[] args)`.

Currently the exception isn't rendered as MSEL ignores props that have no equivalent holes.