### PR TITLE
Support raw SQL projections in Select and OrderBy statements.

### DIFF
--- a/src/Marten.Testing/Linq/SqlProjection/SqlProjectionTests.cs
+++ b/src/Marten.Testing/Linq/SqlProjection/SqlProjectionTests.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Marten.Linq.SqlProjection;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Linq.SqlProjection
+{
+    public class SqlProjectionTests
+    {
+        [Fact]
+        public void Throws_NotSupportedException_when_called_directly()
+        {
+            Should.Throw<NotSupportedException>(
+                () => new object().SqlProjection<string>("COALESCE(d.data ->> 'UserName', ?)", "baz"));
+        }
+    }
+}

--- a/src/Marten/Linq/SqlProjection/SqlProjectionExtensions.cs
+++ b/src/Marten/Linq/SqlProjection/SqlProjectionExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Reflection;
+
+namespace Marten.Linq.SqlProjection
+{
+    public static class SqlProjectionExtensions
+    {
+        public static readonly MethodInfo MethodInfo = typeof(SqlProjectionExtensions)
+            .GetMethod(nameof(SqlProjection),
+                BindingFlags.Public | BindingFlags.Static);
+
+        public static T SqlProjection<T>(this object doc, string sql, params object[] parameters)
+        {
+            throw new NotSupportedException(
+                $"{nameof(SqlProjection)} extension method can only be used in Marten Linq queries.");
+        }
+    }
+}

--- a/src/Marten/Linq/SqlProjection/SqlProjectionSqlFragment.cs
+++ b/src/Marten/Linq/SqlProjection/SqlProjectionSqlFragment.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq.Expressions;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.SqlProjection
+{
+    public static class SqlProjectionSqlFragment
+    {
+        public static ISqlFragment TryParse(Expression expression, Func<Expression, Expression> visit = null)
+        {
+            if (expression == null)
+            {
+                return null;
+            }
+
+            if (expression is UnaryExpression { NodeType: ExpressionType.Convert } unaryExpression)
+            {
+                expression = unaryExpression.Operand;
+            }
+
+            visit ??= x => x;
+
+            if (expression is not MethodCallExpression methodCall)
+            {
+                return null;
+            }
+
+            if (!methodCall.Method.IsGenericMethod ||
+                methodCall.Method.GetGenericMethodDefinition() != SqlProjectionExtensions.MethodInfo)
+            {
+                return null;
+            }
+
+            if (visit(methodCall.Arguments[1]) is not ConstantExpression { Value: string sql })
+            {
+                throw new NotSupportedException("SqlProjection first parameter needs to resolve to a string");
+            }
+
+            if (visit(methodCall.Arguments[2]) is not ConstantExpression { Value: object[] sqlArguments })
+            {
+                throw new NotSupportedException("SqlProjection second parameter needs to resolve to an object[]");
+            }
+
+            var whereFragment = new WhereFragment(sql, sqlArguments);
+            return whereFragment;
+        }
+    }
+}


### PR DESCRIPTION
Fixes bug #1926 
Added for Select and OrderBy. It's a bit hacky but works and 2 passing unit tests enclosed.
From what I see, the LINQ parsing code and visitors need a general refactor.