### PR TITLE
Change fix for avoiding event loss to opt-in

### DIFF
--- a/src/Marten/Events/AppendEventFunction.cs
+++ b/src/Marten/Events/AppendEventFunction.cs
@@ -66,9 +66,9 @@ BEGIN
 		body = bodies[index];
 
 		insert into {databaseSchema}.mt_events
-			(seq_id, id, stream_id, version, data, type, tenant_id, {DocumentMapping.DotNetTypeColumn}, tx_id)
+			(seq_id, id, stream_id, version, data, type, tenant_id, {DocumentMapping.DotNetTypeColumn}{(_events.Options.UseTransactionIdFixToAvoidEventLossInProjectionDaemon ? ", tx_id" : "")})
 		values
-			(seq, event_id, stream, event_version, body, event_type, tenantid, dotnet_types[index], txid_current());
+			(seq, event_id, stream, event_version, body, event_type, tenantid, dotnet_types[index]{(_events.Options.UseTransactionIdFixToAvoidEventLossInProjectionDaemon ? ", txid_current()" : "")});
 
 		index := index + 1;
 	end loop;

--- a/src/Marten/Events/EventsTable.cs
+++ b/src/Marten/Events/EventsTable.cs
@@ -19,7 +19,11 @@ namespace Marten.Events
             AddColumn("timestamp", "timestamptz", "default (now()) NOT NULL");
             AddColumn<TenantIdColumn>();
             AddColumn(new DotNetTypeColumn { Directive = "NULL" });
-            AddColumn("tx_id", "bigint", "default 0 NOT NULL");
+
+            if (events.Options.UseTransactionIdFixToAvoidEventLossInProjectionDaemon)
+            {
+                AddColumn("tx_id", "bigint", "default 0 NOT NULL");
+            }
 
             if (events.TenancyStyle == TenancyStyle.Conjoined)
             {

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -157,6 +157,13 @@ namespace Marten
         [Obsolete("Please use only for migration from Marten 2.*. It might be removed in the next major versions")]
         public bool DuplicatedFieldUseTimestampWithoutTimeZoneForDateTime { get; set; } = true;
 
+        /// <summary>
+        /// Ensures the projection daemon runs without event loss.
+        /// Requires db migrations for existing databases.
+        /// See https://github.com/JasperFx/marten/pull/1880 for details
+        /// </summary>
+        public bool UseTransactionIdFixToAvoidEventLossInProjectionDaemon => false;
+
         internal void CreatePatching()
         {
             if (PLV8Enabled)


### PR DESCRIPTION
Change fix in https://github.com/JasperFx/marten/pull/1880 to be opt-in

In [this pull request](https://github.com/JasperFx/marten/pull/1880)  there was some changes to mt_stream.sql but I can't see where this is used. Is it correct that this file isn't used anymore? https://github.com/JasperFx/marten/pull/1880/files#diff-5c1b8015cc72eceb5dcc20a7679a97e0324aba491dbd4c93598dbe7c2b325b8a

![image](https://user-images.githubusercontent.com/982996/137459304-afe72b59-02ec-4dcb-b6d3-50681fbdd83a.png)


