### PR TITLE
Used Weasel 1.0.3 with a fix for PK name migration

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.0.0</VersionPrefix>
+    <VersionPrefix>4.0.1</VersionPrefix>
     <LangVersion>9.0</LangVersion>
     <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
     <PackageIconUrl>http://jasperfx.github.io/marten/content/images/emblem.png</PackageIconUrl>

--- a/src/Marten.AspNetCore/Marten.AspNetCore.csproj
+++ b/src/Marten.AspNetCore/Marten.AspNetCore.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net5.0</TargetFramework>
 
         <Description>Helpers for Marten-backed AspNetCore applications</Description>
-        <VersionPrefix>4.0.0</VersionPrefix>
+        <VersionPrefix>4.0.1</VersionPrefix>
         <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>
         <GenerateAssemblyProductAttribute>true</GenerateAssemblyProductAttribute>

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>NodaTime extension for Marten</Description>
-        <VersionPrefix>4.0.0</VersionPrefix>
+        <VersionPrefix>4.0.1</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
         <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>

--- a/src/Marten.PLv8/Marten.PLv8.csproj
+++ b/src/Marten.PLv8/Marten.PLv8.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Description>Document transforms and patching extension for Marten</Description>
-        <VersionPrefix>4.0.0</VersionPrefix>
+        <VersionPrefix>4.0.1</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
         <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>

--- a/src/Marten.Schema.Testing/Storage/DocumentTableTester.cs
+++ b/src/Marten.Schema.Testing/Storage/DocumentTableTester.cs
@@ -193,6 +193,20 @@ namespace Marten.Schema.Testing.Storage
         }
 
 
+        [Fact]
+        public async Task can_migrate_pk_index_name()
+        {
+            theTable.PrimaryKeyName = "pk_someothername";
+            writeTable();
+
+            var newTable = new DocumentTable(theMapping);
+
+            await writeAndApplyPatch(AutoCreate.CreateOrUpdate, newTable);
+
+            var theActual = await theTable.FetchExisting(_conn);
+
+            theActual!.PrimaryKeyName.ShouldBe($"pkey_{SchemaConstants.TablePrefix}{theMapping.Alias}_{theMapping.IdMember.Name.ToLower()}");
+        }
 
         [Fact]
         public void can_write_the_basic_table()

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[2.1.0, 6.0.0]" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[2.1.0, 6.0.0]" />
         <PackageReference Include="System.Text.Json" Version="5.0.2" />
-        <PackageReference Include="Weasel.Postgresql" Version="1.0.1" />
+        <PackageReference Include="Weasel.Postgresql" Version="1.0.3" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->


### PR DESCRIPTION
Added test verifying if the new PK name will be used.
Bumped versions to 4.0.1

Fixes #1854.