### PR TITLE
Configure warnings for async code issues

### DIFF
--- a/Analysis.Build.props
+++ b/Analysis.Build.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <AnalysisModeReliability>true</AnalysisModeReliability>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>   
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.63" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="All" Condition=" '$(TargetFrawework)' == 'netstandard2.0' " />
+  </ItemGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,12 +9,4 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
   </PropertyGroup>
-  <PropertyGroup>
-    <AnalysisModeReliability>true</AnalysisModeReliability>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisLevel>latest</AnalysisLevel>   
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.63" PrivateAssets="All" />
-  </ItemGroup>
 </Project>

--- a/src/Marten.CommandLine/Marten.CommandLine.csproj
+++ b/src/Marten.CommandLine/Marten.CommandLine.csproj
@@ -39,4 +39,5 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Oakton" Version="3.1.0" />
     </ItemGroup>
+    <Import Project="../../Analysis.Build.props" />
 </Project>

--- a/src/Marten.PLv8/Marten.PLv8.csproj
+++ b/src/Marten.PLv8/Marten.PLv8.csproj
@@ -21,5 +21,5 @@
     <ItemGroup>
       <EmbeddedResource Include="mt_patching.js" />
     </ItemGroup>
-
+    <Import Project="../../Analysis.Build.props" />
 </Project>

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -50,4 +50,5 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
+    <Import Project="../../Analysis.Build.props" />
 </Project>


### PR DESCRIPTION
 First of all thanks to Jeremy and other maintainers for the great library, I've been using it for years with great success and almost no friction.
 Recently I started working on [Microsoft Orleans](https://dotnet.github.io/orleans/index.html) based project and I'd like to use Marten as a [GrainStorage](https://dotnet.github.io/orleans/docs/grains/grain_persistence/index.html#creating-a-storage-provider). However, Orleans [has it's own TaskScheduler](https://dotnet.github.io/orleans/docs/grains/reentrancy.html) to avoid concurrent calls to grains and marten codebase doesn't follow guidelines for the safe async code. No surprise, it routinely cases deadlocks within Orleans-based project. 
 
 My proposal it to configure warnings for common threading issues and after fixing them change severity level to error. This PR is a starting point which will prevent future code from introducing new issues (I hope). It makes msbuild produce more than 4000 warnings currently. Most of them are `ConfigureAwait(false)` related and can be fixed easily.
 I can fix most of the issues myself but I want to be sure maintainers agree with my proposal first.
  