### PR TITLE
Fix GH-1945

### DIFF
--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[2.1.0, 6.0.0]" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[2.1.0, 6.0.0]" />
         <PackageReference Include="System.Text.Json" Version="5.0.2" />
-        <PackageReference Include="Weasel.Postgresql" Version="1.0.4" />
+        <PackageReference Include="Weasel.Postgresql" Version="1.0.5" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->

--- a/src/Marten/Schema/FullTextIndex.cs
+++ b/src/Marten/Schema/FullTextIndex.cs
@@ -63,7 +63,7 @@ namespace Marten.Schema
         {
             get
             {
-                return new string[] { $"( to_tsvector('{_regConfig}', {_dataConfig}) )"};
+                return new string[] { $"to_tsvector('{_regConfig}',{_dataConfig.Trim()})"};
             }
             set
             {


### PR DESCRIPTION
- Update Marten proj to use Weasel 1.0.5
- Update full text index expression to be inline with Weasel index definition requirement
- Update full text index specification check helper to be inline with Weasel
- Add unit test for upgrading full text index v3 schema to v4
Fixes GH-1945