### PR TITLE
Add support for case-insensitive order by for strings

### DIFF
--- a/src/Marten.Testing/Linq/query_with_order_by.cs
+++ b/src/Marten.Testing/Linq/query_with_order_by.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Linq;
+
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Marten.Testing.Linq
+{
+    [ControlledQueryStoryteller]
+    public class query_with_order_by: IntegrationContext
+    {
+        public query_with_order_by(DefaultStoreFixture fixture): base(fixture)
+        {
+        }
+
+        [Fact]
+        public void query_with_order_by_for_string_property_with_comparer()
+        {
+            CreateTestData();
+
+            RunTest(StringComparer.InvariantCultureIgnoreCase, true);
+            RunTest(StringComparer.OrdinalIgnoreCase, true);
+
+            RunTest(StringComparer.InvariantCulture, false);
+            RunTest(StringComparer.Ordinal, false);
+
+            void RunTest(StringComparer comparer, bool shouldBeCaseInsensitive)
+            {
+                var query = theSession.Query<Target>()
+                    .OrderBy(x => x.String, comparer);
+
+                var sql = query.Explain().Command.CommandText;
+                var result = query.ToList();
+
+                if (shouldBeCaseInsensitive)
+                {
+                    result[0].String.ShouldBe("A");
+                    result[1].String.ShouldBe("b");
+                    result[2].String.ShouldBe("C");
+
+                    sql.ShouldContain("lower", Case.Insensitive);
+                }
+                else
+                {
+                    // Ordering without lower() is dependant on PostgreSQL version/configuration, so order is not asserted here
+                    sql.ShouldNotContain("lower", Case.Insensitive);
+                }
+            }
+        }
+
+        [Fact]
+        public void query_with_order_by_descending_for_string_property_with_comparer()
+        {
+            CreateTestData();
+
+            RunTest(StringComparer.InvariantCultureIgnoreCase, true);
+            RunTest(StringComparer.OrdinalIgnoreCase, true);
+
+            RunTest(StringComparer.InvariantCulture, false);
+            RunTest(StringComparer.Ordinal, false);
+
+            void RunTest(StringComparer comparer, bool shouldBeCaseInsensitive)
+            {
+                var query = theSession.Query<Target>()
+                    .OrderByDescending(x => x.String, comparer);
+
+                var sql = query.Explain().Command.CommandText;
+                var result = query.ToList();
+
+                if (shouldBeCaseInsensitive)
+                {
+                    result[0].String.ShouldBe("C");
+                    result[1].String.ShouldBe("b");
+                    result[2].String.ShouldBe("A");
+
+                    sql.ShouldContain("lower", Case.Insensitive);
+                }
+                else
+                {
+                    // Ordering without lower() is dependant on PostgreSQL version/configuration, so order is not asserted here
+                    sql.ShouldNotContain("lower", Case.Insensitive);
+                }
+            }
+        }
+
+        [Fact]
+        public void query_with_then_by_for_string_property_with_comparer()
+        {
+            CreateTestData(true);
+
+            RunTest(StringComparer.InvariantCultureIgnoreCase, true);
+            RunTest(StringComparer.OrdinalIgnoreCase, true);
+
+            RunTest(StringComparer.InvariantCulture, false);
+            RunTest(StringComparer.Ordinal, false);
+
+            void RunTest(StringComparer comparer, bool shouldBeCaseInsensitive)
+            {
+                var query = theSession.Query<Target>()
+                    .OrderBy(x => x.Number)
+                    .ThenBy(x => x.String, comparer);
+
+                var sql = query.Explain().Command.CommandText;
+                var result = query.ToList();
+
+                if (shouldBeCaseInsensitive)
+                {
+                    result[0].String.ShouldBe("A");
+                    result[1].String.ShouldBe("b");
+                    result[2].String.ShouldBe("C");
+
+                    result[3].String.ShouldBe("A");
+                    result[4].String.ShouldBe("b");
+                    result[5].String.ShouldBe("C");
+
+                    sql.ShouldContain("lower", Case.Insensitive);
+                }
+                else
+                {
+                    // Ordering without lower() is dependant on PostgreSQL version/configuration, so order is not asserted here
+                    sql.ShouldNotContain("lower", Case.Insensitive);
+                }
+            }
+        }
+
+        [Fact]
+        public void query_with_then_by_descending_for_string_property_with_comparer()
+        {
+            CreateTestData(true);
+
+            RunTest(StringComparer.InvariantCultureIgnoreCase, true);
+            RunTest(StringComparer.OrdinalIgnoreCase, true);
+
+            RunTest(StringComparer.InvariantCulture, false);
+            RunTest(StringComparer.Ordinal, false);
+
+            void RunTest(StringComparer comparer, bool shouldBeCaseInsensitive)
+            {
+                var query = theSession.Query<Target>()
+                    .OrderBy(x => x.Number)
+                    .ThenByDescending(x => x.String, comparer);
+
+                var sql = query.Explain().Command.CommandText;
+                var result = query.ToList();
+
+                if (shouldBeCaseInsensitive)
+                {
+                    result[0].String.ShouldBe("C");
+                    result[1].String.ShouldBe("b");
+                    result[2].String.ShouldBe("A");
+
+                    result[3].String.ShouldBe("C");
+                    result[4].String.ShouldBe("b");
+                    result[5].String.ShouldBe("A");
+
+                    sql.ShouldContain("lower", Case.Insensitive);
+                }
+                else
+                {
+                    // Ordering without lower() is dependant on PostgreSQL version/configuration, so order is not asserted here
+                    sql.ShouldNotContain("lower", Case.Insensitive);
+                }
+            }
+        }
+
+        private void CreateTestData(bool createTargetsWithNumberTwo = false)
+        {
+            theSession.Store(new Target
+            {
+                String = "C",
+                Number = 1
+            });
+
+            theSession.Store(new Target
+            {
+                String = "A",
+                Number = 1
+            });
+
+            theSession.Store(new Target
+            {
+                String = "b",
+                Number = 1
+            });
+
+            if (createTargetsWithNumberTwo)
+            {
+                theSession.Store(new Target
+                {
+                    String = "C",
+                    Number = 2
+                });
+
+                theSession.Store(new Target
+                {
+                    String = "A",
+                    Number = 2
+                });
+
+                theSession.Store(new Target
+                {
+                    String = "b",
+                    Number = 2
+                });
+            }
+
+            theSession.SaveChanges();
+        }
+    }
+}

--- a/src/Marten/Linq/Operators/OrderByComparerClause.cs
+++ b/src/Marten/Linq/Operators/OrderByComparerClause.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Marten.Linq.Operators
+{
+    internal class OrderByComparerClause: IBodyClause
+    {
+        private OrderByComparerClause(bool caseInsensitive)
+        {
+            CaseInsensitive = caseInsensitive;
+        }
+
+        public OrderByComparerClause(bool caseInsensitive, Ordering ordering)
+        {
+            CaseInsensitive = caseInsensitive;
+            Orderings.Add(ordering);
+        }
+
+        public bool CaseInsensitive { get; }
+        public List<Ordering> Orderings { get; } = new List<Ordering>();
+
+        public void TransformExpressions(Func<Expression, Expression> transformation) => throw new NotImplementedException();
+
+        public void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index) => throw new NotImplementedException();
+
+        public IBodyClause Clone(CloneContext cloneContext)
+        {
+            var clone = new OrderByComparerClause(CaseInsensitive);
+
+            foreach (var ordering in Orderings)
+            {
+                var clonedOrdering = ordering.Clone(cloneContext);
+                clone.Orderings.Add(clonedOrdering);
+            }
+
+            return clone;
+        }
+    }
+}

--- a/src/Marten/Linq/Operators/OrderByComparerExpressionNode.cs
+++ b/src/Marten/Linq/Operators/OrderByComparerExpressionNode.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Marten.Linq.Operators
+{
+    internal class OrderByComparerExpressionNode: MethodCallExpressionNodeBase
+    {
+        private readonly ResolvedExpressionCache<Expression> _cachedSelector;
+        private readonly LambdaExpression _keySelector;
+
+        public static readonly MethodInfo[] SupportedMethods =
+            typeof(Queryable).GetMethods()
+                .Where(m => m.Name == nameof(Queryable.OrderBy) || m.Name == nameof(Queryable.OrderByDescending) || m.Name == nameof(Queryable.ThenBy) || m.Name == nameof(Queryable.ThenByDescending))
+                .Where(x => x.GetParameters().Length == 3)
+                .ToArray();
+
+        private readonly OrderingDirection _orderingDirection;
+
+        public OrderByComparerExpressionNode(MethodCallExpressionParseInfo parseInfo, LambdaExpression keySelector, ConstantExpression constantExpression)
+            : base(parseInfo)
+        {
+            _keySelector = keySelector;
+            _cachedSelector = new ResolvedExpressionCache<Expression>(this);
+
+            _orderingDirection = parseInfo.ParsedExpression.Method.Name == nameof(Queryable.OrderBy) || parseInfo.ParsedExpression.Method.Name == nameof(Queryable.ThenBy)
+                ? OrderingDirection.Asc
+                : OrderingDirection.Desc;
+
+            ConstantExpression = constantExpression;
+        }
+
+        public ConstantExpression ConstantExpression { get; }
+
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved, ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel, ClauseGenerationContext clauseGenerationContext)
+        {
+            if (_keySelector.ReturnType != typeof(string))
+            {
+                throw new ArgumentException("Only strings are supported when providing order comparer");
+            }
+
+            bool caseInsensitive;
+            if (ReferenceEquals(ConstantExpression.Value, StringComparer.InvariantCultureIgnoreCase)
+                || ReferenceEquals(ConstantExpression.Value, StringComparer.OrdinalIgnoreCase))
+            {
+                caseInsensitive = true;
+            }
+            else if (ReferenceEquals(ConstantExpression.Value, StringComparer.InvariantCulture)
+                || ReferenceEquals(ConstantExpression.Value, StringComparer.Ordinal))
+            {
+                caseInsensitive = false;
+            }
+            else
+            {
+                throw new ArgumentException("Only ordinal and invariant StringComparer static comparer members are allowed as comparer");
+            }
+
+            var orderByClause = new OrderByComparerClause(caseInsensitive, new Ordering(GetResolvedKeySelector(clauseGenerationContext), _orderingDirection));
+            queryModel.BodyClauses.Add(orderByClause);
+        }
+
+        private Expression GetResolvedKeySelector(ClauseGenerationContext clauseGenerationContext)
+        {
+            return _cachedSelector.GetOrCreate(r => r.GetResolvedExpression(_keySelector.Body, _keySelector.Parameters[0], clauseGenerationContext));
+        }
+    }
+}

--- a/src/Marten/Linq/Parsing/LinqHandlerBuilder.cs
+++ b/src/Marten/Linq/Parsing/LinqHandlerBuilder.cs
@@ -90,7 +90,10 @@ namespace Marten.Linq.Parsing
                         CurrentStatement.WhereClauses.Add(@where);
                         break;
                     case OrderByClause orderBy:
-                        CurrentStatement.Orderings.AddRange(orderBy.Orderings);
+                        CurrentStatement.Orderings.AddRange(orderBy.Orderings.Select(x => (x, false)));
+                        break;
+                    case OrderByComparerClause orderBy:
+                        CurrentStatement.Orderings.AddRange(orderBy.Orderings.Select(x => (x, orderBy.CaseInsensitive)));
                         break;
                     case AdditionalFromClause additional:
                         var isComplex = queryModel.BodyClauses.Count > i + 1 || queryModel.ResultOperators.Any() || _provider.AllIncludes.Any();

--- a/src/Marten/Linq/Parsing/MartenQueryParser.cs
+++ b/src/Marten/Linq/Parsing/MartenQueryParser.cs
@@ -12,11 +12,16 @@ namespace Marten.Linq.Parsing
 {
     public class MartenQueryParser: IQueryParser
     {
-        public static readonly MartenQueryParser Flyweight = new MartenQueryParser(r => r.Register(IncludeExpressionNode.SupportedMethods, typeof(IncludeExpressionNode)));
+        public static readonly MartenQueryParser Flyweight = new MartenQueryParser(r =>
+        {
+            r.Register(IncludeExpressionNode.SupportedMethods, typeof(IncludeExpressionNode));
+            r.Register(OrderByComparerExpressionNode.SupportedMethods, typeof(OrderByComparerExpressionNode));
+        });
 
         public static readonly MartenQueryParser TransformQueryFlyweight = new MartenQueryParser(r =>
         {
             r.Register(IncludeExpressionNode.SupportedMethods, typeof(IncludeExpressionNode));
+            r.Register(OrderByComparerExpressionNode.SupportedMethods, typeof(OrderByComparerExpressionNode));
             r.Register(StatsExpressionNode.SupportedMethods, typeof(StatsExpressionNode));
         });
 


### PR DESCRIPTION
This PR adds linq support for OrderBy methods which takes IComparer<T>. For now, only string properties are supported when using invariant or ordinal string comparers. If "IgnoreCase" string comparer is used, then lower()-call is added to generated SQL.

This PR relies heavily on work done by @lahma in #1542.
