### PR TITLE
Fix for GH-1961

### DIFF
--- a/docs/configuration/prebuilding.md
+++ b/docs/configuration/prebuilding.md
@@ -49,6 +49,8 @@ public class Program
                     // *try* to use pre-generated code at runtime
                     opts.GeneratedCodeMode = TypeLoadMode.LoadFromPreBuiltAssembly;
 
+                    opts.Schema.For<Activity>().AddSubClass<Trip>();
+
                     // You have to register all persisted document types ahead of time
                     // RegisterDocumentType<T>() is the equivalent of saying Schema.For<T>()
                     // just to let Marten know that document type exists
@@ -60,7 +62,7 @@ public class Program
                     opts.RegisterCompiledQueryType(typeof(FindUserByAllTheThings));
 
                     // Register all event store projections ahead of time
-                    opts.Projections.Add(new TripAggregationWithCustomName(), ProjectionLifecycle.Async);
+                    opts.Projections.Add(new TripAggregationWithCustomName(), ProjectionLifecycle.Inline);
                     opts.Projections.Add(new DayProjection(), ProjectionLifecycle.Async);
                     opts.Projections.Add(new DistanceProjection(), ProjectionLifecycle.Async);
 
@@ -75,7 +77,7 @@ public class Program
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/Program.cs#L20-L70' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_pre_build_types' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/Program.cs#L20-L72' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_pre_build_types' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Okay, after all that, there should be a new command line option called `codegen` for your project. Assuming

--- a/docs/documents/full-text.md
+++ b/docs/documents/full-text.md
@@ -23,7 +23,7 @@ var store = DocumentStore.For(_ =>
     _.Schema.For<User>().FullTextIndex();
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L95-L103' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_whole_document_full_text_index_through_store_options_with_default' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L97-L105' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_whole_document_full_text_index_through_store_options_with_default' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: tip INFO
@@ -43,7 +43,7 @@ var store = DocumentStore.For(_ =>
     _.Schema.For<User>().FullTextIndex(d => d.FirstName);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L108-L116' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_a_single_property_full_text_index_through_store_options_with_default' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L110-L118' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_a_single_property_full_text_index_through_store_options_with_default' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 * single property with custom settings
@@ -65,7 +65,7 @@ var store = DocumentStore.For(_ =>
         d => d.FirstName);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L121-L135' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_a_single_property_full_text_index_through_store_options_with_custom_settings' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L123-L137' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_a_single_property_full_text_index_through_store_options_with_custom_settings' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 * multiple properties
@@ -81,7 +81,7 @@ var store = DocumentStore.For(_ =>
     _.Schema.For<User>().FullTextIndex(d => d.FirstName, d => d.LastName);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L140-L148' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_multiple_properties_full_text_index_through_store_options_with_default' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L142-L150' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_multiple_properties_full_text_index_through_store_options_with_default' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 * multiple properties with custom settings
@@ -103,7 +103,7 @@ var store = DocumentStore.For(_ =>
         d => d.FirstName, d => d.LastName);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L153-L167' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_multiple_properties_full_text_index_through_store_options_with_custom_settings' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L155-L169' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_multiple_properties_full_text_index_through_store_options_with_custom_settings' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 * more than one index for document with different languages (regConfig)
@@ -121,7 +121,7 @@ var store = DocumentStore.For(_ =>
         .FullTextIndex("italian", d => d.LastName);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L172-L182' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_more_than_one_full_text_index_through_store_options_with_different_reg_config' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L174-L184' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_more_than_one_full_text_index_through_store_options_with_different_reg_config' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Defining Full Text  Index through Attribute
@@ -145,7 +145,7 @@ public class Book
     public string Information { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L14-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_a_full_text_index_through_attribute_on_class_with_default' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L16-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_a_full_text_index_through_attribute_on_class_with_default' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 * single property
@@ -161,7 +161,7 @@ public class UserProfile
     public string Information { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L29-L38' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_a_single_property_full_text_index_through_attribute_with_default' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L31-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_a_single_property_full_text_index_through_attribute_with_default' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: tip INFO
@@ -183,7 +183,7 @@ public class UserDetails
     public string Details { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L40-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_a_single_property_full_text_index_through_attribute_with_custom_settings' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L42-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_a_single_property_full_text_index_through_attribute_with_custom_settings' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 * multiple properties
@@ -202,7 +202,7 @@ public class Article
     public string Text { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L53-L65' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_multiple_properties_full_text_index_through_attribute_with_default' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L55-L67' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_multiple_properties_full_text_index_through_attribute_with_default' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: tip INFO
@@ -230,7 +230,7 @@ public class BlogPost
     public string FrenchText { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L67-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_multiple_properties_full_text_index_through_attribute_with_custom_settings' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L69-L86' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_multiple_properties_full_text_index_through_attribute_with_custom_settings' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Text Search
@@ -247,7 +247,7 @@ var posts = session.Query<BlogPost>()
     .Where(x => x.Search("somefilter"))
     .ToList();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L235-L239' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_search_in_query_sample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L237-L241' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_search_in_query_sample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 * plain text Search (plainto_tsquery)
@@ -259,7 +259,7 @@ var posts = session.Query<BlogPost>()
     .Where(x => x.PlainTextSearch("somefilter"))
     .ToList();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L262-L266' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_plain_search_in_query_sample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L264-L268' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_plain_search_in_query_sample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 * phrase Search (phraseto_tsquery)
@@ -271,7 +271,7 @@ var posts = session.Query<BlogPost>()
     .Where(x => x.PhraseSearch("somefilter"))
     .ToList();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L289-L293' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_phrase_search_in_query_sample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L291-L295' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_phrase_search_in_query_sample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 * web-style Search (websearch_to_tsquery, [supported from Postgres 11+](https://www.postgresql.org/docs/11/textsearch-controls.html)
@@ -283,7 +283,7 @@ var posts = session.Query<BlogPost>()
     .Where(x => x.WebStyleSearch("somefilter"))
     .ToList();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L316-L320' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_web_search_in_query_sample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L318-L322' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_web_search_in_query_sample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 All types of Text Searches can be combined with other Linq queries
@@ -296,7 +296,7 @@ var posts = session.Query<BlogPost>()
     .Where(x => x.PhraseSearch("somefilter"))
     .ToList();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L344-L349' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_text_search_combined_with_other_query_sample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L346-L351' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_text_search_combined_with_other_query_sample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 They allow also to specify language (regConfig) of the text search query (by default `english` is being used)
@@ -308,5 +308,5 @@ var posts = session.Query<BlogPost>()
     .Where(x => x.PhraseSearch("somefilter", "italian"))
     .ToList();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L372-L376' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_text_search_with_non_default_regconfig_sample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Acceptance/full_text_index.cs#L374-L378' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_text_search_with_non_default_regconfig_sample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/src/CommandLineRunner/Program.cs
+++ b/src/CommandLineRunner/Program.cs
@@ -41,6 +41,8 @@ namespace CommandLineRunner
                         // *try* to use pre-generated code at runtime
                         opts.GeneratedCodeMode = TypeLoadMode.LoadFromPreBuiltAssembly;
 
+                        opts.Schema.For<Activity>().AddSubClass<Trip>();
+
                         // You have to register all persisted document types ahead of time
                         // RegisterDocumentType<T>() is the equivalent of saying Schema.For<T>()
                         // just to let Marten know that document type exists
@@ -52,7 +54,7 @@ namespace CommandLineRunner
                         opts.RegisterCompiledQueryType(typeof(FindUserByAllTheThings));
 
                         // Register all event store projections ahead of time
-                        opts.Projections.Add(new TripAggregationWithCustomName(), ProjectionLifecycle.Async);
+                        opts.Projections.Add(new TripAggregationWithCustomName(), ProjectionLifecycle.Inline);
                         opts.Projections.Add(new DayProjection(), ProjectionLifecycle.Async);
                         opts.Projections.Add(new DistanceProjection(), ProjectionLifecycle.Async);
 

--- a/src/CommandLineRunner/TestCommand.cs
+++ b/src/CommandLineRunner/TestCommand.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Marten;
+using Marten.AsyncDaemon.Testing.TestingSupport;
 using Marten.Testing.Documents;
 using Marten.Testing.Events.Aggregation;
 using Marten.Testing.Harness;
@@ -49,6 +50,11 @@ namespace CommandLineRunner
                 var target = Target.Random();
                 session2.Store(target);
                 session2.Store(user);
+
+                session2.Events.StartStream(Guid.NewGuid(), new TripStarted {Day = 5},
+                    Travel.Random(5), Travel.Random(6)
+                );
+
                 await session2.SaveChangesAsync();
 
 

--- a/src/Marten.AsyncDaemon.Testing/TestingSupport/Trip.cs
+++ b/src/Marten.AsyncDaemon.Testing/TestingSupport/Trip.cs
@@ -2,9 +2,14 @@ using System;
 
 namespace Marten.AsyncDaemon.Testing.TestingSupport
 {
-    public class Trip
+    public class Activity
     {
         public Guid Id { get; set; }
+    }
+
+    public class Trip : Activity
+    {
+
 
 
         public int EndedOn { get; set; }

--- a/src/Marten/Events/Aggregation/AggregateProjection.CodeGen.cs
+++ b/src/Marten/Events/Aggregation/AggregateProjection.CodeGen.cs
@@ -31,7 +31,7 @@ namespace Marten.Events.Aggregation
         private readonly string _inlineAggregationHandlerType;
         private readonly string _liveAggregationTypeName;
         private readonly ShouldDeleteMethodCollection _shouldDeleteMethods;
-        private DocumentMapping _aggregateMapping;
+        private IDocumentMapping _aggregateMapping;
         private GeneratedType _inlineGeneratedType;
         private bool _isAsync;
         private GeneratedType _liveGeneratedType;
@@ -91,7 +91,7 @@ namespace Marten.Events.Aggregation
 
             _isAsync = _createMethods.IsAsync || _applyMethods.IsAsync;
 
-            _aggregateMapping = options.Storage.MappingFor(typeof(T));
+            _aggregateMapping = options.Storage.FindMapping(typeof(T));
 
 
             if (_aggregateMapping.IdMember == null)
@@ -358,7 +358,7 @@ namespace Marten.Events.Aggregation
 
         internal override IEnumerable<string> ValidateConfiguration(StoreOptions options)
         {
-            var mapping = options.Storage.MappingFor(typeof(T));
+            var mapping = options.Storage.FindMapping(typeof(T)).Root.As<DocumentMapping>();
             foreach (var p in validateDocumentIdentity(options, mapping)) yield return p;
 
             if (options.Events.TenancyStyle != mapping.TenancyStyle)

--- a/src/Marten/Events/CodeGeneration/ApplyMethodCollection.cs
+++ b/src/Marten/Events/CodeGeneration/ApplyMethodCollection.cs
@@ -35,12 +35,12 @@ namespace Marten.Events.CodeGeneration
         }
 
         public override IEventHandlingFrame CreateEventTypeHandler(Type aggregateType,
-            DocumentMapping aggregateMapping, MethodSlot slot)
+            IDocumentMapping aggregateMapping, MethodSlot slot)
         {
             return new ApplyMethodCall(slot);
         }
 
-        public void BuildApplyMethod(GeneratedType generatedType, DocumentMapping aggregateMapping)
+        public void BuildApplyMethod(GeneratedType generatedType, IDocumentMapping aggregateMapping)
         {
             var returnType = IsAsync
                 ? typeof(ValueTask<>).MakeGenericType(AggregateType)

--- a/src/Marten/Events/CodeGeneration/CreateMethodCollection.cs
+++ b/src/Marten/Events/CodeGeneration/CreateMethodCollection.cs
@@ -42,7 +42,7 @@ namespace Marten.Events.CodeGeneration
             return BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic;
         }
 
-        public void BuildCreateMethod(GeneratedType generatedType, DocumentMapping aggregateMapping)
+        public void BuildCreateMethod(GeneratedType generatedType, IDocumentMapping aggregateMapping)
         {
             var returnType = IsAsync
                 ? typeof(ValueTask<>).MakeGenericType(AggregateType)
@@ -68,7 +68,7 @@ namespace Marten.Events.CodeGeneration
         }
 
         public override IEventHandlingFrame CreateEventTypeHandler(Type aggregateType,
-            DocumentMapping aggregateMapping, MethodSlot slot)
+            IDocumentMapping aggregateMapping, MethodSlot slot)
         {
             if (slot.Method is ConstructorInfo)
             {

--- a/src/Marten/Events/CodeGeneration/MethodCollection.cs
+++ b/src/Marten/Events/CodeGeneration/MethodCollection.cs
@@ -222,13 +222,13 @@ namespace Marten.Events.CodeGeneration
 
 
         public abstract IEventHandlingFrame CreateEventTypeHandler(Type aggregateType,
-            DocumentMapping aggregateMapping, MethodSlot slot);
+            IDocumentMapping aggregateMapping, MethodSlot slot);
 
         public List<MethodSlot> Methods { get; } = new List<MethodSlot>();
 
         public bool IsAsync { get; private set; }
 
-        public static EventTypePatternMatchFrame AddEventHandling(Type aggregateType, DocumentMapping mapping,
+        public static EventTypePatternMatchFrame AddEventHandling(Type aggregateType, IDocumentMapping mapping,
             params MethodCollection[] collections)
         {
             var byType = new Dictionary<Type, EventProcessingFrame>();

--- a/src/Marten/Events/CodeGeneration/ShouldDeleteMethodCollection.cs
+++ b/src/Marten/Events/CodeGeneration/ShouldDeleteMethodCollection.cs
@@ -17,7 +17,7 @@ namespace Marten.Events.CodeGeneration
         }
 
         public override IEventHandlingFrame CreateEventTypeHandler(Type aggregateType,
-            DocumentMapping aggregateMapping, MethodSlot slot)
+            IDocumentMapping aggregateMapping, MethodSlot slot)
         {
             return new ShouldDeleteFrame(slot);
         }

--- a/src/Marten/Events/Projections/EventProjection.cs
+++ b/src/Marten/Events/Projections/EventProjection.cs
@@ -92,7 +92,8 @@ namespace Marten.Events.Projections
                 }
             }
 
-            public override IEventHandlingFrame CreateEventTypeHandler(Type aggregateType, DocumentMapping aggregateMapping,
+            public override IEventHandlingFrame CreateEventTypeHandler(Type aggregateType,
+                IDocumentMapping aggregateMapping,
                 MethodSlot slot)
             {
                 return new ProjectMethodCall(slot);
@@ -133,7 +134,8 @@ namespace Marten.Events.Projections
                 _validArgumentTypes.Add(typeof(IDocumentOperations));
             }
 
-            public override IEventHandlingFrame CreateEventTypeHandler(Type aggregateType, DocumentMapping aggregateMapping,
+            public override IEventHandlingFrame CreateEventTypeHandler(Type aggregateType,
+                IDocumentMapping aggregateMapping,
                 MethodSlot slot)
             {
                 return new CreateMethodFrame(slot);

--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -110,11 +110,6 @@ namespace Marten.Events.Projections
                 projection.Lifecycle = lifecycle.Value;
             }
 
-            foreach (var publishedType in projection.As<IProjectionSource>().PublishedTypes())
-            {
-                _options.Storage.RegisterDocumentType(publishedType);
-            }
-
             projection.AssertValidity();
             All.Add(projection);
         }
@@ -152,11 +147,6 @@ namespace Marten.Events.Projections
         {
             var projection = new TProjection();
 
-            foreach (var publishedType in projection.As<IProjectionSource>().PublishedTypes())
-            {
-                _options.Storage.RegisterDocumentType(publishedType);
-            }
-
             if (lifecycle.HasValue)
             {
                 projection.Lifecycle = lifecycle.Value;
@@ -174,9 +164,8 @@ namespace Marten.Events.Projections
         /// <typeparam name="T"></typeparam>
         /// <param name="lifecycle">Optionally override the ProjectionLifecycle</param>
         /// <returns>The extended storage configuration for document T</returns>
-        public MartenRegistry.DocumentMappingExpression<T> Add<T>(AggregateProjection<T> projection, ProjectionLifecycle? lifecycle = null)
+        public void Add<T>(AggregateProjection<T> projection, ProjectionLifecycle? lifecycle = null)
         {
-            var expression = _options.Schema.For<T>();
             if (lifecycle.HasValue)
             {
                 projection.Lifecycle = lifecycle.Value;
@@ -185,8 +174,6 @@ namespace Marten.Events.Projections
             projection.AssertValidity();
 
             All.Add(projection);
-
-            return expression;
         }
 
         internal bool Any()
@@ -281,6 +268,11 @@ namespace Marten.Events.Projections
         internal string[] AllProjectionNames()
         {
             return All.Select(x => $"'{x.ProjectionName}'").ToArray();
+        }
+
+        internal IEnumerable<Type> AllPublishedTypes()
+        {
+            return All.OfType<IProjectionSource>().SelectMany(x => x.PublishedTypes()).Distinct();
         }
     }
 }

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -79,7 +79,7 @@ namespace Marten
             services.AddSingleton<IGeneratesCode[]>(s =>
             {
                 var options = s.GetRequiredService<StoreOptions>();
-                return new IGeneratesCode[] {options.EventGraph, options};
+                return new IGeneratesCode[] {options, options.EventGraph};
             });
 
             return new MartenConfigurationExpression(services, null);

--- a/src/Marten/Schema/IDocumentMapping.cs
+++ b/src/Marten/Schema/IDocumentMapping.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using Weasel.Postgresql;
 using Marten.Schema.Identity;
 using Marten.Storage;
@@ -9,6 +10,8 @@ namespace Marten.Schema
     internal interface IDocumentMapping
     {
         IDocumentMapping Root { get; }
+
+        MemberInfo IdMember { get; }
 
         Type DocumentType { get; }
 

--- a/src/Marten/Schema/SubClassMapping.cs
+++ b/src/Marten/Schema/SubClassMapping.cs
@@ -43,6 +43,8 @@ namespace Marten.Schema
 
         public DocumentMapping Parent { get; }
 
+        public MemberInfo IdMember => Parent.IdMember;
+
         public string[] Aliases { get; }
         public string Alias { get; set; }
 

--- a/src/Marten/Storage/StorageFeatures.cs
+++ b/src/Marten/Storage/StorageFeatures.cs
@@ -91,7 +91,14 @@ namespace Marten.Storage
             foreach (var pair in _builders.ToArray())
             {
                 // Just forcing them all to be built
-                var mapping = MappingFor(pair.Key);
+                FindMapping(pair.Key);
+            }
+
+            // This needs to be done second so that it can pick up any subclass
+            // relationships
+            foreach (var documentType in _options.Projections.AllPublishedTypes())
+            {
+                FindMapping(documentType);
             }
         }
 


### PR DESCRIPTION
It's involved, see #1961. Key takeaway was to be careful in how we registered document mappings for projections. Needed to be lazy instead of eager. Also a problem w/ the order of generating types, documents need to go first before events.