### PR TITLE
Brought back Event Type Mapping by adding a dedicated MapEventType method to IEventStoreOptions

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -3,6 +3,7 @@ FOR /f %%v IN ('dotnet --version') DO set version=%%v
 set target_framework=
 IF "%version:~0,3%"=="3.1" (set target_framework=netcoreapp3.1)
 IF "%version:~0,2%"=="5." (set target_framework=net5.0)
+IF "%version:~0,2%"=="6." (set target_framework=net5.0)
 
 IF [%target_framework%]==[] (
     echo "BUILD FAILURE: .NET Core 3.1 or .NET 5 SDK required to run build"

--- a/build.ps1
+++ b/build.ps1
@@ -5,6 +5,9 @@ if ($version.StartsWith("3.1")) {
 }
 elseif ($version.StartsWith("5.")) {
     $target_framework="net5.0"
+} 
+elseif ($version.StartsWith("6.")) {
+    $target_framework="net5.0"
 } else {
     Write-Output "BUILD FAILURE: .NET Core 3.1 or .NET 5 SDK required to run build"
     exit 1

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,8 @@ if [[ $version = 3.1* ]]; then
   target_framework="netcoreapp3.1"
 elif [[ $version = 5.* ]]; then
   target_framework="net5.0"
+elif [[ $version = 6.* ]]; then
+  target_framework="net5.0"
 else
   echo "BUILD FAILURE: .NET Core 3.1 or .NET 5 SDK required to run build"
   exit 1

--- a/docs/events/versioning.md
+++ b/docs/events/versioning.md
@@ -19,7 +19,7 @@ When it is not able to find event type with the same assembly, namespace and typ
 Such mapping needs to be defined manually:
 
 - either by registering events with store options `Events.AddEventTypes` method,
-- or by defining custom mapping with `Events.EventMappingFor` method.
+- or by defining custom mapping with `Events.MapEventType` method.
 
 For the case of namespace migration, it's enough to use `AddEventTypes` method as it's generating mapping based on the event type. As an example, change `OrderStatusChanged` event from:
 
@@ -87,14 +87,14 @@ After that Marten will automatically perform a matching based on the type name (
 
 When the event class type name has changed, Marten does not perform automatic mapping but allows to define a custom one.
 
-To do that you need to use `Events.EventMappingFor` method to define the type name for the new event.
+To do that you need to use `Events.MapEventType` method to define the type name for the new event.
 
 Eg. for migrating `OrderStatusChanged` event into `ConfirmedOrderStatusChanged`
 
 <!-- snippet: sample_new_event_type_name -->
 <a id='snippet-sample_new_event_type_name'></a>
 ```cs
-namespace OldEventNamespace
+namespace NewEventNamespace
 {
     public class ConfirmedOrderStatusChanged
     {
@@ -119,8 +119,8 @@ it's needed to register mapping using old event type name (`order_status_changed
 ```cs
 var options = new StoreOptions();
 
-var orderStatusChangedMapping = options.EventGraph.EventMappingFor<OldEventNamespace.ConfirmedOrderStatusChanged>();
-orderStatusChangedMapping.EventTypeName = "order_status_changed";
+options.EventGraph
+    .MapEventType<NewEventNamespace.ConfirmedOrderStatusChanged>("order_status_changed");
 
 var store = new DocumentStore(options);
 ```

--- a/src/Marten.Testing/Events/SchemaChange/NamespaceChange.cs
+++ b/src/Marten.Testing/Events/SchemaChange/NamespaceChange.cs
@@ -47,7 +47,7 @@ namespace Marten.Testing.Events.SchemaChange
 
 
     #region sample_new_event_type_name
-    namespace OldEventNamespace
+    namespace NewEventNamespace
     {
         public class ConfirmedOrderStatusChanged
         {
@@ -81,8 +81,8 @@ namespace Marten.Testing.Events.SchemaChange
             #region sample_event_type_name_migration_options
             var options = new StoreOptions();
 
-            var orderStatusChangedMapping = options.EventGraph.EventMappingFor<OldEventNamespace.ConfirmedOrderStatusChanged>();
-            orderStatusChangedMapping.EventTypeName = "order_status_changed";
+            options.EventGraph
+                .MapEventType<NewEventNamespace.ConfirmedOrderStatusChanged>("order_status_changed");
 
             var store = new DocumentStore(options);
             #endregion

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -124,6 +124,15 @@ namespace Marten.Events
             types.Each(AddEventType);
         }
 
+        public void MapEventType<TEvent>(string eventTypeName) where TEvent : class =>
+            MapEventType(typeof(TEvent), eventTypeName);
+
+        public void MapEventType(Type eventType, string eventTypeName)
+        {
+            var eventMapping = EventMappingFor(eventType);
+            eventMapping.EventTypeName = eventTypeName;
+        }
+
         /// <summary>
         ///     Override the database schema name for event related tables. By default this
         ///     is the same schema as the document storage

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -40,6 +40,22 @@ namespace Marten.Events
         /// <param name="types"></param>
         void AddEventTypes(IEnumerable<Type> types);
 
+        /// <summary>
+        /// Maps CLR event type as particular event type name. This is useful for event type migration.
+        /// See more in docs: https://martendb.io/events/versioning.html#event-type-name-migration
+        /// </summary>
+        /// <param name="eventTypeName">Event type name</param>
+        /// <typeparam name="TEvent">Mapped CLR event type</typeparam>
+        void MapEventType<TEvent>(string eventTypeName) where TEvent : class;
+
+        /// <summary>
+        /// Maps CLR event type as particular event type name. This is useful for event type migration.
+        /// See more in docs: https://martendb.io/events/versioning.html#event-type-name-migration
+        /// </summary>
+        /// <param name="eventType">Event type name</param>
+        /// <param name="eventTypeName">Mapped CLR event type</param>
+        void MapEventType(Type eventType, string eventTypeName);
+
         public MetadataConfig MetadataConfig { get; }
     }
 }


### PR DESCRIPTION
Besides that enabled build script run if someone has .NET 6 installed (like me 😅 ).