### PR TITLE
Fix CA2012 warnings

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -149,7 +149,7 @@ csharp_preserve_single_line_blocks = true
 ###############################
 
 # CA2012: Use ValueTasks correctly
-dotnet_diagnostic.CA2012.severity = warning
+dotnet_diagnostic.CA2012.severity = error
 
 # VSTHRD002 Avoid problematic synchronous waits
 dotnet_diagnostic.VSTHRD002.severity = warning

--- a/src/Marten/Events/Aggregation/AsyncLiveAggregatorBase.cs
+++ b/src/Marten/Events/Aggregation/AsyncLiveAggregatorBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,8 +18,7 @@ namespace Marten.Events.Aggregation
 
         public T Build(IReadOnlyList<IEvent> events, IQuerySession session, T? snapshot)
         {
-            return BuildAsync(events, session, snapshot, CancellationToken.None).GetAwaiter().GetResult();
+            throw new NotSupportedException();
         }
-
     }
 }

--- a/src/Marten/Events/Daemon/ActionParameters.cs
+++ b/src/Marten/Events/Daemon/ActionParameters.cs
@@ -54,15 +54,16 @@ namespace Marten.Events.Daemon
             Cancellation = Group.Cancellation;
         }
 
-        public void ApplySkip(SkipEvent skip)
+        public async Task ApplySkipAsync(SkipEvent skip)
         {
-            Group?.SkipEventSequence(skip.Event.Sequence);
+            if (Group != null)
+            {
+                await Group.SkipEventSequence(skip.Event.Sequence).ConfigureAwait(false);
 
-            // You have to reset the CancellationToken for the group
-            Group?.Reset();
-
-            Cancellation = Group?.Cancellation ?? Cancellation;
-
+                // You have to reset the CancellationToken for the group
+                Group.Reset();
+                Cancellation = Group.Cancellation;
+            }
 
             // Basically saying that the attempts start over when we skip
             Attempts = 0;

--- a/src/Marten/Events/Daemon/ProjectionDaemon.cs
+++ b/src/Marten/Events/Daemon/ProjectionDaemon.cs
@@ -399,7 +399,7 @@ namespace Marten.Events.Daemon
                             return;
                         }
 
-                        parameters.ApplySkip(skip);
+                        await parameters.ApplySkipAsync(skip).ConfigureAwait(false);
 
                         _logger.LogInformation("Skipping event #{Sequence} ({EventType}) in shard '{ShardName}'",
                             skip.Event.Sequence, skip.Event.EventType.GetFullName(), parameters.Shard.Name);

--- a/src/Marten/Util/SOHSkippingStream.cs
+++ b/src/Marten/Util/SOHSkippingStream.cs
@@ -1,0 +1,163 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten.Util
+{
+    internal class SOHSkippingStream: Stream
+    {
+        private readonly Stream _inner;
+
+        public SOHSkippingStream(Stream inner)
+        {
+            _inner = inner;
+        }
+
+        public override int ReadByte()
+        {
+            var initialPosition = _inner.Position;
+            var result = _inner.ReadByte();
+            if (result == 1 && initialPosition == 0) result = _inner.ReadByte();
+
+            return result;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var totalRead = 0;
+            if (_inner.Position == 0)
+            {
+                var readBytes = _inner.Read(buffer, 0, 1);
+                if (readBytes <= 0) return readBytes;
+
+                if (buffer[0] != 1)
+                {
+                    offset += 1;
+                    count -= 1;
+                    totalRead = 1;
+                }
+            }
+
+            return totalRead + _inner.Read(buffer, offset, count);
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count,
+            CancellationToken cancellationToken)
+        {
+            var totalRead = 0;
+            if (_inner.Position == 0)
+            {
+                var readBytes = await _inner.ReadAsync(buffer, 0, 1, cancellationToken).ConfigureAwait(false);
+                if (readBytes <= 0) return readBytes;
+
+                if (buffer[0] != 1)
+                {
+                    offset += 1;
+                    count -= 1;
+                    totalRead = 1;
+                }
+            }
+
+            return totalRead + await _inner.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+        }
+
+
+#if !NETSTANDARD2_0
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            var totalRead = 0;
+            if (_inner.Position == 0)
+            {
+                var singleByteBuffer = buffer[..1];
+
+                var readBytes = await _inner.ReadAsync(singleByteBuffer, cancellationToken).ConfigureAwait(false);
+                if (readBytes <= 0) return readBytes;
+
+                if (singleByteBuffer.Span[0] != 1)
+                {
+                    totalRead = 1;
+                    buffer = buffer[1..];
+                }
+            }
+
+            return totalRead + await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            var totalRead = 0;
+            if (_inner.Position == 0)
+            {
+                var singleByteBuffer = buffer[..1];
+                var readBytes = _inner.Read(singleByteBuffer);
+                if (readBytes <= 0) return readBytes;
+
+                if (singleByteBuffer[0] != 1)
+                {
+                    totalRead = 1;
+                    buffer = buffer[1..];
+                }
+            }
+
+            return totalRead + _inner.Read(buffer);
+        }
+#endif
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback,
+            object state)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            throw new NotSupportedException();
+        }
+
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _inner.Dispose();
+        }
+
+#if !NETSTANDARD2_0
+        public override ValueTask DisposeAsync()
+        {
+            return _inner.DisposeAsync();
+        }
+#endif
+    }
+}

--- a/src/Marten/Util/SharedBuffer.cs
+++ b/src/Marten/Util/SharedBuffer.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Buffers;
+
+namespace Marten.Util
+{
+    internal readonly struct SharedBuffer: IDisposable
+    {
+        private readonly ArraySegment<byte> _buffer;
+
+        private SharedBuffer(ArraySegment<byte> buffer)
+        {
+            _buffer = buffer;
+        }
+
+        public static SharedBuffer RentAndCopy(SOHSkippingStream stream)
+        {
+            var buffer = ArrayPool<byte>.Shared.Rent((int)stream.Length);
+            var totalRead = stream.Read(buffer, 0, buffer.Length);
+            return new SharedBuffer(new ArraySegment<byte>(buffer, 0, totalRead));
+        }
+
+        public void Dispose()
+        {
+            if (_buffer.Array != null)
+                ArrayPool<byte>.Shared.Return(_buffer.Array);
+        }
+
+        public static implicit operator ReadOnlySpan<byte>(SharedBuffer self)
+        {
+            return self._buffer;
+        }
+    }
+}

--- a/src/Marten/Util/StreamExtensions.cs
+++ b/src/Marten/Util/StreamExtensions.cs
@@ -12,27 +12,15 @@ namespace Marten.Util
 
         static readonly Encoding UTF8NoBOM = new UTF8Encoding(false, true);
 
-        public static async Task<Stream> SkipSOHAsync(this Stream stream, CancellationToken token = default)
+        public static SOHSkippingStream ToSOHSkippingStream(this Stream stream)
         {
-            var output = new MemoryStream {Position = 0};
-
-            await stream.CopyStreamSkippingSOHAsync(output, token).ConfigureAwait(false);
-            output.Position = 0;
-
-            return output;
+            return  new SOHSkippingStream(stream);
         }
 
         public static async Task CopyStreamSkippingSOHAsync(this Stream input, Stream output, CancellationToken token = default)
         {
-            var buffer = new byte[1];
-
-            await input.ReadAsync(buffer, 0, 1, token).ConfigureAwait(false);
-            if (buffer[0] != 1)
-            {
-                await output.WriteAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
-            }
-
-            await input.CopyToAsync(output, 4096, token).ConfigureAwait(false);
+            var sohSkippingStream = new SOHSkippingStream(input);
+            await sohSkippingStream.CopyToAsync(output, 4096, token).ConfigureAwait(false);
         }
 
         public static StreamReader GetStreamReader(this Stream stream)


### PR DESCRIPTION
Another bunch of threading issues fixes. 
A couple of changes should be reviewed carefully:
* `SystemTextJsonSerializer` uses `ArrayPool<byte>.Shared` to buffer data from streams hence it's a  performance penalty for sync versions of 'FromJson()' methods. 
* ~~Inverted sync/async calls for `AsyncLiveAggregatorBase` is a breaking change, so any inheritor will have to override and implement sync `Build()` method~~.  I've figured out the purpose of `AsyncLiveAggregatorBase`. It was absolutely wrong idea. There is no good and safe way to call async code from sync hence I replaced sync method with `throw new NoSupportedException()`. 

I suppose it still deserve merging as it's improves reliability.  