### PR TITLE
Do not ignore .Take() when using .Single() in LINQ query

### DIFF
--- a/src/Marten.Testing/Linq/invoking_queryable_through_single_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_through_single_Tests.cs
@@ -65,6 +65,18 @@ namespace Marten.Testing.Linq
         }
 
         [Fact]
+        public void single_hit_with_more_than_one_match_and_take_one_should_not_throw()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 4 });
+            theSession.SaveChanges();
+
+            theSession.Query<Target>().Where(x => x.Number == 2).Take(1).Single().ShouldNotBeNull();
+        }
+
+        [Fact]
         public void single_or_default_hit_with_more_than_one_match()
         {
             theSession.Store(new Target { Number = 1 });

--- a/src/Marten.Testing/Linq/invoking_queryable_through_single_async_Tests.cs
+++ b/src/Marten.Testing/Linq/invoking_queryable_through_single_async_Tests.cs
@@ -66,6 +66,19 @@ namespace Marten.Testing.Linq
         }
 
         [Fact]
+        public async Task single_hit_with_more_than_one_match_and_take_one_should_not_throw()
+        {
+            theSession.Store(new Target { Number = 1 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 2 });
+            theSession.Store(new Target { Number = 4 });
+            await theSession.SaveChangesAsync();
+
+            var target = await theSession.Query<Target>().Where(x => x.Number == 2).Take(1).SingleAsync();
+            target.ShouldNotBeNull();
+        }
+
+        [Fact]
         public async Task single_or_default_hit_with_more_than_one_match()
         {
             theSession.Store(new Target { Number = 1 });

--- a/src/Marten/Linq/Parsing/LinqHandlerBuilder.cs
+++ b/src/Marten/Linq/Parsing/LinqHandlerBuilder.cs
@@ -165,7 +165,11 @@ namespace Marten.Linq.Parsing
                     break;
 
                 case SingleResultOperator single:
-                    CurrentStatement.Limit = 2;
+                    if (CurrentStatement.Limit == 0)
+                    {
+                        CurrentStatement.Limit = 2;
+                    }
+
                     CurrentStatement.SingleValue = true;
                     CurrentStatement.ReturnDefaultWhenEmpty = single.ReturnDefaultWhenEmpty;
                     CurrentStatement.CanBeMultiples = false;


### PR DESCRIPTION
Following query will throw exception if there is more than one document with number 2:
```csharp
session.Query<Target>().Where(x => x.Number == 2).Take(1).Single();
```
When LINQ query with .Single() is parsed, the limit for SQL query is always set to two. I think that the Take(1) should be honored and not be overriden. This PR changes the query parsing to set the limit only if it is not set previously.