### PR TITLE
Any query optimization (avoid counting all rows)

### DIFF
--- a/src/Marten.Testing/Linq/previewing_the_command_from_a_queryable_Tests.cs
+++ b/src/Marten.Testing/Linq/previewing_the_command_from_a_queryable_Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
 using Marten.Linq;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
@@ -9,12 +10,13 @@ namespace Marten.Testing.Linq
 {
     public class previewing_the_command_from_a_queryable_Tests : IntegrationContext
     {
+        protected virtual string ExpectedSchema => "public";
         [Fact]
         public void preview_basic_select_command()
         {
             var cmd = theSession.Query<Target>().ToCommand(FetchType.FetchMany);
 
-            cmd.CommandText.ShouldBe("select d.id, d.data from public.mt_doc_target as d");
+            cmd.CommandText.ShouldBe($"select d.id, d.data from {ExpectedSchema}.mt_doc_target as d");
             cmd.Parameters.Any().ShouldBeFalse();
         }
 
@@ -23,7 +25,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().Where(x => x.Number == 3 && x.Double > 2).ToCommand(FetchType.FetchMany);
 
-            cmd.CommandText.ShouldBe("select d.id, d.data from public.mt_doc_target as d where (CAST(d.data ->> 'Number' as integer) = :p0 and CAST(d.data ->> 'Double' as double precision) > :p1)");
+            cmd.CommandText.ShouldBe($"select d.id, d.data from {ExpectedSchema}.mt_doc_target as d where (CAST(d.data ->> 'Number' as integer) = :p0 and CAST(d.data ->> 'Double' as double precision) > :p1)");
 
             cmd.Parameters.Count.ShouldBe(2);
             cmd.Parameters["p0"].Value.ShouldBe(3);
@@ -35,7 +37,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().ToCommand(FetchType.Count);
 
-            cmd.CommandText.ShouldBe("select count(*) as number from public.mt_doc_target as d");
+            cmd.CommandText.ShouldBe($"select count(*) as number from {ExpectedSchema}.mt_doc_target as d");
         }
 
         [Fact]
@@ -43,7 +45,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().ToCommand(FetchType.Any);
 
-            cmd.CommandText.ShouldBe("select (count(*) > 0) as result from public.mt_doc_target as d");
+            cmd.CommandText.ShouldBe($"select TRUE as result from {ExpectedSchema}.mt_doc_target as d LIMIT :p0");
         }
 
         [Fact]
@@ -51,7 +53,7 @@ namespace Marten.Testing.Linq
         {
             var cmd = theSession.Query<Target>().OrderBy(x => x.Double).ToCommand(FetchType.FetchOne);
 
-            cmd.CommandText.Trim().ShouldBe("select d.id, d.data from public.mt_doc_target as d order by CAST(d.data ->> 'Double' as double precision) LIMIT :p0");
+            cmd.CommandText.Trim().ShouldBe($"select d.id, d.data from {ExpectedSchema}.mt_doc_target as d order by CAST(d.data ->> 'Double' as double precision) LIMIT :p0");
         }
 
         public previewing_the_command_from_a_queryable_Tests(DefaultStoreFixture fixture) : base(fixture)
@@ -59,56 +61,13 @@ namespace Marten.Testing.Linq
         }
     }
 
-    public class previewing_the_command_from_a_queryable_inb_different_schema_Tests : IntegrationContext
+    public class previewing_the_command_from_a_queryable_in_a_different_schema_Tests : previewing_the_command_from_a_queryable_Tests
     {
-        public previewing_the_command_from_a_queryable_inb_different_schema_Tests(DefaultStoreFixture fixture) : base(fixture)
+        protected override string ExpectedSchema => "other";
+
+        public previewing_the_command_from_a_queryable_in_a_different_schema_Tests(DefaultStoreFixture fixture) : base(fixture)
         {
-            StoreOptions(_ => _.DatabaseSchemaName = "other");
-        }
-
-        [Fact]
-        public void preview_basic_select_command()
-        {
-            var cmd = theSession.Query<Target>().ToCommand(FetchType.FetchMany);
-
-            cmd.CommandText.ShouldBe("select d.id, d.data from other.mt_doc_target as d");
-            cmd.Parameters.Any().ShouldBeFalse();
-        }
-
-        [Fact]
-        public void preview_command_with_where_and_parameters()
-        {
-            var cmd = theSession.Query<Target>().Where(x => x.Number == 3 && x.Double > 2).ToCommand(FetchType.FetchMany);
-
-            cmd.CommandText.ShouldBe("select d.id, d.data from other.mt_doc_target as d where (CAST(d.data ->> 'Number' as integer) = :p0 and CAST(d.data ->> 'Double' as double precision) > :p1)");
-
-            cmd.Parameters.Count.ShouldBe(2);
-            cmd.Parameters["p0"].Value.ShouldBe(3);
-            cmd.Parameters["p1"].Value.ShouldBe(2);
-        }
-
-        [Fact]
-        public void preview_basic_count_command()
-        {
-            var cmd = theSession.Query<Target>().ToCommand(FetchType.Count);
-
-            cmd.CommandText.ShouldBe("select count(*) as number from other.mt_doc_target as d");
-        }
-
-        [Fact]
-        public void preview_basic_any_command()
-        {
-            var cmd = theSession.Query<Target>().ToCommand(FetchType.Any);
-
-            cmd.CommandText.ShouldBe("select (count(*) > 0) as result from other.mt_doc_target as d");
-        }
-
-        [Fact]
-        public void preview_select_on_query()
-        {
-            var cmd = theSession.Query<Target>().OrderBy(x => x.Double).ToCommand(FetchType.FetchOne);
-
-            cmd.CommandText.Trim().ShouldBe("select d.id, d.data from other.mt_doc_target as d order by CAST(d.data ->> 'Double' as double precision) LIMIT :p0");
+            StoreOptions(_ => _.DatabaseSchemaName = ExpectedSchema);
         }
     }
 }

--- a/src/Marten/Linq/SqlGeneration/AnySelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/AnySelectClause.cs
@@ -25,7 +25,7 @@ namespace Marten.Linq.SqlGeneration
 
         public void WriteSelectClause(CommandBuilder sql)
         {
-            sql.Append("select (count(*) > 0) as result");
+            sql.Append("select TRUE as result");
             sql.Append(" from ");
             sql.Append(FromObject);
             sql.Append(" as d");

--- a/src/Marten/Linq/SqlGeneration/SelectorStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/SelectorStatement.cs
@@ -54,6 +54,7 @@ namespace Marten.Linq.SqlGeneration
         public void ToAny()
         {
             SelectClause = new AnySelectClause(SelectClause.FromObject);
+            Limit = 1;
         }
 
         public void ToCount<T>()


### PR DESCRIPTION
Current `Any()` implementation compiles to a query `select (count(*) > 0) as result from public.mt_doc_target as d`. It forces postgres to count all related rows which is obviously redundant work. Fastest query I could imaging would be `select exists as result from (select 1 from public.mt_doc_target as d) as temp`. I haven't figured out an easy way to implement this directly within Marten codebase. Luckily I found a workaround that works: `select 1=1 as result from public.mt_doc_target as d LIMIT 1` and gives almost same execution plan as `exists` based query (see below).

I also deduplicated  `previewing_the_command_from_a_queryable_Tests` and `previewing_the_command_from_a_queryable_in_a_different_schema_Tests` with some string interpolation magic.

These are the execution plans to shows the improvement on a 10k rows tables:
 
![image](https://user-images.githubusercontent.com/958861/141647278-fd871be9-5ee9-4165-83f3-48aa3adca264.png)

![image](https://user-images.githubusercontent.com/958861/141647300-53e8f085-e4fe-4786-93a9-3655dc3871b6.png)

![image](https://user-images.githubusercontent.com/958861/141647358-c98538cf-3c94-4838-a3b8-4c2b19a35ad5.png)


