### PR TITLE
.NET 6/Async Pass

### DIFF
--- a/src/Marten.AsyncDaemon.Testing/Marten.AsyncDaemon.Testing.csproj
+++ b/src/Marten.AsyncDaemon.Testing/Marten.AsyncDaemon.Testing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />

--- a/src/Marten.AsyncDaemon.Testing/TestingSupport/DaemonContext.cs
+++ b/src/Marten.AsyncDaemon.Testing/TestingSupport/DaemonContext.cs
@@ -271,7 +271,7 @@ namespace Marten.AsyncDaemon.Testing.TestingSupport
         public class EventPublisher
         {
             private readonly DocumentStore _store;
-            private readonly TaskCompletionSource<bool> _completion = new TaskCompletionSource<bool>();
+            private readonly TaskCompletionSource<bool> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
             public EventPublisher(DocumentStore store)
             {

--- a/src/Marten.Testing/Acceptance/document_inserts.cs
+++ b/src/Marten.Testing/Acceptance/document_inserts.cs
@@ -52,7 +52,7 @@ namespace Marten.Testing.Acceptance
                 query.Query<User>().Count().ShouldBe(4);
             }
         }
-#if NET5_0
+#if NET
         [Fact]
         public void can_insert_records()
         {

--- a/src/Marten.Testing/Bugs/Bug_1891_compiled_query_problem.cs
+++ b/src/Marten.Testing/Bugs/Bug_1891_compiled_query_problem.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Marten.Testing.Bugs
 {
-#if NET5_0
+#if NET
     public class Bug_1891_compiled_query_problem : BugIntegrationContext
     {
         [Fact]

--- a/src/Marten.Testing/Events/Aggregation/aggregate_stream_samples.cs
+++ b/src/Marten.Testing/Events/Aggregation/aggregate_stream_samples.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
 
-#if NET5_0
+#if NET
 #nullable enable
 namespace Marten.Testing.Events.Aggregation
 {

--- a/src/Marten/Events/Aggregation/AggregateProjection.CodeGen.cs
+++ b/src/Marten/Events/Aggregation/AggregateProjection.CodeGen.cs
@@ -395,7 +395,7 @@ namespace Marten.Events.Aggregation
 
             var eventTypes = determineEventTypes();
 
-            var baseFilters = new ISqlFragment[0];
+            var baseFilters = Array.Empty<ISqlFragment>();
             if (!eventTypes.Any(x => x.IsAbstract || x.IsInterface))
             {
                 baseFilters = new ISqlFragment[] {new EventTypeFilter(store.Events, eventTypes)};

--- a/src/Marten/Events/Aggregation/AggregationRuntime.cs
+++ b/src/Marten/Events/Aggregation/AggregationRuntime.cs
@@ -22,7 +22,7 @@ namespace Marten.Events.Aggregation
         ValueTask<EventRangeGroup> GroupEvents(DocumentStore store, EventRange range, CancellationToken cancellationToken);
     }
 
-    public abstract class CrossStreamAggregationRuntime<TDoc, TId>: AggregationRuntime<TDoc, TId>
+    public abstract class CrossStreamAggregationRuntime<TDoc, TId>: AggregationRuntime<TDoc, TId> where TDoc: notnull where TId: notnull
     {
         public CrossStreamAggregationRuntime(IDocumentStore store, IAggregateProjection projection, IEventSlicer<TDoc, TId> slicer, ITenancy tenancy, IDocumentStorage<TDoc, TId> storage) : base(store, projection, slicer, tenancy, storage)
         {

--- a/src/Marten/Events/Daemon/HighWater/HighWaterAgent.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterAgent.cs
@@ -130,7 +130,7 @@ namespace Marten.Events.Daemon.HighWater
             await Task.Delay(delayTime, _token).ConfigureAwait(false);
         }
 
-        public void TimerOnElapsed(object sender, ElapsedEventArgs e)
+        private void TimerOnElapsed(object sender, ElapsedEventArgs e)
         {
             _ = CheckState();
         }

--- a/src/Marten/Events/Daemon/HighWater/HighWaterAgent.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterAgent.cs
@@ -130,7 +130,12 @@ namespace Marten.Events.Daemon.HighWater
             await Task.Delay(delayTime, _token).ConfigureAwait(false);
         }
 
-        private void TimerOnElapsed(object sender, ElapsedEventArgs e)
+        public void TimerOnElapsed(object sender, ElapsedEventArgs e)
+        {
+            _ = CheckState();
+        }
+
+        private async Task CheckState()
         {
             if (_loop.IsFaulted && !_token.IsCancellationRequested)
             {
@@ -139,15 +144,13 @@ namespace Marten.Events.Daemon.HighWater
                 try
                 {
                     _loop.Dispose();
-                    Start().GetAwaiter().GetResult();
+                    await Start().ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Error trying to restart the HighWaterAgent");
                 }
             }
-
-
         }
 
         public void Dispose()

--- a/src/Marten/Events/Daemon/IProjectionDaemon.cs
+++ b/src/Marten/Events/Daemon/IProjectionDaemon.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-
+#nullable enable
 namespace Marten.Events.Daemon
 {
     /// <summary>
@@ -48,7 +48,7 @@ namespace Marten.Events.Daemon
         /// <param name="shardName"></param>
         /// <param name="ex"></param>
         /// <returns></returns>
-        Task StopShard(string shardName, Exception ex = null);
+        Task StopShard(string shardName, Exception? ex = null);
 
         /// <summary>
         /// Starts all known projections shards

--- a/src/Marten/Events/Daemon/ShardStatusWatcher.cs
+++ b/src/Marten/Events/Daemon/ShardStatusWatcher.cs
@@ -16,7 +16,7 @@ namespace Marten.Events.Daemon
         public ShardStatusWatcher(ShardStateTracker tracker, ShardState expected, TimeSpan timeout)
         {
             _condition = x => x.Equals(expected);
-            _completion = new TaskCompletionSource<ShardState>();
+            _completion = new TaskCompletionSource<ShardState>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 
             var timeout1 = new CancellationTokenSource(timeout);
@@ -32,7 +32,7 @@ namespace Marten.Events.Daemon
         public ShardStatusWatcher(string description, Func<ShardState, bool> condition, ShardStateTracker tracker, TimeSpan timeout)
         {
             _condition = condition;
-            _completion = new TaskCompletionSource<ShardState>();
+            _completion = new TaskCompletionSource<ShardState>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 
             var timeout1 = new CancellationTokenSource(timeout);

--- a/src/Marten/Events/Daemon/TenantedEventRange.cs
+++ b/src/Marten/Events/Daemon/TenantedEventRange.cs
@@ -71,10 +71,17 @@ namespace Marten.Events.Daemon
         public override Task ConfigureUpdateBatch(IShardAgent shardAgent, ProjectionUpdateBatch batch,
             EventRangeGroup eventRangeGroup)
         {
+#if NET6_0_OR_GREATER
+            return Parallel.ForEachAsync(Groups, Cancellation,
+                async (tenantGroup, token) =>
+                    await tenantGroup.ApplyEvents(batch, _projection, _store, token).ConfigureAwait(false));
+#else
+
             var tasks = Groups
                 .Select(tenantGroup => tenantGroup.ApplyEvents(batch, _projection, _store, Cancellation)).ToArray();
 
             return Task.WhenAll(tasks);
+#endif
         }
     }
 }

--- a/src/Marten/Linq/Parsing/Methods/StringContains.cs
+++ b/src/Marten/Linq/Parsing/Methods/StringContains.cs
@@ -23,7 +23,7 @@ namespace Marten.Linq.Parsing.Methods
             {
                 typeof(string).GetMethod("Contains", new Type[] { typeof(string), typeof(StringComparison)}),
                 ReflectionHelper.GetMethod<string>(s => s.Contains(null)),
-#if NET5_0
+#if NET
                 ReflectionHelper.GetMethod<string>(s => s.Contains(null, StringComparison.CurrentCulture))
 #endif
             }

--- a/src/Marten/Schema/DocumentCleaner.cs
+++ b/src/Marten/Schema/DocumentCleaner.cs
@@ -233,9 +233,9 @@ END; $$;
         {
             using var connection = _tenant.CreateConnection();
             await connection.OpenAsync().ConfigureAwait(false);
-#if NET5_0
+#if NET
             var tx = await connection.BeginTransactionAsync().ConfigureAwait(false);
-            #else
+#else
             var tx = connection.BeginTransaction();
 #endif
             var deleteEventDataSql = toDeleteEventDataSql();

--- a/src/Marten/Services/BatchQuerying/BatchQueryItem.cs
+++ b/src/Marten/Services/BatchQuerying/BatchQueryItem.cs
@@ -15,7 +15,7 @@ namespace Marten.Services.BatchQuerying
         {
             _handler = handler;
 
-            Completion = new TaskCompletionSource<T>();
+            Completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
 

--- a/src/Marten/Services/ManagedConnectionExtensions.cs
+++ b/src/Marten/Services/ManagedConnectionExtensions.cs
@@ -51,13 +51,13 @@ namespace Marten.Services
         internal static readonly byte[] RightBracket = Encoding.Default.GetBytes("]");
         internal static readonly byte[] Comma = Encoding.Default.GetBytes(",");
 
-#if NET5_0
+#if NET
         internal static ValueTask WriteBytes(this Stream stream, byte[] bytes, CancellationToken token)
         #else
         internal static Task WriteBytes(this Stream stream, byte[] bytes, CancellationToken token)
 #endif
         {
-#if NET5_0
+#if NET
             return stream.WriteAsync(bytes, token);
 #else
             return stream.WriteAsync(bytes, 0, bytes.Length, token);

--- a/src/Marten/Storage/BulkInsertion.cs
+++ b/src/Marten/Storage/BulkInsertion.cs
@@ -68,7 +68,7 @@ namespace Marten.Storage
 #if NETSTANDARD2_0
                 var tx = conn.BeginTransaction();
 
-                #else
+#else
                 var tx = await conn.BeginTransactionAsync(cancellation).ConfigureAwait(false);
 
 #endif

--- a/src/Marten/Storage/BulkInsertion.cs
+++ b/src/Marten/Storage/BulkInsertion.cs
@@ -129,7 +129,7 @@ namespace Marten.Storage
             await conn.OpenAsync(cancellation).ConfigureAwait(false);
 #if NETSTANDARD2_0
             var tx = conn.BeginTransaction();
-            #else
+#else
             var tx = await conn.BeginTransactionAsync(cancellation).ConfigureAwait(false);
 #endif
 


### PR DESCRIPTION
A few items I noticed whilst debugging the daemon:

- Fixed compiler directives that were set to .NET 5-only
- Moved to `Parallel.ForEachAsync` for .NET 6 consumers, replacing the `Task.WhenAll` pattern.
- Dispose the token registration within `waitForAllShardsToComplete`
- Ensure all `TaskCompletionSource`'s are created with `RunContinuationsAsynchronously`
- Adjust highwater timer callback so it isn't doing sync-over-async