### PR TITLE
Fix #1984: recursively reference all assemblies for document persistence

### DIFF
--- a/src/Marten.Testing.OtherAssembly/Bug1984/GenericEntity.cs
+++ b/src/Marten.Testing.OtherAssembly/Bug1984/GenericEntity.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Marten.Testing.OtherAssembly.Bug1984
+{
+    public class GenericEntity<T>
+    {
+        public Guid Id { get; set; }
+        public T Data { get; set; }
+    }
+}

--- a/src/Marten.Testing.ThirdAssembly/Bug1984/Data.cs
+++ b/src/Marten.Testing.ThirdAssembly/Bug1984/Data.cs
@@ -1,0 +1,7 @@
+﻿namespace Marten.Testing.ThirdAssembly.Bug1984
+{
+    public class Data
+    {
+        public string SomeField { get; set; }
+    }
+}

--- a/src/Marten.Testing.ThirdAssembly/Marten.Testing.ThirdAssembly.csproj
+++ b/src/Marten.Testing.ThirdAssembly/Marten.Testing.ThirdAssembly.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Dummy project for test scenario</Description>
+        <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+        <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+        <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+        <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+        <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+        <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+        <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Marten\Marten.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Marten.Testing/Bugs/Bug_1984_need_to_recursively_reference_assemblies_in_lamar_code_generation.cs
+++ b/src/Marten.Testing/Bugs/Bug_1984_need_to_recursively_reference_assemblies_in_lamar_code_generation.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using Marten.Testing.Harness;
+using Marten.Testing.OtherAssembly.Bug1984;
+using Marten.Testing.ThirdAssembly.Bug1984;
+using Xunit;
+
+namespace Marten.Testing.Bugs
+{
+    public class Bug_1984_need_to_recursively_reference_assemblies_in_lamar_code_generation : BugIntegrationContext
+    {
+        public Bug_1984_need_to_recursively_reference_assemblies_in_lamar_code_generation()
+        {
+            StoreOptions(_ => _.Schema.For<GenericEntity<Data>>());
+        }
+
+        [Fact]
+        public async Task Should_be_able_execute_query()
+        {
+            theSession
+                .Store(new GenericEntity<Data>
+                {
+                    Id = Guid.NewGuid(),
+                    Data = new Data()
+                    {
+                        SomeField = "Hello",
+                    }
+                });
+            await theSession.SaveChangesAsync().ConfigureAwait(false);
+        }
+    }
+
+}

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
       <ProjectReference Include="..\Marten\Marten.csproj" />
       <ProjectReference Include="..\Marten.Testing.OtherAssembly\Marten.Testing.OtherAssembly.csproj" />
+      <ProjectReference Include="..\Marten.Testing.ThirdAssembly\Marten.Testing.ThirdAssembly.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Jil" Version="3.0.0-alpha2" />

--- a/src/Marten.sln
+++ b/src/Marten.sln
@@ -61,6 +61,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marten.AspNetCore.Testing",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IssueService", "IssueService\IssueService.csproj", "{B4F97F16-9FF3-4BC6-9B25-2FD2BD91F5E7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marten.Testing.ThirdAssembly", "Marten.Testing.ThirdAssembly\Marten.Testing.ThirdAssembly.csproj", "{5897FB86-03BD-42EE-8FD0-808FD56DB0CA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -155,6 +157,10 @@ Global
 		{B4F97F16-9FF3-4BC6-9B25-2FD2BD91F5E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B4F97F16-9FF3-4BC6-9B25-2FD2BD91F5E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4F97F16-9FF3-4BC6-9B25-2FD2BD91F5E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5897FB86-03BD-42EE-8FD0-808FD56DB0CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5897FB86-03BD-42EE-8FD0-808FD56DB0CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5897FB86-03BD-42EE-8FD0-808FD56DB0CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5897FB86-03BD-42EE-8FD0-808FD56DB0CA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Marten/Internal/CodeGeneration/DocumentPersistenceBuilder.cs
+++ b/src/Marten/Internal/CodeGeneration/DocumentPersistenceBuilder.cs
@@ -112,8 +112,17 @@ namespace Marten.Internal.CodeGeneration
             var bulkWriterType = new BulkLoaderBuilder(_mapping).BuildType(assembly);
 
             var compiler = new AssemblyGenerator();
-            compiler.ReferenceAssembly(typeof(IDocumentStorage<>).Assembly);
-            compiler.ReferenceAssembly(typeof(T).Assembly);
+
+            var types = new[]
+            {
+                typeof(IDocumentStorage<>),
+                typeof(T),
+            };
+
+            foreach (var referencedAssembly in WalkReferencedAssemblies.ForTypes(types))
+            {
+                compiler.ReferenceAssembly(referencedAssembly);
+            }
 
             try
             {

--- a/src/Marten/Internal/CompiledQueries/CompiledQuerySourceBuilder.cs
+++ b/src/Marten/Internal/CompiledQueries/CompiledQuerySourceBuilder.cs
@@ -127,7 +127,7 @@ namespace Marten.Internal.CompiledQueries
         {
             var compiler = new AssemblyGenerator();
 
-            foreach (var referencedAssembly in walkReferencedAssemblies(
+            foreach (var referencedAssembly in WalkReferencedAssemblies.ForTypes(
                 typeof(IDocumentStorage<>),
                 _plan.QueryType,
                 _plan.OutputType))
@@ -136,33 +136,6 @@ namespace Marten.Internal.CompiledQueries
             }
 
             compiler.Compile(assembly);
-        }
-
-        private static IEnumerable<Assembly> walkReferencedAssemblies(params Type[] types)
-        {
-            var stack = new Stack<Type>();
-
-            foreach (var type in types)
-            {
-                stack.Push(type);
-
-                while (stack.Count > 0)
-                {
-                    var current = stack.Pop();
-                    yield return current.Assembly;
-
-                    if (!current.IsGenericType || current.IsGenericTypeDefinition)
-                    {
-                        continue;
-                    }
-
-                    var typeArguments = current.GetGenericArguments();
-                    foreach (var typeArgument in typeArguments)
-                    {
-                        stack.Push(typeArgument);
-                    }
-                }
-            }
         }
 
         private GeneratedType buildHandlerType(GeneratedAssembly assembly,

--- a/src/Marten/Internal/WalkReferencedAssemblies.cs
+++ b/src/Marten/Internal/WalkReferencedAssemblies.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Marten.Internal
+{
+    public static class WalkReferencedAssemblies
+    {
+        public static IEnumerable<Assembly> ForTypes(params Type[] types)
+        {
+            var stack = new Stack<Type>();
+
+            foreach (var type in types)
+            {
+                stack.Push(type);
+
+                while (stack.Count > 0)
+                {
+                    var current = stack.Pop();
+                    yield return current.Assembly;
+
+                    if (!current.IsGenericType || current.IsGenericTypeDefinition)
+                    {
+                        continue;
+                    }
+
+                    var typeArguments = current.GetGenericArguments();
+                    foreach (var typeArgument in typeArguments)
+                    {
+                        stack.Push(typeArgument);
+                    }
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
See #1984 for bug description.

A similar bug was fixed in #1851, I've used the same assembly walking strategy to fix this bug.