### PR TITLE
Npgsql 6 upgrade

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.3.1</VersionPrefix>
+    <VersionPrefix>5.0.0-alpha.4</VersionPrefix>
     <LangVersion>9.0</LangVersion>
     <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
     <PackageIconUrl>http://jasperfx.github.io/marten/content/images/emblem.png</PackageIconUrl>

--- a/src/CommandLineRunner/CommandLineRunner.csproj
+++ b/src/CommandLineRunner/CommandLineRunner.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="LamarCodeGeneration.Commands" Version="2.0.3" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+        <PackageReference Include="LamarCodeGeneration.Commands" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/EventSourceWorker/EventSourceWorker.csproj
+++ b/src/EventSourceWorker/EventSourceWorker.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/EventSourceWorker/Worker.cs
+++ b/src/EventSourceWorker/Worker.cs
@@ -21,7 +21,7 @@ namespace EventSourceWorker
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+                _logger.LogInformation("Worker running at: {time}", DateTimeOffset.UtcNow);
                 await Task.Delay(1000, stoppingToken);
             }
         }

--- a/src/Marten.AspNetCore.Testing/Marten.AspNetCore.Testing.csproj
+++ b/src/Marten.AspNetCore.Testing/Marten.AspNetCore.Testing.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="5.0.1" />
+        <PackageReference Include="Alba" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
         <PackageReference Include="Shouldly" Version="4.0.3" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Marten.AspNetCore/Marten.AspNetCore.csproj
+++ b/src/Marten.AspNetCore/Marten.AspNetCore.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
 
         <Description>Helpers for Marten-backed AspNetCore applications</Description>
-        <VersionPrefix>4.3.1</VersionPrefix>
+        <VersionPrefix>5.0.0-alpha.4</VersionPrefix>
         <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>
         <GenerateAssemblyProductAttribute>true</GenerateAssemblyProductAttribute>

--- a/src/Marten.AsyncDaemon.Testing/Marten.AsyncDaemon.Testing.csproj
+++ b/src/Marten.AsyncDaemon.Testing/Marten.AsyncDaemon.Testing.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Marten.CommandLine/Marten.CommandLine.csproj
+++ b/src/Marten.CommandLine/Marten.CommandLine.csproj
@@ -35,9 +35,9 @@
         <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-        <PackageReference Include="Oakton" Version="3.2.2" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+        <PackageReference Include="Oakton" Version="[3.2.2,4.0.0)" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
         <PackageReference Include="Oakton" Version="4.1.0" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
     </ItemGroup>
     <Import Project="../../Analysis.Build.props" />

--- a/src/Marten.CommandLine/Marten.CommandLine.csproj
+++ b/src/Marten.CommandLine/Marten.CommandLine.csproj
@@ -37,7 +37,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-        <PackageReference Include="Oakton" Version="3.2.2" />
+        <PackageReference Include="Oakton" Version="3.2.2" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+        <PackageReference Include="Oakton" Version="4.1.0" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
     </ItemGroup>
     <Import Project="../../Analysis.Build.props" />
 </Project>

--- a/src/Marten.CommandLine/Marten.CommandLine.csproj
+++ b/src/Marten.CommandLine/Marten.CommandLine.csproj
@@ -35,7 +35,7 @@
         <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
         <PackageReference Include="Oakton" Version="3.2.2" />
     </ItemGroup>

--- a/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
+++ b/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.0">
+      <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       </PackageReference>

--- a/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
+++ b/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
@@ -1,32 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Marten.NodaTime\Marten.NodaTime.csproj" />
-    <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj" />
-    <ProjectReference Include="..\Marten\Marten.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
-  </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      </PackageReference>
+        <ProjectReference Include="..\Marten.NodaTime\Marten.NodaTime.csproj"/>
+        <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj"/>
+        <ProjectReference Include="..\Marten\Marten.csproj"/>
     </ItemGroup>
-  <PropertyGroup>
-    <NoWarn>xUnit1013</NoWarn>
-  </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit" Version="2.4.1"/>
+        <PackageReference Include="NSubstitute" Version="4.2.2"/>
+        <PackageReference Include="Shouldly" Version="4.0.3"/>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+    <PropertyGroup>
+        <NoWarn>xUnit1013</NoWarn>
+    </PropertyGroup>
 </Project>

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -29,7 +29,7 @@
     <ItemGroup>
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
         <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
-        <PackageReference Include="Npgsql.NodaTime" Version="[5.0.10,6.0)" />
+        <PackageReference Include="Npgsql.NodaTime" Version="[6.0.0,7.0)" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -29,7 +29,7 @@
     <ItemGroup>
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
         <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
-        <PackageReference Include="Npgsql.NodaTime" Version="[6.0.0,7.0)" />
+        <PackageReference Include="Npgsql.NodaTime" Version="6.0.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -29,7 +29,7 @@
     <ItemGroup>
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
         <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
-        <PackageReference Include="Npgsql.NodaTime" Version="6.0.1" />
+        <PackageReference Include="Npgsql.NodaTime" Version="[6.0.1,7.0.0)" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>NodaTime extension for Marten</Description>
-        <VersionPrefix>4.3.1</VersionPrefix>
+        <VersionPrefix>5.0.0-alpha.4</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
         <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>

--- a/src/Marten.NodaTime/NodaTimeExtensions.cs
+++ b/src/Marten.NodaTime/NodaTimeExtensions.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Linq;
+using System.Data;
 using Marten.Services;
 using NodaTime;
 using NodaTime.Serialization.JsonNet;
@@ -21,30 +21,63 @@ namespace Marten.NodaTime
         /// <exception cref="NotSupportedException">Thrown if the current serializer is not supported for automatic configuration.</exception>
         public static void UseNodaTime(this StoreOptions storeOptions, bool shouldConfigureJsonSerializer = true)
         {
+            SetNodaTimeMappings();
             NpgsqlConnection.GlobalTypeMapper.UseNodaTime();
 
-            if (shouldConfigureJsonSerializer)
+            if (!shouldConfigureJsonSerializer) return;
+
+            var serializer = storeOptions.Serializer();
+
+            switch (serializer)
             {
-                var serializer = storeOptions.Serializer();
-                if(serializer is JsonNetSerializer jsonNetSerializer)
-                {
+                case JsonNetSerializer jsonNetSerializer:
                     jsonNetSerializer.Customize(s =>
                     {
                         s.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
                     });
-                }
-                else if (serializer is SystemTextJsonSerializer systemTextJsonSerializer)
-                {
+                    break;
+                case SystemTextJsonSerializer systemTextJsonSerializer:
                     systemTextJsonSerializer.Customize(s =>
                     {
                         s.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
                     });
-                }
-                else
-                    throw new NotSupportedException("Current serializer cannot be automatically configured for Nodatime. Set shouldConfigureJsonSerializer to false if you're using your own serializer.");
-
-                storeOptions.Serializer(serializer);
+                    break;
+                default:
+                    throw new NotSupportedException("Current serializer cannot be automatically configured for NodaTime. Set shouldConfigureJsonSerializer to false if you're using your own serializer.");
             }
+
+            storeOptions.Serializer(serializer);
+        }
+
+        public static void SetNodaTimeMappings()
+        {
+            NpgsqlTypeMapper.Mappings.AddRange(
+                new NpgsqlTypeMapping[] {
+                    // Date/time types
+    #pragma warning disable 618 // NpgsqlDateTime is obsolete, remove in 7.0
+                    new(NpgsqlDbType.Timestamp,   DbType.DateTime,       "timestamp without time zone", typeof(DateTime), typeof(NpgsqlDateTime), typeof(LocalDateTime)),
+    #pragma warning disable 618
+                    new(NpgsqlDbType.TimestampTz, DbType.DateTimeOffset, "timestamp with time zone",    typeof(DateTimeOffset), typeof(Instant), typeof(ZonedDateTime)),
+                    new(NpgsqlDbType.Date,        DbType.Date,           "date",                        typeof(NpgsqlDate), typeof(LocalDate)
+    #if NET6_0_OR_GREATER
+                    , typeof(DateOnly)
+    #endif
+                    ),
+                    new(NpgsqlDbType.Time,        DbType.Time,     "time without time zone", typeof(LocalTime)
+    #if NET6_0_OR_GREATER
+                    , typeof(TimeOnly)
+    #endif
+                    ),
+                    new(NpgsqlDbType.TimeTz,      DbType.Object,   "time with time zone", typeof(LocalTime), typeof(LocalTime)),
+                    new(NpgsqlDbType.Interval,    DbType.Object,   "interval", typeof(TimeSpan), typeof(NpgsqlTimeSpan), typeof(Period), typeof(Duration)),
+
+                    new(NpgsqlDbType.Array | NpgsqlDbType.Timestamp,   DbType.Object, "timestamp without time zone[]"),
+                    new(NpgsqlDbType.Array | NpgsqlDbType.TimestampTz, DbType.Object, "timestamp with time zone[]"),
+                    new(NpgsqlDbType.Range | NpgsqlDbType.Timestamp,   DbType.Object, "tsrange"),
+                    new(NpgsqlDbType.Range | NpgsqlDbType.TimestampTz, DbType.Object, "tstzrange"),
+                    new(NpgsqlDbType.Multirange | NpgsqlDbType.Timestamp,   DbType.Object, "tsmultirange"),
+                    new(NpgsqlDbType.Multirange | NpgsqlDbType.TimestampTz, DbType.Object, "tstzmultirange"),
+            });
         }
     }
 }

--- a/src/Marten.NodaTime/NodaTimeExtensions.cs
+++ b/src/Marten.NodaTime/NodaTimeExtensions.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Linq;
 using Marten.Services;
 using NodaTime;
 using NodaTime.Serialization.JsonNet;
 using NodaTime.Serialization.SystemTextJson;
 using Npgsql;
+using NpgsqlTypes;
+using Weasel.Postgresql;
 
 namespace Marten.NodaTime
 {
@@ -39,7 +42,7 @@ namespace Marten.NodaTime
                 }
                 else
                     throw new NotSupportedException("Current serializer cannot be automatically configured for Nodatime. Set shouldConfigureJsonSerializer to false if you're using your own serializer.");
-                
+
                 storeOptions.Serializer(serializer);
             }
         }

--- a/src/Marten.NodaTime/NodaTimeExtensions.cs
+++ b/src/Marten.NodaTime/NodaTimeExtensions.cs
@@ -21,7 +21,7 @@ namespace Marten.NodaTime
         /// <exception cref="NotSupportedException">Thrown if the current serializer is not supported for automatic configuration.</exception>
         public static void UseNodaTime(this StoreOptions storeOptions, bool shouldConfigureJsonSerializer = true)
         {
-            SetNodaTimeMappings();
+            SetNodaTimeTypeMappings();
             NpgsqlConnection.GlobalTypeMapper.UseNodaTime();
 
             if (!shouldConfigureJsonSerializer) return;
@@ -49,7 +49,7 @@ namespace Marten.NodaTime
             storeOptions.Serializer(serializer);
         }
 
-        public static void SetNodaTimeMappings()
+        public static void SetNodaTimeTypeMappings()
         {
             NpgsqlTypeMapper.Mappings.AddRange(
                 new NpgsqlTypeMapping[] {

--- a/src/Marten.PLv8.Testing/Marten.PLv8.Testing.csproj
+++ b/src/Marten.PLv8.Testing/Marten.PLv8.Testing.csproj
@@ -37,7 +37,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.0">
+      <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       </PackageReference>

--- a/src/Marten.PLv8/Marten.PLv8.csproj
+++ b/src/Marten.PLv8/Marten.PLv8.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Description>Document transforms and patching extension for Marten</Description>
-        <VersionPrefix>4.3.1</VersionPrefix>
+        <VersionPrefix>5.0.0-alpha.4</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
         <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>

--- a/src/Marten.Schema.Testing/Documents/Target.cs
+++ b/src/Marten.Schema.Testing/Documents/Target.cs
@@ -75,7 +75,7 @@ namespace Marten.Schema.Testing.Documents
             target.Double = _random.NextDouble();
             target.Long = _random.Next() * 10000;
 
-            target.Date = DateTime.Today.AddDays(_random.Next(-10000, 10000)).ToUniversalTime();
+            target.Date = DateTime.Today.AddDays(_random.Next(-10000, 10000));
 
             if (deep)
             {

--- a/src/Marten.Schema.Testing/Documents/TargetIntId.cs
+++ b/src/Marten.Schema.Testing/Documents/TargetIntId.cs
@@ -68,7 +68,7 @@ namespace Marten.Schema.Testing.Documents
             target.Double = _random.NextDouble();
             target.Long = _random.Next() * 10000;
 
-            target.Date = DateTime.Today.AddDays(_random.Next(-10000, 10000)).ToUniversalTime();
+            target.Date = DateTime.Today.AddDays(_random.Next(-10000, 10000));
 
             if (deep)
             {

--- a/src/Marten.Schema.Testing/Marten.Schema.Testing.csproj
+++ b/src/Marten.Schema.Testing/Marten.Schema.Testing.csproj
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.0">
+      <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       </PackageReference>

--- a/src/Marten.Storyteller/Marten.Storyteller.csproj
+++ b/src/Marten.Storyteller/Marten.Storyteller.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Storyteller" Version="5.4.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Marten.Testing/Bugs/Bug_1454_comparison_between_data_offset_in_child_collection.cs
+++ b/src/Marten.Testing/Bugs/Bug_1454_comparison_between_data_offset_in_child_collection.cs
@@ -24,7 +24,7 @@ namespace Marten.Testing.Bugs
         public void can_query_against_DateTimeOffset()
         {
             theSession.Query<Target>().SelectMany(x => x.Children)
-                .Where(x => x.DateOffset == DateTimeOffset.Now)
+                .Where(x => x.DateOffset == DateTimeOffset.UtcNow)
                 .ToList().ShouldNotBeNull();
         }
     }

--- a/src/Marten.Testing/Bugs/Bug_432_querying_with_UTC_times_with_offset.cs
+++ b/src/Marten.Testing/Bugs/Bug_432_querying_with_UTC_times_with_offset.cs
@@ -229,90 +229,96 @@ namespace Marten.Testing.Bugs
         {
             using (var session = theStore.LightweightSession())
             {
-                var now = GenerateTestDateTime();
+                var now = GenerateTestDateTimeOffset();
                 _output.WriteLine("now: " + now.ToString("o"));
                 var testClass = new DateOffsetClass
                 {
                     Id = Guid.NewGuid(),
-                    DateTimeField = now
+                    DateTimeOffsetField = now
                 };
 
                 session.Store(testClass);
 
                 session.Store(new DateOffsetClass
                 {
-                    DateTimeField = now.Add(5.Minutes())
+                    DateTimeOffsetField = now.Add(5.Minutes())
                 });
 
                 session.Store(new DateOffsetClass
                 {
-                    DateTimeField = now.Add(-5.Minutes())
+                    DateTimeOffsetField = now.Add(-5.Minutes())
                 });
 
                 session.SaveChanges();
 
-                var cmd = session.Query<DateOffsetClass>().Where(x => now >= x.DateTimeField)
+                var cmd = session.Query<DateOffsetClass>().Where(x => now >= x.DateTimeOffsetField)
                     .ToCommand();
 
                 _output.WriteLine(cmd.CommandText);
 
                 session.Query<DateOffsetClass>().ToList().Each(x =>
                 {
-                    _output.WriteLine(x.DateTimeField.ToString("o"));
+                    _output.WriteLine(x.DateTimeOffsetField.ToString("o"));
                 });
 
                 session.Query<DateOffsetClass>()
-                    .Count(x => now >= x.DateTimeField).ShouldBe(2);
+                    .Count(x => now >= x.DateTimeOffsetField).ShouldBe(2);
             }
         }
 
         [Fact]
         public void can_issue_queries_against_the_datetime_offset_as_duplicate_field()
         {
-            StoreOptions(_ => _.Schema.For<DateOffsetClass>().Duplicate(x => x.DateTimeField));
+            StoreOptions(_ => _.Schema.For<DateOffsetClass>().Duplicate(x => x.DateTimeOffsetField));
 
             using (var session = theStore.LightweightSession())
             {
-                var now = GenerateTestDateTime();
+                var now = GenerateTestDateTimeOffset();
                 _output.WriteLine("now: " + now.ToString("o"));
                 var testClass = new DateOffsetClass
                 {
                     Id = Guid.NewGuid(),
-                    DateTimeField = now
+                    DateTimeOffsetField = now
                 };
 
                 session.Store(testClass);
 
                 session.Store(new DateOffsetClass
                 {
-                    DateTimeField = now.Add(5.Minutes())
+                    DateTimeOffsetField = now.Add(5.Minutes())
                 });
 
                 session.Store(new DateOffsetClass
                 {
-                    DateTimeField = now.Add(-5.Minutes())
+                    DateTimeOffsetField = now.Add(-5.Minutes())
                 });
 
                 session.SaveChanges();
 
-                var cmd = session.Query<DateOffsetClass>().Where(x => now >= x.DateTimeField)
+                var cmd = session.Query<DateOffsetClass>().Where(x => now >= x.DateTimeOffsetField)
                     .ToCommand();
 
                 _output.WriteLine(cmd.CommandText);
 
                 session.Query<DateOffsetClass>().ToList().Each(x =>
                 {
-                    _output.WriteLine(x.DateTimeField.ToString("o"));
+                    _output.WriteLine(x.DateTimeOffsetField.ToString("o"));
                 });
 
                 session.Query<DateOffsetClass>()
-                    .Count(x => now >= x.DateTimeField).ShouldBe(2);
+                    .Count(x => now >= x.DateTimeOffsetField).ShouldBe(2);
             }
         }
 
         private static DateTime GenerateTestDateTime()
         {
-            var now = DateTime.UtcNow;
+            var now = DateTime.Now;
+            return now.AddTicks(-(now.Ticks % TimeSpan.TicksPerMillisecond));
+        }
+
+        private static DateTimeOffset GenerateTestDateTimeOffset()
+        {
+            var now = DateTimeOffset.UtcNow;
             return now.AddTicks(-(now.Ticks % TimeSpan.TicksPerMillisecond));
         }
     }
@@ -326,6 +332,6 @@ namespace Marten.Testing.Bugs
     public class DateOffsetClass
     {
         public Guid Id { get; set; }
-        public DateTimeOffset DateTimeField { get; set; }
+        public DateTimeOffset DateTimeOffsetField { get; set; }
     }
 }

--- a/src/Marten.Testing/Bugs/Bug_479_select_datetime_fields.cs
+++ b/src/Marten.Testing/Bugs/Bug_479_select_datetime_fields.cs
@@ -21,7 +21,7 @@ namespace Marten.Testing.Bugs
         {
             var doc = new DocWithDates
             {
-                DateTime = DateTime.Today.ToUniversalTime()
+                DateTime = DateTime.Today
             };
 
             using (var session = theStore.OpenSession())

--- a/src/Marten.Testing/Bugs/Bug_837_missing_func_mt_immutable_timestamp_when_initializing_with_new_Schema.cs
+++ b/src/Marten.Testing/Bugs/Bug_837_missing_func_mt_immutable_timestamp_when_initializing_with_new_Schema.cs
@@ -20,7 +20,7 @@ namespace Marten.Testing.Bugs
 
             using (var session = store.OpenSession())
             {
-                session.Query<Target>().FirstOrDefault(m => m.DateOffset > DateTimeOffset.Now)
+                session.Query<Target>().FirstOrDefault(m => m.DateOffset > DateTimeOffset.UtcNow)
                     .ShouldBeNull();
             }
         }

--- a/src/Marten.Testing/Documents/Target.cs
+++ b/src/Marten.Testing/Documents/Target.cs
@@ -75,7 +75,7 @@ namespace Marten.Testing.Documents
             target.Double = _random.NextDouble();
             target.Long = _random.Next() * 10000;
 
-            target.Date = DateTime.Today.AddDays(_random.Next(-10000, 10000)).ToUniversalTime();
+            target.Date = DateTime.Today.AddDays(_random.Next(-10000, 10000));
 
             if (deep)
             {

--- a/src/Marten.Testing/Documents/TargetIntId.cs
+++ b/src/Marten.Testing/Documents/TargetIntId.cs
@@ -67,7 +67,7 @@ namespace Marten.Testing.Documents
             target.Double = _random.NextDouble();
             target.Long = _random.Next() * 10000;
 
-            target.Date = DateTime.Today.AddDays(_random.Next(-10000, 10000)).ToUniversalTime();
+            target.Date = DateTime.Today.AddDays(_random.Next(-10000, 10000));
 
             if (deep)
             {

--- a/src/Marten.Testing/Events/Examples/Project.cs
+++ b/src/Marten.Testing/Events/Examples/Project.cs
@@ -45,7 +45,7 @@ namespace Marten.Testing.Events.Examples
 
         public Task Handle(NewProjectCommand command)
         {
-            var timestamp = DateTimeOffset.Now;
+            var timestamp = DateTimeOffset.UtcNow;
             var started = new ProjectStarted {Name = command.Name, Timestamp = timestamp};
 
             var tasks = command.Tasks

--- a/src/Marten.Testing/Events/end_to_end_event_capture_and_fetching_the_stream_Tests.cs
+++ b/src/Marten.Testing/Events/end_to_end_event_capture_and_fetching_the_stream_Tests.cs
@@ -237,7 +237,7 @@ namespace Marten.Testing.Events
                     party_at_version_3.ShouldNotBeNull();
 
                     var party_yesterday = session.Events
-                        .AggregateStream<QuestParty>(questId, timestamp: DateTime.UtcNow.AddDays(-1));
+                        .AggregateStream<QuestParty>(questId, timestamp: DateTimeOffset.UtcNow.AddDays(-1));
                     party_yesterday.ShouldBeNull();
                 }
 
@@ -276,7 +276,7 @@ namespace Marten.Testing.Events
                     party_at_version_3.Id.ShouldBe(questId);
 
                     var party_yesterday = session.Events
-                        .AggregateStream<QuestParty>(questId, timestamp: DateTime.UtcNow.AddDays(-1));
+                        .AggregateStream<QuestParty>(questId, timestamp: DateTimeOffset.UtcNow.AddDays(-1));
                     party_yesterday.ShouldBeNull();
                 }
             }).ShouldThrowIf(

--- a/src/Marten.Testing/Events/end_to_end_event_capture_and_fetching_the_stream_with_non_typed_streams_Tests.cs
+++ b/src/Marten.Testing/Events/end_to_end_event_capture_and_fetching_the_stream_with_non_typed_streams_Tests.cs
@@ -192,7 +192,7 @@ namespace Marten.Testing.Events
                 SpecificationExtensions.ShouldNotBeNull(party_at_version_3);
 
                 var party_yesterday = session.Events
-                                             .AggregateStream<QuestParty>(questId, timestamp: DateTime.UtcNow.AddDays(-1));
+                                             .AggregateStream<QuestParty>(questId, timestamp: DateTimeOffset.UtcNow.AddDays(-1));
                 party_yesterday.ShouldBeNull();
             }
 
@@ -231,7 +231,7 @@ namespace Marten.Testing.Events
                 party_at_version_3.Id.ShouldBe(questId);
 
                 var party_yesterday = session.Events
-                                             .AggregateStream<QuestParty>(questId, timestamp: DateTime.UtcNow.AddDays(-1));
+                                             .AggregateStream<QuestParty>(questId, timestamp: DateTimeOffset.UtcNow.AddDays(-1));
                 party_yesterday.ShouldBeNull();
             }
         }

--- a/src/Marten.Testing/Linq/Compatibility/simple_where_clauses.cs
+++ b/src/Marten.Testing/Linq/Compatibility/simple_where_clauses.cs
@@ -86,7 +86,7 @@ namespace Marten.Testing.Linq.Compatibility
             @where(x => x.Decimal.Equals(10));
             @where(x => !x.Decimal.Equals(10));
 
-            var today = DateTime.Today.ToUniversalTime();
+            var today = DateTime.Today;
 
             @where(x => x.Date == today);
             @where(x => x.Date != today);

--- a/src/Marten.Testing/Linq/query_against_dateoffset_Tests.cs
+++ b/src/Marten.Testing/Linq/query_against_dateoffset_Tests.cs
@@ -16,15 +16,15 @@ namespace Marten.Testing.Linq
         [Fact]
         public void query()
         {
-            theSession.Store(new Target{Number = 1, DateOffset = DateTimeOffset.Now.AddMinutes(30)});
-            theSession.Store(new Target{Number = 2, DateOffset = DateTimeOffset.Now.AddDays(1)});
-            theSession.Store(new Target{Number = 3, DateOffset = DateTimeOffset.Now.AddHours(1)});
-            theSession.Store(new Target{Number = 4, DateOffset = DateTimeOffset.Now.AddHours(-2)});
-            theSession.Store(new Target{Number = 5, DateOffset = DateTimeOffset.Now.AddHours(-3)});
+            theSession.Store(new Target{Number = 1, DateOffset = DateTimeOffset.UtcNow.AddMinutes(30)});
+            theSession.Store(new Target{Number = 2, DateOffset = DateTimeOffset.UtcNow.AddDays(1)});
+            theSession.Store(new Target{Number = 3, DateOffset = DateTimeOffset.UtcNow.AddHours(1)});
+            theSession.Store(new Target{Number = 4, DateOffset = DateTimeOffset.UtcNow.AddHours(-2)});
+            theSession.Store(new Target{Number = 5, DateOffset = DateTimeOffset.UtcNow.AddHours(-3)});
 
             theSession.SaveChanges();
 
-            theSession.Query<Target>().Where(x => x.DateOffset > DateTimeOffset.Now).ToArray()
+            theSession.Query<Target>().Where(x => x.DateOffset > DateTimeOffset.UtcNow).ToArray()
                 .Select(x => x.Number)
                 .ShouldHaveTheSameElementsAs(1, 2, 3);
         }
@@ -37,16 +37,16 @@ namespace Marten.Testing.Linq
                 _.Schema.For<Target>().Index(x => x.DateOffset);
             });
 
-            theSession.Store(new Target { Number = 1, DateOffset = DateTimeOffset.Now.AddMinutes(30) });
-            theSession.Store(new Target { Number = 2, DateOffset = DateTimeOffset.Now.AddDays(1) });
-            theSession.Store(new Target { Number = 3, DateOffset = DateTimeOffset.Now.AddHours(1) });
-            theSession.Store(new Target { Number = 4, DateOffset = DateTimeOffset.Now.AddHours(-2) });
-            theSession.Store(new Target { Number = 5, DateOffset = DateTimeOffset.Now.AddHours(-3) });
+            theSession.Store(new Target { Number = 1, DateOffset = DateTimeOffset.UtcNow.AddMinutes(30) });
+            theSession.Store(new Target { Number = 2, DateOffset = DateTimeOffset.UtcNow.AddDays(1) });
+            theSession.Store(new Target { Number = 3, DateOffset = DateTimeOffset.UtcNow.AddHours(1) });
+            theSession.Store(new Target { Number = 4, DateOffset = DateTimeOffset.UtcNow.AddHours(-2) });
+            theSession.Store(new Target { Number = 5, DateOffset = DateTimeOffset.UtcNow.AddHours(-3) });
 
             theSession.SaveChanges();
 
 
-            theSession.Query<Target>().Where(x => x.DateOffset > DateTimeOffset.Now).OrderBy(x => x.DateOffset).ToArray()
+            theSession.Query<Target>().Where(x => x.DateOffset > DateTimeOffset.UtcNow).OrderBy(x => x.DateOffset).ToArray()
                 .Select(x => x.Number)
                 .ShouldHaveTheSameElementsAs(1, 3, 2);
         }

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -22,9 +22,11 @@
   <ItemGroup>
     <PackageReference Include="Jil" Version="3.0.0-alpha2" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Lamar" Version="5.0.4" />
+    <PackageReference Include="Lamar" Version="7.0.0" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
+    <PackageReference Include="Lamar" Version="6.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -43,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.0">
+    <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -1,57 +1,74 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+        <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <None Update="**/*.js;connection.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="bin\**\*">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </None>
-    <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-      <ProjectReference Include="..\Marten\Marten.csproj" />
-      <ProjectReference Include="..\Marten.Testing.OtherAssembly\Marten.Testing.OtherAssembly.csproj" />
-      <ProjectReference Include="..\Marten.Testing.ThirdAssembly\Marten.Testing.ThirdAssembly.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Lamar" Version="7.0.0" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
-    <PackageReference Include="Lamar" Version="6.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Update="**/*.js;connection.txt">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="bin\**\*">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+        </None>
+        <None Include="App.config"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\Marten.Testing.OtherAssembly\Marten.Testing.OtherAssembly.csproj"/>
+        <ProjectReference Include="..\Marten.Testing.ThirdAssembly\Marten.Testing.ThirdAssembly.csproj"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Internals\SqlGeneration" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+        <PackageReference Include="Lamar" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.22"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.22"/>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+        <PackageReference Include="Lamar" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0"/>
+    </ItemGroup>
 
-  <PropertyGroup>
-    <NoWarn>xUnit1013</NoWarn>
-  </PropertyGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+        <PackageReference Include="Lamar" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0"/>
+    </ItemGroup>
+
+
+    <ItemGroup>
+        <PackageReference Include="Jil" Version="3.0.0-alpha2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit" Version="2.4.1"/>
+        <PackageReference Include="NSubstitute" Version="4.2.2"/>
+        <PackageReference Include="Shouldly" Version="4.0.3"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Folder Include="Internals\SqlGeneration"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.2.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <PropertyGroup>
+        <NoWarn>xUnit1013</NoWarn>
+    </PropertyGroup>
 </Project>

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Lamar" Version="5.0.4" />

--- a/src/Marten/Events/EventStatement.cs
+++ b/src/Marten/Events/EventStatement.cs
@@ -101,7 +101,7 @@ namespace Marten.Events
 
         public long Version { get; set; }
 
-        public DateTime? Timestamp { get; set; }
+        public DateTimeOffset? Timestamp { get; set; }
 
         public string TenantId { get; set; } = ALL_TENANTS;
 

--- a/src/Marten/Events/IQueryEventStore.cs
+++ b/src/Marten/Events/IQueryEventStore.cs
@@ -17,7 +17,7 @@ namespace Marten.Events
         /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
         /// <param name="fromVersion">If set, queries for events on or from this version</param>
         /// <returns></returns>
-        IReadOnlyList<IEvent> FetchStream(Guid streamId, long version = 0, DateTime? timestamp = null, long fromVersion = 0);
+        IReadOnlyList<IEvent> FetchStream(Guid streamId, long version = 0, DateTimeOffset? timestamp = null, long fromVersion = 0);
 
         /// <summary>
         /// Synchronously fetches all of the events for the named stream
@@ -28,7 +28,7 @@ namespace Marten.Events
         /// <param name="fromVersion">If set, queries for events on or from this version</param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0, DateTime? timestamp = null, long fromVersion = 0, CancellationToken token = default);
+        Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0, DateTimeOffset? timestamp = null, long fromVersion = 0, CancellationToken token = default);
 
         /// <summary>
         /// Synchronously fetches all of the events for the named stream
@@ -37,7 +37,7 @@ namespace Marten.Events
         /// <param name="version">If set, queries for events up to and including this version</param>
         /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
         /// <returns></returns>
-        IReadOnlyList<IEvent> FetchStream(string streamKey, long version = 0, DateTime? timestamp = null, long fromVersion = 0);
+        IReadOnlyList<IEvent> FetchStream(string streamKey, long version = 0, DateTimeOffset? timestamp = null, long fromVersion = 0);
 
         /// <summary>
         /// Synchronously fetches all of the events for the named stream
@@ -48,7 +48,7 @@ namespace Marten.Events
         /// <param name="fromVersion">If set, queries for events on or from this version</param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<IReadOnlyList<IEvent>> FetchStreamAsync(string streamKey, long version = 0, DateTime? timestamp = null, long fromVersion = 0, CancellationToken token = default);
+        Task<IReadOnlyList<IEvent>> FetchStreamAsync(string streamKey, long version = 0, DateTimeOffset? timestamp = null, long fromVersion = 0, CancellationToken token = default);
 
         /// <summary>
         /// Perform a live aggregation of the raw events in this stream to a T object
@@ -60,7 +60,7 @@ namespace Marten.Events
         /// <param name="fromVersion">If set, queries for events on or from this version</param>
         /// <param name="state">Instance of T to apply events to</param>
         /// <returns></returns>
-        T? AggregateStream<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T? state = null, long fromVersion = 0) where T : class;
+        T? AggregateStream<T>(Guid streamId, long version = 0, DateTimeOffset? timestamp = null, T? state = null, long fromVersion = 0) where T : class;
 
         /// <summary>
         /// Perform a live aggregation of the raw events in this stream to a T object
@@ -73,7 +73,7 @@ namespace Marten.Events
         /// <param name="state">Instance of T to apply events to</param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T?> AggregateStreamAsync<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T? state = null, long fromVersion = 0, CancellationToken token = default) where T : class;
+        Task<T?> AggregateStreamAsync<T>(Guid streamId, long version = 0, DateTimeOffset? timestamp = null, T? state = null, long fromVersion = 0, CancellationToken token = default) where T : class;
 
         /// <summary>
         /// Perform a live aggregation of the raw events in this stream to a T object
@@ -84,7 +84,7 @@ namespace Marten.Events
         /// <param name="timestamp"></param>
         /// <param name="state">Instance of T to apply events to</param>
         /// <returns></returns>
-        T? AggregateStream<T>(string streamKey, long version = 0, DateTime? timestamp = null, T? state = null, long fromVersion = 0) where T : class;
+        T? AggregateStream<T>(string streamKey, long version = 0, DateTimeOffset? timestamp = null, T? state = null, long fromVersion = 0) where T : class;
 
         /// <summary>
         /// Perform a live aggregation of the raw events in this stream to a T object
@@ -97,7 +97,7 @@ namespace Marten.Events
         /// <param name="state">Instance of T to apply events to</param>
         /// <param name="token"></param>
         /// <returns></returns>
-        Task<T?> AggregateStreamAsync<T>(string streamKey, long version = 0, DateTime? timestamp = null, T? state = null, long fromVersion = 0, CancellationToken token = default) where T : class;
+        Task<T?> AggregateStreamAsync<T>(string streamKey, long version = 0, DateTimeOffset? timestamp = null, T? state = null, long fromVersion = 0, CancellationToken token = default) where T : class;
 
         /// <summary>
         /// Query directly against ONLY the raw event data. Use IQuerySession.Query() for aggregated documents!

--- a/src/Marten/Events/QueryEventStore.cs
+++ b/src/Marten/Events/QueryEventStore.cs
@@ -27,7 +27,7 @@ namespace Marten.Events
             _tenant = tenant;
         }
 
-        public IReadOnlyList<IEvent> FetchStream(Guid streamId, long version = 0, DateTime? timestamp = null, long fromVersion = 0)
+        public IReadOnlyList<IEvent> FetchStream(Guid streamId, long version = 0, DateTimeOffset? timestamp = null, long fromVersion = 0)
         {
             var selector = _store.Events.EnsureAsGuidStorage(_session);
 
@@ -41,7 +41,7 @@ namespace Marten.Events
             return _session.ExecuteHandler(handler);
         }
 
-        public Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0, DateTime? timestamp = null, long fromVersion = 0, CancellationToken token = default)
+        public Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0, DateTimeOffset? timestamp = null, long fromVersion = 0, CancellationToken token = default)
         {
             var selector = _store.Events.EnsureAsGuidStorage(_session);
 
@@ -55,7 +55,7 @@ namespace Marten.Events
             return _session.ExecuteHandlerAsync(handler, token);
         }
 
-        public IReadOnlyList<IEvent> FetchStream(string streamKey, long version = 0, DateTime? timestamp = null, long fromVersion = 0)
+        public IReadOnlyList<IEvent> FetchStream(string streamKey, long version = 0, DateTimeOffset? timestamp = null, long fromVersion = 0)
         {
             var selector = _store.Events.EnsureAsStringStorage(_session);
 
@@ -69,7 +69,7 @@ namespace Marten.Events
             return _session.ExecuteHandler(handler);
         }
 
-        public Task<IReadOnlyList<IEvent>> FetchStreamAsync(string streamKey, long version = 0, DateTime? timestamp = null, long fromVersion = 0, CancellationToken token = default)
+        public Task<IReadOnlyList<IEvent>> FetchStreamAsync(string streamKey, long version = 0, DateTimeOffset? timestamp = null, long fromVersion = 0, CancellationToken token = default)
         {
             var selector = _store.Events.EnsureAsStringStorage(_session);
 
@@ -83,7 +83,7 @@ namespace Marten.Events
             return _session.ExecuteHandlerAsync(handler, token);
         }
 
-        public T? AggregateStream<T>(Guid streamId, long version = 0, DateTime? timestamp = null, T? state = null, long fromVersion = 0) where T : class
+        public T? AggregateStream<T>(Guid streamId, long version = 0, DateTimeOffset? timestamp = null, T? state = null, long fromVersion = 0) where T : class
         {
             var events = FetchStream(streamId, version, timestamp, fromVersion);
 
@@ -99,7 +99,7 @@ namespace Marten.Events
             return aggregate;
         }
 
-        public async Task<T?> AggregateStreamAsync<T>(Guid streamId, long version = 0, DateTime? timestamp = null,
+        public async Task<T?> AggregateStreamAsync<T>(Guid streamId, long version = 0, DateTimeOffset? timestamp = null,
             T? state = null, long fromVersion = 0, CancellationToken token = default) where T : class
         {
             var events = await FetchStreamAsync(streamId, version, timestamp, fromVersion, token).ConfigureAwait(false);
@@ -116,7 +116,7 @@ namespace Marten.Events
             return aggregate;
         }
 
-        public T? AggregateStream<T>(string streamKey, long version = 0, DateTime? timestamp = null, T? state = null, long fromVersion = 0) where T : class
+        public T? AggregateStream<T>(string streamKey, long version = 0, DateTimeOffset? timestamp = null, T? state = null, long fromVersion = 0) where T : class
         {
             var events = FetchStream(streamKey, version, timestamp, fromVersion);
             if (!events.Any())
@@ -133,7 +133,7 @@ namespace Marten.Events
             return aggregate;
         }
 
-        public async Task<T?> AggregateStreamAsync<T>(string streamKey, long version = 0, DateTime? timestamp = null,
+        public async Task<T?> AggregateStreamAsync<T>(string streamKey, long version = 0, DateTimeOffset? timestamp = null,
             T? state = null, long fromVersion = 0, CancellationToken token = default) where T : class
         {
             var events = await FetchStreamAsync(streamKey, version, timestamp, fromVersion, token).ConfigureAwait(false);

--- a/src/Marten/Events/StreamAction.cs
+++ b/src/Marten/Events/StreamAction.cs
@@ -125,12 +125,12 @@ namespace Marten.Events
         /// <summary>
         /// The recorded timestamp for these events
         /// </summary>
-        public DateTime? Timestamp { get; internal set; }
+        public DateTimeOffset? Timestamp { get; internal set; }
 
         /// <summary>
         /// When was the stream created
         /// </summary>
-        public DateTime? Created { get; internal set; }
+        public DateTimeOffset? Created { get; internal set; }
 
 
         /// <summary>

--- a/src/Marten/Events/StreamState.cs
+++ b/src/Marten/Events/StreamState.cs
@@ -24,12 +24,12 @@ namespace Marten.Events
         /// <summary>
         /// The last time this stream was appended to
         /// </summary>
-        public DateTime LastTimestamp { get; set;}
+        public DateTimeOffset LastTimestamp { get; set;}
 
         /// <summary>
         /// The time at which this stream was created
         /// </summary>
-        public DateTime Created { get; set;}
+        public DateTimeOffset Created { get; set;}
 
         /// <summary>
         /// The identity of this stream if using strings as the stream
@@ -49,7 +49,7 @@ namespace Marten.Events
         }
 #nullable enable
 
-        public StreamState(Guid id, long version, Type aggregateType, DateTime lastTimestamp, DateTime created)
+        public StreamState(Guid id, long version, Type aggregateType, DateTimeOffset lastTimestamp, DateTimeOffset created)
         {
             Id = id;
             Version = version;
@@ -58,7 +58,7 @@ namespace Marten.Events
             Created = created;
         }
 
-        public StreamState(string key, long version, Type aggregateType, DateTime lastTimestamp, DateTime created)
+        public StreamState(string key, long version, Type aggregateType, DateTimeOffset lastTimestamp, DateTimeOffset created)
         {
             Key = key;
             Version = version;

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -29,7 +29,7 @@
         <PackageReference Include="System.Memory" Version="4.5.4" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
         <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.21" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
         <PackageReference Include="System.Text.Json" Version="6.0.0" />
         <PackageReference Include="Weasel.Postgresql" Version="2.0.0-alpha.3" />

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
         <PackageReference Include="System.Text.Json" Version="6.0.0" />
-        <PackageReference Include="Weasel.Postgresql" Version="2.0.0-alpha.3" />
+        <PackageReference Include="Weasel.Postgresql" Version="2.0.0-alpha.4" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -23,16 +23,16 @@
         <PackageReference Include="LamarCodeGeneration" Version="[4.0.0,5.0.0)" />
         <PackageReference Include="LamarCompiler" Version="[4.0.0,5.0.0)" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-        <PackageReference Include="Npgsql.Json.NET" Version="[5.0.10,6.0)" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Npgsql.Json.NET" Version="[6.0.0,7.0)" />
         <PackageReference Include="Remotion.Linq" Version="2.2.0" />
         <PackageReference Include="System.Memory" Version="4.5.4" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
         <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
-        <PackageReference Include="System.Text.Json" Version="5.0.2" />
-        <PackageReference Include="Weasel.Postgresql" Version="1.3.0" />
+        <PackageReference Include="System.Text.Json" Version="6.0.0" />
+        <PackageReference Include="Weasel.Postgresql" Version="2.0.0-alpha.3" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -19,18 +19,18 @@
         <EmbeddedResource Include="Schema\SchemaObjects.sql" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="BaselineTypeDiscovery" Version="1.1.2" />
-        <PackageReference Include="LamarCodeGeneration" Version="[4.0.0,5.0.0)" />
-        <PackageReference Include="LamarCompiler" Version="[4.0.0,5.0.0)" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+        <PackageReference Include="BaselineTypeDiscovery" Version="1.1.3" />
+        <PackageReference Include="LamarCodeGeneration" Version="4.0.0" />
+        <PackageReference Include="LamarCompiler" Version="4.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="Npgsql.Json.NET" Version="[6.0.0,7.0)" />
         <PackageReference Include="Remotion.Linq" Version="2.2.0" />
         <PackageReference Include="System.Memory" Version="4.5.4" />
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
+        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
         <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.21" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
         <PackageReference Include="System.Text.Json" Version="6.0.0" />
         <PackageReference Include="Weasel.Postgresql" Version="2.0.0-alpha.3" />
     </ItemGroup>

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -18,21 +18,44 @@
         <EmbeddedResource Include="Schema\SQL\*.*" />
         <EmbeddedResource Include="Schema\SchemaObjects.sql" />
     </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="LamarCodeGeneration" Version="[3.2.2,4.0.0)" />
+        <PackageReference Include="LamarCompiler" Version="[3.0.4,4.0.0)" />
+
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.22" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.22" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.22" />
+        <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+        <PackageReference Include="LamarCodeGeneration" Version="[3.2.2,4.0.0)" />
+        <PackageReference Include="LamarCompiler" Version="[3.0.4,4.0.0)" />
+
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+        <PackageReference Include="LamarCodeGeneration" Version="[4.0.0,5.0.0)" />
+        <PackageReference Include="LamarCompiler" Version="[4.0.0,5.0.0)" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    </ItemGroup>
+
     <ItemGroup>
         <PackageReference Include="BaselineTypeDiscovery" Version="1.1.3" />
-        <PackageReference Include="LamarCodeGeneration" Version="4.0.0" />
-        <PackageReference Include="LamarCompiler" Version="4.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="Npgsql.Json.NET" Version="[6.0.0,7.0)" />
+        <PackageReference Include="Npgsql.Json.NET" Version="[6.0.1,7.0.0)" />
         <PackageReference Include="Remotion.Linq" Version="2.2.0" />
         <PackageReference Include="System.Memory" Version="4.5.4" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
         <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
         <PackageReference Include="System.Text.Json" Version="6.0.0" />
-        <PackageReference Include="Weasel.Postgresql" Version="2.0.0-alpha.4" />
+        <PackageReference Include="Weasel.Postgresql" Version="2.0.0-alpha.5" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -51,9 +51,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="Npgsql.Json.NET" Version="[6.0.1,7.0.0)" />
         <PackageReference Include="Remotion.Linq" Version="2.2.0" />
-        <PackageReference Include="System.Memory" Version="4.5.4" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
-        <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
         <PackageReference Include="System.Text.Json" Version="6.0.0" />
         <PackageReference Include="Weasel.Postgresql" Version="2.0.0-alpha.5" />
     </ItemGroup>

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -53,7 +53,7 @@
         <PackageReference Include="Remotion.Linq" Version="2.2.0" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
         <PackageReference Include="System.Text.Json" Version="6.0.0" />
-        <PackageReference Include="Weasel.Postgresql" Version="2.0.0-alpha.5" />
+        <PackageReference Include="Weasel.Postgresql" Version="2.0.0" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->

--- a/src/Marten/Storage/Metadata/LastModifiedColumn.cs
+++ b/src/Marten/Storage/Metadata/LastModifiedColumn.cs
@@ -18,7 +18,7 @@ namespace Marten.Storage.Metadata
             int index, DocumentMapping mapping)
         {
             var variableName = "lastModified";
-            var memberType = typeof(DateTime);
+            var memberType = typeof(DateTimeOffset);
 
             if (Member == null) return;
 

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -543,11 +543,6 @@ namespace Marten
         EnumStorage DuplicatedFieldEnumStorage { get; }
 
         /// <summary>
-        ///     Decides if `timestamp without time zone` database type should be used for `DateTime` DuplicatedField.
-        /// </summary>
-        bool DuplicatedFieldUseTimestampWithoutTimeZoneForDateTime { get; }
-
-        /// <summary>
         ///     Global default parameters for Hilo sequences within the DocumentStore. Can be overridden per document
         ///     type as well
         /// </summary>

--- a/src/MartenBenchmarks/MartenBenchmarks.csproj
+++ b/src/MartenBenchmarks/MartenBenchmarks.csproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <OutputType>Exe</OutputType>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <OutputType>Exe</OutputType>
+        <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+        <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj" />
-    <ProjectReference Include="..\Marten\Marten.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Benchmarks" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj"/>
+        <ProjectReference Include="..\Marten\Marten.csproj"/>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.1"/>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    </ItemGroup>
+    <ItemGroup>
+        <Folder Include="Benchmarks"/>
+    </ItemGroup>
 </Project>

--- a/src/StorytellerRunner/StorytellerRunner.csproj
+++ b/src/StorytellerRunner/StorytellerRunner.csproj
@@ -11,6 +11,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Updated Weasel to 2.0.0 and fixed DateTime related tests to follow new Npgsql rules https://www.npgsql.org/doc/index.html (DateTimeOffset for UTC, DateTime for without time zone).
- Added NodaTime mappings.

See related PR for Weasel: https://github.com/JasperFx/weasel/pull/35