### PR TITLE
Add NGram search functionality. Generates unigrams, bigrams & trigram…

### DIFF
--- a/src/Marten.Testing/Linq/NgramSearchTests.cs
+++ b/src/Marten.Testing/Linq/NgramSearchTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Marten.Testing.Harness;
+using Xunit;
+
+namespace Marten.Testing.Linq
+{
+    public class NgramSearchTests : IntegrationContext
+    {
+        public NgramSearchTests(DefaultStoreFixture fixture) : base(fixture)
+        {
+        }
+
+        public sealed class User
+        {
+            public int Id { get; set; }
+            public string UserName { get; set; }
+
+            public User(int id, string userName)
+            {
+                Id = id;
+                UserName = userName;
+            }
+        }
+
+        [Fact]
+        public void test_ngram_search_returns_data()
+        {
+            string term = null;
+            var userDictionary = new Dictionary<int, User>();
+            using var session = theStore.OpenSession();
+            for (var i = 1; i < 4; i++)
+            {
+                var guid = $"{Guid.NewGuid():N}";
+                if (term == null)
+                {
+                    term = guid.Substring(5);
+                }
+
+                var newUser = new User(i, $"Test user {guid}");
+
+                session.Store(newUser);
+            }
+
+            session.SaveChanges();
+
+            var query = session.Query<User>()
+                //.Where(x => x.Content.PlainTextSearch(term)).ToList();
+                //.Where(x => x.Content.Search(term)).ToList();
+                .Where(x => x.UserName.NgramSearch(term)).ToList();
+            
+            query.ShouldNotBeNull();
+            query.First().UserName.ShouldContain(term);
+        }
+    }
+}

--- a/src/Marten/Linq/Parsing/Methods/FullTextSearchMethodCallParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/FullTextSearchMethodCallParser.cs
@@ -13,7 +13,8 @@ namespace Marten.Linq.Parsing.Methods
         to_tsquery,
         plainto_tsquery,
         phraseto_tsquery,
-        websearch_to_tsquery
+        websearch_to_tsquery,
+        mt_ngram_tsvector
     }
 
     internal abstract class FullTextSearchMethodCallParser: IMethodCallParser

--- a/src/Marten/Linq/Parsing/Methods/NgramSearch.cs
+++ b/src/Marten/Linq/Parsing/Methods/NgramSearch.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using System.Linq.Expressions;
+using Marten.Linq.Fields;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.Parsing.Methods
+{
+    public class NgramSearch: IMethodCallParser
+    {
+        public bool Matches(MethodCallExpression expression)
+        {
+            return expression.Method.Name == nameof(LinqExtensions.NgramSearch)
+                   && expression.Method.DeclaringType == typeof(LinqExtensions);
+        }
+
+        public ISqlFragment Parse(IFieldMapping mapping, ISerializer serializer, MethodCallExpression expression)
+        {
+            var members = FindMembers.Determine(expression);
+
+            var locator = mapping.FieldFor(members).RawLocator;
+            var values = expression.Arguments.Last().Value();
+
+            return new WhereFragment($"mt_grams_vector({locator}) @@ mt_grams_query(?)", values);
+        }
+    }
+}

--- a/src/Marten/LinqExtensions.cs
+++ b/src/Marten/LinqExtensions.cs
@@ -252,5 +252,14 @@ namespace Marten
         {
             throw new NotSupportedException($"{nameof(WebStyleSearch)} extension method can only be used in Marten Linq queries.");
         }
+
+        /// <summary>
+        /// Performs a ngram search against <typeparamref name="T"/> using a custom ngram search function
+        /// </summary>
+        /// <param name="searchTerm">The text to search for.</param>
+        public static bool NgramSearch<T>(this T variable, string searchTerm)
+        {
+            throw new NotSupportedException($"{nameof(NgramSearch)} extension method can only be used in Marten Linq queries.");
+        }
     }
 }

--- a/src/Marten/LinqParsing.cs
+++ b/src/Marten/LinqParsing.cs
@@ -97,7 +97,8 @@ namespace Marten
             new Search(),
             new PhraseSearch(),
             new PlainTextSearch(),
-            new WebStyleSearch()
+            new WebStyleSearch(),
+            new NgramSearch(),
         };
 
 

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -12,6 +12,9 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
+        <None Remove="Schema\SQL\mt_grams_array.sql" />
+        <None Remove="Schema\SQL\mt_grams_query.sql" />
+        <None Remove="Schema\SQL\mt_grams_vector.sql" />
         <None Remove="Schema\SQL\mt_immutable_timestamptz.sql" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -348,6 +348,47 @@ namespace Marten
             }
 
             /// <summary>
+            /// Creates an n-gram index for the field which can be used for substring based matching, similar to the trigram extension but also generates uni-grams and bi-grams.
+            /// </summary>
+            /// <param name="configure">
+            /// </param>
+            /// <returns>
+            /// </returns>
+            public DocumentMappingExpression<T> NgramIndex(Action<NgramIndex> configure)
+            {
+                _builder.Alter = m => m.AddNgramIndex(configure);
+                return this;
+            }
+
+            /// <summary>
+            /// Creates an n-gram index for the field which can be used for substring based matching, similar to the trigram extension but also generates uni-grams and bi-grams.
+            /// </summary>
+            /// <param name="expression">
+            /// </param>
+            /// <returns>
+            /// </returns>
+            public DocumentMappingExpression<T> NgramIndex(Expression<Func<T, object>> expression)
+            {
+                _builder.Alter = m => m.NgramIndex(expression);
+                return this;
+            }
+
+            /// <summary>
+            /// Creates an n-gram index for the field which can be used for substring based matching, similar to the trigram extension but also generates uni-grams and bi-grams.
+            /// </summary>
+            /// <param name="configure">
+            /// </param>
+            /// <param name="expression">
+            /// </param>
+            /// <returns>
+            /// </returns>
+            public DocumentMappingExpression<T> NgramIndex(Action<NgramIndex> configure, Expression<Func<T, object>> expression)
+            {
+                _builder.Alter = m => m.NgramIndex(configure, expression);
+                return this;
+            }
+
+            /// <summary>
             ///     Add a foreign key reference to another document type
             /// </summary>
             /// <param name="expression"></param>

--- a/src/Marten/Schema/NgramIndex.cs
+++ b/src/Marten/Schema/NgramIndex.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Baseline;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tables;
+
+namespace Marten.Schema
+{
+    /// <summary>
+    /// Implements an index that extracts ngrams for the specified field.
+    /// </summary>
+    public class NgramIndex: IndexDefinition
+    {
+        public const string DefaultRegConfig = "english";
+        public const string DefaultDataConfig = "data";
+
+        private string _dataConfig;
+        private readonly DbObjectName _table;
+        private string _indexName;
+
+        public NgramIndex(DocumentMapping mapping, string dataConfig = null, string indexName = null)
+        {
+            _table = mapping.TableName;
+            DataConfig = dataConfig;
+            _indexName = indexName;
+
+            Method = IndexMethod.gin;
+        }
+
+        public NgramIndex(DocumentMapping mapping, MemberInfo[] member)
+            : this(mapping, GetDataConfig(mapping, member))
+        {
+        }
+
+        protected override string deriveIndexName()
+        {
+            var lowerValue = _indexName?.ToLowerInvariant();
+            if (lowerValue?.StartsWith(SchemaConstants.MartenPrefix) == true)
+                return lowerValue.ToLowerInvariant();
+            else if (lowerValue?.IsNotEmpty() == true)
+                return SchemaConstants.MartenPrefix + lowerValue.ToLowerInvariant();
+            else
+            {
+                var arrowIndex = _dataConfig.IndexOf("->>", StringComparison.InvariantCultureIgnoreCase);
+
+                var indexFieldName = arrowIndex != -1 ? _dataConfig.Substring(arrowIndex + 3).Trim().Replace("'", string.Empty).ToLowerInvariant() : _dataConfig;
+                return $"{_table.Name}_idx_ngram_{indexFieldName}";
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the data config.
+        /// </summary>
+        public string DataConfig
+        {
+            get => _dataConfig;
+            set => _dataConfig = value ?? DefaultDataConfig;
+        }
+
+        public override string[] Columns
+        {
+            get
+            {
+                return new string[] { $"mt_grams_vector( {_dataConfig})" };
+            }
+            set
+            {
+                // nothing
+            }
+        }
+
+        private static string GetDataConfig(DocumentMapping mapping, MemberInfo[] members)
+        {
+            var dataConfig = members
+                .Select(m => $"{mapping.FieldFor(m).TypedLocator.Replace("d.", "")}")
+                .Join(" || ' ' || ");
+
+            return $"{dataConfig}";
+        }
+    }
+}

--- a/src/Marten/Schema/SQL/mt_grams_array.sql
+++ b/src/Marten/Schema/SQL/mt_grams_array.sql
@@ -1,0 +1,23 @@
+CREATE OR REPLACE FUNCTION {databaseSchema}.mt_grams_array(words text)
+        RETURNS text[]		
+        LANGUAGE plpgsql
+        IMMUTABLE STRICT
+AS $function$
+        DECLARE result text[];
+        DECLARE word text;
+        DECLARE clean_word text;
+        BEGIN
+                FOREACH word IN ARRAY string_to_array(words, ' ')
+                LOOP
+                     clean_word = regexp_replace(word, '[^a-zA-Z0-9]+', '','g');
+                     FOR i IN 1 .. length(clean_word)
+                     LOOP
+                         result := result || quote_literal(substr(lower(clean_word), i, 1));
+                         result := result || quote_literal(substr(lower(clean_word), i, 2));
+                         result := result || quote_literal(substr(lower(clean_word), i, 3));
+                     END LOOP;
+                END LOOP;
+
+                RETURN ARRAY(SELECT DISTINCT e FROM unnest(result) AS a(e) ORDER BY e);
+        END;
+$function$;

--- a/src/Marten/Schema/SQL/mt_grams_query.sql
+++ b/src/Marten/Schema/SQL/mt_grams_query.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION {databaseSchema}.mt_grams_query(text)
+        RETURNS tsquery		
+        LANGUAGE plpgsql
+        IMMUTABLE STRICT
+AS $function$
+BEGIN
+        RETURN (SELECT array_to_string(mt_grams_array($1), ' & ')::tsquery);
+END
+$function$;

--- a/src/Marten/Schema/SQL/mt_grams_vector.sql
+++ b/src/Marten/Schema/SQL/mt_grams_vector.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION {databaseSchema}.mt_grams_vector(text)
+        RETURNS tsvector		
+        LANGUAGE plpgsql
+        IMMUTABLE STRICT
+AS $function$
+BEGIN
+        RETURN (SELECT array_to_string(mt_grams_array($1), ' ')::tsvector);
+END
+$function$;

--- a/src/Marten/Storage/StorageFeatures.cs
+++ b/src/Marten/Storage/StorageFeatures.cs
@@ -220,6 +220,9 @@ namespace Marten.Storage
         {
             SystemFunctions.AddSystemFunction(_options, "mt_immutable_timestamp", "text");
             SystemFunctions.AddSystemFunction(_options, "mt_immutable_timestamptz", "text");
+            SystemFunctions.AddSystemFunction(_options, "mt_grams_vector", "text");
+            SystemFunctions.AddSystemFunction(_options, "mt_grams_query", "text");
+            SystemFunctions.AddSystemFunction(_options, "mt_grams_array", "text");
 
             Add(SystemFunctions);
 


### PR DESCRIPTION
Add NGram search functionality. Generates unigrams, bigrams & trigrams since that allows us the best search experience. Previously, search was not able to accurately match strings for multi search terms if the term was within a multi word string and within the words. Example, we now accurately match 'rich com text' within 'Communicating Across Contexts (Enriched)'. Currently, defaults to english.