### PR TITLE
Fix #1995 - Early Exit ApplyChanges when Page has No Changes

### DIFF
--- a/src/Marten.Testing/Events/Bugs/Bug_1995_empty_batch_update_failure.cs
+++ b/src/Marten.Testing/Events/Bugs/Bug_1995_empty_batch_update_failure.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Bug1995;
+using Marten;
+using Marten.Events;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+
+using Xunit;
+
+namespace Marten.Testing.Events.Bugs
+{
+    public class Bug_1995_empty_batch_update_failure : BugIntegrationContext
+    {
+        [Fact]
+        public async Task should_be_able_to_apply_an_update_batch_with_no_changes()
+        {
+            using var documentStore = SeparateStore(x =>
+            {
+                x.Events.StreamIdentity = StreamIdentity.AsGuid;
+                x.Projections.Add(new IssueAggregateProjection(), ProjectionLifecycle.Async, "IssueAggregate");
+            });
+
+            await RunTest(documentStore);
+        }
+
+        private static async Task RunTest(IDocumentStore documentStore)
+        {
+            await documentStore.Advanced.Clean.CompletelyRemoveAllAsync();
+
+            await using (var session = documentStore.OpenSession())
+            {
+                for (var i = 0; i < 499; i++)
+                {
+                    var id = Guid.NewGuid();
+                    session.Events.StartStream(id, new Bug1995.IssueCreated { Id = id });
+                }
+
+                await session.SaveChangesAsync();
+            }
+
+            using var daemon = documentStore.BuildProjectionDaemon();
+            await daemon.RebuildProjection<Bug1995.IssueAggregate>(default);
+        }
+    }
+}
+
+namespace Bug1995
+{
+    public class IssueCreated
+    {
+        public Guid Id { get; set; }
+    }
+
+    public class IssueAggregate
+    {
+        public Guid Id { get; set; }
+    }
+
+    public class IssueAggregateProjection : IProjection
+    {
+        public void Apply(IDocumentOperations operations, IReadOnlyList<StreamAction> streams)
+        {
+            var events = streams
+                .SelectMany(x => x.Events)
+                .OrderBy(x => x.Sequence)
+                .Select(x => x.Data)
+                .OfType<IssueCreated>()
+                .ToList();
+
+            operations.Store(events.Select(x => new IssueAggregate { Id = x.Id }));
+        }
+
+        public Task ApplyAsync(IDocumentOperations operations, IReadOnlyList<StreamAction> streams, CancellationToken cancellation)
+        {
+            Apply(operations, streams);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Marten/Events/Daemon/ProjectionUpdateBatch.cs
+++ b/src/Marten/Events/Daemon/ProjectionUpdateBatch.cs
@@ -118,6 +118,11 @@ namespace Marten.Events.Daemon
 
             public void ApplyChanges(IList<Exception> exceptions, IMartenSession session)
             {
+                if (Count == 0)
+                {
+                    return;
+                }
+
                 _command.CommandText = _builder.ToString();
 
                 using var reader = session.Database.ExecuteReader(_command);
@@ -126,6 +131,11 @@ namespace Marten.Events.Daemon
 
             public async Task ApplyChangesAsync(IList<Exception> exceptions, IMartenSession session, CancellationToken token)
             {
+                if (Count == 0)
+                {
+                    return;
+                }
+
                 _command.CommandText = _builder.ToString();
 
                 using var reader = await session.Database.ExecuteReaderAsync(_command, token).ConfigureAwait(false);


### PR DESCRIPTION
When the async daemon processed a batch of SQL command that comes exactly to the `UpdateBatchSize`, there is an empty page in the collection that ends up throwing a `CommandText is not initialized` error. This checks to make sure there is changes, and if not, exits early