### PR TITLE
Added JsonNetObjectContractProvider to enable private non default constructor resolution for Newtonsoft Json.NET

### DIFF
--- a/docs/configuration/json.md
+++ b/docs/configuration/json.md
@@ -152,7 +152,7 @@ private readonly JsonSerializer _serializer = new()
     ContractResolver = new JsonNetContractResolver()
 };
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Services/JsonNetSerializer.cs#L40-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_newtonsoft-configuration' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Services/JsonNetSerializer.cs#L39-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_newtonsoft-configuration' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To customize the Newtonsoft.Json serialization, you need to explicitly supply an instance of Marten's `JsonNetSerializer` as shown below:
@@ -290,8 +290,8 @@ By default `Newtonsoft.Json` only deserializes properties with public setters.
 
 You can allow deserialization of properties with non-public setters by changing the serialization settings in the `DocumentStore` options.
 
-<!-- snippet: sample_customize_json_net_snakecase_nonpublicmembersstorage_nonpublicsetters -->
-<a id='snippet-sample_customize_json_net_snakecase_nonpublicmembersstorage_nonpublicsetters'></a>
+<!-- snippet: sample_customize_json_net_nonpublicsetters -->
+<a id='snippet-sample_customize_json_net_nonpublicsetters'></a>
 ```cs
 var store = DocumentStore.For(_ =>
 {
@@ -302,8 +302,18 @@ var store = DocumentStore.For(_ =>
     _.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.NonPublicSetters);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L177-L187' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_snakecase_nonpublicmembersstorage_nonpublicsetters' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L177-L187' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customize_json_net_nonpublicsetters' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+You can also use other options of `NonPublicMembersStorage`:
+
+- `NonPublicDefaultConstructor` - allows deserialization using non-public default constructor,
+- `NonPublicConstructor` - allows deserialization using any constructor. Construction resolution uses the following precedence:
+  1. Constructor with `JsonConstructor` attribute.
+  2. Constructor with the biggest parameters' count.
+  3. If two constructors have the same parameters' count, use public or take the first one.
+  4. Use default constructor.
+- `All` - Use both properties with non-public setters and non-public constructors.
 
 ## Serialization with System.Text.Json
 

--- a/src/Marten.Testing/Events/Projections/QuestMonsters.cs
+++ b/src/Marten.Testing/Events/Projections/QuestMonsters.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Baseline;
+using Newtonsoft.Json;
 
 namespace Marten.Testing.Events.Projections
 {
@@ -192,16 +193,20 @@ namespace Marten.Testing.Events.Projections
             Monsters = monsters;
         }
 
+        private QuestMonstersWithNonDefaultPublicConstructor()
+        {
+
+        }
+
         public void Apply(MonsterSlayed slayed)
         {
-            if (Monsters == null)
-                Monsters = new List<string>();
+            Monsters ??= new List<string>();
 
             Monsters.Fill(slayed.Name);
         }
     }
 
-    public class QuestMonstersWithDefaultPrivateConstructorAndNonDefaultPublicConstructor: IMonstersView
+    public class WithDefaultPrivateConstructorNonDefaultPublicConstructor: IMonstersView
     {
         public Guid Id { get; private set; }
 
@@ -209,7 +214,7 @@ namespace Marten.Testing.Events.Projections
 
         string[] IMonstersView.Monsters => Monsters.ToArray();
 
-        public QuestMonstersWithDefaultPrivateConstructorAndNonDefaultPublicConstructor(
+        public WithDefaultPrivateConstructorNonDefaultPublicConstructor(
             Guid id,
             string[] monsters
         )
@@ -218,8 +223,151 @@ namespace Marten.Testing.Events.Projections
             Monsters = monsters;
         }
 
-        private QuestMonstersWithDefaultPrivateConstructorAndNonDefaultPublicConstructor()
+        public WithDefaultPrivateConstructorNonDefaultPublicConstructor()
         {
+        }
+
+        public void Apply(MonsterSlayed slayed)
+        {
+            Monsters.Fill(slayed.Name);
+        }
+    }
+
+    public class WithMultiplePublicNonDefaultConstructors: IMonstersView
+    {
+        public Guid Id { get; private set; }
+
+        public IList<string> Monsters { get; private set; } = new List<string>();
+
+        string[] IMonstersView.Monsters => Monsters.ToArray();
+
+        public WithMultiplePublicNonDefaultConstructors(
+            Guid id,
+            string[] monsters
+        ) : this(id)
+        {
+            Monsters = monsters;
+        }
+
+        public WithMultiplePublicNonDefaultConstructors(
+            Guid id
+        )
+        {
+            Id = id;
+        }
+
+        private WithMultiplePublicNonDefaultConstructors()
+        {
+
+        }
+
+        public void Apply(MonsterSlayed slayed)
+        {
+            Monsters.Fill(slayed.Name);
+        }
+    }
+
+    public class WithMultiplePrivateNonDefaultConstructors: IMonstersView
+    {
+        public Guid Id { get; private set; }
+
+        public IList<string> Monsters { get; private set; } = new List<string>();
+
+        string[] IMonstersView.Monsters => Monsters.ToArray();
+
+        private WithMultiplePrivateNonDefaultConstructors(
+            Guid id,
+            string[] monsters
+        ) : this(id)
+        {
+            Monsters = monsters;
+        }
+
+        private WithMultiplePrivateNonDefaultConstructors(
+            Guid id
+        )
+        {
+            Id = id;
+        }
+
+        public WithMultiplePrivateNonDefaultConstructors()
+        {
+
+        }
+
+        public void Apply(MonsterSlayed slayed)
+        {
+            Monsters.Fill(slayed.Name);
+        }
+    }
+
+    public class WithMultiplePrivateNonDefaultConstructorsAndAttribute: IMonstersView
+    {
+        public Guid Id { get; private set; }
+
+        public IList<string> Monsters { get; private set; } = new List<string>();
+
+        string[] IMonstersView.Monsters => Monsters.ToArray();
+
+        [JsonConstructor]
+        private WithMultiplePrivateNonDefaultConstructorsAndAttribute(
+            Guid id,
+            string[] monsters
+        )
+        {
+            Id = id;
+            Monsters = monsters;
+        }
+
+        private WithMultiplePrivateNonDefaultConstructorsAndAttribute(
+            Guid id,
+            string dummyParameters,
+            string toHaveThemMore,
+            string thanConstructorWithAttribute
+        )
+        {
+            Id = id;
+        }
+
+        private WithMultiplePrivateNonDefaultConstructorsAndAttribute()
+        {
+
+        }
+
+        public void Apply(MonsterSlayed slayed)
+        {
+            Monsters.Fill(slayed.Name);
+        }
+    }
+
+    public class WithNonDefaultConstructorsPrivateAndPublicWithEqualParamsCount: IMonstersView
+    {
+        public Guid Id { get; private set; }
+
+        public IList<string> Monsters { get; private set; } = new List<string>();
+
+        string[] IMonstersView.Monsters => Monsters.ToArray();
+
+
+        private WithNonDefaultConstructorsPrivateAndPublicWithEqualParamsCount(
+            Guid id,
+            string dummyParametersToEqualPublicConstructorParamsCount
+        )
+        {
+            Id = id;
+        }
+
+        public WithNonDefaultConstructorsPrivateAndPublicWithEqualParamsCount(
+            Guid id,
+            string[] monsters
+        )
+        {
+            Monsters = monsters;
+        }
+
+        private WithNonDefaultConstructorsPrivateAndPublicWithEqualParamsCount()
+        {
+
         }
 
         public void Apply(MonsterSlayed slayed)

--- a/src/Marten.Testing/Events/Projections/inline_aggregation_with_base_view_class.cs
+++ b/src/Marten.Testing/Events/Projections/inline_aggregation_with_base_view_class.cs
@@ -51,6 +51,7 @@ namespace Marten.Testing.Events.Projections
         {
             var loadedView = theSession.Load<T>(streamId);
 
+            loadedView.ShouldNotBeNull();
             loadedView.Id.ShouldBe(streamId);
             loadedView.Monsters.ShouldHaveTheSameElementsAs("Troll", "Dragon");
 

--- a/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs
+++ b/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs
@@ -172,9 +172,9 @@ namespace Marten.Testing.Examples
             #endregion
         }
 
-        public void customize_json_net_snakecase_nonpublicmembersstorage_nonpublicsetters()
+        public void customize_json_net_nonpublicsetters()
         {
-            #region sample_customize_json_net_snakecase_nonpublicmembersstorage_nonpublicsetters
+            #region sample_customize_json_net_nonpublicsetters
 
             var store = DocumentStore.For(_ =>
             {

--- a/src/Marten/ISerializer.cs
+++ b/src/Marten/ISerializer.cs
@@ -165,6 +165,8 @@ namespace Marten
     {
         Default = 0,
         NonPublicSetters = 1,
-        NonPublicDefaultConstructor = 2
+        NonPublicDefaultConstructor = 2,
+        NonPublicConstructor = 4,
+        All = Default | NonPublicSetters | NonPublicDefaultConstructor | NonPublicConstructor
     }
 }

--- a/src/Marten/Services/Json/JsonNetCollectionToArrayJsonConverter.cs
+++ b/src/Marten/Services/Json/JsonNetCollectionToArrayJsonConverter.cs
@@ -13,9 +13,9 @@ namespace Marten.Services.Json
     /// </summary>
     public class JsonNetCollectionToArrayJsonConverter: JsonConverter
     {
-        public static JsonNetCollectionToArrayJsonConverter Instance = new JsonNetCollectionToArrayJsonConverter();
+        public static JsonNetCollectionToArrayJsonConverter Instance = new();
 
-        private readonly static List<Type> _types = new List<Type>
+        private static readonly List<Type> _types = new()
         {
             typeof(ICollection<>),
             typeof(IList<>),

--- a/src/Marten/Services/Json/JsonNetObjectContractProvider.cs
+++ b/src/Marten/Services/Json/JsonNetObjectContractProvider.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Baseline.ImTools;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+#nullable enable
+
+namespace Marten.Services.Json
+{
+    public static class JsonNetObjectContractProvider
+    {
+        private static readonly Type ConstructorAttributeType = typeof(JsonConstructorAttribute);
+
+        private static readonly Ref<ImHashMap<string, JsonObjectContract>> Constructors =
+            Ref.Of(ImHashMap<string, JsonObjectContract>.Empty);
+
+        public static JsonObjectContract UsingNonDefaultConstructor(
+            JsonObjectContract contract,
+            Type objectType,
+            Func<ConstructorInfo, JsonPropertyCollection, IList<JsonProperty>> createConstructorParameters)
+        {
+            var typeName = objectType.AssemblyQualifiedName!;
+            if (Constructors.Value!.TryFind(typeName, out var value))
+                return value;
+
+            value = OnUsingNonDefaultConstructor(contract, objectType, createConstructorParameters);
+            Constructors.Swap(d => d.AddOrUpdate(typeName, value));
+
+            return value;
+        }
+
+        private static JsonObjectContract OnUsingNonDefaultConstructor(
+            JsonObjectContract contract,
+            Type objectType,
+            Func<ConstructorInfo, JsonPropertyCollection, IList<JsonProperty>> createConstructorParameters)
+        {
+            var nonDefaultConstructor = GetNonDefaultConstructor(objectType);
+
+            if (nonDefaultConstructor == null) return contract;
+
+            contract.OverrideCreator = GetObjectConstructor(nonDefaultConstructor);
+            contract.CreatorParameters.Clear();
+            foreach (var constructorParameter in
+                     createConstructorParameters(nonDefaultConstructor, contract.Properties))
+            {
+                contract.CreatorParameters.Add(constructorParameter);
+            }
+
+            return contract;
+        }
+
+
+        private static ObjectConstructor<object> GetObjectConstructor(MethodBase method)
+        {
+            var c = method as ConstructorInfo;
+
+            if (c == null)
+                return a => method.Invoke(null, a)!;
+
+            if (!c.GetParameters().Any())
+                return _ => c.Invoke(Array.Empty<object?>());
+
+            return a => c.Invoke(a);
+        }
+
+        private static ConstructorInfo? GetNonDefaultConstructor(Type objectType)
+        {
+            // Use default contract for non-object types.
+            if (objectType.IsPrimitive || objectType.IsEnum)
+                return null;
+
+            return GetAttributeConstructor(objectType)
+                   ?? GetTheMostSpecificConstructor(objectType);
+        }
+
+        private static ConstructorInfo? GetAttributeConstructor(Type objectType)
+        {
+            var constructors = objectType
+                .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(c => c.GetCustomAttributes().Any(a => a.GetType() == ConstructorAttributeType)).ToList();
+
+            return constructors.Count switch
+            {
+                1 => constructors[0],
+                > 1 => throw new JsonException($"Multiple constructors with a {ConstructorAttributeType.Name}."),
+                _ => null
+            };
+        }
+
+        private static ConstructorInfo? GetTheMostSpecificConstructor(Type objectType) =>
+            objectType
+                .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .OrderByDescending(e => e.GetParameters().Length)
+                .ThenBy(c => c.IsPublic)
+                .FirstOrDefault();
+    }
+}

--- a/src/Marten/Services/JsonNetSerializer.cs
+++ b/src/Marten/Services/JsonNetSerializer.cs
@@ -10,7 +10,6 @@ using Marten.Util;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Weasel.Core;
-using Weasel.Postgresql;
 using ConstructorHandling = Newtonsoft.Json.ConstructorHandling;
 
 namespace Marten.Services


### PR DESCRIPTION
- Added `JsonNetObjectContractProvider` to enable private non default constructor resolution for Newtonsoft Json.NET
- Added `NonPublicMembersStorage.NonPublicConstructor` option and updated `JsonNetContractResolver` accordingly
- Added tests and updated docs