### PR TITLE
Treat the Identity Field as a Duplicated Field

### DIFF
--- a/src/Marten.Testing/Linq/Bug_id_field_does_not_hit_id_column.cs
+++ b/src/Marten.Testing/Linq/Bug_id_field_does_not_hit_id_column.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using Marten.Linq;
+using Marten.Services;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace Marten.Testing.Linq
+{
+    [SelectionStoryteller]
+    public class Bug_id_field_does_not_hit_id_column: IntegrationContextWithIdentityMap<NulloIdentityMap>
+    {
+        [Fact]
+        public void return_the_correct_number_of_results()
+        {
+            var target = new Target
+            {
+                Id = System.Guid.NewGuid()
+            };
+
+            theStore.BulkInsert(new[] { target });
+
+            var queryable = theSession.Query<Target>()
+                .Where(x => x.Id == target.Id);
+
+            var cmd = queryable.ToCommand(FetchType.FetchMany);
+
+            SpecificationExtensions.ShouldContain(cmd.CommandText, "where d.id = :arg0");
+
+            queryable.ToArray().Length.ShouldBe(1);
+        }
+
+        public Bug_id_field_does_not_hit_id_column(DefaultStoreFixture fixture) : base(fixture)
+        {
+        }
+    }
+}

--- a/src/Marten/Linq/Parsing/SimpleBinaryComparisonExpressionParser.cs
+++ b/src/Marten/Linq/Parsing/SimpleBinaryComparisonExpressionParser.cs
@@ -63,7 +63,7 @@ namespace Marten.Linq.Parsing
 
             var useContainment = mapping.PropertySearching == PropertySearching.ContainmentOperator || field.ShouldUseContainmentOperator();
 
-            var isDuplicated = (mapping.FieldFor(members) is DuplicatedField);
+            var isDuplicated = field is DuplicatedField || field is IdField;
             var isEnumString = field.MemberType.GetTypeInfo().IsEnum && serializer.EnumStorage == EnumStorage.AsString;
 
             if (useContainment &&

--- a/src/Marten/Linq/Parsing/SimpleEqualsParser.cs
+++ b/src/Marten/Linq/Parsing/SimpleEqualsParser.cs
@@ -72,7 +72,7 @@ namespace Marten.Linq.Parsing
 
             if (_supportContainment && ((mapping.PropertySearching == PropertySearching.ContainmentOperator ||
                                          field.ShouldUseContainmentOperator()) &&
-                                        !(field is DuplicatedField)))
+                                        !(field is DuplicatedField || field is IdField)))
             {
                 var dict = new Dictionary<string, object>();
                 ContainmentWhereFragment.CreateDictionaryForSearch(dict, expression, valueToQuery, serializer);


### PR DESCRIPTION
This PR addresses a performance issue where querying over the identity field does not hit the identity column.

BEFORE:
select _ from _ as d where (d.data @> :arg0)
where arg0 = '{"Id":"00ee1302-7109-42e0-bd87-926123931c34"}'

AFTER
select _ from _ as d where (d.id = :arg0)
where arg0 = '00ee1302-7109-42e0-bd87-926123931c34'