### PR TITLE
Protect against null ref in HighWaterAgent.Stop

### DIFF
--- a/src/Marten/Events/Daemon/HighWater/HighWaterAgent.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterAgent.cs
@@ -170,8 +170,8 @@ namespace Marten.Events.Daemon.HighWater
         {
             try
             {
-                _timer.Stop();
-                _loop.Dispose();
+                _timer?.Stop();
+                _loop?.Dispose();
 
                 IsRunning = false;
             }


### PR DESCRIPTION
This might happen if the agent is stopped straight after starting it, e.g. in a unit test. This is similar to how Dispose protects against the same.

To trigger this I'm using the HotColdCoordinator with Marten 4.3.1

```
[16:45:24 ERR] Error trying to stop the HighWaterAgent
System.NullReferenceException: Object reference not set to an instance of an object.
   at Marten.Events.Daemon.HighWater.HighWaterAgent.Stop()
```