### PR TITLE
Ensure ViewProjection uses CrossStreamAggregationRuntime

### DIFF
--- a/src/Marten/Events/Aggregation/AggregateProjection.CodeGen.cs
+++ b/src/Marten/Events/Aggregation/AggregateProjection.CodeGen.cs
@@ -231,8 +231,7 @@ namespace Marten.Events.Aggregation
 
         private void buildInlineAggregationType(GeneratedAssembly assembly)
         {
-            var inlineBaseType =
-                typeof(AggregationRuntime<,>).MakeGenericType(typeof(T), _aggregateMapping.IdType);
+            var inlineBaseType = baseTypeForAggregationRuntime();
 
             _inlineGeneratedType = assembly.AddType(_inlineAggregationHandlerType, inlineBaseType);
 


### PR DESCRIPTION
Fixes #2031 

The test from the original fix has been modified to ensure that the daemon applies the events from the other streams in separate slices rather than all together. The test was flawed as it loaded all 3 events into a slice. The `IsNew` logic looks at the first event to determine that it's a new projection and then applies all 3 events on the same document resulting in no loss of data. When they are applied in separate slices, the data loss does occur as they are no longer all applied on the same document.