### PR TITLE
Select transform with dictionary fails

### DIFF
--- a/src/Marten.Testing/Bugs/Bug_XXXX_select_transform_dictionary.cs
+++ b/src/Marten.Testing/Bugs/Bug_XXXX_select_transform_dictionary.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Bug2057;
+
+using Marten.Testing.Harness;
+
+using Shouldly;
+
+using Weasel.Postgresql;
+
+using Xunit;
+
+namespace Marten.Testing.Linq
+{
+    public class Bug_2057_select_transform_dictionary: BugIntegrationContext
+    {
+        [Fact]
+        public async Task should_be_able_select_dictionary()
+        {
+            using var documentStore = SeparateStore(x =>
+            {
+                x.AutoCreateSchemaObjects = AutoCreate.All;
+                x.Schema.For<TestEntity>();
+            });
+
+            await documentStore.Advanced.Clean.DeleteAllDocumentsAsync();
+
+            await using var session = documentStore.OpenSession();
+            session.Store(new TestEntity
+            {
+                Name = "Test",
+                Values = new Dictionary<string, string>
+                {
+                    { "Key", "Value" },
+                    { "Key2", "Value2" }
+                }
+            });
+
+            await session.SaveChangesAsync();
+
+            await using var querySession = documentStore.QuerySession();
+
+            var results = await querySession.Query<TestEntity>()
+                .Select(x => new TestDto
+                {
+                    Name = x.Name,
+                    Values = x.Values
+                })
+                .ToListAsync();
+
+            results.Count.ShouldBe(1);
+            results[0].Name.ShouldBe("Test");
+            results[0].Values.Keys.ShouldContain("Key");
+            results[0].Values["Key"].ShouldBe("Value");
+            results[0].Values.Keys.ShouldContain("Key2");
+            results[0].Values["Key2"].ShouldBe("Value2");
+        }
+    }
+}
+
+namespace Bug2057
+{
+    public class TestEntity
+    {
+        public Guid Id { get; set; }
+
+        public string Name { get; set; }
+        public Dictionary<string, string> Values { get; set; }
+    }
+
+    public class TestDto
+    {
+        public string Name { get; set; }
+        public Dictionary<string, string> Values { get; set; }
+    }
+}

--- a/src/Marten/Linq/Parsing/SelectTransformBuilder.cs
+++ b/src/Marten/Linq/Parsing/SelectTransformBuilder.cs
@@ -98,6 +98,12 @@ namespace Marten.Linq.Parsing
                         ? field.RawLocator ?? field.TypedLocator
                         : field.TypedLocator;
 
+                    if (field is DictionaryField)
+                    {
+                        // DictionaryField.RawLocator does not have cast to JSONB so TypedLocator is used
+                        locator = field.TypedLocator;
+                    }
+
                     return $"'{Name}', {locator}";
                 }
             }


### PR DESCRIPTION
If you have query with select that selects dictionary from entity, the query fails because the JSON returned from database cannot be deserialized. Following exception is thrown
```
Newtonsoft.Json.JsonSerializationException
Error converting value "{"Key": "Value", "Key2": "Value2"}" to type 'System.Collections.Generic.Dictionary`2[System.String,System.String]'. Path 'Values', line 1, position 71.
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType(JsonReader reader, Object value, CultureInfo culture, JsonContract contract, Type targetType)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)
   at Marten.Services.JsonNetSerializer.FromJson[T](DbDataReader reader, Int32 index) in C:\marten\src\Marten\Services\JsonNetSerializer.cs:line 113
   at Marten.Services.JsonNetSerializer.FromJsonAsync[T](DbDataReader reader, Int32 index, CancellationToken cancellationToken) in C:\marten\src\Marten\Services\JsonNetSerializer.cs:line 123
   at Marten.Linq.Selectors.SerializationSelector`1.ResolveAsync(DbDataReader reader, CancellationToken token) in C:\marten\src\Marten\Linq\Selectors\SerializationSelector.cs:line 0
   at Marten.Linq.QueryHandlers.ListQueryHandler`1.HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token) in C:\marten\src\Marten\Linq\QueryHandlers\ListQueryHandler.cs:line 70
   at Marten.Linq.MartenLinqQueryProvider.ExecuteHandlerAsync[T](IQueryHandler`1 handler, CancellationToken token) in C:\marten\src\Marten\Linq\MartenLinqQueryProvider.cs:line 96
   at Marten.Testing.Linq.Bug_2057_select_transform_dictionary.should_be_able_select_dictionary() in C:\marten\src\Marten.Testing\Bugs\Bug_2057_select_transform_dictionary.cs:line 46
```
The problem seems to be that the generated select clause does not have cast for the dictionary and it is selected as string and not JSON. This in turn causes the deserialization to fail.

I'm not sure if this fix is correct and should the `DictionaryField.RawLocator` property be changed instead to include the cast. However adding separate check from `DictionaryField` in `SelectTransformBuilder` felt a bit safer change than changing the RawLocator.