### PR TITLE
Optimizes Safe Sequence Finder using Current Safe Sequence Id

### DIFF
--- a/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
@@ -34,6 +34,7 @@ namespace Marten.Events.Daemon.HighWater
             var statistics = await loadCurrentStatistics(token).ConfigureAwait(false);
 
             _safeSequenceFinder.SafeTimestamp = safeTimestamp;
+            _safeSequenceFinder.SafeSequenceId = statistics.SafeStartMark;
             var safeSequence = await _runner.Query(_safeSequenceFinder, token).ConfigureAwait(false);
             if (safeSequence.HasValue)
             {

--- a/src/Marten/Events/Daemon/HighWater/SafeSequenceFinder.cs
+++ b/src/Marten/Events/Daemon/HighWater/SafeSequenceFinder.cs
@@ -12,11 +12,18 @@ namespace Marten.Events.Daemon.HighWater
     {
         private readonly NpgsqlCommand _findSafeSequence;
         private readonly NpgsqlParameter _safeTimestamp;
+        private readonly NpgsqlParameter _safeSequenceId;
 
         public SafeSequenceFinder(EventGraph graph)
         {
-            _findSafeSequence = new NpgsqlCommand($@"select min(seq_id) from {graph.DatabaseSchemaName}.mt_events where mt_events.timestamp >= :timestamp");
+            _findSafeSequence = new NpgsqlCommand($@"select min(seq_id) from {graph.DatabaseSchemaName}.mt_events where mt_events.seq_id > :sequence_id and mt_events.timestamp >= :timestamp");
             _safeTimestamp = _findSafeSequence.AddNamedParameter("timestamp", DateTimeOffset.MinValue);
+            _safeSequenceId = _findSafeSequence.AddNamedParameter("sequence_id", 0);
+        }
+
+        public long SafeSequenceId
+        {
+            set => _safeSequenceId.Value = value;
         }
 
         public DateTimeOffset SafeTimestamp


### PR DESCRIPTION
Rather than doing a full table scan on the `mt_events` table to filter down to rows past a given timestamp, updates query to take advantage of index by also filtering out rows before the latest safe sequence id