### PR TITLE
Add StorageFeatures property to IDocumentStore

### DIFF
--- a/src/Marten/IDocumentStore.cs
+++ b/src/Marten/IDocumentStore.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Marten.Events.Daemon;
 using Marten.Schema;
 using Marten.Services;
+using Marten.Storage;
 using Microsoft.Extensions.Logging;
 using Weasel.Core.Migrations;
 using IsolationLevel = System.Data.IsolationLevel;
@@ -17,6 +18,11 @@ namespace Marten
     /// </summary>
     public interface IDocumentStore: IDisposable
     {
+        /// <summary>
+        /// Access to custom schema features in this Marten-enabled Postgresql database
+        /// </summary>
+        StorageFeatures Storage { get; }
+
         /// <summary>
         /// Information about the current configuration of this IDocumentStore
         /// </summary>


### PR DESCRIPTION
While attempting to add a sequence to the database through marten I discovered that `IDocumentStore` was missing the `Storage` property needed to refer to the sequence [as per this documentation](https://martendb.io/scenarios/using-sequence-for-unique-id.html#snippet-sample_scenario-usingsequenceforuniqueid-querymatter).

This change adds the missing property :)

Workaround at the moment is to do the following:
```c#
IDocumentStore _store = GetStoreFromDI();
(_store as DocumentStore)!.Storage.FindFeature(typeof(EntityId<TEntity>)).Objects.OfType<Sequence>().Single();
```