### PR TITLE
Support adding metadata to individual events in the same session

### DIFF
--- a/docs/events/metadata.md
+++ b/docs/events/metadata.md
@@ -29,7 +29,7 @@ The actual metadata is accessible from the `IEvent` interface or `Event<T>` even
 <!-- snippet: sample_IEvent -->
 <a id='snippet-sample_ievent'></a>
 ```cs
-public interface IEvent
+public interface IEvent : IEventMetadata
 {
     /// <summary>
     /// Unique identifier for the event. Uses a sequential Guid
@@ -90,6 +90,15 @@ public interface IEvent
     string DotNetTypeName { get; set; }
 
     /// <summary>
+    /// Has this event been archived and no longer applicable
+    /// to projected views
+    /// </summary>
+    bool IsArchived { get; set; }
+}
+
+public interface IEventMetadata
+{
+    /// <summary>
     /// Optional metadata describing the causation id
     /// </summary>
     string? CausationId { get; set; }
@@ -117,13 +126,83 @@ public interface IEvent
     /// <param name="key"></param>
     /// <returns></returns>
     object? GetHeader(string key);
-
-    /// <summary>
-    /// Has this event been archived and no longer applicable
-    /// to projected views
-    /// </summary>
-    bool IsArchived { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Event.cs#L8-L105' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ievent' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Event.cs#L8-L108' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ievent' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## Overrides
+
+It is possible to apply or override metadata for individual events within a session. Note that when the events are saved, any metadata values set for the session are applied first, with individual event metadata overrides applied after.
+
+Use the following commands to apply metadata to specific events:
+
+<!-- snippet: sample_event_metadata_overrides -->
+<a id='snippet-sample_event_metadata_overrides'></a>
+```cs
+[Fact]
+public async Task check_event_metadata_overrides()
+{
+    StoreOptions(_ => _.Events.MetadataConfig.EnableAll());
+
+    const string correlationId = "test-correlation-id";
+    theSession.CorrelationId = correlationId;
+
+    const string causationId = "test-causation-id";
+    theSession.CausationId = causationId;
+
+    const string userDefinedMetadata1Name = "my-header-1";
+    const string userDefinedMetadata1Value = "my-header-1-value";
+    theSession.SetHeader(userDefinedMetadata1Name, userDefinedMetadata1Value);
+    const string userDefinedMetadata2Name = "my-header-2";
+    const string userDefinedMetadata2Value = "my-header-2-value";
+    theSession.SetHeader(userDefinedMetadata2Name, userDefinedMetadata2Value);
+
+    // override the correlation ids
+    const string correlationIdOverride = "override-correlation-id";
+    theSession.Events.ApplyCorrelationId(correlationIdOverride, started, joined);
+
+    // override the causation ids
+    const string causationIdOverride = "override-causation-id";
+    theSession.Events.ApplyCausationId(causationIdOverride, started, joined);
+
+    // update an existing header on one event
+    const string overrideMetadata1Value = "my-header-1-override-value";
+    theSession.Events.ApplyHeader(userDefinedMetadata1Name, overrideMetadata1Value, started);
+
+    // add a new header on one event
+    const string overrideMetadata3Name = "my-header-override";
+    const string overrideMetadata3Value = "my-header-override-value";
+    theSession.Events.ApplyHeader(overrideMetadata3Name, overrideMetadata3Value, slayed);
+
+    // actually add the events to the session
+    // this can be done before or after metadata overrides are applied
+    var streamId = theSession.Events
+        .StartStream<QuestParty>(started, joined, slayed).Id;
+    await theSession.SaveChangesAsync();
+
+    var events = await theSession.Events.FetchStreamAsync(streamId);
+
+    events[0].CorrelationId.ShouldBe(correlationIdOverride);
+    events[1].CorrelationId.ShouldBe(correlationIdOverride);
+    events[2].CorrelationId.ShouldBe(correlationId);
+
+    events[0].CausationId.ShouldBe(causationIdOverride);
+    events[1].CausationId.ShouldBe(causationIdOverride);
+    events[2].CausationId.ShouldBe(causationId);
+
+    events[0].GetHeader(userDefinedMetadata1Name).ToString().ShouldBe(overrideMetadata1Value);
+    events[0].GetHeader(userDefinedMetadata2Name).ToString().ShouldBe(userDefinedMetadata2Value);
+    events[0].GetHeader(overrideMetadata3Name).ShouldBeNull();
+
+    events[1].GetHeader(userDefinedMetadata1Name).ToString().ShouldBe(userDefinedMetadata1Value);
+    events[1].GetHeader(userDefinedMetadata2Name).ToString().ShouldBe(userDefinedMetadata2Value);
+    events[1].GetHeader(overrideMetadata3Name).ShouldBeNull();
+
+    events[2].GetHeader(userDefinedMetadata1Name).ToString().ShouldBe(userDefinedMetadata1Value);
+    events[2].GetHeader(userDefinedMetadata2Name).ToString().ShouldBe(userDefinedMetadata2Value);
+    events[2].GetHeader(overrideMetadata3Name).ToString().ShouldBe(overrideMetadata3Value);
+}
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/flexible_event_metadata.cs#L216-L283' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_event_metadata_overrides' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/events/querying.md
+++ b/docs/events/querying.md
@@ -41,7 +41,7 @@ The data returned is a list of `IEvent` objects, where each is a strongly-typed 
 <!-- snippet: sample_IEvent -->
 <a id='snippet-sample_ievent'></a>
 ```cs
-public interface IEvent
+public interface IEvent : IEventMetadata
 {
     /// <summary>
     /// Unique identifier for the event. Uses a sequential Guid
@@ -102,6 +102,15 @@ public interface IEvent
     string DotNetTypeName { get; set; }
 
     /// <summary>
+    /// Has this event been archived and no longer applicable
+    /// to projected views
+    /// </summary>
+    bool IsArchived { get; set; }
+}
+
+public interface IEventMetadata
+{
+    /// <summary>
     /// Optional metadata describing the causation id
     /// </summary>
     string? CausationId { get; set; }
@@ -129,15 +138,9 @@ public interface IEvent
     /// <param name="key"></param>
     /// <returns></returns>
     object? GetHeader(string key);
-
-    /// <summary>
-    /// Has this event been archived and no longer applicable
-    /// to projected views
-    /// </summary>
-    bool IsArchived { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Event.cs#L8-L105' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ievent' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Event.cs#L8-L108' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ievent' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Stream State

--- a/docs/events/storage.md
+++ b/docs/events/storage.md
@@ -108,7 +108,7 @@ public string? CorrelationId { get; set; }
 /// </summary>
 public Dictionary<string, object>? Headers { get; set; }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Event.cs#L124-L174' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_event_metadata' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Event.cs#L127-L177' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_event_metadata' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The full event data is available on `EventStream` and `IEvent` objects immediately after committing a transaction that involves event capture. See [diagnostics and instrumentation](/diagnostics) for more information on capturing event data in the instrumentation hooks.

--- a/docs/scenarios/copy-and-transform-stream.md
+++ b/docs/scenarios/copy-and-transform-stream.md
@@ -23,7 +23,7 @@ using (var session = theStore.OpenSession())
     session.SaveChanges();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/ScenarioCopyAndReplaceStream.cs#L32-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-copyandtransformstream-setup' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/ScenarioCopyAndReplaceStream.cs#L33-L44' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-copyandtransformstream-setup' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Next, we introduce a new event type to expand the `MembersJoined` to a series of events, one for each member.
@@ -54,7 +54,7 @@ public class MemberJoined
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/ScenarioCopyAndReplaceStream.cs#L103-L126' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-copyandtransformstream-newevent' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/ScenarioCopyAndReplaceStream.cs#L110-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-copyandtransformstream-newevent' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Lastly, we want trolls (`MonsterSlayed`) removed from our stream. However, the stream is a series of ordered, immutable data, with no functionality to patch or otherwise modify existing data. Instead of trying to mutate the stream, we can use the copy and transform pattern to introduce a new event stream. We do this by copying the existing stream to a new one, while applying any needed transforms to the event data being copied. We also make sure to copy any metadata from the original events, and apply a new header to the events to track which stream they came from.
@@ -76,20 +76,26 @@ using (var session = theStore.OpenSession())
             case MonsterSlayed monster:
             {
                 // Trolls we remove from our transformed stream
-                return monster.Name.Equals("Troll") ? new object[] { } : new[] { monster };
+                if (monster.Name.Equals("Troll")) return Array.Empty<object>();
+
+                session.Events.ApplyHeader("copied_from_event", x.Id, monster);
+                return new[] { monster };
             }
             case MembersJoined members:
             {
                 // MembersJoined events we transform into a series of events
-                return MemberJoined.From(members);
+                var membersEvents = MemberJoined.From(members).Cast<object>().ToArray();
+                session.Events.ApplyHeader("copied_from_event", x.Id, events: membersEvents);
+                return membersEvents;
             }
         }
 
+        session.Events.ApplyHeader("copied_from_event", x.Id, x.Data);
         return new[] { x.Data };
     }).Where(x => x != null).ToArray();
 
     // Add "moved from" header to all events being written to new stream 
-    session.Events.ApplyHeader("moved from", started.Name, transformedEvents);
+    session.Events.ApplyHeader("moved_from_stream", started.Name, transformedEvents);
 
     var moveTo = $"{started.Name} without Trolls";
     // Mark the old stream as moved.
@@ -107,7 +113,7 @@ using (var session = theStore.OpenSession())
     session.SaveChanges();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/ScenarioCopyAndReplaceStream.cs#L45-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-copyandtransformstream-transform' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/ScenarioCopyAndReplaceStream.cs#L46-L98' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-copyandtransformstream-transform' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 As the new stream is produced, within the same transaction we introduce an event dictating the stream being copied to have been moved. This should serve as an indication to no longer append new events into the stream. Furthermore, it ensures that the underlying stream being copied has not changed during the copy & transform process (as we assert on the expected stream version).
@@ -120,5 +126,5 @@ public class StreamMovedTo
     public string To { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/ScenarioCopyAndReplaceStream.cs#L128-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-copyandtransformstream-streammoved' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/ScenarioCopyAndReplaceStream.cs#L135-L140' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_scenario-copyandtransformstream-streammoved' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers.cs
+++ b/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers.cs
@@ -455,6 +455,7 @@ namespace EventSourcingTests
             Options.Events.AddEventType(typeof(MembersJoined));
             Options.Events.AddEventType(typeof(MembersDeparted));
             Options.Events.AddEventType(typeof(QuestStarted));
+            Options.Events.MetadataConfig.EnableAll();
         }
     }
 

--- a/src/EventSourcingTests/flexible_event_metadata.cs
+++ b/src/EventSourcingTests/flexible_event_metadata.cs
@@ -166,6 +166,23 @@ namespace EventSourcingTests
         }
 
         [Fact]
+        public async Task check_user_defined_metadata_not_exists()
+        {
+            StoreOptions(_ => _.Events.MetadataConfig.HeadersEnabled = true);
+            const string userDefinedMetadataName = "my-custom-metadata";
+
+            var streamId = theSession.Events
+                .StartStream<QuestParty>(started, joined, slayed).Id;
+            await theSession.SaveChangesAsync();
+
+            var events = await theSession.Events.FetchStreamAsync(streamId);
+            foreach (var @event in events)
+            {
+                @event.GetHeader(userDefinedMetadataName).ShouldBeNull();
+            }
+        }
+
+        [Fact]
         public async Task check_flexible_metadata_with_all_enabled()
         {
             StoreOptions(_ => _.Events.MetadataConfig.EnableAll());

--- a/src/EventSourcingTests/flexible_event_metadata.cs
+++ b/src/EventSourcingTests/flexible_event_metadata.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using EventSourcingTests.Projections;
 using Marten;
+using Marten.Services.Json;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
@@ -212,5 +213,36 @@ namespace EventSourcingTests
             }
         }
 
+
+        [Fact]
+        public async Task check_writing_empty_headers_system_text_json()
+        {
+            StoreOptions(_ =>
+            {
+                _.Events.MetadataConfig.EnableAll();
+                _.UseDefaultSerialization(serializerType: SerializerType.SystemTextJson);
+            });
+
+            var streamId = theSession.Events
+                .StartStream<QuestParty>(started).Id;
+            await theSession.SaveChangesAsync();
+            // Should not throw System.NullReferenceException here
+        }
+
+
+        [Fact]
+        public async Task check_writing_empty_headers_newtonsoft_json()
+        {
+            StoreOptions(_ =>
+            {
+                _.Events.MetadataConfig.EnableAll();
+                _.UseDefaultSerialization(serializerType: SerializerType.Newtonsoft);
+            });
+
+            var streamId = theSession.Events
+                .StartStream<QuestParty>(started).Id;
+            await theSession.SaveChangesAsync();
+            // Should not throw System.NullReferenceException here
+        }
     }
 }

--- a/src/Marten/Events/Event.cs
+++ b/src/Marten/Events/Event.cs
@@ -6,7 +6,7 @@ using Marten.Storage;
 namespace Marten.Events
 {
     #region sample_IEvent
-    public interface IEvent
+    public interface IEvent : IEventMetadata
     {
         /// <summary>
         /// Unique identifier for the event. Uses a sequential Guid
@@ -67,6 +67,15 @@ namespace Marten.Events
         string DotNetTypeName { get; set; }
 
         /// <summary>
+        /// Has this event been archived and no longer applicable
+        /// to projected views
+        /// </summary>
+        bool IsArchived { get; set; }
+    }
+
+    public interface IEventMetadata
+    {
+        /// <summary>
         /// Optional metadata describing the causation id
         /// </summary>
         string? CausationId { get; set; }
@@ -94,12 +103,6 @@ namespace Marten.Events
         /// <param name="key"></param>
         /// <returns></returns>
         object? GetHeader(string key);
-
-        /// <summary>
-        /// Has this event been archived and no longer applicable
-        /// to projected views
-        /// </summary>
-        bool IsArchived { get; set; }
     }
 
     #endregion

--- a/src/Marten/Events/Event.cs
+++ b/src/Marten/Events/Event.cs
@@ -187,7 +187,7 @@ namespace Marten.Events
 
         public object? GetHeader(string key)
         {
-            return Headers?[key];
+            return Headers?.TryGetValue(key, out var value) ?? false ? value : null;
         }
 
         public bool IsArchived { get; set; }

--- a/src/Marten/Events/IEventStore.cs
+++ b/src/Marten/Events/IEventStore.cs
@@ -333,5 +333,60 @@ namespace Marten.Events
         /// </summary>
         /// <param name="streamKey"></param>
         void ArchiveStream(string streamKey);
+
+        /// <summary>
+        /// Apply a single header to multiple events in the current session.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <param name="events"></param>
+        /// <remarks>
+        /// Metadata is applied after session-wide metadata and will override any conflicting keys/values.
+        /// </remarks>
+        void ApplyHeader(string key, object? value, params object[] events);
+
+        /// <summary>
+        /// Apply a collection of headers to multiple events in the current session.
+        /// Setting value to null will remove the override.
+        /// </summary>
+        /// <param name="headers"></param>
+        /// <param name="events"></param>
+        /// <remarks>
+        /// Metadata is applied after session-wide metadata and will override any conflicting keys/values.
+        /// </remarks>
+        void ApplyHeaders(IDictionary<string, object> headers, params object[] events);
+
+        /// <summary>
+        /// Apply a correlation id to multiple events in the current session.
+        /// Setting to null will remove the override.
+        /// </summary>
+        /// <param name="headers"></param>
+        /// <param name="events"></param>
+        /// <remarks>
+        /// Metadata is applied after session-wide metadata and will override any conflicting keys/values.
+        /// </remarks>
+        void ApplyCorrelationId(string? correlationId, params object[] events);
+
+        /// <summary>
+        /// Apply a causation id to multiple events in the current session.
+        /// Setting to null will remove the override.
+        /// </summary>
+        /// <param name="headers"></param>
+        /// <param name="events"></param>
+        /// <remarks>
+        /// Metadata is applied after session-wide metadata and will override any conflicting keys/values.
+        /// </remarks>
+        void ApplyCausationId(string? causationId, params object[] events);
+
+        /// <summary>
+        /// Apply metadata from an existing event to an event in the current session.
+        /// CorrelationId, CausationId and Headers will be applied.
+        /// </summary>
+        /// <param name="headers"></param>
+        /// <param name="events"></param>
+        /// <remarks>
+        /// Metadata is applied after session-wide metadata and will override any conflicting keys/values.
+        /// </remarks>
+        void CopyMetadata(IEventMetadata metadata, object @event);
     }
 }

--- a/src/Marten/IDocumentSession.cs
+++ b/src/Marten/IDocumentSession.cs
@@ -65,11 +65,12 @@ namespace Marten
         string? LastModifiedBy { get; set; }
 
         /// <summary>
-        /// Set an optional user defined metadata value by key
+        /// Set an optional user defined metadata value by key.
+        /// If the value is null then the key is removed.
         /// </summary>
         /// <param name="key"></param>
         /// <param name="value"></param>
-        void SetHeader(string key, object value);
+        void SetHeader(string key, object? value);
 
         /// <summary>
         /// Get an optional user defined metadata value by key

--- a/src/Marten/Internal/IMartenSession.cs
+++ b/src/Marten/Internal/IMartenSession.cs
@@ -66,6 +66,12 @@ namespace Marten.Internal
         Dictionary<string, object>? Headers { get; }
 
         /// <summary>
+        /// Optional overridden metadata values for specific events in this unit of work.
+        /// This may be null.
+        /// </summary>
+        IDictionary<object, MetadataOverrides>? EventMetadataOverrides { get; }
+
+        /// <summary>
         /// Execute a single command against the database with this session's connection
         /// </summary>
         /// <param name="cmd"></param>

--- a/src/Marten/Internal/MetadataOverrides.cs
+++ b/src/Marten/Internal/MetadataOverrides.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+#nullable enable
+namespace Marten.Internal
+{
+    public class MetadataOverrides
+    {
+        public MetadataOverrides(object @event)
+        {
+            Event = @event;
+        }
+
+        public object Event { get; }
+
+        /// <summary>
+        /// Optional metadata describing the causation id for this
+        /// unit of work
+        /// </summary>
+        public string? CausationId { get; set; }
+
+        /// <summary>
+        /// Optional metadata describing the correlation id for this
+        /// unit of work
+        /// </summary>
+        public string? CorrelationId { get; set; }
+
+        /// <summary>
+        /// Optional metadata values. This may be null.
+        /// </summary>
+        public Dictionary<string, object>? Headers { get; set; }
+    }
+}

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -211,7 +211,7 @@ namespace Marten.Internal.Sessions
 
         public object? GetHeader(string key)
         {
-            return Headers?[key];
+            return Headers?.TryGetValue(key, out var value) ?? false ? value : null;
         }
 
         /// <summary>

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -202,9 +202,20 @@ namespace Marten.Internal.Sessions
             ChangeTrackers.RemoveAll(x => x.Document.GetType().CanBeCastTo(type));
         }
 
-        public void SetHeader(string key, object value)
+        public void SetHeader(string key, object? value)
         {
+            if (value is null && Headers is null)
+            {
+                return;
+            }
+
             Headers ??= new Dictionary<string, object>();
+
+            if (value is null)
+            {
+                Headers.Remove(key);
+                return;
+            }
 
             Headers[key] = value;
         }
@@ -212,6 +223,20 @@ namespace Marten.Internal.Sessions
         public object? GetHeader(string key)
         {
             return Headers?.TryGetValue(key, out var value) ?? false ? value : null;
+        }
+
+        public MetadataOverrides GetOrCreateEventMetadataOverrides(object @event)
+        {
+            if (EventMetadataOverrides?.TryGetValue(@event, out var overrides) ?? false)
+            {
+                return overrides;
+            }
+
+            EventMetadataOverrides ??= new Dictionary<object, MetadataOverrides>();
+
+            var newOverride = new MetadataOverrides(@event);
+            EventMetadataOverrides[@event] = newOverride;
+            return newOverride;
         }
 
         /// <summary>

--- a/src/Marten/Internal/Sessions/QuerySession.Metadata.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Metadata.cs
@@ -21,6 +21,11 @@ namespace Marten.Internal.Sessions
         /// </summary>
         public Dictionary<string, object>? Headers { get; protected set; }
 
+        /// <summary>
+        ///     This is meant to be lazy created, and can be null
+        /// </summary>
+        public IDictionary<object, MetadataOverrides>? EventMetadataOverrides { get; protected set; }
+
         public Guid? VersionFor<TDoc>(TDoc entity) where TDoc : notnull
         {
             return StorageFor<TDoc>().VersionFor(entity, this);

--- a/src/Marten/Services/SystemTextJsonSerializer.cs
+++ b/src/Marten/Services/SystemTextJsonSerializer.cs
@@ -60,6 +60,11 @@ namespace Marten.Services
 
         public string ToJson(object document)
         {
+            if (document is null)
+            {
+                // Cannot call "GetType()" on null, so mimic Newtonsoft.Json behaviour
+                return "null";
+            }
             return JsonSerializer.Serialize(document, document.GetType(), _options);
         }
 


### PR DESCRIPTION
A set of methods have been added to IEventStore to allow metadata (correlationids, causationids and user defined headers) to be added to one or more specific events within a session. This is in addition to standard session metadata, and overrided values take precedence.  There is also a method that allows for event metadata to be copied from an existing IEvent to other events.

Documentation has been updated where applicable and new tests have been written to cover the new functionality.
I have also updated the copy and transform stream scenario to include usage of this new metadata - as this scenario is the motivation behind supporting this functionality.

Other fixes:
- Saving null objects when using SystemTextJson caused a null reference exception (eg headers enabled and write event with no headers). New behaviour is to detect nulls and return a hardcoded "null" string.
- When calling IEvent.GetHeader with headers disabled (or no headers on event), null would be returned. However if headers were enabled and the dictionary exists, a KeyNotFoundException is thrown. Fixed this to also return null.
