### PR TITLE
ViewProjections support `Identity<TEvent>()` with no function - uses stream id

### DIFF
--- a/docs/documents/querying/linq/booleans.md
+++ b/docs/documents/querying/linq/booleans.md
@@ -20,5 +20,5 @@ public void query_by_booleans(IDocumentSession session)
     session.Query<Target>().Where(x => x.Flag == false).ToArray();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L128-L144' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_boolean_queries' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L154-L170' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_boolean_queries' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/documents/querying/linq/nulls.md
+++ b/docs/documents/querying/linq/nulls.md
@@ -15,5 +15,5 @@ public void query_by_nullable_type_nulls(IDocumentSession session)
     session.Query<Target>().Where(x => x.Inner == null);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L146-L157' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_by_nullable_types' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L172-L183' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_by_nullable_types' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/events/projections/view-projections.md
+++ b/docs/events/projections/view-projections.md
@@ -241,7 +241,7 @@ public class UserGroupsAssignmentProjection: ViewProjection<UserGroupsAssignment
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/ViewProjections/simple_multi_stream_projection_wih_one_to_many.cs#L11-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_view-projection-simple-with-one-to-many' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/ViewProjections/simple_multi_stream_projection_with_one_to_many.cs#L11-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_view-projection-simple-with-one-to-many' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## View Projection with Custom Grouper

--- a/docs/events/querying.md
+++ b/docs/events/querying.md
@@ -173,8 +173,8 @@ public class fetching_stream_state: IntegrationContext
         state.Id.ShouldBe(theStreamId);
         state.Version.ShouldBe(2);
         state.AggregateType.ShouldBe(typeof(Quest));
-        state.LastTimestamp.ShouldNotBe(DateTime.MinValue);
-        state.Created.ShouldNotBe(DateTime.MinValue);
+        state.LastTimestamp.ShouldNotBe(DateTimeOffset.MinValue);
+        state.Created.ShouldNotBe(DateTimeOffset.MinValue);
     }
 
     [Fact]
@@ -185,8 +185,8 @@ public class fetching_stream_state: IntegrationContext
         state.Id.ShouldBe(theStreamId);
         state.Version.ShouldBe(2);
         state.AggregateType.ShouldBe(typeof(Quest));
-        state.LastTimestamp.ShouldNotBe(DateTime.MinValue);
-        state.Created.ShouldNotBe(DateTime.MinValue);
+        state.LastTimestamp.ShouldNotBe(DateTimeOffset.MinValue);
+        state.Created.ShouldNotBe(DateTimeOffset.MinValue);
     }
 
     [Fact]
@@ -203,7 +203,7 @@ public class fetching_stream_state: IntegrationContext
         state.Id.ShouldBe(theStreamId);
         state.Version.ShouldBe(2);
         state.AggregateType.ShouldBe(typeof(Quest));
-        state.LastTimestamp.ShouldNotBe(DateTime.MinValue);
+        state.LastTimestamp.ShouldNotBe(DateTimeOffset.MinValue);
     }
 
     [Fact]

--- a/src/EventSourcingTests/Projections/ViewProjections/TestClasses.cs
+++ b/src/EventSourcingTests/Projections/ViewProjections/TestClasses.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace EventSourcingTests.Projections.ViewProjections
@@ -136,4 +136,26 @@ namespace EventSourcingTests.Projections.ViewProjections
     }
 
     #endregion
+
+    public class UserFollowsUsers : IUserEvent
+    {
+        public Guid UserId { get; }
+
+        public IReadOnlyList<Guid> FollowingUsers { get; }
+
+        public UserFollowsUsers(Guid userId, IReadOnlyList<Guid> followingUsers)
+        {
+            UserId = userId;
+            FollowingUsers = followingUsers;
+        }
+    }
+
+    public class UserSocialCircle
+    {
+        public Guid Id { get; set; }
+
+        public List<Guid> FollowingUsers { get; set; } = new();
+
+        public List<Guid> FollowedByUsers { get; set; } = new();
+    }
 }

--- a/src/EventSourcingTests/Projections/ViewProjections/simple_multi_stream_projection_with_one_to_many.cs
+++ b/src/EventSourcingTests/Projections/ViewProjections/simple_multi_stream_projection_with_one_to_many.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Projections.ViewProjections.SimpleWithOneToMany
+{
+    #region sample_view-projection-simple-with-one-to-many
+    public class UserGroupsAssignmentProjection: ViewProjection<UserGroupsAssignment, Guid>
+    {
+        public UserGroupsAssignmentProjection()
+        {
+            Identity<UserRegistered>(x => x.UserId);
+            Identities<MultipleUsersAssignedToGroup>(x => x.UserIds);
+        }
+
+        public void Apply(UserRegistered @event, UserGroupsAssignment view)
+        {
+            view.Id = @event.UserId;
+        }
+
+        public void Apply(MultipleUsersAssignedToGroup @event, UserGroupsAssignment view)
+        {
+            view.Groups.Add(@event.GroupId);
+        }
+    }
+
+    #endregion
+
+    public class simple_multi_stream_projection_with_one_to_many: OneOffConfigurationsContext
+    {
+        [Fact]
+        public async Task multi_stream_projections_should_work()
+        {
+
+            // --------------------------------
+            // Create Groups
+            // --------------------------------
+            // Regular Users
+            // Admin Users
+            // --------------------------------
+
+            var regularUsersGroupCreated = new UserGroupCreated(Guid.NewGuid(), "Regular Users");
+            theSession.Events.Append(regularUsersGroupCreated.GroupId, regularUsersGroupCreated);
+
+            var adminUsersGroupCreated = new UserGroupCreated(Guid.NewGuid(), "Admin Users");
+            theSession.Events.Append(adminUsersGroupCreated.GroupId, adminUsersGroupCreated);
+
+            await theSession.SaveChangesAsync();
+
+            // --------------------------------
+            // Create Users
+            // --------------------------------
+            // Anna
+            // John
+            // Maggie
+            // Alan
+            // --------------------------------
+
+            var annaRegistered = new UserRegistered(Guid.NewGuid(), "Anna");
+            theSession.Events.Append(annaRegistered.UserId, annaRegistered);
+
+            var johnRegistered = new UserRegistered(Guid.NewGuid(), "John");
+            theSession.Events.Append(johnRegistered.UserId, johnRegistered);
+
+            var maggieRegistered = new UserRegistered(Guid.NewGuid(), "Maggie");
+            theSession.Events.Append(maggieRegistered.UserId, maggieRegistered);
+
+            var alanRegistered = new UserRegistered(Guid.NewGuid(), "Alan");
+            theSession.Events.Append(alanRegistered.UserId, alanRegistered);
+
+            await theSession.SaveChangesAsync();
+
+            // --------------------------------
+            // Assign users to Groups
+            // --------------------------------
+            // Anna, Maggie => Admin
+            // John, Alan   => Regular
+            // --------------------------------
+
+            var annaAndMaggieAssignedToAdminUsersGroup = new MultipleUsersAssignedToGroup(adminUsersGroupCreated.GroupId,
+                new List<Guid> {annaRegistered.UserId, maggieRegistered.UserId});
+            theSession.Events.Append(annaAndMaggieAssignedToAdminUsersGroup.GroupId,
+                annaAndMaggieAssignedToAdminUsersGroup);
+
+            var johnAndAlanAssignedToRegularUsersGroup = new MultipleUsersAssignedToGroup(regularUsersGroupCreated.GroupId,
+                new List<Guid> {johnRegistered.UserId, alanRegistered.UserId});
+            theSession.Events.Append(johnAndAlanAssignedToRegularUsersGroup.GroupId,
+                johnAndAlanAssignedToRegularUsersGroup);
+
+            await theSession.SaveChangesAsync();
+
+            // --------------------------------
+            // Check users' groups assignment
+            // --------------------------------
+            // Anna, Maggie => Admin
+            // John, Alan   => Regular
+            // --------------------------------
+
+            var annaGroupAssignment = await theSession.LoadAsync<UserGroupsAssignment>(annaRegistered.UserId);
+            annaGroupAssignment.ShouldNotBeNull();
+            annaGroupAssignment.Id.ShouldBe(annaRegistered.UserId);
+            annaGroupAssignment.Groups.ShouldHaveTheSameElementsAs(adminUsersGroupCreated.GroupId);
+
+            var maggieGroupAssignment = await theSession.LoadAsync<UserGroupsAssignment>(maggieRegistered.UserId);
+            maggieGroupAssignment.ShouldNotBeNull();
+            maggieGroupAssignment.Id.ShouldBe(maggieRegistered.UserId);
+            maggieGroupAssignment.Groups.ShouldHaveTheSameElementsAs(adminUsersGroupCreated.GroupId);
+
+            var johnGroupAssignment = await theSession.LoadAsync<UserGroupsAssignment>(johnRegistered.UserId);
+            johnGroupAssignment.ShouldNotBeNull();
+            johnGroupAssignment.Id.ShouldBe(johnRegistered.UserId);
+            johnGroupAssignment.Groups.ShouldHaveTheSameElementsAs(regularUsersGroupCreated.GroupId);
+
+            var alanGroupAssignment = await theSession.LoadAsync<UserGroupsAssignment>(alanRegistered.UserId);
+            alanGroupAssignment.ShouldNotBeNull();
+            alanGroupAssignment.Id.ShouldBe(alanRegistered.UserId);
+            alanGroupAssignment.Groups.ShouldHaveTheSameElementsAs(regularUsersGroupCreated.GroupId);
+        }
+
+        public simple_multi_stream_projection_with_one_to_many()
+        {
+            StoreOptions(_ =>
+            {
+                _.DatabaseSchemaName = "simple_multi_stream_projection_one_to_many";
+                _.Projections.Add<UserGroupsAssignmentProjection>(ProjectionLifecycle.Inline);
+            });
+        }
+    }
+}

--- a/src/EventSourcingTests/Projections/ViewProjections/simple_multi_stream_projection_with_one_to_many_using_self_aggregate.cs
+++ b/src/EventSourcingTests/Projections/ViewProjections/simple_multi_stream_projection_with_one_to_many_using_self_aggregate.cs
@@ -12,7 +12,7 @@ namespace EventSourcingTests.Projections.ViewProjections.SimpleWithOneToMany
     {
         public UserSocialCircleProjection()
         {
-            Identity<UserRegistered>(x => x.UserId);
+            Identity<UserRegistered>();
 
             // Multiple Identity methods can be called for the same event
             // Useful for describing different projection mappings
@@ -21,9 +21,7 @@ namespace EventSourcingTests.Projections.ViewProjections.SimpleWithOneToMany
         }
 
         public void Apply(UserRegistered @event, UserSocialCircle view)
-        {
-            view.Id = @event.UserId;
-        }
+            => view.Id = @event.UserId;
 
         public void Apply(UserFollowsUsers @event, UserSocialCircle view)
         {

--- a/src/EventSourcingTests/Projections/ViewProjections/simple_multi_stream_projection_with_one_to_many_using_self_aggregate.cs
+++ b/src/EventSourcingTests/Projections/ViewProjections/simple_multi_stream_projection_with_one_to_many_using_self_aggregate.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Projections.ViewProjections.SimpleWithOneToMany
+{
+    public class UserSocialCircleProjection: ViewProjection<UserSocialCircle, Guid>
+    {
+        public UserSocialCircleProjection()
+        {
+            Identity<UserRegistered>(x => x.UserId);
+
+            // Multiple Identity methods can be called for the same event
+            // Useful for describing different projection mappings
+            Identity<UserFollowsUsers>();
+            Identities<UserFollowsUsers>(x => x.FollowingUsers);
+        }
+
+        public void Apply(UserRegistered @event, UserSocialCircle view)
+        {
+            view.Id = @event.UserId;
+        }
+
+        public void Apply(UserFollowsUsers @event, UserSocialCircle view)
+        {
+            if (@event.UserId == view.Id)
+            {
+                view.FollowingUsers.AddRange(@event.FollowingUsers.Where(user => !view.FollowingUsers.Contains(user)));
+            }
+
+            if (@event.FollowingUsers.Contains(view.Id) && !view.FollowedByUsers.Contains(@event.UserId))
+            {
+                view.FollowedByUsers.Add(@event.UserId);
+            }
+        }
+    }
+    
+
+    public class simple_multi_stream_projection_with_one_to_many_using_self_aggregate: OneOffConfigurationsContext
+    {
+        [Fact]
+        public async Task multi_stream_projections_should_work()
+        {
+            // --------------------------------
+            // Create Users
+            // --------------------------------
+            // Anna
+            // John
+            // Maggie
+            // Alan
+            // --------------------------------
+
+            var annaRegistered = new UserRegistered(Guid.NewGuid(), "Anna");
+            theSession.Events.Append(annaRegistered.UserId, annaRegistered);
+
+            var johnRegistered = new UserRegistered(Guid.NewGuid(), "John");
+            theSession.Events.Append(johnRegistered.UserId, johnRegistered);
+
+            var maggieRegistered = new UserRegistered(Guid.NewGuid(), "Maggie");
+            theSession.Events.Append(maggieRegistered.UserId, maggieRegistered);
+
+            var alanRegistered = new UserRegistered(Guid.NewGuid(), "Alan");
+            theSession.Events.Append(alanRegistered.UserId, alanRegistered);
+
+            await theSession.SaveChangesAsync();
+
+            // --------------------------------
+            // Follow others
+            // --------------------------------
+            // Anna   => John, Alan
+            // John   => Anna
+            // Maggie => Anna, Alan
+            // --------------------------------
+
+            var annaFollowsOthers = new UserFollowsUsers(annaRegistered.UserId,
+                new[] { johnRegistered.UserId, alanRegistered.UserId });
+            theSession.Events.Append(annaFollowsOthers.UserId, annaFollowsOthers);
+
+            var johnFollowsOthers = new UserFollowsUsers(johnRegistered.UserId,
+                new[] { annaRegistered.UserId });
+            theSession.Events.Append(johnFollowsOthers.UserId, johnFollowsOthers);
+
+            var maggieFollowsOthers = new UserFollowsUsers(maggieRegistered.UserId,
+                new[] {annaRegistered.UserId, alanRegistered.UserId});
+            theSession.Events.Append(maggieFollowsOthers.UserId, maggieFollowsOthers);
+
+            await theSession.SaveChangesAsync();
+
+            // --------------------------------
+            // Check social circles
+            // ================================
+            // Follows
+            // --------------------------------
+            // Anna   => John, Alan
+            // John   => Anna
+            // Maggie => Anna, Alan
+            // Alan   => <none>
+            // --------------------------------
+            // Is followed by
+            // --------------------------------
+            // Anna   => John, Maggie
+            // John   => Anna
+            // Maggie => <none>
+            // Alan   => Anna, Maggie
+            // --------------------------------
+
+            var annaSocialCircles = await theSession.LoadAsync<UserSocialCircle>(annaRegistered.UserId);
+            annaSocialCircles.ShouldNotBeNull();
+            annaSocialCircles.Id.ShouldBe(annaRegistered.UserId);
+            annaSocialCircles.FollowingUsers.ShouldHaveTheSameElementsAs(johnRegistered.UserId, alanRegistered.UserId);
+            annaSocialCircles.FollowedByUsers.ShouldHaveTheSameElementsAs(johnRegistered.UserId, maggieRegistered.UserId);
+
+            var johnSocialCircles = await theSession.LoadAsync<UserSocialCircle>(johnRegistered.UserId);
+            johnSocialCircles.ShouldNotBeNull();
+            johnSocialCircles.Id.ShouldBe(johnRegistered.UserId);
+            johnSocialCircles.FollowingUsers.ShouldHaveTheSameElementsAs(annaRegistered.UserId);
+            johnSocialCircles.FollowedByUsers.ShouldHaveTheSameElementsAs(annaRegistered.UserId);
+
+            var maggieSocialCircles = await theSession.LoadAsync<UserSocialCircle>(maggieRegistered.UserId);
+            maggieSocialCircles.ShouldNotBeNull();
+            maggieSocialCircles.Id.ShouldBe(maggieRegistered.UserId);
+            maggieSocialCircles.FollowingUsers.ShouldHaveTheSameElementsAs(annaRegistered.UserId, alanRegistered.UserId);
+            maggieSocialCircles.FollowedByUsers.ShouldBeEmpty();
+
+            var alanSocialCircles = await theSession.LoadAsync<UserSocialCircle>(alanRegistered.UserId);
+            alanSocialCircles.ShouldNotBeNull();
+            alanSocialCircles.Id.ShouldBe(alanRegistered.UserId);
+            alanSocialCircles.FollowingUsers.ShouldBeEmpty();
+            alanSocialCircles.FollowedByUsers.ShouldHaveTheSameElementsAs(annaRegistered.UserId, maggieRegistered.UserId);
+        }
+
+        public simple_multi_stream_projection_with_one_to_many_using_self_aggregate()
+        {
+            StoreOptions(_ =>
+            {
+                _.DatabaseSchemaName = "simple_multi_stream_projection_one_to_many_using_self_aggregate";
+                _.Projections.Add<UserSocialCircleProjection>(ProjectionLifecycle.Inline);
+            });
+        }
+    }
+}

--- a/src/EventSourcingTests/fetching_stream_state.cs
+++ b/src/EventSourcingTests/fetching_stream_state.cs
@@ -108,8 +108,8 @@ namespace EventSourcingTests
             state.Id.ShouldBe(theStreamId);
             state.Version.ShouldBe(2);
             state.AggregateType.ShouldBe(typeof(Quest));
-            state.LastTimestamp.ShouldNotBe(DateTime.MinValue);
-            state.Created.ShouldNotBe(DateTime.MinValue);
+            state.LastTimestamp.ShouldNotBe(DateTimeOffset.MinValue);
+            state.Created.ShouldNotBe(DateTimeOffset.MinValue);
         }
 
         [Fact]
@@ -120,8 +120,8 @@ namespace EventSourcingTests
             state.Id.ShouldBe(theStreamId);
             state.Version.ShouldBe(2);
             state.AggregateType.ShouldBe(typeof(Quest));
-            state.LastTimestamp.ShouldNotBe(DateTime.MinValue);
-            state.Created.ShouldNotBe(DateTime.MinValue);
+            state.LastTimestamp.ShouldNotBe(DateTimeOffset.MinValue);
+            state.Created.ShouldNotBe(DateTimeOffset.MinValue);
         }
 
         [Fact]
@@ -138,7 +138,7 @@ namespace EventSourcingTests
             state.Id.ShouldBe(theStreamId);
             state.Version.ShouldBe(2);
             state.AggregateType.ShouldBe(typeof(Quest));
-            state.LastTimestamp.ShouldNotBe(DateTime.MinValue);
+            state.LastTimestamp.ShouldNotBe(DateTimeOffset.MinValue);
         }
 
         [Fact]

--- a/src/Marten/Events/Aggregation/TenantSliceGroup.cs
+++ b/src/Marten/Events/Aggregation/TenantSliceGroup.cs
@@ -89,7 +89,7 @@ namespace Marten.Events.Aggregation
             var matching = events.Where(x => x.Data is TEvent);
             foreach (var @event in matching)
             {
-                var id = singleIdSource((TEvent)@event.Data);
+                var id = singleIdSource((TEvent) @event.Data);
                 AddEvent(id, @event);
             }
         }
@@ -97,21 +97,24 @@ namespace Marten.Events.Aggregation
         public void AddEvents<TEvent>(IEnumerable<IEvent> events)
         {
             var matching = events.Where(x => x.Data is TEvent);
-            foreach (var @event in matching)
+            if (typeof(TId) == typeof(Guid))
             {
-                if (typeof(TId) == typeof(Guid))
+                foreach (var @event in matching)
                 {
                     AddEvent((TId)(object)@event.StreamId, @event);
                 }
-                else if (typeof(TId) == typeof(string))
+            }
+            else if (typeof(TId) == typeof(string))
+            {
+                foreach (var @event in matching)
                 {
                     AddEvent((TId)(object)@event.StreamKey, @event);
                 }
-                else
-                {
-                    throw new InvalidOperationException(
-                        "Can only map events by stream id/key if the projection id is Guid or String");
-                }
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    "Can only map events by stream id/key if the projection id is Guid or String");
             }
         }
 

--- a/src/Marten/Events/Projections/MultiStreamGrouper.cs
+++ b/src/Marten/Events/Projections/MultiStreamGrouper.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Baseline;
 using Marten.Events.Aggregation;
 
 namespace Marten.Events.Projections
@@ -9,7 +11,7 @@ namespace Marten.Events.Projections
     /// </summary>
     /// <typeparam name="TId"></typeparam>
     /// <typeparam name="TEvent"></typeparam>
-    internal class MultiStreamGrouper<TId, TEvent>: IGrouper<TId> where TEvent : notnull
+    internal class MultiStreamGrouper<TId, TEvent>: IGrouper<TId>
     {
         private readonly Func<TEvent, IReadOnlyList<TId>> _func;
 

--- a/src/Marten/Events/Projections/MultiStreamGrouper.cs
+++ b/src/Marten/Events/Projections/MultiStreamGrouper.cs
@@ -9,7 +9,7 @@ namespace Marten.Events.Projections
     /// </summary>
     /// <typeparam name="TId"></typeparam>
     /// <typeparam name="TEvent"></typeparam>
-    internal class MultiStreamGrouper<TId, TEvent>: IGrouper<TId>
+    internal class MultiStreamGrouper<TId, TEvent>: IGrouper<TId> where TEvent : notnull
     {
         private readonly Func<TEvent, IReadOnlyList<TId>> _func;
 
@@ -29,18 +29,18 @@ namespace Marten.Events.Projections
     /// </summary>
     /// <typeparam name="TId"></typeparam>
     /// <typeparam name="TEvent"></typeparam>
-    internal class MultiStreamGrouperWithIEvent<TId, TEvent>: IGrouper<TId>
+    internal class MultiStreamGrouperWithIEvent<TId, TEvent>: IGrouper<TId> where TEvent : notnull
     {
-        private readonly Func<TEvent, IEvent, IReadOnlyList<TId>> _func;
+        private readonly Func<IEvent<TEvent>, IReadOnlyList<TId>> _func;
 
-        public MultiStreamGrouperWithIEvent(Func<TEvent, IEvent, IReadOnlyList<TId>> expression)
+        public MultiStreamGrouperWithIEvent(Func<IEvent<TEvent>, IReadOnlyList<TId>> expression)
         {
             _func = expression;
         }
 
         public void Apply(IEnumerable<IEvent> events, ITenantSliceGroup<TId> grouping)
         {
-            grouping.AddEvents(_func, events);
+            grouping.AddEventsUsingWrappedEvent(_func, events);
         }
     }
 }

--- a/src/Marten/Events/Projections/MultiStreamGrouper.cs
+++ b/src/Marten/Events/Projections/MultiStreamGrouper.cs
@@ -23,24 +23,4 @@ namespace Marten.Events.Projections
             grouping.AddEvents(_func, events);
         }
     }
-
-    /// <summary>
-    /// This type of grouper potentially sorts one event into multiple aggregates
-    /// </summary>
-    /// <typeparam name="TId"></typeparam>
-    /// <typeparam name="TEvent"></typeparam>
-    internal class MultiStreamGrouperWithIEvent<TId, TEvent>: IGrouper<TId> where TEvent : notnull
-    {
-        private readonly Func<IEvent<TEvent>, IReadOnlyList<TId>> _func;
-
-        public MultiStreamGrouperWithIEvent(Func<IEvent<TEvent>, IReadOnlyList<TId>> expression)
-        {
-            _func = expression;
-        }
-
-        public void Apply(IEnumerable<IEvent> events, ITenantSliceGroup<TId> grouping)
-        {
-            grouping.AddEventsUsingWrappedEvent(_func, events);
-        }
-    }
 }

--- a/src/Marten/Events/Projections/MultiStreamGrouper.cs
+++ b/src/Marten/Events/Projections/MultiStreamGrouper.cs
@@ -1,7 +1,5 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using Baseline;
 using Marten.Events.Aggregation;
 
 namespace Marten.Events.Projections
@@ -16,6 +14,26 @@ namespace Marten.Events.Projections
         private readonly Func<TEvent, IReadOnlyList<TId>> _func;
 
         public MultiStreamGrouper(Func<TEvent, IReadOnlyList<TId>> expression)
+        {
+            _func = expression;
+        }
+
+        public void Apply(IEnumerable<IEvent> events, ITenantSliceGroup<TId> grouping)
+        {
+            grouping.AddEvents(_func, events);
+        }
+    }
+
+    /// <summary>
+    /// This type of grouper potentially sorts one event into multiple aggregates
+    /// </summary>
+    /// <typeparam name="TId"></typeparam>
+    /// <typeparam name="TEvent"></typeparam>
+    internal class MultiStreamGrouperWithIEvent<TId, TEvent>: IGrouper<TId>
+    {
+        private readonly Func<TEvent, IEvent, IReadOnlyList<TId>> _func;
+
+        public MultiStreamGrouperWithIEvent(Func<TEvent, IEvent, IReadOnlyList<TId>> expression)
         {
             _func = expression;
         }

--- a/src/Marten/Events/Projections/SingleStreamGrouper.cs
+++ b/src/Marten/Events/Projections/SingleStreamGrouper.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Baseline;
 using Marten.Events.Aggregation;
 
 namespace Marten.Events.Projections
@@ -23,26 +21,6 @@ namespace Marten.Events.Projections
         public void Apply(IEnumerable<IEvent> events, ITenantSliceGroup<TId> grouping)
         {
             grouping.AddEvents(_func, events);
-        }
-    }
-
-    /// <summary>
-    /// Assigns an event to only one stream
-    /// </summary>
-    /// <typeparam name="TId"></typeparam>
-    /// <typeparam name="TEvent"></typeparam>
-    internal class SingleStreamGrouperWithIEvent<TId, TEvent>: IGrouper<TId> where TEvent : notnull
-    {
-        private readonly Func<IEvent<TEvent>, TId> _func;
-
-        public SingleStreamGrouperWithIEvent(Func<IEvent<TEvent>, TId> expression)
-        {
-            _func = expression;
-        }
-
-        public void Apply(IEnumerable<IEvent> events, ITenantSliceGroup<TId> grouping)
-        {
-            grouping.AddEventsUsingWrappedEvent(_func, events);
         }
     }
 }

--- a/src/Marten/Events/Projections/SingleStreamGrouper.cs
+++ b/src/Marten/Events/Projections/SingleStreamGrouper.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Baseline;
 using Marten.Events.Aggregation;
 
 namespace Marten.Events.Projections
@@ -9,7 +11,7 @@ namespace Marten.Events.Projections
     /// </summary>
     /// <typeparam name="TId"></typeparam>
     /// <typeparam name="TEvent"></typeparam>
-    internal class SingleStreamGrouper<TId, TEvent>: IGrouper<TId> where TEvent : notnull
+    internal class SingleStreamGrouper<TId, TEvent> : IGrouper<TId>
     {
         private readonly Func<TEvent, TId> _func;
 
@@ -17,7 +19,7 @@ namespace Marten.Events.Projections
         {
             _func = expression;
         }
-        
+
         public void Apply(IEnumerable<IEvent> events, ITenantSliceGroup<TId> grouping)
         {
             grouping.AddEvents(_func, events);

--- a/src/Marten/Events/Projections/SingleStreamGrouper.cs
+++ b/src/Marten/Events/Projections/SingleStreamGrouper.cs
@@ -11,11 +11,31 @@ namespace Marten.Events.Projections
     /// </summary>
     /// <typeparam name="TId"></typeparam>
     /// <typeparam name="TEvent"></typeparam>
-    internal class SingleStreamGrouper<TId, TEvent> : IGrouper<TId>
+    internal class SingleStreamGrouper<TId, TEvent>: IGrouper<TId>
     {
         private readonly Func<TEvent, TId> _func;
 
         public SingleStreamGrouper(Func<TEvent, TId> expression)
+        {
+            _func = expression;
+        }
+        
+        public void Apply(IEnumerable<IEvent> events, ITenantSliceGroup<TId> grouping)
+        {
+            grouping.AddEvents(_func, events);
+        }
+    }
+
+    /// <summary>
+    /// Assigns an event to only one stream
+    /// </summary>
+    /// <typeparam name="TId"></typeparam>
+    /// <typeparam name="TEvent"></typeparam>
+    internal class SingleStreamGrouperWithIEvent<TId, TEvent>: IGrouper<TId>
+    {
+        private readonly Func<TEvent, IEvent, TId> _func;
+
+        public SingleStreamGrouperWithIEvent(Func<TEvent, IEvent, TId> expression)
         {
             _func = expression;
         }

--- a/src/Marten/Events/Projections/SingleStreamGrouper.cs
+++ b/src/Marten/Events/Projections/SingleStreamGrouper.cs
@@ -11,7 +11,7 @@ namespace Marten.Events.Projections
     /// </summary>
     /// <typeparam name="TId"></typeparam>
     /// <typeparam name="TEvent"></typeparam>
-    internal class SingleStreamGrouper<TId, TEvent>: IGrouper<TId>
+    internal class SingleStreamGrouper<TId, TEvent>: IGrouper<TId> where TEvent : notnull
     {
         private readonly Func<TEvent, TId> _func;
 
@@ -31,18 +31,18 @@ namespace Marten.Events.Projections
     /// </summary>
     /// <typeparam name="TId"></typeparam>
     /// <typeparam name="TEvent"></typeparam>
-    internal class SingleStreamGrouperWithIEvent<TId, TEvent>: IGrouper<TId>
+    internal class SingleStreamGrouperWithIEvent<TId, TEvent>: IGrouper<TId> where TEvent : notnull
     {
-        private readonly Func<TEvent, IEvent, TId> _func;
+        private readonly Func<IEvent<TEvent>, TId> _func;
 
-        public SingleStreamGrouperWithIEvent(Func<TEvent, IEvent, TId> expression)
+        public SingleStreamGrouperWithIEvent(Func<IEvent<TEvent>, TId> expression)
         {
             _func = expression;
         }
 
         public void Apply(IEnumerable<IEvent> events, ITenantSliceGroup<TId> grouping)
         {
-            grouping.AddEvents(_func, events);
+            grouping.AddEventsUsingWrappedEvent(_func, events);
         }
     }
 }

--- a/src/Marten/Events/Projections/SingleStreamGrouperByEventStreamId.cs
+++ b/src/Marten/Events/Projections/SingleStreamGrouperByEventStreamId.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Marten.Events.Aggregation;
+
+namespace Marten.Events.Projections
+{
+    /// <summary>
+    /// Assigns an event to only one stream based on its stream id
+    /// </summary>
+    /// <typeparam name="TId"></typeparam>
+    /// <typeparam name="TEvent"></typeparam>
+    internal class SingleStreamGrouperByEventStreamId<TId, TEvent>: IGrouper<TId> where TEvent : notnull
+    {
+        public void Apply(IEnumerable<IEvent> events, ITenantSliceGroup<TId> grouping)
+        {
+            grouping.AddEvents<TEvent>(events);
+        }
+    }
+}

--- a/src/Marten/Events/Projections/ViewProjection.cs
+++ b/src/Marten/Events/Projections/ViewProjection.cs
@@ -109,12 +109,28 @@ namespace Marten.Events.Projections
             _groupers.Add(new SingleStreamGrouper<TId, TEvent>(identityFunc));
         }
 
+        public void Identity<TEvent>(Func<TEvent, IEvent, TId> identityFunc)
+        {
+            if (_customSlicer != null)
+                throw new InvalidOperationException(
+                    "There is already a custom event slicer registered for this projection");
+            _groupers.Add(new SingleStreamGrouperWithIEvent<TId,TEvent>(identityFunc));
+        }
+
         public void Identities<TEvent>(Func<TEvent, IReadOnlyList<TId>> identitiesFunc)
         {
             if (_customSlicer != null)
                 throw new InvalidOperationException(
                     "There is already a custom event slicer registered for this projection");
             _groupers.Add(new MultiStreamGrouper<TId, TEvent>(identitiesFunc));
+        }
+
+        public void Identities<TEvent>(Func<TEvent, IEvent, IReadOnlyList<TId>> identitiesFunc) where TEvent : notnull
+        {
+            if (_customSlicer != null)
+                throw new InvalidOperationException(
+                    "There is already a custom event slicer registered for this projection");
+            _groupers.Add(new MultiStreamGrouperWithIEvent<TId, TEvent>(identitiesFunc));
         }
 
         /// <summary>

--- a/src/Marten/Events/Projections/ViewProjection.cs
+++ b/src/Marten/Events/Projections/ViewProjection.cs
@@ -107,12 +107,11 @@ namespace Marten.Events.Projections
         /// <typeparam name="TEvent"></typeparam>
         /// <param name="identityFunc"></param>
         /// <exception cref="InvalidOperationException"></exception>
-        public void Identity<TEvent>(Func<TEvent, TId> identityFunc) where TEvent : notnull
+        public void Identity<TEvent>(Func<TEvent, TId> identityFunc)
         {
             if (_customSlicer != null)
                 throw new InvalidOperationException(
                     "There is already a custom event slicer registered for this projection");
-
             _groupers.Add(new SingleStreamGrouper<TId, TEvent>(identityFunc));
         }
 
@@ -121,7 +120,7 @@ namespace Marten.Events.Projections
         /// </summary>
         /// <typeparam name="TEvent"></typeparam>
         /// <exception cref="InvalidOperationException"></exception>
-        public void Identity<TEvent>() where TEvent : notnull
+        public void Identity<TEvent>()
         {
             if (_customSlicer != null)
                 throw new InvalidOperationException(

--- a/src/Marten/Events/Projections/ViewProjection.cs
+++ b/src/Marten/Events/Projections/ViewProjection.cs
@@ -101,15 +101,20 @@ namespace Marten.Events.Projections
                 .Distinct().ToArray();
         }
 
-        public void Identity<TEvent>(Func<TEvent, TId> identityFunc)
+        public void Identity<TEvent>(Func<TEvent, TId> identityFunc) where TEvent : notnull
         {
+            if (typeof(IEvent).IsAssignableFrom(typeof(TEvent)))
+                throw new InvalidOperationException(
+                    $"Use {nameof(EventIdentity)}<{nameof(TEvent)}>() when mapping a event wrapped in {nameof(IEvent<TEvent>)} to this projection.");
+
             if (_customSlicer != null)
                 throw new InvalidOperationException(
                     "There is already a custom event slicer registered for this projection");
+
             _groupers.Add(new SingleStreamGrouper<TId, TEvent>(identityFunc));
         }
 
-        public void Identity<TEvent>(Func<TEvent, IEvent, TId> identityFunc)
+        public void EventIdentity<TEvent>(Func<IEvent<TEvent>, TId> identityFunc) where TEvent : notnull
         {
             if (_customSlicer != null)
                 throw new InvalidOperationException(
@@ -119,13 +124,17 @@ namespace Marten.Events.Projections
 
         public void Identities<TEvent>(Func<TEvent, IReadOnlyList<TId>> identitiesFunc)
         {
+            if (typeof(IEvent).IsAssignableFrom(typeof(TEvent)))
+                throw new InvalidOperationException(
+                    $"Use {nameof(EvenIdentities)}<{nameof(TEvent)}>() when mapping a event wrapped in {nameof(IEvent<TEvent>)} to this projection.");
+
             if (_customSlicer != null)
                 throw new InvalidOperationException(
                     "There is already a custom event slicer registered for this projection");
             _groupers.Add(new MultiStreamGrouper<TId, TEvent>(identitiesFunc));
         }
 
-        public void Identities<TEvent>(Func<TEvent, IEvent, IReadOnlyList<TId>> identitiesFunc) where TEvent : notnull
+        public void EvenIdentities<TEvent>(Func<IEvent<TEvent>, IReadOnlyList<TId>> identitiesFunc) where TEvent : notnull
         {
             if (_customSlicer != null)
                 throw new InvalidOperationException(


### PR DESCRIPTION
If events are designed to not include the stream id on their event object (instead relying on IEvent metadata to store the id), it can be difficult to build view projections for theses events, as only a custom grouper/slicer exposes the IEvent.

This change adds a method `Idientity<TEvent>()` to view projections. This overload doesnt take a function and assumes that matching events will use their stream id/key to map to the document aggregate id.

Examples of how this works (from new tests):

```cs
public class UserGroupsAssignmentProjectionUsingSelfAggregate: ViewProjection<UserGroupsAssignment, Guid>
{
    public UserGroupsAssignmentProjectionUsingSelfAggregate()
    {
        // This is just specifying the aggregate document id
        // per event type. This assumes that each event
        // applies to only one aggregated view document
        Identity<UserRegistered>();
        Identity<SingleUserAssignedToGroup>(x => x.UserId);
    }

    public void Apply(UserRegistered @event, UserGroupsAssignment view)
        => view.Id = @event.UserId;

    public void Apply(SingleUserAssignedToGroup @event, UserGroupsAssignment view)
        => view.Groups.Add(@event.GroupId);
}
```

And with a one-to-many fanout (was quite happy to find this just works):

```cs
public class UserSocialCircleProjection: ViewProjection<UserSocialCircle, Guid>
{
    public UserSocialCircleProjection()
    {
        Identity<UserRegistered>();

        // Multiple Identity methods can be called for the same event
        // Useful for describing different projection mappings
        Identity<UserFollowsUsers>();
        Identities<UserFollowsUsers>(x => x.FollowingUsers);
    }

    public void Apply(UserRegistered @event, UserSocialCircle view)
        => view.Id = @event.UserId;

    public void Apply(UserFollowsUsers @event, UserSocialCircle view)
    {
        if (@event.UserId == view.Id)
        {
            view.FollowingUsers.AddRange(@event.FollowingUsers.Where(user => !view.FollowingUsers.Contains(user)));
        }

        if (@event.FollowingUsers.Contains(view.Id) && !view.FollowedByUsers.Contains(@event.UserId))
        {
            view.FollowedByUsers.Add(@event.UserId);
        }
    }
}
```

Other changes:
- Fixed DateTime>DateTimeOffset implicit conversions in some unit tests to get all tests green.
- Added codedoc for `Identity` and `Identities` methods