### PR TITLE
Custom aggregation recipe, other daemon optimizations. Closes GH-2123…

### DIFF
--- a/docs/documents/querying/linq/booleans.md
+++ b/docs/documents/querying/linq/booleans.md
@@ -20,5 +20,5 @@ public void query_by_booleans(IDocumentSession session)
     session.Query<Target>().Where(x => x.Flag == false).ToArray();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L128-L144' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_boolean_queries' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L154-L170' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_boolean_queries' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/documents/querying/linq/nulls.md
+++ b/docs/documents/querying/linq/nulls.md
@@ -15,5 +15,5 @@ public void query_by_nullable_type_nulls(IDocumentSession session)
     session.Query<Target>().Where(x => x.Inner == null);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L146-L157' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_by_nullable_types' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L172-L183' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_by_nullable_types' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/events/metadata.md
+++ b/docs/events/metadata.md
@@ -123,7 +123,15 @@ public interface IEvent
     /// to projected views
     /// </summary>
     bool IsArchived { get; set; }
+
+    /// <summary>
+    /// Marten's name for the aggregate type that will be persisted
+    /// to the streams table. This will only be available when running
+    /// within the Async Daemon
+    /// </summary>
+    public string? AggregateTypeName { get; set; }
+
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Event.cs#L8-L105' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ievent' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Event.cs#L8-L113' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ievent' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/events/projections/rebuilding.md
+++ b/docs/events/projections/rebuilding.md
@@ -20,7 +20,7 @@ public class DistanceProjection: EventProjection
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/event_projections_end_to_end.cs#L155-L171' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_create_in_event_projection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/event_projections_end_to_end.cs#L156-L172' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_create_in_event_projection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 <!-- snippet: sample_rebuild-single-projection -->
@@ -36,5 +36,5 @@ await PublishSingleThreaded();
 // rebuild projection `Distance`
 await agent.RebuildProjection("Distance", CancellationToken.None);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/event_projections_end_to_end.cs#L87-L97' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_rebuild-single-projection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/event_projections_end_to_end.cs#L88-L98' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_rebuild-single-projection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/events/querying.md
+++ b/docs/events/querying.md
@@ -135,9 +135,17 @@ public interface IEvent
     /// to projected views
     /// </summary>
     bool IsArchived { get; set; }
+
+    /// <summary>
+    /// Marten's name for the aggregate type that will be persisted
+    /// to the streams table. This will only be available when running
+    /// within the Async Daemon
+    /// </summary>
+    public string? AggregateTypeName { get; set; }
+
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Event.cs#L8-L105' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ievent' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Event.cs#L8-L113' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ievent' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Stream State

--- a/docs/events/storage.md
+++ b/docs/events/storage.md
@@ -104,7 +104,7 @@ public string? CorrelationId { get; set; }
 /// </summary>
 public Dictionary<string, object>? Headers { get; set; }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Event.cs#L124-L174' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_event_metadata' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Event.cs#L132-L182' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_event_metadata' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The full event data is available on `EventStream` and `IEvent` objects immediately after committing a transaction that involves event capture. See [diagnostics and instrumentation](/diagnostics) for more information on capturing event data in the instrumentation hooks.

--- a/src/CommandLineRunner/FindUserByAllTheThings.cs
+++ b/src/CommandLineRunner/FindUserByAllTheThings.cs
@@ -8,16 +8,16 @@ namespace CommandLineRunner
 {
     public class FindUserByAllTheThings: ICompiledQuery<User>
     {
-        public string Username { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
+        public string? Username { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
 
         public Expression<Func<IMartenQueryable<User>, User>> QueryIs()
         {
             return query =>
-                query.Where(x => x.FirstName == FirstName && Username == x.UserName)
-                    .Where(x => x.LastName == LastName)
-                    .Single();
+                query
+                    .Where(x => x.FirstName == FirstName && Username == x.UserName)
+                    .Single(x => x.LastName == LastName);
         }
     }
 }

--- a/src/EventSourcingTests/Aggregation/CustomAggregationTests.cs
+++ b/src/EventSourcingTests/Aggregation/CustomAggregationTests.cs
@@ -1,0 +1,451 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Baseline;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Daemon;
+using Marten.Events.Projections;
+using Marten.Exceptions;
+using Marten.Internal.Sessions;
+using Marten.Linq.SoftDeletes;
+using Marten.Metadata;
+using Marten.Storage;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Microsoft.CodeAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Aggregation
+{
+    public class CustomAggregationTests
+    {
+        [Fact]
+        public void default_projection_name_is_type_name()
+        {
+            new MyCustomAggregation().ProjectionName.ShouldBe(nameof(MyCustomAggregation));
+        }
+
+        [Fact]
+        public void default_lifecycle_should_be_async()
+        {
+            new MyCustomAggregation().Lifecycle.ShouldBe(ProjectionLifecycle.Async);
+        }
+
+        [Fact]
+        public void async_options_is_not_null()
+        {
+            new MyCustomAggregation().As<IProjectionSource>().Options.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void assert_invalid_with_no_slicer()
+        {
+            Exception<InvalidProjectionException>.ShouldBeThrownBy(() =>
+            {
+                new MyCustomAggregateWithNoSlicer().CompileAndAssertValidity();
+            });
+        }
+
+        [Fact]
+        public void assert_invalid_with_incomplete_slicing_rules()
+        {
+            var projection = new MyCustomAggregateWithNoSlicer();
+            projection.AggregateEvents(x => {});
+
+            Exception<InvalidProjectionException>.ShouldBeThrownBy(() =>
+            {
+                new MyCustomAggregateWithNoSlicer().CompileAndAssertValidity();
+            });
+        }
+
+        [Fact]
+        public void valid_slicing_with_configured_slicing()
+        {
+            var projection = new MyCustomAggregateWithNoSlicer();
+            projection.AggregateEvents(x => x.Identity<INumbered>(n => n.Number));
+
+            projection.Slicer.ShouldBeOfType<EventSlicer<CustomAggregate, int>>();
+        }
+
+        [Fact]
+        public void throws_if_you_try_to_slice_by_string_on_something_besides_guid_or_string()
+        {
+            var wrong = new EmptyCustomProjection<User, int>();
+
+            Exception<InvalidProjectionException>.ShouldBeThrownBy(() =>
+            {
+                wrong.AggregateByStream();
+            });
+        }
+
+        [Fact]
+        public void use_per_stream_aggregation_by_guid()
+        {
+            var withGuid = new EmptyCustomProjection<User, Guid>();
+            withGuid.AggregateByStream();
+
+            withGuid.Slicer.ShouldBeOfType<ByStreamId<User>>();
+        }
+
+        [Fact]
+        public void use_per_stream_aggregation_by_string()
+        {
+            var withGuid = new EmptyCustomProjection<StringDoc, string>();
+            withGuid.AggregateByStream();
+
+            withGuid.Slicer.ShouldBeOfType<ByStreamKey<StringDoc>>();
+        }
+
+    }
+
+    public class EmptyCustomProjection<TDoc, TId>: CustomAggregation<TDoc, TId>
+    {
+        public override ValueTask ApplyChangesAsync(DocumentSessionBase session, EventSlice<TDoc, TId> slice, CancellationToken cancellation,
+            ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class custom_aggregation_end_to_end: OneOffConfigurationsContext
+    {
+        private void appendCustomEvent(int number, char letter)
+        {
+            theSession.Events.Append(Guid.NewGuid(), new CustomEvent(number, letter));
+        }
+
+        [Fact]
+        public async Task use_inline_asynchronous()
+        {
+            StoreOptions(opts => opts.Projections.Add(new MyCustomAggregation(), ProjectionLifecycle.Inline));
+
+            await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+            await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+
+            appendCustomEvent(1, 'a');
+            appendCustomEvent(1, 'a');
+            appendCustomEvent(1, 'b');
+            appendCustomEvent(1, 'c');
+            appendCustomEvent(1, 'd');
+            appendCustomEvent(2, 'a');
+            appendCustomEvent(2, 'a');
+            appendCustomEvent(3, 'b');
+            appendCustomEvent(3, 'd');
+            appendCustomEvent(1, 'a');
+            appendCustomEvent(1, 'a');
+
+            await theSession.SaveChangesAsync();
+
+            var agg1 = await theSession.LoadAsync<CustomAggregate>(1);
+            agg1
+                .ShouldBe(new CustomAggregate{Id = 1, ACount = 4, BCount = 1, CCount = 1, DCount = 1});
+
+            (await theSession.LoadAsync<CustomAggregate>(2))
+                .ShouldBe(new CustomAggregate{Id = 2, ACount = 2, BCount = 0, CCount = 0, DCount = 0});
+
+            (await theSession.LoadAsync<CustomAggregate>(3))
+                .ShouldBe(new CustomAggregate{Id = 3, ACount = 0, BCount = 1, CCount = 0, DCount = 1});
+
+        }
+
+        [Fact]
+        public void use_inline_synchronous()
+        {
+            StoreOptions(opts => opts.Projections.Add(new MyCustomAggregation(), ProjectionLifecycle.Inline));
+
+            theStore.Advanced.Clean.DeleteAllDocuments();
+            theStore.Advanced.Clean.DeleteAllEventData();
+
+            appendCustomEvent(1, 'a');
+            appendCustomEvent(1, 'a');
+            appendCustomEvent(1, 'b');
+            appendCustomEvent(1, 'c');
+            appendCustomEvent(1, 'd');
+            appendCustomEvent(2, 'a');
+            appendCustomEvent(2, 'a');
+            appendCustomEvent(3, 'b');
+            appendCustomEvent(3, 'd');
+            appendCustomEvent(1, 'a');
+            appendCustomEvent(1, 'a');
+
+            theSession.SaveChanges();
+
+            theSession.Load<CustomAggregate>(1)
+                .ShouldBe(new CustomAggregate{Id = 1, ACount = 4, BCount = 1, CCount = 1, DCount = 1});
+
+            theSession.Load<CustomAggregate>(2)
+                .ShouldBe(new CustomAggregate{Id = 2, ACount = 2, BCount = 0, CCount = 0, DCount = 0});
+
+            theSession.Load<CustomAggregate>(3)
+                .ShouldBe(new CustomAggregate{Id = 3, ACount = 0, BCount = 1, CCount = 0, DCount = 1});
+
+        }
+
+    }
+
+    public class CustomEvent : INumbered
+    {
+        public CustomEvent(int number, char letter)
+        {
+            Number = number;
+            Letter = letter;
+        }
+
+        public int Number { get; set; }
+        public char Letter { get; set; }
+    }
+
+    public interface INumbered
+    {
+        public int Number { get; }
+    }
+
+    public class MyCustomAggregateWithNoSlicer: CustomAggregation<CustomAggregate, int>
+    {
+        public override ValueTask ApplyChangesAsync(DocumentSessionBase session, EventSlice<CustomAggregate, int> slice, CancellationToken cancellation,
+            ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline)
+        {
+            throw new NotImplementedException();
+        }
+
+
+    }
+
+
+    public class MyCustomAggregation: CustomAggregation<CustomAggregate, int>
+    {
+        public MyCustomAggregation()
+        {
+            AggregateEvents(s =>
+            {
+                s.Identity<INumbered>(x => x.Number);
+            });
+        }
+
+        public override ValueTask ApplyChangesAsync(DocumentSessionBase session, EventSlice<CustomAggregate, int> slice, CancellationToken cancellation,
+            ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline)
+        {
+            var aggregate = slice.Aggregate ?? new CustomAggregate { Id = slice.Id };
+
+            foreach (var @event in slice.Events())
+            {
+                if (@event.Data is CustomEvent e)
+                {
+                    switch (e.Letter)
+                    {
+                        case 'a':
+                            aggregate.ACount++;
+                            break;
+
+                        case 'b':
+                            aggregate.BCount++;
+                            break;
+
+                        case 'c':
+                            aggregate.CCount++;
+                            break;
+
+                        case 'd':
+                            aggregate.DCount++;
+                            break;
+                    }
+                }
+            }
+
+            session.Store(aggregate);
+            return new ValueTask();
+        }
+
+    }
+
+    public class CustomAggregate
+    {
+        public int Id { get; set; }
+
+        public int ACount { get; set; }
+        public int BCount { get; set; }
+        public int CCount { get; set; }
+        public int DCount { get; set; }
+
+        protected bool Equals(CustomAggregate other)
+        {
+            return Id == other.Id && ACount == other.ACount && BCount == other.BCount && CCount == other.CCount && DCount == other.DCount;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+
+            return Equals((CustomAggregate)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Id, ACount, BCount, CCount, DCount);
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(Id)}: {Id}, {nameof(ACount)}: {ACount}, {nameof(BCount)}: {BCount}, {nameof(CCount)}: {CCount}, {nameof(DCount)}: {DCount}";
+        }
+    }
+
+    public class using_custom_aggregate_with_soft_deletes_and_update_only_events : OneOffConfigurationsContext, IAsyncLifetime
+    {
+        public using_custom_aggregate_with_soft_deletes_and_update_only_events()
+        {
+            StoreOptions(opts => opts.Projections.Add(new StartAndStopProjection()));
+        }
+
+        public Task InitializeAsync()
+        {
+            return theStore.Advanced.Clean.CompletelyRemoveAllAsync();
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task update_only_when_aggregate_does_not_exist()
+        {
+            var stream = Guid.NewGuid();
+
+            // This should do nothing because the aggregate isn't started yet
+            theSession.Events.StartStream(stream, new Increment(), new Increment());
+            await theSession.SaveChangesAsync();
+
+            (await theSession.LoadAsync<StartAndStopAggregate>(stream)).ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task start_and_increment()
+        {
+            var stream = Guid.NewGuid();
+
+            // This should do nothing because the aggregate isn't started yet
+            theSession.Events.StartStream(stream, new Start(), new Increment(), new Increment());
+            await theSession.SaveChangesAsync();
+
+            var aggregate = await theSession.LoadAsync<StartAndStopAggregate>(stream);
+            aggregate.Count.ShouldBe(2);
+        }
+
+        [Fact]
+        public async Task trigger_initial_delete()
+        {
+            var stream = Guid.NewGuid();
+
+            // This should do nothing because the aggregate isn't started yet
+            theSession.Events.StartStream(stream, new Start(), new Increment(), new Increment());
+            await theSession.SaveChangesAsync();
+
+            var aggregate = await theSession.LoadAsync<StartAndStopAggregate>(stream);
+            aggregate.ShouldNotBeNull();
+
+            theSession.Events.Append(stream, new Increment(), new End(), new Increment());
+            await theSession.SaveChangesAsync();
+
+            aggregate = await theSession.LoadAsync<StartAndStopAggregate>(stream);
+            aggregate.Count.ShouldBe(3);
+            aggregate.Deleted.ShouldBeTrue();
+        }
+    }
+
+    public class StartAndStopAggregate : ISoftDeleted
+    {
+        // These are Marten controlled
+        public bool Deleted { get; set; }
+        public DateTimeOffset? DeletedAt { get; set; }
+
+        public int Count { get; set; }
+
+        public Guid Id { get; set; }
+
+        public void Increment()
+        {
+            Count++;
+        }
+    }
+
+    public class Start{}
+    public class End{}
+    public class Restart{}
+    public class Increment{}
+
+    public class StartAndStopProjection: CustomAggregation<StartAndStopAggregate, Guid>
+    {
+        public StartAndStopProjection()
+        {
+            AggregateByStream();
+
+        }
+
+        public override ValueTask ApplyChangesAsync(DocumentSessionBase session, EventSlice<StartAndStopAggregate, Guid> slice, CancellationToken cancellation,
+            ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline)
+        {
+
+            var aggregate = slice.Aggregate;
+
+
+            foreach (var data in slice.AllData())
+            {
+                switch (data)
+                {
+                    case Start:
+                        aggregate = new StartAndStopAggregate
+                        {
+                            // Have to assign the identity ourselves
+                            Id = slice.Id
+                        };
+                        break;
+                    case Increment when aggregate is { Deleted: false }:
+                        // Use explicit code to only apply this event
+                        // if the aggregate already exists
+                        aggregate.Increment();
+                        break;
+                    case End when aggregate is { Deleted: false }:
+                        // This will be a "soft delete" because the aggregate type
+                        // implements the IDeleted interface
+                        session.Delete(aggregate);
+                        aggregate.Deleted = true; // Got to help Marten out a little bit here
+                        break;
+                    case Restart when (aggregate == null || aggregate.Deleted):
+                        // Got to "undo" the soft delete status
+                        session
+                            .UndoDeleteWhere<StartAndStopAggregate>(x => x.Id == slice.Id);
+                        break;
+                }
+            }
+
+            // Apply any updates!
+            if (aggregate != null)
+            {
+                session.Store(aggregate);
+            }
+
+
+            // We didn't do anything that required an asynchronous call
+            return new ValueTask();
+        }
+    }
+}

--- a/src/EventSourcingTests/Aggregation/aggregation_projection_validation_rules.cs
+++ b/src/EventSourcingTests/Aggregation/aggregation_projection_validation_rules.cs
@@ -119,7 +119,7 @@ namespace EventSourcingTests.Aggregation
         public void happy_path_validation_for_aggregation()
         {
             var projection = new AllGood();
-            projection.AssertValidity();
+            projection.CompileAndAssertValidity();
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace EventSourcingTests.Aggregation
         public void find_bad_method_names_that_are_not_ignored()
         {
             var projection = new BadMethodName();
-            var ex = Should.Throw<InvalidProjectionException>(() => projection.AssertValidity());
+            var ex = Should.Throw<InvalidProjectionException>(() => projection.CompileAndAssertValidity());
 
             ex.Message.ShouldContain("Unrecognized method name 'DoStuff'. Either mark with [MartenIgnore] or use one of 'Apply', 'Create', 'ShouldDelete'", StringComparisonOption.NormalizeWhitespaces);
         }
@@ -146,7 +146,7 @@ namespace EventSourcingTests.Aggregation
         public void find_invalid_argument_type()
         {
             var projection = new InvalidArgumentType();
-            var ex = Should.Throw<InvalidProjectionException>(() => projection.AssertValidity());
+            var ex = Should.Throw<InvalidProjectionException>(() => projection.CompileAndAssertValidity());
             ex.InvalidMethods.Single()
                 .Errors
                 .ShouldContain($"Parameter of type 'Marten.IDocumentOperations' is not supported. Valid options are System.Threading.CancellationToken, Marten.IQuerySession, {typeof(MyAggregate).FullNameInCode()}, {typeof(AEvent).FullNameInCode()}, Marten.Events.IEvent, Marten.Events.IEvent<{typeof(AEvent).FullNameInCode()}>");
@@ -156,7 +156,7 @@ namespace EventSourcingTests.Aggregation
         public void missing_event_altogether()
         {
             var projection = new MissingEventType1();
-            var ex = Should.Throw<InvalidProjectionException>(() => projection.AssertValidity());
+            var ex = Should.Throw<InvalidProjectionException>(() => projection.CompileAndAssertValidity());
             ex.InvalidMethods.Single()
                 .Errors.ShouldContain(MethodSlot.NoEventType);
         }
@@ -165,14 +165,14 @@ namespace EventSourcingTests.Aggregation
         public void marten_can_guess_the_event_based_on_what_is_left()
         {
             var projection = new CanGuessEventType();
-            projection.AssertValidity();
+            projection.CompileAndAssertValidity();
         }
 
         [Fact]
         public void invalid_return_type()
         {
             var projection = new BadReturnType();
-            var ex = Should.Throw<InvalidProjectionException>(() => projection.AssertValidity());
+            var ex = Should.Throw<InvalidProjectionException>(() => projection.CompileAndAssertValidity());
             ex.InvalidMethods.Single()
                 .Errors.ShouldContain(
                     $"Parameter of type 'Marten.IDocumentOperations' is not supported. Valid options are System.Threading.CancellationToken, Marten.IQuerySession, {typeof(MyAggregate).FullNameInCode()}, {typeof(AEvent).FullNameInCode()}, Marten.Events.IEvent, Marten.Events.IEvent<{typeof(AEvent).FullNameInCode()}>", "Return type 'string' is invalid. The valid options are System.Threading.CancellationToken, Marten.IQuerySession, Marten.Testing.Events.Aggregation.MyAggregate");
@@ -182,7 +182,7 @@ namespace EventSourcingTests.Aggregation
         public void missing_required_parameter()
         {
             var projection = new MissingMandatoryType();
-            var ex = Should.Throw<InvalidProjectionException>(() => projection.AssertValidity());
+            var ex = Should.Throw<InvalidProjectionException>(() => projection.CompileAndAssertValidity());
 
             ex.InvalidMethods.Single()
                 .Errors.ShouldContain($"Aggregate type '{typeof(MyAggregate).FullNameInCode()}' is required as a parameter");

--- a/src/EventSourcingTests/Projections/EventProjectionTests.cs
+++ b/src/EventSourcingTests/Projections/EventProjectionTests.cs
@@ -179,7 +179,7 @@ namespace EventSourcingTests.Projections
             var projection = new EmptyProjection();
             Should.Throw<InvalidProjectionException>(() =>
             {
-                projection.AssertValidity();
+                projection.CompileAndAssertValidity();
             });
         }
     }

--- a/src/Marten.AsyncDaemon.Testing/EventRangeGroupTests.cs
+++ b/src/Marten.AsyncDaemon.Testing/EventRangeGroupTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Events.Daemon;
+using Marten.Storage;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
@@ -83,13 +84,12 @@ namespace Marten.AsyncDaemon.Testing
             // nothing
         }
 
-        public override Task ConfigureUpdateBatch(IShardAgent shardAgent, ProjectionUpdateBatch batch,
-            EventRangeGroup eventRangeGroup)
+        public override Task ConfigureUpdateBatch(IShardAgent shardAgent, ProjectionUpdateBatch batch)
         {
             throw new NotSupportedException();
         }
 
-        public override ValueTask SkipEventSequence(long eventSequence)
+        public override ValueTask SkipEventSequence(long eventSequence, IMartenDatabase database)
         {
             throw new NotSupportedException();
         }

--- a/src/Marten.AsyncDaemon.Testing/ViewProjectionTests.cs
+++ b/src/Marten.AsyncDaemon.Testing/ViewProjectionTests.cs
@@ -36,9 +36,9 @@ namespace Marten.AsyncDaemon.Testing
 
             var allEvents = await theSession.Events.QueryAllRawEvents().ToListAsync();
 
-            var projection = (IEventSlicer<Day, int>)new DayProjection();
+            var slicer = new DayProjection().Slicer;
 
-            var slices = await projection.SliceAsyncEvents(theSession, allEvents.ToList());
+            var slices = await slicer.SliceAsyncEvents(theSession, allEvents.ToList());
 
             foreach (var slice in slices.SelectMany(x => x.Slices).ToArray())
             {

--- a/src/Marten.AsyncDaemon.Testing/basic_async_daemon_tests.cs
+++ b/src/Marten.AsyncDaemon.Testing/basic_async_daemon_tests.cs
@@ -73,13 +73,13 @@ namespace Marten.AsyncDaemon.Testing
             var range1 = new EventRange(shardName, 0, 10);
 
 
-            await fetcher.Load(shardName, range1, CancellationToken.None);
+            await fetcher.Load(range1, CancellationToken.None);
 
             var range2 = new EventRange(shardName, 10, 20);
-            await fetcher.Load(shardName, range2, CancellationToken.None);
+            await fetcher.Load(range2, CancellationToken.None);
 
             var range3 = new EventRange(shardName, 20, 38);
-            await fetcher.Load(shardName, range3, CancellationToken.None);
+            await fetcher.Load(range3, CancellationToken.None);
 
             range1.Events.Count.ShouldBe(10);
             range2.Events.Count.ShouldBe(10);
@@ -96,7 +96,7 @@ namespace Marten.AsyncDaemon.Testing
 
             var shardName = new ShardName("name");
             var range1 = new EventRange(shardName, 0, NumberOfEvents);
-            await fetcher1.Load(shardName, range1, CancellationToken.None);
+            await fetcher1.Load(range1, CancellationToken.None);
 
             var uniqueTypeCount = range1.Events.Select(x => x.EventType).Distinct()
                 .Count();
@@ -107,7 +107,7 @@ namespace Marten.AsyncDaemon.Testing
             using var fetcher2 = new EventFetcher(theStore, theStore.Tenancy.Default.Database, new ISqlFragment[]{filter});
 
             var range2 = new EventRange(shardName, 0, NumberOfEvents);
-            await fetcher2.Load(shardName, range2, CancellationToken.None);
+            await fetcher2.Load(range2, CancellationToken.None);
             range2.Events
                 .Select(x => x.EventType)
                 .OrderBy(x => x.Name).Distinct()

--- a/src/Marten.AsyncDaemon.Testing/build_aggregate_projection.cs
+++ b/src/Marten.AsyncDaemon.Testing/build_aggregate_projection.cs
@@ -27,6 +27,7 @@ namespace Marten.AsyncDaemon.Testing
         public void uses_event_type_filter_for_base_filter_when_not_using_base_types()
         {
             var projection = new TripAggregationWithCustomName();
+            projection.CompileAndAssertValidity();
             var filter = projection.As<IProjectionSource>()
                 .AsyncProjectionShards(theStore)
                 .First()

--- a/src/Marten.AsyncDaemon.Testing/custom_aggregation_in_async_daemon.cs
+++ b/src/Marten.AsyncDaemon.Testing/custom_aggregation_in_async_daemon.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.AsyncDaemon.Testing.TestingSupport;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Daemon;
+using Marten.Events.Projections;
+using Marten.Internal.Sessions;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Marten.AsyncDaemon.Testing
+{
+    public class custom_aggregation_in_async_daemon : OneOffConfigurationsContext
+    {
+        private readonly ITestOutputHelper _output;
+
+        public custom_aggregation_in_async_daemon(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        private void appendCustomEvent(int number, char letter)
+        {
+            theSession.Events.Append(Guid.NewGuid(), new CustomEvent(number, letter));
+        }
+
+        [Fact]
+        public async Task run_end_to_end()
+        {
+            StoreOptions(opts =>
+            {
+                var myCustomAggregation = new MyCustomAggregation();
+                opts.Projections.Add(myCustomAggregation, ProjectionLifecycle.Async);
+                opts.Logger(new TestOutputMartenLogger(_output));
+            });
+
+            await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+            await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+
+            appendCustomEvent(1, 'a');
+            appendCustomEvent(1, 'a');
+            appendCustomEvent(1, 'b');
+            appendCustomEvent(1, 'c');
+            appendCustomEvent(1, 'd');
+            appendCustomEvent(2, 'a');
+            appendCustomEvent(2, 'a');
+            appendCustomEvent(3, 'b');
+            appendCustomEvent(3, 'd');
+            appendCustomEvent(1, 'a');
+            appendCustomEvent(1, 'a');
+
+            await theSession.SaveChangesAsync();
+
+            using var daemon = await theStore.BuildProjectionDaemonAsync(logger:new TestLogger<IProjection>(_output));
+            await daemon.StartAllShards();
+
+            await  daemon.Tracker.WaitForShardState("Custom:All", 11);
+
+            var agg1 = await theSession.LoadAsync<CustomAggregate>(1);
+            agg1
+                .ShouldBe(new CustomAggregate{Id = 1, ACount = 4, BCount = 1, CCount = 1, DCount = 1});
+
+            (await theSession.LoadAsync<CustomAggregate>(2))
+                .ShouldBe(new CustomAggregate{Id = 2, ACount = 2, BCount = 0, CCount = 0, DCount = 0});
+
+            (await theSession.LoadAsync<CustomAggregate>(3))
+                .ShouldBe(new CustomAggregate{Id = 3, ACount = 0, BCount = 1, CCount = 0, DCount = 1});
+
+        }
+    }
+
+
+    public class CustomEvent : INumbered
+    {
+        public CustomEvent(int number, char letter)
+        {
+            Number = number;
+            Letter = letter;
+        }
+
+        public int Number { get; set; }
+        public char Letter { get; set; }
+    }
+
+    public interface INumbered
+    {
+        public int Number { get; }
+    }
+
+
+    public class MyCustomAggregation: CustomAggregation<CustomAggregate, int>
+    {
+        public MyCustomAggregation()
+        {
+            ProjectionName = "Custom";
+
+            Slicer = new EventSlicer<CustomAggregate, int>().Identity<INumbered>(x =>
+                x.Number);
+        }
+
+        public override ValueTask ApplyChangesAsync(DocumentSessionBase session, EventSlice<CustomAggregate, int> slice, CancellationToken cancellation,
+            ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline)
+        {
+            var aggregate = slice.Aggregate ?? new CustomAggregate { Id = slice.Id };
+
+            foreach (var @event in slice.Events())
+            {
+                if (@event.Data is CustomEvent e)
+                {
+                    switch (e.Letter)
+                    {
+                        case 'a':
+                            aggregate.ACount++;
+                            break;
+
+                        case 'b':
+                            aggregate.BCount++;
+                            break;
+
+                        case 'c':
+                            aggregate.CCount++;
+                            break;
+
+                        case 'd':
+                            aggregate.DCount++;
+                            break;
+                    }
+                }
+            }
+
+            session.Store(aggregate);
+            return new ValueTask();
+        }
+
+    }
+
+    public class CustomAggregate
+    {
+        public int Id { get; set; }
+
+        public int ACount { get; set; }
+        public int BCount { get; set; }
+        public int CCount { get; set; }
+        public int DCount { get; set; }
+
+        protected bool Equals(CustomAggregate other)
+        {
+            return Id == other.Id && ACount == other.ACount && BCount == other.BCount && CCount == other.CCount && DCount == other.DCount;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+
+            return Equals((CustomAggregate)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Id, ACount, BCount, CCount, DCount);
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(Id)}: {Id}, {nameof(ACount)}: {ACount}, {nameof(BCount)}: {BCount}, {nameof(CCount)}: {CCount}, {nameof(DCount)}: {DCount}";
+        }
+    }
+}

--- a/src/Marten.AsyncDaemon.Testing/event_fetcher_tests.cs
+++ b/src/Marten.AsyncDaemon.Testing/event_fetcher_tests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Baseline.ImTools;
+using Marten.AsyncDaemon.Testing.TestingSupport;
+using Marten.Events;
+using Marten.Events.Daemon;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Postgresql.SqlGeneration;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Marten.AsyncDaemon.Testing
+{
+    public class event_fetcher_tests : OneOffConfigurationsContext, IAsyncLifetime
+    {
+        private readonly List<ISqlFragment> theFilters = new List<ISqlFragment>();
+        private readonly EventRange theRange;
+        private readonly ShardName theShardName = new ShardName("foo", "All");
+
+        public event_fetcher_tests()
+        {
+            theRange = new EventRange(theShardName, 0, 100);
+        }
+
+        internal async Task executeAfterLoadingEvents(Action<IEventStore> loadEvents)
+        {
+            loadEvents(theSession.Events);
+            await theSession.SaveChangesAsync();
+
+            var fetcher = new EventFetcher(theStore, theStore.Tenancy.Default.Database, theFilters.ToArray());
+            await fetcher.Load(theRange, default);
+        }
+
+
+        [Fact]
+        public async Task simple_fetch_with_guid_identifiers()
+        {
+            var stream = Guid.NewGuid();
+            await executeAfterLoadingEvents(e =>
+            {
+
+                e.Append(stream, new AEvent(), new BEvent(), new CEvent(), new DEvent());
+            });
+
+            await theSession.SaveChangesAsync();
+
+            theRange.Events.Count.ShouldBe(4);
+            var @event = theRange.Events[0];
+            @event.StreamId.ShouldBe(stream);
+            @event.Version.ShouldBe(1);
+            @event.Data.ShouldBeOfType<AEvent>();
+        }
+
+        [Fact]
+        public async Task simple_fetch_with_string_identifiers()
+        {
+            StoreOptions(x => x.Events.StreamIdentity = StreamIdentity.AsString);
+
+            var stream = Guid.NewGuid().ToString();
+            await executeAfterLoadingEvents(e =>
+            {
+
+                e.Append(stream, new AEvent(), new BEvent(), new CEvent(), new DEvent());
+            });
+
+            await theSession.SaveChangesAsync();
+
+            theRange.Events.Count.ShouldBe(4);
+            var @event = theRange.Events[0];
+            @event.StreamKey.ShouldBe(stream);
+            @event.Version.ShouldBe(1);
+            @event.Data.ShouldBeOfType<AEvent>();
+        }
+
+        [Fact]
+        public async Task should_get_the_aggregate_type_name_if_exists()
+        {
+            await executeAfterLoadingEvents(e =>
+            {
+                e.Append(Guid.NewGuid(), new AEvent(), new BEvent(), new CEvent(), new DEvent());
+                e.StartStream<Letters>(Guid.NewGuid(), new AEvent(), new BEvent(), new CEvent(), new DEvent(),
+                    new DEvent());
+
+            });
+
+            for (var i = 0; i < 4; i++)
+            {
+                theRange.Events[i].AggregateTypeName.ShouldBeNull();
+            }
+
+            for (var i = 4; i < theRange.Events.Count; i++)
+            {
+                theRange.Events[i].AggregateTypeName.ShouldBe("letters");
+            }
+        }
+
+
+        [Fact]
+        public async Task filter_on_aggregate_type_name_if_exists()
+        {
+            theFilters.Add(new AggregateTypeFilter(typeof(Letters), theStore.Events));
+
+            await executeAfterLoadingEvents(e =>
+            {
+                e.Append(Guid.NewGuid(), new AEvent(), new BEvent(), new CEvent(), new DEvent());
+                e.StartStream<Letters>(Guid.NewGuid(), new AEvent(), new BEvent(), new CEvent(), new DEvent(),
+                    new DEvent());
+
+            });
+
+            theRange.Events.Count.ShouldBe(5);
+            foreach (var @event in theRange.Events)
+            {
+                @event.AggregateTypeName.ShouldBe("letters");
+            }
+
+        }
+
+        public Task InitializeAsync()
+        {
+            return theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    public class Letters
+    {
+        public int ACount { get; set; }
+        public int BCount { get; set; }
+        public int CCount { get; set; }
+        public int DCount { get; set; }
+    }
+}

--- a/src/Marten.AsyncDaemon.Testing/event_projections_end_to_end.cs
+++ b/src/Marten.AsyncDaemon.Testing/event_projections_end_to_end.cs
@@ -27,6 +27,7 @@ namespace Marten.AsyncDaemon.Testing
         public void uses_event_type_filter()
         {
             var projection = new DistanceProjection();
+            projection.CompileAndAssertValidity();
             var filter = projection.As<IProjectionSource>()
                 .AsyncProjectionShards(theStore)
                 .First()

--- a/src/Marten.AsyncDaemon.Testing/multi_tenancy_by_database.cs
+++ b/src/Marten.AsyncDaemon.Testing/multi_tenancy_by_database.cs
@@ -110,7 +110,7 @@ namespace Marten.AsyncDaemon.Testing
         }
 
         [Fact]
-        public async Task fail_when_trying_to_create_daemon_with_no_tenant_sync()
+        public void fail_when_trying_to_create_daemon_with_no_tenant_sync()
         {
             Should.Throw<DefaultTenantUsageDisabledException>(() =>
             {

--- a/src/Marten/Events/Aggregation/ByStreamId.cs
+++ b/src/Marten/Events/Aggregation/ByStreamId.cs
@@ -7,7 +7,11 @@ using Marten.Storage;
 #nullable enable
 namespace Marten.Events.Aggregation
 {
-    internal class ByStreamId<TDoc>: IEventSlicer<TDoc, Guid>
+    /// <summary>
+    /// Slicer strategy by stream id (Guid identified streams)
+    /// </summary>
+    /// <typeparam name="TDoc"></typeparam>
+    public class ByStreamId<TDoc>: IEventSlicer<TDoc, Guid>
     {
         public ValueTask<IReadOnlyList<EventSlice<TDoc, Guid>>> SliceInlineActions(IQuerySession querySession,
             IEnumerable<StreamAction> streams)

--- a/src/Marten/Events/Aggregation/ByStreamKey.cs
+++ b/src/Marten/Events/Aggregation/ByStreamKey.cs
@@ -6,7 +6,11 @@ using Marten.Storage;
 #nullable enable
 namespace Marten.Events.Aggregation
 {
-    internal class ByStreamKey<TDoc>: IEventSlicer<TDoc, string>
+    /// <summary>
+    /// Slicer strategy by stream key (string identified streams)
+    /// </summary>
+    /// <typeparam name="TDoc"></typeparam>
+    public class ByStreamKey<TDoc>: IEventSlicer<TDoc, string>
     {
         public ValueTask<IReadOnlyList<EventSlice<TDoc, string>>> SliceInlineActions(IQuerySession querySession,
             IEnumerable<StreamAction> streams)

--- a/src/Marten/Events/Aggregation/CustomAggregation.cs
+++ b/src/Marten/Events/Aggregation/CustomAggregation.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Baseline;
+using LamarCodeGeneration;
+using Marten.Events.Daemon;
+using Marten.Events.Projections;
+using Marten.Exceptions;
+using Marten.Internal.Sessions;
+using Marten.Internal.Storage;
+using Marten.Services;
+using Marten.Storage;
+
+namespace Marten.Events.Aggregation
+{
+    public abstract class CustomAggregation<TDoc, TId> : ProjectionBase, IAggregationRuntime<TDoc, TId>, IProjectionSource
+    {
+        protected CustomAggregation()
+        {
+            ProjectionName = GetType().NameInCode();
+        }
+
+        public IEventSlicer<TDoc, TId> Slicer { get; protected internal set; }
+
+        void IProjection.Apply(IDocumentOperations operations, IReadOnlyList<StreamAction> streams)
+        {
+#pragma warning disable VSTHRD002
+            this.As<IProjection>().ApplyAsync(operations, streams, CancellationToken.None).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+        }
+
+        internal override void CompileAndAssertValidity()
+        {
+            if (Slicer == null)
+            {
+                throw new InvalidProjectionException(
+                    $"Projection {GetType().FullNameInCode()} does not have a configured event slicer.");
+            }
+
+            if (Slicer is EventSlicer<TDoc, TId> slicer && !slicer.HasAnyRules())
+            {
+                throw new InvalidProjectionException(
+                    $"Projection {GetType().FullNameInCode()} has incomplete event slicer configuration.");
+            }
+        }
+
+        public void UseCustomSlicer(IEventSlicer<TDoc, TId> custom)
+        {
+            Slicer = custom;
+        }
+
+        async Task IProjection.ApplyAsync(IDocumentOperations operations, IReadOnlyList<StreamAction> streams, CancellationToken cancellation)
+        {
+            var slices = await Slicer.SliceInlineActions(operations, streams).ConfigureAwait(false);
+
+            var martenSession = (DocumentSessionBase)operations;
+
+            await martenSession.Database.EnsureStorageExistsAsync(typeof(TDoc), cancellation).ConfigureAwait(false);
+
+            var storage = (IDocumentStorage<TDoc, TId>)martenSession.StorageFor<TDoc>();
+            foreach (var slice in slices)
+            {
+                slice.Aggregate = await storage.LoadAsync(slice.Id, martenSession, cancellation).ConfigureAwait(false);
+                await ApplyChangesAsync(martenSession, slice, cancellation).ConfigureAwait(false);
+            }
+        }
+
+        async ValueTask<EventRangeGroup> IAggregationRuntime.GroupEvents(DocumentStore store, IMartenDatabase database, EventRange range,
+            CancellationToken cancellationToken)
+        {
+            using var session = store.OpenSession(SessionOptions.ForDatabase(database));
+            var groups = await Slicer.SliceAsyncEvents(session, range.Events).ConfigureAwait(false);
+
+            return new TenantSliceRange<TDoc, TId>(store, this, range, groups, cancellationToken);
+        }
+
+        /// <summary>
+        /// Apply any document changes based on the incoming slice of events to the underlying aggregate document
+        /// </summary>
+        /// <param name="session"></param>
+        /// <param name="slice"></param>
+        /// <param name="cancellation"></param>
+        /// <param name="lifecycle"></param>
+        /// <returns></returns>
+        public abstract ValueTask ApplyChangesAsync(DocumentSessionBase session, EventSlice<TDoc, TId> slice,
+            CancellationToken cancellation,
+            ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline);
+
+        /// <summary>
+        /// Override to give Marten "hints" about whether the aggregate is all new based on the incoming
+        /// event slice. The default implementation is always false.
+        /// </summary>
+        /// <param name="slice"></param>
+        /// <returns></returns>
+        public virtual bool IsNew(EventSlice<TDoc, TId> slice)
+        {
+            return false;
+        }
+
+        private IDocumentStorage<TDoc, TId> _storage;
+        IDocumentStorage<TDoc, TId> IAggregationRuntime<TDoc, TId>.Storage => _storage;
+
+
+        /// <summary>
+        /// Must be overridden to use as an async projection. Takes a range of events, and sorts them
+        /// into an EventSlice for each detected aggregate document
+        /// </summary>
+        /// <param name="store"></param>
+        /// <param name="database"></param>
+        /// <param name="range"></param>
+        /// <param name="cancellation"></param>
+        /// <returns></returns>
+        /// <exception cref="NotSupportedException"></exception>
+        public ValueTask<IReadOnlyList<TenantSliceGroup<TDoc, TId>>> GroupEventRange(DocumentStore store,
+            IMartenDatabase database,
+            EventRange range, CancellationToken cancellation)
+        {
+            using var session = store.OpenSession(SessionOptions.ForDatabase(database));
+            return Slicer.SliceAsyncEvents(session, range.Events);
+        }
+
+        Type IReadOnlyProjectionData.ProjectionType => GetType();
+        AsyncOptions IProjectionSource.Options { get; } = new AsyncOptions();
+
+        IEnumerable<Type> IProjectionSource.PublishedTypes()
+        {
+            yield return typeof(TDoc);
+        }
+
+        IReadOnlyList<AsyncProjectionShard> IProjectionSource.AsyncProjectionShards(DocumentStore store)
+        {
+            readDocumentStorage(store);
+
+            var filters = BuildFilters(store);
+
+            return new List<AsyncProjectionShard> {new(this, filters)};
+        }
+
+        private void readDocumentStorage(DocumentStore store)
+        {
+            var storage = store.Options.Providers.StorageFor<TDoc>();
+            _storage = storage.Lightweight as IDocumentStorage<TDoc, TId>;
+            if (_storage == null)
+                throw new InvalidOperationException(
+                    $"Document type {typeof(TDoc).FullNameInCode()} has identity type {storage.QueryOnly.IdType.NameInCode()}, but projection {GetType().FullNameInCode()} is defined with id type {typeof(TId).NameInCode()}");
+        }
+
+        async ValueTask<EventRangeGroup> IProjectionSource.GroupEvents(DocumentStore store, IMartenDatabase daemonDatabase, EventRange range,
+            CancellationToken cancellationToken)
+        {
+            var groups = await GroupEventRange(store, daemonDatabase, range, cancellationToken).ConfigureAwait(false);
+
+            return new TenantSliceRange<TDoc, TId>(store, this, range, groups, cancellationToken);
+        }
+
+        IProjection IProjectionSource.Build(DocumentStore store)
+        {
+            readDocumentStorage(store);
+            return this;
+        }
+
+        /// <summary>
+        /// Configure event aggregation "slicing" using Marten's default, configurable event
+        /// slicer
+        /// </summary>
+        /// <param name="configure"></param>
+        public void AggregateEvents(Action<EventSlicer<TDoc, TId>> configure)
+        {
+            var slicer = new EventSlicer<TDoc, TId>();
+            configure(slicer);
+
+            Slicer = slicer;
+        }
+
+        /// <summary>
+        /// Aggregate events by the containing stream identity
+        /// </summary>
+        public void AggregateByStream()
+        {
+            if (typeof(TId) == typeof(Guid))
+            {
+                Slicer = (IEventSlicer<TDoc, TId>)new ByStreamId<TDoc>();
+            }
+            else if (typeof(TId) == typeof(string))
+            {
+                Slicer = (IEventSlicer<TDoc, TId>)new ByStreamKey<TDoc>();
+            }
+            else
+            {
+                throw new InvalidProjectionException(
+                    $"Invalid identity type {typeof(TId).NameInCode()} for aggregating by stream in projection {GetType().FullNameInCode()}");
+            }
+        }
+    }
+}

--- a/src/Marten/Events/Aggregation/EventSlice.cs
+++ b/src/Marten/Events/Aggregation/EventSlice.cs
@@ -29,6 +29,11 @@ namespace Marten.Events.Projections
             }
         }
 
+        public EventSlice(TId id, IQuerySession querySession, IEnumerable<IEvent>? events = null): this(id,
+            new Tenant(Tenancy.DefaultTenantId, querySession.Database), events)
+        {
+        }
+
         /// <summary>
         /// Is this action the start of a new stream or appending
         /// to an existing stream?
@@ -75,6 +80,18 @@ namespace Marten.Events.Projections
         /// All the events in this slice
         /// </summary>
         public IReadOnlyList<IEvent> Events() => _events;
+
+        /// <summary>
+        /// Iterate through just the event data
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<object> AllData()
+        {
+            foreach (var @event in _events)
+            {
+                yield return @event.Data;
+            }
+        }
 
         internal void ApplyFanOutRules(IEnumerable<IFanOutRule> rules)
         {

--- a/src/Marten/Events/Aggregation/EventSlicer.cs
+++ b/src/Marten/Events/Aggregation/EventSlicer.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten.Events.Projections;
+using Marten.Storage;
+
+namespace Marten.Events.Aggregation
+{
+    public class EventSlicer<TDoc, TId>: IEventSlicer<TDoc, TId>
+    {
+        private readonly List<IFanOutRule> _beforeGroupingFanoutRules = new List<IFanOutRule>();
+        private readonly List<IFanOutRule> _afterGroupingFanoutRules = new List<IFanOutRule>();
+        private readonly IList<IGrouper<TId>> _groupers = new List<IGrouper<TId>>();
+        private readonly IList<IAggregateGrouper<TId>> _lookupGroupers = new List<IAggregateGrouper<TId>>();
+        private bool _groupByTenant = false;
+
+        public EventSlicer<TDoc, TId> GroupByTenant()
+        {
+            _groupByTenant = true;
+            return this;
+        }
+
+        internal bool HasAnyRules()
+        {
+            return _groupers.Any() || _lookupGroupers.Any() || _lookupGroupers.Any();
+        }
+
+        internal IEnumerable<Type> DetermineEventTypes()
+        {
+            foreach (var rule in _beforeGroupingFanoutRules)
+            {
+                yield return rule.OriginatingType;
+            }
+
+            foreach (var rule in _afterGroupingFanoutRules)
+            {
+                yield return rule.OriginatingType;
+            }
+        }
+
+        public EventSlicer<TDoc, TId> Identity<TEvent>(Func<TEvent, TId> identityFunc)
+        {
+            _groupers.Add(new SingleStreamGrouper<TId, TEvent>(identityFunc));
+            return this;
+        }
+
+        public EventSlicer<TDoc, TId> Identities<TEvent>(Func<TEvent, IReadOnlyList<TId>> identitiesFunc)
+        {
+            _groupers.Add(new MultiStreamGrouper<TId, TEvent>(identitiesFunc));
+            return this;
+        }
+
+        /// <summary>
+        /// Apply a custom event grouping strategy for events. This is additive to Identity() or Identities()
+        /// </summary>
+        /// <param name="grouper"></param>
+        /// <exception cref="InvalidOperationException"></exception>
+        public EventSlicer<TDoc, TId> CustomGrouping(IAggregateGrouper<TId> grouper)
+        {
+            _lookupGroupers.Add(grouper);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Apply "fan out" operations to the given TEvent type that inserts an enumerable of TChild events right behind the parent
+        /// event in the event stream
+        /// </summary>
+        /// <param name="fanOutFunc"></param>
+        /// <param name="mode">Should the fan out operation happen after grouping, or before? Default is after</param>
+        /// <typeparam name="TEvent"></typeparam>
+        /// <typeparam name="TChild"></typeparam>
+        public EventSlicer<TDoc, TId> FanOut<TEvent, TChild>(Func<TEvent, IEnumerable<TChild>> fanOutFunc, FanoutMode mode = FanoutMode.AfterGrouping)
+        {
+            var fanout = new FanOutOperator<TEvent, TChild>(fanOutFunc)
+            {
+                Mode = mode
+            };
+
+            switch (mode)
+            {
+                case FanoutMode.AfterGrouping:
+                    _afterGroupingFanoutRules.Add(fanout);
+                    break;
+
+                case FanoutMode.BeforeGrouping:
+                    _beforeGroupingFanoutRules.Add(fanout);
+                    break;
+            }
+
+            return this;
+        }
+
+
+
+        public async ValueTask<IReadOnlyList<EventSlice<TDoc, TId>>> SliceInlineActions(IQuerySession querySession, IEnumerable<StreamAction> streams)
+        {
+            var events = streams.SelectMany(x => x.Events).ToList();
+
+            var groups = await SliceAsyncEvents(querySession, events).ConfigureAwait(false);
+            return groups.SelectMany(x => x.Slices).ToList();
+        }
+
+        public async ValueTask<IReadOnlyList<TenantSliceGroup<TDoc, TId>>> SliceAsyncEvents(IQuerySession querySession, List<IEvent> events)
+        {
+            foreach (var fanOutRule in _beforeGroupingFanoutRules)
+            {
+                fanOutRule.Apply(events);
+            }
+
+            if (_groupByTenant)
+            {
+                var byTenant = events.GroupBy(x => x.TenantId);
+                var groupTasks = byTenant.Select(async tGroup =>
+                {
+                    var tenant = new Tenant(tGroup.Key, querySession.Database);
+                    return await groupSingleTenant(tenant, querySession.ForTenant(tGroup.Key), tGroup.ToList()).ConfigureAwait(false);
+                });
+
+                var list = new List<TenantSliceGroup<TDoc, TId>>();
+                foreach (var groupTask in groupTasks)
+                {
+                    list.Add(await groupTask.ConfigureAwait(false));
+                }
+
+                return list;
+            }
+
+            // This path is for *NOT* conjoined multi-tenanted projections, but we have to respect per-database tenancy
+            var group = await groupSingleTenant(new Tenant(Tenancy.DefaultTenantId, querySession.Database), querySession, events).ConfigureAwait(false);
+
+            return new List<TenantSliceGroup<TDoc, TId>> {group};
+        }
+
+        private async Task<TenantSliceGroup<TDoc, TId>> groupSingleTenant(Tenant tenant, IQuerySession querySession, IList<IEvent> events)
+        {
+            var @group = new TenantSliceGroup<TDoc, TId>(tenant);
+
+            foreach (var grouper in _groupers)
+            {
+                grouper.Apply(events, @group);
+            }
+
+            foreach (var lookupGrouper in _lookupGroupers)
+            {
+                await lookupGrouper.Group(querySession, events, @group).ConfigureAwait(false);
+            }
+
+            group.ApplyFanOutRules(_afterGroupingFanoutRules);
+
+            return @group;
+        }
+    }
+}

--- a/src/Marten/Events/Aggregation/IAggregationRuntime.cs
+++ b/src/Marten/Events/Aggregation/IAggregationRuntime.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Events.Daemon;
+using Marten.Events.Projections;
+using Marten.Internal.Sessions;
+using Marten.Internal.Storage;
+using Marten.Storage;
+
+namespace Marten.Events.Aggregation
+{
+    /// <summary>
+    /// Internal interface for runtime event aggregation
+    /// </summary>
+    public interface IAggregationRuntime : IProjection
+    {
+        ValueTask<EventRangeGroup> GroupEvents(DocumentStore store, IMartenDatabase database, EventRange range,
+            CancellationToken cancellationToken);
+    }
+
+    public interface IAggregationRuntime<TDoc, TId>: IAggregationRuntime where TDoc : notnull where TId : notnull
+    {
+        ValueTask ApplyChangesAsync(DocumentSessionBase session,
+            EventSlice<TDoc, TId> slice, CancellationToken cancellation,
+            ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline);
+
+        bool IsNew(EventSlice<TDoc, TId> slice);
+        IDocumentStorage<TDoc, TId> Storage { get; }
+
+        IEventSlicer<TDoc, TId> Slicer { get; }
+
+        [Obsolete]
+        ValueTask<IReadOnlyList<TenantSliceGroup<TDoc, TId>>> GroupEventRange(DocumentStore store,
+            IMartenDatabase database, EventRange range, CancellationToken cancellation);
+    }
+}
+

--- a/src/Marten/Events/Daemon/ActionParameters.cs
+++ b/src/Marten/Events/Daemon/ActionParameters.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Events.Daemon.Resiliency;
+using Marten.Storage;
 using Microsoft.Extensions.Logging;
 
 namespace Marten.Events.Daemon
@@ -54,11 +55,11 @@ namespace Marten.Events.Daemon
             Cancellation = Group.Cancellation;
         }
 
-        public async Task ApplySkipAsync(SkipEvent skip)
+        public async Task ApplySkipAsync(SkipEvent skip, IMartenDatabase database)
         {
             if (Group != null)
             {
-                await Group.SkipEventSequence(skip.Event.Sequence).ConfigureAwait(false);
+                await Group.SkipEventSequence(skip.Event.Sequence, database).ConfigureAwait(false);
 
                 // You have to reset the CancellationToken for the group
                 Group.Reset();

--- a/src/Marten/Events/Daemon/AggregateTypeFilter.cs
+++ b/src/Marten/Events/Daemon/AggregateTypeFilter.cs
@@ -1,0 +1,35 @@
+using System;
+using NpgsqlTypes;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Events.Daemon
+{
+    /// <summary>
+    /// Filter on a single aggregate type
+    /// </summary>
+    internal class AggregateTypeFilter : ISqlFragment
+    {
+        public AggregateTypeFilter(Type aggregateType, EventGraph events)
+        {
+            AggregateType = aggregateType;
+            Alias = events.AggregateAliasFor(aggregateType);
+        }
+
+        public Type AggregateType { get; }
+
+        public string Alias { get; }
+
+        public void Apply(CommandBuilder builder)
+        {
+            var parameter = builder.AddParameter(Alias, NpgsqlDbType.Varchar);
+            builder.Append("s.type = :");
+            builder.Append(parameter.ParameterName);
+        }
+
+        public bool Contains(string sqlText)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Marten/Events/Daemon/AsyncProjectionShard.cs
+++ b/src/Marten/Events/Daemon/AsyncProjectionShard.cs
@@ -8,7 +8,7 @@ namespace Marten.Events.Daemon
     /// <summary>
     ///     Definition of a single projection shard to be executed asynchronously
     /// </summary>
-    internal class AsyncProjectionShard
+    public class AsyncProjectionShard
     {
         public AsyncProjectionShard(string shardName, IProjectionSource source, ISqlFragment[] filters)
         {

--- a/src/Marten/Events/Daemon/EventFetcher.cs
+++ b/src/Marten/Events/Daemon/EventFetcher.cs
@@ -1,12 +1,18 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Baseline;
 using Baseline.Dates;
 using Marten.Internal.Sessions;
 using Marten.Linq.QueryHandlers;
 using Marten.Services;
 using Marten.Storage;
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Events.Daemon
@@ -19,9 +25,11 @@ namespace Marten.Events.Daemon
         private readonly IDocumentStore _store;
         private readonly IMartenDatabase _database;
         private readonly ISqlFragment[] _filters;
-        private IEventStorage _storage;
-        private readonly EventStatement _statement;
-        private readonly IQueryHandler<IReadOnlyList<IEvent>> _handler;
+        private readonly IEventStorage _storage;
+        private readonly NpgsqlParameter _floor;
+        private readonly NpgsqlParameter _ceiling;
+        private readonly NpgsqlCommand _command;
+        private readonly int _aggregateIndex;
 
         public EventFetcher(IDocumentStore store, IMartenDatabase database, ISqlFragment[] filters)
         {
@@ -31,9 +39,31 @@ namespace Marten.Events.Daemon
 
             using var session = querySession();
             _storage = session.EventStorage();
-            _statement = new EventStatement(_storage) {Filters = _filters};
 
-            _handler = new ListQueryHandler<IEvent>(_statement, _storage);
+            var schemaName = store.Options.Events.DatabaseSchemaName;
+
+            var builder = new CommandBuilder();
+            builder.Append($"select {_storage.SelectFields().Select(x => "d." + x).Join(", ")}, s.type as stream_type");
+            builder.Append($" from {schemaName}.mt_events as d inner join {schemaName}.mt_streams as s on d.stream_id = s.id");
+
+            if (_store.Options.Events.TenancyStyle == TenancyStyle.Conjoined)
+            {
+                builder.Append(" and d.tenant_id = s.tenant_id");
+            }
+
+            var parameters = builder.AppendWithParameters($" where d.seq_id > ? and d.seq_id <= ?");
+            _floor = parameters[0];
+            _ceiling = parameters[1];
+            _floor.NpgsqlDbType = _ceiling.NpgsqlDbType = NpgsqlDbType.Bigint;
+
+            foreach (var filter in filters)
+            {
+                builder.Append(" and ");
+                filter.Apply(builder);
+            }
+
+            _command = builder.Compile();
+            _aggregateIndex = _storage.SelectFields().Length;
         }
 
         private QuerySession querySession()
@@ -51,22 +81,41 @@ namespace Marten.Events.Daemon
             teardown();
         }
 
-        public async Task Load(ShardName projectionShardName, EventRange range, CancellationToken token)
+        public async Task Load(EventRange range, CancellationToken token)
         {
-            using var session = querySession();
-
             // There's an assumption here that this method is only called sequentially
             // and never at the same time on the same instance
-            _statement.Range = range;
 
             try
             {
-                range.Events = new List<IEvent>(await session.ExecuteHandlerAsync(_handler, token).ConfigureAwait(false));
+                range.Events = new List<IEvent>();
+
+                using var session = querySession();
+                _floor.Value = range.SequenceFloor;
+                _ceiling.Value = range.SequenceCeiling;
+
+                using var reader = await session.ExecuteReaderAsync(_command, token).ConfigureAwait(false);
+                while (await reader.ReadAsync(token).ConfigureAwait(false))
+                {
+                    var @event = await _storage.ResolveAsync(reader, token).ConfigureAwait(false);
+
+                    if (!await reader.IsDBNullAsync(_aggregateIndex, token).ConfigureAwait(false))
+                    {
+                        @event.AggregateTypeName = await reader.GetFieldValueAsync<string>(_aggregateIndex, token).ConfigureAwait(false);
+                    }
+
+                    range.Events.Add(@event);
+                }
+
+
+
             }
             catch (Exception e)
             {
-                throw new EventFetcherException(projectionShardName, _database, e);
+                throw new EventFetcherException(range.ShardName, _database, e);
             }
+
+            Debug.WriteLine("here");
         }
     }
 }

--- a/src/Marten/Events/Daemon/EventRangeGroup.cs
+++ b/src/Marten/Events/Daemon/EventRangeGroup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Marten.Storage;
 
 namespace Marten.Events.Daemon
 {
@@ -54,8 +55,7 @@ namespace Marten.Events.Daemon
 
         public abstract void Dispose();
 
-        public abstract Task ConfigureUpdateBatch(IShardAgent shardAgent, ProjectionUpdateBatch batch,
-            EventRangeGroup eventRangeGroup);
-        public abstract ValueTask SkipEventSequence(long eventSequence);
+        public abstract Task ConfigureUpdateBatch(IShardAgent shardAgent, ProjectionUpdateBatch batch);
+        public abstract ValueTask SkipEventSequence(long eventSequence, IMartenDatabase database);
     }
 }

--- a/src/Marten/Events/Daemon/IShardAgent.cs
+++ b/src/Marten/Events/Daemon/IShardAgent.cs
@@ -11,13 +11,9 @@ namespace Marten.Events.Daemon
     // This is public because it's used by the generated code
     public interface IShardAgent
     {
-        ProjectionUpdateBatch StartNewBatch(EventRangeGroup group);
-        Task ExecuteBatch(ProjectionUpdateBatch batch);
-
         void StartRange(EventRange range);
 
         Task TryAction(Func<Task> action, CancellationToken token, Action<ILogger, Exception> logException = null, EventRangeGroup group = null, GroupActionMode actionMode = GroupActionMode.Parent);
 
-        bool IsStopping();
     }
 }

--- a/src/Marten/Events/Daemon/ProjectionDaemon.cs
+++ b/src/Marten/Events/Daemon/ProjectionDaemon.cs
@@ -149,7 +149,7 @@ namespace Marten.Events.Daemon
         {
             if (_agents.TryGetValue(shardName, out var agent))
             {
-                if (agent.IsStopping()) return;
+                if (agent.IsStopping) return;
 
                 var parameters = new ActionParameters(agent, async () =>
                 {
@@ -196,7 +196,7 @@ namespace Marten.Events.Daemon
             {
                 try
                 {
-                    if (agent.IsStopping()) continue;
+                    if (agent.IsStopping) continue;
 
                     await agent.Stop().ConfigureAwait(false);
                 }
@@ -431,7 +431,7 @@ namespace Marten.Events.Daemon
                             return;
                         }
 
-                        await parameters.ApplySkipAsync(skip).ConfigureAwait(false);
+                        await parameters.ApplySkipAsync(skip, Database).ConfigureAwait(false);
 
                         _logger.LogInformation("Skipping event #{Sequence} ({EventType}@{DatabaseIdentifier}) in shard '{ShardName}'",
                             skip.Event.Sequence, skip.Event.EventType.GetFullName(), parameters.Shard.Name, Database.Identifier);
@@ -453,7 +453,7 @@ namespace Marten.Events.Daemon
             {
                 var deadLetterEvent = new DeadLetterEvent(@event, shardName, exception);
                 var session =
-                    _store.OpenSession(new SessionOptions { AllowAnyTenant = true, Tracking = DocumentTracking.None });
+                    _store.OpenSession(SessionOptions.ForDatabase(Database));
 
                 await using (session.ConfigureAwait(false))
                 {

--- a/src/Marten/Events/Daemon/TenantActionGroup.cs
+++ b/src/Marten/Events/Daemon/TenantActionGroup.cs
@@ -18,17 +18,11 @@ namespace Marten.Events.Daemon
             foreach (var action in _actions) action.TenantId = _tenant.TenantId;
         }
 
-        public Task ApplyEvents(ProjectionUpdateBatch batch, IProjection projection, DocumentStore store,
+        public async Task ApplyEvents(ProjectionUpdateBatch batch, IProjection projection, DocumentStore store,
             CancellationToken cancellationToken)
         {
-            return Task.Run(async () =>
-            {
-                var operations = new ProjectionDocumentSession(store, _tenant, batch);
-                await using (operations.ConfigureAwait(false))
-                {
-                    await projection.ApplyAsync(operations, _actions, cancellationToken).ConfigureAwait(false);
-                }
-            }, cancellationToken);
+            await using var operations = new ProjectionDocumentSession(store, _tenant, batch);
+            await projection.ApplyAsync(operations, _actions, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Marten/Events/Event.cs
+++ b/src/Marten/Events/Event.cs
@@ -100,6 +100,14 @@ namespace Marten.Events
         /// to projected views
         /// </summary>
         bool IsArchived { get; set; }
+
+        /// <summary>
+        /// Marten's name for the aggregate type that will be persisted
+        /// to the streams table. This will only be available when running
+        /// within the Async Daemon
+        /// </summary>
+        public string? AggregateTypeName { get; set; }
+
     }
 
     #endregion
@@ -191,6 +199,8 @@ namespace Marten.Events
         }
 
         public bool IsArchived { get; set; }
+
+        public string? AggregateTypeName { get; set; }
 
         protected bool Equals(Event<T> other)
         {

--- a/src/Marten/Events/Projections/IProjectionSource.cs
+++ b/src/Marten/Events/Projections/IProjectionSource.cs
@@ -7,7 +7,7 @@ using Marten.Storage;
 
 namespace Marten.Events.Projections
 {
-    internal interface IProjectionSource : IReadOnlyProjectionData
+    public interface IProjectionSource : IReadOnlyProjectionData
     {
         AsyncOptions Options { get; }
 

--- a/src/Marten/Events/Projections/ProjectionBase.cs
+++ b/src/Marten/Events/Projections/ProjectionBase.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Marten.Events.Daemon;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Events.Projections
+{
+    public abstract class ProjectionBase
+    {
+        private readonly IList<ISqlFragment> _filters = new List<ISqlFragment>();
+
+        /// <summary>
+        /// Descriptive name for this projection in the async daemon. The default is the type name of the projection
+        /// </summary>
+        public string ProjectionName { get; set; }
+
+        /// <summary>
+        /// The projection lifecycle that governs when this projection is executed
+        /// </summary>
+        public ProjectionLifecycle Lifecycle { get; set; } = ProjectionLifecycle.Async;
+
+        internal ISqlFragment[] BuildFilters(DocumentStore store)
+        {
+            return buildFilters(store).ToArray();
+        }
+
+        private IEnumerable<ISqlFragment> buildFilters(DocumentStore store)
+        {
+            if (IncludedEventTypes.Any() && !IncludedEventTypes.Any(x => x.IsAbstract || x.IsInterface))
+            {
+                yield return new EventTypeFilter(store.Options.EventGraph, IncludedEventTypes.ToArray());
+            }
+
+            if (StreamType != null)
+            {
+                yield return new AggregateTypeFilter(StreamType, store.Options.EventGraph);
+            }
+
+            foreach (var filter in _filters)
+            {
+                yield return filter;
+            }
+
+        }
+
+        /// <summary>
+        /// Optimize this projection within the Async Daemon by
+        /// limiting the event types processed through this projection
+        /// to include type "T". This is inclusive.
+        ///
+        /// If this list is empty, the async daemon will fetch every possible
+        /// type of event at runtime
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        public IList<Type> IncludedEventTypes { get; } = new List<Type>();
+
+        /// <summary>
+        /// Short hand syntax to tell Marten that this projection takes in the event type T
+        /// This is not mandatory, but can be used to optimize the asynchronous projections
+        /// to create an "allow list" in the IncludedEventTypes collection
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        public void IncludeType<T>()
+        {
+            IncludedEventTypes.Add(typeof(T));
+        }
+
+        /// <summary>
+        /// Limit the events processed by this projection to only streams
+        /// marked with this stream type
+        /// </summary>
+        internal Type StreamType { get; set; }
+
+        /// <summary>
+        /// Limit the events processed by this projection to only streams
+        /// marked with the given streamType.
+        ///
+        /// ONLY APPLIED TO ASYNCHRONOUS PROJECTIONS
+        /// </summary>
+        /// <param name="streamType"></param>
+        public void FilterIncomingEventsOnStreamType(Type streamType)
+        {
+            StreamType = streamType;
+        }
+
+        internal virtual void CompileAndAssertValidity()
+        {
+            // Nothing
+        }
+    }
+}

--- a/src/Marten/Events/Projections/ProjectionWrapper.cs
+++ b/src/Marten/Events/Projections/ProjectionWrapper.cs
@@ -50,7 +50,7 @@ namespace Marten.Events.Projections
         public ValueTask<EventRangeGroup> GroupEvents(DocumentStore store, IMartenDatabase daemonDatabase, EventRange range,
             CancellationToken cancellationToken)
         {
-            return new ValueTask<EventRangeGroup>(new TenantedEventRange(store, daemonDatabase, _projection, range, cancellationToken));
+            return new ValueTask<EventRangeGroup>(new TenantedEventRangeGroup(store, daemonDatabase, _projection, range, cancellationToken));
         }
     }
 }

--- a/src/Marten/Events/Schema/StreamsTable.cs
+++ b/src/Marten/Events/Schema/StreamsTable.cs
@@ -20,7 +20,9 @@ namespace Marten.Events.Schema
 {
     internal class StreamsTable: Table
     {
-        public StreamsTable(EventGraph events) : base(new DbObjectName(events.DatabaseSchemaName, "mt_streams"))
+        public const string TableName = "mt_streams";
+
+        public StreamsTable(EventGraph events) : base(new DbObjectName(events.DatabaseSchemaName, TableName))
         {
             var idColumn = events.StreamIdentity == StreamIdentity.AsGuid
                 ? new StreamTableColumn("id", x => x.Id)


### PR DESCRIPTION
…. Closes GH-1992. Closes GH-1956. Closes GH-2042

Optimized event fetching in async daemon

The aggregate type name is now available from EventFetcher

new AggregateTypeFilter for async daemon for later

New ProjectionBase underneath EventProjection and AggregateProjection. Extended event filtering on async daemon

Little clean up on AggregationRuntime

Minor refactoring simplification in daemon support code

Mild cleanup to ShardAgent

Mild refactorings to TenantActionGroup

Refactoring on AggregationRuntime to get ready for custom aggregations

refactored IAggregationRuntime/AggregationRuntime in preparation for custom aggregations

basic functionality of the CustomAggregate is working end to end

pulled the configurable slicing into EventSlicer out of ViewProjection

more robust support for custom aggregation slicing

mild fix to make sure all sessions used within the daemon are multi-tenant database aware