### PR TITLE
update SimpleExec from 6.2.0 to 10.0.0-beta.1

### DIFF
--- a/build/build.cs
+++ b/build/build.cs
@@ -42,10 +42,10 @@ namespace martenbuild
                 File.WriteAllText("src/Marten.Testing/connection.txt", GetEnvironmentVariable("connection")));
 
             Target("install", () =>
-                RunNpm("install"));
+                Run("npm", "install"));
 
             Target("mocha", DependsOn("install"), () =>
-                RunNpm("run test"));
+                Run("npm", "run test"));
 
             Target("compile", DependsOn("clean"), () =>
             {
@@ -118,12 +118,12 @@ namespace martenbuild
 
             Target("docs", DependsOn("install", "install-mdsnippets"), () => {
                 // Run docs site
-                RunNpm("run docs");
+                Run("npm", "run docs");
             });
 
             Target("docs-build", DependsOn("install", "install-mdsnippets"), () => {
                 // Run docs site
-                RunNpm("run docs-build");
+                Run("npm", "run docs-build");
             });
 
             Target("docs-import-v3", DependsOn("docs-build"), () =>
@@ -153,10 +153,10 @@ namespace martenbuild
 
 
             Target("publish-docs-preview", DependsOn("docs-import-v3"), () =>
-                RunNpm("run deploy"));
+                Run("npm", "run deploy"));
 
             Target("publish-docs", DependsOn("docs-import-v3"), () =>
-                RunNpm("run deploy:prod"));
+                Run("npm", "run deploy:prod"));
 
             Target("benchmarks", () =>
                 Run("dotnet", "run --project src/MartenBenchmarks --configuration Release"));
@@ -271,9 +271,6 @@ namespace martenbuild
 
             baseDir.Delete(true);
         }
-
-        private static void RunNpm(string args) =>
-            Run("npm", args, windowsName: "cmd.exe", windowsArgs: $"/c npm {args}");
 
         private static string GetEnvironmentVariable(string variableName)
         {

--- a/build/build.csproj
+++ b/build/build.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Bullseye" Version="3.3.0" />
     <PackageReference Include="Npgsql" Version="4.1.3.1" />
-    <PackageReference Include="SimpleExec" Version="6.2.0" />
+    <PackageReference Include="SimpleExec" Version="10.0.0-beta.1" />
     <PackageReference Include="Westwind.Utilities" Version="3.0.37" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
SimpleExec 10.0.0 [no longer requires](https://github.com/adamralph/simple-exec/pull/438) separate `windowsName` and `windowsArgs` for executing `.cmd` files which are in `PATH` without specifying the file extension. The resolution of the file paths is done internally in SimpleExec.

I'm raising this PR as a beta test of the feature, in a real world build that relies on it. I hope you don't mind.