### PR TITLE
update SimpleExec from 10.0.0-beta.1 to 10.0.0-beta.2

### DIFF
--- a/build/build.csproj
+++ b/build/build.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Bullseye" Version="3.3.0" />
     <PackageReference Include="Npgsql" Version="4.1.3.1" />
-    <PackageReference Include="SimpleExec" Version="10.0.0-beta.1" />
+    <PackageReference Include="SimpleExec" Version="10.0.0-beta.2" />
     <PackageReference Include="Westwind.Utilities" Version="3.0.37" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
In beta 2, running `dotnet` on Windows is echoed as just `dotnet` instead of the full path (as in 9.1.0). Similar for any other `.exe` resolved through path.