### PR TITLE
Add support for asserting database configuration on startup

### DIFF
--- a/src/CoreTests/Bugs/Bug_2135_open_session_should_use_provided_connection_string.cs
+++ b/src/CoreTests/Bugs/Bug_2135_open_session_should_use_provided_connection_string.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-using BugXXXX;
+using Bug2135;
 
 using Marten;
 using Marten.Services;
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace CoreTests.Bugs
 {
-    public class Bug_XXXX_open_session_should_use_provided_connection_string: BugIntegrationContext
+    public class Bug_2135_open_session_should_use_provided_connection_string: BugIntegrationContext
     {
         [Fact]
         public async Task should_use_provided_connection_string()
@@ -72,7 +72,7 @@ namespace CoreTests.Bugs
     }
 }
 
-namespace BugXXXX
+namespace Bug2135
 {
     public class TestEntity
     {

--- a/src/CoreTests/MartenServiceCollectionExtensionsTests.cs
+++ b/src/CoreTests/MartenServiceCollectionExtensionsTests.cs
@@ -161,6 +161,30 @@ namespace CoreTests
         }
 
         [Fact]
+        public async Task assert_configuration_on_startup()
+        {
+            await using var container = Container.For(services =>
+            {
+                services.AddLogging();
+                services.AddMarten(opts =>
+                    {
+                        opts.Connection(ConnectionSource.ConnectionString);
+                        opts.RegisterDocumentType<User>();
+                    })
+                    .AssertDatabaseMatchesConfigurationOnStartup();
+            });
+
+            var store = container.GetInstance<IDocumentStore>();
+            await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+            var instance = container.Model.For<IHostedService>().Instances.First();
+            instance.ImplementationType.ShouldBe(typeof(MartenActivator));
+            instance.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+
+            await Assert.ThrowsAsync<DatabaseValidationException>(() => container.GetAllInstances<IHostedService>().First().StartAsync(default));
+        }
+
+        [Fact]
         public void use_custom_factory_by_type()
         {
             using var container = Container.For(x =>

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -437,6 +437,20 @@ namespace Marten
                 return this;
             }
 
+            /// <summary>
+            /// Adds a hosted service to your .Net application that will assert that database matches configuration before the
+            /// rest of the application starts running. Prevents the application from starting if database does not match configuration.
+            /// </summary>
+            /// <returns></returns>
+            public MartenConfigurationExpression AssertDatabaseMatchesConfigurationOnStartup()
+            {
+                ensureMartenActivatorIsRegistered();
+
+                Services.ConfigureMarten(opts => opts.ShouldAssertDatabaseMatchesConfigurationOnStartup = true);
+
+                return this;
+            }
+
             private void ensureMartenActivatorIsRegistered()
             {
                 if (!Services.Any(x =>

--- a/src/Marten/Services/MartenActivator.cs
+++ b/src/Marten/Services/MartenActivator.cs
@@ -1,7 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Baseline;
-using Baseline.ImTools;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Npgsql;
@@ -37,6 +36,15 @@ namespace Marten.Services
                 foreach (PostgresqlDatabase database in await databases)
                 {
                     await database.ApplyAllConfiguredChangesToDatabaseAsync(this, AutoCreate.CreateOrUpdate).ConfigureAwait(false);
+                }
+            }
+
+            if (Store.Options.ShouldAssertDatabaseMatchesConfigurationOnStartup)
+            {
+                var databases = Store.Tenancy.BuildDatabases().ConfigureAwait(false);
+                foreach (var database in await databases)
+                {
+                    await database.AssertDatabaseMatchesConfigurationAsync().ConfigureAwait(false);
                 }
             }
 

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -71,6 +71,10 @@ namespace Marten
         /// </summary>
         internal bool ShouldApplyChangesOnStartup { get; set; } = false;
 
+        /// <summary>
+        /// Used internally by the MartenActivator
+        /// </summary>
+        internal bool ShouldAssertDatabaseMatchesConfigurationOnStartup { get; set; } = false;
 
         private ImHashMap<Type, IFieldMapping> _childFieldMappings = ImHashMap<Type, IFieldMapping>.Empty;
 


### PR DESCRIPTION
This PR adds support for asserting database configuration on startup. This feature is implemented the same way as applying all database changes on startup.

If `AssertDatabaseMatchesConfigurationOnStartup` is called for `MartenConfigurationExpression`, during startup `AssertDatabaseMatchesConfigurationAsync` is called for all known databases. As possible configuration mismatch will throw exception this also prevents the application from starting if any database does not match configuration.