### PR TITLE
fix: set hint path

### DIFF
--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -54,7 +54,7 @@ namespace Marten
             string path = AppContext.BaseDirectory.ToFullPath();
             if (hintPath.IsNotEmpty())
             {
-                path.AppendPath(hintPath).ToFullPath();
+                path = path.AppendPath(hintPath).ToFullPath();
             }
             else
             {


### PR DESCRIPTION
In `SetApplicationProject`, if a `hintPath` was specified it was accidentally discarded - this tiny PR fixes that.