### PR TITLE
Fix concurrency error when calling append several times for string identity

### DIFF
--- a/src/DocumentDbTests/Bugs/Bug_673_multiple_version_assertions.cs
+++ b/src/DocumentDbTests/Bugs/Bug_673_multiple_version_assertions.cs
@@ -1,4 +1,5 @@
 using System;
+using Marten.Events;
 using Marten.Testing.Harness;
 using Xunit;
 
@@ -10,6 +11,32 @@ namespace DocumentDbTests.Bugs
         public void replaces_the_max_version_assertion()
         {
             var streamId = Guid.NewGuid();
+
+            using (var session = theStore.OpenSession())
+            {
+                session.Events.Append(streamId, new WhateverEvent(), new WhateverEvent());
+
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.OpenSession())
+            {
+                var state = session.Events.FetchStreamState(streamId);
+                // ... do some stuff
+                var expectedVersion = state.Version + 1;
+                session.Events.Append(streamId, expectedVersion, new WhateverEvent());
+                // ... do some more stuff
+                expectedVersion += 1;
+                session.Events.Append(streamId, expectedVersion, new WhateverEvent());
+                session.SaveChanges();
+            }
+        }
+
+        [Fact]
+        public void replaces_the_max_version_assertion_for_string_identity()
+        {
+            UseStreamIdentity(StreamIdentity.AsString);
+            var streamId = Guid.NewGuid().ToString();
 
             using (var session = theStore.OpenSession())
             {

--- a/src/Marten/Events/EventStore.Append.cs
+++ b/src/Marten/Events/EventStore.Append.cs
@@ -50,7 +50,7 @@ namespace Marten.Events
         public StreamAction Append(string stream, long expectedVersion, params object[] events)
         {
             var eventStream = Append(stream, events);
-            eventStream.ExpectedVersionOnServer = expectedVersion - events.Length;
+            eventStream.ExpectedVersionOnServer = expectedVersion - eventStream.Events.Count;
 
             return eventStream;
         }


### PR DESCRIPTION
Before the fix the new test will fail with `Unexpected starting version number for event stream 'xxxx', expected 3 but was 2`.
This happened because it wasn't aware of previous calls to `Append`.

Same fix is previous applied for guid identify in https://github.com/JasperFx/marten/commit/b860265961b414b3840bae8bdea0445015febe42