### PR TITLE
Upgrade to Weasel 5.3

### DIFF
--- a/src/Marten.CommandLine/Marten.CommandLine.csproj
+++ b/src/Marten.CommandLine/Marten.CommandLine.csproj
@@ -34,7 +34,7 @@
         <PackageReference Include="LamarCodeGeneration.Commands" Version="6.1.1" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-        <PackageReference Include="Weasel.CommandLine" Version="5.2.0" />
+        <PackageReference Include="Weasel.CommandLine" Version="5.3.0" />
     </ItemGroup>
     <ItemGroup>
       <Folder Include="Commands\Patch" />

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -57,7 +57,7 @@
         <PackageReference Include="Remotion.Linq" Version="2.2.0" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
         <PackageReference Include="System.Text.Json" Version="6.0.0" />
-        <PackageReference Include="Weasel.Postgresql" Version="5.2.0" />
+        <PackageReference Include="Weasel.Postgresql" Version="5.3.0" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->


### PR DESCRIPTION
Slightly better command line options w/ the new Oakton IStatefulResource model, can play in the new generalized Oakton activator for all stateful resources