### PR TITLE
Stop daemon and release db lock when exception occur on shard start

### DIFF
--- a/src/Marten/Events/Daemon/HotColdCoordinator.cs
+++ b/src/Marten/Events/Daemon/HotColdCoordinator.cs
@@ -91,6 +91,8 @@ namespace Marten.Events.Daemon
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failure while trying to start all async projection shards for database {Database}", _database.Identifier);
+
+                    await Stop().ConfigureAwait(false);
                 }
             }
             else


### PR DESCRIPTION
When `startAllProjections` fails for whatever reason (properly mostly transient db errors) the hot cold coordinator is in a limbo state where some shards could be started and others not. The lock got attained in the first place but the hot cold coordinator still tries to get a lock, but never will.

The proposed solution is to stop the daemon, release the lock and let the hot cold coordinator try to start it again. 

https://github.com/JasperFx/marten/blob/3e6099a6c595bd98573bb57c3e97ba39902330d1/src/Marten/Events/Daemon/HotColdCoordinator.cs#L84-L94