### PR TITLE
Starts Async Daemon when Store is Eagerly Initialized

### DIFF
--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -509,6 +509,11 @@ namespace Marten
             /// <returns></returns>
             public MartenConfigurationExpression AddAsyncDaemon(DaemonMode mode)
             {
+                if(_options != null)
+                {
+                    _options.Projections.AsyncMode = mode;
+                }
+
                 Services.ConfigureMarten(opts => opts.Projections.AsyncMode = mode);
                 Services.AddSingleton<IHostedService, AsyncProjectionHostedService>();
 


### PR DESCRIPTION
Fixes #2185

Sets the `AsyncMode` on the in-memory `StoreOptions` when adding the async daemon so it operates when users use the `InitializeStore` functionality.