### PR TITLE
Combine sql and parameter(s) to one log statement

### DIFF
--- a/src/CoreTests/Logging/DefaultMartenLoggerTests.cs
+++ b/src/CoreTests/Logging/DefaultMartenLoggerTests.cs
@@ -3,12 +3,33 @@ using System.Text;
 using Marten;
 using Microsoft.Extensions.Logging;
 using Npgsql;
+using Shouldly;
 using Xunit;
 
 namespace CoreTests.Logging
 {
     public class DefaultMartenLoggerTests
     {
+        [Fact]
+        public void log_success()
+        {
+            var sb = new StringBuilder();
+            var logger = new DefaultMartenLogger(new XunitLogger(sb));
+            var command = new NpgsqlCommand()
+            {
+                CommandText = "select * from users where id = @id and name = @name",
+                Parameters =
+                {
+                    new NpgsqlParameter("id", "{1}"),
+                    new NpgsqlParameter("name", "{2}")
+                }
+            };
+            logger.LogSuccess(command);
+
+            var result = sb.ToString().Trim();
+            result.ShouldBe($"Marten executed in 0 ms, SQL: select * from users where id = @id and name = @name\n  id: {{1}}{Environment.NewLine}  name: {{2}}");
+        }
+
         [Fact]
         public void log_failure_should_not_throw()
         {

--- a/src/Marten/DefaultMartenLogger.cs
+++ b/src/Marten/DefaultMartenLogger.cs
@@ -37,12 +37,11 @@ namespace Marten
 
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug("Marten executed in {milliseconds} ms, SQL: {SQL}", _stopwatch?.ElapsedMilliseconds ?? 0 ,command.CommandText);
-
-                foreach (NpgsqlParameter p in command.Parameters)
-                {
-                    _logger.LogDebug("    {ParameterName}: {ParameterValue}", p.ParameterName, p.Value);
-                }
+                var message = "Marten executed in {milliseconds} ms, SQL: {SQL}\n{PARAMS}";
+                var parameters = command.Parameters.OfType<NpgsqlParameter>()
+                    .Select(p => $"  {p.ParameterName}: {p.Value}")
+                    .Join(Environment.NewLine);
+                _logger.LogDebug(message, _stopwatch?.ElapsedMilliseconds ?? 0, command.CommandText, parameters);
             }
         }
 


### PR DESCRIPTION
When enabling debug logs the sql parameters was quite spammy