### PR TITLE
Handle when TenantId has not been set

### DIFF
--- a/src/Marten/Services/SessionOptions.cs
+++ b/src/Marten/Services/SessionOptions.cs
@@ -15,7 +15,7 @@ namespace Marten.Services
         internal IConnectionLifetime Initialize(DocumentStore store, CommandRunnerMode mode)
         {
             Mode = mode;
-            Tenant ??= TenantId != null ? store.Tenancy.GetTenant(TenantId) : store.Tenancy.Default;
+            Tenant ??= TenantId != Tenancy.DefaultTenantId ? store.Tenancy.GetTenant(TenantId) : store.Tenancy.Default;
 
             if (!AllowAnyTenant && !store.Options.Advanced.DefaultTenantUsageEnabled &&
                 Tenant.TenantId == Marten.Storage.Tenancy.DefaultTenantId)
@@ -65,7 +65,7 @@ namespace Marten.Services
         internal async Task<IConnectionLifetime> InitializeAsync(DocumentStore store, CommandRunnerMode mode, CancellationToken token)
         {
             Mode = mode;
-            Tenant ??= TenantId != null ? await store.Tenancy.GetTenantAsync(TenantId).ConfigureAwait(false) : store.Tenancy.Default;
+            Tenant ??= TenantId != Tenancy.DefaultTenantId ? store.Tenancy.GetTenant(TenantId) : store.Tenancy.Default;
 
             if (!store.Options.Advanced.DefaultTenantUsageEnabled &&
                 Tenant.TenantId == Marten.Storage.Tenancy.DefaultTenantId)


### PR DESCRIPTION
Solves https://github.com/JasperFx/marten/issues/2174

The issue there was that TenantId was never null during code generation, so it always tried to get tenant from StaticMultiTenancy, instead of getting default.