### PR TITLE
Do not open transaction by default when using OpenSessionAsync

### DIFF
--- a/src/Marten/Services/SessionOptions.cs
+++ b/src/Marten/Services/SessionOptions.cs
@@ -86,7 +86,10 @@ namespace Marten.Services
                     ? new ReadOnlyMartenControlledConnectionTransaction(this)
                     : new MartenControlledConnectionTransaction(this);
 
-                await transaction.BeginTransactionAsync(token).ConfigureAwait(false);
+                if (IsolationLevel == IsolationLevel.Serializable)
+                {
+                    await transaction.BeginTransactionAsync(token).ConfigureAwait(false);
+                }
 
                 return transaction;
             }


### PR DESCRIPTION
When Marten handles connection and session, OpenSession does open connection and begin transaction only when Serializable isolation level is used. Async version of OpenSession opens connection and begins transaction always. This PR changes the async version of OpenSession to work the same way as sync version.