### PR TITLE
Prevent append operation on archived streams

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -362,7 +362,7 @@ The `IMartenLogger` can be swapped out on any `IQuerySession` or `IDocumentSessi
 // session to pipe Marten logging to the xUnit.Net output
 theSession.Logger = new TestOutputMartenLogger(_output);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/archiving_events.cs#L226-L232' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_replacing_logger_per_session' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/archiving_events.cs#L227-L233' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_replacing_logger_per_session' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Previewing the PostgreSQL Query Plan

--- a/docs/events/archiving.md
+++ b/docs/events/archiving.md
@@ -16,7 +16,7 @@ public async Task SampleArchive(IDocumentSession session, string streamId)
     await session.SaveChangesAsync();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/archiving_events.cs#L26-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_archive_stream_usage' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/archiving_events.cs#L27-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_archive_stream_usage' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 As in all cases with an `IDocumentSession`, you need to call `SaveChanges()` to commit the
@@ -35,7 +35,7 @@ var events = await theSession.Events
     .Where(x => x.IsArchived)
     .ToListAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/archiving_events.cs#L161-L168' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_querying_for_archived_events' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/archiving_events.cs#L162-L169' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_querying_for_archived_events' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also query for all events both archived and not archived with `MaybeArchived()`
@@ -47,5 +47,5 @@ like so:
 var events = await theSession.Events.QueryAllRawEvents()
     .Where(x => x.MaybeArchived()).ToListAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/archiving_events.cs#L192-L197' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_for_maybe_archived_events' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/archiving_events.cs#L193-L198' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_for_maybe_archived_events' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/src/Marten/Events/EventGraph.Processing.cs
+++ b/src/Marten/Events/EventGraph.Processing.cs
@@ -113,6 +113,10 @@ namespace Marten.Events
                     }
                     else
                     {
+                        if (state.IsArchived)
+                        {
+                            throw new InvalidStreamOperationException($"Attempted to append event to archived stream with Id '{state.Id}'.");
+                        }
                         stream.PrepareEvents(state.Version, this, sequences, session);
                         session.QueueOperation(storage.UpdateStreamVersion(stream));
                     }

--- a/src/Marten/Events/EventGraph.Processing.cs
+++ b/src/Marten/Events/EventGraph.Processing.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Events.Operations;
+using Marten.Exceptions;
 using Marten.Internal;
 using Marten.Internal.Operations;
 using Marten.Internal.Sessions;
@@ -52,6 +53,10 @@ namespace Marten.Events
                     }
                     else
                     {
+                        if (state.IsArchived)
+                        {
+                            throw new InvalidStreamOperationException($"Attempted to append event to archived stream with Id '{state.Id}'.");
+                        }
                         stream.PrepareEvents(state.Version, this, sequences, session);
                         session.QueueOperation(storage.UpdateStreamVersion(stream));
                     }

--- a/src/Marten/Exceptions/InvalidStreamOperationException.cs
+++ b/src/Marten/Exceptions/InvalidStreamOperationException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Marten.Exceptions
+{
+    public class InvalidStreamOperationException: Exception
+    {
+        public InvalidStreamOperationException(string message):
+            base(message)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
`IEventStore.ArchiveStream(<streamIdentifier>)` can be used to archive a stream. One that operation is committed, the stream, along with all its events are marked as archived in the database. However, any subsequent append operations for the stream will append events to the stream as un-archived. That leaves the stream in an inconsistent state, where the stream itself is archived, but with both associated archived and un-archived events.

This enhancement ensures that appending events to an already archived stream is not allowed to prevent this issue.