### PR TITLE
Added the ability to delete a mix of documents

### DIFF
--- a/src/DocumentDbTests/Deleting/deleting_multiple_documents.cs
+++ b/src/DocumentDbTests/Deleting/deleting_multiple_documents.cs
@@ -48,6 +48,39 @@ namespace DocumentDbTests.Deleting
             }
         }
 
+        [Theory]
+        [SessionTypes]
+        public void delete_multiple_types_of_documents_with_delete_objects(DocumentTracking tracking)
+        {
+            DocumentTracking = tracking;
+
+            // Store a mix of different document types
+            var user1 = new User { FirstName = "Jamie", LastName = "Vaughan" };
+            var issue1 = new Issue { Title = "Running low on coffee" };
+            var company1 = new Company { Name = "ECorp" };
+
+            theSession.StoreObjects(new object[] { user1, issue1, company1 });
+
+            theSession.SaveChanges();
+
+            // Delete a mix of documents types
+            using (var session = theStore.OpenSession())
+            {
+                session.DeleteObjects(new object[] { user1, company1 });
+
+                session.SaveChanges();
+            }
+
+            using (var session = theStore.QuerySession())
+            {
+                // Assert the deleted documents no longer exist
+                session.Load<User>(user1.Id).ShouldBeNull();
+                session.Load<Company>(company1.Id).ShouldBeNull();
+
+                session.Load<Issue>(issue1.Id).Title.ShouldBe("Running low on coffee");
+            }
+        }
+
         public deleting_multiple_documents(DefaultStoreFixture fixture) : base(fixture)
         {
         }

--- a/src/Marten/IDocumentOperations.cs
+++ b/src/Marten/IDocumentOperations.cs
@@ -54,6 +54,12 @@ namespace Marten
         void DeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull;
 
         /// <summary>
+        /// Delete an enumerable of potentially mixed documents
+        /// </summary>
+        /// <param name="documents"></param>
+        void DeleteObjects(IEnumerable<object> documents);
+
+        /// <summary>
         /// Explicitly marks multiple documents as needing to be inserted or updated upon the next call to SaveChanges()
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -77,7 +83,7 @@ namespace Marten
         void Store<T>(T entity, Guid version) where T : notnull;
 
         /// <summary>
-        /// DocumentStore an enumerable of potentially mixed documents
+        /// Store an enumerable of potentially mixed documents
         /// </summary>
         /// <param name="documents"></param>
         void StoreObjects(IEnumerable<object> documents);

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -153,8 +153,8 @@ namespace Marten.Internal.Sessions
 
             documents.Where(x => x != null).GroupBy(x => x.GetType()).Each(group =>
             {
-                var handler = typeof(InsertHandler<>).CloseAndBuildAs<IHandler>(group.Key);
-                handler.Store(this, group);
+                var handler = typeof(InsertHandler<>).CloseAndBuildAs<IObjectHandler>(group.Key);
+                handler.Execute(this, group);
             });
         }
 
@@ -177,8 +177,8 @@ namespace Marten.Internal.Sessions
             foreach (var group in documentsGroupedByType)
             {
                 // Build the right handler for the group type
-                var handler = typeof(Handler<>).CloseAndBuildAs<IHandler>(group.Key);
-                handler.Store(this, group);
+                var handler = typeof(StoreHandler<>).CloseAndBuildAs<IObjectHandler>(group.Key);
+                handler.Execute(this, group);
             }
         }
 
@@ -319,25 +319,36 @@ namespace Marten.Internal.Sessions
             foreach (var type in patchedTypes) EjectAllOfType(type);
         }
 
-        internal interface IHandler
+        internal interface IObjectHandler
         {
-            void Store(IDocumentSession session, IEnumerable<object> objects);
+            void Execute(IDocumentSession session, IEnumerable<object> objects);
         }
 
-        internal class Handler<T>: IHandler where T : notnull
+        internal class StoreHandler<T>: IObjectHandler where T : notnull
         {
-            public void Store(IDocumentSession session, IEnumerable<object> objects)
+            public void Execute(IDocumentSession session, IEnumerable<object> objects)
             {
                 // Delegate to the Store<T>() method
                 session.Store(objects.OfType<T>().ToArray());
             }
         }
 
-        internal class InsertHandler<T>: IHandler where T : notnull
+        internal class InsertHandler<T>: IObjectHandler where T : notnull
         {
-            public void Store(IDocumentSession session, IEnumerable<object> objects)
+            public void Execute(IDocumentSession session, IEnumerable<object> objects)
             {
                 session.Insert(objects.OfType<T>().ToArray());
+            }
+        }
+
+        internal class DeleteHandler<T>: IObjectHandler where T : notnull
+        {
+            public void Execute(IDocumentSession session, IEnumerable<object> objects)
+            {
+                foreach (var document in objects.OfType<T>())
+                {
+                    session.Delete(document);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #2271

The goal of this change is to implement a counterpart for the `StoreObjects(IEnumerable<object> documents)` function with a `DeleteObjects(IEnumerable<object> documents)` function.