### PR TITLE
Fetch stream for writing does not return aggregate when it is multi tenanted

### DIFF
--- a/src/Marten/Internal/Storage/IDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IDocumentStorage.cs
@@ -128,12 +128,12 @@ namespace Marten.Internal.Storage
 
     internal static class DocumentStoreExtensions
     {
-        public static void AddTenancyFilter(this IDocumentStorage storage, CommandBuilder sql)
+        public static void AddTenancyFilter(this IDocumentStorage storage, CommandBuilder sql, string tenantId)
         {
             if (storage.TenancyStyle == TenancyStyle.Conjoined)
             {
                 sql.Append($" and {CurrentTenantFilter.Filter}");
-                sql.AddNamedParameter(TenantIdArgument.ArgName, "");
+                sql.AddNamedParameter(TenantIdArgument.ArgName, tenantId);
             }
         }
 

--- a/src/Marten/Linq/QueryHandlers/LoadByIdArrayHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/LoadByIdArrayHandler.cs
@@ -50,7 +50,7 @@ namespace Marten.Linq.QueryHandlers
 
             sql.Append(")");
 
-            storage.AddTenancyFilter(sql);
+            storage.AddTenancyFilter(sql, session.TenantId);
         }
 
         public IReadOnlyList<T> Handle(DbDataReader reader, IMartenSession session)

--- a/src/Marten/Linq/QueryHandlers/LoadByIdHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/LoadByIdHandler.cs
@@ -44,7 +44,7 @@ namespace Marten.Linq.QueryHandlers
 
             sql.AppendParameter(_id);
 
-            storage.AddTenancyFilter(sql);
+            storage.AddTenancyFilter(sql, session.TenantId);
         }
 
 


### PR DESCRIPTION
If aggregate is multi tenanted `EventStore.FetchForWriting` does not return the aggregate for existing stream.

The issue is that LoadByIdHandler adds tenant id parameter with empty value. This value is replaced with actual tenant id in BuildCommand methods. However the FetchInlinedPlan does not use BuildCommand methods and the tenant id is never set for the query fetching the aggregate.

I changed the LoadByIdHandler so that it sets the tenant id value also when adding the parameter. I couldn't come up with reason why this would not work. If there is a reason for not setting the tenant id in LoadByIdHandler, it can be set in FetchInlinedPlan before executing the command.