### PR TITLE
Fix StorageOperationWithDeletionsComparer

### DIFF
--- a/src/DocumentDbTests/Bugs/Bug_PR_2277_upsert_deleted_with_unique_key.cs
+++ b/src/DocumentDbTests/Bugs/Bug_PR_2277_upsert_deleted_with_unique_key.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading.Tasks;
+using Marten.Testing.Harness;
+using Xunit;
+
+namespace DocumentDbTests.Bugs
+{
+    public class Bug_PR_2277_upsert_deleted_with_unique_key: IntegrationContext
+    {
+        public Bug_PR_2277_upsert_deleted_with_unique_key(DefaultStoreFixture fixture): base(fixture)
+        {
+        }
+
+        [Fact]
+        public async Task can_upsert_deleted_record_with_unique_key()
+        {
+            StoreOptions(_ =>
+            {
+                _.Schema.For<RecordA>().Duplicate(r => r.UniqueKey, configure: c => c.IsUnique = true);
+            });
+
+            var recordA = new RecordA { Id = Guid.NewGuid(), UniqueKey = "test123" };
+            var recordB = new RecordB { Id = Guid.NewGuid(), UniqueKey = "test123" };
+            await theStore.BulkInsertAsync(new[] { recordA });
+            await theStore.BulkInsertAsync(new[] { recordB });
+
+            theSession.Delete(recordA);
+            theSession.Delete(recordB);
+            theSession.Store(new RecordA { Id = Guid.NewGuid(), UniqueKey = "test123" });
+            theSession.Store(new RecordB { Id = Guid.NewGuid(), UniqueKey = "test123" });
+
+            await theSession.SaveChangesAsync();
+        }
+
+        public class RecordA
+        {
+            public Guid Id { get; set; }
+            public string UniqueKey { get; set; }
+        }
+
+        public class RecordB
+        {
+            public Guid Id { get; set; }
+            public string UniqueKey { get; set; }
+        }
+    }
+}

--- a/src/Marten/Internal/UnitOfWork.cs
+++ b/src/Marten/Internal/UnitOfWork.cs
@@ -268,7 +268,7 @@ namespace Marten.Internal
                 {
                     // Arbitrary order if one is a delete but the other is not, because this will force the sorting
                     // to try and compare these documents against others and fall in to the below checks.
-                    return yIsDelete ? -1 : 0;
+                    return yIsDelete ? 1 : -1;
                 }
 
                 if (xIsDelete)


### PR DESCRIPTION
I found an issue when we have a transaction with more then one document and there are deletion and upsert queries with unique constraint.

**Steps to reproduce:**
- Add document to the table with duplicate field and unique value
- Create a new session 
- Delete document and insert new one with the same unique value
- Do some operation on any other document
- Save the changes

**Result:**
Marten.Exceptions.DocumentAlreadyExistsException is thrown

StorageOperationWithDeletionsComparer sorts the queries in wrong way as deletion documents are on the bottom of list and delete queries are executed after upsert. It causes the error "Marten.Exceptions.DocumentAlreadyExistsException: Document already exists". In case when we have only one document modified sorting is skipped.

