### PR TITLE
Add timeout option to `IProjectionDaemon.RebuildProjection`

### DIFF
--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -305,10 +305,10 @@ public static async Task UseAsyncDaemon(IDocumentStore store, CancellationToken 
     await daemon.StartAllShards();
 
     // or instead, rebuild a single projection
-    await daemon.RebuildProjection("a projection name", cancellation);
+    await daemon.RebuildProjection("a projection name", 5.Minutes(), cancellation);
 
     // or a single projection by its type
-    await daemon.RebuildProjection<TripAggregationWithCustomName>(cancellation);
+    await daemon.RebuildProjection<TripAggregationWithCustomName>(5.Minutes(), cancellation);
 
     // Be careful with this. Wait until the async daemon has completely
     // caught up with the currently known high water mark

--- a/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs
+++ b/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs
@@ -150,10 +150,10 @@ namespace CommandLineRunner
 
 
             // or instead, rebuild a single projection
-            await daemon.RebuildProjection("a projection name", cancellation);
+            await daemon.RebuildProjection("a projection name", 5.Minutes(), cancellation);
 
             // or a single projection by its type
-            await daemon.RebuildProjection<TripAggregationWithCustomName>(cancellation);
+            await daemon.RebuildProjection<TripAggregationWithCustomName>(5.Minutes(), cancellation);
 
             // Be careful with this. Wait until the async daemon has completely
             // caught up with the currently known high water mark

--- a/src/Marten/Events/Daemon/IProjectionDaemon.cs
+++ b/src/Marten/Events/Daemon/IProjectionDaemon.cs
@@ -10,7 +10,8 @@ namespace Marten.Events.Daemon
     public interface IProjectionDaemon : IDisposable
     {
         /// <summary>
-        /// Rebuilds a single projection by projection name inline
+        /// Rebuilds a single projection by projection name inline.
+        /// Will timeout if a shard takes longer than 5 minutes.
         /// </summary>
         /// <param name="projectionName"></param>
         /// <param name="token"></param>
@@ -19,12 +20,31 @@ namespace Marten.Events.Daemon
 
 
         /// <summary>
-        /// Rebuilds a single projection by projection type inline
+        /// Rebuilds a single projection by projection type inline.
+        /// Will timeout if a shard takes longer than 5 minutes.
         /// </summary>
         /// <typeparam name="TView">Projection view type</typeparam>
         /// <param name="token"></param>
         /// <returns></returns>
         Task RebuildProjection<TView>(CancellationToken token);
+
+        /// <summary>
+        /// Rebuilds a single projection by projection name inline
+        /// </summary>
+        /// <param name="projectionName"></param>
+        /// <param name="shardTimeout"></param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task RebuildProjection(string projectionName, TimeSpan shardTimeout, CancellationToken token);
+
+
+        /// <summary>
+        /// Rebuilds a single projection by projection type inline
+        /// </summary>
+        /// <typeparam name="TView">Projection view type</typeparam>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task RebuildProjection<TView>(TimeSpan shardTimeout, CancellationToken token);
 
         /// <summary>
         /// Starts a single projection shard by name


### PR DESCRIPTION
Internally there is a per-shard timeout of 5 minutes when calling RebuildProjection. This change makes that timeout configurable.

I'm a little unsure about the inclusion of the cancellation token, it feels weird to have two cancellation conditions.