### PR TITLE
Fix #2258 - Include Loads all Related Documents when Using Limit/Offset

### DIFF
--- a/src/DocumentDbTests/Bugs/Bug_2224_Include_needs_to_respect_Take_and_Skip_in_main_body.cs
+++ b/src/DocumentDbTests/Bugs/Bug_2224_Include_needs_to_respect_Take_and_Skip_in_main_body.cs
@@ -85,35 +85,35 @@ namespace DocumentDbTests.Bugs
             list.Count.ShouldBe(1);
         }
 
-        // [Fact] -- JDM to come back to this
-        // public async Task Bug_2258_get_all_related_documents()
-        // {
-        //     var tenant1 = new Tenant2();
-        //     var tenant2 = new Tenant2();
-        //     var tenant3 = new Tenant2();
-        //
-        //     theSession.Store(tenant1, tenant2, tenant3);
-        //
-        //     await theSession.SaveChangesAsync();
-        //
-        //     var user1 = new User2 { TenantIds = new List<Guid> { tenant1.Id, tenant2.Id, tenant3.Id } };
-        //     theSession.Store(user1);
-        //     await theSession.SaveChangesAsync();
-        //
-        //     theSession.Logger = new TestOutputMartenLogger(_output);
-        //
-        //     var tenants = new Dictionary<Guid, Tenant2>();
-        //     var user = await theSession
-        //         .Query<User2>()
-        //         .Include(x => x.TenantIds, tenants)
-        //         .SingleOrDefaultAsync(x => x.Id == user1.Id);
-        //
-        //     user.Id.ShouldBe(user1.Id);
-        //     tenants.Count.ShouldBe(3);
-        //     tenants.ContainsKey(tenant1.Id).ShouldBeTrue();
-        //     tenants.ContainsKey(tenant2.Id).ShouldBeTrue();
-        //     tenants.ContainsKey(tenant3.Id).ShouldBeTrue();
-        // }
+        [Fact]
+        public async Task Bug_2258_get_all_related_documents()
+        {
+            var tenant1 = new Tenant2();
+            var tenant2 = new Tenant2();
+            var tenant3 = new Tenant2();
+
+            theSession.Store(tenant1, tenant2, tenant3);
+
+            await theSession.SaveChangesAsync();
+
+            var user1 = new User2 { TenantIds = new List<Guid> { tenant1.Id, tenant2.Id, tenant3.Id } };
+            theSession.Store(user1);
+            await theSession.SaveChangesAsync();
+
+            theSession.Logger = new TestOutputMartenLogger(_output);
+
+            var tenants = new Dictionary<Guid, Tenant2>();
+            var user = await theSession
+                .Query<User2>()
+                .Include(x => x.TenantIds, tenants)
+                .SingleOrDefaultAsync(x => x.Id == user1.Id);
+
+            user.Id.ShouldBe(user1.Id);
+            tenants.Count.ShouldBe(3);
+            tenants.ContainsKey(tenant1.Id).ShouldBeTrue();
+            tenants.ContainsKey(tenant2.Id).ShouldBeTrue();
+            tenants.ContainsKey(tenant3.Id).ShouldBeTrue();
+        }
 
         [Fact]
         public async Task include_with_pagination()

--- a/src/Marten/Linq/Fields/ArrayField.cs
+++ b/src/Marten/Linq/Fields/ArrayField.cs
@@ -48,7 +48,7 @@ namespace Marten.Linq.Fields
             }
             else
             {
-                LocatorForFlattenedElements = LocatorForIncludedDocumentId;
+                LocatorForFlattenedElements = $"unnest({LocatorForIncludedDocumentId})";;
             }
 
 

--- a/src/Marten/Linq/Fields/ArrayField.cs
+++ b/src/Marten/Linq/Fields/ArrayField.cs
@@ -40,7 +40,7 @@ namespace Marten.Linq.Fields
 
 
             LocatorForIncludedDocumentId =
-                $"unnest(CAST(ARRAY(SELECT jsonb_array_elements_text(CAST({rawLocator} as jsonb))) as {innerPgType}[]))";
+                $"CAST(ARRAY(SELECT jsonb_array_elements_text(CAST({rawLocator} as jsonb))) as {innerPgType}[])";
 
             if (PgType.EqualsIgnoreCase("JSONB"))
             {

--- a/src/Marten/Linq/Includes/IIncludePlan.cs
+++ b/src/Marten/Linq/Includes/IIncludePlan.cs
@@ -10,9 +10,8 @@ namespace Marten.Linq.Includes
 
         string IdAlias { get; }
         string TempTableSelector { get; }
-        bool RequiresLateralJoin();
+        bool IsIdCollection();
         int Index { set; }
-        string LeftJoinExpression { get; }
         string ExpressionName { get; }
         Statement BuildStatement(string tempTableName, IPagedStatement paging);
 

--- a/src/Marten/Linq/Includes/InTempTableWhereFragment.cs
+++ b/src/Marten/Linq/Includes/InTempTableWhereFragment.cs
@@ -10,19 +10,21 @@ namespace Marten.Linq.Includes
         private readonly string _tempTableName;
         private readonly string _tempTableColumn;
         private readonly IPagedStatement _paging;
+        private readonly bool _isIdCollection;
 
-        public InTempTableWhereFragment(string tempTableName, string tempTableColumn, IPagedStatement paging)
+        public InTempTableWhereFragment(string tempTableName, string tempTableColumn, IPagedStatement paging, bool isIdCollection)
         {
             _tempTableName = tempTableName;
             _tempTableColumn = tempTableColumn;
             _paging = paging;
+            _isIdCollection = isIdCollection;
         }
 
         public void Apply(CommandBuilder builder)
         {
             builder.Append("id in (select ");
-            builder.Append(_tempTableColumn);
-            builder.Append(" from ");
+            builder.Append(_isIdCollection ? $"unnest({_tempTableColumn})" : _tempTableColumn);
+            builder.Append($" from (select {_tempTableColumn} from ");
             builder.Append(_tempTableName);
 
             if (_paging.Offset > 0)
@@ -37,6 +39,7 @@ namespace Marten.Linq.Includes
                 builder.Append(_paging.Limit);
             }
 
+            builder.Append($") as {_tempTableName}");
             builder.Append(")");
         }
 

--- a/src/Marten/Linq/Includes/IncludeIdentitySelectorStatement.cs
+++ b/src/Marten/Linq/Includes/IncludeIdentitySelectorStatement.cs
@@ -95,7 +95,6 @@ namespace Marten.Linq.Includes
             sql.Append(" from ");
             sql.Append(FromObject);
             sql.Append(" as d ");
-            sql.Append(_includes.Where(x => x.RequiresLateralJoin()).Select(x => x.LeftJoinExpression).Join(" "));
         }
 
         public string[] SelectFields()

--- a/src/Marten/Linq/Includes/IncludePlan.cs
+++ b/src/Marten/Linq/Includes/IncludePlan.cs
@@ -31,14 +31,11 @@ namespace Marten.Linq.Includes
             {
                 IdAlias = "id" + (value + 1);
                 ExpressionName = "include"+ (value + 1);
-
-                TempTableSelector = RequiresLateralJoin()
-                    ? $"{ExpressionName}.{IdAlias}"
-                    : $"{ConnectingField.LocatorForIncludedDocumentId} as {IdAlias}";
+                TempTableSelector = $"{ConnectingField.LocatorForIncludedDocumentId} as {IdAlias}";
             }
         }
 
-        public bool RequiresLateralJoin()
+        public bool IsIdCollection()
         {
             return ConnectingField is ArrayField;
         }
@@ -66,7 +63,7 @@ namespace Marten.Linq.Includes
             public IncludedDocumentStatement(IDocumentStorage<T> storage, IncludePlan<T> includePlan,
                 string tempTableName, IPagedStatement paging) : base(storage, storage.Fields)
             {
-                var initial = new InTempTableWhereFragment(tempTableName, includePlan.IdAlias, paging);
+                var initial = new InTempTableWhereFragment(tempTableName, includePlan.IdAlias, paging, includePlan.IsIdCollection());
                 Where = storage.FilterDocuments(null, initial);
             }
 

--- a/src/Marten/Linq/SqlGeneration/DocumentStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/DocumentStatement.cs
@@ -117,7 +117,7 @@ namespace Marten.Linq.SqlGeneration
             SelectClause = includeIdentitySelectorStatement;
 
             // Don't do any paging here, or it'll break the Statistics
-            clone.Where = new InTempTableWhereFragment(includeIdentitySelectorStatement.ExportName, "id", PagedStatement.Empty);
+            clone.Where = new InTempTableWhereFragment(includeIdentitySelectorStatement.ExportName, "id", PagedStatement.Empty, false);
 
             return clone;
         }


### PR DESCRIPTION
Because the temp table was unnesting array collections, the limit was being incorrectly applied to the related documents. This PR attempts to solve that problem by pulling the raw array as a column in the temp table, and deferring the unnesting to the `where` clause. 

@jeremydmiller If you have any feedback on this, I'm all ears, but it does appear to fix the test as written for #2258 and preserve all other tested functionality. The thing I'm the least happy with was the change to the `InTempTableWhereFragment` needing to do this:

```sql
where id in (select unnest(id1) from (select id1 from mt_temptable1 limit 10) as mt_temptable1)
```

It works, and I couldn't think of a better way to apply the limit only to the root document, not to the related documents. But it feels gross all the same.