### PR TITLE
.Contains fails when the array happens to be empty

### DIFF
--- a/src/DocumentDbTests/Reading/Linq/query_using_contains.cs
+++ b/src/DocumentDbTests/Reading/Linq/query_using_contains.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Linq;
+using Marten.Testing.Harness;
+using Xunit;
+
+namespace DocumentDbTests.Reading.Linq
+{
+    public class query_using_contains : IntegrationContext
+    {
+        [Fact]
+        public async Task get_distinct_number()
+        {
+            theStore.Options.Schema.For<Target>()
+                .Duplicate(x => x.UserIds);
+
+            theSession.Store(new Target {Id = 1, IsPublic = true, UserIds = new [] { 1, 2, 3, 4, 5, 6 }});
+            theSession.Store(new Target {Id = 2, IsPublic = false, UserIds = new int[] { }});
+            theSession.Store(new Target {Id = 3, IsPublic = true, UserIds = new [] { 1, 2, 3 }});
+            theSession.Store(new Target {Id = 4, IsPublic = true, UserIds = new [] { 1, 2, 6 }});
+            theSession.Store(new Target {Id = 5, IsPublic = true, UserIds = new [] { 4, 5, 6 }});
+            theSession.Store(new Target {Id = 6, IsPublic = true, UserIds = new [] { 6 }});
+
+            await theSession.SaveChangesAsync();
+
+            using (var sess = theStore.LightweightSession())
+            {
+                // This currently fails due to the way the query uses unnest to assume the array has items
+                // since the array is empty the unnest results in 0 records to query against
+                var result1 = theSession.Query<Target>().Where(x => x.IsPublic == false || x.UserIds.Contains(10)).ToList();
+
+                result1.ShouldContain(x => x.Id == 2);
+
+                // This should pass without any error as the query will return results
+                var result2 = await theSession.Query<Target>().Where(x => x.IsPublic || x.UserIds.Contains(5)).ToListAsync();
+
+                result2.ShouldContain(x => x.Id == 1);
+                result2.ShouldContain(x => x.Id == 5);
+            }
+        }
+
+        public query_using_contains(DefaultStoreFixture fixture) : base(fixture)
+        {
+        }
+
+        public class Target
+        {
+            public int Id { get; set; }
+
+            public bool IsPublic { get; set; }
+
+            public int[] UserIds { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
There's 2 tests, one that succeeds and one that fails. 

The first one fails due to the `unnest` usage.


(query cleaned up to make it readable)
```
WITH mt_temp_id_list1CTE as (
    select ctid, 
              unnest(CAST(ARRAY(SELECT jsonb_array_elements_text(CAST(d.data ->> 'UserIds' as jsonb))) as integer[])) as data 
    from public.mt_doc_query_using_contains_target as d 
    WHERE CAST(d.data ->> 'IsPublic' as boolean) = :p0
), mt_temp_id_list2CTE as (
     select ctid from mt_temp_id_list1CTE where data = :p1
)
select d.id, d.data 
from public.mt_doc_query_using_contains_target as d 
where ctid in (select ctid from mt_temp_id_list2CTE)
```

There's a couple of issues with the generated query.

If you have a condition like 
```
.Where(x => x.IsPublic == false || x.UserIds.Contains(10))
```

The first part of the query does an Unnest, if an array is Empty this will result in no rows returned for the empty array record.

The second part is filtering on the IsPublic boolean as part of the unnest.

Since the query is an OR, unless the 2 conditions are combined it wont work. 

Since this is a contains the query could be simplified alot to something like:

```sql
-- when the fields are duplicated
select *
from game.mt_doc_chatchannel
where is_public is true
  or 4 = any(user_ids);

-- When the fields are not duplicated
select *
from game.mt_doc_chatchannel
where (data ->> 'isPublic')::bool is true
  or (data -> 'userIds') @> '4'::jsonb;
```