### PR TITLE
Linq fix for AnyTenant call with a compound Where clause

### DIFF
--- a/src/Marten/Linq/SqlGeneration/WhereFragmentExtensions.cs
+++ b/src/Marten/Linq/SqlGeneration/WhereFragmentExtensions.cs
@@ -11,7 +11,23 @@ namespace Marten.Linq.SqlGeneration
     {
         public static bool SpecifiesTenant(this ISqlFragment fragment)
         {
-            return fragment.Flatten().OfType<ITenantWhereFragment>().Any();
+            if (fragment is ITenantWhereFragment)
+            {
+                return true;
+            }
+
+            if (fragment is CompoundWhereFragment cwf)
+            {
+                foreach (var child in cwf.Children)
+                {
+                    if (SpecifiesTenant(child))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         public static bool SpecifiesEventArchivalStatus(this ISqlFragment query)


### PR DESCRIPTION
When a Where clause in a LINQ statement contains AnyTenant() call and multiple other predicates the generated SQL will add the default tenancy WHERE clause.

This is due to `WhereFragmentExtensions.SpecifiesTenant` using the `Flatten` method that does not recursively flatten a `CompoundWhereFragment` fragment.

I was not sure whether that `Flatten` method should be changed so instead changed the extension method to, without using LINQ to avoid unnecessary allocations, look for a `ITenantWhereFragment` fragment