### PR TITLE
Save changes fails if session only has stream without events

### DIFF
--- a/src/Marten/Internal/UnitOfWork.cs
+++ b/src/Marten/Internal/UnitOfWork.cs
@@ -349,7 +349,7 @@ namespace Marten.Internal
 
         public bool HasOutstandingWork()
         {
-            return _operations.Any() || Streams.Any() || _eventOperations.Any();
+            return _operations.Any() || Streams.Any(x => x.Events.Count > 0) || _eventOperations.Any();
         }
 
         public void EjectAll()


### PR DESCRIPTION
If session's work tracker only has event streams but none of those has any events, following exception is thrown when saving changes:
```
System.InvalidOperationException
CommandText property has not been initialized
   at Npgsql.NpgsqlCommand.ProcessRawQuery(SqlQueryParser parser, Boolean standardConformingStrings, NpgsqlBatchCommand batchCommand)
   at Npgsql.NpgsqlCommand.ExecuteReader(CommandBehavior behavior, Boolean async, CancellationToken cancellationToken)
   at Npgsql.NpgsqlCommand.ExecuteReader(CommandBehavior behavior, Boolean async, CancellationToken cancellationToken)
   at Marten.Internal.Sessions.QuerySession.ExecuteReaderAsync(NpgsqlCommand command, CancellationToken token) in C:\Work\_ExternalProjects\marten\src\Marten\Internal\Sessions\QuerySession.Connection.cs:line 101
   at Baseline.Exceptions.ExceptionTransformExtensions.TransformAndThrow(IEnumerable`1 transforms, Exception ex)
   at Baseline.Exceptions.ExceptionTransforms.TransformAndThrow(Exception ex)
   at Marten.Exceptions.MartenExceptionTransformer.WrapAndThrow(NpgsqlCommand command, Exception exception) in C:\Work\_ExternalProjects\marten\src\Marten\Exceptions\MartenExceptionTransformer.cs:line 46
   at Marten.Internal.Sessions.QuerySession.handleCommandException(NpgsqlCommand cmd, Exception e) in C:\Work\_ExternalProjects\marten\src\Marten\Internal\Sessions\QuerySession.Connection.cs:line 27
   at Marten.Internal.Sessions.QuerySession.ExecuteReaderAsync(NpgsqlCommand command, CancellationToken token) in C:\Work\_ExternalProjects\marten\src\Marten\Internal\Sessions\QuerySession.Connection.cs:line 110
   at Marten.Internal.UpdateBatch.ApplyChangesAsync(IMartenSession session, CancellationToken token) in C:\Work\_ExternalProjects\marten\src\Marten\Internal\UpdateBatch.cs:line 72
   at Baseline.Exceptions.ExceptionTransformExtensions.TransformAndThrow(IEnumerable`1 transforms, Exception ex)
   at Marten.Internal.UpdateBatch.ApplyChangesAsync(IMartenSession session, CancellationToken token) in C:\Work\_ExternalProjects\marten\src\Marten\Internal\UpdateBatch.cs:line 77
   at Marten.Internal.Sessions.DocumentSessionBase.ExecuteBatchAsync(IUpdateBatch batch, CancellationToken token) in C:\Work\_ExternalProjects\marten\src\Marten\Internal\Sessions\DocumentSessionBase.SaveChanges.cs:line 182
   at Marten.Internal.Sessions.DocumentSessionBase.ExecuteBatchAsync(IUpdateBatch batch, CancellationToken token) in C:\Work\_ExternalProjects\marten\src\Marten\Internal\Sessions\DocumentSessionBase.SaveChanges.cs:line 204
   at Marten.Internal.Sessions.DocumentSessionBase.SaveChangesAsync(CancellationToken token) in C:\Work\_ExternalProjects\marten\src\Marten\Internal\Sessions\DocumentSessionBase.SaveChanges.cs:line 114
```
The issue seems to be that `WorkTracker.HasOutstandingWork()` returns true but when the streams are handled in `EventGraph.ProcessEvents` streams without events are skipped. Because of this there are no operations to be performed.

This PR changes the `WorkTracker.HasOutstandingWork()` to check that the streams does have events.