### PR TITLE
Bug: MultiTenant Session in IAggregateGrouper does not fetch streams

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_2296_tenant_session_in_grouper.cs
+++ b/src/EventSourcingTests/Bugs/Bug_2296_tenant_session_in_grouper.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace EventSourcingTests.Bugs
 {
-    public class Bug_session_in_grouper : OneOffConfigurationsContext
+    public class Bug_2296_tenant_session_in_grouper : OneOffConfigurationsContext
     {
         [Fact]
         public async Task CanQueryTenantedStreamsInAsyncProjectionGrouper()
@@ -36,11 +36,8 @@ namespace EventSourcingTests.Bugs
             var streamKey = CombGuidIdGeneration.NewGuid().ToString();
             tenantedSession.Events.StartStream(streamKey,
                 new CountEvent {Tag = "Foo"},
-                new CountEvent {Tag = "Foo"},
                 new CountEvent {Tag = "Bar"},
                 new CountEvent {Tag = "Bar"},
-                new CountEvent {Tag = "Bar"},
-                new CountEvent {Tag = "Baz"},
                 new CountEvent {Tag = "Baz"},
                 new CountEvent {Tag = "Baz"},
                 new CountEvent {Tag = "Baz"});
@@ -50,9 +47,9 @@ namespace EventSourcingTests.Bugs
 
             var counts1 = await tenantedSession.Query<CountsByTag>().ToListAsync();
 
-            Assert.Equal(2, counts1.First(c => c.Tag == "Foo").Count);
-            Assert.Equal(3, counts1.First(c => c.Tag == "Bar").Count);
-            Assert.Equal(4, counts1.First(c => c.Tag == "Baz").Count);
+            Assert.Equal(1, counts1.First(c => c.Tag == "Foo").Count);
+            Assert.Equal(2, counts1.First(c => c.Tag == "Bar").Count);
+            Assert.Equal(3, counts1.First(c => c.Tag == "Baz").Count);
 
             tenantedSession.Events.Append(streamKey, new ResetEvent());
             await tenantedSession.SaveChangesAsync();

--- a/src/EventSourcingTests/Bugs/Bug_tenanted_query_session_in_projection_grouper.cs
+++ b/src/EventSourcingTests/Bugs/Bug_tenanted_query_session_in_projection_grouper.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Baseline.Dates;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Schema;
+using Marten.Schema.Identity;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Xunit;
+
+namespace EventSourcingTests.Bugs
+{
+    public class Bug_session_in_grouper : OneOffConfigurationsContext
+    {
+        [Fact]
+        public async Task CanQueryTenantedStreamsInAsyncProjectionGrouper()
+        {
+            StoreOptions(_ =>
+            {
+                _.Policies.AllDocumentsAreMultiTenanted();
+                _.Events.TenancyStyle = TenancyStyle.Conjoined;
+                _.Events.StreamIdentity = StreamIdentity.AsString;
+                _.Projections.Add<CountsByTagProjector>(ProjectionLifecycle.Async);
+            });
+
+            const string tenant = "myTenant";
+            await using var tenantedSession = theStore.LightweightSession(tenant);
+
+            using var daemon = await theStore.BuildProjectionDaemonAsync();
+            await daemon.StartAllShards();
+
+            var streamKey = CombGuidIdGeneration.NewGuid().ToString();
+            tenantedSession.Events.StartStream(streamKey,
+                new CountEvent {Tag = "Foo"},
+                new CountEvent {Tag = "Foo"},
+                new CountEvent {Tag = "Bar"},
+                new CountEvent {Tag = "Bar"},
+                new CountEvent {Tag = "Bar"},
+                new CountEvent {Tag = "Baz"},
+                new CountEvent {Tag = "Baz"},
+                new CountEvent {Tag = "Baz"},
+                new CountEvent {Tag = "Baz"});
+            await tenantedSession.SaveChangesAsync();
+
+            await daemon.WaitForNonStaleData(5.Seconds());
+
+            var counts1 = await tenantedSession.Query<CountsByTag>().ToListAsync();
+
+            Assert.Equal(2, counts1.First(c => c.Tag == "Foo").Count);
+            Assert.Equal(3, counts1.First(c => c.Tag == "Bar").Count);
+            Assert.Equal(4, counts1.First(c => c.Tag == "Baz").Count);
+
+            tenantedSession.Events.Append(streamKey, new ResetEvent());
+            await tenantedSession.SaveChangesAsync();
+
+            await daemon.WaitForNonStaleData(5.Seconds());
+
+            var counts2 = await tenantedSession.Query<CountsByTag>().ToListAsync();
+
+            Assert.Equal(0, counts2.First(c => c.Tag == "Foo").Count);
+            Assert.Equal(0, counts2.First(c => c.Tag == "Bar").Count);
+            Assert.Equal(0, counts2.First(c => c.Tag == "Baz").Count);
+        }
+
+        public class CountEvent
+        {
+            public string Tag { get; set; }
+        }
+
+        public class ResetEvent
+        {
+        }
+
+        public class CountsByTag
+        {
+            [Identity]
+            public string Tag { get; set; }
+            public int Count { get; set; } = 0;
+        }
+
+        public class CountsByTagProjector: MultiStreamAggregation<CountsByTag, string>
+        {
+            public CountsByTagProjector()
+            {
+                Identity<CountEvent>(e => e.Tag);
+                CustomGrouping(new EventGrouper());
+            }
+
+            public void Apply(CountEvent @event, CountsByTag view)
+            {
+                view.Count++;
+            }
+
+            public void Apply(ResetEvent @event, CountsByTag view)
+            {
+                view.Count = 0;
+            }
+
+            public class EventGrouper: IAggregateGrouper<string>
+            {
+                public async Task Group(IQuerySession session, IEnumerable<IEvent> events, ITenantSliceGroup<string> grouping)
+                {
+                    var resetEvents = events.OfType<IEvent<ResetEvent>>().ToList();
+                    if (!resetEvents.Any())
+                    {
+                        return;
+                    }
+
+                    foreach (var resetEvent in resetEvents)
+                    {
+                        // DEBUG HERE
+                        // check session.TenantId and session.Events._tenant.TenantId
+                        // returns empty collection, should return all events in stream.
+                        var streamEvents =
+                            await session.Events.FetchStreamAsync(resetEvent.StreamKey!, version: resetEvent.Version);
+
+                        foreach (var tag in streamEvents.OfType<IEvent<CountEvent>>().GroupBy(foo => foo.Data.Tag).Select(g => g.Key))
+                        {
+                            grouping.AddEvent(tag, resetEvent);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -25,7 +25,7 @@ namespace Marten.Internal.Sessions
         }
 
         internal DocumentSessionBase(DocumentStore store, SessionOptions sessionOptions, IConnectionLifetime connection,
-            ISessionWorkTracker workTracker): base(store, sessionOptions, connection)
+            ISessionWorkTracker workTracker, Tenant? tenant = default): base(store, sessionOptions, connection, tenant)
         {
             Concurrency = sessionOptions.ConcurrencyChecks;
             _workTracker = workTracker;

--- a/src/Marten/Internal/Sessions/NestedTenantQuerySession.cs
+++ b/src/Marten/Internal/Sessions/NestedTenantQuerySession.cs
@@ -1,5 +1,4 @@
 using Baseline;
-using Marten.Internal.CodeGeneration;
 using Marten.Internal.Storage;
 using Marten.Storage;
 
@@ -9,15 +8,12 @@ namespace Marten.Internal.Sessions
     {
         private readonly QuerySession _parent;
 
-        internal NestedTenantQuerySession(QuerySession parent, Tenant tenant) : base((DocumentStore) parent.DocumentStore, parent.SessionOptions, parent._connection)
+        internal NestedTenantQuerySession(QuerySession parent, Tenant tenant) : base((DocumentStore) parent.DocumentStore, parent.SessionOptions, parent._connection, tenant)
         {
             Listeners.AddRange(parent.Listeners);
             _parent = parent;
             Versions = parent.Versions;
             ItemMap = parent.ItemMap;
-
-            TenantId = tenant.TenantId;
-            Database = tenant.Database;
         }
 
         public IQuerySession Parent => _parent;

--- a/src/Marten/Internal/Sessions/NestedTenantSession.cs
+++ b/src/Marten/Internal/Sessions/NestedTenantSession.cs
@@ -1,6 +1,5 @@
 using System;
 using Baseline;
-using Marten.Internal.CodeGeneration;
 using Marten.Internal.Storage;
 using Marten.Storage;
 #nullable enable
@@ -10,16 +9,12 @@ namespace Marten.Internal.Sessions
     {
         private readonly DocumentSessionBase _parent;
 
-        internal NestedTenantSession(DocumentSessionBase parent, Tenant tenant) : base((DocumentStore) parent.DocumentStore, parent.SessionOptions, parent._connection, parent._workTracker)
+        internal NestedTenantSession(DocumentSessionBase parent, Tenant tenant) : base((DocumentStore) parent.DocumentStore, parent.SessionOptions, parent._connection, parent._workTracker, tenant)
         {
             Listeners.AddRange(parent.Listeners);
             _parent = parent;
             Versions = parent.Versions;
             ItemMap = parent.ItemMap;
-
-            TenantId = tenant.TenantId;
-            Database = tenant.Database;
-
         }
 
         public IDocumentSession Parent => _parent;

--- a/src/Marten/Internal/Sessions/QuerySession.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.cs
@@ -42,11 +42,12 @@ namespace Marten.Internal.Sessions
 
         internal QuerySession(DocumentStore store,
             SessionOptions sessionOptions,
-            IConnectionLifetime connection)
+            IConnectionLifetime connection,
+            Tenant? tenant = default)
         {
             _store = store;
-            TenantId = sessionOptions.Tenant?.TenantId ?? sessionOptions.TenantId;
-            Database = sessionOptions.Tenant?.Database ?? throw new ArgumentNullException(nameof(SessionOptions.Tenant));
+            TenantId = tenant?.TenantId ?? sessionOptions.Tenant?.TenantId ?? sessionOptions.TenantId;
+            Database = tenant?.Database ?? sessionOptions.Tenant?.Database ?? throw new ArgumentNullException(nameof(SessionOptions.Tenant));
 
             SessionOptions = sessionOptions;
 
@@ -68,7 +69,7 @@ namespace Marten.Internal.Sessions
 
             _retryPolicy = Options.RetryPolicy();
 
-            Events = CreateEventStore(store, sessionOptions.Tenant);
+            Events = CreateEventStore(store, tenant ?? sessionOptions.Tenant);
 
             Logger = store.Options.Logger().StartSession(this);
         }


### PR DESCRIPTION
Suspect this is an inconsistency with setting the tenant id. Inspecting inside the grouper I can see that `session.TenantId` is the expected tenant but `session.Events._tenant.TenantId` is `*DEFAULT*`.


Included a fix - Pass the tenant from `NestedTenantSession` and `NestedTenantQuerySession` into the base `QuerySession`. I don't like how this now means there is an optional argument to the query session constructor though.