### PR TITLE
Fix null ref source in shard agent

### DIFF
--- a/src/Marten/Events/Daemon/ShardAgent.cs
+++ b/src/Marten/Events/Daemon/ShardAgent.cs
@@ -454,9 +454,9 @@ namespace Marten.Events.Daemon
 
             Position = batch.Range.SequenceCeiling;
 
-            _tracker!.Publish(new ShardState(ShardName, batch.Range.SequenceCeiling){Action = ShardAction.Updated});
+            _tracker?.Publish(new ShardState(ShardName, batch.Range.SequenceCeiling){Action = ShardAction.Updated});
 
-            _commandBlock!.Post(Command.Completed(batch.Range));
+            _commandBlock?.Post(Command.Completed(batch.Range));
         }
 
         public long Position { get; private set; }


### PR DESCRIPTION
I see the below exception pop up in our logs from time-to-time after a successful rebuild, after the shard has already stopped.

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Marten.Events.Daemon.ShardAgent.ExecuteBatch(ProjectionUpdateBatch batch)
   at Marten.Events.Daemon.ShardAgent.<>c__DisplayClass44_0.<<processRange>b__2>d.MoveNext()
--- End of stack trace from previous location ---
   at Marten.Events.Daemon.ProjectionDaemon.TryAction(ActionParameters parameters)
```

I assume it's either the tracker or command block already being set to null by this point.