### PR TITLE
Discussion: Add test to show inline projection rebuilds stopping at gaps.

### DIFF
--- a/src/Marten.AsyncDaemon.Testing/build_aggregate_multiple_projections.cs
+++ b/src/Marten.AsyncDaemon.Testing/build_aggregate_multiple_projections.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Baseline.Dates;
@@ -6,7 +7,10 @@ using Marten.AsyncDaemon.Testing.TestingSupport;
 using Marten.Events.Aggregation;
 using Marten.Events.Daemon;
 using Marten.Events.Projections;
+using Marten.Testing;
+using NpgsqlTypes;
 using Shouldly;
+using Weasel.Postgresql;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -137,6 +141,108 @@ namespace Marten.AsyncDaemon.Testing
                 truckName.ShouldBe("truck-name-2");
             }
 
+        }
+
+        [Fact]
+        public async Task bug_repro_2()
+        {
+            // register projection
+            StoreOptions(x =>
+            {
+                x.Projections.Add<CarAggregation>();
+            }, true);
+
+            // create car stream with 1000 events
+            using (var session = theStore.LightweightSession())
+            {
+                var events = new List<CarNamed>();
+
+                for (var i = 0; i < 1000; i++)
+                {
+                    events.Add(new CarNamed { Value = $"car-name-{i}" });
+                }
+
+                session.Events.StartStream(Guid.NewGuid(), events);
+                await session.SaveChangesAsync();
+            }
+
+            // create some gaps
+            long startingId = 25;
+            var group1 = Enumerable.Range(0, 5).Select(x => x + startingId).ToArray();
+            var group2 = Enumerable.Range(0, 5).Select(x => x + startingId + 10).ToArray();
+            var group3 = Enumerable.Range(0, 5).Select(x => x + startingId + 20).ToArray();
+            var group4 = Enumerable.Range(0, 5).Select(x => x + startingId + 45).ToArray();
+
+            var groupsToRemove = group1.Concat(group2).Concat(group3).Concat(group4).ToArray();
+
+            await deleteEvents(groupsToRemove);
+
+            var projections = new[] { "CarView" };
+
+            // rebuild the projection
+            var daemon = await theStore.BuildProjectionDaemonAsync(logger: Logger);
+
+            await daemon.StartDaemon();
+
+            try
+            {
+                foreach (var projection in projections)
+                {
+                    await daemon.RebuildProjection($"{nameof(build_aggregate_multiple_projections)}.{projection}", default);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+            finally
+            {
+                await daemon.StopAll();
+                daemon.Dispose();
+            }
+
+            // assert that the projections have reached max seq_id
+            using (var session = theStore.QuerySession())
+            {
+                var waterMark = await GetHighWaterMark();
+                var maxSeqId = await GetMaxSeqId();
+
+                var cars = await session.Query<CarView>().ToListAsync();
+
+                waterMark.ShouldBe(maxSeqId);
+                cars.Last().Name.ShouldBe("car-name-999");
+            }
+        }
+
+        protected async Task deleteEvents(params long[] ids)
+        {
+            using var conn = theStore.CreateConnection();
+            await conn.OpenAsync();
+
+            await conn
+                .CreateCommand($"delete from {theStore.Events.DatabaseSchemaName}.mt_events where seq_id = ANY(:ids)")
+                .With("ids", ids, NpgsqlDbType.Bigint | NpgsqlDbType.Array)
+                .ExecuteNonQueryAsync();
+        }
+
+        protected async Task<long> GetHighWaterMark()
+        {
+            using var conn = theStore.CreateConnection();
+            await conn.OpenAsync();
+
+            return (long)await conn
+                .CreateCommand($"select last_seq_id from {theStore.Events.DatabaseSchemaName}.mt_event_progression where name = 'HighWaterMark'")
+                .ExecuteScalarAsync();
+        }
+
+        protected async Task<long> GetMaxSeqId()
+        {
+            using var conn = theStore.CreateConnection();
+            await conn.OpenAsync();
+
+            return (long)await conn
+                .CreateCommand($"select max(seq_id) from {theStore.Events.DatabaseSchemaName}.mt_events")
+                .ExecuteScalarAsync();
         }
     }
 }


### PR DESCRIPTION
This test is to reproduce an issue we noticed in one of our environments, where inline projection rebuilds would get stuck on gaps in the event stream.  Early gaps within the event stream were caused by some catastrophic failures, though I'd expect the projection rebuilds to be able to deal with gaps and move on.