### PR TITLE
Ignore where clause expressions such as `where([x] != null)` and `where([x] == null)`

### DIFF
--- a/src/DocumentDbTests/Reading/Linq/query_with_source_reference_comparision_tests.cs
+++ b/src/DocumentDbTests/Reading/Linq/query_with_source_reference_comparision_tests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Linq;
+using Marten.Testing.Harness;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Documents;
+using Shouldly;
+using Xunit;
+
+namespace DocumentDbTests.Reading.Linq
+{
+    public class query_with_source_reference_comparision_tests: IntegrationContext
+    {
+        public query_with_source_reference_comparision_tests(DefaultStoreFixture fixture) : base(fixture)
+        {
+        }
+
+        [Fact]
+        public async Task ignore_source_reference_comparision()
+        {
+            for (var i = 0; i < 10; i++)
+            {
+                var issueTitle = i % 2 == 0 ? "E" : "O";
+                var issue = new Issue {Id = Guid.NewGuid(), Title = issueTitle};
+                theSession.Store(issue);
+            }
+            await theSession.SaveChangesAsync();
+            var issues = await theSession.Query<Issue>()
+                .Where(i => i != null)
+                .ToListAsync();
+            issues.Count.ShouldBe(10);
+        }
+
+        [Fact]
+        public async Task ignore_nested_source_reference_comparision()
+        {
+            for (var i = 0; i < 10; i++)
+            {
+                var issueTitle = i % 2 == 0 ? "E" : "O";
+                var issue = new Issue {Id = Guid.NewGuid(), Title = issueTitle};
+                theSession.Store(issue);
+            }
+            await theSession.SaveChangesAsync();
+            var issues = await theSession.Query<Issue>()
+                .Where(i => (i != null && i.Title == "E") || (i == null && i.Title == "E"))
+                .ToListAsync();
+            issues.Count.ShouldBe(5);
+        }
+    }
+}

--- a/src/Marten/Linq/Filters/IgnoredWhereClauseFragment.cs
+++ b/src/Marten/Linq/Filters/IgnoredWhereClauseFragment.cs
@@ -1,0 +1,13 @@
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.Filters
+{
+    internal class IgnoredWhereClauseFragment: ISqlFragment
+    {
+        public void Apply(CommandBuilder builder)
+        {
+        }
+        public bool Contains(string sqlText) => false;
+    }
+}

--- a/src/Marten/Linq/Parsing/WhereClauseParser.cs
+++ b/src/Marten/Linq/Parsing/WhereClauseParser.cs
@@ -8,12 +8,10 @@ using Marten.Internal;
 using Marten.Linq.Fields;
 using Marten.Linq.Filters;
 using Marten.Linq.SqlGeneration;
-using Microsoft.CodeAnalysis.Operations;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
 using Remotion.Linq.Clauses.ResultOperators;
 using Remotion.Linq.Parsing;
-using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Parsing

--- a/src/Marten/Linq/SqlGeneration/DocumentStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/DocumentStatement.cs
@@ -24,6 +24,9 @@ namespace Marten.Linq.SqlGeneration
         // TODO -- return IEnumerable<ISqlFragment> instead
         protected override ISqlFragment buildWhereFragment(IMartenSession session)
         {
+            if (WhereClauses.Count == 0)
+                return Storage.DefaultWhereFragment();
+
             var parser = new WhereClauseParser(session, this);
 
             ISqlFragment where = null;

--- a/src/Marten/Linq/SqlGeneration/DocumentStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/DocumentStatement.cs
@@ -28,42 +28,28 @@ namespace Marten.Linq.SqlGeneration
                 return Storage.DefaultWhereFragment();
 
             var parser = new WhereClauseParser(session, this);
+            var parsedWhereClauses = WhereClauses
+                .Select(x => parser.Build(x))
+                .Where(w => w is not IgnoredWhereClauseFragment)
+                .ToArray();
 
-            ISqlFragment where = null;
-
-            switch (WhereClauses.Count)
+            switch (parsedWhereClauses.Length)
             {
                 case 0:
                     return Storage.DefaultWhereFragment();
 
                 case 1:
-                    where = parser.Build(WhereClauses.Single());
-                    if (where is IgnoredWhereClauseFragment)
-                    {
-                        return Storage.DefaultWhereFragment();
-                    }
-                    break;
+                {
+                    var whereClause = parsedWhereClauses[0];
+                    return Storage.FilterDocuments(null, whereClause);
+                }
 
                 default:
-                    var wheres = WhereClauses.Select(x => parser.Build(x))
-                        .Where(w => w is not IgnoredWhereClauseFragment)
-                        .ToArray();
-                    if (!wheres.Any())
-                    {
-                        return Storage.DefaultWhereFragment();
-                    }
-                    else if (wheres.Length == 1)
-                    {
-                        where = wheres[0];
-                        break;
-                    }
-                    else
-                    {
-                        where = CompoundWhereFragment.And(wheres);
-                        break;
-                    }
+                {
+                    var whereClause = CompoundWhereFragment.And(parsedWhereClauses);
+                    return Storage.FilterDocuments(null, whereClause);
+                }
             }
-            return Storage.FilterDocuments(null, where);
         }
 
         public override void CompileLocal(IMartenSession session)


### PR DESCRIPTION
The inspiration for this enhancement to the LINQ provider comes from my attempt to integrate Marten with the HotChocolate GraphQl library (https://chillicream.com/docs/hotchocolate/). That library comes with some useful out the box features like filtering (https://chillicream.com/docs/hotchocolate/fetching-data/filtering).
For that feature to work, I simply need a data source from which I can retrieve some `IQueryable<T>`.
Let's say I have the following object:
```
public class Book
{
    public Guid Id { get; set; }
    public string Content { get; set; }
    public bool IsPopular { get; set; }
    public int Rating { get; set; }
}
```
And that I want to execute the following query:
```
{
  books (where: {rating: {gt: 50}}) {
    id
    content
    isPopular
    rating
  }
}
```
HotChocolate will generate a LINQ expression for that where clause that it will then attempt to apply the the Marten `IQueryable` that looks like the following:
`where([x] != null AndAlso [x].Rating > 50)`

At the moment, Marten does not know how to process the first part of that expression, and will trigger an exception.
This enhancement fixes that issue.
