### PR TITLE
Resilient projection rebuilds

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -184,7 +184,7 @@ public class FakeListener: IChangeListener
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/basic_async_daemon_tests.cs#L47-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asyncdaemonlistener' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/basic_async_daemon_tests.cs#L52-L64' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asyncdaemonlistener' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Wiring a Async Daemon listener:
@@ -198,7 +198,7 @@ StoreOptions(x =>
     x.Projections.AsyncListeners.Add(listener);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/basic_async_daemon_tests.cs#L64-L71' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asynclisteners' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/basic_async_daemon_tests.cs#L69-L76' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asynclisteners' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Custom Logging

--- a/src/Marten.AsyncDaemon.Testing/TestingSupport/TripStream.cs
+++ b/src/Marten.AsyncDaemon.Testing/TestingSupport/TripStream.cs
@@ -6,6 +6,8 @@ using Marten.Events;
 
 namespace Marten.AsyncDaemon.Testing.TestingSupport
 {
+
+
     public class TripStream
     {
         public static List<TripStream> RandomStreams(int number)
@@ -85,6 +87,8 @@ namespace Marten.AsyncDaemon.Testing.TestingSupport
                     Events.Add(arrival);
                 }
             }
+
+            Events.Add(new FailingEvent());
 
             if (randomNumber > .5)
             {

--- a/src/Marten.AsyncDaemon.Testing/basic_async_daemon_tests.cs
+++ b/src/Marten.AsyncDaemon.Testing/basic_async_daemon_tests.cs
@@ -175,7 +175,7 @@ namespace Marten.AsyncDaemon.Testing
             var uniqueTypeCount = range1.Events.Select(x => x.EventType).Distinct()
                 .Count();
 
-            uniqueTypeCount.ShouldBe(5);
+            uniqueTypeCount.ShouldBe(6);
 
             var filter = new EventTypeFilter(theStore.Events, new Type[] {typeof(Travel), typeof(Arrival)});
             using var fetcher2 = new EventFetcher(theStore, theAgent, theStore.Tenancy.Default.Database, new ISqlFragment[]{filter});

--- a/src/Marten.AsyncDaemon.Testing/event_fetcher_tests.cs
+++ b/src/Marten.AsyncDaemon.Testing/event_fetcher_tests.cs
@@ -29,7 +29,7 @@ namespace Marten.AsyncDaemon.Testing
             loadEvents(theSession.Events);
             await theSession.SaveChangesAsync();
 
-            var fetcher = new EventFetcher(theStore, theStore.Tenancy.Default.Database, theFilters.ToArray());
+            var fetcher = new EventFetcher(theStore, null, theStore.Tenancy.Default.Database, theFilters.ToArray());
             await fetcher.Load(theRange, default);
         }
 

--- a/src/Marten.AsyncDaemon.Testing/rebuilds_with_serialization_or_poison_pill_events.cs
+++ b/src/Marten.AsyncDaemon.Testing/rebuilds_with_serialization_or_poison_pill_events.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Baseline.Dates;
+using Marten.AsyncDaemon.Testing.TestingSupport;
+using Marten.Events.Daemon;
+using Marten.Events.Projections;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Marten.AsyncDaemon.Testing;
+
+public class rebuilds_with_serialization_or_poison_pill_events : DaemonContext
+{
+    public rebuilds_with_serialization_or_poison_pill_events(ITestOutputHelper output) : base(output)
+    {
+        SometimesFailingTripProjection.FailingEventFails = false;
+        FailingEvent.SerializationFails = false;
+    }
+
+    [Fact]
+    public async Task rebuild_the_projection_happy_path()
+    {
+        NumberOfStreams = 10;
+
+        Logger.LogDebug("The expected number of events is {NumberOfEvents}", NumberOfEvents);
+
+        StoreOptions(x => x.Projections.Add(new SometimesFailingTripProjection(), ProjectionLifecycle.Async), true);
+
+        var agent = await StartDaemon();
+
+        await PublishSingleThreaded();
+
+        var waiter = agent.Tracker.WaitForShardState(new ShardState("Trip:All", NumberOfEvents), 30.Seconds());
+
+        await waiter;
+        Logger.LogDebug("About to rebuild Trip:All");
+        await agent.RebuildProjection("Trip", CancellationToken.None);
+        Logger.LogDebug("Done rebuilding Trip:All");
+        await CheckAllExpectedAggregatesAgainstActuals();
+    }
+
+    [Fact]
+    public async Task rebuild_the_projection_skip_serialization_failures()
+    {
+        NumberOfStreams = 10;
+
+        Logger.LogDebug("The expected number of events is {NumberOfEvents}", NumberOfEvents);
+
+        StoreOptions(x => x.Projections.Add(new SometimesFailingTripProjection(), ProjectionLifecycle.Async), true);
+
+        var agent = await StartDaemon();
+
+        await PublishSingleThreaded();
+
+        var waiter = agent.Tracker.WaitForShardState(new ShardState("Trip:All", NumberOfEvents), 30.Seconds());
+
+        await waiter;
+        Logger.LogDebug("About to rebuild Trip:All");
+
+        // Simulating serialization failures
+        FailingEvent.SerializationFails = true;
+
+        await agent.RebuildProjection("Trip", CancellationToken.None);
+        Logger.LogDebug("Done rebuilding Trip:All");
+        await CheckAllExpectedAggregatesAgainstActuals();
+
+        var deadLetters = await theSession.Query<DeadLetterEvent>().Where(x => x.ShardName == "Trip:All")
+            .ToListAsync();
+
+        var badEventCount = Streams.SelectMany(x => x.Events).OfType<FailingEvent>().Count();
+        deadLetters.Count.ShouldBe(badEventCount);
+    }
+
+    [Fact]
+    public async Task rebuild_the_projection_skip_failed_events()
+    {
+        FailingEvent.SerializationFails = true;
+
+        NumberOfStreams = 10;
+
+        Logger.LogDebug("The expected number of events is {NumberOfEvents}", NumberOfEvents);
+
+        StoreOptions(x => x.Projections.Add(new SometimesFailingTripProjection(), ProjectionLifecycle.Async), true);
+
+        var agent = await StartDaemon();
+
+        await PublishSingleThreaded();
+
+        var waiter = agent.Tracker.WaitForShardState(new ShardState("Trip:All", NumberOfEvents), 30.Seconds());
+
+        await waiter;
+        Logger.LogDebug("About to rebuild Trip:All");
+        await agent.RebuildProjection("Trip", CancellationToken.None);
+        Logger.LogDebug("Done rebuilding Trip:All");
+        await CheckAllExpectedAggregatesAgainstActuals();
+
+        var deadLetters = await theSession.Query<DeadLetterEvent>().Where(x => x.ShardName == "Trip:All")
+            .ToListAsync();
+
+        var badEventCount = Streams.SelectMany(x => x.Events).OfType<FailingEvent>().Count();
+        deadLetters.Count.ShouldBe(badEventCount);
+    }
+}
+
+public class SometimesFailingTripProjection: TripAggregationWithCustomName
+{
+    public static bool FailingEventFails = false;
+
+
+    public void Apply(FailingEvent e, Trip trip)
+    {
+        if (FailingEventFails) throw new InvalidOperationException("You shall not pass!");
+    }
+}
+
+public class FailingEvent
+{
+    public static bool SerializationFails = false;
+
+    public FailingEvent()
+    {
+        if (SerializationFails) throw new DivideByZeroException("Boom!");
+    }
+}
+

--- a/src/Marten/Events/Aggregation/TenantSliceGroup.cs
+++ b/src/Marten/Events/Aggregation/TenantSliceGroup.cs
@@ -190,7 +190,7 @@ namespace Marten.Events.Aggregation
                     slice.Aggregate = aggregate;
                 }
 
-                _builder.Post(slice);
+                _builder?.Post(slice);
             }
         }
 

--- a/src/Marten/Events/Daemon/EventFetcher.cs
+++ b/src/Marten/Events/Daemon/EventFetcher.cs
@@ -23,6 +23,7 @@ namespace Marten.Events.Daemon
     internal class EventFetcher : IDisposable
     {
         private readonly IDocumentStore _store;
+        private readonly IShardAgent _shardAgent;
         private readonly IMartenDatabase _database;
         private readonly ISqlFragment[] _filters;
         private readonly IEventStorage _storage;
@@ -31,9 +32,11 @@ namespace Marten.Events.Daemon
         private readonly NpgsqlCommand _command;
         private readonly int _aggregateIndex;
 
-        public EventFetcher(IDocumentStore store, IMartenDatabase database, ISqlFragment[] filters)
+        public EventFetcher(IDocumentStore store, IShardAgent shardAgent, IMartenDatabase database,
+            ISqlFragment[] filters)
         {
             _store = store;
+            _shardAgent = shardAgent;
             _database = database;
             _filters = filters;
 
@@ -92,7 +95,7 @@ namespace Marten.Events.Daemon
             {
                 range.Events = new List<IEvent>();
 
-                using var session = querySession();
+                await using var session = querySession();
                 _floor.Value = range.SequenceFloor;
                 _ceiling.Value = range.SequenceCeiling;
 

--- a/src/Marten/Events/Daemon/IShardAgent.cs
+++ b/src/Marten/Events/Daemon/IShardAgent.cs
@@ -15,5 +15,7 @@ namespace Marten.Events.Daemon
 
         Task TryAction(Func<Task> action, CancellationToken token, Action<ILogger, Exception>? logException = null, EventRangeGroup? group = null, GroupActionMode actionMode = GroupActionMode.Parent);
 
+        ShardName Name { get; }
+        ShardExecutionMode Mode { get; set; }
     }
 }

--- a/src/Marten/Events/Daemon/RebuildingEventFetcher.cs
+++ b/src/Marten/Events/Daemon/RebuildingEventFetcher.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Marten.Exceptions;
+using Marten.Storage;
+using Microsoft.Extensions.Logging;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Events.Daemon
+{
+    internal class RebuildingEventFetcher: EventFetcher
+    {
+        private readonly IDocumentStore _store;
+        private readonly ShardAgent _shardAgent;
+        private readonly BatchBlock<DeadLetterEvent> _batching;
+        private long _serializationErrorCount;
+        private readonly ActionBlock<DeadLetterEvent[]> _storing;
+        private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
+
+        public RebuildingEventFetcher(IDocumentStore store, ShardAgent shardAgent, IMartenDatabase database, ISqlFragment[] filters) : base(store, shardAgent, database, filters)
+        {
+            _store = store;
+            _shardAgent = shardAgent;
+
+            _batching = new BatchBlock<DeadLetterEvent>(100);
+            _storing = new ActionBlock<DeadLetterEvent[]>(persistLetters, new ExecutionDataflowBlockOptions
+            {
+                CancellationToken = _cancellation.Token,
+                EnsureOrdered = true,
+                MaxDegreeOfParallelism = 1
+            });
+
+            _batching.LinkTo(_storing);
+        }
+
+        private async Task persistLetters(DeadLetterEvent[] arg)
+        {
+            _serializationErrorCount += arg.Length;
+            try
+            {
+                await _store.BulkInsertDocumentsAsync(arg).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                if (!_cancellation.IsCancellationRequested)
+                {
+                    await Task.Delay(100).ConfigureAwait(false);
+                    if (!_cancellation.IsCancellationRequested)
+                    {
+                        _storing.Post(arg); // retry
+                    }
+                }
+            }
+        }
+
+        protected override async Task handleEvent(EventRange range, CancellationToken token, DbDataReader reader)
+        {
+            try
+            {
+                await base.handleEvent(range, token, reader).ConfigureAwait(false);
+            }
+            catch (EventDeserializationFailureException e)
+            {
+                _shardAgent.Logger.LogError(e, "Error de-serializing event {Sequence}", e.Sequence);
+                var deadLetter = e.ToDeadLetterEvent(_shardAgent.Name);
+                _batching.Post(deadLetter);
+            }
+        }
+
+        public async Task<long> Complete()
+        {
+            _batching.Complete();
+            await _batching.Completion.ConfigureAwait(false);
+            _storing.Complete();
+            await _storing.Completion.ConfigureAwait(false);
+
+            return _serializationErrorCount;
+        }
+    }
+}

--- a/src/Marten/Events/Daemon/ShardAgent.cs
+++ b/src/Marten/Events/Daemon/ShardAgent.cs
@@ -182,7 +182,7 @@ namespace Marten.Events.Daemon
             _tracker = daemon.Tracker;
             _daemon = daemon;
 
-            _fetcher = new EventFetcher(_store, _daemon.Database, _projectionShard.EventFilters);
+            _fetcher = new EventFetcher(_store, this, _daemon.Database, _projectionShard.EventFilters);
             _grouping = new TransformBlock<EventRange, EventRangeGroup>(groupEventRange, singleFileOptions);
 
             _building = new ActionBlock<EventRangeGroup>(processRange, singleFileOptions);

--- a/src/Marten/Exceptions/EventDeserializationFailureException.cs
+++ b/src/Marten/Exceptions/EventDeserializationFailureException.cs
@@ -1,0 +1,32 @@
+using System;
+using LamarCodeGeneration;
+using Marten.Events.Daemon;
+
+namespace Marten.Exceptions
+{
+    /// <summary>
+    /// Thrown if Marten encounters an exception while trying to deserialize
+    /// or upcast a persisted event
+    /// </summary>
+    public class EventDeserializationFailureException : Exception
+    {
+        public EventDeserializationFailureException(long sequence, Exception innerException) : base("Event deserialization error on sequence = " + sequence, innerException)
+        {
+            Sequence = sequence;
+        }
+
+        public long Sequence { get; }
+
+        internal DeadLetterEvent ToDeadLetterEvent(ShardName name)
+        {
+            return new DeadLetterEvent
+            {
+                EventSequence = Sequence,
+                ExceptionMessage = Message,
+                ExceptionType = GetType().FullNameInCode(),
+                ProjectionName = name.ProjectionName,
+                ShardName = name.Key,
+            };
+        }
+    }
+}


### PR DESCRIPTION
Work in progress. This is to make the rebuild projection process able to skip over serialization or poison pill events, while providing options for "fast fail"