### PR TITLE
Reference Weasel.Postgresql 5.7.1

### DIFF
--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -61,7 +61,7 @@
         <PackageReference Include="Remotion.Linq" Version="2.2.0" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
         <PackageReference Include="System.Text.Json" Version="6.0.0" />
-        <PackageReference Include="Weasel.Postgresql" Version="5.7.0" />
+        <PackageReference Include="Weasel.Postgresql" Version="5.7.1" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->


### PR DESCRIPTION
The motivation for upgrading this package is to fix an issue with creating database patches for some versions of Postgres.
I submitted a fix for that issue a few weeks ago, but given that the source code in Weasel has been extracted out of this project,
the issue still exists in Marten.

See https://github.com/JasperFx/weasel/pull/67 for more details. 

Upgrading `Weasel.Postgresql` to `5.7.1`, which contains the fix, addresses the issue.