### PR TITLE
Fixed mapping of the upcasting functions to allow multiple schema versions handling

### DIFF
--- a/build/build.cs
+++ b/build/build.cs
@@ -182,7 +182,7 @@ namespace martenbuild
 
             Target("init-db", () =>
             {
-                Run("docker-compose", "up -d");
+                Run("docker", "compose up -d");
 
                 WaitForDatabaseToBeReady();
 

--- a/docs/events/versioning.md
+++ b/docs/events/versioning.md
@@ -307,7 +307,7 @@ public record ShoppingCartOpened(
     Guid ClientId
 );
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L21-L28' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcasters_old_event_type' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L20-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcasters_old_event_type' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 We want to enrich it with shopping cart status and client name. To have a more straightforward structure, we'd like to group the client id and name into a nested object.
@@ -334,7 +334,7 @@ public enum ShoppingCartStatus
     Cancelled = 4
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L30-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcasters_new_event_type' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L29-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcasters_new_event_type' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Marten provides extended capabilities around that and enables different styles for handling the upcasting transformations.
@@ -360,7 +360,7 @@ options.Events
             )
     );
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L183-L195' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_event_lambda_with_clr_types' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L182-L194' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_event_lambda_with_clr_types' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 It will default take the event type name based on the old CLR type. You can also define it explicitly. It can be helpful if you changed the event schema more than once, and the old CLR class doesn't represent the initial event type name. You can do that with:
@@ -379,7 +379,7 @@ options.Events
             )
     );
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L225-L238' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_event_lambda_with_clr_types_and_explicit_type_name' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L224-L237' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_event_lambda_with_clr_types_and_explicit_type_name' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Raw JSON transformation with Json .NET:
@@ -403,7 +403,7 @@ options.Events
         )
     );
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L585-L603' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_event_lambda_with_jsonnet_jobject' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L584-L602' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_event_lambda_with_jsonnet_jobject' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Add also static import of helper classes to get a concise syntax as above:
@@ -413,7 +413,7 @@ Add also static import of helper classes to get a concise syntax as above:
 ```cs
 using static Marten.Services.Json.Transformations.JsonNet.JsonTransformations;
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L524-L528' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_json_net_static_using' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L523-L527' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_json_net_static_using' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Raw JSON transformation with System.Text.Json:
@@ -440,7 +440,7 @@ options.Events
         })
     );
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L384-L405' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_event_lambda_with_systemtextjson_json_document' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L383-L404' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_event_lambda_with_systemtextjson_json_document' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Add also static import of helper classes to get a concise syntax as above:
@@ -450,7 +450,7 @@ Add also static import of helper classes to get a concise syntax as above:
 ```cs
 using static Marten.Services.Json.Transformations.SystemTextJson.JsonTransformations;
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L315-L319' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_system_text_json_static_using' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L314-L318' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_system_text_json_static_using' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Upcasting with classes
@@ -473,7 +473,7 @@ public class ShoppingCartOpenedUpcaster:
         );
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L76-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcaster_with_clr_types_and_event_type_name_from_old_type' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L75-L88' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcaster_with_clr_types_and_event_type_name_from_old_type' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Just like with functions, by default, it takes the event type name based on the old CLR type. You can also define it explicitly. It can be helpful if you changed the event schema more than once, and the old CLR class doesn't represent the initial event type name. You can do that with:
@@ -496,7 +496,7 @@ public class ShoppingCartOpenedUpcaster:
         );
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L124-L141' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcaster_with_clr_types_and_explicit_event_type_name' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L123-L140' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcaster_with_clr_types_and_explicit_event_type_name' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Raw JSON transformation with Json .NET:
@@ -519,7 +519,7 @@ public class ShoppingCartOpenedUpcaster:
         );
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L530-L547' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcaster_with_clr_types_and_event_type_name_from_old_type_with_jsonnet_jobject' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L529-L546' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcaster_with_clr_types_and_event_type_name_from_old_type_with_jsonnet_jobject' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To use it, add the following using:
@@ -529,7 +529,7 @@ To use it, add the following using:
 ```cs
 using Marten.Services.Json.Transformations.JsonNet;
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L518-L522' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_json_net_class_using' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L517-L521' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_json_net_class_using' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Raw JSON transformation with System.Text.Json:
@@ -556,7 +556,7 @@ public class ShoppingCartOpenedUpcaster:
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L321-L342' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcaster_with_clr_types_and_event_type_name_from_old_type_with_systemtextjson_json_document' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L320-L341' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcaster_with_clr_types_and_event_type_name_from_old_type_with_systemtextjson_json_document' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To use it, add the following using:
@@ -566,7 +566,7 @@ To use it, add the following using:
 ```cs
 using Marten.Services.Json.Transformations.SystemTextJson;
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L309-L313' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_system_text_json_class_using' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L308-L312' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_system_text_json_class_using' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Registering upcaster class
@@ -576,7 +576,7 @@ using Marten.Services.Json.Transformations.SystemTextJson;
 ```cs
 options.Events.Upcast<ShoppingCartOpenedUpcaster>();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L270-L274' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_event_class_with_clr_types' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L269-L273' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_event_class_with_clr_types' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Async Only Upcasters
@@ -600,7 +600,7 @@ public interface IClientRepository
     Task<string> GetClientName(Guid clientId, CancellationToken ct);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L54-L61' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcaster_dependency' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L53-L60' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcaster_dependency' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can use it in all the ways presented above.
@@ -628,7 +628,7 @@ options.Events
         }
     );
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L200-L220' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcast_event_lambda_with_clr_types' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L199-L219' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcast_event_lambda_with_clr_types' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Function with CLR types and explicit event type name
@@ -655,7 +655,7 @@ options.Events
         }
     );
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L244-L265' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcast_event_lambda_with_clr_types_and_explicit_type_name' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L243-L264' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcast_event_lambda_with_clr_types_and_explicit_type_name' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Function with raw JSON transformation with Json .NET:
@@ -686,7 +686,7 @@ options.Events
         )
     );
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L608-L633' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcast_event_lambda_with_jsonnet_jobject' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L607-L632' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcast_event_lambda_with_jsonnet_jobject' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Add also static import of helper classes to get a concise syntax as above:
@@ -696,7 +696,7 @@ Add also static import of helper classes to get a concise syntax as above:
 ```cs
 using static Marten.Services.Json.Transformations.JsonNet.JsonTransformations;
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L524-L528' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_json_net_static_using' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L523-L527' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_json_net_static_using' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Function with raw JSON transformation with System.Text.Json:
@@ -729,7 +729,7 @@ options.Events
         })
     );
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L410-L437' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcast_event_lambda_with_systemtextjson_json_document' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L409-L436' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcast_event_lambda_with_systemtextjson_json_document' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Add also static import of helper classes to get a concise syntax as above:
@@ -739,7 +739,7 @@ Add also static import of helper classes to get a concise syntax as above:
 ```cs
 using static Marten.Services.Json.Transformations.SystemTextJson.JsonTransformations;
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L315-L319' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_system_text_json_static_using' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L314-L318' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_system_text_json_static_using' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Class with CLR types
@@ -774,7 +774,7 @@ public class ShoppingCartOpenedAsyncOnlyUpcaster:
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L91-L120' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_only_upcaster_with_clr_types_and_event_type_name_from_old_type' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L90-L119' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_only_upcaster_with_clr_types_and_event_type_name_from_old_type' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Class with CLR types and explicit event type name
@@ -813,7 +813,7 @@ public class ShoppingCartOpenedAsyncOnlyUpcaster:
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L143-L176' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_only_upcaster_with_clr_types_and_explicit_event_type_name' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L142-L175' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_only_upcaster_with_clr_types_and_explicit_event_type_name' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Class with raw JSON transformation with Json .NET:
@@ -851,7 +851,7 @@ public class ShoppingCartOpenedAsyncOnlyUpcaster:
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L549-L579' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcaster_with_jsonnet_jobject' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L548-L578' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcaster_with_jsonnet_jobject' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To use it, add the following using:
@@ -861,7 +861,7 @@ To use it, add the following using:
 ```cs
 using Marten.Services.Json.Transformations.JsonNet;
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L518-L522' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_json_net_class_using' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L517-L521' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_json_net_class_using' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Class with raw JSON transformation with System.Text.Json:
@@ -901,7 +901,7 @@ public class ShoppingCartOpenedAsyncOnlyUpcaster:
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L344-L378' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcaster_with_systemtextjson_json_document' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L343-L377' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcaster_with_systemtextjson_json_document' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To use it, add the following using:
@@ -911,7 +911,7 @@ To use it, add the following using:
 ```cs
 using Marten.Services.Json.Transformations.SystemTextJson;
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L309-L313' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_system_text_json_class_using' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L308-L312' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_upcast_system_text_json_class_using' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Registering Upcaster class
@@ -921,5 +921,5 @@ using Marten.Services.Json.Transformations.SystemTextJson;
 ```cs
 options.Events.Upcast(new ShoppingCartOpenedAsyncOnlyUpcaster(clientRepository));
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L279-L283' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcast_event_class_with_clr_types' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L278-L282' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcast_event_class_with_clr_types' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/events/versioning.md
+++ b/docs/events/versioning.md
@@ -283,7 +283,7 @@ public class ShoppingCartOpened
 <!-- endSnippet -->
 
 ::: warning
-Remember that if you use this attribute, new events will still produce the old (mapped) event type name.
+Remember that if you use this attribute, new events will still produce the old (mapped) property name.
 
 One of the consequences is that you won't be able to [query event data](/events/querying) by this property. Marten while performing database query using a direct mapping from CLR expressions. The query will then use the new name, while you'll find the old one in the payload. As we're querying JSON, it won't throw an exception, but just not find the respectful event data returning no results.
 :::
@@ -923,3 +923,5 @@ options.Events.Upcast(new ShoppingCartOpenedAsyncOnlyUpcaster(clientRepository))
 ```
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/SchemaChange/Upcasters.cs#L278-L282' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_async_upcast_event_class_with_clr_types' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Working with multiple Event type versions

--- a/src/EventSourcingTests/SchemaChange/MultipleSchemaVersions.cs
+++ b/src/EventSourcingTests/SchemaChange/MultipleSchemaVersions.cs
@@ -1,0 +1,318 @@
+#nullable enable
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EventSourcingTests.SchemaChange.MultipleVersions.V3;
+using LamarCodeGeneration;
+using Marten.Events;
+using Marten.Testing;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.SchemaChange
+{
+    namespace MultipleVersions.V1
+    {
+        public record ShoppingCartOpened(
+            Guid ShoppingCartId,
+            Guid ClientId
+        );
+
+        public record ProductItemAddedToShoppingCart(
+            Guid ShoppingCartId,
+            Guid ProductId,
+            int Quantity
+        );
+
+        public record ShoppingCart(
+            Guid ShoppingCartId,
+            Guid ClientId,
+            Dictionary<Guid, int> ProductItems
+        )
+        {
+            public static ShoppingCart Create(ShoppingCartOpened @event) =>
+                new ShoppingCart(@event.ShoppingCartId, @event.ClientId, new Dictionary<Guid, int>());
+
+            public ShoppingCart Apply(ProductItemAddedToShoppingCart @event) =>
+                this with
+                {
+                    ProductItems = ProductItems.Select(x => new { ProductId = x.Key, Quantity = x.Value })
+                        .Union(new[] { new { @event.ProductId, @event.Quantity } })
+                        .GroupBy(x => x.ProductId)
+                        .ToDictionary(x => x.Key, x => x.Sum(k => k.Quantity))
+                };
+        }
+    }
+
+    namespace MultipleVersions.V2
+    {
+        public enum ShoppingCartStatus
+        {
+            UnderFraudDetection = 1,
+            Opened = 2,
+            Confirmed = 3,
+            Cancelled = 4
+        }
+
+        namespace WithTheSameName
+        {
+            public record ShoppingCartOpened(
+                Guid ShoppingCartId,
+                Guid ClientId,
+                ShoppingCartStatus Status = ShoppingCartStatus.Opened,
+                DateTime? OpenedAt = null
+            );
+
+            public record ProductItemAddedToShoppingCart(
+                Guid ShoppingCartId,
+                Guid ProductId,
+                int Quantity,
+                decimal? Price = null
+            );
+
+            public record ShoppingCart(
+                Guid Id,
+                Guid ClientId,
+                Dictionary<Guid, int> ProductItems,
+                ShoppingCartStatus Status = ShoppingCartStatus.Opened,
+                DateTime? OpenedAt = null
+            )
+            {
+                public static ShoppingCart Create(ShoppingCartOpened @event) =>
+                    new ShoppingCart(
+                        @event.ShoppingCartId,
+                        @event.ClientId,
+                        new Dictionary<Guid, int>(),
+                        @event.Status,
+                        @event.OpenedAt
+                    );
+
+                public ShoppingCart Apply(ProductItemAddedToShoppingCart @event) =>
+                    this with
+                    {
+                        ProductItems = ProductItems.Select(x => new { ProductId = x.Key, Quantity = x.Value })
+                            .Union(new[] { new { @event.ProductId, @event.Quantity } })
+                            .GroupBy(x => x.ProductId)
+                            .ToDictionary(x => x.Key, x => x.Sum(k => k.Quantity))
+                    };
+            }
+        }
+
+        namespace WithDifferentName
+        {
+            public record ShoppingCartOpenedV2(
+                Guid ShoppingCartId,
+                Guid ClientId,
+                ShoppingCartStatus Status = ShoppingCartStatus.Opened,
+                DateTime? OpenedAt = null
+            );
+
+            public record ProductItemAddedToShoppingCartV2(
+                Guid ShoppingCartId,
+                Guid ProductId,
+                int Quantity,
+                decimal? Price = null
+            );
+
+            public record ShoppingCart(
+                Guid Id,
+                Guid ClientId,
+                Dictionary<Guid, int> ProductItems,
+                ShoppingCartStatus Status = ShoppingCartStatus.Opened,
+                DateTime? OpenedAt = null
+            )
+            {
+                public static ShoppingCart Create(ShoppingCartOpenedV2 @event) =>
+                    new ShoppingCart(
+                        @event.ShoppingCartId,
+                        @event.ClientId,
+                        new Dictionary<Guid, int>(),
+                        @event.Status,
+                        @event.OpenedAt
+                    );
+
+                public ShoppingCart Apply(ProductItemAddedToShoppingCartV2 @event) =>
+                    this with
+                    {
+                        ProductItems = ProductItems.Select(x => new { ProductId = x.Key, Quantity = x.Value })
+                            .Union(new[] { new { @event.ProductId, @event.Quantity } })
+                            .GroupBy(x => x.ProductId)
+                            .ToDictionary(x => x.Key, x => x.Sum(k => k.Quantity))
+                    };
+            }
+        }
+    }
+
+    namespace MultipleVersions.V3
+    {
+        public record Client(
+            Guid Id,
+            string Name = "Unknown"
+        );
+
+        public record ProductItem(
+            Guid ProductId,
+            int Quantity,
+            decimal? Price = null
+        );
+
+        namespace WithTheSameName
+        {
+            public record ShoppingCartOpenedV3(
+                Guid CartId,
+                Client Client,
+                ShoppingCartStatus Status = ShoppingCartStatus.Opened,
+                DateTime? OpenedAt = null
+            );
+
+            public record ProductItemAddedToShoppingCartV3(
+                Guid ShoppingCartId,
+                ProductItem ProductItem
+            );
+
+            public record ShoppingCart(
+                Guid Id,
+                Client Client,
+                Dictionary<Guid, int> ProductItems,
+                ShoppingCartStatus Status = ShoppingCartStatus.Opened,
+                DateTime? OpenedAt = null
+            )
+            {
+                public static ShoppingCart Create(ShoppingCartOpenedV3 @event) =>
+                    new ShoppingCart(
+                        @event.CartId,
+                        @event.Client,
+                        new Dictionary<Guid, int>(),
+                        @event.Status,
+                        @event.OpenedAt
+                    );
+
+                public ShoppingCart Apply(ProductItemAddedToShoppingCartV3 @event) =>
+                    this with
+                    {
+                        ProductItems = ProductItems.Select(x => new { ProductId = x.Key, Quantity = x.Value })
+                            .Union(new[] { new { @event.ProductItem.ProductId, @event.ProductItem.Quantity } })
+                            .GroupBy(x => x.ProductId)
+                            .ToDictionary(x => x.Key, x => x.Sum(k => k.Quantity))
+                    };
+            }
+        }
+
+        namespace WithDifferentName
+        {
+            public record ShoppingCartOpened(
+                Guid CartId,
+                Client Client,
+                ShoppingCartStatus Status = ShoppingCartStatus.Opened,
+                DateTime? OpenedAt = null
+            );
+
+            public record ProductItemAddedToShoppingCart(
+                Guid ShoppingCartId,
+                ProductItem ProductItem
+            );
+
+            public record ShoppingCart(
+                Guid Id,
+                Client Client,
+                Dictionary<Guid, int> ProductItems,
+                ShoppingCartStatus Status = ShoppingCartStatus.Opened,
+                DateTime? OpenedAt = null
+            )
+            {
+                public static ShoppingCart Create(ShoppingCartOpened @event) =>
+                    new ShoppingCart(
+                        @event.CartId,
+                        @event.Client,
+                        new Dictionary<Guid, int>(),
+                        @event.Status,
+                        @event.OpenedAt
+                    );
+
+                public ShoppingCart Apply(ProductItemAddedToShoppingCart @event) =>
+                    this with
+                    {
+                        ProductItems = ProductItems.Select(x => new { ProductId = x.Key, Quantity = x.Value })
+                            .Union(new[] { new { @event.ProductItem.ProductId, @event.ProductItem.Quantity } })
+                            .GroupBy(x => x.ProductId)
+                            .ToDictionary(x => x.Key, x => x.Sum(k => k.Quantity))
+                    };
+            }
+        }
+    }
+
+    public class MultipleSchemaVersions: OneOffConfigurationsContext
+    {
+        [Fact]
+        public async Task Sth()
+        {
+            // test events data
+            var shoppingCartId = Guid.NewGuid();
+            var clientId = Guid.NewGuid();
+            var productId = Guid.NewGuid();
+            var initialQuantity = 3;
+            var additionalQuantity = 2;
+            var andMoreQuantity = 4;
+
+            StoreOptions(options => options.GeneratedCodeMode = TypeLoadMode.Auto);
+            await theStore.EnsureStorageExistsAsync(typeof(StreamAction));
+
+            await using (var session = theStore.OpenSession())
+            {
+                session.Events.Append(shoppingCartId,
+                    new MultipleVersions.V1.ShoppingCartOpened(shoppingCartId, clientId));
+                session.Events.Append(shoppingCartId,
+                    new MultipleVersions.V1.ProductItemAddedToShoppingCart(shoppingCartId, productId, initialQuantity));
+                await session.SaveChangesAsync();
+            }
+
+            using var store = SeparateStore(options =>
+            {
+                options.GeneratedCodeMode = TypeLoadMode.Auto;
+                options.Events
+                    .Upcast<MultipleVersions.V1.ShoppingCartOpened,
+                        MultipleVersions.V3.WithDifferentName.ShoppingCartOpened>(@event =>
+                        new MultipleVersions.V3.WithDifferentName.ShoppingCartOpened(
+                            @event.ShoppingCartId,
+                            new MultipleVersions.V3.Client(@event.ClientId)
+                        )
+                    )
+                    .Upcast<MultipleVersions.V1.ProductItemAddedToShoppingCart,
+                        MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCart>(@event =>
+                        new MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCart(
+                            @event.ShoppingCartId,
+                            new ProductItem(@event.ProductId, @event.Quantity)
+                        )
+                    )
+                    .Upcast<MultipleVersions.V2.WithDifferentName.ShoppingCartOpenedV2,
+                        MultipleVersions.V3.WithDifferentName.ShoppingCartOpened>(@event =>
+                        new MultipleVersions.V3.WithDifferentName.ShoppingCartOpened(
+                            @event.ShoppingCartId,
+                            new MultipleVersions.V3.Client(@event.ClientId)
+                        )
+                    )
+                    .Upcast<MultipleVersions.V2.WithDifferentName.ProductItemAddedToShoppingCartV2,
+                        MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCart>(@event =>
+                        new MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCart(
+                            @event.ShoppingCartId,
+                            new ProductItem(@event.ProductId, @event.Quantity, @event.Price)
+                        )
+                    );
+            });
+            {
+                await using var session = store.OpenSession();
+                var shoppingCartNew =
+                    await session.Events.AggregateStreamAsync<MultipleVersions.V3.WithDifferentName.ShoppingCart>(
+                        shoppingCartId);
+
+                shoppingCartNew.Id.ShouldBe(shoppingCartId);
+                shoppingCartNew.Client.ShouldNotBeNull();
+                shoppingCartNew.Client.Id.ShouldBe(clientId);
+            }
+        }
+    }
+}
+#endif

--- a/src/EventSourcingTests/SchemaChange/MultipleSchemaVersions.cs
+++ b/src/EventSourcingTests/SchemaChange/MultipleSchemaVersions.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using EventSourcingTests.SchemaChange.MultipleVersions.V3;
 using LamarCodeGeneration;
 using Marten.Events;
 using Marten.Testing;
@@ -28,7 +27,7 @@ namespace EventSourcingTests.SchemaChange
         );
 
         public record ShoppingCart(
-            Guid ShoppingCartId,
+            Guid Id,
             Guid ClientId,
             Dictionary<Guid, int> ProductItems
         )
@@ -51,10 +50,10 @@ namespace EventSourcingTests.SchemaChange
     {
         public enum ShoppingCartStatus
         {
-            UnderFraudDetection = 1,
-            Opened = 2,
-            Confirmed = 3,
-            Cancelled = 4
+            Opened,
+            UnderFraudDetection,
+            Confirmed,
+            Cancelled
         }
 
         namespace WithTheSameName
@@ -148,6 +147,14 @@ namespace EventSourcingTests.SchemaChange
 
     namespace MultipleVersions.V3
     {
+        public enum ShoppingCartStatus
+        {
+            Opened,
+            UnderFraudDetection,
+            Confirmed,
+            Cancelled
+        }
+
         public record Client(
             Guid Id,
             string Name = "Unknown"
@@ -160,48 +167,6 @@ namespace EventSourcingTests.SchemaChange
         );
 
         namespace WithTheSameName
-        {
-            public record ShoppingCartOpenedV3(
-                Guid CartId,
-                Client Client,
-                ShoppingCartStatus Status = ShoppingCartStatus.Opened,
-                DateTime? OpenedAt = null
-            );
-
-            public record ProductItemAddedToShoppingCartV3(
-                Guid ShoppingCartId,
-                ProductItem ProductItem
-            );
-
-            public record ShoppingCart(
-                Guid Id,
-                Client Client,
-                Dictionary<Guid, int> ProductItems,
-                ShoppingCartStatus Status = ShoppingCartStatus.Opened,
-                DateTime? OpenedAt = null
-            )
-            {
-                public static ShoppingCart Create(ShoppingCartOpenedV3 @event) =>
-                    new ShoppingCart(
-                        @event.CartId,
-                        @event.Client,
-                        new Dictionary<Guid, int>(),
-                        @event.Status,
-                        @event.OpenedAt
-                    );
-
-                public ShoppingCart Apply(ProductItemAddedToShoppingCartV3 @event) =>
-                    this with
-                    {
-                        ProductItems = ProductItems.Select(x => new { ProductId = x.Key, Quantity = x.Value })
-                            .Union(new[] { new { @event.ProductItem.ProductId, @event.ProductItem.Quantity } })
-                            .GroupBy(x => x.ProductId)
-                            .ToDictionary(x => x.Key, x => x.Sum(k => k.Quantity))
-                    };
-            }
-        }
-
-        namespace WithDifferentName
         {
             public record ShoppingCartOpened(
                 Guid CartId,
@@ -242,77 +207,308 @@ namespace EventSourcingTests.SchemaChange
                     };
             }
         }
+
+        namespace WithDifferentName
+        {
+            public record ShoppingCartOpenedV3(
+                Guid CartId,
+                Client Client,
+                ShoppingCartStatus Status = ShoppingCartStatus.Opened,
+                DateTime? OpenedAt = null
+            );
+
+            public record ProductItemAddedToShoppingCartV3(
+                Guid ShoppingCartId,
+                ProductItem ProductItem
+            );
+
+            public record ShoppingCart(
+                Guid Id,
+                Guid ClientId,
+                Dictionary<Guid, int> ProductItems,
+                ShoppingCartStatus Status = ShoppingCartStatus.Opened,
+                DateTime? OpenedAt = null
+            )
+            {
+                public static ShoppingCart Create(ShoppingCartOpenedV3 @event) =>
+                    new ShoppingCart(
+                        @event.CartId,
+                        @event.Client.Id,
+                        new Dictionary<Guid, int>(),
+                        @event.Status,
+                        @event.OpenedAt
+                    );
+
+                public ShoppingCart Apply(ProductItemAddedToShoppingCartV3 @event) =>
+                    this with
+                    {
+                        ProductItems = ProductItems.Select(x => new { ProductId = x.Key, Quantity = x.Value })
+                            .Union(new[] { new { @event.ProductItem.ProductId, @event.ProductItem.Quantity } })
+                            .GroupBy(x => x.ProductId)
+                            .ToDictionary(x => x.Key, x => x.Sum(k => k.Quantity))
+                    };
+            }
+        }
     }
 
     public class MultipleSchemaVersions: OneOffConfigurationsContext
     {
         [Fact]
-        public async Task Sth()
+        public async Task UpcastingWithMultipleSchemaAndDifferentTypeNamesShouldWork()
         {
             // test events data
             var shoppingCartId = Guid.NewGuid();
             var clientId = Guid.NewGuid();
             var productId = Guid.NewGuid();
-            var initialQuantity = 3;
-            var additionalQuantity = 2;
-            var andMoreQuantity = 4;
+            var currentQuantity = 3;
+            var price = 1.23m;
 
-            StoreOptions(options => options.GeneratedCodeMode = TypeLoadMode.Auto);
-            await theStore.EnsureStorageExistsAsync(typeof(StreamAction));
-
-            await using (var session = theStore.OpenSession())
-            {
-                session.Events.Append(shoppingCartId,
-                    new MultipleVersions.V1.ShoppingCartOpened(shoppingCartId, clientId));
-                session.Events.Append(shoppingCartId,
-                    new MultipleVersions.V1.ProductItemAddedToShoppingCart(shoppingCartId, productId, initialQuantity));
-                await session.SaveChangesAsync();
-            }
-
-            using var store = SeparateStore(options =>
+            StoreOptions(options =>
             {
                 options.GeneratedCodeMode = TypeLoadMode.Auto;
+                options.Projections.SelfAggregate<MultipleVersions.V1.ShoppingCart>();
+            });
+            await theStore.EnsureStorageExistsAsync(typeof(StreamAction));
+
+            await AppendEventsInV1Schema(
+                shoppingCartId,
+                clientId,
+                productId,
+                currentQuantity
+            );
+
+            currentQuantity = await CheckV2Upcasting(
+                shoppingCartId,
+                clientId,
+                productId,
+                currentQuantity,
+                price
+            );
+
+            await CheckV3Upcasting(
+                shoppingCartId,
+                clientId,
+                productId,
+                currentQuantity,
+                price
+            );
+        }
+
+        private async Task AppendEventsInV1Schema(Guid shoppingCartId, Guid clientId, Guid productId,
+            int initialQuantity)
+        {
+            await using var session = theStore.OpenSession();
+            session.Events.Append(shoppingCartId,
+                new MultipleVersions.V1.ShoppingCartOpened(shoppingCartId, clientId));
+            session.Events.Append(shoppingCartId,
+                new MultipleVersions.V1.ProductItemAddedToShoppingCart(shoppingCartId, productId, initialQuantity));
+            await session.SaveChangesAsync();
+        }
+
+        private async Task<int> CheckV2Upcasting(Guid shoppingCartId,
+            Guid clientId,
+            Guid productId,
+            int currentQuantity,
+            decimal price)
+        {
+            using var storeV2 = SeparateStore(options =>
+            {
+                options.GeneratedCodeMode = TypeLoadMode.Auto;
+                options.Projections.SelfAggregate<MultipleVersions.V2.WithDifferentName.ShoppingCart>();
+                ////////////////////////////////////////////////////////
+                // 2.1. Define Upcast methods from V1 to V2
+                ////////////////////////////////////////////////////////
                 options.Events
-                    .Upcast<MultipleVersions.V1.ShoppingCartOpened,
-                        MultipleVersions.V3.WithDifferentName.ShoppingCartOpened>(@event =>
-                        new MultipleVersions.V3.WithDifferentName.ShoppingCartOpened(
+                    .Upcast((MultipleVersions.V1.ShoppingCartOpened @event) =>
+                        new MultipleVersions.V2.WithDifferentName.ShoppingCartOpenedV2(
                             @event.ShoppingCartId,
-                            new MultipleVersions.V3.Client(@event.ClientId)
+                            @event.ClientId
                         )
                     )
-                    .Upcast<MultipleVersions.V1.ProductItemAddedToShoppingCart,
-                        MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCart>(@event =>
-                        new MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCart(
+                    .Upcast((MultipleVersions.V1.ProductItemAddedToShoppingCart @event) =>
+                        new MultipleVersions.V2.WithDifferentName.ProductItemAddedToShoppingCartV2(
                             @event.ShoppingCartId,
-                            new ProductItem(@event.ProductId, @event.Quantity)
-                        )
-                    )
-                    .Upcast<MultipleVersions.V2.WithDifferentName.ShoppingCartOpenedV2,
-                        MultipleVersions.V3.WithDifferentName.ShoppingCartOpened>(@event =>
-                        new MultipleVersions.V3.WithDifferentName.ShoppingCartOpened(
-                            @event.ShoppingCartId,
-                            new MultipleVersions.V3.Client(@event.ClientId)
-                        )
-                    )
-                    .Upcast<MultipleVersions.V2.WithDifferentName.ProductItemAddedToShoppingCartV2,
-                        MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCart>(@event =>
-                        new MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCart(
-                            @event.ShoppingCartId,
-                            new ProductItem(@event.ProductId, @event.Quantity, @event.Price)
+                            @event.ProductId,
+                            @event.Quantity
                         )
                     );
             });
             {
-                await using var session = store.OpenSession();
-                var shoppingCartNew =
-                    await session.Events.AggregateStreamAsync<MultipleVersions.V3.WithDifferentName.ShoppingCart>(
-                        shoppingCartId);
+                await using var session = storeV2.OpenSession();
 
-                shoppingCartNew.Id.ShouldBe(shoppingCartId);
-                shoppingCartNew.Client.ShouldNotBeNull();
-                shoppingCartNew.Client.Id.ShouldBe(clientId);
+                ////////////////////////////////////////////////////////
+                // 2.2. Append Event with V2 schema
+                ////////////////////////////////////////////////////////
+                var additionalQuantity = 2;
+                session.Events.Append(shoppingCartId,
+                    new MultipleVersions.V2.WithDifferentName.ProductItemAddedToShoppingCartV2(
+                        shoppingCartId,
+                        productId,
+                        additionalQuantity,
+                        price
+                    )
+                );
+                await session.SaveChangesAsync();
+
+                ////////////////////////////////////////////////////////
+                // 2.3. Ensure that all events are read with V2 schema
+                ////////////////////////////////////////////////////////
+                var events = await session.Events.FetchStreamAsync(shoppingCartId);
+                events.Count.ShouldBe(3);
+                events[0].ShouldBeOfType<MultipleVersions.V2.WithDifferentName.ShoppingCartOpenedV2>(
+                    typeof(MultipleVersions.V1.ShoppingCartOpened).GetEventTypeName()
+                );
+                events[1].ShouldBeOfType<MultipleVersions.V2.WithDifferentName.ProductItemAddedToShoppingCartV2>(
+                    typeof(MultipleVersions.V1.ProductItemAddedToShoppingCart).GetEventTypeName()
+                );
+                events[2].ShouldBeOfType<MultipleVersions.V2.WithDifferentName.ProductItemAddedToShoppingCartV2>(
+                    typeof(MultipleVersions.V2.WithDifferentName.ProductItemAddedToShoppingCartV2).GetEventTypeName()
+                );
+
+                ////////////////////////////////////////////////////////
+                // 2.4. Ensure that aggregation is using V2 schema
+                ////////////////////////////////////////////////////////
+                var shoppingCartV2 =
+                    await session.Events.AggregateStreamAsync<MultipleVersions.V2.WithDifferentName.ShoppingCart>(
+                        shoppingCartId
+                    );
+
+                var shoppingCartV2Projection =
+                    await session.LoadAsync<MultipleVersions.V2.WithDifferentName.ShoppingCart>(shoppingCartId);
+
+                shoppingCartV2
+                    .ShouldNotBeNull()
+                    .ShouldBeEquivalentTo(
+                        new MultipleVersions.V2.WithDifferentName.ShoppingCart(
+                            shoppingCartId,
+                            clientId,
+                            new Dictionary<Guid, int> { { productId, currentQuantity + additionalQuantity } },
+                            MultipleVersions.V2.ShoppingCartStatus.Opened,
+                            null
+                        )
+                    );
+
+                shoppingCartV2Projection.ShouldBeEquivalentTo(shoppingCartV2);
+
+                return currentQuantity + additionalQuantity;
             }
         }
+
+
+        private async Task CheckV3Upcasting(
+            Guid shoppingCartId,
+            Guid clientId,
+            Guid productId,
+            int currentQuantity,
+            decimal price
+        )
+        {
+            using var storeV3 = SeparateStore(options =>
+            {
+                options.GeneratedCodeMode = TypeLoadMode.Auto;
+                options.Projections.SelfAggregate<MultipleVersions.V3.WithDifferentName.ShoppingCart>();
+                ////////////////////////////////////////////////////////
+                // 3.1. Define Upcast methods from V1 to V3, and from V2 to V3
+                ////////////////////////////////////////////////////////
+                options.Events
+                    .Upcast((MultipleVersions.V1.ShoppingCartOpened @event) =>
+                        new MultipleVersions.V3.WithDifferentName.ShoppingCartOpenedV3(
+                            @event.ShoppingCartId,
+                            new MultipleVersions.V3.Client(@event.ClientId)
+                        )
+                    )
+                    .Upcast((MultipleVersions.V1.ProductItemAddedToShoppingCart @event) =>
+                        new MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCartV3(
+                            @event.ShoppingCartId,
+                            new MultipleVersions.V3.ProductItem(@event.ProductId, @event.Quantity)
+                        )
+                    )
+                    .Upcast((MultipleVersions.V2.WithDifferentName.ShoppingCartOpenedV2 @event) =>
+                        new MultipleVersions.V3.WithDifferentName.ShoppingCartOpenedV3(
+                            @event.ShoppingCartId,
+                            new MultipleVersions.V3.Client(@event.ClientId)
+                        )
+                    )
+                    .Upcast((MultipleVersions.V2.WithDifferentName.ProductItemAddedToShoppingCartV2 @event) =>
+                        new MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCartV3(
+                            @event.ShoppingCartId,
+                            new MultipleVersions.V3.ProductItem(@event.ProductId, @event.Quantity, @event.Price)
+                        )
+                    );
+            });
+            {
+                await using var session = storeV3.OpenSession();
+
+                ////////////////////////////////////////////////////////
+                // 3.2. Append Event with V3 schema
+                ////////////////////////////////////////////////////////
+                var additionalQuantity = 4;
+                session.Events.Append(shoppingCartId,
+                    new MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCartV3(
+                        shoppingCartId,
+                        new MultipleVersions.V3.ProductItem(
+                            productId,
+                            additionalQuantity,
+                            price
+                        )
+                    )
+                );
+                await session.SaveChangesAsync();
+
+                ////////////////////////////////////////////////////////
+                // 3.3. Ensure that all events are read with V2 schema
+                ////////////////////////////////////////////////////////
+                var events = await session.Events.FetchStreamAsync(shoppingCartId);
+                events.Count.ShouldBe(4);
+                events[0].ShouldBeOfType<MultipleVersions.V3.WithDifferentName.ShoppingCartOpenedV3>(
+                    typeof(MultipleVersions.V1.ShoppingCartOpened).GetEventTypeName()
+                );
+                events[1].ShouldBeOfType<MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCartV3>(
+                    typeof(MultipleVersions.V1.ProductItemAddedToShoppingCart).GetEventTypeName()
+                );
+                events[2].ShouldBeOfType<MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCartV3>(
+                    typeof(MultipleVersions.V2.WithDifferentName.ProductItemAddedToShoppingCartV2).GetEventTypeName()
+                );
+                events[3].ShouldBeOfType<MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCartV3>(
+                    typeof(MultipleVersions.V3.WithDifferentName.ProductItemAddedToShoppingCartV3).GetEventTypeName()
+                );
+
+                ////////////////////////////////////////////////////////
+                // 3.4. Ensure that aggregation is using V3 schema
+                ////////////////////////////////////////////////////////
+                var shoppingCartV3 =
+                    await session.Events.AggregateStreamAsync<MultipleVersions.V3.WithDifferentName.ShoppingCart>(
+                        shoppingCartId
+                    );
+
+                var shoppingCartV3Projection =
+                    await session.LoadAsync<MultipleVersions.V3.WithDifferentName.ShoppingCart>(shoppingCartId);
+
+                shoppingCartV3
+                    .ShouldNotBeNull()
+                    .ShouldBeEquivalentTo(
+                        new MultipleVersions.V3.WithDifferentName.ShoppingCart(
+                            shoppingCartId,
+                            clientId,
+                            new Dictionary<Guid, int> { { productId, currentQuantity + additionalQuantity } },
+                            MultipleVersions.V3.ShoppingCartStatus.Opened,
+                            null
+                        )
+                    );
+
+                shoppingCartV3Projection.ShouldBeEquivalentTo(shoppingCartV3);
+            }
+        }
+    }
+}
+
+public static class UpcastingTestsExtensions
+{
+    public static void ShouldBeOfType<TEvent>(this IEvent @event, string eventTypeName)
+    {
+        @event.EventTypeName.ShouldBe(eventTypeName);
+        @event.EventType.ShouldBe(typeof(TEvent));
+        @event.Data.ShouldBeOfType<TEvent>();
     }
 }
 #endif

--- a/src/EventSourcingTests/SchemaChange/Upcasters.cs
+++ b/src/EventSourcingTests/SchemaChange/Upcasters.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Marten;
 using Marten.Events;
-using Marten.Internal.Sessions;
 using Marten.Services.Json;
 using Marten.Services.Json.Transformations;
 using Marten.Testing;
@@ -773,7 +772,7 @@ namespace EventSourcingTests.SchemaChange
 
             await theStore.EnsureStorageExistsAsync(typeof(StreamAction));
 
-            await using (var session = (DocumentSessionBase)theStore.OpenSession())
+            await using (var session = theStore.OpenSession())
             {
                 session.Events.Append(shoppingCartId, (IEnumerable<object>)shoppingCart.DequeueEvents());
                 await session.SaveChangesAsync();

--- a/src/Marten.Testing/Harness/OneOffConfigurationsContext.cs
+++ b/src/Marten.Testing/Harness/OneOffConfigurationsContext.cs
@@ -82,8 +82,6 @@ namespace Marten.Testing.Harness
 
             _store = new DocumentStore(options);
 
-
-
             _disposables.Add(_store);
 
             return _store;

--- a/src/Marten/Events/CodeGeneration/CreateMethodCollection.cs
+++ b/src/Marten/Events/CodeGeneration/CreateMethodCollection.cs
@@ -65,7 +65,12 @@ namespace Marten.Events.CodeGeneration
 
             method.Frames.Add(new DefaultAggregateConstruction(AggregateType, generatedType)
             {
-                IfStyle = IfStyle.None
+                IfStyle = IfStyle.None,
+                AdditionalNoConstructorExceptionDetails =
+                    "  or Create method for {{@event.DotNetTypeName}} event type." +
+                    "Check more about the create method convention in documentation: https://martendb.io/events/projections/event-projections.html#create-method-convention. " +
+                    "If you're using Upcasting, check if {{@event.DotNetTypeName}} is an old event type. If it is, make sure to define transformation for it to new event type. " +
+                    "Read more in Upcasting docs: https://martendb.io/events/versioning.html#upcasting-advanced-payload-transformations"
             });
         }
 

--- a/src/Marten/Events/CodeGeneration/DefaultAggregateConstruction.cs
+++ b/src/Marten/Events/CodeGeneration/DefaultAggregateConstruction.cs
@@ -34,6 +34,8 @@ namespace Marten.Events.CodeGeneration
 
         public IfStyle IfStyle { get; set; } = IfStyle.Else;
 
+        public string AdditionalNoConstructorExceptionDetails { get; set; } = string.Empty;
+
         public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
         {
             _event = chain.FindVariable(typeof(IEvent));
@@ -47,10 +49,8 @@ namespace Marten.Events.CodeGeneration
             if (_constructor == null)
             {
                 writer.WriteLine(
-                    $"throw new {typeof(InvalidOperationException).FullNameInCode()}(\"There is no default constructor or Create method for {_returnType.FullNameInCode()} event type." +
-                    "Check more about the create convention in documentation: https://martendb.io/events/projections/event-projections.html#create-method-convention." +
-                    $"If you're using Upcasting, check if {_returnType.FullNameInCode()} is an old event type. If it is, make sure to define mapping for it to new event type." +
-                    "Read more in Upcasting docs: https://martendb.io/events/versioning.html#upcasting-advanced-payload-transformations.\");");
+                    $"throw new {typeof(InvalidOperationException).FullNameInCode()}(\"There is no default constructor for {_returnType.FullNameInCode()}{AdditionalNoConstructorExceptionDetails}.\");"
+                );
             }
             else if (_setter != null)
             {

--- a/src/Marten/Events/CodeGeneration/DefaultAggregateConstruction.cs
+++ b/src/Marten/Events/CodeGeneration/DefaultAggregateConstruction.cs
@@ -47,7 +47,10 @@ namespace Marten.Events.CodeGeneration
             if (_constructor == null)
             {
                 writer.WriteLine(
-                    $"throw new {typeof(InvalidOperationException).FullNameInCode()}(\"There is no default constructor for {_returnType.FullNameInCode()}\");");
+                    $"throw new {typeof(InvalidOperationException).FullNameInCode()}(\"There is no default constructor or Create method for {_returnType.FullNameInCode()} event type." +
+                    "Check more about the create convention in documentation: https://martendb.io/events/projections/event-projections.html#create-method-convention." +
+                    $"If you're using Upcasting, check if {_returnType.FullNameInCode()} is an old event type. If it is, make sure to define mapping for it to new event type." +
+                    "Read more in Upcasting docs: https://martendb.io/events/versioning.html#upcasting-advanced-payload-transformations.\");");
             }
             else if (_setter != null)
             {

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -155,46 +155,36 @@ namespace Marten.Events
             JsonTransformation jsonTransformation = null
         )
         {
-            var eventMapping = EventMappingFor(eventType);
+            var eventMapping = typeof(EventMapping<>).CloseAndBuildAs<EventMapping>(this, eventType);
             eventMapping.EventTypeName = eventTypeName;
             eventMapping.JsonTransformation(jsonTransformation);
 
+            _byEventName.Fill(eventTypeName, eventMapping);
+
             return this;
         }
 
         public IEventStoreOptions Upcast<TOldEvent, TEvent>(
             string eventTypeName,
             Func<TOldEvent, TEvent> upcast
-        ) where TOldEvent : class where TEvent : class
-        {
-            var eventMapping = EventMappingFor<TEvent>();
-            eventMapping.EventTypeName = eventTypeName;
-            eventMapping.JsonTransformation(JsonTransformations.Upcast(upcast));
-
-            return this;
-        }
+        ) where TOldEvent : class where TEvent : class =>
+            Upcast(typeof(TEvent), eventTypeName, JsonTransformations.Upcast(upcast));
 
         public IEventStoreOptions Upcast<TOldEvent, TEvent>(
             Func<TOldEvent, TEvent> upcast
         ) where TOldEvent : class where TEvent : class =>
-            Upcast(typeof(TOldEvent).GetEventTypeName(), upcast);
+            Upcast(typeof(TEvent), typeof(TOldEvent).GetEventTypeName(), JsonTransformations.Upcast(upcast));
 
         public IEventStoreOptions Upcast<TOldEvent, TEvent>(
             string eventTypeName,
             Func<TOldEvent, CancellationToken, Task<TEvent>> upcastAsync
-        ) where TOldEvent : class where TEvent : class
-        {
-            var eventMapping = EventMappingFor<TEvent>();
-            eventMapping.EventTypeName = eventTypeName;
-            eventMapping.JsonTransformation(JsonTransformations.Upcast(upcastAsync));
-
-            return this;
-        }
+        ) where TOldEvent : class where TEvent : class =>
+            Upcast(typeof(TEvent), eventTypeName, JsonTransformations.Upcast(upcastAsync));
 
         public IEventStoreOptions Upcast<TOldEvent, TEvent>(
             Func<TOldEvent, CancellationToken, Task<TEvent>> upcastAsync
-        ) where TOldEvent : class where TEvent : class =>
-            Upcast(typeof(TOldEvent).GetEventTypeName(), upcastAsync);
+        ) where TOldEvent : class where TEvent : class  =>
+            Upcast(typeof(TEvent), typeof(TOldEvent).GetEventTypeName(), JsonTransformations.Upcast(upcastAsync));
 
         public IEventStoreOptions Upcast(params IEventUpcaster[] upcasters)
         {

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -15,6 +15,7 @@ using Marten.Storage;
 using Marten.Util;
 using NpgsqlTypes;
 using Weasel.Core;
+using static Marten.Events.EventMappingExtensions;
 
 namespace Marten.Events
 {
@@ -173,7 +174,7 @@ namespace Marten.Events
         public IEventStoreOptions Upcast<TOldEvent, TEvent>(
             Func<TOldEvent, TEvent> upcast
         ) where TOldEvent : class where TEvent : class =>
-            Upcast(typeof(TEvent), typeof(TOldEvent).GetEventTypeName(), JsonTransformations.Upcast(upcast));
+            Upcast(typeof(TEvent), GetEventTypeName<TOldEvent>(), JsonTransformations.Upcast(upcast));
 
         public IEventStoreOptions Upcast<TOldEvent, TEvent>(
             string eventTypeName,
@@ -184,7 +185,7 @@ namespace Marten.Events
         public IEventStoreOptions Upcast<TOldEvent, TEvent>(
             Func<TOldEvent, CancellationToken, Task<TEvent>> upcastAsync
         ) where TOldEvent : class where TEvent : class  =>
-            Upcast(typeof(TEvent), typeof(TOldEvent).GetEventTypeName(), JsonTransformations.Upcast(upcastAsync));
+            Upcast(typeof(TEvent), GetEventTypeName<TOldEvent>(), JsonTransformations.Upcast(upcastAsync));
 
         public IEventStoreOptions Upcast(params IEventUpcaster[] upcasters)
         {

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -28,6 +28,7 @@ using NpgsqlTypes;
 using Remotion.Linq;
 using Weasel.Core;
 using Weasel.Postgresql.SqlGeneration;
+using static Marten.Events.EventMappingExtensions;
 
 namespace Marten.Events
 {
@@ -53,7 +54,7 @@ namespace Marten.Events
             _parent = parent;
             DocumentType = eventType;
 
-            EventTypeName = eventType.GetEventTypeName();
+            EventTypeName = GetEventTypeName(eventType);
             IdMember = DocumentType.GetProperty(nameof(IEvent.Id));
 
             _inner = new DocumentMapping(eventType, parent.Options);
@@ -351,7 +352,7 @@ namespace Marten.Events
     /// <summary>
     /// Class <c>EventMappingExtensions</c> exposes extensions and helpers to handle event type mapping.
     /// </summary>
-    internal static class EventMappingExtensions
+    public static class EventMappingExtensions
     {
         /// <summary>
         /// Translates by convention the CLR type name into string event type name.
@@ -359,7 +360,74 @@ namespace Marten.Events
         /// </summary>
         /// <param name="eventType">CLR event type</param>
         /// <returns>Mapped string event type name</returns>
-        internal static string GetEventTypeName(this Type eventType) =>
+        public static string GetEventTypeName(Type eventType) =>
             eventType.IsGenericType ? eventType.ShortNameInCode() : eventType.Name.ToTableAlias();
+
+        /// <summary>
+        /// Translates by convention the CLR type name into string event type name.
+        /// It can handle both regular and generic types.
+        /// </summary>
+        /// <typeparam name="TEvent">CLR event type</typeparam>
+        /// <returns>Mapped string event type name</returns>
+        public static string GetEventTypeName<TEvent>() =>
+            GetEventTypeName(typeof(TEvent));
+
+        /// <summary>
+        /// Translates by convention the event type name into string event type name and suffix.
+        /// It can handle both regular and generic types.
+        /// </summary>
+        /// <param name="eventTypeName">event type name</param>
+        /// <param name="suffix">Type name suffix</param>
+        /// <returns>Mapped string event type name in the format: $"{eventTypeName}_{suffix}"</returns>
+        public static string GetEventTypeNameWithSuffix(string eventTypeName, string suffix) =>
+            $"{eventTypeName}_{suffix}";
+
+        /// <summary>
+        /// Translates by convention the CLR type name into string event type name and suffix.
+        /// It can handle both regular and generic types.
+        /// </summary>
+        /// <param name="eventType">CLR event type</param>
+        /// <returns>Mapped string event type name with suffix</returns>
+        public static string GetEventTypeNameWithSuffix(Type eventType, string suffix) =>
+            GetEventTypeNameWithSuffix(GetEventTypeName(eventType), suffix);
+
+        /// <summary>
+        /// Translates by convention the CLR type name into string event type name and suffix.
+        /// It can handle both regular and generic types.
+        /// </summary>
+        /// <typeparam name="TEvent">CLR event type</typeparam>
+        /// <returns>Mapped string event type name with suffix</returns>
+        public static string GetEventTypeNameWithSuffix<TEvent>(string suffix) =>
+            GetEventTypeNameWithSuffix(typeof(TEvent), suffix);
+
+        /// <summary>
+        /// Translates by convention the CLR type name into string event type name with schema version suffix.
+        /// It can handle both regular and generic types.
+        /// </summary>
+        /// <param name="eventType">CLR event type</param>
+        /// <param name="schemaVersion">Event schema version</param>
+        /// <returns>Mapped string event type name with schema version suffix</returns>
+        public static string GetEventTypeNameWithSchemaVersion(Type eventType, uint schemaVersion) =>
+            GetEventTypeNameWithSuffix(eventType, $"v{schemaVersion}");
+
+        /// <summary>
+        /// Translates by convention the CLR type name into string event type name with schema version suffix.
+        /// It can handle both regular and generic types.
+        /// </summary>
+        /// <typeparam name="TEvent">CLR event type</typeparam>
+        /// <param name="schemaVersion">Event schema version</param>
+        /// <returns>Mapped string event type name with schema version suffix</returns>
+        public static string GetEventTypeNameWithSchemaVersion<TEvent>(uint schemaVersion) =>
+            GetEventTypeNameWithSchemaVersion(typeof(TEvent), schemaVersion);
+
+        /// <summary>
+        /// Translates by convention the event type name into string event type name with schema version suffix.
+        /// It can handle both regular and generic types.
+        /// </summary>
+        /// <param name="eventTypeName">event type name</param>
+        /// <param name="schemaVersion">Event schema version</param>
+        /// <returns>Mapped string event type name in the format: $"{eventTypeName}_{version}"</returns>
+        public static string GetEventTypeNameWithSchemaVersion(string eventTypeName, uint schemaVersion) =>
+            GetEventTypeNameWithSuffix(eventTypeName, $"v{schemaVersion}");
     }
 }

--- a/src/Marten/Services/Json/Transformations/EventUpcaster.cs
+++ b/src/Marten/Services/Json/Transformations/EventUpcaster.cs
@@ -3,8 +3,8 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.Events;
 using Marten.Exceptions;
+using static Marten.Events.EventMappingExtensions;
 
 namespace Marten.Services.Json.Transformations
 {
@@ -84,7 +84,7 @@ namespace Marten.Services.Json.Transformations
         /// <summary>
         /// Event type name that you would like to transform. By default it uses the default convention
         /// </summary>
-        public virtual string EventTypeName => EventType.GetEventTypeName();
+        public virtual string EventTypeName => GetEventTypeName(EventType);
 
         public abstract object FromDbDataReader(ISerializer serializer, DbDataReader dbDataReader, int index);
 
@@ -154,7 +154,7 @@ namespace Marten.Services.Json.Transformations
     public abstract class EventUpcaster<TOldEvent, TEvent>: EventUpcaster<TEvent>
         where TOldEvent : notnull where TEvent : notnull
     {
-        public override string EventTypeName => (typeof(TOldEvent)).GetEventTypeName();
+        public override string EventTypeName => GetEventTypeName<TOldEvent>();
 
         public override object FromDbDataReader(ISerializer serializer, DbDataReader dbDataReader, int index) =>
             JsonTransformations.FromDbDataReader<TOldEvent, TEvent>(Upcast)(serializer, dbDataReader, index);
@@ -245,7 +245,7 @@ namespace Marten.Services.Json.Transformations
     public abstract class AsyncOnlyEventUpcaster<TOldEvent, TEvent>: EventUpcaster<TEvent>
         where TOldEvent : notnull where TEvent : notnull
     {
-        public override string EventTypeName => (typeof(TOldEvent)).GetEventTypeName();
+        public override string EventTypeName => GetEventTypeName<TOldEvent>();
 
         public override object FromDbDataReader(ISerializer serializer, DbDataReader dbDataReader, int index) =>
             throw new MartenException(


### PR DESCRIPTION
PR fixed the mapping for upcasting function to allow multiple schema version handling.

Before that change, it was:
- old event type name => new CLR type,
- new CLR type => old event type name

Now it'll be:
- old event type name => new CLR type,
- new event type name => new CLR type,
- new CLR type => new event type name

That enables multiple schema version handling.

I also added a set of syntactic sugar for multiple schema version registration. It enables automated convention with the version suffix.
