### PR TITLE
Reproduction for InvalidOperationException during rebuilds

### DIFF
--- a/src/Marten.AsyncDaemon.Testing/Bugs/Bug_sequential_rebuilds_throws_internally.cs
+++ b/src/Marten.AsyncDaemon.Testing/Bugs/Bug_sequential_rebuilds_throws_internally.cs
@@ -1,0 +1,90 @@
+#if NET6_0_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Marten.AsyncDaemon.Testing.Bugs;
+
+public class Bug_sequential_rebuilds_throws_internally: BugIntegrationContext
+{
+
+    private readonly ITestOutputHelper _output;
+
+    public Bug_sequential_rebuilds_throws_internally(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task rebuild_throw_reproduction()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.Add<RandomProjection.Projector>(ProjectionLifecycle.Inline);
+        });
+
+        var stream = Guid.NewGuid();
+
+        theSession.Events.StartStream(stream,
+            new CreatedEvent(Guid.NewGuid(), Guid.NewGuid().ToString()));
+
+        await theSession.SaveChangesAsync();
+
+        var events = new List<UpdatedEvent>();
+
+        for (var i = 0; i < 1000; i++)
+        {
+            events.Add(new UpdatedEvent(stream, $"event-value-{i}"));
+        }
+
+        theSession.Events.Append(stream, events);
+        await theSession.SaveChangesAsync();
+
+        using var logger = _output.BuildLogger();
+        using var daemon1 = await theStore.BuildProjectionDaemonAsync(logger: logger);
+        await daemon1.StartDaemon();
+
+        await daemon1.RebuildProjection("Bug_sequential_rebuilds_throws_internally.RandomProjection", default);
+
+        await daemon1.StopAll();
+
+        await daemon1.StartDaemon();
+
+        await daemon1.RebuildProjection("Bug_sequential_rebuilds_throws_internally.RandomProjection", default);
+
+        await daemon1.StopAll();
+
+        Assert.All(logger.Entries, entry => entry.Exception.ShouldBeNull());
+    }
+
+    public record CreatedEvent(Guid Id, string Value);
+    public record UpdatedEvent(Guid Id, string Value);
+
+    public record RandomProjection(Guid Id, string Value)
+    {
+        public class Projector: SingleStreamAggregation<RandomProjection>
+        {
+            public static RandomProjection Create(CreatedEvent @event)
+            {
+                return new RandomProjection(@event.Id, @event.Value);
+            }
+
+            public RandomProjection Apply(UpdatedEvent @event, RandomProjection current)
+            {
+                return current with
+                {
+                    Value = @event.Value
+                };
+            }
+        }
+    }
+
+}
+#endif

--- a/src/Marten.AsyncDaemon.Testing/Marten.AsyncDaemon.Testing.csproj
+++ b/src/Marten.AsyncDaemon.Testing/Marten.AsyncDaemon.Testing.csproj
@@ -9,6 +9,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+        <PackageReference Include="Divergic.Logging.Xunit" Version="4.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Recreation for the below exception:
```
Failed while trying to detect high water statistics
System.InvalidOperationException: An open data reader exists for this command.
   at Npgsql.NpgsqlCommand.set_Connection(NpgsqlConnection value)
   at Marten.Services.AutoOpenSingleQueryRunner.Query[T](ISingleQueryHandler`1 handler, CancellationToken cancellation) in C:\Source\marten\src\Marten\Services\AutoOpenSingleQueryRunner.cs:line 25
   at Marten.Events.Daemon.HighWater.HighWaterDetector.loadCurrentStatistics(CancellationToken token) in C:\Source\marten\src\Marten\Events\Daemon\HighWater\HighWaterDetector.cs:line 96
   at Marten.Events.Daemon.HighWater.HighWaterDetector.Detect(CancellationToken token) in C:\Source\marten\src\Marten\Events\Daemon\HighWater\HighWaterDetector.cs:line 55
   at Marten.Events.Daemon.HighWater.HighWaterAgent.DetectChanges() in C:\Source\marten\src\Marten\Events\Daemon\HighWater\HighWaterAgent.cs:line 80
```