### PR TITLE
Fix issue with UserSuppliedQueryHandler when criteria contains 'SELECT' clause

### DIFF
--- a/src/DocumentDbTests/Reading/BatchedQuerying/batched_querying_acceptance_Tests.cs
+++ b/src/DocumentDbTests/Reading/BatchedQuerying/batched_querying_acceptance_Tests.cs
@@ -169,6 +169,19 @@ public class batched_querying_acceptance_Tests : OneOffConfigurationsContext
     }
 
     [Fact]
+    public async Task can_query_with_user_supplied_subquery()
+    {
+        var batch = theSession.CreateBatchQuery();
+
+        var list = batch.Query<User>("order by (select random())");
+
+        await batch.Execute();
+
+        (await list).ShouldContain(x => x.Id == user1.Id);
+        (await list).ShouldContain(x => x.Id == user2.Id);
+    }
+
+    [Fact]
     public async Task can_find_the_first_value()
     {
         var batch = theSession.CreateBatchQuery();

--- a/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
@@ -12,7 +12,6 @@ using Marten.Linq.Selectors;
 using Marten.Linq.SqlGeneration;
 using Marten.Services;
 using Weasel.Postgresql;
-using Marten.Util;
 using Npgsql;
 
 namespace Marten.Linq.QueryHandlers
@@ -26,9 +25,9 @@ namespace Marten.Linq.QueryHandlers
 
         public UserSuppliedQueryHandler(IMartenSession session, string sql, object[] parameters)
         {
-            _sql = sql;
+            _sql = sql.TrimStart();
             _parameters = parameters;
-            SqlContainsCustomSelect = _sql.Contains("select", StringComparison.OrdinalIgnoreCase);
+            SqlContainsCustomSelect = _sql.StartsWith("select", StringComparison.OrdinalIgnoreCase);
 
             _selectClause = GetSelectClause(session);
             _selector = (ISelector<T>) _selectClause.BuildSelector(session);
@@ -42,7 +41,7 @@ namespace Marten.Linq.QueryHandlers
             {
                 _selectClause.WriteSelectClause(builder);
 
-                if (_sql.TrimStart().StartsWith("where", StringComparison.OrdinalIgnoreCase))
+                if (_sql.StartsWith("where", StringComparison.OrdinalIgnoreCase))
                 {
                     builder.Append(" ");
                 }
@@ -51,8 +50,6 @@ namespace Marten.Linq.QueryHandlers
                     builder.Append(" where ");
                 }
             }
-
-
 
             var firstParameter = _parameters.FirstOrDefault();
 


### PR DESCRIPTION
The issue is that if you pass in a raw `WHERE` clause or `ORDER BY` clause that contains a condition with a nested `SELECT` statement, `UserSuppliedQueryHandler` thinks that it already contains the document `SELECT` statement since it was using a `Contains` check rather than a `StartsWith` check. This PR changes the check from a `Contains` to a `StartsWith`.  