### PR TITLE
Implement `All` quantifier operation

### DIFF
--- a/src/DocumentDbTests/Reading/Linq/invoking_queryable_all_operation_tests.cs
+++ b/src/DocumentDbTests/Reading/Linq/invoking_queryable_all_operation_tests.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DocumentDbTests.Reading.Linq;
+
+public class invoking_queryable_all_operation_tests: IntegrationContext
+{
+    public invoking_queryable_all_operation_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public void invoking_queryable_all_operation_test1()
+    {
+        theSession.Store(new User { FirstName = "Hank" , Roles = new []{ "R1", default(string)}});
+        theSession.Store(new User { FirstName = "Bill" , Roles = new []{ "R3", "R5"} });
+        theSession.Store(new User { FirstName = "Sam" , Roles = new []{ "R1", "R2"} });
+        theSession.Store(new User { FirstName = "Tom" , Roles = new []{ "R3", "R5"} });
+        theSession.Store(new User { FirstName = "Joe" , Roles = new []{ "R1", "R1"} });
+        theSession.Store(new User { FirstName = "Tom" , Roles = new []{ "R1", "R1"} });
+        theSession.Store(new User { FirstName = "Joe" , Roles = new []{ default(string), default(string)} });
+        theSession.SaveChanges();
+
+        var results = theSession.Query<User>()
+            .Where(u => u.Roles.All(r => r == "R1"))
+            .ToList();
+
+        results.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void invoking_queryable_all_operation_test2()
+    {
+        theSession.Store(new User { FirstName = "Hank" , Roles = new []{ "R1", default(string)}});
+        theSession.Store(new User { FirstName = "Bill" , Roles = new []{ "R3", "R5"} });
+        theSession.Store(new User { FirstName = "Sam" , Roles = new []{ "R1", "R2"} });
+        theSession.Store(new User { FirstName = "Tom" , Roles = new []{ "R3", "R5"} });
+        theSession.Store(new User { FirstName = "Joe" , Roles = new []{ "R1", "R1"} });
+        theSession.Store(new User { FirstName = "Tom" , Roles = new []{ "R1", "R1"} });
+        theSession.Store(new User { FirstName = "Joe" , Roles = new []{ default(string), default(string)} });
+        theSession.SaveChanges();
+
+        var results = theSession.Query<User>()
+            .Where(u => u.FirstName == "Joe" && u.Roles.All(r => r == "R1"))
+            .ToList();
+
+        results.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void invoking_queryable_all_operation_test3()
+    {
+        theSession.Store(new User { FirstName = "Hank" , Roles = new []{ "R1", default(string)}});
+        theSession.Store(new User { FirstName = "Bill" , Roles = new []{ "R3", "R5"} });
+        theSession.Store(new User { FirstName = "Sam" , Roles = new []{ "R1", "R2"} });
+        theSession.Store(new User { FirstName = "Tom" , Roles = new []{ "R3", "R5"} });
+        theSession.Store(new User { FirstName = "Joe" , Roles = new []{ "R1", "R1"} });
+        theSession.Store(new User { FirstName = "Tom" , Roles = new []{ "R1", "R1"} });
+        theSession.Store(new User { FirstName = "Joe" , Roles = new []{ default(string), default(string)} });
+        theSession.SaveChanges();
+
+        var results = theSession.Query<User>()
+            .Where(u => u.FirstName == "Jean" && u.Roles.All(r => r == "R1"))
+            .ToList();
+
+        results.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void invoking_queryable_all_operation_test4()
+    {
+        theSession.Store(new User { FirstName = "Hank" , Roles = new []{ "R1", default(string)}});
+        theSession.Store(new User { FirstName = "Bill" , Roles = new []{ "R3", "R5"} });
+        theSession.Store(new User { FirstName = "Sam" , Roles = new []{ "R1", "R2"} });
+        theSession.Store(new User { FirstName = "Tom" , Roles = new []{ "R3", "R5"} });
+        theSession.Store(new User { FirstName = "Joe" , Roles = new []{ "R1", "R1"} });
+        theSession.Store(new User { FirstName = "Tom" , Roles = new []{ "R1", "R1"} });
+        theSession.Store(new User { FirstName = "Joe" , Roles = new []{ default(string), default(string)} });
+        theSession.SaveChanges();
+
+        var results = theSession.Query<User>()
+            .Where(u => u.Roles.All(r => r == null))
+            .ToList();
+
+        results.Count.ShouldBe(1);
+    }
+}

--- a/src/Marten/Linq/Fields/ArrayField.cs
+++ b/src/Marten/Linq/Fields/ArrayField.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Baseline;
@@ -33,24 +32,16 @@ namespace Marten.Linq.Fields
                 PgType = "jsonb";
             }
 
-
-
             TypedLocator = $"CAST({rawLocator} as {PgType})";
-
-
 
             LocatorForIncludedDocumentId =
                 $"CAST(ARRAY(SELECT jsonb_array_elements_text(CAST({rawLocator} as jsonb))) as {innerPgType}[])";
 
-            if (PgType.EqualsIgnoreCase("JSONB"))
-            {
-                LocatorForFlattenedElements = $"unnest(CAST(ARRAY(SELECT jsonb_array_elements(CAST({rawLocator} as jsonb))) as jsonb[]))";
-            }
-            else
-            {
-                LocatorForFlattenedElements = $"unnest({LocatorForIncludedDocumentId})";;
-            }
+            LocatorForElements = PgType.EqualsIgnoreCase("JSONB") ?
+                $"CAST(ARRAY(SELECT jsonb_array_elements(CAST({rawLocator} as jsonb))) as jsonb[])" :
+                LocatorForIncludedDocumentId;
 
+            LocatorForFlattenedElements = $"unnest({LocatorForElements})";
 
         }
 
@@ -73,5 +64,7 @@ namespace Marten.Linq.Fields
         }
 
         public string LocatorForFlattenedElements { get; }
+
+        public string LocatorForElements { get; }
     }
 }

--- a/src/Marten/Linq/SqlGeneration/AllComparisonFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/AllComparisonFilter.cs
@@ -1,0 +1,36 @@
+using System;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.SqlGeneration;
+public class AllComparisonFilter: IReversibleWhereFragment
+{
+    private readonly ComparisonFilter _nestedFilter;
+
+    public AllComparisonFilter(ComparisonFilter nestedFilter)
+    {
+        _nestedFilter = nestedFilter ?? throw new ArgumentNullException(nameof(nestedFilter));
+    }
+
+    public void Apply(CommandBuilder builder)
+    {
+        if (_nestedFilter.Right is CommandParameter { Value: null })
+        {
+            builder.Append(" true = ALL (SELECT unnest(data) is null)");
+            return;
+        }
+
+        _nestedFilter.Right.Apply(builder);
+        builder.Append(" ");
+        builder.Append(_nestedFilter.Op);
+        builder.Append($" ALL (data)");
+    }
+
+    public bool Contains(string sqlText) => _nestedFilter.Contains(sqlText);
+
+    public ISqlFragment Reverse()
+    {
+        _nestedFilter.Reverse();
+        return this;
+    }
+}

--- a/src/Marten/Linq/SqlGeneration/AllIdSelectorStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/AllIdSelectorStatement.cs
@@ -1,0 +1,25 @@
+using Marten.Internal;
+using Marten.Linq.Fields;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.SqlGeneration;
+
+internal class AllIdSelectorStatement: IdSelectorStatement
+{
+    public AllIdSelectorStatement(IMartenSession session, IFieldMapping fields, Statement parent): base(session, fields, parent)
+    {
+    }
+
+    protected override void writeWhereClause(CommandBuilder sql)
+    {
+        if (Where is not ComparisonFilter comparisonFilter)
+        {
+            return;
+        }
+
+        sql.Append(" where ");
+        Where = new AllComparisonFilter(comparisonFilter);
+        Where.Apply(sql);
+    }
+}

--- a/src/Marten/Linq/SqlGeneration/ContainsIdSelectorStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/ContainsIdSelectorStatement.cs
@@ -1,7 +1,6 @@
 using System.Linq.Expressions;
 using Marten.Internal;
 using Weasel.Postgresql;
-using Marten.Util;
 using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.SqlGeneration
@@ -14,7 +13,7 @@ namespace Marten.Linq.SqlGeneration
         private readonly string _from;
         private readonly CommandParameter _parameter;
 
-        public ContainsIdSelectorStatement(FlattenerStatement parent, IMartenSession session, ConstantExpression constant) : base(null)
+        public ContainsIdSelectorStatement(SubQueryStatement parent, IMartenSession session, ConstantExpression constant) : base(null)
         {
             ConvertToCommonTableExpression(session);
             _from = parent.ExportName;

--- a/src/Marten/Linq/SqlGeneration/CountComparisonStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/CountComparisonStatement.cs
@@ -3,7 +3,6 @@ using System.Linq.Expressions;
 using Marten.Internal;
 using Marten.Linq.Fields;
 using Weasel.Postgresql;
-using Marten.Util;
 using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.SqlGeneration
@@ -14,10 +13,10 @@ namespace Marten.Linq.SqlGeneration
     internal class CountComparisonStatement: JsonStatement, IComparableFragment
     {
         private readonly string _tableName;
-        private readonly FlattenerStatement _flattened;
+        private readonly SubQueryStatement _flattened;
 
         public CountComparisonStatement(IMartenSession session, Type documentType, IFieldMapping fields,
-            FlattenerStatement parent): base(documentType, fields, parent)
+            SubQueryStatement parent): base(documentType, fields, parent)
         {
             ConvertToCommonTableExpression(session);
             parent.InsertAfter(this);

--- a/src/Marten/Linq/SqlGeneration/DocumentStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/DocumentStatement.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Baseline;
 using Marten.Internal;
 using Marten.Internal.Storage;
 using Marten.Linq.Includes;
 using Marten.Linq.Parsing;
-using Microsoft.CodeAnalysis.FlowAnalysis;
 using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.SqlGeneration
@@ -71,7 +69,7 @@ namespace Marten.Linq.SqlGeneration
                     var topLevelWhere = fragments.CombineFragments();
                     foreach (var subQuery in subQueries)
                     {
-                        subQuery.Flattener.Where = topLevelWhere;
+                        subQuery.SubQueryStatement.Where = topLevelWhere;
                     }
                 }
 

--- a/src/Marten/Linq/SqlGeneration/IdSelectorStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/IdSelectorStatement.cs
@@ -1,7 +1,6 @@
 using Marten.Internal;
 using Marten.Linq.Fields;
 using Weasel.Postgresql;
-using Marten.Util;
 using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.SqlGeneration
@@ -38,13 +37,13 @@ namespace Marten.Linq.SqlGeneration
     {
         private readonly string _tableName;
 
-        internal WhereCtIdInSubQuery(string tableName, FlattenerStatement flattenerStatement)
+        internal WhereCtIdInSubQuery(string tableName, SubQueryStatement subQueryStatement)
         {
             _tableName = tableName;
-            Flattener = flattenerStatement;
+            SubQueryStatement = subQueryStatement;
         }
 
-        public FlattenerStatement Flattener { get; }
+        public SubQueryStatement SubQueryStatement { get; }
 
         public void Apply(CommandBuilder builder)
         {

--- a/src/Marten/Linq/SqlGeneration/Statement.cs
+++ b/src/Marten/Linq/SqlGeneration/Statement.cs
@@ -112,7 +112,7 @@ namespace Marten.Linq.SqlGeneration
         protected abstract void configure(CommandBuilder builder);
 
 
-        protected void writeWhereClause(CommandBuilder sql)
+        protected virtual void writeWhereClause(CommandBuilder sql)
         {
             if (Where != null)
             {


### PR DESCRIPTION
Currently, Marten has support for the `Any` and `Contains` [quantifier operations](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/linq/quantifier-operations), but not for the `All` one. 

This enhancement adds support for the missing one.