### PR TITLE
Avoid using IHostEnvironment.IsDevelopment in OptimizeArtifactWorkflow

### DIFF
--- a/src/CoreTests/using_optimized_artifact_workflow.cs
+++ b/src/CoreTests/using_optimized_artifact_workflow.cs
@@ -146,4 +146,26 @@ public class using_optimized_artifact_workflow
         rules.GeneratedNamespace.ShouldBe("Marten.Generated");
         rules.SourceCodeWritingEnabled.ShouldBeFalse();
     }
+
+    [Fact]
+    public void using_optimized_mode_in_production_override_environment_name()
+    {
+        using var host = new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(ConnectionSource.ConnectionString).OptimizeArtifactWorkflow("Local");
+            })
+            .UseEnvironment("Local")
+            .Start();
+
+        var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
+
+        var rules = store.Options.CreateGenerationRules();
+
+        store.Options.AutoCreateSchemaObjects.ShouldBe(AutoCreate.CreateOrUpdate);
+        store.Options.GeneratedCodeMode.ShouldBe(TypeLoadMode.Auto);
+
+        rules.GeneratedNamespace.ShouldBe("Marten.Generated");
+        rules.SourceCodeWritingEnabled.ShouldBeTrue();
+    }
 }


### PR DESCRIPTION
From [Microsoft Docs](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.hostenvironmentenvextensions.isenvironment?view=dotnet-plat-ext-6.0):
> Environment names are generally specific to an application. Libraries designed for use in many different applications should avoid coupling behavior to specific environment names.

fixes #2367