### PR TITLE
Restricted In Linq operator to regular fields

### DIFF
--- a/src/DocumentDbTests/Reading/Linq/LinqExtensionsTests.cs
+++ b/src/DocumentDbTests/Reading/Linq/LinqExtensionsTests.cs
@@ -9,56 +9,109 @@ namespace DocumentDbTests.Reading.Linq;
 
 public class LinqExtensionsTests
 {
-    [Fact]
-    public void IsOneOf_shows_if_value_is_contained_in_the_specified_collection()
+    private static int[] Ints = { 0, 1, 2, 3 };
+
+    private static readonly Guid[] Guids = { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+    private static readonly string[] Strings =
     {
-        1.IsOneOf(1, 2).ShouldBeTrue();
-        1.IsOneOf(2, 1).ShouldBeTrue();
-        1.IsOneOf(2, 3).ShouldBeFalse();
-        1.IsOneOf(new List<int> {1, 2}).ShouldBeTrue();
-        1.IsOneOf(new List<int> {2, 1}).ShouldBeTrue();
-        1.IsOneOf(new List<int> {2, 3}).ShouldBeFalse();
+        Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString()
+    };
+
+    [Fact]
+    public void IsOneOf_shows_if_value_is_contained_in_the_specified_collection_of_ints() =>
+        IsOneOf_shows_if_value_is_contained_in_the_specified_collection(Ints);
+
+    [Fact]
+    public void IsOneOf_shows_if_value_is_contained_in_the_specified_collection_of_guids() =>
+        IsOneOf_shows_if_value_is_contained_in_the_specified_collection(Guids);
+
+    [Fact]
+    public void IsOneOf_shows_if_value_is_contained_in_the_specified_collection_of_strings() =>
+        IsOneOf_shows_if_value_is_contained_in_the_specified_collection(Strings);
+
+    private void IsOneOf_shows_if_value_is_contained_in_the_specified_collection<T>(T[] values)
+    {
+        values[1].IsOneOf(values[1], values[2]).ShouldBeTrue();
+        values[1].IsOneOf(values[2], values[1]).ShouldBeTrue();
+        values[1].IsOneOf(values[2], values[3]).ShouldBeFalse();
+        values[1].IsOneOf(new List<T> { values[1], values[2] }).ShouldBeTrue();
+        values[1].IsOneOf(new List<T> { values[2], values[1] }).ShouldBeTrue();
+        values[1].IsOneOf(new List<T> { values[2], values[3] }).ShouldBeFalse();
     }
 
     [Fact]
-    public void In_shows_if_value_is_contained_in_the_specified_collection()
+    public void In_shows_if_value_is_contained_in_the_specified_collection_of_ints() =>
+        In_shows_if_value_is_contained_in_the_specified_collection(Ints);
+
+    [Fact]
+    public void In_shows_if_value_is_contained_in_the_specified_collection_of_guids() =>
+        In_shows_if_value_is_contained_in_the_specified_collection(Guids);
+
+    [Fact]
+    public void In_shows_if_value_is_contained_in_the_specified_collection_of_strings() =>
+        In_shows_if_value_is_contained_in_the_specified_collection(Strings);
+
+    private void In_shows_if_value_is_contained_in_the_specified_collection<T>(T[] values)
     {
-        1.In(1, 2).ShouldBeTrue();
-        1.In(2, 1).ShouldBeTrue();
-        1.In(2, 3).ShouldBeFalse();
-        1.In(new List<int> {1, 2}).ShouldBeTrue();
-        1.In(new List<int> {2, 1}).ShouldBeTrue();
-        1.In(new List<int> {2, 3}).ShouldBeFalse();
+        values[1].In(values[1], values[2]).ShouldBeTrue();
+        values[1].In(values[2], values[1]).ShouldBeTrue();
+        values[1].In(values[2], values[3]).ShouldBeFalse();
+        values[1].In(new List<T> { values[1], values[2] }).ShouldBeTrue();
+        values[1].In(new List<T> { values[2], values[1] }).ShouldBeTrue();
+        values[1].In(new List<T> { values[2], values[3] }).ShouldBeFalse();
     }
 
     [Fact]
-    public void IsSupersetOf_shows_if_collection_is_superset_of_the_specified_collection()
+    public void IsSupersetOf_shows_if_collection_is_superset_of_the_specified_collection_of_ints() =>
+        IsSupersetOf_shows_if_collection_is_superset_of_the_specified_collection(Ints);
+
+    [Fact]
+    public void IsSupersetOf_shows_if_collection_is_superset_of_the_specified_collection_of_guids() =>
+        IsSupersetOf_shows_if_collection_is_superset_of_the_specified_collection(Guids);
+
+    [Fact]
+    public void IsSupersetOf_shows_if_collection_is_superset_of_the_specified_collection_of_strings() =>
+        IsSupersetOf_shows_if_collection_is_superset_of_the_specified_collection(Strings);
+
+    private void IsSupersetOf_shows_if_collection_is_superset_of_the_specified_collection<T>(T[] values)
     {
-        new[] {1, 2, 3}.IsSupersetOf(1, 2).ShouldBeTrue();
-        new[] {1, 2, 3}.IsSupersetOf(2, 3).ShouldBeTrue();
-        new[] {1, 2, 3}.IsSupersetOf(1, 2, 3).ShouldBeTrue();
-        new[] {1, 2}.IsSupersetOf(1, 2, 3).ShouldBeFalse();
-        new[] {2, 3}.IsSupersetOf(1, 2, 3).ShouldBeFalse();
-        new[] {1, 2, 3}.IsSupersetOf(new List<int> {1, 2}).ShouldBeTrue();
-        new[] {1, 2, 3}.IsSupersetOf(new List<int> {2, 3}).ShouldBeTrue();
-        new[] {1, 2, 3}.IsSupersetOf(new List<int> {1, 2, 3}).ShouldBeTrue();
-        new[] {1, 2}.IsSupersetOf(new List<int> {1, 2, 3}).ShouldBeFalse();
-        new[] {2, 3}.IsSupersetOf(new List<int> {1, 2, 3}).ShouldBeFalse();
+        new[] { values[1], values[2], values[3] }.IsSupersetOf(values[1], values[2]).ShouldBeTrue();
+        new[] { values[1], values[2], values[3] }.IsSupersetOf(values[2], values[3]).ShouldBeTrue();
+        new[] { values[1], values[2], values[3] }.IsSupersetOf(values[1], values[2], values[3]).ShouldBeTrue();
+        new[] { values[1], values[2] }.IsSupersetOf(values[1], values[2], values[3]).ShouldBeFalse();
+        new[] { values[2], values[3] }.IsSupersetOf(values[1], values[2], values[3]).ShouldBeFalse();
+        new[] { values[1], values[2], values[3] }.IsSupersetOf(new List<T> { values[1], values[2] }).ShouldBeTrue();
+        new[] { values[1], values[2], values[3] }.IsSupersetOf(new List<T> { values[2], values[3] }).ShouldBeTrue();
+        new[] { values[1], values[2], values[3] }.IsSupersetOf(new List<T> { values[1], values[2], values[3] }).ShouldBeTrue();
+        new[] { values[1], values[2] }.IsSupersetOf(new List<T> { values[1], values[2], values[3] }).ShouldBeFalse();
+        new[] { values[2], values[3] }.IsSupersetOf(new List<T> { values[1], values[2], values[3] }).ShouldBeFalse();
     }
 
     [Fact]
-    public void IsSubsetOf_shows_if_collection_is_subset_of_the_specified_collection()
+    public void IsSubsetOf_shows_if_collection_is_subset_of_the_specified_collection_of_ints() =>
+        IsSubsetOf_shows_if_collection_is_subset_of_the_specified_collection(Ints);
+
+    [Fact]
+    public void IsSubsetOf_shows_if_collection_is_subset_of_the_specified_collection_of_guids() =>
+        IsSubsetOf_shows_if_collection_is_subset_of_the_specified_collection(Guids);
+
+    [Fact]
+    public void IsSubsetOf_shows_if_collection_is_subset_of_the_specified_collection_of_strings() =>
+        IsSubsetOf_shows_if_collection_is_subset_of_the_specified_collection(Strings);
+
+    private void IsSubsetOf_shows_if_collection_is_subset_of_the_specified_collection<T>(T[] values)
     {
-        new[] {1, 2}.IsSubsetOf(1, 2, 3).ShouldBeTrue();
-        new[] {2, 3}.IsSubsetOf(1, 2, 3).ShouldBeTrue();
-        new[] {1, 2, 3}.IsSubsetOf(1, 2, 3).ShouldBeTrue();
-        new[] {1, 2, 3}.IsSubsetOf(1, 2).ShouldBeFalse();
-        new[] {1, 2, 3}.IsSubsetOf(2, 3).ShouldBeFalse();
-        new[] {1, 2}.IsSubsetOf(new List<int> {1, 2, 3}).ShouldBeTrue();
-        new[] {2, 3}.IsSubsetOf(new List<int> {1, 2, 3}).ShouldBeTrue();
-        new[] {1, 2, 3}.IsSubsetOf(new List<int> {1, 2, 3}).ShouldBeTrue();
-        new[] {1, 2, 3}.IsSubsetOf(new List<int> {1, 2}).ShouldBeFalse();
-        new[] {1, 2, 3}.IsSubsetOf(new List<int> {2, 3}).ShouldBeFalse();
+        new[] { values[1], values[2] }.IsSubsetOf(values[1], values[2], values[3]).ShouldBeTrue();
+        new[] { values[2], values[3] }.IsSubsetOf(values[1], values[2], values[3]).ShouldBeTrue();
+        new[] { values[1], values[2], values[3] }.IsSubsetOf(values[1], values[2], values[3]).ShouldBeTrue();
+        new[] { values[1], values[2], values[3] }.IsSubsetOf(values[1], values[2]).ShouldBeFalse();
+        new[] { values[1], values[2], values[3] }.IsSubsetOf(values[2], values[3]).ShouldBeFalse();
+        new[] { values[1], values[2] }.IsSubsetOf(new List<T> { values[1], values[2], values[3] }).ShouldBeTrue();
+        new[] { values[2], values[3] }.IsSubsetOf(new List<T> { values[1], values[2], values[3] }).ShouldBeTrue();
+        new[] { values[1], values[2], values[3] }.IsSubsetOf(new List<T> { values[1], values[2], values[3] }).ShouldBeTrue();
+        new[] { values[1], values[2], values[3] }.IsSubsetOf(new List<T> { values[1], values[2] }).ShouldBeFalse();
+        new[] { values[1], values[2], values[3] }.IsSubsetOf(new List<T> { values[2], values[3] }).ShouldBeFalse();
     }
 
     [Fact]
@@ -71,6 +124,18 @@ public class LinqExtensionsTests
         "".IsEmpty().ShouldBeTrue();
         " ".IsEmpty().ShouldBeFalse();
         "a".IsEmpty().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsOneOf_throws_NotSupportedException_when_called_for_list()
+    {
+        Should.Throw<NotSupportedException>(() => new List<object>().IsOneOf(new List<object> {"a", "b"}));
+    }
+
+    [Fact]
+    public void In_throws_NotSupportedException_when_called_for_list()
+    {
+        Should.Throw<NotSupportedException>(() => new List<object>().In(new List<object> {"a", "b"}));
     }
 
     [Fact]

--- a/src/DocumentDbTests/Reading/Linq/query_with_IsSubsetOf_Tests.cs
+++ b/src/DocumentDbTests/Reading/Linq/query_with_IsSubsetOf_Tests.cs
@@ -42,8 +42,6 @@ public class query_with_IsSubsetOf_Tests : IntegrationContext
         #endregion
     }
 
-
-
     private Target[] _allTargets;
 
     private static Target CreateTarget(params string[] tags)

--- a/src/DocumentDbTests/Reading/Linq/query_with_is_one_of_Tests.cs
+++ b/src/DocumentDbTests/Reading/Linq/query_with_is_one_of_Tests.cs
@@ -10,121 +10,186 @@ using Xunit;
 
 namespace DocumentDbTests.Reading.Linq;
 
-public class query_with_is_one_of_Tests : IntegrationContext
+public class query_with_is_one_of_Tests: IntegrationContext
 {
-    public static TheoryData<Func<int[], Expression<Func<Target, bool>>>> SupportedIsOneOfWithArray =
-        new TheoryData<Func<int[], Expression<Func<Target, bool>>>>
-        {
-            validNumbers => x => x.Number.IsOneOf(validNumbers),
-            validNumbers => x => x.Number.In(validNumbers)
-        };
+    public static TheoryData<Func<int[], Expression<Func<Target, bool>>>> SupportedIsOneOfWithIntArray =
+        new() { validNumbers => x => x.Number.IsOneOf(validNumbers), validNumbers => x => x.Number.In(validNumbers) };
 
-    public static TheoryData<Func<int[], Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithArray =
-        new TheoryData<Func<int[], Expression<Func<Target, bool>>>>
-        {
-            validNumbers => x => !x.Number.IsOneOf(validNumbers),
-            validNumbers => x => !x.Number.In(validNumbers)
-        };
+    public static TheoryData<Func<int[], Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithIntArray =
+        new() { validNumbers => x => !x.Number.IsOneOf(validNumbers), validNumbers => x => !x.Number.In(validNumbers) };
 
-    public static TheoryData<Func<List<int>, Expression<Func<Target, bool>>>> SupportedIsOneOfWithList =
-        new TheoryData<Func<List<int>, Expression<Func<Target, bool>>>>
-        {
-            validNumbers => x => x.Number.IsOneOf(validNumbers),
-            validNumbers => x => x.Number.In(validNumbers)
-        };
+    public static TheoryData<Func<List<int>, Expression<Func<Target, bool>>>> SupportedIsOneOfWithIntList =
+        new() { validNumbers => x => x.Number.IsOneOf(validNumbers), validNumbers => x => x.Number.In(validNumbers) };
 
-    public static TheoryData<Func<List<int>, Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithList =
-        new TheoryData<Func<List<int>, Expression<Func<Target, bool>>>>
-        {
-            validNumbers => x => !x.Number.IsOneOf(validNumbers),
-            validNumbers => x => !x.Number.In(validNumbers)
-        };
+    public static TheoryData<Func<List<int>, Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithIntList =
+        new() { validNumbers => x => !x.Number.IsOneOf(validNumbers), validNumbers => x => !x.Number.In(validNumbers) };
 
-    [Theory]
-    [MemberData(nameof(SupportedIsOneOfWithArray))]
-    public void can_query_against_integers(Func<int[], Expression<Func<Target, bool>>> isOneOf)
-    {
+    public static TheoryData<Func<Guid[], Expression<Func<Target, bool>>>> SupportedIsOneOfWithGuidArray =
+        new() { validGuids => x => x.OtherGuid.IsOneOf(validGuids), validGuids => x => x.OtherGuid.In(validGuids) };
 
-        var targets = Target.GenerateRandomData(100).ToArray();
-        theStore.BulkInsert(targets);
+    public static TheoryData<Func<Guid[], Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithGuidArray =
+        new() { validGuids => x => !x.OtherGuid.IsOneOf(validGuids), validGuids => x => !x.OtherGuid.In(validGuids) };
 
-        var validNumbers = targets.Select(x => x.Number).Distinct().Take(3).ToArray();
+    public static TheoryData<Func<List<Guid>, Expression<Func<Target, bool>>>> SupportedIsOneOfWithGuidList =
+        new() { validGuids => x => x.OtherGuid.IsOneOf(validGuids), validGuids => x => x.OtherGuid.In(validGuids) };
 
-        var found = theSession.Query<Target>().Where(isOneOf(validNumbers)).ToArray();
+    public static TheoryData<Func<List<Guid>, Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithGuidList =
+        new() { validGuids => x => !x.OtherGuid.IsOneOf(validGuids), validGuids => x => !x.OtherGuid.In(validGuids) };
 
-        found.Count().ShouldBeLessThan(100);
+    public static TheoryData<Func<string[], Expression<Func<Target, bool>>>> SupportedIsOneOfWithStringArray =
+        new() { validStrings => x => x.String.IsOneOf(validStrings), validStrings => x => x.String.In(validStrings) };
 
-        var expected = targets
-            .Where(x => validNumbers
-                .Contains(x.Number))
-            .OrderBy(x => x.Id)
-            .Select(x => x.Id)
-            .ToArray();
+    public static TheoryData<Func<string[], Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithStringArray =
+        new() { validStrings => x => !x.String.IsOneOf(validStrings), validStrings => x => !x.String.In(validStrings) };
 
-        found.OrderBy(x => x.Id).Select(x => x.Id)
-            .ShouldHaveTheSameElementsAs(expected);
-    }
+    public static TheoryData<Func<List<string>, Expression<Func<Target, bool>>>> SupportedIsOneOfWithStringList =
+        new() { validStrings => x => x.String.IsOneOf(validStrings), validStrings => x => x.String.In(validStrings) };
+
+    public static TheoryData<Func<List<string>, Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithStringList =
+        new() { validStrings => x => !x.String.IsOneOf(validStrings), validStrings => x => !x.String.In(validStrings) };
 
     [Theory]
-    [MemberData(nameof(SupportedNotIsOneOfWithArray))]
-    public void can_query_against_integers_with_not_operator(Func<int[], Expression<Func<Target, bool>>> notIsOneOf)
+    [MemberData(nameof(SupportedIsOneOfWithIntArray))]
+    public void can_query_against_integers(Func<int[], Expression<Func<Target, bool>>> isOneOf) =>
+        can_query_against_array(isOneOf, x => x.Number);
+
+    [Theory]
+    [MemberData(nameof(SupportedIsOneOfWithGuidArray))]
+    public void can_query_against_guids(Func<Guid[], Expression<Func<Target, bool>>> isOneOf) =>
+        can_query_against_array(isOneOf, x => x.OtherGuid);
+
+    [Theory]
+    [MemberData(nameof(SupportedIsOneOfWithStringArray))]
+    public void can_query_against_strings(Func<string[], Expression<Func<Target, bool>>> isOneOf) =>
+        can_query_against_array(isOneOf, x => x.String);
+
+    private void can_query_against_array<T>(Func<T[], Expression<Func<Target, bool>>> isOneOf, Func<Target, T> select)
     {
         var targets = Target.GenerateRandomData(100).ToArray();
         theStore.BulkInsert(targets);
 
-        var validNumbers = targets.Select(x => x.Number).Distinct().Take(3).ToArray();
+        var validValues = targets.Select(select).Distinct().Take(3).ToArray();
 
-        var found = theSession.Query<Target>().Where(notIsOneOf(validNumbers)).ToArray();
-
-        var expected = targets
-            .Where(x => !validNumbers
-                .Contains(x.Number))
-            .OrderBy(x => x.Id)
-            .Select(x => x.Id)
-            .ToArray();
-
-        found.OrderBy(x => x.Id).Select(x => x.Id)
-            .ShouldHaveTheSameElementsAs(expected);
-    }
-
-    [Theory]
-    [MemberData(nameof(SupportedIsOneOfWithList))]
-    public void can_query_against_integers_list(Func<List<int>, Expression<Func<Target, bool>>> isOneOf)
-    {
-        var targets = Target.GenerateRandomData(100).ToArray();
-        theStore.BulkInsert(targets);
-
-        var validNumbers = targets.Select(x => x.Number).Distinct().Take(3).ToList();
-
-        var found = theSession.Query<Target>().Where(isOneOf(validNumbers)).ToArray();
+        var found = theSession.Query<Target>().Where(isOneOf(validValues)).ToArray();
 
         found.Length.ShouldBeLessThan(100);
 
         var expected = targets
-            .Where(x => validNumbers
-                .Contains(x.Number))
+            .Where(x => validValues.Contains(select(x)))
             .OrderBy(x => x.Id)
             .Select(x => x.Id)
-            .ToList();
+            .ToArray();
 
         found.OrderBy(x => x.Id).Select(x => x.Id)
             .ShouldHaveTheSameElementsAs(expected);
     }
 
     [Theory]
-    [MemberData(nameof(SupportedNotIsOneOfWithList))]
-    public void can_query_against_integers_with_not_operator_list(Func<List<int>, Expression<Func<Target, bool>>> notIsOneOf)
+    [MemberData(nameof(SupportedNotIsOneOfWithIntArray))]
+    public void can_query_against_integers_with_not_operator(Func<int[], Expression<Func<Target, bool>>> notIsOneOf)
+        => can_query_against_array_with_not_operator(notIsOneOf, x => x.Number);
+
+    [Theory]
+    [MemberData(nameof(SupportedNotIsOneOfWithGuidArray))]
+    public void can_query_against_guids_with_not_operator(Func<Guid[], Expression<Func<Target, bool>>> notIsOneOf)
+        => can_query_against_array_with_not_operator(notIsOneOf, x => x.OtherGuid);
+
+
+    [Theory]
+    [MemberData(nameof(SupportedNotIsOneOfWithStringArray))]
+    public void can_query_against_strings_with_not_operator(Func<string[], Expression<Func<Target, bool>>> notIsOneOf)
+        => can_query_against_array_with_not_operator(notIsOneOf, x => x.String);
+
+    private void can_query_against_array_with_not_operator<T>(
+        Func<T[], Expression<Func<Target, bool>>> notIsOneOf,
+        Func<Target, T> select
+    )
     {
         var targets = Target.GenerateRandomData(100).ToArray();
         theStore.BulkInsert(targets);
 
-        var validNumbers = targets.Select(x => x.Number).Distinct().Take(3).ToList();
+        var validValues = targets.Select(select).Distinct().Take(3).ToArray();
 
-        var found = theSession.Query<Target>().Where(notIsOneOf(validNumbers)).ToArray();
+        var found = theSession.Query<Target>().Where(notIsOneOf(validValues)).ToArray();
 
         var expected = targets
-            .Where(x => !validNumbers
-                .Contains(x.Number))
+            .Where(x => !validValues.Contains(select(x)))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToArray();
+
+        found.OrderBy(x => x.Id).Select(x => x.Id)
+            .ShouldHaveTheSameElementsAs(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(SupportedIsOneOfWithIntList))]
+    public void can_query_against_integers_list(Func<List<int>, Expression<Func<Target, bool>>> isOneOf)
+        => can_query_against_list(isOneOf, x => x.Number);
+
+    [Theory]
+    [MemberData(nameof(SupportedIsOneOfWithGuidList))]
+    public void can_query_against_guids_list(Func<List<Guid>, Expression<Func<Target, bool>>> isOneOf)
+        => can_query_against_list(isOneOf, x => x.OtherGuid);
+
+    [Theory]
+    [MemberData(nameof(SupportedIsOneOfWithStringList))]
+    public void can_query_against_strings_list(Func<List<string>, Expression<Func<Target, bool>>> isOneOf)
+        => can_query_against_list(isOneOf, x => x.String);
+
+    private void can_query_against_list<T>(Func<List<T>, Expression<Func<Target, bool>>> isOneOf, Func<Target, T> select)
+    {
+        var targets = Target.GenerateRandomData(100).ToArray();
+        theStore.BulkInsert(targets);
+
+        var validValues = targets.Select(select).Distinct().Take(3).ToList();
+
+        var found = theSession.Query<Target>().Where(isOneOf(validValues)).ToArray();
+
+        found.Length.ShouldBeLessThan(100);
+
+        var expected = targets
+            .Where(x => validValues.Contains(select(x)))
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .ToArray();
+
+        found.OrderBy(x => x.Id).Select(x => x.Id)
+            .ShouldHaveTheSameElementsAs(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(SupportedNotIsOneOfWithIntList))]
+    public void can_query_against_integers_with_not_operator_list(
+        Func<List<int>, Expression<Func<Target, bool>>> notIsOneOf) =>
+        can_query_against_list_with_not_operator(notIsOneOf, x => x.Number);
+
+    [Theory]
+    [MemberData(nameof(SupportedNotIsOneOfWithGuidList))]
+    public void can_query_against_guids_with_not_operator_list(
+        Func<List<Guid>, Expression<Func<Target, bool>>> notIsOneOf) =>
+        can_query_against_list_with_not_operator(notIsOneOf, x => x.OtherGuid);
+
+    [Theory]
+    [MemberData(nameof(SupportedNotIsOneOfWithStringList))]
+    public void can_query_against_strings_with_not_operator_list(
+        Func<List<string>, Expression<Func<Target, bool>>> notIsOneOf) =>
+        can_query_against_list_with_not_operator(notIsOneOf, x => x.String);
+
+    private void can_query_against_list_with_not_operator<T>(
+        Func<List<T>, Expression<Func<Target, bool>>> notIsOneOf,
+        Func<Target, T> select
+    )
+    {
+        var targets = Target.GenerateRandomData(100).ToArray();
+        theStore.BulkInsert(targets);
+
+        var validValues = targets.Select(select).Distinct().Take(3).ToList();
+
+        var found = theSession.Query<Target>().Where(notIsOneOf(validValues)).ToArray();
+
+        var expected = targets
+            .Where(x => !validValues.Contains(select(x)))
             .OrderBy(x => x.Id)
             .Select(x => x.Id)
             .ToList();
@@ -133,7 +198,8 @@ public class query_with_is_one_of_Tests : IntegrationContext
             .ShouldHaveTheSameElementsAs(expected);
     }
 
-    public query_with_is_one_of_Tests(DefaultStoreFixture fixture) : base(fixture)
+
+    public query_with_is_one_of_Tests(DefaultStoreFixture fixture): base(fixture)
     {
     }
 }

--- a/src/DocumentDbTests/Reading/Linq/query_with_is_one_of_Tests.cs
+++ b/src/DocumentDbTests/Reading/Linq/query_with_is_one_of_Tests.cs
@@ -13,40 +13,88 @@ namespace DocumentDbTests.Reading.Linq;
 public class query_with_is_one_of_Tests: IntegrationContext
 {
     public static TheoryData<Func<int[], Expression<Func<Target, bool>>>> SupportedIsOneOfWithIntArray =
-        new() { validNumbers => x => x.Number.IsOneOf(validNumbers), validNumbers => x => x.Number.In(validNumbers) };
+        new()
+        {
+            validNumbers => x => x.Number.IsOneOf(validNumbers),
+            validNumbers => x => x.Number.In(validNumbers)
+        };
 
     public static TheoryData<Func<int[], Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithIntArray =
-        new() { validNumbers => x => !x.Number.IsOneOf(validNumbers), validNumbers => x => !x.Number.In(validNumbers) };
+        new()
+        {
+            validNumbers => x => !x.Number.IsOneOf(validNumbers),
+            validNumbers => x => !x.Number.In(validNumbers)
+        };
 
     public static TheoryData<Func<List<int>, Expression<Func<Target, bool>>>> SupportedIsOneOfWithIntList =
-        new() { validNumbers => x => x.Number.IsOneOf(validNumbers), validNumbers => x => x.Number.In(validNumbers) };
+        new()
+        {
+            validNumbers => x => x.Number.IsOneOf(validNumbers),
+            validNumbers => x => x.Number.In(validNumbers)
+        };
 
     public static TheoryData<Func<List<int>, Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithIntList =
-        new() { validNumbers => x => !x.Number.IsOneOf(validNumbers), validNumbers => x => !x.Number.In(validNumbers) };
+        new()
+        {
+            validNumbers => x => !x.Number.IsOneOf(validNumbers),
+            validNumbers => x => !x.Number.In(validNumbers)
+        };
 
     public static TheoryData<Func<Guid[], Expression<Func<Target, bool>>>> SupportedIsOneOfWithGuidArray =
-        new() { validGuids => x => x.OtherGuid.IsOneOf(validGuids), validGuids => x => x.OtherGuid.In(validGuids) };
+        new()
+        {
+            validGuids => x => x.OtherGuid.IsOneOf(validGuids),
+            validGuids => x => x.OtherGuid.In(validGuids)
+        };
 
     public static TheoryData<Func<Guid[], Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithGuidArray =
-        new() { validGuids => x => !x.OtherGuid.IsOneOf(validGuids), validGuids => x => !x.OtherGuid.In(validGuids) };
+        new()
+        {
+            validGuids => x => !x.OtherGuid.IsOneOf(validGuids),
+            validGuids => x => !x.OtherGuid.In(validGuids)
+        };
 
     public static TheoryData<Func<List<Guid>, Expression<Func<Target, bool>>>> SupportedIsOneOfWithGuidList =
-        new() { validGuids => x => x.OtherGuid.IsOneOf(validGuids), validGuids => x => x.OtherGuid.In(validGuids) };
+        new()
+        {
+            validGuids => x => x.OtherGuid.IsOneOf(validGuids),
+            validGuids => x => x.OtherGuid.In(validGuids)
+        };
 
     public static TheoryData<Func<List<Guid>, Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithGuidList =
-        new() { validGuids => x => !x.OtherGuid.IsOneOf(validGuids), validGuids => x => !x.OtherGuid.In(validGuids) };
+        new()
+        {
+            validGuids => x => !x.OtherGuid.IsOneOf(validGuids),
+            validGuids => x => !x.OtherGuid.In(validGuids)
+        };
 
     public static TheoryData<Func<string[], Expression<Func<Target, bool>>>> SupportedIsOneOfWithStringArray =
-        new() { validStrings => x => x.String.IsOneOf(validStrings), validStrings => x => x.String.In(validStrings) };
+        new()
+        {
+            validStrings => x => x.String.IsOneOf(validStrings),
+            validStrings => x => x.String.In(validStrings)
+        };
 
     public static TheoryData<Func<string[], Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithStringArray =
-        new() { validStrings => x => !x.String.IsOneOf(validStrings), validStrings => x => !x.String.In(validStrings) };
+        new()
+        {
+            validStrings => x => !x.String.IsOneOf(validStrings),
+            validStrings => x => !x.String.In(validStrings)
+        };
 
     public static TheoryData<Func<List<string>, Expression<Func<Target, bool>>>> SupportedIsOneOfWithStringList =
-        new() { validStrings => x => x.String.IsOneOf(validStrings), validStrings => x => x.String.In(validStrings) };
+        new()
+        {
+            validStrings => x => x.String.IsOneOf(validStrings),
+            validStrings => x => x.String.In(validStrings)
+        };
 
     public static TheoryData<Func<List<string>, Expression<Func<Target, bool>>>> SupportedNotIsOneOfWithStringList =
-        new() { validStrings => x => !x.String.IsOneOf(validStrings), validStrings => x => !x.String.In(validStrings) };
+        new()
+        {
+            validStrings => x => !x.String.IsOneOf(validStrings),
+            validStrings => x => !x.String.In(validStrings)
+        };
 
     [Theory]
     [MemberData(nameof(SupportedIsOneOfWithIntArray))]

--- a/src/Marten.Testing/Documents/Target.cs
+++ b/src/Marten.Testing/Documents/Target.cs
@@ -47,6 +47,7 @@ public class Target
         target.AnotherString = _otherStrings[_random.Next(0, 10)];
         target.Number = _random.Next();
         target.AnotherNumber = _random.Next();
+        target.OtherGuid = Guid.NewGuid();
 
         target.Flag = _random.Next(0, 10) > 5;
 
@@ -83,12 +84,14 @@ public class Target
 
             var number = _random.Next(1, 10);
             target.Children = new Target[number];
-            for (int i = 0; i < number; i++)
+            for (var i = 0; i < number; i++)
             {
                 target.Children[i] = Random();
             }
 
             target.StringDict = Enumerable.Range(0, _random.Next(1, 10)).ToDictionary(i => $"key{i}", i => $"value{i}");
+            target.String = _strings[_random.Next(0, 10)];
+            target.OtherGuid = Guid.NewGuid();
         }
 
         return target;

--- a/src/Marten/Linq/Parsing/Methods/IsOneOf.cs
+++ b/src/Marten/Linq/Parsing/Methods/IsOneOf.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Linq.Expressions;
+using Baseline;
 using Marten.Linq.Fields;
 using Marten.Linq.Filters;
 using Marten.Linq.SqlGeneration;
@@ -13,7 +14,8 @@ namespace Marten.Linq.Parsing.Methods
         public bool Matches(MethodCallExpression expression)
         {
             return (expression.Method.Name == nameof(LinqExtensions.IsOneOf)
-                    || expression.Method.Name == nameof(LinqExtensions.In))
+                    || (expression.Method.Name == nameof(LinqExtensions.In) &&
+                        !expression.Arguments.First().Type.IsGenericEnumerable()))
                    && expression.Method.DeclaringType == typeof(LinqExtensions);
         }
 

--- a/src/Marten/Linq/Parsing/Methods/IsSubsetOf.cs
+++ b/src/Marten/Linq/Parsing/Methods/IsSubsetOf.cs
@@ -14,7 +14,7 @@ namespace Marten.Linq.Parsing.Methods
     {
         public bool Matches(MethodCallExpression expression)
         {
-            MethodInfo method = expression.Method;
+            var method = expression.Method;
             return IsMartenLinqExtension(method) ||
                    IsISetMethod(method);
         }

--- a/src/Marten/Linq/Parsing/Methods/IsSupersetOf.cs
+++ b/src/Marten/Linq/Parsing/Methods/IsSupersetOf.cs
@@ -14,7 +14,7 @@ namespace Marten.Linq.Parsing.Methods
     {
         public bool Matches(MethodCallExpression expression)
         {
-            MethodInfo method = expression.Method;
+            var method = expression.Method;
             return IsMartenLinqExtension(method) ||
                    IsISetMethod(method);
         }

--- a/src/Marten/LinqExtensions.cs
+++ b/src/Marten/LinqExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Baseline;
@@ -16,8 +15,12 @@ namespace Marten
         /// <param name="variable"></param>
         /// <param name="matches"></param>
         /// <returns></returns>
+        /// <exception cref="NotSupportedException">when called for collection</exception>
         public static bool IsOneOf<T>(this T variable, params T[] matches)
         {
+            if (typeof(T).IsArray || typeof(T).IsGenericEnumerable())
+                throw new NotSupportedException("IsOneOf operator should not be used for collections. Use IsSubsetOf instead.");
+
             return matches.Contains(variable);
         }
 
@@ -40,8 +43,12 @@ namespace Marten
         /// <param name="variable"></param>
         /// <param name="matches"></param>
         /// <returns></returns>
+        /// <exception cref="NotSupportedException">when called for collection</exception>
         public static bool In<T>(this T variable, params T[] matches)
         {
+            if (typeof(T).IsArray || typeof(T).IsGenericEnumerable())
+                throw new NotSupportedException("In operator should not be used for collections. Use IsSubsetOf instead.");
+
             return matches.Contains(variable);
         }
 


### PR DESCRIPTION
@borgez, this is intentional; use `IsSubsetOf` instead. Because of how `params []` in C# work, it was possible to call `In` and `IsOneOf` for List or other generic collections. This is unintended usage. I restricted the `In` and `IsOneOf` LINQ operators to regular fields and added missing tests. 

Unfortunately, the compiler will still allow it, but we'll get at least more meaningful error information.

Fixes #2357.