### PR TITLE
Fixed bulk insert of documents with nullable value types (e.g. int?)

### DIFF
--- a/src/Marten/Internal/CodeGeneration/BulkLoader.cs
+++ b/src/Marten/Internal/CodeGeneration/BulkLoader.cs
@@ -19,7 +19,7 @@ namespace Marten.Internal.CodeGeneration
             _storage = storage;
         }
 
-        public object GetNullableGuid(Guid? value)
+        public object GetNullable<TValue>(TValue? value) where TValue: struct
         {
             return value.HasValue ? value.Value : DBNull.Value;
         }


### PR DESCRIPTION
It seems that we only supported `Guid` and `Enum`, ignoring the rest of the value types.

Fixes  #1668