### PR TITLE
QueryableExtensions.WriteSingle use optional argument onFoundStatus

### DIFF
--- a/src/IssueService/Controllers/IssueController.cs
+++ b/src/IssueService/Controllers/IssueController.cs
@@ -39,13 +39,17 @@ namespace IssueService.Controllers
         #region sample_write_single_document_by_id_to_httpresponse
 
         [HttpGet("/issue/{issueId}")]
-        public Task Get(Guid issueId, [FromServices] IQuerySession session)
+        public Task Get(Guid issueId, [FromServices] IQuerySession session, [FromQuery] string? sc = null)
         {
             // This "streams" the raw JSON to the HttpResponse
             // w/o ever having to read the full JSON string or
             // deserialize/serialize within the HTTP request
-            return session.Json
-                .WriteById<Issue>(issueId, HttpContext);
+            return sc is null
+                ? session.Json
+                    .WriteById<Issue>(issueId, HttpContext)
+                : session.Json
+                    .WriteById<Issue>(issueId, HttpContext, onFoundStatus: int.Parse(sc));
+
         }
 
         #endregion
@@ -53,10 +57,13 @@ namespace IssueService.Controllers
         #region sample_use_linq_to_write_single_document_to_httpcontext
 
         [HttpGet("/issue2/{issueId}")]
-        public Task Get2(Guid issueId, [FromServices] IQuerySession session)
+        public Task Get2(Guid issueId, [FromServices] IQuerySession session, [FromQuery] string? sc = null)
         {
-            return session.Query<Issue>().Where(x => x.Id == issueId)
-                .WriteSingle(HttpContext);
+            return sc is null
+                ? session.Query<Issue>().Where(x => x.Id == issueId)
+                    .WriteSingle(HttpContext)
+                : session.Query<Issue>().Where(x => x.Id == issueId)
+                    .WriteSingle(HttpContext, onFoundStatus: int.Parse(sc));
         }
 
         #endregion
@@ -64,10 +71,13 @@ namespace IssueService.Controllers
         #region sample_write_single_document_to_httpcontext_with_compiled_query
 
         [HttpGet("/issue3/{issueId}")]
-        public Task Get3(Guid issueId, [FromServices] IQuerySession session)
+        public Task Get3(Guid issueId, [FromServices] IQuerySession session, [FromQuery] string? sc = null)
         {
-            return session.Query<Issue>().Where(x => x.Id == issueId)
-                .WriteSingle(HttpContext);
+            return sc is null
+                ? session.Query<Issue>().Where(x => x.Id == issueId)
+                    .WriteSingle(HttpContext)
+                : session.Query<Issue>().Where(x => x.Id == issueId)
+                    .WriteSingle(HttpContext, onFoundStatus: int.Parse(sc));
         }
 
         #endregion
@@ -76,14 +86,16 @@ namespace IssueService.Controllers
         #region sample_writing_multiple_documents_to_httpcontext
 
         [HttpGet("/issue/open")]
-        public Task OpenIssues([FromServices] IQuerySession session)
+        public Task OpenIssues([FromServices] IQuerySession session, [FromQuery] string? sc = null)
         {
             // This "streams" the raw JSON to the HttpResponse
             // w/o ever having to read the full JSON string or
             // deserialize/serialize within the HTTP request
-            return session.Query<Issue>()
-                .Where(x => x.Open)
-                .WriteArray(HttpContext);
+            return sc is null
+                ? session.Query<Issue>().Where(x => x.Open)
+                    .WriteArray(HttpContext)
+                : session.Query<Issue>().Where(x => x.Open)
+                    .WriteArray(HttpContext, onFoundStatus: int.Parse(sc));
         }
 
         #endregion
@@ -91,9 +103,11 @@ namespace IssueService.Controllers
         #region sample_using_compiled_query_with_json_streaming
 
         [HttpGet("/issue2/open")]
-        public Task OpenIssues2([FromServices] IQuerySession session)
+        public Task OpenIssues2([FromServices] IQuerySession session, [FromQuery] string? sc = null)
         {
-            return session.WriteArray(new OpenIssues(), HttpContext);
+            return sc is null
+                ? session.WriteArray(new OpenIssues(), HttpContext)
+                : session.WriteArray(new OpenIssues(), HttpContext, onFoundStatus: int.Parse(sc));
         }
 
         #endregion

--- a/src/Marten.AspNetCore.Testing/web_service_streaming_tests.cs
+++ b/src/Marten.AspNetCore.Testing/web_service_streaming_tests.cs
@@ -42,8 +42,11 @@ public class web_service_streaming_tests : IClassFixture<AppFixture>
         theHost = fixture.Host;
     }
 
-    [Fact]
-    public async Task stream_a_single_document_hit()
+    [Theory]
+    [InlineData(null)]
+    [InlineData(200)]
+    [InlineData(201)]
+    public async Task stream_a_single_document_hit(int? onFoundStatus)
     {
         var issue = new Issue {Description = "It's bad", Open = true};
 
@@ -56,8 +59,13 @@ public class web_service_streaming_tests : IClassFixture<AppFixture>
 
         var result = await theHost.Scenario(s =>
         {
-            s.Get.Url($"/issue/{issue.Id}");
-            s.StatusCodeShouldBeOk();
+            var sendExpression = s.Get.Url($"/issue/{issue.Id}");
+            if (onFoundStatus.HasValue)
+            {
+                sendExpression.QueryString("sc", onFoundStatus.ToString());
+            }
+
+            s.StatusCodeShouldBe(onFoundStatus ?? 200);
             s.ContentTypeShouldBe("application/json");
         });
 
@@ -77,8 +85,11 @@ public class web_service_streaming_tests : IClassFixture<AppFixture>
     }
 
 
-    [Fact]
-    public async Task stream_a_single_document_hit_2()
+    [Theory]
+    [InlineData(null)]
+    [InlineData(200)]
+    [InlineData(201)]
+    public async Task stream_a_single_document_hit_2(int? onFoundStatus)
     {
         var issue = new Issue {Description = "It's bad", Open = true};
 
@@ -91,8 +102,13 @@ public class web_service_streaming_tests : IClassFixture<AppFixture>
 
         var result = await theHost.Scenario(s =>
         {
-            s.Get.Url($"/issue2/{issue.Id}");
-            s.StatusCodeShouldBeOk();
+            var sendExpression = s.Get.Url($"/issue2/{issue.Id}");
+            if (onFoundStatus.HasValue)
+            {
+                sendExpression.QueryString("sc", onFoundStatus.ToString());
+            }
+
+            s.StatusCodeShouldBe(onFoundStatus ?? 200);
             s.ContentTypeShouldBe("application/json");
         });
 
@@ -111,8 +127,11 @@ public class web_service_streaming_tests : IClassFixture<AppFixture>
         });
     }
 
-    [Fact]
-    public async Task stream_an_array_of_documents()
+    [Theory]
+    [InlineData(null)]
+    [InlineData(200)]
+    [InlineData(201)]            
+    public async Task stream_an_array_of_documents(int? onFoundStatus)
     {
         var store = theHost.Services.GetRequiredService<IDocumentStore>();
         await store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Issue));
@@ -127,8 +146,13 @@ public class web_service_streaming_tests : IClassFixture<AppFixture>
 
         var result = await theHost.Scenario(s =>
         {
-            s.Get.Url("/issue/open");
-            s.StatusCodeShouldBeOk();
+            var sendExpression = s.Get.Url("/issue/open");
+            if (onFoundStatus.HasValue)
+            {
+                sendExpression.QueryString("sc", onFoundStatus.ToString());
+            }
+
+            s.StatusCodeShouldBe(onFoundStatus ?? 200);
             s.ContentTypeShouldBe("application/json");
 
         });
@@ -138,8 +162,11 @@ public class web_service_streaming_tests : IClassFixture<AppFixture>
     }
 
 
-    [Fact]
-    public async Task stream_a_single_document_hit_with_compiled_query()
+    [Theory]
+    [InlineData(null)]
+    [InlineData(200)]
+    [InlineData(201)]
+    public async Task stream_a_single_document_hit_with_compiled_query(int? onFoundStatus)
     {
         var issue = new Issue {Description = "It's bad", Open = true};
 
@@ -152,8 +179,13 @@ public class web_service_streaming_tests : IClassFixture<AppFixture>
 
         var result = await theHost.Scenario(s =>
         {
-            s.Get.Url($"/issue3/{issue.Id}");
-            s.StatusCodeShouldBeOk();
+            var sendExpression = s.Get.Url($"/issue3/{issue.Id}");
+            if (onFoundStatus.HasValue)
+            {
+                sendExpression.QueryString("sc", onFoundStatus.ToString());
+            }
+
+            s.StatusCodeShouldBe(onFoundStatus ?? 200);
             s.ContentTypeShouldBe("application/json");
         });
 
@@ -172,8 +204,11 @@ public class web_service_streaming_tests : IClassFixture<AppFixture>
         });
     }
 
-    [Fact]
-    public async Task stream_an_array_of_documents_with_compiled_query()
+    [Theory]
+    [InlineData(null)]
+    [InlineData(200)]
+    [InlineData(201)]
+    public async Task stream_an_array_of_documents_with_compiled_query(int? onFoundStatus)
     {
         var store = theHost.Services.GetRequiredService<IDocumentStore>();
         await store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Issue));
@@ -188,8 +223,13 @@ public class web_service_streaming_tests : IClassFixture<AppFixture>
 
         var result = await theHost.Scenario(s =>
         {
-            s.Get.Url("/issue2/open");
-            s.StatusCodeShouldBeOk();
+            var sendExpression = s.Get.Url("/issue2/open");
+            if (onFoundStatus.HasValue)
+            {
+                sendExpression.QueryString("sc", onFoundStatus.ToString());
+            }
+
+            s.StatusCodeShouldBe(onFoundStatus ?? 200);
             s.ContentTypeShouldBe("application/json");
 
         });

--- a/src/Marten.AspNetCore/QueryableExtensions.cs
+++ b/src/Marten.AspNetCore/QueryableExtensions.cs
@@ -18,7 +18,8 @@ public static class QueryableExtensions
     /// <param name="contentType"></param>
     /// <param name="onFoundStatus">Defaults to 200</param>
     /// <typeparam name="T"></typeparam>
-    public static async Task WriteSingle<T>(this IQueryable<T> queryable, HttpContext context, string contentType = "application/json", int onFoundStatus = 200)
+    public static async Task WriteSingle<T>(this IQueryable<T> queryable, HttpContext context,
+        string contentType = "application/json", int onFoundStatus = 200)
     {
         var stream = new MemoryStream();
         var found = await queryable.StreamJsonFirstOrDefault(stream, context.RequestAborted).ConfigureAwait(false);
@@ -45,14 +46,15 @@ public static class QueryableExtensions
     /// <param name="queryable"></param>
     /// <param name="context"></param>
     /// <param name="contentType"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
     /// <typeparam name="T"></typeparam>
     public static async Task WriteArray<T>(this IQueryable<T> queryable, HttpContext context,
-        string contentType = "application/json")
+        string contentType = "application/json", int onFoundStatus = 200)
     {
         var stream = new MemoryStream();
         await queryable.StreamJsonArray(stream, context.RequestAborted).ConfigureAwait(false);
 
-        context.Response.StatusCode = 200;
+        context.Response.StatusCode = onFoundStatus;
         context.Response.ContentLength = stream.Length;
         context.Response.ContentType = contentType;
 
@@ -67,14 +69,16 @@ public static class QueryableExtensions
     /// <param name="id"></param>
     /// <param name="context"></param>
     /// <param name="contentType"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
     /// <typeparam name="T"></typeparam>
-    public static async Task WriteById<T>(this IJsonLoader json, string id, HttpContext context, string contentType = "application/json") where T : class
+    public static async Task WriteById<T>(this IJsonLoader json, string id, HttpContext context,
+        string contentType = "application/json", int onFoundStatus = 200) where T : class
     {
         var stream = new MemoryStream();
         var found = await json.StreamById<T>(id, stream).ConfigureAwait(false);
         if (found)
         {
-            context.Response.StatusCode = 200;
+            context.Response.StatusCode = onFoundStatus;
             context.Response.ContentLength = stream.Length;
             context.Response.ContentType = contentType;
 
@@ -95,14 +99,16 @@ public static class QueryableExtensions
     /// <param name="id"></param>
     /// <param name="context"></param>
     /// <param name="contentType"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
     /// <typeparam name="T"></typeparam>
-    public static async Task WriteById<T>(this IJsonLoader json, Guid id, HttpContext context, string contentType = "application/json") where T : class
+    public static async Task WriteById<T>(this IJsonLoader json, Guid id, HttpContext context,
+        string contentType = "application/json", int onFoundStatus = 200) where T : class
     {
         var stream = new MemoryStream();
         var found = await json.StreamById<T>(id, stream).ConfigureAwait(false);
         if (found)
         {
-            context.Response.StatusCode = 200;
+            context.Response.StatusCode = onFoundStatus;
             context.Response.ContentLength = stream.Length;
             context.Response.ContentType = contentType;
 
@@ -123,14 +129,16 @@ public static class QueryableExtensions
     /// <param name="id"></param>
     /// <param name="context"></param>
     /// <param name="contentType"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
     /// <typeparam name="T"></typeparam>
-    public static async Task WriteById<T>(this IJsonLoader json, int id, HttpContext context, string contentType = "application/json") where T : class
+    public static async Task WriteById<T>(this IJsonLoader json, int id, HttpContext context,
+        string contentType = "application/json", int onFoundStatus = 200) where T : class
     {
         var stream = new MemoryStream();
         var found = await json.StreamById<T>(id, stream).ConfigureAwait(false);
         if (found)
         {
-            context.Response.StatusCode = 200;
+            context.Response.StatusCode = onFoundStatus;
             context.Response.ContentLength = stream.Length;
             context.Response.ContentType = contentType;
 
@@ -151,14 +159,16 @@ public static class QueryableExtensions
     /// <param name="id"></param>
     /// <param name="context"></param>
     /// <param name="contentType"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
     /// <typeparam name="T"></typeparam>
-    public static async Task WriteById<T>(this IJsonLoader json, long id, HttpContext context, string contentType = "application/json") where T : class
+    public static async Task WriteById<T>(this IJsonLoader json, long id, HttpContext context,
+        string contentType = "application/json", int onFoundStatus = 200) where T : class
     {
         var stream = new MemoryStream();
         var found = await json.StreamById<T>(id, stream).ConfigureAwait(false);
         if (found)
         {
-            context.Response.StatusCode = 200;
+            context.Response.StatusCode = onFoundStatus;
             context.Response.ContentLength = stream.Length;
             context.Response.ContentType = contentType;
 
@@ -180,15 +190,17 @@ public static class QueryableExtensions
     /// <param name="query"></param>
     /// <param name="context"></param>
     /// <param name="contentType"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
     /// <typeparam name="TDoc"></typeparam>
     /// <typeparam name="TOut"></typeparam>
-    public static async Task WriteOne<TDoc, TOut>(this IQuerySession session, ICompiledQuery<TDoc, TOut> query, HttpContext context, string contentType = "application/json")
+    public static async Task WriteOne<TDoc, TOut>(this IQuerySession session, ICompiledQuery<TDoc, TOut> query, HttpContext context,
+        string contentType = "application/json", int onFoundStatus = 200)
     {
         var stream = new MemoryStream();
         var found = await session.StreamJsonOne(query, stream, context.RequestAborted).ConfigureAwait(false);
         if (found)
         {
-            context.Response.StatusCode = 200;
+            context.Response.StatusCode = onFoundStatus;
             context.Response.ContentLength = stream.Length;
             context.Response.ContentType = contentType;
 
@@ -210,14 +222,16 @@ public static class QueryableExtensions
     /// <param name="query"></param>
     /// <param name="context"></param>
     /// <param name="contentType"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
     /// <typeparam name="TDoc"></typeparam>
     /// <typeparam name="TOut"></typeparam>
-    public static async Task WriteArray<TDoc, TOut>(this IQuerySession session, ICompiledQuery<TDoc, TOut> query, HttpContext context, string contentType = "application/json")
+    public static async Task WriteArray<TDoc, TOut>(this IQuerySession session, ICompiledQuery<TDoc, TOut> query, HttpContext context,
+        string contentType = "application/json", int onFoundStatus = 200)
     {
         var stream = new MemoryStream();
         await session.StreamJsonMany(query, stream, context.RequestAborted).ConfigureAwait(false);
 
-        context.Response.StatusCode = 200;
+        context.Response.StatusCode = onFoundStatus;
         context.Response.ContentLength = stream.Length;
         context.Response.ContentType = contentType;
 

--- a/src/Marten.AspNetCore/QueryableExtensions.cs
+++ b/src/Marten.AspNetCore/QueryableExtensions.cs
@@ -10,13 +10,13 @@ namespace Marten.AspNetCore;
 public static class QueryableExtensions
 {
     /// <summary>
-    /// Write the JSON contents of a single document response from the Linq query to the HttpContext response, with status code 200 if found or
+    /// Write the JSON contents of a single document response from the Linq query to the HttpContext response, with status code <paramref name="onFoundStatus"/> if found or
     /// 404 if not found
     /// </summary>
     /// <param name="queryable"></param>
     /// <param name="context"></param>
     /// <param name="contentType"></param>
-    /// <param name="onFoundStatus"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
     /// <typeparam name="T"></typeparam>
     public static async Task WriteSingle<T>(this IQueryable<T> queryable, HttpContext context, string contentType = "application/json", int onFoundStatus = 200)
     {
@@ -25,7 +25,7 @@ public static class QueryableExtensions
 
         if (found)
         {
-            context.Response.StatusCode = 200;
+            context.Response.StatusCode = onFoundStatus;
             context.Response.ContentLength = stream.Length;
             context.Response.ContentType = contentType;
 


### PR DESCRIPTION
The optional argument wasn't used before. This change sets the response statuscode to the given value.

Or should this argument be dropped? It's not available on the other methods, but that would be a breaking change.