### PR TITLE
Fix transformation for unique contraint on events

### DIFF
--- a/src/EventSourcingTests/EventStreamUnexpectedMaxEventIdExceptionTransformTest.cs
+++ b/src/EventSourcingTests/EventStreamUnexpectedMaxEventIdExceptionTransformTest.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten.Exceptions;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests;
+
+public class EventStreamUnexpectedMaxEventIdExceptionTransformTest: IntegrationContext
+{
+    public EventStreamUnexpectedMaxEventIdExceptionTransformTest(DefaultStoreFixture fixture):
+        base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task throw_transformed_exception_with_details_redacted()
+    {
+        var streamId = Guid.NewGuid();
+        var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+        var departed = new MembersDeparted { Members = new[] { "Thom" } };
+        theSession.Events.StartStream<Quest>(streamId, joined);
+        theSession.Events.Append(streamId, departed);
+        await theSession.SaveChangesAsync();
+
+        var forceEventStreamUnexpectedMaxEventIdException = async () =>
+        {
+            await Parallel.ForEachAsync(Enumerable.Range(1, 5), async (_, token) =>
+            {
+                await using var session = theStore.OpenSession();
+                session.Events.Append(streamId, departed);
+                await session.SaveChangesAsync(token);
+            });
+        };
+
+        Should.Throw<EventStreamUnexpectedMaxEventIdException>(forceEventStreamUnexpectedMaxEventIdException)
+            .Message.ShouldBe("duplicate key value violates unique constraint \"pk_mt_events_stream_and_version\"");
+    }
+
+    [Fact]
+    public async Task throw_transformed_exception_with_details_available()
+    {
+        var connectionString = ConnectionSource.ConnectionString + ";Include Error Detail=true";
+        StoreOptions(storeOptions => storeOptions.Connection(connectionString));
+
+        var streamId = Guid.NewGuid();
+        var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
+        var departed = new MembersDeparted { Members = new[] { "Thom" } };
+        theSession.Events.StartStream<Quest>(streamId, joined);
+        theSession.Events.Append(streamId, departed);
+        await theSession.SaveChangesAsync();
+
+        var forceEventStreamUnexpectedMaxEventIdException = async () =>
+        {
+            await Parallel.ForEachAsync(Enumerable.Range(1, 5), async (_, token) =>
+            {
+                await using var session = theStore.OpenSession();
+                session.Events.Append(streamId, departed);
+                await session.SaveChangesAsync(token);
+            });
+        };
+
+        Should.Throw<EventStreamUnexpectedMaxEventIdException>(forceEventStreamUnexpectedMaxEventIdException)
+            .Message.ShouldBe($"Unexpected starting version number for event stream '{streamId}', expected 2 but was 3");
+    }
+}

--- a/src/Marten/Exceptions/EventStreamUnexpectedMaxEventIdException.cs
+++ b/src/Marten/Exceptions/EventStreamUnexpectedMaxEventIdException.cs
@@ -18,5 +18,9 @@ public class EventStreamUnexpectedMaxEventIdException: ConcurrencyException
     {
     }
 
+    public EventStreamUnexpectedMaxEventIdException(string message) : base(message, null, null)
+    {
+    }
+
     public Type AggregateType { get; }
 }

--- a/src/Marten/Services/EventStreamUnexpectedMaxEventIdExceptionTransform.cs
+++ b/src/Marten/Services/EventStreamUnexpectedMaxEventIdExceptionTransform.cs
@@ -11,8 +11,8 @@ internal class EventStreamUnexpectedMaxEventIdExceptionTransform: IExceptionTran
     private const string ExpectedMessage =
         "duplicate key value violates unique constraint \"pk_mt_events_stream_and_version\"";
 
-    private const string StreamId = "<streamid>";
-    private const string Version = "<version>";
+    private const string StreamId = "streamid";
+    private const string Version = "version";
 
     [Obsolete("let's get rid of this")]
     public static readonly EventStreamUnexpectedMaxEventIdExceptionTransform Instance = new();
@@ -28,7 +28,7 @@ internal class EventStreamUnexpectedMaxEventIdExceptionTransform: IExceptionTran
             return false;
         }
 
-        var postgresException = (PostgresException)original.InnerException;
+        var postgresException = original as PostgresException;
 
         object id = null;
         Type aggregateType = null;
@@ -64,8 +64,8 @@ internal class EventStreamUnexpectedMaxEventIdExceptionTransform: IExceptionTran
 
     private static bool Matches(Exception e)
     {
-        return e?.InnerException is PostgresException pe
-               && pe.SqlState == PostgresErrorCodes.UniqueViolation
-               && pe.Message.Contains(ExpectedMessage);
+        return e is PostgresException pe
+            && pe.SqlState == PostgresErrorCodes.UniqueViolation
+            && pe.Message.Contains(ExpectedMessage);
     }
 }


### PR DESCRIPTION
A previous update to Npgsql (my best guess 😇) broke the exception transformer for optimistic concurrency errors on events.

As also noted [here](https://github.com/JasperFx/marten/pull/1500), test for this transform is a bit tricky but I haven't had any issues with these tests local but a couple of spins in the pipeline should show any improprieties 🤞 