### PR TITLE
Add migration note about PLV8 removal

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -31,6 +31,11 @@ Other key, breaking changes:
 * If an application bootstraps Marten through the `IServiceCollection.AddMarten()` extension methods, the default logging in Marten is through the standard
   `ILogger` of the application
 * In order to support more LINQ query permutations, LINQ queries are temporarily not using the GIN indexable operators on documents that have `GinIndexJsonData()` set. Support for this can be tracked [here](https://github.com/JasperFx/marten/issues/2051)
+* PLV8 support is disabled by default and moved to a separate package.
+If an application was setting `StoreOptions.PLV8Enabled = false` to disable PLV8,
+that line should be removed as the setting no longer exists. If an application
+had `StoreOptions.PLV8Enabled = true` and was using PLV8, you will need to add
+the [Marten.PLv8 package](/documents/plv8).
 
 ## Key Changes in 3.0.0
 

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -28,10 +28,6 @@ var store = DocumentStore.For(storeOptions =>
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/CamelCasing.cs#L11-L16' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sample-serialize-to-camelcase' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-## Disable PLV8
-
-If you don't want PLV8 (required for JavaScript transformations) related items in your database schema, you can disable PLV8 altogether by setting `StoreOptions.PLV8Enabled` to false.
-
 ## More diagnostics data outside of Marten
 
 If you cannot obtain the desired diagnostic data through Marten's [diagnostics](/diagnostics), consider using the [Npgsql logging facilities](https://www.npgsql.org/doc/logging.html), by hooking into `NpgsqlLogManager.Provider`, or by using the [performance counters exposed by Npgsql](https://www.npgsql.org/doc/performance.html).


### PR DESCRIPTION
The PLV8Enabled option no longer exists as of https://github.com/JasperFx/marten/issues/1812, so the mention in the FAQ is confusing.

Add a note to the migration guide to direct people to the separate nuget package.