### PR TITLE
Added note to docs about parameter casting

### DIFF
--- a/docs/documents/execute-custom-sql.md
+++ b/docs/documents/execute-custom-sql.md
@@ -1,6 +1,8 @@
 # Execute custom SQL in session
 
-Use `QueueSqlCommand(string sql, params object[] parameterValues)`  method to register and execute any custom/arbitrary SQL commands with the underlying unit of work, as part of the batched commands within `IDocumentSession`. "?" placeholders can be used to denote parameter values.
+Use `QueueSqlCommand(string sql, params object[] parameterValues)` method to register and execute any custom/arbitrary SQL commands with the underlying unit of work, as part of the batched commands within `IDocumentSession`. 
+
+`?` placeholders can be used to denote parameter values. Postgres [type casts `::`](https://www.postgresql.org/docs/15/sql-expressions.html#SQL-SYNTAX-TYPE-CASTS) can applied to the parameter if needed.
 
 <!-- snippet: sample_QueueSqlCommand -->
 <a id='snippet-sample_queuesqlcommand'></a>
@@ -10,6 +12,8 @@ theSession.QueueSqlCommand("insert into names (name) values ('Babu')");
 theSession.Store(Target.Random());
 theSession.QueueSqlCommand("insert into names (name) values ('Oskar')");
 theSession.Store(Target.Random());
+var json = "{ \"answer\": 42 }";
+theSession.QueueSqlCommand("insert into data (raw_value) values (?::jsonb)", json);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/executing_arbitrary_sql_as_part_of_transaction.cs#L34-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_queuesqlcommand' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/executing_arbitrary_sql_as_part_of_transaction.cs#L39-L47' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_queuesqlcommand' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/documents/execute-custom-sql.md
+++ b/docs/documents/execute-custom-sql.md
@@ -2,7 +2,7 @@
 
 Use `QueueSqlCommand(string sql, params object[] parameterValues)` method to register and execute any custom/arbitrary SQL commands with the underlying unit of work, as part of the batched commands within `IDocumentSession`. 
 
-`?` placeholders can be used to denote parameter values. Postgres [type casts `::`](https://www.postgresql.org/docs/15/sql-expressions.html#SQL-SYNTAX-TYPE-CASTS) can applied to the parameter if needed.
+`?` placeholders can be used to denote parameter values. Postgres [type casts `::`](https://www.postgresql.org/docs/15/sql-expressions.html#SQL-SYNTAX-TYPE-CASTS) can be applied to the parameter if needed.
 
 <!-- snippet: sample_QueueSqlCommand -->
 <a id='snippet-sample_queuesqlcommand'></a>

--- a/src/CoreTests/executing_arbitrary_sql_as_part_of_transaction.cs
+++ b/src/CoreTests/executing_arbitrary_sql_as_part_of_transaction.cs
@@ -27,6 +27,11 @@ public class executing_arbitrary_sql_as_part_of_transaction : OneOffConfiguratio
             table.AddColumn<string>("name").AsPrimaryKey();
 
             opts.Storage.ExtendedSchemaObjects.Add(table);
+
+            table = new Table("data");
+            table.AddColumn("raw_value", "jsonb");
+
+            opts.Storage.ExtendedSchemaObjects.Add(table);
         });
 
         await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
@@ -37,6 +42,8 @@ public class executing_arbitrary_sql_as_part_of_transaction : OneOffConfiguratio
         theSession.Store(Target.Random());
         theSession.QueueSqlCommand("insert into names (name) values ('Oskar')");
         theSession.Store(Target.Random());
+        var json = "{ \"answer\": 42 }";
+        theSession.QueueSqlCommand("insert into data (raw_value) values (?::jsonb)", json);
         #endregion
 
         await theSession.SaveChangesAsync();


### PR DESCRIPTION
This PR adds a note about parameter casting to [Execute custom SQL in session](https://martendb.io/documents/execute-custom-sql.html).

Closes https://github.com/JasperFx/marten/issues/2422
See https://github.com/JasperFx/marten/issues/2422#issuecomment-1345342217

