### PR TITLE
Fix RebuildProjection<TView> shardTimeout param passing

### DIFF
--- a/src/Marten/Events/Daemon/ProjectionDaemon.cs
+++ b/src/Marten/Events/Daemon/ProjectionDaemon.cs
@@ -224,7 +224,7 @@ internal class ProjectionDaemon: IProjectionDaemon
         if (typeof(TView).CanBeCastTo(typeof(ProjectionBase)) && typeof(TView).HasDefaultConstructor())
         {
             var projection = (ProjectionBase)Activator.CreateInstance(typeof(TView))!;
-            return RebuildProjection(projection.ProjectionName, token);
+            return RebuildProjection(projection.ProjectionName, shardTimeout, token);
         }
 
         return RebuildProjection(typeof(TView).Name, shardTimeout, token);


### PR DESCRIPTION
Hello everyone,

when calling RebuildProjection<TView> shardTimeout is not passed in the subroutine in the case of
`typeof(TView).CanBeCastTo(typeof(ProjectionBase)) && typeof(TView).HasDefaultConstructor()`
and defaults always to 5.Minutes().

best regards