### PR TITLE
Fix side effect on postprocessUpdateAsync

### DIFF
--- a/src/Marten/Internal/Operations/StorageOperation.cs
+++ b/src/Marten/Internal/Operations/StorageOperation.cs
@@ -118,15 +118,7 @@ public abstract class StorageOperation<T, TId>: IDocumentStorageOperation, IExce
     protected async Task postprocessUpdateAsync(DbDataReader reader, IList<Exception> exceptions,
         CancellationToken token)
     {
-        if (!await reader.ReadAsync(token).ConfigureAwait(false))
-        {
-            exceptions.Add(new NonExistentDocumentException(typeof(T), _id));
-        }
-
-        ;
-
-        var isNull = await reader.IsDBNullAsync(0, token).ConfigureAwait(false);
-        if (isNull)
+        if (!await reader.ReadAsync(token).ConfigureAwait(false) || await reader.IsDBNullAsync(0, token).ConfigureAwait(false))
         {
             exceptions.Add(new NonExistentDocumentException(typeof(T), _id));
         }


### PR DESCRIPTION
Hello everyone,

I have not digged to deep into the issue but i observe an error when rebuilding the projection. I ran into the issue where i got an exception from postprocessUpdateAsync while trying to execute
`await reader.IsDBNullAsync(0, token).ConfigureAwait(false)`
after
`!await reader.ReadAsync(token).ConfigureAwait(false)`

since there is no data so IsDBNullAsync throw an exception. When compared to the non async method postprocessUpdate all is written in one line with conditional or operator ||. For me it looks like it should behave the same. What do you think?

best regards