### PR TITLE
Fix a compatibility issue with .NET 7 and Marten 3.x

### DIFF
--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -61,7 +61,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[2.0.0, 7.0.0)" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[2.0.0, 8.0.0)" />
     </ItemGroup>
 
 


### PR DESCRIPTION
Basically same thing as last time: https://github.com/JasperFx/marten/pull/2217

I understand you might be reluctant to publish this on such an old branch, but i thought i would give it a shot anyway.

As also stated last time, we have a lot of microservices and it is no easy task to migrate from v3 to v5. We have been migrating alot of our services since last time, but it is no small undertaking for us to convert every single one, we simply need more time.