### PR TITLE
Add index for nullable `LocalDate`

### DIFF
--- a/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
+++ b/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
@@ -122,6 +122,8 @@ public class noda_time_acceptance: OneOffConfigurationsContext
             _.UseDefaultSerialization(serializerType: serializerType);
             _.UseNodaTime();
             _.DatabaseSchemaName = "NodaTime";
+            _.Schema.For<TargetWithDates>()
+                .Duplicate(x => x.NullableLocalDate);
         }, true);
 
         theStore.Advanced.Clean.CompletelyRemoveAll();

--- a/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
+++ b/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.NodaTime.Testing.TestData;
+using Marten.NodaTimeExtensions.Testing.TestData;
 using Marten.Services.Json;
 using Marten.Testing.Harness;
 using NodaTime;
@@ -13,7 +13,7 @@ using Shouldly;
 using Weasel.Core;
 using Xunit;
 
-namespace Marten.NodaTime.Testing.Acceptance;
+namespace Marten.NodaTimeExtensions.Testing.Acceptance;
 
 public class MonsterSlayed
 {

--- a/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
+++ b/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.NodaTimeExtensions.Testing.TestData;
+using Marten.NodaTimePlugin.Testing.TestData;
 using Marten.Services.Json;
 using Marten.Testing.Harness;
 using NodaTime;
@@ -13,7 +13,7 @@ using Shouldly;
 using Weasel.Core;
 using Xunit;
 
-namespace Marten.NodaTimeExtensions.Testing.Acceptance;
+namespace Marten.NodaTimePlugin.Testing.Acceptance;
 
 public class MonsterSlayed
 {

--- a/src/Marten.NodaTime.Testing/Bug_2307_JObject_in_dictionary_duplicated_field.cs
+++ b/src/Marten.NodaTime.Testing/Bug_2307_JObject_in_dictionary_duplicated_field.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten;
-using Marten.NodaTimeExtensions;
+using Marten.NodaTimePlugin;
 using Marten.Testing.Harness;
 using Newtonsoft.Json.Linq;
 using NodaTime;

--- a/src/Marten.NodaTime.Testing/Bug_2307_JObject_in_dictionary_duplicated_field.cs
+++ b/src/Marten.NodaTime.Testing/Bug_2307_JObject_in_dictionary_duplicated_field.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten;
-using Marten.NodaTime;
+using Marten.NodaTimeExtensions;
 using Marten.Testing.Harness;
 using Newtonsoft.Json.Linq;
 using NodaTime;

--- a/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
+++ b/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-        <RootNamespace>Marten.NodaTimeExtensions.Testing</RootNamespace>
+        <RootNamespace>Marten.NodaTimePlugin.Testing</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
+++ b/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <RootNamespace>Marten.NodaTimeExtensions.Testing</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Marten.NodaTime.Testing/TestData/TargetWithDates.cs
+++ b/src/Marten.NodaTime.Testing/TestData/TargetWithDates.cs
@@ -1,7 +1,7 @@
 using System;
 using NodaTime;
 
-namespace Marten.NodaTimeExtensions.Testing.TestData;
+namespace Marten.NodaTimePlugin.Testing.TestData;
 
 public class TargetWithDates: IEquatable<TargetWithDates>
 {

--- a/src/Marten.NodaTime.Testing/TestData/TargetWithDates.cs
+++ b/src/Marten.NodaTime.Testing/TestData/TargetWithDates.cs
@@ -1,7 +1,7 @@
 using System;
 using NodaTime;
 
-namespace Marten.NodaTime.Testing.TestData;
+namespace Marten.NodaTimeExtensions.Testing.TestData;
 
 public class TargetWithDates: IEquatable<TargetWithDates>
 {

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -12,6 +12,7 @@
         <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <nullable>enable</nullable>
+        <RootNamespace>Marten.NodaTimeExtensions</RootNamespace>
     </PropertyGroup>
 
     <!--SourceLink specific settings-->

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -12,7 +12,7 @@
         <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <nullable>enable</nullable>
-        <RootNamespace>Marten.NodaTimeExtensions</RootNamespace>
+        <RootNamespace>Marten.NodaTimePlugin</RootNamespace>
     </PropertyGroup>
 
     <!--SourceLink specific settings-->

--- a/src/Marten.NodaTime/NodaTimeExtensions.cs
+++ b/src/Marten.NodaTime/NodaTimeExtensions.cs
@@ -8,7 +8,7 @@ using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 
-namespace Marten.NodaTimeExtensions;
+namespace Marten.NodaTimePlugin;
 
 public static class NodaTimeExtensions
 {

--- a/src/Marten.NodaTime/NodaTimeExtensions.cs
+++ b/src/Marten.NodaTime/NodaTimeExtensions.cs
@@ -8,7 +8,7 @@ using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 
-namespace Marten.NodaTime;
+namespace Marten.NodaTimeExtensions;
 
 public static class NodaTimeExtensions
 {


### PR DESCRIPTION
Creating an index on a nullable nodatime type fails when generating types with the following:

```
System.InvalidOperationException
Compilation failures!
CS0234: The type or namespace name 'LocalDate' does not exist in the namespace 'Marten.NodaTime' (are you missing an assembly reference?)
CS1503: Argument 1: cannot convert from 'NodaTime.LocalDate?' to 'Marten.NodaTime.LocalDate?'
```

The problem started in 5.11 after this commit https://github.com/JasperFx/marten/commit/61483008e1ab04c14f9e9baafae93c43cd4767da

Problematic Diff in generated document `GetNullable<NodaTime.LocalDate>`:

**Before 5.11**
```
public override void LoadRow(Npgsql.NpgsqlBinaryImporter writer, Dinero.Voucher.Aggregates.VoucherAggregate document, Marten.Storage.Tenant tenant, Marten.ISerializer serializer)
        {
            writer.Write(document.LatestReminderDate, NpgsqlTypes.NpgsqlDbType.Date);
            writer.Write(document.GetType().FullName, NpgsqlTypes.NpgsqlDbType.Varchar);
            writer.Write(document.Id, NpgsqlTypes.NpgsqlDbType.Uuid);
            writer.Write(Marten.Schema.Identity.CombGuidIdGeneration.NewGuid(), NpgsqlTypes.NpgsqlDbType.Uuid);
            writer.Write(serializer.ToJson(document), NpgsqlTypes.NpgsqlDbType.Jsonb);
        }
```
 
**After 5.11**
```
public override void LoadRow(Npgsql.NpgsqlBinaryImporter writer, Dinero.Voucher.Aggregates.VoucherAggregate document, Marten.Storage.Tenant tenant, Marten.ISerializer serializer)
        {
            writer.Write(GetNullable<NodaTime.LocalDate>(document.LatestReminderDate), NpgsqlTypes.NpgsqlDbType.Date);
            writer.Write(document.GetType().FullName, NpgsqlTypes.NpgsqlDbType.Varchar);
            writer.Write(document.Id, NpgsqlTypes.NpgsqlDbType.Uuid);
            writer.Write(Marten.Schema.Identity.CombGuidIdGeneration.NewGuid(), NpgsqlTypes.NpgsqlDbType.Uuid);
            writer.Write(serializer.ToJson(document), NpgsqlTypes.NpgsqlDbType.Jsonb);
        }
```
