### PR TITLE
Hot cold coordinator: Don't stop polling on errors.

### DIFF
--- a/src/Marten/Events/Daemon/HotColdCoordinator.cs
+++ b/src/Marten/Events/Daemon/HotColdCoordinator.cs
@@ -148,7 +148,6 @@ internal class HotColdCoordinator: INodeCoordinator, ISingleQueryRunner, IDispos
 
             _logger.LogError(e, "Error trying to attain the async daemon lock for database {Database}",
                 _database.Identifier);
-            return false;
         }
 
         if (gotLock)


### PR DESCRIPTION
If an error occurs during polling for ownership, the daemon will just idle. This change will ensure the coordinator keeps polling for ownership on errors.

The errors we see is transient errors like `System.IO.EndOfStreamException: Attempted to read past the end of the stream.` , but I think it makes sense to keep polling on all kind of errors. 