### PR TITLE
Fix multithreading issues in Patching API

### DIFF
--- a/src/Marten.PLv8.Testing/Patching/Bug_1173_patch_typenamehandling_bug.cs
+++ b/src/Marten.PLv8.Testing/Patching/Bug_1173_patch_typenamehandling_bug.cs
@@ -23,53 +23,49 @@ public class Bug_1173_patch_typenamehandling_bug: BugIntegrationContext
     [Fact]
     public void can_support_typenamehandling()
     {
-        using (var store = SeparateStore(_ =>
-               {
-                   var serializer = new JsonNetSerializer();
-                   serializer.Customize(config =>
-                   {
-                       config.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Objects;
-                   });
-                   _.Serializer(serializer);
-                   _.AutoCreateSchemaObjects = AutoCreate.All;
-
-                   _.UseJavascriptTransformsAndPatching();
-               }))
+        using var store = SeparateStore(_ =>
         {
-            using (var session = store.OpenSession())
+            var serializer = new JsonNetSerializer();
+            serializer.Customize(config =>
             {
-                var obj = new PatchTypeA
-                {
-                    Id = "1",
-                    TypeB =
-                        new PatchTypeB
-                        {
-                            Name = "test"
-                        }
-                };
+                config.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Objects;
+            });
+            _.Serializer(serializer);
+            _.AutoCreateSchemaObjects = AutoCreate.All;
 
-                session.Store(obj);
-                session.SaveChanges();
-            }
-            using (var session = store.OpenSession())
+            _.UseJavascriptTransformsAndPatching();
+        });
+        using (var session = store.OpenSession())
+        {
+            var obj = new PatchTypeA
             {
-                var newObj = new PatchTypeB
-                {
-                    Name = "test2"
-                };
+                Id = "1",
+                TypeB =
+                    new PatchTypeB
+                    {
+                        Name = "test"
+                    }
+            };
 
-                session.Patch<PatchTypeA>("1").Set(set => set.TypeB, newObj);
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession())
+            session.Store(obj);
+            session.SaveChanges();
+        }
+        using (var session = store.OpenSession())
+        {
+            var newObj = new PatchTypeB
             {
-                var result = session.Json.FindById<PatchTypeA>("1");
-                var expected = "{\"Id\": \"1\", \"$type\": \"Marten.PLv8.Testing.Patching.PatchTypeA, Marten.PLv8.Testing\", \"TypeB\": {\"Name\": \"test2\", \"$type\": \"Marten.PLv8.Testing.Patching.PatchTypeB, Marten.PLv8.Testing\"}}";
-                Assert.Equal(expected, result);
-            }
+                Name = "test2"
+            };
+
+            session.Patch<PatchTypeA>("1").Set(set => set.TypeB, newObj);
+            session.SaveChanges();
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var result = session.Json.FindById<PatchTypeA>("1");
+            var expected = "{\"Id\": \"1\", \"$type\": \"Marten.PLv8.Testing.Patching.PatchTypeA, Marten.PLv8.Testing\", \"TypeB\": {\"Name\": \"test2\", \"$type\": \"Marten.PLv8.Testing.Patching.PatchTypeB, Marten.PLv8.Testing\"}}";
+            Assert.Equal(expected, result);
         }
     }
-
-
 }

--- a/src/Marten.PLv8.Testing/Patching/Bug_2460_parallel_patching.cs
+++ b/src/Marten.PLv8.Testing/Patching/Bug_2460_parallel_patching.cs
@@ -11,7 +11,7 @@ namespace Marten.PLv8.Testing.Patching;
 
 public class Bug_2460_parallel_patching: BugIntegrationContext
 {
-    private const int itemsCount = 1000;
+    private const int itemsCount = 100;
     private const int patchedNumber = 1337;
 
     [Fact]

--- a/src/Marten.PLv8.Testing/Patching/Bug_2460_parallel_patching.cs
+++ b/src/Marten.PLv8.Testing/Patching/Bug_2460_parallel_patching.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten.PLv8.Patching;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace Marten.PLv8.Testing.Patching;
+
+public class Bug_2460_parallel_patching: BugIntegrationContext
+{
+    private const int itemsCount = 1000;
+    private const int patchedNumber = 1337;
+
+    [Fact]
+    public async Task can_support_parallel_processing()
+    {
+        using var store = SeparateStore(_ =>
+            _.UseJavascriptTransformsAndPatching()
+        );
+
+        var items = new List<Item>();
+
+        // Seed items
+        await using (var session = store.LightweightSession())
+        {
+            // Delete old items
+            session.DeleteWhere<Item>(_ => true);
+            await session.SaveChangesAsync();
+
+            // Create new items
+            for (var i = 0; i < itemsCount; i++)
+            {
+                var id = Guid.NewGuid();
+                var item = new Item { Id = id, Number = i };
+                items.Add(item);
+                session.Store(item);
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        // Check count
+        await using (var querySession = store.QuerySession())
+        {
+            var count = await querySession.Query<Item>().CountAsync();
+            count.ShouldBe(itemsCount);
+        }
+
+        // Patch items concurrently
+        await Task.WhenAll(items.Select(item => PatchItemAsync(store, item.Id)));
+
+        // Check count after update
+        await using (var querySession = store.QuerySession())
+        {
+            var count = await querySession.Query<Item>().Where(x => x.Number == patchedNumber).CountAsync();
+            count.ShouldBe(itemsCount);
+        }
+    }
+
+    private static async Task PatchItemAsync(IDocumentStore store, Guid itemId)
+    {
+        await Task.Delay(100);
+        await using var session = store.LightweightSession();
+        session.Patch<Item>(itemId).Set(x => x.Number, patchedNumber);
+        await session.SaveChangesAsync();
+    }
+
+    public class Item
+    {
+        public Guid Id { get; set; }
+        public int Number { get; set; }
+    }
+}

--- a/src/Marten.PLv8.Testing/Patching/PatchExpressionTests.cs
+++ b/src/Marten.PLv8.Testing/Patching/PatchExpressionTests.cs
@@ -23,8 +23,6 @@ public class PatchExpressionTests : OneOffConfigurationsContext
 {
     private readonly PatchExpression<Target> _expression;
 
-
-
     public PatchExpressionTests()
     {
         StoreOptions(x => x.UseJavascriptTransformsAndPatching());
@@ -52,7 +50,6 @@ public class PatchExpressionTests : OneOffConfigurationsContext
     [Fact]
     public async Task Patch_And_Load_Should_Return_Non_Stale_Result()
     {
-
         var id = Guid.NewGuid();
         await using (var sess = theStore.LightweightSession())
         {
@@ -69,8 +66,6 @@ public class PatchExpressionTests : OneOffConfigurationsContext
         public Guid Id { get; set; }
         public string Name { get; set; }
     }
-
-
 
     [Fact]
     public void builds_patch_for_set_name()

--- a/src/Marten.Testing/Harness/OneOffConfigurationsContext.cs
+++ b/src/Marten.Testing/Harness/OneOffConfigurationsContext.cs
@@ -42,8 +42,7 @@ namespace Marten.Testing.Harness
         {
             var options = new StoreOptions
             {
-                DatabaseSchemaName = SchemaName,
-
+                DatabaseSchemaName = SchemaName
             };
 
             options.Connection(ConnectionSource.ConnectionString);
@@ -90,7 +89,7 @@ namespace Marten.Testing.Harness
             {
                 if (_store == null)
                 {
-                    StoreOptions(x => {});
+                    StoreOptions(_ => {});
                 }
 
                 return _store;
@@ -101,11 +100,11 @@ namespace Marten.Testing.Harness
         {
             get
             {
-                if (_session == null)
-                {
-                    _session = theStore.OpenSession(DocumentTracking);
-                    _disposables.Add(_session);
-                }
+                if (_session != null)
+                    return _session;
+
+                _session = theStore.OpenSession(DocumentTracking);
+                _disposables.Add(_session);
 
                 return _session;
             }
@@ -115,8 +114,6 @@ namespace Marten.Testing.Harness
         /// Sets the default DocumentTracking for this context. Default is "None"
         /// </summary>
         protected DocumentTracking DocumentTracking { get; set; } = DocumentTracking.None;
-
-
 
         public void Dispose()
         {


### PR DESCRIPTION
The Patching API database schema feature didn't use the concurrent dictionary but a regular one. That was causing issues if multiple requests were trying to access it at once. Added `ImHashMap` to have thread-safe access and additional locking not to have redundant loading of a patch function js file. Added necessary tests.

Fixes #2460 

_**Note:** Best to review with [whitespace changes hidden](https://github.com/JasperFx/marten/pull/2462/files?diff=split&w=1) as I did some small reformatting._ 