### PR TITLE
Fixed flakiness related CI tests parallelisation issues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ variables:
   dotnet_version: '7.x'
   node_version: 16.x
   pg_db: marten_testing
-  marten_testing_database: "Host=localhost;Port=5432;Database=marten_testing;Username=postgres;Password=Password12!"
+  marten_testing_database: "Host=localhost;Port=5432;Database=marten_testing;Username=postgres;Password=Password12!;Timeout=60;Cancellation Timeout=5000; Command Timeout=60"
 
 jobs:
   - job: build_net6

--- a/src/EventSourcingTests/EventStreamUnexpectedMaxEventIdExceptionTransformTest.cs
+++ b/src/EventSourcingTests/EventStreamUnexpectedMaxEventIdExceptionTransformTest.cs
@@ -52,17 +52,19 @@ public class EventStreamUnexpectedMaxEventIdExceptionTransformTest: IntegrationC
         theSession.Events.Append(streamId, departed);
         await theSession.SaveChangesAsync();
 
-        var forceEventStreamUnexpectedMaxEventIdException = async () =>
+        async Task ForceEventStreamUnexpectedMaxEventIdException()
         {
-            await Parallel.ForEachAsync(Enumerable.Range(1, 5), async (_, token) =>
+            await Parallel.ForEachAsync(Enumerable.Range(1, 30), async (_, token) =>
             {
                 await using var session = theStore.OpenSession();
                 session.Events.Append(streamId, departed);
                 await session.SaveChangesAsync(token);
             });
-        };
+        }
 
-        Should.Throw<EventStreamUnexpectedMaxEventIdException>(forceEventStreamUnexpectedMaxEventIdException)
-            .Message.ShouldBe($"Unexpected starting version number for event stream '{streamId}', expected 2 but was 3");
+        var expectedPattern =
+            "Unexpected starting version number for event stream '" + streamId + "', expected [0-9]{1,2} but was [0-9]{1,2}";
+        Should.Throw<EventStreamUnexpectedMaxEventIdException>(ForceEventStreamUnexpectedMaxEventIdException)
+            .Message.ShouldMatch(expectedPattern);
     }
 }


### PR DESCRIPTION
- Improved CI configuration to support tests added in #2462.
- Run schema migrations upfront in the Patching tests.
- Fixes #2480 - Increased parallelisation in `throw_transformed_exception_with_details_available` and adjusted error message test.
