### PR TITLE
Fix DocumentMapping.IdMember setter

### DIFF
--- a/src/DocumentDbTests/Bugs/Bug_2327_using_identity_extension_on_class_with_invalid_type_id_field.cs
+++ b/src/DocumentDbTests/Bugs/Bug_2327_using_identity_extension_on_class_with_invalid_type_id_field.cs
@@ -1,6 +1,8 @@
 using Marten.Testing.Harness;
 using Shouldly;
 using System;
+using System.Linq;
+using Marten.Schema;
 using Xunit;
 
 namespace DocumentDbTests.Bugs;
@@ -13,6 +15,19 @@ public class Bug_2327_using_identity_extension_on_class_with_invalid_type_id_fie
         Action action = () => StoreOptions(storeOptions =>
             storeOptions.Schema.For<OverriddenIdWithInvalidTypeIdField>().Identity(x => x.DocumentId));
         action.ShouldNotThrow();
+    }
+
+    [Fact]
+    public void should_not_set_id_member_property_when_new_value_has_invalid_type()
+    {
+        var mapping = DocumentMapping.For<OverriddenIdWithInvalidTypeIdField>();
+        var fieldWithInvalidTypeForId = typeof(OverriddenIdWithInvalidTypeIdField)
+            .GetMember(nameof(OverriddenIdWithInvalidTypeIdField.Id)).First();
+
+        Action action = () => mapping.IdMember = fieldWithInvalidTypeForId;
+
+        action.ShouldThrow<ArgumentOutOfRangeException>();
+        mapping.IdMember.ShouldNotBe(fieldWithInvalidTypeForId);
     }
 
     public class OverriddenIdWithInvalidTypeIdField

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -118,14 +118,14 @@ public class DocumentMapping: FieldMapping, IDocumentMapping, IDocumentType
         get => _idMember;
         set
         {
-            _idMember = value;
-
-            if (_idMember != null && !_idMember.GetMemberType()
+            if (value != null && !value.GetMemberType()
                     .IsOneOf(_validIdTypes))
             {
                 throw new ArgumentOutOfRangeException(nameof(IdMember),
                     "Id members must be an int, long, Guid, or string");
             }
+
+            _idMember = value;
 
             if (_idMember != null)
             {


### PR DESCRIPTION
While working on #2391, I found this bug that may cause some strange behaviors. When setting DocumentMapping.IdMember to an invalid type ArgumentOutOfRangeException was thrown, but IdMember was charged to this invalid type anyway.