### PR TITLE
Concurrency check for Update in DocumentSessionBase

### DIFF
--- a/src/DocumentDbTests/Bugs/optimistic_concurrency_with_update_method.cs
+++ b/src/DocumentDbTests/Bugs/optimistic_concurrency_with_update_method.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Threading.Tasks;
+using Marten.Exceptions;
+using Marten.Metadata;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DocumentDbTests.Bugs;
+
+public class OptimisticConcurrencyWithUpdateMethodStoreFixture: StoreFixture
+{
+    public OptimisticConcurrencyWithUpdateMethodStoreFixture(): base("optimistic_concurrency_with_update_method")
+    {
+    }
+}
+
+public class optimistic_concurrency_with_update_method: StoreContext<OptimisticConcurrencyWithUpdateMethodStoreFixture>,
+    IClassFixture<OptimisticConcurrencyWithUpdateMethodStoreFixture>
+{
+    public optimistic_concurrency_with_update_method(OptimisticConcurrencyWithUpdateMethodStoreFixture fixture):
+        base(fixture)
+    {
+    }
+
+    [Fact]
+    public void can_update_with_optimistic_concurrency()
+    {
+        var doc1 = new CoffeeShop();
+        using (var session1 = theStore.LightweightSession())
+        {
+            session1.Insert(doc1);
+            session1.SaveChanges();
+        }
+
+        using (var session2 = theStore.LightweightSession())
+        {
+            var doc2 = session2.Load<CoffeeShop>(doc1.Id);
+            doc2.Name = "Mozart's";
+
+            session2.Update(doc2);
+            session2.SaveChanges();
+        }
+
+        using (var session3 = theStore.QuerySession())
+        {
+            session3.Load<CoffeeShop>(doc1.Id).Name.ShouldBe("Mozart's");
+        }
+    }
+
+    [Fact]
+    public async Task can_update_with_optimistic_concurrency_async()
+    {
+        var doc1 = new CoffeeShop();
+        await using (var session1 = theStore.OpenSession())
+        {
+            session1.Insert(doc1);
+            await session1.SaveChangesAsync();
+        }
+
+        await using (var session2 = theStore.OpenSession())
+        {
+            var doc2 = await session2.LoadAsync<CoffeeShop>(doc1.Id);
+            doc2.Name = "Mozart's";
+
+            session2.Update(doc2);
+            await session2.SaveChangesAsync();
+        }
+
+        await using (var session3 = theStore.QuerySession())
+        {
+            (await session3.LoadAsync<CoffeeShop>(doc1.Id)).Name.ShouldBe("Mozart's");
+        }
+    }
+
+    [Fact]
+    public void update_with_stale_version_throws_exception()
+    {
+        var doc1 = new CoffeeShop();
+        using (var session1 = theStore.LightweightSession())
+        {
+            session1.Insert(doc1);
+            session1.SaveChanges();
+        }
+
+        using (var session2 = theStore.LightweightSession())
+        {
+            var doc2 = session2.Load<CoffeeShop>(doc1.Id);
+            doc2.Name = "Mozart's";
+
+            // Some random version that won't match
+            doc2.Version = Guid.NewGuid();
+
+            session2.Update(doc2);
+
+            var ex = Exception<ConcurrencyException>.ShouldBeThrownBy(() =>
+            {
+                session2.SaveChanges();
+            });
+
+            ex.Message.ShouldBe($"Optimistic concurrency check failed for {typeof(CoffeeShop).FullName} #{doc1.Id}");
+        }
+    }
+
+    [Fact]
+    public async Task update_with_stale_version_throws_exception_async()
+    {
+        var doc1 = new CoffeeShop();
+        await using (var session1 = theStore.LightweightSession())
+        {
+            session1.Insert(doc1);
+            await session1.SaveChangesAsync();
+        }
+
+        await using (var session2 = theStore.LightweightSession())
+        {
+            var doc2 = session2.Load<CoffeeShop>(doc1.Id);
+            doc2.Name = "Mozart's";
+
+            // Some random version that won't match
+            doc2.Version = Guid.NewGuid();
+
+            session2.Update(doc2);
+
+            var ex = await Exception<ConcurrencyException>.ShouldBeThrownByAsync(async () =>
+            {
+                await session2.SaveChangesAsync();
+            });
+
+            ex.Message.ShouldBe($"Optimistic concurrency check failed for {typeof(CoffeeShop).FullName} #{doc1.Id}");
+        }
+    }
+}
+
+public class CoffeeShop: IVersioned
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = "Starbucks";
+    public Guid Version { get; set; }
+}

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -140,11 +140,23 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
         {
             var storage = StorageFor<T>();
 
-            foreach (var entity in entities)
+            if (Concurrency == ConcurrencyChecks.Disabled && storage.UseOptimisticConcurrency)
             {
-                storage.Store(this, entity);
-                var op = storage.Update(entity, this, TenantId);
-                _workTracker.Add(op);
+                foreach (var entity in entities)
+                {
+                    storage.Store(this, entity);
+                    var op = storage.Update(entity, this, TenantId);
+                    _workTracker.Add(op);
+                }
+            }
+            else
+            {
+                foreach (var entity in entities)
+                {
+                    storeEntity(entity, storage);
+                    var op = storage.Update(entity, this, TenantId);
+                    _workTracker.Add(op);
+                }
             }
         }
     }


### PR DESCRIPTION
I've added support of concurrency check when `Update` method of `DocumentSessionBase` is used. It is based on implementation used for `Store` method.