### PR TITLE
Bumped Weasel version to enable Advisory Locks retries when got Admin Shutdown (57P01) Postgres error was thrown

### DIFF
--- a/Analysis.Build.props
+++ b/Analysis.Build.props
@@ -6,7 +6,7 @@
         <AnalysisLevel>latest</AnalysisLevel>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.5.22" PrivateAssets="All"/>
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="All" Condition=" '$(TargetFrawework)' == 'netstandard2.0' "/>
     </ItemGroup>
 </Project>

--- a/src/AspNetCoreWithMarten/AspNetCoreWithMarten.csproj
+++ b/src/AspNetCoreWithMarten/AspNetCoreWithMarten.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.0">
+      <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       </PackageReference>

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -16,12 +16,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="8.1.0" />
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="10.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="8.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="Lamar" Version="10.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -122,7 +122,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/DocumentDbTests/DocumentDbTests.csproj
+++ b/src/DocumentDbTests/DocumentDbTests.csproj
@@ -15,8 +15,8 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="8.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="Lamar" Version="10.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/EventPublisher/EventPublisher.csproj
+++ b/src/EventPublisher/EventPublisher.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Lamar" Version="8.1.0" />
-      <PackageReference Include="Spectre.Console" Version="0.45.0" />
+      <PackageReference Include="Lamar" Version="10.0.1" />
+      <PackageReference Include="Spectre.Console" Version="0.46.0" />
     </ItemGroup>
 </Project>

--- a/src/EventSourcingTests/EventSourcingTests.csproj
+++ b/src/EventSourcingTests/EventSourcingTests.csproj
@@ -15,8 +15,8 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="8.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="Lamar" Version="10.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/IssueService/IssueService.csproj
+++ b/src/IssueService/IssueService.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Marten.AspNetCore.Testing/Marten.AspNetCore.Testing.csproj
+++ b/src/Marten.AspNetCore.Testing/Marten.AspNetCore.Testing.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="7.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="Alba" Version="7.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="Shouldly" Version="4.1.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Marten.AsyncDaemon.Testing/Marten.AsyncDaemon.Testing.csproj
+++ b/src/Marten.AsyncDaemon.Testing/Marten.AsyncDaemon.Testing.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
         <PackageReference Include="Divergic.Logging.Xunit" Version="4.2.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -22,7 +22,7 @@
       <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.0">
+      <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       </PackageReference>

--- a/src/Marten.CommandLine.Tests/Marten.CommandLine.Tests.csproj
+++ b/src/Marten.CommandLine.Tests/Marten.CommandLine.Tests.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="NSubstitute" Version="4.4.0" />
         <PackageReference Include="Shouldly" Version="4.1.0" />
         <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/Marten.CommandLine/Marten.CommandLine.csproj
+++ b/src/Marten.CommandLine/Marten.CommandLine.csproj
@@ -31,7 +31,7 @@
         <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="JasperFx.CodeGeneration.Commands" Version="1.0.0" />
+        <PackageReference Include="JasperFx.CodeGeneration.Commands" Version="1.0.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
         <PackageReference Include="Oakton" Version="6.0.0" />
         <PackageReference Include="Weasel.CommandLine" Version="6.0.0-alpha.6" />

--- a/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
+++ b/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -20,7 +20,7 @@
         <PackageReference Include="xunit" Version="2.4.2" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -30,7 +30,7 @@
     <ItemGroup>
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.1" />
         <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
-        <PackageReference Include="Npgsql.NodaTime" Version="[7.0.0,8.0.0)" />
+        <PackageReference Include="Npgsql.NodaTime" Version="7.0.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Marten.PLv8.Testing/Marten.PLv8.Testing.csproj
+++ b/src/Marten.PLv8.Testing/Marten.PLv8.Testing.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -17,7 +17,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="8.1.0" />
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="10.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     </ItemGroup>
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.0">
+      <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       </PackageReference>

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -24,8 +24,8 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="8.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="Lamar" Version="10.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -40,7 +40,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -37,14 +37,14 @@
     <ItemGroup>
         <PackageReference Include="JasperFx.Core" Version="1.1.0" />
         <PackageReference Include="JasperFx.TypeDiscovery" Version="1.0.0" />
-        <PackageReference Include="JasperFx.CodeGeneration" Version="1.0.0" />
-        <PackageReference Include="JasperFx.RuntimeCompiler" Version="1.0.0" />
+        <PackageReference Include="JasperFx.CodeGeneration" Version="1.0.1" />
+        <PackageReference Include="JasperFx.RuntimeCompiler" Version="1.0.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-        <PackageReference Include="Npgsql.Json.NET" Version="[7.0.0,8.0.0)" />
+        <PackageReference Include="Npgsql.Json.NET" Version="7.0.1" />
         <PackageReference Include="Remotion.Linq" Version="2.2.0" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
-        <PackageReference Include="Weasel.Postgresql" Version="6.0.0-alpha.6" />
-        <PackageReference Include="System.Text.Json" Version="7.0.0" />
+        <PackageReference Include="Weasel.Postgresql" Version="6.0.0-alpha.7" />
+        <PackageReference Include="System.Text.Json" Version="7.0.1" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->

--- a/src/MartenBenchmarks/MartenBenchmarks.csproj
+++ b/src/MartenBenchmarks/MartenBenchmarks.csproj
@@ -12,7 +12,7 @@
         <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
     </ItemGroup>
     <ItemGroup>
         <Folder Include="Benchmarks" />

--- a/src/samples/MinimalAPI/MinimalAPI.csproj
+++ b/src/samples/MinimalAPI/MinimalAPI.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Admin Shutdown (`57P01`) error mean that database is not available (e.g. it's restarting). Npgsql from version 6 supports connection pool reset behind the scenes for this scenario (see https://github.com/npgsql/npgsql/issues/2896). I added the wrapper in Weasel (see: https://github.com/JasperFx/weasel/pull/79) to return `false` for this case and allow retry mechanisms (that we already have in Marten) for database creation.

That should (hopefully) fix failing tests in CI.
Bumped also dependencies to the latest versions.

@jeremydmiller fyi.