### PR TITLE
Enabled the possibility of applying projections with different Conjoined Tenancy scopes for projections.

### DIFF
--- a/docs/configuration/storeoptions.md
+++ b/docs/configuration/storeoptions.md
@@ -15,7 +15,7 @@ public static DocumentStore For(Action<StoreOptions> configure)
     return new DocumentStore(options);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/DocumentStore.cs#L486-L496' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_documentstore.for' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/DocumentStore.cs#L492-L502' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_documentstore.for' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The major parts of `StoreOptions` are shown in the class diagram below:

--- a/docs/documents/multi-tenancy.md
+++ b/docs/documents/multi-tenancy.md
@@ -8,7 +8,7 @@ Once configured for multi-tenancy, Marten exposes it via sessions (`IQuerySessio
 
 ## Scoping Sessions to Tenancy
 
-The following sample demonstrates scoping a document session to tenancy identified as *tenant1*. With multi-tenancy enabled, the persisted `User` objects are then associated with the tenancy of the session.
+The following sample demonstrates scoping a document session to tenancy identified as _tenant1_. With multi-tenancy enabled, the persisted `User` objects are then associated with the tenancy of the session.
 
 <!-- snippet: sample_tenancy-scoping-session-write -->
 <a id='snippet-sample_tenancy-scoping-session-write'></a>
@@ -149,9 +149,9 @@ In some cases, You may want to disable using the default tenant for storing docu
 
 The three levels of tenancy that Marten supports are expressed in the enum `TenancyStyle` with effective values of:
 
-* `Single`, no multi-tenancy
-* `Conjoined`, multi-tenancy through tenant id
-* `Separate`, multi-tenancy through separate databases or schemas
+- `Single`, no multi-tenancy
+- `Conjoined`, multi-tenancy through tenant id
+- `Separate`, multi-tenancy through separate databases or schemas
 
 Tenancy can be configured at the store level, applying to all documents or, at the most fine-grained level, on individual documents.
 
@@ -179,7 +179,18 @@ Tenancy can be configured at a document level through document mappings. This al
 storeOptions.Policies.ForAllDocuments(x => x.TenancyStyle = TenancyStyle.Single);
 storeOptions.Schema.For<Target>().MultiTenanted();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/document_policies.cs#L59-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-configure-override' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/document_policies.cs#L59-L64' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-configure-override' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+You can also do it the other way round, having the default set to `TenancyStyle.Conjoined` and overriding it to `TenancyStyle.Single` for `Target`.
+
+<!-- snippet: sample_tenancy-configure-override-with-single-tenancy -->
+<a id='snippet-sample_tenancy-configure-override-with-single-tenancy'></a>
+```cs
+storeOptions.Policies.ForAllDocuments(x => x.TenancyStyle = TenancyStyle.Conjoined);
+storeOptions.Schema.For<Target>().SingleTenanted();
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/document_policies.cs#L76-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-configure-override-with-single-tenancy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Implementation Details

--- a/docs/events/configuration.md
+++ b/docs/events/configuration.md
@@ -62,3 +62,19 @@ var store = DocumentStore.For(opts =>
 ```
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ConfiguringDocumentStore.cs#L226-L236' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_making_the_events_multi_tenanted' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+By default, if you try to define projection with a single tenancy, Marten will throw an exception at runtime informing you about the mismatch.
+
+You can enable global projections for conjoined tenancy.
+
+<!-- snippet: sample_enabling_global_projections_for_conjoined_tenancy -->
+<a id='snippet-sample_enabling_global_projections_for_conjoined_tenancy'></a>
+```cs
+opts.Events.EnableGlobalProjectionsForConjoinedTenancy = true;
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/aggregation_projection_validation_rules.cs#L93-L97' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_global_projections_for_conjoined_tenancy' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: warning
+If you enable global projections for conjoined tenancy, Marten won't validate potential tenancy mismatch and won't throw an exception for that case.
+:::

--- a/docs/events/projections/index.md
+++ b/docs/events/projections/index.md
@@ -38,9 +38,7 @@ The out-of-the box convention is to expose `public Apply(<EventType>)` methods o
 Sticking with the fantasy theme, the `QuestParty` class shown below could be used to aggregate streams of quest data:
 
 <!-- snippet: sample_QuestParty -->
-
 <a id='snippet-sample_questparty'></a>
-
 ```cs
 public class QuestParty
 {
@@ -63,9 +61,7 @@ public class QuestParty
     }
 }
 ```
-
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/QuestParty.cs#L8-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_questparty' title='Start of snippet'>anchor</a></sup>
-
 <!-- endSnippet -->
 
 New in Marten 1.2 is the ability to use `Event<T>` metadata within your projections, assuming that you're not trying to run the aggregations inline.
@@ -74,9 +70,7 @@ The syntax using the built in aggregation technique is to take in `Event<T>` as 
 where `T` is the event type you're interested in:
 
 <!-- snippet: sample_QuestPartyWithEvents -->
-
 <a id='snippet-sample_questpartywithevents'></a>
-
 ```cs
 public class QuestPartyWithEvents
 {
@@ -122,9 +116,7 @@ public class QuestPartyWithEvents
     }
 }
 ```
-
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/QuestPartyWithEvents.cs#L8-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_questpartywithevents' title='Start of snippet'>anchor</a></sup>
-
 <!-- endSnippet -->
 
 ## Live Aggregation via .Net
@@ -132,9 +124,7 @@ public class QuestPartyWithEvents
 You can always fetch a stream of events and build an aggregate completely live from the current event data by using this syntax:
 
 <!-- snippet: sample_events-aggregate-on-the-fly -->
-
 <a id='snippet-sample_events-aggregate-on-the-fly'></a>
-
 ```cs
 await using (var session = store.LightweightSession())
 {
@@ -149,9 +139,7 @@ await using (var session = store.LightweightSession())
         .AggregateStreamAsync<QuestParty>(questId, timestamp: DateTime.UtcNow.AddDays(-1));
 }
 ```
-
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L87-L101' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_events-aggregate-on-the-fly' title='Start of snippet'>anchor</a></sup>
-
 <!-- endSnippet -->
 
 There is also a matching asynchronous `AggregateStreamAsync()` mechanism as well. Additionally, you can do stream aggregations in batch queries with
@@ -164,9 +152,7 @@ _First off, be aware that event metadata (e.g. stream version and sequence numbe
 If you would prefer that the projected aggregate document be updated _inline_ with the events being appended, you simply need to register the aggregation type in the `StoreOptions` upfront when you build up your document store like this:
 
 <!-- snippet: sample_registering-quest-party -->
-
 <a id='snippet-sample_registering-quest-party'></a>
-
 ```cs
 var store = DocumentStore.For(_ =>
 {
@@ -183,9 +169,7 @@ var store = DocumentStore.For(_ =>
     _.Projections.Snapshot<QuestParty>();
 });
 ```
-
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/inline_aggregation_by_stream_with_multiples.cs#L24-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering-quest-party' title='Start of snippet'>anchor</a></sup>
-
 <!-- endSnippet -->
 
 At this point, you would be able to query against `QuestParty` as just another document type.

--- a/docs/events/projections/multi-stream-projections.md
+++ b/docs/events/projections/multi-stream-projections.md
@@ -34,9 +34,7 @@ The last two mechanisms will allow you to use additional information in the unde
 Jumping right into an example, having defined events and views as:
 
 <!-- snippet: sample_view-projection-test-classes -->
-
 <a id='snippet-sample_view-projection-test-classes'></a>
-
 ```cs
 public interface IUserEvent
 {
@@ -167,9 +165,7 @@ public class UserGroupsAssignment
     public List<Guid> Groups { get; set; } = new();
 }
 ```
-
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/MultiStreamProjections/TestClasses.cs#L6-L138' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_view-projection-test-classes' title='Start of snippet'>anchor</a></sup>
-
 <!-- endSnippet -->
 
 ## Simple Event to Single Cross-Stream Projection
@@ -177,9 +173,7 @@ public class UserGroupsAssignment
 Here's a simple example of creating an aggregated view by user id:
 
 <!-- snippet: sample_view-projection-simple -->
-
 <a id='snippet-sample_view-projection-simple'></a>
-
 ```cs
 public class UserGroupsAssignmentProjection: MultiStreamProjection<UserGroupsAssignment, Guid>
 {
@@ -199,9 +193,7 @@ public class UserGroupsAssignmentProjection: MultiStreamProjection<UserGroupsAss
         => view.Groups.Add(@event.GroupId);
 }
 ```
-
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/MultiStreamProjections/simple_multi_stream_projection.cs#L10-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_view-projection-simple' title='Start of snippet'>anchor</a></sup>
-
 <!-- endSnippet -->
 
 Note that the primary difference between this and `SingleStreamProjection<T>` is the calls to `Identity<TEvent>()` to specify how the events are grouped
@@ -209,9 +201,7 @@ into separate aggregates across streams. We can also do the equivalent of the co
 we care about and use this:
 
 <!-- snippet: sample_view-projection-simple-2 -->
-
 <a id='snippet-sample_view-projection-simple-2'></a>
-
 ```cs
 public class UserGroupsAssignmentProjection2: MultiStreamProjection<UserGroupsAssignment, Guid>
 {
@@ -234,9 +224,7 @@ public class UserGroupsAssignmentProjection2: MultiStreamProjection<UserGroupsAs
         => view.Groups.Add(@event.GroupId);
 }
 ```
-
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/MultiStreamProjections/simple_multi_stream_projection.cs#L31-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_view-projection-simple-2' title='Start of snippet'>anchor</a></sup>
-
 <!-- endSnippet -->
 
 ## Simple Example of Events Updating Multiple Views
@@ -246,9 +234,7 @@ different `UserGroupsAssignment` projected documents with the usage of the `Iden
 shown below:
 
 <!-- snippet: sample_view-projection-simple-with-one-to-many -->
-
 <a id='snippet-sample_view-projection-simple-with-one-to-many'></a>
-
 ```cs
 public class UserGroupsAssignmentProjection: MultiStreamProjection<UserGroupsAssignment, Guid>
 {
@@ -269,9 +255,7 @@ public class UserGroupsAssignmentProjection: MultiStreamProjection<UserGroupsAss
     }
 }
 ```
-
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/MultiStreamProjections/simple_multi_stream_projection_wih_one_to_many.cs#L11-L32' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_view-projection-simple-with-one-to-many' title='Start of snippet'>anchor</a></sup>
-
 <!-- endSnippet -->
 
 ## View Projection with Custom Grouper
@@ -286,9 +270,7 @@ your grouping logic does require loading the actual aggregate documents, you nee
 As simpler mechanism to group events to aggregate documents is to supply a custom `IAggregatorGrouper<TId>` as shown below:
 
 <!-- snippet: sample_view-projection-custom-grouper-with-querysession -->
-
 <a id='snippet-sample_view-projection-custom-grouper-with-querysession'></a>
-
 ```cs
 public class LicenseFeatureToggledEventGrouper: IAggregateGrouper<Guid>
 {
@@ -348,9 +330,7 @@ public class UserFeatureTogglesProjection: MultiStreamProjection<UserFeatureTogg
     }
 }
 ```
-
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/custom_grouper_with_document_session.cs#L15-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_view-projection-custom-grouper-with-querysession' title='Start of snippet'>anchor</a></sup>
-
 <!-- endSnippet -->
 
 ## View Projection with Custom Slicer
@@ -364,9 +344,7 @@ If `Identity()` or `Identities()` is too limiting for your event aggregation rul
 own `IEventSlicer` that can split and assign events to any number of aggregated document views. Below is an example:
 
 <!-- snippet: sample_view-projection-custom-slicer -->
-
 <a id='snippet-sample_view-projection-custom-slicer'></a>
-
 ```cs
 public class UserGroupsAssignmentProjection: MultiStreamProjection<UserGroupsAssignment, Guid>
 {
@@ -410,9 +388,7 @@ public class UserGroupsAssignmentProjection: MultiStreamProjection<UserGroupsAss
     }
 }
 ```
-
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/custom_slicer.cs#L16-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_view-projection-custom-slicer' title='Start of snippet'>anchor</a></sup>
-
 <!-- endSnippet -->
 
 ## Event "Fan Out" Rules
@@ -421,23 +397,17 @@ The `ViewProjection` also provides the ability to "fan out" child events from a 
 create an aggregated view. As an example, a `Travel` event we use in Marten testing contains a list of `Movement` objects:
 
 <!-- snippet: sample_Travel_Movements -->
-
 <a id='snippet-sample_travel_movements'></a>
-
 ```cs
 public IList<Movement> Movements { get; set; } = new List<Movement>();
 ```
-
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/Travel.cs#L28-L32' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_travel_movements' title='Start of snippet'>anchor</a></sup>
-
 <!-- endSnippet -->
 
 In a sample `ViewProjection`, we do a "fan out" of the `Travel.Movements` members into separate events being processed through the projection:
 
 <!-- snippet: sample_showing_fanout_rules -->
-
 <a id='snippet-sample_showing_fanout_rules'></a>
-
 ```cs
 public class DayProjection: MultiStreamProjection<Day, int>
 {
@@ -481,7 +451,5 @@ public class DayProjection: MultiStreamProjection<Day, int>
     }
 }
 ```
-
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/ViewProjectionTests.cs#L126-L170' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_showing_fanout_rules' title='Start of snippet'>anchor</a></sup>
-
 <!-- endSnippet -->

--- a/src/CoreTests/Sessions/TenantedSessionFactoryTests.cs
+++ b/src/CoreTests/Sessions/TenantedSessionFactoryTests.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using Marten;
+using Marten.Events.Projections;
+using Marten.Internal.Sessions;
+using Marten.Internal.Storage;
+using Marten.Services;
+using Marten.Sessions;
+using Marten.Storage;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+#nullable enable
+
+namespace CoreTests.Sessions;
+
+using static TenantedSessionFactoryTests.Configuration;
+
+public class TenantedSessionFactoryTests
+{
+    // |---------------------------------------------------------|
+    // | SCENARIOS                                               |
+    // |---------------------------------------------------------|
+    // | SESSION     | SLICE       | STORAGE   | RESULT          |
+    // |-------------|-------------|-----------|-----------------|
+    // | DEFAULT     | DEFAULT     | SINGLE    | THE SAME        |
+    // | DEFAULT     | DEFAULT     | CONJOINED | THE SAME        |
+    // | DEFAULT     | NON-DEFAULT | SINGLE    | THE SAME        |
+    // | DEFAULT     | NON-DEFAULT | CONJOINED | NEW NON-DEFAULT |
+    // | NON-DEFAULT | DEFAULT     | SINGLE    | NEW DEFAULT     |
+    // | NON-DEFAULT | DEFAULT     | CONJOINED | THE SAME        |
+    // | NON-DEFAULT | NON-DEFAULT | SINGLE    | NEW DEFAULT     |
+    // | NON-DEFAULT | NON-DEFAULT | CONJOINED | THE SAME        |
+    [Theory]
+    [MemberData(nameof(Configurations))]
+    public void Verify(Configuration setup)
+    {
+        var session = SessionWith(setup);
+
+        var slice = SliceWith(setup);
+
+        var storage = StorageWith(setup);
+
+        var newSession = session.UseTenancyBasedOnSliceAndStorage(storage, slice);
+
+        if (!setup.ExpectsNewSession)
+        {
+            newSession.ShouldBe(session);
+        }
+        else
+        {
+            newSession.ShouldNotBe(session);
+            newSession.ShouldBeOfType<NestedTenantSession>();
+            newSession.TenantId.ShouldBe(setup.ExpectedNewSessionTenantId);
+        }
+    }
+
+    public static TheoryData<Configuration> Configurations
+    {
+        get
+        {
+            return new TheoryData<Configuration>
+            {
+                TheSame(Default, Default, TenancyStyle.Single),
+                TheSame(Default, Default, TenancyStyle.Conjoined),
+                TheSame(Default, NonDefault, TenancyStyle.Single),
+                New(Default, NonDefault, TenancyStyle.Conjoined, NonDefault),
+                TheSame(Default, NonDefault, TenancyStyle.Conjoined,
+                    isTenantStoredInCurrentDatabase: false
+                ),
+                New(NonDefault, Default, TenancyStyle.Single, Default),
+                New(NonDefault, Default, TenancyStyle.Single, Default,
+                    allowAnyTenant: false,
+                    defaultTenantUsageEnabled: true
+                ),
+                New(NonDefault, Default, TenancyStyle.Single, Default,
+                    allowAnyTenant: true,
+                    defaultTenantUsageEnabled: false
+                ),
+                TheSame(NonDefault, Default, TenancyStyle.Single,
+                    allowAnyTenant: false,
+                    defaultTenantUsageEnabled: false
+                ),
+                TheSame(NonDefault, Default, TenancyStyle.Conjoined),
+                New(NonDefault, NonDefault, TenancyStyle.Single, Default),
+                New(NonDefault, NonDefault, TenancyStyle.Single, Default,
+                    allowAnyTenant: false,
+                    defaultTenantUsageEnabled: true
+                ),
+                New(NonDefault, NonDefault, TenancyStyle.Single, Default,
+                    allowAnyTenant: true,
+                    defaultTenantUsageEnabled: false
+                ),
+                TheSame(NonDefault, NonDefault, TenancyStyle.Single,
+                    allowAnyTenant: false,
+                    defaultTenantUsageEnabled: false
+                ),
+                TheSame(NonDefault, NonDefault, TenancyStyle.Conjoined),
+            };
+        }
+    }
+
+    private static readonly string Default = Tenancy.DefaultTenantId;
+    private static readonly string NonDefault = "NON_DEFAULT";
+
+
+    public record Configuration(
+        string SessionTenant,
+        string SliceTenant,
+        TenancyStyle StorageTenancyStyle,
+        bool IsTenantStoredInCurrentDatabase,
+        bool AllowAnyTenant,
+        bool DefaultTenantUsageEnabled,
+        bool ExpectsNewSession,
+        string? ExpectedNewSessionTenantId = default
+    )
+    {
+        public static Configuration TheSame(
+            string sessionTenant,
+            string sliceTenant,
+            TenancyStyle storageTenancyStyle,
+            bool isTenantStoredInCurrentDatabase = true,
+            bool allowAnyTenant = true,
+            bool defaultTenantUsageEnabled = true
+        ) => new(
+            sessionTenant,
+            sliceTenant,
+            storageTenancyStyle,
+            isTenantStoredInCurrentDatabase,
+            allowAnyTenant,
+            defaultTenantUsageEnabled,
+            false);
+
+        public static Configuration New(
+            string sessionTenant,
+            string sliceTenant,
+            TenancyStyle storageTenancyStyle,
+            string? expectedNewSessionTenantId,
+            bool allowAnyTenant = true,
+            bool defaultTenantUsageEnabled = true
+        ) => new(
+            sessionTenant,
+            sliceTenant,
+            storageTenancyStyle,
+            true,
+            true,
+            true,
+            true,
+            expectedNewSessionTenantId
+        );
+    }
+
+    private static DocumentSessionBase SessionWith(Configuration setup) =>
+        DocumentSessionStub.Setup(setup);
+
+    private static IEventSlice SliceWith(Configuration setup)
+    {
+        var slice = Substitute.For<IEventSlice>();
+
+        // ReSharper disable once ConstantConditionalAccessQualifier
+        slice.Tenant.Returns(new Tenant(setup.SliceTenant, Substitute.For<IMartenDatabase>()));
+
+        return slice;
+    }
+
+    private static IDocumentStorage StorageWith(Configuration setup)
+    {
+        var storage = Substitute.For<IDocumentStorage>();
+        storage.TenancyStyle.Returns(setup.StorageTenancyStyle);
+        return storage;
+    }
+
+    internal class DocumentSessionStub: DocumentSessionBase
+    {
+        public static DocumentSessionStub Setup(Configuration setup)
+        {
+            var tenancy = Substitute.For<ITenancy>();
+            tenancy.IsTenantStoredInCurrentDatabase(default, default)
+                .ReturnsForAnyArgs(setup.IsTenantStoredInCurrentDatabase);
+
+            var options = new StoreOptions();
+            options.Connection("dummy");
+            options.Tenancy = tenancy;
+            options.Advanced.DefaultTenantUsageEnabled = setup.DefaultTenantUsageEnabled;
+
+            var sessionOptions =
+                new SessionOptions
+                {
+                    Tenant = new Tenant(setup.SessionTenant, Substitute.For<IMartenDatabase>()),
+                    AllowAnyTenant = setup.AllowAnyTenant
+                };
+
+            return new DocumentSessionStub(options, sessionOptions, setup.SessionTenant);
+        }
+
+        private DocumentSessionStub(StoreOptions options, SessionOptions sessionOptions, string tenantId):
+            base(
+                new DocumentStore(options),
+                sessionOptions,
+                Substitute.For<IConnectionLifetime>()
+            ) =>
+            TenantId = tenantId;
+
+        protected internal override void ejectById<T>(long id) =>
+            throw new NotImplementedException();
+
+        protected internal override void ejectById<T>(int id) =>
+            throw new NotImplementedException();
+
+        protected internal override void ejectById<T>(Guid id) =>
+            throw new NotImplementedException();
+
+        protected internal override void ejectById<T>(string id) =>
+            throw new NotImplementedException();
+    }
+}

--- a/src/CoreTests/Sessions/TenantedSessionFactoryTests.cs
+++ b/src/CoreTests/Sessions/TenantedSessionFactoryTests.cs
@@ -55,54 +55,48 @@ public class TenantedSessionFactoryTests
         }
     }
 
-    public static TheoryData<Configuration> Configurations
-    {
-        get
+    public static TheoryData<Configuration> Configurations =>
+        new()
         {
-            return new TheoryData<Configuration>
-            {
-                TheSame(Default, Default, TenancyStyle.Single),
-                TheSame(Default, Default, TenancyStyle.Conjoined),
-                TheSame(Default, NonDefault, TenancyStyle.Single),
-                New(Default, NonDefault, TenancyStyle.Conjoined, NonDefault),
-                TheSame(Default, NonDefault, TenancyStyle.Conjoined,
-                    isTenantStoredInCurrentDatabase: false
-                ),
-                New(NonDefault, Default, TenancyStyle.Single, Default),
-                New(NonDefault, Default, TenancyStyle.Single, Default,
-                    allowAnyTenant: false,
-                    defaultTenantUsageEnabled: true
-                ),
-                New(NonDefault, Default, TenancyStyle.Single, Default,
-                    allowAnyTenant: true,
-                    defaultTenantUsageEnabled: false
-                ),
-                TheSame(NonDefault, Default, TenancyStyle.Single,
-                    allowAnyTenant: false,
-                    defaultTenantUsageEnabled: false
-                ),
-                TheSame(NonDefault, Default, TenancyStyle.Conjoined),
-                New(NonDefault, NonDefault, TenancyStyle.Single, Default),
-                New(NonDefault, NonDefault, TenancyStyle.Single, Default,
-                    allowAnyTenant: false,
-                    defaultTenantUsageEnabled: true
-                ),
-                New(NonDefault, NonDefault, TenancyStyle.Single, Default,
-                    allowAnyTenant: true,
-                    defaultTenantUsageEnabled: false
-                ),
-                TheSame(NonDefault, NonDefault, TenancyStyle.Single,
-                    allowAnyTenant: false,
-                    defaultTenantUsageEnabled: false
-                ),
-                TheSame(NonDefault, NonDefault, TenancyStyle.Conjoined),
-            };
-        }
-    }
+            TheSame(Default, Default, TenancyStyle.Single),
+            TheSame(Default, Default, TenancyStyle.Conjoined),
+            TheSame(Default, NonDefault, TenancyStyle.Single),
+            New(Default, NonDefault, TenancyStyle.Conjoined, NonDefault),
+            TheSame(Default, NonDefault, TenancyStyle.Conjoined,
+                isTenantStoredInCurrentDatabase: false
+            ),
+            New(NonDefault, Default, TenancyStyle.Single, Default),
+            New(NonDefault, Default, TenancyStyle.Single, Default,
+                allowAnyTenant: false,
+                defaultTenantUsageEnabled: true
+            ),
+            New(NonDefault, Default, TenancyStyle.Single, Default,
+                allowAnyTenant: true,
+                defaultTenantUsageEnabled: false
+            ),
+            TheSame(NonDefault, Default, TenancyStyle.Single,
+                allowAnyTenant: false,
+                defaultTenantUsageEnabled: false
+            ),
+            TheSame(NonDefault, Default, TenancyStyle.Conjoined),
+            New(NonDefault, NonDefault, TenancyStyle.Single, Default),
+            New(NonDefault, NonDefault, TenancyStyle.Single, Default,
+                allowAnyTenant: false,
+                defaultTenantUsageEnabled: true
+            ),
+            New(NonDefault, NonDefault, TenancyStyle.Single, Default,
+                allowAnyTenant: true,
+                defaultTenantUsageEnabled: false
+            ),
+            TheSame(NonDefault, NonDefault, TenancyStyle.Single,
+                allowAnyTenant: false,
+                defaultTenantUsageEnabled: false
+            ),
+            TheSame(NonDefault, NonDefault, TenancyStyle.Conjoined),
+        };
 
     private static readonly string Default = Tenancy.DefaultTenantId;
     private static readonly string NonDefault = "NON_DEFAULT";
-
 
     public record Configuration(
         string SessionTenant,

--- a/src/DocumentDbTests/Configuration/document_policies.cs
+++ b/src/DocumentDbTests/Configuration/document_policies.cs
@@ -57,13 +57,32 @@ public class document_policies: OneOffConfigurationsContext
         StoreOptions(storeOptions =>
         {
             #region sample_tenancy-configure-override
+
             storeOptions.Policies.ForAllDocuments(x => x.TenancyStyle = TenancyStyle.Single);
             storeOptions.Schema.For<Target>().MultiTenanted();
+
             #endregion
         });
 
         theStore.StorageFeatures.MappingFor(typeof(Target))
             .TenancyStyle.ShouldBe(TenancyStyle.Conjoined);
+    }
+
+    [Fact]
+    public void fluent_interface_overrides_policies_with_single_tenancy()
+    {
+        StoreOptions(storeOptions =>
+        {
+            #region sample_tenancy-configure-override-with-single-tenancy
+
+            storeOptions.Policies.ForAllDocuments(x => x.TenancyStyle = TenancyStyle.Conjoined);
+            storeOptions.Schema.For<Target>().SingleTenanted();
+
+            #endregion
+        });
+
+        theStore.StorageFeatures.MappingFor(typeof(Target))
+            .TenancyStyle.ShouldBe(TenancyStyle.Single);
     }
 
     [MultiTenanted]

--- a/src/EventSourcingTests/Aggregation/AggregationTestingSupport.cs
+++ b/src/EventSourcingTests/Aggregation/AggregationTestingSupport.cs
@@ -31,7 +31,6 @@ public class TestEventSlice: EventSlice<MyAggregate, Guid>
 
     internal Event<EEvent> E() => Add<EEvent>();
 
-
     internal Event<T> Add<T>() where T : new()
     {
         var @event = new Event<T>(new T());

--- a/src/EventSourcingTests/Aggregation/aggregation_projection_validation_rules.cs
+++ b/src/EventSourcingTests/Aggregation/aggregation_projection_validation_rules.cs
@@ -64,14 +64,11 @@ public class aggregation_projection_validation_rules
         errorMessageFor(x =>
         {
             x.Events.StreamIdentity = StreamIdentity.AsString;
-            x.Projections.SelfAggregate<GuidIdentifiedAggregate>(ProjectionLifecycle.Async);
+            x.Projections.Snapshot<GuidIdentifiedAggregate>(SnapshotLifecycle.Async);
         }).ShouldContain(
             $"Id type mismatch. The stream identity type is string, but the aggregate document {typeof(GuidIdentifiedAggregate).FullNameInCode()} id type is Guid",
-            StringComparisonOption.Default);
-            x.Projections.Snapshot<GuidIdentifiedAggregate>(SnapshotLifecycle.Async);
-        });
-
-        message.ShouldContain($"Id type mismatch. The stream identity type is string, but the aggregate document {typeof(GuidIdentifiedAggregate).FullNameInCode()} id type is Guid", StringComparisonOption.Default);
+            StringComparisonOption.Default
+        );
     }
 
     [Fact]
@@ -81,7 +78,9 @@ public class aggregation_projection_validation_rules
         {
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
             opts.Projections.Snapshot<GuidIdentifiedAggregate>(SnapshotLifecycle.Async);
-        }).ShouldContain($"Tenancy storage style mismatch between the events (Conjoined) and the aggregate type {typeof(GuidIdentifiedAggregate).FullNameInCode()} (Single)", StringComparisonOption.Default);
+        }).ShouldContain(
+            $"Tenancy storage style mismatch between the events (Conjoined) and the aggregate type {typeof(GuidIdentifiedAggregate).FullNameInCode()} (Single)",
+            StringComparisonOption.Default);
     }
 
     [Fact]
@@ -90,8 +89,14 @@ public class aggregation_projection_validation_rules
         shouldNotThrow(opts =>
         {
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+
+            #region sample_enabling_global_projections_for_conjoined_tenancy
+
             opts.Events.EnableGlobalProjectionsForConjoinedTenancy = true;
-            opts.Projections.SelfAggregate<GuidIdentifiedAggregate>(ProjectionLifecycle.Async);
+
+            #endregion
+
+            opts.Projections.Snapshot<GuidIdentifiedAggregate>(SnapshotLifecycle.Async);
         });
     }
 

--- a/src/EventSourcingTests/Projections/MultiTenants/ConjoinedTenancyProjectionsTests.cs
+++ b/src/EventSourcingTests/Projections/MultiTenants/ConjoinedTenancyProjectionsTests.cs
@@ -23,6 +23,7 @@ public class ConjoinedTenancyProjectionsTests: IntegrationContext
         {
             opts.Policies.AllDocumentsAreMultiTenanted();
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.EnableGlobalProjectionsForConjoinedTenancy = true;
 
             opts.Schema.For<ResourcesGlobalSummary>().SingleTenanted();
 

--- a/src/EventSourcingTests/Projections/MultiTenants/ConjoinedTenancyProjectionsTests.cs
+++ b/src/EventSourcingTests/Projections/MultiTenants/ConjoinedTenancyProjectionsTests.cs
@@ -17,7 +17,7 @@ public class ConjoinedTenancyProjectionsTests: IntegrationContext
     }
 
     [Fact]
-    public async Task ForSystemTextJson_AndTenantedSession_ProjectionShouldBeUpdated()
+    public async Task ForEventsAppendedToTenantedSession_AndConjoinedTenancyProjection_ShouldBeUpdated()
     {
         StoreOptions(opts =>
         {

--- a/src/EventSourcingTests/Projections/MultiTenants/ConjoinedTenancyProjectionsTests.cs
+++ b/src/EventSourcingTests/Projections/MultiTenants/ConjoinedTenancyProjectionsTests.cs
@@ -3,48 +3,28 @@ using System.Threading.Tasks;
 using Marten;
 using Marten.Events.Aggregation;
 using Marten.Events.Projections;
-using Marten.Linq;
-using Marten.Services;
 using Marten.Storage;
 using Marten.Testing.Harness;
-using Weasel.Core;
-using Xunit;
 using Shouldly;
+using Xunit;
 
-namespace EventSourcingTests.Json;
+namespace EventSourcingTests.Projections.MultiTenants;
 
-public class SystemTextJsonRecordSerializationTests: IntegrationContext
+public class ConjoinedTenancyProjectionsTests: IntegrationContext
 {
-    public SystemTextJsonRecordSerializationTests(DefaultStoreFixture fixture): base(fixture)
+    public ConjoinedTenancyProjectionsTests(DefaultStoreFixture fixture): base(fixture)
     {
     }
 
     [Fact]
-    public async Task ForSystemTextJson_ProjectionShouldBeUpdated()
+    public async Task ForSystemTextJson_AndTenantedSession_ProjectionShouldBeUpdated()
     {
         StoreOptions(opts =>
         {
-            // Optionally configure the serializer directly
-            opts.Serializer(new SystemTextJsonSerializer
-            {
-                // Optionally override the enum storage
-                EnumStorage = EnumStorage.AsString,
-
-                // Optionally override the member casing
-                Casing = Casing.CamelCase,
-            });
-
             opts.Policies.AllDocumentsAreMultiTenanted();
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
-            opts.Events.MetadataConfig.EnableAll();
-            opts.Schema.For<Resource>().DatabaseSchemaName("resources");
 
             opts.Projections.Add<ResourceProjection>(ProjectionLifecycle.Inline);
-
-            opts.AutoCreateSchemaObjects = AutoCreate.All;
-
-            opts.DatabaseSchemaName = "fleetmonitor";
-            opts.Events.DatabaseSchemaName = "events";
         });
 
         var organisationId = Guid.NewGuid().ToString();

--- a/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs
+++ b/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs
@@ -77,7 +77,7 @@ namespace Marten.AsyncDaemon.Testing.TestingSupport
     #endregion
 }
 
-namespace TripProjection.SelfAggregate
+namespace TripProjection.StreamAggregation
 {
     internal class RegistrationSamples
     {

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -74,7 +74,8 @@ public partial class DocumentStore: IDocumentStore
             var asyncProjectionList =
                 Options.Projections.All.Where(x => x.Lifecycle == ProjectionLifecycle.Async).Select(x => x.ToString())!
                     .Join(", ");
-            Console.WriteLine($"Projections {asyncProjectionList} will not be executed without the async daemon enabled");
+            Console.WriteLine(
+                $"Projections {asyncProjectionList} will not be executed without the async daemon enabled");
         }
     }
 
@@ -266,7 +267,7 @@ public partial class DocumentStore: IDocumentStore
         string tenantId,
         IsolationLevel isolationLevel = IsolationLevel.ReadCommitted
     ) =>
-        DirtyTrackedSession(new SessionOptions { IsolationLevel = isolationLevel, TenantId = tenantId});
+        DirtyTrackedSession(new SessionOptions { IsolationLevel = isolationLevel, TenantId = tenantId });
 
     public IDocumentSession DirtyTrackedSession(SessionOptions options)
     {
@@ -277,13 +278,15 @@ public partial class DocumentStore: IDocumentStore
     public Task<IDocumentSession> DirtyTrackedSerializableSessionAsync(
         CancellationToken cancellation = default
     ) =>
-        DirtyTrackedSerializableSessionAsync(new SessionOptions { IsolationLevel = IsolationLevel.Serializable }, cancellation);
+        DirtyTrackedSerializableSessionAsync(new SessionOptions { IsolationLevel = IsolationLevel.Serializable },
+            cancellation);
 
     public Task<IDocumentSession> DirtyTrackedSerializableSessionAsync(
         string tenantId,
         CancellationToken cancellation = default
     ) =>
-        DirtyTrackedSerializableSessionAsync(new SessionOptions { IsolationLevel = IsolationLevel.Serializable, TenantId = tenantId}, cancellation);
+        DirtyTrackedSerializableSessionAsync(
+            new SessionOptions { IsolationLevel = IsolationLevel.Serializable, TenantId = tenantId }, cancellation);
 
     public Task<IDocumentSession> DirtyTrackedSerializableSessionAsync(
         SessionOptions options,
@@ -296,13 +299,13 @@ public partial class DocumentStore: IDocumentStore
     }
 
     public IDocumentSession LightweightSession(IsolationLevel isolationLevel = IsolationLevel.ReadCommitted) =>
-        LightweightSession(new SessionOptions { IsolationLevel = isolationLevel});
+        LightweightSession(new SessionOptions { IsolationLevel = isolationLevel });
 
     public IDocumentSession LightweightSession(
         string tenantId,
         IsolationLevel isolationLevel = IsolationLevel.ReadCommitted
     ) =>
-        LightweightSession(new SessionOptions { IsolationLevel = isolationLevel, TenantId = tenantId});
+        LightweightSession(new SessionOptions { IsolationLevel = isolationLevel, TenantId = tenantId });
 
     public IDocumentSession LightweightSession(SessionOptions options)
     {
@@ -313,13 +316,15 @@ public partial class DocumentStore: IDocumentStore
     public Task<IDocumentSession> LightweightSerializableSessionAsync(
         CancellationToken cancellation = default
     ) =>
-        LightweightSerializableSessionAsync(new SessionOptions { IsolationLevel = IsolationLevel.Serializable}, cancellation);
+        LightweightSerializableSessionAsync(new SessionOptions { IsolationLevel = IsolationLevel.Serializable },
+            cancellation);
 
     public Task<IDocumentSession> LightweightSerializableSessionAsync(
         string tenantId,
         CancellationToken cancellation = default
     ) =>
-        LightweightSerializableSessionAsync(new SessionOptions { IsolationLevel = IsolationLevel.Serializable, TenantId = tenantId}, cancellation);
+        LightweightSerializableSessionAsync(
+            new SessionOptions { IsolationLevel = IsolationLevel.Serializable, TenantId = tenantId }, cancellation);
 
     public Task<IDocumentSession> LightweightSerializableSessionAsync(
         SessionOptions options,
@@ -362,15 +367,15 @@ public partial class DocumentStore: IDocumentStore
         string tenantId,
         CancellationToken cancellation = default
     ) =>
-        QuerySerializableSessionAsync(new SessionOptions { TenantId = tenantId, IsolationLevel = IsolationLevel.Serializable}, cancellation);
+        QuerySerializableSessionAsync(
+            new SessionOptions { TenantId = tenantId, IsolationLevel = IsolationLevel.Serializable }, cancellation);
 
-    public IProjectionDaemon BuildProjectionDaemon(string? tenantIdOrDatabaseIdentifier = null, ILogger? logger = null)
+    public IProjectionDaemon BuildProjectionDaemon(
+        string? tenantIdOrDatabaseIdentifier = null,
+        ILogger? logger = null
+    )
     {
-        if (!Options.Advanced.DefaultTenantUsageEnabled && !(Tenancy is DefaultTenancy) &&
-            tenantIdOrDatabaseIdentifier.IsEmpty())
-        {
-            throw new DefaultTenantUsageDisabledException();
-        }
+        AssertTenantOrDatabaseIdentifierIsValid(tenantIdOrDatabaseIdentifier);
 
         logger ??= new NulloLogger();
 
@@ -382,13 +387,12 @@ public partial class DocumentStore: IDocumentStore
         return new ProjectionDaemon(this, database, detector, logger);
     }
 
-    public async ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(string? tenantIdOrDatabaseIdentifier = null,
-        ILogger? logger = null)
+    public async ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(
+        string? tenantIdOrDatabaseIdentifier = null,
+        ILogger? logger = null
+    )
     {
-        if (!Options.Advanced.DefaultTenantUsageEnabled && tenantIdOrDatabaseIdentifier.IsEmpty())
-        {
-            throw new DefaultTenantUsageDisabledException();
-        }
+        AssertTenantOrDatabaseIdentifierIsValid(tenantIdOrDatabaseIdentifier);
 
         logger ??= new NulloLogger();
 
@@ -406,7 +410,8 @@ public partial class DocumentStore: IDocumentStore
         We recommend using lightweight session by default. Read more in documentation: https://martendb.io/documents/sessions.html.
         """
     )]
-    public async Task<IDocumentSession> OpenSerializableSessionAsync(SessionOptions options, CancellationToken token = default)
+    public async Task<IDocumentSession> OpenSerializableSessionAsync(SessionOptions options,
+        CancellationToken token = default)
     {
         var connection = await options.InitializeAsync(this, CommandRunnerMode.Transactional, token)
             .ConfigureAwait(false);
@@ -434,7 +439,8 @@ public partial class DocumentStore: IDocumentStore
         IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
         CancellationToken token = default
     ) =>
-        OpenSerializableSessionAsync(new SessionOptions { Tracking = tracking, IsolationLevel = isolationLevel }, token);
+        OpenSerializableSessionAsync(new SessionOptions { Tracking = tracking, IsolationLevel = isolationLevel },
+            token);
 
     [Obsolete(
         """
@@ -508,5 +514,15 @@ public partial class DocumentStore: IDocumentStore
         };
 
         return session;
+    }
+
+    private void AssertTenantOrDatabaseIdentifierIsValid(string? tenantIdOrDatabaseIdentifier)
+    {
+        if (!Options.Advanced.DefaultTenantUsageEnabled
+            && Tenancy is not DefaultTenancy
+            && tenantIdOrDatabaseIdentifier.IsEmpty())
+        {
+            throw new DefaultTenantUsageDisabledException();
+        }
     }
 }

--- a/src/Marten/Events/Aggregation/EventSlice.cs
+++ b/src/Marten/Events/Aggregation/EventSlice.cs
@@ -9,6 +9,7 @@ namespace Marten.Events.Projections;
 
 public interface IEventSlice
 {
+    Tenant Tenant { get; }
     IReadOnlyList<IEvent> Events();
 }
 

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -95,6 +95,8 @@ public partial class EventGraph: IEventStoreOptions, IReadOnlyEventStoreOptions
     /// </summary>
     public TenancyStyle TenancyStyle { get; set; } = TenancyStyle.Single;
 
+    public bool EnableGlobalProjectionsForConjoinedTenancy { get; set; }
+
     /// <summary>
     ///     Configure the meta data required to be stored for events. By default meta data fields are disabled
     /// </summary>
@@ -367,7 +369,7 @@ public partial class EventGraph: IEventStoreOptions, IReadOnlyEventStoreOptions
         _store = store;
         foreach (var mapping in _events)
         {
-             mapping.JsonTransformation(null);
+            mapping.JsonTransformation(null);
         }
     }
 }

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -24,6 +24,11 @@ namespace Marten.Events
         TenancyStyle TenancyStyle { get; set; }
 
         /// <summary>
+        /// Enables global project projections (with single tenancy style) for events with conjoined tenancy
+        /// </summary>
+        bool EnableGlobalProjectionsForConjoinedTenancy { get; set; }
+
+        /// <summary>
         ///     Override the database schema name for event related tables. By default this
         ///     is the same schema as the document storage
         /// </summary>

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -658,6 +658,16 @@ public class MartenRegistry
         }
 
         /// <summary>
+        ///     Marks just this document type as being stored with single tenancy style
+        /// </summary>
+        /// <returns></returns>
+        public DocumentMappingExpression<T> SingleTenanted()
+        {
+            _builder.Alter = m => m.TenancyStyle = TenancyStyle.Single;
+            return this;
+        }
+
+        /// <summary>
         ///     Opt into the identity key generation strategy
         /// </summary>
         /// <returns></returns>

--- a/src/Marten/Sessions/TenantedSessionFactory.cs
+++ b/src/Marten/Sessions/TenantedSessionFactory.cs
@@ -1,0 +1,61 @@
+﻿using Marten.Events.Projections;
+using Marten.Internal.Sessions;
+using Marten.Internal.Storage;
+using Marten.Storage;
+
+namespace Marten.Sessions;
+
+internal static class TenantedSessionFactory
+{
+    // |---------------------------------------------------------|
+    // | SCENARIOS                                               |
+    // |---------------------------------------------------------|
+    // | SESSION     | SLICE       | STORAGE   | RESULT          |
+    // |-------------|-------------|-----------|-----------------|
+    // | DEFAULT     | DEFAULT     | SINGLE    | THE SAME        |
+    // | DEFAULT     | DEFAULT     | CONJOINED | THE SAME        |
+    // | DEFAULT     | NON-DEFAULT | SINGLE    | THE SAME        |
+    // | DEFAULT     | NON-DEFAULT | CONJOINED | NEW NON-DEFAULT |
+    // | NON-DEFAULT | DEFAULT     | SINGLE    | NEW DEFAULT     |
+    // | NON-DEFAULT | DEFAULT     | CONJOINED | THE SAME        |
+    // | NON-DEFAULT | NON-DEFAULT | SINGLE    | NEW DEFAULT     |
+    // | NON-DEFAULT | NON-DEFAULT | CONJOINED | THE SAME        |
+    internal static DocumentSessionBase UseTenancyBasedOnSliceAndStorage(
+        this DocumentSessionBase session,
+        IDocumentStorage storage,
+        IEventSlice slice
+    )
+    {
+        var shouldApplyConjoinedTenancy =
+            session.TenantId != slice.Tenant.TenantId
+            && slice.Tenant.TenantId != Tenancy.DefaultTenantId
+            && storage.TenancyStyle == TenancyStyle.Conjoined
+            && session.DocumentStore.Options.Tenancy.IsTenantStoredInCurrentDatabase(
+                session.Database,
+                slice.Tenant.TenantId
+            );
+
+        if (shouldApplyConjoinedTenancy)
+            return session.WithTenant(slice.Tenant.TenantId);
+
+        var isDefaultTenantAllowed =
+            session.SessionOptions.AllowAnyTenant
+            || session.Options.Advanced.DefaultTenantUsageEnabled;
+
+        var shouldApplyDefaultTenancy =
+            isDefaultTenantAllowed
+            && session.TenantId != Tenancy.DefaultTenantId
+            && storage.TenancyStyle == TenancyStyle.Single;
+
+        if (shouldApplyDefaultTenancy)
+            return session.WithDefaultTenant();
+
+        return session;
+    }
+
+    private static DocumentSessionBase WithTenant(this IDocumentSession session, string tenantId) =>
+        (DocumentSessionBase)session.ForTenant(tenantId);
+
+    private static DocumentSessionBase WithDefaultTenant(this IDocumentSession session) =>
+        (DocumentSessionBase)session.ForTenant(Tenancy.DefaultTenantId);
+}


### PR DESCRIPTION
## Summary

1. Enabled the possibility of applying projections with different Conjoined Tenancy scopes for projections.
2. Enabled global projection for events with a conjoined tenancy style.
3. Added possibility to specify that document can be single tenanted (`SingleTenanted` option) when the global convention is to have multi-tenanted.

## Scenarios

| SESSION     | SLICE       | STORAGE   | RESULT          |
|-------------|-------------|-----------|-----------------|
| DEFAULT     | DEFAULT     | SINGLE    | THE SAME        |
| DEFAULT     | DEFAULT     | CONJOINED | THE SAME        |
| DEFAULT     | NON-DEFAULT | SINGLE    | THE SAME        |
| DEFAULT     | NON-DEFAULT | CONJOINED | NEW NON-DEFAULT |
| NON-DEFAULT | DEFAULT     | SINGLE    | NEW DEFAULT     |
| NON-DEFAULT | DEFAULT     | CONJOINED | THE SAME        |
| NON-DEFAULT | NON-DEFAULT | SINGLE    | NEW DEFAULT     |
| NON-DEFAULT | NON-DEFAULT | CONJOINED | THE SAME        |

Plus permutations related to:
- `session.SessionOptions.AllowAnyTenant`
- `session.Options.Advanced.DefaultTenantUsageEnabled`
- `session.DocumentStore.Options.Tenancy.IsTenantStoredInCurrentDatabase`

Fixes #2363

_**Note:** Suggested review with whitespace hidden https://github.com/JasperFx/marten/pull/2497/files?diff=split&w=1._