### PR TITLE
Renamed asynchronous session creation to include explicit Serializable name

### DIFF
--- a/docs/configuration/storeoptions.md
+++ b/docs/configuration/storeoptions.md
@@ -15,7 +15,7 @@ public static DocumentStore For(Action<StoreOptions> configure)
     return new DocumentStore(options);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/DocumentStore.cs#L490-L500' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_documentstore.for' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/DocumentStore.cs#L486-L496' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_documentstore.for' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The major parts of `StoreOptions` are shown in the class diagram below:

--- a/docs/documents/sessions.md
+++ b/docs/documents/sessions.md
@@ -38,13 +38,13 @@ types of sessions are:
 |`IDocumentStore.QuerySession()`|Read Only|No|No|
 |`IDocumentStore.QuerySessionAsync()`|Read Only|No|No|
 |`IDocumentStore.LightweightSession()`|Read/Write|No|No|
-|`IDocumentStore.LightweightSessionAsync()`|Read/Write|No|No|
+|`IDocumentStore.LightweightSerializableSessionAsync()`|Read/Write|No|No|
 |`IDocumentStore.IdentitySession()`|Read/Write|Yes|Yes|
-|`IDocumentStore.IdentitySessionAsync()`|Read/Write|Yes|Yes|
+|`IDocumentStore.IdentitySerializableSessionAsync()`|Read/Write|Yes|Yes|
 |`IDocumentStore.DirtyTrackedSession()`|Read/Write|Yes|Yes|
-|`IDocumentStore.DirtyTrackedSessionAsync()`|Read/Write|Yes|Yes|
-|`IDocumentStore.OpenSession()` _(Obsolete)_|Read/Write|Yes|No|
-|`IDocumentStore.OpenSessionAsync()` _(Obsolete)_|Read/Write|Yes|No|
+|`IDocumentStore.DirtyTrackedSerializableSessionAsync()`|Read/Write|Yes|Yes|
+|`IDocumentStore.OpenSession()` |Read/Write|Yes|No|
+|`IDocumentStore.OpenSerializableSessionAsync()` |Read/Write|Yes|No|
 
 ::: tip INFO
 The recommended session type for read/write operations is `LightWeightDocumentSession`, which gives the best performance. It does not do change tracking, which may not be needed for most cases.
@@ -108,19 +108,19 @@ var badIssues = await session.Query<Issue>()
 
 ## Async session for serializable transactions
 
-Use `IDocumentStore.OpenSessionAsync()` to Open a new `IDocumentSession` with the supplied options and immediately open the database connection and start the transaction for the session. This is appropriate for Serializable transaction sessions. This is added in v5.
+Use `IDocumentStore.LightweightSerializableSessionAsync()` to Open a new `IDocumentSession` with the supplied options and immediately open the database connection and start the transaction for the session. This is appropriate for Serializable transaction sessions. This is added in v5.
 
 <!-- snippet: sample_opening_session_async -->
 <a id='snippet-sample_opening_session_async'></a>
 ```cs
 await using var session =
-    await store.LightweightSessionAsync(SessionOptions.ForConnectionString("another connection string"));
+    await store.LightweightSerializableSessionAsync(SessionOptions.ForConnectionString("another connection string"));
 
 var openIssues = await session.Query<Issue>()
     .Where(x => x.Tags.Contains("open"))
     .ToListAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/OpeningASessionAsync.cs#L19-L28' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_opening_session_async' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/OpeningASessionAsync.cs#L17-L26' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_opening_session_async' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Identity Map Mechanics

--- a/docs/scenarios/aggregates-events-repositories.md
+++ b/docs/scenarios/aggregates-events-repositories.md
@@ -173,7 +173,7 @@ public sealed class AggregateRepository
 
     public async Task StoreAsync(AggregateBase aggregate, CancellationToken ct = default)
     {
-        await using var session = await store.LightweightSessionAsync(token: ct);
+        await using var session = await store.LightweightSerializableSessionAsync(token: ct);
         // Take non-persisted events, push them to the event stream, indexed by the aggregate ID
         var events = aggregate.GetUncommittedEvents().ToArray();
         session.Events.Append(aggregate.Id, aggregate.Version, events);
@@ -188,7 +188,7 @@ public sealed class AggregateRepository
         CancellationToken ct = default
     ) where T : AggregateBase
     {
-        await using var session = await store.LightweightSessionAsync(token: ct);
+        await using var session = await store.LightweightSerializableSessionAsync(token: ct);
         var aggregate = await session.Events.AggregateStreamAsync<T>(id, version ?? 0, token: ct);
         return aggregate ?? throw new InvalidOperationException($"No aggregate by id {id}.");
     }

--- a/src/CoreTests/Bugs/Bug_2135_open_session_should_use_provided_connection_string.cs
+++ b/src/CoreTests/Bugs/Bug_2135_open_session_should_use_provided_connection_string.cs
@@ -60,7 +60,7 @@ namespace CoreTests.Bugs
 
 
             await using (var session =
-                         await testStore.LightweightSessionAsync(SessionOptions.ForConnectionString(connectionString)))
+                         await testStore.LightweightSerializableSessionAsync(SessionOptions.ForConnectionString(connectionString)))
             {
                 new NpgsqlConnectionStringBuilder(session.Connection.ConnectionString).Timeout.ShouldBe(11);
                 session.Store(new TestEntity { Name = "Test 2" });
@@ -68,7 +68,7 @@ namespace CoreTests.Bugs
             }
 
             await using (var session =
-                         await testStore.LightweightSessionAsync(SessionOptions.ForConnectionString(connectionString)))
+                         await testStore.LightweightSerializableSessionAsync(SessionOptions.ForConnectionString(connectionString)))
             {
                 new NpgsqlConnectionStringBuilder(session.Connection.ConnectionString).Timeout.ShouldBe(11);
                 var entities = await session.Query<TestEntity>()

--- a/src/CoreTests/DatabaseMultiTenancy/using_per_database_multitenancy.cs
+++ b/src/CoreTests/DatabaseMultiTenancy/using_per_database_multitenancy.cs
@@ -177,7 +177,7 @@ public class using_per_database_multitenancy: IAsyncLifetime
     public async Task can_open_a_session_to_a_different_database()
     {
         await using var session =
-            await theStore.LightweightSessionAsync(new SessionOptions { TenantId = "tenant1" });
+            await theStore.LightweightSerializableSessionAsync(new SessionOptions { TenantId = "tenant1" });
 
         session.Connection.Database.ShouldBe("database1");
     }

--- a/src/CoreTests/DatabaseMultiTenancy/using_static_database_multitenancy.cs
+++ b/src/CoreTests/DatabaseMultiTenancy/using_static_database_multitenancy.cs
@@ -127,7 +127,7 @@ public class using_static_database_multitenancy: IAsyncLifetime
     public async Task can_open_a_session_to_a_different_database()
     {
         await using var session =
-            await theStore.LightweightSessionAsync(new SessionOptions { TenantId = "tenant1" });
+            await theStore.LightweightSerializableSessionAsync(new SessionOptions { TenantId = "tenant1" });
 
         session.Connection.Database.ShouldBe("database1");
     }

--- a/src/CoreTests/ability_to_use_an_existing_connection_and_transaction.cs
+++ b/src/CoreTests/ability_to_use_an_existing_connection_and_transaction.cs
@@ -79,7 +79,7 @@ public class ability_to_use_an_existing_connection_and_transaction: IntegrationC
     public async Task can_query_async_with_session_enlisted_in_transaction_scope()
     {
         using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-        await using var session = await theStore.LightweightSessionAsync(SessionOptions.ForCurrentTransaction());
+        await using var session = await theStore.LightweightSerializableSessionAsync(SessionOptions.ForCurrentTransaction());
 
         var aTarget = targets.First();
 

--- a/src/EventSourcingTests/ScenarioAggregateAndRepository.cs
+++ b/src/EventSourcingTests/ScenarioAggregateAndRepository.cs
@@ -278,7 +278,7 @@ public sealed class AggregateRepository
 
     public async Task StoreAsync(AggregateBase aggregate, CancellationToken ct = default)
     {
-        await using var session = await store.LightweightSessionAsync(token: ct);
+        await using var session = await store.LightweightSerializableSessionAsync(token: ct);
         // Take non-persisted events, push them to the event stream, indexed by the aggregate ID
         var events = aggregate.GetUncommittedEvents().ToArray();
         session.Events.Append(aggregate.Id, aggregate.Version, events);
@@ -293,7 +293,7 @@ public sealed class AggregateRepository
         CancellationToken ct = default
     ) where T : AggregateBase
     {
-        await using var session = await store.LightweightSessionAsync(token: ct);
+        await using var session = await store.LightweightSerializableSessionAsync(token: ct);
         var aggregate = await session.Events.AggregateStreamAsync<T>(id, version ?? 0, token: ct);
         return aggregate ?? throw new InvalidOperationException($"No aggregate by id {id}.");
     }

--- a/src/Marten.AsyncDaemon.Testing/multi_stream_aggregation_end_to_end.cs
+++ b/src/Marten.AsyncDaemon.Testing/multi_stream_aggregation_end_to_end.cs
@@ -5,6 +5,7 @@ using JasperFx.Core;
 using Marten.AsyncDaemon.Testing.TestingSupport;
 using Marten.Events.Daemon.Resiliency;
 using Marten.Events.Projections;
+using Marten.Metadata;
 using Marten.Schema;
 using Shouldly;
 using Xunit;
@@ -85,12 +86,13 @@ public class multi_stream_aggregation_end_to_end : DaemonContext
     }
 }
 
-public class UserIssues
+public class UserIssues: IVersioned
 {
     [Identity]
     public Guid UserId { get; set; }
 
     public List<Issue> Issues { get; set; } = new List<Issue>();
+    public Guid Version { get; set; }
 }
 
 public class Issue

--- a/src/Marten.Testing/Examples/OpeningASessionAsync.cs
+++ b/src/Marten.Testing/Examples/OpeningASessionAsync.cs
@@ -2,8 +2,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Marten.Services;
 using Marten.Testing.Documents;
-using Marten.Testing.Harness;
-using Npgsql;
 
 namespace Marten.Testing.Examples;
 
@@ -19,7 +17,7 @@ public class OpeningASessionAsync
         #region sample_opening_session_async
 
         await using var session =
-            await store.LightweightSessionAsync(SessionOptions.ForConnectionString("another connection string"));
+            await store.LightweightSerializableSessionAsync(SessionOptions.ForConnectionString("another connection string"));
 
         var openIssues = await session.Query<Issue>()
             .Where(x => x.Tags.Contains("open"))

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -14,7 +14,6 @@ using Marten.Events.Daemon.Resiliency;
 using Marten.Events.Projections;
 using Marten.Exceptions;
 using Marten.Internal.Sessions;
-using Marten.Schema;
 using Marten.Services;
 using Marten.Storage;
 using Microsoft.Extensions.Logging;
@@ -233,32 +232,31 @@ public partial class DocumentStore: IDocumentStore
         return openSession(options);
     }
 
-    public Task<IDocumentSession> IdentitySessionAsync(
-        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
+    public Task<IDocumentSession> IdentitySerializableSessionAsync(
         CancellationToken cancellation = default
     ) =>
-        IdentitySessionAsync(
-            new SessionOptions { IsolationLevel = isolationLevel },
+        IdentitySerializableSessionAsync(
+            new SessionOptions { IsolationLevel = IsolationLevel.Serializable },
             cancellation
         );
 
-    public Task<IDocumentSession> IdentitySessionAsync(
+    public Task<IDocumentSession> IdentitySerializableSessionAsync(
         string tenantId,
-        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
         CancellationToken cancellation = default
     ) =>
-        IdentitySessionAsync(
-            new SessionOptions { IsolationLevel = isolationLevel, TenantId = tenantId },
+        IdentitySerializableSessionAsync(
+            new SessionOptions { IsolationLevel = IsolationLevel.Serializable, TenantId = tenantId },
             cancellation
         );
 
-    public Task<IDocumentSession> IdentitySessionAsync(
+    public Task<IDocumentSession> IdentitySerializableSessionAsync(
         SessionOptions options,
         CancellationToken cancellation = default
     )
     {
+        options.IsolationLevel = IsolationLevel.Serializable;
         options.Tracking = DocumentTracking.IdentityOnly;
-        return OpenSessionAsync(options, cancellation);
+        return OpenSerializableSessionAsync(options, cancellation);
     }
 
     public IDocumentSession DirtyTrackedSession(IsolationLevel isolationLevel = IsolationLevel.ReadCommitted) =>
@@ -276,26 +274,25 @@ public partial class DocumentStore: IDocumentStore
         return openSession(options);
     }
 
-    public Task<IDocumentSession> DirtyTrackedSessionAsync(
-        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
+    public Task<IDocumentSession> DirtyTrackedSerializableSessionAsync(
         CancellationToken cancellation = default
     ) =>
-        DirtyTrackedSessionAsync(new SessionOptions { IsolationLevel = isolationLevel }, cancellation);
+        DirtyTrackedSerializableSessionAsync(new SessionOptions { IsolationLevel = IsolationLevel.Serializable }, cancellation);
 
-    public Task<IDocumentSession> DirtyTrackedSessionAsync(
+    public Task<IDocumentSession> DirtyTrackedSerializableSessionAsync(
         string tenantId,
-        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
         CancellationToken cancellation = default
     ) =>
-        DirtyTrackedSessionAsync(new SessionOptions { IsolationLevel = isolationLevel, TenantId = tenantId}, cancellation);
+        DirtyTrackedSerializableSessionAsync(new SessionOptions { IsolationLevel = IsolationLevel.Serializable, TenantId = tenantId}, cancellation);
 
-    public Task<IDocumentSession> DirtyTrackedSessionAsync(
+    public Task<IDocumentSession> DirtyTrackedSerializableSessionAsync(
         SessionOptions options,
         CancellationToken cancellation = default
     )
     {
+        options.IsolationLevel = IsolationLevel.Serializable;
         options.Tracking = DocumentTracking.DirtyTracking;
-        return OpenSessionAsync(options, cancellation);
+        return OpenSerializableSessionAsync(options, cancellation);
     }
 
     public IDocumentSession LightweightSession(IsolationLevel isolationLevel = IsolationLevel.ReadCommitted) =>
@@ -313,26 +310,25 @@ public partial class DocumentStore: IDocumentStore
         return openSession(options);
     }
 
-    public Task<IDocumentSession> LightweightSessionAsync(
-        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
+    public Task<IDocumentSession> LightweightSerializableSessionAsync(
         CancellationToken cancellation = default
     ) =>
-        LightweightSessionAsync(new SessionOptions { IsolationLevel = isolationLevel}, cancellation);
+        LightweightSerializableSessionAsync(new SessionOptions { IsolationLevel = IsolationLevel.Serializable}, cancellation);
 
-    public Task<IDocumentSession> LightweightSessionAsync(
+    public Task<IDocumentSession> LightweightSerializableSessionAsync(
         string tenantId,
-        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
         CancellationToken cancellation = default
     ) =>
-        LightweightSessionAsync(new SessionOptions { IsolationLevel = isolationLevel, TenantId = tenantId}, cancellation);
+        LightweightSerializableSessionAsync(new SessionOptions { IsolationLevel = IsolationLevel.Serializable, TenantId = tenantId}, cancellation);
 
-    public Task<IDocumentSession> LightweightSessionAsync(
+    public Task<IDocumentSession> LightweightSerializableSessionAsync(
         SessionOptions options,
         CancellationToken cancellation = default
     )
     {
+        options.IsolationLevel = IsolationLevel.Serializable;
         options.Tracking = DocumentTracking.None;
-        return OpenSessionAsync(options, cancellation);
+        return OpenSerializableSessionAsync(options, cancellation);
     }
 
     public IQuerySession QuerySession(SessionOptions options)
@@ -348,7 +344,7 @@ public partial class DocumentStore: IDocumentStore
     public IQuerySession QuerySession(string tenantId) =>
         QuerySession(new SessionOptions { TenantId = tenantId });
 
-    public async Task<IQuerySession> QuerySessionAsync(
+    public async Task<IQuerySession> QuerySerializableSessionAsync(
         SessionOptions options,
         CancellationToken cancellation = default
     )
@@ -359,14 +355,14 @@ public partial class DocumentStore: IDocumentStore
         return new QuerySession(this, options, connection);
     }
 
-    public Task<IQuerySession> QuerySessionAsync(CancellationToken cancellation = default) =>
-        QuerySessionAsync(Marten.Storage.Tenancy.DefaultTenantId, cancellation);
+    public Task<IQuerySession> QuerySerializableSessionAsync(CancellationToken cancellation = default) =>
+        QuerySerializableSessionAsync(Marten.Storage.Tenancy.DefaultTenantId, cancellation);
 
-    public Task<IQuerySession> QuerySessionAsync(
+    public Task<IQuerySession> QuerySerializableSessionAsync(
         string tenantId,
         CancellationToken cancellation = default
     ) =>
-        QuerySessionAsync(new SessionOptions { TenantId = tenantId }, cancellation);
+        QuerySerializableSessionAsync(new SessionOptions { TenantId = tenantId, IsolationLevel = IsolationLevel.Serializable}, cancellation);
 
     public IProjectionDaemon BuildProjectionDaemon(string? tenantIdOrDatabaseIdentifier = null, ILogger? logger = null)
     {
@@ -410,7 +406,7 @@ public partial class DocumentStore: IDocumentStore
         We recommend using lightweight session by default. Read more in documentation: https://martendb.io/documents/sessions.html.
         """
     )]
-    public async Task<IDocumentSession> OpenSessionAsync(SessionOptions options, CancellationToken token = default)
+    public async Task<IDocumentSession> OpenSerializableSessionAsync(SessionOptions options, CancellationToken token = default)
     {
         var connection = await options.InitializeAsync(this, CommandRunnerMode.Transactional, token)
             .ConfigureAwait(false);
@@ -438,7 +434,7 @@ public partial class DocumentStore: IDocumentStore
         IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
         CancellationToken token = default
     ) =>
-        OpenSessionAsync(new SessionOptions { Tracking = tracking, IsolationLevel = isolationLevel }, token);
+        OpenSerializableSessionAsync(new SessionOptions { Tracking = tracking, IsolationLevel = isolationLevel }, token);
 
     [Obsolete(
         """
@@ -453,7 +449,7 @@ public partial class DocumentStore: IDocumentStore
         IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
         CancellationToken token = default
     ) =>
-        OpenSessionAsync(
+        OpenSerializableSessionAsync(
             new SessionOptions { Tracking = tracking, IsolationLevel = isolationLevel, TenantId = tenantId }, token);
 
     /// <summary>

--- a/src/Marten/Events/Daemon/ProjectionDaemon.cs
+++ b/src/Marten/Events/Daemon/ProjectionDaemon.cs
@@ -373,7 +373,7 @@ internal class ProjectionDaemon: IProjectionDaemon
     {
         var sessionOptions = SessionOptions.ForDatabase(Database);
         sessionOptions.AllowAnyTenant = true;
-        await using var session = await _store.LightweightSessionAsync(sessionOptions, token).ConfigureAwait(false);
+        await using var session = await _store.LightweightSerializableSessionAsync(sessionOptions, token).ConfigureAwait(false);
         source.Options.Teardown(session);
 
         foreach (var shard in shards)

--- a/src/Marten/IDocumentStore.cs
+++ b/src/Marten/IDocumentStore.cs
@@ -159,13 +159,6 @@ public interface IDocumentStore: IDisposable
     /// </summary>
     /// <param name="options">Additional options for session</param>
     /// <returns></returns>
-    [Obsolete(
-        """
-        Opening a session without explicitly providing desired type may be dropped in next Marten version.
-        Use explicit method like `LightweightSessionAsync`, `IdentitySessionAsync` or `DirtyTrackedSessionAsync`.
-        We recommend using lightweight session by default. Read more in documentation: https://martendb.io/documents/sessions.html.
-        """
-    )]
     IDocumentSession OpenSession(SessionOptions options);
 
     /// <summary>
@@ -176,14 +169,7 @@ public interface IDocumentStore: IDisposable
     /// <param name="options"></param>
     /// <param name="token"></param>
     /// <returns></returns>
-    [Obsolete(
-        """
-        Opening a session without explicitly providing desired type may be dropped in next Marten version.
-        Use explicit method like `LightweightSessionAsync`, `IdentitySessionAsync` or `DirtyTrackedSessionAsync`.
-        We recommend using lightweight session by default. Read more in documentation: https://martendb.io/documents/sessions.html.
-        """
-    )]
-    Task<IDocumentSession> OpenSessionAsync(SessionOptions options, CancellationToken token = default);
+    Task<IDocumentSession> OpenSerializableSessionAsync(SessionOptions options, CancellationToken token = default);
 
     /// <summary>
     ///     Convenience method to create a new "lightweight" IDocumentSession with no IdentityMap
@@ -214,19 +200,15 @@ public interface IDocumentStore: IDisposable
     ///     or automatic dirty checking
     /// </summary>
     /// <returns></returns>
-    Task<IDocumentSession> LightweightSessionAsync(
-        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
-        CancellationToken token = default
-    );
+    Task<IDocumentSession> LightweightSerializableSessionAsync(CancellationToken token = default);
 
     /// <summary>
     ///     Convenience method to create a new "lightweight" IDocumentSession with no IdentityMap
     ///     or automatic dirty checking
     /// </summary>
     /// <returns></returns>
-    Task<IDocumentSession> LightweightSessionAsync(
+    Task<IDocumentSession> LightweightSerializableSessionAsync(
         string tenantId,
-        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
         CancellationToken token = default
     );
 
@@ -235,7 +217,7 @@ public interface IDocumentStore: IDisposable
     ///     or automatic dirty checking
     /// </summary>
     /// <returns></returns>
-    Task<IDocumentSession> LightweightSessionAsync(SessionOptions options, CancellationToken token = default);
+    Task<IDocumentSession> LightweightSerializableSessionAsync(SessionOptions options, CancellationToken token = default);
 
     /// <summary>
     ///     Convenience method to create an IDocumentSession with IdentityMap but without automatic
@@ -266,19 +248,15 @@ public interface IDocumentStore: IDisposable
     ///     dirty checking
     /// </summary>
     /// <returns></returns>
-    Task<IDocumentSession> IdentitySessionAsync(
-        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
-        CancellationToken token = default
-    );
+    Task<IDocumentSession> IdentitySerializableSessionAsync(CancellationToken token = default);
 
     /// <summary>
     ///     Convenience method to create an IDocumentSession with IdentityMap but without automatic
     ///     dirty checking
     /// </summary>
     /// <returns></returns>
-    Task<IDocumentSession> IdentitySessionAsync(
+    Task<IDocumentSession> IdentitySerializableSessionAsync(
         string tenantId,
-        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
         CancellationToken token = default
     );
 
@@ -287,7 +265,7 @@ public interface IDocumentStore: IDisposable
     ///     dirty checking
     /// </summary>
     /// <returns></returns>
-    Task<IDocumentSession> IdentitySessionAsync(SessionOptions options, CancellationToken token = default);
+    Task<IDocumentSession> IdentitySerializableSessionAsync(SessionOptions options, CancellationToken token = default);
 
     /// <summary>
     ///     Convenience method to create an IDocumentSession with both IdentityMap and automatic
@@ -317,19 +295,15 @@ public interface IDocumentStore: IDisposable
     ///     dirty checking
     /// </summary>
     /// <returns></returns>
-    Task<IDocumentSession> DirtyTrackedSessionAsync(
-        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
-        CancellationToken token = default
-    );
+    Task<IDocumentSession> DirtyTrackedSerializableSessionAsync(CancellationToken token = default);
 
     /// <summary>
     ///     Convenience method to create an IDocumentSession with both IdentityMap and automatic
     ///     dirty checking
     /// </summary>
     /// <returns></returns>
-    Task<IDocumentSession> DirtyTrackedSessionAsync(
+    Task<IDocumentSession> DirtyTrackedSerializableSessionAsync(
         string tenantId,
-        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
         CancellationToken token = default
     );
 
@@ -338,7 +312,7 @@ public interface IDocumentStore: IDisposable
     ///     dirty checking
     /// </summary>
     /// <returns></returns>
-    Task<IDocumentSession> DirtyTrackedSessionAsync(SessionOptions options, CancellationToken token = default);
+    Task<IDocumentSession> DirtyTrackedSerializableSessionAsync(SessionOptions options, CancellationToken token = default);
 
     /// <summary>
     ///     Opens a read-only IQuerySession to the current document store for efficient
@@ -367,14 +341,14 @@ public interface IDocumentStore: IDisposable
     ///     querying without any underlying object tracking.
     /// </summary>
     /// <returns></returns>
-    Task<IQuerySession> QuerySessionAsync(CancellationToken token = default);
+    Task<IQuerySession> QuerySerializableSessionAsync(CancellationToken token = default);
 
     /// <summary>
     ///     Opens a read-only IQuerySession to the current document store for efficient
     ///     querying without any underlying object tracking.
     /// </summary>
     /// <returns></returns>
-    Task<IQuerySession> QuerySessionAsync(string tenantId, CancellationToken token = default);
+    Task<IQuerySession> QuerySerializableSessionAsync(string tenantId, CancellationToken token = default);
 
     /// <summary>
     ///     Opens a read-only IQuerySession to the current document store for efficient
@@ -382,7 +356,7 @@ public interface IDocumentStore: IDisposable
     /// </summary>
     /// <param name="options">Additional options for session. DocumentTracking is not applicable for IQuerySession.</param>
     /// <returns></returns>
-    Task<IQuerySession> QuerySessionAsync(SessionOptions options, CancellationToken token = default);
+    Task<IQuerySession> QuerySerializableSessionAsync(SessionOptions options, CancellationToken token = default);
 
     /// <summary>
     ///     Bulk insert a potentially mixed enumerable of document types


### PR DESCRIPTION
This will be more self-explanatory about intentions and won't get Rider and other IDEs to suggest async versions. Removed Obsolete attribute from methods with StoreOptions