### PR TITLE
Aggregate projections renames

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -164,8 +164,8 @@ export default withMermaid({
                 {
                   text: 'Aggregate Projections', link: '/events/projections/aggregate-projections', items: [
                     { text: 'Live Aggregations', link: '/events/projections/live-aggregates' },
-                    { text: 'Cross-Stream Aggregations', link: '/events/projections/multi-stream-projections' },
-                    { text: 'Custom Aggregations', link: '/events/projections/custom-aggregates' },]
+                    { text: 'Cross-Stream Projection', link: '/events/projections/multi-stream-projections' },
+                    { text: 'Custom Projections', link: '/events/projections/custom-aggregates' },]
                 },
                 { text: 'Event Projections', link: '/events/projections/event-projections' },
                 { text: 'Custom Projections', link: '/events/projections/custom' },

--- a/docs/configuration/prebuilding.md
+++ b/docs/configuration/prebuilding.md
@@ -164,7 +164,7 @@ public static class Program
                     // *try* to use pre-generated code at runtime
                     opts.GeneratedCodeMode = TypeLoadMode.Auto;
 
-                    opts.Schema.For<Activity>().AddSubClass<Trip>();
+                    opts.Schema.For<Activity>().AddSubClass<Marten.AsyncDaemon.Testing.TestingSupport.Trip>();
 
                     // You have to register all persisted document types ahead of time
                     // RegisterDocumentType<T>() is the equivalent of saying Schema.For<T>()
@@ -178,7 +178,7 @@ public static class Program
 
                     // Register all event store projections ahead of time
                     opts.Projections
-                        .Add(new TripAggregationWithCustomName(), ProjectionLifecycle.Async);
+                        .Add(new TripProjectionWithCustomName(), ProjectionLifecycle.Async);
 
                     opts.Projections
                         .Add(new DayProjection(), ProjectionLifecycle.Async);
@@ -187,10 +187,10 @@ public static class Program
                         .Add(new DistanceProjection(), ProjectionLifecycle.Async);
 
                     opts.Projections
-                        .Add(new SimpleAggregate(), ProjectionLifecycle.Inline);
+                        .Add(new SimpleProjection(), ProjectionLifecycle.Inline);
 
                     // This is actually important to register "live" aggregations too for the code generation
-                    opts.Projections.LiveStreamAggregation<SelfAggregatingTrip>();
+                    opts.Projections.LiveStreamAggregation<Trip>();
                 }).AddAsyncDaemon(DaemonMode.Solo);
             });
     }

--- a/docs/configuration/prebuilding.md
+++ b/docs/configuration/prebuilding.md
@@ -190,7 +190,7 @@ public static class Program
                         .Add(new SimpleAggregate(), ProjectionLifecycle.Inline);
 
                     // This is actually important to register "live" aggregations too for the code generation
-                    opts.Projections.Snapshot<SelfAggregatingTrip>(ProjectionLifecycle.Live);
+                    opts.Projections.LiveStreamAggregation<SelfAggregatingTrip>();
                 }).AddAsyncDaemon(DaemonMode.Solo);
             });
     }

--- a/docs/configuration/prebuilding.md
+++ b/docs/configuration/prebuilding.md
@@ -190,7 +190,7 @@ public static class Program
                         .Add(new SimpleAggregate(), ProjectionLifecycle.Inline);
 
                     // This is actually important to register "live" aggregations too for the code generation
-                    opts.Projections.SelfAggregate<SelfAggregatingTrip>(ProjectionLifecycle.Live);
+                    opts.Projections.Snapshot<SelfAggregatingTrip>(ProjectionLifecycle.Live);
                 }).AddAsyncDaemon(DaemonMode.Solo);
             });
     }

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -184,7 +184,7 @@ public class FakeListener: IChangeListener
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/basic_async_daemon_tests.cs#L52-L64' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asyncdaemonlistener' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/basic_async_daemon_tests.cs#L52-L66' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asyncdaemonlistener' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Wiring a Async Daemon listener:
@@ -194,11 +194,11 @@ Wiring a Async Daemon listener:
 var listener = new FakeListener();
 StoreOptions(x =>
 {
-    x.Projections.Add(new TripAggregationWithCustomName(), ProjectionLifecycle.Async);
+    x.Projections.Add(new TripProjectionWithCustomName(), ProjectionLifecycle.Async);
     x.Projections.AsyncListeners.Add(listener);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/basic_async_daemon_tests.cs#L69-L76' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asynclisteners' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/basic_async_daemon_tests.cs#L71-L80' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asynclisteners' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Custom Logging

--- a/docs/documents/concurrency.md
+++ b/docs/documents/concurrency.md
@@ -90,7 +90,7 @@ public void update_with_stale_version_standard()
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Concurrency/optimistic_concurrency.cs#L127-L171' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_update_with_stale_version_standard' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Marten is throwing an AggregateException for the entire batch of chang
+Marten is throwing an `AggregateException` for the entire batch of changes.
 
 ## Using IVersioned
 
@@ -108,6 +108,6 @@ public class MyVersionedDoc: IVersioned
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Metadata/metadata_marker_interfaces.cs#L121-L129' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_myversioneddoc' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Your document type will have the optimistic concurrency checks applied to updates *when* the current version is given to Marten. Moreover, the current version
+Your document type will have the optimistic concurrency checks applied to updates _when_ the current version is given to Marten. Moreover, the current version
 will always be written to the `IVersioned.Version` property when the document is modified or loaded by Marten. This makes `IVersioned` an easy strategy to track
 the current version of documents in web applications.

--- a/docs/events/projections/aggregate-projections.md
+++ b/docs/events/projections/aggregate-projections.md
@@ -487,10 +487,10 @@ internal async Task use_a_self_aggregate()
         opts.Connection("some connection string");
 
         // Run the Trip as an inline projection
-        opts.Projections.SelfAggregate<Trip>(ProjectionLifecycle.Inline);
+        opts.Projections.Snapshot<Trip>(ProjectionLifecycle.Inline);
 
         // Or run it as an asynchronous projection
-        opts.Projections.SelfAggregate<Trip>(ProjectionLifecycle.Async);
+        opts.Projections.Snapshot<Trip>(ProjectionLifecycle.Async);
     });
 
     // Or more likely, use it as a live aggregation:

--- a/docs/events/projections/aggregate-projections.md
+++ b/docs/events/projections/aggregate-projections.md
@@ -487,10 +487,10 @@ internal async Task use_a_self_aggregate()
         opts.Connection("some connection string");
 
         // Run the Trip as an inline projection
-        opts.Projections.Snapshot<Trip>(ProjectionLifecycle.Inline);
+        opts.Projections.Snapshot<Trip>(SnapshotLifecycle.Inline);
 
         // Or run it as an asynchronous projection
-        opts.Projections.Snapshot<Trip>(ProjectionLifecycle.Async);
+        opts.Projections.Snapshot<Trip>(SnapshotLifecycle.Async);
     });
 
     // Or more likely, use it as a live aggregation:

--- a/docs/events/projections/aggregate-projections.md
+++ b/docs/events/projections/aggregate-projections.md
@@ -69,7 +69,7 @@ document that directly mutates itself through method conventions or by sub-class
 <!-- snippet: sample_TripProjection_aggregate -->
 <a id='snippet-sample_tripprojection_aggregate'></a>
 ```cs
-public class TripProjection: SingleStreamAggregation<Trip>
+public class TripProjection: SingleStreamProjection<Trip>
 {
     public TripProjection()
     {
@@ -194,7 +194,7 @@ Or finally, you can use a method named `Create()` on a projection type as shown 
 <!-- snippet: sample_TripProjection_aggregate -->
 <a id='snippet-sample_tripprojection_aggregate'></a>
 ```cs
-public class TripProjection: SingleStreamAggregation<Trip>
+public class TripProjection: SingleStreamProjection<Trip>
 {
     public TripProjection()
     {
@@ -241,7 +241,7 @@ To make changes to an existing aggregate, you can either use inline Lambda funct
 <!-- snippet: sample_using_ProjectEvent_in_aggregate_projection -->
 <a id='snippet-sample_using_projectevent_in_aggregate_projection'></a>
 ```cs
-public class TripProjection: SingleStreamAggregation<Trip>
+public class TripProjection: SingleStreamProjection<Trip>
 {
     public TripProjection()
     {
@@ -272,7 +272,7 @@ I'm not personally that wild about using lots of inline Lambdas like the example
 <!-- snippet: sample_TripProjection_aggregate -->
 <a id='snippet-sample_tripprojection_aggregate'></a>
 ```cs
-public class TripProjection: SingleStreamAggregation<Trip>
+public class TripProjection: SingleStreamProjection<Trip>
 {
     public TripProjection()
     {
@@ -329,9 +329,9 @@ aggregate projection type:
 <!-- snippet: sample_deleting_aggregate_by_event_type -->
 <a id='snippet-sample_deleting_aggregate_by_event_type'></a>
 ```cs
-public class TripAggregation: SingleStreamAggregation<Trip>
+public class TripProjection: SingleStreamProjection<Trip>
 {
-    public TripAggregation()
+    public TripProjection()
     {
         // The current Trip aggregate would be deleted if
         // the projection encountered a TripAborted event
@@ -348,9 +348,9 @@ and maybe even other document state in your Marten database, you can use more ov
 <!-- snippet: sample_deleting_aggregate_by_event_type_and_func -->
 <a id='snippet-sample_deleting_aggregate_by_event_type_and_func'></a>
 ```cs
-public class TripAggregation: SingleStreamAggregation<Trip>
+public class TripProjection: SingleStreamProjection<Trip>
 {
-    public TripAggregation()
+    public TripProjection()
     {
         // The current Trip aggregate would be deleted if
         // the Breakdown event is "critical"
@@ -381,7 +381,7 @@ Another option is to use a method convention with a method named `ShouldDelete()
 <!-- snippet: sample_deleting_aggregate_by_event_type_and_func_with_convention -->
 <a id='snippet-sample_deleting_aggregate_by_event_type_and_func_with_convention'></a>
 ```cs
-public class TripAggregation: SingleStreamAggregation<Trip>
+public class TripProjection: SingleStreamProjection<Trip>
 {
     // The current Trip aggregate would be deleted if
     // the Breakdown event is "critical"
@@ -570,7 +570,7 @@ Below is a small example of accessing event metadata during aggregation:
 <!-- snippet: sample_aggregation_using_event_metadata -->
 <a id='snippet-sample_aggregation_using_event_metadata'></a>
 ```cs
-public class TripProjection: SingleStreamAggregation<Trip>
+public class TripProjection: SingleStreamProjection<Trip>
 {
     // Access event metadata through IEvent<T>
     public Trip Create(IEvent<TripStarted> @event)

--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -44,7 +44,7 @@ var host = await Host.CreateDefaultBuilder()
                 opts.Connection("some connection string");
 
                 // Register any projections you need to run asynchronously
-                opts.Projections.Add<TripAggregationWithCustomName>(ProjectionLifecycle.Async);
+                opts.Projections.Add<TripProjectionWithCustomName>(ProjectionLifecycle.Async);
             })
             // Turn on the async daemon in "Solo" mode
             .AddAsyncDaemon(DaemonMode.Solo);
@@ -67,7 +67,7 @@ var host = await Host.CreateDefaultBuilder()
                 opts.Connection("some connection string");
 
                 // Register any projections you need to run asynchronously
-                opts.Projections.Add<TripAggregationWithCustomName>(ProjectionLifecycle.Async);
+                opts.Projections.Add<TripProjectionWithCustomName>(ProjectionLifecycle.Async);
             })
             // Turn on the async daemon in "HotCold" mode
             // with built in leader election
@@ -75,7 +75,7 @@ var host = await Host.CreateDefaultBuilder()
     })
     .StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L94-L112' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrap_daemon_hotcold' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L90-L108' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrap_daemon_hotcold' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Solo vs. HotCold
@@ -132,10 +132,9 @@ opts.Projections.OnException<InvalidOperationException>()
 // or get more granular
 opts.Projections
     .OnException<InvalidOperationException>(e => e.Message.Contains("Really bad!"))
-
     .Stop(); // stops just the current projection shard
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L52-L64' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_stop_shard_on_exception' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L51-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_stop_shard_on_exception' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 For retry mechanics, you can specify a finite number of retries, then chain
@@ -149,7 +148,7 @@ opts.Projections.OnException<NpgsqlException>()
     .Then
     .Pause(1.Minutes());
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L74-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_exponential_back-off_strategy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L72-L79' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_exponential_back-off_strategy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Default Error Handling Policies
@@ -198,7 +197,7 @@ opts.Projections.OnApplyEventException()
     .AndInner<ArithmeticException>()
     .SkipEvent();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L66-L72' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_poison_pill' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L64-L70' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_poison_pill' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Diagnostics
@@ -228,7 +227,7 @@ public static async Task ShowDaemonDiagnostics(IDocumentStore store)
     Console.WriteLine($"The daemon high water sequence mark is {daemonHighWaterMark}");
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L117-L139' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_daemondiagnostics' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L111-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_daemondiagnostics' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Command Line Support
@@ -310,7 +309,7 @@ public static async Task UseAsyncDaemon(IDocumentStore store, CancellationToken 
     await daemon.RebuildProjection("a projection name", 5.Minutes(), cancellation);
 
     // or a single projection by its type
-    await daemon.RebuildProjection<TripAggregationWithCustomName>(5.Minutes(), cancellation);
+    await daemon.RebuildProjection<TripProjectionWithCustomName>(5.Minutes(), cancellation);
 
     // Be careful with this. Wait until the async daemon has completely
     // caught up with the currently known high water mark
@@ -326,5 +325,5 @@ public static async Task UseAsyncDaemon(IDocumentStore store, CancellationToken 
     await daemon.StopAll();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L141-L171' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_use_async_daemon_alone' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L135-L165' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_use_async_daemon_alone' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/events/projections/custom-aggregates.md
+++ b/docs/events/projections/custom-aggregates.md
@@ -14,7 +14,7 @@ public class End{}
 public class Restart{}
 public class Increment{}
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/CustomAggregationTests.cs#L395-L402' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_custom_aggregate_events' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/CustomProjectionTests.cs#L395-L402' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_custom_aggregate_events' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And a simple aggregate document type like this:
@@ -38,7 +38,7 @@ public class StartAndStopAggregate : ISoftDeleted
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/CustomAggregationTests.cs#L375-L393' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_startandstopaggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/CustomProjectionTests.cs#L375-L393' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_startandstopaggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 As you can see, `StartAndStopAggregate` as a `Guid` as its identity and is also [soft-deleted](/documents/deletes.html#soft-deletes) when stored by
@@ -49,7 +49,7 @@ With all that being done, here's a sample aggregation that inherits from the Mar
 <!-- snippet: sample_custom_aggregate_with_start_and_stop -->
 <a id='snippet-sample_custom_aggregate_with_start_and_stop'></a>
 ```cs
-public class StartAndStopProjection: CustomAggregation<StartAndStopAggregate, Guid>
+public class StartAndStopProjection: CustomProjection<StartAndStopAggregate, Guid>
 {
     public StartAndStopProjection()
     {
@@ -113,7 +113,7 @@ public class StartAndStopProjection: CustomAggregation<StartAndStopAggregate, Gu
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/CustomAggregationTests.cs#L404-L472' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_custom_aggregate_with_start_and_stop' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/CustomProjectionTests.cs#L404-L472' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_custom_aggregate_with_start_and_stop' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Custom Grouping

--- a/docs/events/projections/custom-aggregates.md
+++ b/docs/events/projections/custom-aggregates.md
@@ -1,6 +1,6 @@
 # Custom Aggregations
 
-Once in awhile users are hitting use cases or desired functionality for aggregation projections that just don't fit in well to our [`SingleStreamAggregation<T>`](/events/projections/aggregate-projections) or [`MultiStreamAggregation<TDoc, TId>`](/events/projections/multi-stream-projections) models. Not to worry though, because
+Once in awhile users are hitting use cases or desired functionality for aggregation projections that just don't fit in well to our [`SingleStreamProjection<T>`](/events/projections/aggregate-projections) or [`MultiStreamProjection<TDoc, TId>`](/events/projections/multi-stream-projections) models. Not to worry though, because
 Marten V5.0 introduces the new `CustomAggregation<T>` base type that will let you define aggregation projections with explicit user code while still taking advantage of some of the parallelization
 optimizations that were built for the previous aggregation types running in the [async daemon](/events/projections/async-daemon);
 
@@ -120,8 +120,8 @@ public class StartAndStopProjection: CustomProjection<StartAndStopAggregate, Gui
 
 All aggregations in Marten come in two parts:
 
-1. *Grouping* incoming events into "slices" of events that should be applied to an aggregate by id
-2. *Applying* incoming events from each slice into the identified aggregate
+1. _Grouping_ incoming events into "slices" of events that should be applied to an aggregate by id
+2. _Applying_ incoming events from each slice into the identified aggregate
 
 `CustomAggregate` supports aggregating by the stream identity as shown above. You can also use all the same customizable grouping functionality as
-the older [MultiStreamAggregation](/events/projections/multi-stream-projections) subclass.
+the older [MultiStreamProjection](/events/projections/multi-stream-projections) subclass.

--- a/docs/events/projections/index.md
+++ b/docs/events/projections/index.md
@@ -167,7 +167,7 @@ var store = DocumentStore.For(_ =>
 
     // This is all you need to create the QuestParty projected
     // view
-    _.Projections.SelfAggregate<QuestParty>();
+    _.Projections.Snapshot<QuestParty>();
 });
 ```
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/inline_aggregation_by_stream_with_multiples.cs#L24-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering-quest-party' title='Start of snippet'>anchor</a></sup>

--- a/docs/events/projections/live-aggregates.md
+++ b/docs/events/projections/live-aggregates.md
@@ -1,10 +1,10 @@
 # Live Aggregation
 
 ::: tip
-For information on how to create aggregated projection or "self-aggregates," see [Aggregate Projections](/events/projections/aggregate-projections).
+For information on how to create aggregated projection or snapshots see [Aggregate Projections](/events/projections/aggregate-projections).
 :::
 
-In Event Sourcing, the entity state is stored as the series of events that happened for this specific object, e.g. `InvoiceInitiated`, `InvoiceIssued`, `InvoiceSent`.  All of those events shares the stream id, and have incremented stream version. In other words, they're correlated by the stream id ordered by stream position.
+In Event Sourcing, the entity state is stored as the series of events that happened for this specific object, e.g. `InvoiceInitiated`, `InvoiceIssued`, `InvoiceSent`. All of those events shares the stream id, and have incremented stream version. In other words, they're correlated by the stream id ordered by stream position.
 
 Streams can be thought of as the entities' representation. Traditionally (e.g. in relational or document approach), each entity is stored as a separate record.
 

--- a/docs/events/projections/multi-stream-projections.md
+++ b/docs/events/projections/multi-stream-projections.md
@@ -2,7 +2,7 @@
 
 ::: tip
 This may change again in V6 (sigh), but we have replaced the earlier nomenclature of "ViewProjection" and renamed this concept as
-`MultiStreamAggregation` to hopefully be more intention revealing.
+`MultiStreamProjection` to hopefully be more intention revealing.
 :::
 
 ::: warning
@@ -15,7 +15,7 @@ If you have Multi-Stream Aggregations registered as async and Async Daemon is no
 issue a warning in logs during startup in case of such a mismatch.
 :::
 
-Multi stream projections are designed to handle multi-stream projections where a view is aggregated over events between streams. The `MultiStreamAggregation<TDoc, TId>`
+Multi stream projections are designed to handle multi-stream projections where a view is aggregated over events between streams. The `MultiStreamProjection<TDoc, TId>`
 base class is a subclass of the simpler [Single Stream Projection](/events/projections/aggregate-projections) and supports all the same method conventions and inline event handling, but allows
 the user to specify how events apply to aggregated views in ways besides the simple aggregation by stream model.
 
@@ -197,7 +197,7 @@ public class UserGroupsAssignmentProjection: MultiStreamProjection<UserGroupsAss
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/MultiStreamProjections/simple_multi_stream_projection.cs#L10-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_view-projection-simple' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Note that the primary difference between this and `SingleStreamAggregation<T>` is the calls to `Identity<TEvent>()` to specify how the events are grouped
+Note that the primary difference between this and `SingleStreamProjection<T>` is the calls to `Identity<TEvent>()` to specify how the events are grouped
 into separate aggregates across streams. We can also do the equivalent of the code above by using a common interface `IUserEvent` on the event types
 we care about and use this:
 

--- a/docs/events/projections/multi-stream-projections.md
+++ b/docs/events/projections/multi-stream-projections.md
@@ -176,7 +176,7 @@ Here's a simple example of creating an aggregated view by user id:
 <!-- snippet: sample_view-projection-simple -->
 <a id='snippet-sample_view-projection-simple'></a>
 ```cs
-public class UserGroupsAssignmentProjection: MultiStreamAggregation<UserGroupsAssignment, Guid>
+public class UserGroupsAssignmentProjection: MultiStreamProjection<UserGroupsAssignment, Guid>
 {
     public UserGroupsAssignmentProjection()
     {
@@ -204,7 +204,7 @@ we care about and use this:
 <!-- snippet: sample_view-projection-simple-2 -->
 <a id='snippet-sample_view-projection-simple-2'></a>
 ```cs
-public class UserGroupsAssignmentProjection2: MultiStreamAggregation<UserGroupsAssignment, Guid>
+public class UserGroupsAssignmentProjection2: MultiStreamProjection<UserGroupsAssignment, Guid>
 {
     public UserGroupsAssignmentProjection2()
     {
@@ -237,7 +237,7 @@ shown below:
 <!-- snippet: sample_view-projection-simple-with-one-to-many -->
 <a id='snippet-sample_view-projection-simple-with-one-to-many'></a>
 ```cs
-public class UserGroupsAssignmentProjection: MultiStreamAggregation<UserGroupsAssignment, Guid>
+public class UserGroupsAssignmentProjection: MultiStreamProjection<UserGroupsAssignment, Guid>
 {
     public UserGroupsAssignmentProjection()
     {
@@ -305,7 +305,7 @@ public class LicenseFeatureToggledEventGrouper: IAggregateGrouper<Guid>
 }
 
 // projection with documentsession
-public class UserFeatureTogglesProjection: MultiStreamAggregation<UserFeatureToggles, Guid>
+public class UserFeatureTogglesProjection: MultiStreamProjection<UserFeatureToggles, Guid>
 {
     public UserFeatureTogglesProjection()
     {
@@ -347,7 +347,7 @@ own `IEventSlicer` that can split and assign events to any number of aggregated 
 <!-- snippet: sample_view-projection-custom-slicer -->
 <a id='snippet-sample_view-projection-custom-slicer'></a>
 ```cs
-public class UserGroupsAssignmentProjection: MultiStreamAggregation<UserGroupsAssignment, Guid>
+public class UserGroupsAssignmentProjection: MultiStreamProjection<UserGroupsAssignment, Guid>
 {
     public class CustomSlicer: IEventSlicer<UserGroupsAssignment, Guid>
     {
@@ -410,7 +410,7 @@ In a sample `ViewProjection`, we do a "fan out" of the `Travel.Movements` member
 <!-- snippet: sample_showing_fanout_rules -->
 <a id='snippet-sample_showing_fanout_rules'></a>
 ```cs
-public class DayProjection: MultiStreamAggregation<Day, int>
+public class DayProjection: MultiStreamProjection<Day, int>
 {
     public DayProjection()
     {

--- a/docs/events/quickstart.md
+++ b/docs/events/quickstart.md
@@ -193,11 +193,7 @@ await using (var session = store.LightweightSession())
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L46-L58' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_event-store-start-stream-with-explicit-type' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Now, we would at some point like to see the current state of the quest party
-to check up on where they're at, who is in the party, and maybe how many
-monsters they've slain along the way. To keep things simple, we're going
-to use Marten's self-aggregating feature to model a `QuestParty` that
-can update itself based on our events:
+Now, we would at some point like to see the current state of the quest party to check up on where they're at, who is in the party, and maybe how many monsters they've slain along the way. To keep things simple, we're going to use Marten's live stream aggregation feature to model a `QuestParty` that can update itself based on our events:
 
 <!-- snippet: sample_QuestParty -->
 <a id='snippet-sample_questparty'></a>

--- a/docs/events/quickstart.md
+++ b/docs/events/quickstart.md
@@ -147,7 +147,7 @@ public class MembersEscaped
 var store = DocumentStore.For(_ =>
 {
     _.Connection(ConnectionSource.ConnectionString);
-    _.Projections.SelfAggregate<QuestParty>();
+    _.Projections.Snapshot<QuestParty>();
 });
 
 var questId = Guid.NewGuid();

--- a/src/AspNetCoreWithMarten/EventTypes.cs
+++ b/src/AspNetCoreWithMarten/EventTypes.cs
@@ -38,7 +38,7 @@ public class View2{
     public bool IsEvent4Applied {get; set;}
 }
 
-public class View1Projection : SingleStreamAggregation<View1>
+public class View1Projection : SingleStreamProjection<View1>
 {
     public void Apply(View1 v, Event1 e){
         v.IsEvent1Applied = true;
@@ -47,7 +47,7 @@ public class View1Projection : SingleStreamAggregation<View1>
         v.IsEvent2Applied = true;
     }
 }
-public class View2Projection : SingleStreamAggregation<View2>
+public class View2Projection : SingleStreamProjection<View2>
 {
 
     public void Apply(View2 v, Event3 e){

--- a/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs
+++ b/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs
@@ -26,7 +26,7 @@ public class AsyncDaemonBootstrappingSamples
                         opts.Connection("some connection string");
 
                         // Register any projections you need to run asynchronously
-                        opts.Projections.Add<TripAggregationWithCustomName>(ProjectionLifecycle.Async);
+                        opts.Projections.Add<TripProjectionWithCustomName>(ProjectionLifecycle.Async);
                     })
                     // Turn on the async daemon in "Solo" mode
                     .AddAsyncDaemon(DaemonMode.Solo);
@@ -38,7 +38,6 @@ public class AsyncDaemonBootstrappingSamples
 
     public async Task ErrorHandlingSolo()
     {
-
         var host = await Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
             {
@@ -47,7 +46,7 @@ public class AsyncDaemonBootstrappingSamples
                         opts.Connection("some connection string");
 
                         // Register any projections you need to run asynchronously
-                        opts.Projections.Add<TripAggregationWithCustomName>(ProjectionLifecycle.Async);
+                        opts.Projections.Add<TripProjectionWithCustomName>(ProjectionLifecycle.Async);
 
                         #region sample_stop_shard_on_exception
 
@@ -58,7 +57,6 @@ public class AsyncDaemonBootstrappingSamples
                         // or get more granular
                         opts.Projections
                             .OnException<InvalidOperationException>(e => e.Message.Contains("Really bad!"))
-
                             .Stop(); // stops just the current projection shard
 
                         #endregion
@@ -84,9 +82,7 @@ public class AsyncDaemonBootstrappingSamples
                     .AddAsyncDaemon(DaemonMode.Solo);
             })
             .StartAsync();
-
     }
-
 
 
     public async Task BootstrapHotCold()
@@ -101,7 +97,7 @@ public class AsyncDaemonBootstrappingSamples
                         opts.Connection("some connection string");
 
                         // Register any projections you need to run asynchronously
-                        opts.Projections.Add<TripAggregationWithCustomName>(ProjectionLifecycle.Async);
+                        opts.Projections.Add<TripProjectionWithCustomName>(ProjectionLifecycle.Async);
                     })
                     // Turn on the async daemon in "HotCold" mode
                     // with built in leader election
@@ -110,8 +106,6 @@ public class AsyncDaemonBootstrappingSamples
             .StartAsync();
 
         #endregion
-
-
     }
 
     #region sample_DaemonDiagnostics
@@ -152,7 +146,7 @@ public class AsyncDaemonBootstrappingSamples
         await daemon.RebuildProjection("a projection name", 5.Minutes(), cancellation);
 
         // or a single projection by its type
-        await daemon.RebuildProjection<TripAggregationWithCustomName>(5.Minutes(), cancellation);
+        await daemon.RebuildProjection<TripProjectionWithCustomName>(5.Minutes(), cancellation);
 
         // Be careful with this. Wait until the async daemon has completely
         // caught up with the currently known high water mark

--- a/src/CommandLineRunner/Program.cs
+++ b/src/CommandLineRunner/Program.cs
@@ -84,7 +84,7 @@ public static class Program
                         .Add(new SimpleAggregate(), ProjectionLifecycle.Inline);
 
                     // This is actually important to register "live" aggregations too for the code generation
-                    opts.Projections.Snapshot<SelfAggregatingTrip>(ProjectionLifecycle.Live);
+                    opts.Projections.LiveStreamAggregation<SelfAggregatingTrip>();
                 }).AddAsyncDaemon(DaemonMode.Solo);
             });
     }

--- a/src/CommandLineRunner/Program.cs
+++ b/src/CommandLineRunner/Program.cs
@@ -58,7 +58,7 @@ public static class Program
                     // *try* to use pre-generated code at runtime
                     opts.GeneratedCodeMode = TypeLoadMode.Auto;
 
-                    opts.Schema.For<Activity>().AddSubClass<Trip>();
+                    opts.Schema.For<Activity>().AddSubClass<Marten.AsyncDaemon.Testing.TestingSupport.Trip>();
 
                     // You have to register all persisted document types ahead of time
                     // RegisterDocumentType<T>() is the equivalent of saying Schema.For<T>()
@@ -72,7 +72,7 @@ public static class Program
 
                     // Register all event store projections ahead of time
                     opts.Projections
-                        .Add(new TripAggregationWithCustomName(), ProjectionLifecycle.Async);
+                        .Add(new TripProjectionWithCustomName(), ProjectionLifecycle.Async);
 
                     opts.Projections
                         .Add(new DayProjection(), ProjectionLifecycle.Async);
@@ -81,10 +81,10 @@ public static class Program
                         .Add(new DistanceProjection(), ProjectionLifecycle.Async);
 
                     opts.Projections
-                        .Add(new SimpleAggregate(), ProjectionLifecycle.Inline);
+                        .Add(new SimpleProjection(), ProjectionLifecycle.Inline);
 
                     // This is actually important to register "live" aggregations too for the code generation
-                    opts.Projections.LiveStreamAggregation<SelfAggregatingTrip>();
+                    opts.Projections.LiveStreamAggregation<Trip>();
                 }).AddAsyncDaemon(DaemonMode.Solo);
             });
     }
@@ -92,7 +92,7 @@ public static class Program
 
 #endregion
 
-public class SelfAggregatingTrip
+public class Trip
 {
     public Guid Id { get; set; }
     public string State { get; set; } = null!;
@@ -119,9 +119,9 @@ public class SelfAggregatingTrip
     }
 }
 
-public class SimpleAggregate: SingleStreamProjection<MyAggregate>
+public class SimpleProjection: SingleStreamProjection<MyAggregate>
 {
-    public SimpleAggregate()
+    public SimpleProjection()
     {
         ProjectionName = "AllGood";
     }

--- a/src/CommandLineRunner/Program.cs
+++ b/src/CommandLineRunner/Program.cs
@@ -119,7 +119,7 @@ public class SelfAggregatingTrip
     }
 }
 
-public class SimpleAggregate: SingleStreamAggregation<MyAggregate>
+public class SimpleAggregate: SingleStreamProjection<MyAggregate>
 {
     public SimpleAggregate()
     {

--- a/src/CommandLineRunner/Program.cs
+++ b/src/CommandLineRunner/Program.cs
@@ -84,7 +84,7 @@ public static class Program
                         .Add(new SimpleAggregate(), ProjectionLifecycle.Inline);
 
                     // This is actually important to register "live" aggregations too for the code generation
-                    opts.Projections.SelfAggregate<SelfAggregatingTrip>(ProjectionLifecycle.Live);
+                    opts.Projections.Snapshot<SelfAggregatingTrip>(ProjectionLifecycle.Live);
                 }).AddAsyncDaemon(DaemonMode.Solo);
             });
     }

--- a/src/CoreTests/Diagnostics/read_only_view_of_store_options_on_document_store.cs
+++ b/src/CoreTests/Diagnostics/read_only_view_of_store_options_on_document_store.cs
@@ -144,7 +144,7 @@ public class QuestEnded
 }
 
 
-public class AllSync: SingleStreamAggregation<MyAggregate>
+public class AllSync: SingleStreamProjection<MyAggregate>
 {
     public AllSync()
     {
@@ -197,7 +197,7 @@ public class AllSync: SingleStreamAggregation<MyAggregate>
     }
 }
 
-public class AllGood: SingleStreamAggregation<MyAggregate>
+public class AllGood: SingleStreamProjection<MyAggregate>
 {
     public AllGood()
     {

--- a/src/DocumentDbTests/Indexes/UniqueIndexTests.cs
+++ b/src/DocumentDbTests/Indexes/UniqueIndexTests.cs
@@ -17,9 +17,9 @@ public class UserCreated
     public string Surname { get; set; }
 }
 
-public class UserMultiStreamAggregation : MultiStreamAggregation<UniqueUser, Guid>
+public class UserMultiStreamProjection : MultiStreamProjection<UniqueUser, Guid>
 {
-    public UserMultiStreamAggregation()
+    public UserMultiStreamProjection()
     {
         Identity<UserCreated>(x => x.UserId);
     }
@@ -59,7 +59,7 @@ public class UniqueIndexTests : OneOffConfigurationsContext
         StoreOptions(opts =>
         {
             opts.Events.AddEventTypes(new[] { typeof(UserCreated) });
-            opts.Projections.Add(new UserMultiStreamAggregation());
+            opts.Projections.Add(new UserMultiStreamProjection());
             opts.RegisterDocumentType<UniqueUser>();
         });
     }

--- a/src/EventSourceWorker/Program.cs
+++ b/src/EventSourceWorker/Program.cs
@@ -40,7 +40,7 @@ public class Program
                             options.AutoCreateSchemaObjects = AutoCreate.All;
                         }
 
-                        options.Projections.Add(new TripAggregationWithCustomName());
+                        options.Projections.Add(new TripProjectionWithCustomName());
                     })
                     // Run the asynchronous projections in this node
                     .AddAsyncDaemon(DaemonMode.Solo);

--- a/src/EventSourcingTests/Aggregation/AggregationContext.cs
+++ b/src/EventSourcingTests/Aggregation/AggregationContext.cs
@@ -12,14 +12,14 @@ namespace EventSourcingTests.Aggregation;
 
 public class AggregationContext : IntegrationContext
 {
-    protected SingleStreamAggregation<MyAggregate> _projection;
+    protected SingleStreamProjection<MyAggregate> _projection;
 
     public AggregationContext(DefaultStoreFixture fixture) : base(fixture)
     {
         theStore.Advanced.Clean.DeleteDocumentsByType(typeof(MyAggregate));
     }
 
-    public void UsingDefinition<T>() where T : SingleStreamAggregation<MyAggregate>, new()
+    public void UsingDefinition<T>() where T : SingleStreamProjection<MyAggregate>, new()
     {
         _projection = new T();
 
@@ -28,9 +28,9 @@ public class AggregationContext : IntegrationContext
         _projection.Compile(theStore.Options, rules);
     }
 
-    public void UsingDefinition(Action<SingleStreamAggregation<MyAggregate>> configure)
+    public void UsingDefinition(Action<SingleStreamProjection<MyAggregate>> configure)
     {
-        _projection = new SingleStreamAggregation<MyAggregate>();
+        _projection = new SingleStreamProjection<MyAggregate>();
         configure(_projection);
 
 

--- a/src/EventSourcingTests/Aggregation/CustomProjectionTests.cs
+++ b/src/EventSourcingTests/Aggregation/CustomProjectionTests.cs
@@ -23,24 +23,24 @@ using Xunit;
 
 namespace EventSourcingTests.Aggregation;
 
-public class CustomAggregationTests
+public class CustomProjectionTests
 {
     [Fact]
     public void default_projection_name_is_type_name()
     {
-        new MyCustomAggregation().ProjectionName.ShouldBe(nameof(MyCustomAggregation));
+        new MyCustomProjection().ProjectionName.ShouldBe(nameof(MyCustomProjection));
     }
 
     [Fact]
     public void default_lifecycle_should_be_async()
     {
-        new MyCustomAggregation().Lifecycle.ShouldBe(ProjectionLifecycle.Async);
+        new MyCustomProjection().Lifecycle.ShouldBe(ProjectionLifecycle.Async);
     }
 
     [Fact]
     public void async_options_is_not_null()
     {
-        new MyCustomAggregation().As<IProjectionSource>().Options.ShouldNotBeNull();
+        new MyCustomProjection().As<IProjectionSource>().Options.ShouldNotBeNull();
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public class CustomAggregationTests
 
 }
 
-public class EmptyCustomProjection<TDoc, TId>: CustomAggregation<TDoc, TId>
+public class EmptyCustomProjection<TDoc, TId>: CustomProjection<TDoc, TId>
 {
     public override ValueTask ApplyChangesAsync(DocumentSessionBase session, EventSlice<TDoc, TId> slice, CancellationToken cancellation,
         ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline)
@@ -113,7 +113,7 @@ public class EmptyCustomProjection<TDoc, TId>: CustomAggregation<TDoc, TId>
     }
 }
 
-public class custom_aggregation_end_to_end: OneOffConfigurationsContext
+public class custom_projection_end_to_end: OneOffConfigurationsContext
 {
     private void appendCustomEvent(int number, char letter)
     {
@@ -123,7 +123,7 @@ public class custom_aggregation_end_to_end: OneOffConfigurationsContext
     [Fact]
     public async Task use_inline_asynchronous()
     {
-        StoreOptions(opts => opts.Projections.Add(new MyCustomAggregation(), ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Add(new MyCustomProjection(), ProjectionLifecycle.Inline));
 
         await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
         await theStore.Advanced.Clean.DeleteAllEventDataAsync();
@@ -157,7 +157,7 @@ public class custom_aggregation_end_to_end: OneOffConfigurationsContext
     [Fact]
     public void use_inline_synchronous()
     {
-        StoreOptions(opts => opts.Projections.Add(new MyCustomAggregation(), ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Add(new MyCustomProjection(), ProjectionLifecycle.Inline));
 
         theStore.Advanced.Clean.DeleteAllDocuments();
         theStore.Advanced.Clean.DeleteAllEventData();
@@ -206,7 +206,7 @@ public interface INumbered
     public int Number { get; }
 }
 
-public class MyCustomAggregateWithNoSlicer: CustomAggregation<CustomAggregate, int>
+public class MyCustomAggregateWithNoSlicer: CustomProjection<CustomAggregate, int>
 {
     public override ValueTask ApplyChangesAsync(DocumentSessionBase session, EventSlice<CustomAggregate, int> slice, CancellationToken cancellation,
         ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline)
@@ -218,9 +218,9 @@ public class MyCustomAggregateWithNoSlicer: CustomAggregation<CustomAggregate, i
 }
 
 
-public class MyCustomAggregation: CustomAggregation<CustomAggregate, int>
+public class MyCustomProjection: CustomProjection<CustomAggregate, int>
 {
-    public MyCustomAggregation()
+    public MyCustomProjection()
     {
         AggregateEvents(s =>
         {
@@ -403,7 +403,7 @@ public class Increment{}
 
 #region sample_custom_aggregate_with_start_and_stop
 
-public class StartAndStopProjection: CustomAggregation<StartAndStopAggregate, Guid>
+public class StartAndStopProjection: CustomProjection<StartAndStopAggregate, Guid>
 {
     public StartAndStopProjection()
     {

--- a/src/EventSourcingTests/Aggregation/LiveAggregatorBuilderTests.cs
+++ b/src/EventSourcingTests/Aggregation/LiveAggregatorBuilderTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace EventSourcingTests.Aggregation;
 
-public class SelfLiveAggregatorBuilderTests
+public class LiveAggregatorBuilderTests
 {
     [Fact]
     public void try_existing_QuestParty()
@@ -46,7 +46,7 @@ public class FakeAggregate
         return Task.FromResult(this);
     }
 
-    public Task<FakeAggregate> Apply(IEvent<SelfLiveAggregatorBuilderTests.EventE> @event, IQuerySession session)
+    public Task<FakeAggregate> Apply(IEvent<LiveAggregatorBuilderTests.EventE> @event, IQuerySession session)
     {
         return Task.FromResult(this);
     }

--- a/src/EventSourcingTests/Aggregation/SelfLiveAggregatorBuilderTests.cs
+++ b/src/EventSourcingTests/Aggregation/SelfLiveAggregatorBuilderTests.cs
@@ -14,14 +14,14 @@ public class SelfLiveAggregatorBuilderTests
     [Fact]
     public void try_existing_QuestParty()
     {
-        var aggregator = new SingleStreamAggregation<QuestParty>().Build(new StoreOptions());
+        var aggregator = new SingleStreamProjection<QuestParty>().Build(new StoreOptions());
         aggregator.ShouldNotBeNull();
     }
 
     [Fact]
     public void try_with_all_possibilities()
     {
-        new SingleStreamAggregation<FakeAggregate>()
+        new SingleStreamProjection<FakeAggregate>()
             .Build(new StoreOptions())
             .ShouldNotBeNull();
     }

--- a/src/EventSourcingTests/Aggregation/aggregates_should_be_registered_as_document_mappings_automatically.cs
+++ b/src/EventSourcingTests/Aggregation/aggregates_should_be_registered_as_document_mappings_automatically.cs
@@ -40,7 +40,7 @@ public class aggregates_should_be_registered_as_document_mappings_automatically:
     {
         StoreOptions(_ =>
         {
-            _.Projections.SelfAggregate<QuestParty>();
+            _.Projections.Snapshot<QuestParty>();
         });
 
         theStore.StorageFeatures.AllDocumentMappings.Select(x => x.DocumentType)
@@ -52,7 +52,7 @@ public class aggregates_should_be_registered_as_document_mappings_automatically:
     {
         StoreOptions(_ =>
         {
-            _.Projections.SelfAggregate<QuestParty>(ProjectionLifecycle.Async);
+            _.Projections.Snapshot<QuestParty>(ProjectionLifecycle.Async);
         });
 
         theStore.StorageFeatures.AllDocumentMappings.Select(x => x.DocumentType)

--- a/src/EventSourcingTests/Aggregation/aggregates_should_be_registered_as_document_mappings_automatically.cs
+++ b/src/EventSourcingTests/Aggregation/aggregates_should_be_registered_as_document_mappings_automatically.cs
@@ -52,7 +52,7 @@ public class aggregates_should_be_registered_as_document_mappings_automatically:
     {
         StoreOptions(_ =>
         {
-            _.Projections.Snapshot<QuestParty>(ProjectionLifecycle.Async);
+            _.Projections.Snapshot<QuestParty>(SnapshotLifecycle.Async);
         });
 
         theStore.StorageFeatures.AllDocumentMappings.Select(x => x.DocumentType)

--- a/src/EventSourcingTests/Aggregation/aggregation_projection_validation_rules.cs
+++ b/src/EventSourcingTests/Aggregation/aggregation_projection_validation_rules.cs
@@ -39,7 +39,7 @@ public class aggregation_projection_validation_rules
         var message = errorMessageFor(x =>
         {
             x.Events.StreamIdentity = StreamIdentity.AsGuid;
-            x.Projections.SelfAggregate<StringIdentifiedAggregate>(ProjectionLifecycle.Async);
+            x.Projections.Snapshot<StringIdentifiedAggregate>(ProjectionLifecycle.Async);
         });
 
         message.ShouldContain($"Id type mismatch. The stream identity type is System.Guid, but the aggregate document {typeof(StringIdentifiedAggregate).FullNameInCode()} id type is string", StringComparisonOption.Default);
@@ -52,7 +52,7 @@ public class aggregation_projection_validation_rules
         var message = errorMessageFor(x =>
         {
             x.Events.StreamIdentity = StreamIdentity.AsString;
-            x.Projections.SelfAggregate<GuidIdentifiedAggregate>(ProjectionLifecycle.Async);
+            x.Projections.Snapshot<GuidIdentifiedAggregate>(ProjectionLifecycle.Async);
         });
 
         message.ShouldContain($"Id type mismatch. The stream identity type is string, but the aggregate document {typeof(GuidIdentifiedAggregate).FullNameInCode()} id type is Guid", StringComparisonOption.Default);
@@ -64,7 +64,7 @@ public class aggregation_projection_validation_rules
         errorMessageFor(opts =>
         {
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
-            opts.Projections.SelfAggregate<GuidIdentifiedAggregate>(ProjectionLifecycle.Async);
+            opts.Projections.Snapshot<GuidIdentifiedAggregate>(ProjectionLifecycle.Async);
         }).ShouldContain($"Tenancy storage style mismatch between the events (Conjoined) and the aggregate type {typeof(GuidIdentifiedAggregate).FullNameInCode()} (Single)", StringComparisonOption.Default);
     }
 
@@ -73,7 +73,7 @@ public class aggregation_projection_validation_rules
     {
         errorMessageFor(opts =>
         {
-            opts.Projections.SelfAggregate<GuidIdentifiedAggregate>(ProjectionLifecycle.Async);
+            opts.Projections.Snapshot<GuidIdentifiedAggregate>(ProjectionLifecycle.Async);
             opts.Schema.For<GuidIdentifiedAggregate>().MultiTenanted();
         }).ShouldContain($"Tenancy storage style mismatch between the events (Single) and the aggregate type {typeof(GuidIdentifiedAggregate).FullNameInCode()} (Conjoined)", StringComparisonOption.Default);
     }

--- a/src/EventSourcingTests/Aggregation/aggregation_projection_validation_rules.cs
+++ b/src/EventSourcingTests/Aggregation/aggregation_projection_validation_rules.cs
@@ -39,7 +39,7 @@ public class aggregation_projection_validation_rules
         var message = errorMessageFor(x =>
         {
             x.Events.StreamIdentity = StreamIdentity.AsGuid;
-            x.Projections.Snapshot<StringIdentifiedAggregate>(ProjectionLifecycle.Async);
+            x.Projections.Snapshot<StringIdentifiedAggregate>(SnapshotLifecycle.Async);
         });
 
         message.ShouldContain($"Id type mismatch. The stream identity type is System.Guid, but the aggregate document {typeof(StringIdentifiedAggregate).FullNameInCode()} id type is string", StringComparisonOption.Default);
@@ -52,7 +52,7 @@ public class aggregation_projection_validation_rules
         var message = errorMessageFor(x =>
         {
             x.Events.StreamIdentity = StreamIdentity.AsString;
-            x.Projections.Snapshot<GuidIdentifiedAggregate>(ProjectionLifecycle.Async);
+            x.Projections.Snapshot<GuidIdentifiedAggregate>(SnapshotLifecycle.Async);
         });
 
         message.ShouldContain($"Id type mismatch. The stream identity type is string, but the aggregate document {typeof(GuidIdentifiedAggregate).FullNameInCode()} id type is Guid", StringComparisonOption.Default);
@@ -64,7 +64,7 @@ public class aggregation_projection_validation_rules
         errorMessageFor(opts =>
         {
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
-            opts.Projections.Snapshot<GuidIdentifiedAggregate>(ProjectionLifecycle.Async);
+            opts.Projections.Snapshot<GuidIdentifiedAggregate>(SnapshotLifecycle.Async);
         }).ShouldContain($"Tenancy storage style mismatch between the events (Conjoined) and the aggregate type {typeof(GuidIdentifiedAggregate).FullNameInCode()} (Single)", StringComparisonOption.Default);
     }
 
@@ -73,7 +73,7 @@ public class aggregation_projection_validation_rules
     {
         errorMessageFor(opts =>
         {
-            opts.Projections.Snapshot<GuidIdentifiedAggregate>(ProjectionLifecycle.Async);
+            opts.Projections.Snapshot<GuidIdentifiedAggregate>(SnapshotLifecycle.Async);
             opts.Schema.For<GuidIdentifiedAggregate>().MultiTenanted();
         }).ShouldContain($"Tenancy storage style mismatch between the events (Single) and the aggregate type {typeof(GuidIdentifiedAggregate).FullNameInCode()} (Conjoined)", StringComparisonOption.Default);
     }

--- a/src/EventSourcingTests/Aggregation/aggregation_projection_validation_rules.cs
+++ b/src/EventSourcingTests/Aggregation/aggregation_projection_validation_rules.cs
@@ -87,7 +87,7 @@ public class aggregation_projection_validation_rules
         }).ShouldNotBeNull();
     }
 
-    public class EmptyProjection: SingleStreamAggregation<GuidIdentifiedAggregate>
+    public class EmptyProjection: SingleStreamProjection<GuidIdentifiedAggregate>
     {
 
     }
@@ -189,7 +189,7 @@ public class aggregation_projection_validation_rules
     }
 }
 
-public class MissingMandatoryType: SingleStreamAggregation<MyAggregate>
+public class MissingMandatoryType: SingleStreamProjection<MyAggregate>
 {
     public void Apply(AEvent @event)
     {
@@ -197,7 +197,7 @@ public class MissingMandatoryType: SingleStreamAggregation<MyAggregate>
     }
 }
 
-public class BadReturnType: SingleStreamAggregation<MyAggregate>
+public class BadReturnType: SingleStreamProjection<MyAggregate>
 {
     public string Apply(AEvent @event, MyAggregate aggregate, IDocumentOperations operations)
     {
@@ -205,7 +205,7 @@ public class BadReturnType: SingleStreamAggregation<MyAggregate>
     }
 }
 
-public class MissingEventType1: SingleStreamAggregation<MyAggregate>
+public class MissingEventType1: SingleStreamProjection<MyAggregate>
 {
     public void Apply(MyAggregate aggregate, IDocumentOperations operations)
     {
@@ -213,7 +213,7 @@ public class MissingEventType1: SingleStreamAggregation<MyAggregate>
     }
 }
 
-public class CanGuessEventType: SingleStreamAggregation<MyAggregate>
+public class CanGuessEventType: SingleStreamProjection<MyAggregate>
 {
     public void Apply(AEvent a, MyAggregate aggregate, IQuerySession session)
     {
@@ -221,7 +221,7 @@ public class CanGuessEventType: SingleStreamAggregation<MyAggregate>
     }
 }
 
-public class InvalidArgumentType: SingleStreamAggregation<MyAggregate>
+public class InvalidArgumentType: SingleStreamProjection<MyAggregate>
 {
     public void Apply(AEvent @event, MyAggregate aggregate, IDocumentOperations operations)
     {
@@ -229,7 +229,7 @@ public class InvalidArgumentType: SingleStreamAggregation<MyAggregate>
     }
 }
 
-public class BadMethodName: SingleStreamAggregation<MyAggregate>
+public class BadMethodName: SingleStreamProjection<MyAggregate>
 {
     public void DoStuff(AEvent @event, MyAggregate aggregate)
     {
@@ -248,7 +248,7 @@ public class BadMethodName: SingleStreamAggregation<MyAggregate>
     }
 }
 
-public class AllGood: SingleStreamAggregation<MyAggregate>
+public class AllGood: SingleStreamProjection<MyAggregate>
 {
     public AllGood()
     {

--- a/src/EventSourcingTests/Aggregation/fetching_inline_aggregates_for_writing.cs
+++ b/src/EventSourcingTests/Aggregation/fetching_inline_aggregates_for_writing.cs
@@ -15,7 +15,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_new_stream_for_writing_Guid_identifier()
     {
-        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline));
 
         var streamId = Guid.NewGuid();
 
@@ -38,7 +38,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_new_stream_for_writing_Guid_identifier_exception_handling()
     {
-        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline));
 
         var streamId = Guid.NewGuid();
 
@@ -67,7 +67,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_existing_stream_for_writing_Guid_identifier()
     {
-        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline));
 
         var streamId = Guid.NewGuid();
 
@@ -94,7 +94,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
         StoreOptions(opts =>
         {
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
-            opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline).MultiTenanted();
+            opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline).MultiTenanted();
         });
 
         var streamId = Guid.NewGuid();
@@ -121,7 +121,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(SnapshotLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
@@ -148,7 +148,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(SnapshotLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
@@ -177,7 +177,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline).MultiTenanted();
+            opts.Projections.Snapshot<SimpleAggregateAsString>(SnapshotLifecycle.Inline).MultiTenanted();
             opts.Events.StreamIdentity = StreamIdentity.AsString;
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
         });
@@ -205,7 +205,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_existing_stream_exclusively_happy_path_for_writing_Guid_identifier()
     {
-        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline));
 
 
         var streamId = Guid.NewGuid();
@@ -230,7 +230,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_existing_stream_for_writing_Guid_identifier_sad_path()
     {
-        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline));
 
 
         var streamId = Guid.NewGuid();
@@ -255,7 +255,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(SnapshotLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
@@ -283,7 +283,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(SnapshotLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
@@ -313,7 +313,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
         [Fact]
     public async Task fetch_existing_stream_for_writing_Guid_identifier_with_expected_version()
     {
-        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline));
 
 
         var streamId = Guid.NewGuid();
@@ -333,7 +333,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_existing_stream_for_writing_Guid_identifier_with_expected_version_immediate_sad_path()
     {
-        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline));
 
 
         var streamId = Guid.NewGuid();
@@ -351,7 +351,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_existing_stream_for_writing_Guid_identifier_with_expected_version_sad_path_on_save_changes()
     {
-        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline));
 
 
         var streamId = Guid.NewGuid();
@@ -385,7 +385,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(SnapshotLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
@@ -408,7 +408,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(SnapshotLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
@@ -429,7 +429,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(SnapshotLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 

--- a/src/EventSourcingTests/Aggregation/fetching_inline_aggregates_for_writing.cs
+++ b/src/EventSourcingTests/Aggregation/fetching_inline_aggregates_for_writing.cs
@@ -15,7 +15,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_new_stream_for_writing_Guid_identifier()
     {
-        StoreOptions(opts => opts.Projections.SelfAggregate<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
 
         var streamId = Guid.NewGuid();
 
@@ -38,7 +38,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_new_stream_for_writing_Guid_identifier_exception_handling()
     {
-        StoreOptions(opts => opts.Projections.SelfAggregate<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
 
         var streamId = Guid.NewGuid();
 
@@ -67,7 +67,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_existing_stream_for_writing_Guid_identifier()
     {
-        StoreOptions(opts => opts.Projections.SelfAggregate<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
 
         var streamId = Guid.NewGuid();
 
@@ -94,7 +94,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
         StoreOptions(opts =>
         {
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
-            opts.Projections.SelfAggregate<SimpleAggregate>(ProjectionLifecycle.Inline).MultiTenanted();
+            opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline).MultiTenanted();
         });
 
         var streamId = Guid.NewGuid();
@@ -121,7 +121,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.SelfAggregate<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
@@ -148,7 +148,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.SelfAggregate<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
@@ -177,7 +177,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.SelfAggregate<SimpleAggregateAsString>(ProjectionLifecycle.Inline).MultiTenanted();
+            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline).MultiTenanted();
             opts.Events.StreamIdentity = StreamIdentity.AsString;
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
         });
@@ -205,7 +205,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_existing_stream_exclusively_happy_path_for_writing_Guid_identifier()
     {
-        StoreOptions(opts => opts.Projections.SelfAggregate<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
 
 
         var streamId = Guid.NewGuid();
@@ -230,7 +230,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_existing_stream_for_writing_Guid_identifier_sad_path()
     {
-        StoreOptions(opts => opts.Projections.SelfAggregate<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
 
 
         var streamId = Guid.NewGuid();
@@ -255,7 +255,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.SelfAggregate<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
@@ -283,7 +283,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.SelfAggregate<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
@@ -313,7 +313,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
         [Fact]
     public async Task fetch_existing_stream_for_writing_Guid_identifier_with_expected_version()
     {
-        StoreOptions(opts => opts.Projections.SelfAggregate<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
 
 
         var streamId = Guid.NewGuid();
@@ -333,7 +333,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_existing_stream_for_writing_Guid_identifier_with_expected_version_immediate_sad_path()
     {
-        StoreOptions(opts => opts.Projections.SelfAggregate<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
 
 
         var streamId = Guid.NewGuid();
@@ -351,7 +351,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     [Fact]
     public async Task fetch_existing_stream_for_writing_Guid_identifier_with_expected_version_sad_path_on_save_changes()
     {
-        StoreOptions(opts => opts.Projections.SelfAggregate<SimpleAggregate>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(ProjectionLifecycle.Inline));
 
 
         var streamId = Guid.NewGuid();
@@ -385,7 +385,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.SelfAggregate<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
@@ -408,7 +408,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.SelfAggregate<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
@@ -429,7 +429,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     {
         StoreOptions(opts =>
         {
-            opts.Projections.SelfAggregate<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
+            opts.Projections.Snapshot<SimpleAggregateAsString>(ProjectionLifecycle.Inline);
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 

--- a/src/EventSourcingTests/Aggregation/setting_version_number_on_aggregate.cs
+++ b/src/EventSourcingTests/Aggregation/setting_version_number_on_aggregate.cs
@@ -118,7 +118,7 @@ public class setting_version_number_on_aggregate : OneOffConfigurationsContext
     [Fact]
     public async Task set_version_on_aggregate_with_explicit_Version_attribute()
     {
-        StoreOptions(opts => opts.Projections.Snapshot<MyAggregateWithDifferentVersionProperty>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<MyAggregateWithDifferentVersionProperty>(SnapshotLifecycle.Inline));
 
         var stream = theSession.Events.StartStream(new AEvent(), new AEvent(), new AEvent());
         await theSession.SaveChangesAsync();

--- a/src/EventSourcingTests/Aggregation/setting_version_number_on_aggregate.cs
+++ b/src/EventSourcingTests/Aggregation/setting_version_number_on_aggregate.cs
@@ -118,7 +118,7 @@ public class setting_version_number_on_aggregate : OneOffConfigurationsContext
     [Fact]
     public async Task set_version_on_aggregate_with_explicit_Version_attribute()
     {
-        StoreOptions(opts => opts.Projections.SelfAggregate<MyAggregateWithDifferentVersionProperty>(ProjectionLifecycle.Inline));
+        StoreOptions(opts => opts.Projections.Snapshot<MyAggregateWithDifferentVersionProperty>(ProjectionLifecycle.Inline));
 
         var stream = theSession.Events.StartStream(new AEvent(), new AEvent(), new AEvent());
         await theSession.SaveChangesAsync();

--- a/src/EventSourcingTests/Aggregation/setting_version_number_on_aggregate.cs
+++ b/src/EventSourcingTests/Aggregation/setting_version_number_on_aggregate.cs
@@ -56,7 +56,7 @@ public class setting_version_number_on_aggregate : OneOffConfigurationsContext
 
 
 
-    public class SampleSingleStream : SingleStreamAggregation<MyAggregate>
+    public class SampleSingleStream : SingleStreamProjection<MyAggregate>
     {
         public SampleSingleStream ()
         {

--- a/src/EventSourcingTests/Aggregation/when_doing_inline_per_stream_aggregations_with_Guid_stream_identity.cs
+++ b/src/EventSourcingTests/Aggregation/when_doing_inline_per_stream_aggregations_with_Guid_stream_identity.cs
@@ -220,7 +220,7 @@ public class when_doing_inline_per_stream_aggregations_with_Guid_stream_identity
 
     }
 
-    public class SometimesDeletes: SingleStreamAggregation<MyAggregate>
+    public class SometimesDeletes: SingleStreamProjection<MyAggregate>
     {
         public void Apply(AEvent @event, MyAggregate aggregate)
         {

--- a/src/EventSourcingTests/Aggregation/when_doing_live_aggregations.cs
+++ b/src/EventSourcingTests/Aggregation/when_doing_live_aggregations.cs
@@ -211,7 +211,7 @@ public class UserUpdated
     public Guid UserId { get; set; }
 }
 
-public class UsingMetadata : SingleStreamAggregation<MyAggregate>
+public class UsingMetadata : SingleStreamProjection<MyAggregate>
 {
     public MyAggregate Create(CreateEvent create, IEvent e)
     {
@@ -232,7 +232,7 @@ public class UsingMetadata : SingleStreamAggregation<MyAggregate>
     }
 }
 
-public class AsyncEverything: SingleStreamAggregation<MyAggregate>
+public class AsyncEverything: SingleStreamProjection<MyAggregate>
 {
     public async Task<MyAggregate> Create(UserStarted @event, IQuerySession session, CancellationToken cancellation)
     {
@@ -257,7 +257,7 @@ public class AsyncEverything: SingleStreamAggregation<MyAggregate>
 
 }
 
-public class AsyncCreateSyncApply: SingleStreamAggregation<MyAggregate>
+public class AsyncCreateSyncApply: SingleStreamProjection<MyAggregate>
 {
     public async Task<MyAggregate> Create(UserStarted @event, IQuerySession session, CancellationToken cancellation)
     {
@@ -290,7 +290,7 @@ public class AsyncCreateSyncApply: SingleStreamAggregation<MyAggregate>
 
 }
 
-public class SyncCreateAsyncApply: SingleStreamAggregation<MyAggregate>
+public class SyncCreateAsyncApply: SingleStreamProjection<MyAggregate>
 {
     public MyAggregate Create(CreateEvent @event)
     {
@@ -331,7 +331,7 @@ public class SyncCreateAsyncApply: SingleStreamAggregation<MyAggregate>
 }
 
 
-public class AllSync: SingleStreamAggregation<MyAggregate>
+public class AllSync: SingleStreamProjection<MyAggregate>
 {
     public AllSync()
     {

--- a/src/EventSourcingTests/Aggregation/when_using_inline_lambdas_to_define_immutable_projection.cs
+++ b/src/EventSourcingTests/Aggregation/when_using_inline_lambdas_to_define_immutable_projection.cs
@@ -38,7 +38,7 @@ public class when_using_inline_lambdas_to_define_immutable_projection : OneOffCo
 
     public record MyAggregateRecord(Guid Id, string Created, string UpdatedBy);
 
-    public class MyAggregateImmutableProjection: SingleStreamAggregation<MyAggregateRecord>
+    public class MyAggregateImmutableProjection: SingleStreamProjection<MyAggregateRecord>
     {
         public MyAggregateImmutableProjection()
         {

--- a/src/EventSourcingTests/Bugs/Bug_1679_use_inner_type_for_stream_aggregation.cs
+++ b/src/EventSourcingTests/Bugs/Bug_1679_use_inner_type_for_stream_aggregation.cs
@@ -9,14 +9,14 @@ using Xunit;
 
 namespace EventSourcingTests.Bugs;
 
-public class Bug_1679_use_inner_type_for_self_aggregate : AggregationContext
+public class Bug_1679_use_inner_type_for_stream_aggregation : AggregationContext
 {
-    public Bug_1679_use_inner_type_for_self_aggregate(DefaultStoreFixture fixture) : base(fixture)
+    public Bug_1679_use_inner_type_for_stream_aggregation(DefaultStoreFixture fixture) : base(fixture)
     {
     }
 
     [Fact]
-    public async Task try_self_aggregate_with_inner_class()
+    public async Task try_live_stream_aggregation_with_inner_class()
     {
         var stream = Guid.NewGuid();
         theSession.Events.StartStream(stream, new AEvent(), new AEvent(), new AEvent(), new BEvent(), new BEvent(),
@@ -44,7 +44,5 @@ public class Bug_1679_use_inner_type_for_self_aggregate : AggregationContext
         {
             return Task.FromResult(this);
         }
-
-
     }
 }

--- a/src/EventSourcingTests/Bugs/Bug_1754_multiple_event_stream_creations_one_session.cs
+++ b/src/EventSourcingTests/Bugs/Bug_1754_multiple_event_stream_creations_one_session.cs
@@ -19,8 +19,8 @@ namespace EventSourcingTests.Bugs
             using var documentStore = SeparateStore(x =>
             {
                 x.Events.StreamIdentity = StreamIdentity.AsString; // easier to debug
-                x.Projections.Snapshot<DataImportAggregate>(ProjectionLifecycle.Inline);
-                x.Projections.Snapshot<DataItemAggregate>(ProjectionLifecycle.Inline);
+                x.Projections.Snapshot<DataImportAggregate>(SnapshotLifecycle.Inline);
+                x.Projections.Snapshot<DataItemAggregate>(SnapshotLifecycle.Inline);
             });
 
             await documentStore.Advanced.Clean.CompletelyRemoveAllAsync();
@@ -51,8 +51,8 @@ namespace EventSourcingTests.Bugs
             using var documentStore = SeparateStore(x =>
             {
                 x.Events.StreamIdentity = StreamIdentity.AsString; // easier to debug
-                x.Projections.Snapshot<DataImportAggregate>(ProjectionLifecycle.Inline);
-                x.Projections.Snapshot<DataItemAggregate>(ProjectionLifecycle.Inline);
+                x.Projections.Snapshot<DataImportAggregate>(SnapshotLifecycle.Inline);
+                x.Projections.Snapshot<DataItemAggregate>(SnapshotLifecycle.Inline);
             });
 
             documentStore.Advanced.Clean.CompletelyRemoveAll();

--- a/src/EventSourcingTests/Bugs/Bug_1754_multiple_event_stream_creations_one_session.cs
+++ b/src/EventSourcingTests/Bugs/Bug_1754_multiple_event_stream_creations_one_session.cs
@@ -19,8 +19,8 @@ namespace EventSourcingTests.Bugs
             using var documentStore = SeparateStore(x =>
             {
                 x.Events.StreamIdentity = StreamIdentity.AsString; // easier to debug
-                x.Projections.SelfAggregate<DataImportAggregate>(ProjectionLifecycle.Inline);
-                x.Projections.SelfAggregate<DataItemAggregate>(ProjectionLifecycle.Inline);
+                x.Projections.Snapshot<DataImportAggregate>(ProjectionLifecycle.Inline);
+                x.Projections.Snapshot<DataItemAggregate>(ProjectionLifecycle.Inline);
             });
 
             await documentStore.Advanced.Clean.CompletelyRemoveAllAsync();
@@ -51,8 +51,8 @@ namespace EventSourcingTests.Bugs
             using var documentStore = SeparateStore(x =>
             {
                 x.Events.StreamIdentity = StreamIdentity.AsString; // easier to debug
-                x.Projections.SelfAggregate<DataImportAggregate>(ProjectionLifecycle.Inline);
-                x.Projections.SelfAggregate<DataItemAggregate>(ProjectionLifecycle.Inline);
+                x.Projections.Snapshot<DataImportAggregate>(ProjectionLifecycle.Inline);
+                x.Projections.Snapshot<DataItemAggregate>(ProjectionLifecycle.Inline);
             });
 
             documentStore.Advanced.Clean.CompletelyRemoveAll();

--- a/src/EventSourcingTests/Bugs/Bug_1758_creating_stream_runs_extra_selects_and_deletes.cs
+++ b/src/EventSourcingTests/Bugs/Bug_1758_creating_stream_runs_extra_selects_and_deletes.cs
@@ -20,9 +20,9 @@ public class Bug_1758_creating_stream_runs_extra_selects_and_deletes : BugIntegr
 
         using var documentStore = SeparateStore(x =>
         {
-            x.Projections.SelfAggregate<AggregateA>(ProjectionLifecycle.Inline);
-            x.Projections.SelfAggregate<AggregateB>(ProjectionLifecycle.Inline);
-            x.Projections.SelfAggregate<AggregateC>(ProjectionLifecycle.Inline);
+            x.Projections.Snapshot<AggregateA>(ProjectionLifecycle.Inline);
+            x.Projections.Snapshot<AggregateB>(ProjectionLifecycle.Inline);
+            x.Projections.Snapshot<AggregateC>(ProjectionLifecycle.Inline);
             x.Logger(logger);
         });
 

--- a/src/EventSourcingTests/Bugs/Bug_1758_creating_stream_runs_extra_selects_and_deletes.cs
+++ b/src/EventSourcingTests/Bugs/Bug_1758_creating_stream_runs_extra_selects_and_deletes.cs
@@ -20,9 +20,9 @@ public class Bug_1758_creating_stream_runs_extra_selects_and_deletes : BugIntegr
 
         using var documentStore = SeparateStore(x =>
         {
-            x.Projections.Snapshot<AggregateA>(ProjectionLifecycle.Inline);
-            x.Projections.Snapshot<AggregateB>(ProjectionLifecycle.Inline);
-            x.Projections.Snapshot<AggregateC>(ProjectionLifecycle.Inline);
+            x.Projections.Snapshot<AggregateA>(SnapshotLifecycle.Inline);
+            x.Projections.Snapshot<AggregateB>(SnapshotLifecycle.Inline);
+            x.Projections.Snapshot<AggregateC>(SnapshotLifecycle.Inline);
             x.Logger(logger);
         });
 

--- a/src/EventSourcingTests/Bugs/Bug_1781_inline_projection_foreign_key_constraint_failure.cs
+++ b/src/EventSourcingTests/Bugs/Bug_1781_inline_projection_foreign_key_constraint_failure.cs
@@ -21,8 +21,8 @@ namespace EventSourcingTests.Bugs
             using var documentStore = SeparateStore(x =>
             {
                 x.Events.StreamIdentity = StreamIdentity.AsString;
-                x.Projections.SelfAggregate<DataImportAggregate>(ProjectionLifecycle.Inline);
-                x.Projections.SelfAggregate<DataItemAggregate>(ProjectionLifecycle.Inline)
+                x.Projections.Snapshot<DataImportAggregate>(ProjectionLifecycle.Inline);
+                x.Projections.Snapshot<DataItemAggregate>(ProjectionLifecycle.Inline)
                     .ForeignKey<DataImportAggregate>(y => y.ImportId);
             });
 
@@ -35,9 +35,9 @@ namespace EventSourcingTests.Bugs
             using var documentStore = SeparateStore(x =>
             {
                 x.Events.StreamIdentity = StreamIdentity.AsString;
-                x.Projections.SelfAggregate<DataItemAggregate>(ProjectionLifecycle.Inline)
+                x.Projections.Snapshot<DataItemAggregate>(ProjectionLifecycle.Inline)
                     .ForeignKey<DataImportAggregate>(y => y.ImportId);
-                x.Projections.SelfAggregate<DataImportAggregate>(ProjectionLifecycle.Inline);
+                x.Projections.Snapshot<DataImportAggregate>(ProjectionLifecycle.Inline);
             });
 
             await RunTest(documentStore);

--- a/src/EventSourcingTests/Bugs/Bug_1781_inline_projection_foreign_key_constraint_failure.cs
+++ b/src/EventSourcingTests/Bugs/Bug_1781_inline_projection_foreign_key_constraint_failure.cs
@@ -21,8 +21,8 @@ namespace EventSourcingTests.Bugs
             using var documentStore = SeparateStore(x =>
             {
                 x.Events.StreamIdentity = StreamIdentity.AsString;
-                x.Projections.Snapshot<DataImportAggregate>(ProjectionLifecycle.Inline);
-                x.Projections.Snapshot<DataItemAggregate>(ProjectionLifecycle.Inline)
+                x.Projections.Snapshot<DataImportAggregate>(SnapshotLifecycle.Inline);
+                x.Projections.Snapshot<DataItemAggregate>(SnapshotLifecycle.Inline)
                     .ForeignKey<DataImportAggregate>(y => y.ImportId);
             });
 
@@ -35,9 +35,9 @@ namespace EventSourcingTests.Bugs
             using var documentStore = SeparateStore(x =>
             {
                 x.Events.StreamIdentity = StreamIdentity.AsString;
-                x.Projections.Snapshot<DataItemAggregate>(ProjectionLifecycle.Inline)
+                x.Projections.Snapshot<DataItemAggregate>(SnapshotLifecycle.Inline)
                     .ForeignKey<DataImportAggregate>(y => y.ImportId);
-                x.Projections.Snapshot<DataImportAggregate>(ProjectionLifecycle.Inline);
+                x.Projections.Snapshot<DataImportAggregate>(SnapshotLifecycle.Inline);
             });
 
             await RunTest(documentStore);

--- a/src/EventSourcingTests/Bugs/Bug_2281_stream_action_without_events_save_changes_throws.cs
+++ b/src/EventSourcingTests/Bugs/Bug_2281_stream_action_without_events_save_changes_throws.cs
@@ -21,7 +21,7 @@ namespace EventSourcingTests.Bugs
         {
             using var documentStore = SeparateStore(x =>
             {
-                x.Projections.SelfAggregate<TestEntity>(ProjectionLifecycle.Inline);
+                x.Projections.Snapshot<TestEntity>(ProjectionLifecycle.Inline);
             });
 
             var entityOneId = await CreateEntityForTest(documentStore, "Entity one", 0);
@@ -53,7 +53,7 @@ namespace EventSourcingTests.Bugs
         {
             using var documentStore = SeparateStore(x =>
             {
-                x.Projections.SelfAggregate<TestEntity>(ProjectionLifecycle.Inline);
+                x.Projections.Snapshot<TestEntity>(ProjectionLifecycle.Inline);
             });
 
             var entityOneId = await CreateEntityForTest(documentStore, "Entity one", 2);

--- a/src/EventSourcingTests/Bugs/Bug_2281_stream_action_without_events_save_changes_throws.cs
+++ b/src/EventSourcingTests/Bugs/Bug_2281_stream_action_without_events_save_changes_throws.cs
@@ -21,7 +21,7 @@ namespace EventSourcingTests.Bugs
         {
             using var documentStore = SeparateStore(x =>
             {
-                x.Projections.Snapshot<TestEntity>(ProjectionLifecycle.Inline);
+                x.Projections.Snapshot<TestEntity>(SnapshotLifecycle.Inline);
             });
 
             var entityOneId = await CreateEntityForTest(documentStore, "Entity one", 0);
@@ -53,7 +53,7 @@ namespace EventSourcingTests.Bugs
         {
             using var documentStore = SeparateStore(x =>
             {
-                x.Projections.Snapshot<TestEntity>(ProjectionLifecycle.Inline);
+                x.Projections.Snapshot<TestEntity>(SnapshotLifecycle.Inline);
             });
 
             var entityOneId = await CreateEntityForTest(documentStore, "Entity one", 2);

--- a/src/EventSourcingTests/Bugs/Bug_2296_tenant_session_in_grouper.cs
+++ b/src/EventSourcingTests/Bugs/Bug_2296_tenant_session_in_grouper.cs
@@ -79,7 +79,7 @@ public class Bug_2296_tenant_session_in_grouper : OneOffConfigurationsContext
         public int Count { get; set; } = 0;
     }
 
-    public class CountsByTagProjector: MultiStreamAggregation<CountsByTag, string>
+    public class CountsByTagProjector: MultiStreamProjection<CountsByTag, string>
     {
         public CountsByTagProjector()
         {

--- a/src/EventSourcingTests/Bugs/codegen_issue_with_IEvent.cs
+++ b/src/EventSourcingTests/Bugs/codegen_issue_with_IEvent.cs
@@ -55,7 +55,7 @@ public class FooAuditLog
     public List<string> Changes { get; set; } = new List<string>();
 }
 
-public class FooProjection: MultiStreamAggregation<FooAuditLog, Guid>
+public class FooProjection: MultiStreamProjection<FooAuditLog, Guid>
 {
     public FooProjection()
     {
@@ -79,7 +79,7 @@ public record RecordLogCreated(Guid Id): IRecordLogEvent;
 
 public record RecordLogUpdated(Guid Id): IRecordLogEvent;
 
-public class RecordProjection: MultiStreamAggregation<RecordAuditLog, Guid>
+public class RecordProjection: MultiStreamProjection<RecordAuditLog, Guid>
 {
     public RecordProjection()
     {

--- a/src/EventSourcingTests/EventStreamUnexpectedMaxEventIdExceptionTransformTest.cs
+++ b/src/EventSourcingTests/EventStreamUnexpectedMaxEventIdExceptionTransformTest.cs
@@ -18,6 +18,8 @@ public class EventStreamUnexpectedMaxEventIdExceptionTransformTest: IntegrationC
     [Fact]
     public async Task throw_transformed_exception_with_details_redacted()
     {
+        await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+
         var streamId = Guid.NewGuid();
         var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
         var departed = new MembersDeparted { Members = new[] { "Thom" } };
@@ -27,7 +29,7 @@ public class EventStreamUnexpectedMaxEventIdExceptionTransformTest: IntegrationC
 
         var forceEventStreamUnexpectedMaxEventIdException = async () =>
         {
-            await Parallel.ForEachAsync(Enumerable.Range(1, 5), async (_, token) =>
+            await Parallel.ForEachAsync(Enumerable.Range(1, 20), async (_, token) =>
             {
                 await using var session = theStore.LightweightSession();
                 session.Events.Append(streamId, departed);
@@ -42,6 +44,8 @@ public class EventStreamUnexpectedMaxEventIdExceptionTransformTest: IntegrationC
     [Fact]
     public async Task throw_transformed_exception_with_details_available()
     {
+        await theStore.Schema.ApplyAllConfiguredChangesToDatabaseAsync();
+
         var connectionString = ConnectionSource.ConnectionString + ";Include Error Detail=true";
         StoreOptions(storeOptions => storeOptions.Connection(connectionString));
 

--- a/src/EventSourcingTests/Examples/Project.cs
+++ b/src/EventSourcingTests/Examples/Project.cs
@@ -22,7 +22,7 @@ public class Startup
             // inline as new events are captured
             opts
                 .Projections
-                .SelfAggregate<Project>(ProjectionLifecycle.Inline);
+                .Snapshot<Project>(ProjectionLifecycle.Inline);
 
         });
     }

--- a/src/EventSourcingTests/Examples/Project.cs
+++ b/src/EventSourcingTests/Examples/Project.cs
@@ -22,7 +22,7 @@ public class Startup
             // inline as new events are captured
             opts
                 .Projections
-                .Snapshot<Project>(ProjectionLifecycle.Inline);
+                .Snapshot<Project>(SnapshotLifecycle.Inline);
 
         });
     }

--- a/src/EventSourcingTests/Examples/TeleHealth/BoardViewProjection.cs
+++ b/src/EventSourcingTests/Examples/TeleHealth/BoardViewProjection.cs
@@ -8,7 +8,7 @@ using Marten.Events.Projections;
 
 namespace EventSourcingTests.Examples.TeleHealth;
 
-public class BoardViewProjection: ExperimentalMultiStreamAggregation<BoardView, Guid>
+public class BoardViewProjection: ExperimentalMultiStreamProjection<BoardView, Guid>
 {
     protected override ValueTask GroupEvents(IEventGrouping<Guid> grouping, IQuerySession session, List<IEvent> events)
     {

--- a/src/EventSourcingTests/Examples/TripProjectionWithEventMetadata.cs
+++ b/src/EventSourcingTests/Examples/TripProjectionWithEventMetadata.cs
@@ -22,7 +22,7 @@ public class TripEnded{}
 
 #region sample_aggregation_using_event_metadata
 
-public class TripProjection: SingleStreamAggregation<Trip>
+public class TripProjection: SingleStreamProjection<Trip>
 {
     // Access event metadata through IEvent<T>
     public Trip Create(IEvent<TripStarted> @event)

--- a/src/EventSourcingTests/Examples/event_store_quickstart.cs
+++ b/src/EventSourcingTests/Examples/event_store_quickstart.cs
@@ -17,7 +17,7 @@ public class event_store_quickstart
         var store = DocumentStore.For(_ =>
         {
             _.Connection(ConnectionSource.ConnectionString);
-            _.Projections.SelfAggregate<QuestParty>();
+            _.Projections.Snapshot<QuestParty>();
         });
 
         var questId = Guid.NewGuid();

--- a/src/EventSourcingTests/Internal/Generated/DocumentStorage/InnerAggregateProvider1153673020.cs
+++ b/src/EventSourcingTests/Internal/Generated/DocumentStorage/InnerAggregateProvider1153673020.cs
@@ -14,14 +14,14 @@ using Weasel.Postgresql;
 namespace Marten.Generated.DocumentStorage
 {
     // START: UpsertInnerAggregateOperation1153673020
-    public class UpsertInnerAggregateOperation1153673020 : Marten.Internal.Operations.StorageOperation<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>
+    public class UpsertInnerAggregateOperation1153673020 : Marten.Internal.Operations.StorageOperation<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>
     {
-        private readonly EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate _document;
+        private readonly EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate _document;
         private readonly System.Guid _id;
         private readonly System.Collections.Generic.Dictionary<System.Guid, System.Guid> _versions;
         private readonly Marten.Schema.DocumentMapping _mapping;
 
-        public UpsertInnerAggregateOperation1153673020(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, System.Guid id, System.Collections.Generic.Dictionary<System.Guid, System.Guid> versions, Marten.Schema.DocumentMapping mapping) : base(document, id, versions, mapping)
+        public UpsertInnerAggregateOperation1153673020(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, System.Guid id, System.Collections.Generic.Dictionary<System.Guid, System.Guid> versions, Marten.Schema.DocumentMapping mapping) : base(document, id, versions, mapping)
         {
             _document = document;
             _id = id;
@@ -45,7 +45,7 @@ namespace Marten.Generated.DocumentStorage
         }
 
 
-        public override void ConfigureParameters(Npgsql.NpgsqlParameter[] parameters, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session)
+        public override void ConfigureParameters(Npgsql.NpgsqlParameter[] parameters, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session)
         {
             parameters[0].NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Jsonb;
             parameters[0].Value = session.Serializer.ToJson(_document);
@@ -83,14 +83,14 @@ namespace Marten.Generated.DocumentStorage
     
     
     // START: InsertInnerAggregateOperation1153673020
-    public class InsertInnerAggregateOperation1153673020 : Marten.Internal.Operations.StorageOperation<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>
+    public class InsertInnerAggregateOperation1153673020 : Marten.Internal.Operations.StorageOperation<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>
     {
-        private readonly EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate _document;
+        private readonly EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate _document;
         private readonly System.Guid _id;
         private readonly System.Collections.Generic.Dictionary<System.Guid, System.Guid> _versions;
         private readonly Marten.Schema.DocumentMapping _mapping;
 
-        public InsertInnerAggregateOperation1153673020(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, System.Guid id, System.Collections.Generic.Dictionary<System.Guid, System.Guid> versions, Marten.Schema.DocumentMapping mapping) : base(document, id, versions, mapping)
+        public InsertInnerAggregateOperation1153673020(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, System.Guid id, System.Collections.Generic.Dictionary<System.Guid, System.Guid> versions, Marten.Schema.DocumentMapping mapping) : base(document, id, versions, mapping)
         {
             _document = document;
             _id = id;
@@ -114,7 +114,7 @@ namespace Marten.Generated.DocumentStorage
         }
 
 
-        public override void ConfigureParameters(Npgsql.NpgsqlParameter[] parameters, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session)
+        public override void ConfigureParameters(Npgsql.NpgsqlParameter[] parameters, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session)
         {
             parameters[0].NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Jsonb;
             parameters[0].Value = session.Serializer.ToJson(_document);
@@ -152,14 +152,14 @@ namespace Marten.Generated.DocumentStorage
     
     
     // START: UpdateInnerAggregateOperation1153673020
-    public class UpdateInnerAggregateOperation1153673020 : Marten.Internal.Operations.StorageOperation<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>
+    public class UpdateInnerAggregateOperation1153673020 : Marten.Internal.Operations.StorageOperation<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>
     {
-        private readonly EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate _document;
+        private readonly EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate _document;
         private readonly System.Guid _id;
         private readonly System.Collections.Generic.Dictionary<System.Guid, System.Guid> _versions;
         private readonly Marten.Schema.DocumentMapping _mapping;
 
-        public UpdateInnerAggregateOperation1153673020(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, System.Guid id, System.Collections.Generic.Dictionary<System.Guid, System.Guid> versions, Marten.Schema.DocumentMapping mapping) : base(document, id, versions, mapping)
+        public UpdateInnerAggregateOperation1153673020(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, System.Guid id, System.Collections.Generic.Dictionary<System.Guid, System.Guid> versions, Marten.Schema.DocumentMapping mapping) : base(document, id, versions, mapping)
         {
             _document = document;
             _id = id;
@@ -183,7 +183,7 @@ namespace Marten.Generated.DocumentStorage
         }
 
 
-        public override void ConfigureParameters(Npgsql.NpgsqlParameter[] parameters, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session)
+        public override void ConfigureParameters(Npgsql.NpgsqlParameter[] parameters, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session)
         {
             parameters[0].NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Jsonb;
             parameters[0].Value = session.Serializer.ToJson(_document);
@@ -221,7 +221,7 @@ namespace Marten.Generated.DocumentStorage
     
     
     // START: QueryOnlyInnerAggregateSelector1153673020
-    public class QueryOnlyInnerAggregateSelector1153673020 : Marten.Internal.CodeGeneration.DocumentSelectorWithOnlySerializer, Marten.Linq.Selectors.ISelector<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>
+    public class QueryOnlyInnerAggregateSelector1153673020 : Marten.Internal.CodeGeneration.DocumentSelectorWithOnlySerializer, Marten.Linq.Selectors.ISelector<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>
     {
         private readonly Marten.Internal.IMartenSession _session;
         private readonly Marten.Schema.DocumentMapping _mapping;
@@ -234,20 +234,20 @@ namespace Marten.Generated.DocumentStorage
 
 
 
-        public EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate Resolve(System.Data.Common.DbDataReader reader)
+        public EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate Resolve(System.Data.Common.DbDataReader reader)
         {
 
-            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document;
-            document = _serializer.FromJson<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>(reader, 0);
+            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document;
+            document = _serializer.FromJson<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>(reader, 0);
             return document;
         }
 
 
-        public async System.Threading.Tasks.Task<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> ResolveAsync(System.Data.Common.DbDataReader reader, System.Threading.CancellationToken token)
+        public async System.Threading.Tasks.Task<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate> ResolveAsync(System.Data.Common.DbDataReader reader, System.Threading.CancellationToken token)
         {
 
-            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document;
-            document = await _serializer.FromJsonAsync<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>(reader, 0, token).ConfigureAwait(false);
+            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document;
+            document = await _serializer.FromJsonAsync<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>(reader, 0, token).ConfigureAwait(false);
             return document;
         }
 
@@ -257,7 +257,7 @@ namespace Marten.Generated.DocumentStorage
     
     
     // START: LightweightInnerAggregateSelector1153673020
-    public class LightweightInnerAggregateSelector1153673020 : Marten.Internal.CodeGeneration.DocumentSelectorWithVersions<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>, Marten.Linq.Selectors.ISelector<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>
+    public class LightweightInnerAggregateSelector1153673020 : Marten.Internal.CodeGeneration.DocumentSelectorWithVersions<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>, Marten.Linq.Selectors.ISelector<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>
     {
         private readonly Marten.Internal.IMartenSession _session;
         private readonly Marten.Schema.DocumentMapping _mapping;
@@ -270,23 +270,23 @@ namespace Marten.Generated.DocumentStorage
 
 
 
-        public EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate Resolve(System.Data.Common.DbDataReader reader)
+        public EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate Resolve(System.Data.Common.DbDataReader reader)
         {
             var id = reader.GetFieldValue<System.Guid>(0);
 
-            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document;
-            document = _serializer.FromJson<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>(reader, 1);
+            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document;
+            document = _serializer.FromJson<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>(reader, 1);
             _session.MarkAsDocumentLoaded(id, document);
             return document;
         }
 
 
-        public async System.Threading.Tasks.Task<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> ResolveAsync(System.Data.Common.DbDataReader reader, System.Threading.CancellationToken token)
+        public async System.Threading.Tasks.Task<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate> ResolveAsync(System.Data.Common.DbDataReader reader, System.Threading.CancellationToken token)
         {
             var id = await reader.GetFieldValueAsync<System.Guid>(0, token);
 
-            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document;
-            document = await _serializer.FromJsonAsync<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>(reader, 1, token).ConfigureAwait(false);
+            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document;
+            document = await _serializer.FromJsonAsync<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>(reader, 1, token).ConfigureAwait(false);
             _session.MarkAsDocumentLoaded(id, document);
             return document;
         }
@@ -297,7 +297,7 @@ namespace Marten.Generated.DocumentStorage
     
     
     // START: IdentityMapInnerAggregateSelector1153673020
-    public class IdentityMapInnerAggregateSelector1153673020 : Marten.Internal.CodeGeneration.DocumentSelectorWithIdentityMap<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>, Marten.Linq.Selectors.ISelector<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>
+    public class IdentityMapInnerAggregateSelector1153673020 : Marten.Internal.CodeGeneration.DocumentSelectorWithIdentityMap<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>, Marten.Linq.Selectors.ISelector<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>
     {
         private readonly Marten.Internal.IMartenSession _session;
         private readonly Marten.Schema.DocumentMapping _mapping;
@@ -310,26 +310,26 @@ namespace Marten.Generated.DocumentStorage
 
 
 
-        public EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate Resolve(System.Data.Common.DbDataReader reader)
+        public EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate Resolve(System.Data.Common.DbDataReader reader)
         {
             var id = reader.GetFieldValue<System.Guid>(0);
             if (_identityMap.TryGetValue(id, out var existing)) return existing;
 
-            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document;
-            document = _serializer.FromJson<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>(reader, 1);
+            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document;
+            document = _serializer.FromJson<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>(reader, 1);
             _session.MarkAsDocumentLoaded(id, document);
             _identityMap[id] = document;
             return document;
         }
 
 
-        public async System.Threading.Tasks.Task<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> ResolveAsync(System.Data.Common.DbDataReader reader, System.Threading.CancellationToken token)
+        public async System.Threading.Tasks.Task<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate> ResolveAsync(System.Data.Common.DbDataReader reader, System.Threading.CancellationToken token)
         {
             var id = await reader.GetFieldValueAsync<System.Guid>(0, token);
             if (_identityMap.TryGetValue(id, out var existing)) return existing;
 
-            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document;
-            document = await _serializer.FromJsonAsync<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>(reader, 1, token).ConfigureAwait(false);
+            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document;
+            document = await _serializer.FromJsonAsync<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>(reader, 1, token).ConfigureAwait(false);
             _session.MarkAsDocumentLoaded(id, document);
             _identityMap[id] = document;
             return document;
@@ -341,7 +341,7 @@ namespace Marten.Generated.DocumentStorage
     
     
     // START: DirtyTrackingInnerAggregateSelector1153673020
-    public class DirtyTrackingInnerAggregateSelector1153673020 : Marten.Internal.CodeGeneration.DocumentSelectorWithDirtyChecking<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>, Marten.Linq.Selectors.ISelector<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>
+    public class DirtyTrackingInnerAggregateSelector1153673020 : Marten.Internal.CodeGeneration.DocumentSelectorWithDirtyChecking<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>, Marten.Linq.Selectors.ISelector<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>
     {
         private readonly Marten.Internal.IMartenSession _session;
         private readonly Marten.Schema.DocumentMapping _mapping;
@@ -354,13 +354,13 @@ namespace Marten.Generated.DocumentStorage
 
 
 
-        public EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate Resolve(System.Data.Common.DbDataReader reader)
+        public EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate Resolve(System.Data.Common.DbDataReader reader)
         {
             var id = reader.GetFieldValue<System.Guid>(0);
             if (_identityMap.TryGetValue(id, out var existing)) return existing;
 
-            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document;
-            document = _serializer.FromJson<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>(reader, 1);
+            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document;
+            document = _serializer.FromJson<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>(reader, 1);
             _session.MarkAsDocumentLoaded(id, document);
             _identityMap[id] = document;
             StoreTracker(_session, document);
@@ -368,13 +368,13 @@ namespace Marten.Generated.DocumentStorage
         }
 
 
-        public async System.Threading.Tasks.Task<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> ResolveAsync(System.Data.Common.DbDataReader reader, System.Threading.CancellationToken token)
+        public async System.Threading.Tasks.Task<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate> ResolveAsync(System.Data.Common.DbDataReader reader, System.Threading.CancellationToken token)
         {
             var id = await reader.GetFieldValueAsync<System.Guid>(0, token);
             if (_identityMap.TryGetValue(id, out var existing)) return existing;
 
-            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document;
-            document = await _serializer.FromJsonAsync<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>(reader, 1, token).ConfigureAwait(false);
+            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document;
+            document = await _serializer.FromJsonAsync<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>(reader, 1, token).ConfigureAwait(false);
             _session.MarkAsDocumentLoaded(id, document);
             _identityMap[id] = document;
             StoreTracker(_session, document);
@@ -387,7 +387,7 @@ namespace Marten.Generated.DocumentStorage
     
     
     // START: QueryOnlyInnerAggregateDocumentStorage1153673020
-    public class QueryOnlyInnerAggregateDocumentStorage1153673020 : Marten.Internal.Storage.QueryOnlyDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>
+    public class QueryOnlyInnerAggregateDocumentStorage1153673020 : Marten.Internal.Storage.QueryOnlyDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>
     {
         private readonly Marten.Schema.DocumentMapping _document;
 
@@ -398,59 +398,59 @@ namespace Marten.Generated.DocumentStorage
 
 
 
-        public override System.Guid AssignIdentity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, string tenantId, Marten.Storage.IMartenDatabase database)
+        public override System.Guid AssignIdentity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, string tenantId, Marten.Storage.IMartenDatabase database)
         {
             if (document.Id == Guid.Empty) _setter(document, Marten.Schema.Identity.CombGuidIdGeneration.NewGuid());
             return document.Id;
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Update(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Update(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
 
             return new Marten.Generated.DocumentStorage.UpdateInnerAggregateOperation1153673020
             (
                 document, Identity(document),
-                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>(),
+                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>(),
                 _document
                 
             );
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Insert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Insert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
 
             return new Marten.Generated.DocumentStorage.InsertInnerAggregateOperation1153673020
             (
                 document, Identity(document),
-                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>(),
+                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>(),
                 _document
                 
             );
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Upsert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Upsert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
 
             return new Marten.Generated.DocumentStorage.UpsertInnerAggregateOperation1153673020
             (
                 document, Identity(document),
-                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>(),
+                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>(),
                 _document
                 
             );
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Overwrite(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Overwrite(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
             throw new System.NotSupportedException();
         }
 
 
-        public override System.Guid Identity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document)
+        public override System.Guid Identity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document)
         {
             return document.Id;
         }
@@ -479,7 +479,7 @@ namespace Marten.Generated.DocumentStorage
     
     
     // START: LightweightInnerAggregateDocumentStorage1153673020
-    public class LightweightInnerAggregateDocumentStorage1153673020 : Marten.Internal.Storage.LightweightDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>
+    public class LightweightInnerAggregateDocumentStorage1153673020 : Marten.Internal.Storage.LightweightDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>
     {
         private readonly Marten.Schema.DocumentMapping _document;
 
@@ -490,59 +490,59 @@ namespace Marten.Generated.DocumentStorage
 
 
 
-        public override System.Guid AssignIdentity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, string tenantId, Marten.Storage.IMartenDatabase database)
+        public override System.Guid AssignIdentity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, string tenantId, Marten.Storage.IMartenDatabase database)
         {
             if (document.Id == Guid.Empty) _setter(document, Marten.Schema.Identity.CombGuidIdGeneration.NewGuid());
             return document.Id;
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Update(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Update(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
 
             return new Marten.Generated.DocumentStorage.UpdateInnerAggregateOperation1153673020
             (
                 document, Identity(document),
-                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>(),
+                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>(),
                 _document
                 
             );
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Insert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Insert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
 
             return new Marten.Generated.DocumentStorage.InsertInnerAggregateOperation1153673020
             (
                 document, Identity(document),
-                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>(),
+                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>(),
                 _document
                 
             );
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Upsert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Upsert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
 
             return new Marten.Generated.DocumentStorage.UpsertInnerAggregateOperation1153673020
             (
                 document, Identity(document),
-                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>(),
+                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>(),
                 _document
                 
             );
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Overwrite(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Overwrite(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
             throw new System.NotSupportedException();
         }
 
 
-        public override System.Guid Identity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document)
+        public override System.Guid Identity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document)
         {
             return document.Id;
         }
@@ -571,7 +571,7 @@ namespace Marten.Generated.DocumentStorage
     
     
     // START: IdentityMapInnerAggregateDocumentStorage1153673020
-    public class IdentityMapInnerAggregateDocumentStorage1153673020 : Marten.Internal.Storage.IdentityMapDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>
+    public class IdentityMapInnerAggregateDocumentStorage1153673020 : Marten.Internal.Storage.IdentityMapDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>
     {
         private readonly Marten.Schema.DocumentMapping _document;
 
@@ -582,59 +582,59 @@ namespace Marten.Generated.DocumentStorage
 
 
 
-        public override System.Guid AssignIdentity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, string tenantId, Marten.Storage.IMartenDatabase database)
+        public override System.Guid AssignIdentity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, string tenantId, Marten.Storage.IMartenDatabase database)
         {
             if (document.Id == Guid.Empty) _setter(document, Marten.Schema.Identity.CombGuidIdGeneration.NewGuid());
             return document.Id;
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Update(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Update(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
 
             return new Marten.Generated.DocumentStorage.UpdateInnerAggregateOperation1153673020
             (
                 document, Identity(document),
-                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>(),
+                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>(),
                 _document
                 
             );
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Insert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Insert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
 
             return new Marten.Generated.DocumentStorage.InsertInnerAggregateOperation1153673020
             (
                 document, Identity(document),
-                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>(),
+                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>(),
                 _document
                 
             );
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Upsert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Upsert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
 
             return new Marten.Generated.DocumentStorage.UpsertInnerAggregateOperation1153673020
             (
                 document, Identity(document),
-                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>(),
+                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>(),
                 _document
                 
             );
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Overwrite(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Overwrite(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
             throw new System.NotSupportedException();
         }
 
 
-        public override System.Guid Identity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document)
+        public override System.Guid Identity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document)
         {
             return document.Id;
         }
@@ -663,7 +663,7 @@ namespace Marten.Generated.DocumentStorage
     
     
     // START: DirtyTrackingInnerAggregateDocumentStorage1153673020
-    public class DirtyTrackingInnerAggregateDocumentStorage1153673020 : Marten.Internal.Storage.DirtyCheckedDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>
+    public class DirtyTrackingInnerAggregateDocumentStorage1153673020 : Marten.Internal.Storage.DirtyCheckedDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>
     {
         private readonly Marten.Schema.DocumentMapping _document;
 
@@ -674,59 +674,59 @@ namespace Marten.Generated.DocumentStorage
 
 
 
-        public override System.Guid AssignIdentity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, string tenantId, Marten.Storage.IMartenDatabase database)
+        public override System.Guid AssignIdentity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, string tenantId, Marten.Storage.IMartenDatabase database)
         {
             if (document.Id == Guid.Empty) _setter(document, Marten.Schema.Identity.CombGuidIdGeneration.NewGuid());
             return document.Id;
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Update(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Update(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
 
             return new Marten.Generated.DocumentStorage.UpdateInnerAggregateOperation1153673020
             (
                 document, Identity(document),
-                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>(),
+                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>(),
                 _document
                 
             );
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Insert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Insert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
 
             return new Marten.Generated.DocumentStorage.InsertInnerAggregateOperation1153673020
             (
                 document, Identity(document),
-                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>(),
+                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>(),
                 _document
                 
             );
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Upsert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Upsert(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
 
             return new Marten.Generated.DocumentStorage.UpsertInnerAggregateOperation1153673020
             (
                 document, Identity(document),
-                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>(),
+                session.Versions.ForType<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>(),
                 _document
                 
             );
         }
 
 
-        public override Marten.Internal.Operations.IStorageOperation Overwrite(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
+        public override Marten.Internal.Operations.IStorageOperation Overwrite(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Internal.IMartenSession session, string tenant)
         {
             throw new System.NotSupportedException();
         }
 
 
-        public override System.Guid Identity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document)
+        public override System.Guid Identity(EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document)
         {
             return document.Id;
         }
@@ -755,11 +755,11 @@ namespace Marten.Generated.DocumentStorage
     
     
     // START: InnerAggregateBulkLoader1153673020
-    public class InnerAggregateBulkLoader1153673020 : Marten.Internal.CodeGeneration.BulkLoader<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>
+    public class InnerAggregateBulkLoader1153673020 : Marten.Internal.CodeGeneration.BulkLoader<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>
     {
-        private readonly Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid> _storage;
+        private readonly Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid> _storage;
 
-        public InnerAggregateBulkLoader1153673020(Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid> storage) : base(storage)
+        public InnerAggregateBulkLoader1153673020(Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid> storage) : base(storage)
         {
             _storage = storage;
         }
@@ -776,7 +776,7 @@ namespace Marten.Generated.DocumentStorage
         public const string CREATE_TEMP_TABLE_FOR_COPYING_SQL = "create temporary table mt_doc_inner_aggregate_temp as select * from public.mt_doc_inner_aggregate limit 0";
 
 
-        public override void LoadRow(Npgsql.NpgsqlBinaryImporter writer, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Storage.Tenant tenant, Marten.ISerializer serializer)
+        public override void LoadRow(Npgsql.NpgsqlBinaryImporter writer, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Storage.Tenant tenant, Marten.ISerializer serializer)
         {
             writer.Write(document.GetType().FullName, NpgsqlTypes.NpgsqlDbType.Varchar);
             writer.Write(document.Id, NpgsqlTypes.NpgsqlDbType.Uuid);
@@ -785,7 +785,7 @@ namespace Marten.Generated.DocumentStorage
         }
 
 
-        public override async System.Threading.Tasks.Task LoadRowAsync(Npgsql.NpgsqlBinaryImporter writer, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate document, Marten.Storage.Tenant tenant, Marten.ISerializer serializer, System.Threading.CancellationToken cancellation)
+        public override async System.Threading.Tasks.Task LoadRowAsync(Npgsql.NpgsqlBinaryImporter writer, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate document, Marten.Storage.Tenant tenant, Marten.ISerializer serializer, System.Threading.CancellationToken cancellation)
         {
             await writer.WriteAsync(document.GetType().FullName, NpgsqlTypes.NpgsqlDbType.Varchar, cancellation);
             await writer.WriteAsync(document.Id, NpgsqlTypes.NpgsqlDbType.Uuid, cancellation);
@@ -829,7 +829,7 @@ namespace Marten.Generated.DocumentStorage
     
     
     // START: InnerAggregateProvider1153673020
-    public class InnerAggregateProvider1153673020 : Marten.Internal.Storage.DocumentProvider<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>
+    public class InnerAggregateProvider1153673020 : Marten.Internal.Storage.DocumentProvider<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>
     {
         private readonly Marten.Schema.DocumentMapping _mapping;
 

--- a/src/EventSourcingTests/Internal/Generated/EventStore/AggregateProjectionRuntimeSupport1201339788.cs
+++ b/src/EventSourcingTests/Internal/Generated/EventStore/AggregateProjectionRuntimeSupport1201339788.cs
@@ -12,11 +12,11 @@ namespace Marten.Generated.EventStore
     // START: AggregateProjectionLiveAggregation1201339788
     public class AggregateProjectionLiveAggregation1201339788 : Marten.Events.Aggregation.SyncLiveAggregatorBase<EventSourcingTests.Aggregation.Invoice>
     {
-        private readonly Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Aggregation.Invoice> _singleStreamAggregation;
+        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Aggregation.Invoice> _singleStreamProjection;
 
-        public AggregateProjectionLiveAggregation1201339788(Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Aggregation.Invoice> singleStreamAggregation)
+        public AggregateProjectionLiveAggregation1201339788(Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Aggregation.Invoice> singleStreamProjection)
         {
-            _singleStreamAggregation = singleStreamAggregation;
+            _singleStreamProjection = singleStreamProjection;
         }
 
 
@@ -72,16 +72,16 @@ namespace Marten.Generated.EventStore
         private readonly Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Aggregation.Invoice, System.Guid> _slicer;
         private readonly Marten.Storage.ITenancy _tenancy;
         private readonly Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Aggregation.Invoice, System.Guid> _storage;
-        private readonly Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Aggregation.Invoice> _singleStreamAggregation;
+        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Aggregation.Invoice> _singleStreamProjection;
 
-        public AggregateProjectionInlineHandler1201339788(Marten.IDocumentStore store, Marten.Events.Aggregation.IAggregateProjection projection, Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Aggregation.Invoice, System.Guid> slicer, Marten.Storage.ITenancy tenancy, Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Aggregation.Invoice, System.Guid> storage, Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Aggregation.Invoice> singleStreamAggregation) : base(store, projection, slicer, storage)
+        public AggregateProjectionInlineHandler1201339788(Marten.IDocumentStore store, Marten.Events.Aggregation.IAggregateProjection projection, Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Aggregation.Invoice, System.Guid> slicer, Marten.Storage.ITenancy tenancy, Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Aggregation.Invoice, System.Guid> storage, Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Aggregation.Invoice> singleStreamProjection) : base(store, projection, slicer, storage)
         {
             _store = store;
             _projection = projection;
             _slicer = slicer;
             _tenancy = tenancy;
             _storage = storage;
-            _singleStreamAggregation = singleStreamAggregation;
+            _singleStreamProjection = singleStreamProjection;
         }
 
 

--- a/src/EventSourcingTests/Internal/Generated/EventStore/AggregateProjectionRuntimeSupport1433489248.cs
+++ b/src/EventSourcingTests/Internal/Generated/EventStore/AggregateProjectionRuntimeSupport1433489248.cs
@@ -10,21 +10,21 @@ using System.Linq;
 namespace Marten.Generated.EventStore
 {
     // START: AggregateProjectionLiveAggregation1433489248
-    public class AggregateProjectionLiveAggregation1433489248 : Marten.Events.Aggregation.AsyncLiveAggregatorBase<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>
+    public class AggregateProjectionLiveAggregation1433489248 : Marten.Events.Aggregation.AsyncLiveAggregatorBase<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate>
     {
-        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> _singleStreamProjection;
+        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate> _singleStreamProjection;
 
-        public AggregateProjectionLiveAggregation1433489248(Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> singleStreamProjection)
+        public AggregateProjectionLiveAggregation1433489248(Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate> singleStreamProjection)
         {
             _singleStreamProjection = singleStreamProjection;
         }
 
 
 
-        public override async System.Threading.Tasks.ValueTask<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> BuildAsync(System.Collections.Generic.IReadOnlyList<Marten.Events.IEvent> events, Marten.IQuerySession session, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate snapshot, System.Threading.CancellationToken cancellation)
+        public override async System.Threading.Tasks.ValueTask<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate> BuildAsync(System.Collections.Generic.IReadOnlyList<Marten.Events.IEvent> events, Marten.IQuerySession session, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate snapshot, System.Threading.CancellationToken cancellation)
         {
             if (!events.Any()) return null;
-            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate innerAggregate = null;
+            EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate innerAggregate = null;
             snapshot ??= Create(events[0], session);
             foreach (var @event in events)
             {
@@ -35,13 +35,13 @@ namespace Marten.Generated.EventStore
         }
 
 
-        public EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate Create(Marten.Events.IEvent @event, Marten.IQuerySession session)
+        public EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate Create(Marten.Events.IEvent @event, Marten.IQuerySession session)
         {
-            return new EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate();
+            return new EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate();
         }
 
 
-        public async System.Threading.Tasks.ValueTask<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> Apply(Marten.Events.IEvent @event, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate aggregate, Marten.IQuerySession session, System.Threading.CancellationToken cancellation)
+        public async System.Threading.Tasks.ValueTask<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate> Apply(Marten.Events.IEvent @event, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate aggregate, Marten.IQuerySession session, System.Threading.CancellationToken cancellation)
         {
             switch (@event)
             {
@@ -68,16 +68,16 @@ namespace Marten.Generated.EventStore
     
     
     // START: AggregateProjectionInlineHandler1433489248
-    public class AggregateProjectionInlineHandler1433489248 : Marten.Events.Aggregation.AggregationRuntime<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid>
+    public class AggregateProjectionInlineHandler1433489248 : Marten.Events.Aggregation.AggregationRuntime<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid>
     {
         private readonly Marten.IDocumentStore _store;
         private readonly Marten.Events.Aggregation.IAggregateProjection _projection;
-        private readonly Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid> _slicer;
+        private readonly Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid> _slicer;
         private readonly Marten.Storage.ITenancy _tenancy;
-        private readonly Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid> _storage;
-        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> _singleStreamProjection;
+        private readonly Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid> _storage;
+        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate> _singleStreamProjection;
 
-        public AggregateProjectionInlineHandler1433489248(Marten.IDocumentStore store, Marten.Events.Aggregation.IAggregateProjection projection, Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid> slicer, Marten.Storage.ITenancy tenancy, Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid> storage, Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> singleStreamProjection) : base(store, projection, slicer, storage)
+        public AggregateProjectionInlineHandler1433489248(Marten.IDocumentStore store, Marten.Events.Aggregation.IAggregateProjection projection, Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid> slicer, Marten.Storage.ITenancy tenancy, Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid> storage, Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate> singleStreamProjection) : base(store, projection, slicer, storage)
         {
             _store = store;
             _projection = projection;
@@ -89,24 +89,24 @@ namespace Marten.Generated.EventStore
 
 
 
-        public override async System.Threading.Tasks.ValueTask<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> ApplyEvent(Marten.IQuerySession session, Marten.Events.Projections.EventSlice<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid> slice, Marten.Events.IEvent evt, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate aggregate, System.Threading.CancellationToken cancellationToken)
+        public override async System.Threading.Tasks.ValueTask<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate> ApplyEvent(Marten.IQuerySession session, Marten.Events.Projections.EventSlice<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate, System.Guid> slice, Marten.Events.IEvent evt, EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate aggregate, System.Threading.CancellationToken cancellationToken)
         {
             switch (evt)
             {
                 case Marten.Events.IEvent<EventSourcingTests.EventA> event_EventA96:
-                    aggregate ??= new EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate();
+                    aggregate ??= new EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate();
                     aggregate.Apply(event_EventA96.Data);
                     return aggregate;
                 case Marten.Events.IEvent<EventSourcingTests.EventB> event_EventB97:
-                    aggregate ??= new EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate();
+                    aggregate ??= new EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate();
                     aggregate.Apply(event_EventB97);
                     return aggregate;
                 case Marten.Events.IEvent<EventSourcingTests.EventC> event_EventC98:
-                    aggregate ??= new EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate();
+                    aggregate ??= new EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate();
                     aggregate = aggregate.Apply(event_EventC98);
                     return aggregate;
                 case Marten.Events.IEvent<EventSourcingTests.EventD> event_EventD99:
-                    aggregate ??= new EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate();
+                    aggregate ??= new EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate();
                     aggregate = await aggregate.Apply(event_EventD99.Data, session);
                     return aggregate;
             }
@@ -115,9 +115,9 @@ namespace Marten.Generated.EventStore
         }
 
 
-        public EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate Create(Marten.Events.IEvent @event, Marten.IQuerySession session)
+        public EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate Create(Marten.Events.IEvent @event, Marten.IQuerySession session)
         {
-            return new EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate();
+            return new EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_stream_aggregation.InnerAggregate();
         }
 
     }

--- a/src/EventSourcingTests/Internal/Generated/EventStore/AggregateProjectionRuntimeSupport1433489248.cs
+++ b/src/EventSourcingTests/Internal/Generated/EventStore/AggregateProjectionRuntimeSupport1433489248.cs
@@ -12,11 +12,11 @@ namespace Marten.Generated.EventStore
     // START: AggregateProjectionLiveAggregation1433489248
     public class AggregateProjectionLiveAggregation1433489248 : Marten.Events.Aggregation.AsyncLiveAggregatorBase<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate>
     {
-        private readonly Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> _singleStreamAggregation;
+        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> _singleStreamProjection;
 
-        public AggregateProjectionLiveAggregation1433489248(Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> singleStreamAggregation)
+        public AggregateProjectionLiveAggregation1433489248(Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> singleStreamProjection)
         {
-            _singleStreamAggregation = singleStreamAggregation;
+            _singleStreamProjection = singleStreamProjection;
         }
 
 
@@ -75,16 +75,16 @@ namespace Marten.Generated.EventStore
         private readonly Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid> _slicer;
         private readonly Marten.Storage.ITenancy _tenancy;
         private readonly Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid> _storage;
-        private readonly Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> _singleStreamAggregation;
+        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> _singleStreamProjection;
 
-        public AggregateProjectionInlineHandler1433489248(Marten.IDocumentStore store, Marten.Events.Aggregation.IAggregateProjection projection, Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid> slicer, Marten.Storage.ITenancy tenancy, Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid> storage, Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> singleStreamAggregation) : base(store, projection, slicer, storage)
+        public AggregateProjectionInlineHandler1433489248(Marten.IDocumentStore store, Marten.Events.Aggregation.IAggregateProjection projection, Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid> slicer, Marten.Storage.ITenancy tenancy, Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate, System.Guid> storage, Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_1679_use_inner_type_for_self_aggregate.InnerAggregate> singleStreamProjection) : base(store, projection, slicer, storage)
         {
             _store = store;
             _projection = projection;
             _slicer = slicer;
             _tenancy = tenancy;
             _storage = storage;
-            _singleStreamAggregation = singleStreamAggregation;
+            _singleStreamProjection = singleStreamProjection;
         }
 
 

--- a/src/EventSourcingTests/Internal/Generated/EventStore/AggregateProjectionRuntimeSupport1898706479.cs
+++ b/src/EventSourcingTests/Internal/Generated/EventStore/AggregateProjectionRuntimeSupport1898706479.cs
@@ -12,11 +12,11 @@ namespace Marten.Generated.EventStore
     // START: AggregateProjectionLiveAggregation1898706479
     public class AggregateProjectionLiveAggregation1898706479 : Marten.Events.Aggregation.SyncLiveAggregatorBase<EventSourcingTests.Projections.QuestParty>
     {
-        private readonly Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Projections.QuestParty> _singleStreamAggregation;
+        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Projections.QuestParty> _singleStreamProjection;
 
-        public AggregateProjectionLiveAggregation1898706479(Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Projections.QuestParty> singleStreamAggregation)
+        public AggregateProjectionLiveAggregation1898706479(Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Projections.QuestParty> singleStreamProjection)
         {
-            _singleStreamAggregation = singleStreamAggregation;
+            _singleStreamProjection = singleStreamProjection;
         }
 
 
@@ -72,16 +72,16 @@ namespace Marten.Generated.EventStore
         private readonly Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Projections.QuestParty, System.Guid> _slicer;
         private readonly Marten.Storage.ITenancy _tenancy;
         private readonly Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Projections.QuestParty, System.Guid> _storage;
-        private readonly Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Projections.QuestParty> _singleStreamAggregation;
+        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Projections.QuestParty> _singleStreamProjection;
 
-        public AggregateProjectionInlineHandler1898706479(Marten.IDocumentStore store, Marten.Events.Aggregation.IAggregateProjection projection, Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Projections.QuestParty, System.Guid> slicer, Marten.Storage.ITenancy tenancy, Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Projections.QuestParty, System.Guid> storage, Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Projections.QuestParty> singleStreamAggregation) : base(store, projection, slicer, storage)
+        public AggregateProjectionInlineHandler1898706479(Marten.IDocumentStore store, Marten.Events.Aggregation.IAggregateProjection projection, Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Projections.QuestParty, System.Guid> slicer, Marten.Storage.ITenancy tenancy, Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Projections.QuestParty, System.Guid> storage, Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Projections.QuestParty> singleStreamProjection) : base(store, projection, slicer, storage)
         {
             _store = store;
             _projection = projection;
             _slicer = slicer;
             _tenancy = tenancy;
             _storage = storage;
-            _singleStreamAggregation = singleStreamAggregation;
+            _singleStreamProjection = singleStreamProjection;
         }
 
 

--- a/src/EventSourcingTests/Internal/Generated/EventStore/AggregateProjectionRuntimeSupport85257776.cs
+++ b/src/EventSourcingTests/Internal/Generated/EventStore/AggregateProjectionRuntimeSupport85257776.cs
@@ -12,11 +12,11 @@ namespace Marten.Generated.EventStore
     // START: AggregateProjectionLiveAggregation85257776
     public class AggregateProjectionLiveAggregation85257776 : Marten.Events.Aggregation.SyncLiveAggregatorBase<EventSourcingTests.Aggregation.RoomsAvailability>
     {
-        private readonly Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Aggregation.RoomsAvailability> _singleStreamAggregation;
+        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Aggregation.RoomsAvailability> _singleStreamProjection;
 
-        public AggregateProjectionLiveAggregation85257776(Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Aggregation.RoomsAvailability> singleStreamAggregation)
+        public AggregateProjectionLiveAggregation85257776(Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Aggregation.RoomsAvailability> singleStreamProjection)
         {
-            _singleStreamAggregation = singleStreamAggregation;
+            _singleStreamProjection = singleStreamProjection;
         }
 
 
@@ -72,16 +72,16 @@ namespace Marten.Generated.EventStore
         private readonly Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Aggregation.RoomsAvailability, System.Guid> _slicer;
         private readonly Marten.Storage.ITenancy _tenancy;
         private readonly Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Aggregation.RoomsAvailability, System.Guid> _storage;
-        private readonly Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Aggregation.RoomsAvailability> _singleStreamAggregation;
+        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Aggregation.RoomsAvailability> _singleStreamProjection;
 
-        public AggregateProjectionInlineHandler85257776(Marten.IDocumentStore store, Marten.Events.Aggregation.IAggregateProjection projection, Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Aggregation.RoomsAvailability, System.Guid> slicer, Marten.Storage.ITenancy tenancy, Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Aggregation.RoomsAvailability, System.Guid> storage, Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Aggregation.RoomsAvailability> singleStreamAggregation) : base(store, projection, slicer, storage)
+        public AggregateProjectionInlineHandler85257776(Marten.IDocumentStore store, Marten.Events.Aggregation.IAggregateProjection projection, Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Aggregation.RoomsAvailability, System.Guid> slicer, Marten.Storage.ITenancy tenancy, Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Aggregation.RoomsAvailability, System.Guid> storage, Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Aggregation.RoomsAvailability> singleStreamProjection) : base(store, projection, slicer, storage)
         {
             _store = store;
             _projection = projection;
             _slicer = slicer;
             _tenancy = tenancy;
             _storage = storage;
-            _singleStreamAggregation = singleStreamAggregation;
+            _singleStreamProjection = singleStreamProjection;
         }
 
 

--- a/src/EventSourcingTests/Internal/Generated/EventStore/AggregateProjectionRuntimeSupport973344970.cs
+++ b/src/EventSourcingTests/Internal/Generated/EventStore/AggregateProjectionRuntimeSupport973344970.cs
@@ -12,11 +12,11 @@ namespace Marten.Generated.EventStore
     // START: AggregateProjectionLiveAggregation973344970
     public class AggregateProjectionLiveAggregation973344970 : Marten.Events.Aggregation.SyncLiveAggregatorBase<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity>
     {
-        private readonly Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity> _singleStreamAggregation;
+        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity> _singleStreamProjection;
 
-        public AggregateProjectionLiveAggregation973344970(Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity> singleStreamAggregation)
+        public AggregateProjectionLiveAggregation973344970(Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity> singleStreamProjection)
         {
-            _singleStreamAggregation = singleStreamAggregation;
+            _singleStreamProjection = singleStreamProjection;
         }
 
 
@@ -73,16 +73,16 @@ namespace Marten.Generated.EventStore
         private readonly Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity, System.Guid> _slicer;
         private readonly Marten.Storage.ITenancy _tenancy;
         private readonly Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity, System.Guid> _storage;
-        private readonly Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity> _singleStreamAggregation;
+        private readonly Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity> _singleStreamProjection;
 
-        public AggregateProjectionInlineHandler973344970(Marten.IDocumentStore store, Marten.Events.Aggregation.IAggregateProjection projection, Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity, System.Guid> slicer, Marten.Storage.ITenancy tenancy, Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity, System.Guid> storage, Marten.Events.Aggregation.SingleStreamAggregation<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity> singleStreamAggregation) : base(store, projection, slicer, storage)
+        public AggregateProjectionInlineHandler973344970(Marten.IDocumentStore store, Marten.Events.Aggregation.IAggregateProjection projection, Marten.Events.Aggregation.IEventSlicer<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity, System.Guid> slicer, Marten.Storage.ITenancy tenancy, Marten.Internal.Storage.IDocumentStorage<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity, System.Guid> storage, Marten.Events.Aggregation.SingleStreamProjection<EventSourcingTests.Bugs.Bug_2025_event_inheritance_in_projection.Identity> singleStreamProjection) : base(store, projection, slicer, storage)
         {
             _store = store;
             _projection = projection;
             _slicer = slicer;
             _tenancy = tenancy;
             _storage = storage;
-            _singleStreamAggregation = singleStreamAggregation;
+            _singleStreamProjection = singleStreamProjection;
         }
 
 

--- a/src/EventSourcingTests/Json/SystemTextJsonRecordSerializationTests.cs
+++ b/src/EventSourcingTests/Json/SystemTextJsonRecordSerializationTests.cs
@@ -82,7 +82,7 @@ public record ResourceEnabledEvent(): Event;
 
 public record ResourceDisabledEvent(): Event;
 
-public class ResourceProjection: SingleStreamAggregation<Resource>
+public class ResourceProjection: SingleStreamProjection<Resource>
 {
     public ResourceProjection()
     {

--- a/src/EventSourcingTests/Projections/AggregationProjectionTests.cs
+++ b/src/EventSourcingTests/Projections/AggregationProjectionTests.cs
@@ -53,7 +53,7 @@ public class AggregationProjectionTests
     [Fact]
     public void adding_filter_for_another_aggregate_type()
     {
-        var projection = new SingleStreamAggregation<MyAggregate>();
+        var projection = new SingleStreamProjection<MyAggregate>();
         projection.ProjectEvent<AEvent>(a => { });
         projection.FilterIncomingEventsOnStreamType(typeof(OtherAggregate));
         projection.AssembleAndAssertValidity();
@@ -69,7 +69,7 @@ public class AggregationProjectionTests
 public interface IThing{}
 public class Thing : IThing{}
 
-public class SampleAggregate: SingleStreamAggregation<MyAggregate>
+public class SampleAggregate: SingleStreamProjection<MyAggregate>
 {
     public SampleAggregate()
     {

--- a/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/custom_grouper_with_document_session.cs
+++ b/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/custom_grouper_with_document_session.cs
@@ -45,7 +45,7 @@ public class LicenseFeatureToggledEventGrouper: IAggregateGrouper<Guid>
 }
 
 // projection with documentsession
-public class UserFeatureTogglesProjection: MultiStreamAggregation<UserFeatureToggles, Guid>
+public class UserFeatureTogglesProjection: MultiStreamProjection<UserFeatureToggles, Guid>
 {
     public UserFeatureTogglesProjection()
     {

--- a/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/custom_grouper_with_events_transformation.cs
+++ b/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/custom_grouper_with_events_transformation.cs
@@ -38,7 +38,7 @@ namespace EventSourcingTests.Projections.ViewProjections.CustomGroupers
         public double Hours { get; set; }
     }
 
-    public class MonthlyAllocationProjection: MultiStreamAggregation<MonthlyAllocation, string>
+    public class MonthlyAllocationProjection: MultiStreamProjection<MonthlyAllocation, string>
     {
         public MonthlyAllocationProjection()
         {

--- a/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/custom_slicer.cs
+++ b/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/custom_slicer.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace EventSourcingTests.Projections.MultiStreamProjections.CustomGroupers;
 
 #region sample_view-projection-custom-slicer
-public class UserGroupsAssignmentProjection: MultiStreamAggregation<UserGroupsAssignment, Guid>
+public class UserGroupsAssignmentProjection: MultiStreamProjection<UserGroupsAssignment, Guid>
 {
     public class CustomSlicer: IEventSlicer<UserGroupsAssignment, Guid>
     {

--- a/src/EventSourcingTests/Projections/MultiStreamProjections/simple_multi_stream_projection.cs
+++ b/src/EventSourcingTests/Projections/MultiStreamProjections/simple_multi_stream_projection.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace EventSourcingTests.Projections.MultiStreamProjections;
 
 #region sample_view-projection-simple
-public class UserGroupsAssignmentProjection: MultiStreamAggregation<UserGroupsAssignment, Guid>
+public class UserGroupsAssignmentProjection: MultiStreamProjection<UserGroupsAssignment, Guid>
 {
     public UserGroupsAssignmentProjection()
     {
@@ -29,7 +29,7 @@ public class UserGroupsAssignmentProjection: MultiStreamAggregation<UserGroupsAs
 #endregion
 
 #region sample_view-projection-simple-2
-public class UserGroupsAssignmentProjection2: MultiStreamAggregation<UserGroupsAssignment, Guid>
+public class UserGroupsAssignmentProjection2: MultiStreamProjection<UserGroupsAssignment, Guid>
 {
     public UserGroupsAssignmentProjection2()
     {

--- a/src/EventSourcingTests/Projections/MultiStreamProjections/simple_multi_stream_projection_wih_one_to_many.cs
+++ b/src/EventSourcingTests/Projections/MultiStreamProjections/simple_multi_stream_projection_wih_one_to_many.cs
@@ -10,7 +10,7 @@ namespace EventSourcingTests.Projections.MultiStreamProjections.Samples
 {
     #region sample_view-projection-simple-with-one-to-many
 
-    public class UserGroupsAssignmentProjection: MultiStreamAggregation<UserGroupsAssignment, Guid>
+    public class UserGroupsAssignmentProjection: MultiStreamProjection<UserGroupsAssignment, Guid>
     {
         public UserGroupsAssignmentProjection()
         {

--- a/src/EventSourcingTests/Projections/custom_transformation_of_events.cs
+++ b/src/EventSourcingTests/Projections/custom_transformation_of_events.cs
@@ -107,9 +107,9 @@ public class LapFinished : LapEvent
 
 }
 
-public class LapMultiStreamAggregation: MultiStreamAggregation<Lap, Guid>
+public class LapMultiStreamProjection: MultiStreamProjection<Lap, Guid>
 {
-    public LapMultiStreamAggregation()
+    public LapMultiStreamProjection()
     {
         // This tells the projection how to "split" the events
         // and identify the document. It should be able to use
@@ -184,7 +184,7 @@ public class ReaderUnsubscribed : SubscriptionEvent
     }
 }
 
-public class NewsletterSubscriptionProjection : MultiStreamAggregation<NewsletterSubscription, Guid>
+public class NewsletterSubscriptionProjection : MultiStreamProjection<NewsletterSubscription, Guid>
 {
     public NewsletterSubscriptionProjection()
     {

--- a/src/EventSourcingTests/Projections/inline_aggregation_by_stream_with_multiples.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_by_stream_with_multiples.cs
@@ -34,15 +34,15 @@ public class inline_aggregation_by_stream_with_multiples: OneOffConfigurationsCo
 
             // This is all you need to create the QuestParty projected
             // view
-            _.Projections.SelfAggregate<QuestParty>();
+            _.Projections.Snapshot<QuestParty>();
         });
         #endregion
 
         StoreOptions(_ =>
         {
             _.AutoCreateSchemaObjects = AutoCreate.All;
-            _.Projections.SelfAggregate<QuestParty>();
-            _.Projections.SelfAggregate<QuestMonsters>();
+            _.Projections.Snapshot<QuestParty>();
+            _.Projections.Snapshot<QuestMonsters>();
         });
 
         var streamId = theSession.Events
@@ -62,8 +62,8 @@ public class inline_aggregation_by_stream_with_multiples: OneOffConfigurationsCo
         {
             _.AutoCreateSchemaObjects = AutoCreate.All;
 
-            _.Projections.SelfAggregate<QuestMonsters>();
-            _.Projections.SelfAggregate<QuestParty>();
+            _.Projections.Snapshot<QuestMonsters>();
+            _.Projections.Snapshot<QuestParty>();
         });
 
         var streamId = theSession.Events

--- a/src/EventSourcingTests/Projections/inline_aggregation_with_base_view_class.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_base_view_class.cs
@@ -18,9 +18,9 @@ public class inline_aggregation_with_base_view_class: OneOffConfigurationsContex
         StoreOptions(_ =>
         {
             _.AutoCreateSchemaObjects = AutoCreate.All;
-            _.Projections.SelfAggregate<QuestMonstersWithBaseClass>();
-            _.Projections.SelfAggregate<QuestMonstersWithBaseClassAndIdOverloaded>();
-            _.Projections.SelfAggregate<QuestMonstersWithBaseClassAndIdOverloadedWithNew>();
+            _.Projections.Snapshot<QuestMonstersWithBaseClass>();
+            _.Projections.Snapshot<QuestMonstersWithBaseClassAndIdOverloaded>();
+            _.Projections.Snapshot<QuestMonstersWithBaseClassAndIdOverloadedWithNew>();
         });
 
         streamId = theSession.Events

--- a/src/EventSourcingTests/Projections/inline_aggregation_with_non_public_setter.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_non_public_setter.cs
@@ -20,8 +20,8 @@ public class inline_aggregation_with_non_public_setter: OneOffConfigurationsCont
         {
             _.AutoCreateSchemaObjects = AutoCreate.All;
             _.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.NonPublicSetters);
-            _.Projections.SelfAggregate<QuestMonstersWithPrivateIdSetter>();
-            _.Projections.SelfAggregate<QuestMonstersWithProtectedIdSetter>();
+            _.Projections.Snapshot<QuestMonstersWithPrivateIdSetter>();
+            _.Projections.Snapshot<QuestMonstersWithProtectedIdSetter>();
         });
 
         streamId = theSession.Events

--- a/src/EventSourcingTests/Projections/inline_aggregation_with_private_constructor.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_private_constructor.cs
@@ -15,13 +15,13 @@ public class inline_aggregation_with_private_constructor: OneOffConfigurationsCo
         {
             _.AutoCreateSchemaObjects = AutoCreate.All;
             _.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.All);
-            _.Projections.SelfAggregate<QuestMonstersWithPrivateConstructor>();
-            _.Projections.SelfAggregate<QuestMonstersWithNonDefaultPublicConstructor>();
-            _.Projections.SelfAggregate<WithDefaultPrivateConstructorNonDefaultPublicConstructor>();
-            _.Projections.SelfAggregate<WithMultiplePublicNonDefaultConstructors>();
-            _.Projections.SelfAggregate<WithMultiplePrivateNonDefaultConstructors>();
-            _.Projections.SelfAggregate<WithMultiplePrivateNonDefaultConstructorsAndAttribute>();
-            _.Projections.SelfAggregate<WithNonDefaultConstructorsPrivateAndPublicWithEqualParamsCount>();
+            _.Projections.Snapshot<QuestMonstersWithPrivateConstructor>();
+            _.Projections.Snapshot<QuestMonstersWithNonDefaultPublicConstructor>();
+            _.Projections.Snapshot<WithDefaultPrivateConstructorNonDefaultPublicConstructor>();
+            _.Projections.Snapshot<WithMultiplePublicNonDefaultConstructors>();
+            _.Projections.Snapshot<WithMultiplePrivateNonDefaultConstructors>();
+            _.Projections.Snapshot<WithMultiplePrivateNonDefaultConstructorsAndAttribute>();
+            _.Projections.Snapshot<WithNonDefaultConstructorsPrivateAndPublicWithEqualParamsCount>();
         });
     }
 

--- a/src/EventSourcingTests/Projections/inline_aggregation_with_subclass.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_subclass.cs
@@ -14,7 +14,7 @@ public class inline_aggregation_with_subclass : OneOffConfigurationsContext
         {
             x.Schema.For<FooBase>().AddSubClass<FooA>();
 
-            x.Projections.SelfAggregate<FooA>();
+            x.Projections.Snapshot<FooA>();
         });
     }
 

--- a/src/EventSourcingTests/Projections/stream_aggregation.cs
+++ b/src/EventSourcingTests/Projections/stream_aggregation.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace EventSourcingTests.Projections;
 
-public class self_aggregates : OneOffConfigurationsContext
+public class stream_aggregation : OneOffConfigurationsContext
 {
     [Fact]
     public async Task create_with_static_create_method()

--- a/src/EventSourcingTests/SchemaChange/MultipleVersions/MultipleSchemaVersions.cs
+++ b/src/EventSourcingTests/SchemaChange/MultipleVersions/MultipleSchemaVersions.cs
@@ -31,7 +31,7 @@ public class MultipleSchemaVersions: OneOffConfigurationsContext
         StoreOptions(options =>
         {
             options.GeneratedCodeMode = TypeLoadMode.Auto;
-            options.Projections.SelfAggregate<V1.ShoppingCart>();
+            options.Projections.Snapshot<V1.ShoppingCart>();
         });
         await theStore.EnsureStorageExistsAsync(typeof(StreamAction));
 
@@ -78,7 +78,7 @@ public class MultipleSchemaVersions: OneOffConfigurationsContext
         StoreOptions(options =>
         {
             options.GeneratedCodeMode = TypeLoadMode.Auto;
-            options.Projections.SelfAggregate<V1.ShoppingCart>();
+            options.Projections.Snapshot<V1.ShoppingCart>();
         });
         await theStore.EnsureStorageExistsAsync(typeof(StreamAction));
 
@@ -130,7 +130,7 @@ public class MultipleSchemaVersions: OneOffConfigurationsContext
         using var storeV2 = SeparateStore(options =>
         {
             options.GeneratedCodeMode = TypeLoadMode.Auto;
-            options.Projections.SelfAggregate<V2.WithTheSameName.ShoppingCart>();
+            options.Projections.Snapshot<V2.WithTheSameName.ShoppingCart>();
             ////////////////////////////////////////////////////////
             // 2.1. Define Upcast methods from V1 to V2
             ////////////////////////////////////////////////////////
@@ -209,7 +209,7 @@ public class MultipleSchemaVersions: OneOffConfigurationsContext
         using var storeV3 = SeparateStore(options =>
         {
             options.GeneratedCodeMode = TypeLoadMode.Auto;
-            options.Projections.SelfAggregate<V3.WithTheSameName.ShoppingCart>();
+            options.Projections.Snapshot<V3.WithTheSameName.ShoppingCart>();
             ////////////////////////////////////////////////////////
             // 3.1. Define Upcast methods from V1 to V3, and from V2 to V3
             ////////////////////////////////////////////////////////
@@ -290,7 +290,7 @@ public class MultipleSchemaVersions: OneOffConfigurationsContext
         using var storeV2 = SeparateStore(options =>
         {
             options.GeneratedCodeMode = TypeLoadMode.Auto;
-            options.Projections.SelfAggregate<V2.WithDifferentName.ShoppingCart>();
+            options.Projections.Snapshot<V2.WithDifferentName.ShoppingCart>();
             ////////////////////////////////////////////////////////
             // 2.1. Define Upcast methods from V1 to V2
             ////////////////////////////////////////////////////////
@@ -368,7 +368,7 @@ public class MultipleSchemaVersions: OneOffConfigurationsContext
         using var storeV3 = SeparateStore(options =>
         {
             options.GeneratedCodeMode = TypeLoadMode.Auto;
-            options.Projections.SelfAggregate<V3.WithDifferentName.ShoppingCart>();
+            options.Projections.Snapshot<V3.WithDifferentName.ShoppingCart>();
             ////////////////////////////////////////////////////////
             // 3.1. Define Upcast methods from V1 to V3, and from V2 to V3
             ////////////////////////////////////////////////////////

--- a/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_Tests.cs
+++ b/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_Tests.cs
@@ -658,7 +658,7 @@ public class end_to_end_event_capture_and_fetching_the_stream_Tests : OneOffConf
 
             _.Connection(ConnectionSource.ConnectionString);
 
-            _.Projections.SelfAggregate<QuestParty>();
+            _.Projections.Snapshot<QuestParty>();
 
             _.Events.AddEventType(typeof(MembersJoined));
             _.Events.AddEventType(typeof(MembersDeparted));

--- a/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers.cs
+++ b/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers.cs
@@ -449,7 +449,7 @@ public class StringIdentifiedStreamsFixture: StoreFixture
     public StringIdentifiedStreamsFixture() : base("string_identified_streams")
     {
         Options.Events.StreamIdentity = StreamIdentity.AsString;
-        Options.Projections.SelfAggregate<QuestPartyWithStringIdentifier>();
+        Options.Projections.Snapshot<QuestPartyWithStringIdentifier>();
 
         Options.Events.AddEventType(typeof(MembersJoined));
         Options.Events.AddEventType(typeof(MembersDeparted));

--- a/src/EventSourcingTests/event_store_with_string_identifiers_for_stream.cs
+++ b/src/EventSourcingTests/event_store_with_string_identifiers_for_stream.cs
@@ -18,7 +18,7 @@ public class event_store_with_string_identifiers_for_stream: OneOffConfiguration
         {
             #region sample_eventstore-configure-stream-identity
             storeOptions.Events.StreamIdentity = StreamIdentity.AsString;
-            storeOptions.Projections.Snapshot<QuestPartyWithStringIdentifier>(ProjectionLifecycle.Async);
+            storeOptions.Projections.Snapshot<QuestPartyWithStringIdentifier>(SnapshotLifecycle.Async);
             #endregion
         });
     }

--- a/src/EventSourcingTests/event_store_with_string_identifiers_for_stream.cs
+++ b/src/EventSourcingTests/event_store_with_string_identifiers_for_stream.cs
@@ -18,7 +18,7 @@ public class event_store_with_string_identifiers_for_stream: OneOffConfiguration
         {
             #region sample_eventstore-configure-stream-identity
             storeOptions.Events.StreamIdentity = StreamIdentity.AsString;
-            storeOptions.Projections.SelfAggregate<QuestPartyWithStringIdentifier>(ProjectionLifecycle.Async);
+            storeOptions.Projections.Snapshot<QuestPartyWithStringIdentifier>(ProjectionLifecycle.Async);
             #endregion
         });
     }

--- a/src/Marten.AsyncDaemon.Testing/AggregationExamples.cs
+++ b/src/Marten.AsyncDaemon.Testing/AggregationExamples.cs
@@ -15,9 +15,9 @@ namespace Samples.Deleting
 {
     #region sample_deleting_aggregate_by_event_type
 
-    public class TripAggregation: SingleStreamAggregation<Trip>
+    public class TripProjection: SingleStreamProjection<Trip>
     {
-        public TripAggregation()
+        public TripProjection()
         {
             // The current Trip aggregate would be deleted if
             // the projection encountered a TripAborted event
@@ -39,9 +39,9 @@ namespace Samples.Deleting2
 
     #region sample_deleting_aggregate_by_event_type_and_func
 
-    public class TripAggregation: SingleStreamAggregation<Trip>
+    public class TripProjection: SingleStreamProjection<Trip>
     {
-        public TripAggregation()
+        public TripProjection()
         {
             // The current Trip aggregate would be deleted if
             // the Breakdown event is "critical"
@@ -80,7 +80,7 @@ namespace Samples.Deleting3
 
     #region sample_deleting_aggregate_by_event_type_and_func_with_convention
 
-    public class TripAggregation: SingleStreamAggregation<Trip>
+    public class TripProjection: SingleStreamProjection<Trip>
     {
         // The current Trip aggregate would be deleted if
         // the Breakdown event is "critical"

--- a/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2073_tenancy_problems.cs
+++ b/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2073_tenancy_problems.cs
@@ -79,7 +79,7 @@ public record UpdateDoc(string DocumentId, string Content);
 // projection
 public record Document([property: Identity] string DocumentId, string Owner, string Content);
 
-public class DocumentProjection: SingleStreamAggregation<Document>
+public class DocumentProjection: SingleStreamProjection<Document>
 {
     public DocumentProjection()
     {

--- a/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2074_recovering_from_errors.cs
+++ b/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2074_recovering_from_errors.cs
@@ -63,7 +63,7 @@ public class UserIssueCounter
     public int Count { get; set; }
 }
 
-public class UserIssueCounterProjection : MultiStreamAggregation<UserIssueCounter, Guid>
+public class UserIssueCounterProjection : MultiStreamProjection<UserIssueCounter, Guid>
 {
     private static int _attempts;
 

--- a/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2159_using_QuerySession_within_async_aggregation.cs
+++ b/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2159_using_QuerySession_within_async_aggregation.cs
@@ -41,7 +41,7 @@ public class Bug_2159_using_QuerySession_within_async_aggregation : BugIntegrati
     }
 }
 
-public class UserAggregate: SingleStreamAggregation<MyAggregate>
+public class UserAggregate: SingleStreamProjection<MyAggregate>
 {
     public UserAggregate()
     {

--- a/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2177_query_session_tenancy_in_daemon.cs
+++ b/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2177_query_session_tenancy_in_daemon.cs
@@ -87,7 +87,7 @@ namespace Bug2177
         public User User { get; set; }
     }
 
-    public class TicketProjection: SingleStreamAggregation<Ticket>
+    public class TicketProjection: SingleStreamProjection<Ticket>
     {
         public TicketProjection()
         {

--- a/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2201_out_of_order_exception_with_hard_deletes.cs
+++ b/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2201_out_of_order_exception_with_hard_deletes.cs
@@ -52,7 +52,7 @@ public class Bug_2201_out_of_order_exception_with_hard_deletes: BugIntegrationCo
     }
 
 
-    public class TicketProjection: SingleStreamAggregation<Ticket>
+    public class TicketProjection: SingleStreamProjection<Ticket>
     {
         public TicketProjection()
         {

--- a/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2245_async_daemon_getting_stuck.cs
+++ b/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2245_async_daemon_getting_stuck.cs
@@ -132,7 +132,7 @@ public class Bug_2245_async_daemon_getting_stuck : BugIntegrationContext
 
     public record SyncProjection([property: Identity] string Key, string Value)
     {
-        public class Projector : ViewProjection<SyncProjection, string>
+        public class Projector : MultiStreamProjection<SyncProjection, string>
         {
             public Projector()
             {
@@ -159,7 +159,7 @@ public class Bug_2245_async_daemon_getting_stuck : BugIntegrationContext
     public record UnrelatedEvent(string Key, string Value);
     public record AsyncProjection([property: Identity] string Key, string Value)
     {
-        public class Projector : ViewProjection<AsyncProjection, string>
+        public class Projector : MultiStreamProjection<AsyncProjection, string>
         {
             public Projector()
             {

--- a/src/Marten.AsyncDaemon.Testing/Bugs/Bug_sequential_rebuilds_throws_internally.cs
+++ b/src/Marten.AsyncDaemon.Testing/Bugs/Bug_sequential_rebuilds_throws_internally.cs
@@ -67,7 +67,7 @@ public class Bug_sequential_rebuilds_throws_internally: BugIntegrationContext
 
     public record RandomProjection(Guid Id, string Value)
     {
-        public class Projector: SingleStreamAggregation<RandomProjection>
+        public class Projector: SingleStreamProjection<RandomProjection>
         {
             public static RandomProjection Create(CreatedEvent @event)
             {

--- a/src/Marten.AsyncDaemon.Testing/HotCold_leadership_election.cs
+++ b/src/Marten.AsyncDaemon.Testing/HotCold_leadership_election.cs
@@ -15,11 +15,10 @@ using Xunit.Abstractions;
 
 namespace Marten.AsyncDaemon.Testing;
 
-public class HotCold_leadership_election : DaemonContext
+public class HotCold_leadership_election: DaemonContext
 {
-    public HotCold_leadership_election(ITestOutputHelper output) : base(output)
+    public HotCold_leadership_election(ITestOutputHelper output): base(output)
     {
-
     }
 
 
@@ -52,7 +51,7 @@ public class HotCold_leadership_election : DaemonContext
 
         StoreOptions(x =>
         {
-            x.Projections.Add(new TripAggregationWithCustomName(), ProjectionLifecycle.Async);
+            x.Projections.Add(new TripProjectionWithCustomName(), ProjectionLifecycle.Async);
             x.Logger(new TestOutputMartenLogger(_output));
         }, true);
 
@@ -76,7 +75,7 @@ public class HotCold_leadership_election : DaemonContext
 
         StoreOptions(x =>
         {
-            x.Projections.Add(new TripAggregationWithCustomName(), ProjectionLifecycle.Async);
+            x.Projections.Add(new TripProjectionWithCustomName(), ProjectionLifecycle.Async);
         }, true);
 
         var agent = await StartDaemonInHotColdMode();
@@ -170,7 +169,5 @@ public class HotCold_leadership_election : DaemonContext
 
             other.IsRunning.ShouldBeFalse();
         }
-
-
     }
 }

--- a/src/Marten.AsyncDaemon.Testing/MultiStreamAggregationTests.cs
+++ b/src/Marten.AsyncDaemon.Testing/MultiStreamAggregationTests.cs
@@ -55,7 +55,7 @@ public class MultiStreamAggregationTests: OneOffConfigurationsContext
         public IList<long> EventSequenceList { get; set; } = new List<long>();
     }
 
-    public class Projector: MultiStreamAggregation<Projection, Guid>
+    public class Projector: MultiStreamProjection<Projection, Guid>
     {
         public Projector()
         {

--- a/src/Marten.AsyncDaemon.Testing/Resiliency/when_skipping_events_in_daemon.cs
+++ b/src/Marten.AsyncDaemon.Testing/Resiliency/when_skipping_events_in_daemon.cs
@@ -158,7 +158,7 @@ public class ErrorRejectingEventProjection: EventProjection
     }
 }
 
-public class CollateNames: MultiStreamAggregation<NamesByLetter, string>
+public class CollateNames: MultiStreamProjection<NamesByLetter, string>
 {
     public CollateNames()
     {

--- a/src/Marten.AsyncDaemon.Testing/StressTester.cs
+++ b/src/Marten.AsyncDaemon.Testing/StressTester.cs
@@ -157,7 +157,7 @@ public class View2
     public bool IsEvent4Applied { get; set; }
 }
 
-public class View1Projection : SingleStreamAggregation<View1>
+public class View1Projection : SingleStreamProjection<View1>
 {
     public void Apply(View1 v, Event1 e)
     {
@@ -168,7 +168,7 @@ public class View1Projection : SingleStreamAggregation<View1>
         v.IsEvent2Applied = true;
     }
 }
-public class View2Projection : SingleStreamAggregation<View2>
+public class View2Projection : SingleStreamProjection<View2>
 {
 
     public void Apply(View2 v, Event3 e)

--- a/src/Marten.AsyncDaemon.Testing/TestingSupport/TripAggregationWithCustomName.cs
+++ b/src/Marten.AsyncDaemon.Testing/TestingSupport/TripAggregationWithCustomName.cs
@@ -90,10 +90,10 @@ namespace TripProjection.SelfAggregate
                 opts.Connection("some connection string");
 
                 // Run the Trip as an inline projection
-                opts.Projections.Snapshot<Trip>(ProjectionLifecycle.Inline);
+                opts.Projections.Snapshot<Trip>(SnapshotLifecycle.Inline);
 
                 // Or run it as an asynchronous projection
-                opts.Projections.Snapshot<Trip>(ProjectionLifecycle.Async);
+                opts.Projections.Snapshot<Trip>(SnapshotLifecycle.Async);
             });
 
             // Or more likely, use it as a live aggregation:

--- a/src/Marten.AsyncDaemon.Testing/TestingSupport/TripAggregationWithCustomName.cs
+++ b/src/Marten.AsyncDaemon.Testing/TestingSupport/TripAggregationWithCustomName.cs
@@ -90,10 +90,10 @@ namespace TripProjection.SelfAggregate
                 opts.Connection("some connection string");
 
                 // Run the Trip as an inline projection
-                opts.Projections.SelfAggregate<Trip>(ProjectionLifecycle.Inline);
+                opts.Projections.Snapshot<Trip>(ProjectionLifecycle.Inline);
 
                 // Or run it as an asynchronous projection
-                opts.Projections.SelfAggregate<Trip>(ProjectionLifecycle.Async);
+                opts.Projections.Snapshot<Trip>(ProjectionLifecycle.Async);
             });
 
             // Or more likely, use it as a live aggregation:

--- a/src/Marten.AsyncDaemon.Testing/TestingSupport/TripAggregationWithCustomName.cs
+++ b/src/Marten.AsyncDaemon.Testing/TestingSupport/TripAggregationWithCustomName.cs
@@ -44,7 +44,7 @@ namespace Marten.AsyncDaemon.Testing.TestingSupport
 
     #region sample_TripProjection_aggregate
 
-    public class TripProjection: SingleStreamAggregation<Trip>
+    public class TripProjection: SingleStreamProjection<Trip>
     {
         public TripProjection()
         {
@@ -170,7 +170,7 @@ namespace TripProjection.UsingLambdas
 {
     #region sample_using_ProjectEvent_in_aggregate_projection
 
-    public class TripProjection: SingleStreamAggregation<Trip>
+    public class TripProjection: SingleStreamProjection<Trip>
     {
         public TripProjection()
         {

--- a/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs
+++ b/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs
@@ -31,15 +31,14 @@ namespace Marten.AsyncDaemon.Testing.TestingSupport
         }
     }
 
-    public class TripAggregationWithCustomName: TripProjection
+    public class TripProjectionWithCustomName: TripProjection
     {
-        public TripAggregationWithCustomName()
+        public TripProjectionWithCustomName()
         {
-            ProjectionName = "Trip";
+            ProjectionName = "TripCustomName";
             TeardownDataOnRebuild = true;
         }
     }
-
 
 
     #region sample_TripProjection_aggregate
@@ -62,6 +61,7 @@ namespace Marten.AsyncDaemon.Testing.TestingSupport
         // a small performance gain to making them public
         public void Apply(Arrival e, Trip trip) => trip.State = e.State;
         public void Apply(Travel e, Trip trip) => trip.Traveled += e.TotalDistance();
+
         public void Apply(TripEnded e, Trip trip)
         {
             trip.Active = false;
@@ -70,7 +70,7 @@ namespace Marten.AsyncDaemon.Testing.TestingSupport
 
         public Trip Create(TripStarted started)
         {
-            return new Trip {StartedOn = started.Day, Active = true};
+            return new Trip { StartedOn = started.Day, Active = true };
         }
     }
 
@@ -81,9 +81,9 @@ namespace TripProjection.SelfAggregate
 {
     internal class RegistrationSamples
     {
-        #region sample_using_self_aggregate
+        #region sample_using_stream_aggregation
 
-        internal async Task use_a_self_aggregate()
+        internal async Task use_a_stream_aggregation()
         {
             var store = DocumentStore.For(opts =>
             {
@@ -113,7 +113,7 @@ namespace TripProjection.SelfAggregate
     }
 
 
-    #region sample_Trip_self_aggregate
+    #region sample_Trip_stream_aggregation
 
     public class Trip
     {
@@ -148,14 +148,15 @@ namespace TripProjection.SelfAggregate
         // The Apply() methods would mutate the aggregate state
         internal void Apply(Arrival e) => State = e.State;
         internal void Apply(Travel e) => Traveled += e.TotalDistance();
+
         internal void Apply(TripEnded e)
         {
             Active = false;
             EndedOn = e.Day;
         }
 
-        // We think self-aggregates are mostly useful for live aggregations,
-        // but hey, if you want to use a self aggregate as an asynchronous projection,
+        // We think stream aggregation is mostly useful for live aggregations,
+        // but hey, if you want to use a aggregation as an asynchronous projection,
         // you can also specify when the aggregate document should be deleted
         internal bool ShouldDelete(TripAborted e) => true;
         internal bool ShouldDelete(Breakdown e) => e.IsCritical;

--- a/src/Marten.AsyncDaemon.Testing/ViewProjectionTests.cs
+++ b/src/Marten.AsyncDaemon.Testing/ViewProjectionTests.cs
@@ -125,7 +125,7 @@ public class Day
 
 #region sample_showing_fanout_rules
 
-public class DayProjection: MultiStreamAggregation<Day, int>
+public class DayProjection: MultiStreamProjection<Day, int>
 {
     public DayProjection()
     {

--- a/src/Marten.AsyncDaemon.Testing/build_aggregate_multiple_projections.cs
+++ b/src/Marten.AsyncDaemon.Testing/build_aggregate_multiple_projections.cs
@@ -38,9 +38,9 @@ public class build_aggregate_multiple_projections: DaemonContext
     }
 
     //Aggregation 2
-    public class CarAggregation: SingleStreamAggregation<CarView>
+    public class CarProjection: SingleStreamProjection<CarView>
     {
-        public CarAggregation()
+        public CarProjection()
         {
             ProjectionName = "Car";
         }
@@ -71,9 +71,9 @@ public class build_aggregate_multiple_projections: DaemonContext
     }
 
     //Aggregation 2
-    public class TruckAggregation: SingleStreamAggregation<TruckView>
+    public class TruckProjection: SingleStreamProjection<TruckView>
     {
-        public TruckAggregation()
+        public TruckProjection()
         {
             ProjectionName = "Truck";
         }
@@ -97,8 +97,8 @@ public class build_aggregate_multiple_projections: DaemonContext
         //Register both projections
         StoreOptions(x =>
         {
-            x.Projections.Add<CarAggregation>(ProjectionLifecycle.Async);
-            x.Projections.Add<TruckAggregation>(ProjectionLifecycle.Async);
+            x.Projections.Add<CarProjection>(ProjectionLifecycle.Async);
+            x.Projections.Add<TruckProjection>(ProjectionLifecycle.Async);
         }, true);
 
         var agent = await StartDaemon();
@@ -159,7 +159,7 @@ public class build_aggregate_multiple_projections: DaemonContext
         // register projection
         StoreOptions(x =>
         {
-            x.Projections.Add<CarAggregation>();
+            x.Projections.Add<CarProjection>();
             x.Projections.StaleSequenceThreshold = 250.Milliseconds();
             x.Projections.SlowPollingTime = 500.Milliseconds();
         }, true);
@@ -196,7 +196,7 @@ public class build_aggregate_multiple_projections: DaemonContext
 
         try
         {
-            await daemon.RebuildProjection<CarAggregation>(default);
+            await daemon.RebuildProjection<CarProjection>(default);
         }
         catch (Exception ex)
         {
@@ -227,7 +227,7 @@ public class build_aggregate_multiple_projections: DaemonContext
         // register projection
         StoreOptions(x =>
         {
-            x.Projections.Add<CarAggregation>();
+            x.Projections.Add<CarProjection>();
             x.Projections.StaleSequenceThreshold = 250.Milliseconds();
             x.Projections.SlowPollingTime = 500.Milliseconds();
         }, true);
@@ -264,7 +264,7 @@ public class build_aggregate_multiple_projections: DaemonContext
 
         try
         {
-            await daemon.RebuildProjection<CarAggregation>(default);
+            await daemon.RebuildProjection<CarProjection>(default);
         }
         catch (Exception ex)
         {

--- a/src/Marten.AsyncDaemon.Testing/build_aggregate_projection.cs
+++ b/src/Marten.AsyncDaemon.Testing/build_aggregate_projection.cs
@@ -330,7 +330,7 @@ public class build_aggregate_projection: DaemonContext
     }
 
 
-    public class ContactProjectionNullReturn: SingleStreamAggregation<Contact>
+    public class ContactProjectionNullReturn: SingleStreamProjection<Contact>
     {
         public ContactProjectionNullReturn()
         {
@@ -394,7 +394,7 @@ public class build_aggregate_projection: DaemonContext
     }
 
 
-    public class InterfaceCreationProjection: SingleStreamAggregation<Foo>
+    public class InterfaceCreationProjection: SingleStreamProjection<Foo>
     {
         public InterfaceCreationProjection()
         {
@@ -442,7 +442,7 @@ public class build_aggregate_projection: DaemonContext
     }
 
 
-    public class AbstractCreationProjection: SingleStreamAggregation<Foo>
+    public class AbstractCreationProjection: SingleStreamProjection<Foo>
     {
         public AbstractCreationProjection()
         {

--- a/src/Marten.AsyncDaemon.Testing/cross_stream_aggregation.cs
+++ b/src/Marten.AsyncDaemon.Testing/cross_stream_aggregation.cs
@@ -99,7 +99,7 @@ public class cross_stream_aggregation: DaemonContext
     }
 }
 
-public class CrossStreamDayProjection: ExperimentalMultiStreamAggregation<Day, int>
+public class CrossStreamDayProjection: ExperimentalMultiStreamProjection<Day, int>
 {
     public CrossStreamDayProjection()
     {

--- a/src/Marten.AsyncDaemon.Testing/custom_aggregation_in_async_daemon.cs
+++ b/src/Marten.AsyncDaemon.Testing/custom_aggregation_in_async_daemon.cs
@@ -35,7 +35,7 @@ public class custom_aggregation_in_async_daemon : OneOffConfigurationsContext
     {
         StoreOptions(opts =>
         {
-            var myCustomAggregation = new MyCustomAggregation();
+            var myCustomAggregation = new MyCustomProjection();
             opts.Projections.Add(myCustomAggregation, ProjectionLifecycle.Async);
             opts.Logger(new TestOutputMartenLogger(_output));
         });
@@ -94,9 +94,9 @@ public interface INumbered
 }
 
 
-public class MyCustomAggregation: CustomAggregation<CustomAggregate, int>
+public class MyCustomProjection: CustomProjection<CustomAggregate, int>
 {
-    public MyCustomAggregation()
+    public MyCustomProjection()
     {
         ProjectionName = "Custom";
 

--- a/src/Marten.AsyncDaemon.Testing/multi_stream_aggregation_end_to_end.cs
+++ b/src/Marten.AsyncDaemon.Testing/multi_stream_aggregation_end_to_end.cs
@@ -118,7 +118,7 @@ public interface IUserEvent
     public Guid UserId { get; }
 }
 
-public class UserIssueProjection: MultiStreamAggregation<UserIssues, Guid>
+public class UserIssueProjection: MultiStreamProjection<UserIssues, Guid>
 {
     public UserIssueProjection()
     {

--- a/src/Marten.AsyncDaemon.Testing/multi_tenancy_by_database.cs
+++ b/src/Marten.AsyncDaemon.Testing/multi_tenancy_by_database.cs
@@ -165,7 +165,7 @@ public class multi_tenancy_by_database : IAsyncLifetime
     }
 }
 
-public class AllSync: SingleStreamAggregation<MyAggregate>
+public class AllSync: SingleStreamProjection<MyAggregate>
 {
     public AllSync()
     {
@@ -218,7 +218,7 @@ public class AllSync: SingleStreamAggregation<MyAggregate>
     }
 }
 
-public class AllGood: SingleStreamAggregation<MyAggregate>
+public class AllGood: SingleStreamProjection<MyAggregate>
 {
     public AllGood()
     {

--- a/src/Marten.AsyncDaemon.Testing/rebuilds_with_serialization_or_poison_pill_events.cs
+++ b/src/Marten.AsyncDaemon.Testing/rebuilds_with_serialization_or_poison_pill_events.cs
@@ -13,9 +13,9 @@ using Xunit.Abstractions;
 
 namespace Marten.AsyncDaemon.Testing;
 
-public class rebuilds_with_serialization_or_poison_pill_events : DaemonContext
+public class rebuilds_with_serialization_or_poison_pill_events: DaemonContext
 {
-    public rebuilds_with_serialization_or_poison_pill_events(ITestOutputHelper output) : base(output)
+    public rebuilds_with_serialization_or_poison_pill_events(ITestOutputHelper output): base(output)
     {
         SometimesFailingTripProjection.FailingEventFails = false;
         FailingEvent.SerializationFails = false;
@@ -72,7 +72,8 @@ public class rebuilds_with_serialization_or_poison_pill_events : DaemonContext
         FailingEvent.SerializationFails = false;
         await CheckAllExpectedAggregatesAgainstActuals();
 
-        var deadLetters = await theSession.Query<DeadLetterEvent>().Where(x => x.ShardName == "All" && x.ProjectionName == "Trip")
+        var deadLetters = await theSession.Query<DeadLetterEvent>()
+            .Where(x => x.ShardName == "All" && x.ProjectionName == "Trip")
             .ToListAsync();
 
         var badEventCount = Streams.SelectMany(x => x.Events).OfType<FailingEvent>().Count();
@@ -118,7 +119,7 @@ public class rebuilds_with_serialization_or_poison_pill_events : DaemonContext
     }
 }
 
-public class SometimesFailingTripProjection: TripAggregationWithCustomName
+public class SometimesFailingTripProjection: TripProjectionWithCustomName
 {
     public static bool FailingEventFails = false;
 
@@ -138,4 +139,3 @@ public class FailingEvent
         if (SerializationFails) throw new DivideByZeroException("Boom!");
     }
 }
-

--- a/src/Marten/Events/Aggregation/AggregateProjection.cs
+++ b/src/Marten/Events/Aggregation/AggregateProjection.cs
@@ -1,8 +1,0 @@
-using System;
-
-namespace Marten.Events.Aggregation;
-
-[Obsolete("Please switch to SingleStreamAggregation<T> with the exact same syntax")]
-public class AggregateProjection<T>: SingleStreamAggregation<T>
-{
-}

--- a/src/Marten/Events/Aggregation/CustomProjection.cs
+++ b/src/Marten/Events/Aggregation/CustomProjection.cs
@@ -14,11 +14,11 @@ using Marten.Storage;
 
 namespace Marten.Events.Aggregation;
 
-public abstract class CustomAggregation<TDoc, TId>: ProjectionBase, IAggregationRuntime<TDoc, TId>, IProjectionSource
+public abstract class CustomProjection<TDoc, TId>: ProjectionBase, IAggregationRuntime<TDoc, TId>, IProjectionSource
 {
     private IDocumentStorage<TDoc, TId> _storage;
 
-    protected CustomAggregation()
+    protected CustomProjection()
     {
         ProjectionName = GetType().NameInCode();
     }
@@ -200,4 +200,9 @@ public abstract class CustomAggregation<TDoc, TId>: ProjectionBase, IAggregation
                 $"Invalid identity type {typeof(TId).NameInCode()} for aggregating by stream in projection {GetType().FullNameInCode()}");
         }
     }
+}
+
+[Obsolete("Please switch to CustomProjection<TDoc, TId> with the exact same syntax")]
+public abstract class CustomAggregation<TDoc, TId>: CustomProjection<TDoc, TId>
+{
 }

--- a/src/Marten/Events/Aggregation/SingleStreamProjection.cs
+++ b/src/Marten/Events/Aggregation/SingleStreamProjection.cs
@@ -10,9 +10,9 @@ namespace Marten.Events.Aggregation;
 ///     Base class for aggregating events by a stream using Marten-generated pattern matching
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public class SingleStreamAggregation<T>: GeneratedAggregateProjectionBase<T>
+public class SingleStreamProjection<T>: GeneratedAggregateProjectionBase<T>
 {
-    public SingleStreamAggregation(): base(AggregationScope.SingleStream)
+    public SingleStreamProjection(): base(AggregationScope.SingleStream)
     {
     }
 
@@ -69,4 +69,11 @@ public class SingleStreamAggregation<T>: GeneratedAggregateProjectionBase<T>
             }
         }
     }
+}
+
+
+[Obsolete("Please switch to SingleStreamProjection<T> with the exact same syntax")]
+public class SingleStreamAggregation<T>: SingleStreamProjection<T>
+{
+
 }

--- a/src/Marten/Events/Aggregation/SingleStreamProjection.cs
+++ b/src/Marten/Events/Aggregation/SingleStreamProjection.cs
@@ -77,3 +77,9 @@ public class SingleStreamAggregation<T>: SingleStreamProjection<T>
 {
 
 }
+
+[Obsolete("Please switch to SingleStreamProjection<T> with the exact same syntax")]
+public class AggregateProjection<T>: SingleStreamProjection<T>
+{
+
+}

--- a/src/Marten/Events/Aggregation/SingleStreamProjection.cs
+++ b/src/Marten/Events/Aggregation/SingleStreamProjection.cs
@@ -71,7 +71,6 @@ public class SingleStreamProjection<T>: GeneratedAggregateProjectionBase<T>
     }
 }
 
-
 [Obsolete("Please switch to SingleStreamProjection<T> with the exact same syntax")]
 public class SingleStreamAggregation<T>: SingleStreamProjection<T>
 {

--- a/src/Marten/Events/CodeGeneration/ApplyMethodCollection.cs
+++ b/src/Marten/Events/CodeGeneration/ApplyMethodCollection.cs
@@ -17,7 +17,7 @@ internal class ApplyMethodCollection: MethodCollection
     public ApplyMethodCollection(Type projectionType, Type aggregateType): base(MethodName, projectionType,
         aggregateType)
     {
-        LambdaName = nameof(SingleStreamAggregation<string>.ProjectEvent);
+        LambdaName = nameof(SingleStreamProjection<string>.ProjectEvent);
         _validArgumentTypes.Add(typeof(IQuerySession));
         _validArgumentTypes.Add(aggregateType);
 

--- a/src/Marten/Events/Projections/ExperimentalMultiStreamProjection.cs
+++ b/src/Marten/Events/Projections/ExperimentalMultiStreamProjection.cs
@@ -15,12 +15,12 @@ namespace Marten.Events.Projections;
 /// </summary>
 /// <typeparam name="TDoc"></typeparam>
 /// <typeparam name="TId"></typeparam>
-public abstract class ExperimentalMultiStreamAggregation<TDoc, TId>: GeneratedAggregateProjectionBase<TDoc>,
+public abstract class ExperimentalMultiStreamProjection<TDoc, TId>: GeneratedAggregateProjectionBase<TDoc>,
     IEventSlicer<TDoc, TId>
 {
     private TenancyStyle _tenancyStyle;
 
-    protected ExperimentalMultiStreamAggregation(): base(AggregationScope.MultiStream)
+    protected ExperimentalMultiStreamProjection(): base(AggregationScope.MultiStream)
     {
         Lifecycle = ProjectionLifecycle.Async;
     }
@@ -94,4 +94,9 @@ public abstract class ExperimentalMultiStreamAggregation<TDoc, TId>: GeneratedAg
     {
         return typeof(AggregationRuntime<,>).MakeGenericType(typeof(TDoc), _aggregateMapping.IdType);
     }
+}
+
+[Obsolete("Please switch to ExperimentalMultiStreamProjection<TDoc, TId> with the exact same syntax")]
+public abstract class ExperimentalMultiStreamAggregation<TDoc, TId>: ExperimentalMultiStreamProjection<TDoc, TId>
+{
 }

--- a/src/Marten/Events/Projections/MultiStreamProjection.cs
+++ b/src/Marten/Events/Projections/MultiStreamProjection.cs
@@ -148,3 +148,8 @@ public abstract class MultiStreamAggregation<TDoc, TId>: MultiStreamProjection<T
 {
 
 }
+
+[Obsolete("Please switch to MultiStreamProjection<T> with the exact same syntax")]
+public abstract class ViewProjection<TDoc, TId>: MultiStreamProjection<TDoc, TId>
+{
+}

--- a/src/Marten/Events/Projections/MultiStreamProjection.cs
+++ b/src/Marten/Events/Projections/MultiStreamProjection.cs
@@ -16,13 +16,13 @@ namespace Marten.Events.Projections;
 /// </summary>
 /// <typeparam name="TDoc"></typeparam>
 /// <typeparam name="TId"></typeparam>
-public abstract class MultiStreamAggregation<TDoc, TId>: GeneratedAggregateProjectionBase<TDoc>
+public abstract class MultiStreamProjection<TDoc, TId>: GeneratedAggregateProjectionBase<TDoc>
 {
     private readonly EventSlicer<TDoc, TId> _defaultSlicer = new();
 
     private IEventSlicer<TDoc, TId>? _customSlicer;
 
-    protected MultiStreamAggregation(): base(AggregationScope.MultiStream)
+    protected MultiStreamProjection(): base(AggregationScope.MultiStream)
     {
         Lifecycle = ProjectionLifecycle.Async;
     }
@@ -141,4 +141,10 @@ public abstract class MultiStreamAggregation<TDoc, TId>: GeneratedAggregateProje
     {
         return typeof(CrossStreamAggregationRuntime<,>).MakeGenericType(typeof(TDoc), typeof(TId));
     }
+}
+
+[Obsolete("Please switch to MultiStreamProjection<T> with the exact same syntax")]
+public abstract class MultiStreamAggregation<TDoc, TId>: MultiStreamProjection<TDoc, TId>
+{
+
 }

--- a/src/Marten/Events/Projections/ProjectionLifecycle.cs
+++ b/src/Marten/Events/Projections/ProjectionLifecycle.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Marten.Events.Projections;
 
 public enum ProjectionLifecycle
@@ -17,4 +19,39 @@ public enum ProjectionLifecycle
     ///     The projection is only executed on demand
     /// </summary>
     Live
+}
+
+public enum SnapshotLifecycle
+{
+    /// <summary>
+    ///     The snapshot will be updated in the same transaction as
+    ///     the events being captured
+    /// </summary>
+    Inline,
+
+    /// <summary>
+    ///     The snapshot will be made asynchronously within the Async Daemon
+    /// </summary>
+    Async
+}
+
+public static class SnapshotLifecycleExtensions
+{
+    public static SnapshotLifecycle? Map(this ProjectionLifecycle? projectionLifecycle) =>
+        projectionLifecycle switch
+        {
+            ProjectionLifecycle.Inline => SnapshotLifecycle.Inline,
+            ProjectionLifecycle.Async => SnapshotLifecycle.Async,
+            ProjectionLifecycle.Live => throw new ArgumentOutOfRangeException(nameof(projectionLifecycle),
+                "Snapshot lifecycle cannot be live!"),
+            null => null
+        };
+
+    public static ProjectionLifecycle? Map(this SnapshotLifecycle? projectionLifecycle) =>
+        projectionLifecycle switch
+        {
+            SnapshotLifecycle.Inline => ProjectionLifecycle.Inline,
+            SnapshotLifecycle.Async => ProjectionLifecycle.Async,
+            null => null
+        };
 }

--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -84,8 +84,12 @@ public class ProjectionOptions: DaemonSettings
     ///     Optional configuration including teardown instructions for the usage of this
     ///     projection within the async projection daempon
     /// </param>
-    public void Add(IProjection projection, ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline,
-        string projectionName = null, Action<AsyncOptions> asyncConfiguration = null)
+    public void Add(
+        IProjection projection,
+        ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline,
+        string projectionName = null,
+        Action<AsyncOptions> asyncConfiguration = null
+    )
     {
         if (lifecycle == ProjectionLifecycle.Live)
         {
@@ -140,8 +144,9 @@ public class ProjectionOptions: DaemonSettings
         All.Add(projection);
     }
 
+
     /// <summary>
-    /// Use a "self-aggregating" aggregate of type.
+    /// Perform automated snapshot on each event for selected entity type
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="lifecycle">Override the aggregate lifecycle. The default is Inline</param>
@@ -150,7 +155,20 @@ public class ProjectionOptions: DaemonSettings
     ///     projection within the async projection daempon
     /// </param>
     /// <returns>The extended storage configuration for document T</returns>
+    [Obsolete("Use Snapshot method instead.")]
     public MartenRegistry.DocumentMappingExpression<T> SelfAggregate<T>(
+        ProjectionLifecycle? lifecycle = null,
+        Action<AsyncOptions> asyncConfiguration = null
+    ) =>
+        Snapshot<T>(lifecycle, asyncConfiguration);
+
+    /// <summary>
+    /// Perform automated snapshot on each event for selected entity type
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="lifecycle">Override the aggregate lifecycle. The default is Inline</param>
+    /// <returns>The extended storage configuration for document T</returns>
+    public MartenRegistry.DocumentMappingExpression<T> Snapshot<T>(
         ProjectionLifecycle? lifecycle = null,
         Action<AsyncOptions> asyncConfiguration = null
     )

--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -155,7 +155,7 @@ public class ProjectionOptions: DaemonSettings
     ///     projection within the async projection daempon
     /// </param>
     /// <returns>The extended storage configuration for document T</returns>
-    [Obsolete("Use Snapshot method instead.")]
+    [Obsolete("Please switch to Snapshot method with the exact same syntax")]
     public MartenRegistry.DocumentMappingExpression<T> SelfAggregate<T>(
         ProjectionLifecycle? lifecycle = null,
         Action<AsyncOptions> asyncConfiguration = null
@@ -176,7 +176,7 @@ public class ProjectionOptions: DaemonSettings
         // Make sure there's a DocumentMapping for the aggregate
         var expression = _options.Schema.For<T>();
 
-        var source = new SingleStreamAggregation<T> { Lifecycle = lifecycle ?? ProjectionLifecycle.Inline };
+        var source = new SingleStreamProjection<T> { Lifecycle = lifecycle ?? ProjectionLifecycle.Inline };
 
         asyncConfiguration?.Invoke(source.Options);
 
@@ -260,9 +260,9 @@ public class ProjectionOptions: DaemonSettings
         return (ILiveAggregator<T>)aggregator;
     }
 
-    private SingleStreamAggregation<T> tryFindProjectionSourceForAggregateType<T>() where T : class
+    private SingleStreamProjection<T> tryFindProjectionSourceForAggregateType<T>() where T : class
     {
-        var candidate = All.OfType<SingleStreamAggregation<T>>().FirstOrDefault();
+        var candidate = All.OfType<SingleStreamProjection<T>>().FirstOrDefault();
         if (candidate != null)
         {
             return candidate;
@@ -270,10 +270,10 @@ public class ProjectionOptions: DaemonSettings
 
         if (!_liveAggregateSources.TryGetValue(typeof(T), out var source))
         {
-            return new SingleStreamAggregation<T>();
+            return new SingleStreamProjection<T>();
         }
 
-        return source as SingleStreamAggregation<T>;
+        return source as SingleStreamProjection<T>;
     }
 
     internal void AssertValidity(DocumentStore store)

--- a/src/Marten/Events/Projections/ViewProjection.cs
+++ b/src/Marten/Events/Projections/ViewProjection.cs
@@ -1,8 +1,0 @@
-using System;
-
-namespace Marten.Events.Projections;
-
-[Obsolete("Please switch to MultiStreamAggregation<T> with the exact same syntax")]
-public abstract class ViewProjection<TDoc, TId>: MultiStreamAggregation<TDoc, TId>
-{
-}

--- a/src/samples/EventSourcingIntro/Program.cs
+++ b/src/samples/EventSourcingIntro/Program.cs
@@ -70,7 +70,7 @@ public class WarehouseProductReadModel
     public int QuantityOnHand { get; set; }
 }
 
-public class WarehouseProductProjection: SingleStreamAggregation<WarehouseProductReadModel>
+public class WarehouseProductProjection: SingleStreamProjection<WarehouseProductReadModel>
 {
     public WarehouseProductProjection()
     {

--- a/src/samples/MinimalAPI/Program.cs
+++ b/src/samples/MinimalAPI/Program.cs
@@ -30,7 +30,7 @@ builder.Services.AddMarten(opts =>
     opts.DatabaseSchemaName = "cli";
 
     // Register all event store projections ahead of time
-    opts.Projections.Add(new TripAggregationWithCustomName(), ProjectionLifecycle.Async);
+    opts.Projections.Add(new TripProjectionWithCustomName(), ProjectionLifecycle.Async);
     opts.Projections.Add(new DayProjection(), ProjectionLifecycle.Async);
     opts.Projections.Add(new DistanceProjection(), ProjectionLifecycle.Async);
 });


### PR DESCRIPTION
- [x] Renamed `SelfAggregate` registration to `Snapshot` to make the intention more explicit.  Added an explicit `SnapshotLifecycle` enum with `Live` and `Async` options (as there's no sense in performing a snapshot live).
- [x] Added LiveStreamAggregation for Code Generation needs. It registers the entity as a `Live` aggregation. 
- [x] Renamed `SingleStreamAggregation` into `SingleStreamProjection`, leaving the old name as a derived obsolete class.
- [x] Renamed `MultiStreamAggregation` into `MultiStreamProjection`, leaving the old name as a derived obsolete class.
- [x] Renamed `CustomAggregation` into `CustomProjection`
- [x] Renamed `ExperimentalMultiStreamAggregation` into `ExperimentalMultiStreamProjection`
- [x] Update docs

_**Note:** I'll need to revamp our Event Sourcing docs, but I'll do that in the dedicated PR. For now, I just adjusted the naming in the docs to be aligned with the recent convention._ 