### PR TITLE
Add failure scenario for hashset contains

### DIFF
--- a/docs/configuration/storeoptions.md
+++ b/docs/configuration/storeoptions.md
@@ -202,7 +202,7 @@ public class ConfiguresItself
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/DocumentMappingTests.cs#L126-L137' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuremarten-generic' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/DocumentMappingTests.cs#L126-L138' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuremarten-generic' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `DocumentMapping` type is the core configuration class representing how a document type is persisted or
@@ -226,7 +226,7 @@ public class ConfiguresItselfSpecifically
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/DocumentMappingTests.cs#L139-L151' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuremarten-specifically' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/DocumentMappingTests.cs#L140-L153' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuremarten-specifically' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Document Policies

--- a/docs/documents/identity.md
+++ b/docs/documents/identity.md
@@ -94,7 +94,7 @@ options.Policies.ForAllDocuments(m =>
     }
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/Identity/Sequences/CombGuidIdGenerationTests.cs#L47-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring-global-sequentialguid' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/Identity/Sequences/CombGuidIdGenerationTests.cs#L47-L57' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring-global-sequentialguid' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 It is also possible use the SequentialGuid id generation algorithm for a specific document type.
@@ -104,7 +104,7 @@ It is also possible use the SequentialGuid id generation algorithm for a specifi
 ```cs
 options.Schema.For<UserWithGuid>().IdStrategy(new CombGuidIdGeneration());
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/Identity/Sequences/CombGuidIdGenerationTests.cs#L80-L82' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring-mapping-specific-sequentialguid' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/Identity/Sequences/CombGuidIdGenerationTests.cs#L82-L86' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring-mapping-specific-sequentialguid' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Sequential Identifiers with Hilo

--- a/docs/documents/storage.md
+++ b/docs/documents/storage.md
@@ -52,11 +52,10 @@ Or by using an attribute on your document type:
 [DatabaseSchemaName("organization")]
 public class Customer
 {
-    [Identity]
-    public string Name { get; set; }
+    [Identity] public string Name { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/DocumentMappingTests.cs#L812-L821' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_databaseschemaname_attribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/DocumentMappingTests.cs#L818-L826' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_databaseschemaname_attribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Type Aliases

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -6,115 +6,115 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten\Marten.csproj" />
-        <ProjectReference Include="..\Marten.Testing.OtherAssembly\Marten.Testing.OtherAssembly.csproj" />
-        <ProjectReference Include="..\Marten.Testing.ThirdAssembly\Marten.Testing.ThirdAssembly.csproj" />
+        <ProjectReference Include="..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\Marten.Testing.OtherAssembly\Marten.Testing.OtherAssembly.csproj"/>
+        <ProjectReference Include="..\Marten.Testing.ThirdAssembly\Marten.Testing.ThirdAssembly.csproj"/>
     </ItemGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="12.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="12.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="12.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Jil" Version="3.0.0-alpha2"/>
+        <PackageReference Include="Lamar" Version="12.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="NSubstitute" Version="5.0.0" />
-        <PackageReference Include="Shouldly" Version="4.1.0" />
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="NSubstitute" Version="5.0.0"/>
+        <PackageReference Include="Shouldly" Version="4.1.0"/>
     </ItemGroup>
 
     <ItemGroup>
         <Compile Include="..\Marten.Testing\Documents\Account.cs">
-          <Link>Documents\Account.cs</Link>
+            <Link>Documents\Account.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Documents\Company.cs">
-          <Link>Documents\Company.cs</Link>
+            <Link>Documents\Company.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Documents\CriticalIssue.cs">
-          <Link>Documents\CriticalIssue.cs</Link>
+            <Link>Documents\CriticalIssue.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Documents\GuidDoc.cs">
-          <Link>Documents\GuidDoc.cs</Link>
+            <Link>Documents\GuidDoc.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Documents\IntDoc.cs">
-          <Link>Documents\IntDoc.cs</Link>
+            <Link>Documents\IntDoc.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Documents\InvalidDocument.cs">
-          <Link>Documents\InvalidDocument.cs</Link>
+            <Link>Documents\InvalidDocument.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Documents\Issue.cs">
-          <Link>Documents\Issue.cs</Link>
+            <Link>Documents\Issue.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Documents\LongDoc.cs">
-          <Link>Documents\LongDoc.cs</Link>
+            <Link>Documents\LongDoc.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Documents\StringDoc.cs">
-          <Link>Documents\StringDoc.cs</Link>
+            <Link>Documents\StringDoc.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Documents\Target.cs">
-          <Link>Documents\Target.cs</Link>
+            <Link>Documents\Target.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Documents\TargetIntId.cs">
-          <Link>Documents\TargetIntId.cs</Link>
+            <Link>Documents\TargetIntId.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Documents\User.cs">
-          <Link>Documents\User.cs</Link>
+            <Link>Documents\User.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Documents\UserWithInheritedId.cs">
-          <Link>Documents\UserWithInheritedId.cs</Link>
+            <Link>Documents\UserWithInheritedId.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\BugIntegrationContext.cs">
-          <Link>Harness\BugIntegrationContext.cs</Link>
+            <Link>Harness\BugIntegrationContext.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\ConnectionSource.cs">
             <Link>ConnectionSource.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\DefaultStoreFixture.cs">
-          <Link>Harness\DefaultStoreFixture.cs</Link>
+            <Link>Harness\DefaultStoreFixture.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\DestructiveIntegrationContext.cs">
-          <Link>Harness\DestructiveIntegrationContext.cs</Link>
+            <Link>Harness\DestructiveIntegrationContext.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\IntegrationContext.cs">
-          <Link>Harness\IntegrationContext.cs</Link>
+            <Link>Harness\IntegrationContext.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\OneOffConfigurationsContext.cs">
-          <Link>Harness\OneOffConfigurationsContext.cs</Link>
+            <Link>Harness\OneOffConfigurationsContext.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\PgVersionTargetedFact.cs">
-          <Link>PgVersionTargetedFact.cs</Link>
+            <Link>PgVersionTargetedFact.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\SerializerTypeTargetedFact.cs">
-          <Link>SerializerTypeTargetedFact.cs</Link>
+            <Link>SerializerTypeTargetedFact.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\SerializerTypeTargetedTheory.cs">
-          <Link>SerializerTypeTargetedTheory.cs</Link>
+            <Link>SerializerTypeTargetedTheory.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\SpecificationExtensions.cs">
-          <Link>SpecificationExtensions.cs</Link>
+            <Link>SpecificationExtensions.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\StoreContext.cs">
-          <Link>Harness\StoreContext.cs</Link>
+            <Link>Harness\StoreContext.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\StoreFixture.cs">
-          <Link>Harness\StoreFixture.cs</Link>
+            <Link>Harness\StoreFixture.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\TestOutputMartenLogger.cs">
-          <Link>Harness\TestOutputMartenLogger.cs</Link>
+            <Link>Harness\TestOutputMartenLogger.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\Harness\TestsSettings.cs">
-          <Link>Harness\TestsSettings.cs</Link>
+            <Link>Harness\TestsSettings.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\SchemaMigrationExtensions.cs">
-          <Link>SchemaMigrationExtensions.cs</Link>
+            <Link>SchemaMigrationExtensions.cs</Link>
         </Compile>
         <Compile Include="..\Marten.Testing\performance_tuning.cs">
             <Link>performance_tuning.cs</Link>

--- a/src/DocumentDbTests/Bugs/Bug_1563_user_friendly_warning_about_public_type.cs
+++ b/src/DocumentDbTests/Bugs/Bug_1563_user_friendly_warning_about_public_type.cs
@@ -1,14 +1,12 @@
 using System;
-using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
-using Marten.Events.Projections;
 using Marten.Schema;
 using Marten.Testing.Harness;
 using Xunit;
 
 namespace DocumentDbTests.Bugs;
 
-public class Bug_1563_user_friendly_warning_about_public_type : BugIntegrationContext
+public class Bug_1563_user_friendly_warning_about_public_type: BugIntegrationContext
 {
     [DocumentAlias("internal_doc")]
     internal class InternalDoc
@@ -19,7 +17,8 @@ public class Bug_1563_user_friendly_warning_about_public_type : BugIntegrationCo
     [Fact]
     public void good_error_on_non_public_type()
     {
-        var expectedMessage = $"Requested document type '{typeof(InternalDoc).FullNameInCode()}' must be scoped as 'public'";
+        var expectedMessage =
+            $"Requested document type '{typeof(InternalDoc).FullNameInCode()}' must be scoped as 'public'";
 
         var ex = Exception<InvalidOperationException>.ShouldBeThrownBy(() =>
         {
@@ -29,7 +28,5 @@ public class Bug_1563_user_friendly_warning_about_public_type : BugIntegrationCo
         });
 
         ex.Message.ShouldContain(expectedMessage);
-
-
     }
 }

--- a/src/DocumentDbTests/Bugs/hashset_contains.cs
+++ b/src/DocumentDbTests/Bugs/hashset_contains.cs
@@ -3,21 +3,21 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten;
-using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Xunit;
 
 namespace DocumentDbTests.Bugs;
 
-public class hashset_contains : BugIntegrationContext
+public class hashset_contains: BugIntegrationContext
 {
     [Fact]
     public async Task Can_query_by_hashset_contains()
     {
         var value = Guid.NewGuid().ToString();
         theSession.Store(new MySpecialType(Guid.NewGuid(), value));
+        await theSession.SaveChangesAsync();
 
-        var hashset = new HashSet<string>() {value};
+        var hashset = new HashSet<string> { value };
         var items = await theSession
             .Query<MySpecialType>()
             .Where(x => hashset.Contains(x.Value))

--- a/src/DocumentDbTests/Bugs/hashset_contains.cs
+++ b/src/DocumentDbTests/Bugs/hashset_contains.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Xunit;
+
+namespace DocumentDbTests.Bugs;
+
+public class hashset_contains : BugIntegrationContext
+{
+    [Fact]
+    public async Task Can_query_by_hashset_contains()
+    {
+        var value = Guid.NewGuid().ToString();
+        theSession.Store(new MySpecialType(Guid.NewGuid(), value));
+
+        var hashset = new HashSet<string>() {value};
+        var items = await theSession
+            .Query<MySpecialType>()
+            .Where(x => hashset.Contains(x.Value))
+            .ToListAsync();
+
+        Assert.Equal(1, items.Count);
+    }
+
+    public record MySpecialType(Guid Id, string Value);
+}

--- a/src/DocumentDbTests/Configuration/DocumentMappingTests.cs
+++ b/src/DocumentDbTests/Configuration/DocumentMappingTests.cs
@@ -94,7 +94,7 @@ public class DocumentMappingTests
         public int Id;
     }
 
-    public class BaseDocumentSubClass : BaseDocumentWithAttribute
+    public class BaseDocumentSubClass: BaseDocumentWithAttribute
     {
     }
 
@@ -106,8 +106,7 @@ public class DocumentMappingTests
         public string OtherProp;
         public Guid Id { get; set; }
 
-        [DuplicateField]
-        public string Name { get; set; }
+        [DuplicateField] public string Name { get; set; }
 
         public string OtherField { get; set; }
     }
@@ -117,6 +116,7 @@ public class DocumentMappingTests
         public IEnumerable<Type> KeyTypes { get; }
 
         public bool RequiresSequences { get; } = false;
+
         public void GenerateCode(GeneratedMethod assign, DocumentMapping mapping)
         {
             throw new NotSupportedException();
@@ -124,6 +124,7 @@ public class DocumentMappingTests
     }
 
     #region sample_ConfigureMarten-generic
+
     public class ConfiguresItself
     {
         public Guid Id;
@@ -137,6 +138,7 @@ public class DocumentMappingTests
     #endregion
 
     #region sample_ConfigureMarten-specifically
+
     public class ConfiguresItselfSpecifically
     {
         public Guid Id;
@@ -286,7 +288,8 @@ public class DocumentMappingTests
     [Theory]
     [InlineData(EnumStorage.AsInteger, NpgsqlDbType.Integer)]
     [InlineData(EnumStorage.AsString, NpgsqlDbType.Varchar)]
-    public void duplicated_field_enum_storage_should_be_taken_from_store_options_enum_storage_by_default(EnumStorage enumStorage, NpgsqlDbType expectedNpgsqlDbType)
+    public void duplicated_field_enum_storage_should_be_taken_from_store_options_enum_storage_by_default(
+        EnumStorage enumStorage, NpgsqlDbType expectedNpgsqlDbType)
     {
         var storeOptions = new StoreOptions();
         storeOptions.UseDefaultSerialization(enumStorage);
@@ -300,7 +303,9 @@ public class DocumentMappingTests
     [Theory]
     [InlineData(EnumStorage.AsInteger, NpgsqlDbType.Integer)]
     [InlineData(EnumStorage.AsString, NpgsqlDbType.Varchar)]
-    public void duplicated_field_enum_storage_should_be_taken_from_store_options_duplicated_field_enum_storage_when_it_was_changed(EnumStorage enumStorage, NpgsqlDbType expectedNpgsqlDbType)
+    public void
+        duplicated_field_enum_storage_should_be_taken_from_store_options_duplicated_field_enum_storage_when_it_was_changed(
+            EnumStorage enumStorage, NpgsqlDbType expectedNpgsqlDbType)
     {
         var storeOptions = new StoreOptions();
         storeOptions.Advanced.DuplicatedFieldEnumStorage = enumStorage;
@@ -314,10 +319,13 @@ public class DocumentMappingTests
     [Theory]
     [InlineData(true, NpgsqlDbType.Timestamp)]
     [InlineData(false, NpgsqlDbType.TimestampTz)]
-    public void duplicated_field_date_time_db_type_should_be_taken_from_store_options_useTimestampWithoutTimeZoneForDateTime(bool useTimestampWithoutTimeZoneForDateTime, NpgsqlDbType expectedNpgsqlDbType)
+    public void
+        duplicated_field_date_time_db_type_should_be_taken_from_store_options_useTimestampWithoutTimeZoneForDateTime(
+            bool useTimestampWithoutTimeZoneForDateTime, NpgsqlDbType expectedNpgsqlDbType)
     {
         var storeOptions = new StoreOptions();
-        storeOptions.Advanced.DuplicatedFieldUseTimestampWithoutTimeZoneForDateTime = useTimestampWithoutTimeZoneForDateTime;
+        storeOptions.Advanced.DuplicatedFieldUseTimestampWithoutTimeZoneForDateTime =
+            useTimestampWithoutTimeZoneForDateTime;
 
         var mapping = new DocumentMapping<Target>(storeOptions);
 
@@ -787,7 +795,6 @@ public class DocumentMappingTests
                 _.Schema.For<BadDoc>();
             });
         });
-
     }
 
     [Fact]
@@ -800,7 +807,6 @@ public class DocumentMappingTests
                 options.Schema.For<BadDoc>();
             });
         });
-
     }
 
     [Fact]
@@ -814,12 +820,12 @@ public class DocumentMappingTests
     [DatabaseSchemaName("organization")]
     public class Customer
     {
-        [Identity]
-        public string Name { get; set; }
+        [Identity] public string Name { get; set; }
     }
 
     #endregion
 }
+
 public class BadDoc
 {
     public string Name { get; set; }

--- a/src/DocumentDbTests/DocumentDbTests.csproj
+++ b/src/DocumentDbTests/DocumentDbTests.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="11.1.2" />
+        <PackageReference Include="Lamar" Version="12.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>

--- a/src/DocumentDbTests/Writing/Identity/Sequences/CombGuidIdGenerationTests.cs
+++ b/src/DocumentDbTests/Writing/Identity/Sequences/CombGuidIdGenerationTests.cs
@@ -14,7 +14,7 @@ using CombGuidIdGeneration = Marten.Schema.Identity.CombGuidIdGeneration;
 
 namespace DocumentDbTests.Writing.Identity.Sequences;
 
-public class CombGuidIdGenerationTests : OneOffConfigurationsContext
+public class CombGuidIdGenerationTests: OneOffConfigurationsContext
 {
     [Fact]
     public void generate_lots_of_guids()
@@ -45,6 +45,7 @@ public class CombGuidIdGenerationTests : OneOffConfigurationsContext
         StoreOptions(options =>
         {
             #region sample_configuring-global-sequentialguid
+
             options.Policies.ForAllDocuments(m =>
             {
                 if (m.IdType == typeof(Guid))
@@ -52,6 +53,7 @@ public class CombGuidIdGenerationTests : OneOffConfigurationsContext
                     m.IdStrategy = new CombGuidIdGeneration();
                 }
             });
+
             #endregion
         });
 
@@ -78,12 +80,16 @@ public class CombGuidIdGenerationTests : OneOffConfigurationsContext
         StoreOptions(options =>
         {
             #region sample_configuring-mapping-specific-sequentialguid
+
             options.Schema.For<UserWithGuid>().IdStrategy(new CombGuidIdGeneration());
+
             #endregion
         });
 
-        theStore.StorageFeatures.MappingFor(typeof(UserWithGuid)).As<DocumentMapping>().IdStrategy.ShouldBeOfType<CombGuidIdGeneration>();
-        theStore.StorageFeatures.MappingFor(typeof(UserWithGuid2)).As<DocumentMapping>().IdStrategy.ShouldBeOfType<CombGuidIdGeneration>();
+        theStore.StorageFeatures.MappingFor(typeof(UserWithGuid)).As<DocumentMapping>().IdStrategy
+            .ShouldBeOfType<CombGuidIdGeneration>();
+        theStore.StorageFeatures.MappingFor(typeof(UserWithGuid2)).As<DocumentMapping>().IdStrategy
+            .ShouldBeOfType<CombGuidIdGeneration>();
     }
 
     [Fact]
@@ -119,6 +125,4 @@ public class CombGuidIdGenerationTests : OneOffConfigurationsContext
         session.Store(new UserWithGuid { LastName = lastName });
         session.SaveChanges();
     }
-
-
 }

--- a/src/DocumentDbTests/Writing/Identity/Sequences/DocumentIdStrategyTests.cs
+++ b/src/DocumentDbTests/Writing/Identity/Sequences/DocumentIdStrategyTests.cs
@@ -10,7 +10,7 @@ using CombGuidIdGeneration = Marten.Schema.Identity.CombGuidIdGeneration;
 
 namespace DocumentDbTests.Writing.Identity.Sequences;
 
-public class DocumentIdStrategyTests : OneOffConfigurationsContext
+public class DocumentIdStrategyTests: OneOffConfigurationsContext
 {
     [Fact]
     public void uses_no_id_generation_for_non_public_id()
@@ -44,5 +44,4 @@ public class DocumentIdStrategyTests : OneOffConfigurationsContext
 
         public string Name { get; set; }
     }
-
 }

--- a/src/EventPublisher/EventPublisher.csproj
+++ b/src/EventPublisher/EventPublisher.csproj
@@ -7,12 +7,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Marten.AsyncDaemon.Testing\Marten.AsyncDaemon.Testing.csproj" />
-      <ProjectReference Include="..\Marten\Marten.csproj" />
+        <ProjectReference Include="..\Marten.AsyncDaemon.Testing\Marten.AsyncDaemon.Testing.csproj"/>
+        <ProjectReference Include="..\Marten\Marten.csproj"/>
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Lamar" Version="11.1.2" />
-      <PackageReference Include="Spectre.Console" Version="0.46.0" />
+        <PackageReference Include="Lamar" Version="12.0.0"/>
+        <PackageReference Include="Spectre.Console" Version="0.46.0"/>
     </ItemGroup>
 </Project>

--- a/src/EventSourcingTests/Bugs/Bug_2296_tenant_session_in_grouper.cs
+++ b/src/EventSourcingTests/Bugs/Bug_2296_tenant_session_in_grouper.cs
@@ -15,7 +15,7 @@ using CombGuidIdGeneration = Marten.Schema.Identity.CombGuidIdGeneration;
 
 namespace EventSourcingTests.Bugs;
 
-public class Bug_2296_tenant_session_in_grouper : OneOffConfigurationsContext
+public class Bug_2296_tenant_session_in_grouper: OneOffConfigurationsContext
 {
     [Fact]
     public async Task CanQueryTenantedStreamsInAsyncProjectionGrouper()
@@ -36,12 +36,12 @@ public class Bug_2296_tenant_session_in_grouper : OneOffConfigurationsContext
 
         var streamKey = CombGuidIdGeneration.NewGuid().ToString();
         tenantedSession.Events.StartStream(streamKey,
-            new CountEvent {Tag = "Foo"},
-            new CountEvent {Tag = "Bar"},
-            new CountEvent {Tag = "Bar"},
-            new CountEvent {Tag = "Baz"},
-            new CountEvent {Tag = "Baz"},
-            new CountEvent {Tag = "Baz"});
+            new CountEvent { Tag = "Foo" },
+            new CountEvent { Tag = "Bar" },
+            new CountEvent { Tag = "Bar" },
+            new CountEvent { Tag = "Baz" },
+            new CountEvent { Tag = "Baz" },
+            new CountEvent { Tag = "Baz" });
         await tenantedSession.SaveChangesAsync();
 
         await daemon.WaitForNonStaleData(5.Seconds());
@@ -75,8 +75,7 @@ public class Bug_2296_tenant_session_in_grouper : OneOffConfigurationsContext
 
     public class CountsByTag
     {
-        [Identity]
-        public string Tag { get; set; }
+        [Identity] public string Tag { get; set; }
         public int Count { get; set; } = 0;
     }
 
@@ -100,7 +99,8 @@ public class Bug_2296_tenant_session_in_grouper : OneOffConfigurationsContext
 
         public class EventGrouper: IAggregateGrouper<string>
         {
-            public async Task Group(IQuerySession session, IEnumerable<IEvent> events, ITenantSliceGroup<string> grouping)
+            public async Task Group(IQuerySession session, IEnumerable<IEvent> events,
+                ITenantSliceGroup<string> grouping)
             {
                 var resetEvents = events.OfType<IEvent<ResetEvent>>().ToList();
                 if (!resetEvents.Any())
@@ -116,7 +116,8 @@ public class Bug_2296_tenant_session_in_grouper : OneOffConfigurationsContext
                     var streamEvents =
                         await session.Events.FetchStreamAsync(resetEvent.StreamKey!, version: resetEvent.Version);
 
-                    foreach (var tag in streamEvents.OfType<IEvent<CountEvent>>().GroupBy(foo => foo.Data.Tag).Select(g => g.Key))
+                    foreach (var tag in streamEvents.OfType<IEvent<CountEvent>>().GroupBy(foo => foo.Data.Tag)
+                                 .Select(g => g.Key))
                     {
                         grouping.AddEvent(tag, resetEvent);
                     }

--- a/src/EventSourcingTests/EventSourcingTests.csproj
+++ b/src/EventSourcingTests/EventSourcingTests.csproj
@@ -23,7 +23,7 @@
         </PackageReference>
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="NSubstitute" Version="5.0.0" />
-        <PackageReference Include="Shouldly" Version="4.1.0" />
+        <PackageReference Include="Shouldly" Version="4.2.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Marten.AsyncDaemon.Testing/TestingSupport/TestLogger.cs
+++ b/src/Marten.AsyncDaemon.Testing/TestingSupport/TestLogger.cs
@@ -7,7 +7,7 @@ using Xunit.Abstractions;
 
 namespace Marten.AsyncDaemon.Testing.TestingSupport;
 
-public class TestLogger<T> : ILogger<T>, IDisposable
+public class TestLogger<T>: ILogger<T>, IDisposable
 {
     private readonly ITestOutputHelper _output;
 
@@ -16,7 +16,8 @@ public class TestLogger<T> : ILogger<T>, IDisposable
         _output = output;
     }
 
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+        Func<TState, Exception, string> formatter)
     {
         var message = $"{typeof(T).NameInCode()}/{logLevel}: {formatter(state, exception)}";
         Debug.WriteLine(message);

--- a/src/Marten.CommandLine.Tests/Marten.CommandLine.Tests.csproj
+++ b/src/Marten.CommandLine.Tests/Marten.CommandLine.Tests.csproj
@@ -8,10 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="NSubstitute" Version="5.0.0" />
-        <PackageReference Include="Shouldly" Version="4.1.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
+        <PackageReference Include="NSubstitute" Version="5.0.0"/>
+        <PackageReference Include="Shouldly" Version="4.2.1"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -23,8 +23,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Marten.CommandLine\Marten.CommandLine.csproj" />
-      <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj" />
+        <ProjectReference Include="..\Marten.CommandLine\Marten.CommandLine.csproj"/>
+        <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/src/Marten.CommandLine.Tests/ProjectionControllerTests.cs
+++ b/src/Marten.CommandLine.Tests/ProjectionControllerTests.cs
@@ -39,7 +39,7 @@ public static class ProjectionTestingExtensions
     }
 }
 
-public class ProjectionControllerTests : IProjectionHost
+public class ProjectionControllerTests: IProjectionHost
 {
     private readonly IConsoleView theView = Substitute.For<IConsoleView>();
     private readonly ProjectionController theController;
@@ -62,9 +62,10 @@ public class ProjectionControllerTests : IProjectionHost
 
     public bool ListeningForUserTriggeredExit { get; private set; }
 
-    protected readonly List<RebuildRecord> rebuilt = new ();
+    protected readonly List<RebuildRecord> rebuilt = new();
 
-    Task<RebuildStatus> IProjectionHost.TryRebuildShards(IProjectionDatabase database, IReadOnlyList<AsyncProjectionShard> asyncProjectionShards, TimeSpan? shardTimeout)
+    Task<RebuildStatus> IProjectionHost.TryRebuildShards(IProjectionDatabase database,
+        IReadOnlyList<AsyncProjectionShard> asyncProjectionShards, TimeSpan? shardTimeout)
     {
         foreach (var shard in asyncProjectionShards)
         {
@@ -118,10 +119,9 @@ public class ProjectionControllerTests : IProjectionHost
 
     protected AsyncProjectionShard shardFor(string storeName, string shardName)
     {
-        return _stores.FirstOrDefault(x => x.Name == storeName).Shards.FirstOrDefault(x => x.Name.Identity == shardName);
+        return _stores.FirstOrDefault(x => x.Name == storeName).Shards
+            .FirstOrDefault(x => x.Name.Identity == shardName);
     }
-
-
 
     [Fact]
     public async Task display_no_stores_message_if_no_stores()
@@ -182,7 +182,7 @@ public class ProjectionControllerTests : IProjectionHost
         var store2 = withStore("Other", new("Three:All", ProjectionLifecycle.Async),
             new("Four:All", ProjectionLifecycle.Inline));
 
-        var stores = theController.FilterStores(new ProjectionInput{StoreFlag = "other"});
+        var stores = theController.FilterStores(new ProjectionInput { StoreFlag = "other" });
         stores.ShouldHaveTheSameElementsAs<IProjectionStore>(store2);
     }
 
@@ -198,10 +198,10 @@ public class ProjectionControllerTests : IProjectionHost
         var store3 = withStore("Else", new("Six:All", ProjectionLifecycle.Async),
             new("Five:All", ProjectionLifecycle.Inline));
 
-        theView.SelectStores(Arg.Is<string[]>(a => a.SequenceEqual(new []{"Else", "Marten", "Other"})))
+        theView.SelectStores(Arg.Is<string[]>(a => a.SequenceEqual(new[] { "Else", "Marten", "Other" })))
             .Returns(new string[] { "Marten", "Else" });
 
-        var stores = theController.FilterStores(new ProjectionInput{InteractiveFlag = true});
+        var stores = theController.FilterStores(new ProjectionInput { InteractiveFlag = true });
 
         stores.ShouldHaveTheSameElementsAs<IProjectionStore>(store1, store3);
     }
@@ -222,7 +222,7 @@ public class ProjectionControllerTests : IProjectionHost
         var store1 = withStore("Marten", new("Foo:All", ProjectionLifecycle.Async),
             new("Bar:First", ProjectionLifecycle.Inline), new("Bar:Second", ProjectionLifecycle.Inline));
 
-        var shards = theController.FilterShards(new ProjectionInput{ProjectionFlag = "Bar"}, store1);
+        var shards = theController.FilterShards(new ProjectionInput { ProjectionFlag = "Bar" }, store1);
         shards.Select(x => x.Name.Identity)
             .ShouldHaveTheSameElementsAs("Bar:First", "Bar:Second");
     }
@@ -230,13 +230,15 @@ public class ProjectionControllerTests : IProjectionHost
     [Fact]
     public void filter_shards_interactively()
     {
-        var store1 = withStore("Marten", new("Foo:First", ProjectionLifecycle.Async),new("Foo:Second", ProjectionLifecycle.Async),
-            new("Bar:First", ProjectionLifecycle.Inline), new("Bar:Second", ProjectionLifecycle.Inline), ("Tom:All", ProjectionLifecycle.Async));
+        var store1 = withStore("Marten", new("Foo:First", ProjectionLifecycle.Async),
+            new("Foo:Second", ProjectionLifecycle.Async),
+            new("Bar:First", ProjectionLifecycle.Inline), new("Bar:Second", ProjectionLifecycle.Inline),
+            ("Tom:All", ProjectionLifecycle.Async));
 
-        theView.SelectProjections(Arg.Is<string[]>(a => a.SequenceEqual(new []{ "Bar", "Foo", "Tom"})))
+        theView.SelectProjections(Arg.Is<string[]>(a => a.SequenceEqual(new[] { "Bar", "Foo", "Tom" })))
             .Returns(new string[] { "Bar", "Tom" });
 
-        var shards = theController.FilterShards(new ProjectionInput{InteractiveFlag = true}, store1);
+        var shards = theController.FilterShards(new ProjectionInput { InteractiveFlag = true }, store1);
 
         shards.Select(x => x.Name.Identity)
             .ShouldHaveTheSameElementsAs("Bar:First", "Bar:Second", "Tom:All");
@@ -245,8 +247,10 @@ public class ProjectionControllerTests : IProjectionHost
     [Fact]
     public async Task try_to_rebuild_with_no_matching_shards()
     {
-        var store1 = withStore("Marten", new("Foo:First", ProjectionLifecycle.Async),new("Foo:Second", ProjectionLifecycle.Async),
-            new("Bar:First", ProjectionLifecycle.Inline), new("Bar:Second", ProjectionLifecycle.Inline), ("Tom:All", ProjectionLifecycle.Async));
+        var store1 = withStore("Marten", new("Foo:First", ProjectionLifecycle.Async),
+            new("Foo:Second", ProjectionLifecycle.Async),
+            new("Bar:First", ProjectionLifecycle.Inline), new("Bar:Second", ProjectionLifecycle.Inline),
+            ("Tom:All", ProjectionLifecycle.Async));
 
         await theController.Execute(new ProjectionInput { RebuildFlag = true, ProjectionFlag = "NonExistent" });
 
@@ -262,7 +266,7 @@ public class ProjectionControllerTests : IProjectionHost
         var store = withStore("Marten", new("Foo:All", ProjectionLifecycle.Async),
             new("Bar:All", ProjectionLifecycle.Inline));
 
-        await theController.Execute(new ProjectionInput() );
+        await theController.Execute(new ProjectionInput());
 
         ListeningForUserTriggeredExit.ShouldBeTrue();
     }
@@ -287,7 +291,7 @@ public class ProjectionControllerTests : IProjectionHost
 
         var databases = store.HasDatabases("one", "two", "three");
 
-        var filtered = theController.FilterDatabases(new ProjectionInput{DatabaseFlag = "two"}, databases);
+        var filtered = theController.FilterDatabases(new ProjectionInput { DatabaseFlag = "two" }, databases);
         filtered.Single().Identifier.ShouldBe("two");
     }
 
@@ -299,10 +303,10 @@ public class ProjectionControllerTests : IProjectionHost
 
         var databases = store.HasDatabases("one", "two", "three");
 
-        theView.SelectDatabases(Arg.Is<string[]>(a => a.SequenceEqual(new []{ "one", "three", "two"})))
+        theView.SelectDatabases(Arg.Is<string[]>(a => a.SequenceEqual(new[] { "one", "three", "two" })))
             .Returns(new string[] { "three" });
 
-        var filtered = theController.FilterDatabases(new ProjectionInput{InteractiveFlag = true}, databases);
+        var filtered = theController.FilterDatabases(new ProjectionInput { InteractiveFlag = true }, databases);
 
         filtered.Single().Identifier.ShouldBe("three");
     }
@@ -379,12 +383,13 @@ public class ProjectionControllerTests : IProjectionHost
 
         await theController.Execute(new ProjectionInput());
 
-        started[databases[0]].ShouldHaveTheSameElementsAs(shards.Where(x => x.Source.Lifecycle == ProjectionLifecycle.Async));
-        started[databases[1]].ShouldHaveTheSameElementsAs(shards.Where(x => x.Source.Lifecycle == ProjectionLifecycle.Async));
-        started[databases[2]].ShouldHaveTheSameElementsAs(shards.Where(x => x.Source.Lifecycle == ProjectionLifecycle.Async));
-
+        started[databases[0]]
+            .ShouldHaveTheSameElementsAs(shards.Where(x => x.Source.Lifecycle == ProjectionLifecycle.Async));
+        started[databases[1]]
+            .ShouldHaveTheSameElementsAs(shards.Where(x => x.Source.Lifecycle == ProjectionLifecycle.Async));
+        started[databases[2]]
+            .ShouldHaveTheSameElementsAs(shards.Where(x => x.Source.Lifecycle == ProjectionLifecycle.Async));
     }
-
 }
 
 public class RebuildRecord
@@ -432,8 +437,7 @@ public class RebuildRecord
 
     public override string ToString()
     {
-        return $"{nameof(Store)}: {Store.Name}, {nameof(Database)}: {Database.Identifier}, {nameof(Shard)}: {Shard.Name}";
+        return
+            $"{nameof(Store)}: {Store.Name}, {nameof(Database)}: {Database.Identifier}, {nameof(Shard)}: {Shard.Name}";
     }
 }
-
-

--- a/src/Marten.CommandLine/Commands/Projection/ConsoleView.cs
+++ b/src/Marten.CommandLine/Commands/Projection/ConsoleView.cs
@@ -34,7 +34,8 @@ internal class ConsoleView: IConsoleView
         foreach (var projection in projections)
         {
             var shards = store.Shards.Where(x => x.Source == projection).Select(x => x.Name.Identity).Join(", ");
-            table.AddRow(projection.ProjectionName, projection.GetType().FullNameInCode(), shards, projection.Lifecycle.ToString());
+            table.AddRow(projection.ProjectionName, projection.GetType().FullNameInCode(), shards,
+                projection.Lifecycle.ToString());
         }
 
         AnsiConsole.Render(table);
@@ -82,7 +83,7 @@ internal class ConsoleView: IConsoleView
     public void WriteHeader(IProjectionStore store)
     {
         AnsiConsole.WriteLine();
-        AnsiConsole.Write(new Rule($"[bold blue]{store.Name}[/]"){Alignment = Justify.Left});
+        AnsiConsole.Write(new Rule($"[bold blue]{store.Name}[/]") { Justification = Justify.Left });
         AnsiConsole.WriteLine();
     }
 
@@ -100,7 +101,7 @@ internal class ConsoleView: IConsoleView
 
     public void WriteHeader(IProjectionDatabase database)
     {
-        AnsiConsole.Write(new Rule($"Database: {database.Identifier}"){Alignment = Justify.Left});
+        AnsiConsole.Write(new Rule($"Database: {database.Identifier}") { Justification = Justify.Left });
     }
 
     public string[] SelectDatabases(string[] databaseNames)

--- a/src/Marten.CommandLine/Marten.CommandLine.csproj
+++ b/src/Marten.CommandLine/Marten.CommandLine.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->
@@ -31,10 +31,10 @@
         <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="JasperFx.CodeGeneration.Commands" Version="2.3.0"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="Oakton" Version="6.0.0"/>
-        <PackageReference Include="Weasel.CommandLine" Version="6.0.0-rc.1"/>
+        <PackageReference Include="JasperFx.CodeGeneration.Commands" Version="3.0.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+        <PackageReference Include="Oakton" Version="6.0.1" />
+        <PackageReference Include="Weasel.CommandLine" Version="6.0.0-rc.3" />
     </ItemGroup>
-    <Import Project="../../Analysis.Build.props"/>
+    <Import Project="../../Analysis.Build.props" />
 </Project>

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -30,7 +30,7 @@
     <ItemGroup>
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.1" />
         <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
-        <PackageReference Include="Npgsql.NodaTime" Version="7.0.2" />
+        <PackageReference Include="Npgsql.NodaTime" Version="7.0.4" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Marten.PLv8.Testing/Marten.PLv8.Testing.csproj
+++ b/src/Marten.PLv8.Testing/Marten.PLv8.Testing.csproj
@@ -17,7 +17,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="11.1.2" />
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="12.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     </ItemGroup>

--- a/src/Marten.Testing.OtherAssembly/ShortGuid.cs
+++ b/src/Marten.Testing.OtherAssembly/ShortGuid.cs
@@ -16,12 +16,14 @@ public class ShortGuid
     }
 }
 
-public class String2IdGeneration : IIdGeneration
+public class String2IdGeneration: IIdGeneration
 {
     public void GenerateCode(GeneratedMethod method, DocumentMapping mapping)
     {
         var use = new Use(mapping.DocumentType);
-        method.Frames.Code("if ({0}." + mapping.IdMember.Name + " == null) _setter({0}, global::" + typeof (ShortGuid).FullNameInCode() + ".NewGuid());", use);
+        method.Frames.Code(
+            "if ({0}." + mapping.IdMember.Name + " == null) _setter({0}, global::" +
+            typeof(ShortGuid).FullNameInCode() + ".NewGuid());", use);
         method.Frames.Code("return {0}." + mapping.IdMember.Name + ";", use);
     }
 

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="11.1.2" />
+        <PackageReference Include="Lamar" Version="12.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>
@@ -32,7 +32,7 @@
         </PackageReference>
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="NSubstitute" Version="5.0.0" />
-        <PackageReference Include="Shouldly" Version="4.1.0" />
+        <PackageReference Include="Shouldly" Version="4.2.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Marten/Events/Aggregation/SingleStreamProjection.cs
+++ b/src/Marten/Events/Aggregation/SingleStreamProjection.cs
@@ -75,11 +75,9 @@ public class SingleStreamProjection<T>: GeneratedAggregateProjectionBase<T>
 [Obsolete("Please switch to SingleStreamProjection<T> with the exact same syntax")]
 public class SingleStreamAggregation<T>: SingleStreamProjection<T>
 {
-
 }
 
 [Obsolete("Please switch to SingleStreamProjection<T> with the exact same syntax")]
 public class AggregateProjection<T>: SingleStreamProjection<T>
 {
-
 }

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -29,7 +29,7 @@ using Weasel.Core;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
 using static Marten.Events.EventMappingExtensions;
-using FindMembers = JasperFx.Core.Reflection.FindMembers;
+using FindMembers = Marten.Linq.Parsing.FindMembers;
 
 namespace Marten.Events;
 

--- a/src/Marten/Events/Projections/ProjectionWrapper.cs
+++ b/src/Marten/Events/Projections/ProjectionWrapper.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
 using Marten.Events.Daemon;
 using Marten.Storage;

--- a/src/Marten/Events/TestSupport/ProjectionScenario.Assertions.cs
+++ b/src/Marten/Events/TestSupport/ProjectionScenario.Assertions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
 
 namespace Marten.Events.TestSupport;

--- a/src/Marten/Exceptions/DocumentIdTypeMismatchException.cs
+++ b/src/Marten/Exceptions/DocumentIdTypeMismatchException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.Serialization;
-using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
 using Marten.Internal.Storage;
 

--- a/src/Marten/Internal/CompiledQueries/CompiledQuerySourceBuilder.cs
+++ b/src/Marten/Internal/CompiledQueries/CompiledQuerySourceBuilder.cs
@@ -11,7 +11,6 @@ using Marten.Internal.Storage;
 using Marten.Linq.Includes;
 using Marten.Linq.QueryHandlers;
 using Marten.Schema.Arguments;
-using Marten.Util;
 using Weasel.Postgresql;
 
 namespace Marten.Internal.CompiledQueries;

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -12,38 +12,39 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-        <None Remove="Schema\SQL\mt_grams_array.sql"/>
-        <None Remove="Schema\SQL\mt_grams_query.sql"/>
-        <None Remove="Schema\SQL\mt_grams_vector.sql"/>
-        <None Remove="Schema\SQL\mt_immutable_timestamptz.sql"/>
+        <None Remove="Schema\SQL\mt_grams_array.sql" />
+        <None Remove="Schema\SQL\mt_grams_query.sql" />
+        <None Remove="Schema\SQL\mt_grams_vector.sql" />
+        <None Remove="Schema\SQL\mt_immutable_timestamptz.sql" />
     </ItemGroup>
     <ItemGroup>
-        <EmbeddedResource Include="Schema\SQL\*.*"/>
-        <EmbeddedResource Include="Schema\SchemaObjects.sql"/>
+        <EmbeddedResource Include="Schema\SQL\*.*" />
+        <EmbeddedResource Include="Schema\SchemaObjects.sql" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="JasperFx.Core" Version="1.4.0"/>
-        <PackageReference Include="JasperFx.CodeGeneration" Version="3.0.0"/>
-        <PackageReference Include="JasperFx.RuntimeCompiler" Version="3.0.0"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageReference Include="Npgsql.Json.NET" Version="7.0.2"/>
-        <PackageReference Include="Remotion.Linq" Version="2.2.0"/>
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0"/>
-        <PackageReference Include="Weasel.Postgresql" Version="6.0.0-rc.1"/>
-        <PackageReference Include="System.Text.Json" Version="7.0.2"/>
+        <PackageReference Include="JasperFx.Core" Version="1.4.0" />
+        <PackageReference Include="JasperFx.TypeDiscovery" Version="1.0.0" />
+        <PackageReference Include="JasperFx.CodeGeneration" Version="3.0.0" />
+        <PackageReference Include="JasperFx.RuntimeCompiler" Version="3.0.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Npgsql.Json.NET" Version="7.0.4" />
+        <PackageReference Include="Remotion.Linq" Version="2.2.0" />
+        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
+        <PackageReference Include="Weasel.Postgresql" Version="6.0.0-rc.3" />
+        <PackageReference Include="System.Text.Json" Version="7.0.2" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->
@@ -59,7 +60,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     </ItemGroup>
-    <Import Project="../../Analysis.Build.props"/>
+    <Import Project="../../Analysis.Build.props" />
 </Project>

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -534,7 +534,7 @@ public class DocumentMapping: FieldMapping, IDocumentMapping, IDocumentType
 
         if (idType == typeof(Guid))
         {
-            return new Marten.Schema.Identity.CombGuidIdGeneration();
+            return new Identity.CombGuidIdGeneration();
         }
 
         if (idType == typeof(int) || idType == typeof(long))


### PR DESCRIPTION
Using a list works fine so a tad bizarre. This is a bit of rough edge for us as we try to use Hashsets in more places.

```
System.InvalidOperationException
Nullable object must have a value.
   at System.Nullable`1.get_Value()
   at Weasel.Postgresql.SqlGeneration.CommandParameter..ctor(Object value)
   at Weasel.Postgresql.SqlGeneration.WhereFragment.<>c.<.ctor>b__0_0(Object x)
   at System.Linq.Enumerable.SelectArrayIterator`2.ToArray()
   at Weasel.Postgresql.SqlGeneration.WhereFragment..ctor(String sql, Object[] parameters)
   at Marten.Linq.Parsing.Methods.IsInGenericEnumerable.Parse(IFieldMapping mapping, IReadOnlyStoreOptions options, MethodCallExpression expression) in C:\Source\marten\src\Marten\Linq\Parsing\Methods\IsInGenericEnumerable.cs:line 24
   at Marten.LinqParsing.BuildWhereFragment(IFieldMapping mapping, MethodCallExpression expression, IReadOnlyStoreOptions options) in C:\Source\marten\src\Marten\LinqParsing.cs:line 117
   at Marten.Linq.Parsing.WhereClauseParser.VisitMethodCall(MethodCallExpression node) in C:\Source\marten\src\Marten\Linq\Parsing\WhereClauseParser.cs:line 77
   at Marten.Linq.Parsing.WhereClauseParser.Build(WhereClause clause) in C:\Source\marten\src\Marten\Linq\Parsing\WhereClauseParser.cs:line 56
   at Marten.Linq.SqlGeneration.DocumentStatement.buildWhereFragment(IMartenSession session) in C:\Source\marten\src\Marten\Linq\SqlGeneration\DocumentStatement.cs:line 40
   at Marten.Linq.SqlGeneration.Statement.CompileLocal(IMartenSession session) in C:\Source\marten\src\Marten\Linq\SqlGeneration\Statement.cs:line 201
   at Marten.Linq.SqlGeneration.DocumentStatement.CompileLocal(IMartenSession session) in C:\Source\marten\src\Marten\Linq\SqlGeneration\DocumentStatement.cs:line 55
   at Marten.Linq.SqlGeneration.Statement.CompileStructure(IMartenSession session) in C:\Source\marten\src\Marten\Linq\SqlGeneration\Statement.cs:line 194
   at Marten.Linq.Parsing.LinqHandlerBuilder.BuildDatabaseStatement() in C:\Source\marten\src\Marten\Linq\Parsing\LinqHandlerBuilder.cs:line 262
   at Marten.Linq.Parsing.LinqHandlerBuilder.BuildHandler[TResult]() in C:\Source\marten\src\Marten\Linq\Parsing\LinqHandlerBuilder.cs:line 232
```