### PR TITLE
Bumped Weasel version to fix concurrency issue during Marten startup related to NpgsqlTypeMapping

### DIFF
--- a/Analysis.Build.props
+++ b/Analysis.Build.props
@@ -11,7 +11,7 @@
             <ExcludeAssets>none</ExcludeAssets>
             <IncludeAssets>all</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Meziantou.Analyzer" Version="2.0.19">
+        <PackageReference Include="Meziantou.Analyzer" Version="2.0.22">
             <PrivateAssets>all</PrivateAssets>
             <ExcludeAssets>none</ExcludeAssets>
             <IncludeAssets>all</IncludeAssets>

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -16,11 +16,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="11.0.0" />
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="11.1.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="11.0.0" />
+        <PackageReference Include="Lamar" Version="11.1.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>

--- a/src/DocumentDbTests/DocumentDbTests.csproj
+++ b/src/DocumentDbTests/DocumentDbTests.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="11.0.0" />
+        <PackageReference Include="Lamar" Version="11.1.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>

--- a/src/EventPublisher/EventPublisher.csproj
+++ b/src/EventPublisher/EventPublisher.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Lamar" Version="11.0.0" />
+      <PackageReference Include="Lamar" Version="11.1.2" />
       <PackageReference Include="Spectre.Console" Version="0.46.0" />
     </ItemGroup>
 </Project>

--- a/src/EventSourcingTests/EventSourcingTests.csproj
+++ b/src/EventSourcingTests/EventSourcingTests.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="11.0.0" />
+        <PackageReference Include="Lamar" Version="11.1.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Marten.AspNetCore.Testing/Marten.AspNetCore.Testing.csproj
+++ b/src/Marten.AspNetCore.Testing/Marten.AspNetCore.Testing.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="7.3.0" />
+        <PackageReference Include="Alba" Version="7.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Shouldly" Version="4.1.0" />
         <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/Marten.CommandLine/Marten.CommandLine.csproj
+++ b/src/Marten.CommandLine/Marten.CommandLine.csproj
@@ -31,10 +31,10 @@
         <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="JasperFx.CodeGeneration.Commands" Version="2.0.0" />
+        <PackageReference Include="JasperFx.CodeGeneration.Commands" Version="2.2.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
         <PackageReference Include="Oakton" Version="6.0.0" />
-        <PackageReference Include="Weasel.CommandLine" Version="6.0.0-alpha.10" />
+        <PackageReference Include="Weasel.CommandLine" Version="6.0.0-alpha.11" />
     </ItemGroup>
     <Import Project="../../Analysis.Build.props" />
 </Project>

--- a/src/Marten.NodaTime/NodaTimeExtensions.cs
+++ b/src/Marten.NodaTime/NodaTimeExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Data;
 using Marten.Services;
 using NodaTime;
@@ -43,7 +44,8 @@ public static class NodaTimeExtensions
                 });
                 break;
             default:
-                throw new NotSupportedException("Current serializer cannot be automatically configured for NodaTime. Set shouldConfigureJsonSerializer to false if you're using your own serializer.");
+                throw new NotSupportedException(
+                    "Current serializer cannot be automatically configured for NodaTime. Set shouldConfigureJsonSerializer to false if you're using your own serializer.");
         }
 
         storeOptions.Serializer(serializer);
@@ -51,24 +53,64 @@ public static class NodaTimeExtensions
 
     public static void SetNodaTimeTypeMappings()
     {
-        NpgsqlTypeMapper.Mappings.AddRange(
-            new NpgsqlTypeMapping[] {
-                // Date/time types
-#pragma warning disable 618 // NpgsqlDateTime is obsolete, remove in 7.0
-                new(NpgsqlDbType.Timestamp,   DbType.DateTime,       "timestamp without time zone", typeof(DateTime), typeof(LocalDateTime)),
-#pragma warning disable 618
-                new(NpgsqlDbType.TimestampTz, DbType.DateTimeOffset, "timestamp with time zone",    typeof(DateTimeOffset), typeof(Instant), typeof(ZonedDateTime)),
-                new(NpgsqlDbType.Date,        DbType.Date,           "date",                        typeof(LocalDate) , typeof(DateOnly)),
-                new(NpgsqlDbType.Time,        DbType.Time,     "time without time zone", typeof(LocalTime), typeof(TimeOnly)),
-                new(NpgsqlDbType.TimeTz,      DbType.Object,   "time with time zone", typeof(LocalTime), typeof(LocalTime)),
-                new(NpgsqlDbType.Interval,    DbType.Object,   "interval", typeof(TimeSpan), typeof(Period), typeof(Duration)),
-
-                new(NpgsqlDbType.Array | NpgsqlDbType.Timestamp,   DbType.Object, "timestamp without time zone[]"),
-                new(NpgsqlDbType.Array | NpgsqlDbType.TimestampTz, DbType.Object, "timestamp with time zone[]"),
-                new(NpgsqlDbType.Range | NpgsqlDbType.Timestamp,   DbType.Object, "tsrange"),
-                new(NpgsqlDbType.Range | NpgsqlDbType.TimestampTz, DbType.Object, "tstzrange"),
-                new(NpgsqlDbType.Multirange | NpgsqlDbType.Timestamp,   DbType.Object, "tsmultirange"),
-                new(NpgsqlDbType.Multirange | NpgsqlDbType.TimestampTz, DbType.Object, "tstzmultirange"),
-            });
+        foreach (var mapping in Mappings)
+        {
+            NpgsqlTypeMapper.Mappings[mapping.Key] = mapping.Value;
+        }
     }
+
+    private static readonly Dictionary<NpgsqlDbType, NpgsqlTypeMapping> Mappings =
+        new()
+        {
+            // Date/time types
+            {
+                NpgsqlDbType.Timestamp, new(NpgsqlDbType.Timestamp, DbType.DateTime, "timestamp without time zone",
+                    typeof(DateTime),
+                    typeof(LocalDateTime))
+            },
+            {
+                NpgsqlDbType.TimestampTz, new(NpgsqlDbType.TimestampTz, DbType.DateTimeOffset,
+                    "timestamp with time zone",
+                    typeof(DateTimeOffset),
+                    typeof(Instant), typeof(ZonedDateTime))
+            },
+            { NpgsqlDbType.Date, new(NpgsqlDbType.Date, DbType.Date, "date", typeof(LocalDate), typeof(DateOnly)) },
+            {
+                NpgsqlDbType.Time,
+                new(NpgsqlDbType.Time, DbType.Time, "time without time zone", typeof(LocalTime), typeof(TimeOnly))
+            },
+            {
+                NpgsqlDbType.TimeTz,
+                new(NpgsqlDbType.TimeTz, DbType.Object, "time with time zone", typeof(LocalTime), typeof(LocalTime))
+            },
+            {
+                NpgsqlDbType.Interval, new(NpgsqlDbType.Interval, DbType.Object, "interval", typeof(TimeSpan),
+                    typeof(Period),
+                    typeof(Duration))
+            },
+            {
+                NpgsqlDbType.Array | NpgsqlDbType.Timestamp,
+                new(NpgsqlDbType.Array | NpgsqlDbType.Timestamp, DbType.Object, "timestamp without time zone[]")
+            },
+            {
+                NpgsqlDbType.Array | NpgsqlDbType.TimestampTz,
+                new(NpgsqlDbType.Array | NpgsqlDbType.TimestampTz, DbType.Object, "timestamp with time zone[]")
+            },
+            {
+                NpgsqlDbType.Range | NpgsqlDbType.Timestamp,
+                new(NpgsqlDbType.Range | NpgsqlDbType.Timestamp, DbType.Object, "tsrange")
+            },
+            {
+                NpgsqlDbType.Range | NpgsqlDbType.TimestampTz,
+                new(NpgsqlDbType.Range | NpgsqlDbType.TimestampTz, DbType.Object, "tstzrange")
+            },
+            {
+                NpgsqlDbType.Multirange | NpgsqlDbType.Timestamp,
+                new(NpgsqlDbType.Multirange | NpgsqlDbType.Timestamp, DbType.Object, "tsmultirange")
+            },
+            {
+                NpgsqlDbType.Multirange | NpgsqlDbType.TimestampTz,
+                new(NpgsqlDbType.Multirange | NpgsqlDbType.TimestampTz, DbType.Object, "tstzmultirange")
+            }
+        };
 }

--- a/src/Marten.PLv8.Testing/Marten.PLv8.Testing.csproj
+++ b/src/Marten.PLv8.Testing/Marten.PLv8.Testing.csproj
@@ -17,7 +17,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="11.0.0" />
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="11.1.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     </ItemGroup>

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="11.0.0" />
+        <PackageReference Include="Lamar" Version="11.1.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -12,39 +12,39 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-        <None Remove="Schema\SQL\mt_grams_array.sql" />
-        <None Remove="Schema\SQL\mt_grams_query.sql" />
-        <None Remove="Schema\SQL\mt_grams_vector.sql" />
-        <None Remove="Schema\SQL\mt_immutable_timestamptz.sql" />
+        <None Remove="Schema\SQL\mt_grams_array.sql"/>
+        <None Remove="Schema\SQL\mt_grams_query.sql"/>
+        <None Remove="Schema\SQL\mt_grams_vector.sql"/>
+        <None Remove="Schema\SQL\mt_immutable_timestamptz.sql"/>
     </ItemGroup>
     <ItemGroup>
-        <EmbeddedResource Include="Schema\SQL\*.*" />
-        <EmbeddedResource Include="Schema\SchemaObjects.sql" />
+        <EmbeddedResource Include="Schema\SQL\*.*"/>
+        <EmbeddedResource Include="Schema\SchemaObjects.sql"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0"/>
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="JasperFx.Core" Version="1.2.0" />
-        <PackageReference Include="JasperFx.TypeDiscovery" Version="1.0.0" />
-        <PackageReference Include="JasperFx.CodeGeneration" Version="2.0.0" />
-        <PackageReference Include="JasperFx.RuntimeCompiler" Version="2.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Npgsql.Json.NET" Version="7.0.2" />
-        <PackageReference Include="Remotion.Linq" Version="2.2.0" />
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
-        <PackageReference Include="Weasel.Postgresql" Version="6.0.0-alpha.10" />
-        <PackageReference Include="System.Text.Json" Version="7.0.2" />
+        <PackageReference Include="JasperFx.Core" Version="1.2.0"/>
+        <PackageReference Include="JasperFx.TypeDiscovery" Version="1.0.0"/>
+        <PackageReference Include="JasperFx.CodeGeneration" Version="2.2.1"/>
+        <PackageReference Include="JasperFx.RuntimeCompiler" Version="2.2.1"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+        <PackageReference Include="Npgsql.Json.NET" Version="7.0.2"/>
+        <PackageReference Include="Remotion.Linq" Version="2.2.0"/>
+        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0"/>
+        <PackageReference Include="Weasel.Postgresql" Version="6.0.0-alpha.11"/>
+        <PackageReference Include="System.Text.Json" Version="7.0.2"/>
     </ItemGroup>
 
     <!--SourceLink specific settings-->
@@ -60,7 +60,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
     </ItemGroup>
-    <Import Project="../../Analysis.Build.props" />
+    <Import Project="../../Analysis.Build.props"/>
 </Project>


### PR DESCRIPTION
Per @Hawxy at [Discord conversation](https://discord.com/channels/1074998995086225460/1088112401418825799/1088119007258882218), `NpgsqlTypeMapping` is causing the issue when starting multiple Marten instances in parallel:

````
Object reference not set to an instance of an object.
   at Weasel.Postgresql.PostgresqlProvider.<>c__DisplayClass15_0.<GetTypeMapping>b__0(NpgsqlTypeMapping mapping)
   at System.Linq.Enumerable.TryGetLast[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.LastOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at Weasel.Postgresql.PostgresqlProvider.GetTypeMapping(Type type)
   at Weasel.Postgresql.PostgresqlProvider.ResolveDatabaseType(Type type)
   at Weasel.Postgresql.PostgresqlProvider.GetDatabaseType(Type memberType, EnumStorage enumStyle)
   at Marten.Storage.Metadata.MetadataColumn`1..ctor(String name, Expression`1 property) in C:\Source\marten\src\Marten\Storage\Metadata\MetadataColumn.cs:line 100
   at Marten.Storage.Metadata.LastModifiedColumn..ctor() in C:\Source\marten\src\Marten\Storage\Metadata\LastModifiedColumn.cs:line 10
   at Marten.Schema.DocumentMetadataCollection..ctor(DocumentMapping parent) in C:\Source\marten\src\Marten\Schema\DocumentMetadataCollection.cs:line 14
   at Marten.Schema.DocumentMapping..ctor(Type documentType, StoreOptions storeOptions) in C:\Source\marten\src\Marten\Schema\DocumentMapping.cs:line 81
   at Marten.Schema.DocumentMapping`1..ctor(StoreOptions storeOptions) in C:\Source\marten\src\Marten\Schema\DocumentMapping.cs:line 665
   at Marten.DocumentMappingBuilder`1.Build(StoreOptions options) in C:\Source\marten\src\Marten\MartenRegistry.cs:line 47
   at Marten.Storage.StorageFeatures.Build(Type type, StoreOptions options) in C:\Source\marten\src\Marten\Storage\StorageFeatures.cs:line 93
   at Marten.Storage.StorageFeatures.MappingFor(Type documentType) in C:\Source\marten\src\Marten\Storage\StorageFeatures.cs:line 175
   at Marten.Storage.StorageFeatures.FindMapping(Type documentType) in C:\Source\marten\src\Marten\Storage\StorageFeatures.cs:line 194
   at Marten.Storage.StorageFeatures.BuildAllMappings() in C:\Source\marten\src\Marten\Storage\StorageFeatures.cs:line 128
````
Changed `NpgsqlTypeMapping` to use `ImHashMap` for thread-safe usage.

See the fix in Weasel: https://github.com/JasperFx/weasel/pull/84

Besides that:
- Adjusted StorageFeatures to not use IDictionary but thread-safe collections
- Updated also other Criter stack dependencies

@jeremydmiller @babuannamalai FYI