### PR TITLE
Removed default projection lifecycle

### DIFF
--- a/docs/events/appending.md
+++ b/docs/events/appending.md
@@ -82,7 +82,7 @@ session.Events.Append(id, joined, departed);
 
 session.SaveChanges();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_Tests.cs#L557-L564' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_append-events' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_Tests.cs#L582-L591' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_append-events' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Optimistic Versioned Append

--- a/docs/events/projections/aggregate-projections.md
+++ b/docs/events/projections/aggregate-projections.md
@@ -77,10 +77,7 @@ public class TripProjection: SingleStreamProjection<Trip>
 
         DeleteEvent<Breakdown>(x => x.IsCritical);
 
-        DeleteEvent<VacationOver>((trip, v) => trip.Traveled > 1000);
-
-        // Now let's change the lifecycle to inline
-        Lifecycle = ProjectionLifecycle.Inline;
+        DeleteEvent<VacationOver>((trip, _) => trip.Traveled > 1000);
     }
 
     // These methods can be either public, internal, or private but there's
@@ -100,7 +97,7 @@ public class TripProjection: SingleStreamProjection<Trip>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L44-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L44-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And register that projection like this:
@@ -188,7 +185,7 @@ public class Trip
     internal bool ShouldDelete(VacationOver e) => Traveled > 1000;
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L116-L166' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_trip_stream_aggregation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L113-L163' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_trip_stream_aggregation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or finally, you can use a method named `Create()` on a projection type as shown in this sample:
@@ -204,10 +201,7 @@ public class TripProjection: SingleStreamProjection<Trip>
 
         DeleteEvent<Breakdown>(x => x.IsCritical);
 
-        DeleteEvent<VacationOver>((trip, v) => trip.Traveled > 1000);
-
-        // Now let's change the lifecycle to inline
-        Lifecycle = ProjectionLifecycle.Inline;
+        DeleteEvent<VacationOver>((trip, _) => trip.Traveled > 1000);
     }
 
     // These methods can be either public, internal, or private but there's
@@ -227,7 +221,7 @@ public class TripProjection: SingleStreamProjection<Trip>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L44-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L44-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `Create()` method has to return either the aggregate document type or `Task<T>` where `T` is the aggregate document type. There must be an argument for the specific event type or `Event<T>` where `T` is the event type if you need access to event metadata. You can also take in an `IQuerySession` if you need to look up additional data as part of the transformation or `IEvent` in addition to the exact event type just to get at event metadata.
@@ -267,7 +261,7 @@ public class TripProjection: SingleStreamProjection<Trip>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L172-L197' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_projectevent_in_aggregate_projection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L169-L194' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_projectevent_in_aggregate_projection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 I'm not personally that wild about using lots of inline Lambdas like the example above, and to that end, Marten now supports the `Apply()` method convention. Here's the same `TripProjection`, but this time using methods to mutate the `Trip` document:
@@ -283,10 +277,7 @@ public class TripProjection: SingleStreamProjection<Trip>
 
         DeleteEvent<Breakdown>(x => x.IsCritical);
 
-        DeleteEvent<VacationOver>((trip, v) => trip.Traveled > 1000);
-
-        // Now let's change the lifecycle to inline
-        Lifecycle = ProjectionLifecycle.Inline;
+        DeleteEvent<VacationOver>((trip, _) => trip.Traveled > 1000);
     }
 
     // These methods can be either public, internal, or private but there's
@@ -306,7 +297,7 @@ public class TripProjection: SingleStreamProjection<Trip>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L44-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L44-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `Apply()` methods can accept any combination of these arguments:
@@ -475,7 +466,7 @@ public class Trip
     internal bool ShouldDelete(VacationOver e) => Traveled > 1000;
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L116-L166' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_trip_stream_aggregation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L113-L163' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_trip_stream_aggregation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Here's an example of using the various ways of doing `Trip` stream aggregation:
@@ -509,7 +500,7 @@ internal async Task use_a_stream_aggregation()
     var trip = await session.Events.AggregateStreamAsync<Trip>(tripId);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L84-L112' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_stream_aggregation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L81-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_stream_aggregation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Aggregate Versioning

--- a/docs/events/projections/custom.md
+++ b/docs/events/projections/custom.md
@@ -84,8 +84,8 @@ var store = DocumentStore.For(opts =>
     // Marten.PLv8 is necessary for patching
     opts.UseJavascriptTransformsAndPatching();
 
-    // The default lifecycle is inline
-    opts.Projections.Add(new QuestPatchTestProjection());
+    // Use inline lifecycle
+    opts.Projections.Add(new QuestPatchTestProjection(), ProjectionLifecycle.Inline);
 
     // Or use this as an asychronous projection
     opts.Projections.Add(new QuestPatchTestProjection(), ProjectionLifecycle.Async);

--- a/docs/events/projections/index.md
+++ b/docs/events/projections/index.md
@@ -139,7 +139,7 @@ await using (var session = store.LightweightSession())
         .AggregateStreamAsync<QuestParty>(questId, timestamp: DateTime.UtcNow.AddDays(-1));
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L87-L101' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_events-aggregate-on-the-fly' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L93-L108' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_events-aggregate-on-the-fly' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 There is also a matching asynchronous `AggregateStreamAsync()` mechanism as well. Additionally, you can do stream aggregations in batch queries with
@@ -166,10 +166,10 @@ var store = DocumentStore.For(_ =>
 
     // This is all you need to create the QuestParty projected
     // view
-    _.Projections.Snapshot<QuestParty>();
+    _.Projections.Snapshot<QuestParty>(SnapshotLifecycle.Inline);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/inline_aggregation_by_stream_with_multiples.cs#L24-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering-quest-party' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/inline_aggregation_by_stream_with_multiples.cs#L31-L48' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering-quest-party' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 At this point, you would be able to query against `QuestParty` as just another document type.

--- a/docs/events/projections/inline.md
+++ b/docs/events/projections/inline.md
@@ -10,11 +10,7 @@ public class MonsterDefeatedTransform: EventProjection
 {
     public MonsterDefeated Create(IEvent<MonsterSlayed> input)
     {
-        return new MonsterDefeated
-        {
-            Id = input.Id,
-            Monster = input.Data.Name
-        };
+        return new MonsterDefeated { Id = input.Id, Monster = input.Data.Name };
     }
 }
 
@@ -24,7 +20,7 @@ public class MonsterDefeated
     public string Monster { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/inline_transformation_of_events.cs#L149-L168' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_monsterdefeatedtransform' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/inline_transformation_of_events.cs#L157-L173' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_monsterdefeatedtransform' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note that the inline projection is able to use the [event metadata](/events/metadata) at the time the inline projection is executed. That was previously a limitation of Marten that was fixed in Marten V4.
@@ -51,5 +47,5 @@ var streamId = session.Events
 // transaction
 await theSession.SaveChangesAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/inline_transformation_of_events.cs#L27-L48' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_usage_of_inline_projection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/inline_transformation_of_events.cs#L33-L54' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_usage_of_inline_projection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/events/projections/multi-stream-projections.md
+++ b/docs/events/projections/multi-stream-projections.md
@@ -451,5 +451,5 @@ public class DayProjection: MultiStreamProjection<Day, int>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/ViewProjectionTests.cs#L126-L170' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_showing_fanout_rules' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/ViewProjectionTests.cs#L124-L168' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_showing_fanout_rules' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/events/querying.md
+++ b/docs/events/querying.md
@@ -33,7 +33,7 @@ public async Task load_event_stream_async(IDocumentSession session, Guid streamI
         .FetchStreamAsync(streamId, timestamp: DateTime.UtcNow.AddDays(-1));
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L110-L137' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using-fetch-stream' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L117-L145' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using-fetch-stream' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The data returned is a list of `IEvent` objects, where each is a strongly-typed `Event<T>` object shown below:
@@ -258,7 +258,7 @@ public async Task load_a_single_event_asynchronously(IDocumentSession session, G
     var event2 = await session.Events.LoadAsync(eventId);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L139-L158' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_load-a-single-event' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L147-L167' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_load-a-single-event' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Querying Directly Against Event Data

--- a/docs/events/quickstart.md
+++ b/docs/events/quickstart.md
@@ -147,7 +147,7 @@ public class MembersEscaped
 var store = DocumentStore.For(_ =>
 {
     _.Connection(ConnectionSource.ConnectionString);
-    _.Projections.Snapshot<QuestParty>();
+    _.Projections.Snapshot<QuestParty>(SnapshotLifecycle.Inline);
 });
 
 var questId = Guid.NewGuid();
@@ -171,7 +171,7 @@ await using (var session = store.LightweightSession())
     await session.SaveChangesAsync();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L16-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_event-store-quickstart' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L17-L46' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_event-store-quickstart' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In addition to generic `StartStream<T>`, `IEventStore` has a non-generic `StartStream` overload that let you pass explicit type.
@@ -190,7 +190,7 @@ await using (var session = store.LightweightSession())
     await session.SaveChangesAsync();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L46-L58' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_event-store-start-stream-with-explicit-type' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L49-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_event-store-start-stream-with-explicit-type' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Now, we would at some point like to see the current state of the quest party to check up on where they're at, who is in the party, and maybe how many monsters they've slain along the way. To keep things simple, we're going to use Marten's live stream aggregation feature to model a `QuestParty` that can update itself based on our events:
@@ -240,5 +240,5 @@ await using (var session = store.LightweightSession())
         .AggregateStreamAsync<QuestParty>(questId, timestamp: DateTime.UtcNow.AddDays(-1));
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L87-L101' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_events-aggregate-on-the-fly' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L93-L108' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_events-aggregate-on-the-fly' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/src/DocumentDbTests/Indexes/UniqueIndexTests.cs
+++ b/src/DocumentDbTests/Indexes/UniqueIndexTests.cs
@@ -17,7 +17,7 @@ public class UserCreated
     public string Surname { get; set; }
 }
 
-public class UserMultiStreamProjection : MultiStreamProjection<UniqueUser, Guid>
+public class UserMultiStreamProjection: MultiStreamProjection<UniqueUser, Guid>
 {
     public UserMultiStreamProjection()
     {
@@ -43,14 +43,12 @@ public class UniqueUser
     [UniqueIndex(IndexType = UniqueIndexType.DuplicatedField)]
     public string Email { get; set; }
 
-    [UniqueIndex(IndexName = "fullname")]
-    public string FirstName { get; set; }
+    [UniqueIndex(IndexName = "fullname")] public string FirstName { get; set; }
 
-    [UniqueIndex(IndexName = "fullname")]
-    public string Surname { get; set; }
+    [UniqueIndex(IndexName = "fullname")] public string Surname { get; set; }
 }
 
-public class UniqueIndexTests : OneOffConfigurationsContext
+public class UniqueIndexTests: OneOffConfigurationsContext
 {
     public const string UniqueSqlState = "23505";
 
@@ -59,17 +57,24 @@ public class UniqueIndexTests : OneOffConfigurationsContext
         StoreOptions(opts =>
         {
             opts.Events.AddEventTypes(new[] { typeof(UserCreated) });
-            opts.Projections.Add(new UserMultiStreamProjection());
+            opts.Projections.Add(new UserMultiStreamProjection(), ProjectionLifecycle.Async);
             opts.RegisterDocumentType<UniqueUser>();
         });
     }
 
     [Fact]
-    public void given_two_documents_with_the_same_value_for_unique_field_with_multiple_properties_when_created_then_throws_exception()
+    public void
+        given_two_documents_with_the_same_value_for_unique_field_with_multiple_properties_when_created_then_throws_exception()
     {
         //1. Create Events
-        var firstDocument = new UniqueUser { Id = Guid.NewGuid(), Email = "john.doe@gmail.com", FirstName = "John", Surname = "Doe" };
-        var secondDocument = new UniqueUser { Id = Guid.NewGuid(), Email = "some.mail@outlook.com", FirstName = "John", Surname = "Doe" };
+        var firstDocument = new UniqueUser
+        {
+            Id = Guid.NewGuid(), Email = "john.doe@gmail.com", FirstName = "John", Surname = "Doe"
+        };
+        var secondDocument = new UniqueUser
+        {
+            Id = Guid.NewGuid(), Email = "some.mail@outlook.com", FirstName = "John", Surname = "Doe"
+        };
 
 
         using var session = theStore.LightweightSession();
@@ -89,11 +94,13 @@ public class UniqueIndexTests : OneOffConfigurationsContext
     }
 
     [Fact]
-    public void given_two_documents_with_the_same_value_for_unique_field_with_single_property_when_created_then_throws_exception()
+    public void
+        given_two_documents_with_the_same_value_for_unique_field_with_single_property_when_created_then_throws_exception()
     {
         //1. Create Events
         const string email = "john.smith@mail.com";
-        var firstDocument = new UniqueUser { Id = Guid.NewGuid(), Email = email, FirstName = "John", Surname = "Smith" };
+        var firstDocument =
+            new UniqueUser { Id = Guid.NewGuid(), Email = email, FirstName = "John", Surname = "Smith" };
         var secondDocument = new UniqueUser { Id = Guid.NewGuid(), Email = email, FirstName = "John", Surname = "Doe" };
 
         using var session = theStore.LightweightSession();
@@ -113,11 +120,18 @@ public class UniqueIndexTests : OneOffConfigurationsContext
     }
 
     [Fact]
-    public void given_two_events_with_the_same_value_for_unique_field_with_multiple_properties_when_inline_transformation_is_applied_then_throws_exception()
+    public void
+        given_two_events_with_the_same_value_for_unique_field_with_multiple_properties_when_inline_transformation_is_applied_then_throws_exception()
     {
         //1. Create Events
-        var firstEvent = new UserCreated { UserId = Guid.NewGuid(), Email = "john.doe@gmail.com", FirstName = "John", Surname = "Doe" };
-        var secondEvent = new UserCreated { UserId = Guid.NewGuid(), Email = "some.mail@outlook.com", FirstName = "John", Surname = "Doe" };
+        var firstEvent = new UserCreated
+        {
+            UserId = Guid.NewGuid(), Email = "john.doe@gmail.com", FirstName = "John", Surname = "Doe"
+        };
+        var secondEvent = new UserCreated
+        {
+            UserId = Guid.NewGuid(), Email = "some.mail@outlook.com", FirstName = "John", Surname = "Doe"
+        };
 
         using var session = theStore.LightweightSession();
         //2. Publish Events
@@ -136,12 +150,15 @@ public class UniqueIndexTests : OneOffConfigurationsContext
     }
 
     [Fact]
-    public void given_two_events_with_the_same_value_for_unique_field_with_single_property_when_inline_transformation_is_applied_then_throws_exception()
+    public void
+        given_two_events_with_the_same_value_for_unique_field_with_single_property_when_inline_transformation_is_applied_then_throws_exception()
     {
         //1. Create Events
         const string email = "john.smith@mail.com";
-        var firstEvent = new UserCreated { UserId = Guid.NewGuid(), Email = email, FirstName = "John", Surname = "Smith" };
-        var secondEvent = new UserCreated { UserId = Guid.NewGuid(), Email = email, FirstName = "John", Surname = "Doe" };
+        var firstEvent =
+            new UserCreated { UserId = Guid.NewGuid(), Email = email, FirstName = "John", Surname = "Smith" };
+        var secondEvent =
+            new UserCreated { UserId = Guid.NewGuid(), Email = email, FirstName = "John", Surname = "Doe" };
 
         using var session = theStore.LightweightSession();
         //2. Publish Events
@@ -158,5 +175,4 @@ public class UniqueIndexTests : OneOffConfigurationsContext
             ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
         }
     }
-
 }

--- a/src/EventSourceWorker/Program.cs
+++ b/src/EventSourceWorker/Program.cs
@@ -1,6 +1,7 @@
 using Marten;
 using Marten.AsyncDaemon.Testing.TestingSupport;
 using Marten.Events.Daemon.Resiliency;
+using Marten.Events.Projections;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -40,7 +41,7 @@ public class Program
                             options.AutoCreateSchemaObjects = AutoCreate.All;
                         }
 
-                        options.Projections.Add(new TripProjectionWithCustomName());
+                        options.Projections.Add(new TripProjectionWithCustomName(), ProjectionLifecycle.Inline);
                     })
                     // Run the asynchronous projections in this node
                     .AddAsyncDaemon(DaemonMode.Solo);

--- a/src/EventSourcingTests/Aggregation/CustomProjectionTests.cs
+++ b/src/EventSourcingTests/Aggregation/CustomProjectionTests.cs
@@ -313,7 +313,7 @@ public class using_custom_aggregate_with_soft_deletes_and_update_only_events : O
 {
     public using_custom_aggregate_with_soft_deletes_and_update_only_events()
     {
-        StoreOptions(opts => opts.Projections.Add(new StartAndStopProjection()));
+        StoreOptions(opts => opts.Projections.Add(new StartAndStopProjection(), ProjectionLifecycle.Inline));
     }
 
     public Task InitializeAsync()

--- a/src/EventSourcingTests/Aggregation/aggregates_should_be_registered_as_document_mappings_automatically.cs
+++ b/src/EventSourcingTests/Aggregation/aggregates_should_be_registered_as_document_mappings_automatically.cs
@@ -26,7 +26,7 @@ public class aggregates_should_be_registered_as_document_mappings_automatically:
     {
         StoreOptions(opts =>
         {
-            opts.Projections.Add<AllGood>();
+            opts.Projections.Add<AllGood>(ProjectionLifecycle.Inline);
         });
 
         // MyAggregate is the aggregate type for AllGood above
@@ -40,7 +40,7 @@ public class aggregates_should_be_registered_as_document_mappings_automatically:
     {
         StoreOptions(_ =>
         {
-            _.Projections.Snapshot<QuestParty>();
+            _.Projections.Snapshot<QuestParty>(SnapshotLifecycle.Inline);
         });
 
         theStore.StorageFeatures.AllDocumentMappings.Select(x => x.DocumentType)
@@ -58,5 +58,4 @@ public class aggregates_should_be_registered_as_document_mappings_automatically:
         theStore.StorageFeatures.AllDocumentMappings.Select(x => x.DocumentType)
             .ShouldContain(typeof(QuestParty));
     }
-
 }

--- a/src/EventSourcingTests/Aggregation/aggregation_projection_validation_rules.cs
+++ b/src/EventSourcingTests/Aggregation/aggregation_projection_validation_rules.cs
@@ -117,7 +117,7 @@ public class aggregation_projection_validation_rules
     {
         errorMessageFor(opts =>
         {
-            opts.Projections.Add(new Projections.EmptyProjection());
+            opts.Projections.Add(new Projections.EmptyProjection(), ProjectionLifecycle.Inline);
         }).ShouldNotBeNull();
     }
 

--- a/src/EventSourcingTests/Bugs/Bug_2438_generated_code_throwing_nre.cs
+++ b/src/EventSourcingTests/Bugs/Bug_2438_generated_code_throwing_nre.cs
@@ -21,7 +21,7 @@ public class Bug_2438_generated_code_throwing_nre
 
     protected async Task execute_projection()
     {
-        using var container = new Container(services =>
+        await using var container = new Container(services =>
         {
             services.AddMarten(options =>
             {
@@ -35,7 +35,7 @@ public class Bug_2438_generated_code_throwing_nre
                         .ConnectionLimit(-1);
                 });
 
-                options.Projections.Add<MyEventProjection>();
+                options.Projections.Add<MyEventProjection>(ProjectionLifecycle.Inline);
                 options.AutoCreateSchemaObjects = AutoCreate.All;
                 options.GeneratedCodeMode = TypeLoadMode.Auto;
                 options.SetApplicationProject(typeof(MyEventProjection).Assembly);
@@ -48,18 +48,16 @@ public class Bug_2438_generated_code_throwing_nre
 
         session.Events.StartStream(new MyEvent(Guid.NewGuid(), "Stuff"));
         await session.SaveChangesAsync();
-
     }
 
     public record MyEvent(Guid Id, string Stuff);
 
-    public class MyEventProjection : EventProjection
+    public class MyEventProjection: EventProjection
     {
         public MyEventProjection()
         {
             Project<MyEvent>((@event, operations) =>
             {
-
             });
         }
     }

--- a/src/EventSourcingTests/Bugs/codegen_issue_with_IEvent.cs
+++ b/src/EventSourcingTests/Bugs/codegen_issue_with_IEvent.cs
@@ -14,7 +14,7 @@ public class CodeGenIEventIssue: BugIntegrationContext
     {
         var store = StoreOptions(_ =>
         {
-            _.Projections.Add(new FooProjection());
+            _.Projections.Add(new FooProjection(), ProjectionLifecycle.Inline);
         });
 
         using var session = store.LightweightSession();
@@ -27,7 +27,7 @@ public class CodeGenIEventIssue: BugIntegrationContext
     {
         var store = StoreOptions(_ =>
         {
-            _.Projections.Add(new RecordProjection());
+            _.Projections.Add(new RecordProjection(), ProjectionLifecycle.Inline);
         });
 
         using var session = store.LightweightSession();
@@ -60,7 +60,6 @@ public class FooProjection: MultiStreamProjection<FooAuditLog, Guid>
     public FooProjection()
     {
         ProjectionName = nameof(FooAuditLog);
-        Lifecycle = ProjectionLifecycle.Inline;
 
         Identity<FooCreated>(x => x.Id);
 
@@ -84,7 +83,6 @@ public class RecordProjection: MultiStreamProjection<RecordAuditLog, Guid>
     public RecordProjection()
     {
         ProjectionName = nameof(RecordAuditLog);
-        Lifecycle = ProjectionLifecycle.Inline;
 
         Identity<IRecordLogEvent>(x => x.Id);
 

--- a/src/EventSourcingTests/Projections/include_extra_schema_objects_from_projections.cs
+++ b/src/EventSourcingTests/Projections/include_extra_schema_objects_from_projections.cs
@@ -12,13 +12,13 @@ using Xunit;
 
 namespace EventSourcingTests.Projections;
 
-public class include_extra_schema_objects_from_projections : OneOffConfigurationsContext
+public class include_extra_schema_objects_from_projections: OneOffConfigurationsContext
 {
     public include_extra_schema_objects_from_projections()
     {
         StoreOptions(opts =>
         {
-            opts.Projections.Add<TableCreatingProjection>();
+            opts.Projections.Add<TableCreatingProjection>(ProjectionLifecycle.Inline);
         });
     }
 
@@ -71,6 +71,5 @@ public class TableCreatingProjection: EventProjection
 
     public void Project(NameAdded added, IDocumentOperations operations)
     {
-
     }
 }

--- a/src/EventSourcingTests/Projections/inline_aggregation_with_base_view_class.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_base_view_class.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Marten.Events.Projections;
 using Marten.Testing.Harness;
 using Shouldly;
 using Weasel.Core;
@@ -18,9 +19,9 @@ public class inline_aggregation_with_base_view_class: OneOffConfigurationsContex
         StoreOptions(_ =>
         {
             _.AutoCreateSchemaObjects = AutoCreate.All;
-            _.Projections.Snapshot<QuestMonstersWithBaseClass>();
-            _.Projections.Snapshot<QuestMonstersWithBaseClassAndIdOverloaded>();
-            _.Projections.Snapshot<QuestMonstersWithBaseClassAndIdOverloadedWithNew>();
+            _.Projections.Snapshot<QuestMonstersWithBaseClass>(SnapshotLifecycle.Inline);
+            _.Projections.Snapshot<QuestMonstersWithBaseClassAndIdOverloaded>(SnapshotLifecycle.Inline);
+            _.Projections.Snapshot<QuestMonstersWithBaseClassAndIdOverloadedWithNew>(SnapshotLifecycle.Inline);
         });
 
         streamId = theSession.Events

--- a/src/EventSourcingTests/Projections/inline_aggregation_with_non_public_setter.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_non_public_setter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Marten;
+using Marten.Events.Projections;
 using Marten.Testing.Harness;
 using Shouldly;
 using Weasel.Core;
@@ -20,8 +21,8 @@ public class inline_aggregation_with_non_public_setter: OneOffConfigurationsCont
         {
             _.AutoCreateSchemaObjects = AutoCreate.All;
             _.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.NonPublicSetters);
-            _.Projections.Snapshot<QuestMonstersWithPrivateIdSetter>();
-            _.Projections.Snapshot<QuestMonstersWithProtectedIdSetter>();
+            _.Projections.Snapshot<QuestMonstersWithPrivateIdSetter>(SnapshotLifecycle.Inline);
+            _.Projections.Snapshot<QuestMonstersWithProtectedIdSetter>(SnapshotLifecycle.Inline);
         });
 
         streamId = theSession.Events

--- a/src/EventSourcingTests/Projections/inline_aggregation_with_private_constructor.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_private_constructor.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Marten;
+using Marten.Events.Projections;
 using Marten.Testing.Harness;
 using Shouldly;
 using Weasel.Core;
@@ -15,13 +16,14 @@ public class inline_aggregation_with_private_constructor: OneOffConfigurationsCo
         {
             _.AutoCreateSchemaObjects = AutoCreate.All;
             _.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.All);
-            _.Projections.Snapshot<QuestMonstersWithPrivateConstructor>();
-            _.Projections.Snapshot<QuestMonstersWithNonDefaultPublicConstructor>();
-            _.Projections.Snapshot<WithDefaultPrivateConstructorNonDefaultPublicConstructor>();
-            _.Projections.Snapshot<WithMultiplePublicNonDefaultConstructors>();
-            _.Projections.Snapshot<WithMultiplePrivateNonDefaultConstructors>();
-            _.Projections.Snapshot<WithMultiplePrivateNonDefaultConstructorsAndAttribute>();
-            _.Projections.Snapshot<WithNonDefaultConstructorsPrivateAndPublicWithEqualParamsCount>();
+            _.Projections.Snapshot<QuestMonstersWithPrivateConstructor>(SnapshotLifecycle.Inline);
+            _.Projections.Snapshot<QuestMonstersWithNonDefaultPublicConstructor>(SnapshotLifecycle.Inline);
+            _.Projections.Snapshot<WithDefaultPrivateConstructorNonDefaultPublicConstructor>(SnapshotLifecycle.Inline);
+            _.Projections.Snapshot<WithMultiplePublicNonDefaultConstructors>(SnapshotLifecycle.Inline);
+            _.Projections.Snapshot<WithMultiplePrivateNonDefaultConstructors>(SnapshotLifecycle.Inline);
+            _.Projections.Snapshot<WithMultiplePrivateNonDefaultConstructorsAndAttribute>(SnapshotLifecycle.Inline);
+            _.Projections.Snapshot<WithNonDefaultConstructorsPrivateAndPublicWithEqualParamsCount>(
+                SnapshotLifecycle.Inline);
         });
     }
 
@@ -37,7 +39,7 @@ public class inline_aggregation_with_private_constructor: OneOffConfigurationsCo
         Verify<WithNonDefaultConstructorsPrivateAndPublicWithEqualParamsCount>();
     }
 
-    private void Verify<T>() where T: IMonstersView
+    private void Verify<T>() where T : IMonstersView
     {
         var slayed1 = new MonsterSlayed { Name = "Troll" };
         var slayed2 = new MonsterSlayed { Name = "Dragon" };

--- a/src/EventSourcingTests/Projections/inline_aggregation_with_subclass.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_subclass.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Linq;
+using Marten.Events.Projections;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
 
 namespace EventSourcingTests.Projections;
 
-public class inline_aggregation_with_subclass : OneOffConfigurationsContext
+public class inline_aggregation_with_subclass: OneOffConfigurationsContext
 {
     public inline_aggregation_with_subclass()
     {
@@ -14,7 +15,7 @@ public class inline_aggregation_with_subclass : OneOffConfigurationsContext
         {
             x.Schema.For<FooBase>().AddSubClass<FooA>();
 
-            x.Projections.Snapshot<FooA>();
+            x.Projections.Snapshot<FooA>(SnapshotLifecycle.Inline);
         });
     }
 
@@ -23,7 +24,7 @@ public class inline_aggregation_with_subclass : OneOffConfigurationsContext
     {
         var description = "FooDescription";
 
-        var streamId = theSession.Events.StartStream(new FooACreated { Description = description } ).Id;
+        var streamId = theSession.Events.StartStream(new FooACreated { Description = description }).Id;
         theSession.SaveChanges();
 
         var fooInstance = theSession.Query<FooA>().Single(x => x.Id == streamId);
@@ -52,8 +53,7 @@ public abstract class FooBase
     public Guid Id { get; set; }
 }
 
-
-public class FooA : FooBase
+public class FooA: FooBase
 {
     public string Description { get; set; }
 

--- a/src/EventSourcingTests/Projections/inline_transformation_of_events.cs
+++ b/src/EventSourcingTests/Projections/inline_transformation_of_events.cs
@@ -16,11 +16,17 @@ namespace EventSourcingTests.Projections;
 public class inline_transformation_of_events: OneOffConfigurationsContext
 {
     private QuestStarted started = new QuestStarted { Name = "Find the Orb" };
-    private MembersJoined joined = new MembersJoined { Day = 2, Location = "Faldor's Farm", Members = new string[] { "Garion", "Polgara", "Belgarath" } };
+
+    private MembersJoined joined = new MembersJoined
+    {
+        Day = 2, Location = "Faldor's Farm", Members = new string[] { "Garion", "Polgara", "Belgarath" }
+    };
+
     private MonsterSlayed slayed1 = new MonsterSlayed { Name = "Troll" };
     private MonsterSlayed slayed2 = new MonsterSlayed { Name = "Dragon" };
 
-    private MembersJoined joined2 = new MembersJoined { Day = 5, Location = "Sendaria", Members = new string[] { "Silk", "Barak" } };
+    private MembersJoined joined2 =
+        new MembersJoined { Day = 5, Location = "Sendaria", Members = new string[] { "Silk", "Barak" } };
 
     private async Task sample_usage()
     {
@@ -58,7 +64,7 @@ public class inline_transformation_of_events: OneOffConfigurationsContext
             _.AutoCreateSchemaObjects = AutoCreate.All;
             _.Events.TenancyStyle = tenancyStyle;
 
-            _.Projections.Add(new MonsterDefeatedTransform());
+            _.Projections.Add(new MonsterDefeatedTransform(), ProjectionLifecycle.Inline);
         });
 
         var streamId = theSession.Events
@@ -84,7 +90,7 @@ public class inline_transformation_of_events: OneOffConfigurationsContext
         {
             _.AutoCreateSchemaObjects = AutoCreate.All;
 
-            _.Projections.Add(new MonsterDefeatedTransform());
+            _.Projections.Add(new MonsterDefeatedTransform(), ProjectionLifecycle.Inline);
         });
 
         var streamId = theSession.Events
@@ -107,13 +113,15 @@ public class inline_transformation_of_events: OneOffConfigurationsContext
     public async Task async_projection_of_events()
     {
         #region sample_applying-monster-defeated
+
         var store = DocumentStore.For(_ =>
         {
             _.Connection(ConnectionSource.ConnectionString);
             _.DatabaseSchemaName = "monster_defeated";
 
-            _.Projections.Add(new MonsterDefeatedTransform());
+            _.Projections.Add(new MonsterDefeatedTransform(), ProjectionLifecycle.Inline);
         });
+
         #endregion
 
         // The code below is just customizing the document store
@@ -122,7 +130,7 @@ public class inline_transformation_of_events: OneOffConfigurationsContext
         {
             _.AutoCreateSchemaObjects = AutoCreate.All;
 
-            _.Projections.Add(new MonsterDefeatedTransform());
+            _.Projections.Add(new MonsterDefeatedTransform(), ProjectionLifecycle.Inline);
         });
 
         var streamId = theSession.Events
@@ -147,15 +155,12 @@ public class inline_transformation_of_events: OneOffConfigurationsContext
 }
 
 #region sample_MonsterDefeatedTransform
+
 public class MonsterDefeatedTransform: EventProjection
 {
     public MonsterDefeated Create(IEvent<MonsterSlayed> input)
     {
-        return new MonsterDefeated
-        {
-            Id = input.Id,
-            Monster = input.Data.Name
-        };
+        return new MonsterDefeated { Id = input.Id, Monster = input.Data.Name };
     }
 }
 

--- a/src/EventSourcingTests/SchemaChange/MultipleVersions/MultipleSchemaVersions.cs
+++ b/src/EventSourcingTests/SchemaChange/MultipleVersions/MultipleSchemaVersions.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using JasperFx.CodeGeneration;
 using Marten;
 using Marten.Events;
+using Marten.Events.Projections;
 using Marten.Testing;
 using Marten.Testing.Harness;
 using Shouldly;
@@ -31,7 +32,7 @@ public class MultipleSchemaVersions: OneOffConfigurationsContext
         StoreOptions(options =>
         {
             options.GeneratedCodeMode = TypeLoadMode.Auto;
-            options.Projections.Snapshot<V1.ShoppingCart>();
+            options.Projections.Snapshot<V1.ShoppingCart>(SnapshotLifecycle.Inline);
         });
         await theStore.EnsureStorageExistsAsync(typeof(StreamAction));
 
@@ -78,7 +79,7 @@ public class MultipleSchemaVersions: OneOffConfigurationsContext
         StoreOptions(options =>
         {
             options.GeneratedCodeMode = TypeLoadMode.Auto;
-            options.Projections.Snapshot<V1.ShoppingCart>();
+            options.Projections.Snapshot<V1.ShoppingCart>(SnapshotLifecycle.Inline);
         });
         await theStore.EnsureStorageExistsAsync(typeof(StreamAction));
 
@@ -130,7 +131,7 @@ public class MultipleSchemaVersions: OneOffConfigurationsContext
         using var storeV2 = SeparateStore(options =>
         {
             options.GeneratedCodeMode = TypeLoadMode.Auto;
-            options.Projections.Snapshot<V2.WithTheSameName.ShoppingCart>();
+            options.Projections.Snapshot<V2.WithTheSameName.ShoppingCart>(SnapshotLifecycle.Inline);
             ////////////////////////////////////////////////////////
             // 2.1. Define Upcast methods from V1 to V2
             ////////////////////////////////////////////////////////
@@ -209,7 +210,7 @@ public class MultipleSchemaVersions: OneOffConfigurationsContext
         using var storeV3 = SeparateStore(options =>
         {
             options.GeneratedCodeMode = TypeLoadMode.Auto;
-            options.Projections.Snapshot<V3.WithTheSameName.ShoppingCart>();
+            options.Projections.Snapshot<V3.WithTheSameName.ShoppingCart>(SnapshotLifecycle.Inline);
             ////////////////////////////////////////////////////////
             // 3.1. Define Upcast methods from V1 to V3, and from V2 to V3
             ////////////////////////////////////////////////////////
@@ -290,7 +291,7 @@ public class MultipleSchemaVersions: OneOffConfigurationsContext
         using var storeV2 = SeparateStore(options =>
         {
             options.GeneratedCodeMode = TypeLoadMode.Auto;
-            options.Projections.Snapshot<V2.WithDifferentName.ShoppingCart>();
+            options.Projections.Snapshot<V2.WithDifferentName.ShoppingCart>(SnapshotLifecycle.Inline);
             ////////////////////////////////////////////////////////
             // 2.1. Define Upcast methods from V1 to V2
             ////////////////////////////////////////////////////////
@@ -368,7 +369,7 @@ public class MultipleSchemaVersions: OneOffConfigurationsContext
         using var storeV3 = SeparateStore(options =>
         {
             options.GeneratedCodeMode = TypeLoadMode.Auto;
-            options.Projections.Snapshot<V3.WithDifferentName.ShoppingCart>();
+            options.Projections.Snapshot<V3.WithDifferentName.ShoppingCart>(SnapshotLifecycle.Inline);
             ////////////////////////////////////////////////////////
             // 3.1. Define Upcast methods from V1 to V3, and from V2 to V3
             ////////////////////////////////////////////////////////

--- a/src/EventSourcingTests/cannot_register_duplicate_projections_by_name.cs
+++ b/src/EventSourcingTests/cannot_register_duplicate_projections_by_name.cs
@@ -19,8 +19,8 @@ public class cannot_register_duplicate_projections_by_name
             DocumentStore.For(opts =>
             {
                 opts.Connection(ConnectionSource.ConnectionString);
-                opts.Projections.Add<Projection1>();
-                opts.Projections.Add<Projection2>();
+                opts.Projections.Add<Projection1>(ProjectionLifecycle.Inline);
+                opts.Projections.Add<Projection2>(ProjectionLifecycle.Inline);
             });
         });
     }
@@ -50,7 +50,4 @@ public class cannot_register_duplicate_projections_by_name
             return new AEvent();
         }
     }
-
-
-
 }

--- a/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers.cs
+++ b/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using JasperFx.Core;
 using Marten;
 using Marten.Events;
+using Marten.Events.Projections;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
@@ -12,9 +13,12 @@ using Xunit;
 namespace EventSourcingTests;
 
 [Collection("string_identified_streams")]
-public class end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers : StoreContext<StringIdentifiedStreamsFixture>
+public class
+    end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers: StoreContext<
+        StringIdentifiedStreamsFixture>
 {
-    public end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers(StringIdentifiedStreamsFixture fixture) : base(fixture)
+    public end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers(
+        StringIdentifiedStreamsFixture fixture): base(fixture)
     {
     }
 
@@ -44,12 +48,14 @@ public class end_to_end_event_capture_and_fetching_the_stream_with_string_identi
     public async Task capture_events_to_a_new_stream_and_fetch_the_events_back_async()
     {
         #region sample_start-stream-with-aggregate-type
+
         var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
         var departed = new MembersDeparted { Members = new[] { "Thom" } };
 
         var id = "Second";
         theSession.Events.StartStream<Quest>(id, joined, departed);
         await theSession.SaveChangesAsync();
+
         #endregion
 
         var streamEvents = await theSession.Events.FetchStreamAsync(id);
@@ -67,12 +73,14 @@ public class end_to_end_event_capture_and_fetching_the_stream_with_string_identi
     public async Task capture_events_to_a_new_stream_and_fetch_the_events_back_async_with_linq()
     {
         #region sample_start-stream-with-aggregate-type
+
         var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
         var departed = new MembersDeparted { Members = new[] { "Thom" } };
 
         var id = "Third";
         theSession.Events.StartStream<Quest>(id, joined, departed);
         await theSession.SaveChangesAsync();
+
         #endregion
 
         var streamEvents = await theSession.Events.QueryAllRawEvents()
@@ -91,12 +99,14 @@ public class end_to_end_event_capture_and_fetching_the_stream_with_string_identi
     public void capture_events_to_a_new_stream_and_fetch_the_events_back_sync_with_linq()
     {
         #region sample_start-stream-with-aggregate-type
+
         var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
         var departed = new MembersDeparted { Members = new[] { "Thom" } };
 
         var id = "Fourth";
         theSession.Events.StartStream<Quest>(id, joined, departed);
         theSession.SaveChanges();
+
         #endregion
 
         var streamEvents = theSession.Events.QueryAllRawEvents()
@@ -119,7 +129,11 @@ public class end_to_end_event_capture_and_fetching_the_stream_with_string_identi
         using (var session = theStore.LightweightSession())
         {
             //Note Id = questId, is we remove it from first message then AggregateStream will return party.Id=default(Guid) that is not equals to Load<QuestParty> result
-            var started = new QuestStarted { /*Id = questId,*/ Name = "Destroy the One Ring" };
+            var started = new QuestStarted
+            {
+                /*Id = questId,*/
+                Name = "Destroy the One Ring"
+            };
             var joined1 = new MembersJoined(1, "Hobbiton", "Frodo", "Merry");
 
             session.Events.StartStream<Quest>(questId, started, joined1);
@@ -182,6 +196,7 @@ public class end_to_end_event_capture_and_fetching_the_stream_with_string_identi
             var party = session.Load<QuestPartyWithStringIdentifier>(questId);
             party.ShouldNotBeNull();
         }
+
         //GetAll
         using (var session = theStore.LightweightSession())
         {
@@ -191,11 +206,12 @@ public class end_to_end_event_capture_and_fetching_the_stream_with_string_identi
                 party.ShouldNotBeNull();
             }
         }
+
         //This AggregateStream fail with NPE
         using (var session = newStore.LightweightSession())
         {
             // questId is the id of the stream
-            var party = session.Events.AggregateStream<QuestPartyWithStringIdentifier>(questId);//Here we get NPE
+            var party = session.Events.AggregateStream<QuestPartyWithStringIdentifier>(questId); //Here we get NPE
             party.ShouldNotBeNull();
 
             var party_at_version_3 = session.Events
@@ -435,21 +451,19 @@ public class end_to_end_event_capture_and_fetching_the_stream_with_string_identi
 
         session.SaveChanges();
     }
-
 }
 
 [CollectionDefinition("string_identified_streams")]
-public class StringIdentifiedStreamsCollection : ICollectionFixture<StringIdentifiedStreamsFixture>
+public class StringIdentifiedStreamsCollection: ICollectionFixture<StringIdentifiedStreamsFixture>
 {
-
 }
 
 public class StringIdentifiedStreamsFixture: StoreFixture
 {
-    public StringIdentifiedStreamsFixture() : base("string_identified_streams")
+    public StringIdentifiedStreamsFixture(): base("string_identified_streams")
     {
         Options.Events.StreamIdentity = StreamIdentity.AsString;
-        Options.Projections.Snapshot<QuestPartyWithStringIdentifier>();
+        Options.Projections.Snapshot<QuestPartyWithStringIdentifier>(SnapshotLifecycle.Inline);
 
         Options.Events.AddEventType(typeof(MembersJoined));
         Options.Events.AddEventType(typeof(MembersDeparted));

--- a/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2177_query_session_tenancy_in_daemon.cs
+++ b/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2177_query_session_tenancy_in_daemon.cs
@@ -89,11 +89,6 @@ namespace Bug2177
 
     public class TicketProjection: SingleStreamProjection<Ticket>
     {
-        public TicketProjection()
-        {
-            Lifecycle = ProjectionLifecycle.Async;
-        }
-
         public Ticket Create(TicketCreated created) =>
             new() { Id = created.TicketId, Name = created.Name };
 

--- a/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2201_out_of_order_exception_with_hard_deletes.cs
+++ b/src/Marten.AsyncDaemon.Testing/Bugs/Bug_2201_out_of_order_exception_with_hard_deletes.cs
@@ -56,7 +56,6 @@ public class Bug_2201_out_of_order_exception_with_hard_deletes: BugIntegrationCo
     {
         public TicketProjection()
         {
-            Lifecycle = ProjectionLifecycle.Async;
             DeleteEvent<TicketDeleted>();
         }
 

--- a/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs
+++ b/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs
@@ -51,10 +51,7 @@ namespace Marten.AsyncDaemon.Testing.TestingSupport
 
             DeleteEvent<Breakdown>(x => x.IsCritical);
 
-            DeleteEvent<VacationOver>((trip, v) => trip.Traveled > 1000);
-
-            // Now let's change the lifecycle to inline
-            Lifecycle = ProjectionLifecycle.Inline;
+            DeleteEvent<VacationOver>((trip, _) => trip.Traveled > 1000);
         }
 
         // These methods can be either public, internal, or private but there's

--- a/src/Marten.AsyncDaemon.Testing/ViewProjectionTests.cs
+++ b/src/Marten.AsyncDaemon.Testing/ViewProjectionTests.cs
@@ -64,7 +64,7 @@ public class ViewProjectionTests: DaemonContext
     [Fact]
     public async Task run_end_to_end()
     {
-        StoreOptions(x => x.Projections.Add(new DayProjection()));
+        StoreOptions(x => x.Projections.Add(new DayProjection(), ProjectionLifecycle.Async));
 
         await theStore.EnsureStorageExistsAsync(typeof(Day));
 
@@ -99,8 +99,6 @@ public class ViewProjectionTests: DaemonContext
             day.Version.ShouldBeGreaterThan(0);
         }
     }
-
-
 }
 
 public class Day

--- a/src/Marten.AsyncDaemon.Testing/build_aggregate_multiple_projections.cs
+++ b/src/Marten.AsyncDaemon.Testing/build_aggregate_multiple_projections.cs
@@ -85,7 +85,7 @@ public class build_aggregate_multiple_projections: DaemonContext
     }
 
 
-    public build_aggregate_multiple_projections(ITestOutputHelper output) : base(output)
+    public build_aggregate_multiple_projections(ITestOutputHelper output): base(output)
     {
     }
 
@@ -150,7 +150,6 @@ public class build_aggregate_multiple_projections: DaemonContext
             carName.ShouldBe("car-name-2");
             truckName.ShouldBe("truck-name-2");
         }
-
     }
 
     [Fact]
@@ -159,7 +158,7 @@ public class build_aggregate_multiple_projections: DaemonContext
         // register projection
         StoreOptions(x =>
         {
-            x.Projections.Add<CarProjection>();
+            x.Projections.Add<CarProjection>(ProjectionLifecycle.Inline);
             x.Projections.StaleSequenceThreshold = 250.Milliseconds();
             x.Projections.SlowPollingTime = 500.Milliseconds();
         }, true);
@@ -227,7 +226,7 @@ public class build_aggregate_multiple_projections: DaemonContext
         // register projection
         StoreOptions(x =>
         {
-            x.Projections.Add<CarProjection>();
+            x.Projections.Add<CarProjection>(ProjectionLifecycle.Inline);
             x.Projections.StaleSequenceThreshold = 250.Milliseconds();
             x.Projections.SlowPollingTime = 500.Milliseconds();
         }, true);
@@ -307,7 +306,8 @@ public class build_aggregate_multiple_projections: DaemonContext
         await conn.OpenAsync();
 
         return (long)await conn
-            .CreateCommand($"select last_seq_id from {theStore.Events.DatabaseSchemaName}.mt_event_progression where name = 'HighWaterMark'")
+            .CreateCommand(
+                $"select last_seq_id from {theStore.Events.DatabaseSchemaName}.mt_event_progression where name = 'HighWaterMark'")
             .ExecuteScalarAsync();
     }
 

--- a/src/Marten.AsyncDaemon.Testing/build_aggregate_projection.cs
+++ b/src/Marten.AsyncDaemon.Testing/build_aggregate_projection.cs
@@ -297,7 +297,7 @@ public class build_aggregate_projection: DaemonContext
         {
             x.Events.TenancyStyle = TenancyStyle.Conjoined;
             x.Policies.AllDocumentsAreMultiTenanted();
-            x.Projections.Add(new ContactProjectionNullReturn());
+            x.Projections.Add(new ContactProjectionNullReturn(), ProjectionLifecycle.Inline);
         }, true);
 
         var id = Guid.NewGuid();
@@ -328,7 +328,6 @@ public class build_aggregate_projection: DaemonContext
         public ContactProjectionNullReturn()
         {
             ProjectionName = nameof(Contact);
-            Lifecycle = ProjectionLifecycle.Inline;
 
             CreateEvent<ICreateEvent>(Contact.Create);
             ProjectEvent<ContactEdited>(Contact.Apply);
@@ -373,7 +372,7 @@ public class build_aggregate_projection: DaemonContext
         {
             x.Events.TenancyStyle = TenancyStyle.Conjoined;
             x.Policies.AllDocumentsAreMultiTenanted();
-            x.Projections.Add(new InterfaceCreationProjection());
+            x.Projections.Add(new InterfaceCreationProjection(), ProjectionLifecycle.Inline);
         }, true);
 
         var id = Guid.NewGuid();
@@ -403,7 +402,6 @@ public class build_aggregate_projection: DaemonContext
         public InterfaceCreationProjection()
         {
             ProjectionName = nameof(Foo);
-            Lifecycle = ProjectionLifecycle.Inline;
 
             CreateEvent<IFooCreated>(e => new(e.Id, "Foo"));
         }
@@ -427,7 +425,7 @@ public class build_aggregate_projection: DaemonContext
         {
             x.Events.TenancyStyle = TenancyStyle.Conjoined;
             x.Policies.AllDocumentsAreMultiTenanted();
-            x.Projections.Add(new AbstractCreationProjection());
+            x.Projections.Add(new AbstractCreationProjection(), ProjectionLifecycle.Inline);
         }, true);
 
         var id = Guid.NewGuid();
@@ -457,7 +455,6 @@ public class build_aggregate_projection: DaemonContext
         public AbstractCreationProjection()
         {
             ProjectionName = nameof(Foo);
-            Lifecycle = ProjectionLifecycle.Inline;
 
             CreateEvent<AbstractFooCreated>(e => new(e.Id, "Foo"));
         }

--- a/src/Marten.AsyncDaemon.Testing/cross_stream_aggregation.cs
+++ b/src/Marten.AsyncDaemon.Testing/cross_stream_aggregation.cs
@@ -64,7 +64,7 @@ public class cross_stream_aggregation: DaemonContext
     [Fact]
     public async Task run_end_to_end()
     {
-        StoreOptions(x => x.Projections.Add(new CrossStreamDayProjection()));
+        StoreOptions(x => x.Projections.Add(new CrossStreamDayProjection(), ProjectionLifecycle.Async));
 
         await theStore.EnsureStorageExistsAsync(typeof(Day));
 

--- a/src/Marten.AsyncDaemon.Testing/multi_stream_aggregation_end_to_end.cs
+++ b/src/Marten.AsyncDaemon.Testing/multi_stream_aggregation_end_to_end.cs
@@ -13,9 +13,9 @@ using Xunit.Abstractions;
 
 namespace Marten.AsyncDaemon.Testing;
 
-public class multi_stream_aggregation_end_to_end : DaemonContext
+public class multi_stream_aggregation_end_to_end: DaemonContext
 {
-    public multi_stream_aggregation_end_to_end(ITestOutputHelper output) : base(output)
+    public multi_stream_aggregation_end_to_end(ITestOutputHelper output): base(output)
     {
     }
 
@@ -33,15 +33,15 @@ public class multi_stream_aggregation_end_to_end : DaemonContext
         StoreOptions(opts =>
         {
             opts.Projections.AsyncMode = DaemonMode.Solo;
-            opts.Projections.Add<UserIssueProjection>();
+            opts.Projections.Add<UserIssueProjection>(ProjectionLifecycle.Async);
         });
 
 
         await using (var session = theStore.LightweightSession())
         {
-            session.Events.Append(user1, new UserCreated {UserId = user1});
-            session.Events.Append(user2, new UserCreated {UserId = user2});
-            session.Events.Append(user3, new UserCreated {UserId = user3});
+            session.Events.Append(user1, new UserCreated { UserId = user1 });
+            session.Events.Append(user2, new UserCreated { UserId = user2 });
+            session.Events.Append(user3, new UserCreated { UserId = user3 });
 
             await session.SaveChangesAsync();
         }
@@ -54,7 +54,7 @@ public class multi_stream_aggregation_end_to_end : DaemonContext
 
         await using (var session = theStore.LightweightSession())
         {
-            session.Events.Append(issue1, new IssueCreated {UserId = user1, IssueId = issue1});
+            session.Events.Append(issue1, new IssueCreated { UserId = user1, IssueId = issue1 });
             await session.SaveChangesAsync();
         }
 
@@ -64,7 +64,7 @@ public class multi_stream_aggregation_end_to_end : DaemonContext
 
         await using (var session = theStore.LightweightSession())
         {
-            session.Events.Append(issue2, new IssueCreated {UserId = user1, IssueId = issue2});
+            session.Events.Append(issue2, new IssueCreated { UserId = user1, IssueId = issue2 });
             await session.SaveChangesAsync();
         }
 
@@ -72,7 +72,7 @@ public class multi_stream_aggregation_end_to_end : DaemonContext
 
         await using (var session = theStore.LightweightSession())
         {
-            session.Events.Append(issue3, new IssueCreated {UserId = user1, IssueId = issue3});
+            session.Events.Append(issue3, new IssueCreated { UserId = user1, IssueId = issue3 });
             await session.SaveChangesAsync();
         }
 
@@ -88,8 +88,7 @@ public class multi_stream_aggregation_end_to_end : DaemonContext
 
 public class UserIssues: IVersioned
 {
-    [Identity]
-    public Guid UserId { get; set; }
+    [Identity] public Guid UserId { get; set; }
 
     public List<Issue> Issues { get; set; } = new List<Issue>();
     public Guid Version { get; set; }
@@ -124,14 +123,13 @@ public class UserIssueProjection: MultiStreamProjection<UserIssues, Guid>
     {
         ProjectionName = "UserIssue";
 
-        Lifecycle = ProjectionLifecycle.Async;
         Identity<UserCreated>(x => x.UserId);
         Identity<IssueCreated>(x => x.UserId);
     }
 
     public UserIssues Create(UserCreated @event) =>
-        new UserIssues {UserId = @event.UserId, Issues = new List<Issue>()};
+        new UserIssues { UserId = @event.UserId, Issues = new List<Issue>() };
 
     public void Apply(UserIssues state, IssueCreated @event) =>
-        state.Issues.Add(new Issue {Id = @event.IssueId, Name = @event.Name});
+        state.Issues.Add(new Issue { Id = @event.IssueId, Name = @event.Name });
 }

--- a/src/Marten.PLv8.Testing/Patching/patching_api.cs
+++ b/src/Marten.PLv8.Testing/Patching/patching_api.cs
@@ -836,8 +836,8 @@ public class patching_api: OneOffConfigurationsContext
             // Marten.PLv8 is necessary for patching
             opts.UseJavascriptTransformsAndPatching();
 
-            // The default lifecycle is inline
-            opts.Projections.Add(new QuestPatchTestProjection());
+            // Use inline lifecycle
+            opts.Projections.Add(new QuestPatchTestProjection(), ProjectionLifecycle.Inline);
 
             // Or use this as an asychronous projection
             opts.Projections.Add(new QuestPatchTestProjection(), ProjectionLifecycle.Async);
@@ -856,7 +856,7 @@ public class patching_api: OneOffConfigurationsContext
             _.AutoCreateSchemaObjects = AutoCreate.All;
             _.Events.TenancyStyle = tenancyStyle;
 
-            _.Projections.Add(new QuestPatchTestProjection());
+            _.Projections.Add(new QuestPatchTestProjection(), ProjectionLifecycle.Inline);
 
             _.UseJavascriptTransformsAndPatching();
         });

--- a/src/Marten/Events/Projections/ExperimentalMultiStreamProjection.cs
+++ b/src/Marten/Events/Projections/ExperimentalMultiStreamProjection.cs
@@ -22,7 +22,6 @@ public abstract class ExperimentalMultiStreamProjection<TDoc, TId>: GeneratedAgg
 
     protected ExperimentalMultiStreamProjection(): base(AggregationScope.MultiStream)
     {
-        Lifecycle = ProjectionLifecycle.Async;
     }
 
     public virtual ValueTask<IReadOnlyList<EventSlice<TDoc, TId>>> SliceInlineActions(IQuerySession querySession,

--- a/src/Marten/Events/Projections/GeneratedProjection.cs
+++ b/src/Marten/Events/Projections/GeneratedProjection.cs
@@ -22,7 +22,6 @@ public abstract class GeneratedProjection: ProjectionBase, IProjectionSource, IC
     protected GeneratedProjection(string projectionName)
     {
         ProjectionName = projectionName;
-        Lifecycle = ProjectionLifecycle.Inline;
     }
 
     internal StoreOptions StoreOptions { get; set; }

--- a/src/Marten/Events/Projections/MultiStreamProjection.cs
+++ b/src/Marten/Events/Projections/MultiStreamProjection.cs
@@ -24,7 +24,6 @@ public abstract class MultiStreamProjection<TDoc, TId>: GeneratedAggregateProjec
 
     protected MultiStreamProjection(): base(AggregationScope.MultiStream)
     {
-        Lifecycle = ProjectionLifecycle.Async;
     }
 
     internal IEventSlicer<TDoc, TId> Slicer => _customSlicer ?? _defaultSlicer;
@@ -146,7 +145,6 @@ public abstract class MultiStreamProjection<TDoc, TId>: GeneratedAggregateProjec
 [Obsolete("Please switch to MultiStreamProjection<T> with the exact same syntax")]
 public abstract class MultiStreamAggregation<TDoc, TId>: MultiStreamProjection<TDoc, TId>
 {
-
 }
 
 [Obsolete("Please switch to MultiStreamProjection<T> with the exact same syntax")]

--- a/src/Marten/Events/Projections/ProjectionBase.cs
+++ b/src/Marten/Events/Projections/ProjectionBase.cs
@@ -20,7 +20,7 @@ public abstract class ProjectionBase
     /// <summary>
     ///     The projection lifecycle that governs when this projection is executed
     /// </summary>
-    public ProjectionLifecycle Lifecycle { get; set; } = ProjectionLifecycle.Async;
+    public ProjectionLifecycle Lifecycle { get; internal set; } = ProjectionLifecycle.Async;
 
     /// <summary>
     ///     Optimize this projection within the Async Daemon by

--- a/src/Marten/Events/Projections/ProjectionLifecycle.cs
+++ b/src/Marten/Events/Projections/ProjectionLifecycle.cs
@@ -37,21 +37,21 @@ public enum SnapshotLifecycle
 
 public static class SnapshotLifecycleExtensions
 {
-    public static SnapshotLifecycle? Map(this ProjectionLifecycle? projectionLifecycle) =>
+    public static SnapshotLifecycle Map(this ProjectionLifecycle projectionLifecycle) =>
         projectionLifecycle switch
         {
             ProjectionLifecycle.Inline => SnapshotLifecycle.Inline,
             ProjectionLifecycle.Async => SnapshotLifecycle.Async,
             ProjectionLifecycle.Live => throw new ArgumentOutOfRangeException(nameof(projectionLifecycle),
                 "Snapshot lifecycle cannot be live!"),
-            null => null
+            _ => throw new ArgumentOutOfRangeException(nameof(projectionLifecycle), projectionLifecycle, null)
         };
 
-    public static ProjectionLifecycle? Map(this SnapshotLifecycle? projectionLifecycle) =>
+    public static ProjectionLifecycle Map(this SnapshotLifecycle projectionLifecycle) =>
         projectionLifecycle switch
         {
             SnapshotLifecycle.Inline => ProjectionLifecycle.Inline,
             SnapshotLifecycle.Async => ProjectionLifecycle.Async,
-            null => null
+            _ => throw new ArgumentOutOfRangeException(nameof(projectionLifecycle), projectionLifecycle, null)
         };
 }


### PR DESCRIPTION
We had different projection lifecycles that could be dependent on the projection type. That was confusing enough and it could create nasty production issues in the case missing that fact. We decided to make it explicit.