### PR TITLE
Return existing state from AggregateStreamAsync when no events to apply to it

### DIFF
--- a/src/EventSourcingTests/Aggregation/aggregate_stream_into_samples.cs
+++ b/src/EventSourcingTests/Aggregation/aggregate_stream_into_samples.cs
@@ -77,7 +77,6 @@ namespace EventSourcingTests.Aggregation
 
     #endregion
 
-
     #region sample_aggregate-stream-into-state-wrapper
 
     public class CashRegisterRepository
@@ -139,12 +138,30 @@ namespace EventSourcingTests.Aggregation
             const int baseStateVersion = 1;
 
             #region sample_aggregate-stream-into-state-default
+
             await theSession.Events.AggregateStreamAsync(
                 streamId,
                 state: baseState,
                 fromVersion: baseStateVersion
             );
+
             #endregion
+        }
+
+        public async Task AggregatingEmptyStreamIntoStateShouldNotReturnNullButState()
+        {
+            var notExistingStreamId = Guid.NewGuid();
+
+            var state = new FinancialAccount();
+
+            (await theSession.Events.AggregateStreamAsync<FinancialAccount>(
+                notExistingStreamId
+            )).ShouldBeNull();
+
+            (await theSession.Events.AggregateStreamAsync(
+                notExistingStreamId,
+                state: state
+            )).ShouldBe(state);
         }
 
         [Fact]

--- a/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs
+++ b/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs
@@ -5,7 +5,6 @@ using Marten;
 using Marten.AsyncDaemon.Testing.TestingSupport;
 using Marten.Events.Aggregation;
 using Marten.Events.Projections;
-using Marten.Services;
 using Samples.Deleting3;
 
 namespace Marten.AsyncDaemon.Testing.TestingSupport

--- a/src/Marten/Events/QueryEventStore.cs
+++ b/src/Marten/Events/QueryEventStore.cs
@@ -120,7 +120,7 @@ internal class QueryEventStore: IQueryEventStore
 
         if (!events.Any())
         {
-            return null;
+            return state;
         }
 
         var aggregate = aggregator.Build(events, _session, state);
@@ -140,7 +140,7 @@ internal class QueryEventStore: IQueryEventStore
         var events = await FetchStreamAsync(streamId, version, timestamp, fromVersion, token).ConfigureAwait(false);
         if (!events.Any())
         {
-            return null;
+            return state;
         }
 
         var aggregator = _store.Options.Projections.AggregatorFor<T>();
@@ -166,7 +166,7 @@ internal class QueryEventStore: IQueryEventStore
         var events = FetchStream(streamKey, version, timestamp, fromVersion);
         if (!events.Any())
         {
-            return null;
+            return state;
         }
 
         var aggregator = _store.Options.Projections.AggregatorFor<T>();
@@ -187,7 +187,7 @@ internal class QueryEventStore: IQueryEventStore
         var events = await FetchStreamAsync(streamKey, version, timestamp, fromVersion, token).ConfigureAwait(false);
         if (!events.Any())
         {
-            return null;
+            return state;
         }
 
         var aggregator = _store.Options.Projections.AggregatorFor<T>();


### PR DESCRIPTION
Fixes #2541.

This change will be a step ahead to prepare us for archive scenarios when the stream is partially archived, and an empty stream might mean no existing one.