### PR TITLE
Ensure events with both `Create` and `Apply` are only ever handled once

### DIFF
--- a/docs/configuration/hostbuilder.md
+++ b/docs/configuration/hostbuilder.md
@@ -246,7 +246,7 @@ public interface IConfigureMarten
     void Configure(IServiceProvider services, StoreOptions options);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/MartenServiceCollectionExtensions.cs#L732-L743' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iconfiguremarten' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/MartenServiceCollectionExtensions.cs#L734-L745' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iconfiguremarten' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You could alternatively implement a custom `IConfigureMarten` class like so:

--- a/docs/events/projections/aggregate-projections.md
+++ b/docs/events/projections/aggregate-projections.md
@@ -97,7 +97,7 @@ public class TripProjection: SingleStreamProjection<Trip>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L44-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L43-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And register that projection like this:
@@ -116,7 +116,7 @@ var store = DocumentStore.For(opts =>
     opts.Projections.Add<TripProjection>(ProjectionLifecycle.Async);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L17-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_an_aggregate_projection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L16-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_an_aggregate_projection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Any projection based on `SingleStreamProjection<T>` will allow you to define steps by event type to either create, delete, or mutate an aggregate
@@ -185,7 +185,7 @@ public class Trip
     internal bool ShouldDelete(VacationOver e) => Traveled > 1000;
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L113-L163' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_trip_stream_aggregation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L112-L162' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_trip_stream_aggregation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or finally, you can use a method named `Create()` on a projection type as shown in this sample:
@@ -221,7 +221,7 @@ public class TripProjection: SingleStreamProjection<Trip>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L44-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L43-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `Create()` method has to return either the aggregate document type or `Task<T>` where `T` is the aggregate document type. There must be an argument for the specific event type or `Event<T>` where `T` is the event type if you need access to event metadata. You can also take in an `IQuerySession` if you need to look up additional data as part of the transformation or `IEvent` in addition to the exact event type just to get at event metadata.
@@ -261,7 +261,7 @@ public class TripProjection: SingleStreamProjection<Trip>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L169-L194' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_projectevent_in_aggregate_projection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L168-L193' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_projectevent_in_aggregate_projection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 I'm not personally that wild about using lots of inline Lambdas like the example above, and to that end, Marten now supports the `Apply()` method convention. Here's the same `TripProjection`, but this time using methods to mutate the `Trip` document:
@@ -297,7 +297,7 @@ public class TripProjection: SingleStreamProjection<Trip>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L44-L74' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L43-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `Apply()` methods can accept any combination of these arguments:
@@ -466,7 +466,7 @@ public class Trip
     internal bool ShouldDelete(VacationOver e) => Traveled > 1000;
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L113-L163' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_trip_stream_aggregation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L112-L162' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_trip_stream_aggregation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Here's an example of using the various ways of doing `Trip` stream aggregation:
@@ -500,7 +500,7 @@ internal async Task use_a_stream_aggregation()
     var trip = await session.Events.AggregateStreamAsync<Trip>(tripId);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L81-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_stream_aggregation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L80-L108' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_stream_aggregation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Aggregate Versioning

--- a/docs/events/projections/live-aggregates.md
+++ b/docs/events/projections/live-aggregates.md
@@ -231,7 +231,7 @@ await theSession.Events.AggregateStreamAsync(
     fromVersion: baseStateVersion
 );
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/aggregate_stream_into_samples.cs#L141-L147' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_aggregate-stream-into-state-default' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/aggregate_stream_into_samples.cs#L140-L148' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_aggregate-stream-into-state-default' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 It can be helpful, for instance, in snapshotting. Snapshot is a state of the stream at a specific point of time (version). It is a performance optimization that shouldn't be your first choice, but it's an option to consider for performance-critical computations. As you're optimizing your processing, you usually don't want to store a snapshot after each event not to increase the number of writes. Usually, you'd like to do a snapshot on the specific interval or specific event type.
@@ -360,7 +360,7 @@ public class CashRegisterRepository
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/aggregate_stream_into_samples.cs#L81-L131' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_aggregate-stream-into-state-wrapper' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/aggregate_stream_into_samples.cs#L80-L130' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_aggregate-stream-into-state-wrapper' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Then append event and store snapshot on opening accounting month:
@@ -390,7 +390,7 @@ var repository = new CashRegisterRepository(theSession);
 
 await repository.Store(openedCashierShift, cashierShiftOpened);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/aggregate_stream_into_samples.cs#L164-L188' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_aggregate-stream-into-state-store' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/aggregate_stream_into_samples.cs#L181-L205' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_aggregate-stream-into-state-store' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 and read snapshot and following event with:
@@ -400,7 +400,7 @@ and read snapshot and following event with:
 ```cs
 var currentState = await repository.Get(financialAccountId);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/aggregate_stream_into_samples.cs#L207-L211' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_aggregate-stream-into-state-get' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/aggregate_stream_into_samples.cs#L224-L228' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_aggregate-stream-into-state-get' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Live Aggregation from Linq Queries

--- a/src/EventSourcingTests/Bugs/Bug_2528_projections_should_handle_each_event_once.cs
+++ b/src/EventSourcingTests/Bugs/Bug_2528_projections_should_handle_each_event_once.cs
@@ -9,30 +9,115 @@ namespace EventSourcingTests.Bugs;
 public class Bug_2528_projections_should_handle_each_event_once: BugIntegrationContext
 {
     [Fact]
-    public async Task count_of_events_should_match_event_count()
+    public async Task projection_with_create_method_should_use_create_not_apply()
     {
         var streamId = Guid.NewGuid();
         theSession.Events.Append(streamId, new IncrementEvent(), new IncrementEvent(), new IncrementEvent());
         await theSession.SaveChangesAsync();
 
-        var aggregate = await theSession.Events.AggregateStreamAsync<CounterProjection>(streamId);
+        var aggregate = await theSession.Events.AggregateStreamAsync<CounterWithCreate>(streamId);
 
         Assert.NotNull(aggregate);
-        Assert.Equal(3, aggregate.Counter);
+        Assert.Equal(streamId, aggregate.Id);
+        Assert.Equal(1, aggregate.CreateCounter);
+        Assert.Equal(2, aggregate.ApplyCounter);
+    }
+
+    [Fact]
+    public async Task projection_with_default_ctor_should_use_apply()
+    {
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId, new IncrementEvent(), new IncrementEvent(), new IncrementEvent());
+        await theSession.SaveChangesAsync();
+
+        var aggregate = await theSession.Events.AggregateStreamAsync<CounterWithDefaultCtor>(streamId);
+
+        Assert.NotNull(aggregate);
+        Assert.Equal(streamId, aggregate.Id);
+        Assert.Equal(0, aggregate.CreateCounter);
+        Assert.Equal(3, aggregate.ApplyCounter);
+    }
+
+    [Fact]
+    public async Task projection_with_create_and_ctor_should_use_create_on_event_match()
+    {
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId, new IncrementEvent(), new IncrementEvent(), new IncrementEvent());
+        await theSession.SaveChangesAsync();
+
+        var aggregate = await theSession.Events.AggregateStreamAsync<CounterWithCreateAndDefaultCtor>(streamId);
+
+        Assert.NotNull(aggregate);
+        Assert.Equal(streamId, aggregate.Id);
+        Assert.Equal(1, aggregate.CreateCounter);
+        Assert.Equal(2, aggregate.ApplyCounter);
+    }
+
+    [Fact]
+    public async Task projection_with_create_and_ctor_should_use_default_ctor_on_no_event_match()
+    {
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId, new UnrelatedEvent(), new IncrementEvent(), new IncrementEvent(), new IncrementEvent());
+        await theSession.SaveChangesAsync();
+
+        var aggregate = await theSession.Events.AggregateStreamAsync<CounterWithCreateAndDefaultCtor>(streamId);
+
+        Assert.NotNull(aggregate);
+        Assert.Equal(streamId, aggregate.Id);
+        Assert.Equal(0, aggregate.CreateCounter);
+        Assert.Equal(3, aggregate.ApplyCounter);
     }
 
     public record IncrementEvent;
+    public record UnrelatedEvent;
 
-    public record CounterProjection(Guid Id, int Counter)
+    public record CounterWithCreate(Guid Id, int CreateCounter, int ApplyCounter)
     {
-        public static CounterProjection Create(IncrementEvent @event, IEvent metadata)
+        public static CounterWithCreate Create(IncrementEvent @event, IEvent metadata)
         {
-            return new CounterProjection(metadata.StreamId, 1);
+            return new CounterWithCreate(metadata.StreamId, 1, 0);
         }
 
-        public CounterProjection Apply(IncrementEvent @event, CounterProjection current)
+        public CounterWithCreate Apply(IncrementEvent @event, CounterWithCreate current)
         {
-            return current with {Counter = current.Counter + 1};
+            return current with { ApplyCounter = current.ApplyCounter + 1};
+        }
+    }
+
+    public record CounterWithDefaultCtor
+    {
+        public CounterWithDefaultCtor()
+        {
+            // will be initialized through reflection
+            Id = Guid.Empty;
+            CreateCounter = 0;
+            ApplyCounter = 0;
+        }
+
+        public CounterWithDefaultCtor Apply(IncrementEvent @event, CounterWithDefaultCtor current)
+        {
+            return current with { ApplyCounter = current.ApplyCounter + 1 };
+        }
+
+        public Guid Id { get; init; }
+        public int CreateCounter { get; init; }
+        public int ApplyCounter { get; init; }
+    }
+
+    public record CounterWithCreateAndDefaultCtor(Guid Id, int CreateCounter, int ApplyCounter)
+    {
+        public CounterWithCreateAndDefaultCtor(): this(Guid.Empty, 0, 0)
+        {
+        }
+
+        public static CounterWithCreateAndDefaultCtor Create(IncrementEvent @event, IEvent metadata)
+        {
+            return new CounterWithCreateAndDefaultCtor(metadata.StreamId, 1, 0);
+        }
+
+        public CounterWithCreateAndDefaultCtor Apply(IncrementEvent @event, CounterWithCreateAndDefaultCtor current)
+        {
+            return current with { ApplyCounter = current.ApplyCounter + 1 };
         }
     }
 }

--- a/src/EventSourcingTests/Bugs/Bug_2528_projections_should_handle_each_event_once.cs
+++ b/src/EventSourcingTests/Bugs/Bug_2528_projections_should_handle_each_event_once.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading.Tasks;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+public class Bug_2528_projections_should_handle_each_event_once: BugIntegrationContext
+{
+    [Fact]
+    public async Task count_of_events_should_match_event_count()
+    {
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId, new IncrementEvent(), new IncrementEvent(), new IncrementEvent());
+        await theSession.SaveChangesAsync();
+
+        var aggregate = await theSession.Events.AggregateStreamAsync<CounterProjection>(streamId);
+
+        Assert.NotNull(aggregate);
+        Assert.Equal(3, aggregate.Counter);
+    }
+
+    public record IncrementEvent;
+
+    public record CounterProjection(Guid Id, int Counter)
+    {
+        public static CounterProjection Create(IncrementEvent @event, IEvent metadata)
+        {
+            return new CounterProjection(metadata.StreamId, 1);
+        }
+
+        public CounterProjection Apply(IncrementEvent @event, CounterProjection current)
+        {
+            return current with {Counter = current.Counter + 1};
+        }
+    }
+}

--- a/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.CodeGen.cs
+++ b/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.CodeGen.cs
@@ -76,6 +76,7 @@ public abstract partial class GeneratedAggregateProjectionBase<T>
 
         assembly.Rules.ReferenceTypes(_applyMethods.ReferencedTypes().ToArray());
         assembly.Rules.ReferenceTypes(_createMethods.ReferencedTypes().ToArray());
+        assembly.Rules.ReferenceTypes(_createDefaultMethod.ReferencedTypes().ToArray());
         assembly.Rules.ReferenceTypes(_shouldDeleteMethods.ReferencedTypes().ToArray());
 
         // Walk the assembly dependencies for the projection and aggregate types,
@@ -164,6 +165,7 @@ public abstract partial class GeneratedAggregateProjectionBase<T>
         _inlineGeneratedType = assembly.AddType(_inlineAggregationHandlerType, inlineBaseType);
 
         _createMethods.BuildCreateMethod(_inlineGeneratedType, _aggregateMapping);
+        _createDefaultMethod.BuildCreateDefaultMethod(_inlineGeneratedType, _aggregateMapping);
 
         _inlineGeneratedType.AllInjectedFields.Add(new InjectedField(GetType()));
 
@@ -171,6 +173,7 @@ public abstract partial class GeneratedAggregateProjectionBase<T>
 
         _inlineGeneratedType.Setters.AddRange(_applyMethods.Setters());
         _inlineGeneratedType.Setters.AddRange(_createMethods.Setters());
+        _inlineGeneratedType.Setters.AddRange(_createDefaultMethod.Setters());
         _inlineGeneratedType.Setters.AddRange(_shouldDeleteMethods.Setters());
     }
 
@@ -200,6 +203,13 @@ public abstract partial class GeneratedAggregateProjectionBase<T>
         foreach (var slot in _applyMethods.Methods) eventHandlers[slot.EventType].Apply = new ApplyMethodCall(slot);
 
         foreach (var slot in _createMethods.Methods)
+        {
+            eventHandlers[slot.EventType].CreationFrame = slot.Method is ConstructorInfo
+                ? new AggregateConstructorFrame(slot)
+                : new CreateAggregateFrame(slot);
+        }
+
+        foreach (var slot in _createDefaultMethod.Methods)
         {
             eventHandlers[slot.EventType].CreationFrame = slot.Method is ConstructorInfo
                 ? new AggregateConstructorFrame(slot)
@@ -254,10 +264,12 @@ public abstract partial class GeneratedAggregateProjectionBase<T>
         _liveGeneratedType.AllInjectedFields.Add(new InjectedField(GetType()));
 
         _createMethods.BuildCreateMethod(_liveGeneratedType, _aggregateMapping);
+        _createDefaultMethod.BuildCreateDefaultMethod(_liveGeneratedType, _aggregateMapping);
         _applyMethods.BuildApplyMethod(_liveGeneratedType, _aggregateMapping);
 
         _liveGeneratedType.Setters.AddRange(_applyMethods.Setters());
         _liveGeneratedType.Setters.AddRange(_createMethods.Setters());
+        _liveGeneratedType.Setters.AddRange(_createDefaultMethod.Setters());
         _liveGeneratedType.Setters.AddRange(_shouldDeleteMethods.Setters());
     }
 }

--- a/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.cs
+++ b/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.cs
@@ -21,6 +21,7 @@ public abstract partial class GeneratedAggregateProjectionBase<T>: GeneratedProj
     internal readonly ApplyMethodCollection _applyMethods;
 
     internal readonly CreateMethodCollection _createMethods;
+    internal readonly CreateDefaultMethod _createDefaultMethod;
     private readonly string _inlineAggregationHandlerType;
     private readonly string _liveAggregationTypeName;
     internal readonly ShouldDeleteMethodCollection _shouldDeleteMethods;
@@ -36,6 +37,7 @@ public abstract partial class GeneratedAggregateProjectionBase<T>: GeneratedProj
     protected GeneratedAggregateProjectionBase(AggregationScope scope): base(typeof(T).NameInCode())
     {
         _createMethods = new CreateMethodCollection(GetType(), typeof(T));
+        _createDefaultMethod = new CreateDefaultMethod(GetType(), typeof(T));
         _applyMethods = new ApplyMethodCollection(GetType(), typeof(T));
         _shouldDeleteMethods = new ShouldDeleteMethodCollection(GetType(), typeof(T));
 

--- a/src/Marten/Events/CodeGeneration/CallApplyAggregateFrame.cs
+++ b/src/Marten/Events/CodeGeneration/CallApplyAggregateFrame.cs
@@ -12,6 +12,7 @@ internal class CallApplyAggregateFrame: Frame
     private Variable _aggregate;
     private Variable _cancellation;
     private Variable _session;
+    private Variable _usedEventOnCreate;
 
     public CallApplyAggregateFrame(ApplyMethodCollection methods): base(methods.IsAsync)
     {
@@ -27,6 +28,9 @@ internal class CallApplyAggregateFrame: Frame
 
         _session = chain.TryFindVariable(typeof(IQuerySession), VariableSource.All) ??
                    chain.FindVariable(typeof(IDocumentSession));
+
+        _usedEventOnCreate = chain.FindVariableByName(typeof(bool), CallCreateAggregateFrame.UsedEventOnCreateName);
+
         yield return _session;
 
         if (IsAsync)
@@ -43,7 +47,7 @@ internal class CallApplyAggregateFrame: Frame
     {
         if (InsideForEach)
         {
-            writer.Write("BLOCK:foreach (var @event in events.Skip(1))");
+            writer.Write($"BLOCK:foreach (var @event in events.Skip({_usedEventOnCreate.Usage} ? 1 : 0))");
         }
 
         if (IsAsync)

--- a/src/Marten/Events/CodeGeneration/CallApplyAggregateFrame.cs
+++ b/src/Marten/Events/CodeGeneration/CallApplyAggregateFrame.cs
@@ -43,7 +43,7 @@ internal class CallApplyAggregateFrame: Frame
     {
         if (InsideForEach)
         {
-            writer.Write("BLOCK:foreach (var @event in events)");
+            writer.Write("BLOCK:foreach (var @event in events.Skip(1))");
         }
 
         if (IsAsync)

--- a/src/Marten/Events/CodeGeneration/CreateDefaultMethod.cs
+++ b/src/Marten/Events/CodeGeneration/CreateDefaultMethod.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core;
+using Marten.Schema;
+
+namespace Marten.Events.CodeGeneration;
+
+internal class CreateDefaultMethod: MethodCollection
+{
+    public static readonly string MethodName = "CreateDefault";
+
+    public CreateDefaultMethod(Type projectionType, Type aggregateType) : base(MethodName, projectionType,
+        aggregateType)
+    {
+        _validReturnTypes.Fill(aggregateType);
+    }
+
+    internal override void validateMethod(MethodSlot method)
+    {
+        // Nothing, no special rules
+    }
+
+    protected override BindingFlags flags()
+    {
+        return BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic;
+    }
+
+    public void BuildCreateDefaultMethod(GeneratedType generatedType, IDocumentMapping aggregateMapping)
+    {
+        var args = new[] { new Argument(typeof(IEvent), "@event") };
+        var method = new GeneratedMethod(MethodName, AggregateType, args);
+        method.AsyncMode = AsyncMode.None;
+        generatedType.AddMethod(method);
+        method.Frames.Add(new DefaultAggregateConstruction(AggregateType, generatedType)
+        {
+            IfStyle = IfStyle.None,
+            AdditionalNoConstructorExceptionDetails =
+                " or Create method for {@event.DotNetTypeName} event type." +
+                "Check more about the create method convention in documentation: https://martendb.io/events/projections/event-projections.html#create-method-convention. " +
+                "If you're using Upcasting, check if {@event.DotNetTypeName} is an old event type. " +
+                "If it is, make sure to define transformation for it to new event type. " +
+                "Read more in Upcasting docs: https://martendb.io/events/versioning.html#upcasting-advanced-payload-transformations"
+        });
+    }
+
+    public override IEventHandlingFrame CreateEventTypeHandler(Type aggregateType,
+        IDocumentMapping aggregateMapping, MethodSlot slot)
+    {
+        if (slot.Method is ConstructorInfo)
+        {
+            return new AggregateConstructorFrame(slot);
+        }
+
+        return new CreateAggregateFrame(slot);
+    }
+}

--- a/src/Marten/Events/CodeGeneration/CreateMethodCollection.cs
+++ b/src/Marten/Events/CodeGeneration/CreateMethodCollection.cs
@@ -62,17 +62,7 @@ internal class CreateMethodCollection: MethodCollection
         var eventHandling = AddEventHandling(AggregateType, aggregateMapping, this);
         method.Frames.Add(eventHandling);
 
-
-        method.Frames.Add(new DefaultAggregateConstruction(AggregateType, generatedType)
-        {
-            IfStyle = IfStyle.None,
-            AdditionalNoConstructorExceptionDetails =
-                " or Create method for {@event.DotNetTypeName} event type." +
-                "Check more about the create method convention in documentation: https://martendb.io/events/projections/event-projections.html#create-method-convention. " +
-                "If you're using Upcasting, check if {@event.DotNetTypeName} is an old event type. " +
-                "If it is, make sure to define transformation for it to new event type. " +
-                "Read more in Upcasting docs: https://martendb.io/events/versioning.html#upcasting-advanced-payload-transformations"
-        });
+        method.Frames.ReturnNull();
     }
 
     public override IEventHandlingFrame CreateEventTypeHandler(Type aggregateType,


### PR DESCRIPTION
Fixes #2528

Expected outcome: Each event passed into a projection is handled a maximum of once, either with a `Create` or an `Apply` method.

Old behaviour: If the first event in a stream has matching `Create` and `Apply` methods, both would be called.

New behaviour: If a `Create` method matches, that event is then skipped when iterating over apply event methods.

Example of issue:

```c#
    public record IncrementEvent{}

    public record CounterProjection(Guid Id, int Counter)
    {
        public static CounterProjection Create(IncrementEvent @event, IEvent metadata)
        {
            return new CounterProjection(metadata.StreamId, 1);
        }

        public CounterProjection Apply(IncrementEvent @event, CounterProjection current)
        {
            return current with {Counter = current.Counter + 1};
        }
    }

    [Fact]
    public async Task count_of_events_should_match_event_count()
    {
        var streamId = Guid.NewGuid();
        theSession.Events.Append(streamId, new IncrementEvent(), new IncrementEvent(), new IncrementEvent());
        await theSession.SaveChangesAsync();

        var aggregate = await theSession.Events.AggregateStreamAsync<CounterProjection>(streamId);

        Assert.NotNull(aggregate);
        Assert.Equal(3, aggregate.Counter); // Returned 4 before fix
    }
```

This required a bit of fiddling around with the codegeneration which I am definitly not super confident in. Pretty sure my changes are solid thanks to the tests covering them, but my approach may be off.