### PR TITLE
Fix broken markdown link in docs

### DIFF
--- a/docs/schema/extensions.md
+++ b/docs/schema/extensions.md
@@ -1,6 +1,6 @@
 # Schema Feature Extensions
 
-New in Marten 5.4.0 is the ability to add additional features with custom database schema objects that simply plug into Marten's [schema management facilities)[/schema/migrations). The key abstraction is the `IFeatureSchema` interface from the [Weasel.Core](https://www.nuget.org/packages/Weasel.Core/) library.
+New in Marten 5.4.0 is the ability to add additional features with custom database schema objects that simply plug into Marten's [schema management facilities](/schema/migrations). The key abstraction is the `IFeatureSchema` interface from the [Weasel.Core](https://www.nuget.org/packages/Weasel.Core/) library.
 
 Not to worry though, Marten comes with a base class that makes it a bit simpler to build out new features. Here's a very simple example that defines a custom table with one column:
 


### PR DESCRIPTION
Fixed a broken link due to a small parenthesis switch-up.