### PR TITLE
Transaction error

### DIFF
--- a/src/CoreTests/ability_to_use_an_existing_connection_and_transaction.cs
+++ b/src/CoreTests/ability_to_use_an_existing_connection_and_transaction.cs
@@ -137,7 +137,7 @@ public class ability_to_use_an_existing_connection_and_transaction: IntegrationC
             using (var session = theStore.QuerySession())
             {
                 //See https://github.com/npgsql/npgsql/issues/1483 - Npgsql by default is enlisting
-                session.Query<Target>().Count().ShouldBe(102);
+                session.Query<Target>().Count().ShouldBe(2);
             }
 
             scope.Complete();
@@ -146,7 +146,7 @@ public class ability_to_use_an_existing_connection_and_transaction: IntegrationC
         // should be 2 additional targets
         using (var session = theStore.QuerySession())
         {
-            session.Query<Target>().Count().ShouldBe(102);
+            session.Query<Target>().Count().ShouldBe(2);
         }
     }
 

--- a/src/CoreTests/ability_to_use_an_existing_connection_and_transaction.cs
+++ b/src/CoreTests/ability_to_use_an_existing_connection_and_transaction.cs
@@ -26,6 +26,7 @@ public class ability_to_use_an_existing_connection_and_transaction: IntegrationC
 
     protected override Task fixtureSetup()
     {
+        return Task.CompletedTask;
         return theStore.BulkInsertDocumentsAsync(targets);
     }
 
@@ -107,7 +108,7 @@ public class ability_to_use_an_existing_connection_and_transaction: IntegrationC
             using (var session = theStore.QuerySession())
             {
                 //See https://github.com/npgsql/npgsql/issues/1483 - Npgsql by default is enlisting
-                session.Query<Target>().Count().ShouldBe(102);
+                session.Query<Target>().Count().ShouldBe(2);
             }
 
             scope.Complete();


### PR DESCRIPTION
@oskardudycz we discussed this a long time ago on gitter and you asked me to make a PR with a failing test. So about 8 months later, here it is :)

I am having issues with npgsql elevating transactions to prepared and then failing with 
`55000: prepared transactions are disabled`

I modified `enlist_in_transaction_scope_by_transaction` test, so it skips the bulk insertion inside  `fixtureSetup`.
Notice that without the bulk insertion, the seemingly textbook case of enrolling in a transaction fails with the error message above.


