### PR TITLE
Fix: Broken queries on JsonProperty attributes

### DIFF
--- a/src/CoreTests/Bugs/Bug_9001_json_properties_without_names_should_work.cs
+++ b/src/CoreTests/Bugs/Bug_9001_json_properties_without_names_should_work.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using Marten;
+using Marten.Testing.Harness;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+public class Bug_9001_json_properties_without_names: BugIntegrationContext
+{
+    [Fact]
+    public async Task document_with_json_properties_without_names_should_still_be_queryable()
+    {
+        StoreOptions(opts => opts.RegisterDocumentType<DocWithJsonProperties>());
+
+        var newDoc = new DocWithJsonProperties {Id = CombGuidIdGeneration.NewGuid(), Name = "foo"};
+        theSession.Store(newDoc);
+        await theSession.SaveChangesAsync();
+
+        var lookup = await theSession.Query<DocWithJsonProperties>().Where(x => x.Name == "foo").FirstOrDefaultAsync();
+        Assert.NotNull(lookup);
+        Assert.Equal(newDoc.Id, lookup.Id);
+    }
+
+    public class DocWithJsonProperties
+    {
+        public Guid Id { get; set; }
+
+        [JsonProperty]
+        public string Name { get; set; }
+    }
+}

--- a/src/Marten/Linq/Fields/FieldBase.cs
+++ b/src/Marten/Linq/Fields/FieldBase.cs
@@ -51,7 +51,7 @@ public abstract class FieldBase: IField
     private static string determineMemberLocator(Casing casing, MemberInfo member)
     {
         var memberLocator = member.Name.FormatCase(casing);
-        if (member.TryGetAttribute<JsonPropertyAttribute>(out var newtonsoftAtt))
+        if (member.TryGetAttribute<JsonPropertyAttribute>(out var newtonsoftAtt) && newtonsoftAtt.PropertyName is not null)
         {
             memberLocator = newtonsoftAtt.PropertyName;
         }


### PR DESCRIPTION
The `[JsonProperty]` attribute can set a property name override, but doesn't have to. If it doesn't, marten should revert to the default name.

```csharp
    [Fact]
    public async Task document_with_json_properties_without_names_should_still_be_queryable()
    {
        StoreOptions(opts => opts.RegisterDocumentType<DocWithJsonProperties>());

        var newDoc = new DocWithJsonProperties {Id = CombGuidIdGeneration.NewGuid(), Name = "foo"};
        theSession.Store(newDoc);
        await theSession.SaveChangesAsync();

        var lookup = await theSession.Query<DocWithJsonProperties>().Where(x => x.Name == "foo").FirstOrDefaultAsync();
        // expected query
        //  where (d.data ->> 'Name' = $1)

        // actual query
        //  where (d.data ->> '' = $1)

        Assert.NotNull(lookup);
        Assert.Equal(newDoc.Id, lookup.Id);
    }

    public class DocWithJsonProperties
    {
        public Guid Id { get; set; }

        // Lack of "name" here
        [JsonProperty]
        public string Name { get; set; }
    }
```