### PR TITLE
Fix: Runtime error when parsing a query with `Include()` in a multitenant database

### DIFF
--- a/src/CoreTests/Bugs/Bug_2602_include_with_conjoined_tenancy.cs
+++ b/src/CoreTests/Bugs/Bug_2602_include_with_conjoined_tenancy.cs
@@ -6,12 +6,11 @@ using System.Threading.Tasks;
 using JasperFx.Core;
 using Marten;
 using Marten.Testing.Harness;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace CoreTests.Bugs;
 
-public class Bug_9002_include_with_conjoined_tenancy: BugIntegrationContext
+public class Bug_2602_include_with_conjoined_tenancy: BugIntegrationContext
 {
     [Fact]
     public async Task multi_tenant_query_with_include_should_work()

--- a/src/CoreTests/Bugs/Bug_9002_includes_with_conjoined_tenancy_should_work - Copy.cs
+++ b/src/CoreTests/Bugs/Bug_9002_includes_with_conjoined_tenancy_should_work - Copy.cs
@@ -1,0 +1,46 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using Marten;
+using Marten.Testing.Harness;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+public class Bug_9002_include_with_conjoined_tenancy: BugIntegrationContext
+{
+    [Fact]
+    public async Task multi_tenant_query_with_include_should_work()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Policies.AllDocumentsAreMultiTenanted();
+            opts.RegisterDocumentType<User>();
+            opts.RegisterDocumentType<Document>();
+        });
+
+        var newUser = new User(CombGuidIdGeneration.NewGuid(), "Alex");
+        var newDoc = new Document(CombGuidIdGeneration.NewGuid(), "My Story", newUser.Id);
+
+        var session = theStore.LightweightSession("tenant1");
+        session.Store(newUser);
+        session.Store(newDoc);
+        await session.SaveChangesAsync();
+
+        var userDict = new Dictionary<Guid, User>();
+
+        var document = await session.Query<Document>().Include(x => x.Author, userDict).ToListAsync();
+
+        Assert.Single(document);
+        Assert.Single(userDict);
+
+        Assert.Equal(document.Single().Author, userDict.Single().Key);
+    }
+
+    public record Document(Guid Id, string Title, Guid Author);
+    public record User(Guid Id, string Name);
+}

--- a/src/Marten/Linq/Includes/IIncludePlan.cs
+++ b/src/Marten/Linq/Includes/IIncludePlan.cs
@@ -14,5 +14,5 @@ internal interface IIncludePlan
     Type DocumentType { get; }
     IIncludeReader BuildReader(IMartenSession session);
     bool IsIdCollection();
-    Statement BuildStatement(string tempTableName, IPagedStatement paging);
+    Statement BuildStatement(string tempTableName, IPagedStatement paging, IMartenSession session);
 }

--- a/src/Marten/Linq/Includes/IncludeIdentitySelectorStatement.cs
+++ b/src/Marten/Linq/Includes/IncludeIdentitySelectorStatement.cs
@@ -39,7 +39,7 @@ internal class IncludeIdentitySelectorStatement: Statement, ISelectClause
         Statement current = this;
         foreach (var include in includes)
         {
-            var includeStatement = include.BuildStatement(ExportName, OriginalPaging);
+            var includeStatement = include.BuildStatement(ExportName, OriginalPaging, session);
 
             current.InsertAfter(includeStatement);
             current = includeStatement;

--- a/src/Marten/Linq/Includes/IncludePlan.cs
+++ b/src/Marten/Linq/Includes/IncludePlan.cs
@@ -47,9 +47,9 @@ internal class IncludePlan<T>: IIncludePlan
     public string IdAlias { get; private set; }
     public string TempTableSelector { get; private set; }
 
-    public Statement BuildStatement(string tempTableName, IPagedStatement paging)
+    public Statement BuildStatement(string tempTableName, IPagedStatement paging, IMartenSession session)
     {
-        return new IncludedDocumentStatement(_storage, this, tempTableName, paging);
+        return new IncludedDocumentStatement(_storage, this, tempTableName, paging, session);
     }
 
     public IIncludeReader BuildReader(IMartenSession session)
@@ -60,12 +60,16 @@ internal class IncludePlan<T>: IIncludePlan
 
     public class IncludedDocumentStatement: SelectorStatement
     {
-        public IncludedDocumentStatement(IDocumentStorage<T> storage, IncludePlan<T> includePlan,
-            string tempTableName, IPagedStatement paging): base(storage, storage.Fields)
+        public IncludedDocumentStatement(
+            IDocumentStorage<T> storage,
+            IncludePlan<T> includePlan,
+            string tempTableName,
+            IPagedStatement paging,
+            IMartenSession session): base(storage, storage.Fields)
         {
             var initial = new InTempTableWhereFragment(tempTableName, includePlan.IdAlias, paging,
                 includePlan.IsIdCollection());
-            Where = storage.FilterDocuments(null, initial, null);
+            Where = storage.FilterDocuments(null, initial, session);
         }
 
         protected override void configure(CommandBuilder sql)


### PR DESCRIPTION
To reproduce:

Run any of the [include examples from the marten documentation](https://martendb.io/documents/querying/linq/include.html) using a connection with multitenancy/conjoined tenancy enabled. 

Caused by the session not being passed down into the `IncludePlan` so the tenant value cannot be fetched.

Fixes #2583