### PR TITLE
Fix: Similarly named where clauses get incorrectly reused

### DIFF
--- a/src/CoreTests/Bugs/Bug_2603_similar_named_props.cs
+++ b/src/CoreTests/Bugs/Bug_2603_similar_named_props.cs
@@ -33,14 +33,14 @@ public class Bug_2603_similar_named_props: BugIntegrationContext
 
         // actual query:
         //   select d.id, d.data
-        //   from bugs.mt_doc_bug_9003_similar_named_props_document as d
+        //   from bugs.mt_doc_bug_2603_similar_named_props_document as d
         //   where (d.tenant_id = $1  and  (d.data -> 'Foo' ->> 'BarBaz' = $2 or d.data -> 'Foo' ->> 'BarBaz' = $3))
         //                                                            incorrect--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         // parameters: $1 = '*DEFAULT*', $2 = 'aaa', $3 = 'ddd'
 
         // query should be:
         //   select d.id, d.data
-        //   from bugs.mt_doc_bug_9003_similar_named_props_document as d
+        //   from bugs.mt_doc_bug_2603_similar_named_props_document as d
         //   where (d.tenant_id = $1  and  (d.data -> 'Foo' ->> 'BarBaz' = $2 or d.data -> 'FooBar' ->> 'Baz' = $3))
         //                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         // parameters: $1 = '*DEFAULT*', $2 = 'aaa', $3 = 'ddd'

--- a/src/CoreTests/Bugs/Bug_2603_similar_named_props.cs
+++ b/src/CoreTests/Bugs/Bug_2603_similar_named_props.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace CoreTests.Bugs;
 
-public class Bug_9003_similar_named_props: BugIntegrationContext
+public class Bug_2603_similar_named_props: BugIntegrationContext
 {
     [Fact]
     public async Task where_clause_with_similar_names_should_still_be_different()

--- a/src/CoreTests/Bugs/Bug_9003_similar_named_props.cs
+++ b/src/CoreTests/Bugs/Bug_9003_similar_named_props.cs
@@ -1,0 +1,58 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+public class Bug_9003_similar_named_props: BugIntegrationContext
+{
+    [Fact]
+    public async Task where_clause_with_similar_names_should_still_be_different()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Policies.AllDocumentsAreMultiTenanted();
+            opts.RegisterDocumentType<Document>();
+        });
+
+        var doc1 = new Document(Guid.NewGuid(), new Foo("aaa"), new FooBar("bbb"));
+        var doc2 = new Document(Guid.NewGuid(), new Foo("ccc"), new FooBar("ddd"));
+
+        theSession.Store(doc1);
+        theSession.Store(doc2);
+        await theSession.SaveChangesAsync();
+
+        // expected: should match both documents
+        var lookup = await theSession.Query<Document>()
+            .Where(x => x.Foo.BarBaz == "aaa" || x.FooBar.Baz == "ddd")
+            .ToListAsync();
+
+        // actual query:
+        //   select d.id, d.data
+        //   from bugs.mt_doc_bug_9003_similar_named_props_document as d
+        //   where (d.tenant_id = $1  and  (d.data -> 'Foo' ->> 'BarBaz' = $2 or d.data -> 'Foo' ->> 'BarBaz' = $3))
+        //                                                            incorrect--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        // parameters: $1 = '*DEFAULT*', $2 = 'aaa', $3 = 'ddd'
+
+        // query should be:
+        //   select d.id, d.data
+        //   from bugs.mt_doc_bug_9003_similar_named_props_document as d
+        //   where (d.tenant_id = $1  and  (d.data -> 'Foo' ->> 'BarBaz' = $2 or d.data -> 'FooBar' ->> 'Baz' = $3))
+        //                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        // parameters: $1 = '*DEFAULT*', $2 = 'aaa', $3 = 'ddd'
+
+        Assert.Equal(2, lookup.Count);
+        Assert.Contains(lookup, x => x.Id == doc1.Id);
+        Assert.Contains(lookup, x => x.Id == doc2.Id);
+    }
+
+    public record Document(Guid Id, Foo Foo, FooBar FooBar);
+
+    public record Foo(string BarBaz);
+
+    public record FooBar(string Baz);
+}

--- a/src/DocumentDbTests/Indexes/duplicated_field.cs
+++ b/src/DocumentDbTests/Indexes/duplicated_field.cs
@@ -14,11 +14,19 @@ using Shouldly;
 using Weasel.Core;
 using Weasel.Postgresql.Tables;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DocumentDbTests.Indexes;
 
 public class duplicated_field: OneOffConfigurationsContext
 {
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public duplicated_field(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
     [Fact]
     public void can_insert_document_with_duplicated_field_with_DuplicatedFieldEnumStorage_set_to_string()
     {
@@ -255,7 +263,9 @@ public class duplicated_field: OneOffConfigurationsContext
         results
             .Any(x => x.Id == thirdTarget.Id).ShouldBeTrue();
 
-        queryable.ToCommand(FetchType.FetchMany).CommandText.ShouldContain("inner_date = :p0", Case.Insensitive);
+        var text = queryable.ToCommand(FetchType.FetchMany).CommandText;
+        _testOutputHelper.WriteLine(text);
+        text.ShouldContain("inner_date = :p0", Case.Insensitive);
     }
 
     [Fact]

--- a/src/Marten/Linq/Fields/FieldCollection.cs
+++ b/src/Marten/Linq/Fields/FieldCollection.cs
@@ -61,7 +61,7 @@ public class FieldMapping: IFieldMapping
             return FieldFor(members.Single());
         }
 
-        var key = members.Select(x => x.Name).Join("");
+        var key = members.Select(x => x.Name).Join(".");
 
         return _fields.GetOrAdd(key,
             _ => resolveField(members.ToArray()));

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -601,7 +601,7 @@ public class DocumentMapping: FieldMapping, IDocumentMapping, IDocumentType
         bool notNull = false)
     {
         var field = FieldFor(members);
-        var memberName = members.Select(x => x.Name).Join("");
+        var memberName = members.Select(x => x.Name).Join(".");
 
         var duplicatedField = new DuplicatedField(StoreOptions.Advanced.DuplicatedFieldEnumStorage, field,
             StoreOptions.Advanced.DuplicatedFieldUseTimestampWithoutTimeZoneForDateTime, notNull);


### PR DESCRIPTION
When parsing expressions, marten will cache expression paths for future reuse. Unfortunately the caching key is not specific enough. For example, the following nested properties on document x:

* `x.Foo.Bar.Baz`
* `x.FooBar.Baz`
* `x.Foo.BarBaz`
* `x.FooBarBaz`

Will all be cached with a key of `FooBarBaz`. This can lead to incorrect query generation (see included tests).
The solution is to update the cache key to separate all properties with a `.`.