### PR TITLE
Add Dictionary ContainsKey support for value types

### DIFF
--- a/src/DocumentDbTests/Reading/Linq/dictionary_is_translated.cs
+++ b/src/DocumentDbTests/Reading/Linq/dictionary_is_translated.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Marten;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
@@ -16,7 +18,7 @@ public class dictionary_is_translated: IntegrationContext
     }
 
     [Fact]
-    public void dictionary_containskey_is_translated_to_json_map()
+    public void dictionary_string_containskey_is_translated_to_json_map()
     {
         var query = theSession.Query<Target>().Where(t => t.StringDict.ContainsKey("foo"));
         var command = query.ToCommand(Marten.Linq.FetchType.FetchMany);
@@ -25,21 +27,60 @@ public class dictionary_is_translated: IntegrationContext
         (dictParam.Value.ToString() == "foo").ShouldBeTrue();
     }
 
+    [Fact]
+    public void dictionary_guid_containskey_is_translated_to_json_map()
+    {
+        var guid = Guid.NewGuid();
+        var query = theSession.Query<Target>().Where(t => t.GuidDict.ContainsKey(guid));
+        var command = query.ToCommand(Marten.Linq.FetchType.FetchMany);
+        var dictParam = command.Parameters[0];
+        (dictParam.DbType == System.Data.DbType.String).ShouldBeTrue();
+        (dictParam.Value.ToString() == guid.ToString()).ShouldBeTrue();
+    }
+
     // using key0 and value0 for these because the last node, which is deep, should have at least a single dict node
 
     [Fact]
-    public void dict_can_query_using_containskey()
+    public void dict_string_can_query_using_containskey()
     {
         var results = theSession.Query<Target>().Where(x => x.StringDict.ContainsKey("key0")).ToList();
         results.All(r => r.StringDict.ContainsKey("key0")).ShouldBeTrue();
     }
 
     [Fact]
-    public void dict_can_query_using_containsKVP()
+    public async Task dict_guid_can_query_using_containskey()
+    {
+        var guid = Guid.NewGuid();
+        var target = new Target();
+        target.GuidDict.Add(guid, Guid.NewGuid());
+        theSession.Store(target);
+        await theSession.SaveChangesAsync();
+
+        var results = await theSession.Query<Target>().Where(x => x.GuidDict.ContainsKey(guid)).ToListAsync();
+        results.All(r => r.GuidDict.ContainsKey(guid)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void dict_string_can_query_using_containsKVP()
     {
         var kvp = new KeyValuePair<string, string>("key0", "value0");
         var results = theSession.Query<Target>().Where(x => x.StringDict.Contains(kvp)).ToList();
         results.All(r => r.StringDict.Contains(kvp)).ShouldBeTrue();
+    }
+
+    [Fact(Skip = "Remotion treats a Contains on a Dictionary & IDictionary completely differently, thus this currently takes the wrong code path")]
+    public async Task dict_guid_can_query_using_containsKVP()
+    {
+        var guidk = Guid.NewGuid();
+        var guidv = Guid.NewGuid();
+        var target = new Target();
+        target.GuidDict.Add(guidk, guidv);
+        theSession.Store(target);
+        await theSession.SaveChangesAsync();
+
+        var kvp = new KeyValuePair<Guid, Guid>(guidk, guidv);
+        var results = await theSession.Query<Target>().Where(x => x.GuidDict.Contains(kvp)).ToListAsync();
+        results.All(r => r.GuidDict.Contains(kvp)).ShouldBeTrue();
     }
 
     [Fact]

--- a/src/DocumentDbTests/Reading/Linq/dictionary_is_translated.cs
+++ b/src/DocumentDbTests/Reading/Linq/dictionary_is_translated.cs
@@ -68,7 +68,7 @@ public class dictionary_is_translated: IntegrationContext
         results.All(r => r.StringDict.Contains(kvp)).ShouldBeTrue();
     }
 
-    [Fact(Skip = "Remotion treats a Contains on a Dictionary & IDictionary completely differently, thus this currently takes the wrong code path")]
+    [Fact]
     public async Task dict_guid_can_query_using_containsKVP()
     {
         var guidk = Guid.NewGuid();
@@ -79,7 +79,8 @@ public class dictionary_is_translated: IntegrationContext
         await theSession.SaveChangesAsync();
 
         var kvp = new KeyValuePair<Guid, Guid>(guidk, guidv);
-        var results = await theSession.Query<Target>().Where(x => x.GuidDict.Contains(kvp)).ToListAsync();
+        // Only works if the dictionary is in interface form
+        var results = await theSession.Query<Target>().Where(x => ((IDictionary<Guid, Guid>)x.GuidDict).Contains(kvp)).ToListAsync();
         results.All(r => r.GuidDict.Contains(kvp)).ShouldBeTrue();
     }
 

--- a/src/Marten.Testing/Documents/Target.cs
+++ b/src/Marten.Testing/Documents/Target.cs
@@ -102,6 +102,7 @@ public class Target
         Id = Guid.NewGuid();
         StringDict = new Dictionary<string, string>();
         StringList = new List<string>();
+        GuidDict = new Dictionary<Guid, Guid>();
     }
 
     public Guid Id { get; set; }
@@ -149,6 +150,7 @@ public class Target
     public Colors? NullableColor { get; set; }
 
     public IDictionary<string, string> StringDict { get; set; }
+    public Dictionary<Guid, Guid> GuidDict { get; set; }
 
     public Guid UserId { get; set; }
 

--- a/src/Marten/Linq/Parsing/DictionaryExpressions.cs
+++ b/src/Marten/Linq/Parsing/DictionaryExpressions.cs
@@ -41,7 +41,8 @@ public class DictionaryExpressions: IMethodCallParser
                && m.DeclaringType.GetGenericTypeDefinition() == typeof(ICollection<>)
                && m.DeclaringType.GenericTypeArguments[0].IsConstructedGenericType
                && m.DeclaringType.GenericTypeArguments[0].GetGenericTypeDefinition() == typeof(KeyValuePair<,>)
-               && m.DeclaringType.GenericTypeArguments[0].GenericTypeArguments[0] == typeof(string);
+               && (m.DeclaringType.GenericTypeArguments[0].GenericTypeArguments[0] == typeof(string)
+                   || m.DeclaringType.GenericTypeArguments[0].GenericTypeArguments[0].IsValueType);
     }
 
     private static bool IsDictionaryContainsKey(MethodInfo m)


### PR DESCRIPTION
Also permits any subclass of  `IDictionary`, as existing support was limited to the `IDictionary<string, x>` interface.

I loosened the type requirements for `.Contains` as well, but the current implementation only works if an interface is passed due to Remotion treating it as a different type of expression.