### PR TITLE
Enable async projections to respect `EnableDocumentTrackingByIdentity` in regular mode, not only during the rebuild

### DIFF
--- a/src/Marten.AsyncDaemon.Testing/DocumentTrackingByIdentity/CustomProjection_follow_up_operations.cs
+++ b/src/Marten.AsyncDaemon.Testing/DocumentTrackingByIdentity/CustomProjection_follow_up_operations.cs
@@ -13,10 +13,6 @@ namespace Marten.AsyncDaemon.Testing.DocumentTrackingByIdentity;
 
 public class CustomProjection_follow_up_operations: DaemonContext
 {
-    public CustomProjection_follow_up_operations(ITestOutputHelper output): base(output)
-    {
-    }
-
     [Fact]
     public async Task rebuild_with_follow_up_operations_should_work()
     {
@@ -95,5 +91,9 @@ public class CustomProjection_follow_up_operations: DaemonContext
                 }
             }
         }
+    }
+
+    public CustomProjection_follow_up_operations(ITestOutputHelper output): base(output)
+    {
     }
 }

--- a/src/Marten.AsyncDaemon.Testing/DocumentTrackingByIdentity/EventProjectionWithCreate_follow_up_operations.cs
+++ b/src/Marten.AsyncDaemon.Testing/DocumentTrackingByIdentity/EventProjectionWithCreate_follow_up_operations.cs
@@ -57,14 +57,7 @@ public class EventProjectionWithCreate_follow_up_operations: DaemonContext
 
         await daemon.StartDaemon();
 
-        try
-        {
-            await daemon.Tracker.WaitForShardState($"{nameof(EntityProjection)}:All", 2, TimeSpan.FromSeconds(10));
-        }
-        catch (Exception exc)
-        {
-            daemon.StatusFor($"{nameof(EntityProjection)}:All").ShouldBe(AgentStatus.Stopped);
-        }
+        await daemon.Tracker.WaitForShardState($"{nameof(EntityProjection)}:All", 2);
 
         var entity = await session.LoadAsync<Entity>(entityId);
 

--- a/src/Marten.AsyncDaemon.Testing/DocumentTrackingByIdentity/EventProjectionWithCreate_follow_up_operations.cs
+++ b/src/Marten.AsyncDaemon.Testing/DocumentTrackingByIdentity/EventProjectionWithCreate_follow_up_operations.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.AsyncDaemon.Testing.TestingSupport;
+using Marten.Events.Daemon;
+using Marten.Events.Projections;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Marten.AsyncDaemon.Testing.DocumentTrackingByIdentity;
+
+public class EventProjectionWithCreate_follow_up_operations: DaemonContext
+{
+    [Fact]
+    public async Task rebuild_with_follow_up_operations_should_work()
+    {
+        StoreOptions(x => x.Projections.Add<EntityProjection>(ProjectionLifecycle.Inline,
+            asyncOptions => asyncOptions.EnableDocumentTrackingByIdentity = true));
+
+        var entityId = Guid.NewGuid();
+
+        await using var session = theStore.IdentitySession();
+
+        session.Events.StartStream(entityId, new EntityCreated(entityId, "Some name"));
+        await session.SaveChangesAsync();
+        session.Events.Append(entityId, new EntityNameUpdated(entityId, "New name"));
+        await session.SaveChangesAsync();
+
+        var agent = await StartDaemon();
+
+        await agent.RebuildProjection(nameof(EntityProjection), CancellationToken.None);
+
+        var shoppingCartRebuilt = await session.LoadAsync<Entity>(entityId);
+
+        shoppingCartRebuilt!.Id.ShouldBe(entityId);
+        shoppingCartRebuilt.Name.ShouldBe("New name");
+    }
+
+
+    [Fact]
+    public async Task regular_usage_follow_up_operations_should_work()
+    {
+        StoreOptions(x => x.Projections.Add<EntityProjection>(ProjectionLifecycle.Async,
+            asyncOptions => asyncOptions.EnableDocumentTrackingByIdentity = true));
+
+        var entityId = Guid.NewGuid();
+
+        await using var session = theStore.IdentitySession();
+
+        session.Events.StartStream(entityId, new EntityCreated(entityId, "Some name"));
+        await session.SaveChangesAsync();
+        session.Events.Append(entityId, new EntityNameUpdated(entityId, "New name"));
+        await session.SaveChangesAsync();
+
+        var daemon = await StartDaemon();
+
+        await daemon.StartDaemon();
+
+        try
+        {
+            await daemon.Tracker.WaitForShardState($"{nameof(EntityProjection)}:All", 2, TimeSpan.FromSeconds(10));
+        }
+        catch (Exception exc)
+        {
+            daemon.StatusFor($"{nameof(EntityProjection)}:All").ShouldBe(AgentStatus.Stopped);
+        }
+
+        var entity = await session.LoadAsync<Entity>(entityId);
+
+        entity.ShouldNotBeNull();
+
+        entity.Id.ShouldBe(entityId);
+        entity.Name.ShouldBe("New name");
+    }
+
+    public record Entity(Guid Id, string Name);
+
+    public record EntityCreated(Guid Id, string Name);
+
+    public record EntityNameUpdated(Guid Id, string Name);
+
+    public class EntityProjection: EventProjection
+    {
+        public EntityProjection()
+        {
+            ProjectionName = nameof(EntityProjection);
+        }
+
+        public Entity Create(EntityCreated @event)
+            => new(@event.Id, @event.Name);
+
+        public async Task Project(EntityNameUpdated @event, IDocumentOperations operations,
+            CancellationToken cancellationToken)
+        {
+            var stock = await operations.LoadAsync<Entity>(@event.Id, cancellationToken).ConfigureAwait(false);
+            if (stock is null)
+            {
+                throw new ArgumentNullException(nameof(stock), "Stock does not exist!");
+            }
+
+            stock = stock with { Name = @event.Name };
+
+            operations.Store(stock);
+        }
+    }
+
+    public EventProjectionWithCreate_follow_up_operations(ITestOutputHelper output): base(output)
+    {
+    }
+}

--- a/src/Marten.AsyncDaemon.Testing/DocumentTrackingByIdentity/EventProjection_follow_up_operations.cs
+++ b/src/Marten.AsyncDaemon.Testing/DocumentTrackingByIdentity/EventProjection_follow_up_operations.cs
@@ -12,10 +12,6 @@ namespace Marten.AsyncDaemon.Testing.DocumentTrackingByIdentity;
 
 public class EventProjection_follow_up_operations: DaemonContext
 {
-    public EventProjection_follow_up_operations(ITestOutputHelper output): base(output)
-    {
-    }
-
     [Fact]
     public async Task rebuild_with_follow_up_operations_should_work()
     {
@@ -71,5 +67,9 @@ public class EventProjection_follow_up_operations: DaemonContext
                 Assert.NotNull(entity);
             });
         }
+    }
+
+    public EventProjection_follow_up_operations(ITestOutputHelper output): base(output)
+    {
     }
 }

--- a/src/Marten/Events/Daemon/ProjectionDocumentSession.cs
+++ b/src/Marten/Events/Daemon/ProjectionDocumentSession.cs
@@ -11,16 +11,18 @@ namespace Marten.Events.Daemon;
 /// </summary>
 internal class ProjectionDocumentSession: DocumentSessionBase
 {
-    public ProjectionDocumentSession(DocumentStore store, ISessionWorkTracker workTracker,
-        SessionOptions sessionOptions): base(
-        store, sessionOptions, new MartenControlledConnectionTransaction(sessionOptions), workTracker)
+    public ProjectionDocumentSession(
+        DocumentStore store,
+        ISessionWorkTracker workTracker,
+        SessionOptions sessionOptions
+    ): base(store, sessionOptions, new MartenControlledConnectionTransaction(sessionOptions), workTracker)
     {
     }
 
-    protected internal override IDocumentStorage<T> selectStorage<T>(DocumentProvider<T> provider)
-    {
-        return provider.Lightweight;
-    }
+    internal override DocumentTracking TrackingMode => SessionOptions.Tracking;
+
+    protected internal override IDocumentStorage<T> selectStorage<T>(DocumentProvider<T> provider) =>
+        TrackingMode == DocumentTracking.IdentityOnly ? provider.IdentityMap : provider.Lightweight;
 
     protected internal override void ejectById<T>(long id)
     {

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -20,15 +20,23 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
 
     private Dictionary<string, NestedTenantSession>? _byTenant;
 
-    internal DocumentSessionBase(DocumentStore store, SessionOptions sessionOptions, IConnectionLifetime connection):
-        base(store, sessionOptions, connection)
+    internal DocumentSessionBase(
+        DocumentStore store,
+        SessionOptions sessionOptions,
+        IConnectionLifetime connection
+    ): base(store, sessionOptions, connection)
     {
         Concurrency = sessionOptions.ConcurrencyChecks;
         _workTracker = new UnitOfWork(this);
     }
 
-    internal DocumentSessionBase(DocumentStore store, SessionOptions sessionOptions, IConnectionLifetime connection,
-        ISessionWorkTracker workTracker, Tenant? tenant = default): base(store, sessionOptions, connection, tenant)
+    internal DocumentSessionBase(
+        DocumentStore store,
+        SessionOptions sessionOptions,
+        IConnectionLifetime connection,
+        ISessionWorkTracker workTracker,
+        Tenant? tenant = default
+    ): base(store, sessionOptions, connection, tenant)
     {
         Concurrency = sessionOptions.ConcurrencyChecks;
         _workTracker = workTracker;

--- a/src/Marten/Internal/Sessions/QuerySession.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.cs
@@ -40,10 +40,12 @@ public partial class QuerySession: IMartenSession, IQuerySession
     public string TenantId { get; protected set; }
 #nullable enable
 
-    internal QuerySession(DocumentStore store,
+    internal QuerySession(
+        DocumentStore store,
         SessionOptions sessionOptions,
         IConnectionLifetime connection,
-        Tenant? tenant = default)
+        Tenant? tenant = default
+    )
     {
         _store = store;
         TenantId = tenant?.TenantId ?? sessionOptions.Tenant?.TenantId ?? sessionOptions.TenantId;


### PR DESCRIPTION
`ProjectionDocumentSession` didn't handle `DocumentTracking` session options and always returned a lightweight session. Updated the code to return the correct tracking mode depending on the `EnableDocumentTrackingByIdentity` setting.

@jameswoodley, @Hawxy FYI

@ugugun, @alexander-paynova I think it might also be the fix issue we discussed around nulls in async projection handling.