### PR TITLE
Check for null identifier on add event.

### DIFF
--- a/src/Marten/Events/Aggregation/TenantSliceGroup.cs
+++ b/src/Marten/Events/Aggregation/TenantSliceGroup.cs
@@ -91,13 +91,20 @@ public class TenantSliceGroup<TDoc, TId>: ITenantSliceGroup<TId>
 
     public void AddEvent(TId id, IEvent @event)
     {
-        Slices[id].AddEvent(@event);
+        if (id != null)
+        {
+            Slices[id].AddEvent(@event);
+        }
+
     }
 
     public void AddEvents(TId id, IEnumerable<IEvent> events)
     {
-        Slices[id].AddEvents(events);
-    }
+        if (id != null)
+        {
+            Slices[id].AddEvents(events);
+        }
+    } 
 
     public void Dispose()
     {


### PR DESCRIPTION
In projections, if the Id is null, it should not invoke the apply method.  Currently it completely fails the application.