### PR TITLE
Added test for LiveStreamAggregation code file generation

### DIFF
--- a/src/EventSourcingTests/Projections/CodeGeneration/ProjectionCodeGenerationTests.cs
+++ b/src/EventSourcingTests/Projections/CodeGeneration/ProjectionCodeGenerationTests.cs
@@ -5,6 +5,7 @@ using JasperFx.Core.Reflection;
 using Marten;
 using Marten.Events.Aggregation;
 using Marten.Events.Projections;
+using Marten.Internal.CodeGeneration;
 using Shouldly;
 using Xunit;
 
@@ -13,7 +14,7 @@ namespace EventSourcingTests.Projections.CodeGeneration;
 public class ProjectionCodeGenerationTests
 {
     [Fact]
-    public void Snapshot_GeneratesCodeFile()
+    public void Snapshot_GeneratesCodeFiles()
     {
         var options = new StoreOptions();
         options.Connection("Dummy");
@@ -28,11 +29,15 @@ public class ProjectionCodeGenerationTests
         store.Events.As<ICodeFileCollection>().BuildFiles()
             .OfType<SingleStreamProjection<Something>>()
             .ShouldHaveSingleItem();
+
+        options.BuildFiles()
+            .OfType<DocumentProviderBuilder>()
+            .Where(e => e.ProviderName == typeof(Something).ToSuffixedTypeName("Provider"))
+            .ShouldHaveSingleItem();
     }
 
-
     [Fact]
-    public void LiveStreamAggregation_GeneratesCodeFile()
+    public void LiveStreamAggregation_GeneratesCodeFiles()
     {
         var options = new StoreOptions();
         options.Connection("Dummy");
@@ -47,18 +52,91 @@ public class ProjectionCodeGenerationTests
         store.Events.As<ICodeFileCollection>().BuildFiles()
             .OfType<SingleStreamProjection<Something>>()
             .ShouldHaveSingleItem();
+
+        options.BuildFiles()
+            .OfType<DocumentProviderBuilder>()
+            .Where(e => e.ProviderName == typeof(Something).ToSuffixedTypeName("Provider"))
+            .ShouldHaveSingleItem();
     }
 
-    public record SomethingHappened(Guid SomethingId, string SomethingSomething);
+    [Fact]
+    public void SingleStreamProjection_GeneratesCodeFiles()
+    {
+        var options = new StoreOptions();
+        options.Connection("Dummy");
 
-    public record SomethingDifferentHappened(Guid SomethingId, string SomethingSomething);
+        // Given
+        options.Projections.Add<SomethingElseSingleStreamProjection>(ProjectionLifecycle.Inline);
+
+        // When
+        var store = new DocumentStore(options);
+
+        // Then
+        store.Events.As<ICodeFileCollection>().BuildFiles()
+            .OfType<SingleStreamProjection<SomethingElse>>()
+            .ShouldHaveSingleItem();
+
+        options.BuildFiles()
+            .OfType<DocumentProviderBuilder>()
+            .Where(e => e.ProviderName == typeof(SomethingElse).ToSuffixedTypeName("Provider"))
+            .ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void MultiStreamProjection_GeneratesCodeFiles()
+    {
+        var options = new StoreOptions();
+        options.Connection("Dummy");
+
+        // Given
+        options.Projections.Add<SomethingElseMultiStreamProjection>(ProjectionLifecycle.Inline);
+
+        // When
+        var store = new DocumentStore(options);
+
+        // Then
+        store.Events.As<ICodeFileCollection>().BuildFiles()
+            .OfType<MultiStreamProjection<SomethingElse, Guid>>()
+            .ShouldHaveSingleItem();
+
+        options.BuildFiles()
+            .OfType<DocumentProviderBuilder>()
+            .Where(e => e.ProviderName == typeof(SomethingElse).ToSuffixedTypeName("Provider"))
+            .ShouldHaveSingleItem();
+    }
+
+    public record SomethingHasHappened(Guid SomethingId, string SomethingSomething);
+
+    public record SomethingElseHasHappened(Guid SomethingId, string SomethingSomething);
 
     public record Something(Guid Id, string SomethingSomething)
     {
-        public static Something Create(SomethingHappened @event) =>
+        public static Something Create(SomethingHasHappened @event) =>
             new Something(@event.SomethingId, @event.SomethingSomething);
 
-        public Something Apply(SomethingHappened @event) =>
+        public Something Apply(SomethingElseHasHappened @event) =>
             this with { SomethingSomething = @event.SomethingSomething };
+    }
+
+    public record SomethingElse(Guid Id, string SomethingSomething)
+    {
+        public static SomethingElse Create(SomethingHasHappened @event) =>
+            new SomethingElse(@event.SomethingId, @event.SomethingSomething);
+
+        public SomethingElse Apply(SomethingElseHasHappened @event) =>
+            this with { SomethingSomething = @event.SomethingSomething };
+    }
+
+    public class SomethingElseSingleStreamProjection: SingleStreamProjection<SomethingElse>
+    {
+    }
+
+    public class SomethingElseMultiStreamProjection: MultiStreamProjection<SomethingElse, Guid>
+    {
+        public SomethingElseMultiStreamProjection()
+        {
+            Identity<SomethingHasHappened>(e => e.SomethingId);
+            Identity<SomethingHasHappened>(e => e.SomethingId);
+        }
     }
 }

--- a/src/EventSourcingTests/Projections/CodeGeneration/ProjectionCodeGenerationTests.cs
+++ b/src/EventSourcingTests/Projections/CodeGeneration/ProjectionCodeGenerationTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq;
+using JasperFx.CodeGeneration;
+using JasperFx.Core.Reflection;
+using Marten;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Projections.CodeGeneration;
+
+public class ProjectionCodeGenerationTests
+{
+    [Fact]
+    public void Snapshot_GeneratesCodeFile()
+    {
+        var options = new StoreOptions();
+        options.Connection("Dummy");
+
+        // Given
+        options.Projections.Snapshot<Something>(SnapshotLifecycle.Inline);
+
+        // When
+        var store = new DocumentStore(options);
+
+        // Then
+        store.Events.As<ICodeFileCollection>().BuildFiles()
+            .OfType<SingleStreamProjection<Something>>()
+            .ShouldHaveSingleItem();
+    }
+
+
+    [Fact]
+    public void LiveStreamAggregation_GeneratesCodeFile()
+    {
+        var options = new StoreOptions();
+        options.Connection("Dummy");
+
+        // Given
+        options.Projections.LiveStreamAggregation<Something>();
+
+        // When
+        var store = new DocumentStore(options);
+
+        // Then
+        store.Events.As<ICodeFileCollection>().BuildFiles()
+            .OfType<SingleStreamProjection<Something>>()
+            .ShouldHaveSingleItem();
+    }
+
+    public record SomethingHappened(Guid SomethingId, string SomethingSomething);
+
+    public record SomethingDifferentHappened(Guid SomethingId, string SomethingSomething);
+
+    public record Something(Guid Id, string SomethingSomething)
+    {
+        public static Something Create(SomethingHappened @event) =>
+            new Something(@event.SomethingId, @event.SomethingSomething);
+
+        public Something Apply(SomethingHappened @event) =>
+            this with { SomethingSomething = @event.SomethingSomething };
+    }
+}

--- a/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.Validation.cs
+++ b/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.Validation.cs
@@ -19,11 +19,7 @@ public abstract partial class GeneratedAggregateProjectionBase<T>
 
     internal override IEnumerable<string> ValidateConfiguration(StoreOptions options)
     {
-        // Need to use an isolated DocumentMapping for live aggregations to prevent
-        // Marten from building empty tables for the aggregate type
-        var mapping = Lifecycle == ProjectionLifecycle.Live
-            ? new DocumentMapping(typeof(T), options)
-            : options.Storage.FindMapping(typeof(T)).Root.As<DocumentMapping>();
+        var mapping = options.Storage.FindMapping(typeof(T)).Root.As<DocumentMapping>();
 
         foreach (var p in validateDocumentIdentity(options, mapping)) yield return p;
 

--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -178,7 +178,7 @@ public class ProjectionOptions: DaemonSettings
         var expression = singleStreamProjection<T>(ProjectionLifecycle.Live, asyncConfiguration);
 
         // Hack to address https://github.com/JasperFx/marten/issues/2610
-        _options.Storage.RemoveBuilderFor<T>();
+        _options.Storage.MappingFor(typeof(T)).SkipSchemaGeneration = true;
 
         return expression;
     }

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -65,7 +65,6 @@ public class DocumentMapping: FieldMapping, IDocumentMapping, IDocumentType
     private string _alias;
     private string _databaseSchemaName;
 
-
     private HiloSettings _hiloSettings;
     private MemberInfo _idMember;
 
@@ -113,6 +112,9 @@ public class DocumentMapping: FieldMapping, IDocumentMapping, IDocumentType
         }
     }
 
+    // TODO: This should be smarter, maybe nullable option for Schema or some other base type
+    internal bool SkipSchemaGeneration { get; set; }
+
     public MemberInfo IdMember
     {
         get => _idMember;
@@ -147,7 +149,6 @@ public class DocumentMapping: FieldMapping, IDocumentMapping, IDocumentType
     public virtual DbObjectName TableName => new(DatabaseSchemaName, $"{SchemaConstants.TablePrefix}{_alias}");
 
     public DocumentMetadataCollection Metadata { get; }
-
 
     public bool UseOptimisticConcurrency { get; set; }
 
@@ -191,6 +192,7 @@ public class DocumentMapping: FieldMapping, IDocumentMapping, IDocumentType
     public bool StructuralTyped { get; set; }
 
     public string DdlTemplate { get; set; }
+
     IReadOnlyHiloSettings IDocumentType.HiloSettings { get; }
 
     public TenancyStyle TenancyStyle { get; set; } = TenancyStyle.Single;
@@ -198,7 +200,6 @@ public class DocumentMapping: FieldMapping, IDocumentMapping, IDocumentType
     IDocumentType IDocumentType.Root => this;
 
     public DuplicatedField[] DuplicatedFields => fields().OfType<DuplicatedField>().ToArray();
-
 
     public bool IsHierarchy()
     {
@@ -209,7 +210,6 @@ public class DocumentMapping: FieldMapping, IDocumentMapping, IDocumentType
     {
         return Indexes.OfType<DocumentIndex>().Where(x => x.Columns.Contains(column));
     }
-
 
     public string AliasFor(Type subclassType)
     {
@@ -329,7 +329,6 @@ public class DocumentMapping: FieldMapping, IDocumentMapping, IDocumentType
             : type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                 .OrderByDescending(x => x.DeclaringType == type).ToArray();
     }
-
 
     public DocumentIndex AddGinIndexToData()
     {

--- a/src/Marten/Storage/MartenDatabase.DocumentCleaner.cs
+++ b/src/Marten/Storage/MartenDatabase.DocumentCleaner.cs
@@ -83,7 +83,7 @@ WHERE  s.sequence_name like 'mt_%' and s.sequence_schema = ANY(:schemas);";
 
     public void DeleteDocumentsExcept(params Type[] documentTypes)
     {
-        var documentMappings = _options.Storage.AllDocumentMappings.Where(x => !documentTypes.Contains(x.DocumentType));
+        var documentMappings = _options.Storage.DocumentMappingsWithSchema.Where(x => !documentTypes.Contains(x.DocumentType));
         foreach (var mapping in documentMappings)
         {
             var storage = Providers.StorageFor(mapping.DocumentType);
@@ -93,7 +93,7 @@ WHERE  s.sequence_name like 'mt_%' and s.sequence_schema = ANY(:schemas);";
 
     public async Task DeleteDocumentsExceptAsync(CancellationToken ct, params Type[] documentTypes)
     {
-        var documentMappings = _options.Storage.AllDocumentMappings.Where(x => !documentTypes.Contains(x.DocumentType));
+        var documentMappings = _options.Storage.DocumentMappingsWithSchema.Where(x => !documentTypes.Contains(x.DocumentType));
         foreach (var mapping in documentMappings)
         {
             var storage = Providers.StorageFor(mapping.DocumentType);


### PR DESCRIPTION
Changed LiveStreamAggregation implementation to set the `SkipSchemaGeneration` property for `DocumentMapping` instead of entirely removing it from storage.

Updated implementation for schema generation to skip such mappings.

It's more hotfix, than a real revamp, but without introducing breaking changes, it'll be harder to change it.

Fixes #2645

Relates to #2610