### PR TITLE
Rewrote introduction docs to make it more accessible and user friendly

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,26 +1,43 @@
 # Introduction
 
-Click this [link](https://sec.ch9.ms/ch9/2d29/a281311a-76bb-4573-a2a0-2dd7affc2d29/S315dotNETconf_high.mp4) to watch an introductory video on Marten.
+Welcome to the Marten documentation! Join also our friendly [Discord channel](https://discord.gg/WMxrvegf8H) to learn more with us and the community!
 
 ## What is Marten?
 
-Marten is a .NET library that allows developers to use the Postgresql database as both a
-[document database](https://en.wikipedia.org/wiki/Document-oriented_database) and a fully-featured [event store](https://martinfowler.com/eaaDev/EventSourcing.html) -- with the document features serving as the out-of-the-box
-mechanism for projected "read side" views of your events. There is absolutely nothing else to install or run, outside of the Nuget package and Postgresql itself. Marten was made possible by the unique [JSONB](https://www.postgresql.org/docs/current/datatype-json.html) support first introduced in Postgresql 9.4.
+**Marten is a .NET library for building applications using [document-based approach](https://en.wikipedia.org/wiki/Document-oriented_database) and [Event Sourcing](https://martinfowler.com/eaaDev/EventSourcing.html).** We're committed to removing boilerplate work and letting you focus on delivering business value.
 
-Marten was originally built to replace RavenDB inside a very large web application that was suffering stability and performance issues.
-The project name *Marten* came from a quick Google search one day for "what are the natural predators of ravens?" -- which led to us to
-use the [marten](https://en.wikipedia.org/wiki/Marten) as our project codename and avatar.
+Under the hood, we're using [Postgresql](https://www.postgresql.org/), changing it into:
 
-![A Marten](/images/marten.jpeg)
+- a [document database](/documents/),
+- an [event store](/events/).
 
-The Marten project was publicly announced in late 2015 and quickly gained a solid community of interested developers. An event sourcing feature set was
-added, which proved popular with our users. Marten first went into a production system in 2016 and has been going strong ever since. The v4
-release in 2021 marks a massive overhaul of Marten's internals, and introduces new functionality requested by our users to better position Marten for the future.
+The basis for our work is the unique [Postgresql support for JSON storage](https://www.postgresql.org/docs/current/datatype-json.html).
+
+**Thanks to that and other Postgresql capabilities, Marten brings strong consistency into those approaches.**
+
+Marten is feature-rich and focused on accessibility, but we do that without compromising performance.
+
+Whether you're working on a new greenfield project or a bigger enterprise one, Marten will help you to quickly iterate and evolve your system with a focus on business value.
+
+## Main features
+
+Some of the highlights of the main Marten features:
+
+|                                             Feature                                              |                                                                                                                                                                   Description                                                                                                                                                                   |
+| :----------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|                                 [Document Storage](/documents/)                                  |                                                                             Marten allows to use of Postgresql as a document database. That makes development much more flexible, as you store your entities as JSON. It helps in easier evolving your data model.                                                                              |
+|                                     [Event store](/events/)                                      |                                                                                      Accordingly, you can also use Postgresql as a full-fledged event store for Event Sourcing. This approach can help you capture all the business facts in your system.                                                                                       |
+|                [Strong consistency](/documents/sessions/#unit-of-work-mechanics)                 |                                                                                     Marten uses Postgresql transactions capabilities to allow you to have trust in your storage engine. That applies to both document-based and Event Sourcing approaches.                                                                                      |
+|                   [Advanced Linq querying capabilities](/documents/querying/)                    |                                                             You can filter your documents using the LINQ queries. That's the most popular .NET way of doing that. We also support [full-text search](/documents/full-text.md) and [custom SQL queries](/documents/querying/sql.md).                                                             |
+|                            [Events Projections](/events/projections/)                            |     Marten gives a unique feature to store both events and read models in the same storage. You can write your projections and get flexibility in interpreting your events. Projections can be applied [in the same transaction](/events/projections/inline.md) as appended event or [asynchronously](/events/projections/async-daemon.md).     |
+|                       [Automatic schema management](/schema/migrations.md)                       |                                                                        We know that schema management in relational databases can be tedious. That's why we're offering to deal with it for you. Thanks to the simpler storage with JSON format, that gets much easier.                                                                         |
+|                       [Flexible indexing strategies](/documents/indexing/)                       |                                                                                      To get a better performance, you can define various indexing strategies to fit your usage characteristics. Document-based approach doesn't have to mean schema-less!                                                                                       |
+| [ASP.NET integration](/configuration/cli.html) and [Command Line tooling](/configuration/cli.md) |                                                                                                           We provided a set of build-in helpers to get you quickly integrate Marten with your applications without much of a hassle.                                                                                                            |
+|              [Built-in support for Multi-tenancy](/configuration/multitenancy.html)              | Being able to have data isolation for different customer is an essential feature for storage engine. We provide multiple ways of dealing with multi-tenancy: multiple databases, different schemas and sharded-table. Those strategies apply both [document](/documents/multi-tenancy.html) and [event store](/events/multitenancy.html) parts. |
 
 ## .NET Version Compatibility
 
-Marten aligns with the [.NET Core Support Lifecycle](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) to determine platform compatibility. Marten currently targets `net6.0`,  `net7.0`.
+Marten aligns with the [.NET Core Support Lifecycle](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) to determine platform support. Marten currently targets `net6.0`, `net7.0`.
 
 | Marten Version |   .NET Framework   |   .NET Core 3.1    |       .NET 5       |       .NET 6       |       .NET 7       |
 | -------------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
@@ -29,6 +46,10 @@ Marten aligns with the [.NET Core Support Lifecycle](https://dotnet.microsoft.co
 | 4              |        :x:         | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         |
 | 3              | :white_check_mark: | :white_check_mark: |        :x:         |        :x:         |        :x:         |
 
-### Nullable Reference Types
+## History and origins
 
-For enhanced developer ergonomics, Marten is annotated with [NRTs](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references). For new .NET projects, this is automatically enabled. If updating from previous versions of .NET, this can be opted-into via `<Nullable>enable</Nullable>` within your `.csproj`.
+Marten was originally built to replace RavenDB inside a very large web application that was suffering stability and performance issues. The project name _Marten_ came from a quick Google search one day for "what are the natural predators of ravens?" -- which led to us to use the [marten](https://en.wikipedia.org/wiki/Marten) as our project codename and avatar.
+
+![A Marten](/images/marten.jpeg)
+
+The Marten project was publicly announced in late 2015 and quickly gained a solid community of interested developers. An event sourcing feature set was added, which proved popular with our users. Marten first went into a production system in 2016 and has been going strong ever since. The v4 release in 2021 marks a massive overhaul of Marten's internals, and introduces new functionality requested by our users to better position Marten for the future.


### PR DESCRIPTION
I took inspiration from the Nest.js docs, which are praised by the community https://nextjs.org/docs:

Rewrote to show people first what we do, then how we do it and how they can benefit.

Outlined the most important features so people won't miss them.

Removed:
- link to obsolete videos,
- information about NRT, as it should be a standard now and is not adding much value for the reader of the introduction (too many tech details).