### PR TITLE
Fixed Marten Exceptions transformations when NpgslCommand is null

### DIFF
--- a/docs/documents/querying/linq/async-enumerable.md
+++ b/docs/documents/querying/linq/async-enumerable.md
@@ -40,10 +40,9 @@ public async Task query_to_async_enumerable()
     }
 }
 ```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/Linq/invoking_query_with_ToAsyncEnumerable.cs#L18-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_to_async_enumerable' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 ::: warning
 Be aware not to return the IAsyncEnumerable out of the scope in which the session that produces it is used. This would prevent the database connection from being reused afterwards and thus lead to a connection bleed.
 :::
-
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/Linq/invoking_query_with_ToAsyncEnumerable.cs#L18-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_to_async_enumerable' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->

--- a/src/CoreTests/Exceptions/MartenCommandExceptionTests.cs
+++ b/src/CoreTests/Exceptions/MartenCommandExceptionTests.cs
@@ -1,0 +1,17 @@
+using System;
+using Marten.Exceptions;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests.Exceptions;
+
+public class MartenCommandExceptionTests
+{
+    [Fact]
+    public void should_create_MartenCommandException_when_command_is_null()
+    {
+        var createWithNullCommand = () => new MartenCommandException(null, new Exception());
+
+        createWithNullCommand.ShouldNotThrow();
+    }
+}

--- a/src/Marten.sln
+++ b/src/Marten.sln
@@ -23,6 +23,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\README.md = ..\README.md
 		..\Analysis.Build.props = ..\Analysis.Build.props
 		.editorconfig = .editorconfig
+		..\docker-compose.yml = ..\docker-compose.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreWithMarten", "AspNetCoreWithMarten\AspNetCoreWithMarten.csproj", "{739B657C-4E0D-40E8-853E-ADF5C2D3D89D}"

--- a/src/Marten/Exceptions/InvalidConnectionStringException.cs
+++ b/src/Marten/Exceptions/InvalidConnectionStringException.cs
@@ -1,0 +1,54 @@
+using System;
+using JasperFx.Core.Exceptions;
+using Npgsql;
+
+namespace Marten.Exceptions;
+#nullable enable
+
+/// <summary>
+///     Informs that Postgres connection string is invalid
+/// </summary>
+public class InvalidConnectionStringException: MartenCommandException
+{
+    public InvalidConnectionStringException(NpgsqlCommand? command, ArgumentException innerException): base(command,
+        innerException)
+    {
+    }
+
+    public InvalidConnectionStringException(NpgsqlCommand? command, ArgumentException innerException, string prefix):
+        base(
+            command, innerException, prefix)
+    {
+    }
+}
+
+internal class InvalidConnectionStreamExceptionTransform: IExceptionTransform
+{
+#pragma warning disable CS8767 // Nullability needs to be fixed in Jasper.Core
+    public bool TryTransform(Exception original, out Exception? transformed)
+#pragma warning restore CS8767 // Nullability needs to be fixed in Jasper.Core
+    {
+        if (original is ArgumentException e)
+        {
+            var matchesExceptionPattern =
+                e.Message.Contains(
+                    "Format of the initialization string does not conform to specification")
+                && e.Source == "System.Data.Common";
+
+            if (matchesExceptionPattern)
+            {
+                var command = e.Data.Contains(nameof(NpgsqlCommand))
+                    ? e.Data[nameof(NpgsqlCommand)] as NpgsqlCommand
+                    : null;
+
+                transformed =
+                    new InvalidConnectionStringException(command, e, "Invalid connection string.");
+
+                return true;
+            }
+        }
+
+        transformed = null;
+        return false;
+    }
+}

--- a/src/Marten/Exceptions/MartenCommandException.cs
+++ b/src/Marten/Exceptions/MartenCommandException.cs
@@ -2,6 +2,7 @@ using System;
 using Npgsql;
 
 namespace Marten.Exceptions;
+#nullable enable
 
 /// <summary>
 ///     Wraps the Postgres command exceptions. Unifies exception handling and brings additonal information.
@@ -16,9 +17,12 @@ public class MartenCommandException: MartenException
     /// </summary>
     /// <param name="command">failed Postgres command</param>
     /// <param name="innerException">internal exception details</param>
-    public MartenCommandException(NpgsqlCommand command, Exception innerException)
+    public MartenCommandException(NpgsqlCommand? command, Exception innerException)
         : base(ToMessage(command, innerException) + innerException.Message, innerException)
     {
+        if (command == null)
+            return;
+
         Command = new NpgsqlCommand
         {
             CommandText = command.CommandText,
@@ -39,11 +43,14 @@ public class MartenCommandException: MartenException
     /// <param name="innerException">internal exception details</param>
     /// <param name="prefix">prefix that will be added to message</param>
     public MartenCommandException(
-        NpgsqlCommand command,
+        NpgsqlCommand? command,
         Exception innerException,
         string prefix
     ): base(ToMessage(command, innerException, prefix) + innerException.Message, innerException)
     {
+        if (command == null)
+            return;
+
         Command = new NpgsqlCommand
         {
             CommandText = command.CommandText,
@@ -60,11 +67,13 @@ public class MartenCommandException: MartenException
     /// <summary>
     ///     Failed Postgres command
     /// </summary>
-    public NpgsqlCommand Command { get; }
+    public NpgsqlCommand? Command { get; }
 
-    protected static string ToMessage(NpgsqlCommand command,
+    protected static string ToMessage(
+        NpgsqlCommand? command,
         Exception innerException,
-        string prefix = null)
+        string? prefix = null
+    )
     {
         if (prefix != null)
         {
@@ -72,18 +81,14 @@ public class MartenCommandException: MartenException
         }
 
         var explanation = "";
-        if (innerException is NpgsqlException pgex)
-        {
-            if (pgex.InnerException is TimeoutException toex)
-            {
-                if (toex.Message == "Timeout during reading attempt")
-                {
-                    explanation = Environment.NewLine +
-                                  MaybeLockedRowsMessage + Environment.NewLine;
-                }
-            }
-        }
 
+        if (innerException is NpgsqlException
+            {
+                InnerException: TimeoutException { Message: "Timeout during reading attempt" }
+            })
+        {
+            explanation = Environment.NewLine + MaybeLockedRowsMessage + Environment.NewLine;
+        }
 
         return
             $"Marten Command Failure:${Environment.NewLine}{prefix}{explanation}{command?.CommandText}${Environment.NewLine}${Environment.NewLine}";

--- a/src/Marten/Exceptions/MartenExceptionTransformer.cs
+++ b/src/Marten/Exceptions/MartenExceptionTransformer.cs
@@ -4,11 +4,12 @@ using Marten.Services;
 using Npgsql;
 
 namespace Marten.Exceptions;
+#nullable enable
 
 [Obsolete("Replace w/ JasperFx.Core version")]
 internal static class MartenExceptionTransformer
 {
-    private static readonly ExceptionTransforms _transforms = new ExceptionTransforms();
+    private static readonly ExceptionTransforms _transforms = new();
 
     static MartenExceptionTransformer()
     {
@@ -16,6 +17,7 @@ internal static class MartenExceptionTransformer
         _transforms.AddTransform<MartenCommandNotSupportedExceptionTransform>();
         _transforms.AddTransform<UtcDateTimeUsageExceptionTransform>();
         _transforms.AddTransform<DateTimeUsageExceptionTransform>();
+        _transforms.AddTransform<InvalidConnectionStreamExceptionTransform>();
 
         _transforms.IfExceptionIs<PostgresException>()
             .If(e => e.SqlState == PostgresErrorCodes.SerializationFailure)
@@ -29,14 +31,14 @@ internal static class MartenExceptionTransformer
             });
     }
 
-    internal static NpgsqlCommand ReadNpgsqlCommand(this Exception ex)
+    internal static NpgsqlCommand? ReadNpgsqlCommand(this Exception ex)
     {
         return ex.Data.Contains(nameof(NpgsqlCommand))
-            ? (NpgsqlCommand)ex.Data[nameof(NpgsqlCommand)]
+            ? ex.Data[nameof(NpgsqlCommand)] as NpgsqlCommand
             : null;
     }
 
-    internal static void WrapAndThrow(NpgsqlCommand command, Exception exception)
+    internal static void WrapAndThrow(NpgsqlCommand? command, Exception exception)
     {
         if (command != null)
         {


### PR DESCRIPTION
That may happen when the connection string is invalid or is not matching the database configuration (e.g. wrong password).

Added `InvalidConnectionStringException` - a dedicated exception type for when the connection string is invalid. Npgsql is throwing a bit of confusing `ArgumentException`, so I think that it'll be more accessible to add more context.

Fixes #2670