### PR TITLE
Set `DeadLetterEvent` as single tenanted for conjoined tenancy

### DIFF
--- a/src/Marten.AsyncDaemon.Testing/rebuilds_with_serialization_or_poison_pill_events.cs
+++ b/src/Marten.AsyncDaemon.Testing/rebuilds_with_serialization_or_poison_pill_events.cs
@@ -122,7 +122,7 @@ public class rebuilds_with_serialization_or_poison_pill_events: DaemonContext
         SometimesFailingTripProjection.FailingEventFails = false;
         await CheckAllExpectedAggregatesAgainstActuals();
 
-        var deadLetters = await theSession.ForTenant(tenantId)
+        var deadLetters = await theSession
             .Query<DeadLetterEvent>()
             .Where(x => x.ProjectionName == "Trip")
             .ToListAsync();

--- a/src/Marten/Events/Daemon/ProjectionDaemon.cs
+++ b/src/Marten/Events/Daemon/ProjectionDaemon.cs
@@ -382,7 +382,7 @@ internal class ProjectionDaemon: IProjectionDaemon
             session.QueueOperation(new DeleteProjectionProgress(_store.Events, shard.Name.Identity));
 
         // Rewind previous DeadLetterEvents because you're going to replay them all anyway
-        session.DeleteWhere<DeadLetterEvent>(x => x.AnyTenant() && x.ProjectionName == source.ProjectionName);
+        session.DeleteWhere<DeadLetterEvent>(x => x.ProjectionName == source.ProjectionName);
 
         await session.SaveChangesAsync(token).ConfigureAwait(false);
     }
@@ -531,7 +531,7 @@ internal class ProjectionDaemon: IProjectionDaemon
         {
             var deadLetterEvent = new DeadLetterEvent(@event, shardName, exception);
             await using var session =
-                _store.LightweightSession(SessionOptions.ForDatabase(@event.TenantId, Database));
+                _store.LightweightSession(SessionOptions.ForDatabase(Database));
 
             await using (session.ConfigureAwait(false))
             {

--- a/src/Marten/Events/Daemon/ProjectionDaemon.cs
+++ b/src/Marten/Events/Daemon/ProjectionDaemon.cs
@@ -375,7 +375,8 @@ internal class ProjectionDaemon: IProjectionDaemon
     {
         var sessionOptions = SessionOptions.ForDatabase(Database);
         sessionOptions.AllowAnyTenant = true;
-        await using var session = await _store.LightweightSerializableSessionAsync(sessionOptions, token).ConfigureAwait(false);
+        await using var session =
+            await _store.LightweightSerializableSessionAsync(sessionOptions, token).ConfigureAwait(false);
         source.Options.Teardown(session);
 
         foreach (var shard in shards)
@@ -530,8 +531,8 @@ internal class ProjectionDaemon: IProjectionDaemon
         try
         {
             var deadLetterEvent = new DeadLetterEvent(@event, shardName, exception);
-            var session =
-                _store.LightweightSession(SessionOptions.ForDatabase(Database));
+            await using var session =
+                _store.LightweightSession(SessionOptions.ForDatabase(@event.TenantId, Database));
 
             await using (session.ConfigureAwait(false))
             {

--- a/src/Marten/Events/Daemon/ProjectionDaemon.cs
+++ b/src/Marten/Events/Daemon/ProjectionDaemon.cs
@@ -382,7 +382,7 @@ internal class ProjectionDaemon: IProjectionDaemon
             session.QueueOperation(new DeleteProjectionProgress(_store.Events, shard.Name.Identity));
 
         // Rewind previous DeadLetterEvents because you're going to replay them all anyway
-        session.DeleteWhere<DeadLetterEvent>(x => x.ProjectionName == source.ProjectionName);
+        session.DeleteWhere<DeadLetterEvent>(x => x.AnyTenant() && x.ProjectionName == source.ProjectionName);
 
         await session.SaveChangesAsync(token).ConfigureAwait(false);
     }

--- a/src/Marten/Events/Daemon/ProjectionDaemon.cs
+++ b/src/Marten/Events/Daemon/ProjectionDaemon.cs
@@ -375,8 +375,7 @@ internal class ProjectionDaemon: IProjectionDaemon
     {
         var sessionOptions = SessionOptions.ForDatabase(Database);
         sessionOptions.AllowAnyTenant = true;
-        await using var session =
-            await _store.LightweightSerializableSessionAsync(sessionOptions, token).ConfigureAwait(false);
+        await using var session = _store.LightweightSession(sessionOptions);
         source.Options.Teardown(session);
 
         foreach (var shard in shards)

--- a/src/Marten/Events/Daemon/ShardAgent.cs
+++ b/src/Marten/Events/Daemon/ShardAgent.cs
@@ -485,11 +485,11 @@ internal class ShardAgent: IShardAgent, IObserver<ShardState>
             }
             finally
             {
-                batch.Dispose();
+                await batch.DisposeAsync().ConfigureAwait(false);
             }
         }
 
-        batch.Dispose();
+        await batch.DisposeAsync().ConfigureAwait(false);
 
         if (_cancellation.IsCancellationRequested)
         {

--- a/src/Marten/Internal/Storage/LightweightDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/LightweightDocumentStorage.cs
@@ -67,13 +67,11 @@ public abstract class LightweightDocumentStorage<T, TId>: DocumentStorage<T, TId
         var command = BuildLoadManyCommand(ids, session.TenantId);
         var selector = (ISelector<T>)BuildSelector(session);
 
-        await using (var reader = await session.ExecuteReaderAsync(command, token).ConfigureAwait(false))
+        await using var reader = await session.ExecuteReaderAsync(command, token).ConfigureAwait(false);
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
         {
-            while (await reader.ReadAsync(token).ConfigureAwait(false))
-            {
-                var document = await selector.ResolveAsync(reader, token).ConfigureAwait(false);
-                list.Add(document);
-            }
+            var document = await selector.ResolveAsync(reader, token).ConfigureAwait(false);
+            list.Add(document);
         }
 
         return list;

--- a/src/Marten/Services/SessionOptions.cs
+++ b/src/Marten/Services/SessionOptions.cs
@@ -213,6 +213,24 @@ public sealed class SessionOptions
     }
 
     /// <summary>
+    ///     Create a session for tenant within the supplied database
+    /// </summary>
+    /// <param name="tenantId"></param>
+    /// <param name="database"></param>
+    /// <returns></returns>
+    public static SessionOptions ForDatabase(string tenantId, IMartenDatabase database)
+    {
+        return new SessionOptions
+        {
+            Tenant = new Tenant(tenantId, database),
+            AllowAnyTenant = true,
+            OwnsConnection = true,
+            OwnsTransactionLifecycle = true,
+            Tracking = DocumentTracking.None
+        };
+    }
+
+    /// <summary>
     ///     Override the document tracking
     /// </summary>
     /// <param name="tracking"></param>

--- a/src/Marten/Services/SessionOptions.cs
+++ b/src/Marten/Services/SessionOptions.cs
@@ -200,17 +200,8 @@ public sealed class SessionOptions
     /// </summary>
     /// <param name="database"></param>
     /// <returns></returns>
-    public static SessionOptions ForDatabase(IMartenDatabase database)
-    {
-        return new SessionOptions
-        {
-            Tenant = new Tenant(Tenancy.DefaultTenantId, database),
-            AllowAnyTenant = true,
-            OwnsConnection = true,
-            OwnsTransactionLifecycle = true,
-            Tracking = DocumentTracking.None
-        };
-    }
+    public static SessionOptions ForDatabase(IMartenDatabase database) =>
+        ForDatabase(Tenancy.DefaultTenantId, database);
 
     /// <summary>
     ///     Create a session for tenant within the supplied database

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -394,7 +394,7 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger
     {
         Storage.BuildAllMappings();
 
-        Schema.For<DeadLetterEvent>().DatabaseSchemaName(Events.DatabaseSchemaName);
+        Schema.For<DeadLetterEvent>().DatabaseSchemaName(Events.DatabaseSchemaName).SingleTenanted();
 
         foreach (var mapping in Storage.AllDocumentMappings) mapping.CompileAndValidate();
     }


### PR DESCRIPTION
Fixes #2686.

**Set `DeadLetterEvent` as single tenanted for conjoined tenancy.** A dead letter event represents an event skipped for the particular projection. It references that event at a specific global event store sequence. Thus, it has to be global and does not have a tenant. If we rebuild the projection, all read models will be rebuilt using events from all tenants.

Added test ensuring that conjoined tenancy is handled correctly.

**Enhanced ProjectionUpdateBatch disposal.** There could be a race condition when the session was released, but the processing Queue wasn't completed, which caused the session to be null. Added nullable annotations to make that explicit and fixes accordingly (by checking the cancellation token and implementing disposal consistently).



@BrettGFleischer @jeremydmiller FYI