### PR TITLE
AsyncHealthCheck in wrong assembly

### DIFF
--- a/src/Marten.AspNetCore/Marten.AspNetCore.csproj
+++ b/src/Marten.AspNetCore/Marten.AspNetCore.csproj
@@ -22,11 +22,6 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
     </ItemGroup>
-    
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.10"/>
-    </ItemGroup>
-
 
     <Import Project="../../Analysis.Build.props"/>
 </Project>

--- a/src/Marten/Events/Daemon/AsyncDaemonHealthCheckExtensions.cs
+++ b/src/Marten/Events/Daemon/AsyncDaemonHealthCheckExtensions.cs
@@ -13,10 +13,10 @@ namespace Marten.Events.Daemon;
 public static class AsyncDaemonHealthCheckExtensions
 {
     /// <summary>
-    /// Adds a health check for Martens Async Daemon. 
+    /// Adds a health check for Martens Async Daemon.
     /// The health check will verify that no async projection progression is lagging behind more than the <paramref name="maxEventLag"/>
     /// The check will return <see cref="HealthCheckResult.Unhealthy"/> if any progression is more than <paramref name="maxEventLag"/> behind the highWaterMark OR if any exception is thrown while doing the check.
-    /// <example> 
+    /// <example>
     /// <code>
     /// Customized Injection Example: services.AddHealthChecks().AddAsyncDaemonHealthCheck(150);
     /// </code>
@@ -47,12 +47,12 @@ public static class AsyncDaemonHealthCheckExtensions
         /// <summary>
         /// The <see cref="DocumentStore"/> to check health for.
         /// </summary>
-        private IDocumentStore _store;
+        private readonly IDocumentStore _store;
 
         /// <summary>
         /// The allowed event projection processing lag compared to the HighWaterMark.
         /// </summary>
-        private int _maxEventLag;
+        private readonly int _maxEventLag;
 
         internal AsyncDaemonHealthCheck(IDocumentStore store, AsyncDaemonHealthCheckSettings settings)
         {

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -44,6 +44,7 @@
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0"/>
         <PackageReference Include="Weasel.Postgresql" Version="6.1.0"/>
         <PackageReference Include="System.Text.Json" Version="7.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.10"/>
     </ItemGroup>
 
     <!--SourceLink specific settings-->


### PR DESCRIPTION
Realised that this feature was added to the AspNetCore assembly instead of the Marten repo. Moved it to the marten assembly