### PR TITLE
Add stream key variants of batched event query operations

### DIFF
--- a/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
@@ -25,6 +25,13 @@ public interface IBatchEvents
     Task<StreamState> FetchStreamState(Guid streamId);
 
     /// <summary>
+    ///     Load the high level metadata about a single event stream
+    /// </summary>
+    /// <param name="streamKey"></param>
+    /// <returns></returns>
+    Task<StreamState> FetchStreamState(string streamKey);
+
+    /// <summary>
     ///     Fetch all the events for a single event stream
     /// </summary>
     /// <param name="streamId"></param>
@@ -33,6 +40,17 @@ public interface IBatchEvents
     /// <param name="fromVersion">If set, queries for events on or from this version</param>
     /// <returns></returns>
     Task<IReadOnlyList<IEvent>> FetchStream(Guid streamId, long version = 0, DateTime? timestamp = null,
+        long fromVersion = 0);
+
+    /// <summary>
+    ///     Fetch all the events for a single event stream
+    /// </summary>
+    /// <param name="streamKey"></param>
+    /// <param name="version">If set, queries for events up to and including this version</param>
+    /// <param name="timestamp">If set, queries for events captured on or before this timestamp</param>
+    /// <param name="fromVersion">If set, queries for events on or from this version</param>
+    /// <returns></returns>
+    Task<IReadOnlyList<IEvent>> FetchStream(string streamKey, long version = 0, DateTime? timestamp = null,
         long fromVersion = 0);
 }
 


### PR DESCRIPTION
Added missing `IBatchEvents.FetchStreamState(string streamKey)` 
and `IBatchEvents.FetchStream(string streamKey, long version, DateTime? timestamp, long fromVersion)`.

Nothing too complicated here, just filling in some gaps.