### PR TITLE
Allow customization of the snapshot projection

### DIFF
--- a/src/EventSourcingTests/Projections/inline_aggregation_with_custom_projection_configuration.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_custom_projection_configuration.cs
@@ -12,13 +12,53 @@ public class inline_aggregation_with_custom_projection_configuration : OneOffCon
     [Fact]
     public void does_call_custom_projection_configuration()
     {
-        var configureProjection = Substitute.For<Action<SingleStreamProjection<QuestParty>>>();
+        var configureProjection = Substitute.For<Action<SingleStreamProjection<TodoAggregate>>>();
 
         StoreOptions(_ =>
         {
-            _.Projections.Snapshot<QuestParty>(SnapshotLifecycle.Inline, configureProjection);
+            _.Projections.Snapshot<TodoAggregate>(SnapshotLifecycle.Inline, configureProjection);
         });
 
-        configureProjection.Received(1).Invoke(Arg.Any<SingleStreamProjection<QuestParty>>());
+        configureProjection.Received(1).Invoke(Arg.Any<SingleStreamProjection<TodoAggregate>>());
     }
+
+    [Fact]
+    public void does_delete_document_upon_deleted_event()
+    {
+        StoreOptions(_ =>
+        {
+            _.Projections.Snapshot<TodoAggregate>(SnapshotLifecycle.Inline, configureProjection: p =>
+            {
+                p.DeleteEvent<TodoDeleted>();
+            });
+        });
+
+        var todoId = Guid.NewGuid();
+        theSession.Events.StartStream<TodoAggregate>(todoId, new TodoCreated(todoId, "Write code"));
+        theSession.SaveChanges();
+
+        // Make sure the document has been created
+        theSession.Load<TodoAggregate>(todoId).ShouldNotBeNull();
+
+        // Append the delete
+        theSession.Events.Append(todoId, new TodoDeleted(todoId));
+        theSession.SaveChanges();
+
+        // Make sure the document now has been deleted
+        theSession.Load<TodoAggregate>(todoId).ShouldBeNull();
+    }
+}
+
+public record TodoCreated(Guid Id, string Task);
+public record TodoDeleted(Guid Id);
+
+public class TodoAggregate
+{
+    public Guid Id { get; set; }
+    public string Task { get; set; }
+
+    public static TodoAggregate Create(TodoCreated created) => new()
+    {
+        Task = created.Task
+    };
 }

--- a/src/EventSourcingTests/Projections/inline_aggregation_with_custom_projection_configuration.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_custom_projection_configuration.cs
@@ -1,0 +1,24 @@
+using System;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using NSubstitute;
+using Xunit;
+
+namespace EventSourcingTests.Projections;
+
+public class inline_aggregation_with_custom_projection_configuration : OneOffConfigurationsContext
+{
+    [Fact]
+    public void does_call_custom_projection_configuration()
+    {
+        var configureProjection = Substitute.For<Action<SingleStreamProjection<QuestParty>>>();
+
+        StoreOptions(_ =>
+        {
+            _.Projections.Snapshot<QuestParty>(SnapshotLifecycle.Inline, configureProjection);
+        });
+
+        configureProjection.Received(1).Invoke(Arg.Any<SingleStreamProjection<QuestParty>>());
+    }
+}


### PR DESCRIPTION
As discussed with @oskardudycz on discord, here is a little change that allows to customize the snapshot projection.
This helps for cases where one wants to use `.Snapshot<T>(..)` but likes to customize the default `SingleStreamProjection<T>`.