### PR TITLE
Adjusted Async projection test with IoC injection to remove flakiness

### DIFF
--- a/docs/events/projections/ioc.md
+++ b/docs/events/projections/ioc.md
@@ -16,7 +16,7 @@ Let's say you have a custom aggregation projection like this one below that need
 <!-- snippet: sample_ProductProjection -->
 <a id='snippet-sample_productprojection'></a>
 ```cs
-public class ProductProjection : CustomProjection<Product, Guid>
+public class ProductProjection: CustomProjection<Product, Guid>
 {
     private readonly IPriceLookup _lookup;
 
@@ -28,10 +28,14 @@ public class ProductProjection : CustomProjection<Product, Guid>
         ProjectionName = "Product";
     }
 
-    public override ValueTask ApplyChangesAsync(DocumentSessionBase session, EventSlice<Product, Guid> slice, CancellationToken cancellation,
-        ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline)
+    public override ValueTask ApplyChangesAsync(
+        DocumentSessionBase session,
+        EventSlice<Product, Guid> slice,
+        CancellationToken cancellation,
+        ProjectionLifecycle lifecycle = ProjectionLifecycle.Inline
+    )
     {
-        slice.Aggregate ??= new Product{Id = slice.Id};
+        slice.Aggregate ??= new Product { Id = slice.Id };
 
         foreach (var data in slice.AllData())
         {
@@ -52,7 +56,7 @@ public class ProductProjection : CustomProjection<Product, Guid>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/projections_with_IoC_services.cs#L149-L187' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_productprojection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/projections_with_IoC_services.cs#L144-L186' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_productprojection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Now, we *want* to use this projection at runtime within Marten, and need to register the projection
@@ -73,12 +77,14 @@ using var host = await Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
                 opts.DatabaseSchemaName = "ioc";
             })
             // Note that this is chained after the call to AddMarten()
-            .AddProjectionWithServices<ProductProjection>(ProjectionLifecycle.Inline, ServiceLifetime.Singleton);
-
+            .AddProjectionWithServices<ProductProjection>(
+                ProjectionLifecycle.Inline,
+                ServiceLifetime.Singleton
+            );
     })
     .StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/projections_with_IoC_services.cs#L27-L45' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_projection_built_by_services' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/projections_with_IoC_services.cs#L23-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_projection_built_by_services' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note that we're having to explicitly specify the projection lifecycle for the projection used within

--- a/src/EventSourcingTests/Projections/inline_aggregation_with_custom_projection_configuration.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_custom_projection_configuration.cs
@@ -12,13 +12,53 @@ public class inline_aggregation_with_custom_projection_configuration : OneOffCon
     [Fact]
     public void does_call_custom_projection_configuration()
     {
-        var configureProjection = Substitute.For<Action<SingleStreamProjection<QuestParty>>>();
+        var configureProjection = Substitute.For<Action<SingleStreamProjection<TodoAggregate>>>();
 
         StoreOptions(_ =>
         {
-            _.Projections.Snapshot<QuestParty>(SnapshotLifecycle.Inline, configureProjection);
+            _.Projections.Snapshot<TodoAggregate>(SnapshotLifecycle.Inline, configureProjection);
         });
 
-        configureProjection.Received(1).Invoke(Arg.Any<SingleStreamProjection<QuestParty>>());
+        configureProjection.Received(1).Invoke(Arg.Any<SingleStreamProjection<TodoAggregate>>());
     }
+
+    [Fact]
+    public void does_delete_document_upon_deleted_event()
+    {
+        StoreOptions(_ =>
+        {
+            _.Projections.Snapshot<TodoAggregate>(SnapshotLifecycle.Inline, configureProjection: p =>
+            {
+                p.DeleteEvent<TodoDeleted>();
+            });
+        });
+
+        var todoId = Guid.NewGuid();
+        theSession.Events.StartStream<TodoAggregate>(todoId, new TodoCreated(todoId, "Write code"));
+        theSession.SaveChanges();
+
+        // Make sure the document has been created
+        theSession.Load<TodoAggregate>(todoId).ShouldNotBeNull();
+
+        // Append the delete
+        theSession.Events.Append(todoId, new TodoDeleted(todoId));
+        theSession.SaveChanges();
+
+        // Make sure the document now has been deleted
+        theSession.Load<TodoAggregate>(todoId).ShouldBeNull();
+    }
+}
+
+public record TodoCreated(Guid Id, string Task);
+public record TodoDeleted(Guid Id);
+
+public class TodoAggregate
+{
+    public Guid Id { get; set; }
+    public string Task { get; set; }
+
+    public static TodoAggregate Create(TodoCreated created) => new()
+    {
+        Task = created.Task
+    };
 }


### PR DESCRIPTION
The issue was in the race condition, as Async Daemon in tests was started both through the hosted service and then manually to wait for the projection shard.

Added also dedicated DaemonLockId value for async projection with IoC integration tests. It seems like it may be clashing with other async daemons running on the same database when using the default lock id.