### PR TITLE
Adds Constraint Name to Document Already Exists and Marten Command Exceptions

### DIFF
--- a/src/DocumentDbTests/Indexes/UniqueIndexTests.cs
+++ b/src/DocumentDbTests/Indexes/UniqueIndexTests.cs
@@ -36,16 +36,19 @@ public class UserMultiStreamProjection: MultiStreamProjection<UniqueUser, Guid>
 
 public class UniqueUser
 {
+    public const string EmailIndex = "email_index";
+    public const string FullNameIndex = "fullname_index";
+
     public Guid Id { get; set; }
 
     public string UserName { get; set; }
 
-    [UniqueIndex(IndexType = UniqueIndexType.DuplicatedField)]
+    [UniqueIndex(IndexType = UniqueIndexType.DuplicatedField, IndexName = EmailIndex)]
     public string Email { get; set; }
 
-    [UniqueIndex(IndexName = "fullname")] public string FirstName { get; set; }
+    [UniqueIndex(IndexName = FullNameIndex)] public string FirstName { get; set; }
 
-    [UniqueIndex(IndexName = "fullname")] public string Surname { get; set; }
+    [UniqueIndex(IndexName = FullNameIndex)] public string Surname { get; set; }
 }
 
 public class UniqueIndexTests: OneOffConfigurationsContext
@@ -83,14 +86,9 @@ public class UniqueIndexTests: OneOffConfigurationsContext
         session.Store(secondDocument);
 
         //3. Unique Exception Was thrown
-        try
-        {
-            session.SaveChanges();
-        }
-        catch (DocumentAlreadyExistsException exception)
-        {
-            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
-        }
+        var exception = Should.Throw<DocumentAlreadyExistsException>(() => session.SaveChanges());
+        exception.ConstraintName.ShouldBe(UniqueUser.FullNameIndex);
+        ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
     }
 
     [Fact]
@@ -109,14 +107,9 @@ public class UniqueIndexTests: OneOffConfigurationsContext
         session.Store(secondDocument);
 
         //3. Unique Exception Was thrown
-        try
-        {
-            session.SaveChanges();
-        }
-        catch (DocumentAlreadyExistsException exception)
-        {
-            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
-        }
+        var exception = Should.Throw<DocumentAlreadyExistsException>(() => session.SaveChanges());
+        exception.ConstraintName.ShouldBe(UniqueUser.EmailIndex);
+        ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
     }
 
     [Fact]
@@ -139,14 +132,9 @@ public class UniqueIndexTests: OneOffConfigurationsContext
         session.Events.Append(secondEvent.UserId, secondEvent);
 
         //3. Unique Exception Was thrown
-        try
-        {
-            session.SaveChanges();
-        }
-        catch (MartenCommandException exception)
-        {
-            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
-        }
+        var exception = Should.Throw<MartenCommandException>(() => session.SaveChanges());
+        exception.ConstraintName.ShouldBe(UniqueUser.FullNameIndex);
+        ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
     }
 
     [Fact]
@@ -166,13 +154,8 @@ public class UniqueIndexTests: OneOffConfigurationsContext
         session.Events.Append(secondEvent.UserId, secondEvent);
 
         //3. Unique Exception Was thrown
-        try
-        {
-            session.SaveChanges();
-        }
-        catch (DocumentAlreadyExistsException exception)
-        {
-            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
-        }
+        var exception = Should.Throw<DocumentAlreadyExistsException>(() => session.SaveChanges());
+        exception.ConstraintName.ShouldBe(UniqueUser.EmailIndex);
+        ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
     }
 }

--- a/src/Marten/Exceptions/DocumentAlreadyExistsException.cs
+++ b/src/Marten/Exceptions/DocumentAlreadyExistsException.cs
@@ -5,11 +5,12 @@ namespace Marten.Exceptions;
 
 public sealed class DocumentAlreadyExistsException: MartenException
 {
-    public DocumentAlreadyExistsException(Exception inner, Type docType, object id): base(
+    public DocumentAlreadyExistsException(Exception inner, Type docType, object id, string constraintName): base(
         $"Document already exists {docType.FullName}: {id}", inner)
     {
         DocType = docType;
         Id = id;
+        ConstraintName = constraintName;
     }
 
     public DocumentAlreadyExistsException(SerializationInfo info, StreamingContext context): base(info, context)
@@ -18,4 +19,5 @@ public sealed class DocumentAlreadyExistsException: MartenException
 
     public Type DocType { get; }
     public object Id { get; }
+    public string ConstraintName { get; }
 }

--- a/src/Marten/Exceptions/MartenExceptionTransformer.cs
+++ b/src/Marten/Exceptions/MartenExceptionTransformer.cs
@@ -19,7 +19,12 @@ internal static class MartenExceptionTransformer
 
         Transforms.IfExceptionIs<PostgresException>()
             .If(e => e.SqlState == PostgresErrorCodes.SerializationFailure)
-            .ThenTransformTo(e => throw new ConcurrentUpdateException(e));
+            .ThenTransformTo(e => throw new ConcurrentUpdateException(e))
+            .TransformTo(e =>
+            {
+                var command = e.ReadNpgsqlCommand();
+                return new MartenCommandException(command, e);
+            });
 
         Transforms.IfExceptionIs<NpgsqlException>()
             .TransformTo(e =>

--- a/src/Marten/Internal/Operations/StorageOperation.cs
+++ b/src/Marten/Internal/Operations/StorageOperation.cs
@@ -173,7 +173,7 @@ public abstract class StorageOperation<T, TId>: IDocumentStorageOperation, IExce
             {
                 if (e.TableName == _tableName)
                 {
-                    transformed = new DocumentAlreadyExistsException(original, typeof(T), _id);
+                    transformed = new DocumentAlreadyExistsException(original, typeof(T), _id, e.ConstraintName ?? string.Empty);
                     return true;
                 }
             }

--- a/src/Marten/Schema/InsertExceptionTransform.cs
+++ b/src/Marten/Schema/InsertExceptionTransform.cs
@@ -23,7 +23,7 @@ public sealed class InsertExceptionTransform<T>: IExceptionTransform
         if (original.Message?.IndexOf(ExpectedMessage, StringComparison.OrdinalIgnoreCase) > -1 &&
             original.Message?.IndexOf(tableName, StringComparison.Ordinal) > -1)
         {
-            transformed = new DocumentAlreadyExistsException(original, typeof(T), id);
+            transformed = new DocumentAlreadyExistsException(original, typeof(T), id, string.Empty);
             return true;
         }
 


### PR DESCRIPTION
This passes the _ConstraintName_ field of the _PostgresException_ to both the _DocumentAlreadyExists_ and _MartenCommand_ exceptions with the objective of being able to identify exactly which constraint is failing when an exception is thrown without having to read the constraint name from the exception message.

For _DocumentAlreadyExistsException_ I simply passed the constraint name directly from the _TryTransform_ method of _StorageOperation_. 
The ConstraintName property from the PostgresExeception is a nullable string, but since DocumentAlreadyExistsException.cs didn't have a '#nullable' annotation i used the coalesce operator since to pass the string. Not sure if it's just better to make the new **ConstraintName** nullable.

For the _MartenCommandException_ I added a new constructor that takes a _PostgresException_ to be able to extract the constraint name, since there already was a constructor with a string used for something else. Not so confident this is the best solution for this tho.

Also modified the tests in _UniqueIndexTests_.cs to assert that the constraint name is correctly passed to the thrown exceptions.