### PR TITLE
Replaced (internal) `Event<T>` with `IEvent<T>` in docs

### DIFF
--- a/.github/workflows/docs-prs.yml
+++ b/.github/workflows/docs-prs.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-node@v3
         name: Setup node
         with:
-          node-version: "16"
+          node-version: "18"
       - run: npm install -g cspell
         name: Install cSpell
       - run: cspell --config ./docs/cSpell.json "docs/**/*.md"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ env:
   config: Release
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  node_version: 16.x
+  node_version: 18.x
 
 jobs:
   build-and-test-code:

--- a/docs/events/metadata.md
+++ b/docs/events/metadata.md
@@ -24,7 +24,7 @@ var store = DocumentStore.For(opts =>
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MetadataUsage.cs#L114-L127' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configureeventmetadata' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-The actual metadata is accessible from the `IEvent` interface or `Event<T>` event wrappers as shown below:
+The actual metadata is accessible from the `IEvent` interface event wrappers as shown below (which are implemented by internal `Event<T>`):
 
 <!-- snippet: sample_IEvent -->
 <a id='snippet-sample_ievent'></a>

--- a/docs/events/projections/aggregate-projections.md
+++ b/docs/events/projections/aggregate-projections.md
@@ -224,7 +224,7 @@ public class TripProjection: SingleStreamProjection<Trip>
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.AsyncDaemon.Testing/TestingSupport/TripProjectionWithCustomName.cs#L43-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-The `Create()` method has to return either the aggregate document type or `Task<T>` where `T` is the aggregate document type. There must be an argument for the specific event type or `Event<T>` where `T` is the event type if you need access to event metadata. You can also take in an `IQuerySession` if you need to look up additional data as part of the transformation or `IEvent` in addition to the exact event type just to get at event metadata.
+The `Create()` method has to return either the aggregate document type or `Task<T>` where `T` is the aggregate document type. There must be an argument for the specific event type or `IEvent<T>` where `T` is the event type if you need access to event metadata. You can also take in an `IQuerySession` if you need to look up additional data as part of the transformation or `IEvent` in addition to the exact event type just to get at event metadata.
 
 ## Applying Changes to the Aggregate Document
 
@@ -303,7 +303,7 @@ public class TripProjection: SingleStreamProjection<Trip>
 The `Apply()` methods can accept any combination of these arguments:
 
 1. The actual event type
-1. `Event<T>` where the `T` is the actual event type. Use this if you want access to the [event metadata](/events/metadata) like versions or timestamps.
+1. `IEvent<T>` where the `T` is the actual event type. Use this if you want access to the [event metadata](/events/metadata) like versions or timestamps.
 1. `IEvent` access the event metadata. It's perfectly valid to accept both `IEvent` for the metadata and the specific event type just out of convenience.
 1. `IQuerySession` if you need to do additional data lookups
 1. The aggregate type
@@ -405,7 +405,7 @@ public class TripProjection: SingleStreamProjection<Trip>
 The `ShouldDelete()` method can take any combination of these arguments:
 
 1. The actual event type
-1. `Event<T>` where the `T` is the actual event type. Use this if you want access to the [event metadata](/events/metadata) like versions or timestamps.
+1. `IEvent<T>` where the `T` is the actual event type. Use this if you want access to the [event metadata](/events/metadata) like versions or timestamps.
 1. `IQuerySession` if you need to do additional data lookups
 1. The aggregate type
 

--- a/docs/events/projections/event-projections.md
+++ b/docs/events/projections/event-projections.md
@@ -93,7 +93,7 @@ that way. Your other option is to use either the `Create()` or `Project()` metho
 
 The `Create()` method can accept these arguments:
 
-* The actual event type or `Event<T>` where `T` is the event type. One of these is required
+* The actual event type or `IEvent<T>` where `T` is the event type. One of these is required
 * `IEvent` to get access to the event metadata
 * Optionally take in `IDocumentOperations` if you need to access other data. This interface supports all the functionality of `IQuerySession`
 
@@ -106,7 +106,7 @@ The `Create()` method needs to return either:
 
 The `Project()` methods can accept these arguments:
 
-* The actual event type or `Event<T>` where `T` is the event type. One of these is required.
+* The actual event type or `IEvent<T>` where `T` is the event type. One of these is required.
 * `IEvent` to get access to the event metadata
 * `IDocumentOperations` is mandatory, and this is what you'd use to register any document operations
 

--- a/docs/events/projections/index.md
+++ b/docs/events/projections/index.md
@@ -64,9 +64,9 @@ public class QuestParty
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/QuestParty.cs#L8-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_questparty' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-New in Marten 1.2 is the ability to use `Event<T>` metadata within your projections, assuming that you're not trying to run the aggregations inline.
+Marten provides the ability to use `IEvent<T>` metadata within your projections, assuming that you're not trying to run the aggregations inline.
 
-The syntax using the built in aggregation technique is to take in `Event<T>` as the argument to your `Apply(event)` methods,
+The syntax using the built in aggregation technique is to take in `IEvent<T>` as the argument to your `Apply(event)` methods,
 where `T` is the event type you're interested in:
 
 <!-- snippet: sample_QuestPartyWithEvents -->

--- a/docs/events/projections/index.md
+++ b/docs/events/projections/index.md
@@ -67,7 +67,7 @@ public class QuestParty
 Marten provides the ability to use `IEvent<T>` metadata within your projections, assuming that you're not trying to run the aggregations inline.
 
 The syntax using the built in aggregation technique is to take in `IEvent<T>` as the argument to your `Apply(event)` methods,
-where `T` is the event type you're interested in:
+where `T` is the event type you're interested in [Single Stream Projections](/events/projections/aggregate-projections).
 
 <!-- snippet: sample_QuestPartyWithEvents -->
 <a id='snippet-sample_questpartywithevents'></a>

--- a/docs/events/projections/index.md
+++ b/docs/events/projections/index.md
@@ -67,7 +67,7 @@ public class QuestParty
 Marten provides the ability to use `IEvent<T>` metadata within your projections, assuming that you're not trying to run the aggregations inline.
 
 The syntax using the built in aggregation technique is to take in `IEvent<T>` as the argument to your `Apply(event)` methods,
-where `T` is the event type you're interested in [Single Stream Projections](/events/projections/aggregate-projections).
+where `T` is the event type you're interested is covered in [Single Stream Projections](/events/projections/aggregate-projections).
 
 <!-- snippet: sample_QuestPartyWithEvents -->
 <a id='snippet-sample_questpartywithevents'></a>

--- a/docs/events/querying.md
+++ b/docs/events/querying.md
@@ -36,7 +36,7 @@ public async Task load_event_stream_async(IDocumentSession session, Guid streamI
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/event_store_quickstart.cs#L117-L145' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using-fetch-stream' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-The data returned is a list of `IEvent` objects, where each is a strongly-typed `Event<T>` object shown below:
+The data returned is a list of `IEvent` objects, where each is a (internal) strongly-typed `Event<T>` object shown below:
 
 <!-- snippet: sample_IEvent -->
 <a id='snippet-sample_ievent'></a>

--- a/src/Marten/Events/Projections/Examples.cs
+++ b/src/Marten/Events/Projections/Examples.cs
@@ -51,7 +51,7 @@ public class DocumentAttribute: Attribute
     public Type DocumentType { get; }
 }
 
-// All the signatures could take in IQuerySession, or Event<T>
+// All the signatures could take in IQuerySession, or IEvent<T>
 public class SomeDocument1Projector
 {
     public SomeDocument1 Create(SomeEvent1 event1)


### PR DESCRIPTION
In the docs there's `Event<T>` but since https://github.com/JasperFx/marten/commit/cb0d92b05d8e13550ee5b3f95493c9d84c9af119 that type is `internal`. Thus changed the occurences to `IEvent<T>`.

Commit 647a25b9b1d53cb43e49c4d45ddbb24575d1daf5 is cherry-picked from https://github.com/JasperFx/marten/pull/2774 to (hopefully) avoid conflicts.