### PR TITLE
Support to write json with raw SQL to HttpContext

### DIFF
--- a/src/IssueService/Controllers/JsonController.cs
+++ b/src/IssueService/Controllers/JsonController.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using Marten;
+using Marten.AspNetCore;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IssueService.Controllers
+{
+    public class JsonController : ControllerBase
+    {
+        [HttpGet("/json/sql/{value1}/{value2}")]
+        public Task GetJsonFromSql([FromServices] IQuerySession store, string value1, string value2)
+            => store.WriteJson("SELECT jsonb_build_object('Property', ?) UNION SELECT jsonb_build_object('Property', ?);", HttpContext, contentType: "application/json", onFoundStatus: 200, parameters: new object[]{value1, value2});
+
+    }
+}

--- a/src/Marten.AspNetCore.Testing/web_service_streaming_tests.cs
+++ b/src/Marten.AspNetCore.Testing/web_service_streaming_tests.cs
@@ -215,5 +215,22 @@ public class web_service_streaming_tests: IntegrationContext
         read.Length.ShouldBe(issues.Count(x => x.Open));
     }
 
+    [Theory]
+    [InlineData("value1", "value2")]
+    public async Task stream_a_json_with_raw_sql(string value1, string value2)
+    {
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/json/sql/{value1}/{value2}");
+            s.ContentTypeShouldBe("application/json");
+        });
 
+        var read = result.ReadAsJson<SimpleProperty[]>();
+
+        read.Length.ShouldBe(2);
+        read[0].Property.ShouldBe(value1);
+        read[1].Property.ShouldBe(value2);
+    }
+
+    internal record SimpleProperty(string Property);
 }

--- a/src/Marten.AspNetCore/QueryableExtensions.cs
+++ b/src/Marten.AspNetCore/QueryableExtensions.cs
@@ -291,11 +291,12 @@ public static class QueryableExtensions
         string sql,
         HttpContext context,
         string contentType = "application/json",
-        int onFoundStatus = 200
+        int onFoundStatus = 200,
+        params object[] parameters
     )
     {
         var stream = new MemoryStream();
-        _ = await session.StreamJson<int>(stream, context.RequestAborted, sql).ConfigureAwait(false);
+        _ = await session.StreamJson<int>(stream, context.RequestAborted, sql, parameters).ConfigureAwait(false);
 
         context.Response.StatusCode = onFoundStatus;
         context.Response.ContentLength = stream.Length;

--- a/src/Marten.AspNetCore/QueryableExtensions.cs
+++ b/src/Marten.AspNetCore/QueryableExtensions.cs
@@ -276,4 +276,32 @@ public static class QueryableExtensions
         stream.Position = 0;
         await stream.CopyToAsync(context.Response.Body, context.RequestAborted).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Write an raw SQL query result directly to the HttpContext
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="sql"></param>
+    /// <param name="context"></param>
+    /// <param name="contentType"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
+    /// <returns></returns>
+    public static async Task WriteJson(
+        this IQuerySession session,
+        string sql,
+        HttpContext context,
+        string contentType = "application/json",
+        int onFoundStatus = 200
+    )
+    {
+        var stream = new MemoryStream();
+        _ = await session.StreamJson<int>(stream, context.RequestAborted, sql).ConfigureAwait(false);
+
+        context.Response.StatusCode = onFoundStatus;
+        context.Response.ContentLength = stream.Length;
+        context.Response.ContentType = contentType;
+
+        stream.Position = 0;
+        await stream.CopyToAsync(context.Response.Body, context.RequestAborted).ConfigureAwait(false);
+    }
 }


### PR DESCRIPTION
A typical use case occurs when you wish to write a custom query to summarize information and directly pass the response to the HttpResponse, without the need to map and serialize it through a DTO class.