### PR TITLE
Avoid buffering the content before streaming to the response body

### DIFF
--- a/src/Marten.AspNetCore/QueryableExtensions.cs
+++ b/src/Marten.AspNetCore/QueryableExtensions.cs
@@ -59,15 +59,10 @@ public static class QueryableExtensions
         int onFoundStatus = 200
     )
     {
-        var stream = new MemoryStream();
-        await queryable.StreamJsonArray(stream, context.RequestAborted).ConfigureAwait(false);
-
         context.Response.StatusCode = onFoundStatus;
-        context.Response.ContentLength = stream.Length;
         context.Response.ContentType = contentType;
 
-        stream.Position = 0;
-        await stream.CopyToAsync(context.Response.Body, context.RequestAborted).ConfigureAwait(false);
+        await queryable.StreamJsonArray(context.Response.Body, context.RequestAborted).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -266,15 +261,10 @@ public static class QueryableExtensions
         int onFoundStatus = 200
         )
     {
-        var stream = new MemoryStream();
-        await session.StreamJsonMany(query, stream, context.RequestAborted).ConfigureAwait(false);
-
         context.Response.StatusCode = onFoundStatus;
-        context.Response.ContentLength = stream.Length;
         context.Response.ContentType = contentType;
 
-        stream.Position = 0;
-        await stream.CopyToAsync(context.Response.Body, context.RequestAborted).ConfigureAwait(false);
+        await session.StreamJsonMany(query, context.Response.Body, context.RequestAborted).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -285,7 +275,6 @@ public static class QueryableExtensions
     /// <param name="context"></param>
     /// <param name="contentType"></param>
     /// <param name="onFoundStatus">Defaults to 200</param>
-    /// <returns></returns>
     public static async Task WriteJson(
         this IQuerySession session,
         string sql,
@@ -295,14 +284,9 @@ public static class QueryableExtensions
         params object[] parameters
     )
     {
-        var stream = new MemoryStream();
-        _ = await session.StreamJson<int>(stream, context.RequestAborted, sql, parameters).ConfigureAwait(false);
-
         context.Response.StatusCode = onFoundStatus;
-        context.Response.ContentLength = stream.Length;
         context.Response.ContentType = contentType;
 
-        stream.Position = 0;
-        await stream.CopyToAsync(context.Response.Body, context.RequestAborted).ConfigureAwait(false);
+        await session.StreamJson<int>(context.Response.Body, context.RequestAborted, sql, parameters).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
Addressed the point outlined in https://github.com/JasperFx/marten/discussions/2408#discussioncomment-4321349 and contributes to https://github.com/JasperFx/marten/issues/2791 (but does not fix that issue[^1])

For array streaming the whole content was buffered in a memory stream, then copied to the ASP.NET Core's response stream.
This has some downsides:
* the content-length isn't needed, ASP.NET Core will produce a chunked output, which can be read by any client
* it needs copying to the memory stream to the response -- which can be resource intensive for large data
* for large data it's possible that the memory stream gets bigger than 85.000 bytes, so it's above the large object heap (LOH) threshold of the GC, thus that object will live until a Gen-2 collection happens

These points can be avoided by writing to the response stream directly.

[^1]: I'll try to address the pooling, etc. point later, as that's not so straight forward.