### PR TITLE
Modified ConsoleLogger to output array parameter values

### DIFF
--- a/src/Marten/IMartenLogger.cs
+++ b/src/Marten/IMartenLogger.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections;
 using System.Diagnostics;
 using System.Linq;
 using Marten.Services;
@@ -87,7 +88,22 @@ public class ConsoleMartenLogger: IMartenLogger, IMartenSessionLogger
     {
         Console.WriteLine(command.CommandText);
         foreach (var p in command.Parameters.OfType<NpgsqlParameter>())
-            Console.WriteLine($"  {p.ParameterName}: {p.Value}");
+            Console.WriteLine($"  {p.ParameterName}: {GetParameterValue(p)}");
+    }
+
+    private static object? GetParameterValue(NpgsqlParameter p)
+    {
+        if (p.Value is IList enumerable)
+        {
+            var result = "";
+            for (var i = 0; i < Math.Min(enumerable.Count, 5); i++)
+            {
+                result += $"[{i}] {enumerable[i]}; ";
+            }
+            if (enumerable.Count > 5) result += $" + {enumerable.Count - 5} more";
+            return result;
+        }
+        return p.Value;
     }
 
     public void LogFailure(NpgsqlCommand command, Exception ex)


### PR DESCRIPTION
Not sure if this is something you may be interested in.  It's a minor change to the `ConsoleLogger` to output actual parameter values for arrays, rather than just something like `p0: System.Collections.Generic.List`1[System.Guid]`.  Instead output is:

```
  p0: [0]: 018bcff3-2301-49b6-9558-324553be0cb6; [1]: 018bf295-a374-447e-bed1-767e98aa48aa; [2]: 118bf295-a374-447e-bed1-767e98aa48aa; [3]: 218bf295-a374-447e-bed1-767e98aa48aa; [4]: 318bf295-a374-447e-bed1-767e98aa48aa;  + 1 more
  ```
Arbitrarily only displays the first 5 values to avoid clogging up logs too much.

Made my life debugging a test slightly easier, but not sure if it is of general use.  