### PR TITLE
Update storage.md to remove `mt_append_event`

### DIFF
--- a/docs/events/storage.md
+++ b/docs/events/storage.md
@@ -42,9 +42,8 @@ In addition, there are a couple other metadata tables you'll see in your schema:
 * `mt_streams` - Metadata about each event stream
 * `mt_event_progression` - A durable record about the progress of each async projection through the event store
 
-A couple functions that Marten uses internally:
+A function that Marten uses internally:
 
-* `mt_append_event` - Writes event data to the `mt_events` and `mt_streams` tables
 * `mt_mark_event_progression` - Updates the `mt_event_progression` table
 
 And lastly, there's a document type called `DeadLetterEvent` that Marten adds automatically to record information about


### PR DESCRIPTION
As I see from https://github.com/JasperFx/marten/issues/1641 then `mt_append_event` is gone, so it should go from the docs too.

---

Just for my understanding: that function got removed to have correct handling of concurrent appends?