### PR TITLE
Making the event stream version check work for Append to empty stream…

### DIFF
--- a/src/EventSourcingTests/event_statistics.cs
+++ b/src/EventSourcingTests/event_statistics.cs
@@ -7,13 +7,8 @@ using Xunit;
 
 namespace EventSourcingTests;
 
-public class event_statistics : IntegrationContext
+public class event_statistics : OneOffConfigurationsContext
 {
-    public event_statistics(DefaultStoreFixture fixture) : base(fixture)
-    {
-
-    }
-
     [Fact]
     public async Task fetch_from_empty_store()
     {

--- a/src/Marten/Events/EventStore.Append.cs
+++ b/src/Marten/Events/EventStore.Append.cs
@@ -38,6 +38,10 @@ internal partial class EventStore
         var eventStream = Append(stream, events);
         eventStream.ExpectedVersionOnServer = expectedVersion - eventStream.Events.Count;
 
+        if (eventStream.ExpectedVersionOnServer < 0)
+            throw new ArgumentOutOfRangeException(nameof(expectedVersion),
+                "The expected version cannot be less than the number of events being appended");
+
         return eventStream;
     }
 

--- a/src/Marten/Events/StreamAction.cs
+++ b/src/Marten/Events/StreamAction.cs
@@ -311,6 +311,15 @@ public class StreamAction
 
             ExpectedVersionOnServer = currentVersion;
         }
+        else if (ExpectedVersionOnServer.HasValue)
+        {
+            // This is from trying to call Append() with an expected version on a non-existent stream
+            if (ExpectedVersionOnServer.Value != 0)
+            {
+                throw new EventStreamUnexpectedMaxEventIdException((object?)Key ?? Id, AggregateType,
+                    ExpectedVersionOnServer.Value, currentVersion);
+            }
+        }
 
         Version = Events.Last().Version;
     }


### PR DESCRIPTION
…. Closes GH-2864