### PR TITLE
feat: Allow Identity to use IEvent<TEvent>

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_2883_ievent_not_working_as_identity_source_in_multistream_projections.cs
+++ b/src/EventSourcingTests/Bugs/Bug_2883_ievent_not_working_as_identity_source_in_multistream_projections.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Schema;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EventSourcingTests.Bugs;
+
+public class Bug_2883_ievent_not_working_as_identity_source : BugIntegrationContext
+{
+    private readonly ITestOutputHelper _output;
+
+    public Bug_2883_ievent_not_working_as_identity_source(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task CanUseIEventAsSourceForIdentity()
+    {
+        StoreOptions(_ =>
+        {
+            _.Projections.Add<CustomerInsightsProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var customersToCreate = 10;
+
+        {
+            await using var session = theStore.LightweightSession();
+            session.Logger = new TestOutputMartenLogger(_output);
+
+            for (var i = 0; i < customersToCreate; i++)
+            {
+                var stream = session.Events.StartStream(new CustomerCreated());
+            }
+
+            await session.SaveChangesAsync();
+        }
+        {
+            await using var session = theStore.QuerySession();
+
+            var docs = session.Query<CustomerInsightsResponse>().ToList();
+            docs.Count.ShouldBeEquivalentTo(1);
+            docs.First().NewCustomers.ShouldBe(customersToCreate);
+        }
+        var customersToDelete = 5;
+        {
+            await using var session = theStore.LightweightSession();
+            session.Logger = new TestOutputMartenLogger(_output);
+
+            for (var i = 0; i < customersToDelete; i++)
+            {
+                var stream = session.Events.StartStream(new CustomerDeleted());
+            }
+
+            await session.SaveChangesAsync();
+        }
+        {
+            await using var session = theStore.QuerySession();
+
+            var docs = session.Query<CustomerInsightsResponse>().ToList();
+            docs.Count.ShouldBeEquivalentTo(1);
+            docs.First().NewCustomers.ShouldBe(customersToCreate - customersToDelete);
+        }
+    }
+
+
+    public class CustomerInsightsProjection : MultiStreamProjection<CustomerInsightsResponse, string>
+{
+    public CustomerInsightsProjection()
+    {
+        Identity<IEvent<CustomerCreated>>(x => DateOnly.FromDateTime(x.Timestamp.Date).ToString(CultureInfo.InvariantCulture));
+        Identity<IEvent<CustomerDeleted>>(x => DateOnly.FromDateTime(x.Timestamp.Date).ToString(CultureInfo.InvariantCulture));
+    }
+
+    public CustomerInsightsResponse Create(IEvent<CustomerCreated> @event)
+        => new(@event.Timestamp.Date.ToString(CultureInfo.InvariantCulture), DateOnly.FromDateTime(@event.Timestamp.DateTime), 1);
+
+    public CustomerInsightsResponse Apply(IEvent<CustomerCreated> @event, CustomerInsightsResponse current)
+        => current with { NewCustomers = current.NewCustomers + 1 };
+
+    public CustomerInsightsResponse Apply(IEvent<CustomerDeleted> @event, CustomerInsightsResponse current)
+        => current with { NewCustomers = current.NewCustomers - 1 };
+}
+
+public class CustomerDeleted
+{
+}
+
+public record CustomerCreated();
+
+public record CustomerInsightsResponse(string Id, DateOnly Date, int NewCustomers);
+}

--- a/src/Marten/Events/Aggregation/EventSlicer.cs
+++ b/src/Marten/Events/Aggregation/EventSlicer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Marten.Events.Projections;
 using Marten.Storage;
@@ -73,6 +74,16 @@ public class EventSlicer<TDoc, TId>: IEventSlicer<TDoc, TId>
 
     public EventSlicer<TDoc, TId> Identity<TEvent>(Func<TEvent, TId> identityFunc)
     {
+        var eventType = typeof(TEvent);
+        // Check if we are actually dealing with an IEvent<EventType>
+        if (eventType.IsGenericType && eventType.GetGenericTypeDefinition() == typeof(IEvent<>))
+        {
+            var actualEventType = eventType.GetGenericArguments().First();
+            var eventGrouperType = typeof(SingleStreamEventGrouper<,>).MakeGenericType( typeof(TId), actualEventType);
+            _groupers.Add((IGrouper<TId>) Activator.CreateInstance(eventGrouperType, identityFunc));
+            return this;
+        }
+
         _groupers.Add(new SingleStreamGrouper<TId, TEvent>(identityFunc));
         return this;
     }

--- a/src/Marten/Events/Projections/SingleStreamEventGrouper.cs
+++ b/src/Marten/Events/Projections/SingleStreamEventGrouper.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using Marten.Events.Aggregation;
+
+namespace Marten.Events.Projections;
+
+/// <summary>
+///     Assigns an event to only one stream
+/// </summary>
+/// <typeparam name="TId"></typeparam>
+/// <typeparam name="TEvent"></typeparam>
+internal class SingleStreamEventGrouper<TId, TEvent>: IGrouper<TId>
+{
+    private readonly Func<IEvent<TEvent>, TId> _func;
+
+    public SingleStreamEventGrouper(Func<IEvent<TEvent>, TId> expression)
+    {
+        _func = expression;
+    }
+
+    public void Apply(IEnumerable<IEvent> events, ITenantSliceGroup<TId> grouping)
+    {
+        grouping.AddEventsWithMetadata(_func, events);
+    }
+}


### PR DESCRIPTION
Allows using IEvent<TEvent> as a type parameter for Identity in MultiStreamProjections.

Closes #2883 