### PR TITLE
fix: Use count(*) instead of count(1) for performance reasons

### DIFF
--- a/docs/documents/querying/linq/paging.md
+++ b/docs/documents/querying/linq/paging.md
@@ -70,7 +70,7 @@ public void can_get_the_total_in_results()
 For the sake of completeness, the SQL generated in the operation above by Marten would be:
 
 ```sql
-select d.data, d.id, count(1) OVER() as total_rows from public.mt_doc_target as d
+select d.data, d.id, count(*) OVER() as total_rows from public.mt_doc_target as d
 where CAST(d.data ->> 'Number' as integer) > :arg0 LIMIT 5
 ```
 

--- a/documentation/documentation/documents/querying/paging.md
+++ b/documentation/documentation/documents/querying/paging.md
@@ -12,7 +12,7 @@ If you want to create you own paged queries, just use the `Take()` and `Skip()` 
 For the sake of completeness, the SQL generated in the operation above by Marten would be:
 
 <pre>
-select d.data, d.id, count(1) OVER() as total_rows from public.mt_doc_target as d 
+select d.data, d.id, count(*) OVER() as total_rows from public.mt_doc_target as d 
 where CAST(d.data ->> 'Number' as integer) > :arg0 LIMIT 5
 </pre>
 

--- a/src/Marten/Linq/QueryHandlers/LinqConstants.cs
+++ b/src/Marten/Linq/QueryHandlers/LinqConstants.cs
@@ -7,7 +7,7 @@ namespace Marten.Linq.QueryHandlers;
 
 internal class LinqConstants
 {
-    internal static readonly string StatsColumn = "count(1) OVER() as total_rows";
+    internal static readonly string StatsColumn = "count(*) OVER() as total_rows";
     internal static readonly string IdListTableName = "mt_temp_id_list";
 
     internal static readonly ISelector<string> StringValueSelector =


### PR DESCRIPTION
When retrieving query statistics the use of count(*) instead of count(1) is faster for Postgres.

https://www.postgresql.org/message-id/flat/df354b76-a645-73fc-9645-4508e5291d71%40gmx.net