### PR TITLE
feat(#2945): AsyncDaemonHealthCheck - add `maxSameLagTime` option

### DIFF
--- a/docs/events/projections/healthchecks.md
+++ b/docs/events/projections/healthchecks.md
@@ -4,9 +4,15 @@
 The healthcheck is available in the [Marten.AspNetCore](https://www.nuget.org/packages/Marten.AspNetCore) package.
 :::
 
-Marten supports a customizable [HealthChecks](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-7.0). This can be useful when running the async daemon in a containerized environment such as Kubernetes. The check will verify that no projection's progression lags more than `maxEventLag` behind the `HighWaterMark`. The default `maxEventLag` is 100. Read more about events progression tracking and `HighWaterMark` in [Async Daemon documentation](/events/projections/async-daemon).
+Marten supports a customizable [HealthChecks](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-7.0). 
+This can be useful when running the async daemon in a containerized environment such as Kubernetes. 
+Especially if you experience `ProgressionProgressOutOfOrderException` errors in async projections.
 
-The `maxEventLag` setting controls how far behind the `HighWaterMark` any async projection is allowed to lag before it's considered unhealthy. E.g. if the `HighWaterMark` is 1000 and an a system with 3 async projections `ProjA`, `ProjB` and `ProjC` are processed respectively to sequence number 899, 901 and 901 then the system will be considered unhealthy with a `maxEventLag` of 100 (1000 - 899 = 101), BUT healthy with a `mavEventLag` of 101 or higher.
+The check will verify that no projection's progression lags more than `maxEventLag` behind the `HighWaterMark`. 
+The default `maxEventLag` is 100. Read more about events progression tracking and `HighWaterMark` in [Async Daemon documentation](/events/projections/async-daemon).
+
+The `maxEventLag` setting controls how far behind the `HighWaterMark` any async projection is allowed to lag before it's considered unhealthy. 
+E.g. if the `HighWaterMark` is 1000 and an a system with 3 async projections `ProjA`, `ProjB` and `ProjC` are processed respectively to sequence number 899, 901 and 901 then the system will be considered unhealthy with a `maxEventLag` of 100 (1000 - 899 = 101), BUT healthy with a `mavEventLag` of 101 or higher.
 
 ::: tip INFO
 The healthcheck will only be checked against `Async` projections
@@ -17,6 +23,34 @@ The healthcheck will only be checked against `Async` projections
 ```cs
 // Add HealthCheck
 Services.AddHealthChecks().AddMartenAsyncDaemonHealthCheck(maxEventLag: 500);
+
+// Map HealthCheck Endpoint
+app.MapHealthChecks("/health");
+```
+
+If you want to add some time toleration for the healthcheck, you may use additional parameter `maxSameLagTime`.
+It treats as unhealthy projections same as described below, but ONLY IF the same projection lag remains for the given time.
+
+### Example use case #1 
+Assuming that `maxEventLag` = `100` and `maxSameLagTime` = `TimeSpan.FromSeconds(30)`:
+- `HighWaterMark` is 1000 and async projection was processed to sequence number 850 at 2024-02-07 01:30:00 -> 'Healthy' 
+- `HighWaterMark` is 1000 and async projection was processed to sequence number 850 at 2024-02-07 01:30:30 -> 'Unhealthy' 
+
+It's unhealty, because the projection haven't progressed since last healthcheck and `maxSameLagTime` elapsed on the same sequence number.
+
+
+### Example use case #2 
+Assuming that `maxEventLag` = `100` and `maxSameLagTime` = `TimeSpan.FromSeconds(30)`:
+- `HighWaterMark` is 1000 and async projection was processed to sequence number 850 at 2024-02-07 01:30:00 -> 'Healthy'
+- `HighWaterMark` is 1000 and async projection was processed to sequence number 851 at 2024-02-07 01:30:30 -> 'Healthy'
+
+It's healthy, because the projection progressed since last healthcheck.
+
+## Example configuration:
+
+```cs
+// Add HealthCheck
+Services.AddHealthChecks().AddMartenAsyncDaemonHealthCheck(maxEventLag: 500, maxSameLagTime: TimeSpan.FromSeconds(30));
 
 // Map HealthCheck Endpoint
 app.MapHealthChecks("/health");

--- a/src/Marten.AspNetCore/Daemon/AsyncDaemonHealthCheckExtensions.cs
+++ b/src/Marten.AspNetCore/Daemon/AsyncDaemonHealthCheckExtensions.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using JasperFx.Core;
 using Marten.Events.Projections;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Marten.Events.Daemon;
@@ -29,6 +30,7 @@ public static class AsyncDaemonHealthCheckExtensions
     public static IHealthChecksBuilder AddMartenAsyncDaemonHealthCheck(this IHealthChecksBuilder builder, int maxEventLag = 100)
     {
         builder.Services.AddSingleton(new AsyncDaemonHealthCheckSettings(maxEventLag));
+        builder.Services.TryAddSingleton(TimeProvider.System);
         return builder.AddCheck<AsyncDaemonHealthCheck>(nameof(AsyncDaemonHealthCheck), tags: new[] { "Marten", "AsyncDaemon" });
     }
 

--- a/src/Marten.AspNetCore/Daemon/AsyncDaemonHealthCheckExtensions.cs
+++ b/src/Marten.AspNetCore/Daemon/AsyncDaemonHealthCheckExtensions.cs
@@ -1,5 +1,7 @@
 #nullable enable
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,12 +28,20 @@ public static class AsyncDaemonHealthCheckExtensions
     /// </summary>
     /// <param name="builder"><see cref="IHealthChecksBuilder"/></param>
     /// <param name="maxEventLag">(optional) Acceptable lag of an eventprojection before it's considered unhealthy - defaults to 100</param>
+    /// <param name="maxSameLagTime">(optional) Treat projection as healthy if maxEventLag exceeded, but projection sequence changed since last check in given time - defaults to null (uses just maxEventLag)</param>
     /// <returns>If healthy: <see cref="HealthCheckResult.Healthy"/> - else <see cref="HealthCheckResult.Unhealthy"/></returns>
-    public static IHealthChecksBuilder AddMartenAsyncDaemonHealthCheck(this IHealthChecksBuilder builder, int maxEventLag = 100)
+    public static IHealthChecksBuilder AddMartenAsyncDaemonHealthCheck(
+        this IHealthChecksBuilder builder,
+        int maxEventLag = 100,
+        TimeSpan? maxSameLagTime = null
+    )
     {
-        builder.Services.AddSingleton(new AsyncDaemonHealthCheckSettings(maxEventLag));
+        builder.Services.AddSingleton(new AsyncDaemonHealthCheckSettings(maxEventLag, maxSameLagTime));
         builder.Services.TryAddSingleton(TimeProvider.System);
-        return builder.AddCheck<AsyncDaemonHealthCheck>(nameof(AsyncDaemonHealthCheck), tags: new[] { "Marten", "AsyncDaemon" });
+        return builder.AddCheck<AsyncDaemonHealthCheck>(
+            nameof(AsyncDaemonHealthCheck),
+            tags: new[] { "Marten", "AsyncDaemon" }
+        );
     }
 
     /// <summary>
@@ -39,12 +49,12 @@ public static class AsyncDaemonHealthCheckExtensions
     /// </summary>
     /// <param name="MaxEventLag"></param>
     /// <returns></returns>
-    internal record AsyncDaemonHealthCheckSettings(int MaxEventLag);
+    internal record AsyncDaemonHealthCheckSettings(int MaxEventLag, TimeSpan? MaxSameLagTime = null);
 
     /// <summary>
     /// Health check implementation
     /// </summary>
-    internal class AsyncDaemonHealthCheck: IHealthCheck
+    internal class AsyncDaemonHealthCheck : IHealthCheck
     {
         /// <summary>
         /// The <see cref="DocumentStore"/> to check health for.
@@ -56,37 +66,93 @@ public static class AsyncDaemonHealthCheckExtensions
         /// </summary>
         private readonly int _maxEventLag;
 
-        public AsyncDaemonHealthCheck(IDocumentStore store, AsyncDaemonHealthCheckSettings settings)
+        /// <summary>
+        /// The allowed time for event projection is lagging (by maxEventLag).
+        /// If not provided every projection is considered lagging if HighWaterMark - projection.Position >= maxEventLag.
+        /// If provided only if projection.Position is still the same for given time.
+        /// When you want to rely only on time just set _maxEventLag=1 and maxSameLagTime to desired value.
+        /// </summary>
+        private readonly TimeSpan? _maxSameLagTime;
+
+        private readonly TimeProvider _timeProvider;
+
+        private readonly ConcurrentDictionary<string, (DateTime CheckedAt, long Sequence)>
+            _lastProjectionsChecks = new();
+
+        public AsyncDaemonHealthCheck(IDocumentStore store, AsyncDaemonHealthCheckSettings settings, TimeProvider timeProvider)
         {
             _store = store;
+            _timeProvider = timeProvider;
             _maxEventLag = settings.MaxEventLag;
+            _maxSameLagTime = settings.MaxSameLagTime;
         }
-        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
-                                                              CancellationToken cancellationToken = default)
+
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default
+        )
         {
             try
             {
-                var projectionsToCheck = _store.Options
-                                               .Events
-                                               .Projections()
-                                               .Where(x => x.Lifecycle == ProjectionLifecycle.Async) // Only check async projections to avoid issus where inline progression counter is set.
-                                               .Select(x => $"{x.ProjectionName}:All")
-                                               .ToHashSet();
+                var projectionsToCheck = _store.Options.Events.Projections()
+                    .Where(x => x.Lifecycle == ProjectionLifecycle.Async)
+                    .Select(x => $"{x.ProjectionName}:All")
+                    .ToHashSet();
 
-                var allProgress = await _store.Advanced.AllProjectionProgress(token: cancellationToken).ConfigureAwait(true);
+                var allProgress = await _store.Advanced.AllProjectionProgress(token: cancellationToken)
+                    .ConfigureAwait(true);
 
                 var highWaterMark = allProgress.First(x => string.Equals("HighWaterMark", x.ShardName));
-                var projectionMarks = allProgress.Where(x => !string.Equals("HighWaterMark", x.ShardName));
+                var projectionMarks = allProgress.Where(x => !string.Equals("HighWaterMark", x.ShardName)).ToArray();
 
-                var unhealthy = projectionMarks
-                                .Where(x => projectionsToCheck.Contains(x.ShardName))
-                                .Where(x => x.Sequence <= highWaterMark.Sequence - _maxEventLag)
-                                .Select(x => x.ShardName)
-                                .ToArray();
+                var projectionsSequences = projectionMarks.Where(x => projectionsToCheck.Contains(x.ShardName))
+                    .Select(x => new { x.ShardName, x.Sequence })
+                    .ToArray();
 
-                return unhealthy.Any()
-                  ? HealthCheckResult.Unhealthy($"Unhealthy: Async projection sequence is more than {_maxEventLag} events behind for projection(s): {unhealthy.Join(", ")}")
-                  : HealthCheckResult.Healthy("Healthy");
+                var laggingProjections = projectionsSequences
+                    .Where(x => x.Sequence <= highWaterMark.Sequence - _maxEventLag)
+                    .ToArray();
+
+                if (_maxSameLagTime is null)
+                {
+                    return laggingProjections.Any()
+                        ? HealthCheckResult.Unhealthy(
+                            $"Unhealthy: Async projection sequence is more than {_maxEventLag} events behind for projection(s): {laggingProjections.Select(x => x.ShardName).Join(", ")}"
+                        )
+                        : HealthCheckResult.Healthy("Healthy");
+                }
+
+                var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+                var projectionsLaggingWithSamePositionForGivenTime = laggingProjections.Where(
+                        x =>
+                        {
+                            var (laggingSince, lastKnownPosition) =
+                                _lastProjectionsChecks.GetValueOrDefault(x.ShardName, (now, x.Sequence));
+
+                            var isLaggingWithSamePositionForGivenTime =
+                                now.Subtract(laggingSince) >= _maxSameLagTime &&
+                                x.Sequence == lastKnownPosition;
+
+                            return isLaggingWithSamePositionForGivenTime;
+                        }
+                    )
+                    .ToArray();
+
+                foreach (var laggingProjection in laggingProjections)
+                {
+                    _lastProjectionsChecks.AddOrUpdate(
+                        laggingProjection.ShardName,
+                        _ => (now, laggingProjection.Sequence),
+                        (_, _) => (now, laggingProjection.Sequence)
+                    );
+                }
+
+                return projectionsLaggingWithSamePositionForGivenTime.Any()
+                    ? HealthCheckResult.Unhealthy(
+                        $"Unhealthy: Async projection sequence is more than {_maxEventLag} events behind with same sequence for more than {_maxSameLagTime} for projection(s): {projectionsLaggingWithSamePositionForGivenTime.Select(x => x.ShardName).Join(", ")}"
+                    )
+                    : HealthCheckResult.Healthy("Healthy");
             }
             catch (Exception ex)
             {

--- a/src/Marten.AsyncDaemon.Testing/AsyncDaemonHealthCheckExtensionsTests.cs
+++ b/src/Marten.AsyncDaemon.Testing/AsyncDaemonHealthCheckExtensionsTests.cs
@@ -8,6 +8,7 @@ using Marten.Testing.Harness;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Npgsql;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
@@ -19,43 +20,46 @@ namespace Marten.AsyncDaemon.Testing;
 public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
 {
 
-    private FakeHealthCheckBuilderStub builder = new();
+    private FakeHealthCheckBuilderStub _builder = new();
+    private readonly TimeProvider _timeProvider = Substitute.For<TimeProvider>();
+    private readonly DateTime _now = DateTime.UtcNow;
 
     public AsyncDaemonHealthCheckExtensionsTests(ITestOutputHelper output) : base(output)
     {
         _output = output;
+        _timeProvider.GetUtcNow().Returns(_now);
     }
 
     [Fact]
     public void should_add_settings_to_services()
     {
-        builder = new();
-        builder.Services.ShouldNotContain(x => x.ServiceType == typeof(AsyncDaemonHealthCheckSettings));
+        _builder = new();
+        _builder.Services.ShouldNotContain(x => x.ServiceType == typeof(AsyncDaemonHealthCheckSettings));
 
-        builder.AddMartenAsyncDaemonHealthCheck(200);
+        _builder.AddMartenAsyncDaemonHealthCheck(200);
 
-        builder.Services.ShouldContain(x => x.ServiceType == typeof(AsyncDaemonHealthCheckSettings));
+        _builder.Services.ShouldContain(x => x.ServiceType == typeof(AsyncDaemonHealthCheckSettings));
     }
 
     [Fact]
     public void should_add_timeprovider_to_services()
     {
-        builder = new();
-        builder.Services.ShouldNotContain(x => x.ServiceType == typeof(TimeProvider));
+        _builder = new();
+        _builder.Services.ShouldNotContain(x => x.ServiceType == typeof(TimeProvider));
 
-        builder.AddMartenAsyncDaemonHealthCheck(200);
+        _builder.AddMartenAsyncDaemonHealthCheck(200, TimeSpan.FromSeconds(5));
 
-        builder.Services.ShouldContain(x => x.ServiceType == typeof(TimeProvider));
+        _builder.Services.ShouldContain(x => x.ServiceType == typeof(TimeProvider));
     }
 
     [Fact]
     public void should_add_healthcheck_to_services()
     {
-        builder = new();
+        _builder = new();
 
-        builder.AddMartenAsyncDaemonHealthCheck();
+        _builder.AddMartenAsyncDaemonHealthCheck();
 
-        var services = builder.Services.BuildServiceProvider();
+        var services = _builder.Services.BuildServiceProvider();
         var healthCheckRegistrations = services.GetServices<HealthCheckRegistration>();
         healthCheckRegistrations.ShouldContain(reg => reg.Name == nameof(AsyncDaemonHealthCheck));
     }
@@ -72,7 +76,7 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
         session.Events.Append(Guid.NewGuid(), new FakeIrrellevantEvent());
         await session.SaveChangesAsync();
         await agent.Tracker.WaitForHighWaterMark(1);
-        var healthCheck = new AsyncDaemonHealthCheck(theStore, new(100));
+        var healthCheck = new AsyncDaemonHealthCheck(theStore, new(100), _timeProvider);
 
         var result = await healthCheck.CheckHealthAsync(new());
 
@@ -95,7 +99,7 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
         await session.SaveChangesAsync();
         await agent.Tracker.WaitForHighWaterMark(eventCount);
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream2:All", eventCount), 15.Seconds());
-        var healthCheck = new AsyncDaemonHealthCheck(theStore, new(0));
+        var healthCheck = new AsyncDaemonHealthCheck(theStore, new(0), _timeProvider);
 
         var result = await healthCheck.CheckHealthAsync(new());
 
@@ -126,7 +130,7 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream3:All", eventCount), 15.Seconds());
         await agent.Tracker.WaitForShardState(new ShardState("FakeStream4:All", eventCount), 15.Seconds());
         await agent.Tracker.WaitForHighWaterMark(eventCount);
-        var healthCheck = new AsyncDaemonHealthCheck(theStore, new(1));
+        var healthCheck = new AsyncDaemonHealthCheck(theStore, new(1), _timeProvider);
 
         var result = await healthCheck.CheckHealthAsync(new());
 
@@ -160,10 +164,128 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
 
         await theSession.ExecuteAsync(treeCommand);
 
-        var healthCheck = new AsyncDaemonHealthCheck(theStore, new(1));
+        var healthCheck = new AsyncDaemonHealthCheck(theStore, new(1), _timeProvider);
 
         var result = await healthCheck.CheckHealthAsync(new());
 
         result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task should_be_healthy_with_one_projection_lagging_but_within_max_same_lag_time()
+    {
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new FakeSingleStream5Projection(), ProjectionLifecycle.Async);
+            x.Projections.Add(new FakeSingleStream6Projection(), ProjectionLifecycle.Async);
+        });
+        var agent = await StartDaemon();
+        using var session = theStore.LightweightSession();
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+        var eventCount = 500;
+        for (var i = 0; i < eventCount; i++)
+        {
+            session.Events.Append(stream1, new FakeEvent());
+            session.Events.Append(stream2, new FakeEvent());
+        }
+        await session.SaveChangesAsync();
+        await agent.Tracker.WaitForShardState(new ShardState("FakeStream5:All", eventCount), 15.Seconds());
+        await agent.Tracker.WaitForShardState(new ShardState("FakeStream6:All", eventCount), 15.Seconds());
+        await agent.Tracker.WaitForHighWaterMark(eventCount);
+
+        using var treeCommand = new NpgsqlCommand($"update {theStore.Events.DatabaseSchemaName}.mt_event_progression set last_seq_id = 0 where name = 'FakeStream6:All'");
+
+        await theSession.ExecuteAsync(treeCommand);
+
+        var healthCheck = new AsyncDaemonHealthCheck(theStore, new(1, TimeSpan.FromSeconds(30)), _timeProvider);
+
+        var result = await healthCheck.CheckHealthAsync(new());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task should_be_unhealthy_with_one_projection_lagging_for_more_than_max_same_lag_time()
+    {
+        // Given
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new FakeSingleStream5Projection(), ProjectionLifecycle.Async);
+            x.Projections.Add(new FakeSingleStream6Projection(), ProjectionLifecycle.Async);
+        });
+        var agent = await StartDaemon();
+        using var session = theStore.LightweightSession();
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+        var eventCount = 500;
+        for (var i = 0; i < eventCount; i++)
+        {
+            session.Events.Append(stream1, new FakeEvent());
+            session.Events.Append(stream2, new FakeEvent());
+        }
+        await session.SaveChangesAsync();
+        await agent.Tracker.WaitForShardState(new ShardState("FakeStream5:All", eventCount), 15.Seconds());
+        await agent.Tracker.WaitForShardState(new ShardState("FakeStream6:All", eventCount), 15.Seconds());
+        await agent.Tracker.WaitForHighWaterMark(eventCount);
+
+        using var treeCommand = new NpgsqlCommand($"update {theStore.Events.DatabaseSchemaName}.mt_event_progression set last_seq_id = 0 where name = 'FakeStream6:All'");
+
+        await theSession.ExecuteAsync(treeCommand);
+
+        var maxSameLagTime = TimeSpan.FromSeconds(30);
+        var healthCheck = new AsyncDaemonHealthCheck(theStore, new(1, maxSameLagTime), _timeProvider);
+        await healthCheck.CheckHealthAsync(new());
+
+        // When
+        var afterMaxSameLagTime = _now.Add(maxSameLagTime.Add(TimeSpan.FromMilliseconds(1)));
+        _timeProvider.GetUtcNow().Returns(afterMaxSameLagTime);
+        var result = await healthCheck.CheckHealthAsync(new());
+
+        // Then
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task should_be_healthy_with_one_projection_lagging_for_more_than_max_same_lag_time_but_progressing()
+    {
+        // Given
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new FakeSingleStream5Projection(), ProjectionLifecycle.Async);
+            x.Projections.Add(new FakeSingleStream6Projection(), ProjectionLifecycle.Async);
+        });
+        var agent = await StartDaemon();
+        using var session = theStore.LightweightSession();
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+        var eventCount = 500;
+        for (var i = 0; i < eventCount; i++)
+        {
+            session.Events.Append(stream1, new FakeEvent());
+            session.Events.Append(stream2, new FakeEvent());
+        }
+        await session.SaveChangesAsync();
+        await agent.Tracker.WaitForShardState(new ShardState("FakeStream5:All", eventCount), 15.Seconds());
+        await agent.Tracker.WaitForShardState(new ShardState("FakeStream6:All", eventCount), 15.Seconds());
+        await agent.Tracker.WaitForHighWaterMark(eventCount);
+
+        await using var treeCommandSeqId0 = new NpgsqlCommand($"update {theStore.Events.DatabaseSchemaName}.mt_event_progression set last_seq_id = 0 where name = 'FakeStream6:All'");
+        await theSession.ExecuteAsync(treeCommandSeqId0);
+
+        var maxSameLagTime = TimeSpan.FromSeconds(30);
+        var healthCheck = new AsyncDaemonHealthCheck(theStore, new(1, maxSameLagTime), _timeProvider);
+        await healthCheck.CheckHealthAsync(new());
+
+        // When
+        await using var treeCommandSeqId1 = new NpgsqlCommand($"update {theStore.Events.DatabaseSchemaName}.mt_event_progression set last_seq_id = 1 where name = 'FakeStream6:All'");
+        await theSession.ExecuteAsync(treeCommandSeqId1);
+
+        var afterMaxSameLagTime = _now.Add(maxSameLagTime.Add(TimeSpan.FromMilliseconds(1)));
+        _timeProvider.GetUtcNow().Returns(afterMaxSameLagTime);
+        var result = await healthCheck.CheckHealthAsync(new());
+
+        // Then
+        result.Status.ShouldBe(HealthStatus.Healthy);
     }
 }

--- a/src/Marten.AsyncDaemon.Testing/AsyncDaemonHealthCheckExtensionsTests.cs
+++ b/src/Marten.AsyncDaemon.Testing/AsyncDaemonHealthCheckExtensionsTests.cs
@@ -65,6 +65,20 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
     }
 
     [Fact]
+    public async Task should_be_healty_without_events()
+    {
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new FakeSingleStream1Projection(), ProjectionLifecycle.Async);
+        });
+        var healthCheck = new AsyncDaemonHealthCheck(theStore, new(100), _timeProvider);
+
+        var result = await healthCheck.CheckHealthAsync(new());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
     public async Task should_be_healty_with_one_projection_no_relevant_events()
     {
         StoreOptions(x =>

--- a/src/Marten.AsyncDaemon.Testing/AsyncDaemonHealthCheckExtensionsTests.cs
+++ b/src/Marten.AsyncDaemon.Testing/AsyncDaemonHealthCheckExtensionsTests.cs
@@ -38,6 +38,17 @@ public class AsyncDaemonHealthCheckExtensionsTests: DaemonContext
     }
 
     [Fact]
+    public void should_add_timeprovider_to_services()
+    {
+        builder = new();
+        builder.Services.ShouldNotContain(x => x.ServiceType == typeof(TimeProvider));
+
+        builder.AddMartenAsyncDaemonHealthCheck(200);
+
+        builder.Services.ShouldContain(x => x.ServiceType == typeof(TimeProvider));
+    }
+
+    [Fact]
     public void should_add_healthcheck_to_services()
     {
         builder = new();


### PR DESCRIPTION
First implementation version to discuss for:
https://github.com/JasperFx/marten/issues/2945

This PR also fixes bug in the previous implementation: Unhelathy state when no events stored and HighWaterMark not present.

disclaimer:
I may use `FakeTimeProvider` from `Microsoft.Extensions.TimeProvider.Testing` for tests, but:
```
Install failed (project: Marten.AsyncDaemon.Testing, package: Microsoft.Extensions.TimeProvider.Testing v8.1.0) Package restore failed. Rolling back package changes for 'Marten.AsyncDaemon.Testing'. Detected package version outside of dependency constraint: Lamar 12.1.0 requires Microsoft.Extensions.DependencyInjection.Abstractions (>= 6.0.0 && 8.0.0) but version Microsoft.Extensions.DependencyInjection. ... e this issue. Marten.AsyncDaemon.Testing -> Microsoft.Extensions.TimeProvider.Testing 8.1.0 -> Microsoft.Bcl.TimeProvider 8.0.1 -> Microsoft.Bcl.AsyncInterfaces (>= 8.0.0) Marten.AsyncDaemon.Testing -> EventSourcingTests -> Lamar 12.1.0 -> Microsoft.Bcl.AsyncInterfaces (>= 6.0.0 && 8.0.0).
```

