### PR TITLE
Fix issue 2996: Sort by Type.FullName, not just Type.Name

### DIFF
--- a/src/Marten/Events/CodeGeneration/EventTypePatternMatchFrame.cs
+++ b/src/Marten/Events/CodeGeneration/EventTypePatternMatchFrame.cs
@@ -79,7 +79,7 @@ internal class EventTypePatternMatchFrame: Frame
             var sorted = new Stack<Type>();
 
             // Topological sort
-            foreach (var type in typesSet.OrderByDescending(type => type.Name)) //Orders by name at top-level
+            foreach (var type in typesSet.OrderByDescending(type => type.FullName)) //Orders by name at top-level
             {
                 VisitGraph(type, visited, sorted);
             }


### PR DESCRIPTION
In Marten's codegen, event switch-case ordering does not get sorted properly when there are multiple types with the same name but in different namespaces.

e.g.

```C#
namespace Foo {
	public record MyRecord(int foo);				
}

namespace Bar {
	public record MyRecord(int bar);				
}
```

In the above, `EventTypePatternMatchFrame.TypeSorter` will fail to sort `MyRecord` consistently - it uses `type.Name` which does not include the 2 different `MyRecord`s respective namespaces. This means CodeGen is unable to generate reproducible code from run to run, making it problematic for validating generated code in CI pipeline.

This simple PR changes `type.Name` to `type.FullName`.