### PR TITLE
Fix non awaited tasks in WaitForNonStaleProjectionDataAsync()

### DIFF
--- a/src/Marten/Events/AsyncProjectionTestingExtensions.cs
+++ b/src/Marten/Events/AsyncProjectionTestingExtensions.cs
@@ -51,7 +51,7 @@ public static class TestingExtensions
 
     public static async Task WaitForNonStaleProjectionDataAsync(this IMartenDatabase database, TimeSpan timeout)
     {
-        var cancellationSource = new CancellationTokenSource();
+        using var cancellationSource = new CancellationTokenSource();
         cancellationSource.CancelAfter(timeout);
 
         var initial = await database.FetchEventStoreStatistics(cancellationSource.Token).ConfigureAwait(false);

--- a/src/Marten/Events/AsyncProjectionTestingExtensions.cs
+++ b/src/Marten/Events/AsyncProjectionTestingExtensions.cs
@@ -25,8 +25,7 @@ public static class TestingExtensions
         }
         else
         {
-            var tasks = databases
-                .Select(db => db.WaitForNonStaleProjectionDataAsync(timeout)).ToArray();
+            var tasks = databases.Select(db => db.WaitForNonStaleProjectionDataAsync(timeout));
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
     }

--- a/src/Marten/Events/AsyncProjectionTestingExtensions.cs
+++ b/src/Marten/Events/AsyncProjectionTestingExtensions.cs
@@ -26,7 +26,7 @@ public static class TestingExtensions
         else
         {
             var tasks = databases
-                .Select(db => Task.Factory.StartNew(() => db.WaitForNonStaleProjectionDataAsync(timeout))).ToArray();
+                .Select(db => db.WaitForNonStaleProjectionDataAsync(timeout)).ToArray();
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
`Task.Factory.StartNew()` will not await the `WaitForNonStaleProjectionDataAsync()` inside.
So the extension method on the `IDocumentStore` will return "completed" before the actual task on the DB is done.