### PR TITLE
docs(getting-started.md): use new paket-cli syntax

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ PM> Install-Package Marten
 ```
 
 ```shell [Paket]
-paket add nuget Marten
+dotnet paket add Marten
 ```
 
 :::


### PR DESCRIPTION
The previous command used paket add nuget ...
nuget is the default and can be omitted.
The Paket CLI also gives a warning: "Please use the new syntax: 'nuget' is the default argument and should be omitted."

![image](https://github.com/JasperFx/marten/assets/444278/994b6cb2-6dc7-480c-8429-33028d24e83b)
