### PR TITLE
Advanced SQL query

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -123,6 +123,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                 { text: 'Searching with Boolean Flags', link: '/documents/querying/linq/booleans' },
                 { text: 'Searching for NULL Values', link: '/documents/querying/linq/nulls' },
                 { text: 'Querying with Postgres SQL', link: '/documents/querying/sql' },
+                { text: 'Advanced Querying with Postgres SQL', link: '/documents/querying/advanced-sql' },
                 { text: 'Querying for Raw JSON', link: '/documents/querying/query-json' },
                 { text: 'Compiled Queries', link: '/documents/querying/compiled-queries' },
                 { text: 'Batched Queries', link: '/documents/querying/batched-queries' },]

--- a/docs/documents/querying/advanced-sql.md
+++ b/docs/documents/querying/advanced-sql.md
@@ -4,9 +4,9 @@ Besides Linq queries or simple raw SQL queries via `session.Query<T>("where...")
 With this method Marten does not try to add any missing parts to the SQL query, instead you have to provide the whole query string yourself.
 
 Marten just makes some assumptions on how the schema of the SQl query result must look like, in order to be able to map the query result to documents, scalars or other JSON serializable types.
-With `AdvancedSqlQueryAsync` it is even possible to return multiple documents, objects and scalars as a tuple.
+With `AdvancedSqlQueryAsync` / `AdvancedSqlQuery` it is even possible to return multiple documents, objects and scalars as a tuple. Currently up to three result types can be queried for.
 
-The following rules must be followed when doing queries with `AdvancedSqlQueryAsync`:
+The following rules must be followed when doing queries with `AdvancedSqlQueryAsync` / `AdvancedSqlQuery`:
 
 - If a document should be returned, the SQL `SELECT` statement must contain all the columns required by Marten to build
   the document in the correct order. Which columns are needed depends on the session type and if any meta data are
@@ -134,3 +134,5 @@ results[1].detail.Detail.ShouldBe("Likes to cook");
 ```
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/advanced_sql_query.cs#L97-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_sql_query_related_documents_and_scalar' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+For sync queries you can use the `AdvancedSqlQuery<T>(...)` overloads.

--- a/docs/documents/querying/advanced-sql.md
+++ b/docs/documents/querying/advanced-sql.md
@@ -1,0 +1,136 @@
+# Advanced querying with Postgresql SQL
+
+Besides Linq queries or simple raw SQL queries via `session.Query<T>("where...")`, it is also possible to do even more complex SQL queries via `session.AdvancedSqlQueryAsync<T>()`.
+With this method Marten does not try to add any missing parts to the SQL query, instead you have to provide the whole query string yourself.
+
+Marten just makes some assumptions on how the schema of the SQl query result must look like, in order to be able to map the query result to documents, scalars or other JSON serializable types.
+With `AdvancedSqlQueryAsync` it is even possible to return multiple documents, objects and scalars as a tuple.
+
+The following rules must be followed when doing queries with `AdvancedSqlQueryAsync`:
+
+- If a document should be returned, the SQL `SELECT` statement must contain all the columns required by Marten to build
+  the document in the correct order. Which columns are needed depends on the session type and if any meta data are
+  mapped to the document.
+- When having multiple return types, the columns required for each type must be enclosed in a SQL `ROW` statement.
+- For non-document types the column `data` must return the JSON that will be deserialized to this type.
+
+For document types the correct order of columns in the result is:
+
+1. `id` - must always be present, except for `QuerySession`
+2. `data` - must always be present
+3. `mt_doc_type` - must be present only with document hierarchies
+4. `mt_version` - only when versioning is enabled
+5. `mt_last_modified` - only if this metadata is enabled 
+6. `mt_created_at` - only if this metadata is enabled
+7. `correlation_id` - only if this metadata is enabled
+8. `causation_id` - only if this metadata is enabled
+9. `last_modified_by` - only if this metadata is enabled
+10. `mt_deleted` - only if this metadata is enabled
+11. `mt_deleted_at` - only if this metadata is enabled
+
+You can always check the correct result column order, by inspecting the command text created from a Linq query: `var commandText = session.Query<T>().ToCommand().CommandText;`
+
+Querying for a simple scalar value can be done like this:
+
+<!-- snippet: sample_advanced_sql_query_single_scalar -->
+<a id='snippet-sample_advanced_sql_query_single_scalar'></a>
+```cs
+var name = (await session.AdvancedSqlQueryAsync<string>(
+    "select data ->> 'Name' from mt_doc_advanced_sql_query_docwithmeta limit 1",
+    CancellationToken.None)).First();
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/advanced_sql_query.cs#L25-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_sql_query_single_scalar' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Or for multiple scalars returned as a tuple:
+
+<!-- snippet: sample_advanced_sql_query_multiple_scalars -->
+<a id='snippet-sample_advanced_sql_query_multiple_scalars'></a>
+```cs
+var (number,text, boolean) = (await session.AdvancedSqlQueryAsync<int, string, bool>(
+    "select row(5), row('foo'), row(true) from (values(1)) as dummy",
+    CancellationToken.None)).First();
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/advanced_sql_query.cs#L37-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_sql_query_multiple_scalars' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+You can also query for any arbitrary JSON that will get deserialized:
+
+<!-- snippet: sample_advanced_sql_query_json_object -->
+<a id='snippet-sample_advanced_sql_query_json_object'></a>
+```cs
+var result = (await session.AdvancedSqlQueryAsync<Foo, Bar>(
+    "select row(json_build_object('Name', 'foo')), row(json_build_object('Name', 'bar')) from (values(1)) as dummy",
+    CancellationToken.None)).First();
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/advanced_sql_query.cs#L51-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_sql_query_json_object' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Querying for documents requires to return the correct columns:
+
+<!-- snippet: sample_advanced_sql_query_documents -->
+<a id='snippet-sample_advanced_sql_query_documents'></a>
+```cs
+var docs = await session.AdvancedSqlQueryAsync<DocWithoutMeta>(
+    "select id, data from mt_doc_advanced_sql_query_docwithoutmeta order by data ->> 'Name'",
+    CancellationToken.None);
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/advanced_sql_query.cs#L67-L71' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_sql_query_documents' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+If metadata are available, remember to add the correct metadata columns to the result. The order of the columns is
+important!:
+
+<!-- snippet: sample_advanced_sql_query_documents_with_metadata -->
+<a id='snippet-sample_advanced_sql_query_documents_with_metadata'></a>
+```cs
+var doc = (await session.AdvancedSqlQueryAsync<DocWithMeta>(
+    "select id, data, mt_version from mt_doc_advanced_sql_query_docwithmeta where data ->> 'Name' = 'Max'",
+    CancellationToken.None)).First();
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/advanced_sql_query.cs#L83-L87' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_sql_query_documents_with_metadata' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+You can also query for multiple related documents and scalar, e.g. for paging:
+
+<!-- snippet: sample_advanced_sql_query_related_documents_and_scalar -->
+<a id='snippet-sample_advanced_sql_query_related_documents_and_scalar'></a>
+```cs
+session.Store(new DocWithMeta { Id = 1, Name = "Max" });
+session.Store(new DocDetailsWithMeta { Id = 1, Detail = "Likes bees" });
+session.Store(new DocWithMeta { Id = 2, Name = "Michael" });
+session.Store(new DocDetailsWithMeta { Id = 2, Detail = "Is a good chess player" });
+session.Store(new DocWithMeta { Id = 3, Name = "Anne" });
+session.Store(new DocDetailsWithMeta { Id = 3, Detail = "Hates soap operas" });
+session.Store(new DocWithMeta { Id = 4, Name = "Beatrix" });
+session.Store(new DocDetailsWithMeta { Id = 4, Detail = "Likes to cook" });
+await session.SaveChangesAsync();
+
+IReadOnlyList<(DocWithMeta doc, DocDetailsWithMeta detail, long totalResults)> results =
+    await session.AdvancedSqlQueryAsync<DocWithMeta, DocDetailsWithMeta, long>(
+        """
+        select
+          row(a.id, a.data, a.mt_version),
+          row(b.id, b.data, b.mt_version),
+          row(count(*) over())
+        from
+          mt_doc_advanced_sql_query_docwithmeta a
+        left join
+          mt_doc_advanced_sql_query_docdetailswithmeta b on a.id = b.id
+        where
+          (a.data ->> 'Id')::int > 1
+        order by
+          a.data ->> 'Name'
+        limit 2
+        """,
+        CancellationToken.None);
+
+results.Count.ShouldBe(2);
+results[0].totalResults.ShouldBe(3);
+results[0].doc.Name.ShouldBe("Anne");
+results[0].detail.Detail.ShouldBe("Hates soap operas");
+results[1].doc.Name.ShouldBe("Beatrix");
+results[1].detail.Detail.ShouldBe("Likes to cook");
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/advanced_sql_query.cs#L97-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_sql_query_related_documents_and_scalar' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->

--- a/docs/documents/querying/index.md
+++ b/docs/documents/querying/index.md
@@ -5,6 +5,7 @@ Marten provides a wide variety of support for querying and loading document data
 * [Loading Documents by Id](/documents/querying/byid)
 * [Querying with Linq](/documents/querying/linq/)
 * [Querying with Postgres SQL](/documents/querying/sql)
+* [Advanced Querying with Postgres SQL](/documents/querying/advanced-sql)
 * [Retrieving or Streaming JSON](/documents/querying/query-json)
 * [Including Related Documents](/documents/querying/linq/include)
 * [Compiled Queries](/documents/querying/compiled-queries)

--- a/src/DocumentDbTests/Reading/advanced_sql_query.cs
+++ b/src/DocumentDbTests/Reading/advanced_sql_query.cs
@@ -22,9 +22,11 @@ public class advanced_sql_query: IntegrationContext
         using var session = theStore.LightweightSession();
         session.Store(new DocWithMeta { Id = 1, Name = "Max" });
         await session.SaveChangesAsync();
+        #region sample_advanced_sql_query_single_scalar
         var name = (await session.AdvancedSqlQueryAsync<string>(
-            "select data ->> 'Name' from mt_doc_advanced_sql_query_docwithmeta LIMIT 1",
+            "select data ->> 'Name' from mt_doc_advanced_sql_query_docwithmeta limit 1",
             CancellationToken.None)).First();
+        #endregion
         name.ShouldBe("Max");
     }
 
@@ -32,21 +34,25 @@ public class advanced_sql_query: IntegrationContext
     public async void can_query_multiple_scalars()
     {
         using var session = theStore.LightweightSession();
-        var result = (await session.AdvancedSqlQueryAsync<int, string, bool>(
+        #region sample_advanced_sql_query_multiple_scalars
+        var (number,text, boolean) = (await session.AdvancedSqlQueryAsync<int, string, bool>(
             "select row(5), row('foo'), row(true) from (values(1)) as dummy",
             CancellationToken.None)).First();
-        result.Item1.ShouldBe(5);
-        result.Item2.ShouldBe("foo");
-        result.Item3.ShouldBe(true);
+        #endregion
+        number.ShouldBe(5);
+        text.ShouldBe("foo");
+        boolean.ShouldBe(true);
     }
 
     [Fact]
     public async void can_query_non_document_classes_from_json()
     {
         using var session = theStore.LightweightSession();
+        #region sample_advanced_sql_query_json_object
         var result = (await session.AdvancedSqlQueryAsync<Foo, Bar>(
             "select row(json_build_object('Name', 'foo')), row(json_build_object('Name', 'bar')) from (values(1)) as dummy",
             CancellationToken.None)).First();
+        #endregion
         result.Item1.Name.ShouldBe("foo");
         result.Item2.Name.ShouldBe("bar");
     }
@@ -58,9 +64,11 @@ public class advanced_sql_query: IntegrationContext
         session.Store(new DocWithoutMeta { Id = 1, Name = "Max" });
         session.Store(new DocWithoutMeta { Id = 2, Name = "Anne" });
         await session.SaveChangesAsync();
+        #region sample_advanced_sql_query_documents
         var docs = await session.AdvancedSqlQueryAsync<DocWithoutMeta>(
             "select id, data from mt_doc_advanced_sql_query_docwithoutmeta order by data ->> 'Name'",
             CancellationToken.None);
+        #endregion
         docs.Count.ShouldBe(2);
         docs[0].Name.ShouldBe("Anne");
         docs[1].Name.ShouldBe("Max");
@@ -72,9 +80,11 @@ public class advanced_sql_query: IntegrationContext
         using var session = theStore.LightweightSession();
         session.Store(new DocWithMeta { Id = 1, Name = "Max" });
         await session.SaveChangesAsync();
+        #region sample_advanced_sql_query_documents_with_metadata
         var doc = (await session.AdvancedSqlQueryAsync<DocWithMeta>(
             "select id, data, mt_version from mt_doc_advanced_sql_query_docwithmeta where data ->> 'Name' = 'Max'",
             CancellationToken.None)).First();
+        #endregion
         doc.Id.ShouldBe(1);
         doc.Name.ShouldBe("Max");
         doc.Version.ShouldNotBe(Guid.Empty);
@@ -84,6 +94,7 @@ public class advanced_sql_query: IntegrationContext
     public async void can_query_multiple_documents_and_scalar()
     {
         using var session = theStore.LightweightSession();
+        #region sample_advanced_sql_query_related_documents_and_scalar
         session.Store(new DocWithMeta { Id = 1, Name = "Max" });
         session.Store(new DocDetailsWithMeta { Id = 1, Detail = "Likes bees" });
         session.Store(new DocWithMeta { Id = 2, Name = "Michael" });
@@ -112,12 +123,14 @@ public class advanced_sql_query: IntegrationContext
                 limit 2
                 """,
                 CancellationToken.None);
+
         results.Count.ShouldBe(2);
         results[0].totalResults.ShouldBe(3);
         results[0].doc.Name.ShouldBe("Anne");
         results[0].detail.Detail.ShouldBe("Hates soap operas");
         results[1].doc.Name.ShouldBe("Beatrix");
         results[1].detail.Detail.ShouldBe("Likes to cook");
+        #endregion
     }
 
     public class DocWithoutMeta

--- a/src/DocumentDbTests/Reading/advanced_sql_query.cs
+++ b/src/DocumentDbTests/Reading/advanced_sql_query.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using System.Threading;
+using Marten.Metadata;
+using Marten.Testing.Harness;
+using Newtonsoft.Json;
+using Shouldly;
+using Xunit;
+
+namespace DocumentDbTests.Reading;
+
+public class advanced_sql_query: IntegrationContext
+{
+    public advanced_sql_query(DefaultStoreFixture fixture): base(fixture)
+    {
+    }
+
+    [Fact]
+    public async void can_query_scalar()
+    {
+        using var session = theStore.LightweightSession();
+        session.Store(new DocWithMeta { Id = 1, Name = "Max" });
+        await session.SaveChangesAsync();
+        var name = (await session.AdvancedSqlQueryAsync<string>(
+            "select data ->> 'Name' from mt_doc_advanced_sql_query_docwithmeta LIMIT 1",
+            CancellationToken.None)).First();
+        name.ShouldBe("Max");
+    }
+
+    [Fact]
+    public async void can_query_documents()
+    {
+        using var session = theStore.LightweightSession();
+        session.Store(new DocWithoutMeta { Id = 1, Name = "Max" });
+        session.Store(new DocWithoutMeta { Id = 2, Name = "Anne" });
+        await session.SaveChangesAsync();
+        var docs = await session.AdvancedSqlQueryAsync<DocWithoutMeta>(
+            "select id, data from mt_doc_advanced_sql_query_docwithoutmeta order by data ->> 'Name'",
+            CancellationToken.None);
+        docs.Count.ShouldBe(2);
+        docs[0].Name.ShouldBe("Anne");
+        docs[1].Name.ShouldBe("Max");
+    }
+
+    [Fact]
+    public async void can_query_documents_and_will_set_metadata_on_result_documents()
+    {
+        using var session = theStore.LightweightSession();
+        session.Store(new DocWithMeta { Id = 1, Name = "Max" });
+        await session.SaveChangesAsync();
+        var doc = (await session.AdvancedSqlQueryAsync<DocWithMeta>(
+            "select id, data, mt_version from mt_doc_advanced_sql_query_docwithmeta where data ->> 'Name' = 'Max'",
+            CancellationToken.None)).First();
+        doc.Id.ShouldBe(1);
+        doc.Name.ShouldBe("Max");
+        doc.Version.ShouldNotBe(Guid.Empty);
+    }
+
+    public class DocWithoutMeta
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class DocWithMeta: IVersioned
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        [JsonIgnore]
+        public Guid Version { get; set; }
+    }
+}

--- a/src/DocumentDbTests/Reading/advanced_sql_query.cs
+++ b/src/DocumentDbTests/Reading/advanced_sql_query.cs
@@ -133,6 +133,27 @@ public class advanced_sql_query: IntegrationContext
         #endregion
     }
 
+    [Fact]
+    public void can_query_synchrounously()
+    {
+        using var session = theStore.LightweightSession();
+
+        var singleResult  = session.AdvancedSqlQuery<int>("select 5 from (values(1)) as dummy").First();
+        var tuple2Result = session.AdvancedSqlQuery<int, string>(
+            "select row(5), row('foo')from (values(1)) as dummy").First();
+        var tuple3Result = session.AdvancedSqlQuery<int, string, bool>(
+            "select row(5), row('foo'), row(true) from (values(1)) as dummy").First();
+
+        singleResult.ShouldBe(5);
+
+        tuple2Result.Item1.ShouldBe(5);
+        tuple2Result.Item2.ShouldBe("foo");
+
+        tuple3Result.Item1.ShouldBe(5);
+        tuple3Result.Item2.ShouldBe("foo");
+        tuple3Result.Item3.ShouldBe(true);
+    }
+
     public class DocWithoutMeta
     {
         public int Id { get; set; }

--- a/src/DocumentDbTests/Reading/advanced_sql_query.cs
+++ b/src/DocumentDbTests/Reading/advanced_sql_query.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Marten.Metadata;
@@ -25,6 +26,29 @@ public class advanced_sql_query: IntegrationContext
             "select data ->> 'Name' from mt_doc_advanced_sql_query_docwithmeta LIMIT 1",
             CancellationToken.None)).First();
         name.ShouldBe("Max");
+    }
+
+    [Fact]
+    public async void can_query_multiple_scalars()
+    {
+        using var session = theStore.LightweightSession();
+        var result = (await session.AdvancedSqlQueryAsync<int, string, bool>(
+            "select row(5), row('foo'), row(true) from (values(1)) as dummy",
+            CancellationToken.None)).First();
+        result.Item1.ShouldBe(5);
+        result.Item2.ShouldBe("foo");
+        result.Item3.ShouldBe(true);
+    }
+
+    [Fact]
+    public async void can_query_non_document_classes_from_json()
+    {
+        using var session = theStore.LightweightSession();
+        var result = (await session.AdvancedSqlQueryAsync<Foo, Bar>(
+            "select row(json_build_object('Name', 'foo')), row(json_build_object('Name', 'bar')) from (values(1)) as dummy",
+            CancellationToken.None)).First();
+        result.Item1.Name.ShouldBe("foo");
+        result.Item2.Name.ShouldBe("bar");
     }
 
     [Fact]
@@ -56,6 +80,46 @@ public class advanced_sql_query: IntegrationContext
         doc.Version.ShouldNotBe(Guid.Empty);
     }
 
+    [Fact]
+    public async void can_query_multiple_documents_and_scalar()
+    {
+        using var session = theStore.LightweightSession();
+        session.Store(new DocWithMeta { Id = 1, Name = "Max" });
+        session.Store(new DocDetailsWithMeta { Id = 1, Detail = "Likes bees" });
+        session.Store(new DocWithMeta { Id = 2, Name = "Michael" });
+        session.Store(new DocDetailsWithMeta { Id = 2, Detail = "Is a good chess player" });
+        session.Store(new DocWithMeta { Id = 3, Name = "Anne" });
+        session.Store(new DocDetailsWithMeta { Id = 3, Detail = "Hates soap operas" });
+        session.Store(new DocWithMeta { Id = 4, Name = "Beatrix" });
+        session.Store(new DocDetailsWithMeta { Id = 4, Detail = "Likes to cook" });
+        await session.SaveChangesAsync();
+
+        IReadOnlyList<(DocWithMeta doc, DocDetailsWithMeta detail, long totalResults)> results =
+            await session.AdvancedSqlQueryAsync<DocWithMeta, DocDetailsWithMeta, long>(
+                """
+                select
+                  row(a.id, a.data, a.mt_version),
+                  row(b.id, b.data, b.mt_version),
+                  row(count(*) over())
+                from
+                  mt_doc_advanced_sql_query_docwithmeta a
+                left join
+                  mt_doc_advanced_sql_query_docdetailswithmeta b on a.id = b.id
+                where
+                  (a.data ->> 'Id')::int > 1
+                order by
+                  a.data ->> 'Name'
+                limit 2
+                """,
+                CancellationToken.None);
+        results.Count.ShouldBe(2);
+        results[0].totalResults.ShouldBe(3);
+        results[0].doc.Name.ShouldBe("Anne");
+        results[0].detail.Detail.ShouldBe("Hates soap operas");
+        results[1].doc.Name.ShouldBe("Beatrix");
+        results[1].detail.Detail.ShouldBe("Likes to cook");
+    }
+
     public class DocWithoutMeta
     {
         public int Id { get; set; }
@@ -68,5 +132,23 @@ public class advanced_sql_query: IntegrationContext
         public string Name { get; set; }
         [JsonIgnore]
         public Guid Version { get; set; }
+    }
+
+    public class DocDetailsWithMeta: IVersioned
+    {
+        public int Id { get; set; }
+        public string Detail { get; set; }
+        [JsonIgnore]
+        public Guid Version { get; set; }
+    }
+
+    public class Foo
+    {
+        public string Name { get; set; }
+    }
+
+    public class Bar
+    {
+        public string Name { get; set; }
     }
 }

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -198,6 +198,25 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// <returns></returns>
     Task<IReadOnlyList<T>> QueryAsync<T>(string sql, params object[] parameters);
 
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The SQL must contain a select with the required fields in the correct order,
+    ///     depending on the metadata the document might use:
+    ///     <list type="bullet">
+    ///         <item>id</item>
+    ///         <item>data</item>
+    ///         <item>mt_type</item>
+    ///         <item>mt_version</item>
+    ///         <item>...TODO!</item>
+    ///     </list>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<T>> AdvancedSqlQueryAsync<T>(string sql, CancellationToken token, params object[] parameters);
+
     /// <summary>
     ///     Define a batch of deferred queries and load operations to be conducted in one asynchronous request to the
     ///     database for potentially performance

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -148,7 +148,7 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
 
     /// <summary>
     ///     Queries the document storage table for the document type T by supplied SQL. See
-    ///     http://jasperfx.github.io/marten/documentation/documents/querying/sql/ for more information on usage.
+    ///     https://martendb.io/documents/querying/sql.html for more information on usage.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="sql"></param>
@@ -179,7 +179,7 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
 
     /// <summary>
     ///     Asynchronously queries the document storage table for the document type T by supplied SQL. See
-    ///     http://jasperfx.github.io/marten/documentation/documents/querying/sql/ for more information on usage.
+    ///     https://martendb.io/documents/querying/sql.html for more information on usage.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="sql"></param>
@@ -190,7 +190,7 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
 
     /// <summary>
     ///     Asynchronously queries the document storage table for the document type T by supplied SQL. See
-    ///     http://jasperfx.github.io/marten/documentation/documents/querying/sql/ for more information on usage.
+    ///     https://martendb.io/documents/querying/sql.html for more information on usage.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="sql"></param>

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -201,21 +201,47 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
 
     /// <summary>
     ///     Asynchronously queries the document storage with the supplied SQL.
-    ///     The SQL must contain a select with the required fields in the correct order,
-    ///     depending on the metadata the document might use:
-    ///     <list type="bullet">
-    ///         <item>id</item>
-    ///         <item>data</item>
-    ///         <item>mt_type</item>
-    ///         <item>mt_version</item>
-    ///         <item>...TODO!</item>
-    ///     </list>
+    ///     The type parameter can be a document class, a scalar or any JSON-serializable class.
+    ///     If the result is a document, the SQL must contain a select with the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     selected.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="sql"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
     Task<IReadOnlyList<T>> AdvancedSqlQueryAsync<T>(string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order, 
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<(T1, T2)>> AdvancedSqlQueryAsync<T1, T2>(string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order, 
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <typeparam name="T3"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<(T1, T2, T3)>> AdvancedSqlQueryAsync<T1, T2,T3>(string sql, CancellationToken token, params object[] parameters);
 
     /// <summary>
     ///     Define a batch of deferred queries and load operations to be conducted in one asynchronous request to the

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -171,7 +171,6 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     ///     Stream the results of a user-supplied query directly to a stream as a JSON array
     /// </summary>
     /// <param name="destination"></param>
-    /// <param name="token"></param>
     /// <param name="sql"></param>
     /// <param name="parameters"></param>
     /// <typeparam name="T"></typeparam>
@@ -195,7 +194,6 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="sql"></param>
-    /// <param name="token"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
     Task<IReadOnlyList<T>> QueryAsync<T>(string sql, params object[] parameters);

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -244,6 +244,50 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     Task<IReadOnlyList<(T1, T2, T3)>> AdvancedSqlQueryAsync<T1, T2,T3>(string sql, CancellationToken token, params object[] parameters);
 
     /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameter can be a document class, a scalar or any JSON-serializable class.
+    ///     If the result is a document, the SQL must contain a select with the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     selected.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    IReadOnlyList<T> AdvancedSqlQuery<T>(string sql, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order, 
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    IReadOnlyList<(T1, T2)> AdvancedSqlQuery<T1, T2>(string sql, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order, 
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <typeparam name="T3"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    IReadOnlyList<(T1, T2, T3)> AdvancedSqlQuery<T1, T2, T3>(string sql, params object[] parameters);
+
+    /// <summary>
     ///     Define a batch of deferred queries and load operations to be conducted in one asynchronous request to the
     ///     database for potentially performance
     /// </summary>

--- a/src/Marten/Internal/Sessions/QuerySession.Querying.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Querying.cs
@@ -52,6 +52,22 @@ public partial class QuerySession
         return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
     }
 
+    public async Task<IReadOnlyList<T>> AdvancedSqlQueryAsync<T>(string sql, CancellationToken token, params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T>(this, sql, parameters);
+
+        if (handler.SqlSelectContainsStandardColumns)
+        {
+            await Database.EnsureStorageExistsAsync(typeof(T), token).ConfigureAwait(false);
+        }
+
+        var provider = new MartenLinqQueryProvider(this, typeof(T));
+        return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+    }
+
+
     public Task<IReadOnlyList<T>> QueryAsync<T>(string sql, params object[] parameters)
     {
         return QueryAsync<T>(sql, CancellationToken.None, parameters);

--- a/src/Marten/Internal/Sessions/QuerySession.Querying.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Querying.cs
@@ -58,15 +58,44 @@ public partial class QuerySession
 
         var handler = new AdvancedSqlQueryHandler<T>(this, sql, parameters);
 
-        if (handler.SqlSelectContainsStandardColumns)
+        foreach (var documentType in handler.DocumentTypes)
         {
-            await Database.EnsureStorageExistsAsync(typeof(T), token).ConfigureAwait(false);
+            await Database.EnsureStorageExistsAsync(documentType, token).ConfigureAwait(false);
         }
 
         var provider = new MartenLinqQueryProvider(this, typeof(T));
         return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
     }
 
+    public async Task<IReadOnlyList<(T1, T2)>> AdvancedSqlQueryAsync<T1, T2>(string sql, CancellationToken token, params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T1, T2>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes)
+        {
+            await Database.EnsureStorageExistsAsync(documentType, token).ConfigureAwait(false);
+        }
+
+        var provider = new MartenLinqQueryProvider(this, typeof((T1, T2)));
+        return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<(T1, T2, T3)>> AdvancedSqlQueryAsync<T1, T2, T3>(string sql, CancellationToken token, params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes) 
+        {
+            await Database.EnsureStorageExistsAsync(documentType, token).ConfigureAwait(false);
+        }
+
+        var provider = new MartenLinqQueryProvider(this, typeof((T1, T2, T3)));
+        return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+    }
 
     public Task<IReadOnlyList<T>> QueryAsync<T>(string sql, params object[] parameters)
     {

--- a/src/Marten/Internal/Sessions/QuerySession.Querying.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Querying.cs
@@ -52,6 +52,11 @@ public partial class QuerySession
         return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
     }
 
+    public Task<IReadOnlyList<T>> QueryAsync<T>(string sql, params object[] parameters)
+    {
+        return QueryAsync<T>(sql, CancellationToken.None, parameters);
+    }
+
     public async Task<IReadOnlyList<T>> AdvancedSqlQueryAsync<T>(string sql, CancellationToken token, params object[] parameters)
     {
         assertNotDisposed();
@@ -88,7 +93,7 @@ public partial class QuerySession
 
         var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, sql, parameters);
 
-        foreach (var documentType in handler.DocumentTypes) 
+        foreach (var documentType in handler.DocumentTypes)
         {
             await Database.EnsureStorageExistsAsync(documentType, token).ConfigureAwait(false);
         }
@@ -97,9 +102,49 @@ public partial class QuerySession
         return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
     }
 
-    public Task<IReadOnlyList<T>> QueryAsync<T>(string sql, params object[] parameters)
+    public IReadOnlyList<T> AdvancedSqlQuery<T>(string sql, params object[] parameters)
     {
-        return QueryAsync<T>(sql, CancellationToken.None, parameters);
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes)
+        {
+            Database.EnsureStorageExists(documentType);
+        }
+
+        var provider = new MartenLinqQueryProvider(this, typeof(T));
+        return provider.ExecuteHandler(handler);
+    }
+
+    public IReadOnlyList<(T1, T2)> AdvancedSqlQuery<T1, T2>(string sql, params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T1, T2>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes)
+        {
+            Database.EnsureStorageExists(documentType);
+        }
+
+        var provider = new MartenLinqQueryProvider(this, typeof((T1, T2)));
+        return provider.ExecuteHandler(handler);
+    }
+
+    public IReadOnlyList<(T1, T2, T3)> AdvancedSqlQuery<T1, T2, T3>(string sql, params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes)
+        {
+            Database.EnsureStorageExists(documentType);
+        }
+
+        var provider = new MartenLinqQueryProvider(this, typeof((T1, T2, T3)));
+        return provider.ExecuteHandler(handler);
     }
 
     public IBatchedQuery CreateBatchQuery()

--- a/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
@@ -3,105 +3,160 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Marten.Linq.Selectors;
 using Marten.Linq.SqlGeneration;
-using Marten.Services;
-using Npgsql;
 using Weasel.Postgresql;
 
 namespace Marten.Linq.QueryHandlers;
 
-internal class AdvancedSqlQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>
+internal class AdvancedSqlQueryHandler<T>: AdvancedSqlQueryHandlerBase, IQueryHandler<IReadOnlyList<T>>
 {
-    private readonly object[] _parameters;
-    private readonly ISelectClause _selectClause;
-    private readonly ISelector<T> _selector;
-    private readonly string _sql;
-
-    public AdvancedSqlQueryHandler(IMartenSession session, string sql, object[] parameters)
+    public AdvancedSqlQueryHandler(IMartenSession session, string sql, object[] parameters):base(sql, parameters)
     {
-        _sql = sql.TrimStart();
-        _parameters = parameters;
-        SqlSelectContainsStandardColumns = Regex.IsMatch(_sql, @"^select\s+(\S+\.)?id\s*,\s*(\S+\.)?data(\s|,)", RegexOptions.IgnoreCase);
-
-        _selectClause = GetSelectClause(session);
-        _selector = (ISelector<T>)_selectClause.BuildSelector(session);
-    }
-
-    public bool SqlSelectContainsStandardColumns { get; }
-
-    public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
-    {
-        var firstParameter = _parameters.FirstOrDefault();
-
-        if (_parameters.Length == 1 && firstParameter != null && firstParameter.IsAnonymousType())
-        {
-            builder.Append(_sql);
-            builder.AddParameters(firstParameter);
-        }
-        else
-        {
-            var cmdParameters = builder.AppendWithParameters(_sql);
-            if (cmdParameters.Length != _parameters.Length)
-            {
-                throw new InvalidOperationException("Wrong number of supplied parameters");
-            }
-
-            for (var i = 0; i < cmdParameters.Length; i++)
-            {
-                if (_parameters[i] == null)
-                {
-                    cmdParameters[i].Value = DBNull.Value;
-                }
-                else
-                {
-                    cmdParameters[i].Value = _parameters[i];
-                    cmdParameters[i].NpgsqlDbType =
-                        PostgresqlProvider.Instance.ToParameterType(_parameters[i].GetType());
-                }
-            }
-        }
+        RegisterResultType<T>(session);
     }
 
     public IReadOnlyList<T> Handle(DbDataReader reader, IMartenSession session)
     {
-        var list = new List<T>();
-
-        while (reader.Read())
-        {
-            var item = _selector.Resolve(reader);
-            list.Add(item);
-        }
-
-        return list;
+        throw new NotImplementedException();
     }
 
     public async Task<IReadOnlyList<T>> HandleAsync(DbDataReader reader, IMartenSession session,
         CancellationToken token)
     {
         var list = new List<T>();
-
         while (await reader.ReadAsync(token).ConfigureAwait(false))
         {
-            var item = await _selector.ResolveAsync(reader, token).ConfigureAwait(false);
+            var item = await ((ISelector<T>)Selectors[0]).ResolveAsync(reader, token).ConfigureAwait(false);
             list.Add(item);
         }
-
         return list;
     }
+}
 
-    public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)
+internal class AdvancedSqlQueryHandler<T1, T2>: AdvancedSqlQueryHandlerBase, IQueryHandler<IReadOnlyList<(T1, T2)>>
+{
+    public AdvancedSqlQueryHandler(IMartenSession session, string sql, object[] parameters) : base(sql, parameters)
     {
-        return reader.As<NpgsqlDataReader>().StreamMany(stream, token);
+        RegisterResultType<T1>(session);
+        RegisterResultType<T2>(session);
     }
 
+    public IReadOnlyList<(T1, T2)> Handle(DbDataReader reader, IMartenSession session)
+    {
+        throw new NotImplementedException();
+    }
 
-    private ISelectClause GetSelectClause(IMartenSession session)
+    public async Task<IReadOnlyList<(T1, T2)>> HandleAsync(DbDataReader reader, IMartenSession session,
+        CancellationToken token)
+    {
+        var list = new List<(T1, T2)>();
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            var item1 = await ReadNestedRowAsync<T1>(reader, 0, token).ConfigureAwait(false);
+            var item2 = await ReadNestedRowAsync<T2>(reader, 1, token).ConfigureAwait(false);
+            list.Add((item1, item2));
+        }
+        return list;
+    }
+}
+internal class AdvancedSqlQueryHandler<T1, T2, T3>: AdvancedSqlQueryHandlerBase, IQueryHandler<IReadOnlyList<(T1, T2, T3)>>
+{
+    public AdvancedSqlQueryHandler(IMartenSession session, string sql, object[] parameters) : base(sql, parameters)
+    {
+        RegisterResultType<T1>(session);
+        RegisterResultType<T2>(session);
+        RegisterResultType<T3>(session);
+    }
+
+    public IReadOnlyList<(T1, T2, T3)> Handle(DbDataReader reader, IMartenSession session)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<IReadOnlyList<(T1, T2, T3)>> HandleAsync(DbDataReader reader, IMartenSession session,
+        CancellationToken token)
+    {
+        var list = new List<(T1, T2, T3)>();
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            var item1 = await ReadNestedRowAsync<T1>(reader, 0, token).ConfigureAwait(false);
+            var item2 = await ReadNestedRowAsync<T2>(reader, 1, token).ConfigureAwait(false);
+            var item3 = await ReadNestedRowAsync<T3>(reader, 2, token).ConfigureAwait(false);
+            list.Add((item1, item2, item3));
+        }
+        return list;
+    }
+}
+
+internal class AdvancedSqlQueryHandlerBase
+{
+    protected readonly object[] Parameters;
+    protected readonly string Sql;
+    protected List<ISelector> Selectors = new();
+
+    protected AdvancedSqlQueryHandlerBase(string sql, object[] parameters)
+    {
+        Sql = sql.TrimStart();
+        Parameters = parameters;
+    }
+
+    public List<Type> DocumentTypes { get; } = new();
+
+    public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var firstParameter = Parameters.FirstOrDefault();
+
+        if (Parameters.Length == 1 && firstParameter != null && firstParameter.IsAnonymousType())
+        {
+            builder.Append(Sql);
+            builder.AddParameters(firstParameter);
+        }
+        else
+        {
+            var cmdParameters = builder.AppendWithParameters(Sql);
+            if (cmdParameters.Length != Parameters.Length)
+            {
+                throw new InvalidOperationException("Wrong number of supplied parameters");
+            }
+
+            for (var i = 0; i < cmdParameters.Length; i++)
+            {
+                if (Parameters[i] == null)
+                {
+                    cmdParameters[i].Value = DBNull.Value;
+                }
+                else
+                {
+                    cmdParameters[i].Value = Parameters[i];
+                    cmdParameters[i].NpgsqlDbType =
+                        PostgresqlProvider.Instance.ToParameterType(Parameters[i].GetType());
+                }
+            }
+        }
+    }
+
+    protected async Task<T> ReadNestedRowAsync<T>(DbDataReader reader, int rowIndex, CancellationToken token)
+    {
+        var innerReader = reader.GetData(rowIndex) ??
+                          throw new ArgumentException("Invalid row index", nameof(rowIndex));
+
+        await using (innerReader.ConfigureAwait(false))
+        {
+            if (await innerReader.ReadAsync(token).ConfigureAwait(false))
+            {
+                return await ((ISelector<T>)Selectors[rowIndex]).ResolveAsync(innerReader, token).ConfigureAwait(false);
+            }
+        }
+        return default;
+    }
+
+    protected ISelectClause GetSelectClause<T>(IMartenSession session)
     {
         if (typeof(T) == typeof(string))
         {
@@ -113,12 +168,25 @@ internal class AdvancedSqlQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>
             return typeof(ScalarSelectClause<>).CloseAndBuildAs<ISelectClause>(string.Empty, string.Empty, typeof(T));
         }
 
-
-        if (!SqlSelectContainsStandardColumns)
+        if (typeof(T).GetProperty("Id") == null && typeof(T).GetProperty("id") == null)
         {
             return new DataSelectClause<T>(string.Empty, string.Empty);
         }
+        return session.StorageFor<T>();
+    }
 
-        return session.StorageFor(typeof(T));
+    protected void RegisterResultType<T>(IMartenSession session)
+    {
+        var selectClause = GetSelectClause<T>(session);
+        Selectors.Add(selectClause.BuildSelector(session));
+        if (selectClause is IDocumentStorage)
+        {
+            DocumentTypes.Add(typeof(T));
+        }
+    }
+
+    public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+using Marten.Internal;
+using Marten.Linq.Selectors;
+using Marten.Linq.SqlGeneration;
+using Marten.Services;
+using Npgsql;
+using Weasel.Postgresql;
+
+namespace Marten.Linq.QueryHandlers;
+
+internal class AdvancedSqlQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>
+{
+    private readonly object[] _parameters;
+    private readonly ISelectClause _selectClause;
+    private readonly ISelector<T> _selector;
+    private readonly string _sql;
+
+    public AdvancedSqlQueryHandler(IMartenSession session, string sql, object[] parameters)
+    {
+        _sql = sql.TrimStart();
+        _parameters = parameters;
+        SqlSelectContainsStandardColumns = Regex.IsMatch(_sql, @"^select\s+(\S+\.)?id\s*,\s*(\S+\.)?data(\s|,)", RegexOptions.IgnoreCase);
+
+        _selectClause = GetSelectClause(session);
+        _selector = (ISelector<T>)_selectClause.BuildSelector(session);
+    }
+
+    public bool SqlSelectContainsStandardColumns { get; }
+
+    public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var firstParameter = _parameters.FirstOrDefault();
+
+        if (_parameters.Length == 1 && firstParameter != null && firstParameter.IsAnonymousType())
+        {
+            builder.Append(_sql);
+            builder.AddParameters(firstParameter);
+        }
+        else
+        {
+            var cmdParameters = builder.AppendWithParameters(_sql);
+            if (cmdParameters.Length != _parameters.Length)
+            {
+                throw new InvalidOperationException("Wrong number of supplied parameters");
+            }
+
+            for (var i = 0; i < cmdParameters.Length; i++)
+            {
+                if (_parameters[i] == null)
+                {
+                    cmdParameters[i].Value = DBNull.Value;
+                }
+                else
+                {
+                    cmdParameters[i].Value = _parameters[i];
+                    cmdParameters[i].NpgsqlDbType =
+                        PostgresqlProvider.Instance.ToParameterType(_parameters[i].GetType());
+                }
+            }
+        }
+    }
+
+    public IReadOnlyList<T> Handle(DbDataReader reader, IMartenSession session)
+    {
+        var list = new List<T>();
+
+        while (reader.Read())
+        {
+            var item = _selector.Resolve(reader);
+            list.Add(item);
+        }
+
+        return list;
+    }
+
+    public async Task<IReadOnlyList<T>> HandleAsync(DbDataReader reader, IMartenSession session,
+        CancellationToken token)
+    {
+        var list = new List<T>();
+
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            var item = await _selector.ResolveAsync(reader, token).ConfigureAwait(false);
+            list.Add(item);
+        }
+
+        return list;
+    }
+
+    public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)
+    {
+        return reader.As<NpgsqlDataReader>().StreamMany(stream, token);
+    }
+
+
+    private ISelectClause GetSelectClause(IMartenSession session)
+    {
+        if (typeof(T) == typeof(string))
+        {
+            return new ScalarStringSelectClause(string.Empty, string.Empty);
+        }
+
+        if (PostgresqlProvider.Instance.HasTypeMapping(typeof(T)))
+        {
+            return typeof(ScalarSelectClause<>).CloseAndBuildAs<ISelectClause>(string.Empty, string.Empty, typeof(T));
+        }
+
+
+        if (!SqlSelectContainsStandardColumns)
+        {
+            return new DataSelectClause<T>(string.Empty, string.Empty);
+        }
+
+        return session.StorageFor(typeof(T));
+    }
+}

--- a/src/Marten/Services/SystemTextJsonSerializer.cs
+++ b/src/Marten/Services/SystemTextJsonSerializer.cs
@@ -81,7 +81,7 @@ public class SystemTextJsonSerializer: ISerializer
     public async ValueTask<T> FromJsonAsync<T>(DbDataReader reader, int index,
         CancellationToken cancellationToken = default)
     {
-        await using var stream = await reader.As<NpgsqlDataReader>().GetStreamAsync(index, cancellationToken)
+        await using var stream = await reader.GetFieldValueAsync<Stream>(index, cancellationToken)
             .ConfigureAwait(false);
         return await FromJsonAsync<T>(stream, cancellationToken).ConfigureAwait(false);
     }
@@ -94,7 +94,7 @@ public class SystemTextJsonSerializer: ISerializer
 
     public object FromJson(Type type, DbDataReader reader, int index)
     {
-        return FromJson(type, reader.As<NpgsqlDataReader>().GetStream(index));
+        return FromJson(type, reader.GetFieldValue<Stream>(index));
     }
 
     public async ValueTask<object> FromJsonAsync(Type type, Stream stream,
@@ -108,7 +108,7 @@ public class SystemTextJsonSerializer: ISerializer
     public async ValueTask<object> FromJsonAsync(Type type, DbDataReader reader, int index,
         CancellationToken cancellationToken = default)
     {
-        await using var stream = await reader.As<NpgsqlDataReader>().GetStreamAsync(index, cancellationToken)
+        await using var stream = await reader.GetFieldValueAsync<Stream>(index, cancellationToken)
             .ConfigureAwait(false);
         return await FromJsonAsync(type, stream, cancellationToken).ConfigureAwait(false);
     }
@@ -211,6 +211,6 @@ public class SystemTextJsonSerializer: ISerializer
 
     public JsonDocument JsonDocumentFromJson(DbDataReader reader, int index)
     {
-        return JsonDocumentFromJson(reader.As<NpgsqlDataReader>().GetStream(index));
+        return JsonDocumentFromJson(reader.GetFieldValue<Stream>(index));
     }
 }

--- a/src/Marten/Storage/Metadata/RevisionColumn.cs
+++ b/src/Marten/Storage/Metadata/RevisionColumn.cs
@@ -3,10 +3,9 @@ using JasperFx.Core;
 using Marten.Internal.CodeGeneration;
 using Marten.Schema;
 using Marten.Schema.Arguments;
-using Marten.Storage.Metadata;
 using Weasel.Postgresql.Tables;
 
-namespace Marten.Storage;
+namespace Marten.Storage.Metadata;
 
 internal class RevisionColumn: MetadataColumn<int>, ISelectableColumn
 {

--- a/src/Marten/Storage/Metadata/VersionColumn.cs
+++ b/src/Marten/Storage/Metadata/VersionColumn.cs
@@ -2,9 +2,8 @@ using System;
 using JasperFx.CodeGeneration;
 using Marten.Internal.CodeGeneration;
 using Marten.Schema;
-using Marten.Storage.Metadata;
 
-namespace Marten.Storage;
+namespace Marten.Storage.Metadata;
 
 internal class VersionColumn: MetadataColumn<Guid>, ISelectableColumn
 {


### PR DESCRIPTION
AdvancedSqlQueryAsync<T, ...>(sql, ...) allows to perform more complex SQL queries than would be possible with Query<T>(sql). It allows to query documents, scalars and deserializable JSON objects or any combination of these returned as a tuple.
This also allows to query for related documents. Metadata mapping, dirty tracking etc. for documents is fully supported. The full SQL must be provided (no "magic" SQL building) so the user is responsible to provide all the columns needed by Marten in the correct order.

Currently result tuples with up to 3 elements are possible (a single result type will not be returned as a tuple). This could be easily extend, but then I would move all the overloads into a partial class. For the same reason I have not created an extra overload for the async methods without a CancellationToken.

I've tried to implement this as least "invasive" as possible. Only IQuerySession and its implementation are extended, the magic happens in the new AdvancedQueryHandler class.

Future improvments might be:
- More result types
- Instead of mapping columns by index, map them by name (would require larger changes, especially to the generated code)
