### PR TITLE
LinqParsing - MetadataToken is insufficient to uniquely identify an expression method.

### DIFF
--- a/src/Marten/LinqParsing.cs
+++ b/src/Marten/LinqParsing.cs
@@ -140,10 +140,14 @@ public class LinqParsing: IReadOnlyLinqParsing
     ///     https://learn.microsoft.com/en-us/dotnet/api/system.reflection.memberinfo.metadatatoken?view=net-8.0
     ///     MetadataToken -- "A value which, in combination with Module, uniquely identifies a metadata element."
     /// </summary>
-    private long ToKey(MethodCallExpression expression)
+    private static long ToKey(MethodCallExpression expression)
     {
-        int moduleKey = expression.Method.Module.Name.GetHashCode();
-        int expressionKey = expression.Method.MetadataToken;
-        return (long)moduleKey << 32 | (uint)expressionKey;
+        var method = expression.Method;
+        unchecked
+        {
+            int moduleKey = method.Module.FullyQualifiedName.GetHashCode();
+            int expressionKey = method.MetadataToken;
+            return (long)moduleKey << 32 | (uint)expressionKey;
+        }
     }
 }

--- a/src/Marten/LinqParsing.cs
+++ b/src/Marten/LinqParsing.cs
@@ -15,6 +15,7 @@ using Marten.Linq.Parsing.Methods;
 using Marten.Linq.Parsing.Methods.FullText;
 using Marten.Linq.Parsing.Methods.Strings;
 using Marten.Linq.SoftDeletes;
+using Newtonsoft.Json.Linq;
 
 namespace Marten;
 
@@ -95,13 +96,14 @@ public class LinqParsing: IReadOnlyLinqParsing
 
     private readonly StoreOptions _options;
 
+    private static readonly HashSet<string> Encoutered = new HashSet<string>();
 
     /// <summary>
     ///     Add custom Linq expression parsers for your own methods
     /// </summary>
     public readonly IList<IMethodCallParser> MethodCallParsers = new List<IMethodCallParser>();
 
-    private ImHashMap<long, IMethodCallParser> _methodParsers = ImHashMap<long, IMethodCallParser>.Empty;
+    private ImHashMap<string, IMethodCallParser> _methodParsers = ImHashMap<string, IMethodCallParser>.Empty;
 
     internal LinqParsing(StoreOptions options)
     {
@@ -143,8 +145,20 @@ public class LinqParsing: IReadOnlyLinqParsing
     ///     https://learn.microsoft.com/en-us/dotnet/api/system.reflection.memberinfo.metadatatoken?view=net-8.0
     ///     MetadataToken -- "A value which, in combination with Module, uniquely identifies a metadata element."
     /// </summary>
-    private static long ToKey(MethodInfo expressionMethod)
+    private static string ToKey(MethodInfo expressionMethod)
     {
-        return (long)expressionMethod.Module.MetadataToken << 32 | (uint)expressionMethod.MetadataToken;
+        Encoutered.Add(
+            $"{expressionMethod.Module.Name}_{expressionMethod.Module.MetadataToken}_{expressionMethod.MetadataToken}_{expressionMethod.DeclaringType?.Name}_{expressionMethod.Name}");
+
+        Console.WriteLine();
+        Console.WriteLine();
+        Console.WriteLine("---");
+        Console.WriteLine();
+        foreach (var x in Encoutered.ToArray())
+        {
+            Console.WriteLine(x);
+        }
+
+        return $"{expressionMethod.Module.Name}_{expressionMethod.MetadataToken}";
     }
 }


### PR DESCRIPTION
Appologies, I'm having trouble writing a Marten test to reproduce this as I have no control over what dotnet assignes for MetadataToken, however here are a couple of screengrabs from my project running against the latest (887afe724be9d2ed938f8ab4deb7c44c910df0d9) codebase which is just after 7.3.0...

As you can see the IsDeleted and String compare methods in two different modules, Marten and System.Linq respectively, are getting the same hash code, and therefore LinqParsing.cs is caching the wrong value in the _methodParsers hash map.

Looking at the MS docs MetadataToken is only unique per module, and therefore I think the cache key needs to be changed..
https://learn.microsoft.com/en-us/dotnet/api/system.reflection.memberinfo.metadatatoken?view=net-8.0

![image](https://github.com/JasperFx/marten/assets/1295224/9cc1ff74-ff5e-43d2-9836-32adf7a11f74)

![image](https://github.com/JasperFx/marten/assets/1295224/e0e05ca7-659e-4b70-9b36-5281ec3bcc8f)

Here is an example from local execution of my codebase with Marten integrated, where MaybeDeletedParser is being returned for a string comparison:
![image](https://github.com/JasperFx/marten/assets/1295224/8b342e32-7e9f-40bd-a980-9f76f308606a)



```csharp


public class LinqParsing: IReadOnlyLinqParsing
{
    private static readonly HashSet<string> Encoutered = new HashSet<string>();

    internal IMethodCallParser FindMethodParser(MethodCallExpression expression)
    {
        var key = ToKey(expression.Method);
...

    private static long ToKey(MethodInfo expressionMethod)
    {
        Encoutered.Add(
            $"{expressionMethod.Module.Name}_{expressionMethod.Module.MetadataToken}_{expressionMethod.MetadataToken}_{expressionMethod.DeclaringType?.Name}_{expressionMethod.Name}");

        Console.WriteLine();
        Console.WriteLine();
        Console.WriteLine("---");
        Console.WriteLine();
        foreach (var x in Encoutered)
        {
            Console.WriteLine(x);
        }
...
```

Output:
```
Marten.dll_1_100663701_LinqExtensions_IsOneOf
Marten.dll_1_100666478_MatchesSqlExtensions_MatchesSql
Marten.dll_1_100665670_SoftDeletedExtensions_MaybeDeleted   // Duplicate
System.Linq.dll_1_100663360_Enumerable_Any
System.Linq.dll_1_100663395_Enumerable_Contains
Marten.dll_1_100663704_LinqExtensions_In
System.Private.CoreLib.dll_1_100665670_String_Contains   // Duplicate
```

Another repro path output:
```
Marten.dll_1_100663701_LinqExtensions_IsOneOf
Marten.dll_1_100665672_SoftDeletedExtensions_DeletedSince
Marten.dll_1_100665671_SoftDeletedExtensions_IsDeleted
System.Linq.dll_1_100663360_Enumerable_Any
System.Linq.dll_1_100663395_Enumerable_Contains
Marten.dll_1_100663704_LinqExtensions_In
Marten.dll_1_100665670_SoftDeletedExtensions_MaybeDeleted   // Dupe
Marten.dll_1_100666478_MatchesSqlExtensions_MatchesSql
System.Private.CoreLib.dll_1_100665670_String_Contains   // Dupe
```

Note I see "100665670" twice for two different methods
