### PR TITLE
fix: FetchForWritng() async projection returns null if there are no additional events to apply

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_9999_fetch_for_writing_async_projection_with_no_additional_events_should_return_projection.cs
+++ b/src/EventSourcingTests/Bugs/Bug_9999_fetch_for_writing_async_projection_with_no_additional_events_should_return_projection.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Events;
+using Marten.Events.Projections;
+using Marten.Schema;
+using Marten.Testing.Harness;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+public class Bug_9999_fetch_for_writing_async_projection_with_no_additional_events_should_return_projection : BugIntegrationContext
+{
+    // ! IMPORTANT - this does not fail on the bug - for some reason the dynamic codegen doesn't produce the error.
+    // TODO: Rework this to properly highlight the error
+    [Fact]
+    public async Task override_the_optimistic_concurrency_on_projected_document()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Snapshot<TestProjection>(SnapshotLifecycle.Async);
+        });
+
+        var streamKey = Guid.NewGuid().ToString();
+
+        theSession.Events.StartStream(streamKey, new EventA("foo"), new EventB());
+        await theSession.SaveChangesAsync();
+
+        using var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.RebuildProjectionAsync<TestProjection>(CancellationToken.None);
+
+        var result = await theSession.Events.FetchForWriting<TestProjection>(streamKey);
+
+        Assert.Equal(2, result.CurrentVersion);
+        Assert.Equal(2, result.StartingVersion);
+        Assert.NotNull(result.Aggregate);
+        Assert.Equal(streamKey, result.Aggregate.StreamKey);
+        // TODO: There is a weird bug here where ~25% of the time this is set to null. Seems to happen intermittently across all frameworks. No idea why.
+        Assert.Equal("foo", result.Aggregate.Name);
+    }
+
+    public record EventA(string Name);
+    public record EventB;
+}
+
+// put it here to avoid a bug with rebuilding projections whose types are nested classes
+// TODO: Write up this bug
+public record TestProjection
+{
+    [Identity]
+    public string StreamKey { get; set; } = null!;
+
+    public string Name { get; set; } = null!;
+
+    public static TestProjection Create(EventA @event) =>
+        new TestProjection
+        {
+            Name = @event.Name,
+        };
+}

--- a/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.CodeGen.cs
+++ b/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.CodeGen.cs
@@ -280,14 +280,11 @@ public abstract partial class GeneratedAggregateProjectionBase<T>
 
         buildMethod.DerivedVariables.Add(Variable.For<IQuerySession>("(IQuerySession)session"));
 
-        buildMethod.Frames.Code("if (!events.Any()) return null;");
-
-        buildMethod.Frames.Add(new DeclareAggregateFrame(typeof(T)));
-
-        var callCreateAggregateFrame = new CallCreateAggregateFrame(_createMethods);
-
         // This is the existing snapshot passed into the LiveAggregator
         var snapshot = buildMethod.Arguments.Single(x => x.VariableType == typeof(T));
+        buildMethod.Frames.Code($"if (!events.Any()) return {snapshot.Usage};");
+
+        var callCreateAggregateFrame = new CallCreateAggregateFrame(_createMethods);
         callCreateAggregateFrame.CoalesceAssignTo(snapshot);
 
         buildMethod.Frames.Add(callCreateAggregateFrame);


### PR DESCRIPTION
When applying events to update an async projection snapshot, existing behavior returns null instead of the snapshot if there are no events to apply.
From codegen:

```csharp
        public override GroupProjection Build(IReadOnlyList<IEvent> events, IQuerySession session, GroupProjection snapshot)
        {
            if (!events.Any()) return null;  // This is the problem, there are no additional events to apply, should return snapshot
            GroupProjection groupProjection = null; // this also appears to be a no-op
            
            // ...

            return snapshot;
        }
```


Testing this has been a headache - I am clearly missing something when it comes to properly testing generated code. In theory the included test matches my applications code but does not reproduce the issue. Additionally the following other bugs are identified:

- Calling `RebuildProjection` on a projection whose type is a nested class does not work due to the way the type name is compared to the registered projections. 
- The projection randomly is not populated, with the 'Name' property being null. But this only happens 25% of the time - feels like async projection stuff happening in the background but I thought `RebuildProjection` would block until the rebuild is done.