### PR TITLE
Fix faulty connection handling in advisory lock

### DIFF
--- a/src/Marten/Events/Daemon/Coordination/AdvisoryLock.cs
+++ b/src/Marten/Events/Daemon/Coordination/AdvisoryLock.cs
@@ -39,7 +39,7 @@ internal class AdvisoryLock : IAsyncDisposable
             await _conn.OpenAsync(token).ConfigureAwait(false);
         }
 
-        if (_conn.State == ConnectionState.Broken)
+        if (_conn.State == ConnectionState.Closed)
         {
             try
             {
@@ -53,6 +53,8 @@ internal class AdvisoryLock : IAsyncDisposable
             {
                 _conn = null;
             }
+
+            return false;
         }
 
 

--- a/src/Marten/Events/Daemon/Coordination/AdvisoryLock.cs
+++ b/src/Marten/Events/Daemon/Coordination/AdvisoryLock.cs
@@ -28,7 +28,7 @@ internal class AdvisoryLock : IAsyncDisposable
 
     public bool HasLock(int lockId)
     {
-        return _conn is not { State: ConnectionState.Broken } && _locks.Contains(lockId);
+        return _conn is not { State: ConnectionState.Closed } && _locks.Contains(lockId);
     }
 
     public async Task<bool> TryAttainLockAsync(int lockId, CancellationToken token)
@@ -73,7 +73,7 @@ internal class AdvisoryLock : IAsyncDisposable
     {
         if (!_locks.Contains(lockId)) return;
 
-        if (_conn == null || _conn.State == ConnectionState.Broken)
+        if (_conn == null || _conn.State == ConnectionState.Closed)
         {
             _locks.Remove(lockId);
             return;


### PR DESCRIPTION
Noticed this never recovered after I forced a node failover today. `Broken` is unimplemented and doesn't do anything.