### PR TITLE
Switch to Polly.Core & Bump version

### DIFF
--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -44,7 +44,7 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
         <!-- This is forced by Npgsql peer dependency -->
         <PackageReference Include="Npgsql.Json.NET" Version="8.0.0" />
-        <PackageReference Include="Polly" Version="8.2.1" />
+        <PackageReference Include="Polly.Core" Version="8.3.1" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
         <PackageReference Include="System.Text.Json" Version="8.0.0" />
         <PackageReference Include="Weasel.Postgresql" Version="7.3.0" />


### PR DESCRIPTION
It seems Marten was already using the v8 stuff from Polly.Core, but still depending on Polly (legacy): https://www.pollydocs.org/migration-v8.html

I changed the dependency and bumped to latest: https://github.com/App-vNext/Polly/releases

