### PR TITLE
Switch to central package management

### DIFF
--- a/Analysis.Build.props
+++ b/Analysis.Build.props
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+
 <Project>
     <PropertyGroup>
         <AnalysisModeReliability>true</AnalysisModeReliability>
@@ -6,17 +6,17 @@
         <AnalysisLevel>latest</AnalysisLevel>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.8.14">
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
             <PrivateAssets>all</PrivateAssets>
             <ExcludeAssets>none</ExcludeAssets>
             <IncludeAssets>all</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Meziantou.Analyzer" Version="2.0.113">
+        <PackageReference Include="Meziantou.Analyzer">
             <PrivateAssets>all</PrivateAssets>
             <ExcludeAssets>none</ExcludeAssets>
             <IncludeAssets>all</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
             <PrivateAssets>all</PrivateAssets>
             <ExcludeAssets>none</ExcludeAssets>
             <IncludeAssets>all</IncludeAssets>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,74 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Alba" Version="7.4.1" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageVersion Include="Bogus" Version="35.0.1" />
+    <PackageVersion Include="Bullseye" Version="4.0.0" />
+    <PackageVersion Include="Confluent.Kafka" Version="2.3.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="Divergic.Logging.Xunit" Version="4.3.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="JasperFx.CodeGeneration" Version="3.5.0" />
+    <PackageVersion Include="JasperFx.CodeGeneration.Commands" Version="3.4.0" />
+    <PackageVersion Include="JasperFx.Core" Version="1.5.1" />
+    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="3.5.0" />
+    <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
+    <PackageVersion Include="Lamar" Version="13.0.2" />
+    <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="13.0.2" />
+    <PackageVersion Include="MarkdownSnippets.MsBuild" Version="25.1.0" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.113" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.8.14" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="NodaTime.Serialization.JsonNet" Version="3.1.0" />
+    <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.1.2" />
+    <PackageVersion Include="Npgsql" Version="4.1.3.1" />
+    <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Npgsql.Json.NET" Version="8.0.0" />
+    <PackageVersion Include="Npgsql.NodaTime" Version="8.0.0" />
+    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="Oakton" Version="6.1.0" />
+    <PackageVersion Include="Ogooreck" Version="0.8.0" />
+    <PackageVersion Include="Polly" Version="8.2.1" />
+    <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="SimpleExec" Version="10.0.0-beta.2" />
+    <PackageVersion Include="Spectre.Console" Version="0.48.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
+    <PackageVersion Include="Weasel.CommandLine" Version="7.3.1" />
+    <PackageVersion Include="Weasel.Postgresql" Version="7.3.1" />
+    <PackageVersion Include="Westwind.Utilities" Version="3.0.37" />
+    <PackageVersion Include="xunit" Version="2.6.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.25" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/build/build.csproj
+++ b/build/build.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,13 +7,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Include="build.cs"/>
+        <Compile Include="build.cs" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bullseye" Version="4.0.0"/>
-        <PackageReference Include="Npgsql" Version="4.1.3.1"/>
-        <PackageReference Include="SimpleExec" Version="10.0.0-beta.2"/>
-        <PackageReference Include="Westwind.Utilities" Version="3.0.37"/>
+        <PackageReference Include="Bullseye" />
+        <PackageReference Include="Npgsql" />
+        <PackageReference Include="SimpleExec" />
+        <PackageReference Include="Westwind.Utilities" />
     </ItemGroup>
 </Project>

--- a/src/AspNetCoreWithMarten/AspNetCoreWithMarten.csproj
+++ b/src/AspNetCoreWithMarten/AspNetCoreWithMarten.csproj
@@ -7,13 +7,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten.AspNetCore\Marten.AspNetCore.csproj"/>
-        <ProjectReference Include="..\Marten.CommandLine\Marten.CommandLine.csproj"/>
-        <ProjectReference Include="..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\Marten.AspNetCore\Marten.AspNetCore.csproj" />
+        <ProjectReference Include="..\Marten.CommandLine\Marten.CommandLine.csproj" />
+        <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="25.1.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/CommandLineRunner/CommandLineRunner.csproj
+++ b/src/CommandLineRunner/CommandLineRunner.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten.AsyncDaemon.Testing\Marten.AsyncDaemon.Testing.csproj"/>
-        <ProjectReference Include="..\Marten.CommandLine\Marten.CommandLine.csproj"/>
+        <ProjectReference Include="..\Marten.AsyncDaemon.Testing\Marten.AsyncDaemon.Testing.csproj" />
+        <ProjectReference Include="..\Marten.CommandLine\Marten.CommandLine.csproj" />
     </ItemGroup>
 </Project>

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -16,19 +16,19 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="13.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="Npgsql.DependencyInjection" Version="8.0.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Jil" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Npgsql.DependencyInjection" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.6.2" />
-        <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="Shouldly" Version="4.2.1" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>
@@ -122,7 +122,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="25.1.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/DocumentDbTests/DocumentDbTests.csproj
+++ b/src/DocumentDbTests/DocumentDbTests.csproj
@@ -12,22 +12,22 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="12.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Jil" />
+        <PackageReference Include="Lamar" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.6.2" />
-        <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="Shouldly" Version="4.2.1" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="25.1.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/EventPublisher/EventPublisher.csproj
+++ b/src/EventPublisher/EventPublisher.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten.AsyncDaemon.Testing\Marten.AsyncDaemon.Testing.csproj"/>
-        <ProjectReference Include="..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\Marten.AsyncDaemon.Testing\Marten.AsyncDaemon.Testing.csproj" />
+        <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Spectre.Console" Version="0.48.0" />
+        <PackageReference Include="Spectre.Console" />
     </ItemGroup>
 </Project>

--- a/src/EventSourceWorker/EventSourceWorker.csproj
+++ b/src/EventSourceWorker/EventSourceWorker.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten.AsyncDaemon.Testing\Marten.AsyncDaemon.Testing.csproj"/>
-        <ProjectReference Include="..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\Marten.AsyncDaemon.Testing\Marten.AsyncDaemon.Testing.csproj" />
+        <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
 </Project>

--- a/src/EventSourcingTests/EventSourcingTests.csproj
+++ b/src/EventSourcingTests/EventSourcingTests.csproj
@@ -12,24 +12,24 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="13.0.2" />
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Jil" />
+        <PackageReference Include="Lamar" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.6.2" />
-        <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="Shouldly" Version="4.2.1" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="25.1.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/IssueService/IssueService.csproj
+++ b/src/IssueService/IssueService.csproj
@@ -5,11 +5,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten.AspNetCore\Marten.AspNetCore.csproj"/>
+        <ProjectReference Include="..\Marten.AspNetCore\Marten.AspNetCore.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/LinqTests/LinqTests.csproj
+++ b/src/LinqTests/LinqTests.csproj
@@ -12,21 +12,21 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="12.1.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="Jil" />
+        <PackageReference Include="Lamar" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.6.2" />
-        <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="Shouldly" Version="4.2.1" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="25.1.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/Marten.AspNetCore.Testing/Marten.AspNetCore.Testing.csproj
+++ b/src/Marten.AspNetCore.Testing/Marten.AspNetCore.Testing.csproj
@@ -6,22 +6,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="7.4.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="Shouldly" Version="4.2.1"/>
-        <PackageReference Include="xunit" Version="2.6.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="Alba" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\IssueService\IssueService.csproj"/>
+        <ProjectReference Include="..\IssueService\IssueService.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Marten.AspNetCore/Marten.AspNetCore.csproj
+++ b/src/Marten.AspNetCore/Marten.AspNetCore.csproj
@@ -16,24 +16,24 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.25"/>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.14"/>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     </ItemGroup>
 
-    <Import Project="../../Analysis.Build.props"/>
+    <Import Project="../../Analysis.Build.props" />
 </Project>

--- a/src/Marten.AsyncDaemon.Testing/Marten.AsyncDaemon.Testing.csproj
+++ b/src/Marten.AsyncDaemon.Testing/Marten.AsyncDaemon.Testing.csproj
@@ -5,26 +5,26 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="13.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0"/>
-        <PackageReference Include="Divergic.Logging.Xunit" Version="4.3.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+        <PackageReference Include="Divergic.Logging.Xunit" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.6.2"/>
+        <PackageReference Include="xunit" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\EventSourcingTests\EventSourcingTests.csproj"/>
-        <ProjectReference Include="..\Marten.AspNetCore\Marten.AspNetCore.csproj"/>
-        <ProjectReference Include="..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\EventSourcingTests\EventSourcingTests.csproj" />
+        <ProjectReference Include="..\Marten.AspNetCore\Marten.AspNetCore.csproj" />
+        <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="25.1.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/Marten.CommandLine.Tests/Marten.CommandLine.Tests.csproj
+++ b/src/Marten.CommandLine.Tests/Marten.CommandLine.Tests.csproj
@@ -8,23 +8,23 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="NSubstitute" Version="5.1.0"/>
-        <PackageReference Include="Shouldly" Version="4.2.1"/>
-        <PackageReference Include="xunit" Version="2.6.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten.CommandLine\Marten.CommandLine.csproj"/>
-        <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj"/>
+        <ProjectReference Include="..\Marten.CommandLine\Marten.CommandLine.csproj" />
+        <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Marten.CommandLine/Marten.CommandLine.csproj
+++ b/src/Marten.CommandLine/Marten.CommandLine.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->
@@ -33,10 +33,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="JasperFx.CodeGeneration.Commands" Version="3.4.0"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-        <PackageReference Include="Oakton" Version="6.1.0"/>
-        <PackageReference Include="Weasel.CommandLine" Version="7.3.1"/>
+        <PackageReference Include="JasperFx.CodeGeneration.Commands" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+        <PackageReference Include="Oakton" />
+        <PackageReference Include="Weasel.CommandLine" />
     </ItemGroup>
-    <Import Project="../../Analysis.Build.props"/>
+    <Import Project="../../Analysis.Build.props" />
 </Project>

--- a/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
+++ b/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
@@ -6,21 +6,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten.NodaTime\Marten.NodaTime.csproj"/>
-        <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj"/>
-        <ProjectReference Include="..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\Marten.NodaTime\Marten.NodaTime.csproj" />
+        <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj" />
+        <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.6.2"/>
+        <PackageReference Include="xunit" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="25.1.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>NodaTime extension for Marten</Description>
         <VersionPrefix>7.0.0-beta.5</VersionPrefix>
@@ -28,12 +28,12 @@
         <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.1.0"/>
-        <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.1.2"/>
-        <PackageReference Include="Npgsql.NodaTime" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="NodaTime.Serialization.JsonNet" />
+        <PackageReference Include="NodaTime.Serialization.SystemTextJson" />
+        <PackageReference Include="Npgsql.NodaTime" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
 </Project>

--- a/src/Marten.PLv8.Testing/Marten.PLv8.Testing.csproj
+++ b/src/Marten.PLv8.Testing/Marten.PLv8.Testing.csproj
@@ -7,35 +7,35 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="xunit" Version="2.6.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="12.1.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0"/>
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten.PLv8\Marten.PLv8.csproj"/>
-        <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj"/>
+        <ProjectReference Include="..\Marten.PLv8\Marten.PLv8.csproj" />
+        <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj" />
     </ItemGroup>
 
     <ItemGroup>
         <None Update="*.js">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <EmbeddedResource Include="*.js"/>
+        <EmbeddedResource Include="*.js" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="25.1.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/Marten.PLv8/Marten.PLv8.csproj
+++ b/src/Marten.PLv8/Marten.PLv8.csproj
@@ -29,15 +29,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>
-        <EmbeddedResource Include="mt_patching.js"/>
+        <EmbeddedResource Include="mt_patching.js" />
     </ItemGroup>
-    <Import Project="../../Analysis.Build.props"/>
+    <Import Project="../../Analysis.Build.props" />
 </Project>

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -21,18 +21,18 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar" Version="12.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Jil" />
+        <PackageReference Include="Lamar" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.6.2" />
-        <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="Shouldly" Version="4.2.1" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>
@@ -40,7 +40,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="25.1.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/Marten.sln
+++ b/src/Marten.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30709.64
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten", "Marten\Marten.csproj", "{FCCA5D3A-B632-4D81-B839-F6344FDD01F1}"
 EndProject
@@ -19,29 +19,30 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MartenBenchmarks", "MartenB
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5A91B8F9-52F8-4322-BE34-E3A281902BEC}"
 	ProjectSection(SolutionItems) = preProject
-		..\Directory.Build.props = ..\Directory.Build.props
-		..\README.md = ..\README.md
-		..\Analysis.Build.props = ..\Analysis.Build.props
 		.editorconfig = .editorconfig
+		..\Analysis.Build.props = ..\Analysis.Build.props
+		..\Directory.Build.props = ..\Directory.Build.props
+		..\Directory.Packages.props = ..\Directory.Packages.props
 		..\docker-compose.yml = ..\docker-compose.yml
 		..\package.json = ..\package.json
+		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreWithMarten", "AspNetCoreWithMarten\AspNetCoreWithMarten.csproj", "{739B657C-4E0D-40E8-853E-ADF5C2D3D89D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marten.AsyncDaemon.Testing", "Marten.AsyncDaemon.Testing\Marten.AsyncDaemon.Testing.csproj", "{5F7D1952-24BB-4A60-8C45-DF1911097A4F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten.AsyncDaemon.Testing", "Marten.AsyncDaemon.Testing\Marten.AsyncDaemon.Testing.csproj", "{5F7D1952-24BB-4A60-8C45-DF1911097A4F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventSourceWorker", "EventSourceWorker\EventSourceWorker.csproj", "{3688AF80-FB24-4C3C-95FD-A2AB4680CD67}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventSourceWorker", "EventSourceWorker\EventSourceWorker.csproj", "{3688AF80-FB24-4C3C-95FD-A2AB4680CD67}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventPublisher", "EventPublisher\EventPublisher.csproj", "{BA27DA3D-74CA-4891-ADCE-889FA0C2D123}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventPublisher", "EventPublisher\EventPublisher.csproj", "{BA27DA3D-74CA-4891-ADCE-889FA0C2D123}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommandLineRunner", "CommandLineRunner\CommandLineRunner.csproj", "{B297B011-B5D1-4B3C-8503-484A93F2F073}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommandLineRunner", "CommandLineRunner\CommandLineRunner.csproj", "{B297B011-B5D1-4B3C-8503-484A93F2F073}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marten.PLv8", "Marten.PLv8\Marten.PLv8.csproj", "{25357907-98A3-49E7-A4C9-E366EA56B364}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten.PLv8", "Marten.PLv8\Marten.PLv8.csproj", "{25357907-98A3-49E7-A4C9-E366EA56B364}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marten.PLv8.Testing", "Marten.PLv8.Testing\Marten.PLv8.Testing.csproj", "{8CBEFD7A-C757-43FE-A1C8-62FBE98178C8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten.PLv8.Testing", "Marten.PLv8.Testing\Marten.PLv8.Testing.csproj", "{8CBEFD7A-C757-43FE-A1C8-62FBE98178C8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MemoryUsageChecker", "MemoryUsageChecker\MemoryUsageChecker.csproj", "{7825A721-7B23-4007-B6EA-8F6E9590F6FD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MemoryUsageChecker", "MemoryUsageChecker\MemoryUsageChecker.csproj", "{7825A721-7B23-4007-B6EA-8F6E9590F6FD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CommandLine", "CommandLine", "{DA7EC300-12F5-4B80-B5DF-B7B71E344E24}"
 EndProject
@@ -51,52 +52,52 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NodaTime", "NodaTime", "{50
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AspNetCore", "AspNetCore", "{B64DB93D-C374-4F49-ADB9-8A398D14AE2E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marten.AspNetCore", "Marten.AspNetCore\Marten.AspNetCore.csproj", "{ADD3C5F7-BAC9-4AB8-9E09-8D7A2EE17AD3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten.AspNetCore", "Marten.AspNetCore\Marten.AspNetCore.csproj", "{ADD3C5F7-BAC9-4AB8-9E09-8D7A2EE17AD3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marten.AspNetCore.Testing", "Marten.AspNetCore.Testing\Marten.AspNetCore.Testing.csproj", "{7CD2A84A-CD1B-44F5-AB94-ADE5D644AA86}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten.AspNetCore.Testing", "Marten.AspNetCore.Testing\Marten.AspNetCore.Testing.csproj", "{7CD2A84A-CD1B-44F5-AB94-ADE5D644AA86}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IssueService", "IssueService\IssueService.csproj", "{B4F97F16-9FF3-4BC6-9B25-2FD2BD91F5E7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IssueService", "IssueService\IssueService.csproj", "{B4F97F16-9FF3-4BC6-9B25-2FD2BD91F5E7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marten.Testing.ThirdAssembly", "Marten.Testing.ThirdAssembly\Marten.Testing.ThirdAssembly.csproj", "{5897FB86-03BD-42EE-8FD0-808FD56DB0CA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten.Testing.ThirdAssembly", "Marten.Testing.ThirdAssembly\Marten.Testing.ThirdAssembly.csproj", "{5897FB86-03BD-42EE-8FD0-808FD56DB0CA}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Testing", "Testing", "{91D87D73-EC07-4067-8A64-26A2E4F6BC83}"
 	ProjectSection(SolutionItems) = preProject
 		TestSetup.cs = TestSetup.cs
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreTests", "CoreTests\CoreTests.csproj", "{5D24D07B-BABC-41B0-A057-D7E914DB37E6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreTests", "CoreTests\CoreTests.csproj", "{5D24D07B-BABC-41B0-A057-D7E914DB37E6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocumentDbTests", "DocumentDbTests\DocumentDbTests.csproj", "{CE932887-AFB1-46BD-B5B6-4F96B92CB201}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocumentDbTests", "DocumentDbTests\DocumentDbTests.csproj", "{CE932887-AFB1-46BD-B5B6-4F96B92CB201}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventSourcingTests", "EventSourcingTests\EventSourcingTests.csproj", "{D8C569BD-A2A5-471B-9C00-18F5981FC552}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventSourcingTests", "EventSourcingTests\EventSourcingTests.csproj", "{D8C569BD-A2A5-471B-9C00-18F5981FC552}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultiDatabaseCommandLineRunner", "MultiDatabaseCommandLineRunner\MultiDatabaseCommandLineRunner.csproj", "{29691E7B-2F1B-4F58-8B5E-AD58C5732D1F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MultiDatabaseCommandLineRunner", "MultiDatabaseCommandLineRunner\MultiDatabaseCommandLineRunner.csproj", "{29691E7B-2F1B-4F58-8B5E-AD58C5732D1F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventStoreMigrations", "EventStoreMigrations\EventStoreMigrations.csproj", "{EB30BFF6-86EF-4053-B2BF-4D65CF76C874}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventStoreMigrations", "EventStoreMigrations\EventStoreMigrations.csproj", "{EB30BFF6-86EF-4053-B2BF-4D65CF76C874}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{79961196-DB50-4AD3-B749-D231799BCF2E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventSourcingIntro", "samples\EventSourcingIntro\EventSourcingIntro.csproj", "{41FC568A-72A2-46A3-A2DA-4C85E4512090}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventSourcingIntro", "samples\EventSourcingIntro\EventSourcingIntro.csproj", "{41FC568A-72A2-46A3-A2DA-4C85E4512090}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MinimalAPI", "samples\MinimalAPI\MinimalAPI.csproj", "{7B710A53-373B-4A7D-B49E-53C15E6A8CA8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinimalAPI", "samples\MinimalAPI\MinimalAPI.csproj", "{7B710A53-373B-4A7D-B49E-53C15E6A8CA8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marten.CommandLine.Tests", "Marten.CommandLine.Tests\Marten.CommandLine.Tests.csproj", "{0962E83F-482B-4316-A8AB-3B714EEEC3AA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marten.CommandLine.Tests", "Marten.CommandLine.Tests\Marten.CommandLine.Tests.csproj", "{0962E83F-482B-4316-A8AB-3B714EEEC3AA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinqTests", "LinqTests\LinqTests.csproj", "{94EF979D-F2C0-4479-9D1D-63647042E915}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinqTests", "LinqTests\LinqTests.csproj", "{94EF979D-F2C0-4479-9D1D-63647042E915}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Helpdesk", "Helpdesk", "{F3DADE49-9C89-4F74-BCCE-7DAFD35675E9}"
 	ProjectSection(SolutionItems) = preProject
-		samples\Helpdesk\README.md = samples\Helpdesk\README.md
 		samples\Helpdesk\docker-compose.yml = samples\Helpdesk\docker-compose.yml
+		samples\Helpdesk\README.md = samples\Helpdesk\README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Helpdesk.Api", "samples\Helpdesk\Helpdesk.Api\Helpdesk.Api.csproj", "{5E18DEBD-C768-4636-B167-7DA2A4954F43}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Helpdesk.Api", "samples\Helpdesk\Helpdesk.Api\Helpdesk.Api.csproj", "{5E18DEBD-C768-4636-B167-7DA2A4954F43}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Helpdesk.Api.Tests", "samples\Helpdesk\Helpdesk.Api.Tests\Helpdesk.Api.Tests.csproj", "{B0629D41-CA4E-4123-BC98-79A04D708A3E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Helpdesk.Api.Tests", "samples\Helpdesk\Helpdesk.Api.Tests\Helpdesk.Api.Tests.csproj", "{B0629D41-CA4E-4123-BC98-79A04D708A3E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PatchingTests", "PatchingTests\PatchingTests.csproj", "{EE82EFC4-FBC1-4181-9AB8-671222B60C3F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PatchingTests", "PatchingTests\PatchingTests.csproj", "{EE82EFC4-FBC1-4181-9AB8-671222B60C3F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultiTenancyTests", "MultiTenancyTests\MultiTenancyTests.csproj", "{34AE89FF-76B5-4B50-9190-4E7C602F5C2F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MultiTenancyTests", "MultiTenancyTests\MultiTenancyTests.csproj", "{34AE89FF-76B5-4B50-9190-4E7C602F5C2F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -236,32 +237,29 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {52B7158F-0A24-47D9-9CF7-3FA94170041A}
-	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{D5E592AD-5368-4E97-A3AC-6729FA43CB51} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
+		{B88916DD-8CAF-42F8-BB40-7CE6C4E49491} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
 		{8478E6CB-FE2E-4476-B4B5-60F61DA16D74} = {DA7EC300-12F5-4B80-B5DF-B7B71E344E24}
-		{25357907-98A3-49E7-A4C9-E366EA56B364} = {ADA0C720-8095-44CA-917B-BAC97DD85A96}
-		{8CBEFD7A-C757-43FE-A1C8-62FBE98178C8} = {ADA0C720-8095-44CA-917B-BAC97DD85A96}
 		{7B9552F4-9102-4A89-A150-C2F916CFF11E} = {505E6CF5-1BCD-4C18-BAE3-03C7872A7FBB}
 		{1B5F9030-63ED-49B2-B001-F58E899CCA5F} = {505E6CF5-1BCD-4C18-BAE3-03C7872A7FBB}
+		{739B657C-4E0D-40E8-853E-ADF5C2D3D89D} = {79961196-DB50-4AD3-B749-D231799BCF2E}
+		{5F7D1952-24BB-4A60-8C45-DF1911097A4F} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
+		{3688AF80-FB24-4C3C-95FD-A2AB4680CD67} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
+		{BA27DA3D-74CA-4891-ADCE-889FA0C2D123} = {79961196-DB50-4AD3-B749-D231799BCF2E}
+		{B297B011-B5D1-4B3C-8503-484A93F2F073} = {DA7EC300-12F5-4B80-B5DF-B7B71E344E24}
+		{25357907-98A3-49E7-A4C9-E366EA56B364} = {ADA0C720-8095-44CA-917B-BAC97DD85A96}
+		{8CBEFD7A-C757-43FE-A1C8-62FBE98178C8} = {ADA0C720-8095-44CA-917B-BAC97DD85A96}
 		{ADD3C5F7-BAC9-4AB8-9E09-8D7A2EE17AD3} = {B64DB93D-C374-4F49-ADB9-8A398D14AE2E}
 		{7CD2A84A-CD1B-44F5-AB94-ADE5D644AA86} = {B64DB93D-C374-4F49-ADB9-8A398D14AE2E}
 		{B4F97F16-9FF3-4BC6-9B25-2FD2BD91F5E7} = {B64DB93D-C374-4F49-ADB9-8A398D14AE2E}
-		{B297B011-B5D1-4B3C-8503-484A93F2F073} = {DA7EC300-12F5-4B80-B5DF-B7B71E344E24}
-		{5F7D1952-24BB-4A60-8C45-DF1911097A4F} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
-		{D5E592AD-5368-4E97-A3AC-6729FA43CB51} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
-		{B88916DD-8CAF-42F8-BB40-7CE6C4E49491} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
 		{5897FB86-03BD-42EE-8FD0-808FD56DB0CA} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
 		{5D24D07B-BABC-41B0-A057-D7E914DB37E6} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
 		{CE932887-AFB1-46BD-B5B6-4F96B92CB201} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
 		{D8C569BD-A2A5-471B-9C00-18F5981FC552} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
 		{29691E7B-2F1B-4F58-8B5E-AD58C5732D1F} = {DA7EC300-12F5-4B80-B5DF-B7B71E344E24}
 		{EB30BFF6-86EF-4053-B2BF-4D65CF76C874} = {DA7EC300-12F5-4B80-B5DF-B7B71E344E24}
-		{739B657C-4E0D-40E8-853E-ADF5C2D3D89D} = {79961196-DB50-4AD3-B749-D231799BCF2E}
-		{BA27DA3D-74CA-4891-ADCE-889FA0C2D123} = {79961196-DB50-4AD3-B749-D231799BCF2E}
 		{41FC568A-72A2-46A3-A2DA-4C85E4512090} = {79961196-DB50-4AD3-B749-D231799BCF2E}
-		{3688AF80-FB24-4C3C-95FD-A2AB4680CD67} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
 		{7B710A53-373B-4A7D-B49E-53C15E6A8CA8} = {79961196-DB50-4AD3-B749-D231799BCF2E}
 		{0962E83F-482B-4316-A8AB-3B714EEEC3AA} = {DA7EC300-12F5-4B80-B5DF-B7B71E344E24}
 		{94EF979D-F2C0-4479-9D1D-63647042E915} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
@@ -270,5 +268,8 @@ Global
 		{B0629D41-CA4E-4123-BC98-79A04D708A3E} = {F3DADE49-9C89-4F74-BCCE-7DAFD35675E9}
 		{EE82EFC4-FBC1-4181-9AB8-671222B60C3F} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
 		{34AE89FF-76B5-4B50-9190-4E7C602F5C2F} = {91D87D73-EC07-4067-8A64-26A2E4F6BC83}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {52B7158F-0A24-47D9-9CF7-3FA94170041A}
 	EndGlobalSection
 EndGlobal

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -23,31 +23,31 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="JasperFx.Core" Version="1.5.1" />
-        <PackageReference Include="JasperFx.CodeGeneration" Version="3.5.0" />
-        <PackageReference Include="JasperFx.RuntimeCompiler" Version="3.5.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="JasperFx.Core" />
+        <PackageReference Include="JasperFx.CodeGeneration" />
+        <PackageReference Include="JasperFx.RuntimeCompiler" />
+        <PackageReference Include="Newtonsoft.Json" />
         <!-- This is forced by Npgsql peer dependency -->
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <!-- This is forced by Npgsql peer dependency -->
-        <PackageReference Include="Npgsql.Json.NET" Version="8.0.0" />
-        <PackageReference Include="Polly" Version="8.2.1" />
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.0" />
-        <PackageReference Include="Weasel.Postgresql" Version="7.3.1" />
+        <PackageReference Include="Npgsql.Json.NET" />
+        <PackageReference Include="Polly" />
+        <PackageReference Include="System.Threading.Tasks.Dataflow" />
+        <PackageReference Include="System.Text.Json" />
+        <PackageReference Include="Weasel.Postgresql" />
     </ItemGroup>
 
     <!--SourceLink specific settings-->
@@ -63,7 +63,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     </ItemGroup>
     <Import Project="../../Analysis.Build.props" />
 </Project>

--- a/src/MartenBenchmarks/MartenBenchmarks.csproj
+++ b/src/MartenBenchmarks/MartenBenchmarks.csproj
@@ -8,13 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj"/>
-        <ProjectReference Include="..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj" />
+        <ProjectReference Include="..\Marten\Marten.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.10"/>
+        <PackageReference Include="BenchmarkDotNet" />
     </ItemGroup>
     <ItemGroup>
-        <Folder Include="Benchmarks"/>
+        <Folder Include="Benchmarks" />
     </ItemGroup>
 </Project>

--- a/src/MultiTenancyTests/MultiTenancyTests.csproj
+++ b/src/MultiTenancyTests/MultiTenancyTests.csproj
@@ -17,19 +17,19 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
 
-        <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="Shouldly" Version="4.2.1" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>
@@ -120,7 +120,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="25.1.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/PatchingTests/PatchingTests.csproj
+++ b/src/PatchingTests/PatchingTests.csproj
@@ -7,19 +7,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="xunit" Version="2.6.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="12.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     </ItemGroup>
 
     <ItemGroup>
@@ -34,7 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MarkdownSnippets.MsBuild" Version="25.1.0">
+        <PackageReference Include="MarkdownSnippets.MsBuild">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/TestingSupport/TestingSupport.csproj
+++ b/src/TestingSupport/TestingSupport.csproj
@@ -8,17 +8,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marten\Marten.csproj"/>
-        <ProjectReference Include="..\Marten.Testing.OtherAssembly\Marten.Testing.OtherAssembly.csproj"/>
-        <ProjectReference Include="..\Marten.Testing.ThirdAssembly\Marten.Testing.ThirdAssembly.csproj"/>
+        <ProjectReference Include="..\Marten\Marten.csproj" />
+        <ProjectReference Include="..\Marten.Testing.OtherAssembly\Marten.Testing.OtherAssembly.csproj" />
+        <ProjectReference Include="..\Marten.Testing.ThirdAssembly\Marten.Testing.ThirdAssembly.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0"/>
-        <PackageReference Include="Jil" Version="3.0.0-alpha2"/>
-        <PackageReference Include="Lamar" Version="7.1.1"/>
-        <PackageReference Include="NSubstitute" Version="4.3.0"/>
-        <PackageReference Include="Shouldly" Version="4.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Jil" />
+        <PackageReference Include="Lamar" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 </Project>

--- a/src/samples/Helpdesk/Helpdesk.Api.Tests/Helpdesk.Api.Tests.csproj
+++ b/src/samples/Helpdesk/Helpdesk.Api.Tests/Helpdesk.Api.Tests.csproj
@@ -5,25 +5,25 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="7.4.1" />
-        <PackageReference Include="FluentAssertions" Version="6.12.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="NSubstitute" Version="5.1.0"/>
-        <PackageReference Include="xunit" Version="2.6.3"/>
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0"/>
-        <PackageReference Include="Ogooreck" Version="0.8.0"/>
-        <PackageReference Include="Bogus" Version="35.0.1"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+        <PackageReference Include="Alba" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+        <PackageReference Include="Ogooreck" />
+        <PackageReference Include="Bogus" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Helpdesk.Api\Helpdesk.Api.csproj"/>
+        <ProjectReference Include="..\Helpdesk.Api\Helpdesk.Api.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/samples/Helpdesk/Helpdesk.Api/Helpdesk.Api.csproj
+++ b/src/samples/Helpdesk/Helpdesk.Api/Helpdesk.Api.csproj
@@ -8,9 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-        <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
+        <PackageReference Include="Confluent.Kafka" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/MinimalAPI/MinimalAPI.csproj
+++ b/src/samples/MinimalAPI/MinimalAPI.csproj
@@ -7,14 +7,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Marten.AspNetCore\Marten.AspNetCore.csproj"/>
-        <ProjectReference Include="..\..\Marten.AsyncDaemon.Testing\Marten.AsyncDaemon.Testing.csproj"/>
-        <ProjectReference Include="..\..\Marten.CommandLine\Marten.CommandLine.csproj"/>
-        <ProjectReference Include="..\..\Marten\Marten.csproj"/>
+        <ProjectReference Include="..\..\Marten.AspNetCore\Marten.AspNetCore.csproj" />
+        <ProjectReference Include="..\..\Marten.AsyncDaemon.Testing\Marten.AsyncDaemon.Testing.csproj" />
+        <ProjectReference Include="..\..\Marten.CommandLine\Marten.CommandLine.csproj" />
+        <ProjectReference Include="..\..\Marten\Marten.csproj" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Rendons à César...

All the merit goes to the creator of https://github.com/Webreaper/CentralisedPackageConverter

Two things to note:
1/ there were multiple nugets with different versions. The migration bumped them to the max version that was referenced
2) Except for xUnit, for which I used version 

```
<PackageVersion Include="xunit" Version="2.6.2" />
<PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4" />
```
instead of 

```
<PackageVersion Include="xunit" Version="2.6.3" />
<PackageVersion Include="xunit.runner.visualstudio" Version="2.5.5" />
```

which has a new analyzer which was not happy with the fixture injection in tests.
https://xunit.net/xunit.analyzers/rules/xUnit1041
As I was not sure which fix to apply, I chose the safe path: rollback to working version