### PR TITLE
Support NpgsqlMultiHostDataSource

### DIFF
--- a/docs/configuration/hostbuilder.md
+++ b/docs/configuration/hostbuilder.md
@@ -129,7 +129,7 @@ services.AddMarten()
     .UseLightweightSessions()
     .UseNpgsqlDataSource();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/MartenServiceCollectionExtensionsTests.cs#L291-L299' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_usenpgsqldatasource' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/MartenServiceCollectionExtensionsTests.cs#L292-L300' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_usenpgsqldatasource' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If you're on .NET 8 (and above), you can also use a dedicated [keyed registration](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8#keyed-di-services). This can be useful for scenarios where you need more than one data source registered:
@@ -143,8 +143,38 @@ services.AddMarten()
     .UseLightweightSessions()
     .UseNpgsqlDataSource();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/MartenServiceCollectionExtensionsTests.cs#L291-L299' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_usenpgsqldatasource' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/MartenServiceCollectionExtensionsTests.cs#L292-L300' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_usenpgsqldatasource' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Using a Multi-Host Data Source <Badge type="tip" text="7.11" />
+
+Marten includes support for `NpgsqlMultiHostDataSource`, allowing you to spread queries over your read replicas, potentially improving throughput in read-heavy applications. To get started, your connection string should specify your primary host along a list of replicas, per [Npgsql documentation](https://www.npgsql.org/doc/failover-and-load-balancing.html).
+
+Configuring `NpgsqlMultiHostDataSource` is very similar to a normal data source, simply swapping it for `AddMultiHostNpgsqlDataSource`. Marten will always use the primary node for queries with a `NpgsqlMultiHostDataSource` unless you explicitly opt to use the standby nodes. You can adjust what type of node Marten uses for querying via the `MultiHostSettings` store options:
+
+<!-- snippet: sample_using_UseNpgsqlDataSourceMultiHost -->
+<a id='snippet-sample_using_usenpgsqldatasourcemultihost'></a>
+```cs
+services.AddMultiHostNpgsqlDataSource(ConnectionSource.ConnectionString);
+
+services.AddMarten(x =>
+    {
+        // Will prefer standby nodes for querying.
+        x.Advanced.MultiHostSettings.ReadSessionPreference = TargetSessionAttributes.PreferStandby;
+    })
+    .UseLightweightSessions()
+    .UseNpgsqlDataSource();
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/MartenServiceCollectionExtensionsTests.cs#L314-L326' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_usenpgsqldatasourcemultihost' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: warning
+Marten will only use your read node preference with user queries (using IQuerySession) that are using a Marten-managed lifetime. 
+
+Internal queries, including the async daemon, will always use your primary node for reliability.
+
+Ensure your replication delay is acceptable as you risk returning outdated queries.
+:::
 
 ## Composite Configuration with ConfigureMarten()
 

--- a/docs/schema/migrations.md
+++ b/docs/schema/migrations.md
@@ -154,7 +154,7 @@ services.AddMarten(opts =>
     // database changes on application startup
     .ApplyAllDatabaseChangesOnStartup();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/MartenServiceCollectionExtensionsTests.cs#L149-L162' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_applyalldatabasechangesonstartup' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/MartenServiceCollectionExtensionsTests.cs#L150-L163' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_applyalldatabasechangesonstartup' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In the option above, Marten is calling the same functionality within an `IHostedService` background task.

--- a/src/Marten/Internal/Sessions/AutoClosingLifetime.cs
+++ b/src/Marten/Internal/Sessions/AutoClosingLifetime.cs
@@ -101,7 +101,7 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
         Logger.OnBeforeExecute(command);
 
         // Do NOT use a using block here because we're returning the reader
-        var conn = _database.CreateConnection();
+        var conn = _database.CreateConnection(ConnectionUsage.Read);
         conn.Open();
 
         try
@@ -125,7 +125,7 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
         Logger.OnBeforeExecute(command);
 
         // Do NOT use a using block here because we're returning the reader
-        var conn = _database.CreateConnection();
+        var conn = _database.CreateConnection(ConnectionUsage.Read);
         await conn.OpenAsync(token).ConfigureAwait(false);
 
         try
@@ -149,7 +149,7 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
         Logger.OnBeforeExecute(batch);
 
         // Do NOT use a using block here because we're returning the reader
-        var conn = _database.CreateConnection();
+        var conn = _database.CreateConnection(ConnectionUsage.Read);
         conn.Open();
 
         try
@@ -172,7 +172,7 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
         Logger.OnBeforeExecute(batch);
 
         // Do NOT use a using block here because we're returning the reader
-        var conn = _database.CreateConnection();
+        var conn = _database.CreateConnection(ConnectionUsage.Read);
         await conn.OpenAsync(token).ConfigureAwait(false);
 
         try

--- a/src/Marten/Storage/IMartenDatabase.cs
+++ b/src/Marten/Storage/IMartenDatabase.cs
@@ -109,6 +109,7 @@ public interface IMartenDatabase: IDatabase, IConnectionSource<NpgsqlConnection>
     Task<long> ProjectionProgressFor(ShardName name,
         CancellationToken token = default);
 
+    NpgsqlConnection CreateConnection(ConnectionUsage connectionUsage = ConnectionUsage.ReadWrite);
 
     /// <summary>
     /// Find the position of the event store sequence just below the supplied timestamp. Will
@@ -118,4 +119,10 @@ public interface IMartenDatabase: IDatabase, IConnectionSource<NpgsqlConnection>
     /// <param name="token"></param>
     /// <returns></returns>
     Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token);
+}
+
+public enum ConnectionUsage
+{
+    Read,
+    ReadWrite
 }

--- a/src/Marten/Storage/MartenDatabase.Execution.cs
+++ b/src/Marten/Storage/MartenDatabase.Execution.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Services;
+using Npgsql;
 
 namespace Marten.Storage;
 
@@ -67,4 +68,15 @@ public partial class MartenDatabase : ISingleQueryRunner
 
         await command.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
     }
+
+    public NpgsqlConnection CreateConnection(ConnectionUsage connectionUsage = ConnectionUsage.ReadWrite)
+    {
+        if (connectionUsage == ConnectionUsage.Read)
+        {
+            return CreateConnection(Options.Advanced.MultiHostSettings.ReadSessionPreference);
+        }
+
+        return CreateConnection(Options.Advanced.MultiHostSettings.WriteSessionPreference);
+    }
+
 }

--- a/src/Marten/Storage/StandinDatabase.cs
+++ b/src/Marten/Storage/StandinDatabase.cs
@@ -228,6 +228,11 @@ internal class StandinDatabase: IMartenDatabase
         throw new NotImplementedException();
     }
 
+    public NpgsqlConnection CreateConnection(ConnectionUsage connectionUsage = ConnectionUsage.ReadWrite)
+    {
+        throw new NotImplementedException();
+    }
+
     public void Dispose()
     {
         ((IDisposable)Tracker)?.Dispose();

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -966,6 +966,20 @@ public interface IReadOnlyAdvancedOptions
     ///     Option to enable or disable usage of default tenant when using multi-tenanted documents
     /// </summary>
     bool DefaultTenantUsageEnabled { get; }
+
+}
+
+public sealed class MultiHostSettings
+{
+    /// <summary>
+    /// Sets the target session attributes for read-only sessions. Defaults to <see cref="TargetSessionAttributes.Primary"/>
+    /// </summary>
+    public TargetSessionAttributes ReadSessionPreference { get; set; } = TargetSessionAttributes.Primary;
+
+    /// <summary>
+    /// Sets the target session attributes for write sessions. Defaults to <see cref="TargetSessionAttributes.Primary"/>
+    /// </summary>
+    public TargetSessionAttributes WriteSessionPreference { get; set; } = TargetSessionAttributes.Primary;
 }
 
 public class AdvancedOptions: IReadOnlyAdvancedOptions
@@ -1009,6 +1023,11 @@ public class AdvancedOptions: IReadOnlyAdvancedOptions
     ///     written
     /// </summary>
     public PostgresqlMigrator Migrator { get; } = new();
+
+    /// <summary>
+    /// Configuration options when using a <see cref="NpgsqlMultiHostDataSource"/>
+    /// </summary>
+    public MultiHostSettings MultiHostSettings { get; } = new();
 
     /// <summary>
     ///     Decides if `timestamp without time zone` database type should be used for `DateTime` DuplicatedField.

--- a/src/MultiHostTests/00_init.sql
+++ b/src/MultiHostTests/00_init.sql
@@ -1,0 +1,2 @@
+CREATE USER replicator WITH REPLICATION ENCRYPTED PASSWORD 'replicator_password';
+SELECT pg_create_physical_replication_slot('replication_slot');

--- a/src/MultiHostTests/MultiHostConfigurationContext.cs
+++ b/src/MultiHostTests/MultiHostConfigurationContext.cs
@@ -1,0 +1,109 @@
+﻿using Marten;
+using Marten.Internal.CodeGeneration;
+using Marten.Testing.Harness;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace MultiHostTests
+{
+    /// <summary>
+    /// Use this if the tests in a fixture are going to use
+    /// all custom StoreOptions configuration
+    /// </summary>
+    [Collection("OneOffs")]
+    public abstract class MultiHostConfigurationContext: IDisposable
+    {
+        protected readonly string _schemaName;
+        private DocumentStore _store;
+        private IDocumentSession _session;
+        protected readonly IList<IDisposable> _disposables = new List<IDisposable>();
+        private readonly string ConnectionString = "Host=localhost:5440,localhost:5441;Database=marten_testing;Username=user;password=password;Command Timeout=5";
+
+        public string SchemaName => _schemaName;
+
+        protected MultiHostConfigurationContext()
+        {
+            _schemaName = GetType().Name.ToLower().Sanitize();
+        }
+
+        public IList<IDisposable> Disposables => _disposables;
+
+        protected DocumentStore StoreOptions(Action<StoreOptions> configure, bool cleanAll = true)
+        {
+            var options = new StoreOptions();
+            var host = new NpgsqlDataSourceBuilder(ConnectionString).BuildMultiHost();
+            options.Connection(host);
+
+            options.Advanced.MultiHostSettings.ReadSessionPreference = TargetSessionAttributes.Standby;
+            options.Advanced.MultiHostSettings.WriteSessionPreference = TargetSessionAttributes.Primary;
+
+            // Can be overridden
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.NameDataLength = 100;
+            options.DatabaseSchemaName = _schemaName;
+
+            configure(options);
+
+            if (cleanAll)
+            {
+                using var conn = host.CreateConnection(TargetSessionAttributes.Primary);
+                conn.Open();
+                conn.CreateCommand($"drop schema if exists {_schemaName} cascade")
+                    .ExecuteNonQuery();
+            }
+
+            _store = new DocumentStore(options);
+
+            _disposables.Add(_store);
+            _disposables.Add(host);
+
+            return _store;
+        }
+
+        protected DocumentStore theStore
+        {
+            get
+            {
+                if (_store == null)
+                {
+                    StoreOptions(_ => { });
+                }
+
+                return _store;
+            }
+            set
+            {
+                _store = value;
+            }
+        }
+
+        protected IDocumentSession theSession
+        {
+            get
+            {
+                if (_session != null)
+                    return _session;
+
+                _session = theStore.LightweightSession();
+                _disposables.Add(_session);
+
+                return _session;
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var disposable in _disposables)
+            {
+                disposable.Dispose();
+            }
+        }
+
+        protected Task AppendEvent(Guid streamId, params object[] events)
+        {
+            theSession.Events.Append(streamId, events);
+            return theSession.SaveChangesAsync();
+        }
+    }
+}

--- a/src/MultiHostTests/MultiHostTests.cs
+++ b/src/MultiHostTests/MultiHostTests.cs
@@ -1,0 +1,30 @@
+using Npgsql;
+
+namespace MultiHostTests;
+
+public class MultiHostTests : MultiHostConfigurationContext
+{
+
+    [Fact]
+    public async Task QueryHitsReplicaWhenConfigured()
+    {
+        var result = await theSession.QueryAsync<bool>("SELECT pg_is_in_recovery();");
+        var isReplica = result[0];
+
+        Assert.True(isReplica);
+    }
+
+    [Fact]
+    public async Task QueryHitsPrimaryWhenConfigured()
+    {
+        StoreOptions(x =>
+        {
+            x.Advanced.MultiHostSettings.ReadSessionPreference = TargetSessionAttributes.Primary;
+        });
+
+        var result = await theSession.QueryAsync<bool>("SELECT pg_is_in_recovery();");
+        var isReplica = result[0];
+
+        Assert.False(isReplica);
+    }
+}

--- a/src/MultiHostTests/MultiHostTests.csproj
+++ b/src/MultiHostTests/MultiHostTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="xunit" Version="2.6.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj" />
+      <ProjectReference Include="..\Marten\Marten.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/MultiHostTests/docker-compose.yaml
+++ b/src/MultiHostTests/docker-compose.yaml
@@ -1,0 +1,54 @@
+#https://medium.com/@eremeykin/how-to-setup-single-primary-postgresql-replication-with-docker-compose-98c48f233bbf
+version: '3.8'
+x-postgres-common:
+  &postgres-common
+  image: postgres:16-alpine
+  user: postgres
+  restart: always
+  healthcheck:
+    test: 'pg_isready -U user --dbname=postgres'
+    interval: 10s
+    timeout: 5s
+    retries: 5
+
+services:
+  postgres_primary:
+    <<: *postgres-common
+    ports:
+      - 5440:5432
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_DB: marten_testing
+      POSTGRES_PASSWORD: password
+      POSTGRES_HOST_AUTH_METHOD: "scram-sha-256\nhost replication all 0.0.0.0/0 md5"
+      POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256"
+    command: |
+      postgres
+      -c wal_level=replica
+      -c hot_standby=on
+      -c max_wal_senders=10
+      -c max_replication_slots=10
+      -c hot_standby_feedback=on
+    volumes:
+      - ./00_init.sql:/docker-entrypoint-initdb.d/00_init.sql
+
+  postgres_replica:
+    <<: *postgres-common
+    ports:
+      - 5441:5432
+    environment:
+      PGUSER: replicator
+      PGPASSWORD: replicator_password
+    command: |
+      bash -c "
+      until pg_basebackup --pgdata=/var/lib/postgresql/data -R --slot=replication_slot --host=postgres_primary --port=5432
+      do
+      echo 'Waiting for primary to connect...'
+      sleep 1s
+      done
+      echo 'Backup done, starting replica...'
+      chmod 0700 /var/lib/postgresql/data
+      postgres
+      "
+    depends_on:
+      - postgres_primary


### PR DESCRIPTION
Requires https://github.com/JasperFx/weasel/pull/126

This is a draft for the time being to see if the design is suitable. I've tried to achieve this with the least amount of code changes possible. Docs yet to be written.
Some considerations:
- `NpgsqlMultiHostDataSource` registers itself in the DI container as a normal data source, so marten won't explicitly know it's a multi host source until it tries to fetch a connection from it. If marten has no defaults for multi host usage then the data source will return _any_ connection type and potentially cause unexpected errors as it tries to write against a read replica. For this reason, I've baked in some sane fallbacks for marten & weasel. 
- If a `NpgsqlMultiHostDataSource` is present we won't target the replica by default, it's up to the user to weigh up the potential pitfalls of replica lag.
- I'm only targeting user queries for this functionality. All internal queries including daemon operation will remain pointed at the primary node for reliability. (although for distributed projections/rebuilds there might be performance benefits to using the replicas)
- Does Wolverine have support for a user-supplied data source yet? The fix for `Wolverine.Postgres` is just to get users to only supply a datasource capable of creating primary node connections `dataSource.WithTargetSession(TargetSessionAttributes.Primary);`
- This implementation only supports the `AutoClosingLifetime`. I'm unsure if it's practical to support the others just yet.