### PR TITLE
Refactor type readiness check to avoid `NullReferenceException`

### DIFF
--- a/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.CodeGen.cs
+++ b/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.CodeGen.cs
@@ -149,11 +149,25 @@ public abstract partial class GeneratedAggregateProjectionBase<T>
 
     internal ILiveAggregator<T> BuildLiveAggregator()
     {
+        if (_liveType == null)
+        {
+            throw new ArgumentNullException(nameof(_liveType), $"Expected {nameof(_liveType)} to have value");
+        }
+
+        if (_liveGeneratedType == null)
+        {
+            throw new ArgumentNullException(nameof(_liveGeneratedType), $"Expected {nameof(_liveGeneratedType)} to have value");
+        }
+
         var aggregator = (ILiveAggregator<T>)Activator.CreateInstance(_liveType, this);
 
         foreach (var setter in _liveGeneratedType.Setters)
         {
             var prop = _liveType.GetProperty(setter.PropName);
+            if (prop == null)
+            {
+                throw new ArgumentNullException(nameof(prop), $"Expected {nameof(prop)} to have value");
+            }
             prop.SetValue(aggregator, setter.InitialValue);
         }
 
@@ -182,12 +196,21 @@ public abstract partial class GeneratedAggregateProjectionBase<T>
         var storage = store.Options.Providers.StorageFor<T>().Lightweight;
         var slicer = buildEventSlicer(store.Options);
 
+        if (_inlineType == null)
+        {
+            throw new ArgumentNullException(nameof(_inlineType), $"Expected {nameof(_inlineType)} to have value");
+        }
+
         var inline = (IAggregationRuntime)Activator.CreateInstance(_inlineType, store, this, slicer,
             storage, this);
 
         foreach (var setter in _inlineGeneratedType.Setters)
         {
             var prop = _inlineType.GetProperty(setter.PropName);
+            if (prop == null)
+            {
+                throw new ArgumentNullException(nameof(prop), $"Expected {nameof(prop)} to have value");
+            }
             prop.SetValue(inline, setter.InitialValue);
         }
 

--- a/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.CodeGen.cs
+++ b/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.CodeGen.cs
@@ -22,11 +22,11 @@ public abstract partial class GeneratedAggregateProjectionBase<T>
 
     public ILiveAggregator<T> Build(StoreOptions options)
     {
-        if (_liveType == null)
+        if (!_hasGenerated)
         {
             lock (_compilationLock)
             {
-                if (_liveType == null)
+                if (!_hasGenerated)
                 {
                     Compile(options);
                 }
@@ -62,11 +62,11 @@ public abstract partial class GeneratedAggregateProjectionBase<T>
         this.As<ICodeFile>().InitializeSynchronously(rules, options.EventGraph, null);
 
         // You have to do this for the sake of the Setters
-        if (_liveGeneratedType == null || _liveType == null)
+        if (!_hasGenerated)
         {
             lock (_assembleLocker)
             {
-                if (_liveGeneratedType == null)
+                if (!_hasGenerated)
                 {
                     assembleTypes(new GeneratedAssembly(rules), options);
                 }

--- a/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.CodeGen.cs
+++ b/src/Marten/Events/Aggregation/GeneratedAggregateProjectionBase.CodeGen.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core;
@@ -18,13 +19,11 @@ namespace Marten.Events.Aggregation;
 
 public abstract partial class GeneratedAggregateProjectionBase<T>
 {
-    private readonly object _compilationLock = new();
-
     public ILiveAggregator<T> Build(StoreOptions options)
     {
         if (!_hasGenerated)
         {
-            lock (_compilationLock)
+            lock (_assembleLocker)
             {
                 if (!_hasGenerated)
                 {

--- a/src/Marten/Events/Projections/GeneratedProjection.cs
+++ b/src/Marten/Events/Projections/GeneratedProjection.cs
@@ -18,7 +18,7 @@ namespace Marten.Events.Projections;
 /// </summary>
 public abstract class GeneratedProjection: ProjectionBase, IProjectionSource, ICodeFile
 {
-    private bool _hasGenerated;
+    protected bool _hasGenerated;
 
     protected GeneratedProjection(string projectionName)
     {

--- a/src/Marten/Events/Projections/GeneratedProjection.cs
+++ b/src/Marten/Events/Projections/GeneratedProjection.cs
@@ -37,8 +37,6 @@ public abstract class GeneratedProjection: ProjectionBase, IProjectionSource, IC
 
     void ICodeFile.AssembleTypes(GeneratedAssembly assembly)
     {
-        lock (_assembleLocker)
-        {
             if (_hasGenerated)
                 return;
             lock (_assembleLocker)
@@ -48,7 +46,6 @@ public abstract class GeneratedProjection: ProjectionBase, IProjectionSource, IC
                 assembleTypes(assembly, StoreOptions);
                 _hasGenerated = true;
             }
-        }
     }
 
     Task<bool> ICodeFile.AttachTypes(GenerationRules rules, Assembly assembly, IServiceProvider services,

--- a/src/Marten/Events/Projections/GeneratedProjection.cs
+++ b/src/Marten/Events/Projections/GeneratedProjection.cs
@@ -37,15 +37,16 @@ public abstract class GeneratedProjection: ProjectionBase, IProjectionSource, IC
 
     void ICodeFile.AssembleTypes(GeneratedAssembly assembly)
     {
+        if (_hasGenerated)
+            return;
+
+        lock (_assembleLocker)
+        {
             if (_hasGenerated)
                 return;
-            lock (_assembleLocker)
-            {
-                if (_hasGenerated)
-                    return;
-                assembleTypes(assembly, StoreOptions);
-                _hasGenerated = true;
-            }
+            assembleTypes(assembly, StoreOptions);
+            _hasGenerated = true;
+        }
     }
 
     Task<bool> ICodeFile.AttachTypes(GenerationRules rules, Assembly assembly, IServiceProvider services,


### PR DESCRIPTION
We encountered a issue where our service would throw a `NullReferenceException` during startup, necessitating a reboot for recovery. This problem arises particularly when multiple operations execute in parallel at startup, such as `Events.AggregateStreamAsync<T>` and `Events.Append(...) + SaveChanges`. This situation triggers the compilation/build of generated types through different execution paths but not in a synchronized manner.

Through debugging, we observed that the setters for our aggregate in the generated document were not set when the error occurred. This led us to scrutinize the compile/build code, particularly the assembleTypes method, where the essential processing happens. We identified a specific flaw where the lock code checks the `_liveGeneratedType` property, but the setters are assigned afterward. This discrepancy creates a window where the code incorrectly assumes the compilation/build process is complete, proceeding to operations that depend on setters that have not yet been initialized.

The fix involves changing the source of truth for checking if types are ready from `_liveType` and `_liveGeneratedType` (which are set mid-process and hence unreliable) to a more dependable flag: `_hasGenerated`. This change ensures a more accurate and consistent readiness check, preventing the premature usage of types.

Example from our debug where we can see that `BuildLiveAggregator` is called before the setters are ready ("Setters is now set"). 

>8: Starting building inline projections
>8: generateIfNecessary
>8: got _assembleLocker
>8: Generating
>8: tryAttachTypes
>8: BuildLiveAggregationType thread 
>8: _liveGeneratedType is now set
>5: BuildLiveAggregator: Pre BuildLiveAggregator called
>5: BuildLiveAggregator: _liveType is not null. _liveGeneratedType have value: True
>5: BuildLiveAggregator: for Marten.Generated.SingleStreamProjectionLiveAggregation525137164: Setters count 0
>8: Setters is now set

**The exception:**
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at XxxAggregate Marten.Generated.EventStore.SingleStreamProjectionLiveAggregation792320531.Apply(IEvent event, XxxAggregate aggregate, IQuerySession session) in /source/xxx.Service/Internal/Generated/EventStore/SingleStreamProjectionRuntimeSupport792320531.cs:line 92
   at XxxAggregate Marten.Generated.EventStore.SingleStreamProjectionLiveAggregation792320531.Build(IReadOnlyList<IEvent> events, IQuerySession session, XxxAggregate snapshot) in /source/xxx.Service/Internal/Generated/EventStore/SingleStreamProjectionRuntimeSupport792320531.cs:line 52
   at ValueTask<T> Marten.Events.Aggregation.SyncLiveAggregatorBase<T>.BuildAsync(IReadOnlyList<IEvent> events, IQuerySession session, T snapshot, CancellationToken cancellation)
   at async ValueTask<T> Marten.Events.Aggregation.AggregateVersioning<T>.BuildAsync(IReadOnlyList<IEvent> events, IQuerySession session, T snapshot, CancellationToken cancellation)
   at async Task<T> Marten.Events.QueryEventStore.AggregateStreamAsync<T>(Guid streamId, long version, DateTimeOffset? timestamp, T state, long fromVersion, CancellationToken token)
   at async Task<TAggregate> xxx.RepositoryV2.Load<TAggregate>(Guid id, long version) in /_/Xxx.EventSourcing.MartenV2/RepositoryV2.cs:line 49
```

**Test**
I managed to create a reproducible test through a workaround that involved inserting a sleep immediately after setting `_liveGeneratedType`. This approach also necessitated having events pre-persisted before executing the test to simulate the real-world scenario accurately. While this test is not included, it is accessible for review at the following URL: https://github.com/leh2/marten/commit/246c83c4e8fb608a2ff4cd3f405486d2fb7f2531.

It's important to note that in our implementation, we leverage private apply methods, which exhibit somewhat different behavior in the generated document.
