### PR TITLE
Ability to fetch db names for documents/aggregates from marten options.

### DIFF
--- a/docs/documents/querying/advanced-sql.md
+++ b/docs/documents/querying/advanced-sql.md
@@ -140,3 +140,65 @@ results[1].detail.Detail.ShouldBe("Likes to cook");
 <!-- endSnippet -->
 
 For sync queries you can use the `AdvancedSqlQuery<T>(...)` overloads.
+
+## Getting document and schema names
+
+Tables can be referenced with raw sql, but it is also possible to have marten tell you names of documents and aggregates.
+
+These names can be found on the `Schema` property of the StoreOptions:
+
+<!-- snippet: sample_document_schema_resolver_options -->
+<a id='snippet-sample_document_schema_resolver_options'></a>
+```cs
+var schema = theSession.DocumentStore.Options.Schema;
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/DocumentSchemaResolverTests.cs#L40-L42' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_document_schema_resolver_options' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Using this you can resolve schemas:
+
+<!-- snippet: sample_document_schema_resolver_resolve_schemas -->
+<a id='snippet-sample_document_schema_resolver_resolve_schemas'></a>
+```cs
+var schema = theSession.DocumentStore.Options.Schema;
+
+schema.DatabaseSchemaName.ShouldBe("public");
+schema.EventsSchemaName.ShouldBe("public");
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/DocumentSchemaResolverTests.cs#L24-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_document_schema_resolver_resolve_schemas' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+And documents/aggregates:
+
+<!-- snippet: sample_document_schema_resolver_resolve_documents -->
+<a id='snippet-sample_document_schema_resolver_resolve_documents'></a>
+```cs
+var schema = theSession.DocumentStore.Options.Schema;
+
+schema.For<Account>().ShouldBe("public.mt_doc_account");
+schema.For<Company>().ShouldBe("public.mt_doc_company");
+schema.For<User>().ShouldBe("public.mt_doc_user");
+
+// `qualified: false` returns the table name without schema
+schema.For<Account>(qualified: false).ShouldBe("mt_doc_account");
+schema.For<Company>(qualified: false).ShouldBe("mt_doc_company");
+schema.For<User>(qualified: false).ShouldBe("mt_doc_user");
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/DocumentSchemaResolverTests.cs#L93-L104' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_document_schema_resolver_resolve_documents' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+And also marten event tables:
+
+<!-- snippet: sample_document_schema_resolver_resolve_event_tables -->
+<a id='snippet-sample_document_schema_resolver_resolve_event_tables'></a>
+```cs
+schema.ForStreams().ShouldBe("public.mt_streams");
+schema.ForEvents().ShouldBe("public.mt_events");
+schema.ForEventProgression().ShouldBe("public.mt_event_progression");
+
+schema.ForStreams(qualified: false).ShouldBe("mt_streams");
+schema.ForEvents(qualified: false).ShouldBe("mt_events");
+schema.ForEventProgression(qualified: false).ShouldBe("mt_event_progression");
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/DocumentSchemaResolverTests.cs#L134-L143' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_document_schema_resolver_resolve_event_tables' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->

--- a/src/CoreTests/DocumentSchemaResolverTests.cs
+++ b/src/CoreTests/DocumentSchemaResolverTests.cs
@@ -5,6 +5,7 @@ using Marten.Events.Projections;
 using Marten.Schema;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
+using Shouldly;
 using Xunit;
 
 namespace CoreTests;
@@ -20,10 +21,12 @@ public class DocumentSchemaResolverTests : OneOffConfigurationsContext
             options.DatabaseSchemaName = newOptions.DatabaseSchemaName;
         }, false);
 
+        #region sample_document_schema_resolver_resolve_schemas
         var schema = theSession.DocumentStore.Options.Schema;
 
-        Assert.Equal("public", schema.DatabaseSchemaName);
-        Assert.Equal("public", schema.EventsSchemaName);
+        schema.DatabaseSchemaName.ShouldBe("public");
+        schema.EventsSchemaName.ShouldBe("public");
+        #endregion
     }
 
     [Fact]
@@ -34,10 +37,12 @@ public class DocumentSchemaResolverTests : OneOffConfigurationsContext
             options.DatabaseSchemaName = "custom_schema_name";
         }, false);
 
+        #region sample_document_schema_resolver_options
         var schema = theSession.DocumentStore.Options.Schema;
+        #endregion
 
-        Assert.Equal("custom_schema_name", schema.DatabaseSchemaName);
-        Assert.Equal("custom_schema_name", schema.EventsSchemaName);
+        schema.DatabaseSchemaName.ShouldBe("custom_schema_name");
+        schema.EventsSchemaName.ShouldBe("custom_schema_name");
     }
 
     [Fact]
@@ -51,8 +56,8 @@ public class DocumentSchemaResolverTests : OneOffConfigurationsContext
 
         var schema = theSession.DocumentStore.Options.Schema;
 
-        Assert.Equal("custom_schema_name", schema.DatabaseSchemaName);
-        Assert.Equal("custom_event_schema_name", schema.EventsSchemaName);
+        schema.DatabaseSchemaName.ShouldBe("custom_schema_name");
+        schema.EventsSchemaName.ShouldBe("custom_event_schema_name");
     }
 
     [Fact]
@@ -67,29 +72,36 @@ public class DocumentSchemaResolverTests : OneOffConfigurationsContext
 
         var schema = theSession.DocumentStore.Options.Schema;
 
-        Assert.Equal("documentschemaresolvertests.mt_doc_account", schema.For<Account>());
-        Assert.Equal("documentschemaresolvertests.mt_doc_company", schema.For<Company>());
-        Assert.Equal("documentschemaresolvertests.mt_doc_user", schema.For<User>());
+        schema.For<Account>().ShouldBe("documentschemaresolvertests.mt_doc_account");
+        schema.For<Company>().ShouldBe("documentschemaresolvertests.mt_doc_company");
+        schema.For<User>().ShouldBe("documentschemaresolvertests.mt_doc_user");
 
-        Assert.Equal("mt_doc_account", schema.For<Account>(qualified: false));
-        Assert.Equal("mt_doc_company", schema.For<Company>(qualified: false));
-        Assert.Equal("mt_doc_user", schema.For<User>(qualified: false));
+        schema.For<Account>(qualified: false).ShouldBe("mt_doc_account");
+        schema.For<Company>(qualified: false).ShouldBe("mt_doc_company");
+        schema.For<User>(qualified: false).ShouldBe("mt_doc_user");
     }
 
     [Fact]
     public void ValidateUnregisteredDocumentNames()
     {
-        StoreOptions(_ => { }, false);
+        StoreOptions(options =>
+        {
+            var newOptions = new StoreOptions();
+            options.DatabaseSchemaName = newOptions.DatabaseSchemaName;
+        }, false);
 
+        #region sample_document_schema_resolver_resolve_documents
         var schema = theSession.DocumentStore.Options.Schema;
 
-        Assert.Equal("documentschemaresolvertests.mt_doc_account", schema.For<Account>());
-        Assert.Equal("documentschemaresolvertests.mt_doc_company", schema.For<Company>());
-        Assert.Equal("documentschemaresolvertests.mt_doc_user", schema.For<User>());
+        schema.For<Account>().ShouldBe("public.mt_doc_account");
+        schema.For<Company>().ShouldBe("public.mt_doc_company");
+        schema.For<User>().ShouldBe("public.mt_doc_user");
 
-        Assert.Equal("mt_doc_account", schema.For<Account>(qualified: false));
-        Assert.Equal("mt_doc_company", schema.For<Company>(qualified: false));
-        Assert.Equal("mt_doc_user", schema.For<User>(qualified: false));
+        // `qualified: false` returns the table name without schema
+        schema.For<Account>(qualified: false).ShouldBe("mt_doc_account");
+        schema.For<Company>(qualified: false).ShouldBe("mt_doc_company");
+        schema.For<User>(qualified: false).ShouldBe("mt_doc_user");
+        #endregion
     }
 
     [Fact]
@@ -104,25 +116,31 @@ public class DocumentSchemaResolverTests : OneOffConfigurationsContext
 
         var schema = theSession.DocumentStore.Options.Schema;
 
-        Assert.Equal("custom_doc_schema.mt_doc_custom_account", schema.For<Account>());
+        schema.For<Account>().ShouldBe("custom_doc_schema.mt_doc_custom_account");
 
-        Assert.Equal("mt_doc_custom_account", schema.For<Account>(qualified: false));
+        schema.For<Account>(qualified: false).ShouldBe("mt_doc_custom_account");
     }
 
     [Fact]
     public void ValidateEventTableNames()
     {
-        StoreOptions(_ => { }, false);
+        StoreOptions(options => {
+            var newOptions = new StoreOptions();
+            options.DatabaseSchemaName = newOptions.DatabaseSchemaName;
+        }, false);
 
         var schema = theSession.DocumentStore.Options.Schema;
 
-        Assert.Equal("documentschemaresolvertests.mt_streams", schema.ForStreams());
-        Assert.Equal("documentschemaresolvertests.mt_events", schema.ForEvents());
-        Assert.Equal("documentschemaresolvertests.mt_event_progression", schema.ForEventProgression());
+        #region sample_document_schema_resolver_resolve_event_tables
 
-        Assert.Equal("mt_streams", schema.ForStreams(qualified: false));
-        Assert.Equal("mt_events", schema.ForEvents(qualified: false));
-        Assert.Equal("mt_event_progression", schema.ForEventProgression(qualified: false));
+        schema.ForStreams().ShouldBe("public.mt_streams");
+        schema.ForEvents().ShouldBe("public.mt_events");
+        schema.ForEventProgression().ShouldBe("public.mt_event_progression");
+
+        schema.ForStreams(qualified: false).ShouldBe("mt_streams");
+        schema.ForEvents(qualified: false).ShouldBe("mt_events");
+        schema.ForEventProgression(qualified: false).ShouldBe("mt_event_progression");
+        #endregion
     }
 
     [Fact]
@@ -135,13 +153,13 @@ public class DocumentSchemaResolverTests : OneOffConfigurationsContext
 
         var schema = theSession.DocumentStore.Options.Schema;
 
-        Assert.Equal("custom_event_schema_name.mt_streams", schema.ForStreams());
-        Assert.Equal("custom_event_schema_name.mt_events", schema.ForEvents());
-        Assert.Equal("custom_event_schema_name.mt_event_progression", schema.ForEventProgression());
+        schema.ForStreams().ShouldBe("custom_event_schema_name.mt_streams");
+        schema.ForEvents().ShouldBe("custom_event_schema_name.mt_events");
+        schema.ForEventProgression().ShouldBe("custom_event_schema_name.mt_event_progression");
 
-        Assert.Equal("mt_streams", schema.ForStreams(qualified: false));
-        Assert.Equal("mt_events", schema.ForEvents(qualified: false));
-        Assert.Equal("mt_event_progression", schema.ForEventProgression(qualified: false));
+        schema.ForStreams(qualified: false).ShouldBe("mt_streams");
+        schema.ForEvents(qualified: false).ShouldBe("mt_events");
+        schema.ForEventProgression(qualified: false).ShouldBe("mt_event_progression");
     }
 
     [Fact]
@@ -155,13 +173,11 @@ public class DocumentSchemaResolverTests : OneOffConfigurationsContext
 
         var schema = theSession.DocumentStore.Options.Schema;
 
-        Assert.Equal(
-            "documentschemaresolvertests.mt_doc_documentschemaresolvertests_projectiona",
-            schema.For<ProjectionA>());
-        Assert.Equal("documentschemaresolvertests.mt_doc_custom_projection_alias", schema.For<ProjectionB>());
+        schema.For<ProjectionA>().ShouldBe("documentschemaresolvertests.mt_doc_documentschemaresolvertests_projectiona");
+        schema.For<ProjectionB>().ShouldBe("documentschemaresolvertests.mt_doc_custom_projection_alias");
 
-        Assert.Equal("mt_doc_documentschemaresolvertests_projectiona", schema.For<ProjectionA>(qualified: false));
-        Assert.Equal("mt_doc_custom_projection_alias",                 schema.For<ProjectionB>(qualified: false));
+        schema.For<ProjectionA>(qualified: false).ShouldBe("mt_doc_documentschemaresolvertests_projectiona");
+        schema.For<ProjectionB>(qualified: false).ShouldBe("mt_doc_custom_projection_alias");
     }
 
     public record FooEvent;

--- a/src/CoreTests/DocumentSchemaResolverTests.cs
+++ b/src/CoreTests/DocumentSchemaResolverTests.cs
@@ -1,0 +1,185 @@
+using System;
+using Marten;
+using Marten.Events;
+using Marten.Events.Projections;
+using Marten.Schema;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Xunit;
+
+namespace CoreTests;
+
+public class DocumentSchemaResolverTests : OneOffConfigurationsContext
+{
+    [Fact]
+    public void ValidateDefaultSchemaNames()
+    {
+        StoreOptions(options =>
+        {
+            var newOptions = new StoreOptions();
+            options.DatabaseSchemaName = newOptions.DatabaseSchemaName;
+        }, false);
+
+        var schema = theSession.DocumentStore.Options.Schema;
+
+        Assert.Equal("public", schema.DatabaseSchemaName);
+        Assert.Equal("public", schema.EventsSchemaName);
+    }
+
+    [Fact]
+    public void ValidateCustomSchemaNames()
+    {
+        StoreOptions(options =>
+        {
+            options.DatabaseSchemaName = "custom_schema_name";
+        }, false);
+
+        var schema = theSession.DocumentStore.Options.Schema;
+
+        Assert.Equal("custom_schema_name", schema.DatabaseSchemaName);
+        Assert.Equal("custom_schema_name", schema.EventsSchemaName);
+    }
+
+    [Fact]
+    public void ValidateCustomEventSchemaNames()
+    {
+        StoreOptions(options =>
+        {
+            options.DatabaseSchemaName = "custom_schema_name";
+            options.Events.DatabaseSchemaName = "custom_event_schema_name";
+        }, false);
+
+        var schema = theSession.DocumentStore.Options.Schema;
+
+        Assert.Equal("custom_schema_name", schema.DatabaseSchemaName);
+        Assert.Equal("custom_event_schema_name", schema.EventsSchemaName);
+    }
+
+    [Fact]
+    public void ValidateRegisteredDocumentNames()
+    {
+        StoreOptions(options =>
+        {
+            options.RegisterDocumentType<Account>();
+            options.RegisterDocumentType<Company>();
+            options.RegisterDocumentType<User>();
+        }, false);
+
+        var schema = theSession.DocumentStore.Options.Schema;
+
+        Assert.Equal("documentschemaresolvertests.mt_doc_account", schema.For<Account>());
+        Assert.Equal("documentschemaresolvertests.mt_doc_company", schema.For<Company>());
+        Assert.Equal("documentschemaresolvertests.mt_doc_user", schema.For<User>());
+
+        Assert.Equal("mt_doc_account", schema.For<Account>(qualified: false));
+        Assert.Equal("mt_doc_company", schema.For<Company>(qualified: false));
+        Assert.Equal("mt_doc_user", schema.For<User>(qualified: false));
+    }
+
+    [Fact]
+    public void ValidateUnregisteredDocumentNames()
+    {
+        StoreOptions(_ => { }, false);
+
+        var schema = theSession.DocumentStore.Options.Schema;
+
+        Assert.Equal("documentschemaresolvertests.mt_doc_account", schema.For<Account>());
+        Assert.Equal("documentschemaresolvertests.mt_doc_company", schema.For<Company>());
+        Assert.Equal("documentschemaresolvertests.mt_doc_user", schema.For<User>());
+
+        Assert.Equal("mt_doc_account", schema.For<Account>(qualified: false));
+        Assert.Equal("mt_doc_company", schema.For<Company>(qualified: false));
+        Assert.Equal("mt_doc_user", schema.For<User>(qualified: false));
+    }
+
+    [Fact]
+    public void ValidateDocumentWithCustomTableNames()
+    {
+        StoreOptions(options =>
+        {
+            options.RegisterDocumentType<Account>();
+            options.Schema.For<Account>().DatabaseSchemaName("custom_doc_schema");
+            options.Schema.For<Account>().DocumentAlias("custom_account");
+        }, false);
+
+        var schema = theSession.DocumentStore.Options.Schema;
+
+        Assert.Equal("custom_doc_schema.mt_doc_custom_account", schema.For<Account>());
+
+        Assert.Equal("mt_doc_custom_account", schema.For<Account>(qualified: false));
+    }
+
+    [Fact]
+    public void ValidateEventTableNames()
+    {
+        StoreOptions(_ => { }, false);
+
+        var schema = theSession.DocumentStore.Options.Schema;
+
+        Assert.Equal("documentschemaresolvertests.mt_streams", schema.ForStreams());
+        Assert.Equal("documentschemaresolvertests.mt_events", schema.ForEvents());
+        Assert.Equal("documentschemaresolvertests.mt_event_progression", schema.ForEventProgression());
+
+        Assert.Equal("mt_streams", schema.ForStreams(qualified: false));
+        Assert.Equal("mt_events", schema.ForEvents(qualified: false));
+        Assert.Equal("mt_event_progression", schema.ForEventProgression(qualified: false));
+    }
+
+    [Fact]
+    public void ValidateEventTableNamesWithCustomSchema()
+    {
+        StoreOptions(options =>
+        {
+            options.Events.DatabaseSchemaName = "custom_event_schema_name";
+        }, false);
+
+        var schema = theSession.DocumentStore.Options.Schema;
+
+        Assert.Equal("custom_event_schema_name.mt_streams", schema.ForStreams());
+        Assert.Equal("custom_event_schema_name.mt_events", schema.ForEvents());
+        Assert.Equal("custom_event_schema_name.mt_event_progression", schema.ForEventProgression());
+
+        Assert.Equal("mt_streams", schema.ForStreams(qualified: false));
+        Assert.Equal("mt_events", schema.ForEvents(qualified: false));
+        Assert.Equal("mt_event_progression", schema.ForEventProgression(qualified: false));
+    }
+
+    [Fact]
+    public void ValidateProjectionNames()
+    {
+        StoreOptions(options =>
+        {
+            options.Projections.Snapshot<ProjectionA>(SnapshotLifecycle.Inline);
+            options.Projections.Snapshot<ProjectionB>(SnapshotLifecycle.Async);
+        }, false);
+
+        var schema = theSession.DocumentStore.Options.Schema;
+
+        Assert.Equal(
+            "documentschemaresolvertests.mt_doc_documentschemaresolvertests_projectiona",
+            schema.For<ProjectionA>());
+        Assert.Equal("documentschemaresolvertests.mt_doc_custom_projection_alias", schema.For<ProjectionB>());
+
+        Assert.Equal("mt_doc_documentschemaresolvertests_projectiona", schema.For<ProjectionA>(qualified: false));
+        Assert.Equal("mt_doc_custom_projection_alias",                 schema.For<ProjectionB>(qualified: false));
+    }
+
+    public record FooEvent;
+
+    public record ProjectionA(Guid Id)
+    {
+        public static ProjectionA Create(IEvent<FooEvent> @event)
+        {
+            return new ProjectionA(@event.StreamId);
+        }
+    }
+
+    [DocumentAlias("custom_projection_alias")]
+    public record ProjectionB(Guid Id)
+    {
+        public static ProjectionB Create(IEvent<FooEvent> @event)
+        {
+            return new ProjectionB(@event.StreamId);
+        }
+    }
+}

--- a/src/Marten/IDocumentSchemaResolver.cs
+++ b/src/Marten/IDocumentSchemaResolver.cs
@@ -1,0 +1,57 @@
+#nullable enable
+namespace Marten;
+
+public interface IDocumentSchemaResolver
+{
+    /// <summary>
+    ///     The schema name used to store the documents.
+    /// </summary>
+    string DatabaseSchemaName { get; }
+
+    /// <summary>
+    ///     The database schema name for event related tables. By default this
+    ///     is the same schema as the document storage
+    /// </summary>
+    string EventsSchemaName { get; }
+
+    /// <summary>
+    ///     Find the database name of the table backing <typeparamref name="TDocument"/>. Supports documents and projections.
+    /// </summary>
+    /// <typeparam name="TDocument">The document or projection to look up.</typeparam>
+    /// <param name="qualified" default="true">
+    ///     When true (default) the qualified name is returned (schema and table name).
+    ///     Otherwise only the table name is returned.
+    /// </param>
+    /// <returns>The name of <typeparamref name="TDocument"/> in the database.</returns>
+    string For<TDocument>(bool qualified = true);
+
+    /// <summary>
+    ///     Find the database name of the table backing the events table. Supports documents and projections.
+    /// </summary>
+    /// <param name="qualified" default="true">
+    ///     When true (default) the qualified name is returned (schema and table name).
+    ///     Otherwise only the table name is returned.
+    /// </param>
+    /// <returns>The name of events table in the database.</returns>
+    string ForEvents(bool qualified = true);
+
+    /// <summary>
+    ///     Find the database name of the table backing the event streams table. Supports documents and projections.
+    /// </summary>
+    /// <param name="qualified" default="true">
+    ///     When true (default) the qualified name is returned (schema and table name).
+    ///     Otherwise only the table name is returned.
+    /// </param>
+    /// <returns>The name of event streams table in the database.</returns>
+    string ForStreams(bool qualified = true);
+
+    /// <summary>
+    ///     Find the database name of the table backing the event progression table. Supports documents and projections.
+    /// </summary>
+    /// <param name="qualified" default="true">
+    ///     When true (default) the qualified name is returned (schema and table name).
+    ///     Otherwise only the table name is returned.
+    /// </param>
+    /// <returns>The name of event progression table in the database.</returns>
+    string ForEventProgression(bool qualified = true);
+}

--- a/src/Marten/IReadOnlyStoreOptions.cs
+++ b/src/Marten/IReadOnlyStoreOptions.cs
@@ -83,4 +83,9 @@ public interface IReadOnlyStoreOptions
     IDocumentType FindOrResolveDocumentType(Type documentType);
 
     void AssertDocumentTypeIsSoftDeleted(Type documentType);
+
+    /// <summary>
+    /// Get database schema names for configured tables
+    /// </summary>
+    IDocumentSchemaResolver Schema { get; }
 }


### PR DESCRIPTION
Closes #3125 

As per the above issue, the usage is as follows:

```csharp
IQuerySession session;

var schema = session.DocumentStore.Options.Schema;

var a = schema.DatabaseSchemaName;  // "public"
var b = schema.EventsSchemaName;    // "public" // can be different

var c = schema.For<User>();            // "public.mt_doc_user"
var d = schema.For<UserProjection>();  // "public.mt_doc_userprojection"
var e = schema.ForStreams();           // "public.mt_streams"
var f = schema.ForEvents();            // "public.mt_events"
var g = schema.ForEventProgression();  // "public.mt_event_progression"

var h = schema.For<User>(qualified: false);            // "mt_doc_user"
var i = schema.For<UserProjection>(qualified: false);  // "mt_doc_userprojection"
var j = schema.ForStreams(qualified: false);           // "mt_streams"
var k = schema.ForEvents(qualified: false);            // "mt_events"
var l = schema.ForEventProgression(qualified: false);  // "mt_event_progression"
```

I have updated the advanced sql examples to fetch table names this way, and have added a section to the documentation describing the functionality.