### PR TITLE
Being able to specify where an event subscription starts

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -181,8 +181,11 @@ const config: UserConfig<DefaultTheme.Config> = {
                 { text: 'Rebuilding Projections', link: '/events/projections/rebuilding' },
                 { text: 'Projections and IoC Services', link: '/events/projections/ioc' },
                 { text: 'Async Daemon HealthChecks', link: '/events/projections/healthchecks' },]
+            }, 
+            {
+                text: 'Event Subscriptions',
+                link: '/events/subscriptions'
             },
-
             {
               text: 'Event Versioning',
               link: '/events/versioning'

--- a/docs/events/streaming/index.md
+++ b/docs/events/streaming/index.md
@@ -1,3 +1,0 @@
-# TODO
-
-Add general introduction to the streaming/queuing concept and locate Marten inside that.

--- a/docs/events/streaming/sink.md
+++ b/docs/events/streaming/sink.md
@@ -1,3 +1,0 @@
-# TODO
-
-Explain how to put data from queues to Marten

--- a/docs/events/streaming/source.md
+++ b/docs/events/streaming/source.md
@@ -1,3 +1,0 @@
-# TODO
-
-Explain how to put data to queues to Marten

--- a/docs/events/subscriptions.md
+++ b/docs/events/subscriptions.md
@@ -1,13 +1,11 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Marten.Events.Daemon;
-using Marten.Events.Daemon.Internals;
+# Event Subscriptions <Badge type="tip" text="7.7" />
 
-namespace Marten.Subscriptions;
+Hey folks, there will be much more on this topic soon. Right now, it's in Marten > 7.6, but part of the core Marten team is
+working with a client to prove out this feature. When that's done, we'll fill in the docs and sample code.
 
-#region sample_ISubscription
-
+<!-- snippet: sample_ISubscription -->
+<a id='snippet-sample_isubscription'></a>
+```cs
 /// <summary>
 /// Basic abstraction for custom subscriptions to Marten events through the async daemon. Use this in
 /// order to do custom processing against an ordered stream of the events
@@ -26,5 +24,12 @@ public interface ISubscription : IAsyncDisposable
         IDocumentOperations operations,
         CancellationToken cancellationToken);
 }
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Subscriptions/ISubscription.cs#L9-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_isubscription' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
-#endregion
+## Registering Subscriptions
+
+## Event Filtering
+
+## Rewinding or Replaying Subscriptions

--- a/src/Marten.AsyncDaemon.Testing/AsyncOptionsTests.cs
+++ b/src/Marten.AsyncDaemon.Testing/AsyncOptionsTests.cs
@@ -1,13 +1,23 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Marten.Events.Daemon;
 using Marten.Internal.Operations;
+using Marten.Storage;
 using Marten.Testing.Documents;
+using Marten.Testing.Harness;
 using NSubstitute;
+using Shouldly;
 using Xunit;
 
 namespace Marten.AsyncDaemon.Testing;
 
 public class AsyncOptionsTests
 {
+    private readonly IMartenDatabase theDatabase = Substitute.For<IMartenDatabase>();
+    private readonly ShardName theName = new ShardName("Fake", "All");
+    private readonly CancellationToken theToken = CancellationToken.None;
+
     [Fact]
     public void teardown_by_view_type_1()
     {
@@ -22,4 +32,213 @@ public class AsyncOptionsTests
         operations.Received().QueueOperation(new TruncateTable(typeof(Target)));
         operations.Received().QueueOperation(new TruncateTable(typeof(User)));
     }
+
+    [Fact]
+    public async Task determine_starting_position_if_rebuild()
+    {
+        var options = new AsyncOptions();
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Rebuild, theDatabase, theToken))
+            .ShouldBe(new Position(0, true));
+
+    }
+
+    [Fact]
+    public async Task determine_starting_position_if_continuous_and_no_other_constraints()
+    {
+        theDatabase.ProjectionProgressFor(theName, theToken).Returns(111L);
+
+        var options = new AsyncOptions();
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Continuous, theDatabase, theToken))
+            .ShouldBe(new Position(111L, false));
+    }
+
+    [Fact]
+    public async Task subscribe_from_present()
+    {
+        var options = new AsyncOptions();
+        options.SubscribeFromPresent();
+
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Continuous, theDatabase, theToken))
+            .ShouldBe(new Position(2000L, true));
+    }
+
+    [Fact]
+    public async Task do_not_match_on_database_name()
+    {
+        theDatabase.ProjectionProgressFor(theName, theToken).Returns(111L);
+        theDatabase.Identifier.Returns("One");
+
+        var options = new AsyncOptions();
+        options.SubscribeFromPresent("Two");
+
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Continuous, theDatabase, theToken))
+            .ShouldBe(new Position(111L, false));
+    }
+
+    [Fact]
+    public async Task do_match_on_database_name()
+    {
+        theDatabase.ProjectionProgressFor(theName, theToken).Returns(111L);
+        theDatabase.Identifier.Returns("One");
+
+        var options = new AsyncOptions();
+        options.SubscribeFromPresent("One");
+
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Continuous, theDatabase, theToken))
+            .ShouldBe(new Position(2000L, true));
+    }
+
+    [Fact]
+    public async Task subscribe_from_time_hit_with_no_prior()
+    {
+        theDatabase.ProjectionProgressFor(theName, theToken).Returns(0);
+        theDatabase.Identifier.Returns("One");
+
+        var subscriptionTime = (DateTimeOffset)DateTime.Today;
+
+        theDatabase.FindEventStoreFloorAtTimeAsync(subscriptionTime, theToken).Returns(222L);
+
+        var options = new AsyncOptions();
+        options.SubscribeFromTime(subscriptionTime);
+
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Continuous, theDatabase, theToken))
+            .ShouldBe(new Position(222L, true));
+    }
+
+    [Fact]
+    public async Task subscribe_from_time_miss_with_no_prior()
+    {
+        theDatabase.ProjectionProgressFor(theName, theToken).Returns(0);
+        theDatabase.Identifier.Returns("One");
+
+        var subscriptionTime = (DateTimeOffset)DateTime.Today;
+
+        theDatabase.FindEventStoreFloorAtTimeAsync(subscriptionTime, theToken).Returns((long?)null);
+
+        var options = new AsyncOptions();
+        options.SubscribeFromTime(subscriptionTime);
+
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Continuous, theDatabase, theToken))
+            .ShouldBe(new Position(0, false));
+    }
+
+    [Fact]
+    public async Task subscribe_from_time_hit_with_prior_lower_than_threshold()
+    {
+        theDatabase.ProjectionProgressFor(theName, theToken).Returns(200L);
+        theDatabase.Identifier.Returns("One");
+
+        var subscriptionTime = (DateTimeOffset)DateTime.Today;
+
+        theDatabase.FindEventStoreFloorAtTimeAsync(subscriptionTime, theToken).Returns(222L);
+
+        var options = new AsyncOptions();
+        options.SubscribeFromTime(subscriptionTime);
+
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Continuous, theDatabase, theToken))
+            .ShouldBe(new Position(222L, true));
+    }
+
+    [Fact]
+    public async Task subscribe_from_time_hit_with_prior_higher_than_threshold()
+    {
+        theDatabase.ProjectionProgressFor(theName, theToken).Returns(500L);
+        theDatabase.Identifier.Returns("One");
+
+        var subscriptionTime = (DateTimeOffset)DateTime.Today;
+
+        theDatabase.FindEventStoreFloorAtTimeAsync(subscriptionTime, theToken).Returns(222L);
+
+        var options = new AsyncOptions();
+        options.SubscribeFromTime(subscriptionTime);
+
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Continuous, theDatabase, theToken))
+            .ShouldBe(new Position(500L, false));
+    }
+
+    [Fact]
+    public async Task subscribe_from_time_hit_with_prior_higher_than_threshold_and_rebuild()
+    {
+        theDatabase.ProjectionProgressFor(theName, theToken).Returns(500L);
+        theDatabase.Identifier.Returns("One");
+
+        var subscriptionTime = (DateTimeOffset)DateTime.Today;
+
+        theDatabase.FindEventStoreFloorAtTimeAsync(subscriptionTime, theToken).Returns(222L);
+
+        var options = new AsyncOptions();
+        options.SubscribeFromTime(subscriptionTime);
+
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Rebuild, theDatabase, theToken))
+            .ShouldBe(new Position(222L, true));
+    }
+
+    [Fact]
+    public async Task subscribe_from_sequence_hit_with_no_prior()
+    {
+        theDatabase.ProjectionProgressFor(theName, theToken).Returns(100);
+        theDatabase.Identifier.Returns("One");
+
+        var options = new AsyncOptions();
+        options.SubscribeFromSequence(222L);
+
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Continuous, theDatabase, theToken))
+            .ShouldBe(new Position(222L, true));
+    }
+
+    [Fact]
+    public async Task subscribe_from_sequence_miss_with_no_prior()
+    {
+        theDatabase.ProjectionProgressFor(theName, theToken).Returns(0);
+        theDatabase.Identifier.Returns("One");
+
+        var options = new AsyncOptions();
+        options.SubscribeFromSequence(222L);
+
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Continuous, theDatabase, theToken))
+            .ShouldBe(new Position(222L, true));
+    }
+
+    [Fact]
+    public async Task subscribe_from_sequence_hit_with_prior_lower_than_threshold()
+    {
+        theDatabase.ProjectionProgressFor(theName, theToken).Returns(200L);
+        theDatabase.Identifier.Returns("One");
+
+        var options = new AsyncOptions();
+        options.SubscribeFromSequence(222L);
+
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Continuous, theDatabase, theToken))
+            .ShouldBe(new Position(222L, true));
+    }
+
+    [Fact]
+    public async Task subscribe_from_sequence_hit_with_prior_higher_than_threshold()
+    {
+        theDatabase.ProjectionProgressFor(theName, theToken).Returns(500L);
+        theDatabase.Identifier.Returns("One");
+
+        var options = new AsyncOptions();
+        options.SubscribeFromSequence(222L);
+
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Continuous, theDatabase, theToken))
+            .ShouldBe(new Position(500L, false));
+    }
+
+    [Fact]
+    public async Task subscribe_from_sequence_hit_with_prior_higher_than_threshold_and_rebuild()
+    {
+        theDatabase.ProjectionProgressFor(theName, theToken).Returns(500L);
+        theDatabase.Identifier.Returns("One");
+
+        var options = new AsyncOptions();
+        options.SubscribeFromSequence(222L);
+
+        (await options.DetermineStartingPositionAsync(2000L, theName, ShardExecutionMode.Rebuild, theDatabase, theToken))
+            .ShouldBe(new Position(222L, true));
+    }
+
+
+
+
 }

--- a/src/Marten.AsyncDaemon.Testing/Subscriptions/subscriptions_end_to_end.cs
+++ b/src/Marten.AsyncDaemon.Testing/Subscriptions/subscriptions_end_to_end.cs
@@ -59,6 +59,42 @@ public class subscriptions_end_to_end: OneOffConfigurationsContext
     }
 
     [Fact]
+    public async Task start_subscription_at_sequence_floor()
+    {
+        using var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+
+        var events1 = new object[] { new EventSourcingTests.Aggregation.AEvent(), new EventSourcingTests.Aggregation.AEvent(), new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent() };
+        var events2 = new object[] { new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.AEvent(), new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.CEvent() };
+        var events3 = new object[] { new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.AEvent(), new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.CEvent() };
+        var events4 = new object[] { new EventSourcingTests.Aggregation.EEvent(), new EventSourcingTests.Aggregation.BEvent(), new EventSourcingTests.Aggregation.DEvent(), new EventSourcingTests.Aggregation.CEvent() };
+
+        theSession.Events.StartStream(Guid.NewGuid(), events1);
+        theSession.Events.StartStream(Guid.NewGuid(), events2);
+        theSession.Events.StartStream(Guid.NewGuid(), events3);
+        theSession.Events.StartStream(Guid.NewGuid(), events4);
+
+        await theSession.SaveChangesAsync();
+
+        await theStore.WaitForNonStaleProjectionDataAsync(20.Seconds());
+
+        var secondSubscription = new FakeSubscription();
+        var secondStore = SeparateStore(opts =>
+        {
+            opts.Projections.Subscribe(secondSubscription, o => o.Options.SubscribeFromSequence(8));
+        });
+
+        await daemon.StopAllAsync();
+
+        using var daemon2 = await secondStore.BuildProjectionDaemonAsync();
+        await daemon2.StartAllAsync();
+        await Task.Delay(2000); // yeah, I know
+        await secondStore.WaitForNonStaleProjectionDataAsync(20.Seconds());
+
+        secondSubscription.EventsEncountered.Count.ShouldBe(8);
+    }
+
+    [Fact]
     public async Task run_events_through_and_rewind_from_scratch()
     {
         using var daemon = await theStore.BuildProjectionDaemonAsync();

--- a/src/Marten/Events/Daemon/AsyncOptions.cs
+++ b/src/Marten/Events/Daemon/AsyncOptions.cs
@@ -1,7 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core;
 using Marten.Internal.Operations;
+using Marten.Storage;
 using Weasel.Core;
+
+#nullable enable
 
 namespace Marten.Events.Daemon;
 
@@ -82,5 +89,149 @@ public class AsyncOptions
     internal void Teardown(IDocumentOperations operations)
     {
         foreach (var action in _actions) action(operations);
+    }
+
+    internal Task<Position> DetermineStartingPositionAsync(long highWaterMark, ShardName name, ShardExecutionMode mode,
+        IMartenDatabase database,
+        CancellationToken token)
+    {
+        var strategy = matchStrategy(database);
+        return strategy.DetermineStartingPositionAsync(highWaterMark, name, mode, database, token);
+    }
+
+    private IPositionStrategy matchStrategy(IMartenDatabase database)
+    {
+        return _strategies.Where(x => x.DatabaseName.IsNotEmpty()).FirstOrDefault(x => x.DatabaseName!.EqualsIgnoreCase(database.Identifier))
+                       ?? _strategies.FirstOrDefault(x => x.DatabaseName.IsEmpty()) ?? CatchUp.Instance;
+    }
+
+    private readonly List<IPositionStrategy> _strategies = new();
+
+    /// <summary>
+    /// Direct that this subscription or projection should only start from events that are appended
+    /// after the subscription is started
+    /// </summary>
+    /// <param name="databaseIdentifier">Optionally applies this rule to *only* the named database in the case of
+    /// using a multi-tenancy per multiple databases strategy</param>
+    /// <returns></returns>
+    public AsyncOptions SubscribeFromPresent(string? databaseIdentifier = null)
+    {
+        _strategies.Add(new FromPresent(databaseIdentifier));
+        return this;
+    }
+
+    /// <summary>
+    /// Direct that this subscription or projection should only start from events that have a timestamp
+    /// greater than the supplied eventTimestampFloor
+    /// </summary>
+    /// <param name="eventTimestampFloor">The floor time of the events where this subscription should be started</param>
+    /// <param name="databaseIdentifier">Optionally applies this rule to *only* the named database in the case of
+    /// using a multi-tenancy per multiple databases strategy</param>
+    /// <returns></returns>
+    public AsyncOptions SubscribeFromTime(DateTimeOffset eventTimestampFloor, string? databaseIdentifier = null)
+    {
+        _strategies.Add(new FromTime(databaseIdentifier, eventTimestampFloor));
+        return this;
+    }
+
+    /// <summary>
+    /// Direct that this subscription or projection should only start from events that have a sequence
+    /// greater than the supplied sequenceFloor
+    /// </summary>
+    /// <param name="sequenceFloor"></param>
+    /// <param name="databaseIdentifier">Optionally applies this rule to *only* the named database in the case of
+    /// using a multi-tenancy per multiple databases strategy</param>
+    /// <returns></returns>
+    public AsyncOptions SubscribeFromSequence(long sequenceFloor, string? databaseIdentifier = null)
+    {
+        _strategies.Add(new FromSequence(databaseIdentifier, sequenceFloor));
+        return this;
+    }
+}
+
+internal record Position(long Floor, bool ShouldUpdateProgressFirst);
+
+internal interface IPositionStrategy
+{
+    string? DatabaseName { get;}
+
+    Task<Position> DetermineStartingPositionAsync(long highWaterMark, ShardName name, ShardExecutionMode mode,
+        IMartenDatabase database,
+        CancellationToken token);
+}
+
+internal class FromSequence(string? databaseName, long sequence): IPositionStrategy
+{
+    public string? DatabaseName { get; } = databaseName;
+    public long Sequence { get; } = sequence;
+
+    public async Task<Position> DetermineStartingPositionAsync(long highWaterMark, ShardName name,
+        ShardExecutionMode mode,
+        IMartenDatabase database, CancellationToken token)
+    {
+        if (mode == ShardExecutionMode.Rebuild)
+        {
+            return new Position(Sequence, true);
+        }
+
+        var current = await database.ProjectionProgressFor(name, token).ConfigureAwait(false);
+
+        return current >= Sequence
+            ? new Position(current, false)
+            : new Position(Sequence, true);
+    }
+}
+
+internal class FromTime(string? databaseName, DateTimeOffset time): IPositionStrategy
+{
+    public string? DatabaseName { get; } = databaseName;
+    public DateTimeOffset EventFloorTime { get; } = time;
+
+    public async Task<Position> DetermineStartingPositionAsync(long highWaterMark, ShardName name,
+        ShardExecutionMode mode,
+        IMartenDatabase database, CancellationToken token)
+    {
+        var floor = await database.FindEventStoreFloorAtTimeAsync(EventFloorTime, token).ConfigureAwait(false) ?? 0;
+
+        if (mode == ShardExecutionMode.Rebuild)
+        {
+            return new Position(floor, true);
+        }
+
+        var current = await database.ProjectionProgressFor(name, token).ConfigureAwait(false);
+
+        return current >= floor ? new Position(current, false) : new Position(floor, true);
+    }
+}
+
+internal class FromPresent(string? databaseName): IPositionStrategy
+{
+    public string? DatabaseName { get; } = databaseName;
+
+    public Task<Position> DetermineStartingPositionAsync(long highWaterMark, ShardName name, ShardExecutionMode mode,
+        IMartenDatabase database, CancellationToken token)
+    {
+        return Task.FromResult(new Position(highWaterMark, true));
+    }
+}
+
+internal class CatchUp: IPositionStrategy
+{
+    internal static CatchUp Instance = new();
+
+    private CatchUp(){}
+
+    public string? DatabaseName { get; set; } = null;
+
+    public async Task<Position> DetermineStartingPositionAsync(long highWaterMark, ShardName name,
+        ShardExecutionMode mode,
+        IMartenDatabase database,
+        CancellationToken token)
+    {
+        return mode == ShardExecutionMode.Continuous
+            ? new Position(await database.ProjectionProgressFor(name, token).ConfigureAwait(false), false)
+
+            // No point in doing the extra database hop
+            : new Position(0, true);
     }
 }

--- a/src/Marten/Events/Daemon/ISubscriptionAgent.cs
+++ b/src/Marten/Events/Daemon/ISubscriptionAgent.cs
@@ -75,5 +75,6 @@ public interface ISubscriptionAgent: ISubscriptionController
     Task RecordDeadLetterEventAsync(DeadLetterEvent @event);
 
     DateTimeOffset? PausedTime { get; }
+    AsyncOptions Options { get; }
     Task ReplayAsync(SubscriptionExecutionRequest request, long highWaterMark, TimeSpan timeout);
 }

--- a/src/Marten/Storage/IMartenDatabase.cs
+++ b/src/Marten/Storage/IMartenDatabase.cs
@@ -110,4 +110,12 @@ public interface IMartenDatabase: IDatabase, IConnectionSource<NpgsqlConnection>
         CancellationToken token = default);
 
 
+    /// <summary>
+    /// Find the position of the event store sequence just below the supplied timestamp. Will
+    /// return null if there are no events below that time threshold
+    /// </summary>
+    /// <param name="timestamp"></param>
+    /// <param name="token"></param>
+    /// <returns></returns>
+    Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token);
 }

--- a/src/Marten/Storage/StandinDatabase.cs
+++ b/src/Marten/Storage/StandinDatabase.cs
@@ -223,6 +223,11 @@ internal class StandinDatabase: IMartenDatabase
         throw new NotImplementedException();
     }
 
+    public async Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token)
+    {
+        throw new NotImplementedException();
+    }
+
     public void Dispose()
     {
         ((IDisposable)Tracker)?.Dispose();


### PR DESCRIPTION
Way more power around setting subscription starts

Logic for determining the starting position of subscriptions

Refactoring on AsyncOptions before additional position rules

Put the starting position logic for subscriptions in AsyncOptions