### PR TITLE
Add .NET 8 compatibility with Marten 3.x

### DIFF
--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -61,7 +61,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[2.0.0, 8.0.0)" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[2.0.0, 9.0.0)" />
     </ItemGroup>
 
 


### PR DESCRIPTION
Continuation of our previous yearly requests: https://github.com/JasperFx/marten/pull/2431

We have still not fufilled our goal of converting every microservice away from Marten 3.x 🙁  

We are however progressing nicely, but have also met some setback due to this bug: https://github.com/JasperFx/marten/pull/3121 (which btw was fixed by an employee at our company, so we do contribute back 🥳).

.NET 7 is going end-of-support pretty soon, so we want to migrate away as soon as possible. Because of this we sincerely hope to get some more time to do the upgrades through this PR. We are pretty confident that we are able to convert everything before .NET 8 goes end-of-support, so hopefully this will be our last request 😄 🤞  