### PR TITLE
fix fulltext index definitions

### DIFF
--- a/src/DocumentDbTests/Bugs/Bug_3173_fulltextindex_should_map_properties.cs
+++ b/src/DocumentDbTests/Bugs/Bug_3173_fulltextindex_should_map_properties.cs
@@ -1,0 +1,38 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Testing.Harness;
+using Xunit;
+
+namespace DocumentDbTests.Bugs;
+
+public class Bug_3173_fulltextindex_should_map_properties: BugIntegrationContext
+{
+    [Fact]
+    public async Task create_full_text_index_with_property_mapping()
+    {
+        StoreOptions(o =>
+        {
+            o.RegisterDocumentType<FullTextIndexDoc>();
+            o.Schema.For<FullTextIndexDoc>().FullTextIndex(x => x.Value);
+        });
+
+        theSession.Store(new FullTextIndexDoc("Id-1", "Val-1"));
+        await theSession.SaveChangesAsync();
+
+        // use an orm like Dapper in Marten <7.0 to run the same query
+        var indexDefinitions = await theSession.AdvancedSqlQueryAsync<string>(
+            $"""
+             select indexdef
+             from pg_catalog.pg_indexes
+             where schemaname = '{SchemaName}'
+             and indexname like '%\_idx\_fts' escape '\'
+             and indexname like ('%' || ? || '%' ) escape '\'
+             """, CancellationToken.None,
+            theSession.DocumentStore.Options.Schema.For<FullTextIndexDoc>(false).Replace("_", "\\_"));
+
+        var def = Assert.Single(indexDefinitions);
+        Assert.Contains("(data ->> 'Value'::text)", def);
+    }
+}
+
+public record FullTextIndexDoc(string Id, string Value);

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -482,7 +482,7 @@ public class DocumentMapping: IDocumentMapping, IDocumentType
         string indexName = null
     )
     {
-        var index = FullTextIndexDefinitionFactory.From(this, regConfig);
+        var index = FullTextIndexDefinitionFactory.From(this, members, regConfig);
         if (indexName != null)
             index.Name = indexName;
 

--- a/src/Marten/Schema/Indexing/FullText/FullTextIndexDefinitionFactory.cs
+++ b/src/Marten/Schema/Indexing/FullText/FullTextIndexDefinitionFactory.cs
@@ -32,8 +32,8 @@ public static class FullTextIndexDefinitionFactory
     ) =>
         new(
             PostgresqlObjectName.From(mapping.TableName),
-            regConfig ?? FullTextIndexDefinition.DefaultRegConfig,
             GetDataConfig(mapping, members),
+            regConfig ?? FullTextIndexDefinition.DefaultRegConfig,
             indexPrefix: SchemaConstants.MartenPrefix
         );
 


### PR DESCRIPTION
Closes #3173 

A couple of small typos that seemed to happen when moving the index code into Weasel