### PR TITLE
Make ToAsyncEnumerable() set the QueryStatistics.TotalResult

### DIFF
--- a/src/LinqTests/Operators/async_enumerable.cs
+++ b/src/LinqTests/Operators/async_enumerable.cs
@@ -41,4 +41,31 @@ public class AsyncEnumerable : IntegrationContext
     }
 
     #endregion
+
+    [Fact]
+    public async Task query_to_async_enumerable_with_query_statistics()
+    {
+        var targets = Target.GenerateRandomData(20).ToArray();
+        await theStore.BulkInsertAsync(targets);
+
+        var ids = new List<Guid>();
+
+        var results = theSession.Query<Target>()
+            .Stats(out var stats)
+            .ToAsyncEnumerable();
+
+        stats.TotalResults.ShouldBe(0);
+
+        await foreach (var target in results)
+        {
+            stats.TotalResults.ShouldBe(20);
+            ids.Add(target.Id);
+        }
+
+        ids.Count.ShouldBe(20);
+        foreach (var target in targets)
+        {
+            ids.ShouldContain(target.Id);
+        }
+    }
 }

--- a/src/Marten/Linq/MartenLinqQueryable.cs
+++ b/src/Marten/Linq/MartenLinqQueryable.cs
@@ -150,7 +150,7 @@ internal class MartenLinqQueryable<T> : IOrderedQueryable<T>, IMartenQueryable<T
 
     public IAsyncEnumerable<T> ToAsyncEnumerable(CancellationToken token = default)
     {
-        return MartenProvider.ExecuteAsyncEnumerable<T>(Expression, token);
+        return MartenProvider.ExecuteAsyncEnumerable<T>(Expression, MartenProvider, token);
     }
 
     public Task<bool> AnyAsync(CancellationToken token)


### PR DESCRIPTION
TotalResult will not be available before enumeration of the result started. But I think, this might still be useful for providing progress information when iterating over a large result set.

This is the easiest / least "intrusive" implementation I could come up with.
