### PR TITLE
Docs: add IHost cleanup / reset samples

### DIFF
--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -24,7 +24,23 @@ That's unfortunately happened to Marten users with the `tenantId` values passed 
 again. To guard against that, you can force Marten to convert all supplied tenant ids from the outside world to either
 upper or lower case to try to stop these kinds of case sensitivity bugs in their tracks like so:
 
-snippet: sample_using_tenant_id_style
+<!-- snippet: sample_using_tenant_id_style -->
+<a id='snippet-sample_using_tenant_id_style'></a>
+```cs
+var store = DocumentStore.For(opts =>
+{
+    // This is the default
+    opts.TenantIdStyle = TenantIdStyle.CaseSensitive;
+
+    // Or opt into this behavior:
+    opts.TenantIdStyle = TenantIdStyle.ForceLowerCase;
+
+    // Or force all tenant ids to be converted to upper case internally
+    opts.TenantIdStyle = TenantIdStyle.ForceUpperCase;
+});
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MultiTenancy.cs#L12-L26' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_tenant_id_style' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 ## Static Database to Tenant Mapping
 

--- a/docs/configuration/storeoptions.md
+++ b/docs/configuration/storeoptions.md
@@ -15,7 +15,7 @@ public static DocumentStore For(Action<StoreOptions> configure)
     return new DocumentStore(options);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/DocumentStore.cs#L510-L520' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_documentstore.for' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/DocumentStore.cs#L521-L531' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_documentstore.for' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The major parts of `StoreOptions` are shown in the class diagram below:

--- a/docs/documents/multi-tenancy.md
+++ b/docs/documents/multi-tenancy.md
@@ -43,7 +43,7 @@ using (var session = store.LightweightSession("tenant1"))
     session.SaveChanges();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MultiTenancy.cs#L35-L45' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-scoping-session-write-2' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MultiTenancy.cs#L54-L64' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-scoping-session-write-2' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 As with storing, the load operations respect tenancy of the session.
@@ -61,7 +61,7 @@ using (var query = store.QuerySession("tenant1"))
         .ShouldHaveTheSameElementsAs("Bill", "Lindsey");
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MultiTenancy.cs#L55-L67' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-scoping-session-read' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MultiTenancy.cs#L74-L86' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-scoping-session-read' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Lastly, unlike reading operations, `IDocumentSession.Store` offers an overload to explicitly pass in a tenant identifier, bypassing any tenancy associated with the session. Similar overload for tenancy exists for `IDocumentStore.BulkInsert`.
@@ -162,7 +162,7 @@ using (var query = store.QuerySession("tenant1"))
         .ShouldHaveTheSameElementsAs("Bill", "Lindsey");
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MultiTenancy.cs#L55-L67' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-scoping-session-read' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MultiTenancy.cs#L74-L86' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-scoping-session-read' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Marten will automatically filter the LINQ query for the current tenant _if the current document type is tenanted_. However, if
@@ -212,7 +212,7 @@ storeOptions.Policies.AllDocumentsAreMultiTenanted();
 // Shorthand for
 // storeOptions.Policies.ForAllDocuments(_ => _.TenancyStyle = TenancyStyle.Conjoined);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MultiTenancy.cs#L24-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-configure-through-policy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MultiTenancy.cs#L43-L49' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-configure-through-policy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Tenancy At Document Level & Policy Overrides

--- a/docs/events/projections/custom.md
+++ b/docs/events/projections/custom.md
@@ -7,6 +7,8 @@ To build your own Marten projection, you just need a class that implements the `
 ```cs
 /// <summary>
 ///     Interface for all event projections
+///     IProjection implementations define the projection type and handle its projection document lifecycle
+///     Optimized for inline usage
 /// </summary>
 public interface IProjection
 {
@@ -28,7 +30,7 @@ public interface IProjection
         CancellationToken cancellation);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Projections/IProjection.cs#L8-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iprojection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Projections/IProjection.cs#L8-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iprojection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `StreamAction` aggregates outstanding events by the event stream, which is how Marten tracks events inside of an `IDocumentSession` that has

--- a/docs/events/projections/multi-stream-projections.md
+++ b/docs/events/projections/multi-stream-projections.md
@@ -430,7 +430,31 @@ document per tenant id in a projected document -- like maybe the number of open 
 To do that, there's a recipe for the "event slicing" in multi-stream projections with Marten to just group by the event's
 tenant id and make that the identity of the projected document. That usage is shown below:
 
-snippet: sample_rollup_projection_by_tenant_id
+<!-- snippet: sample_rollup_projection_by_tenant_id -->
+<a id='snippet-sample_rollup_projection_by_tenant_id'></a>
+```cs
+public class RollupProjection: MultiStreamProjection<Rollup, string>
+{
+    public RollupProjection()
+    {
+        // This opts into doing the event slicing by tenant id
+        RollUpByTenant();
+    }
+
+    public void Apply(Rollup state, AEvent e) => state.ACount++;
+    public void Apply(Rollup state, BEvent e) => state.BCount++;
+}
+
+public class Rollup
+{
+    [Identity]
+    public string TenantId { get; set; }
+    public int ACount { get; set; }
+    public int BCount { get; set; }
+}
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/MultiStreamProjections/rolling_up_by_tenant.cs#L55-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_rollup_projection_by_tenant_id' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 Do note that you'll probably also need this flag in your configuration:
 

--- a/docs/schema/cleaning.md
+++ b/docs/schema/cleaning.md
@@ -11,34 +11,46 @@ This service is exposed as the `IDocumentStore.Advanced.Clean` property. You can
 <!-- snippet: sample_clean_out_documents -->
 <a id='snippet-sample_clean_out_documents'></a>
 ```cs
-public void clean_out_documents(IDocumentStore store)
+public async Task clean_out_documents(IDocumentStore store)
 {
     // Completely remove all the database schema objects related
     // to the User document type
-    store.Advanced.Clean.CompletelyRemove(typeof(User));
+    await store.Advanced.Clean.CompletelyRemoveAsync(typeof(User));
 
     // Tear down and remove all Marten related database schema objects
-    store.Advanced.Clean.CompletelyRemoveAll();
+    await store.Advanced.Clean.CompletelyRemoveAllAsync();
 
     // Deletes all the documents stored in a Marten database
-    store.Advanced.Clean.DeleteAllDocuments();
+    await store.Advanced.Clean.DeleteAllDocumentsAsync();
+
+    // Deletes all the event data stored in a Marten database
+    await store.Advanced.Clean.DeleteAllEventDataAsync();
 
     // Deletes all of the persisted User documents
-    store.Advanced.Clean.DeleteDocumentsByType(typeof(User));
+    await store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(User));
 
     // For cases where you may want to keep some document types,
     // but eliminate everything else. This is here specifically to support
     // automated testing scenarios where you have some static data that can
     // be safely reused across tests
-    store.Advanced.Clean.DeleteDocumentsExcept(typeof(Company), typeof(User));
+    await store.Advanced.Clean.DeleteDocumentsExceptAsync(typeof(Company), typeof(User));
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/DocumentCleanerExamples.cs#L7-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_clean_out_documents' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/DocumentCleanerExamples.cs#L9-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_clean_out_documents' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also tear down all Data from the `IHost` instance using the `IHost.CleanAllMartenDataAsync()` method.
 
 <!-- snippet: sample_clean_out_documents_ihost -->
+<a id='snippet-sample_clean_out_documents_ihost'></a>
+```cs
+public async Task clean_out_documents(IHost host)
+{
+    // Clean off all Marten data in the default DocumentStore for this host
+    await host.CleanAllMartenDataAsync();
+}
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/DocumentCleanerExamples.cs#L38-L44' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_clean_out_documents_ihost' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Reset all data
@@ -58,4 +70,25 @@ await theStore.Advanced.ResetAllData();
 Use `IHost.ResetAllMartenDataAsync()` to delete all current document, event data and then (re)applies the configured initial data from the `IHost` instance.
 
 <!-- snippet: sample_reset_all_data_ihost -->
+<a id='snippet-sample_reset_all_data_ihost'></a>
+```cs
+using var host = await Host.CreateDefaultBuilder()
+    .ConfigureServices(
+        services =>
+        {
+            services.AddMarten(
+                    opts =>
+                    {
+                        opts.Connection(ConnectionSource.ConnectionString);
+                        opts.Logger(new TestOutputMartenLogger(_output));
+                    }
+                )
+                .InitializeWith(new reset_all_data_usage.Users());
+        }
+    )
+    .StartAsync();
+
+await host.ResetAllMartenDataAsync();
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/SessionMechanics/reset_all_data_usage_ihost.cs#L21-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_reset_all_data_ihost' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/schema/cleaning.md
+++ b/docs/schema/cleaning.md
@@ -49,3 +49,7 @@ await theStore.Advanced.ResetAllData();
 ```
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/SessionMechanics/reset_all_data_usage.cs#L45-L49' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_reset_all_data' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+Use `IHost.ResetAllMartenDataAsync()` to delete all current document, event data and then (re)applies the configured initial data from the `IHost` instance.
+
+<!-- snippet: sample_reset_all_data_ihost -->

--- a/docs/schema/cleaning.md
+++ b/docs/schema/cleaning.md
@@ -36,6 +36,11 @@ public void clean_out_documents(IDocumentStore store)
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/DocumentCleanerExamples.cs#L7-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_clean_out_documents' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+You can also tear down all Data from the `IHost` instance using the `IHost.CleanAllMartenDataAsync()` method.
+
+<!-- snippet: sample_clean_out_documents_ihost -->
+<!-- endSnippet -->
+
 ## Reset all data
 
 Use `IDocumentStore.Advanced.ResetAllData()` to deletes all current document, event data and then (re)applies the configured initial data.

--- a/docs/schema/cleaning.md
+++ b/docs/schema/cleaning.md
@@ -53,3 +53,4 @@ await theStore.Advanced.ResetAllData();
 Use `IHost.ResetAllMartenDataAsync()` to delete all current document, event data and then (re)applies the configured initial data from the `IHost` instance.
 
 <!-- snippet: sample_reset_all_data_ihost -->
+<!-- endSnippet -->

--- a/src/DocumentDbTests/DocumentDbTests.csproj
+++ b/src/DocumentDbTests/DocumentDbTests.csproj
@@ -12,6 +12,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
         <PackageReference Include="Jil" Version="3.0.0-alpha2" />

--- a/src/DocumentDbTests/SessionMechanics/reset_all_data_usage_ihost.cs
+++ b/src/DocumentDbTests/SessionMechanics/reset_all_data_usage_ihost.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DocumentDbTests.SessionMechanics;
+
+public class reset_all_data_usage_ihost
+{
+    private readonly ITestOutputHelper _output;
+
+    public reset_all_data_usage_ihost(
+        ITestOutputHelper output
+    ) => _output = output;
+
+    [Fact]
+    public async Task can_reset_all_data_on_ihost()
+    {
+        #region sample_reset_all_data_ihost
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(
+                services =>
+                {
+                    services.AddMarten(
+                            opts =>
+                            {
+                                opts.Connection(ConnectionSource.ConnectionString);
+                                opts.Logger(new TestOutputMartenLogger(_output));
+                            }
+                        )
+                        .InitializeWith(new reset_all_data_usage.Users());
+                }
+            )
+            .StartAsync();
+
+        await host.ResetAllMartenDataAsync();
+        #endregion
+    }
+}

--- a/src/Marten.Testing/Examples/DocumentCleanerExamples.cs
+++ b/src/Marten.Testing/Examples/DocumentCleanerExamples.cs
@@ -9,22 +9,22 @@ public class DocumentCleanerExamples
     {
         // Completely remove all the database schema objects related
         // to the User document type
-        store.Advanced.Clean.CompletelyRemove(typeof(User));
+        store.Advanced.Clean.CompletelyRemoveAsync(typeof(User));
 
         // Tear down and remove all Marten related database schema objects
-        store.Advanced.Clean.CompletelyRemoveAll();
+        store.Advanced.Clean.CompletelyRemoveAllAsync();
 
         // Deletes all the documents stored in a Marten database
-        store.Advanced.Clean.DeleteAllDocuments();
+        store.Advanced.Clean.DeleteAllDocumentsAsync();
 
         // Deletes all of the persisted User documents
-        store.Advanced.Clean.DeleteDocumentsByType(typeof(User));
+        store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(User));
 
         // For cases where you may want to keep some document types,
         // but eliminate everything else. This is here specifically to support
         // automated testing scenarios where you have some static data that can
         // be safely reused across tests
-        store.Advanced.Clean.DeleteDocumentsExcept(typeof(Company), typeof(User));
+        store.Advanced.Clean.DeleteDocumentsExceptAsync(typeof(Company), typeof(User));
     }
 
     #endregion

--- a/src/Marten.Testing/Examples/DocumentCleanerExamples.cs
+++ b/src/Marten.Testing/Examples/DocumentCleanerExamples.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Marten.Testing.Documents;
+using Microsoft.Extensions.Hosting;
 
 namespace Marten.Testing.Examples;
 
@@ -31,5 +32,14 @@ public class DocumentCleanerExamples
         await store.Advanced.Clean.DeleteDocumentsExceptAsync(typeof(Company), typeof(User));
     }
 
+    #endregion
+
+
+    #region sample_clean_out_documents_ihost
+    public async Task clean_out_documents(IHost host)
+    {
+        // Clean off all Marten data in the default DocumentStore for this host
+        await host.CleanAllMartenDataAsync();
+    }
     #endregion
 }

--- a/src/Marten.Testing/Examples/DocumentCleanerExamples.cs
+++ b/src/Marten.Testing/Examples/DocumentCleanerExamples.cs
@@ -17,6 +17,9 @@ public class DocumentCleanerExamples
         // Deletes all the documents stored in a Marten database
         store.Advanced.Clean.DeleteAllDocumentsAsync();
 
+        // Deletes all the event data stored in a Marten database
+        store.Advanced.Clean.DeleteAllEventDataAsync();
+
         // Deletes all of the persisted User documents
         store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(User));
 

--- a/src/Marten.Testing/Examples/DocumentCleanerExamples.cs
+++ b/src/Marten.Testing/Examples/DocumentCleanerExamples.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Marten.Testing.Documents;
 
 namespace Marten.Testing.Examples;
@@ -5,29 +6,29 @@ namespace Marten.Testing.Examples;
 public class DocumentCleanerExamples
 {
     #region sample_clean_out_documents
-    public void clean_out_documents(IDocumentStore store)
+    public async Task clean_out_documents(IDocumentStore store)
     {
         // Completely remove all the database schema objects related
         // to the User document type
-        store.Advanced.Clean.CompletelyRemoveAsync(typeof(User));
+        await store.Advanced.Clean.CompletelyRemoveAsync(typeof(User));
 
         // Tear down and remove all Marten related database schema objects
-        store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
 
         // Deletes all the documents stored in a Marten database
-        store.Advanced.Clean.DeleteAllDocumentsAsync();
+        await store.Advanced.Clean.DeleteAllDocumentsAsync();
 
         // Deletes all the event data stored in a Marten database
-        store.Advanced.Clean.DeleteAllEventDataAsync();
+        await store.Advanced.Clean.DeleteAllEventDataAsync();
 
         // Deletes all of the persisted User documents
-        store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(User));
+        await store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(User));
 
         // For cases where you may want to keep some document types,
         // but eliminate everything else. This is here specifically to support
         // automated testing scenarios where you have some static data that can
         // be safely reused across tests
-        store.Advanced.Clean.DeleteDocumentsExceptAsync(typeof(Company), typeof(User));
+        await store.Advanced.Clean.DeleteDocumentsExceptAsync(typeof(Company), typeof(User));
     }
 
     #endregion


### PR DESCRIPTION
Adds samples for the `IHost` cleanup / reset methods added in 7.16.0 (13d901d216dca4bf3d92fd1e122bded2c704b996).

Also updates the cleanup docs to include Event cleanup and shows async versions instead of obsolete synchronous versions.