### PR TITLE
Add NRT coverage for Linq namespace

### DIFF
--- a/src/Marten/Linq/CollectionUsage.Includes.cs
+++ b/src/Marten/Linq/CollectionUsage.Includes.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -36,7 +37,7 @@ public partial class CollectionUsage
                 var storage = session.StorageFor(includedType);
 
                 var type = typeof(ListIncludePlan<>).MakeGenericType(includedType);
-                var plan = (IIncludePlan)Activator.CreateInstance(type, storage, member, receiver);
+                var plan = (IIncludePlan)Activator.CreateInstance(type, storage, member, receiver)!;
 
                 if (expression.Arguments.Count == 3)
                 {
@@ -51,7 +52,7 @@ public partial class CollectionUsage
                 var storage = session.StorageFor(includedType);
 
                 var type = typeof(IncludePlan<>).MakeGenericType(includedType);
-                var plan = (IIncludePlan)Activator.CreateInstance(type, storage, member, receiver);
+                var plan = (IIncludePlan)Activator.CreateInstance(type, storage, member, receiver)!;
 
                 if (expression.Arguments.Count == 3)
                 {
@@ -67,7 +68,7 @@ public partial class CollectionUsage
                 var storage = session.StorageFor(includedType);
 
                 var type = typeof(DictionaryIncludePlan<,>).MakeGenericType(includedType, idType);
-                var plan = (IIncludePlan)Activator.CreateInstance(type, storage, member, receiver);
+                var plan = (IIncludePlan)Activator.CreateInstance(type, storage, member, receiver)!;
 
                 if (expression.Arguments.Count == 3)
                 {

--- a/src/Marten/Linq/CollectionUsage.Parsing.cs
+++ b/src/Marten/Linq/CollectionUsage.Parsing.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/CollectionUsage.cs
+++ b/src/Marten/Linq/CollectionUsage.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
@@ -25,8 +26,8 @@ public partial class CollectionUsage
     public SingleValueMode? SingleValueMode { get; set; }
     public bool IsAny { get; set; }
     public bool IsDistinct { get; set; }
-    public CollectionUsage Inner { get; internal set; }
-    public Expression SelectMany { get; set; }
+    public CollectionUsage Inner { get; internal set; } = null!;
+    public Expression SelectMany { get; set; } = null!;
 
 
     public void WriteLimit(int limit)

--- a/src/Marten/Linq/ConfigureExplainExpressions.cs
+++ b/src/Marten/Linq/ConfigureExplainExpressions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Text;
 
 namespace Marten.Linq;

--- a/src/Marten/Linq/CreatedAt/CreatedBeforeParser.cs
+++ b/src/Marten/Linq/CreatedAt/CreatedBeforeParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using System.Linq.Expressions;
@@ -13,7 +14,7 @@ namespace Marten.Linq.CreatedAt;
 public class CreatedBeforeParser: IMethodCallParser
 {
     private static readonly MethodInfo _method =
-        typeof(CreatedAtExtensions).GetMethod(nameof(CreatedAtExtensions.CreatedBefore));
+        typeof(CreatedAtExtensions).GetMethod(nameof(CreatedAtExtensions.CreatedBefore))!;
 
     public bool Matches(MethodCallExpression expression)
     {

--- a/src/Marten/Linq/CreatedAt/CreatedSinceParser.cs
+++ b/src/Marten/Linq/CreatedAt/CreatedSinceParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using System.Linq.Expressions;
@@ -13,7 +14,7 @@ namespace Marten.Linq.CreatedAt;
 public class CreatedSinceParser: IMethodCallParser
 {
     private static readonly MethodInfo _method =
-        typeof(CreatedAtExtensions).GetMethod(nameof(CreatedAtExtensions.CreatedSince));
+        typeof(CreatedAtExtensions).GetMethod(nameof(CreatedAtExtensions.CreatedSince))!;
 
     public bool Matches(MethodCallExpression expression)
     {

--- a/src/Marten/Linq/FetchType.cs
+++ b/src/Marten/Linq/FetchType.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Linq;
 
 /// <summary>

--- a/src/Marten/Linq/ICompiledQuery.cs
+++ b/src/Marten/Linq/ICompiledQuery.cs
@@ -23,7 +23,7 @@ public interface IQueryPlanning
 
 #region sample_ICompiledQuery
 
-public interface ICompiledQuery<TDoc, TOut>
+public interface ICompiledQuery<TDoc, TOut> where TDoc: notnull
 {
     Expression<Func<IMartenQueryable<TDoc>, TOut>> QueryIs();
 }

--- a/src/Marten/Linq/ILinqQuery.cs
+++ b/src/Marten/Linq/ILinqQuery.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq.Expressions;
 

--- a/src/Marten/Linq/Includes/DictionaryIncludePlan.cs
+++ b/src/Marten/Linq/Includes/DictionaryIncludePlan.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using Marten.Internal.Storage;
@@ -5,7 +6,7 @@ using Marten.Linq.Members;
 
 namespace Marten.Linq.Includes;
 
-internal class DictionaryIncludePlan<T, TId>: IncludePlan<T>
+internal class DictionaryIncludePlan<T, TId>: IncludePlan<T> where T : notnull
 {
     public DictionaryIncludePlan(IDocumentStorage<T> storage, IQueryableMember connectingMember,
         IDictionary<TId, T> dictionary): base(storage, connectingMember, BuildAction(storage, dictionary))

--- a/src/Marten/Linq/Includes/IIncludePlan.cs
+++ b/src/Marten/Linq/Includes/IIncludePlan.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq.Expressions;
 using Marten.Internal;

--- a/src/Marten/Linq/Includes/IIncludeReader.cs
+++ b/src/Marten/Linq/Includes/IIncludeReader.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Marten/Linq/Includes/IdInIncludedDocumentIdentifierFilter.cs
+++ b/src/Marten/Linq/Includes/IdInIncludedDocumentIdentifierFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Linq.Members;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
@@ -7,10 +8,10 @@ namespace Marten.Linq.Includes;
 internal class IdInIncludedDocumentIdentifierFilter: ISqlFragment
 {
     private readonly IQueryableMember _connectingMember;
-    private readonly IQueryableMember _identifyingMember;
+    private readonly IQueryableMember? _identifyingMember;
     private readonly string _fromObject;
 
-    public IdInIncludedDocumentIdentifierFilter(string fromObject, IQueryableMember connectingMember, IQueryableMember identifyingMember)
+    public IdInIncludedDocumentIdentifierFilter(string fromObject, IQueryableMember connectingMember, IQueryableMember? identifyingMember)
     {
         _fromObject = fromObject;
         _connectingMember = connectingMember;

--- a/src/Marten/Linq/Includes/Include.cs
+++ b/src/Marten/Linq/Includes/Include.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using Marten.Exceptions;
@@ -17,7 +18,7 @@ public static class Include
     ///     Used internally to process Include() operations
     ///     in the Linq support
     /// </summary>
-    public static IIncludeReader ReaderToAction<T>(IMartenSession session, Action<T> action)
+    public static IIncludeReader ReaderToAction<T>(IMartenSession session, Action<T> action) where T : notnull
     {
         var storage = session.StorageFor<T>();
 
@@ -29,7 +30,7 @@ public static class Include
     ///     Used internally to process Include() operations
     ///     in the Linq support
     /// </summary>
-    public static IIncludeReader ReaderToList<T>(IMartenSession session, IList<T> list)
+    public static IIncludeReader ReaderToList<T>(IMartenSession session, IList<T> list) where T : notnull
     {
         return ReaderToAction<T>(session, list.Add);
     }
@@ -38,7 +39,7 @@ public static class Include
     ///     Used internally to process Include() operations
     ///     in the Linq support
     /// </summary>
-    public static IIncludeReader ReaderToDictionary<T, TId>(IMartenSession session, IDictionary<TId, T> dictionary)
+    public static IIncludeReader ReaderToDictionary<T, TId>(IMartenSession session, IDictionary<TId, T> dictionary) where T : notnull where TId : notnull
     {
         var storage = session.StorageFor<T>();
         if (storage is IDocumentStorage<T, TId> s)

--- a/src/Marten/Linq/Includes/IncludePlan.cs
+++ b/src/Marten/Linq/Includes/IncludePlan.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,7 +14,7 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Includes;
 
-internal class IncludePlan<T>: IIncludePlan
+internal class IncludePlan<T>: IIncludePlan where T : notnull
 {
     private readonly Action<T> _callback;
     private readonly IQueryableMember _connectingMember;

--- a/src/Marten/Linq/Includes/IncludeQueryHandler.cs
+++ b/src/Marten/Linq/Includes/IncludeQueryHandler.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Data.Common;
 using System.IO;

--- a/src/Marten/Linq/Includes/IncludeReader.cs
+++ b/src/Marten/Linq/Includes/IncludeReader.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Data.Common;
 using System.Threading;

--- a/src/Marten/Linq/Includes/ListIncludePlan.cs
+++ b/src/Marten/Linq/Includes/ListIncludePlan.cs
@@ -1,10 +1,11 @@
+#nullable enable
 using System.Collections.Generic;
 using Marten.Internal.Storage;
 using Marten.Linq.Members;
 
 namespace Marten.Linq.Includes;
 
-internal class ListIncludePlan<T>: IncludePlan<T>
+internal class ListIncludePlan<T>: IncludePlan<T> where T : notnull
 {
     public ListIncludePlan(IDocumentStorage<T> storage, IQueryableMember connectingMember, IList<T> list): base(storage,
         connectingMember, list.Add)

--- a/src/Marten/Linq/Includes/PassthroughSelectStatement.cs
+++ b/src/Marten/Linq/Includes/PassthroughSelectStatement.cs
@@ -6,12 +6,9 @@ namespace Marten.Linq.Includes;
 
 internal class PassthroughSelectStatement: SelectorStatement
 {
-    private readonly ISelectClause _innerSelectClause;
-
     public PassthroughSelectStatement(string tableName, ISelectClause innerSelectClause)
     {
-        _innerSelectClause = innerSelectClause;
-        SelectClause = _innerSelectClause;
+        SelectClause = innerSelectClause;
         TableName = tableName;
     }
 

--- a/src/Marten/Linq/Includes/TemporaryTableStatement.cs
+++ b/src/Marten/Linq/Includes/TemporaryTableStatement.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Internal;
 using Marten.Internal.Storage;
 using Marten.Linq.SqlGeneration;

--- a/src/Marten/Linq/LastModified/ModifiedBeforeParser.cs
+++ b/src/Marten/Linq/LastModified/ModifiedBeforeParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using System.Linq.Expressions;
@@ -13,7 +14,7 @@ namespace Marten.Linq.LastModified;
 public class ModifiedBeforeParser: IMethodCallParser
 {
     private static readonly MethodInfo _method =
-        typeof(LastModifiedExtensions).GetMethod(nameof(LastModifiedExtensions.ModifiedBefore));
+        typeof(LastModifiedExtensions).GetMethod(nameof(LastModifiedExtensions.ModifiedBefore))!;
 
     public bool Matches(MethodCallExpression expression)
     {

--- a/src/Marten/Linq/LastModified/ModifiedSinceParser.cs
+++ b/src/Marten/Linq/LastModified/ModifiedSinceParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using System.Linq.Expressions;
@@ -13,7 +14,7 @@ namespace Marten.Linq.LastModified;
 public class ModifiedSinceParser: IMethodCallParser
 {
     private static readonly MethodInfo _method =
-        typeof(LastModifiedExtensions).GetMethod(nameof(LastModifiedExtensions.ModifiedSince));
+        typeof(LastModifiedExtensions).GetMethod(nameof(LastModifiedExtensions.ModifiedSince))!;
 
     public bool Matches(MethodCallExpression expression)
     {

--- a/src/Marten/Linq/MartenLinqQueryProvider.cs
+++ b/src/Marten/Linq/MartenLinqQueryProvider.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -27,7 +28,7 @@ internal class MartenLinqQueryProvider: IQueryProvider
 
     public Type SourceType { get; }
 
-    internal QueryStatistics Statistics { get; set; }
+    internal QueryStatistics Statistics { get; set; } = null!;
 
     public IQueryable CreateQuery(Expression expression)
     {
@@ -51,7 +52,7 @@ internal class MartenLinqQueryProvider: IQueryProvider
 
         ensureStorageExists(parser);
 
-        return ExecuteHandler(handler);
+        return ExecuteHandler(handler)!;
     }
 
     private void ensureStorageExists(LinqQueryParser parser)
@@ -72,7 +73,7 @@ internal class MartenLinqQueryProvider: IQueryProvider
     }
 
 
-    public async Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken token,
+    public async Task<TResult?> ExecuteAsync<TResult>(Expression expression, CancellationToken token,
         SingleValueMode valueMode)
     {
         try
@@ -93,7 +94,7 @@ internal class MartenLinqQueryProvider: IQueryProvider
     }
 
     public async Task<int> StreamJson<TResult>(Stream stream, Expression expression, CancellationToken token,
-        SingleValueMode mode)
+        SingleValueMode mode) where TResult: notnull
     {
         try
         {
@@ -116,7 +117,7 @@ internal class MartenLinqQueryProvider: IQueryProvider
         return default;
     }
 
-    public async Task<T> ExecuteHandlerAsync<T>(IQueryHandler<T> handler, CancellationToken token)
+    public async Task<T?> ExecuteHandlerAsync<T>(IQueryHandler<T> handler, CancellationToken token)
     {
         try
         {
@@ -133,7 +134,7 @@ internal class MartenLinqQueryProvider: IQueryProvider
         return default;
     }
 
-    public T ExecuteHandler<T>(IQueryHandler<T> handler)
+    public T? ExecuteHandler<T>(IQueryHandler<T> handler)
     {
         try
         {

--- a/src/Marten/Linq/MartenLinqQueryable.cs
+++ b/src/Marten/Linq/MartenLinqQueryable.cs
@@ -87,7 +87,7 @@ internal class MartenLinqQueryable<T> : IOrderedQueryable<T>, IMartenQueryable<T
     {
         return Include(callback).On(idSource, filter);
     }
-    
+
     public IMartenQueryable<T> Include<TInclude, TKey>(Expression<Func<T, object>> idSource,
         IDictionary<TKey, TInclude> dictionary) where TInclude : notnull where TKey : notnull
     {
@@ -238,7 +238,7 @@ internal class MartenLinqQueryable<T> : IOrderedQueryable<T>, IMartenQueryable<T
     {
         return MartenProvider.StreamMany(Expression, destination, token);
     }
-    
+
     public NpgsqlCommand ToPreviewCommand(FetchType fetchType)
     {
         var parser = new LinqQueryParser(MartenProvider, Session, Expression);

--- a/src/Marten/Linq/MatchesSql/MatchesSqlParser.cs
+++ b/src/Marten/Linq/MatchesSql/MatchesSqlParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -13,18 +14,18 @@ public class MatchesSqlParser: IMethodCallParser
 {
     private static readonly MethodInfo _sqlMethod =
         typeof(MatchesSqlExtensions).GetMethod(nameof(MatchesSqlExtensions.MatchesSql),
-            new[] { typeof(object), typeof(string), typeof(object[]) });
+            new[] { typeof(object), typeof(string), typeof(object[]) })!;
 
     private static readonly MethodInfo _fragmentMethod =
         typeof(MatchesSqlExtensions).GetMethod(nameof(MatchesSqlExtensions.MatchesSql),
-            new[] { typeof(object), typeof(ISqlFragment) });
+            new[] { typeof(object), typeof(ISqlFragment) })!;
 
     public bool Matches(MethodCallExpression expression)
     {
         return Equals(expression.Method, _sqlMethod) || Equals(expression.Method, _fragmentMethod);
     }
 
-    public ISqlFragment Parse(IQueryableMemberCollection memberCollection, IReadOnlyStoreOptions options,
+    public ISqlFragment? Parse(IQueryableMemberCollection memberCollection, IReadOnlyStoreOptions options,
         MethodCallExpression expression)
     {
         if (expression.Method.Equals(_sqlMethod))
@@ -46,7 +47,7 @@ public class MatchesJsonPathParser: IMethodCallParser
 {
     private static readonly MethodInfo _sqlMethod =
         typeof(MatchesSqlExtensions).GetMethod(nameof(MatchesSqlExtensions.MatchesJsonPath),
-            new[] { typeof(object), typeof(string), typeof(object[]) });
+            new[] { typeof(object), typeof(string), typeof(object[]) })!;
 
     public bool Matches(MethodCallExpression expression)
     {
@@ -58,7 +59,7 @@ public class MatchesJsonPathParser: IMethodCallParser
     {
         var arguments = expression.Arguments[2].Value().As<object[]>().Select(x => new CommandParameter(x)).ToArray();
 
-        return new  LiteralSqlWithJsonPath(expression.Arguments[1].Value().As<string>(), arguments);
+        return new LiteralSqlWithJsonPath(expression.Arguments[1].Value().As<string>(), arguments);
     }
 }
 

--- a/src/Marten/Linq/Members/BooleanMember.cs
+++ b/src/Marten/Linq/Members/BooleanMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Reflection;
 using Marten.Linq.SqlGeneration.Filters;
 using Weasel.Postgresql.SqlGeneration;

--- a/src/Marten/Linq/Members/ChildCollectionCount.cs
+++ b/src/Marten/Linq/Members/ChildCollectionCount.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/Members/ChildCollectionJsonPathCountFilter.cs
+++ b/src/Marten/Linq/Members/ChildCollectionJsonPathCountFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/Members/ChildCollectionMember.cs
+++ b/src/Marten/Linq/Members/ChildCollectionMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Marten/Linq/Members/ChildCollectionWhereClause.cs
+++ b/src/Marten/Linq/Members/ChildCollectionWhereClause.cs
@@ -1,4 +1,5 @@
-using System;
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JasperFx.Core;
 using Marten.Linq.SqlGeneration.Filters;
@@ -18,7 +19,7 @@ internal class ChildCollectionWhereClause: IWhereFragmentHolder
     public ISqlFragment Fragment => _fragment;
 
     public static bool TryBuildInlineFragment(ISqlFragment fragment, ICollectionMember collectionMember,
-        ISerializer serializer, out ICollectionAwareFilter filter)
+        ISerializer serializer, [NotNullWhen(true)]out ICollectionAwareFilter? filter)
     {
         if (fragment is ICollectionAware collectionAware && collectionAware.CanReduceInChildCollection())
         {

--- a/src/Marten/Linq/Members/ChildDocument.cs
+++ b/src/Marten/Linq/Members/ChildDocument.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -27,7 +28,7 @@ internal class ChildDocument: QueryableMember, IQueryableMemberCollection, IComp
 
         NullTestLocator = $"{parent.RawLocator} ->> '{MemberName}'";
 
-        ElementType = member.GetMemberType();
+        ElementType = member.GetMemberType()!;
     }
 
     public override ISqlFragment CreateComparison(string op, ConstantExpression constant)

--- a/src/Marten/Linq/Members/CollectionLengthMember.cs
+++ b/src/Marten/Linq/Members/CollectionLengthMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using Weasel.Postgresql.SqlGeneration;
 

--- a/src/Marten/Linq/Members/DateTimeMember.cs
+++ b/src/Marten/Linq/Members/DateTimeMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Reflection;
 
 namespace Marten.Linq.Members;

--- a/src/Marten/Linq/Members/DateTimeOffsetMember.cs
+++ b/src/Marten/Linq/Members/DateTimeOffsetMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Reflection;
 
 namespace Marten.Linq.Members;

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryContainsKey.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryContainsKey.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryContainsKeyFilter.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryContainsKeyFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -12,23 +13,20 @@ namespace Marten.Linq.Members.Dictionaries;
 
 internal class DictionaryContainsKeyFilter: ISqlFragment, ICompiledQueryAwareFilter
 {
-    private readonly object _value;
     private readonly string _keyText;
     private readonly IDictionaryMember _member;
 
     public DictionaryContainsKeyFilter(IDictionaryMember member, ISerializer serializer, ConstantExpression constant)
     {
-        _value = constant.Value;
-        _keyText = (_value is not null && _value is Enum) ? _value.ToString() : serializer.ToCleanJson(_value);
+        var value = constant.Value;
+        _keyText = (value is Enum) ? value.ToString()! : serializer.ToCleanJson(value);
 
         _member = member;
     }
 
     public DictionaryContainsKeyFilter(IDictionaryMember member, ISerializer serializer, object value)
     {
-        _value = value;
-        _keyText = serializer.ToCleanJson(_value);
-
+        _keyText = serializer.ToCleanJson(value);
         _member = member;
     }
 

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryCountMember.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryCountMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using Weasel.Postgresql.SqlGeneration;
 

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryIsEmpty.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryIsEmpty.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Linq.Parsing;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryIsNotEmpty.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryIsNotEmpty.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Linq.Parsing;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryItemMember.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryItemMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using Marten.Exceptions;
 using Marten.Linq.Parsing;
@@ -7,7 +8,7 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Members.Dictionaries;
 
-internal class DictionaryItemMember<TKey, TValue>: QueryableMember, IComparableMember
+internal class DictionaryItemMember<TKey, TValue>: QueryableMember, IComparableMember where TKey: notnull where TValue: notnull
 {
     public DictionaryItemMember(DictionaryMember<TKey, TValue> parent, TKey key)
         : base(parent, key.ToString(), typeof(TValue))

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryKeysMember.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryKeysMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryMember.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -13,7 +14,7 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Members.Dictionaries;
 
-internal class DictionaryMember<TKey, TValue>: QueryableMember, IComparableMember, IDictionaryMember, ICollectionMember
+internal class DictionaryMember<TKey, TValue>: QueryableMember, IComparableMember, IDictionaryMember, ICollectionMember where TKey : notnull where TValue : notnull
 {
     private readonly StoreOptions _options;
     private readonly DictionaryKeysMember _keys;

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryValuesContainFilter.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryValuesContainFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using Marten.Exceptions;
 using Marten.Linq.SqlGeneration.Filters;
@@ -12,23 +13,20 @@ namespace Marten.Linq.Members.Dictionaries;
 internal class DictionaryValuesContainFilter: ISqlFragment, ICollectionAware, ICollectionAwareFilter
 {
     private readonly IDictionaryMember _member;
-    private readonly ISerializer _serializer;
     private readonly string _text;
 
     public DictionaryValuesContainFilter(IDictionaryMember member, ISerializer serializer, ConstantExpression constant)
     {
         _member = member;
-        _serializer = serializer;
 
-        _text = constant.Value is string ? (string)constant.Value : _serializer.ToCleanJson(constant.Value);
+        _text = constant.Value as string ?? serializer.ToCleanJson(constant.Value);
     }
 
     public DictionaryValuesContainFilter(IDictionaryMember member, ISerializer serializer, object value)
     {
         _member = member;
-        _serializer = serializer;
 
-        _text = value is string s ? s : _serializer.ToCleanJson(value);
+        _text = value is string s ? s : serializer.ToCleanJson(value);
     }
 
     public void Apply(ICommandBuilder builder)

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryValuesMember.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryValuesMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Marten/Linq/Members/Dictionaries/IDictionaryMember.cs
+++ b/src/Marten/Linq/Members/Dictionaries/IDictionaryMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Marten.Linq.Members.Dictionaries;

--- a/src/Marten/Linq/Members/Dictionaries/KeyValuePairMemberCollection.cs
+++ b/src/Marten/Linq/Members/Dictionaries/KeyValuePairMemberCollection.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -8,18 +9,17 @@ namespace Marten.Linq.Members.Dictionaries;
 
 internal class KeyValuePairMemberCollection<TKey, TValue> : IQueryableMemberCollection
 {
-    private readonly Type _pairType;
     private readonly IQueryableMember _key;
     private readonly IQueryableMember _value;
 
     public KeyValuePairMemberCollection(StoreOptions options)
     {
-        _pairType = typeof(KeyValuePair<TKey, TValue>);
+        var pairType = typeof(KeyValuePair<TKey, TValue>);
         var root = new RootMember(typeof(IDictionary<TKey, TValue>));
-        _key = options.CreateQueryableMember(_pairType.GetProperty("Key"), root, typeof(TKey));
-        _value = options.CreateQueryableMember(_pairType.GetProperty("Value"), root, typeof(TValue));
+        _key = options.CreateQueryableMember(pairType.GetProperty("Key")!, root, typeof(TKey));
+        _value = options.CreateQueryableMember(pairType.GetProperty("Value")!, root, typeof(TValue));
 
-        ElementType = _pairType;
+        ElementType = pairType;
     }
 
     public IQueryableMember FindMember(MemberInfo member)

--- a/src/Marten/Linq/Members/DocumentQueryableMemberCollection.cs
+++ b/src/Marten/Linq/Members/DocumentQueryableMemberCollection.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Marten/Linq/Members/DuplicatedArrayField.cs
+++ b/src/Marten/Linq/Members/DuplicatedArrayField.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -43,7 +44,7 @@ internal class DuplicatedArrayField: DuplicatedField, ICollectionMember, IQuerya
 
     private readonly WholeDataMember _wholeDataMember;
     private readonly ArrayLengthMember _count;
-    private string _innerPgType;
+    private readonly string _innerPgType;
 
 
     public ISqlFragment IsEmpty { get; }

--- a/src/Marten/Linq/Members/DuplicatedField.cs
+++ b/src/Marten/Linq/Members/DuplicatedField.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Marten/Linq/Members/EnumAsIntegerMember.cs
+++ b/src/Marten/Linq/Members/EnumAsIntegerMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using System.Reflection;
 using Marten.Exceptions;

--- a/src/Marten/Linq/Members/EnumAsStringMember.cs
+++ b/src/Marten/Linq/Members/EnumAsStringMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -31,7 +32,7 @@ public class EnumAsStringMember: QueryableMember, IComparableMember
             };
         }
 
-        var stringValue = Enum.GetName(MemberType, constant.Value);
+        var stringValue = Enum.GetName(MemberType, constant.Value)!;
         return new MemberComparisonFilter(this, new CommandParameter(stringValue, NpgsqlDbType.Varchar), op);
     }
 

--- a/src/Marten/Linq/Members/HasValueMember.cs
+++ b/src/Marten/Linq/Members/HasValueMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/Members/IBooleanMember.cs
+++ b/src/Marten/Linq/Members/IBooleanMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Members;

--- a/src/Marten/Linq/Members/ICollectionMember.cs
+++ b/src/Marten/Linq/Members/ICollectionMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq.Expressions;
 using Marten.Internal;

--- a/src/Marten/Linq/Members/IComparableMember.cs
+++ b/src/Marten/Linq/Members/IComparableMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using Weasel.Postgresql.SqlGeneration;
 

--- a/src/Marten/Linq/Members/IHasChildrenMembers.cs
+++ b/src/Marten/Linq/Members/IHasChildrenMembers.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Reflection;
 
 namespace Marten.Linq.Members;

--- a/src/Marten/Linq/Members/IMemberSource.cs
+++ b/src/Marten/Linq/Members/IMemberSource.cs
@@ -1,4 +1,6 @@
+#nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Marten.Linq.Members;
@@ -9,5 +11,5 @@ namespace Marten.Linq.Members;
 public interface IMemberSource
 {
     bool TryResolve(string dataLocator, StoreOptions options, ISerializer serializer, Type documentType,
-        MemberInfo memberInfo, out IQueryableMember member);
+        MemberInfo memberInfo, [NotNullWhen(true)]out IQueryableMember? member);
 }

--- a/src/Marten/Linq/Members/IQueryableMember.cs
+++ b/src/Marten/Linq/Members/IQueryableMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/Members/IQueryableMemberCollection.cs
+++ b/src/Marten/Linq/Members/IQueryableMemberCollection.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 

--- a/src/Marten/Linq/Members/IdMember.cs
+++ b/src/Marten/Linq/Members/IdMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
@@ -16,7 +17,7 @@ internal class IdMember: IQueryableMember, IComparableMember
 
     public IdMember(MemberInfo member)
     {
-        MemberType = member.GetMemberType();
+        MemberType = member.GetMemberType()!;
 
         JSONBLocator = $"CAST({RawLocator} as jsonb)";
         Ancestors = Array.Empty<IQueryableMember>();

--- a/src/Marten/Linq/Members/ModuloComparison.cs
+++ b/src/Marten/Linq/Members/ModuloComparison.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using Marten.Linq.Parsing;
 using Weasel.Postgresql;
@@ -9,8 +10,8 @@ internal class ModuloOperator: IComparableMember, ISqlFragment
 {
     private readonly ISqlFragment _left;
     private readonly ISqlFragment _right;
-    private string _op;
-    private CommandParameter _value;
+    private string _op = null!;
+    private CommandParameter _value = null!;
 
     public ModuloOperator(BinaryExpression expression, IQueryableMemberCollection members)
     {

--- a/src/Marten/Linq/Members/NotMember.cs
+++ b/src/Marten/Linq/Members/NotMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using Weasel.Postgresql.SqlGeneration;
 

--- a/src/Marten/Linq/Members/QueryableMember.cs
+++ b/src/Marten/Linq/Members/QueryableMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
@@ -18,7 +19,7 @@ namespace Marten.Linq.Members;
 public abstract class QueryableMember: IQueryableMember, IHasChildrenMembers
 {
     private HasValueMember? _hasValue;
-    private string _nullTestLocator;
+    private string? _nullTestLocator;
 
     /// <summary>
     /// </summary>
@@ -29,7 +30,7 @@ public abstract class QueryableMember: IQueryableMember, IHasChildrenMembers
         if (parent == null) throw new ArgumentNullException(nameof(parent));
 
         Member = member;
-        MemberType = member is ElementMember m ? m.ReflectedType : member.GetMemberType();
+        MemberType = member is ElementMember m ? m.ReflectedType : member.GetMemberType()!;
 
         JsonPathSegment = MemberName = member.ToJsonKey(casing);
         RawLocator = TypedLocator = $"{parent.RawLocator} ->> '{MemberName}'";

--- a/src/Marten/Linq/Members/ScalarSelectManyStatement.cs
+++ b/src/Marten/Linq/Members/ScalarSelectManyStatement.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Linq.SqlGeneration;
 using Weasel.Postgresql;
 

--- a/src/Marten/Linq/Members/ScalarSelectManyStringStatement.cs
+++ b/src/Marten/Linq/Members/ScalarSelectManyStringStatement.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Linq.SqlGeneration;
 
 namespace Marten.Linq.Members;

--- a/src/Marten/Linq/Members/SimpleCastMember.cs
+++ b/src/Marten/Linq/Members/SimpleCastMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Reflection;
 using Marten.Linq.Members.ValueCollections;
 using Weasel.Core;

--- a/src/Marten/Linq/Members/StringMember.cs
+++ b/src/Marten/Linq/Members/StringMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Reflection;
 using Marten.Linq.Members.ValueCollections;

--- a/src/Marten/Linq/Members/ValueCollections/ArrayIndexMember.cs
+++ b/src/Marten/Linq/Members/ValueCollections/ArrayIndexMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Reflection;
 

--- a/src/Marten/Linq/Members/ValueCollections/ElementComparisonFilter.cs
+++ b/src/Marten/Linq/Members/ValueCollections/ElementComparisonFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using JasperFx.Core.Reflection;

--- a/src/Marten/Linq/Members/ValueCollections/ElementMember.cs
+++ b/src/Marten/Linq/Members/ValueCollections/ElementMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Reflection;
 
@@ -7,7 +8,7 @@ internal class ElementMember: MemberInfo
 {
     public ElementMember(MemberInfo parent, Type elementType)
     {
-        DeclaringType = parent.ReflectedType;
+        DeclaringType = parent.ReflectedType!;
         ReflectedType = elementType;
     }
 

--- a/src/Marten/Linq/Members/ValueCollections/IValueCollectionMember.cs
+++ b/src/Marten/Linq/Members/ValueCollections/IValueCollectionMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Linq.Members.ValueCollections;
 
 internal interface IValueCollectionMember : IQueryableMemberCollection

--- a/src/Marten/Linq/Members/ValueCollections/SelectManyValueCollection.cs
+++ b/src/Marten/Linq/Members/ValueCollections/SelectManyValueCollection.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -12,7 +13,6 @@ namespace Marten.Linq.Members.ValueCollections;
 internal class SelectManyValueCollection: IValueCollectionMember
 {
     private readonly StoreOptions _options;
-    private readonly IQueryableMember _parentMember;
     private readonly RootMember _root;
     public Type ElementType { get; }
 
@@ -40,8 +40,6 @@ internal class SelectManyValueCollection: IValueCollectionMember
         var elementMember = new ElementMember(typeof(ICollection<>).MakeGenericType(elementType), elementType);
         var element = (QueryableMember)options.CreateQueryableMember(elementMember, parentMember, elementType);
         element.RawLocator = element.TypedLocator = "data";
-
-        _parentMember = parentMember;
 
         Element = element;
     }

--- a/src/Marten/Linq/Members/ValueCollections/SimpleElementMember.cs
+++ b/src/Marten/Linq/Members/ValueCollections/SimpleElementMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/Members/ValueCollections/ValueCollectionMember.cs
+++ b/src/Marten/Linq/Members/ValueCollections/ValueCollectionMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -30,7 +31,7 @@ internal class ValueCollectionMember: QueryableMember, ICollectionMember, IValue
             MemberType = element.ReflectedType!;
         }
 
-        ElementType = MemberType.DetermineElementType();
+        ElementType = MemberType.DetermineElementType()!;
         var rawLocator = RawLocator;
         var innerPgType = PostgresqlProvider.Instance.GetDatabaseType(ElementType, EnumStorage.AsInteger);
         var pgType = PostgresqlProvider.Instance.HasTypeMapping(ElementType) ? innerPgType + "[]" : "jsonb";

--- a/src/Marten/Linq/Members/WholeDataMember.cs
+++ b/src/Marten/Linq/Members/WholeDataMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/OrderingDirection.cs
+++ b/src/Marten/Linq/OrderingDirection.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Linq;
 
 /// <summary>

--- a/src/Marten/Linq/Parsing/IMethodCallParser.cs
+++ b/src/Marten/Linq/Parsing/IMethodCallParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using Marten.Linq.Members;
 using Weasel.Postgresql.SqlGeneration;
@@ -32,7 +33,7 @@ public interface IMethodCallParser
     /// <param name="expression"></param>
     /// <param name="serializer"></param>
     /// <returns></returns>
-    ISqlFragment Parse(IQueryableMemberCollection memberCollection, IReadOnlyStoreOptions options,
+    ISqlFragment? Parse(IQueryableMemberCollection memberCollection, IReadOnlyStoreOptions options,
         MethodCallExpression expression);
 }
 

--- a/src/Marten/Linq/Parsing/LinqInternalExtensions.cs
+++ b/src/Marten/Linq/Parsing/LinqInternalExtensions.cs
@@ -1,6 +1,8 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -64,7 +66,7 @@ internal static class LinqInternalExtensions
         string memberName)
     {
         var member = collection.ElementType.GetProperty(memberName) ??
-                     (MemberInfo)collection.ElementType.GetField(memberName);
+                     (MemberInfo)collection.ElementType.GetField(memberName)!;
 
         return collection.FindMember(member);
     }
@@ -197,7 +199,7 @@ internal static class LinqInternalExtensions
                node.Expression.ToString().StartsWith("value(");
     }
 
-    public static bool TryToParseConstant(this Expression expression, out ConstantExpression constant)
+    public static bool TryToParseConstant(this Expression? expression, [NotNullWhen(true)]out ConstantExpression? constant)
     {
         if (expression == null)
         {
@@ -286,13 +288,13 @@ internal static class LinqInternalExtensions
     {
         if (expression is ConstantExpression c)
         {
-            return c.Value;
+            return c.Value!;
         }
 
-        return ReduceToConstant(expression).Value;
+        return ReduceToConstant(expression).Value!;
     }
 
-    public static bool IsValueExpression(this Expression expression)
+    public static bool IsValueExpression([NotNullWhen(true)]this Expression? expression)
     {
         if (expression == null)
         {

--- a/src/Marten/Linq/Parsing/LinqQueryParser.Handlers.cs
+++ b/src/Marten/Linq/Parsing/LinqQueryParser.Handlers.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +16,7 @@ internal partial class LinqQueryParser
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static IQueryHandler<TResult> BuildHandler<TDocument, TResult>(ISelector<TDocument> selector,
-        ISqlFragment statement)
+        ISqlFragment statement) where TResult : notnull where TDocument : notnull
     {
         if (typeof(TResult).CanBeCastTo<IEnumerable<TDocument>>())
         {
@@ -26,7 +27,7 @@ internal partial class LinqQueryParser
                                         typeof(TResult).FullNameInCode());
     }
 
-    public IQueryHandler<TResult> BuildHandler<TResult>()
+    public IQueryHandler<TResult> BuildHandler<TResult>() where TResult : notnull
     {
         if (!_collectionUsages.Any())
         {
@@ -49,7 +50,7 @@ internal partial class LinqQueryParser
         return handler;
     }
 
-    private IQueryHandler<TResult> buildHandlerForCurrentStatement<TResult>(Statement top, SelectorStatement selector)
+    private IQueryHandler<TResult> buildHandlerForCurrentStatement<TResult>(Statement top, SelectorStatement selector) where TResult : notnull
     {
         if (selector.SingleValue)
         {

--- a/src/Marten/Linq/Parsing/LinqQueryParser.Preview.cs
+++ b/src/Marten/Linq/Parsing/LinqQueryParser.Preview.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Weasel.Postgresql;
 
 namespace Marten.Linq.Parsing;

--- a/src/Marten/Linq/Parsing/LinqQueryParser.Statements.cs
+++ b/src/Marten/Linq/Parsing/LinqQueryParser.Statements.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using Marten.Linq.SqlGeneration;
 

--- a/src/Marten/Linq/Parsing/LinqQueryParser.cs
+++ b/src/Marten/Linq/Parsing/LinqQueryParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Marten/Linq/Parsing/MemberFinder.cs
+++ b/src/Marten/Linq/Parsing/MemberFinder.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Marten/Linq/Parsing/Methods/AllMethodParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/AllMethodParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/Parsing/Methods/AnySubQueryParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/AnySubQueryParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -34,10 +35,10 @@ internal class AnySubQueryParser: IMethodCallParser
     public ISqlFragment Parse(IQueryableMemberCollection memberCollection, IReadOnlyStoreOptions options,
         MethodCallExpression expression)
     {
-        Expression memberExpression = null;
-        Expression body = null;
+        Expression? memberExpression = null;
+        Expression? body = null;
 
-        ICollectionMember member = null;
+        ICollectionMember? member = null;
 
         if (expression.Arguments.Count == 1)
         {

--- a/src/Marten/Linq/Parsing/Methods/AnyTenant.cs
+++ b/src/Marten/Linq/Parsing/Methods/AnyTenant.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using Marten.Linq.Members;
 using Marten.Linq.SqlGeneration.Filters;

--- a/src/Marten/Linq/Parsing/Methods/EnumerableContains.cs
+++ b/src/Marten/Linq/Parsing/Methods/EnumerableContains.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -83,7 +84,7 @@ internal class HashSetEnumerableContains: IMethodCallParser
             // This is the value.Contains() pattern
             var collectionMember = memberCollection.MemberFor(expression.Arguments.Last());
 
-            return new WhereFragment($"{collectionMember.TypedLocator} = ANY(?)", correctToArray(constant.Value));
+            return new WhereFragment($"{collectionMember.TypedLocator} = ANY(?)", correctToArray(constant.Value!));
         }
 
         var collection = memberCollection as ICollectionMember ??

--- a/src/Marten/Linq/Parsing/Methods/FullText/FullTextSearchMethodCallParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/FullText/FullTextSearchMethodCallParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq.Expressions;
 using Marten.Linq.Members;

--- a/src/Marten/Linq/Parsing/Methods/FullText/NgramSearch.cs
+++ b/src/Marten/Linq/Parsing/Methods/FullText/NgramSearch.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using System.Linq.Expressions;
 using Marten.Linq.Members;

--- a/src/Marten/Linq/Parsing/Methods/FullText/PhraseSearch.cs
+++ b/src/Marten/Linq/Parsing/Methods/FullText/PhraseSearch.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Linq.Parsing.Methods.FullText;
 
 internal class PhraseSearch: FullTextSearchMethodCallParser

--- a/src/Marten/Linq/Parsing/Methods/FullText/PlainTextSearch.cs
+++ b/src/Marten/Linq/Parsing/Methods/FullText/PlainTextSearch.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Linq.Parsing.Methods.FullText;
 
 internal class PlainTextSearch: FullTextSearchMethodCallParser

--- a/src/Marten/Linq/Parsing/Methods/FullText/Search.cs
+++ b/src/Marten/Linq/Parsing/Methods/FullText/Search.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Linq.Parsing.Methods.FullText;
 
 internal class Search: FullTextSearchMethodCallParser

--- a/src/Marten/Linq/Parsing/Methods/FullText/WebStyleSearch.cs
+++ b/src/Marten/Linq/Parsing/Methods/FullText/WebStyleSearch.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Linq.Parsing.Methods.FullText;
 
 internal class WebStyleSearch: FullTextSearchMethodCallParser

--- a/src/Marten/Linq/Parsing/Methods/IsEmpty.cs
+++ b/src/Marten/Linq/Parsing/Methods/IsEmpty.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using Marten.Linq.Members;
 using Weasel.Postgresql.SqlGeneration;

--- a/src/Marten/Linq/Parsing/Methods/IsNotOneOf.cs
+++ b/src/Marten/Linq/Parsing/Methods/IsNotOneOf.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using System.Linq.Expressions;
 using Marten.Linq.Members;

--- a/src/Marten/Linq/Parsing/Methods/IsOneOf.cs
+++ b/src/Marten/Linq/Parsing/Methods/IsOneOf.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -24,7 +25,7 @@ internal class IsOneOf: IMethodCallParser
     {
         var queryableMember = memberCollection.MemberFor(expression.Arguments[0]);
         var locator = queryableMember.TypedLocator;
-        var values = expression.Arguments[1].ReduceToConstant().Value;
+        var values = expression.Arguments[1].ReduceToConstant().Value!;
 
         if (queryableMember.MemberType.IsEnum)
         {

--- a/src/Marten/Linq/Parsing/Methods/IsSubsetOf.cs
+++ b/src/Marten/Linq/Parsing/Methods/IsSubsetOf.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -37,7 +38,7 @@ internal class IsSubsetOf: IMethodCallParser
     private static bool isISetMethod(MethodInfo method)
     {
         return method.Name == "IsSubsetOf" &&
-               method.DeclaringType
+               method.DeclaringType!
                    .GetInterfaces()
                    .Where(i => i.IsGenericType)
                    .Any(i => i.GetGenericTypeDefinition() == typeof(ISet<>));

--- a/src/Marten/Linq/Parsing/Methods/IsSupersetOf.cs
+++ b/src/Marten/Linq/Parsing/Methods/IsSupersetOf.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -36,7 +37,7 @@ internal class IsSupersetOf: IMethodCallParser
     private static bool isISetMethod(MethodInfo method)
     {
         return method.Name == "IsSupersetOf" &&
-               method.DeclaringType
+               method.DeclaringType!
                    .GetInterfaces()
                    .Where(i => i.IsGenericType)
                    .Any(i => i.GetGenericTypeDefinition() == typeof(ISet<>));

--- a/src/Marten/Linq/Parsing/Methods/SimpleEqualsParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/SimpleEqualsParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/Parsing/Methods/SimpleNotEqualsParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/SimpleNotEqualsParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Marten.Linq.Parsing.Methods;

--- a/src/Marten/Linq/Parsing/Methods/Strings/EqualsIgnoreCaseParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/EqualsIgnoreCaseParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using System.Linq.Expressions;
 using JasperFx.Core;

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringComparisonParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringComparisonParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringContains.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringContains.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using System.Reflection;

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringEndsWith.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringEndsWith.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Reflection;
 using JasperFx.CodeGeneration;
@@ -18,8 +19,8 @@ internal class StringEndsWith: StringComparisonParser
     };
 
     public StringEndsWith(): base(
-        ReflectionHelper.GetMethod<string>(s => s.EndsWith(null)),
-        ReflectionHelper.GetMethod<string>(s => s.EndsWith(null, StringComparison.CurrentCulture))
+        ReflectionHelper.GetMethod<string>(s => s.EndsWith(null))!,
+        ReflectionHelper.GetMethod<string>(s => s.EndsWith(null, StringComparison.CurrentCulture))!
     )
     {
     }

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringEquals.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringEquals.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using JasperFx.Core.Reflection;
 using Marten.Linq.Members;
@@ -10,10 +11,10 @@ namespace Marten.Linq.Parsing.Methods.Strings;
 internal class StringEquals: StringComparisonParser
 {
     public StringEquals(): base(
-        ReflectionHelper.GetMethod<string>(s => s.Equals(string.Empty)),
-        ReflectionHelper.GetMethod<string>(s => s.Equals(string.Empty, StringComparison.CurrentCulture)),
-        ReflectionHelper.GetMethod(() => string.Equals(string.Empty, string.Empty)),
-        ReflectionHelper.GetMethod(() => string.Equals(string.Empty, string.Empty, StringComparison.CurrentCulture)))
+        ReflectionHelper.GetMethod<string>(s => s.Equals(string.Empty))!,
+        ReflectionHelper.GetMethod<string>(s => s.Equals(string.Empty, StringComparison.CurrentCulture))!,
+        ReflectionHelper.GetMethod(() => string.Equals(string.Empty, string.Empty))!,
+        ReflectionHelper.GetMethod(() => string.Equals(string.Empty, string.Empty, StringComparison.CurrentCulture))!)
     {
     }
 

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringIsNullOrEmpty.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringIsNullOrEmpty.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using Marten.Linq.Members;
 using Marten.Linq.SqlGeneration.Filters;

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringIsNullOrWhiteSpace.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringIsNullOrWhiteSpace.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using Marten.Linq.Members;
 using Weasel.Postgresql.SqlGeneration;

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringStartsWith.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringStartsWith.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Reflection;
 using JasperFx.CodeGeneration;
@@ -13,8 +14,8 @@ namespace Marten.Linq.Parsing.Methods.Strings;
 internal class StringStartsWith: StringComparisonParser
 {
     public StringStartsWith(): base(
-        ReflectionHelper.GetMethod<string>(s => s.StartsWith(null)),
-        ReflectionHelper.GetMethod<string>(s => s.StartsWith(null, StringComparison.CurrentCulture))
+        ReflectionHelper.GetMethod<string>(s => s.StartsWith(null!))!,
+        ReflectionHelper.GetMethod<string>(s => s.StartsWith(null!, StringComparison.CurrentCulture))!
     )
     {
     }
@@ -47,7 +48,7 @@ internal class StringStartsWithFilter: ISqlFragment, ICompiledQueryAwareFilter
         builder.Append(_operator);
         builder.AppendParameter($"{StringComparisonParser.EscapeValue(_rawValue)}%");
 
-        ParameterName = builder.LastParameterName;
+        ParameterName = builder.LastParameterName!;
     }
 
     public string ParameterName { get; private set; }

--- a/src/Marten/Linq/Parsing/Methods/TenantIsOneOf.cs
+++ b/src/Marten/Linq/Parsing/Methods/TenantIsOneOf.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using System.Linq.Expressions;
 using JasperFx.Core.Reflection;

--- a/src/Marten/Linq/Parsing/Operators/AnyOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/AnyOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 
 namespace Marten.Linq.Parsing.Operators;

--- a/src/Marten/Linq/Parsing/Operators/DistinctOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/DistinctOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 
 namespace Marten.Linq.Parsing.Operators;

--- a/src/Marten/Linq/Parsing/Operators/IncludeOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/IncludeOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Diagnostics;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/Parsing/Operators/IncludePlanOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/IncludePlanOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using System.Linq.Expressions;
 using Marten.Linq.Includes;
@@ -17,6 +18,6 @@ internal class IncludePlanOperator: LinqOperator
 
         var usage = query.CollectionUsageFor(elementType);
 
-        usage.Includes.Add((IIncludePlan)expression.Arguments.Last().ReduceToConstant().Value);
+        usage.Includes.Add((IIncludePlan)expression.Arguments.Last().ReduceToConstant().Value!);
     }
 }

--- a/src/Marten/Linq/Parsing/Operators/LastOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/LastOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq.Expressions;
 

--- a/src/Marten/Linq/Parsing/Operators/LinqOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/LinqOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 
 namespace Marten.Linq.Parsing.Operators;

--- a/src/Marten/Linq/Parsing/Operators/OperatorLibrary.cs
+++ b/src/Marten/Linq/Parsing/Operators/OperatorLibrary.cs
@@ -1,4 +1,6 @@
+#nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core;
 
 namespace Marten.Linq.Parsing.Operators;
@@ -52,7 +54,7 @@ internal class OperatorLibrary
         _operators = _operators.AddOrUpdate(methodName, new OrderingOperator(methodName, direction));
     }
 
-    public bool TryFind(string methodName, out LinqOperator? op)
+    public bool TryFind(string methodName, [NotNullWhen(true)]out LinqOperator? op)
     {
         return _operators.TryFind(methodName, out op);
     }

--- a/src/Marten/Linq/Parsing/Operators/OrderBySqlOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/OrderBySqlOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -13,7 +14,7 @@ internal class OrderBySqlOperator : LinqOperator
     {
         var sql = expression.Arguments.Last().ReduceToConstant();
         var usage = query.CollectionUsageFor(expression);
-        var ordering = new Ordering((string)sql.Value);
+        var ordering = new Ordering((string)sql.Value!);
 
         usage.OrderingExpressions.Insert(0, ordering);
     }
@@ -29,7 +30,7 @@ internal class ThenBySqlOperator : LinqOperator
     {
         var sql = expression.Arguments.Last().ReduceToConstant();
         var usage = query.CollectionUsageFor(expression);
-        var ordering = new Ordering((string)sql.Value);
+        var ordering = new Ordering((string)sql.Value!);
 
         usage.OrderingExpressions.Insert(0, ordering);
     }

--- a/src/Marten/Linq/Parsing/Operators/Ordering.cs
+++ b/src/Marten/Linq/Parsing/Operators/Ordering.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using JasperFx.Core;
 using Marten.Linq.Members;
@@ -6,8 +7,8 @@ namespace Marten.Linq.Parsing.Operators;
 
 public class Ordering
 {
-    public string MemberName { get; set; }
-    private readonly string _literal;
+    public string? MemberName { get; set; }
+    private readonly string? _literal;
 
     public Ordering(Expression expression, OrderingDirection direction)
     {
@@ -26,7 +27,7 @@ public class Ordering
         Direction = direction;
     }
 
-    public string Literal => _literal;
+    public string? Literal => _literal;
 
     public Expression Expression { get; }
 

--- a/src/Marten/Linq/Parsing/Operators/OrderingOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/OrderingOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq.Expressions;
 
@@ -20,7 +21,7 @@ public class OrderingOperator: LinqOperator
         var ordering = new Ordering(memberArgument, Direction);
         if (expression.Arguments[1].Type == typeof(string))
         {
-            var property = (string)expression.Arguments[1].ReduceToConstant().Value;
+            var property = (string)expression.Arguments[1].ReduceToConstant().Value!;
             QueryableExtensions.GetSortProperty(ref property, out var sortOrder);
             ordering.Direction = sortOrder == "asc" ? OrderingDirection.Asc : OrderingDirection.Desc;
             ordering.MemberName = property;

--- a/src/Marten/Linq/Parsing/Operators/SelectManyOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/SelectManyOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using System.Linq.Expressions;
 

--- a/src/Marten/Linq/Parsing/Operators/SelectOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/SelectOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using System.Linq.Expressions;
 

--- a/src/Marten/Linq/Parsing/Operators/SingleValueOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/SingleValueOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 
 namespace Marten.Linq.Parsing.Operators;

--- a/src/Marten/Linq/Parsing/Operators/SkipOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/SkipOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using System.Linq.Expressions;
 using JasperFx.Core.Reflection;

--- a/src/Marten/Linq/Parsing/Operators/TakeOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/TakeOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using System.Linq.Expressions;
 using JasperFx.Core.Reflection;

--- a/src/Marten/Linq/Parsing/Operators/WhereOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/WhereOperator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq.Expressions;
 using JasperFx.Core;

--- a/src/Marten/Linq/Parsing/SelectParser.cs
+++ b/src/Marten/Linq/Parsing/SelectParser.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/Marten/Linq/Parsing/SelectorVisitor.cs
+++ b/src/Marten/Linq/Parsing/SelectorVisitor.cs
@@ -1,3 +1,5 @@
+// visitor usage is impossible to annotate
+#nullable disable
 using System;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/Parsing/SimpleExpression.cs
+++ b/src/Marten/Linq/Parsing/SimpleExpression.cs
@@ -1,3 +1,4 @@
+#nullable disable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
@@ -192,7 +193,7 @@ internal class AdvancedSqlQueryHandlerBase
         return default;
     }
 
-    protected ISelectClause GetSelectClause<T>(IMartenSession session)
+    protected ISelectClause GetSelectClause<T>(IMartenSession session) where T : notnull
     {
         if (typeof(T) == typeof(string))
         {

--- a/src/Marten/Linq/QueryHandlers/LinqConstants.cs
+++ b/src/Marten/Linq/QueryHandlers/LinqConstants.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Reflection;
 using Marten.Linq.Selectors;
@@ -16,5 +17,5 @@ internal class LinqConstants
     internal static readonly string CONTAINS = nameof(string.Contains);
     internal static readonly string ANY = "Any";
     internal static readonly string ALL = "All";
-    internal static readonly PropertyInfo ArrayLength = typeof(Array).GetProperty(nameof(Array.Length));
+    internal static readonly PropertyInfo ArrayLength = typeof(Array).GetProperty(nameof(Array.Length))!;
 }

--- a/src/Marten/Linq/QueryHandlers/ListQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/ListQueryHandler.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Data.Common;
 using System.IO;
@@ -15,11 +16,11 @@ using Weasel.Postgresql.SqlGeneration;
 namespace Marten.Linq.QueryHandlers;
 
 internal class ListQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>, IQueryHandler<IEnumerable<T>>,
-    IMaybeStatefulHandler
+    IMaybeStatefulHandler where T : notnull
 {
-    private readonly ISqlFragment _statement;
+    private readonly ISqlFragment? _statement;
 
-    public ListQueryHandler(ISqlFragment statement, ISelector<T> selector)
+    public ListQueryHandler(ISqlFragment? statement, ISelector<T> selector)
     {
         _statement = statement;
         Selector = selector;
@@ -55,7 +56,7 @@ internal class ListQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>, IQueryHandl
 
     public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
     {
-        _statement.Apply(builder);
+        _statement?.Apply(builder);
     }
 
     public IReadOnlyList<T> Handle(DbDataReader reader, IMartenSession session)

--- a/src/Marten/Linq/QueryHandlers/ListWithStatsQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/ListWithStatsQueryHandler.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Data.Common;
 using System.IO;
@@ -16,14 +17,14 @@ using Weasel.Postgresql.SqlGeneration;
 namespace Marten.Linq.QueryHandlers;
 
 internal class ListWithStatsQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>, IQueryHandler<IEnumerable<T>>,
-    IMaybeStatefulHandler
+    IMaybeStatefulHandler where T : notnull
 {
     private readonly int _countIndex;
     private readonly ISelector<T> _selector;
-    private readonly ISqlFragment _statement;
+    private readonly ISqlFragment? _statement;
     private readonly QueryStatistics _statistics;
 
-    public ListWithStatsQueryHandler(int countIndex, ISqlFragment statement, ISelector<T> selector,
+    public ListWithStatsQueryHandler(int countIndex, ISqlFragment? statement, ISelector<T> selector,
         QueryStatistics statistics)
     {
         _countIndex = countIndex;
@@ -60,7 +61,7 @@ internal class ListWithStatsQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>, IQ
 
     public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
     {
-        _statement.Apply(builder);
+        _statement?.Apply(builder);
     }
 
     public IReadOnlyList<T> Handle(DbDataReader reader, IMartenSession session)

--- a/src/Marten/Linq/QueryHandlers/LoadByIdHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/LoadByIdHandler.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Data.Common;
 using System.IO;
 using System.Threading;
@@ -12,7 +13,7 @@ using Weasel.Postgresql;
 
 namespace Marten.Linq.QueryHandlers;
 
-internal class LoadByIdHandler<T, TId>: IQueryHandler<T>
+internal class LoadByIdHandler<T, TId>: IQueryHandler<T> where T : notnull where TId : notnull
 {
     private readonly TId _id;
     private readonly IDocumentStorage<T> storage;

--- a/src/Marten/Linq/QueryHandlers/OneResultHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/OneResultHandler.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Data.Common;
 using System.IO;
@@ -14,16 +15,16 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.QueryHandlers;
 
-internal class OneResultHandler<T>: IQueryHandler<T>, IMaybeStatefulHandler
+internal class OneResultHandler<T>: IQueryHandler<T>, IMaybeStatefulHandler where T : notnull
 {
     private const string NoElementsMessage = "Sequence contains no elements";
     private const string MoreThanOneElementMessage = "Sequence contains more than one element";
     private readonly bool _canBeMultiples;
     private readonly bool _canBeNull;
     private readonly ISelector<T> _selector;
-    private readonly ISqlFragment _statement;
+    private readonly ISqlFragment? _statement;
 
-    public OneResultHandler(ISqlFragment statement, ISelector<T> selector,
+    public OneResultHandler(ISqlFragment? statement, ISelector<T> selector,
         bool canBeNull = true, bool canBeMultiples = true)
     {
         _statement = statement;
@@ -47,7 +48,7 @@ internal class OneResultHandler<T>: IQueryHandler<T>, IMaybeStatefulHandler
 
     public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
     {
-        _statement.Apply(builder);
+        _statement?.Apply(builder);
     }
 
     public T Handle(DbDataReader reader, IMartenSession session)

--- a/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
@@ -70,7 +71,7 @@ internal class UserSuppliedQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>
 
             for (var i = 0; i < cmdParameters.Length; i++)
             {
-                if (_parameters[i] == null)
+                if (_parameters[i] == null!)
                 {
                     cmdParameters[i].Value = DBNull.Value;
                 }

--- a/src/Marten/Linq/QueryPlan.cs
+++ b/src/Marten/Linq/QueryPlan.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using Npgsql;
@@ -14,19 +15,19 @@ public class QueryPlan
     /// </summary>
     [JsonPropertyName("Node Type")]
     [JsonProperty(PropertyName = "Node Type")]
-    public string NodeType { get; set; }
+    public string NodeType { get; set; } = null!;
 
     /// <summary>
     ///     The table name from which the 'select' was queried.
     /// </summary>
     [JsonPropertyName("Relation Name")]
     [JsonProperty(PropertyName = "Relation Name")]
-    public string RelationName { get; set; }
+    public string RelationName { get; set; } = null!;
 
     /// <summary>
     ///     The table alias that was used (if none was used, <see cref="RelationName" /> is returned).
     /// </summary>
-    public string Alias { get; set; }
+    public string Alias { get; set; } = null!;
 
     /// <summary>
     ///     The cost of initialising the query.
@@ -80,15 +81,15 @@ public class QueryPlan
 
     [JsonPropertyName("Output")]
     [JsonProperty(PropertyName = "Output")]
-    public string[] Output { get; set; }
+    public string[] Output { get; set; } = null!;
 
     [JsonPropertyName("Sort Key")]
     [JsonProperty(PropertyName = "Sort Key")]
-    public string[] SortKey { get; set; }
+    public string[] SortKey { get; set; } = null!;
 
     [JsonPropertyName("Sort Method")]
     [JsonProperty(PropertyName = "Sort Method")]
-    public string SortMethod { get; set; }
+    public string SortMethod { get; set; } = null!;
 
     [JsonPropertyName("Sort Space Used")]
     [JsonProperty(PropertyName = "Sort Space Used")]
@@ -96,11 +97,11 @@ public class QueryPlan
 
     [JsonPropertyName("Sort Space Type")]
     [JsonProperty(PropertyName = "Sort Space Type")]
-    public string SortSpaceType { get; set; }
+    public string SortSpaceType { get; set; } = null!;
 
     [JsonPropertyName("Plans")]
     [JsonProperty(PropertyName = "Plans")]
-    public QueryPlan[] Plans { get; set; }
+    public QueryPlan[] Plans { get; set; } = null!;
 
     // Lifted these from QueryPlanContainer so as not to change the returned type alltogether :|
     public decimal PlanningTime { get; set; }
@@ -110,12 +111,12 @@ public class QueryPlan
     /// <summary>
     ///     The command executed by Marten
     /// </summary>
-    public NpgsqlCommand Command { get; set; }
+    public NpgsqlCommand Command { get; set; } = null!;
 }
 
 internal class QueryPlanContainer
 {
-    public QueryPlan Plan { get; set; }
+    public QueryPlan Plan { get; set; } = null!;
 
     [JsonPropertyName("Planning Time")]
     [JsonProperty(PropertyName = "Planning Time")]

--- a/src/Marten/Linq/QueryStatistics.cs
+++ b/src/Marten/Linq/QueryStatistics.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Linq;
 
 /// <summary>

--- a/src/Marten/Linq/Selectors/CastingSelector.cs
+++ b/src/Marten/Linq/Selectors/CastingSelector.cs
@@ -1,10 +1,11 @@
+#nullable enable
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Marten.Linq.Selectors;
 
-internal class CastingSelector<T, TRoot>: ISelector<T> where T : TRoot
+internal class CastingSelector<T, TRoot>: ISelector<T> where T : TRoot where TRoot : notnull
 {
     private readonly ISelector<TRoot> _inner;
 

--- a/src/Marten/Linq/Selectors/ISelector.cs
+++ b/src/Marten/Linq/Selectors/ISelector.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Marten/Linq/Selectors/SerializationSelector.cs
+++ b/src/Marten/Linq/Selectors/SerializationSelector.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Marten/Linq/SoftDeletes/DeletedBeforeParser.cs
+++ b/src/Marten/Linq/SoftDeletes/DeletedBeforeParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using System.Linq.Expressions;
@@ -16,7 +17,7 @@ namespace Marten.Linq.SoftDeletes;
 internal class DeletedBeforeParser: IMethodCallParser
 {
     private static readonly MethodInfo _method =
-        typeof(SoftDeletedExtensions).GetMethod(nameof(SoftDeletedExtensions.DeletedBefore));
+        typeof(SoftDeletedExtensions).GetMethod(nameof(SoftDeletedExtensions.DeletedBefore))!;
 
     public bool Matches(MethodCallExpression expression)
     {

--- a/src/Marten/Linq/SoftDeletes/DeletedSinceParser.cs
+++ b/src/Marten/Linq/SoftDeletes/DeletedSinceParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using System.Linq.Expressions;
@@ -16,7 +17,7 @@ namespace Marten.Linq.SoftDeletes;
 internal class DeletedSinceParser: IMethodCallParser
 {
     private static readonly MethodInfo _method =
-        typeof(SoftDeletedExtensions).GetMethod(nameof(SoftDeletedExtensions.DeletedSince));
+        typeof(SoftDeletedExtensions).GetMethod(nameof(SoftDeletedExtensions.DeletedSince))!;
 
     public bool Matches(MethodCallExpression expression)
     {

--- a/src/Marten/Linq/SoftDeletes/IsDeletedParser.cs
+++ b/src/Marten/Linq/SoftDeletes/IsDeletedParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using System.Reflection;
 using Marten.Linq.Members;
@@ -12,7 +13,7 @@ namespace Marten.Linq.SoftDeletes;
 internal class IsDeletedParser: IMethodCallParser
 {
     private static readonly MethodInfo _method =
-        typeof(SoftDeletedExtensions).GetMethod(nameof(SoftDeletedExtensions.IsDeleted));
+        typeof(SoftDeletedExtensions).GetMethod(nameof(SoftDeletedExtensions.IsDeleted))!;
 
     public bool Matches(MethodCallExpression expression)
     {

--- a/src/Marten/Linq/SoftDeletes/IsSoftDeletedMember.cs
+++ b/src/Marten/Linq/SoftDeletes/IsSoftDeletedMember.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
@@ -27,7 +28,7 @@ public class IsSoftDeletedMember : IQueryableMember, IComparableMember, IBoolean
 
     public ISqlFragment CreateComparison(string op, ConstantExpression constant)
     {
-        var value = constant.Value.Equals(true);
+        var value = constant.Value!.Equals(true);
 
         return value ? IsDeletedFilter.Instance : IsNotDeletedFilter.Instance;
     }

--- a/src/Marten/Linq/SoftDeletes/MaybeDeletedParser.cs
+++ b/src/Marten/Linq/SoftDeletes/MaybeDeletedParser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using System.Reflection;
 using Marten.Linq.Members;
@@ -12,7 +13,7 @@ namespace Marten.Linq.SoftDeletes;
 internal class MaybeDeletedParser: IMethodCallParser, ISoftDeletedFilter
 {
     private static readonly MethodInfo _method =
-        typeof(SoftDeletedExtensions).GetMethod(nameof(SoftDeletedExtensions.MaybeDeleted));
+        typeof(SoftDeletedExtensions).GetMethod(nameof(SoftDeletedExtensions.MaybeDeleted))!;
 
 
     private static readonly string _sql = $"d.{SchemaConstants.DeletedColumn} is not null";

--- a/src/Marten/Linq/SoftDeletes/SoftDeletedExtensions.cs
+++ b/src/Marten/Linq/SoftDeletes/SoftDeletedExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Marten.Linq.SoftDeletes;

--- a/src/Marten/Linq/SqlGeneration/AnySelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/AnySelectClause.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Data.Common;
 using System.IO;

--- a/src/Marten/Linq/SqlGeneration/CountClause.cs
+++ b/src/Marten/Linq/SqlGeneration/CountClause.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Data.Common;
 using System.IO;

--- a/src/Marten/Linq/SqlGeneration/DataSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/DataSelectClause.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using JasperFx.Core;
 using Marten.Internal;

--- a/src/Marten/Linq/SqlGeneration/Deletion.cs
+++ b/src/Marten/Linq/SqlGeneration/Deletion.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Internal.Storage;
 using Marten.Services;
 using Weasel.Postgresql.SqlGeneration;
@@ -15,6 +16,6 @@ internal class Deletion: StatementOperation, IDeletion
     {
     }
 
-    public object Document { get; set; }
-    public object Id { get; set; }
+    public object Document { get; set; } = null!;
+    public object Id { get; set; } = null!;
 }

--- a/src/Marten/Linq/SqlGeneration/DistinctSelectionStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/DistinctSelectionStatement.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Internal;
 using Weasel.Postgresql;
 

--- a/src/Marten/Linq/SqlGeneration/ExplodeCollectionStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/ExplodeCollectionStatement.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Internal;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;

--- a/src/Marten/Linq/SqlGeneration/FilterStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/FilterStatement.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using Marten.Internal;

--- a/src/Marten/Linq/SqlGeneration/Filters/AllValuesAreNullFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/AllValuesAreNullFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Internal;
 using Marten.Linq.Members;
 using Weasel.Postgresql;
@@ -10,7 +11,7 @@ internal class AllValuesAreNullFilter: ISubQueryFilter
 {
     private static readonly ISqlFragment _filter = new WhereFragment("true = ALL (select unnest(data) is null)");
 
-    private string _exportName;
+    private string? _exportName;
 
     public AllValuesAreNullFilter(ICollectionMember member)
     {
@@ -27,7 +28,7 @@ internal class AllValuesAreNullFilter: ISubQueryFilter
         }
 
         builder.Append("d.ctid in (select ctid from ");
-        builder.Append(_exportName);
+        builder.Append(_exportName!);
         builder.Append(")");
 
         if (Not)
@@ -47,7 +48,7 @@ internal class AllValuesAreNullFilter: ISubQueryFilter
         return this;
     }
 
-    public void PlaceUnnestAbove(IMartenSession session, SelectorStatement statement, ISqlFragment topLevelWhere = null)
+    public void PlaceUnnestAbove(IMartenSession session, SelectorStatement statement, ISqlFragment? topLevelWhere = null)
     {
         // First need to unnest the collection into its own recordset
         var unnest = new ExplodeCollectionStatement(session, statement, Member.ArrayLocator) { Where = topLevelWhere };

--- a/src/Marten/Linq/SqlGeneration/Filters/AllValuesEqualFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/AllValuesEqualFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq.Expressions;
 using Marten.Linq.Members;
 using Weasel.Postgresql;
@@ -18,7 +19,7 @@ internal class AllValuesEqualFilter: ISqlFragment
 
     public void Apply(ICommandBuilder builder)
     {
-        builder.AppendParameter(_constant.Value);
+        builder.AppendParameter(_constant.Value!);
         builder.Append(" = ALL(");
         builder.Append(_member.ArrayLocator);
         builder.Append(")");

--- a/src/Marten/Linq/SqlGeneration/Filters/BooleanFieldIsFalse.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/BooleanFieldIsFalse.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Linq.Members;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;

--- a/src/Marten/Linq/SqlGeneration/Filters/BooleanFieldIsTrue.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/BooleanFieldIsTrue.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Linq.Members;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;

--- a/src/Marten/Linq/SqlGeneration/Filters/ByIdFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/ByIdFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using NpgsqlTypes;
 using Weasel.Postgresql;
@@ -5,7 +6,7 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.SqlGeneration.Filters;
 
-public class ByIdFilter<T>: ISqlFragment
+public class ByIdFilter<T>: ISqlFragment where T: notnull
 {
     private readonly CommandParameter _parameter;
 

--- a/src/Marten/Linq/SqlGeneration/Filters/CollectionIsEmpty.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/CollectionIsEmpty.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Linq.Members;
 using Marten.Linq.Parsing;
 using Weasel.Postgresql;

--- a/src/Marten/Linq/SqlGeneration/Filters/CollectionIsNotEmpty.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/CollectionIsNotEmpty.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using Marten.Linq.Members;

--- a/src/Marten/Linq/SqlGeneration/Filters/ContainmentWhereFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/ContainmentWhereFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -159,7 +160,7 @@ public class ContainmentWhereFilter: ICollectionAwareFilter, ICollectionAware, I
 
     public void PlaceMemberValue(IQueryableMember member, ConstantExpression constant)
     {
-        _usages.Add(new DictionaryValueUsage(constant.Value));
+        _usages.Add(new DictionaryValueUsage(constant.Value!));
 
         var dict = _data;
         for (var i = 1; i < member.Ancestors.Length; i++)

--- a/src/Marten/Linq/SqlGeneration/Filters/CurrentTenantFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/CurrentTenantFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using Marten.Storage.Metadata;
 using Weasel.Postgresql;

--- a/src/Marten/Linq/SqlGeneration/Filters/DeepCollectionIsNotEmpty.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/DeepCollectionIsNotEmpty.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using JasperFx.Core;

--- a/src/Marten/Linq/SqlGeneration/Filters/EqualsFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/EqualsFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
 

--- a/src/Marten/Linq/SqlGeneration/Filters/ExcludeSoftDeletedFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/ExcludeSoftDeletedFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Schema;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;

--- a/src/Marten/Linq/SqlGeneration/Filters/FullTextWhereFragment.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/FullTextWhereFragment.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Linq;
 using Marten.Linq.Parsing.Methods.FullText;
 using Marten.Schema;
@@ -33,7 +34,7 @@ internal class FullTextWhereFragment: ISqlFragment
         builder.AppendWithParameters(Sql)[0].Value = _searchTerm;
     }
 
-    private static string GetDataConfig(DocumentMapping mapping, string regConfig)
+    private static string GetDataConfig(DocumentMapping? mapping, string regConfig)
     {
         if (mapping == null)
         {

--- a/src/Marten/Linq/SqlGeneration/Filters/ICollectionAware.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/ICollectionAware.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using Marten.Linq.Members;
 using Weasel.Postgresql;

--- a/src/Marten/Linq/SqlGeneration/Filters/ITenantFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/ITenantFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.SqlGeneration.Filters;

--- a/src/Marten/Linq/SqlGeneration/Filters/IsNotNullFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/IsNotNullFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Linq.Members;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;

--- a/src/Marten/Linq/SqlGeneration/Filters/IsNullFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/IsNullFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Linq.Members;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;

--- a/src/Marten/Linq/SqlGeneration/Filters/MemberComparisonFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/MemberComparisonFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using JasperFx.Core.Reflection;
@@ -49,7 +50,7 @@ internal class MemberComparisonFilter: ComparisonFilter, ICollectionAware
 
     public void BuildJsonPathFilter(ICommandBuilder builder, Dictionary<string, object> parameters)
     {
-        var rawValue = Right.As<CommandParameter>().Value;
+        var rawValue = Right.As<CommandParameter>().Value!;
         var parameter = parameters.AddJsonPathParameter(rawValue);
 
         builder.Append("@.");

--- a/src/Marten/Linq/SqlGeneration/Filters/SpecificTenantFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/SpecificTenantFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Schema.Arguments;
 using Marten.Storage.Metadata;
 using Weasel.Postgresql;

--- a/src/Marten/Linq/SqlGeneration/Filters/SubQueryFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/SubQueryFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Internal;
 using Marten.Linq.Members;
 using Weasel.Postgresql;
@@ -8,12 +9,12 @@ namespace Marten.Linq.SqlGeneration.Filters;
 internal interface ISubQueryFilter : IReversibleWhereFragment
 {
     void PlaceUnnestAbove(IMartenSession session, SelectorStatement statement,
-        ISqlFragment topLevelWhere = null);
+        ISqlFragment? topLevelWhere = null);
 }
 
 internal class SubQueryFilter: ISubQueryFilter
 {
-    private string _exportName;
+    private string? _exportName;
 
     public SubQueryFilter(ICollectionMember member, ISqlFragment inner)
     {
@@ -43,7 +44,7 @@ internal class SubQueryFilter: ISubQueryFilter
         }
 
         builder.Append("d.ctid in (select ctid from ");
-        builder.Append(_exportName);
+        builder.Append(_exportName!);
         builder.Append(")");
 
         if (Not)

--- a/src/Marten/Linq/SqlGeneration/Filters/TenantIsOneOfFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/TenantIsOneOfFilter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Storage.Metadata;
 using NpgsqlTypes;
 using Weasel.Postgresql;

--- a/src/Marten/Linq/SqlGeneration/Filters/WriteSerializedJsonParameterFrame.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/WriteSerializedJsonParameterFrame.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -131,7 +132,7 @@ internal class DictionaryDeclaration : IDictionaryPart
                     var usage = usages.FirstOrDefault(x => x.Value.Equals(array[0]));
                     if (usage != null)
                     {
-                        var arrayValue = new ArrayScalarValue(pair.Key, usage.QueryMember);
+                        var arrayValue = new ArrayScalarValue(pair.Key, usage.QueryMember!);
                         Parts.Add(arrayValue);
                     }
                 }
@@ -149,7 +150,7 @@ internal class DictionaryDeclaration : IDictionaryPart
                 var usage = usages.FirstOrDefault(x => x.Value.Equals(pair.Value));
                 if (usage != null)
                 {
-                    var value = new DictionaryValue(pair.Key, usage.QueryMember);
+                    var value = new DictionaryValue(pair.Key, usage.QueryMember!);
                     Parts.Add(value);
                 }
                 else

--- a/src/Marten/Linq/SqlGeneration/FromFragment.cs
+++ b/src/Marten/Linq/SqlGeneration/FromFragment.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using JasperFx.Core;
 using Weasel.Core;
 using Weasel.Postgresql;

--- a/src/Marten/Linq/SqlGeneration/HardDelete.cs
+++ b/src/Marten/Linq/SqlGeneration/HardDelete.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Internal.Operations;
 using Marten.Internal.Storage;
 using Weasel.Postgresql;

--- a/src/Marten/Linq/SqlGeneration/IOperationFragment.cs
+++ b/src/Marten/Linq/SqlGeneration/IOperationFragment.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Internal.Operations;
 using Weasel.Postgresql.SqlGeneration;
 

--- a/src/Marten/Linq/SqlGeneration/IScalarSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/IScalarSelectClause.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace Marten.Linq.SqlGeneration;
 
 internal interface IScalarSelectClause

--- a/src/Marten/Linq/SqlGeneration/Literal.cs
+++ b/src/Marten/Linq/SqlGeneration/Literal.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
 

--- a/src/Marten/Linq/SqlGeneration/NewScalarSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/NewScalarSelectClause.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Data.Common;
 using System.Threading;

--- a/src/Marten/Linq/SqlGeneration/NewScalarStringSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/NewScalarStringSelectClause.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Data.Common;
 using System.Threading;

--- a/src/Marten/Linq/SqlGeneration/OrderByFragment.cs
+++ b/src/Marten/Linq/SqlGeneration/OrderByFragment.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using Weasel.Postgresql;

--- a/src/Marten/Linq/SqlGeneration/ScalarSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/ScalarSelectClause.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Data.Common;
 using System.Threading;

--- a/src/Marten/Linq/SqlGeneration/ScalarStringSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/ScalarStringSelectClause.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Data.Common;
 using System.Threading;

--- a/src/Marten/Linq/SqlGeneration/SelectDataSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/SelectDataSelectClause.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using JasperFx.Core;
 using Marten.Internal;

--- a/src/Marten/Linq/SqlGeneration/SelectorStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/SelectorStatement.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using JasperFx.Core;
@@ -121,7 +122,7 @@ public class SelectorStatement: Statement, IWhereFragmentHolder
                 {
                     var others = compound.Children.Where(x => !subQueries.Contains(x)).ToArray();
 
-                    ISqlFragment topLevel = null;
+                    ISqlFragment? topLevel = null;
                     switch (others.Length)
                     {
                         case 0:

--- a/src/Marten/Linq/SqlGeneration/SoftDelete.cs
+++ b/src/Marten/Linq/SqlGeneration/SoftDelete.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Internal.Operations;
 using Marten.Internal.Storage;
 using Marten.Schema;

--- a/src/Marten/Linq/SqlGeneration/Statement.WhereParsing.cs
+++ b/src/Marten/Linq/SqlGeneration/Statement.WhereParsing.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/Marten/Linq/SqlGeneration/Statement.cs
+++ b/src/Marten/Linq/SqlGeneration/Statement.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;

--- a/src/Marten/Linq/SqlGeneration/StatementOperation.cs
+++ b/src/Marten/Linq/SqlGeneration/StatementOperation.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Data.Common;

--- a/src/Marten/Linq/SqlGeneration/StatsSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/StatsSelectClause.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using JasperFx.Core;

--- a/src/Marten/Linq/SqlGeneration/UnSoftDelete.cs
+++ b/src/Marten/Linq/SqlGeneration/UnSoftDelete.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Marten.Internal.Operations;
 using Marten.Internal.Storage;
 using Marten.Schema;

--- a/src/Marten/Linq/SqlGeneration/WhereFragmentExtensions.cs
+++ b/src/Marten/Linq/SqlGeneration/WhereFragmentExtensions.cs
@@ -1,3 +1,5 @@
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Marten.Events.Archiving;
 using Marten.Linq.SqlGeneration.Filters;
@@ -28,7 +30,7 @@ internal static class WhereFragmentExtensions
         return false;
     }
 
-    public static bool TryFindTenantAwareFilter(this ISqlFragment fragment, out ITenantFilter tenantFilter)
+    public static bool TryFindTenantAwareFilter(this ISqlFragment fragment, [NotNullWhen(true)]out ITenantFilter? tenantFilter)
     {
         if (fragment is SelectorStatement statement)
         {

--- a/src/Marten/Services/BatchQuerying/BatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQuery.cs
@@ -30,22 +30,22 @@ internal class BatchedQuery: IBatchedQuery, IBatchEvents
 
     public IBatchEvents Events => this;
 
-    public Task<T> Load<T>(string id) where T : class
+    public Task<T?> Load<T>(string id) where T : class
     {
         return load<T, string>(id);
     }
 
-    public Task<T> Load<T>(int id) where T : class
+    public Task<T?> Load<T>(int id) where T : class
     {
         return load<T, int>(id);
     }
 
-    public Task<T> Load<T>(long id) where T : class
+    public Task<T?> Load<T>(long id) where T : class
     {
         return load<T, long>(id);
     }
 
-    public Task<T> Load<T>(Guid id) where T : class
+    public Task<T?> Load<T>(Guid id) where T : class
     {
         return load<T, Guid>(id);
     }
@@ -131,7 +131,7 @@ internal class BatchedQuery: IBatchedQuery, IBatchEvents
         }
     }
 
-    public Task<TResult> Query<TDoc, TResult>(ICompiledQuery<TDoc, TResult> query)
+    public Task<TResult> Query<TDoc, TResult>(ICompiledQuery<TDoc, TResult> query) where TDoc : class
     {
         _documentTypes.Add(typeof(TDoc));
         // Smelly downcast, but we'll allow it
@@ -212,14 +212,14 @@ internal class BatchedQuery: IBatchedQuery, IBatchEvents
         return item.Result;
     }
 
-    private Task<T> load<T, TId>(TId id) where T : class where TId : notnull
+    private Task<T?> load<T, TId>(TId id) where T : class where TId : notnull
     {
         _documentTypes.Add(typeof(T));
         var storage = _parent.StorageFor<T>();
         if (storage is IDocumentStorage<T, TId> s)
         {
             var handler = new LoadByIdHandler<T, TId>(s, id);
-            return AddItem(handler);
+            return AddItem(handler)!;
         }
 
         throw new DocumentIdTypeMismatchException(storage, typeof(TId));

--- a/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
@@ -67,7 +67,7 @@ public interface IBatchedQuery
     /// <typeparam name="T"></typeparam>
     /// <param name="id"></param>
     /// <returns></returns>
-    Task<T> Load<T>(string id) where T : class;
+    Task<T?> Load<T>(string id) where T : class;
 
     /// <summary>
     ///     Load a single document of Type "T" by id
@@ -75,7 +75,7 @@ public interface IBatchedQuery
     /// <typeparam name="T"></typeparam>
     /// <param name="id"></param>
     /// <returns></returns>
-    Task<T> Load<T>(int id) where T : class;
+    Task<T?> Load<T>(int id) where T : class;
 
     /// <summary>
     ///     Load a single document of Type "T" by id
@@ -83,7 +83,7 @@ public interface IBatchedQuery
     /// <typeparam name="T"></typeparam>
     /// <param name="id"></param>
     /// <returns></returns>
-    Task<T> Load<T>(long id) where T : class;
+    Task<T?> Load<T>(long id) where T : class;
 
     /// <summary>
     ///     Load a single document of Type "T" by id
@@ -91,7 +91,7 @@ public interface IBatchedQuery
     /// <typeparam name="T"></typeparam>
     /// <param name="id"></param>
     /// <returns></returns>
-    Task<T> Load<T>(Guid id) where T : class;
+    Task<T?> Load<T>(Guid id) where T : class;
 
     /// <summary>
     ///     Load a one or more documents of Type "T" by id's
@@ -130,7 +130,7 @@ public interface IBatchedQuery
     /// <typeparam name="TResult"></typeparam>
     /// <param name="query"></param>
     /// <returns></returns>
-    Task<TResult> Query<TDoc, TResult>(ICompiledQuery<TDoc, TResult> query);
+    Task<TResult> Query<TDoc, TResult>(ICompiledQuery<TDoc, TResult> query) where TDoc : class;
 
     /// <summary>
     ///     Force the batched query to execute synchronously


### PR DESCRIPTION
With remotion gone the massive NRT blackhole has been removed and this part of the codebase can be annotated. The compiler directives will be removed in a later PR once the entire codebase is ready to go. Also fixed some incorrect annotations around bulk queries. 