### PR TITLE
Add AdvancedSql.StreamAsync<>()

### DIFF
--- a/docs/documents/querying/advanced-sql.md
+++ b/docs/documents/querying/advanced-sql.md
@@ -1,12 +1,12 @@
 # Advanced querying with Postgresql SQL
 
-Besides Linq queries or simple raw SQL queries via `session.Query<T>("where...")`, it is also possible to do even more complex SQL queries via `session.AdvancedSqlQueryAsync<T>()`.
+Besides Linq queries or simple raw SQL queries via `session.Query<T>("where...")`, it is also possible to do even more complex SQL queries via `session.AdvancedSql.QueryAsync<T>()`.
 With this method Marten does not try to add any missing parts to the SQL query, instead you have to provide the whole query string yourself.
 
 Marten just makes some assumptions on how the schema of the SQl query result must look like, in order to be able to map the query result to documents, scalars or other JSON serializable types.
-With `AdvancedSqlQueryAsync` / `AdvancedSqlQuery` it is even possible to return multiple documents, objects and scalars as a tuple. Currently up to three result types can be queried for.
+With `AdvancedSql.QueryAsync` / `AdvancedSql.Query` it is even possible to return multiple documents, objects and scalars as a tuple. Currently up to three result types can be queried for.
 
-The following rules must be followed when doing queries with `AdvancedSqlQueryAsync` / `AdvancedSqlQuery`:
+The following rules must be followed when doing queries with `AdvancedSql.QueryAsync` / `AdvancedSql.Query`:
 
 - If a document should be returned, the SQL `SELECT` statement must contain all the columns required by Marten to build
   the document in the correct order. Which columns are needed depends on the session type and if any meta data are
@@ -36,7 +36,7 @@ Querying for a simple scalar value can be done like this:
 <a id='snippet-sample_advanced_sql_query_single_scalar'></a>
 ```cs
 var schema = session.DocumentStore.Options.Schema;
-var name = (await session.AdvancedSqlQueryAsync<string>(
+var name = (await session.AdvancedSql.QueryAsync<string>(
     $"select data ->> 'Name' from {schema.For<DocWithMeta>()} limit 1",
     CancellationToken.None)).First();
 ```
@@ -48,7 +48,7 @@ Or for multiple scalars returned as a tuple:
 <!-- snippet: sample_advanced_sql_query_multiple_scalars -->
 <a id='snippet-sample_advanced_sql_query_multiple_scalars'></a>
 ```cs
-var (number,text, boolean) = (await session.AdvancedSqlQueryAsync<int, string, bool>(
+var (number,text, boolean) = (await session.AdvancedSql.QueryAsync<int, string, bool>(
     "select row(5), row('foo'), row(true) from (values(1)) as dummy",
     CancellationToken.None)).First();
 ```
@@ -60,7 +60,7 @@ You can also query for any arbitrary JSON that will get deserialized:
 <!-- snippet: sample_advanced_sql_query_json_object -->
 <a id='snippet-sample_advanced_sql_query_json_object'></a>
 ```cs
-var result = (await session.AdvancedSqlQueryAsync<Foo, Bar>(
+var result = (await session.AdvancedSql.QueryAsync<Foo, Bar>(
     "select row(json_build_object('Name', 'foo')), row(json_build_object('Name', 'bar')) from (values(1)) as dummy",
     CancellationToken.None)).First();
 ```
@@ -73,7 +73,7 @@ Querying for documents requires to return the correct columns:
 <a id='snippet-sample_advanced_sql_query_documents'></a>
 ```cs
 var schema = session.DocumentStore.Options.Schema;
-var docs = await session.AdvancedSqlQueryAsync<DocWithoutMeta>(
+var docs = await session.AdvancedSql.QueryAsync<DocWithoutMeta>(
     $"select id, data from {schema.For<DocWithoutMeta>()} order by data ->> 'Name'",
     CancellationToken.None);
 ```
@@ -87,7 +87,7 @@ important!:
 <a id='snippet-sample_advanced_sql_query_documents_with_metadata'></a>
 ```cs
 var schema = session.DocumentStore.Options.Schema;
-var doc = (await session.AdvancedSqlQueryAsync<DocWithMeta>(
+var doc = (await session.AdvancedSql.QueryAsync<DocWithMeta>(
     $"select id, data, mt_version from {schema.For<DocWithMeta>()} where data ->> 'Name' = 'Max'",
     CancellationToken.None)).First();
 ```
@@ -111,7 +111,7 @@ await session.SaveChangesAsync();
 
 var schema = session.DocumentStore.Options.Schema;
 IReadOnlyList<(DocWithMeta doc, DocDetailsWithMeta detail, long totalResults)> results =
-    await session.AdvancedSqlQueryAsync<DocWithMeta, DocDetailsWithMeta, long>(
+    await session.AdvancedSql.QueryAsync<DocWithMeta, DocDetailsWithMeta, long>(
         $"""
         select
           row(a.id, a.data, a.mt_version),
@@ -139,20 +139,50 @@ results[1].detail.Detail.ShouldBe("Likes to cook");
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/advanced_sql_query.cs#L100-L137' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_sql_query_related_documents_and_scalar' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-For sync queries you can use the `AdvancedSqlQuery<T>(...)` overloads.
+For sync queries you can use the `AdvancedSql.Query<T>(...)` overloads.
 
-## Getting document and schema names
+When you need to query for large datasets, the `AdvancedSql.StreamAsync<>(...)` methods can be used. They will return
+an IAsyncEnumerable<>, which you can use to iterate over the result set. See:
 
-Tables can be referenced with raw sql, but it is also possible to have marten tell you names of documents and aggregates.
-
-These names can be found on the `Schema` property of the StoreOptions:
-
-<!-- snippet: sample_document_schema_resolver_options -->
-<a id='snippet-sample_document_schema_resolver_options'></a>
+<!-- snippet: sample_advanced_sql_stream_related_documents_and_scalar -->
+<a id='snippet-sample_advanced_sql_stream_related_documents_and_scalar'></a>
 ```cs
-var schema = theSession.DocumentStore.Options.Schema;
+session.Store(new DocWithMeta { Id = 1, Name = "Max" });
+session.Store(new DocDetailsWithMeta { Id = 1, Detail = "Likes bees" });
+session.Store(new DocWithMeta { Id = 2, Name = "Michael" });
+session.Store(new DocDetailsWithMeta { Id = 2, Detail = "Is a good chess player" });
+session.Store(new DocWithMeta { Id = 3, Name = "Anne" });
+session.Store(new DocDetailsWithMeta { Id = 3, Detail = "Hates soap operas" });
+session.Store(new DocWithMeta { Id = 4, Name = "Beatrix" });
+session.Store(new DocDetailsWithMeta { Id = 4, Detail = "Likes to cook" });
+await session.SaveChangesAsync();
+
+var schema = session.DocumentStore.Options.Schema;
+
+var asyncEnumerable = session.AdvancedSql.StreamAsync<DocWithMeta, DocDetailsWithMeta, long>(
+        $"""
+        select
+          row(a.id, a.data, a.mt_version),
+          row(b.id, b.data, b.mt_version),
+          row(count(*) over())
+        from
+          {schema.For<DocWithMeta>()} a
+        left join
+          {schema.For<DocDetailsWithMeta>()} b on a.id = b.id
+        where
+          (a.data ->> 'Id')::int > 1
+        order by
+          a.data ->> 'Name'
+        """,
+        CancellationToken.None);
+
+var collectedResults = new List<(DocWithMeta doc, DocDetailsWithMeta detail, long totalResults)>();
+await foreach (var result in asyncEnumerable)
+{
+    collectedResults.Add(result);
+}
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/DocumentSchemaResolverTests.cs#L40-L42' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_document_schema_resolver_options' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/advanced_sql_query.cs#L144-L179' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_sql_stream_related_documents_and_scalar' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Using this you can resolve schemas:

--- a/src/DocumentDbTests/Reading/advanced_sql_query.cs
+++ b/src/DocumentDbTests/Reading/advanced_sql_query.cs
@@ -24,7 +24,7 @@ public class advanced_sql_query: IntegrationContext
         await session.SaveChangesAsync();
         #region sample_advanced_sql_query_single_scalar
         var schema = session.DocumentStore.Options.Schema;
-        var name = (await session.AdvancedSqlQueryAsync<string>(
+        var name = (await session.AdvancedSql.QueryAsync<string>(
             $"select data ->> 'Name' from {schema.For<DocWithMeta>()} limit 1",
             CancellationToken.None)).First();
         #endregion
@@ -36,7 +36,7 @@ public class advanced_sql_query: IntegrationContext
     {
         await using var session = theStore.LightweightSession();
         #region sample_advanced_sql_query_multiple_scalars
-        var (number,text, boolean) = (await session.AdvancedSqlQueryAsync<int, string, bool>(
+        var (number,text, boolean) = (await session.AdvancedSql.QueryAsync<int, string, bool>(
             "select row(5), row('foo'), row(true) from (values(1)) as dummy",
             CancellationToken.None)).First();
         #endregion
@@ -50,7 +50,7 @@ public class advanced_sql_query: IntegrationContext
     {
         await using var session = theStore.LightweightSession();
         #region sample_advanced_sql_query_json_object
-        var result = (await session.AdvancedSqlQueryAsync<Foo, Bar>(
+        var result = (await session.AdvancedSql.QueryAsync<Foo, Bar>(
             "select row(json_build_object('Name', 'foo')), row(json_build_object('Name', 'bar')) from (values(1)) as dummy",
             CancellationToken.None)).First();
         #endregion
@@ -67,7 +67,7 @@ public class advanced_sql_query: IntegrationContext
         await session.SaveChangesAsync();
         #region sample_advanced_sql_query_documents
         var schema = session.DocumentStore.Options.Schema;
-        var docs = await session.AdvancedSqlQueryAsync<DocWithoutMeta>(
+        var docs = await session.AdvancedSql.QueryAsync<DocWithoutMeta>(
             $"select id, data from {schema.For<DocWithoutMeta>()} order by data ->> 'Name'",
             CancellationToken.None);
         #endregion
@@ -84,7 +84,7 @@ public class advanced_sql_query: IntegrationContext
         await session.SaveChangesAsync();
         #region sample_advanced_sql_query_documents_with_metadata
         var schema = session.DocumentStore.Options.Schema;
-        var doc = (await session.AdvancedSqlQueryAsync<DocWithMeta>(
+        var doc = (await session.AdvancedSql.QueryAsync<DocWithMeta>(
             $"select id, data, mt_version from {schema.For<DocWithMeta>()} where data ->> 'Name' = 'Max'",
             CancellationToken.None)).First();
         #endregion
@@ -110,7 +110,7 @@ public class advanced_sql_query: IntegrationContext
 
         var schema = session.DocumentStore.Options.Schema;
         IReadOnlyList<(DocWithMeta doc, DocDetailsWithMeta detail, long totalResults)> results =
-            await session.AdvancedSqlQueryAsync<DocWithMeta, DocDetailsWithMeta, long>(
+            await session.AdvancedSql.QueryAsync<DocWithMeta, DocDetailsWithMeta, long>(
                 $"""
                 select
                   row(a.id, a.data, a.mt_version),
@@ -194,10 +194,10 @@ public class advanced_sql_query: IntegrationContext
     {
         using var session = theStore.LightweightSession();
 
-        var singleResult  = session.AdvancedSqlQuery<int>("select 5 from (values(1)) as dummy").First();
-        var tuple2Result = session.AdvancedSqlQuery<int, string>(
+        var singleResult  = session.AdvancedSql.Query<int>("select 5 from (values(1)) as dummy").First();
+        var tuple2Result = session.AdvancedSql.Query<int, string>(
             "select row(5), row('foo')from (values(1)) as dummy").First();
-        var tuple3Result = session.AdvancedSqlQuery<int, string, bool>(
+        var tuple3Result = session.AdvancedSql.Query<int, string, bool>(
             "select row(5), row('foo'), row(true) from (values(1)) as dummy").First();
 
         singleResult.ShouldBe(5);

--- a/src/DocumentDbTests/Reading/advanced_sql_query.cs
+++ b/src/DocumentDbTests/Reading/advanced_sql_query.cs
@@ -138,6 +138,58 @@ public class advanced_sql_query: IntegrationContext
     }
 
     [Fact]
+    public async void can_async_stream_multiple_documents_and_scalar()
+    {
+        await using var session = theStore.LightweightSession();
+        #region sample_advanced_sql_stream_related_documents_and_scalar
+        session.Store(new DocWithMeta { Id = 1, Name = "Max" });
+        session.Store(new DocDetailsWithMeta { Id = 1, Detail = "Likes bees" });
+        session.Store(new DocWithMeta { Id = 2, Name = "Michael" });
+        session.Store(new DocDetailsWithMeta { Id = 2, Detail = "Is a good chess player" });
+        session.Store(new DocWithMeta { Id = 3, Name = "Anne" });
+        session.Store(new DocDetailsWithMeta { Id = 3, Detail = "Hates soap operas" });
+        session.Store(new DocWithMeta { Id = 4, Name = "Beatrix" });
+        session.Store(new DocDetailsWithMeta { Id = 4, Detail = "Likes to cook" });
+        await session.SaveChangesAsync();
+
+        var schema = session.DocumentStore.Options.Schema;
+
+        var asyncEnumerable = session.AdvancedSql.StreamAsync<DocWithMeta, DocDetailsWithMeta, long>(
+                $"""
+                select
+                  row(a.id, a.data, a.mt_version),
+                  row(b.id, b.data, b.mt_version),
+                  row(count(*) over())
+                from
+                  {schema.For<DocWithMeta>()} a
+                left join
+                  {schema.For<DocDetailsWithMeta>()} b on a.id = b.id
+                where
+                  (a.data ->> 'Id')::int > 1
+                order by
+                  a.data ->> 'Name'
+                """,
+                CancellationToken.None);
+
+        var collectedResults = new List<(DocWithMeta doc, DocDetailsWithMeta detail, long totalResults)>();
+        await foreach (var result in asyncEnumerable)
+        {
+            collectedResults.Add(result);
+        }
+        #endregion
+        collectedResults.Count.ShouldBe(3);
+        collectedResults[0].totalResults.ShouldBe(3);
+        collectedResults[0].doc.Name.ShouldBe("Anne");
+        collectedResults[0].detail.Detail.ShouldBe("Hates soap operas");
+        collectedResults[1].totalResults.ShouldBe(3);
+        collectedResults[1].doc.Name.ShouldBe("Beatrix");
+        collectedResults[1].detail.Detail.ShouldBe("Likes to cook");
+        collectedResults[2].totalResults.ShouldBe(3);
+        collectedResults[2].doc.Name.ShouldBe("Michael");
+        collectedResults[2].detail.Detail.ShouldBe("Is a good chess player");
+    }
+
+    [Fact]
     public void can_query_synchrounously()
     {
         using var session = theStore.LightweightSession();

--- a/src/Marten/IAdvancedSql.cs
+++ b/src/Marten/IAdvancedSql.cs
@@ -1,0 +1,53 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Marten;
+
+public interface IAdvancedSql
+{
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns>An async enumerable iterating over the results</returns>
+    IAsyncEnumerable<T> StreamAsync<T>(string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns>An async enumerable iterating over the list of result tuples</returns>
+    IAsyncEnumerable<(T1, T2)> StreamAsync<T1, T2>(string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <typeparam name="T3"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns>An async enumerable iterating over the list of result tuples</returns>
+    IAsyncEnumerable<(T1, T2, T3)> StreamAsync<T1, T2, T3>(string sql, CancellationToken token, params object[] parameters);
+}

--- a/src/Marten/IAdvancedSql.cs
+++ b/src/Marten/IAdvancedSql.cs
@@ -1,11 +1,100 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Marten;
 
 public interface IAdvancedSql
 {
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameter can be a document class, a scalar or any JSON-serializable class.
+    ///     If the result is a document, the SQL must contain a select with the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     selected.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<T>> QueryAsync<T>(string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<(T1, T2)>> QueryAsync<T1, T2>(string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <typeparam name="T3"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<(T1, T2, T3)>> QueryAsync<T1, T2, T3>(string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameter can be a document class, a scalar or any JSON-serializable class.
+    ///     If the result is a document, the SQL must contain a select with the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     selected.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    IReadOnlyList<T> Query<T>(string sql, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    IReadOnlyList<(T1, T2)> Query<T1, T2>(string sql, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <typeparam name="T3"></typeparam>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    IReadOnlyList<(T1, T2, T3)> Query<T1, T2, T3>(string sql, params object[] parameters);
+
     /// <summary>
     ///     Asynchronously queries the document storage with the supplied SQL.
     ///     The type parameters can be any document class, scalar or JSON-serializable class.

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -716,4 +716,10 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// <param name="token"></param>
     /// <returns></returns>
     Task<DbDataReader> ExecuteReaderAsync(NpgsqlCommand command, CancellationToken token = default);
+
+    /// <summary>
+    ///     Advanced sql query methods, to allow you to query the database
+    ///     beyond what you can do with LINQ.
+    /// </summary>
+    IAdvancedSql AdvancedSql { get; }
 }

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -203,7 +203,6 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// <returns></returns>
     Task<IReadOnlyList<T>> QueryAsync<T>(string sql, params object[] parameters);
 
-
     /// <summary>
     ///     Asynchronously queries the document storage with the supplied SQL.
     ///     The type parameter can be a document class, a scalar or any JSON-serializable class.
@@ -215,6 +214,7 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// <param name="sql"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
+    [Obsolete("Will be removed in 8.0. Use AdvancedSql.QueryAsync<T>(...) instead.")]
     Task<IReadOnlyList<T>> AdvancedSqlQueryAsync<T>(string sql, CancellationToken token, params object[] parameters);
 
     /// <summary>
@@ -230,6 +230,7 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// <param name="sql"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
+    [Obsolete("Will be removed in 8.0. Use AdvancedSql.QueryAsync<T1, T2>(...) instead.")]
     Task<IReadOnlyList<(T1, T2)>> AdvancedSqlQueryAsync<T1, T2>(string sql, CancellationToken token, params object[] parameters);
 
     /// <summary>
@@ -246,6 +247,7 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// <param name="sql"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
+    [Obsolete("Will be removed in 8.0. Use AdvancedSql.QueryAsync<T1, T2, T3>(...) instead.")]
     Task<IReadOnlyList<(T1, T2, T3)>> AdvancedSqlQueryAsync<T1, T2,T3>(string sql, CancellationToken token, params object[] parameters);
 
     /// <summary>
@@ -259,6 +261,7 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// <param name="sql"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
+    [Obsolete("Will be removed in 8.0. Use AdvancedSql.QueryAsync<T>(...) instead.")]
     IReadOnlyList<T> AdvancedSqlQuery<T>(string sql, params object[] parameters);
 
     /// <summary>
@@ -274,6 +277,7 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// <param name="sql"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
+    [Obsolete("Will be removed in 8.0. Use AdvancedSql.QueryAsync<T1, T2>(...) instead.")]
     IReadOnlyList<(T1, T2)> AdvancedSqlQuery<T1, T2>(string sql, params object[] parameters);
 
     /// <summary>
@@ -290,6 +294,7 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// <param name="sql"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
+    [Obsolete("Will be removed in 8.0. Use AdvancedSql.QueryAsync<T1, T2, T3>(...) instead.")]
     IReadOnlyList<(T1, T2, T3)> AdvancedSqlQuery<T1, T2, T3>(string sql, params object[] parameters);
 
     /// <summary>

--- a/src/Marten/Internal/Sessions/QuerySession.AdvancedSql.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.AdvancedSql.cs
@@ -1,14 +1,106 @@
+using Marten.Linq;
 using Marten.Linq.QueryHandlers;
 using Marten.Util;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Marten.Internal.Sessions;
 
 public partial class QuerySession: IAdvancedSql
 {
-    public async IAsyncEnumerable<T> StreamAsync<T>(string sql, [EnumeratorCancellation] CancellationToken token,
+    async Task<IReadOnlyList<T>> IAdvancedSql.QueryAsync<T>(string sql, CancellationToken token, params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes)
+        {
+            await Database.EnsureStorageExistsAsync(documentType, token).ConfigureAwait(false);
+        }
+
+        var provider = new MartenLinqQueryProvider(this, typeof(T));
+        return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+    }
+
+    async Task<IReadOnlyList<(T1, T2)>> IAdvancedSql.QueryAsync<T1, T2>(string sql, CancellationToken token, params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T1, T2>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes)
+        {
+            await Database.EnsureStorageExistsAsync(documentType, token).ConfigureAwait(false);
+        }
+
+        var provider = new MartenLinqQueryProvider(this, typeof((T1, T2)));
+        return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+    }
+
+    async Task<IReadOnlyList<(T1, T2, T3)>> IAdvancedSql.QueryAsync<T1, T2, T3>(string sql, CancellationToken token, params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes)
+        {
+            await Database.EnsureStorageExistsAsync(documentType, token).ConfigureAwait(false);
+        }
+
+        var provider = new MartenLinqQueryProvider(this, typeof((T1, T2, T3)));
+        return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+    }
+
+    IReadOnlyList<T> IAdvancedSql.Query<T>(string sql, params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes)
+        {
+            Database.EnsureStorageExists(documentType);
+        }
+
+        var provider = new MartenLinqQueryProvider(this, typeof(T));
+        return provider.ExecuteHandler(handler);
+    }
+
+    IReadOnlyList<(T1, T2)> IAdvancedSql.Query<T1, T2>(string sql, params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T1, T2>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes)
+        {
+            Database.EnsureStorageExists(documentType);
+        }
+
+        var provider = new MartenLinqQueryProvider(this, typeof((T1, T2)));
+        return provider.ExecuteHandler(handler);
+    }
+
+    IReadOnlyList<(T1, T2, T3)> IAdvancedSql.Query<T1, T2, T3>(string sql, params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes)
+        {
+            Database.EnsureStorageExists(documentType);
+        }
+
+        var provider = new MartenLinqQueryProvider(this, typeof((T1, T2, T3)));
+        return provider.ExecuteHandler(handler);
+    }
+
+    async IAsyncEnumerable<T> IAdvancedSql.StreamAsync<T>(string sql, [EnumeratorCancellation] CancellationToken token,
         params object[] parameters)
     {
         assertNotDisposed();
@@ -29,7 +121,7 @@ public partial class QuerySession: IAdvancedSql
         }
     }
 
-    public async IAsyncEnumerable<(T1, T2)> StreamAsync<T1, T2>(string sql, [EnumeratorCancellation] CancellationToken token,
+    async IAsyncEnumerable<(T1, T2)> IAdvancedSql.StreamAsync<T1, T2>(string sql, [EnumeratorCancellation] CancellationToken token,
         params object[] parameters)
     {
         assertNotDisposed();
@@ -50,7 +142,7 @@ public partial class QuerySession: IAdvancedSql
         }
     }
 
-    public async IAsyncEnumerable<(T1, T2, T3)> StreamAsync<T1, T2, T3>(string sql, [EnumeratorCancellation] CancellationToken token,
+    async IAsyncEnumerable<(T1, T2, T3)> IAdvancedSql.StreamAsync<T1, T2, T3>(string sql, [EnumeratorCancellation] CancellationToken token,
         params object[] parameters)
     {
         assertNotDisposed();

--- a/src/Marten/Internal/Sessions/QuerySession.AdvancedSql.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.AdvancedSql.cs
@@ -1,0 +1,73 @@
+using Marten.Linq.QueryHandlers;
+using Marten.Util;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Marten.Internal.Sessions;
+
+public partial class QuerySession: IAdvancedSql
+{
+    public async IAsyncEnumerable<T> StreamAsync<T>(string sql, [EnumeratorCancellation] CancellationToken token,
+        params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes)
+        {
+            await Database.EnsureStorageExistsAsync(documentType, token).ConfigureAwait(false);
+        }
+
+        var batch = this.BuildCommand(handler);
+        await using var reader = await ExecuteReaderAsync(batch, token).ConfigureAwait(false);
+
+        await foreach (var result in handler.EnumerateResults(reader, token))
+        {
+            yield return result;
+        }
+    }
+
+    public async IAsyncEnumerable<(T1, T2)> StreamAsync<T1, T2>(string sql, [EnumeratorCancellation] CancellationToken token,
+        params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T1, T2>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes)
+        {
+            await Database.EnsureStorageExistsAsync(documentType, token).ConfigureAwait(false);
+        }
+
+        var batch = this.BuildCommand(handler);
+        await using var reader = await ExecuteReaderAsync(batch, token).ConfigureAwait(false);
+
+        await foreach (var result in handler.EnumerateResults(reader, token))
+        {
+            yield return result;
+        }
+    }
+
+    public async IAsyncEnumerable<(T1, T2, T3)> StreamAsync<T1, T2, T3>(string sql, [EnumeratorCancellation] CancellationToken token,
+        params object[] parameters)
+    {
+        assertNotDisposed();
+
+        var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, sql, parameters);
+
+        foreach (var documentType in handler.DocumentTypes)
+        {
+            await Database.EnsureStorageExistsAsync(documentType, token).ConfigureAwait(false);
+        }
+
+        var batch = this.BuildCommand(handler);
+        await using var reader = await ExecuteReaderAsync(batch, token).ConfigureAwait(false);
+
+        await foreach (var result in handler.EnumerateResults(reader, token))
+        {
+            yield return result;
+        }
+    }
+}

--- a/src/Marten/Internal/Sessions/QuerySession.Querying.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Querying.cs
@@ -57,95 +57,26 @@ public partial class QuerySession
         return QueryAsync<T>(sql, CancellationToken.None, parameters);
     }
 
-    public async Task<IReadOnlyList<T>> AdvancedSqlQueryAsync<T>(string sql, CancellationToken token, params object[] parameters)
-    {
-        assertNotDisposed();
+    // TODO -- Obsolete, remove in 8.0, replaced by AdvancedSql.Query*
+    #region Obsolete AdvancedSqlQuery*
+    public Task<IReadOnlyList<T>> AdvancedSqlQueryAsync<T>(string sql, CancellationToken token,
+        params object[] parameters) => ((IAdvancedSql)this).QueryAsync<T>(sql, token, parameters);
 
-        var handler = new AdvancedSqlQueryHandler<T>(this, sql, parameters);
+    public Task<IReadOnlyList<(T1, T2)>> AdvancedSqlQueryAsync<T1, T2>(string sql, CancellationToken token,
+        params object[] parameters) => ((IAdvancedSql)this).QueryAsync<T1, T2>(sql, token, parameters);
 
-        foreach (var documentType in handler.DocumentTypes)
-        {
-            await Database.EnsureStorageExistsAsync(documentType, token).ConfigureAwait(false);
-        }
+    public Task<IReadOnlyList<(T1, T2, T3)>> AdvancedSqlQueryAsync<T1, T2, T3>(string sql, CancellationToken token,
+        params object[] parameters) => ((IAdvancedSql)this).QueryAsync<T1, T2, T3>(sql, token, parameters);
 
-        var provider = new MartenLinqQueryProvider(this, typeof(T));
-        return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
-    }
+    public IReadOnlyList<T> AdvancedSqlQuery<T>(string sql, params object[] parameters) =>
+        ((IAdvancedSql)this).Query<T>(sql, parameters);
 
-    public async Task<IReadOnlyList<(T1, T2)>> AdvancedSqlQueryAsync<T1, T2>(string sql, CancellationToken token, params object[] parameters)
-    {
-        assertNotDisposed();
+    public IReadOnlyList<(T1, T2)> AdvancedSqlQuery<T1, T2>(string sql, params object[] parameters) =>
+        ((IAdvancedSql)this).Query<T1, T2>(sql, parameters);
 
-        var handler = new AdvancedSqlQueryHandler<T1, T2>(this, sql, parameters);
-
-        foreach (var documentType in handler.DocumentTypes)
-        {
-            await Database.EnsureStorageExistsAsync(documentType, token).ConfigureAwait(false);
-        }
-
-        var provider = new MartenLinqQueryProvider(this, typeof((T1, T2)));
-        return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
-    }
-
-    public async Task<IReadOnlyList<(T1, T2, T3)>> AdvancedSqlQueryAsync<T1, T2, T3>(string sql, CancellationToken token, params object[] parameters)
-    {
-        assertNotDisposed();
-
-        var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, sql, parameters);
-
-        foreach (var documentType in handler.DocumentTypes)
-        {
-            await Database.EnsureStorageExistsAsync(documentType, token).ConfigureAwait(false);
-        }
-
-        var provider = new MartenLinqQueryProvider(this, typeof((T1, T2, T3)));
-        return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
-    }
-
-    public IReadOnlyList<T> AdvancedSqlQuery<T>(string sql, params object[] parameters)
-    {
-        assertNotDisposed();
-
-        var handler = new AdvancedSqlQueryHandler<T>(this, sql, parameters);
-
-        foreach (var documentType in handler.DocumentTypes)
-        {
-            Database.EnsureStorageExists(documentType);
-        }
-
-        var provider = new MartenLinqQueryProvider(this, typeof(T));
-        return provider.ExecuteHandler(handler);
-    }
-
-    public IReadOnlyList<(T1, T2)> AdvancedSqlQuery<T1, T2>(string sql, params object[] parameters)
-    {
-        assertNotDisposed();
-
-        var handler = new AdvancedSqlQueryHandler<T1, T2>(this, sql, parameters);
-
-        foreach (var documentType in handler.DocumentTypes)
-        {
-            Database.EnsureStorageExists(documentType);
-        }
-
-        var provider = new MartenLinqQueryProvider(this, typeof((T1, T2)));
-        return provider.ExecuteHandler(handler);
-    }
-
-    public IReadOnlyList<(T1, T2, T3)> AdvancedSqlQuery<T1, T2, T3>(string sql, params object[] parameters)
-    {
-        assertNotDisposed();
-
-        var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, sql, parameters);
-
-        foreach (var documentType in handler.DocumentTypes)
-        {
-            Database.EnsureStorageExists(documentType);
-        }
-
-        var provider = new MartenLinqQueryProvider(this, typeof((T1, T2, T3)));
-        return provider.ExecuteHandler(handler);
-    }
+    public IReadOnlyList<(T1, T2, T3)> AdvancedSqlQuery<T1, T2, T3>(string sql, params object[] parameters) =>
+        ((IAdvancedSql)this).Query<T1, T2, T3>(sql, parameters);
+    #endregion
 
     public IBatchedQuery CreateBatchQuery()
     {

--- a/src/Marten/Internal/Sessions/QuerySession.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.cs
@@ -110,4 +110,6 @@ public partial class QuerySession: IMartenSession, IQuerySession
 
     public int RequestCount { get; set; }
     public IDocumentStore DocumentStore => _store;
+
+    public IAdvancedSql AdvancedSql => this;
 }

--- a/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
@@ -14,7 +15,7 @@ using Weasel.Postgresql;
 
 namespace Marten.Linq.QueryHandlers;
 
-internal class AdvancedSqlQueryHandler<T>: AdvancedSqlQueryHandlerBase, IQueryHandler<IReadOnlyList<T>>
+internal class AdvancedSqlQueryHandler<T>: AdvancedSqlQueryHandlerBase<T>, IQueryHandler<IReadOnlyList<T>>
 {
     public AdvancedSqlQueryHandler(IMartenSession session, string sql, object[] parameters):base(sql, parameters)
     {
@@ -32,20 +33,17 @@ internal class AdvancedSqlQueryHandler<T>: AdvancedSqlQueryHandlerBase, IQueryHa
         return list;
     }
 
-    public async Task<IReadOnlyList<T>> HandleAsync(DbDataReader reader, IMartenSession session,
-        CancellationToken token)
+    public override async IAsyncEnumerable<T> EnumerateResults(DbDataReader reader,
+        [EnumeratorCancellation] CancellationToken token)
     {
-        var list = new List<T>();
         while (await reader.ReadAsync(token).ConfigureAwait(false))
         {
-            var item = await ((ISelector<T>)Selectors[0]).ResolveAsync(reader, token).ConfigureAwait(false);
-            list.Add(item);
+            yield return await ((ISelector<T>)Selectors[0]).ResolveAsync(reader, token).ConfigureAwait(false);
         }
-        return list;
     }
 }
 
-internal class AdvancedSqlQueryHandler<T1, T2>: AdvancedSqlQueryHandlerBase, IQueryHandler<IReadOnlyList<(T1, T2)>>
+internal class AdvancedSqlQueryHandler<T1, T2>: AdvancedSqlQueryHandlerBase<(T1, T2)>, IQueryHandler<IReadOnlyList<(T1, T2)>>
 {
     public AdvancedSqlQueryHandler(IMartenSession session, string sql, object[] parameters) : base(sql, parameters)
     {
@@ -65,20 +63,18 @@ internal class AdvancedSqlQueryHandler<T1, T2>: AdvancedSqlQueryHandlerBase, IQu
         return list;
     }
 
-    public async Task<IReadOnlyList<(T1, T2)>> HandleAsync(DbDataReader reader, IMartenSession session,
-        CancellationToken token)
+    public override async IAsyncEnumerable<(T1, T2)> EnumerateResults(DbDataReader reader,
+        [EnumeratorCancellation] CancellationToken token)
     {
-        var list = new List<(T1, T2)>();
         while (await reader.ReadAsync(token).ConfigureAwait(false))
         {
             var item1 = await ReadNestedRowAsync<T1>(reader, 0, token).ConfigureAwait(false);
             var item2 = await ReadNestedRowAsync<T2>(reader, 1, token).ConfigureAwait(false);
-            list.Add((item1, item2));
+            yield return (item1, item2);
         }
-        return list;
     }
 }
-internal class AdvancedSqlQueryHandler<T1, T2, T3>: AdvancedSqlQueryHandlerBase, IQueryHandler<IReadOnlyList<(T1, T2, T3)>>
+internal class AdvancedSqlQueryHandler<T1, T2, T3>: AdvancedSqlQueryHandlerBase<(T1, T2, T3)>, IQueryHandler<IReadOnlyList<(T1, T2, T3)>>
 {
     public AdvancedSqlQueryHandler(IMartenSession session, string sql, object[] parameters) : base(sql, parameters)
     {
@@ -100,22 +96,20 @@ internal class AdvancedSqlQueryHandler<T1, T2, T3>: AdvancedSqlQueryHandlerBase,
         return list;
     }
 
-    public async Task<IReadOnlyList<(T1, T2, T3)>> HandleAsync(DbDataReader reader, IMartenSession session,
-        CancellationToken token)
+    public override async IAsyncEnumerable<(T1, T2, T3)> EnumerateResults(DbDataReader reader,
+        [EnumeratorCancellation] CancellationToken token)
     {
-        var list = new List<(T1, T2, T3)>();
         while (await reader.ReadAsync(token).ConfigureAwait(false))
         {
             var item1 = await ReadNestedRowAsync<T1>(reader, 0, token).ConfigureAwait(false);
             var item2 = await ReadNestedRowAsync<T2>(reader, 1, token).ConfigureAwait(false);
             var item3 = await ReadNestedRowAsync<T3>(reader, 2, token).ConfigureAwait(false);
-            list.Add((item1, item2, item3));
+            yield return (item1, item2, item3);
         }
-        return list;
     }
 }
 
-internal class AdvancedSqlQueryHandlerBase
+internal abstract class AdvancedSqlQueryHandlerBase<TResult>
 {
     protected readonly object[] Parameters;
     protected readonly string Sql;
@@ -225,4 +219,18 @@ internal class AdvancedSqlQueryHandlerBase
     {
         throw new NotImplementedException();
     }
+
+    public async Task<IReadOnlyList<TResult>> HandleAsync(DbDataReader reader, IMartenSession session,
+        CancellationToken token)
+    {
+        var list = new List<TResult>();
+        await foreach (var result in EnumerateResults(reader, token).ConfigureAwait(false))
+        {
+            list.Add(result);
+        }
+
+        return list;
+    }
+
+    public abstract IAsyncEnumerable<TResult> EnumerateResults(DbDataReader reader, CancellationToken token);
 }


### PR DESCRIPTION
There's now a new interface on IAdvancedSql that wraps all advanced sql query methods and adds new methods to stream the results via IAsyncEnumrable.

The old AdvancedSql*-methods are marked as obsolete and delegate to the new methods.

The new AdavancedSql methods are implemented as explicit interface implementations on the QuerySession class as a separate partial class. The alternative would be to make IQuerySession.Advanced return a separate implementation of IAdvancedSql. Let me know, if you prefer this and I will change the PR.