### PR TITLE
fix: Tenanted bulk loading should consider tenant id as part of document identity

### DIFF
--- a/src/Marten/Internal/CodeGeneration/BulkLoader.cs
+++ b/src/Marten/Internal/CodeGeneration/BulkLoader.cs
@@ -69,7 +69,7 @@ public abstract class BulkLoader<T, TId>: IBulkLoader<T>
         IEnumerable<T> documents,
         CancellationToken cancellation)
     {
-        await using var writer = conn.BeginBinaryImport(TempLoaderSql());
+        await using var writer = await conn.BeginBinaryImportAsync(TempLoaderSql(), cancellation).ConfigureAwait(false);
         foreach (var document in documents)
         {
             await writer.StartRowAsync(cancellation).ConfigureAwait(false);


### PR DESCRIPTION
This fixes 2 issues:

- A massive performance issue where not joining or updating on tenant id meant that no index could be used
- The bug where if the same Id exists in multiple tenants then an update would happen instead of an insert.

Also has a small tweak to calling binay import to use the async method where appropriate.