### PR TITLE
Fix event load exceptions causing rebuilds to finish early

### DIFF
--- a/src/Marten/Events/Daemon/Internals/EventPage.cs
+++ b/src/Marten/Events/Daemon/Internals/EventPage.cs
@@ -13,9 +13,9 @@ public class EventPage: List<IEvent>
     public long Floor { get; }
     public long Ceiling { get; private set; }
 
-    public void CalculateCeiling(int batchSize, long highWaterMark)
+    public void CalculateCeiling(int batchSize, long highWaterMark, int skippedEvents)
     {
-        Ceiling = Count == batchSize
+        Ceiling = (Count + skippedEvents) == batchSize
             ? this.Last().Sequence
             : highWaterMark;
     }

--- a/src/Marten/Events/Daemon/Internals/EventPage.cs
+++ b/src/Marten/Events/Daemon/Internals/EventPage.cs
@@ -13,7 +13,7 @@ public class EventPage: List<IEvent>
     public long Floor { get; }
     public long Ceiling { get; private set; }
 
-    public void CalculateCeiling(int batchSize, long highWaterMark, int skippedEvents)
+    public void CalculateCeiling(int batchSize, long highWaterMark, int skippedEvents = 0)
     {
         Ceiling = (Count + skippedEvents) == batchSize
             ? this.Last().Sequence

--- a/src/Marten/Events/Daemon/Internals/SubscriptionAgent.cs
+++ b/src/Marten/Events/Daemon/Internals/SubscriptionAgent.cs
@@ -157,7 +157,7 @@ public class SubscriptionAgent: ISubscriptionAgent, IAsyncDisposable
     public async Task ReplayAsync(SubscriptionExecutionRequest request, long highWaterMark, TimeSpan timeout)
     {
         Mode = ShardExecutionMode.Rebuild;
-        _rebuild = new TaskCompletionSource();
+        _rebuild = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         _execution.Mode = ShardExecutionMode.Rebuild;
         ErrorOptions = request.ErrorHandling;
         _runtime = request.Runtime;

--- a/src/Marten/Events/Daemon/ProjectionDaemon.cs
+++ b/src/Marten/Events/Daemon/ProjectionDaemon.cs
@@ -130,7 +130,7 @@ public partial class ProjectionDaemon : IProjectionDaemon, IObserver<ShardState>
             // Ensure that the agent is stopped if it is already running
             await stopIfRunningAsync(agent.Name.Identity).ConfigureAwait(false);
 
-            var errorOptions = _store.Options.Projections.Errors;
+            var errorOptions = _store.Options.Projections.RebuildErrors;
 
             var request = new SubscriptionExecutionRequest(0, ShardExecutionMode.Rebuild, errorOptions, this);
             await agent.ReplayAsync(request, highWaterMark, shardTimeout).ConfigureAwait(false);


### PR DESCRIPTION
I ran into this today when I updated a minor version of nodatime and had half my entities disappear. Turns out an exception was being thrown during deserialization and it was causing the ceiling calculation to skip everything after the exception. Not fun.