### PR TITLE
Add event projection failure scenario when using "Update"

### DIFF
--- a/src/Daemon.StressTest/Daemon.StressTest.csproj
+++ b/src/Daemon.StressTest/Daemon.StressTest.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <UserSecretsId>dotnet-Daemon.StressTest-410047a1-795c-4829-a878-448e39dc2086</UserSecretsId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
+        <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+        <PackageReference Include="Serilog.Sinks.Async" Version="2.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Marten\Marten.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/Daemon.StressTest/Program.cs
+++ b/src/Daemon.StressTest/Program.cs
@@ -1,0 +1,44 @@
+using Daemon.StressTest;
+using JasperFx.CodeGeneration;
+using Marten;
+using Marten.Events.Daemon.Resiliency;
+using Marten.Events.Projections;
+using Serilog;
+using Serilog.Events;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+var logger = new LoggerConfiguration()
+    .MinimumLevel.Information()
+    .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+    .MinimumLevel.Override("Microsoft.Extensions.Http", LogEventLevel.Warning)
+    .MinimumLevel.Override("Npgsql.Command", LogEventLevel.Warning)
+    .Enrich.FromLogContext()
+    .WriteTo.Async(a => a.Console());
+
+builder.Services.AddSerilog(logger.CreateLogger());
+
+builder.Services.AddMarten(c =>
+{
+    c.CreateDatabasesForTenants(t => t
+        .ForTenant()
+        .CheckAgainstPgDatabase());
+
+    c.Connection("");
+    c.UseNewtonsoftForSerialization();
+
+    c.Projections.Add<StressedEventProjection>(ProjectionLifecycle.Async);
+
+    c.Policies.AllDocumentsAreMultiTenanted();
+
+    c.GeneratedCodeMode = TypeLoadMode.Auto;
+    c.SourceCodeWritingEnabled = true;
+
+}).AddAsyncDaemon(DaemonMode.Solo)
+.ApplyAllDatabaseChangesOnStartup();
+
+
+builder.Services.AddHostedService<Worker>();
+
+var host = builder.Build();
+host.Run();

--- a/src/Daemon.StressTest/Properties/launchSettings.json
+++ b/src/Daemon.StressTest/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Daemon.StressTest": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Daemon.StressTest/StressedEventProjection.cs
+++ b/src/Daemon.StressTest/StressedEventProjection.cs
@@ -1,0 +1,37 @@
+﻿using Marten;
+using Marten.Events;
+using Marten.Events.Projections;
+
+namespace Daemon.StressTest;
+
+public class StressedEventProjection : EventProjection
+{
+    public StressedEventProjection()
+    {
+        Options.EnableDocumentTrackingByIdentity = true;
+
+        Options.DeleteViewTypeOnTeardown(typeof(EventProjectionDocument));
+    }
+
+    public EventProjectionDocument Create(IEvent<CreateEventProjectionEvent> @event, IDocumentOperations ops)
+    {
+         return new EventProjectionDocument(@event.Data.Id, "RandomStuff");
+    }
+
+    public async Task Project(IEvent<UpdateEventProjectionEvent> @event, IDocumentOperations ops)
+    {
+        var doc = await ops.LoadAsync<EventProjectionDocument>(@event.Data.Id);
+
+        var updated = doc with { Stuff = "RandomStuff2" };
+
+        ops.Update(updated);
+    }
+}
+
+
+
+public record CreateEventProjectionEvent(Guid Id);
+
+public record UpdateEventProjectionEvent(Guid Id);
+
+public record EventProjectionDocument(Guid Id, string Stuff);

--- a/src/Daemon.StressTest/Worker.cs
+++ b/src/Daemon.StressTest/Worker.cs
@@ -1,0 +1,37 @@
+using Marten;
+
+namespace Daemon.StressTest;
+
+public class Worker: BackgroundService
+{
+    private readonly ILogger<Worker> _logger;
+    private readonly IDocumentStore _store;
+
+    public Worker(ILogger<Worker> logger, IDocumentStore store)
+    {
+        _logger = logger;
+        _store = store;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await _store.Advanced.Clean.DeleteAllEventDataAsync();
+        await _store.Advanced.Clean.DeleteAllDocumentsAsync();
+        await Task.Delay(3000);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await using var session = _store.OpenSession($"tenant{Random.Shared.Next(1, 10)}");
+
+            var id = Guid.NewGuid();
+
+            session.Events.StartStream(id, new CreateEventProjectionEvent(id), new UpdateEventProjectionEvent(id));
+
+            await session.SaveChangesAsync();
+
+            _logger.LogInformation("Appended Events with StreamID: {streamId}", id);
+
+            await Task.Delay(100, stoppingToken);
+        }
+    }
+}

--- a/src/Marten.sln
+++ b/src/Marten.sln
@@ -112,6 +112,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ValueTypeTests", "ValueType
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpTypes", "FSharpTypes\FSharpTypes.fsproj", "{B1F935FC-55DC-418B-A5DC-6049A5C06871}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Daemon.StressTest", "Daemon.StressTest\Daemon.StressTest.csproj", "{34ACE7DA-6034-465F-A281-93A872E5E160}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -270,6 +272,10 @@ Global
 		{B1F935FC-55DC-418B-A5DC-6049A5C06871}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B1F935FC-55DC-418B-A5DC-6049A5C06871}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B1F935FC-55DC-418B-A5DC-6049A5C06871}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34ACE7DA-6034-465F-A281-93A872E5E160}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34ACE7DA-6034-465F-A281-93A872E5E160}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34ACE7DA-6034-465F-A281-93A872E5E160}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34ACE7DA-6034-465F-A281-93A872E5E160}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Marten/Internal/Operations/StorageOperation.cs
+++ b/src/Marten/Internal/Operations/StorageOperation.cs
@@ -280,4 +280,9 @@ public abstract class StorageOperation<T, TId>: IDocumentStorageOperation, IExce
             parameter.Value = session.Serializer.ToJson(session.Headers);
         }
     }
+
+    public override string ToString()
+    {
+        return $"{_id}";
+    }
 }


### PR DESCRIPTION
Unsure if this is related to community reported issues, but whilst building out a potential reproduction I ran into this. `ops.Store` works fine but `ops.Update` fails. The observations I've made is that the operations & batch execution appear in the correct order. The last operation in a batch ends up throwing a `Marten.Exceptions.NonExistentDocumentException`