### PR TITLE
Avoid wasted db round trips by not loading single stream projections for new streams

### DIFF
--- a/src/Marten/Events/Aggregation/AggregationRuntime.cs
+++ b/src/Marten/Events/Aggregation/AggregationRuntime.cs
@@ -67,7 +67,8 @@ public abstract class AggregationRuntime<TDoc, TId>: IAggregationRuntime<TDoc, T
         }
 
         var aggregate = slice.Aggregate;
-        if (slice.Aggregate == null && lifecycle == ProjectionLifecycle.Inline)
+        // do not load if sliced by stream and the stream does not yet exist
+        if (slice.Aggregate == null && lifecycle == ProjectionLifecycle.Inline && (Slicer is not ISingleStreamSlicer || slice.ActionType != StreamActionType.Start))
         {
             aggregate = await Storage.LoadAsync(slice.Id, session, cancellation).ConfigureAwait(false);
         }

--- a/src/Marten/Events/Aggregation/ByStreamId.cs
+++ b/src/Marten/Events/Aggregation/ByStreamId.cs
@@ -22,7 +22,7 @@ public class ByStreamId<TDoc>: IEventSlicer<TDoc, Guid>, ISingleStreamSlicer
         return new ValueTask<IReadOnlyList<EventSlice<TDoc, Guid>>>(streams.Select(s =>
         {
             var tenant = new Tenant(s.TenantId, querySession.Database);
-            return new EventSlice<TDoc, Guid>(s.Id, tenant, s.Events);
+            return new EventSlice<TDoc, Guid>(s.Id, tenant, s.Events){ActionType = s.ActionType};
         }).ToList());
     }
 

--- a/src/Marten/Events/Aggregation/ByStreamKey.cs
+++ b/src/Marten/Events/Aggregation/ByStreamKey.cs
@@ -19,7 +19,7 @@ public class ByStreamKey<TDoc>: IEventSlicer<TDoc, string>, ISingleStreamSlicer
         return new ValueTask<IReadOnlyList<EventSlice<TDoc, string>>>(streams.Select(s =>
         {
             var tenant = new Tenant(s.TenantId, querySession.Database);
-            return new EventSlice<TDoc, string>(s.Key!, tenant, s.Events);
+            return new EventSlice<TDoc, string>(s.Key!, tenant, s.Events){ActionType = s.ActionType};
         }).ToList());
     }
 

--- a/src/Marten/Events/Aggregation/EventSlice.cs
+++ b/src/Marten/Events/Aggregation/EventSlice.cs
@@ -38,12 +38,22 @@ public class EventSlice<TDoc, TId>: IEventSlice, IComparer<IEvent>
     {
     }
 
+    private readonly StreamActionType? _actionType;
+
     /// <summary>
     ///     Is this action the start of a new stream or appending
     ///     to an existing stream?
     /// </summary>
-    public StreamActionType ActionType => _events[0].Version == 1 ? StreamActionType.Start : StreamActionType.Append;
-
+    /// <remarks>
+    ///     Default's to determining from the version of the first event on
+    ///     stream, but can be overridden so that the value works with
+    ///     QuickAppend
+    /// </remarks>
+    public StreamActionType ActionType
+    {
+        get => _actionType ?? (_events[0].Version == 1 ? StreamActionType.Start : StreamActionType.Append);
+        init => _actionType = value;
+    }
 
     /// <summary>
     ///     The aggregate identity


### PR DESCRIPTION
Found as part of https://github.com/JasperFx/marten/issues/3307, if you start 1000 streams and have 1 inline projection, then there will be 1000 calls to fetch the current inline projection, one for each stream. By testing if the slicer is for single streams and the sliced events represent the start of a stream, we can eliminate these calls.