### PR TITLE
Create temp table for bulk loading with "LIKE" clause

### DIFF
--- a/src/DocumentDbTests/Writing/bulk_loading.cs
+++ b/src/DocumentDbTests/Writing/bulk_loading.cs
@@ -598,6 +598,24 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         }
     }
 
+    [Fact]
+    public async Task can_bulk_insert_soft_deletable_documents_when_using_overwrite_mode()
+    {
+        StoreOptions(x => x.Schema.For<User>().SoftDeletedWithIndex());
+
+        var doc1 = new User();
+        var doc2 = new User();
+
+        var documents = new object[] { doc1, doc2 };
+
+        await theStore.BulkInsertAsync(documents, BulkInsertMode.OverwriteExisting);
+
+        await using (var querying = theStore.QuerySession())
+        {
+            querying.Query<User>().Count().ShouldBe(2);
+        }
+    }
+
     public Task InitializeAsync()
     {
         return theStore.Advanced.Clean.DeleteAllDocumentsAsync();

--- a/src/Marten/Internal/CodeGeneration/BulkLoaderBuilder.cs
+++ b/src/Marten/Internal/CodeGeneration/BulkLoaderBuilder.cs
@@ -122,6 +122,6 @@ public class BulkLoaderBuilder
 
     public string CreateTempTableForCopying()
     {
-        return $"create temporary table {_tempTable} as select * from {_mapping.TableName.QualifiedName} limit 0";
+        return $"create temporary table {_tempTable} (like {_mapping.TableName.QualifiedName} including defaults)";
     }
 }


### PR DESCRIPTION
Using "LIKE" and "INCLUDING DEFAULTS" is required to e.g. set mt_deleted to the default falue FALSE, otherwise it will be set to NULL.