### PR TITLE
Prevent accidental usage of generic Add for live projections

### DIFF
--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -332,6 +332,11 @@ public class ProjectionOptions: DaemonSettings
     )
         where TProjection : GeneratedProjection, new()
     {
+        if (lifecycle == ProjectionLifecycle.Live)
+        {
+            throw new InvalidOperationException("The generic overload of Add does not support Live projections, please use the non-generic overload.");
+        }
+
         var projection = new TProjection { Lifecycle = lifecycle };
 
         asyncConfiguration?.Invoke(projection.Options);


### PR DESCRIPTION
We need the non-generic version to be used to disable schema generation for the type