### PR TITLE
Update 'Cross-Stream Projections' to 'Multi-Stream Projections'

### DIFF
--- a/docs/events/projections/aggregate-projections.md
+++ b/docs/events/projections/aggregate-projections.md
@@ -127,7 +127,7 @@ projection class. It's completely up to your preference to decide which to use.
 
 Alternatively, if your aggregate will never be deleted you can use a stream aggregation as explained in the last section of this page.
 
-To create aggregate projections that include events in multiple streams, see [Cross-Stream Projections](/events/projections/multi-stream-projections).
+To create aggregate projections that include events in multiple streams, see [Multi-Stream Projections](/events/projections/multi-stream-projections).
 
 ## Aggregate Creation
 


### PR DESCRIPTION
Updates the documentation so that it says 'Multi-Stream Projections' instead of 'Cross-Stream Projections'. 

The page and document that the user is redirected when clicking on 'Cross-Stream Projections' is actually 'Multi-Stream Projections'. The same page is present in other redirects with the proper name.