### PR TITLE
fix await with polly

### DIFF
--- a/src/Marten/Internal/Sessions/QuerySession.Execution.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Execution.cs
@@ -29,7 +29,7 @@ public partial class QuerySession
     public Task<int> ExecuteAsync(NpgsqlCommand command, CancellationToken token = new())
     {
         RequestCount++;
-        return _resilience.Execute(static (e, t) => e.Lifetime.ExecuteAsync(e.Command, t), new CommandExecution(command, _connection), token);
+        return _resilience.ExecuteAsync(static (e, t) => new ValueTask<int>(e.Lifetime.ExecuteAsync(e.Command, t)), new CommandExecution(command, _connection), token).AsTask();
     }
 
     public DbDataReader ExecuteReader(NpgsqlCommand command)
@@ -41,7 +41,7 @@ public partial class QuerySession
     public Task<DbDataReader> ExecuteReaderAsync(NpgsqlCommand command, CancellationToken token = default)
     {
         RequestCount++;
-        return _resilience.Execute(static (e, t) => e.Lifetime.ExecuteReaderAsync(e.Command, t), new CommandExecution(command, _connection), token);
+        return _resilience.ExecuteAsync(static (e, t) => new ValueTask<DbDataReader>(e.Lifetime.ExecuteReaderAsync(e.Command, t)), new CommandExecution(command, _connection), token).AsTask();
     }
 
     internal record BatchExecution(NpgsqlBatch Batch, IConnectionLifetime Lifetime);
@@ -55,7 +55,7 @@ public partial class QuerySession
     public Task<DbDataReader> ExecuteReaderAsync(NpgsqlBatch batch, CancellationToken token = default)
     {
         RequestCount++;
-        return _resilience.Execute(static (e, t) => e.Lifetime.ExecuteReaderAsync(e.Batch, t), new BatchExecution(batch, _connection), token);
+        return _resilience.ExecuteAsync(static (e, t) => new ValueTask<DbDataReader>(e.Lifetime.ExecuteReaderAsync(e.Batch, t)), new BatchExecution(batch, _connection), token).AsTask();
     }
 
     internal T? LoadOne<T>(NpgsqlCommand command, ISelector<T> selector)


### PR DESCRIPTION
This PR is related to this issue: https://github.com/JasperFx/marten/issues/3375. Please see my issue for a repro of the issue.

I was having issues that polly wasn't retrying, even though it appeared that the retry policy was being used. 

So I did some tracing. It turned out that the policy returned successfully. Which is weird, because my query was failing. 

I also noticed that the catch block in the linq provider (https://github.com/JasperFx/marten/blob/master/src/Marten/Linq/MartenLinqQueryProvider.cs#L131) wasn't being hit. 

this gave me the idea that we weren't awaiting in the right place. Turns out that was the case.

The resilience pipeline wasn't using async, which meant that it was successfully building a Task, not awaiting said task.

Could you point me to a good place where I can add a good unit test for this?

Thanks!