### PR TITLE
Allow id to have a foreign key reference

### DIFF
--- a/src/DocumentDbTests/ForeignKeys/configuring_foreign_key_fields.cs
+++ b/src/DocumentDbTests/ForeignKeys/configuring_foreign_key_fields.cs
@@ -62,7 +62,7 @@ public class configuring_foreign_key_fields : OneOffConfigurationsContext
         store.StorageFeatures.MappingFor(typeof(FooExtra))
             .As<DocumentMapping>()
             .ForeignKeys
-            .ShouldContain(x => x.ColumnNames[0] == "foo_id");
+            .ShouldContain(x => x.ColumnNames[0] == "id");
     }
 
     #region sample_issue-with-fk-attribute

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -587,9 +587,16 @@ public class DocumentMapping: IDocumentMapping, IDocumentType
         var referenceMapping =
             referenceType != DocumentType ? StoreOptions.Storage.MappingFor(referenceType) : this;
 
-        var duplicateField = DuplicateField(members);
-
-        var foreignKey = new DocumentForeignKey(duplicateField.ColumnName, this, referenceMapping);
+        DocumentForeignKey foreignKey;
+        if (members.Contains(IdMember))
+        {
+            foreignKey = new DocumentForeignKey("id", this, referenceMapping);
+        }
+        else
+        {
+            var duplicateField = DuplicateField(members);
+            foreignKey = new DocumentForeignKey(duplicateField.ColumnName, this, referenceMapping);
+        }
         ForeignKeys.Add(foreignKey);
 
         return foreignKey;


### PR DESCRIPTION
This only requires to NOT create a duplicate field, because there already is an id column.

I think this is very usable when having a 1:1 relationship between different document types.