### PR TITLE
docs: Clarify warning about metadata in inline projections

### DIFF
--- a/docs/events/projections/index.md
+++ b/docs/events/projections/index.md
@@ -91,6 +91,8 @@ There is also a matching asynchronous `AggregateStreamAsync()` mechanism as well
 
 ## Inline Projections
 
+_First off, be aware that some event metadata (`IEvent.Version` and `IEvent.Sequence`) is not available during the execution of inline projections when using the ["Quick" append mode](/events/appending). If you need to use this metadata in your projections, please use asynchronous or live projections, or use the "Rich" append mode._
+
 If you would prefer that the projected aggregate document be updated _inline_ with the events being appended, you simply need to register the aggregation type in the `StoreOptions` upfront when you build up your document store like this:
 
 <!-- snippet: sample_registering-quest-party -->

--- a/docs/events/projections/index.md
+++ b/docs/events/projections/index.md
@@ -91,8 +91,6 @@ There is also a matching asynchronous `AggregateStreamAsync()` mechanism as well
 
 ## Inline Projections
 
-_First off, be aware that event metadata (e.g. stream version and sequence number) are not available during the execution of inline projections. If you need to use event metadata in your projections, please use asynchronous or live projections._
-
 If you would prefer that the projected aggregate document be updated _inline_ with the events being appended, you simply need to register the aggregation type in the `StoreOptions` upfront when you build up your document store like this:
 
 <!-- snippet: sample_registering-quest-party -->

--- a/documentation/documentation/events/projections/index.md
+++ b/documentation/documentation/events/projections/index.md
@@ -80,8 +80,6 @@ There is also a matching asynchronous `AggregateStreamAsync()` mechanism as well
 
 ## Inline Projections
 
-_First off, be aware that event metadata (e.g. stream version and sequence number) are not available duing the execution of inline projections. If you need to use event metadata in your projections, please use asynchronous or live projections._
-
 If you would prefer that the projected aggregate document be updated _inline_ with the events being appended, you simply need to register the aggregation type in the `StoreOptions` upfront when you build up your document store like this:
 
 <[sample:registering-quest-party]>

--- a/documentation/documentation/events/projections/index.md
+++ b/documentation/documentation/events/projections/index.md
@@ -80,6 +80,8 @@ There is also a matching asynchronous `AggregateStreamAsync()` mechanism as well
 
 ## Inline Projections
 
+_First off, be aware that some event metadata (`IEvent.Version` and `IEvent.Sequence`) is not available during the execution of inline projections when using the ["Quick" append mode](/events/appending). If you need to use this metadata in your projections, please use asynchronous or live projections, or use the "Rich" append mode._
+
 If you would prefer that the projected aggregate document be updated _inline_ with the events being appended, you simply need to register the aggregation type in the `StoreOptions` upfront when you build up your document store like this:
 
 <[sample:registering-quest-party]>


### PR DESCRIPTION
This limitation no longer applies, according to https://github.com/JasperFx/marten/discussions/3431#discussioncomment-10726662