### PR TITLE
Changed accessibility of some IQueryableMember implementations

### DIFF
--- a/src/Marten/Linq/Members/ChildCollectionMember.cs
+++ b/src/Marten/Linq/Members/ChildCollectionMember.cs
@@ -17,7 +17,7 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Members;
 
-internal class ChildCollectionMember: QueryableMember, ICollectionMember, IQueryableMemberCollection
+public class ChildCollectionMember: QueryableMember, ICollectionMember, IQueryableMemberCollection
 {
     private readonly IQueryableMember _count;
     private readonly StoreOptions _options;

--- a/src/Marten/Linq/Members/ValueCollections/SelectManyValueCollection.cs
+++ b/src/Marten/Linq/Members/ValueCollections/SelectManyValueCollection.cs
@@ -10,7 +10,7 @@ namespace Marten.Linq.Members.ValueCollections;
 /// This takes the place of the ValueCollectionMember when this member
 /// is used inside of a SelectMany() clause
 /// </summary>
-internal class SelectManyValueCollection: IValueCollectionMember
+public class SelectManyValueCollection: IValueCollectionMember
 {
     private readonly StoreOptions _options;
     private readonly RootMember _root;

--- a/src/Marten/Linq/Members/ValueCollections/SimpleElementMember.cs
+++ b/src/Marten/Linq/Members/ValueCollections/SimpleElementMember.cs
@@ -10,7 +10,7 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Members.ValueCollections;
 
-internal class SimpleElementMember: IQueryableMember, IComparableMember
+public class SimpleElementMember: IQueryableMember, IComparableMember
 {
     public SimpleElementMember(Type memberType, string pgType)
     {

--- a/src/Marten/Linq/Members/ValueCollections/ValueCollectionMember.cs
+++ b/src/Marten/Linq/Members/ValueCollections/ValueCollectionMember.cs
@@ -18,7 +18,7 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Members.ValueCollections;
 
-internal class ValueCollectionMember: QueryableMember, ICollectionMember, IValueCollectionMember, ISelectableMember
+public class ValueCollectionMember: QueryableMember, ICollectionMember, IValueCollectionMember, ISelectableMember
 {
     private readonly IQueryableMember _count;
     private readonly WholeDataMember _wholeDataMember;


### PR DESCRIPTION
Changed accessibility of some IQueryableMember implementations to make it easier for users to create bespoke implementations by inheriting from them. Lays the ground work for F# DU linq querying support. 

When i'm done, i will first experiment my implementation on my side for a couple of weeks to ensure the workflow is convenient and battle-tested before upstreaming it back to Marten.