### PR TITLE
Extend comment for Aggregate projections async code example - remind devs to start async daemon 

### DIFF
--- a/docs/events/projections/aggregate-projections.md
+++ b/docs/events/projections/aggregate-projections.md
@@ -104,6 +104,10 @@ public class TripProjection: SingleStreamProjection<Trip>
 
 And register that projection like this:
 
+::: tip
+Remember to start the Async Daemon when using async projections, see [Asynchronous Projections Daemon](/events/projections/async-daemon.html)
+:::
+
 <!-- snippet: sample_registering_an_aggregate_projection -->
 <a id='snippet-sample_registering_an_aggregate_projection'></a>
 ```cs


### PR DESCRIPTION
TLDR; expanded the comment in the code to remind devs to start the Asyn Daemon when using async projection.

In the code example for aggregate projections an example is given using an Asynchronous projection. The example given will not work out of the box as the Async Daemon is not started in the Marten bootstrap / config. 

I found this confusing and wasted an hour trying to debug when in fact I should have just read further to discover the Async Daemon is not enabled by default but ... DMMT (Don't make me think) . 

A simple additional comment to remind devs to read forward can fix this, unfortunately its not possible to add a hyperlink in a code block in GitHub markdown but the additional text in the comment should hopefully be enough to make a new Marten dev aware that something must be done to make async projections work.

