### PR TITLE
Fix StreamAction.AddEvent not assigning an Event.Id

### DIFF
--- a/src/EventSourcingTests/QuickAppend/quick_appending_events_workflow_specs.cs
+++ b/src/EventSourcingTests/QuickAppend/quick_appending_events_workflow_specs.cs
@@ -46,7 +46,7 @@ public class quick_appending_events_workflow_specs
             {
 
                 @event.TenantId.ShouldNotBeNull();
-                @event.Timestamp.ShouldNotBe(DateTime.MinValue);
+                @event.Timestamp.ShouldNotBe(DateTimeOffset.MinValue);
             }
 
             return Task.CompletedTask;

--- a/src/EventSourcingTests/appending_events_workflow_specs.cs
+++ b/src/EventSourcingTests/appending_events_workflow_specs.cs
@@ -48,7 +48,7 @@ public class appending_events_workflow_specs
             {
 
                 @event.TenantId.ShouldNotBeNull();
-                @event.Timestamp.ShouldNotBe(DateTime.MinValue);
+                @event.Timestamp.ShouldNotBe(DateTimeOffset.MinValue);
             }
 
             return Task.CompletedTask;

--- a/src/Marten/Events/Projections/EventSlice.cs
+++ b/src/Marten/Events/Projections/EventSlice.cs
@@ -229,7 +229,7 @@ public class EventSlice<TDoc, TId>: IEventSlice, IComparer<IEvent>, IEventSlice<
             e.EventTypeName = mapping.EventTypeName;
             e.TenantId = Tenant.TenantId;
             e.Timestamp = now;
-            e.Id = Guid.NewGuid();
+            // Dont assign e.Id so StreamAction.Append can auto assign a CombGuid
         }
 
         if (eventGraph.StreamIdentity == StreamIdentity.AsGuid)

--- a/src/Marten/Events/StreamAction.cs
+++ b/src/Marten/Events/StreamAction.cs
@@ -114,17 +114,11 @@ public class StreamAction
 
     internal StreamAction AddEvents(IReadOnlyList<IEvent> events)
     {
-        _events.AddRange(events);
+        _events.EnsureCapacity(_events.Count + events.Count);
 
         foreach (var @event in events)
         {
-            if (@event.Id == Guid.Empty)
-            {
-                @event.Id = CombGuidIdGeneration.NewGuid();
-            }
-
-            @event.StreamId = Id;
-            @event.StreamKey = Key;
+            AddEvent(@event);
         }
 
         return this;
@@ -132,6 +126,11 @@ public class StreamAction
 
     internal StreamAction AddEvent(IEvent @event)
     {
+        if (@event.Id == Guid.Empty)
+        {
+            @event.Id = CombGuidIdGeneration.NewGuid();
+        }
+
         @event.StreamId = Id;
         @event.StreamKey = Key;
 


### PR DESCRIPTION
I did a more detailed scan of where and when Event.Id might get assigned, and also stumbled upon `e.Id = Guid.NewGuid();` in `EventSlice.cs`.

I think this should use a CombGuid instead, just like all other cases, so I changed that as well.

This fixes issue #3533