### PR TITLE
Update docs to use ResetAllMartenDataAsync()

### DIFF
--- a/docs/schema/cleaning.md
+++ b/docs/schema/cleaning.md
@@ -69,7 +69,7 @@ public async Task clean_out_database_documents(IHost host)
 
 ## Reset all data
 
-Use `IDocumentStore.Advanced.ResetAllData()` to deletes all current document, event data and then (re)applies the configured initial data.
+Use `IDocumentStore.Advanced.ResetAllData()` to delete all current document and event data, and then (re)apply the configured initial data.
 
 <!-- snippet: sample_reset_all_data -->
 <a id='snippet-sample_reset_all_data'></a>
@@ -81,7 +81,7 @@ await theStore.Advanced.ResetAllData();
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/SessionMechanics/reset_all_data_usage.cs#L45-L49' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_reset_all_data' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Use `IHost.ResetAllMartenDataAsync()` to delete all current document, event data and then (re)applies the configured initial data from the `IHost` instance.
+Use `IHost.ResetAllMartenDataAsync()` to delete all current document and event data, restart the AsyncDaemon if it us running, and then (re)apply the configured initial data from the `IHost` instance.
 
 <!-- snippet: sample_reset_all_data_ihost -->
 <a id='snippet-sample_reset_all_data_ihost'></a>

--- a/docs/testing/integration.md
+++ b/docs/testing/integration.md
@@ -100,8 +100,9 @@ public abstract class IntegrationContext : IAsyncLifetime
      
     public async Task InitializeAsync()
     {
-        // Using Marten, wipe out all data and reset the state
-        await Store.Advanced.ResetAllData();
+        // Using Marten, wipe out all data and reset the state.
+        // Also restart the async daemon if in use.
+        await Host.ResetAllMartenDataAsync();
     }
  
     // This is required because of the IAsyncLifetime 


### PR DESCRIPTION
Store.Advanced.ResetAllData() is part of what you need to do for test initialization, but if you use the AsyncDaemon in your setup, all tests after the first one will timeout on Store.WaitForNonStaleProjectionDataAsync().

Quick couple line change to the documentation. Happy to iterate if this should be added to more places.