### PR TITLE
Made IScalarSelectClause public

### DIFF
--- a/src/Marten/Linq/SqlGeneration/IScalarSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/IScalarSelectClause.cs
@@ -1,7 +1,7 @@
 #nullable enable
 namespace Marten.Linq.SqlGeneration;
 
-internal interface IScalarSelectClause
+public interface IScalarSelectClause
 {
     string MemberName { get; }
     void ApplyOperator(string op);


### PR DESCRIPTION
Made IScalarSelectClause.cs public to allow to define custom IValueTypeMember implementations. Required to implement IValueTypeMember.BuildSelectClause(fromObject).