### PR TITLE
public AggregatorFor method

### DIFF
--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -430,7 +430,7 @@ public class ProjectionOptions: DaemonSettings
         return All.Any() || _subscriptions.Any();
     }
 
-    internal ILiveAggregator<T> AggregatorFor<T>() where T : class
+    public ILiveAggregator<T> AggregatorFor<T>() where T : class
     {
         if (_liveAggregators.TryFind(typeof(T), out var aggregator))
         {


### PR DESCRIPTION
Made AggregatorFor<T> public in order to be able to fetch generated live aggregations of projections from codegen.

I made this in relation to a person project of mine where I would like to fetch data for multiple streams live at the same time.

The flow I wish to achieve is for live aggregation of streams on top of snapshots with multiple streams.
This is to enable being able perform a predicate on the snapshot with async lifecycle.
Afterwards fetching the rest of these streams live to ensure 100% up to date view.
Then applying the predicate once again to ensure no false results in the query.

This ofcause has a flaw of not fetching all streams in the inital query, thereby not get the entire result. But that is acceptable in the scenario I have.