### PR TITLE
Fixes #3597: InvalidCastException in FetchForWriting

### DIFF
--- a/src/Marten/Events/Fetching/FetchInlinedPlan.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.cs
@@ -100,7 +100,7 @@ internal class FetchInlinedPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> where
         IDocumentStorage<TDoc, TId> storage = null;
         if (session.Options.Events.UseIdentityMapForAggregates)
         {
-            storage = (IDocumentStorage<TDoc, TId>)session.Options.Providers.StorageFor<TDoc>();
+            storage = session.Options.ResolveCorrectedDocumentStorage<TDoc, TId>(DocumentTracking.IdentityOnly);
             // Opt into the identity map mechanics for this aggregate type just in case
             // you're using a lightweight session
             session.UseIdentityMapFor<TDoc>();


### PR DESCRIPTION
**Fixes #3597: InvalidCastException in FetchForWriting**

This PR resolves #3597, where the `FetchForWriting<T>` (the overload accepting an expected version) would throw an `InvalidCastException` under the following conditions:
- The aggregate is Inline.
- `UseIdentityMapForAggregates = true`.

### Changes Made
- Fixed the bug in `FetchInlinedPlan.cs`.
- Added tests specifically for the bug.

### Testing
- [x] Initial tests run successfully.
- [x] Added tests for the bug.
- [x] Verified that all tests (new and existing) pass.

### Notes
- I only wrote tests for the `Guid` identifier case. Many of the existing tests target both `Guid` and `string` identifier aggregates. While my tests should cover the scenario effectively, I am happy to add tests for the `string` variants if needed. Let me know if this is required.
- I should note that many of the tests in the `StressTests` project failed, but they fail for me with or without my changes.

### Feedback
This is my first pull request, and I am eager to learn! If any changes are needed, I will address them promptly. Any additional feedback on the implementation or testing strategy is also welcome.
