### PR TITLE
Fix some issues with PostgreSQL not running with an english locale

### DIFF
--- a/src/CoreTests/adding_custom_schema_objects.cs
+++ b/src/CoreTests/adding_custom_schema_objects.cs
@@ -126,7 +126,7 @@ public class adding_custom_schema_objects: OneOffConfigurationsContext
         martenException.InnerException.ShouldNotBeNull();
         martenException.InnerException.As<PostgresException>().ShouldSatisfyAllConditions(
             e => e.SqlState.ShouldBe(PostgresErrorCodes.UndefinedFunction),
-            e => e.MessageText.ShouldBe("function unaccent(unknown) does not exist")
+            e => e.MessageText.ShouldContain("unaccent(unknown)")
         );
     }
 

--- a/src/DocumentDbTests/Indexes/UniqueIndexTests.cs
+++ b/src/DocumentDbTests/Indexes/UniqueIndexTests.cs
@@ -51,8 +51,6 @@ public class UniqueUser
 
 public class UniqueIndexTests: OneOffConfigurationsContext
 {
-    public const string UniqueSqlState = "23505";
-
     public UniqueIndexTests()
     {
         StoreOptions(opts =>
@@ -90,7 +88,7 @@ public class UniqueIndexTests: OneOffConfigurationsContext
         }
         catch (DocumentAlreadyExistsException exception)
         {
-            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
+            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(PostgresErrorCodes.UniqueViolation);
         }
     }
 
@@ -116,7 +114,7 @@ public class UniqueIndexTests: OneOffConfigurationsContext
         }
         catch (DocumentAlreadyExistsException exception)
         {
-            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
+            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(PostgresErrorCodes.UniqueViolation);
         }
     }
 
@@ -146,7 +144,7 @@ public class UniqueIndexTests: OneOffConfigurationsContext
         }
         catch (MartenCommandException exception)
         {
-            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
+            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(PostgresErrorCodes.UniqueViolation);
         }
     }
 
@@ -173,7 +171,7 @@ public class UniqueIndexTests: OneOffConfigurationsContext
         }
         catch (DocumentAlreadyExistsException exception)
         {
-            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
+            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(PostgresErrorCodes.UniqueViolation);
         }
     }
 }

--- a/src/DocumentDbTests/MultiTenancy/UniqueIndexMultiTenantTests.cs
+++ b/src/DocumentDbTests/MultiTenancy/UniqueIndexMultiTenantTests.cs
@@ -12,8 +12,6 @@ namespace DocumentDbTests.MultiTenancy;
 
 public class UniqueIndexMultiTenantTests: OneOffConfigurationsContext
 {
-    public const string UniqueSqlState = "23505";
-
     public class Project
     {
         public Project()
@@ -69,7 +67,7 @@ public class UniqueIndexMultiTenantTests: OneOffConfigurationsContext
         }
         catch (DocumentAlreadyExistsException exception)
         {
-            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
+            ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(PostgresErrorCodes.UniqueViolation);
         }
     }
 
@@ -100,7 +98,7 @@ public class UniqueIndexMultiTenantTests: OneOffConfigurationsContext
             }
             catch (DocumentAlreadyExistsException exception)
             {
-                ((PostgresException)exception.InnerException).SqlState.ShouldBe(UniqueSqlState);
+                ((PostgresException)exception.InnerException).SqlState.ShouldBe(PostgresErrorCodes.UniqueViolation);
             }
         }
 
@@ -124,7 +122,7 @@ public class UniqueIndexMultiTenantTests: OneOffConfigurationsContext
             }
             catch (DocumentAlreadyExistsException exception)
             {
-                ((PostgresException)exception.InnerException).SqlState.ShouldBe(UniqueSqlState);
+                ((PostgresException)exception.InnerException).SqlState.ShouldBe(PostgresErrorCodes.UniqueViolation);
             }
         }
     }
@@ -157,7 +155,7 @@ public class UniqueIndexMultiTenantTests: OneOffConfigurationsContext
             }
             catch (DocumentAlreadyExistsException exception)
             {
-                ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(UniqueSqlState);
+                ((PostgresException)exception.InnerException)?.SqlState.ShouldBe(PostgresErrorCodes.UniqueViolation);
             }
         }
 
@@ -181,7 +179,7 @@ public class UniqueIndexMultiTenantTests: OneOffConfigurationsContext
             }
             catch (DocumentAlreadyExistsException exception)
             {
-                ((PostgresException)exception.InnerException).SqlState.ShouldBe(UniqueSqlState);
+                ((PostgresException)exception.InnerException).SqlState.ShouldBe(PostgresErrorCodes.UniqueViolation);
             }
         }
     }

--- a/src/EventSourcingTests/EventStreamUnexpectedMaxEventIdExceptionTransformTest.cs
+++ b/src/EventSourcingTests/EventStreamUnexpectedMaxEventIdExceptionTransformTest.cs
@@ -38,7 +38,7 @@ public class EventStreamUnexpectedMaxEventIdExceptionTransformTest: IntegrationC
         };
 
         (await Should.ThrowAsync<EventStreamUnexpectedMaxEventIdException>(forceEventStreamUnexpectedMaxEventIdException))
-            .Message.ShouldBe("duplicate key value violates unique constraint \"pk_mt_events_stream_and_version\"");
+            .Message.ShouldContain("pk_mt_events_stream_and_version");
     }
 
     [Fact(Skip = "TODO -- too unreliable on CI")]

--- a/src/EventSourcingTests/EventStreamUnexpectedMaxEventIdExceptionTransformTest.cs
+++ b/src/EventSourcingTests/EventStreamUnexpectedMaxEventIdExceptionTransformTest.cs
@@ -15,7 +15,7 @@ public class EventStreamUnexpectedMaxEventIdExceptionTransformTest: IntegrationC
     {
     }
 
-    //[Fact] -- TODO -- too unreliable on CI
+    [Fact(Skip = "TODO -- too unreliable on CI")]
     public async Task throw_transformed_exception_with_details_redacted()
     {
         await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
@@ -41,7 +41,7 @@ public class EventStreamUnexpectedMaxEventIdExceptionTransformTest: IntegrationC
             .Message.ShouldBe("duplicate key value violates unique constraint \"pk_mt_events_stream_and_version\"");
     }
 
-    //[Fact] -- TODO -- too unreliable on CI
+    [Fact(Skip = "TODO -- too unreliable on CI")]
     public async Task throw_transformed_exception_with_details_available()
     {
         await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.cs
@@ -171,7 +171,7 @@ internal class FetchAsyncPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> where T
         }
         catch (Exception e)
         {
-            if (e.InnerException is NpgsqlException inner && inner.Message.Contains("current transaction is aborted"))
+            if (e.InnerException is NpgsqlException { SqlState: PostgresErrorCodes.InFailedSqlTransaction })
             {
                 throw new StreamLockedException(id, e.InnerException);
             }
@@ -278,7 +278,7 @@ internal class FetchAsyncPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> where T
         }
         catch (Exception e)
         {
-            if (e.InnerException is NpgsqlException inner && inner.Message.Contains("current transaction is aborted"))
+            if (e.InnerException is NpgsqlException { SqlState: PostgresErrorCodes.InFailedSqlTransaction })
             {
                 throw new StreamLockedException(id, e.InnerException);
             }

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.cs
@@ -80,7 +80,7 @@ internal class FetchInlinedPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> where
         }
         catch (Exception e)
         {
-            if (e.InnerException is NpgsqlException inner && inner.Message.Contains("current transaction is aborted"))
+            if (e.InnerException is NpgsqlException { SqlState: PostgresErrorCodes.InFailedSqlTransaction })
             {
                 throw new StreamLockedException(id, e.InnerException);
             }
@@ -154,7 +154,7 @@ internal class FetchInlinedPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> where
         }
         catch (Exception e)
         {
-            if (e.InnerException is NpgsqlException inner && inner.Message.Contains("current transaction is aborted"))
+            if (e.InnerException is NpgsqlException { SqlState: PostgresErrorCodes.InFailedSqlTransaction })
             {
                 throw new StreamLockedException(id, e.InnerException);
             }

--- a/src/Marten/Events/Fetching/FetchLivePlan.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.cs
@@ -77,7 +77,7 @@ internal class FetchLivePlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> where TD
         }
         catch (Exception e)
         {
-            if (e.InnerException is NpgsqlException inner && inner.Message.Contains("current transaction is aborted"))
+            if (e.InnerException is NpgsqlException { SqlState: PostgresErrorCodes.InFailedSqlTransaction })
             {
                 throw new StreamLockedException(id, e.InnerException);
             }
@@ -142,7 +142,7 @@ internal class FetchLivePlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> where TD
         }
         catch (Exception e)
         {
-            if (e.InnerException is NpgsqlException inner && inner.Message.Contains("current transaction is aborted"))
+            if (e.InnerException is NpgsqlException { SqlState: PostgresErrorCodes.InFailedSqlTransaction })
             {
                 throw new StreamLockedException(id, e.InnerException);
             }

--- a/src/Marten/Events/Operations/InsertStreamBase.cs
+++ b/src/Marten/Events/Operations/InsertStreamBase.cs
@@ -4,10 +4,12 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Exceptions;
+using Marten.Events.Schema;
 using Marten.Exceptions;
 using Marten.Internal;
 using Marten.Internal.Operations;
 using Marten.Services;
+using Npgsql;
 using Weasel.Postgresql;
 
 namespace Marten.Events.Operations;
@@ -47,8 +49,11 @@ public abstract class InsertStreamBase: IStorageOperation, IExceptionTransform, 
 
     private static bool matches(Exception e)
     {
-        return e.Message.Contains("23505: duplicate key value violates unique constraint") &&
-               e.Message.Contains("streams");
+        return e is PostgresException
+        {
+            SqlState: PostgresErrorCodes.UniqueViolation,
+            TableName: StreamsTable.TableName
+        };
     }
 
     public bool TryTransform(Exception original, out Exception transformed)

--- a/src/Marten/Internal/ProviderGraph.cs
+++ b/src/Marten/Internal/ProviderGraph.cs
@@ -85,7 +85,7 @@ public class ProviderGraph: IProviderGraph
                 }
                 catch (Exception e)
                 {
-                    if (e.Message.Contains("is inaccessible due to its protection level"))
+                    if (e is InvalidOperationException && !mapping.DocumentType.IsPublic)
                     {
                         throw new InvalidOperationException(
                             $"Requested document type '{mapping.DocumentType.FullNameInCode()}' must be scoped as 'public' in order to be used as a document type inside of Marten",

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -162,7 +162,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
         }
         catch (PostgresException e)
         {
-            if (!e.Message.Contains("does not exist"))
+            if (e.SqlState != PostgresErrorCodes.UndefinedTable)
             {
                 throw;
             }
@@ -178,7 +178,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
         }
         catch (PostgresException e)
         {
-            if (!e.Message.Contains("does not exist"))
+            if (e.SqlState != PostgresErrorCodes.UndefinedTable)
             {
                 throw;
             }

--- a/src/Marten/Services/EventStreamUnexpectedMaxEventIdExceptionTransform.cs
+++ b/src/Marten/Services/EventStreamUnexpectedMaxEventIdExceptionTransform.cs
@@ -9,12 +9,6 @@ namespace Marten.Services;
 
 internal class EventStreamUnexpectedMaxEventIdExceptionTransform: IExceptionTransform
 {
-    private const string ExpectedMessage =
-        "duplicate key value violates unique constraint \"pk_mt_events_stream_and_version\"";
-
-    private const string ExpectedMessageForArchivedStreamParitioning =
-        "duplicate key value violates unique constraint \"mt_events_default_stream_id_version_is_archived_idx\"";
-
     private const string DetailsRedactedMessage = "Detail redacted as it may contain sensitive data. " +
         "Specify 'Include Error Detail' in the connection string to include this information.";
 
@@ -22,7 +16,7 @@ internal class EventStreamUnexpectedMaxEventIdExceptionTransform: IExceptionTran
     private const string Version = "version";
 
     private static readonly Regex EventStreamUniqueExceptionDetailsRegex =
-        new(@"^Key \(stream_id, version\)=\((?<streamid>.*?), (?<version>\w+)\)");
+        new(@"\(stream_id, version\)=\((?<streamid>.*?), (?<version>\w+)\)");
 
     public bool TryTransform(Exception original, out Exception transformed)
     {
@@ -73,6 +67,6 @@ internal class EventStreamUnexpectedMaxEventIdExceptionTransform: IExceptionTran
     {
         return e is PostgresException pe
             && pe.SqlState == PostgresErrorCodes.UniqueViolation
-            && (pe.Message.Contains(ExpectedMessage) || pe.Message.Contains(ExpectedMessageForArchivedStreamParitioning));
+            && (pe.ConstraintName == "pk_mt_events_stream_and_version" || pe.ConstraintName == "mt_events_default_stream_id_version_is_archived_idx");
     }
 }


### PR DESCRIPTION
Instead of relying on exception messages, use SqlState, because exception messages might be language dependent.
