### PR TITLE
Add overload that allows a custom parameter placeholder.

### DIFF
--- a/docs/documents/execute-custom-sql.md
+++ b/docs/documents/execute-custom-sql.md
@@ -2,10 +2,10 @@
 
 Use `QueueSqlCommand(string sql, params object[] parameterValues)` method to register and execute any custom/arbitrary SQL commands with the underlying unit of work, as part of the batched commands within `IDocumentSession`. 
 
-`?` placeholders can be used to denote parameter values. Postgres [type casts `::`](https://www.postgresql.org/docs/15/sql-expressions.html#SQL-SYNTAX-TYPE-CASTS) can be applied to the parameter if needed.
+`?` placeholders can be used to denote parameter values. Postgres [type casts `::`](https://www.postgresql.org/docs/15/sql-expressions.html#SQL-SYNTAX-TYPE-CASTS) can be applied to the parameter if needed. If the `?` character is not suitable as a placeholder because you need to use `?` in your sql query, you can change the placeholder by providing an alternative. Pass this in before the sql argument. 
 
 <!-- snippet: sample_QueueSqlCommand -->
-<a id='snippet-sample_queuesqlcommand'></a>
+<a id='snippet-sample_QueueSqlCommand'></a>
 ```cs
 theSession.QueueSqlCommand("insert into names (name) values ('Jeremy')");
 theSession.QueueSqlCommand("insert into names (name) values ('Babu')");
@@ -14,6 +14,8 @@ theSession.QueueSqlCommand("insert into names (name) values ('Oskar')");
 theSession.Store(Target.Random());
 var json = "{ \"answer\": 42 }";
 theSession.QueueSqlCommand("insert into data (raw_value) values (?::jsonb)", json);
+// Use ^ as the parameter placeholder
+theSession.QueueSqlCommand('^', "insert into data (raw_value) values (^::jsonb)", json);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/executing_arbitrary_sql_as_part_of_transaction.cs#L39-L47' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_queuesqlcommand' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/executing_arbitrary_sql_as_part_of_transaction.cs#L39-L49' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_QueueSqlCommand' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/documents/querying/advanced-sql.md
+++ b/docs/documents/querying/advanced-sql.md
@@ -139,6 +139,19 @@ results[1].detail.Detail.ShouldBe("Likes to cook");
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/advanced_sql_query.cs#L101-L138' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_sql_query_related_documents_and_scalar' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+All `AdvancedSql` methods also support parameters:
+
+<!-- snippet: sample_document_schema_resolver_resolve_schemas -->
+<a id='snippet-sample_document_schema_resolver_resolve_schemas'></a>
+```cs
+var schema = theSession.DocumentStore.Options.Schema;
+
+schema.DatabaseSchemaName.ShouldBe("public");
+schema.EventsSchemaName.ShouldBe("public");
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/DocumentSchemaResolverTests.cs#L24-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_document_schema_resolver_resolve_schemas' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
 For sync queries you can use the `AdvancedSql.Query<T>(...)` overloads.
 
 When you need to query for large datasets, the `AdvancedSql.StreamAsync<>(...)` methods can be used. They will return
@@ -182,7 +195,7 @@ await foreach (var result in asyncEnumerable)
     collectedResults.Add(result);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/advanced_sql_query.cs#L145-L180' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_sql_stream_related_documents_and_scalar' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/advanced_sql_query.cs#L173-L208' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_sql_stream_related_documents_and_scalar' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Using this you can resolve schemas:

--- a/docs/documents/querying/linq/sql.md
+++ b/docs/documents/querying/linq/sql.md
@@ -21,16 +21,21 @@ public async Task query_with_matches_sql()
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/query_by_sql.cs#L267-L282' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_with_matches_sql' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-**But**, if you want to take advantage of the more recent and very powerful JSONPath style querying, use this flavor of 
-the same functionality that behaves exactly the same, but uses the '^' character for parameter placeholders to disambiguate
-from the '?' character that is widely used in JSONPath expressions:
+**But**, if you want to take advantage of the more recent and very powerful JSONPath style querying, you will find that using `?` as a placeholder is not suitable, as that character is widely used in JSONPath expressions.  If you encounter this issue or write another query where the `?` character is not suitable, you can change the placeholder by providing an alternative. Pass this in before the sql argument.
+
+Older version of Marten also offer the `MatchesJsonPath()` method which uses the `^` character as a placeholder. This will continue to be supported.
 
 <!-- snippet: sample_using_MatchesJsonPath -->
-<a id='snippet-sample_using_matchesjsonpath'></a>
+<a id='snippet-sample_using_MatchesJsonPath'></a>
 ```cs
 var results2 = await theSession
+    .Query<Target>().Where(x => x.MatchesSql('^', "d.data @? '$ ? (@.Children[*] == null || @.Children[*].size() == 0)'"))
+    .ToListAsync();
+
+// older approach that only supports the ^ placeholder
+var results3 = await theSession
     .Query<Target>().Where(x => x.MatchesJsonPath("d.data @? '$ ? (@.Children[*] == null || @.Children[*].size() == 0)'"))
     .ToListAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Bugs/Bug_3087_using_JsonPath_with_MatchesSql.cs#L28-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_matchesjsonpath' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Bugs/Bug_3087_using_JsonPath_with_MatchesSql.cs#L28-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_MatchesJsonPath' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/documents/querying/linq/sql.md
+++ b/docs/documents/querying/linq/sql.md
@@ -18,7 +18,7 @@ public async Task query_with_matches_sql()
     user.Id.ShouldBe(u.Id);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/query_by_sql.cs#L267-L282' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_with_matches_sql' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/query_by_sql.cs#L336-L351' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_with_matches_sql' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 **But**, if you want to take advantage of the more recent and very powerful JSONPath style querying, you will find that using `?` as a placeholder is not suitable, as that character is widely used in JSONPath expressions.  If you encounter this issue or write another query where the `?` character is not suitable, you can change the placeholder by providing an alternative. Pass this in before the sql argument.

--- a/docs/documents/querying/sql.md
+++ b/docs/documents/querying/sql.md
@@ -25,8 +25,12 @@ Or with parameterized SQL:
 ```cs
 var millers = session
     .Query<User>("where data ->> 'LastName' = ?", "Miller");
+
+// custom placeholder parameter
+var millers2 = await session
+    .QueryAsync<User>('$', "where data ->> 'LastName' = $", "Miller");
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/QueryBySql.cs#L20-L25' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_with_sql_and_parameters' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/QueryBySql.cs#L20-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_with_sql_and_parameters' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And finally asynchronously:
@@ -37,7 +41,7 @@ And finally asynchronously:
 var millers = await session
     .QueryAsync<User>("where data ->> 'LastName' = ?", "Miller");
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/QueryBySql.cs#L30-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_with_sql_async' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/QueryBySql.cs#L34-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_with_sql_async' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 All of the samples so far are selecting the whole `User` document and merely supplying

--- a/docs/documents/querying/sql.md
+++ b/docs/documents/querying/sql.md
@@ -54,7 +54,7 @@ a document body, but in that case you will need to supply the full SQL statement
 var sumResults = await session
     .QueryAsync<int>("select count(*) from mt_doc_target");
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/query_by_sql.cs#L376-L381' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_by_full_sql' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/query_by_sql.cs#L458-L463' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_by_full_sql' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 When querying single JSONB properties into a primitive/value type, you'll need to cast the value to the respective postgres type:
@@ -65,7 +65,7 @@ When querying single JSONB properties into a primitive/value type, you'll need t
 var times = await session.QueryAsync<DateTimeOffset>(
     "SELECT (data ->> 'ModifiedAt')::timestamptz from mt_doc_user");
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/query_by_sql.cs#L330-L335' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using-queryasync-casting' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/query_by_sql.cs#L412-L417' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using-queryasync-casting' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The basic rules for how Marten handles user-supplied queries are:

--- a/src/CoreTests/executing_arbitrary_sql_as_part_of_transaction.cs
+++ b/src/CoreTests/executing_arbitrary_sql_as_part_of_transaction.cs
@@ -44,6 +44,8 @@ public class executing_arbitrary_sql_as_part_of_transaction : OneOffConfiguratio
         theSession.Store(Target.Random());
         var json = "{ \"answer\": 42 }";
         theSession.QueueSqlCommand("insert into data (raw_value) values (?::jsonb)", json);
+        // Use ^ as the parameter placeholder
+        theSession.QueueSqlCommand('^', "insert into data (raw_value) values (^::jsonb)", json);
         #endregion
 
         await theSession.SaveChangesAsync();

--- a/src/DocumentDbTests/Reading/advanced_sql_query.cs
+++ b/src/DocumentDbTests/Reading/advanced_sql_query.cs
@@ -139,6 +139,34 @@ public class advanced_sql_query: IntegrationContext
     }
 
     [Fact]
+    public async Task can_query_with_parameters()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(new DocWithMeta { Id = 1, Name = "Max" });
+        await session.SaveChangesAsync();
+
+        #region sample_advanced_sql_query_parameters
+        var schema = session.DocumentStore.Options.Schema;
+
+        var name = (await session.AdvancedSql.QueryAsync<string>(
+            $"select data ->> ? from {schema.For<DocWithMeta>()} limit 1",
+            CancellationToken.None,
+            "Name")).First();
+
+        // Use ^ as the parameter placeholder
+        var name2 = (await session.AdvancedSql.QueryAsync<string>(
+            '^',
+            $"select data ->> ^ from {schema.For<DocWithMeta>()} limit 1",
+            CancellationToken.None,
+            "Name")).First();
+
+        #endregion
+
+        name.ShouldBe("Max");
+        name2.ShouldBe("Max");
+    }
+
+    [Fact]
     public async Task can_async_stream_multiple_documents_and_scalar()
     {
         await using var session = theStore.LightweightSession();

--- a/src/LinqTests/Bugs/Bug_3087_using_JsonPath_with_MatchesSql.cs
+++ b/src/LinqTests/Bugs/Bug_3087_using_JsonPath_with_MatchesSql.cs
@@ -28,6 +28,11 @@ public class Bug_3087_using_JsonPath_with_MatchesSql : BugIntegrationContext
         #region sample_using_MatchesJsonPath
 
         var results2 = await theSession
+            .Query<Target>().Where(x => x.MatchesSql('^', "d.data @? '$ ? (@.Children[*] == null || @.Children[*].size() == 0)'"))
+            .ToListAsync();
+
+        // older approach that only supports the ^ placeholder
+        var results3 = await theSession
             .Query<Target>().Where(x => x.MatchesJsonPath("d.data @? '$ ? (@.Children[*] == null || @.Children[*].size() == 0)'"))
             .ToListAsync();
 

--- a/src/Marten.Testing/Examples/QueryBySql.cs
+++ b/src/Marten.Testing/Examples/QueryBySql.cs
@@ -15,12 +15,16 @@ public class QueryBySql
         #endregion
     }
 
-    public void QueryWithParameters(IQuerySession session)
+    public async Task QueryWithParameters(IQuerySession session)
     {
         #region sample_query_with_sql_and_parameters
 
         var millers = session
             .Query<User>("where data ->> 'LastName' = ?", "Miller");
+
+        // custom placeholder parameter
+        var millers2 = await session
+            .QueryAsync<User>('$', "where data ->> 'LastName' = $", "Miller");
 
         #endregion
     }

--- a/src/Marten/Events/Projections/Flattened/CallUpsertFunctionFrame.cs
+++ b/src/Marten/Events/Projections/Flattened/CallUpsertFunctionFrame.cs
@@ -16,8 +16,12 @@ internal class CallUpsertFunctionFrame: MethodCall, IEventHandlingFrame
     private readonly DbObjectName _functionIdentifier;
     private readonly MemberInfo[] _members;
 
+    private static readonly MethodInfo QueueSqlMethod =
+        typeof(IDocumentOperations).GetMethod(nameof(IDocumentOperations.QueueSqlCommand),
+            [typeof(string), typeof(object[])])!;
+
     public CallUpsertFunctionFrame(Type eventType, DbObjectName functionIdentifier, List<IColumnMap> columnMaps,
-        MemberInfo[] members): base(typeof(IDocumentOperations), nameof(IDocumentOperations.QueueSqlCommand))
+        MemberInfo[] members): base(typeof(IDocumentOperations), QueueSqlMethod)
     {
         _functionIdentifier = functionIdentifier ?? throw new ArgumentNullException(nameof(functionIdentifier));
         _columnMaps = columnMaps;

--- a/src/Marten/Events/Projections/Flattened/DeleteRowFrame.cs
+++ b/src/Marten/Events/Projections/Flattened/DeleteRowFrame.cs
@@ -19,8 +19,12 @@ internal class DeleteRowFrame: MethodCall, IEventHandlingFrame
     private readonly Table _table;
     private Variable? _event;
 
+    private static readonly MethodInfo QueueSqlMethod =
+        typeof(IDocumentOperations).GetMethod(nameof(IDocumentOperations.QueueSqlCommand),
+            [typeof(string), typeof(object[])])!;
+
     public DeleteRowFrame(Table table, Type eventType, MemberInfo[] members): base(typeof(IDocumentOperations),
-        nameof(IDocumentOperations.QueueSqlCommand))
+        QueueSqlMethod)
     {
         if (!members.Any())
         {

--- a/src/Marten/IAdvancedSql.cs
+++ b/src/Marten/IAdvancedSql.cs
@@ -1,7 +1,9 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Marten.Internal.Sessions;
 
 namespace Marten;
 
@@ -19,6 +21,21 @@ public interface IAdvancedSql
     /// <param name="parameters"></param>
     /// <returns></returns>
     Task<IReadOnlyList<T>> QueryAsync<T>(string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameter can be a document class, a scalar or any JSON-serializable class.
+    ///     If the result is a document, the SQL must contain a select with the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     selected.
+    ///     Use <paramref name="placeholder"/> to specify a character that will be replaced by positional parameters.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<T>> QueryAsync<T>(char placeholder, string sql, CancellationToken token, params object[] parameters);
 
     /// <summary>
     ///     Asynchronously queries the document storage with the supplied SQL.
@@ -42,6 +59,23 @@ public interface IAdvancedSql
     ///     For document types, the row must contain the required fields in the correct order,
     ///     depending on the session type and the metadata the document might use, at least id and data must be
     ///     provided.
+    ///     Use <paramref name="placeholder"/> to specify a character that will be replaced by positional parameters.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<(T1, T2)>> QueryAsync<T1, T2>(char placeholder, string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
     /// </summary>
     /// <typeparam name="T1"></typeparam>
     /// <typeparam name="T2"></typeparam>
@@ -50,6 +84,24 @@ public interface IAdvancedSql
     /// <param name="parameters"></param>
     /// <returns></returns>
     Task<IReadOnlyList<(T1, T2, T3)>> QueryAsync<T1, T2, T3>(string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    ///     Use <paramref name="placeholder"/> to specify a character that will be replaced by positional parameters.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <typeparam name="T3"></typeparam>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<(T1, T2, T3)>> QueryAsync<T1, T2, T3>(char placeholder, string sql, CancellationToken token, params object[] parameters);
 
     /// <summary>
     ///     Asynchronously queries the document storage with the supplied SQL.
@@ -62,6 +114,7 @@ public interface IAdvancedSql
     /// <param name="sql"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
+    [Obsolete(QuerySession.SynchronousRemoval)]
     IReadOnlyList<T> Query<T>(string sql, params object[] parameters);
 
     /// <summary>
@@ -77,6 +130,7 @@ public interface IAdvancedSql
     /// <param name="sql"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
+    [Obsolete(QuerySession.SynchronousRemoval)]
     IReadOnlyList<(T1, T2)> Query<T1, T2>(string sql, params object[] parameters);
 
     /// <summary>
@@ -93,6 +147,7 @@ public interface IAdvancedSql
     /// <param name="sql"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
+    [Obsolete(QuerySession.SynchronousRemoval)]
     IReadOnlyList<(T1, T2, T3)> Query<T1, T2, T3>(string sql, params object[] parameters);
 
     /// <summary>
@@ -116,6 +171,22 @@ public interface IAdvancedSql
     ///     For document types, the row must contain the required fields in the correct order,
     ///     depending on the session type and the metadata the document might use, at least id and data must be
     ///     provided.
+    ///     Use <paramref name="placeholder"/> to specify a character that will be replaced by positional parameters.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns>An async enumerable iterating over the results</returns>
+    IAsyncEnumerable<T> StreamAsync<T>(char placeholder, string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
     /// </summary>
     /// <typeparam name="T1"></typeparam>
     /// <typeparam name="T2"></typeparam>
@@ -123,6 +194,23 @@ public interface IAdvancedSql
     /// <param name="parameters"></param>
     /// <returns>An async enumerable iterating over the list of result tuples</returns>
     IAsyncEnumerable<(T1, T2)> StreamAsync<T1, T2>(string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    ///     Use <paramref name="placeholder"/> to specify a character that will be replaced by positional parameters.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns>An async enumerable iterating over the list of result tuples</returns>
+    IAsyncEnumerable<(T1, T2)> StreamAsync<T1, T2>(char placeholder, string sql, CancellationToken token, params object[] parameters);
 
     /// <summary>
     ///     Asynchronously queries the document storage with the supplied SQL.
@@ -139,4 +227,22 @@ public interface IAdvancedSql
     /// <param name="parameters"></param>
     /// <returns>An async enumerable iterating over the list of result tuples</returns>
     IAsyncEnumerable<(T1, T2, T3)> StreamAsync<T1, T2, T3>(string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage with the supplied SQL.
+    ///     The type parameters can be any document class, scalar or JSON-serializable class.
+    ///     For each result type parameter, the SQL SELECT statement must contain a ROW.
+    ///     For document types, the row must contain the required fields in the correct order,
+    ///     depending on the session type and the metadata the document might use, at least id and data must be
+    ///     provided.
+    ///     Use <paramref name="placeholder"/> to specify a character that will be replaced by positional parameters.
+    /// </summary>
+    /// <typeparam name="T1"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    /// <typeparam name="T3"></typeparam>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns>An async enumerable iterating over the list of result tuples</returns>
+    IAsyncEnumerable<(T1, T2, T3)> StreamAsync<T1, T2, T3>(char placeholder, string sql, CancellationToken token, params object[] parameters);
 }

--- a/src/Marten/IDocumentOperations.cs
+++ b/src/Marten/IDocumentOperations.cs
@@ -233,6 +233,15 @@ public interface IDocumentOperations: IQuerySession
     void QueueSqlCommand(string sql, params object[] parameterValues);
 
     /// <summary>
+    ///     Registers a SQL command to be executed with the underlying unit of work as part of the batched command.
+    ///     Use <paramref name="placeholder"/> to specify a character that will be replaced by positional parameters.
+    /// </summary>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="parameterValues"></param>
+    void QueueSqlCommand(char placeholder, string sql, params object[] parameterValues);
+
+    /// <summary>
     /// In the case of a lightweight session, this will direct Marten to opt into identity map mechanics
     /// for only the document type T. This is a micro-optimization added for the event sourcing + projections
     /// support

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -184,6 +184,7 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// <param name="sql"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
+    [Obsolete(QuerySession.SynchronousRemoval)]
     IReadOnlyList<T> Query<T>(string sql, params object[] parameters);
 
     /// <summary>
@@ -198,6 +199,19 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     Task<int> StreamJson<T>(Stream destination, CancellationToken token, string sql, params object[] parameters);
 
     /// <summary>
+    ///     Stream the results of a user-supplied query directly to a stream as a JSON array.
+    ///     Use <paramref name="placeholder"/> to specify a character that will be replaced by positional parameters.
+    /// </summary>
+    /// <param name="destination"></param>
+    /// <param name="token"></param>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    Task<int> StreamJson<T>(Stream destination, CancellationToken token, char placeholder, string sql, params object[] parameters);
+
+    /// <summary>
     ///     Stream the results of a user-supplied query directly to a stream as a JSON array
     /// </summary>
     /// <param name="destination"></param>
@@ -206,6 +220,18 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     Task<int> StreamJson<T>(Stream destination, string sql, params object[] parameters);
+
+    /// <summary>
+    ///     Stream the results of a user-supplied query directly to a stream as a JSON array.
+    ///     Use <paramref name="placeholder"/> to specify a character that will be replaced by positional parameters.
+    /// </summary>
+    /// <param name="destination"></param>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    Task<int> StreamJson<T>(Stream destination, char placeholder, string sql, params object[] parameters);
 
     /// <summary>
     ///     Asynchronously queries the document storage table for the document type T by supplied SQL. See
@@ -221,12 +247,37 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// <summary>
     ///     Asynchronously queries the document storage table for the document type T by supplied SQL. See
     ///     https://martendb.io/documents/querying/sql.html for more information on usage.
+    ///     Use <paramref name="placeholder"/> to specify a character that will be replaced by positional parameters.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="token"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<T>> QueryAsync<T>(char placeholder, string sql, CancellationToken token, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage table for the document type T by supplied SQL. See
+    ///     https://martendb.io/documents/querying/sql.html for more information on usage.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="sql"></param>
     /// <param name="parameters"></param>
     /// <returns></returns>
     Task<IReadOnlyList<T>> QueryAsync<T>(string sql, params object[] parameters);
+
+    /// <summary>
+    ///     Asynchronously queries the document storage table for the document type T by supplied SQL. See
+    ///     https://martendb.io/documents/querying/sql.html for more information on usage.
+    ///     Use <paramref name="placeholder"/> to specify a character that will be replaced by positional parameters.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<T>> QueryAsync<T>(char placeholder, string sql, params object[] parameters);
 
     /// <summary>
     ///     Asynchronously queries the document storage with the supplied SQL.

--- a/src/Marten/Internal/Operations/ExecuteSqlStorageOperation.cs
+++ b/src/Marten/Internal/Operations/ExecuteSqlStorageOperation.cs
@@ -12,17 +12,19 @@ namespace Marten.Internal.Operations;
 internal class ExecuteSqlStorageOperation: IStorageOperation, NoDataReturnedCall
 {
     private readonly string _commandText;
+    private readonly char _placeholder;
     private readonly object[] _parameterValues;
 
-    public ExecuteSqlStorageOperation(string commandText, params object[] parameterValues)
+    public ExecuteSqlStorageOperation(char placeholder, string commandText, params object[] parameterValues)
     {
         _commandText = commandText.TrimEnd(';');
+        _placeholder = placeholder;
         _parameterValues = parameterValues;
     }
 
     public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
     {
-        var parameters = builder.AppendWithParameters(_commandText);
+        var parameters = builder.AppendWithParameters(_commandText, _placeholder);
         if (parameters.Length != _parameterValues.Length)
         {
             throw new InvalidOperationException(

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -227,12 +227,17 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
 
     public void QueueSqlCommand(string sql, params object[] parameterValues)
     {
+        QueueSqlCommand(DefaultParameterPlaceholder, sql, parameterValues: parameterValues);
+    }
+
+    public void QueueSqlCommand(char placeholder, string sql, params object[] parameterValues)
+    {
         sql = sql.TrimEnd(';');
         if (sql.Contains(';'))
             throw new ArgumentOutOfRangeException(nameof(sql),
                 "You must specify one SQL command at a time because of Marten's usage of command batching. ';' cannot be used as a command separator here.");
 
-        var operation = new ExecuteSqlStorageOperation(sql, parameterValues);
+        var operation = new ExecuteSqlStorageOperation(placeholder, sql, parameterValues);
         QueueOperation(operation);
     }
 

--- a/src/Marten/Internal/Sessions/QuerySession.AdvancedSql.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.AdvancedSql.cs
@@ -10,11 +10,16 @@ namespace Marten.Internal.Sessions;
 
 public partial class QuerySession: IAdvancedSql
 {
-    async Task<IReadOnlyList<T>> IAdvancedSql.QueryAsync<T>(string sql, CancellationToken token, params object[] parameters)
+    Task<IReadOnlyList<T>> IAdvancedSql.QueryAsync<T>(string sql, CancellationToken token, params object[] parameters)
+    {
+        return ((IAdvancedSql)this).QueryAsync<T>(DefaultParameterPlaceholder, sql, token, parameters);
+    }
+
+    async Task<IReadOnlyList<T>> IAdvancedSql.QueryAsync<T>(char placeholder, string sql, CancellationToken token, params object[] parameters)
     {
         assertNotDisposed();
 
-        var handler = new AdvancedSqlQueryHandler<T>(this, sql, parameters);
+        var handler = new AdvancedSqlQueryHandler<T>(this, placeholder, sql, parameters);
 
         foreach (var documentType in handler.DocumentTypes)
         {
@@ -25,11 +30,16 @@ public partial class QuerySession: IAdvancedSql
         return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
     }
 
-    async Task<IReadOnlyList<(T1, T2)>> IAdvancedSql.QueryAsync<T1, T2>(string sql, CancellationToken token, params object[] parameters)
+    Task<IReadOnlyList<(T1, T2)>> IAdvancedSql.QueryAsync<T1, T2>(string sql, CancellationToken token, params object[] parameters)
+    {
+        return ((IAdvancedSql)this).QueryAsync<T1, T2>(DefaultParameterPlaceholder, sql, token, parameters);
+    }
+
+    async Task<IReadOnlyList<(T1, T2)>> IAdvancedSql.QueryAsync<T1, T2>(char placeholder, string sql, CancellationToken token, params object[] parameters)
     {
         assertNotDisposed();
 
-        var handler = new AdvancedSqlQueryHandler<T1, T2>(this, sql, parameters);
+        var handler = new AdvancedSqlQueryHandler<T1, T2>(this, placeholder, sql, parameters);
 
         foreach (var documentType in handler.DocumentTypes)
         {
@@ -40,11 +50,16 @@ public partial class QuerySession: IAdvancedSql
         return await provider.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
     }
 
-    async Task<IReadOnlyList<(T1, T2, T3)>> IAdvancedSql.QueryAsync<T1, T2, T3>(string sql, CancellationToken token, params object[] parameters)
+    Task<IReadOnlyList<(T1, T2, T3)>> IAdvancedSql.QueryAsync<T1, T2, T3>(string sql, CancellationToken token, params object[] parameters)
+    {
+        return ((IAdvancedSql)this).QueryAsync<T1, T2, T3>(DefaultParameterPlaceholder, sql, token, parameters);
+    }
+
+    async Task<IReadOnlyList<(T1, T2, T3)>> IAdvancedSql.QueryAsync<T1, T2, T3>(char placeholder, string sql, CancellationToken token, params object[] parameters)
     {
         assertNotDisposed();
 
-        var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, sql, parameters);
+        var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, placeholder, sql, parameters);
 
         foreach (var documentType in handler.DocumentTypes)
         {
@@ -59,7 +74,7 @@ public partial class QuerySession: IAdvancedSql
     {
         assertNotDisposed();
 
-        var handler = new AdvancedSqlQueryHandler<T>(this, sql, parameters);
+        var handler = new AdvancedSqlQueryHandler<T>(this, DefaultParameterPlaceholder, sql, parameters);
 
         foreach (var documentType in handler.DocumentTypes)
         {
@@ -74,7 +89,7 @@ public partial class QuerySession: IAdvancedSql
     {
         assertNotDisposed();
 
-        var handler = new AdvancedSqlQueryHandler<T1, T2>(this, sql, parameters);
+        var handler = new AdvancedSqlQueryHandler<T1, T2>(this, DefaultParameterPlaceholder, sql, parameters);
 
         foreach (var documentType in handler.DocumentTypes)
         {
@@ -89,7 +104,7 @@ public partial class QuerySession: IAdvancedSql
     {
         assertNotDisposed();
 
-        var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, sql, parameters);
+        var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, DefaultParameterPlaceholder, sql, parameters);
 
         foreach (var documentType in handler.DocumentTypes)
         {
@@ -100,12 +115,15 @@ public partial class QuerySession: IAdvancedSql
         return provider.ExecuteHandler(handler);
     }
 
-    async IAsyncEnumerable<T> IAdvancedSql.StreamAsync<T>(string sql, [EnumeratorCancellation] CancellationToken token,
+    IAsyncEnumerable<T> IAdvancedSql.StreamAsync<T>(string sql, CancellationToken token, params object[] parameters)
+        => ((IAdvancedSql)this).StreamAsync<T>(DefaultParameterPlaceholder, sql, token, parameters);
+
+    async IAsyncEnumerable<T> IAdvancedSql.StreamAsync<T>(char placeholder, string sql, [EnumeratorCancellation] CancellationToken token,
         params object[] parameters)
     {
         assertNotDisposed();
 
-        var handler = new AdvancedSqlQueryHandler<T>(this, sql, parameters);
+        var handler = new AdvancedSqlQueryHandler<T>(this, placeholder, sql, parameters);
 
         foreach (var documentType in handler.DocumentTypes)
         {
@@ -121,12 +139,17 @@ public partial class QuerySession: IAdvancedSql
         }
     }
 
-    async IAsyncEnumerable<(T1, T2)> IAdvancedSql.StreamAsync<T1, T2>(string sql, [EnumeratorCancellation] CancellationToken token,
+    IAsyncEnumerable<(T1, T2)> IAdvancedSql.StreamAsync<T1, T2>(string sql, CancellationToken token, params object[] parameters)
+    {
+        return ((IAdvancedSql)this).StreamAsync<T1, T2>(DefaultParameterPlaceholder, sql, token, parameters);
+    }
+
+    async IAsyncEnumerable<(T1, T2)> IAdvancedSql.StreamAsync<T1, T2>(char placeholder, string sql, [EnumeratorCancellation] CancellationToken token,
         params object[] parameters)
     {
         assertNotDisposed();
 
-        var handler = new AdvancedSqlQueryHandler<T1, T2>(this, sql, parameters);
+        var handler = new AdvancedSqlQueryHandler<T1, T2>(this, placeholder, sql, parameters);
 
         foreach (var documentType in handler.DocumentTypes)
         {
@@ -142,12 +165,17 @@ public partial class QuerySession: IAdvancedSql
         }
     }
 
-    async IAsyncEnumerable<(T1, T2, T3)> IAdvancedSql.StreamAsync<T1, T2, T3>(string sql, [EnumeratorCancellation] CancellationToken token,
+    IAsyncEnumerable<(T1, T2, T3)> IAdvancedSql.StreamAsync<T1, T2, T3>(string sql, CancellationToken token, params object[] parameters)
+    {
+        return ((IAdvancedSql)this).StreamAsync<T1, T2, T3>(DefaultParameterPlaceholder, sql, token, parameters);
+    }
+
+    async IAsyncEnumerable<(T1, T2, T3)> IAdvancedSql.StreamAsync<T1, T2, T3>(char placeholder, string sql, [EnumeratorCancellation] CancellationToken token,
         params object[] parameters)
     {
         assertNotDisposed();
 
-        var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, sql, parameters);
+        var handler = new AdvancedSqlQueryHandler<T1, T2, T3>(this, placeholder, sql, parameters);
 
         foreach (var documentType in handler.DocumentTypes)
         {

--- a/src/Marten/Internal/Sessions/QuerySession.Json.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Json.cs
@@ -53,18 +53,27 @@ public partial class QuerySession
         return await stream.ReadAllTextAsync().ConfigureAwait(false);
     }
 
-    public Task<int> StreamJson<T>(Stream destination, CancellationToken token, string sql, params object[] parameters)
+    public Task<int> StreamJson<T>(Stream destination, CancellationToken token, char placeholder, string sql, params object[] parameters)
     {
         assertNotDisposed();
-        var handler = new UserSuppliedQueryHandler<T>(this, sql, parameters);
+        var handler = new UserSuppliedQueryHandler<T>(this, placeholder, sql, parameters);
         var builder = new CommandBuilder();
         handler.ConfigureCommand(builder, this);
         return StreamMany(builder.Compile(), destination, token);
+    }
+    public Task<int> StreamJson<T>(Stream destination, CancellationToken token, string sql, params object[] parameters)
+    {
+        return StreamJson<T>(destination, token, DefaultParameterPlaceholder, sql, parameters);
     }
 
     public Task<int> StreamJson<T>(Stream destination, string sql, params object[] parameters)
     {
         return StreamJson<T>(destination, CancellationToken.None, sql, parameters);
+    }
+
+    public Task<int> StreamJson<T>(Stream destination, char placeholder, string sql, params object[] parameters)
+    {
+        return StreamJson<T>(destination, CancellationToken.None, placeholder, sql, parameters);
     }
 
     public async Task<int> StreamJson<T>(IQueryHandler<T> handler, Stream destination, CancellationToken token)

--- a/src/Marten/Internal/Sessions/QuerySession.Json.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Json.cs
@@ -53,6 +53,11 @@ public partial class QuerySession
         return await stream.ReadAllTextAsync().ConfigureAwait(false);
     }
 
+    public Task<int> StreamJson<T>(Stream destination, CancellationToken token, string sql, params object[] parameters)
+    {
+        return StreamJson<T>(destination, token, DefaultParameterPlaceholder, sql, parameters);
+    }
+
     public Task<int> StreamJson<T>(Stream destination, CancellationToken token, char placeholder, string sql, params object[] parameters)
     {
         assertNotDisposed();
@@ -60,10 +65,6 @@ public partial class QuerySession
         var builder = new CommandBuilder();
         handler.ConfigureCommand(builder, this);
         return StreamMany(builder.Compile(), destination, token);
-    }
-    public Task<int> StreamJson<T>(Stream destination, CancellationToken token, string sql, params object[] parameters)
-    {
-        return StreamJson<T>(destination, token, DefaultParameterPlaceholder, sql, parameters);
     }
 
     public Task<int> StreamJson<T>(Stream destination, string sql, params object[] parameters)

--- a/src/Marten/Internal/Sessions/QuerySession.Querying.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Querying.cs
@@ -35,7 +35,7 @@ public partial class QuerySession
     {
         assertNotDisposed();
 
-        var handler = new UserSuppliedQueryHandler<T>(this, sql, parameters);
+        var handler = new UserSuppliedQueryHandler<T>(this, DefaultParameterPlaceholder, sql, parameters);
 
         if (!handler.SqlContainsCustomSelect)
         {
@@ -46,11 +46,16 @@ public partial class QuerySession
         return provider.ExecuteHandler(handler);
     }
 
-    public async Task<IReadOnlyList<T>> QueryAsync<T>(string sql, CancellationToken token, params object[] parameters)
+    public Task<IReadOnlyList<T>> QueryAsync<T>(string sql, CancellationToken token, params object[] parameters)
+    {
+        return QueryAsync<T>(DefaultParameterPlaceholder, sql, token, parameters);
+    }
+
+    public async Task<IReadOnlyList<T>> QueryAsync<T>(char placeholder, string sql, CancellationToken token, params object[] parameters)
     {
         assertNotDisposed();
 
-        var handler = new UserSuppliedQueryHandler<T>(this, sql, parameters);
+        var handler = new UserSuppliedQueryHandler<T>(this, placeholder, sql, parameters);
 
         if (!handler.SqlContainsCustomSelect)
         {
@@ -64,6 +69,11 @@ public partial class QuerySession
     public Task<IReadOnlyList<T>> QueryAsync<T>(string sql, params object[] parameters)
     {
         return QueryAsync<T>(sql, CancellationToken.None, parameters);
+    }
+
+    public Task<IReadOnlyList<T>> QueryAsync<T>(char placeholder, string sql, params object[] parameters)
+    {
+        return QueryAsync<T>(placeholder, sql, CancellationToken.None, parameters);
     }
 
     // TODO -- Obsolete, remove in 8.0, replaced by AdvancedSql.Query*

--- a/src/Marten/Internal/Sessions/QuerySession.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.cs
@@ -17,6 +17,8 @@ public partial class QuerySession: IMartenSession, IQuerySession
     public const string SynchronousRemoval =
         "All synchronous APIs that result in database calls will be removed in Marten 8.0. Please use the asynchronous equivalent";
 
+    internal const char DefaultParameterPlaceholder = '?';
+
     private readonly DocumentStore _store;
     private readonly ResiliencePipeline _resilience;
 

--- a/src/Marten/Linq/MatchesSql/MatchesSqlExtensions.cs
+++ b/src/Marten/Linq/MatchesSql/MatchesSqlExtensions.cs
@@ -33,6 +33,21 @@ public static class MatchesSqlExtensions
     }
 
     /// <summary>
+    ///     The search results should match the specified raw sql fragment.
+    ///     Use <paramref name="placeholder"/> to specify a character that will be replaced by positional parameters.
+    /// </summary>
+    /// <param name="doc"></param>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    public static bool MatchesSql(this object doc, char placeholder, string sql, params object[] parameters)
+    {
+        throw new NotSupportedException(
+            $"{nameof(MatchesSql)} extension method can only be used in Marten Linq queries.");
+    }
+
+    /// <summary>
     ///     The search results should match the specified raw sql fragment that is assumed to include JSONPath. Use "^" for parameters instead of "?" to disambiguate from JSONPath
     /// </summary>
     /// <param name="doc"></param>
@@ -42,6 +57,6 @@ public static class MatchesSqlExtensions
     public static bool MatchesJsonPath(this object doc, string sql, params object[] parameters)
     {
         throw new NotSupportedException(
-            $"{nameof(MatchesSql)} extension method can only be used in Marten Linq queries.");
+            $"{nameof(MatchesJsonPath)} extension method can only be used in Marten Linq queries.");
     }
 }

--- a/src/Marten/Linq/MatchesSql/MatchesSqlParser.cs
+++ b/src/Marten/Linq/MatchesSql/MatchesSqlParser.cs
@@ -16,6 +16,10 @@ public class MatchesSqlParser: IMethodCallParser
         typeof(MatchesSqlExtensions).GetMethod(nameof(MatchesSqlExtensions.MatchesSql),
             new[] { typeof(object), typeof(string), typeof(object[]) })!;
 
+    private static readonly MethodInfo _sqlMethodWithPlaceholder =
+        typeof(MatchesSqlExtensions).GetMethod(nameof(MatchesSqlExtensions.MatchesSql),
+            new[] { typeof(object), typeof(char), typeof(string), typeof(object[]) })!;
+
     private static readonly MethodInfo _fragmentMethod =
         typeof(MatchesSqlExtensions).GetMethod(nameof(MatchesSqlExtensions.MatchesSql),
             new[] { typeof(object), typeof(ISqlFragment) })!;
@@ -32,6 +36,13 @@ public class MatchesSqlParser: IMethodCallParser
         {
             return new WhereFragment(expression.Arguments[1].Value().As<string>(),
                 expression.Arguments[2].Value().As<object[]>());
+        }
+
+        if (expression.Method.Equals(_sqlMethodWithPlaceholder))
+        {
+            return new CustomizableWhereFragment(expression.Arguments[1].Value().As<string>(),
+                expression.Arguments[2].Value().As<char>().ToString(),
+                expression.Arguments[3].Value().As<object[]>());
         }
 
         if (expression.Method.Equals(_fragmentMethod))

--- a/src/Marten/Linq/MatchesSql/MatchesSqlParser.cs
+++ b/src/Marten/Linq/MatchesSql/MatchesSqlParser.cs
@@ -26,7 +26,7 @@ public class MatchesSqlParser: IMethodCallParser
 
     public bool Matches(MethodCallExpression expression)
     {
-        return Equals(expression.Method, _sqlMethod) || Equals(expression.Method, _fragmentMethod);
+        return Equals(expression.Method, _sqlMethod) || Equals(expression.Method, _sqlMethodWithPlaceholder) || Equals(expression.Method, _fragmentMethod);
     }
 
     public ISqlFragment? Parse(IQueryableMemberCollection memberCollection, IReadOnlyStoreOptions options,
@@ -40,8 +40,8 @@ public class MatchesSqlParser: IMethodCallParser
 
         if (expression.Method.Equals(_sqlMethodWithPlaceholder))
         {
-            return new CustomizableWhereFragment(expression.Arguments[1].Value().As<string>(),
-                expression.Arguments[2].Value().As<char>().ToString(),
+            return new CustomizableWhereFragment(expression.Arguments[2].Value().As<string>(),
+                expression.Arguments[1].Value().As<char>().ToString(),
                 expression.Arguments[3].Value().As<object[]>());
         }
 

--- a/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
@@ -18,7 +18,7 @@ namespace Marten.Linq.QueryHandlers;
 
 internal class AdvancedSqlQueryHandler<T>: AdvancedSqlQueryHandlerBase<T>, IQueryHandler<IReadOnlyList<T>>
 {
-    public AdvancedSqlQueryHandler(IMartenSession session, string sql, object[] parameters):base(sql, parameters)
+    public AdvancedSqlQueryHandler(IMartenSession session, char placeholder, string sql, object[] parameters): base(placeholder, sql, parameters)
     {
         RegisterResultType<T>(session);
     }
@@ -46,7 +46,7 @@ internal class AdvancedSqlQueryHandler<T>: AdvancedSqlQueryHandlerBase<T>, IQuer
 
 internal class AdvancedSqlQueryHandler<T1, T2>: AdvancedSqlQueryHandlerBase<(T1, T2)>, IQueryHandler<IReadOnlyList<(T1, T2)>>
 {
-    public AdvancedSqlQueryHandler(IMartenSession session, string sql, object[] parameters) : base(sql, parameters)
+    public AdvancedSqlQueryHandler(IMartenSession session, char placeholder, string sql, object[] parameters) : base(placeholder, sql, parameters)
     {
         RegisterResultType<T1>(session);
         RegisterResultType<T2>(session);
@@ -77,7 +77,7 @@ internal class AdvancedSqlQueryHandler<T1, T2>: AdvancedSqlQueryHandlerBase<(T1,
 }
 internal class AdvancedSqlQueryHandler<T1, T2, T3>: AdvancedSqlQueryHandlerBase<(T1, T2, T3)>, IQueryHandler<IReadOnlyList<(T1, T2, T3)>>
 {
-    public AdvancedSqlQueryHandler(IMartenSession session, string sql, object[] parameters) : base(sql, parameters)
+    public AdvancedSqlQueryHandler(IMartenSession session, char placeholder, string sql, object[] parameters) : base(placeholder, sql, parameters)
     {
         RegisterResultType<T1>(session);
         RegisterResultType<T2>(session);
@@ -112,13 +112,15 @@ internal class AdvancedSqlQueryHandler<T1, T2, T3>: AdvancedSqlQueryHandlerBase<
 
 internal abstract class AdvancedSqlQueryHandlerBase<TResult>
 {
+    protected readonly char Placeholder;
     protected readonly object[] Parameters;
     protected readonly string Sql;
     protected List<ISelector> Selectors = new();
 
-    protected AdvancedSqlQueryHandlerBase(string sql, object[] parameters)
+    protected AdvancedSqlQueryHandlerBase(char placeholder, string sql, object[] parameters)
     {
         Sql = sql.TrimStart();
+        Placeholder = placeholder;
         Parameters = parameters;
     }
 
@@ -135,7 +137,7 @@ internal abstract class AdvancedSqlQueryHandlerBase<TResult>
         }
         else
         {
-            var cmdParameters = builder.AppendWithParameters(Sql);
+            var cmdParameters = builder.AppendWithParameters(Sql, Placeholder);
             if (cmdParameters.Length != Parameters.Length)
             {
                 throw new InvalidOperationException("Wrong number of supplied parameters");

--- a/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
@@ -18,14 +18,16 @@ namespace Marten.Linq.QueryHandlers;
 
 internal class UserSuppliedQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>
 {
+    private readonly char _placeholder;
     private readonly object[] _parameters;
     private readonly ISelectClause _selectClause;
     private readonly ISelector<T> _selector;
     private readonly string _sql;
 
-    public UserSuppliedQueryHandler(IMartenSession session, string sql, object[] parameters)
+    public UserSuppliedQueryHandler(IMartenSession session, char placeholder, string sql, object[] parameters)
     {
         _sql = sql.TrimStart();
+        _placeholder = placeholder;
         _parameters = parameters;
         SqlContainsCustomSelect = _sql.StartsWith("select", StringComparison.OrdinalIgnoreCase)
                                   || IsWithFollowedBySelect(_sql);
@@ -63,7 +65,7 @@ internal class UserSuppliedQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>
         }
         else
         {
-            var cmdParameters = builder.AppendWithParameters(_sql);
+            var cmdParameters = builder.AppendWithParameters(_sql, _placeholder);
             if (cmdParameters.Length != _parameters.Length)
             {
                 throw new InvalidOperationException("Wrong number of supplied parameters");

--- a/src/Marten/Services/BatchQuerying/BatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQuery.cs
@@ -59,7 +59,12 @@ internal class BatchedQuery: IBatchedQuery, IBatchEvents
 
     public Task<IReadOnlyList<T>> Query<T>(string sql, params object[] parameters) where T : class
     {
-        var handler = new UserSuppliedQueryHandler<T>(Parent, sql, parameters);
+        return Query<T>(QuerySession.DefaultParameterPlaceholder, sql, parameters);
+    }
+
+    public Task<IReadOnlyList<T>> Query<T>(char placeholder, string sql, params object[] parameters) where T : class
+    {
+        var handler = new UserSuppliedQueryHandler<T>(Parent, placeholder, sql, parameters);
         if (!handler.SqlContainsCustomSelect)
         {
             _documentTypes.Add(typeof(T));

--- a/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
@@ -114,6 +114,17 @@ public interface IBatchedQuery
     Task<IReadOnlyList<T>> Query<T>(string sql, params object[] parameters) where T : class;
 
     /// <summary>
+    ///     Execute a user provided query against "T".
+    ///      Use <paramref name="placeholder"/> to specify a character that will be replaced by positional parameters.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="placeholder"></param>
+    /// <param name="sql"></param>
+    /// <param name="parameters"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<T>> Query<T>(char placeholder, string sql, params object[] parameters) where T : class;
+
+    /// <summary>
     ///     Execute this batched query
     /// </summary>
     /// <param name="token"></param>


### PR DESCRIPTION
The `char placeholder` param is always before the `string sql` param. This is to ensure that the overload is backwards compatible.,

Updated all methods that accept parameters except for:
- Sync methods that are marked obsolete
- `MatchesJsonPath` - This should probably be marked as obsolete as the placeholder overload does the same thing but better.

Todo:
- [x] Tests. 
- [x] Documentation