### PR TITLE
Input validation on projection registration to prevent invalid registrations of SingleStreamProjection

### DIFF
--- a/src/EventSourcingTests/Projections/SingleStreamProjectionTests.cs
+++ b/src/EventSourcingTests/Projections/SingleStreamProjectionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using EventSourcingTests.Aggregation;
 using Marten;
 using Marten.Events;
@@ -40,5 +41,16 @@ public class SingleStreamProjectionTests
         projection.ConfigureAggregateMapping(mapping, mapping.StoreOptions);
 
         mapping.UseVersionFromMatchingStream.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void you_cannot_accidentally_try_to_add_single_stream_projection_through_the_snapshot()
+    {
+        var options = new StoreOptions();
+
+        Should.Throw<InvalidOperationException>(() =>
+        {
+            options.Projections.Snapshot<AllGood>(SnapshotLifecycle.Inline);
+        });
     }
 }

--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -324,6 +324,10 @@ public class ProjectionOptions: DaemonSettings
         Action<AsyncOptions> asyncConfiguration = null
     )
     {
+        if (typeof(T).CanBeCastTo<IProjectionSource>())
+            throw new InvalidOperationException(
+                $"This registration mechanism can only be used for an aggregate type that is 'self-aggregating'. Please use the Projections.Add() API instead to register {typeof(T).FullNameInCode()}");
+
         // Make sure there's a DocumentMapping for the aggregate
         var expression = _options.Schema.For<T>();
 


### PR DESCRIPTION
…confusion on Snapshot registrations