### PR TITLE
Ignore `ApplicationAssembly` when scanning compiled types using `AutoRegister`

### DIFF
--- a/src/Marten/StoreOptions.Registration.cs
+++ b/src/Marten/StoreOptions.Registration.cs
@@ -135,7 +135,10 @@ public partial class StoreOptions
 
     internal void Scan(StoreOptions options)
     {
-        var assemblies = _assemblies.Union([options.ApplicationAssembly]).ToArray();
+        var assemblies = options.ApplicationAssembly == null
+            ? _assemblies.ToArray()
+            : _assemblies.Union([options.ApplicationAssembly]).ToArray();
+
         var publicTypes =
             TypeRepository.FindTypes(assemblies, TypeClassification.Concretes | TypeClassification.Closed, type => type.IsPublic || type.IsNestedPublic)
                 .ToArray();


### PR DESCRIPTION
Fixes null reference exception when `ApplicationAssembly` is not defined yet, #3644