### PR TITLE
Patch predicates with no member access

### DIFF
--- a/src/Marten/Linq/Parsing/JsonPathCreator.cs
+++ b/src/Marten/Linq/Parsing/JsonPathCreator.cs
@@ -42,6 +42,7 @@ public sealed class JsonPathCreator(ISerializer serializer) : ExpressionVisitor
         return jsonPath;
     }
 
+    
     protected override Expression VisitUnary(UnaryExpression node)
     {
         if (node.NodeType == ExpressionType.Not)
@@ -55,6 +56,16 @@ public sealed class JsonPathCreator(ISerializer serializer) : ExpressionVisitor
         return node;
     }
 
+    protected override Expression VisitLambda<T>(Expression<T> node)
+    {
+        return Visit(node.Body);
+    }
+    protected override Expression VisitParameter(ParameterExpression node)
+    {
+        _jsonPathBuilder.Append("@");
+        return node;
+    }
+    
     protected override Expression VisitBinary(BinaryExpression node)
     {
         if (node.Left is MemberExpression leftMember)

--- a/src/PatchingTests/Patching/patching_api.cs
+++ b/src/PatchingTests/Patching/patching_api.cs
@@ -829,6 +829,25 @@ public class patching_api: OneOffConfigurationsContext
     }
 
     #endregion
+    
+    [Fact]
+    public async Task remove_simple_element_by_predicate(){
+        var target = Target.Random();
+        var initialCount = target.NumberArray.Length;
+        var random = new Random();
+        var toRemove = target.NumberArray[random.Next(0, initialCount)];
+        
+        theSession.Store(target);
+        await theSession.SaveChangesAsync();
+
+        theSession.Patch<Target>(target.Id).Remove(x => x.NumberArray, x => x == toRemove);
+        await theSession.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession();
+        var target2 = query.Load<Target>(target.Id);
+        target2.NumberArray.ShouldNotContain(t => t == toRemove);
+
+    }
 
     [Fact]
     public async Task throw_exception_if_a_method_call_is_used_for_remove_complex_element_by_predicate()


### PR DESCRIPTION
While fixing https://github.com/JasperFx/marten/pull/3696 i discovered this bug where we generate an invalid JsonPath if doing a predicate like

`x => x > 10` OR `x => x == "foo"`

since the visitor only vists MemberExpressions and hence skips the ParameterExpression of x.