### PR TITLE
Feature/bug n gram not public schema

### DIFF
--- a/src/LinqTests/Bugs/Bug_3708_NGram_in_other_schema.cs
+++ b/src/LinqTests/Bugs/Bug_3708_NGram_in_other_schema.cs
@@ -8,7 +8,7 @@ using Weasel.Core;
 
 namespace LinqTests.Bugs;
 
-public class Bug_xxx_NGram_in_other_schema : BugIntegrationContext
+public class Bug_3708_NGram_in_other_schema : BugIntegrationContext
 {
     private string AnotherSchema = "not_public";
 

--- a/src/LinqTests/Bugs/Bug_xxx_NGram_in_other_schema.cs
+++ b/src/LinqTests/Bugs/Bug_xxx_NGram_in_other_schema.cs
@@ -10,15 +10,18 @@ namespace LinqTests.Bugs;
 
 public class Bug_xxx_NGram_in_other_schema : BugIntegrationContext
 {
+    private string AnotherSchema = "not_public";
+
     [Fact]
     public async Task not_public_schema()
     {
+        CleanSchema(AnotherSchema);
         StoreOptions(opts =>
         {
             var documentMappingExpression = opts.Schema.For<DifferentSchema>();
-            documentMappingExpression.DatabaseSchemaName("not_public");
+            documentMappingExpression.DatabaseSchemaName(AnotherSchema);
             documentMappingExpression.NgramIndex(x => x.Name);
-        });
+        }, true);
 
         var elayne = new Foo { Name = "Elayne", Status = StatusEnum.Active };
         theSession.Store(elayne);
@@ -33,12 +36,12 @@ public class Bug_xxx_NGram_in_other_schema : BugIntegrationContext
     [Fact]
     public async Task change_default_schema_to_not_public()
     {
+        CleanSchema(AnotherSchema);
         StoreOptions(opts =>
         {
-            var optsDatabaseSchemaName = "not_public";
-            opts.DatabaseSchemaName = optsDatabaseSchemaName;
+            opts.DatabaseSchemaName = AnotherSchema;
             var documentMappingExpression = opts.Schema.For<DifferentSchema>();
-            documentMappingExpression.DatabaseSchemaName(optsDatabaseSchemaName);
+            documentMappingExpression.DatabaseSchemaName(AnotherSchema);
             documentMappingExpression.NgramIndex(x => x.Name);
         });
 

--- a/src/LinqTests/Bugs/Bug_xxx_NGram_in_other_schema.cs
+++ b/src/LinqTests/Bugs/Bug_xxx_NGram_in_other_schema.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Core;
+
+namespace LinqTests.Bugs;
+
+public class Bug_xxx_NGram_in_other_schema : BugIntegrationContext
+{
+    [Fact]
+    public async Task use_the_query()
+    {
+        StoreOptions(opts =>
+        {
+            var documentMappingExpression = opts.Schema.For<DifferentSchema>();
+            documentMappingExpression.DatabaseSchemaName("not_public");
+            documentMappingExpression.NgramIndex(x => x.Name);
+        });
+
+        var elayne = new Foo { Name = "Elayne", Status = StatusEnum.Active };
+        theSession.Store(elayne);
+        theSession.Store(new DifferentSchema{ Name = "This is something i would like to find using NGRAM"});
+        await theSession.SaveChangesAsync();
+
+        var results = await theSession.Query<DifferentSchema>().Where(x => x.Name.NgramSearch("ing")).ToListAsync();
+
+        results.Any().ShouldBeTrue();
+    }
+}
+
+public class DifferentSchema
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+}

--- a/src/LinqTests/Bugs/Bug_xxx_NGram_in_other_schema.cs
+++ b/src/LinqTests/Bugs/Bug_xxx_NGram_in_other_schema.cs
@@ -11,12 +11,34 @@ namespace LinqTests.Bugs;
 public class Bug_xxx_NGram_in_other_schema : BugIntegrationContext
 {
     [Fact]
-    public async Task use_the_query()
+    public async Task not_public_schema()
     {
         StoreOptions(opts =>
         {
             var documentMappingExpression = opts.Schema.For<DifferentSchema>();
             documentMappingExpression.DatabaseSchemaName("not_public");
+            documentMappingExpression.NgramIndex(x => x.Name);
+        });
+
+        var elayne = new Foo { Name = "Elayne", Status = StatusEnum.Active };
+        theSession.Store(elayne);
+        theSession.Store(new DifferentSchema{ Name = "This is something i would like to find using NGRAM"});
+        await theSession.SaveChangesAsync();
+
+        var results = await theSession.Query<DifferentSchema>().Where(x => x.Name.NgramSearch("ing")).ToListAsync();
+
+        results.Any().ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task change_default_schema_to_not_public()
+    {
+        StoreOptions(opts =>
+        {
+            var optsDatabaseSchemaName = "not_public";
+            opts.DatabaseSchemaName = optsDatabaseSchemaName;
+            var documentMappingExpression = opts.Schema.For<DifferentSchema>();
+            documentMappingExpression.DatabaseSchemaName(optsDatabaseSchemaName);
             documentMappingExpression.NgramIndex(x => x.Name);
         });
 

--- a/src/Marten.Testing/Harness/OneOffConfigurationsContext.cs
+++ b/src/Marten.Testing/Harness/OneOffConfigurationsContext.cs
@@ -70,10 +70,7 @@ namespace Marten.Testing.Harness
 
             if (cleanAll)
             {
-                using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-                conn.Open();
-                conn.CreateCommand($"drop schema if exists {_schemaName} cascade")
-                    .ExecuteNonQuery();
+                CleanSchema(_schemaName);
             }
 
             _store = new DocumentStore(options);
@@ -81,6 +78,14 @@ namespace Marten.Testing.Harness
             _disposables.Add(_store);
 
             return _store;
+        }
+
+        protected void CleanSchema(string schemaName)
+        {
+            using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+            conn.Open();
+            conn.CreateCommand($"drop schema if exists {schemaName} cascade")
+                .ExecuteNonQuery();
         }
 
         protected DocumentStore theStore

--- a/src/Marten/Schema/NgramIndex.cs
+++ b/src/Marten/Schema/NgramIndex.cs
@@ -24,7 +24,7 @@ public class NgramIndex: IndexDefinition
 
     public NgramIndex(DocumentMapping mapping, string dataConfig = null, string indexName = null)
     {
-        _databaseSchemaName = mapping.DatabaseSchemaName;
+        _databaseSchemaName = mapping.StoreOptions.DatabaseSchemaName;
         _table = mapping.TableName;
         DataConfig = dataConfig;
         _indexName = indexName;


### PR DESCRIPTION
Seems like there is an issue with the  mt_grams_vector not being applied or "used" wrongly when using ngram and having entities defined in a different schema.


This is the raw exception:
Npgsql.PostgresException
42883: function not_public.mt_grams_vector(text) does not exist

If i change the "default" schema on the documentstore it seems to create the objects.