### PR TITLE
Make sure to process compound parts depth first and do it recursively

### DIFF
--- a/src/LinqTests/ChildCollections/query_against_child_collections.cs
+++ b/src/LinqTests/ChildCollections/query_against_child_collections.cs
@@ -55,6 +55,33 @@ public class query_against_child_collections: OneOffConfigurationsContext
     }
 
     [Fact]
+    public async Task bug_3710_can_query_childcollection_inside_nested_or(){
+        //Test case based on https://github.com/JasperFx/marten/issues/3710
+        await buildUpTargetData();
+        var random = new Random();
+        var randomtarget = targets[random.Next(targets.Length)];
+        // We are using the NestedObject collection here as we know it always has elements.
+        var somenestedtarget = randomtarget.NestedObject.Targets.First();
+        //This is a query on the form (subquery or something) and subquery
+        Expression<Func<Target, bool>> predicate = p => 
+                    (
+                        p.NestedObject.Targets.Any(x => x.String.Contains(somenestedtarget.String)) 
+                        || 
+                        p.String == randomtarget.String
+                    )
+                    && 
+                    p.NestedObject.Targets.Any(x => x.String.Contains(somenestedtarget.String));
+
+
+        var result = await theSession.Query<Target>()
+            .Where(predicate)
+            .ToListAsync();
+
+        result.Count.ShouldBeGreaterThan(0);
+        result.ShouldAllBe(predicate);
+    }
+
+    [Fact]
     public async Task can_query_with_containment_operator()
     {
         await buildUpTargetData();

--- a/src/LinqTests/ChildCollections/query_against_child_collections.cs
+++ b/src/LinqTests/ChildCollections/query_against_child_collections.cs
@@ -68,9 +68,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         Expression<Func<Target, bool>> predicate = x => (isFalse || (isTrue && x.NestedObject.Targets.Any(z => z.AnotherString.Contains(somenestedtarget.AnotherString)))) && isTrue;
 
-        var query = theSession.Query<Target>().Where(predicate);
-        var command = query.ToCommand();
-        var result = await query.ToListAsync();
+        var result = await theSession.Query<Target>().Where(predicate).ToListAsync();
         result.Count.ShouldBeGreaterThan(0);
         result.ShouldAllBe(predicate);
     }

--- a/src/Marten/Linq/SqlGeneration/SelectorStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/SelectorStatement.cs
@@ -115,6 +115,15 @@ public class SelectorStatement: Statement, IWhereFragmentHolder
     {
         if (Wheres[0] is CompoundWhereFragment compound)
         {
+            // See https://github.com/JasperFx/marten/issues/3025
+            foreach (var deepCompound in compound.Children.OfType<CompoundWhereFragment>())
+            {
+                foreach (var subQueryFilter in deepCompound.Children.OfType<ISubQueryFilter>())
+                {
+                    subQueryFilter.PlaceUnnestAbove(session, this);
+                }
+            }
+
             if (compound.Children.OfType<ISubQueryFilter>().Any())
             {
                 var subQueries = compound.Children.OfType<ISubQueryFilter>().ToArray();
@@ -146,15 +155,6 @@ public class SelectorStatement: Statement, IWhereFragmentHolder
                 else
                 {
                     foreach (var subQuery in subQueries) subQuery.PlaceUnnestAbove(session, this);
-                }
-            }
-
-            // See https://github.com/JasperFx/marten/issues/3025
-            foreach (var deepCompound in compound.Children.OfType<CompoundWhereFragment>())
-            {
-                foreach (var subQueryFilter in deepCompound.Children.OfType<ISubQueryFilter>())
-                {
-                    subQueryFilter.PlaceUnnestAbove(session, this);
                 }
             }
         }


### PR DESCRIPTION
Minimal code added, only modifying the fix already made for #3025 to be 

1. Before so we process any subqueries in CompoundWhereFragments before the top level Subqueries
2. Doing it recursively do discover subqueries on deeper levels.

Fixes https://github.com/JasperFx/marten/issues/3710 and #3392 