### PR TITLE
Applying unaccent to ngram searches for better multilingual experience

### DIFF
--- a/docs/documents/full-text.md
+++ b/docs/documents/full-text.md
@@ -307,7 +307,7 @@ var posts = session.Query<BlogPost>()
 
 ## Partial text search in a multi-word text (NGram search)
 
-Marten provides the ability to search partial text or words in a string containing multiple words using NGram search. This is quite similar in functionality to [NGrams in Elastic Search](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-ngram-tokenizer.html). As an example, we can now accurately match `rich com text` within `Communicating Across Contexts (Enriched)`. NGram search uses English by default but applies [Posgres unaccent function](https://www.postgresql.org/docs/current/unaccent.html) before creating ngrams and on your search input for a better multilingual experience. NGram search also encompasses and handles unigrams, bigrams and trigrams. This functionality is added in v5.
+Marten provides the ability to search partial text or words in a string containing multiple words using NGram search. This is quite similar in functionality to [NGrams in Elastic Search](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-ngram-tokenizer.html). As an example, we can now accurately match `rich com text` within `Communicating Across Contexts (Enriched)`. NGram search uses English by default but applies [Postgres unaccent function](https://www.postgresql.org/docs/current/unaccent.html) both before creating ngrams and on search input for a better multilingual experience. NGram search also encompasses and handles unigrams, bigrams and trigrams. This functionality is added in v5.
 
 <!-- snippet: sample_ngram_search -->
 <a id='snippet-sample_ngram_search'></a>

--- a/docs/documents/full-text.md
+++ b/docs/documents/full-text.md
@@ -307,7 +307,7 @@ var posts = session.Query<BlogPost>()
 
 ## Partial text search in a multi-word text (NGram search)
 
-Marten provides the ability to search partial text or words in a string containing multiple words using NGram search. This is quite similar in functionality to [NGrams in Elastic Search](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-ngram-tokenizer.html). As an example, we can now accurately match `rich com text` within `Communicating Across Contexts (Enriched)`. NGram search uses English by default. NGram search also encompasses and handles unigrams, bigrams and trigrams. This functionality is added in v5.
+Marten provides the ability to search partial text or words in a string containing multiple words using NGram search. This is quite similar in functionality to [NGrams in Elastic Search](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-ngram-tokenizer.html). As an example, we can now accurately match `rich com text` within `Communicating Across Contexts (Enriched)`. NGram search uses English by default but applies [Posgres unaccent function](https://www.postgresql.org/docs/current/unaccent.html) before creating ngrams and on your search input for a better multilingual experience. NGram search also encompasses and handles unigrams, bigrams and trigrams. This functionality is added in v5.
 
 <!-- snippet: sample_ngram_search -->
 <a id='snippet-sample_ngram_search'></a>

--- a/src/DocumentDbTests/Indexes/NgramSearchTests.cs
+++ b/src/DocumentDbTests/Indexes/NgramSearchTests.cs
@@ -153,4 +153,41 @@ public class NgramSearchTests : Marten.Testing.Harness.OneOffConfigurationsConte
         result.ShouldHaveSingleItem();
         ShouldBeStringTestExtensions.ShouldContain(result[0].Address.Line1, term);
     }
+
+    [Fact]
+    public async Task test_ngram_when_using_non_ascii_characters(){
+         var store = DocumentStore.For(_ =>
+        {
+            _.Connection(Marten.Testing.Harness.ConnectionSource.ConnectionString);
+            _.DatabaseSchemaName = "ngram_test";
+            _.Schema.For<User>().NgramIndex(x => x.UserName);
+        });
+
+        await using var session = store.LightweightSession();
+
+
+        //The ngram uðmu should only exist in bjork, if special characters ignored it will return Umut
+        var umut = new User(1, "Umut Aral");
+        var bjork = new User(2, "Björk Guðmundsdóttir");
+
+        //The ngram øre should only exist in bjork, if special characters ignored it will return Chris Rea
+        var kierkegaard = new User(3, "Søren Kierkegaard");
+        var rea = new User(4, "Chris Rea");
+
+        session.Store(umut);
+        session.Store(bjork);
+        session.Store(kierkegaard);
+        session.Store(rea);
+        
+        await session.SaveChangesAsync();
+
+        var result = await session
+            .Query<User>()
+            .Where(x => x.UserName.NgramSearch("uðmu") || x.UserName.NgramSearch("øre"))
+            .ToListAsync();
+
+        result.Count.ShouldBe(2);
+        result.ShouldContain(x => x.UserName == kierkegaard.UserName);
+        result.ShouldContain(x => x.UserName == bjork.UserName);
+    }
 }

--- a/src/Marten/Schema/SQL/mt_grams_array.sql
+++ b/src/Marten/Schema/SQL/mt_grams_array.sql
@@ -14,7 +14,7 @@ BEGIN
                 FOREACH
 word IN ARRAY string_to_array(words, ' ')
                 LOOP
-                     clean_word = regexp_replace(word, '[^a-zA-Z0-9]+', '','g');
+                     clean_word = regexp_replace(unaccent(word), '[^a-zA-Z0-9]+', '','g');
 FOR i IN 1 .. length(clean_word)
                      LOOP
                          result := result || quote_literal(substr(lower(clean_word), i, 1));


### PR DESCRIPTION
This will give less surprises for people trying to search in non english texts. 