### PR TITLE
Fix JSONB null check in mt_jsonb_fix_null_parent.sql

### DIFF
--- a/src/Marten/Schema/SQL/mt_jsonb_fix_null_parent.sql
+++ b/src/Marten/Schema/SQL/mt_jsonb_fix_null_parent.sql
@@ -13,7 +13,7 @@ BEGIN
     WHILE i <=(dst_path_array_length - 1)
     LOOP
         dst_path_segment = dst_path_segment || ARRAY[dst_path[i]];
-        IF retval #> dst_path_segment = 'null'::jsonb THEN
+        IF retval #> dst_path_segment IS NULL OR retval #> dst_path_segment = 'null'::jsonb THEN
             retval = jsonb_set(retval, dst_path_segment, '{}'::jsonb, TRUE);
         END IF;
         i = i + 1;


### PR DESCRIPTION
Fixing issue described in #3722, where the mt_jsonb_fix_null_parent function wouldn't create the full hierarchy of nested properties.