### PR TITLE
ArchiveStream needed to take its TenantId from the active session in …

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>7.39.3</Version>
+        <Version>7.39.4</Version>
         <LangVersion>12.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/src/LinqTests/Acceptance/custom_linq_extensions.cs
+++ b/src/LinqTests/Acceptance/custom_linq_extensions.cs
@@ -36,7 +36,7 @@ public class custom_linq_extensions
             opts.DatabaseSchemaName = "isblue";
         });
 
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Advanced.Clean.DeleteAllDocumentsAsync();
 
         var targets = new List<ColorTarget>();
         for (var i = 0; i < 25; i++)

--- a/src/Marten/Events/Archiving/ArchiveStreamOperation.cs
+++ b/src/Marten/Events/Archiving/ArchiveStreamOperation.cs
@@ -22,6 +22,8 @@ internal class ArchiveStreamOperation: IStorageOperation
         _streamId = streamId;
     }
 
+    public string? TenantId { get; set; }
+
     public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
     {
         if (_events.TenancyStyle == TenancyStyle.Conjoined)
@@ -29,7 +31,7 @@ internal class ArchiveStreamOperation: IStorageOperation
             var parameters = builder.AppendWithParameters($"select {_events.DatabaseSchemaName}.{ArchiveStreamFunction.Name}(?, ?)");
             parameters[0].Value = _streamId;
             parameters[0].NpgsqlDbType = _events.StreamIdDbType;
-            parameters[1].Value = session.TenantId;
+            parameters[1].Value = TenantId ?? session.TenantId;
             parameters[1].NpgsqlDbType = NpgsqlDbType.Varchar;
         }
         else

--- a/src/Marten/Events/EventStore.Archiving.cs
+++ b/src/Marten/Events/EventStore.Archiving.cs
@@ -8,13 +8,13 @@ internal partial class EventStore
 {
     public void ArchiveStream(Guid streamId)
     {
-        var op = new ArchiveStreamOperation(_store.Events, streamId);
+        var op = new ArchiveStreamOperation(_store.Events, streamId){TenantId = _session.TenantId};
         _session.QueueOperation(op);
     }
 
     public void ArchiveStream(string streamKey)
     {
-        var op = new ArchiveStreamOperation(_store.Events, streamKey);
+        var op = new ArchiveStreamOperation(_store.Events, streamKey){TenantId = _session.TenantId};
         _session.QueueOperation(op);
     }
 }

--- a/src/Marten/Storage/BulkInsertion.cs
+++ b/src/Marten/Storage/BulkInsertion.cs
@@ -284,6 +284,8 @@ internal class BulkInsertion: IDisposable
     private async Task bulkInsertDocumentsAsync<T>(IReadOnlyCollection<T> documents, int batchSize,
         NpgsqlConnection conn, BulkInsertMode mode, CancellationToken cancellation)
     {
+        await _tenant.Database.EnsureStorageExistsAsync(typeof(T), cancellation).ConfigureAwait(false);
+
         var provider = _tenant.Database.Providers.StorageFor<T>();
         var loader = provider.BulkLoader;
 


### PR DESCRIPTION
…case of ForTenant() usage. Closes GH-3729