### PR TITLE
Replaced term LightWeightDocumentSession in Session documentation with LightweightSession

### DIFF
--- a/docs/documents/sessions.md
+++ b/docs/documents/sessions.md
@@ -13,7 +13,7 @@ class QuerySession
 class IDocumentSession
 class DocumentStore
 class IdentityMapDocumentSession
-class LightWeightDocumentSession
+class LightweightSession
 class DirtyCheckingDocumentSession
 
 IDocumentStore --> IQuerySession: Builds
@@ -25,7 +25,7 @@ IQuerySession <|.. IDocumentSession
 IDocumentStore <|.. DocumentStore
 
 IDocumentSession <|.. IdentityMapDocumentSession
-IDocumentSession <|.. LightWeightDocumentSession
+IDocumentSession <|.. LightweightSession
 IDocumentSession <|.. DirtyCheckingDocumentSession
 ```
 
@@ -46,7 +46,7 @@ types of sessions are:
 | `IDocumentStore.OpenSerializableSessionAsync()`         | Read/Write     | Yes              | No                 |
 
 ::: tip INFO
-The recommended session type for read/write operations is `LightWeightDocumentSession`, which gives the best performance. It does not do change tracking, which may not be needed for most cases.
+The recommended session type for read/write operations is `LightweightSession`, which gives the best performance. It does not do change tracking, which may not be needed for most cases.
 
 For read-only access, use `QuerySession`.
 :::


### PR DESCRIPTION
I was reading through https://martendb.io/documents/sessions.html#opening-sessions and was confused when I couldn't find any mention of `LightWeightDocumentSession` anywhere, and doubly so since it was listed as the recommended session type for read/write operations. Not sure if the name changed from a previous version, or maybe it's about to change; just couldn't find it right now :) 

(I did find `LightweightDocumentStorage` so maybe this is just a temporary thing)