### PR TITLE
Add a failing test for projection rebuild not re-creating all documents with EventAppendMode.Quick

### DIFF
--- a/src/DaemonTests/Bugs/Bug_projection_rebuild_skips_document_in_quick_mode.cs
+++ b/src/DaemonTests/Bugs/Bug_projection_rebuild_skips_document_in_quick_mode.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.Bugs;
+
+public class Bug_projection_rebuild_skips_document_in_quick_mode : BugIntegrationContext
+{
+    [Fact]
+    public async Task should_rebuild_all_documents()
+    {
+        StoreOptions(_ =>
+        {
+            _.Events.AppendMode = EventAppendMode.Quick;
+            // _.Events.AppendMode = EventAppendMode.Rich; // Works in Rich-Mode!
+
+            _.Projections.Add<CompanyProjection>(ProjectionLifecycle.Async);
+            _.Projections.Add<CompanyUniqueEmailProjection>(ProjectionLifecycle.Inline);
+        });
+
+        theSession.Events.StartStream<Company>(
+            new CompanyCreated("Microsoft", "info@microsoft.com"),
+            new CompanyNameChanged("Microsoft Inc."),
+            new CompanyNameChanged("Microsoft Ltd."));
+
+        theSession.Events.StartStream<Company>(
+            new CompanyCreated("Apple", "sales@apple.com"));
+
+        theSession.Events.StartStream<Company>(
+            new CompanyCreated("JasperFx", "sales@jasperfx.com"));
+
+        await theSession.SaveChangesAsync();
+
+        // Let the daemon run so the async CompanyProjection can catch up
+        using (var daemon = await theStore.BuildProjectionDaemonAsync())
+        {
+            await daemon.StartAllAsync();
+            await daemon.WaitForNonStaleData(10.Seconds());
+        }
+
+        // Just making sure we have everything as expected
+        var allCompanies = await theSession.Query<Company>().ToListAsync();
+        allCompanies.Count.ShouldBe(3);
+        var allCompanyEmails = await theSession.Query<CompanyUniqueEmail>().ToListAsync();
+        allCompanyEmails.Count.ShouldBe(3);
+
+        // Now comes the fun - rebuilding the projection
+        using (var daemon = await theStore.BuildProjectionDaemonAsync())
+        {
+            await daemon.StartAllAsync();
+            await daemon.RebuildProjectionAsync<CompanyUniqueEmailProjection>(CancellationToken.None);
+
+            await daemon.WaitForNonStaleData(10.Seconds());
+        }
+
+        // Count should be 3 again - but is it?
+        var allCompanyEmailsAfterRebuild = await theSession.Query<CompanyUniqueEmail>().ToListAsync();
+        allCompanyEmailsAfterRebuild.Count.ShouldBe(3);
+    }
+}
+
+public record CompanyCreated(string Name, string Email);
+public record CompanyNameChanged(string NewName);
+
+public class Company
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+    public string Email { get; set; }
+}
+public class CompanyProjection: SingleStreamProjection<Company>
+{
+    public Company Create(CompanyCreated e)
+    {
+        return new Company
+        {
+            Name = e.Name,
+            Email = e.Email,
+        };
+    }
+
+    public void Apply(CompanyNameChanged e, Company company)
+    {
+        company.Name = e.NewName;
+    }
+}
+
+public class CompanyUniqueEmail
+{
+    public Guid Id { get; set; }
+    public string Email { get; set; }
+}
+public class CompanyUniqueEmailProjection: SingleStreamProjection<CompanyUniqueEmail>
+{
+    public CompanyUniqueEmail Create(CompanyCreated e)
+    {
+        return new CompanyUniqueEmail
+        {
+            Email = e.Email.ToLowerInvariant(),
+        };
+    }
+}


### PR DESCRIPTION
As discussed [on discord before](https://discord.com/channels/1074998995086225460/1074999076896112661/1365279600682336374), I was able to reproduce the issue and create a failing test.

Seems related to the `EventAppendMode.Quick`, but I don't know the code well enough to fix the issue myself.