### PR TITLE
- Added support for defining a computed index on an FSharpOption of t…

### DIFF
--- a/src/DocumentDbTests/Indexes/computed_indexes.cs
+++ b/src/DocumentDbTests/Indexes/computed_indexes.cs
@@ -184,6 +184,39 @@ public class computed_indexes: OneOffConfigurationsContext
     }
 
     [Fact]
+    public async Task fsharp_date_related_options_indexes_are_created()
+    {
+        /* In this test, we ensure that the indexes can be created without error.
+          There was a bug such that the family of immutable functions  mt_immutable_timestamp & Cie weren't used which resulted in an exception when the
+          index definition was executed in postgresql.
+        */
+
+        StoreOptions(_ =>
+        {
+            var columns = new Expression<Func<Target, object>>[]
+            {
+                x => x.FSharpDateOption,
+                x => x.FSharpDateOnlyOption,
+                x => x.FSharpTimeOnlyOption,
+                x => x.FSharpDateTimeOffsetOption,
+            };
+            _.Schema.For<Target>().Index(columns, opt =>
+            {
+                opt.Name = "mt_doc_target_idx_fsharp_date_options";
+            });
+        });
+
+        var data = Target.GenerateRandomData(100).ToArray();
+        await theStore.BulkInsertAsync(data.ToArray());
+
+        var table = await theStore.Tenancy.Default.Database.ExistingTableFor(typeof(Target));
+        var index = table.IndexFor("mt_doc_target_idx_fsharp_date_options");
+
+        index.ToDDL(table).ShouldBe("CREATE INDEX mt_doc_target_idx_fsharp_date_options ON computed_indexes.mt_doc_target USING btree (computed_indexes.mt_immutable_timestamp((data ->> 'FSharpDateOption')), computed_indexes.mt_immutable_date((data ->> 'FSharpDateOnlyOption')), computed_indexes.mt_immutable_time((data ->> 'FSharpTimeOnlyOption')), computed_indexes.mt_immutable_timestamptz((data ->> 'FSharpDateTimeOffsetOption')));");
+
+    }
+
+    [Fact]
     public async Task create_multi_property_string_index_with_casing()
     {
         StoreOptions(_ =>

--- a/src/FSharpTypes/FSharpTypes.fsproj
+++ b/src/FSharpTypes/FSharpTypes.fsproj
@@ -9,9 +9,15 @@
     <ItemGroup>
         <Compile Include="Library.fs"/>
     </ItemGroup>
+    
 
     <ItemGroup>
       <ProjectReference Include="..\LinqTestsTypes\LinqTestsTypes.csproj" />
+    </ItemGroup>
+    
+
+    <ItemGroup>
+      <PackageReference Update="FSharp.Core" Version="8.0.100" />
     </ItemGroup>
 
 </Project>

--- a/src/LinqTestsTypes/LinqTestsTypes.csproj
+++ b/src/LinqTestsTypes/LinqTestsTypes.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="FSharp.Core" Version="9.0.100" />
+      <PackageReference Include="FSharp.Core" Version="[8.0.0,)" />
       <PackageReference Include="JasperFx.Core" Version="1.9.0" />
     </ItemGroup>
 

--- a/src/Marten.Testing/Documents/Target.cs
+++ b/src/Marten.Testing/Documents/Target.cs
@@ -96,15 +96,12 @@ public class Target
         }
 
         var value = _random.Next(0, 100);
-        if (value > 10)
-        {
-            target.NullableNumber = value;
-        }
+        if (value > 10) target.NullableNumber = value;
 
         if (value > 20)
         {
             var list = new List<string>();
-            for (var i = 0; i < 5; i++)
+            for (int i = 0; i < 5; i++)
             {
                 list.Add(_strings[_random.Next(0, 10)]);
             }

--- a/src/Marten.Testing/Documents/Target.cs
+++ b/src/Marten.Testing/Documents/Target.cs
@@ -5,7 +5,6 @@ using System.Text.Json.Serialization;
 using JasperFx.Core;
 using Microsoft.FSharp.Core;
 
-#nullable enable
 namespace Marten.Testing.Documents;
 
 public enum Colors
@@ -60,6 +59,9 @@ public class Target
             target.FSharpDecimalOption = new FSharpOption<decimal>(_random.Next(0, 10));
             target.FSharpLongOption = new FSharpOption<long>(_random.Next(0, 10));
             target.FSharpStringOption = new FSharpOption<string>(_strings[_random.Next(0, 10)]);
+            target.FSharpBoolOption = new FSharpOption<bool>(_random.Next(0, 10) > 5);
+            target.FSharpDateOnlyOption = new FSharpOption<DateOnly>(new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, DateTime.UtcNow.Day));
+            target.FSharpTimeOnlyOption = new FSharpOption<TimeOnly>(new TimeOnly(DateTime.UtcNow.Hour, DateTime.UtcNow.Minute, DateTime.UtcNow.Second));
         }
 
         target.PaddedString = " " + target.String + " ";
@@ -67,7 +69,7 @@ public class Target
         target.Number = _random.Next();
         target.AnotherNumber = _random.Next();
         target.OtherGuid = Guid.NewGuid();
-       
+
         target.Flag = _random.Next(0, 10) > 5;
 
         target.Float = float.Parse(_random.NextDouble().ToString());
@@ -94,12 +96,15 @@ public class Target
         }
 
         var value = _random.Next(0, 100);
-        if (value > 10) target.NullableNumber = value;
+        if (value > 10)
+        {
+            target.NullableNumber = value;
+        }
 
         if (value > 20)
         {
             var list = new List<string>();
-            for (int i = 0; i < 5; i++)
+            for (var i = 0; i < 5; i++)
             {
                 list.Add(_strings[_random.Next(0, 10)]);
             }
@@ -168,6 +173,9 @@ public class Target
     public FSharpOption<string> FSharpStringOption { get; set; }
     public FSharpOption<DateTime> FSharpDateOption { get; set; }
     public FSharpOption<DateTimeOffset> FSharpDateTimeOffsetOption { get; set; }
+    public FSharpOption<DateOnly> FSharpDateOnlyOption { get; set; }
+    public FSharpOption<TimeOnly> FSharpTimeOnlyOption { get; set; }
+
 
     public string AnotherString { get; set; }
 

--- a/src/Marten.Testing/Documents/Target.cs
+++ b/src/Marten.Testing/Documents/Target.cs
@@ -59,7 +59,6 @@ public class Target
             target.FSharpDecimalOption = new FSharpOption<decimal>(_random.Next(0, 10));
             target.FSharpLongOption = new FSharpOption<long>(_random.Next(0, 10));
             target.FSharpStringOption = new FSharpOption<string>(_strings[_random.Next(0, 10)]);
-            target.FSharpBoolOption = new FSharpOption<bool>(_random.Next(0, 10) > 5);
             target.FSharpDateOnlyOption = new FSharpOption<DateOnly>(new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, DateTime.UtcNow.Day));
             target.FSharpTimeOnlyOption = new FSharpOption<TimeOnly>(new TimeOnly(DateTime.UtcNow.Hour, DateTime.UtcNow.Minute, DateTime.UtcNow.Second));
         }

--- a/src/Marten.Testing/Harness/ConnectionSource.cs
+++ b/src/Marten.Testing/Harness/ConnectionSource.cs
@@ -10,7 +10,7 @@ public class ConnectionSource: ConnectionFactory
     // Keep the default timeout pretty short
     public static readonly string ConnectionString = Environment.GetEnvironmentVariable("marten_testing_database")
                                                      ??
-                                                     "Host=localhost;Port=5432;Database=marten_linq_testing;Username=postgres;password=postgres;Command Timeout=5";
+                                                     "Host=localhost;Port=5432;Database=marten_testing;Username=postgres;password=postgres;Command Timeout=5";
 
     static ConnectionSource()
     {

--- a/src/Marten.Testing/Harness/ConnectionSource.cs
+++ b/src/Marten.Testing/Harness/ConnectionSource.cs
@@ -10,7 +10,7 @@ public class ConnectionSource: ConnectionFactory
     // Keep the default timeout pretty short
     public static readonly string ConnectionString = Environment.GetEnvironmentVariable("marten_testing_database")
                                                      ??
-                                                     "Host=localhost;Port=5432;Database=marten_testing;Username=postgres;password=postgres;Command Timeout=5";
+                                                     "Host=localhost;Port=5432;Database=marten_linq_testing;Username=postgres;password=postgres;Command Timeout=5";
 
     static ConnectionSource()
     {

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -48,7 +48,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FSharp.Core" Version="9.0.100" />
+        <PackageReference Include="FSharp.Core" Version="[8.0.100,)" />
         <PackageReference Include="JasperFx.Core" Version="1.12.0" />
         <PackageReference Include="JasperFx.CodeGeneration" Version="3.7.2" />
         <PackageReference Include="JasperFx.RuntimeCompiler" Version="3.7.2" />

--- a/src/Marten/StoreOptions.MemberFactory.cs
+++ b/src/Marten/StoreOptions.MemberFactory.cs
@@ -70,22 +70,22 @@ public partial class StoreOptions
                 : new EnumAsStringMember(parent, serializer.Casing, member);
         }
 
-        if (memberType == typeof(DateTime))
+        if (memberType == typeof(DateTime) || memberType == typeof(FSharpOption<DateTime>))
         {
             return new DateTimeMember(this, parent, casing, member);
         }
 
-        if (memberType == typeof(DateTimeOffset))
+        if (memberType == typeof(DateTimeOffset) || memberType == typeof(FSharpOption<DateTimeOffset>))
         {
             return new DateTimeOffsetMember(this, parent, casing, member);
         }
 
-        if (memberType == typeof(DateOnly))
+        if (memberType == typeof(DateOnly) || memberType == typeof(FSharpOption<DateOnly>))
         {
             return new DateOnlyMember(this, parent, casing, member);
         }
 
-        if (memberType == typeof(TimeOnly))
+        if (memberType == typeof(TimeOnly)  || memberType == typeof(FSharpOption<TimeOnly>) )
         {
             return new TimeOnlyMember(this, parent, casing, member);
         }


### PR DESCRIPTION
…ype DateTime, DateOnly, TimeOnly and DateTimeOffset 
- Fixed FSharp dependency to allow any FSharp.Core package greater or equal to 8.0.100 (instead of requiring FSharp 9.0 in a strict manner)

Closes #3774