### PR TITLE
fix FK reference from multi tenanted doc to single tenanted doc

### DIFF
--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -971,8 +971,8 @@ internal static class ForeignKeyExtensions
 {
     public static void TryMoveTenantIdFirst(this ForeignKey foreignKey, DocumentMapping mapping)
     {
-        // Guard clause, do nothing if this document is not tenanted
-        if (mapping.TenancyStyle == TenancyStyle.Single) return;
+        // Guard clause, do nothing if this document is not tenanted or foreign key doesn't contain tenant id
+        if (mapping.TenancyStyle == TenancyStyle.Single || foreignKey.ColumnNames.Any(x => x != TenantIdColumn.Name)) return;
 
         foreignKey.ColumnNames = new string[] { TenantIdColumn.Name }
             .Concat(foreignKey.ColumnNames.Where(x => x != TenantIdColumn.Name)).ToArray();


### PR DESCRIPTION
Until v7.35.1 it was possible to define FK indexes between multi tenanted document and single tenanted document in single server configuration. Starting from that version Marten included `tenant_id` in FK reference to single tenanted document which ended up in PSQL exception:

`Npgsql.PostgresException: 42703: column "tenant_id" referenced in foreign key constraint does not exist`

SQL that includes invalid FK REFERENCE:

```
DROP TABLE IF EXISTS public.mt_doc_single_tenanted_doc CASCADE;
CREATE TABLE public.mt_doc_single_tenanted_doc (
    id                  uuid                        NOT NULL,
    data                jsonb                       NOT NULL,
    mt_last_modified    timestamp with time zone    NULL DEFAULT (transaction_timestamp()),
    mt_version          uuid                        NOT NULL DEFAULT (md5(random()::text || clock_timestamp()::text)::uuid),
    mt_dotnet_type      varchar                     NULL,
    mt_created_at       timestamp with time zone    NULL DEFAULT (transaction_timestamp()),
    correlation_id      varchar                     NULL,
    causation_id        varchar                     NULL,
    last_modified_by    varchar                     NULL,
    headers             jsonb                       NULL,
    mt_deleted          boolean                     NULL DEFAULT FALSE,
    mt_deleted_at       timestamp with time zone    NULL,
CONSTRAINT mt_doc_single_tenanted_doc_id PRIMARY KEY (id)
);


DROP TABLE IF EXISTS public.mt_doc_multi_tenanted_doc CASCADE;
CREATE TABLE public.mt_doc_multi_tenanted_doc (
    tenant_id                           varchar                     NOT NULL DEFAULT '*DEFAULT*',
    id                                  uuid                        NOT NULL,
    data                                jsonb                       NOT NULL,
    mt_last_modified                    timestamp with time zone    NULL DEFAULT (transaction_timestamp()),
    mt_version                          uuid                        NOT NULL DEFAULT (md5(random()::text || clock_timestamp()::text)::uuid),
    mt_dotnet_type                      varchar                     NULL,
    mt_created_at                       timestamp with time zone    NULL DEFAULT (transaction_timestamp()),
    correlation_id                      varchar                     NULL,
    causation_id                        varchar                     NULL,
    last_modified_by                    varchar                     NULL,
    headers                             jsonb                       NULL,
    single_tenanted_doc_id              uuid                        NULL,
CONSTRAINT pkey_mt_multi_tenanted_doc_tenant_id_id PRIMARY KEY (tenant_id, id)
);

ALTER TABLE public.mt_doc_multi_tenanted_doc
ADD CONSTRAINT mt_doc_multi_tenanted_doc_tenant_id_single_tenanted_doc_id_fkey FOREIGN KEY(tenant_id, single_tenanted_doc_id)
REFERENCES public.mt_doc_single_tenanted_doc(tenant_id, id);
```

This PR aims to fix the issue.