### PR TITLE
Improved select parsing

### DIFF
--- a/src/LinqTests/Operators/string_compare_operator.cs
+++ b/src/LinqTests/Operators/string_compare_operator.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Documents;
@@ -11,29 +13,216 @@ public class string_compare_operator: IntegrationContext
     [Fact]
     public async Task string_compare_works()
     {
-        theSession.Store(new Target { String = "Apple" });
-        theSession.Store(new Target { String = "Banana" });
-        theSession.Store(new Target { String = "Cherry" });
-        theSession.Store(new Target { String = "Durian" });
+        // Arrange
+        var targets = new[]
+        {
+            new Target { String = "Apple" },
+            new Target { String = "Banana" },
+            new Target { String = "Cherry" },
+            new Target { String = "Durian" }
+        };
+
+        theSession.Store(targets);
         await theSession.SaveChangesAsync();
 
-        var queryable = theSession.Query<Target>().Where(x => string.Compare(x.String, "Cherry") > 0);
+        // Act
+        var queryable = theSession.Query<Target>()
+            .Where(x => string.Compare(x.String, "Cherry") > 0);
 
-        queryable.ToList().Count.ShouldBe(1);
+        // Assert
+        var expected = targets
+            .Where(x => string.Compare(x.String, "Cherry") > 0)
+            .Select(x => x.String);
+
+        queryable.Select(x => x.String).ToList().ShouldBe(expected);
     }
 
     [Fact]
     public async Task string_compare_to_works()
     {
-        theSession.Store(new Target { String = "Apple" });
-        theSession.Store(new Target { String = "Banana" });
-        theSession.Store(new Target { String = "Cherry" });
-        theSession.Store(new Target { String = "Durian" });
+        // Arrange
+        var targets = new[]
+        {
+            new Target { String = "Apple" },
+            new Target { String = "Banana" },
+            new Target { String = "Cherry" },
+            new Target { String = "Durian" }
+        };
+
+        theSession.Store(targets);
         await theSession.SaveChangesAsync();
 
-        var queryable = theSession.Query<Target>().Where(x => x.String.CompareTo("Banana") > 0);
+        // Act
+        var queryable = theSession.Query<Target>()
+            .Where(x => x.String.CompareTo("Banana") > 0);
 
-        queryable.ToList().Count.ShouldBe(2);
+        // Assert
+        var expected = targets
+            .Where(x => x.String.CompareTo("Banana") > 0)
+            .Select(x => x.String);
+
+        queryable.Select(x => x.String).ToList().ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task string_compare_ignore_case_works()
+    {
+        // Arrange
+        var targets = new[]
+        {
+            new Target { String = "apple" },
+            new Target { String = "Banana" },
+            new Target { String = "cherry" },
+            new Target { String = "Durian" }
+        };
+
+        theSession.Store(targets);
+        await theSession.SaveChangesAsync();
+
+        // Act
+        var queryable = theSession.Query<Target>()
+            .Where(x => string.Compare(x.String, "BANANA", StringComparison.OrdinalIgnoreCase) > 0);
+
+        // Assert
+        var expected = targets
+            .Where(x => string.Compare(x.String, "BANANA", StringComparison.OrdinalIgnoreCase) > 0)
+            .Select(x => x.String);
+
+        queryable.Select(x => x.String).ToList().ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task string_compare_with_invariant_culture_and_ignore_case_works()
+    {
+        // Arrange
+        var targets = new[]
+        {
+            new Target { String = "apple" },
+            new Target { String = "Banana" },
+            new Target { String = "cherry" }
+        };
+
+        theSession.Store(targets);
+        await theSession.SaveChangesAsync();
+
+        // Act
+        var queryable = theSession.Query<Target>()
+            .Where(x => string.Compare(x.String, "APPLE", CultureInfo.InvariantCulture, CompareOptions.IgnoreCase) == 0);
+
+        // Assert
+        var expected = targets
+            .Where(x => string.Compare(x.String, "APPLE", CultureInfo.InvariantCulture, CompareOptions.IgnoreCase) == 0)
+            .Select(x => x.String);
+
+        queryable.Select(x => x.String).ToList().ShouldBe(expected);
+    }
+
+    [Fact]
+    // Test requires the following SQL to be run: create collation "tr-TR" (locale='tr-TR.utf8');
+    public async Task string_compare_with_turkish_culture_case_insensitive_behavior()
+    {
+        // Arrange
+        var turkishCulture = CultureInfo.GetCultureInfo("tr-TR");
+        var targets = new[]
+        {
+            new Target { String = "İi" }, // Turkish uppercase İ
+            new Target { String = "ıi" }  // Turkish lowercase ı
+        };
+
+        theSession.Store(targets);
+        await theSession.SaveChangesAsync();
+
+        // Act
+        var queryable = theSession.Query<Target>()
+            .Where(x => string.Compare(x.String, "ii", turkishCulture, CompareOptions.IgnoreCase) == 0);
+
+        // Assert
+        var expected = targets
+            .Where(x => string.Compare(x.String, "ii", turkishCulture, CompareOptions.IgnoreCase) == 0)
+            .Select(x => x.String);
+
+        queryable.Select(x => x.String).ToList().ShouldBe(expected, ignoreOrder: true);
+    }
+
+    [Fact]
+    // Test requires the following SQL to be run: create collation "en-US" (locale='en-US.utf8');
+    public async Task string_compare_with_english_culture_ignore_case_works()
+    {
+        // Arrange
+        var englishCulture = CultureInfo.GetCultureInfo("en-US");
+        var targets = new[]
+        {
+            new Target { String = "Apple" },
+            new Target { String = "apple" }
+        };
+
+        theSession.Store(targets);
+        await theSession.SaveChangesAsync();
+
+        // Act
+        var queryable = theSession.Query<Target>()
+            .Where(x => string.Compare(x.String, "APPLE", true, englishCulture) == 0);
+
+        // Assert
+        var expected = targets
+            .Where(x => string.Compare(x.String, "APPLE", true, englishCulture) == 0)
+            .Select(x => x.String);
+
+        queryable.Select(x => x.String).ToList().ShouldBe(expected);
+    }
+
+    [Fact]
+    // Test requires the following SQL to be run: create collation "de-DE" (locale='de-DE.utf8');
+    public async Task string_compare_with_german_culture_and_compare_options_works()
+    {
+        // Arrange
+        var germanCulture = CultureInfo.GetCultureInfo("de-DE");
+        var targets = new[]
+        {
+            new Target { String = "Straße" },
+            new Target { String = "Strasse" }
+        };
+
+        theSession.Store(targets);
+        await theSession.SaveChangesAsync();
+
+        // Act
+        var queryable = theSession.Query<Target>()
+            .Where(x => string.Compare(x.String, "Strasse", germanCulture, CompareOptions.IgnoreSymbols) == 0);
+
+        // Assert
+        var expected = targets
+            .Where(x => string.Compare(x.String, "Strasse", germanCulture, CompareOptions.IgnoreSymbols) == 0)
+            .Select(x => x.String);
+
+        queryable.Select(x => x.String).ToList().ShouldBe(expected);
+    }
+
+    [Fact]
+    // Test requires the following SQL to be run: create collation "da-DK" (locale='da-DK.utf8');
+    public async Task string_compare_to_with_culture_works()
+    {
+        // Arrange
+        var danishCulture = CultureInfo.GetCultureInfo("da-DK");
+        var targets = new[]
+        {
+            new Target { String = "Apple" },
+            new Target { String = "Æble" }
+        };
+
+        theSession.Store(targets);
+        await theSession.SaveChangesAsync();
+
+        // Act
+        var queryable = theSession.Query<Target>()
+            .Where(x => string.Compare(x.String, "Apple", danishCulture, CompareOptions.None) > 0);
+
+        // Assert
+        var expected = targets
+            .Where(x => string.Compare(x.String, "Apple", danishCulture, CompareOptions.None) > 0)
+            .Select(x => x.String);
+
+        queryable.Select(x => x.String).ToList().ShouldBe(expected);
     }
 
     public string_compare_operator(DefaultStoreFixture fixture) : base(fixture)

--- a/src/Marten/Linq/Parsing/CompareToComparable.cs
+++ b/src/Marten/Linq/Parsing/CompareToComparable.cs
@@ -18,7 +18,7 @@ internal class CompareToComparable: IComparableMember
 
     public ISqlFragment CreateComparison(string op, ConstantExpression constant)
     {
-        // Only compare to 0 is valid: CompareTo() > 0 → ">", CompareTo() == 0 → "=", etc.
+        // Only compare to 0 is valid: CompareTo() > 0 → ">", CompareTo() == 0 → "=", CompareTo() < 0 → "<"
         if (constant.Value is int intValue && intValue == 0)
         {
             var leftFragment = _left.FindValueFragment();

--- a/src/Marten/Linq/Parsing/SelectorVisitor.cs
+++ b/src/Marten/Linq/Parsing/SelectorVisitor.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using JasperFx.Core.Reflection;
+using Marten.Exceptions;
 using Marten.Linq.Members;
 using Marten.Linq.SqlGeneration;
 using Marten.Util;
@@ -58,7 +59,19 @@ public class SelectorVisitor: ExpressionVisitor
             return null;
         }
 
-        return base.VisitMethodCall(node);
+        try
+        {
+            return base.VisitMethodCall(node);
+        }
+        catch (BadLinqExpressionException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            SelectParser.ThrowForUnsupportedMethod(node, e);
+            return null;
+        }
     }
 
     protected override Expression VisitUnary(UnaryExpression node)

--- a/src/Marten/Linq/Parsing/StringCompareComparable.cs
+++ b/src/Marten/Linq/Parsing/StringCompareComparable.cs
@@ -1,6 +1,8 @@
+using System;
+using System.Globalization;
 using System.Linq.Expressions;
-using Marten.Exceptions;
 using Marten.Linq.Members;
+using Marten.Linq.SqlGeneration;
 using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Parsing;
@@ -9,25 +11,52 @@ internal class StringCompareComparable: IComparableMember
 {
     private readonly SimpleExpression _left;
     private readonly SimpleExpression _right;
+    private readonly StringComparison? _stringComparison;
+    private readonly bool _ignoreCase;
+    private readonly CultureInfo _culture;
+    private readonly CompareOptions _compareOptions;
 
-    internal StringCompareComparable(SimpleExpression left, SimpleExpression right)
+    public StringCompareComparable(
+        SimpleExpression left,
+        SimpleExpression right,
+        StringComparison? stringComparison = null,
+        bool ignoreCase = false,
+        CultureInfo culture = null,
+        CompareOptions compareOptions = CompareOptions.None)
     {
         _left = left;
         _right = right;
+        _stringComparison = stringComparison;
+        _ignoreCase = ignoreCase;
+        _culture = culture;
+        _compareOptions = compareOptions;
     }
 
     public ISqlFragment CreateComparison(string op, ConstantExpression constant)
     {
-        if (constant.Value is int intValue && intValue == 0)
-        {
-            var leftFragment = _left.FindValueFragment();
-            var rightFragment = _right.FindValueFragment();
+        var leftFragment = _left.FindValueFragment();
+        var rightFragment = _right.FindValueFragment();
 
-            return new ComparisonFilter(leftFragment, rightFragment, op);
-        }
-        else
+        // Only apply COLLATE for non-invariant cultures
+        if (_culture != null && !string.IsNullOrEmpty(_culture.Name) && _culture != CultureInfo.InvariantCulture)
         {
-            throw new BadLinqExpressionException("string.Compare must be compared to 0");
+            leftFragment = new CollatedFragment(leftFragment, _culture);
+            rightFragment = new CollatedFragment(rightFragment, _culture);
         }
+
+        // Handle case insensitivity
+        var useCaseInsensitive = _ignoreCase || _compareOptions == CompareOptions.IgnoreCase ||
+            (_stringComparison.HasValue &&
+             (_stringComparison.Value == StringComparison.OrdinalIgnoreCase ||
+              _stringComparison.Value == StringComparison.CurrentCultureIgnoreCase ||
+              _stringComparison.Value == StringComparison.InvariantCultureIgnoreCase));
+
+        if (useCaseInsensitive)
+        {
+            leftFragment = new LowerCaseFragment(leftFragment);
+            rightFragment = new LowerCaseFragment(rightFragment);
+        }
+
+        return new ComparisonFilter(leftFragment, rightFragment, op);
     }
 }

--- a/src/Marten/Linq/SqlGeneration/CollatedFragment.cs
+++ b/src/Marten/Linq/SqlGeneration/CollatedFragment.cs
@@ -1,0 +1,25 @@
+using System.Globalization;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.SqlGeneration
+{
+    public class CollatedFragment: ISqlFragment
+    {
+        private readonly ISqlFragment _inner;
+        private readonly CultureInfo _culture;
+
+        public CollatedFragment(ISqlFragment inner, CultureInfo culture)
+        {
+            _inner = inner;
+            _culture = culture;
+        }
+
+        public void Apply(ICommandBuilder builder)
+        {
+            builder.Append("(");
+            _inner.Apply(builder);
+            builder.Append($") COLLATE \"{_culture.Name}\"");
+        }
+    }
+}

--- a/src/Marten/Linq/SqlGeneration/LowerCaseFragment.cs
+++ b/src/Marten/Linq/SqlGeneration/LowerCaseFragment.cs
@@ -1,0 +1,22 @@
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.SqlGeneration
+{
+    public class LowerCaseFragment: ISqlFragment
+    {
+        private readonly ISqlFragment _inner;
+
+        public LowerCaseFragment(ISqlFragment inner)
+        {
+            _inner = inner;
+        }
+
+        public void Apply(ICommandBuilder builder)
+        {
+            builder.Append("LOWER(");
+            _inner.Apply(builder);
+            builder.Append(")");
+        }
+    }
+}


### PR DESCRIPTION
Throws exceptions if it is unable to parse a select projection.
Before, it would either not run the `Select` but still return the query without the projection, or return an empty queryable. Now, it throws an exception if it cannot parse.