### PR TITLE
Fixes summary of StartStream overload for string IDs

### DIFF
--- a/src/Marten/Events/IEventOperations.cs
+++ b/src/Marten/Events/IEventOperations.cs
@@ -89,7 +89,7 @@ public interface IEventOperations
     StreamAction StartStream(Type aggregateType, Guid id, params object[] events);
 
     /// <summary>
-    ///     Creates a new event stream based on a user-supplied Guid and appends the events in order to the new stream
+    ///     Creates a new event stream based on a user-supplied string ID  and appends the events in order to the new stream
     ///     - WILL THROW AN EXCEPTION IF THE STREAM ALREADY EXISTS
     /// </summary>
     /// <typeparam name="TAggregate"></typeparam>


### PR DESCRIPTION
The current summary makes reference to GUIDs even though it is the string version of the overload. 