### PR TITLE
Make SingleTenanted attribute work properly

### DIFF
--- a/src/DocumentDbTests/DocumentDbTests.csproj
+++ b/src/DocumentDbTests/DocumentDbTests.csproj
@@ -56,6 +56,9 @@
         <Compile Include="..\Marten.Testing\Documents\LongDoc.cs">
             <Link>LongDoc.cs</Link>
         </Compile>
+        <Compile Include="..\Marten.Testing\Documents\SingleTenantedDocument.cs">
+          <Link>Documents\SingleTenantedDocument.cs</Link>
+        </Compile>
         <Compile Include="..\Marten.Testing\Documents\StringDoc.cs">
             <Link>Documents\StringDoc.cs</Link>
         </Compile>

--- a/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs
+++ b/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs
@@ -773,4 +773,21 @@ public class conjoined_multi_tenancy: StoreContext<MultiTenancyFixture>, IClassF
         var blue = theStore.QuerySession("Red");
         (await blue.LoadAsync<StringDoc>(target.Id)).ShouldNotBeNull();
     }
+
+    [Fact]
+    public async Task store_document_marked_with_single_tenant_attribute()
+    {
+        var target = new SingleTenantedDocument { Id = Guid.NewGuid() };
+
+        await using (var session = theStore.LightweightSession("Red"))
+        {
+            session.Store(target);
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.QuerySession("Blue"))
+        {
+            (await session.LoadAsync<SingleTenantedDocument>(target.Id)).ShouldNotBeNull();
+        }
+    }
 }

--- a/src/Marten.Testing/Documents/SingleTenantedDocument.cs
+++ b/src/Marten.Testing/Documents/SingleTenantedDocument.cs
@@ -1,0 +1,10 @@
+using System;
+using Marten.Schema;
+
+namespace Marten.Testing.Documents;
+
+[SingleTenanted]
+public class SingleTenantedDocument
+{
+    public Guid Id { get; set; }
+}

--- a/src/Marten/Schema/SingleTenantedAttribute.cs
+++ b/src/Marten/Schema/SingleTenantedAttribute.cs
@@ -15,7 +15,7 @@ public class SingleTenantedAttribute: MartenAttribute
 {
     public override void Modify(DocumentMapping mapping)
     {
-        mapping.TenancyStyle = TenancyStyle.Conjoined;
+        mapping.TenancyStyle = TenancyStyle.Single;
         if (mapping.Partitioning != null && mapping.Partitioning is ListPartitioning lp &&
             lp.PartitionManager is ManagedListPartitions)
         {


### PR DESCRIPTION
The [SingleTenanted] document attribute was incorrectly setting documents to `TenancyStyle.Conjoined`.

This pull request fixes the attribute and also adds a test to verify the fix.