### PR TITLE
Fix camel casing typo in JSON field names documentation.

### DIFF
--- a/docs/configuration/json.md
+++ b/docs/configuration/json.md
@@ -55,7 +55,7 @@ By default, Marten stores field names "as they are" (C# naming convention is Pas
 
 You can have them also automatically formatted to:
 
-- `CamelCase`,
+- `camelCase`,
 - `snake_case`
 
 by changing the relevant serializer settings:


### PR DESCRIPTION
This pull request includes a small documentation update in `docs/configuration/json.md`. The change corrects the casing of "camelCase" in the list of field name formatting options to align with standard naming conventions.