### PR TITLE
Fix blind replace of `d.` in TypedLocator causing issues when schema name ends with `d`

### DIFF
--- a/src/DocumentDbTests/Bugs/Bug_3778_schema_name_issue.cs
+++ b/src/DocumentDbTests/Bugs/Bug_3778_schema_name_issue.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten.Testing;
+using Marten.Testing.Harness;
+using Xunit;
+
+namespace DocumentDbTests.Bugs;
+
+public class Bug_3778_schema_name_issue: OneOffConfigurationsContext
+{
+    private string Schema = "pprd";
+
+    [Fact]
+    public async Task TestSchemaNameEndingWith_d_BeingCutOff_In_Index()
+    {
+        StoreOptions(options =>
+        {
+            options.Connection(ConnectionSource.ConnectionString);
+            options.AutoCreateSchemaObjects = AutoCreate.All;
+            options.DatabaseSchemaName = Schema;
+            options.Schema.For<User3778>()
+                .Index(d => d.Created);
+        });
+
+        await theStore.EnsureStorageExistsAsync(typeof(User3778));
+    }
+}
+
+public record User3778(Guid Id, string Name, DateTimeOffset Created);

--- a/src/Marten/Linq/Members/DateTimeMember.cs
+++ b/src/Marten/Linq/Members/DateTimeMember.cs
@@ -14,7 +14,7 @@ public class DateTimeMember: QueryableMember, IComparableMember
 
     public override string SelectorForDuplication(string pgType)
     {
-        return TypedLocator.Replace("d.data->", "data->");
+        return TypedLocator.Replace("d.data ->", "data ->");
     }
 }
 
@@ -27,7 +27,7 @@ public class DateOnlyMember: QueryableMember, IComparableMember
 
     public override string SelectorForDuplication(string pgType)
     {
-        return TypedLocator.Replace("d.data->", "data->");
+        return TypedLocator.Replace("d.data ->", "data ->");
     }
 
 }

--- a/src/Marten/Linq/Members/DateTimeMember.cs
+++ b/src/Marten/Linq/Members/DateTimeMember.cs
@@ -14,8 +14,7 @@ public class DateTimeMember: QueryableMember, IComparableMember
 
     public override string SelectorForDuplication(string pgType)
     {
-        var updatedRawLocator = RawLocator.Replace("d.", "", StringComparison.InvariantCulture);
-        return TypedLocator.Replace(RawLocator, updatedRawLocator, StringComparison.InvariantCulture);
+        return TypedLocator.Replace("d.data->", "data->");
     }
 }
 
@@ -28,8 +27,7 @@ public class DateOnlyMember: QueryableMember, IComparableMember
 
     public override string SelectorForDuplication(string pgType)
     {
-        var updatedRawLocator = RawLocator.Replace("d.", "");
-        return TypedLocator.Replace(RawLocator, updatedRawLocator);
+        return TypedLocator.Replace("d.data->", "data->");
     }
 
 }
@@ -43,8 +41,7 @@ public class TimeOnlyMember: QueryableMember, IComparableMember
 
     public override string SelectorForDuplication(string pgType)
     {
-        var updatedRawLocator = RawLocator.Replace("d.", "");
-        return TypedLocator.Replace(RawLocator, updatedRawLocator);
+        return TypedLocator.Replace("d.data ->", "data ->");
     }
 
 }

--- a/src/Marten/Linq/Members/DateTimeMember.cs
+++ b/src/Marten/Linq/Members/DateTimeMember.cs
@@ -14,7 +14,8 @@ public class DateTimeMember: QueryableMember, IComparableMember
 
     public override string SelectorForDuplication(string pgType)
     {
-        return TypedLocator.Replace("d.", "");
+        var updatedRawLocator = RawLocator.Replace("d.", "", StringComparison.InvariantCulture);
+        return TypedLocator.Replace(RawLocator, updatedRawLocator, StringComparison.InvariantCulture);
     }
 }
 
@@ -27,7 +28,8 @@ public class DateOnlyMember: QueryableMember, IComparableMember
 
     public override string SelectorForDuplication(string pgType)
     {
-        return TypedLocator.Replace("d.", "");
+        var updatedRawLocator = RawLocator.Replace("d.", "");
+        return TypedLocator.Replace(RawLocator, updatedRawLocator);
     }
 
 }
@@ -41,7 +43,8 @@ public class TimeOnlyMember: QueryableMember, IComparableMember
 
     public override string SelectorForDuplication(string pgType)
     {
-        return TypedLocator.Replace("d.", "");
+        var updatedRawLocator = RawLocator.Replace("d.", "");
+        return TypedLocator.Replace(RawLocator, updatedRawLocator);
     }
 
 }

--- a/src/Marten/Linq/Members/DateTimeOffsetMember.cs
+++ b/src/Marten/Linq/Members/DateTimeOffsetMember.cs
@@ -1,7 +1,9 @@
 #nullable enable
 using System;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Marten.Linq.SqlGeneration.Filters;
 using Weasel.Postgresql.SqlGeneration;
 
@@ -17,7 +19,8 @@ public class DateTimeOffsetMember: QueryableMember, IComparableMember
 
     public override string SelectorForDuplication(string pgType)
     {
-        return TypedLocator.Replace("d.", "");
+        var updatedRawLocator = RawLocator.Replace("d.", "");
+        return TypedLocator.Replace(RawLocator, updatedRawLocator);
     }
 
     public override ISqlFragment CreateComparison(string op, ConstantExpression constant)

--- a/src/Marten/Linq/Members/DateTimeOffsetMember.cs
+++ b/src/Marten/Linq/Members/DateTimeOffsetMember.cs
@@ -1,9 +1,7 @@
 #nullable enable
 using System;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using Marten.Linq.SqlGeneration.Filters;
 using Weasel.Postgresql.SqlGeneration;
 
@@ -19,8 +17,7 @@ public class DateTimeOffsetMember: QueryableMember, IComparableMember
 
     public override string SelectorForDuplication(string pgType)
     {
-        var updatedRawLocator = RawLocator.Replace("d.", "");
-        return TypedLocator.Replace(RawLocator, updatedRawLocator);
+        return TypedLocator.Replace("d.data ->", "data ->");
     }
 
     public override ISqlFragment CreateComparison(string op, ConstantExpression constant)

--- a/src/Marten/Schema/ComputedIndex.cs
+++ b/src/Marten/Schema/ComputedIndex.cs
@@ -83,8 +83,8 @@ public class ComputedIndex: IndexDefinition
                 casing = Casings.Default;
             }
 
-            var rawLocator = member.RawLocator.Replace("d.", "");
-            var typedLocator = member.TypedLocator.Replace(member.RawLocator, rawLocator);
+            var rawLocator = member.RawLocator.Replace("d.data ->", "data ->");
+            var typedLocator = member.TypedLocator.Replace("d.data ->", "data ->");
 
             var sql = member.MemberType.IsEnumerable()
                 ? member is ChildCollectionMember ? typedLocator : rawLocator

--- a/src/Marten/Schema/ComputedIndex.cs
+++ b/src/Marten/Schema/ComputedIndex.cs
@@ -83,11 +83,12 @@ public class ComputedIndex: IndexDefinition
                 casing = Casings.Default;
             }
 
-            var sql = member.MemberType.IsEnumerable()
-                ? member is ChildCollectionMember ? member.TypedLocator : member.RawLocator
-                : member.TypedLocator;
+            var rawLocator = member.RawLocator.Replace("d.", "");
+            var typedLocator = member.TypedLocator.Replace(member.RawLocator, rawLocator);
 
-            sql = sql.Replace("d.", "");
+            var sql = member.MemberType.IsEnumerable()
+                ? member is ChildCollectionMember ? typedLocator : rawLocator
+                : typedLocator;
 
             switch (casing)
             {

--- a/src/Marten/Schema/NgramIndex.cs
+++ b/src/Marten/Schema/NgramIndex.cs
@@ -75,8 +75,9 @@ public class NgramIndex: IndexDefinition
 
     private static string GetDataConfig(DocumentMapping mapping, MemberInfo[] members)
     {
-        var dataConfig = $"{mapping.QueryMembers.MemberFor(members).TypedLocator.Replace("d.", "")}";
-
-        return $"{dataConfig}";
+        var member = mapping.QueryMembers.MemberFor(members);
+        var rawLocator = member.RawLocator.Replace("d.", "");
+        var typedLocator = member.TypedLocator.Replace(member.RawLocator, rawLocator);
+        return $"{typedLocator}";
     }
 }

--- a/src/Marten/Schema/NgramIndex.cs
+++ b/src/Marten/Schema/NgramIndex.cs
@@ -75,9 +75,7 @@ public class NgramIndex: IndexDefinition
 
     private static string GetDataConfig(DocumentMapping mapping, MemberInfo[] members)
     {
-        var member = mapping.QueryMembers.MemberFor(members);
-        var rawLocator = member.RawLocator.Replace("d.", "");
-        var typedLocator = member.TypedLocator.Replace(member.RawLocator, rawLocator);
-        return $"{typedLocator}";
+        var dataConfig = $"{mapping.QueryMembers.MemberFor(members).TypedLocator.Replace("d.data ->", "data ->")}";
+        return $"{dataConfig}";
     }
 }


### PR DESCRIPTION
- Fix blind replace of d.in TypedLocator causing issues when schema name ends with d
- Fixes GH-3778