### PR TITLE
Replace `Count()` method with `Count` and `Length` properties

### DIFF
--- a/src/DocumentDbTests/Indexes/full_text_index.cs
+++ b/src/DocumentDbTests/Indexes/full_text_index.cs
@@ -227,7 +227,7 @@ public class full_text_index: OneOffConfigurationsContext
 
         #endregion
 
-        result.Count().ShouldBe(1);
+        result.Count.ShouldBe(1);
     }
 
     [PgVersionTargetedFact(MinimumVersion = "10.0")]

--- a/src/DocumentDbTests/Reading/BatchedQuerying/batched_querying_acceptance_Tests.cs
+++ b/src/DocumentDbTests/Reading/BatchedQuerying/batched_querying_acceptance_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -369,7 +369,7 @@ public class batched_querying_acceptance_Tests: OneOffConfigurationsContext, IAs
 
         var list = await task;
 
-        list.Count().ShouldBe(2);
+        list.Count.ShouldBe(2);
         list.Any(x => x.Id == target1.Id).ShouldBeTrue();
         list.Any(x => x.Id == target3.Id).ShouldBeTrue();
     }
@@ -403,7 +403,7 @@ public class batched_querying_acceptance_Tests: OneOffConfigurationsContext, IAs
 
         var list = await task;
 
-        list.Count().ShouldBe(2);
+        list.Count.ShouldBe(2);
         list.Any(x => x.Id == target1.Id).ShouldBeTrue();
         list.Any(x => x.Id == target3.Id).ShouldBeTrue();
     }

--- a/src/DocumentDbTests/Reading/Json/streaming_json_results.cs
+++ b/src/DocumentDbTests/Reading/Json/streaming_json_results.cs
@@ -631,7 +631,7 @@ public class streaming_json_results : IntegrationContext
         var customers = theStore.Options.Serializer().FromJson<Customer[]>(stream);
         customers.Length.ShouldBe(2);
 
-        customerJson.Count().ShouldBe(148); // magic number that just happens to be the length of the JSON string returned
+        customerJson.Length.ShouldBe(148); // magic number that just happens to be the length of the JSON string returned
     }
 
 

--- a/src/DocumentDbTests/SessionMechanics/DocumentSession_change_set_tracking_Tests.cs
+++ b/src/DocumentDbTests/SessionMechanics/DocumentSession_change_set_tracking_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten.Linq.SqlGeneration;
@@ -58,7 +58,7 @@ public class DocumentSession_change_set_tracking_Tests : IntegrationContext
         theSession.Store(new Target());
         await theSession.SaveChangesAsync();
 
-        logger.Commits.Count().ShouldBe(2);
+        logger.Commits.Count.ShouldBe(2);
         logger.LastCommit.Updated.Count().ShouldBe(1);
     }
 

--- a/src/DocumentDbTests/Writing/Identity/using_int_identity.cs
+++ b/src/DocumentDbTests/Writing/Identity/using_int_identity.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
@@ -71,7 +71,7 @@ public class using_int_identity : IntegrationContext
         await theSession.SaveChangesAsync();
 
         using var session = theStore.QuerySession();
-        (await session.LoadManyAsync<IntDoc>(4, 5, 6)).Count().ShouldBe(3);
+        (await session.LoadManyAsync<IntDoc>(4, 5, 6)).Count.ShouldBe(3);
     }
 
     public using_int_identity(DefaultStoreFixture fixture) : base(fixture)

--- a/src/DocumentDbTests/Writing/Identity/using_long_identity.cs
+++ b/src/DocumentDbTests/Writing/Identity/using_long_identity.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
@@ -71,7 +71,7 @@ public class using_long_identity : IntegrationContext
         await theSession.SaveChangesAsync();
 
         using var session = theStore.QuerySession();
-        (await session.LoadManyAsync<LongDoc>(4, 5, 6)).Count().ShouldBe(3);
+        (await session.LoadManyAsync<LongDoc>(4, 5, 6)).Count.ShouldBe(3);
     }
 
     public using_long_identity(DefaultStoreFixture fixture) : base(fixture)

--- a/src/DocumentDbTests/Writing/Identity/using_string_identity.cs
+++ b/src/DocumentDbTests/Writing/Identity/using_string_identity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Documents;
@@ -95,7 +95,7 @@ public class using_string_identity : IntegrationContext
         await theSession.SaveChangesAsync();
 
         using var session = theStore.QuerySession();
-        (await session.LoadManyAsync<Account>("A", "B", "E")).Count().ShouldBe(3);
+        (await session.LoadManyAsync<Account>("A", "B", "E")).Count.ShouldBe(3);
     }
 
     public using_string_identity(DefaultStoreFixture fixture) : base(fixture)

--- a/src/DocumentDbTests/Writing/document_inserts.cs
+++ b/src/DocumentDbTests/Writing/document_inserts.cs
@@ -60,7 +60,7 @@ public class document_inserts: IntegrationContext
 
         using (var query = theStore.QuerySession())
         {
-            query.Query<RecordDocument>().ToList().Count().ShouldBe(1);
+            query.Query<RecordDocument>().ToList().Count.ShouldBe(1);
         }
     }
 

--- a/src/DocumentDbTests/Writing/storing_documents.cs
+++ b/src/DocumentDbTests/Writing/storing_documents.cs
@@ -219,7 +219,7 @@ public class storing_documents: IntegrationContext
 
         using var querySession = theStore.QuerySession();
         var users = await querySession.LoadManyAsync<User>(user2.Id, user3.Id, user4.Id);
-        users.Count().ShouldBe(3);
+        users.Count.ShouldBe(3);
     }
 
     [Theory]
@@ -252,7 +252,7 @@ public class storing_documents: IntegrationContext
 
         await using var querySession = store.QuerySession();
         var users = await querySession.LoadManyAsync<User>(user2.Id, user3.Id, user4.Id);
-        users.Count().ShouldBe(3);
+        users.Count.ShouldBe(3);
 
         #endregion
     }

--- a/src/EventSourcingTests/QuickAppend/quick_append_event_capture_and_fetching_the_stream.cs
+++ b/src/EventSourcingTests/QuickAppend/quick_append_event_capture_and_fetching_the_stream.cs
@@ -58,7 +58,7 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
 
             var streamEvents = await session.Events.FetchStreamAsync(id);
 
-            streamEvents.Count().ShouldBe(2);
+            streamEvents.Count.ShouldBe(2);
             streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
             streamEvents.ElementAt(0).Version.ShouldBe(1);
             streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -87,7 +87,7 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
 
             var streamEvents = await session.Events.FetchStreamAsync(id);
 
-            streamEvents.Count().ShouldBe(2);
+            streamEvents.Count.ShouldBe(2);
             streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
             streamEvents.ElementAt(0).Version.ShouldBe(1);
             streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -117,7 +117,7 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
             var streamEvents = await session.Events.QueryAllRawEvents()
                 .Where(x => x.StreamId == id).OrderBy(x => x.Version).ToListAsync();
 
-            streamEvents.Count().ShouldBe(2);
+            streamEvents.Count.ShouldBe(2);
             streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
             streamEvents.ElementAt(0).Version.ShouldBe(1);
             streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -147,7 +147,7 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
             var streamEvents = session.Events.QueryAllRawEvents()
                 .Where(x => x.StreamId == id).OrderBy(x => x.Version).ToList();
 
-            streamEvents.Count().ShouldBe(2);
+            streamEvents.Count.ShouldBe(2);
             streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
             streamEvents.ElementAt(0).Version.ShouldBe(1);
             streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -280,7 +280,7 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(2);
+                streamEvents.Count.ShouldBe(2);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -311,7 +311,7 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(2);
+                streamEvents.Count.ShouldBe(2);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -351,7 +351,7 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(3);
+                streamEvents.Count.ShouldBe(3);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<QuestStarted>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersJoined>();
@@ -384,7 +384,7 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(2);
+                streamEvents.Count.ShouldBe(2);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -414,7 +414,7 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(2);
+                streamEvents.Count.ShouldBe(2);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -447,7 +447,7 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(2);
+                streamEvents.Count.ShouldBe(2);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -486,7 +486,7 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(3);
+                streamEvents.Count.ShouldBe(3);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<QuestStarted>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersJoined>();

--- a/src/EventSourcingTests/QuickAppend/quick_append_event_capture_and_fetching_the_stream_with_string_identifiers.cs
+++ b/src/EventSourcingTests/QuickAppend/quick_append_event_capture_and_fetching_the_stream_with_string_identifiers.cs
@@ -32,7 +32,7 @@ public class
 
         var streamEvents = await theSession.Events.FetchStreamAsync(id);
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -57,7 +57,7 @@ public class
 
         var streamEvents = await theSession.Events.FetchStreamAsync(id);
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -83,7 +83,7 @@ public class
         var streamEvents = await theSession.Events.QueryAllRawEvents()
             .Where(x => x.StreamKey == id).OrderBy(x => x.Version).ToListAsync();
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -109,7 +109,7 @@ public class
         var streamEvents = theSession.Events.QueryAllRawEvents()
             .Where(x => x.StreamKey == id).OrderBy(x => x.Version).ToList();
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -289,7 +289,7 @@ public class
 
         var streamEvents = await session.Events.FetchStreamAsync(id);
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -311,7 +311,7 @@ public class
 
         var streamEvents = await session.Events.FetchStreamAsync(id);
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -342,7 +342,7 @@ public class
 
             var streamEvents = await session.Events.FetchStreamAsync(id);
 
-            streamEvents.Count().ShouldBe(3);
+            streamEvents.Count.ShouldBe(3);
             streamEvents.ElementAt(0).Data.ShouldBeOfType<QuestStarted>();
             streamEvents.ElementAt(0).Version.ShouldBe(1);
             streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersJoined>();
@@ -365,7 +365,7 @@ public class
 
         var streamEvents = await session.Events.FetchStreamAsync(id);
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -388,7 +388,7 @@ public class
 
         var streamEvents = await session.Events.FetchStreamAsync(id);
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -418,7 +418,7 @@ public class
 
             var streamEvents = await session.Events.FetchStreamAsync(id);
 
-            streamEvents.Count().ShouldBe(3);
+            streamEvents.Count.ShouldBe(3);
             streamEvents.ElementAt(0).Data.ShouldBeOfType<QuestStarted>();
             streamEvents.ElementAt(0).Version.ShouldBe(1);
             streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersJoined>();

--- a/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream.cs
+++ b/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream.cs
@@ -61,7 +61,7 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
 
             var streamEvents = await session.Events.FetchStreamAsync(id);
 
-            streamEvents.Count().ShouldBe(2);
+            streamEvents.Count.ShouldBe(2);
             streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
             streamEvents.ElementAt(0).Version.ShouldBe(1);
             streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -94,7 +94,7 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
 
             var streamEvents = await session.Events.FetchStreamAsync(id);
 
-            streamEvents.Count().ShouldBe(2);
+            streamEvents.Count.ShouldBe(2);
             streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
             streamEvents.ElementAt(0).Version.ShouldBe(1);
             streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -128,7 +128,7 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
             var streamEvents = await session.Events.QueryAllRawEvents()
                 .Where(x => x.StreamId == id).OrderBy(x => x.Version).ToListAsync();
 
-            streamEvents.Count().ShouldBe(2);
+            streamEvents.Count.ShouldBe(2);
             streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
             streamEvents.ElementAt(0).Version.ShouldBe(1);
             streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -162,7 +162,7 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
             var streamEvents = session.Events.QueryAllRawEvents()
                 .Where(x => x.StreamId == id).OrderBy(x => x.Version).ToList();
 
-            streamEvents.Count().ShouldBe(2);
+            streamEvents.Count.ShouldBe(2);
             streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
             streamEvents.ElementAt(0).Version.ShouldBe(1);
             streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -299,7 +299,7 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(2);
+                streamEvents.Count.ShouldBe(2);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -330,7 +330,7 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(2);
+                streamEvents.Count.ShouldBe(2);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -370,7 +370,7 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(3);
+                streamEvents.Count.ShouldBe(3);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<QuestStarted>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersJoined>();
@@ -403,7 +403,7 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(2);
+                streamEvents.Count.ShouldBe(2);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -433,7 +433,7 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(2);
+                streamEvents.Count.ShouldBe(2);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -466,7 +466,7 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(2);
+                streamEvents.Count.ShouldBe(2);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -509,7 +509,7 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
 
                 var streamEvents = await session.Events.FetchStreamAsync(id);
 
-                streamEvents.Count().ShouldBe(3);
+                streamEvents.Count.ShouldBe(3);
                 streamEvents.ElementAt(0).Data.ShouldBeOfType<QuestStarted>();
                 streamEvents.ElementAt(0).Version.ShouldBe(1);
                 streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersJoined>();

--- a/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers.cs
+++ b/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers.cs
@@ -36,7 +36,7 @@ public class
 
         var streamEvents = await theSession.Events.FetchStreamAsync(id);
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -61,7 +61,7 @@ public class
 
         var streamEvents = await theSession.Events.FetchStreamAsync(id);
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -87,7 +87,7 @@ public class
         var streamEvents = await theSession.Events.QueryAllRawEvents()
             .Where(x => x.StreamKey == id).OrderBy(x => x.Version).ToListAsync();
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -113,7 +113,7 @@ public class
         var streamEvents = theSession.Events.QueryAllRawEvents()
             .Where(x => x.StreamKey == id).OrderBy(x => x.Version).ToList();
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -219,7 +219,7 @@ public class
 
         var streamEvents = await session.Events.FetchStreamAsync(id);
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -241,7 +241,7 @@ public class
 
         var streamEvents = await session.Events.FetchStreamAsync(id);
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -272,7 +272,7 @@ public class
 
             var streamEvents = await session.Events.FetchStreamAsync(id);
 
-            streamEvents.Count().ShouldBe(3);
+            streamEvents.Count.ShouldBe(3);
             streamEvents.ElementAt(0).Data.ShouldBeOfType<QuestStarted>();
             streamEvents.ElementAt(0).Version.ShouldBe(1);
             streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersJoined>();
@@ -295,7 +295,7 @@ public class
 
         var streamEvents = await session.Events.FetchStreamAsync(id);
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -318,7 +318,7 @@ public class
 
         var streamEvents = await session.Events.FetchStreamAsync(id);
 
-        streamEvents.Count().ShouldBe(2);
+        streamEvents.Count.ShouldBe(2);
         streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
         streamEvents.ElementAt(0).Version.ShouldBe(1);
         streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
@@ -348,7 +348,7 @@ public class
 
             var streamEvents = await session.Events.FetchStreamAsync(id);
 
-            streamEvents.Count().ShouldBe(3);
+            streamEvents.Count.ShouldBe(3);
             streamEvents.ElementAt(0).Data.ShouldBeOfType<QuestStarted>();
             streamEvents.ElementAt(0).Version.ShouldBe(1);
             streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersJoined>();

--- a/src/LinqTests/Acceptance/query_with_inheritance.cs
+++ b/src/LinqTests/Acceptance/query_with_inheritance.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using JasperFx;
@@ -128,7 +128,7 @@ public class query_with_inheritance: OneOffConfigurationsContext
         await theSession.SaveChangesAsync();
 
         var list = theSession.Query<IPapaSmurf>().ToList();
-        list.Count().ShouldBe(3);
+        list.Count.ShouldBe(3);
         list.Count(s => s.Ability == "Invent").ShouldBe(1);
     }
 
@@ -144,7 +144,7 @@ public class query_with_inheritance: OneOffConfigurationsContext
         await theSession.SaveChangesAsync();
 
         var list = await theSession.Query<IPapaSmurf>().ToListAsync();
-        list.Count().ShouldBe(3);
+        list.Count.ShouldBe(3);
         list.Count(s => s.Ability == "Invent").ShouldBe(1);
     }
 

--- a/src/LinqTests/Acceptance/select_many.cs
+++ b/src/LinqTests/Acceptance/select_many.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -39,7 +39,7 @@ public class select_many : IntegrationContext
 
             var names = query.Query<Product>().SelectMany(x => x.Tags).ToList();
             names
-                .Count().ShouldBe(9);
+                .Count.ShouldBe(9);
         }
     }
     #endregion
@@ -117,7 +117,7 @@ public class select_many : IntegrationContext
 
             var names = query.Query<ProductWithList>().SelectMany(x => x.Tags).ToList();
             names
-                .Count().ShouldBe(9);
+                .Count.ShouldBe(9);
         }
     }
 
@@ -249,7 +249,7 @@ public class select_many : IntegrationContext
 
             var names = query.Query<ProductWithNumbers>().SelectMany(x => x.Tags).ToList();
             names
-                .Count().ShouldBe(9);
+                .Count.ShouldBe(9);
         }
     }
 
@@ -274,7 +274,7 @@ public class select_many : IntegrationContext
 
             var names = query.Query<ProductWithNumbers>().SelectMany(x => x.Tags).ToList();
             names
-                .Count().ShouldBe(9);
+                .Count.ShouldBe(9);
         }
     }
 

--- a/src/LinqTests/Compiled/compiled_queries.cs
+++ b/src/LinqTests/Compiled/compiled_queries.cs
@@ -255,7 +255,7 @@ public class compiled_queries: IntegrationContext
         stream.Position = 0;
 
         var users = theStore.Options.Serializer().FromJson<User[]>(stream);
-        users.Count().ShouldBe(2);
+        users.Length.ShouldBe(2);
         users.ElementAt(0).UserName.ShouldBe("jdm");
         users.ElementAt(1).UserName.ShouldBe("shadetreedev");
     }
@@ -270,7 +270,7 @@ public class compiled_queries: IntegrationContext
         stream.Position = 0;
 
         var users = theStore.Options.Serializer().FromJson<User[]>(stream);
-        users.Count().ShouldBe(2);
+        users.Length.ShouldBe(2);
         users.ElementAt(0).UserName.ShouldBe("jdm");
         users.ElementAt(1).UserName.ShouldBe("shadetreedev");
     }

--- a/src/LinqTests/Operators/is_subset_of_operator.cs
+++ b/src/LinqTests/Operators/is_subset_of_operator.cs
@@ -70,7 +70,7 @@ public class is_subset_of_operator : IntegrationContext
             .Select(x => x.Id);
 
         // than
-        found.Count().ShouldBe(2);
+        found.Length.ShouldBe(2);
         found.OrderBy(x => x.Id).Select(x => x.Id).ShouldHaveTheSameElementsAs(expected);
     }
 
@@ -108,7 +108,7 @@ select d.id, d.data from public.mt_doc_target as d where CAST(d.data ->> 'TagsHa
             .Select(x => x.Id);
 
         // than
-        found.Count().ShouldBe(2);
+        found.Length.ShouldBe(2);
         found.OrderBy(x => x.Id).Select(x => x.Id).ShouldHaveTheSameElementsAs(expected);
     }
 }

--- a/src/LinqTests/Operators/is_super_set_of_operator.cs
+++ b/src/LinqTests/Operators/is_super_set_of_operator.cs
@@ -62,7 +62,7 @@ public class is_super_set_of_operator : IntegrationContext
             .Select(x => x.Id);
 
         // than
-        found.Count().ShouldBe(3);
+        found.Length.ShouldBe(3);
         found.OrderBy(x => x.Id).Select(x => x.Id).ShouldHaveTheSameElementsAs(expected);
     }
 
@@ -85,7 +85,7 @@ public class is_super_set_of_operator : IntegrationContext
             .Select(x => x.Id);
 
         // than
-        found.Count().ShouldBe(3);
+        found.Length.ShouldBe(3);
         found.OrderBy(x => x.Id).Select(x => x.Id).ShouldHaveTheSameElementsAs(expected);
     }
 

--- a/src/Marten/Events/TestSupport/ProjectionScenario.EventOperations.cs
+++ b/src/Marten/Events/TestSupport/ProjectionScenario.EventOperations.cs
@@ -29,7 +29,7 @@ public partial class ProjectionScenario
     public StreamAction Append(Guid stream, params object[] events)
     {
         var step = action(e => e.Append(stream, events));
-        if (events.Count() > 3)
+        if (events.Length > 3)
         {
             step.Description = $"Append({stream}, events)";
         }
@@ -74,7 +74,7 @@ public partial class ProjectionScenario
     public StreamAction Append(Guid stream, long expectedVersion, params object[] events)
     {
         var step = action(e => e.Append(stream, expectedVersion, events));
-        if (events.Count() > 3)
+        if (events.Length > 3)
         {
             step.Description = $"Append({stream}, {expectedVersion}, events)";
         }
@@ -106,7 +106,7 @@ public partial class ProjectionScenario
     public StreamAction Append(string stream, long expectedVersion, params object[] events)
     {
         var step = action(e => e.Append(stream, expectedVersion, events));
-        if (events.Count() > 3)
+        if (events.Length > 3)
         {
             step.Description = $"Append(\"{stream}\", {expectedVersion}, events)";
         }
@@ -122,7 +122,7 @@ public partial class ProjectionScenario
     public StreamAction StartStream<TAggregate>(Guid id, params object[] events) where TAggregate : class
     {
         var step = action(e => e.StartStream<TAggregate>(id, events));
-        if (events.Count() > 3)
+        if (events.Length > 3)
         {
             step.Description = $"StartStream<{typeof(TAggregate).FullNameInCode()}>({id}, events)";
         }
@@ -154,7 +154,7 @@ public partial class ProjectionScenario
     public StreamAction StartStream(Type aggregateType, Guid id, params object[] events)
     {
         var step = action(e => e.StartStream(aggregateType, id, events));
-        if (events.Count() > 3)
+        if (events.Length > 3)
         {
             step.Description = $"StartStream({aggregateType.FullNameInCode()}>({id}, events)";
         }
@@ -187,7 +187,7 @@ public partial class ProjectionScenario
     public StreamAction StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class
     {
         var step = action(e => e.StartStream<TAggregate>(streamKey, events));
-        if (events.Count() > 3)
+        if (events.Length > 3)
         {
             step.Description = $"StartStream<{typeof(TAggregate).FullNameInCode()}>(\"{streamKey}\", events)";
         }
@@ -219,7 +219,7 @@ public partial class ProjectionScenario
     public StreamAction StartStream(Type aggregateType, string streamKey, params object[] events)
     {
         var step = action(e => e.StartStream(aggregateType, streamKey, events));
-        if (events.Count() > 3)
+        if (events.Length > 3)
         {
             step.Description = $"StartStream({aggregateType.FullNameInCode()}>(\"{streamKey}\", events)";
         }
@@ -250,7 +250,7 @@ public partial class ProjectionScenario
     public StreamAction StartStream(Guid id, params object[] events)
     {
         var step = action(e => e.StartStream(id, events));
-        if (events.Count() > 3)
+        if (events.Length > 3)
         {
             step.Description = $"StartStream({id}, events)";
         }
@@ -280,7 +280,7 @@ public partial class ProjectionScenario
     public StreamAction StartStream(string streamKey, params object[] events)
     {
         var step = action(e => e.StartStream(streamKey, events));
-        if (events.Count() > 3)
+        if (events.Length > 3)
         {
             step.Description = $"StartStream(\"{streamKey}\", events)";
         }
@@ -313,7 +313,7 @@ public partial class ProjectionScenario
     {
         var streamId = Guid.NewGuid();
         var step = action(e => e.StartStream<TAggregate>(streamId, events));
-        if (events.Count() > 3)
+        if (events.Length > 3)
         {
             step.Description = $"StartStream<{typeof(TAggregate).FullNameInCode()}>(events)";
         }
@@ -347,7 +347,7 @@ public partial class ProjectionScenario
     {
         var streamId = Guid.NewGuid();
         var step = action(e => e.StartStream(aggregateType, streamId, events));
-        if (events.Count() > 3)
+        if (events.Length > 3)
         {
             step.Description = $"StartStream({aggregateType.FullNameInCode()}>(events)";
         }
@@ -380,7 +380,7 @@ public partial class ProjectionScenario
     {
         var streamId = Guid.NewGuid();
         var step = action(e => e.StartStream(streamId, events));
-        if (events.Count() > 3)
+        if (events.Length > 3)
         {
             step.Description = "StartStream(events)";
         }

--- a/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
+++ b/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
@@ -298,7 +298,7 @@ public class CompiledQueryPlan : ICommandBuilder
 
     public object TryCreateUniqueTemplate(Type type)
     {
-        var constructor = type.GetConstructors().MaxBy(x => x.GetParameters().Count());
+        var constructor = type.GetConstructors().MaxBy(x => x.GetParameters().Length);
 
 
         if (constructor == null)

--- a/src/Marten/Linq/Members/ChildCollectionMember.cs
+++ b/src/Marten/Linq/Members/ChildCollectionMember.cs
@@ -223,7 +223,7 @@ internal class AllCollectionConditionFilter: ISubQueryFilter, IWhereFragmentHold
 
     public void Compile(MethodCallExpression methodCallExpression)
     {
-        if (Wheres.Count() == 1)
+        if (Wheres.Count == 1)
         {
             switch (Wheres.Single())
             {

--- a/src/Marten/Pagination/PagedList.cs
+++ b/src/Marten/Pagination/PagedList.cs
@@ -32,7 +32,7 @@ public class PagedList<T>: IPagedList<T>
     /// <summary>
     ///     Return the number of records in the paged query result
     /// </summary>
-    public long Count => _items.Count();
+    public long Count => _items.Count;
 
     /// <summary>
     ///     Generic Enumerator


### PR DESCRIPTION
Replace Count() with Count and length, Performance improvement