### PR TITLE
Add note about AutoStartHost for integration tests

### DIFF
--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -5,6 +5,16 @@ The usage of Marten.CommandLine shown in this document is only valid for applica
 [generic host builder](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host) with Marten registered in the application's IoC container.
 :::
 
+::: warning
+When writing integration tests, make sure to enable host auto-start in your test setup:
+
+```csharp
+JasperFxEnvironment.AutoStartHost = true;
+```
+
+Without this setting, creating the test server will fail. See also [Creating an Integration Test Harness](https://wolverinefx.net/tutorials/cqrs-with-marten.html#creating-an-integration-test-harness)
+:::
+
 There is a separate NuGet package called _Marten.CommandLine_ that can be used to quickly add command-line tooling directly to
 your .Net Core application that uses Marten. _Marten.CommandLine_ is an extension library to [Oakton](https://jasperfx.github.io/oakton) that
 is the actual command line parser in this case.


### PR DESCRIPTION
I ran into some issues when running integration tests after switching my app to use app.RunJasperFxCommands(). At first, my WebApp worked fine without the CLI tools integration, so I didn’t notice anything was wrong. But once I added RunJasperFxCommands(), the test server wouldn’t start anymore.


I only found this info by chance in this section of the Wolverine docs:
 https://wolverinefx.net/tutorials/cqrs-with-marten.html#creating-an-integration-test-harness

It might also be worth including this hint in the main testing guide here:
 https://wolverinefx.net/guide/testing.html#test-automation-support
Since that’s where most people (including me) would probably look first.