### PR TITLE
Avoid unnecessary zero-length array allocations

### DIFF
--- a/src/DaemonTests/Internals/basic_functionality.cs
+++ b/src/DaemonTests/Internals/basic_functionality.cs
@@ -225,7 +225,7 @@ public class basic_functionality: DaemonContext
     public async Task event_fetcher_simple_case()
     {
         var fetcher =
-            new EventLoader(theStore, (MartenDatabase)theStore.Tenancy.Default.Database, new AsyncOptions(), new ISqlFragment[0]);
+            new EventLoader(theStore, (MartenDatabase)theStore.Tenancy.Default.Database, new AsyncOptions(), []);
 
         NumberOfStreams = 10;
         await PublishSingleThreaded();

--- a/src/DaemonTests/TestingSupport/TripStream.cs
+++ b/src/DaemonTests/TestingSupport/TripStream.cs
@@ -225,7 +225,7 @@ public class TripStream
     {
         if (IsFinishedPublishing())
         {
-            events = new object[0];
+            events = [];
             return false;
         }
 

--- a/src/EventSourcingTests/ScenarioCopyAndReplaceStream.cs
+++ b/src/EventSourcingTests/ScenarioCopyAndReplaceStream.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using EventSourcingTests.Projections;
 using Marten.Testing.Harness;
@@ -53,7 +53,7 @@ public class ScenarioCopyAndReplaceStream : StoreContext<StringIdentifiedStreams
                     case MonsterSlayed monster:
                     {
                         // Trolls we remove from our transformed stream
-                        return monster.Name.Equals("Troll") ? new object[] { } : new[] { monster };
+                        return monster.Name.Equals("Troll") ? [] : new[] { monster };
                     }
                     case MembersJoined members:
                     {

--- a/src/LinqTests/Bugs/Bug_1884_multi_tenancy_and_Any_query.cs
+++ b/src/LinqTests/Bugs/Bug_1884_multi_tenancy_and_Any_query.cs
@@ -33,14 +33,14 @@ public class Bug_1884_multi_tenancy_and_Any_query: BugIntegrationContext
         await using (var session = store.LightweightSession("tenant1"))
         {
             session.Store(new User { Id = "u1", UserName = "Bill", Roles = new[] { "admin" } });
-            session.Store(new User { Id = "u2", UserName = "Lindsey", Roles = new string[0] });
+            session.Store(new User { Id = "u2", UserName = "Lindsey", Roles = [] });
             await session.SaveChangesAsync();
         }
 
         // Write some User documents to tenant "tenant2"
         await using (var session = store.LightweightSession("tenant2"))
         {
-            session.Store(new User { Id = "u1", UserName = "Frank", Roles = new string[0] });
+            session.Store(new User { Id = "u1", UserName = "Frank", Roles = [] });
             session.Store(new User { Id = "u2", UserName = "Jill", Roles = new[] { "admin", "user" } });
             await session.SaveChangesAsync();
         }
@@ -68,7 +68,7 @@ public class Bug_1884_multi_tenancy_and_Any_query: BugIntegrationContext
         using (var session = theStore.LightweightSession("tenant1"))
         {
             session.Store(new User { Id = "u1", UserName = "Bill", Roles = new[] { "admin" } });
-            session.Store(new User { Id = "u2", UserName = "Lindsey", Roles = new string[0] });
+            session.Store(new User { Id = "u2", UserName = "Lindsey", Roles = [] });
             await session.SaveChangesAsync();
         }
 
@@ -77,7 +77,7 @@ public class Bug_1884_multi_tenancy_and_Any_query: BugIntegrationContext
         // Write some User documents to tenant "tenant2"
         using (var session = theStore.LightweightSession("tenant2"))
         {
-            session.Store(new User { Id = "u3", UserName = "Frank", Roles = new string[0] });
+            session.Store(new User { Id = "u3", UserName = "Frank", Roles = [] });
             session.Store(new User { Id = "u4", UserName = "Jill", Roles = new[] { "admin", "user" } });
             await session.SaveChangesAsync();
         }
@@ -115,7 +115,7 @@ public class Bug_1884_multi_tenancy_and_Any_query: BugIntegrationContext
         using (var session = theStore.LightweightSession("tenant1"))
         {
             session.Store(new User { Id = "u1", UserName = "Bill", Roles = new[] { "admin" } });
-            session.Store(new User { Id = "u2", UserName = "Lindsey", Roles = new string[0] });
+            session.Store(new User { Id = "u2", UserName = "Lindsey", Roles = [] });
             await session.SaveChangesAsync();
         }
 
@@ -124,7 +124,7 @@ public class Bug_1884_multi_tenancy_and_Any_query: BugIntegrationContext
         // Write some User documents to tenant "tenant2"
         using (var session = theStore.LightweightSession("tenant2"))
         {
-            session.Store(new User { Id = "u3", UserName = "Frank", Roles = new string[0] });
+            session.Store(new User { Id = "u3", UserName = "Frank", Roles = [] });
             session.Store(new User { Id = "u4", UserName = "Jill", Roles = new[] { "admin", "user" } });
             await session.SaveChangesAsync();
         }

--- a/src/LinqTests/Bugs/Bug_2563_sub_collection_queries_and_OR.cs
+++ b/src/LinqTests/Bugs/Bug_2563_sub_collection_queries_and_OR.cs
@@ -23,7 +23,7 @@ public class Bug_2563_sub_collection_queries_and_OR : BugIntegrationContext
             .Duplicate(x => x.UserIds);
 
         theSession.Store(new Bug2563Target {Id = 1, IsPublic = false, UserIds = new [] { 1, 2, 3, 4, 5, 6 }});
-        theSession.Store(new Bug2563Target {Id = 2, IsPublic = false, UserIds = new int[] { }});
+        theSession.Store(new Bug2563Target {Id = 2, IsPublic = false, UserIds = [] });
         theSession.Store(new Bug2563Target {Id = 3, IsPublic = true, UserIds = new [] { 1, 2, 3 }});
         theSession.Store(new Bug2563Target {Id = 4, IsPublic = true, UserIds = new [] { 1, 2, 6 }});
         theSession.Store(new Bug2563Target {Id = 5, IsPublic = false, UserIds = new [] { 4, 5, 6 }});

--- a/src/LinqTests/ChildCollections/query_against_child_collections.cs
+++ b/src/LinqTests/ChildCollections/query_against_child_collections.cs
@@ -757,7 +757,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
         targetithchildren.Children = new[] { new Target(), };
         var nochildrennullarray = new Target { Number = 2 };
         var nochildrenemptyarray = new Target { Number = 3 };
-        nochildrenemptyarray.Children = new Target[] { };
+        nochildrenemptyarray.Children = [];
         theSession.Store(nochildrennullarray);
         theSession.Store(nochildrenemptyarray);
         theSession.Store(targetithchildren);

--- a/src/LinqTests/Includes/end_to_end_query_with_include.cs
+++ b/src/LinqTests/Includes/end_to_end_query_with_include.cs
@@ -294,7 +294,7 @@ public class end_to_end_query_with_include: IntegrationContext
         var user = new User();
         var issue1 = new Issue { AssigneeId = user.Id, Tags = new[] { "DIY" }, Title = "Garage Door is busted" };
         var issue2 = new Issue { AssigneeId = user.Id, Tags = new[] { "TAG" }, Title = "Garage Door is busted" };
-        var issue3 = new Issue { AssigneeId = user.Id, Tags = new string[] { }, Title = "Garage Door is busted" };
+        var issue3 = new Issue { AssigneeId = user.Id, Tags = [], Title = "Garage Door is busted" };
 
         var requestedTags = new[] { "DIY", "TAG" };
 
@@ -913,7 +913,7 @@ public class end_to_end_query_with_include: IntegrationContext
         await theStore.BulkInsertAsync(new[] { user1, user2, user3 });
 
         var group1 = new Group { Name = "Users", Users = new[] { user1.Id, user2.Id, user3.Id } };
-        var group2 = new Group { Name = "Empty", Users = new Guid[0] };
+        var group2 = new Group { Name = "Empty", Users = [] };
 
         using (var session = theStore.LightweightSession())
         {

--- a/src/Marten.Testing/Examples/Searching_Within_Child_Collections.cs
+++ b/src/Marten.Testing/Examples/Searching_Within_Child_Collections.cs
@@ -13,7 +13,7 @@ public class Searching_Within_Child_Collections
         public Guid Id;
 
         public IList<User> Users = new List<User>();
-        public Company[] Companies = new Company[0];
+        public Company[] Companies = [];
 
         public string[] Names;
         public IList<string> NameList;


### PR DESCRIPTION
Avoid unnecessary zero-length array allocations. Use Array.Empty() instead.
CA1825

