### PR TITLE
CA1826: Use property instead of Linq Enumerable method

### DIFF
--- a/src/CoreTests/DocumentCleanerTests.cs
+++ b/src/CoreTests/DocumentCleanerTests.cs
@@ -239,7 +239,7 @@ public class DocumentCleanerTests: OneOffConfigurationsContext
             var values = await session.QueryAsync<int>(@"select count(*) from information_schema.sequences s
 where s.sequence_name like ? and s.sequence_schema = any(?);", "mt_%", allSchemas);
 
-            return values.First();
+            return values[0];
         }
 
         (await GetSequenceCount(theStore)).ShouldBeGreaterThan(0);

--- a/src/CoreTests/adding_custom_schema_objects.cs
+++ b/src/CoreTests/adding_custom_schema_objects.cs
@@ -94,7 +94,7 @@ public class adding_custom_schema_objects: OneOffConfigurationsContext
 
         var result = await session.QueryAsync<bool>("select unaccent('Æ') = 'AE';");
 
-        result.First().ShouldBe(true);
+        result[0].ShouldBe(true);
     }
 
     [Fact]
@@ -158,7 +158,7 @@ public class adding_custom_schema_objects: OneOffConfigurationsContext
         await using var sessionNext = theStore.QuerySession(tenantId);
         var result = await sessionNext.QueryAsync<bool>("select unaccent('Æ') = 'AE';");
 
-        result.First().ShouldBe(true);
+        result[0].ShouldBe(true);
     }
 
     [Fact]
@@ -186,7 +186,7 @@ public class adding_custom_schema_objects: OneOffConfigurationsContext
 
         var session = theStore.QuerySession(tenantId);
         var result = await session.QueryAsync<bool>("select unaccent('Æ') = 'AE';");
-        result.First().ShouldBe(true);
+        result[0].ShouldBe(true);
     }
 
     [Fact]
@@ -221,8 +221,8 @@ $f$  language sql immutable;
         var match = await session.QueryAsync<string>("select iif(1 = 1, 'value matches'::text, 'no match'::text);");
         var noMatch = await session.QueryAsync<string>("select iif(1 = 2, 'value matches'::text, 'no match'::text);");
 
-        match.First().ShouldBe("value matches");
-        noMatch.First().ShouldBe("no match");
+        match[0].ShouldBe("value matches");
+        noMatch[0].ShouldBe("no match");
     }
 
     [Fact]
@@ -249,7 +249,7 @@ $f$  language sql immutable;
         var value = await session.QueryAsync<int>("select nextval('banana_seq')");
         var valueAgain = await session.QueryAsync<int>("select nextval('banana_seq')");
 
-        valueAgain.First().ShouldBe(value.First() + 1);
+        valueAgain[0].ShouldBe(value[0] + 1);
     }
 
     private async Task DropDatabaseIfExists(string databaseName)

--- a/src/DaemonTests/Aggregations/build_aggregate_multiple_projections.cs
+++ b/src/DaemonTests/Aggregations/build_aggregate_multiple_projections.cs
@@ -217,7 +217,7 @@ public class build_aggregate_multiple_projections: DaemonContext
             var cars = await session.Query<CarView>().ToListAsync();
 
             waterMark.ShouldBe(maxSeqId);
-            cars.Last().Name.ShouldBe("car-name-999");
+            cars[cars.Count - 1].Name.ShouldBe("car-name-999");
         }
     }
 
@@ -283,7 +283,7 @@ public class build_aggregate_multiple_projections: DaemonContext
             var cars = await session.Query<CarView>().ToListAsync();
 
             waterMark.ShouldBe(maxSeqId);
-            cars.Last().Name.ShouldBe("car-name-999");
+            cars[cars.Count - 1].Name.ShouldBe("car-name-999");
         }
     }
 

--- a/src/DocumentDbTests/Configuration/DocumentMappingTests.cs
+++ b/src/DocumentDbTests/Configuration/DocumentMappingTests.cs
@@ -475,7 +475,7 @@ public class DocumentMappingTests
 
         var table = new DocumentTable(mapping);
 
-        var typeColumn = table.Columns.Last();
+        var typeColumn = table.Columns[table.Columns.Count - 1];
         typeColumn.Name.ShouldBe(SchemaConstants.DocumentTypeColumn);
         typeColumn.Type.ShouldBe("varchar");
     }

--- a/src/EventSourcingTests/Aggregation/stream_compacting.cs
+++ b/src/EventSourcingTests/Aggregation/stream_compacting.cs
@@ -261,7 +261,7 @@ public class stream_compacting : OneOffConfigurationsContext
         var events = await theSession.Events.FetchStreamAsync(streamId);
         events.Count.ShouldBe(5);
 
-        var compacted = events.First().ShouldBeOfType < Event<Compacted<Letters>>>();
+        var compacted = events[0].ShouldBeOfType < Event<Compacted<Letters>>>();
         compacted.Version.ShouldBe(5);
         compacted.Data.Snapshot.ACount.ShouldBe(2);
         compacted.Data.Snapshot.BCount.ShouldBe(1);
@@ -332,7 +332,7 @@ public class stream_compacting : OneOffConfigurationsContext
         var events = await theSession.Events.FetchStreamAsync(streamId);
         events.Count.ShouldBe(5);
 
-        var compacted = events.First().ShouldBeOfType < Event<Compacted<LetterCountsByString>>>();
+        var compacted = events[0].ShouldBeOfType < Event<Compacted<LetterCountsByString>>>();
         compacted.Version.ShouldBe(5);
         compacted.Data.Snapshot.ACount.ShouldBe(2);
         compacted.Data.Snapshot.BCount.ShouldBe(1);

--- a/src/EventSourcingTests/event_store_with_string_identifiers_for_stream.cs
+++ b/src/EventSourcingTests/event_store_with_string_identifiers_for_stream.cs
@@ -35,7 +35,7 @@ public class event_store_with_string_identifiers_for_stream: OneOffConfiguration
 
         pk.Type.ShouldBe("varchar");
         pk.Name.ShouldBe("id");
-        table.Columns.First().Name.ShouldBe("id");
+        table.Columns[0].Name.ShouldBe("id");
     }
 
     [Fact]

--- a/src/EventSourcingTests/removing_protected_information.cs
+++ b/src/EventSourcingTests/removing_protected_information.cs
@@ -170,7 +170,7 @@ public class removing_protected_information : OneOffConfigurationsContext
         joined.Headers["opid"].ShouldBe(1);
 
         // The last event does not get masked
-        events.Last().Headers["color"].ShouldBe("blue");
+        events[events.Count - 1].Headers["color"].ShouldBe("blue");
 
         // Should *not* apply here
         var events2 = await theSession.Events.FetchStreamAsync(streamId2);
@@ -232,7 +232,7 @@ public class removing_protected_information : OneOffConfigurationsContext
         joined.Headers["opid"].ShouldBe(1);
 
         // The last event does not get masked
-        events.Last().Headers["color"].ShouldBe("blue");
+        events[events.Count - 1].Headers["color"].ShouldBe("blue");
 
         // Should *not* apply here
         var events2 = await theSession.Events.FetchStreamAsync(streamId2);
@@ -290,7 +290,7 @@ public class removing_protected_information : OneOffConfigurationsContext
         }
 
         // The last event does not get masked
-        events.Last().Headers["color"].ShouldBe("blue");
+        events[events.Count - 1].Headers["color"].ShouldBe("blue");
 
         // Should *not* apply here
         var events2 = await theSession.Events.FetchStreamAsync(streamId2);
@@ -354,7 +354,7 @@ public class removing_protected_information : OneOffConfigurationsContext
         joined.Headers["opid"].ShouldBe(1);
 
         // The last event does not get masked
-        events.Last().Headers["color"].ShouldBe("blue");
+        events[events.Count - 1].Headers["color"].ShouldBe("blue");
 
         // Should *not* apply here
         var events2 = await theSession.Events.FetchStreamAsync(streamId2);

--- a/src/EventSourcingTests/replacing_events.cs
+++ b/src/EventSourcingTests/replacing_events.cs
@@ -22,21 +22,21 @@ public class replacing_events : OneOffConfigurationsContext
 
         var events = await theSession.Events.FetchStreamAsync(streamId);
 
-        var sequence = events.Last().Sequence;
+        var sequence = events[events.Count - 1].Sequence;
 
         var joined2 = new MembersJoined { Members = ["Moiraine", "Lan"] };
         theSession.Events.CompletelyReplaceEvent(sequence, joined2);
         await theSession.SaveChangesAsync();
 
         var events2 = await theSession.Events.FetchStreamAsync(streamId);
-        var final = events2.Last().ShouldBeOfType<Event<MembersJoined>>();
+        var final = events2[events2.Count - 1].ShouldBeOfType<Event<MembersJoined>>();
 
         // These should not change
-        final.Version.ShouldBe(events.Last().Version);
-        final.Sequence.ShouldBe(events.Last().Sequence);
+        final.Version.ShouldBe(events[events.Count - 1].Version);
+        final.Sequence.ShouldBe(events[events.Count - 1].Sequence);
 
         // Id gets changed
-        final.Id.ShouldNotBe(events.Last().Id);
+        final.Id.ShouldNotBe(events[events.Count - 1].Id);
 
         // These need to get changed
         final.Data.Members.ShouldBe(["Moiraine", "Lan"]);
@@ -64,22 +64,22 @@ public class replacing_events : OneOffConfigurationsContext
 
         var events = await theSession.Events.FetchStreamAsync(streamId);
 
-        var sequence = events.Last().Sequence;
+        var sequence = events[events.Count - 1].Sequence;
 
         var joined2 = new MembersJoined { Members = ["Moiraine", "Lan"] };
         theSession.Events.CompletelyReplaceEvent(sequence, joined2);
         await theSession.SaveChangesAsync();
 
         var events2 = await theSession.Events.FetchStreamAsync(streamId);
-        var final = events2.Last().ShouldBeOfType<Event<MembersJoined>>();
+        var final = events2[events2.Count - 1].ShouldBeOfType<Event<MembersJoined>>();
 
         // These should not change
-        final.Version.ShouldBe(events.Last().Version);
-        final.Sequence.ShouldBe(events.Last().Sequence);
+        final.Version.ShouldBe(events[events.Count - 1].Version);
+        final.Sequence.ShouldBe(events[events.Count - 1].Sequence);
 
         // Id gets changed
-        final.Id.ShouldNotBe(events.Last().Id);
-        final.Timestamp.ShouldNotBe(events.Last().Timestamp);
+        final.Id.ShouldNotBe(events[events.Count - 1].Id);
+        final.Timestamp.ShouldNotBe(events[events.Count - 1].Timestamp);
 
         // These need to get changed
         final.Data.Members.ShouldBe(["Moiraine", "Lan"]);

--- a/src/Marten.NodaTime.Testing/Bug_2307_JObject_in_dictionary_duplicated_field.cs
+++ b/src/Marten.NodaTime.Testing/Bug_2307_JObject_in_dictionary_duplicated_field.cs
@@ -55,7 +55,7 @@ public class Bug_2307_JObject_in_dictionary_duplicated_field: BugIntegrationCont
                 .ToListAsync(default);
 
             instanceFilesTask.Count.ShouldBePositive();
-            instanceFilesTask.First().InstanceData["Data"].ShouldBe("Pew Pew");
+            instanceFilesTask[0].InstanceData["Data"].ShouldBe("Pew Pew");
         }
     }
 }

--- a/src/Marten/Events/EventStore.StreamCompacting.cs
+++ b/src/Marten/Events/EventStore.StreamCompacting.cs
@@ -112,8 +112,8 @@ public class StreamCompactingRequest<T>
 
         var sequences = events.Select(x => x.Sequence).Take(events.Count - 1).ToArray();
 
-        Version = events.Last().Version;
-        Sequence = events.Last().Sequence;
+        Version = events[events.Count - 1].Version;
+        Sequence = events[events.Count - 1].Sequence;
 
         // 3. Aggregate up to the new snapshot
         var aggregate = await aggregator.BuildAsync(events, session, default, CancellationToken).ConfigureAwait(false);

--- a/src/Marten/Events/QueryEventStore.cs
+++ b/src/Marten/Events/QueryEventStore.cs
@@ -79,7 +79,7 @@ internal class QueryEventStore: IQueryEventStore
             return state;
         }
 
-        if (version != 0 && version > events.Last().Version) return null;
+        if (version != 0 && version > events[events.Count - 1].Version) return null;
 
         var aggregator = _store.Options.Projections.AggregatorFor<T>();
         var aggregate = await aggregator.BuildAsync(events, _session, state, token).ConfigureAwait(false);
@@ -133,7 +133,7 @@ internal class QueryEventStore: IQueryEventStore
             return state;
         }
 
-        if (version != 0 && version > events.Last().Version) return null;
+        if (version != 0 && version > events[events.Count - 1].Version) return null;
 
         var aggregator = _store.Options.Projections.AggregatorFor<T>();
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1826

Performance Improvements for the testing projects.