### PR TITLE
Adding rebuild projection bug on MultiStreamProjections with Services.

### DIFF
--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -33,14 +33,20 @@
 
     <ItemGroup>
         <PackageReference Include="FSharp.Core" Version="9.0.100" />
-        <PackageReference Include="JasperFx" Version="1.5.0" />
-        <PackageReference Include="JasperFx.Events" Version="1.7.1" />
-        <PackageReference Include="JasperFx.RuntimeCompiler" Version="4.0.0" />
+<!--        <PackageReference Include="JasperFx" Version="1.5.0" />-->
+<!--        <PackageReference Include="JasperFx.Events" Version="1.7.1" />-->
+<!--        <PackageReference Include="JasperFx.RuntimeCompiler" Version="4.0.0" />-->
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <!-- This is forced by Npgsql peer dependency -->
         <PackageReference Include="Npgsql.Json.NET" Version="9.0.2" />
         <PackageReference Include="Polly.Core" Version="8.5.2" />
         <PackageReference Include="Weasel.Postgresql" Version="8.1.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\jasperfx\src\JasperFx.Events\JasperFx.Events.csproj" />
+      <ProjectReference Include="..\..\..\jasperfx\src\JasperFx.RuntimeCompiler\JasperFx.RuntimeCompiler.csproj" />
+      <ProjectReference Include="..\..\..\jasperfx\src\JasperFx\JasperFx.csproj" />
     </ItemGroup>
 
     <Import Project="../../Analysis.Build.props" />


### PR DESCRIPTION
Getting the following error when trying to rebuild a projection that has been add via AddProjectionWithServices, and a MultiStreamProjection.


To Reproduce run the "use_multistream_projection_as_scoped_and_inline_on_martenStore" test.

```at Marten.Generated.DocumentStorage.LightweightLocationDocumentStorage705746301.Overwrite(Location document, IMartenSession session, String tenant) in /home/micah/novil-next/src/WebApp/Novil.Web/Internal/Generated/DocumentStorage/LocationProvider705746301.cs:line 562
         at Marten.Internal.Sessions.ProjectionStorage`2.StoreProjection(TDoc aggregate, IEvent lastEvent, AggregationScope scope) in /_/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs:line 114
         at JasperFx.Events.Daemon.AggregationRunner`4.ApplyChangesAsync(ShardExecutionMode mode, IProjectionBatch batch, TOperations operations, EventSlice`2 slice, IProjectionStorage`2 storage, IAggregateCache`2 cache, CancellationToken cancellation)
         at JasperFx.Events.Daemon.AggregationRunner`4.<>c__DisplayClass14_0.<<BuildBatchAsync>b__0>d.MoveNext() in /_/src/JasperFx.Events/Daemon/AggregationRunner.cs:line 56
      --- End of stack trace from previous location ---
         at JasperFx.Events.Daemon.AggregationRunner`4.BuildBatchAsync(EventRange range, ShardExecutionMode mode, CancellationToken cancellation) in /_/src/JasperFx.Events/Daemon/AggregationRunner.cs:line 99
         at JasperFx.Events.Daemon.GroupedProjectionExecution.buildBatchAsync(EventRange range, CancellationToken cancellationToken) in /_/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs:line 219
fail: Marten.Events.Daemon.ProjectionDaemon[0]
      Error trying to build and apply changes to event subscription Location:All from 1500 to 2000
      System.NotSupportedException: Specified method is not supported.
         at Marten.Generated.DocumentStorage.LightweightLocationDocumentStorage705746301.Overwrite(Location document, IMartenSession session, String tenant) in /home/micah/novil-next/src/WebApp/Novil.Web/Internal/Generated/DocumentStorage/LocationProvider705746301.cs:line 562
         at Marten.Internal.Sessions.ProjectionStorage`2.StoreProjection(TDoc aggregate, IEvent lastEvent, AggregationScope scope) in /_/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs:line 114
         at JasperFx.Events.Daemon.AggregationRunner`4.ApplyChangesAsync(ShardExecutionMode mode, IProjectionBatch batch, TOperations operations, EventSlice`2 slice, IProjectionStorage`2 storage, IAggregateCache`2 cache, CancellationToken cancellation)
         at JasperFx.Events.Daemon.AggregationRunner`4.<>c__DisplayClass14_0.<<BuildBatchAsync>b__0>d.MoveNext() in /_/src/JasperFx.Events/Daemon/AggregationRunner.cs:line 56
      --- End of stack trace from previous location ---
         at JasperFx.Events.Daemon.AggregationRunner`4.BuildBatchAsync(EventRange range, ShardExecutionMode mode, CancellationToken cancellation) in /_/src/JasperFx.Events/Daemon/AggregationRunner.cs:line 99
         at JasperFx.Events.Daemon.GroupedProjectionExecution.buildBatchAsync(EventRange range, CancellationToken cancellationToken) in /_/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs:line 219
         at JasperFx.Events.Daemon.GroupedProjectionExecution.buildBatchAsync(EventRange range, CancellationToken cancellationToken) in /_/src/JasperFx.Events/Daemon/GroupedPro
Finished rebuilding Location in 569 ms```

