### PR TITLE
Use ObjectDisposedException throw helper

### DIFF
--- a/src/Marten/Internal/Sessions/QuerySession.Disposal.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Disposal.cs
@@ -38,9 +38,6 @@ public partial class QuerySession
 
     protected void assertNotDisposed()
     {
-        if (_disposed)
-        {
-            throw new ObjectDisposedException("This session has been disposed");
-        }
+        ObjectDisposedException.ThrowIf(_disposed, "This session has been disposed");
     }
 }


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1513

It seems that the second parameter needs to the instance of the object (by passing `this` keyword or the Type of the containing class), and the message of the exception can not be changed. But I did not want to make a breaking change, even if it was very small, so I passed the string as it is without any change