### PR TITLE
3896 support duplicating and indexing fields on subclass documents in hierarchies

### DIFF
--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -29,7 +29,7 @@ scenarios.
 To use the expanded command line options to a .NET application, add this last line of code shown below to your `Program.cs`:
 
 <!-- snippet: sample_using_WebApplication_1 -->
-<a id='snippet-sample_using_webapplication_1'></a>
+<a id='snippet-sample_using_WebApplication_1'></a>
 ```cs
 var builder = WebApplication.CreateBuilder(args);
 
@@ -37,20 +37,20 @@ var builder = WebApplication.CreateBuilder(args);
 // Must be done before calling builder.Build() at least
 builder.Host.ApplyJasperFxExtensions();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/MinimalAPI/Program.cs#L10-L18' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_webapplication_1' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/MinimalAPI/Program.cs#L10-L18' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_WebApplication_1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And finally, use JasperFx as the command line parser and executor by replacing `App.Run()` as the last line of code in your
 `Program.cs` file:
 
 <!-- snippet: sample_using_WebApplication_2 -->
-<a id='snippet-sample_using_webapplication_2'></a>
+<a id='snippet-sample_using_WebApplication_2'></a>
 ```cs
 // Instead of App.Run(), use the app.RunJasperFxCommands(args)
 // as the last line of your Program.cs file
 return await app.RunJasperFxCommands(args);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/MinimalAPI/Program.cs#L56-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_webapplication_2' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/MinimalAPI/Program.cs#L56-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_WebApplication_2' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In your command line in the project directory, you can run:

--- a/docs/configuration/hostbuilder.md
+++ b/docs/configuration/hostbuilder.md
@@ -3,7 +3,7 @@
 As briefly shown in the [getting started](/) page, Marten comes with the `AddMarten()` extension method for the .NET `IServiceCollection` to quickly add Marten to any ASP&#46;NET Core or Worker Service application:
 
 <!-- snippet: sample_StartupConfigureServices -->
-<a id='snippet-sample_startupconfigureservices'></a>
+<a id='snippet-sample_StartupConfigureServices'></a>
 ```cs
 // This is the absolute, simplest way to integrate Marten into your
 // .NET application with Marten's default configuration
@@ -26,7 +26,7 @@ builder.Services.AddMarten(options =>
 // string to Marten
 .UseNpgsqlDataSource();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Program.cs#L16-L37' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_startupconfigureservices' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Program.cs#L16-L37' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_StartupConfigureServices' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `AddMarten()` method will add these service registrations to your application:
@@ -61,20 +61,20 @@ All the examples in this page are assuming the usage of the default IoC containe
 First, if you are using Marten completely out of the box with no customizations (besides attributes on your documents), you can just supply a connection string to the underlying Postgresql database like this:
 
 <!-- snippet: sample_AddMartenByConnectionString -->
-<a id='snippet-sample_addmartenbyconnectionstring'></a>
+<a id='snippet-sample_AddMartenByConnectionString'></a>
 ```cs
 var connectionString = Configuration.GetConnectionString("postgres");
 
 // By only the connection string
 services.AddMarten(connectionString);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/ByConnectionString/Startup.cs#L18-L26' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_addmartenbyconnectionstring' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/ByConnectionString/Startup.cs#L18-L26' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AddMartenByConnectionString' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The second option is to supply a [nested closure](https://martinfowler.com/dslCatalog/nestedClosure.html) to configure Marten inline like so:
 
 <!-- snippet: sample_AddMartenByNestedClosure -->
-<a id='snippet-sample_addmartenbynestedclosure'></a>
+<a id='snippet-sample_AddMartenByNestedClosure'></a>
 ```cs
 var connectionString = Configuration.GetConnectionString("postgres");
 
@@ -91,13 +91,13 @@ services.CritterStackDefaults(x =>
     x.Production.ResourceAutoCreate = AutoCreate.None;
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/ByNestedClosure/Startup.cs#L26-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_addmartenbynestedclosure' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/ByNestedClosure/Startup.cs#L26-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AddMartenByNestedClosure' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Lastly, if you prefer, you can pass a Marten `StoreOptions` object to `AddMarten()` like this example:
 
 <!-- snippet: sample_AddMartenByStoreOptions -->
-<a id='snippet-sample_addmartenbystoreoptions'></a>
+<a id='snippet-sample_AddMartenByStoreOptions'></a>
 ```cs
 var connectionString = Configuration.GetConnectionString("postgres");
 
@@ -113,7 +113,7 @@ services.CritterStackDefaults(x =>
     x.Production.ResourceAutoCreate = AutoCreate.None;
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/ByStoreOptions/Startup.cs#L25-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_addmartenbystoreoptions' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/ByStoreOptions/Startup.cs#L25-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AddMartenByStoreOptions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Using NpgsqlDataSource <Badge type="tip" text="7.0" />
@@ -130,7 +130,7 @@ You can also use the [NpgsqlDataSource](https://www.npgsql.org/doc/basic-usage.h
 You can use the `AddNpgsqlDataSource` method from [Npgsql.DependencyInjection package](https://www.nuget.org/packages/Npgsql.DependencyInjection) to perform a setup by calling the `UseNpgsqlDataSourceMethod`:
 
 <!-- snippet: sample_using_UseNpgsqlDataSource -->
-<a id='snippet-sample_using_usenpgsqldatasource'></a>
+<a id='snippet-sample_using_UseNpgsqlDataSource'></a>
 ```cs
 services.AddNpgsqlDataSource(ConnectionSource.ConnectionString);
 
@@ -138,13 +138,13 @@ services.AddMarten()
     .UseLightweightSessions()
     .UseNpgsqlDataSource();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/bootstrapping_with_service_collection_extensions.cs#L330-L338' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_usenpgsqldatasource' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/bootstrapping_with_service_collection_extensions.cs#L330-L338' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_UseNpgsqlDataSource' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If you're on .NET 8 (and above), you can also use a dedicated [keyed registration](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8#keyed-di-services). This can be useful for scenarios where you need more than one data source registered:
 
 <!-- snippet: sample_using_UseNpgsqlDataSource_keyed -->
-<a id='snippet-sample_using_usenpgsqldatasource_keyed'></a>
+<a id='snippet-sample_using_UseNpgsqlDataSource_keyed'></a>
 ```cs
 const string dataSourceKey = "marten_data_source";
 
@@ -154,7 +154,7 @@ services.AddMarten()
     .UseLightweightSessions()
     .UseNpgsqlDataSource(dataSourceKey);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/bootstrapping_with_service_collection_extensions.cs#L380-L390' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_usenpgsqldatasource_keyed' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/bootstrapping_with_service_collection_extensions.cs#L380-L390' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_UseNpgsqlDataSource_keyed' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Using a Multi-Host Data Source <Badge type="tip" text="7.11" />
@@ -164,7 +164,7 @@ Marten includes support for `NpgsqlMultiHostDataSource`, allowing you to spread 
 Configuring `NpgsqlMultiHostDataSource` is very similar to a normal data source, simply swapping it for `AddMultiHostNpgsqlDataSource`. Marten will always use the primary node for queries with a `NpgsqlMultiHostDataSource` unless you explicitly opt to use the standby nodes. You can adjust what type of node Marten uses for querying via the `MultiHostSettings` store options:
 
 <!-- snippet: sample_using_UseNpgsqlDataSourceMultiHost -->
-<a id='snippet-sample_using_usenpgsqldatasourcemultihost'></a>
+<a id='snippet-sample_using_UseNpgsqlDataSourceMultiHost'></a>
 ```cs
 services.AddMultiHostNpgsqlDataSource(ConnectionSource.ConnectionString);
 
@@ -176,7 +176,7 @@ services.AddMarten(x =>
     .UseLightweightSessions()
     .UseNpgsqlDataSource();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/bootstrapping_with_service_collection_extensions.cs#L352-L364' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_usenpgsqldatasourcemultihost' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/bootstrapping_with_service_collection_extensions.cs#L352-L364' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_UseNpgsqlDataSourceMultiHost' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: warning
@@ -197,7 +197,7 @@ The `AddMarten()` mechanism assumes that you are expressing all of the Marten co
 Fear not, Marten V5.0 introduced a new way to add or modify the Marten configuration from `AddMarten()`. Let's assume that we're building a system that has a subsystem related to *users* and want to segregate all the service registrations and Marten configuration related to *users* into a single place like this extension method:
 
 <!-- snippet: sample_AddUserModule -->
-<a id='snippet-sample_addusermodule'></a>
+<a id='snippet-sample_AddUserModule'></a>
 ```cs
 public static IServiceCollection AddUserModule(this IServiceCollection services)
 {
@@ -214,7 +214,7 @@ public static IServiceCollection AddUserModule(this IServiceCollection services)
     return services;
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/BootstrappingExamples.cs#L14-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_addusermodule' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/BootstrappingExamples.cs#L14-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AddUserModule' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And next, let's put that into context with its usage inside your application's bootstrapping:
@@ -242,7 +242,7 @@ The `ConfigureMarten()` method is the interesting part of the code samples above
 service that implements the `IConfigureMarten` interface into the underlying IoC container:
 
 <!-- snippet: sample_IConfigureMarten -->
-<a id='snippet-sample_iconfiguremarten'></a>
+<a id='snippet-sample_IConfigureMarten'></a>
 ```cs
 /// <summary>
 ///     Mechanism to register additional Marten configuration that is applied after AddMarten()
@@ -253,13 +253,13 @@ public interface IConfigureMarten
     void Configure(IServiceProvider services, StoreOptions options);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/MartenServiceCollectionExtensions.cs#L877-L888' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iconfiguremarten' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/MartenServiceCollectionExtensions.cs#L877-L888' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IConfigureMarten' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You could alternatively implement a custom `IConfigureMarten` (or `IConfigureMarten<T> where T : IDocumentStore` if you're working with multiple databases class like so:
 
 <!-- snippet: sample_UserMartenConfiguration -->
-<a id='snippet-sample_usermartenconfiguration'></a>
+<a id='snippet-sample_UserMartenConfiguration'></a>
 ```cs
 internal class UserMartenConfiguration: IConfigureMarten
 {
@@ -270,13 +270,13 @@ internal class UserMartenConfiguration: IConfigureMarten
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/BootstrappingExamples.cs#L64-L75' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_usermartenconfiguration' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/BootstrappingExamples.cs#L64-L75' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_UserMartenConfiguration' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 and registering it in your IoC container something like this:
 
 <!-- snippet: sample_AddUserModule2 -->
-<a id='snippet-sample_addusermodule2'></a>
+<a id='snippet-sample_AddUserModule2'></a>
 ```cs
 public static IServiceCollection AddUserModule2(this IServiceCollection services)
 {
@@ -293,7 +293,7 @@ public static IServiceCollection AddUserModule2(this IServiceCollection services
     return services;
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/BootstrappingExamples.cs#L36-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_addusermodule2' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/BootstrappingExamples.cs#L36-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AddUserModule2' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Using IoC Services for Configuring Marten <Badge type="tip" text="7.7" />
@@ -305,7 +305,7 @@ be used to selectively configure Marten using potentially asynchronous methods a
 That interface signature is:
 
 <!-- snippet: sample_IAsyncConfigureMarten -->
-<a id='snippet-sample_iasyncconfiguremarten'></a>
+<a id='snippet-sample_IAsyncConfigureMarten'></a>
 ```cs
 /// <summary>
 ///     Mechanism to register additional Marten configuration that is applied after AddMarten()
@@ -317,13 +317,13 @@ public interface IAsyncConfigureMarten
     ValueTask Configure(StoreOptions options, CancellationToken cancellationToken);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/MartenServiceCollectionExtensions.cs#L890-L902' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iasyncconfiguremarten' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/MartenServiceCollectionExtensions.cs#L890-L902' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IAsyncConfigureMarten' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 As an example from the tests, here's a custom version that uses the Feature Management service:
 
 <!-- snippet: sample_FeatureManagementUsingExtension -->
-<a id='snippet-sample_featuremanagementusingextension'></a>
+<a id='snippet-sample_FeatureManagementUsingExtension'></a>
 ```cs
 public class FeatureManagementUsingExtension: IAsyncConfigureMarten
 {
@@ -343,7 +343,7 @@ public class FeatureManagementUsingExtension: IAsyncConfigureMarten
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/configuring_marten_with_async_extensions.cs#L77-L97' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_featuremanagementusingextension' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/configuring_marten_with_async_extensions.cs#L77-L97' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_FeatureManagementUsingExtension' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And lastly, these extensions can be registered directly against `IServiceCollection` like so:
@@ -369,7 +369,7 @@ compatibility with early Marten and RavenDb behavior before that. To opt into us
 without the identity map behavior, use this syntax:
 
 <!-- snippet: sample_AddMartenWithLightweightSessions -->
-<a id='snippet-sample_addmartenwithlightweightsessions'></a>
+<a id='snippet-sample_AddMartenWithLightweightSessions'></a>
 ```cs
 var connectionString = Configuration.GetConnectionString("postgres");
 
@@ -382,7 +382,7 @@ services.AddMarten(opts =>
     // session factory behavior
     .UseLightweightSessions();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/LightweightSessions/Startup.cs#L23-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_addmartenwithlightweightsessions' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/LightweightSessions/Startup.cs#L23-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AddMartenWithLightweightSessions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Customizing Session Creation Globally
@@ -391,7 +391,7 @@ By default, Marten will create a document session with the basic identity map en
 as shown in this example:
 
 <!-- snippet: sample_CustomSessionFactory -->
-<a id='snippet-sample_customsessionfactory'></a>
+<a id='snippet-sample_CustomSessionFactory'></a>
 ```cs
 public class CustomSessionFactory: ISessionFactory
 {
@@ -419,13 +419,13 @@ public class CustomSessionFactory: ISessionFactory
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/ConfiguringSessionCreation/Startup.cs#L13-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customsessionfactory' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/ConfiguringSessionCreation/Startup.cs#L13-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_CustomSessionFactory' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To register the custom session factory, use the `BuildSessionsWith()` method as shown in this example:
 
 <!-- snippet: sample_AddMartenWithCustomSessionCreation -->
-<a id='snippet-sample_addmartenwithcustomsessioncreation'></a>
+<a id='snippet-sample_AddMartenWithCustomSessionCreation'></a>
 ```cs
 var connectionString = Configuration.GetConnectionString("postgres");
 
@@ -446,7 +446,7 @@ services.CritterStackDefaults(x =>
     x.Production.ResourceAutoCreate = AutoCreate.None;
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/ConfiguringSessionCreation/Startup.cs#L56-L75' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_addmartenwithcustomsessioncreation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/ConfiguringSessionCreation/Startup.cs#L56-L75' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AddMartenWithCustomSessionCreation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The session factories can also be used to build out and attach custom `IDocumentSessionListener` objects or replace the logging as we'll see in the next section.
@@ -461,20 +461,20 @@ session identification in your application? That's now possible by using a custo
 Taking the example of an ASP&#46;NET Core application, let's say that you have a small service scoped to an HTTP request that tracks a correlation identifier for the request like this:
 
 <!-- snippet: sample_CorrelationIdWithISession -->
-<a id='snippet-sample_correlationidwithisession'></a>
+<a id='snippet-sample_CorrelationIdWithISession'></a>
 ```cs
 public interface ISession
 {
     Guid CorrelationId { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/PerScopeSessionCreation/Startup.cs#L17-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_correlationidwithisession' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/PerScopeSessionCreation/Startup.cs#L17-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_CorrelationIdWithISession' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And a custom Marten session logger to add the correlation identifier to the log output like this:
 
 <!-- snippet: sample_CorrelatedMartenLogger -->
-<a id='snippet-sample_correlatedmartenlogger'></a>
+<a id='snippet-sample_CorrelatedMartenLogger'></a>
 ```cs
 public class CorrelatedMartenLogger: IMartenSessionLogger
 {
@@ -528,13 +528,13 @@ public class CorrelatedMartenLogger: IMartenSessionLogger
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/PerScopeSessionCreation/Startup.cs#L24-L76' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_correlatedmartenlogger' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/PerScopeSessionCreation/Startup.cs#L24-L76' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_CorrelatedMartenLogger' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Now, let's move on to building out a custom session factory that will attach our correlated marten logger to sessions being resolved from the IoC container:
 
 <!-- snippet: sample_CustomSessionFactoryByScope -->
-<a id='snippet-sample_customsessionfactorybyscope'></a>
+<a id='snippet-sample_CustomSessionFactoryByScope'></a>
 ```cs
 public class ScopedSessionFactory: ISessionFactory
 {
@@ -568,13 +568,13 @@ public class ScopedSessionFactory: ISessionFactory
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/PerScopeSessionCreation/Startup.cs#L79-L111' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customsessionfactorybyscope' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/PerScopeSessionCreation/Startup.cs#L79-L111' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_CustomSessionFactoryByScope' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Lastly, let's register our new session factory, but this time we need to take care to register the session factory as `Scoped` in the underlying container so we're using the correct `ISession` at runtime:
 
 <!-- snippet: sample_AddMartenWithCustomSessionCreationByScope -->
-<a id='snippet-sample_addmartenwithcustomsessioncreationbyscope'></a>
+<a id='snippet-sample_AddMartenWithCustomSessionCreationByScope'></a>
 ```cs
 var connectionString = Configuration.GetConnectionString("postgres");
 
@@ -594,7 +594,7 @@ services.CritterStackDefaults(x =>
     x.Production.ResourceAutoCreate = AutoCreate.None;
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/PerScopeSessionCreation/Startup.cs#L127-L146' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_addmartenwithcustomsessioncreationbyscope' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/PerScopeSessionCreation/Startup.cs#L127-L146' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AddMartenWithCustomSessionCreationByScope' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: tip
@@ -621,7 +621,7 @@ To utilize the type system and your application's underlying IoC container, the 
 below targeting a separate "invoicing" database:
 
 <!-- snippet: sample_IInvoicingStore -->
-<a id='snippet-sample_iinvoicingstore'></a>
+<a id='snippet-sample_IInvoicingStore'></a>
 ```cs
 // These marker interfaces *must* be public
 public interface IInvoicingStore : IDocumentStore
@@ -629,7 +629,7 @@ public interface IInvoicingStore : IDocumentStore
 
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/MultipleDocumentStores.cs#L63-L71' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iinvoicingstore' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/MultipleDocumentStores.cs#L63-L71' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IInvoicingStore' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 A couple notes on the interface:
@@ -640,7 +640,7 @@ A couple notes on the interface:
 And now to bootstrap that separate store in our system:
 
 <!-- snippet: sample_bootstrapping_separate_Store -->
-<a id='snippet-sample_bootstrapping_separate_store'></a>
+<a id='snippet-sample_bootstrapping_separate_Store'></a>
 ```cs
 using var host = Host.CreateDefaultBuilder()
     .ConfigureServices(services =>
@@ -675,14 +675,14 @@ using var host = Host.CreateDefaultBuilder()
         });
     }).StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/MultipleDocumentStores.cs#L16-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_separate_store' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/MultipleDocumentStores.cs#L16-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_separate_Store' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 At runtime we can inject an instance of our new `IInvoicingStore` and work with it like any other
 Marten `IDocumentStore` as shown below in an internal `InvoicingService`:
 
 <!-- snippet: sample_InvoicingService -->
-<a id='snippet-sample_invoicingservice'></a>
+<a id='snippet-sample_InvoicingService'></a>
 ```cs
 public class InvoicingService
 {
@@ -705,5 +705,5 @@ public class InvoicingService
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/MultipleDocumentStores.cs#L73-L96' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_invoicingservice' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/MultipleDocumentStores.cs#L73-L96' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_InvoicingService' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/configuration/ioc.md
+++ b/docs/configuration/ioc.md
@@ -20,7 +20,7 @@ use the `AddMarten()` method directly with Lamar as well.
 Using [Lamar](https://jasperfx.github.io/lamar) as the example container, we recommend registering Marten something like this:
 
 <!-- snippet: sample_MartenServices -->
-<a id='snippet-sample_martenservices'></a>
+<a id='snippet-sample_MartenServices'></a>
 ```cs
 public class MartenServices : ServiceRegistry
 {
@@ -49,7 +49,7 @@ public class MartenServices : ServiceRegistry
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/DevelopmentModeRegistry.cs#L8-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_martenservices' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/DevelopmentModeRegistry.cs#L8-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_MartenServices' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 There are really only two key points here:

--- a/docs/configuration/json.md
+++ b/docs/configuration/json.md
@@ -232,7 +232,7 @@ Please talk to the Marten team before you undergo any significant effort to supp
 Internally, Marten uses an adapter interface for JSON serialization:
 
 <!-- snippet: sample_ISerializer -->
-<a id='snippet-sample_iserializer'></a>
+<a id='snippet-sample_ISerializer'></a>
 ```cs
 /// <summary>
 ///     When selecting data through Linq Select() transforms,
@@ -338,7 +338,7 @@ public interface ISerializer
     string ToJsonWithTypes(object document);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/ISerializer.cs#L11-L117' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iserializer' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/ISerializer.cs#L11-L117' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ISerializer' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To support a new serialization library or customize the JSON serialization options, you can write a new version of `ISerializer` and plug it

--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -267,7 +267,7 @@ It is strongly recommended that you first refer to the existing Marten options f
 The multi-tenancy strategy is pluggable. Start by implementing the `Marten.Storage.ITenancy` interface:
 
 <!-- snippet: sample_ITenancy -->
-<a id='snippet-sample_itenancy'></a>
+<a id='snippet-sample_ITenancy'></a>
 ```cs
 /// <summary>
 ///     Pluggable interface for Marten multi-tenancy by database
@@ -314,19 +314,19 @@ public interface ITenancy: IDatabaseSource, IDisposable, IDatabaseUser
     bool IsTenantStoredInCurrentDatabase(IMartenDatabase database, string tenantId);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Storage/ITenancy.cs#L21-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_itenancy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Storage/ITenancy.cs#L21-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ITenancy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Assuming that we have a custom `ITenancy` model:
 
 <!-- snippet: sample_MySpecialTenancy -->
-<a id='snippet-sample_myspecialtenancy'></a>
+<a id='snippet-sample_MySpecialTenancy'></a>
 ```cs
 // Make sure you implement the Dispose() method and
 // dispose all MartenDatabase objects
 public class MySpecialTenancy: ITenancy
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/using_per_database_multitenancy.cs#L29-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_myspecialtenancy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/using_per_database_multitenancy.cs#L29-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_MySpecialTenancy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 We can utilize that by applying that model at configuration time:

--- a/docs/configuration/retries.md
+++ b/docs/configuration/retries.md
@@ -7,7 +7,7 @@ Marten's previous, homegrown `IRetryPolicy` mechanism was completely replaced by
 Out of the box, Marten is using [Polly.Core](https://www.pollydocs.org/) for resiliency on most operations with this setup:
 
 <!-- snippet: sample_default_Polly_setup -->
-<a id='snippet-sample_default_polly_setup'></a>
+<a id='snippet-sample_default_Polly_setup'></a>
 ```cs
 // default Marten policies
 return builder
@@ -22,7 +22,7 @@ return builder
         BackoffType = DelayBackoffType.Exponential
     });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Util/ResilientPipelineBuilderExtensions.cs#L14-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_default_polly_setup' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Util/ResilientPipelineBuilderExtensions.cs#L14-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_default_Polly_setup' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The general idea is to have _some_ level of retry with an exponential backoff on typical transient errors encountered

--- a/docs/configuration/storeoptions.md
+++ b/docs/configuration/storeoptions.md
@@ -5,7 +5,7 @@ The static builder methods like `DocumentStore.For(configuration)` or `IServiceC
 syntactic sugar around building up a `StoreOptions` object and passing that to the constructor function of a `DocumentStore`:
 
 <!-- snippet: sample_DocumentStore.For -->
-<a id='snippet-sample_documentstore.for'></a>
+<a id='snippet-sample_DocumentStore.For'></a>
 ```cs
 public static DocumentStore For(Action<StoreOptions> configure)
 {
@@ -15,7 +15,7 @@ public static DocumentStore For(Action<StoreOptions> configure)
     return new DocumentStore(options);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/DocumentStore.cs#L485-L495' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_documentstore.for' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/DocumentStore.cs#L485-L495' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_DocumentStore.For' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The major parts of `StoreOptions` are shown in the class diagram below:
@@ -83,7 +83,7 @@ to compose your document type configuration in additional `MartenRegistry` objec
 To use your own subclass of `MartenRegistry` and place declarations in the constructor function like this example:
 
 <!-- snippet: sample_OrganizationRegistry -->
-<a id='snippet-sample_organizationregistry'></a>
+<a id='snippet-sample_OrganizationRegistry'></a>
 ```cs
 public class OrganizationRegistry: MartenRegistry
 {
@@ -94,13 +94,13 @@ public class OrganizationRegistry: MartenRegistry
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/MartenRegistryTests.cs#L173-L184' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_organizationregistry' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/MartenRegistryTests.cs#L173-L184' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_OrganizationRegistry' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To apply your new `MartenRegistry`, just include it when you bootstrap the `IDocumentStore` as in this example:
 
 <!-- snippet: sample_including_a_custom_MartenRegistry -->
-<a id='snippet-sample_including_a_custom_martenregistry'></a>
+<a id='snippet-sample_including_a_custom_MartenRegistry'></a>
 ```cs
 var store = DocumentStore.For(opts =>
 {
@@ -109,7 +109,7 @@ var store = DocumentStore.For(opts =>
     opts.Connection(ConnectionSource.ConnectionString);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/MartenRegistryTests.cs#L206-L215' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_including_a_custom_martenregistry' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/MartenRegistryTests.cs#L206-L215' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_including_a_custom_MartenRegistry' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Do note that you could happily use multiple `MartenRegistry` classes in larger applications if that is advantageous.
@@ -140,7 +140,7 @@ If there's some kind of customization you'd like to use attributes for that isn'
 you're still in luck. If you write a subclass of the `MartenAttribute` shown below:
 
 <!-- snippet: sample_MartenAttribute -->
-<a id='snippet-sample_martenattribute'></a>
+<a id='snippet-sample_MartenAttribute'></a>
 ```cs
 public abstract class MartenAttribute: Attribute
 {
@@ -167,7 +167,7 @@ public abstract class MartenAttribute: Attribute
     public virtual void Register(Type discoveredType, StoreOptions options){}
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Schema/MartenAttribute.cs#L12-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_martenattribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Schema/MartenAttribute.cs#L12-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_MartenAttribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And decorate either classes or individual field or properties on a document type, your custom attribute will be
@@ -178,7 +178,7 @@ As an example, an attribute to add a gin index to the JSONB storage for more eff
 would look like this:
 
 <!-- snippet: sample_GinIndexedAttribute -->
-<a id='snippet-sample_ginindexedattribute'></a>
+<a id='snippet-sample_GinIndexedAttribute'></a>
 ```cs
 [AttributeUsage(AttributeTargets.Class)]
 public class GinIndexedAttribute: MartenAttribute
@@ -189,7 +189,7 @@ public class GinIndexedAttribute: MartenAttribute
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Schema/GinIndexedAttribute.cs#L10-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ginindexedattribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Schema/GinIndexedAttribute.cs#L10-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_GinIndexedAttribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Embedding Configuration in Document Types
@@ -199,7 +199,7 @@ and invoke that to let the document type make its own customizations for its sto
 the unit tests:
 
 <!-- snippet: sample_ConfigureMarten-generic -->
-<a id='snippet-sample_configuremarten-generic'></a>
+<a id='snippet-sample_ConfigureMarten-generic'></a>
 ```cs
 public class ConfiguresItself
 {
@@ -211,7 +211,7 @@ public class ConfiguresItself
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/DocumentMappingTests.cs#L891-L903' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuremarten-generic' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/DocumentMappingTests.cs#L891-L903' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ConfigureMarten-generic' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `DocumentMapping` type is the core configuration class representing how a document type is persisted or
@@ -222,7 +222,7 @@ You can optionally take in the more specific `DocumentMapping<T>` for your docum
 some convenience methods for indexing or duplicating fields that depend on .Net Expression's:
 
 <!-- snippet: sample_ConfigureMarten-specifically -->
-<a id='snippet-sample_configuremarten-specifically'></a>
+<a id='snippet-sample_ConfigureMarten-specifically'></a>
 ```cs
 public class ConfiguresItselfSpecifically
 {
@@ -235,7 +235,7 @@ public class ConfiguresItselfSpecifically
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/DocumentMappingTests.cs#L905-L918' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuremarten-specifically' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/DocumentMappingTests.cs#L905-L918' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ConfigureMarten-specifically' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Document Policies

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -44,7 +44,7 @@ All of the functionality in this section was added as part of Marten v0.8
 Marten has a facility for listening and even intercepting document persistence events with the `IDocumentSessionListener` interface:
 
 <!-- snippet: sample_IDocumentSessionListener -->
-<a id='snippet-sample_idocumentsessionlistener'></a>
+<a id='snippet-sample_IDocumentSessionListener'></a>
 ```cs
 public interface IChangeListener
 {
@@ -106,7 +106,7 @@ public interface IDocumentSessionListener
     void DocumentAddedForStorage(object id, object document);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/IDocumentSessionListener.cs#L27-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_idocumentsessionlistener' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/IDocumentSessionListener.cs#L27-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IDocumentSessionListener' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can build and inject your own listeners by adding them to the `StoreOptions` object you use to configure a `DocumentStore`:
@@ -212,7 +212,7 @@ Listeners will never get activated during projection rebuilds to safe guard agai
 
 A sample listener:
 <!-- snippet: sample_AsyncDaemonListener -->
-<a id='snippet-sample_asyncdaemonlistener'></a>
+<a id='snippet-sample_AsyncDaemonListener'></a>
 ```cs
 public class FakeListener: IChangeListener
 {
@@ -237,12 +237,12 @@ public class FakeListener: IChangeListener
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Internals/basic_functionality.cs#L123-L148' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asyncdaemonlistener' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Internals/basic_functionality.cs#L123-L148' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AsyncDaemonListener' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Wiring a Async Daemon listener:
 <!-- snippet: sample_AsyncListeners -->
-<a id='snippet-sample_asynclisteners'></a>
+<a id='snippet-sample_AsyncListeners'></a>
 ```cs
 var listener = new FakeListener();
 StoreOptions(x =>
@@ -251,7 +251,7 @@ StoreOptions(x =>
     x.Projections.AsyncListeners.Add(listener);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Internals/basic_functionality.cs#L153-L162' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asynclisteners' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Internals/basic_functionality.cs#L153-L162' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AsyncListeners' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Custom Logging
@@ -259,7 +259,7 @@ StoreOptions(x =>
 Marten v0.8 comes with a new mechanism to plug in custom logging to the `IDocumentStore`, `IQuerySession`, and `IDocumentSession` activity:
 
 <!-- snippet: sample_IMartenLogger -->
-<a id='snippet-sample_imartenlogger'></a>
+<a id='snippet-sample_IMartenLogger'></a>
 ```cs
 /// <summary>
 ///     Records command usage, schema changes, and sessions within Marten
@@ -342,7 +342,7 @@ public interface IMartenSessionLogger
     public void OnBeforeExecute(NpgsqlBatch batch);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/IMartenLogger.cs#L11-L96' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_imartenlogger' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/IMartenLogger.cs#L11-L96' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IMartenLogger' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To apply these logging abstractions, you can either plug your own `IMartenLogger` into the `StoreOptions` object and allow that default logger to create the individual session loggers:
@@ -373,7 +373,7 @@ session.Logger = new RecordingLogger();
 The session logging is a different abstraction specifically so that you _could_ track database commands issued per session. In effect, my own shop is going to use this capability to understand what HTTP endpoints or service bus message handlers are being unnecessarily chatty in their database interactions. We also hope that the contextual logging of commands per document session makes it easier to understand how our systems behave.
 
 <!-- snippet: sample_ConsoleMartenLogger -->
-<a id='snippet-sample_consolemartenlogger'></a>
+<a id='snippet-sample_ConsoleMartenLogger'></a>
 ```cs
 public class ConsoleMartenLogger: IMartenLogger, IMartenSessionLogger
 {
@@ -473,7 +473,7 @@ public class ConsoleMartenLogger: IMartenLogger, IMartenSessionLogger
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/IMartenLogger.cs#L98-L198' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_consolemartenlogger' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/IMartenLogger.cs#L98-L198' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ConsoleMartenLogger' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Accessing Diagnostics

--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -97,7 +97,7 @@ that allow you to use Linq queries without the runtime overhead of continuously 
 Back to the sample endpoint above where we write an array of all the open issues. We can express the same query in a simple compiled query like this:
 
 <!-- snippet: sample_OpenIssues -->
-<a id='snippet-sample_openissues'></a>
+<a id='snippet-sample_OpenIssues'></a>
 ```cs
 public class OpenIssues: ICompiledListQuery<Issue>
 {
@@ -107,7 +107,7 @@ public class OpenIssues: ICompiledListQuery<Issue>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L114-L124' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_openissues' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L114-L124' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_OpenIssues' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And use that in an MVC Controller method like this:
@@ -131,7 +131,7 @@ sample, here's an example compiled query that reads a single `Issue` document by
 id:
 
 <!-- snippet: sample_IssueById -->
-<a id='snippet-sample_issuebyid'></a>
+<a id='snippet-sample_IssueById'></a>
 ```cs
 public class IssueById: ICompiledQuery<Issue, Issue>
 {
@@ -143,7 +143,7 @@ public class IssueById: ICompiledQuery<Issue, Issue>
     public Guid Id { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L126-L138' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_issuebyid' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L126-L138' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IssueById' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And the usage of that to write JSON directly to the `HttpContext` in a controller method:

--- a/docs/documents/concurrency.md
+++ b/docs/documents/concurrency.md
@@ -26,7 +26,7 @@ as being revisioned
 In Marten's case, you have to explicitly opt into optimistic versioning for each document type. You can do that with either an attribute on your document type like so:
 
 <!-- snippet: sample_UseOptimisticConcurrencyAttribute -->
-<a id='snippet-sample_useoptimisticconcurrencyattribute'></a>
+<a id='snippet-sample_UseOptimisticConcurrencyAttribute'></a>
 ```cs
 [UseOptimisticConcurrency]
 public class CoffeeShop: Shop
@@ -37,7 +37,7 @@ public class CoffeeShop: Shop
     public ICollection<Guid> Employees { get; set; } = new List<Guid>();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Concurrency/optimistic_concurrency.cs#L827-L837' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_useoptimisticconcurrencyattribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Concurrency/optimistic_concurrency.cs#L827-L837' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_UseOptimisticConcurrencyAttribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or by using Marten's configuration API to do it programmatically:
@@ -112,7 +112,7 @@ Marten is throwing an `AggregateException` for the entire batch of changes.
 A new feature in Marten V4 is the `IVersioned` marker interface. If your document type implements this interface as shown below:
 
 <!-- snippet: sample_MyVersionedDoc -->
-<a id='snippet-sample_myversioneddoc'></a>
+<a id='snippet-sample_MyVersionedDoc'></a>
 ```cs
 public class MyVersionedDoc: IVersioned
 {
@@ -120,7 +120,7 @@ public class MyVersionedDoc: IVersioned
     public Guid Version { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Metadata/metadata_marker_interfaces.cs#L121-L129' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_myversioneddoc' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Metadata/metadata_marker_interfaces.cs#L121-L129' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_MyVersionedDoc' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Your document type will have the optimistic concurrency checks applied to updates _when_ the current version is given to Marten. Moreover, the current version
@@ -143,7 +143,7 @@ You can opt into this behavior on a document by document basis by using the flue
 like this:
 
 <!-- snippet: sample_UseNumericRevisions_fluent_interface -->
-<a id='snippet-sample_usenumericrevisions_fluent_interface'></a>
+<a id='snippet-sample_UseNumericRevisions_fluent_interface'></a>
 ```cs
 using var store = DocumentStore.For(opts =>
 {
@@ -154,7 +154,7 @@ using var store = DocumentStore.For(opts =>
     opts.Schema.For<Incident>().UseNumericRevisions(true);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/RevisionedDocuments.cs#L13-L24' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_usenumericrevisions_fluent_interface' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/RevisionedDocuments.cs#L13-L24' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_UseNumericRevisions_fluent_interface' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 or by implementing the `IRevisioned` interface in a document type:

--- a/docs/documents/deletes.md
+++ b/docs/documents/deletes.md
@@ -50,13 +50,13 @@ public Task DeleteByDocument(IDocumentSession session, User user)
 Marten also provides the ability to delete any documents of a certain type meeting a Linq expression using the `IDocumentSession.DeleteWhere<T>()` method:
 
 <!-- snippet: sample_DeleteWhere -->
-<a id='snippet-sample_deletewhere'></a>
+<a id='snippet-sample_DeleteWhere'></a>
 ```cs
 theSession.DeleteWhere<Target>(x => x.Double == 578);
 
 await theSession.SaveChangesAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Deleting/delete_many_documents_by_query.cs#L30-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deletewhere' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Deleting/delete_many_documents_by_query.cs#L30-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_DeleteWhere' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 A couple things to note:
@@ -70,7 +70,7 @@ A couple things to note:
 Documents of mixed or varying types can be deleted using `IDocumentSession.DeleteObjects(IEnumerable<object> documents)` method.
 
 <!-- snippet: sample_DeleteObjects -->
-<a id='snippet-sample_deleteobjects'></a>
+<a id='snippet-sample_DeleteObjects'></a>
 ```cs
 // Store a mix of different document types
 var user1 = new User { FirstName = "Jamie", LastName = "Vaughan" };
@@ -89,7 +89,7 @@ using (var documentSession = theStore.LightweightSession())
     await documentSession.SaveChangesAsync();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Deleting/deleting_multiple_documents.cs#L60-L79' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deleteobjects' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Deleting/deleting_multiple_documents.cs#L60-L79' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_DeleteObjects' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Soft Deletes
@@ -104,7 +104,7 @@ documents marked as _deleted_ unless you explicitly state otherwise in the Linq 
 You can direct Marten to make a document type soft deleted by either marking the class with an attribute:
 
 <!-- snippet: sample_SoftDeletedAttribute -->
-<a id='snippet-sample_softdeletedattribute'></a>
+<a id='snippet-sample_SoftDeletedAttribute'></a>
 ```cs
 [SoftDeleted]
 public class SoftDeletedDoc
@@ -112,7 +112,7 @@ public class SoftDeletedDoc
     public Guid Id;
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Deleting/configuring_mapping_deletion_style.cs#L21-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_softdeletedattribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Deleting/configuring_mapping_deletion_style.cs#L21-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_SoftDeletedAttribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or by using the fluent interface off of `StoreOptions`:
@@ -132,7 +132,7 @@ With Marten v4.0, you can also opt into soft-deleted mechanics by having your do
 interface as shown below:
 
 <!-- snippet: sample_implementing_ISoftDeleted -->
-<a id='snippet-sample_implementing_isoftdeleted'></a>
+<a id='snippet-sample_implementing_ISoftDeleted'></a>
 ```cs
 public class MySoftDeletedDoc: ISoftDeleted
 {
@@ -146,7 +146,7 @@ public class MySoftDeletedDoc: ISoftDeleted
     public DateTimeOffset? DeletedAt { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Metadata/metadata_marker_interfaces.cs#L131-L145' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_implementing_isoftdeleted' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Metadata/metadata_marker_interfaces.cs#L131-L145' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_implementing_ISoftDeleted' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 More on `ISoftDeleted` in a later section on exposing soft-deleted metadata directly
@@ -156,7 +156,7 @@ Also starting in Marten v4.0, you can also say globally that you want all docume
 to be soft-deleted unless explicitly configured otherwise like this:
 
 <!-- snippet: sample_AllDocumentTypesShouldBeSoftDeleted -->
-<a id='snippet-sample_alldocumenttypesshouldbesoftdeleted'></a>
+<a id='snippet-sample_AllDocumentTypesShouldBeSoftDeleted'></a>
 ```cs
 internal void AllDocumentTypesShouldBeSoftDeleted()
 {
@@ -167,7 +167,7 @@ internal void AllDocumentTypesShouldBeSoftDeleted()
     });
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/Deletes.cs#L36-L47' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_alldocumenttypesshouldbesoftdeleted' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/Deletes.cs#L36-L47' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AllDocumentTypesShouldBeSoftDeleted' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Querying a "Soft Deleted" Document Type
@@ -485,7 +485,7 @@ public async Task query_is_soft_deleted_since_docs()
 _Neither `DeletedSince` nor `DeletedBefore` are inclusive searches as shown_below:
 
 <!-- snippet: sample_AllDocumentTypesShouldBeSoftDeleted -->
-<a id='snippet-sample_alldocumenttypesshouldbesoftdeleted'></a>
+<a id='snippet-sample_AllDocumentTypesShouldBeSoftDeleted'></a>
 ```cs
 internal void AllDocumentTypesShouldBeSoftDeleted()
 {
@@ -496,7 +496,7 @@ internal void AllDocumentTypesShouldBeSoftDeleted()
     });
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/Deletes.cs#L36-L47' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_alldocumenttypesshouldbesoftdeleted' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/Deletes.cs#L36-L47' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AllDocumentTypesShouldBeSoftDeleted' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Undoing Soft-Deleted Documents
@@ -505,7 +505,7 @@ New in Marten v4.0 is a mechanism to mark any soft-deleted documents matching a 
 as not being deleted. The only usage so far is using a Linq expression as shown below:
 
 <!-- snippet: sample_UndoDeletion -->
-<a id='snippet-sample_undodeletion'></a>
+<a id='snippet-sample_UndoDeletion'></a>
 ```cs
 internal Task UndoDeletion(IDocumentSession session, Guid userId)
 {
@@ -516,7 +516,7 @@ internal Task UndoDeletion(IDocumentSession session, Guid userId)
     return session.SaveChangesAsync();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/Deletes.cs#L23-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_undodeletion' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/Deletes.cs#L23-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_UndoDeletion' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Explicit Hard Deletes
@@ -525,7 +525,7 @@ New in v4.0 is the ability to force Marten to perform hard deletes even on docum
 that are normally soft-deleted:
 
 <!-- snippet: sample_HardDeletes -->
-<a id='snippet-sample_harddeletes'></a>
+<a id='snippet-sample_HardDeletes'></a>
 ```cs
 internal void ExplicitlyHardDelete(IDocumentSession session, User document)
 {
@@ -542,7 +542,7 @@ internal void ExplicitlyHardDelete(IDocumentSession session, User document)
     // to actually perform the operations
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/Deletes.cs#L49-L66' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_harddeletes' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/Deletes.cs#L49-L66' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_HardDeletes' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Deletion Metadata on Documents
@@ -552,7 +552,7 @@ and when it was deleted is to implement the `ISoftDeleted` interface as shown
 in this sample document:
 
 <!-- snippet: sample_implementing_ISoftDeleted -->
-<a id='snippet-sample_implementing_isoftdeleted'></a>
+<a id='snippet-sample_implementing_ISoftDeleted'></a>
 ```cs
 public class MySoftDeletedDoc: ISoftDeleted
 {
@@ -566,7 +566,7 @@ public class MySoftDeletedDoc: ISoftDeleted
     public DateTimeOffset? DeletedAt { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Metadata/metadata_marker_interfaces.cs#L131-L145' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_implementing_isoftdeleted' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Metadata/metadata_marker_interfaces.cs#L131-L145' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_implementing_ISoftDeleted' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Implementing `ISoftDeleted` on your document means that:
@@ -583,7 +583,7 @@ Now, if you don't want to couple your document types to Marten by implementing t
 you're still in business. Let's say you have this document type:
 
 <!-- snippet: sample_ASoftDeletedDoc -->
-<a id='snippet-sample_asoftdeleteddoc'></a>
+<a id='snippet-sample_ASoftDeletedDoc'></a>
 ```cs
 public class ASoftDeletedDoc
 {
@@ -595,7 +595,7 @@ public class ASoftDeletedDoc
     public DateTimeOffset? DeletedWhen { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Metadata/metadata_marker_interfaces.cs#L147-L159' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asoftdeleteddoc' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Metadata/metadata_marker_interfaces.cs#L147-L159' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ASoftDeletedDoc' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can manually -- and independently -- map the `IsDeleted` and `DeletedWhen` properties

--- a/docs/documents/execute-custom-sql.md
+++ b/docs/documents/execute-custom-sql.md
@@ -5,7 +5,7 @@ Use `QueueSqlCommand(string sql, params object[] parameterValues)` method to reg
 `?` placeholders can be used to denote parameter values. Postgres [type casts `::`](https://www.postgresql.org/docs/15/sql-expressions.html#SQL-SYNTAX-TYPE-CASTS) can be applied to the parameter if needed. If the `?` character is not suitable as a placeholder because you need to use `?` in your sql query, you can change the placeholder by providing an alternative. Pass this in before the sql argument. 
 
 <!-- snippet: sample_QueueSqlCommand -->
-<a id='snippet-sample_queuesqlcommand'></a>
+<a id='snippet-sample_QueueSqlCommand'></a>
 ```cs
 theSession.QueueSqlCommand("insert into names (name) values ('Jeremy')");
 theSession.QueueSqlCommand("insert into names (name) values ('Babu')");
@@ -17,5 +17,5 @@ theSession.QueueSqlCommand("insert into data (raw_value) values (?::jsonb)", jso
 // Use ^ as the parameter placeholder
 theSession.QueueSqlCommand('^', "insert into data (raw_value) values (^::jsonb)", json);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/executing_arbitrary_sql_as_part_of_transaction.cs#L40-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_queuesqlcommand' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/executing_arbitrary_sql_as_part_of_transaction.cs#L40-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_QueueSqlCommand' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/documents/full-text.md
+++ b/docs/documents/full-text.md
@@ -296,13 +296,13 @@ var posts = session.Query<BlogPost>()
 They allow also to specify language (regConfig) of the text search query (by default `english` is being used)
 
 <!-- snippet: sample_text_search_with_non_default_regConfig_sample -->
-<a id='snippet-sample_text_search_with_non_default_regconfig_sample'></a>
+<a id='snippet-sample_text_search_with_non_default_regConfig_sample'></a>
 ```cs
 var posts = session.Query<BlogPost>()
     .Where(x => x.PhraseSearch("somefilter", "italian"))
     .ToList();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Indexes/full_text_index.cs#L396-L402' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_text_search_with_non_default_regconfig_sample' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Indexes/full_text_index.cs#L396-L402' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_text_search_with_non_default_regConfig_sample' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Partial text search in a multi-word text (NGram search)

--- a/docs/documents/hierarchies.md
+++ b/docs/documents/hierarchies.md
@@ -80,21 +80,24 @@ public class Smurf: ISmurf
 
 public interface IPapaSmurf: ISmurf
 {
+    bool IsVillageLeader { get; set; }
 }
 
 public class PapaSmurf: Smurf, IPapaSmurf
 {
+    public bool IsVillageLeader { get; set; }
+
+    public bool IsPapa { get; set; } = true;
 }
 
 public class PapySmurf: Smurf, IPapaSmurf
 {
+    public bool IsVillageLeader { get; set; }
 }
 
-public class BrainySmurf: PapaSmurf
-{
-}
+public class BrainySmurf: PapaSmurf;
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Acceptance/query_with_inheritance.cs#L13-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_smurfs-hierarchy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Acceptance/query_with_inheritance.cs#L15-L48' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_smurfs-hierarchy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If you wish to query over one of hierarchy classes and be able to get all of its documents as well as its subclasses,
@@ -125,7 +128,7 @@ public query_with_inheritance(ITestOutputHelper output)
     });
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Acceptance/query_with_inheritance.cs#L92-L117' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_add-subclass-hierarchy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Acceptance/query_with_inheritance.cs#L96-L121' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_add-subclass-hierarchy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note that if you wish to use aliases on certain subclasses, you could pass a `MappedType`, which contains the type to map
@@ -142,9 +145,10 @@ _.Schema.For<ISmurf>()
         typeof(PapySmurf),
         typeof(IPapaSmurf),
         typeof(BrainySmurf)
-    );
+    )
+    .Duplicate<IPapaSmurf>(x => x.IsVillageLeader); // Put a duplicated index on subclass property;
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Acceptance/query_with_inheritance.cs#L54-L65' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_add-subclass-hierarchy-with-aliases' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Acceptance/query_with_inheritance.cs#L56-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_add-subclass-hierarchy-with-aliases' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Now you can query the "complex" hierarchy in the following ways:
@@ -239,6 +243,37 @@ public async Task get_all_subclasses_of_an_interface()
 
     theSession.Query<IPapaSmurf>().Count().ShouldBe(3);
 }
+
+[Fact]
+public async Task search_on_property_of_subclass()
+{
+    var smurf = new Smurf {Ability = "Follow the herd"};
+    var papa = new PapaSmurf {Ability = "Lead", IsVillageLeader = true };
+    var papy = new PapySmurf {Ability = "Lead"};
+    var brainy = new BrainySmurf {Ability = "Invent"};
+    theSession.Store(smurf, papa, brainy, papy);
+
+    await theSession.SaveChangesAsync();
+
+    (await theSession.Query<Smurf>().WhereSub<PapaSmurf>(x => x.IsVillageLeader).CountAsync()).ShouldBe(1);
+}
+
+[Fact]
+public async Task search_on_property_of_subclass_and_parent()
+{
+    var smurf = new Smurf {Ability = "Follow the herd"};
+    var papa = new PapaSmurf {Ability = "Lead" };
+    var papy = new PapySmurf {Ability = "Lead"};
+    var brainy = new BrainySmurf {Ability = "Invent"};
+    theSession.Store(smurf, papa, brainy, papy);
+
+    await theSession.SaveChangesAsync();
+
+    (await theSession.Query<Smurf>()
+        .WhereSub<PapaSmurf>(x => x.IsPapa)
+        .Where(x => x.Ability == "Invent")
+        .CountAsync()).ShouldBe(1);
+}
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Acceptance/query_with_inheritance.cs#L151-L243' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query-subclass-hierarchy' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Acceptance/query_with_inheritance.cs#L155-L278' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query-subclass-hierarchy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/documents/identity.md
+++ b/docs/documents/identity.md
@@ -55,7 +55,7 @@ the `[Identity]` attribute to force Marten to use a property or field as the ide
 the "id" or "Id" or "ID" convention:
 
 <!-- snippet: sample_IdentityAttribute -->
-<a id='snippet-sample_identityattribute'></a>
+<a id='snippet-sample_IdentityAttribute'></a>
 ```cs
 public class NonStandardDoc
 {
@@ -63,7 +63,7 @@ public class NonStandardDoc
     public string Name;
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/Identity/using_natural_identity_keys.cs#L74-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_identityattribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/Identity/using_natural_identity_keys.cs#L74-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IdentityAttribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The identity property or field can also be configured through `StoreOptions` by using the `Schema` to obtain a document mapping:
@@ -183,7 +183,7 @@ var store = DocumentStore.For(_ =>
 Marten 1.2 adds a convenience method to reset the "floor" of the Hilo sequence for a single document type:
 
 <!-- snippet: sample_ResetHiloSequenceFloor -->
-<a id='snippet-sample_resethilosequencefloor'></a>
+<a id='snippet-sample_ResetHiloSequenceFloor'></a>
 ```cs
 var store = DocumentStore.For(opts =>
 {
@@ -195,7 +195,7 @@ var store = DocumentStore.For(opts =>
 // type to 2500
 await store.Tenancy.Default.Database.ResetHiloSequenceFloor<IntDoc>(2500);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/Identity/Sequences/hilo_configuration_overrides.cs#L20-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_resethilosequencefloor' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/Identity/Sequences/hilo_configuration_overrides.cs#L20-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ResetHiloSequenceFloor' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This functionality was added specifically to aid in importing data from an existing data source. Do note that this functionality simply guarantees
@@ -218,14 +218,14 @@ so you will not be able to use any kind of punctuation characters or spaces.
 Let's say you have a document type with a `string` for the identity member like this one:
 
 <!-- snippet: sample_DocumentWithStringId -->
-<a id='snippet-sample_documentwithstringid'></a>
+<a id='snippet-sample_DocumentWithStringId'></a>
 ```cs
 public class DocumentWithStringId
 {
     public string Id { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/Identity/Sequences/IdentityKeyGenerationTests.cs#L31-L38' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_documentwithstringid' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/Identity/Sequences/IdentityKeyGenerationTests.cs#L31-L38' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_DocumentWithStringId' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can use the "identity key" option for identity generation that would create string values of the pattern `[type alias]/[sequence]` where the type alias is typically the document class name in all lower case and the sequence is a _HiLo_ sequence number.
@@ -233,7 +233,7 @@ You can use the "identity key" option for identity generation that would create 
 You can opt into the _identity key_ strategy for identity and even override the document alias name with this syntax:
 
 <!-- snippet: sample_using_IdentityKey -->
-<a id='snippet-sample_using_identitykey'></a>
+<a id='snippet-sample_using_IdentityKey'></a>
 ```cs
 var store = DocumentStore.For(opts =>
 {
@@ -243,7 +243,7 @@ var store = DocumentStore.For(opts =>
         .DocumentAlias("doc");
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/Identity/Sequences/IdentityKeyGenerationTests.cs#L42-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_identitykey' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/Identity/Sequences/IdentityKeyGenerationTests.cs#L42-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_IdentityKey' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Custom Identity Strategies
@@ -413,7 +413,7 @@ As you might infer -- or not -- there's a couple rules and internal behavior:
 For another example, here's a usage of an `int` wrapped identifier:
 
 <!-- snippet: sample_order2_with_STRONG_TYPED_identifier -->
-<a id='snippet-sample_order2_with_strong_typed_identifier'></a>
+<a id='snippet-sample_order2_with_STRONG_TYPED_identifier'></a>
 ```cs
 [StronglyTypedId(Template.Int)]
 public readonly partial struct Order2Id;
@@ -424,7 +424,7 @@ public class Order2
     public string Name { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/ValueTypeTests/StrongTypedId/int_based_document_operations.cs#L262-L273' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_order2_with_strong_typed_identifier' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/ValueTypeTests/StrongTypedId/int_based_document_operations.cs#L262-L273' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_order2_with_STRONG_TYPED_identifier' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: warning

--- a/docs/documents/indexing/duplicated-fields.md
+++ b/docs/documents/indexing/duplicated-fields.md
@@ -35,7 +35,7 @@ public class Employee
 Or by using the fluent interface off of `StoreOptions`:
 
 <!-- snippet: sample_IndexExamples -->
-<a id='snippet-sample_indexexamples'></a>
+<a id='snippet-sample_IndexExamples'></a>
 ```cs
 var store = DocumentStore.For(options =>
 {
@@ -73,7 +73,7 @@ var store = DocumentStore.For(options =>
     });
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MartenRegistryExamples.cs#L66-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_indexexamples' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MartenRegistryExamples.cs#L66-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IndexExamples' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In the case above, Marten would add an extra columns to the generated `mt_doc_user` table with `first_name` and `department`. Some users find duplicated fields to be useful for user supplied SQL queries.

--- a/docs/documents/indexing/foreign-keys.md
+++ b/docs/documents/indexing/foreign-keys.md
@@ -8,7 +8,7 @@ One of our sample document types in Marten is the `Issue` class that has
 a couple properties that link to the id's of related `User` documents:
 
 <!-- snippet: sample_Issue -->
-<a id='snippet-sample_issue'></a>
+<a id='snippet-sample_Issue'></a>
 ```cs
 public class Issue
 {
@@ -33,7 +33,7 @@ public class Issue
     public string Status { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Documents/Issue.cs#L5-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_issue' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Documents/Issue.cs#L5-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_Issue' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If I want to enforce referential integrity between the `Issue` document and the `User` documents,

--- a/docs/documents/indexing/gin-gist-indexes.md
+++ b/docs/documents/indexing/gin-gist-indexes.md
@@ -6,7 +6,7 @@ To optimize a wider range of ad-hoc queries against the document JSONB, you can 
 the JSON field in the database:
 
 <!-- snippet: sample_IndexExamples -->
-<a id='snippet-sample_indexexamples'></a>
+<a id='snippet-sample_IndexExamples'></a>
 ```cs
 var store = DocumentStore.For(options =>
 {
@@ -44,7 +44,7 @@ var store = DocumentStore.For(options =>
     });
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MartenRegistryExamples.cs#L66-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_indexexamples' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MartenRegistryExamples.cs#L66-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IndexExamples' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 **Marten may be changed to make the GIN index on the data field be automatic in the future.**

--- a/docs/documents/indexing/ignore-indexes.md
+++ b/docs/documents/indexing/ignore-indexes.md
@@ -3,7 +3,7 @@
 Any custom index on a Marten defined document table added outside of Marten can potentially cause issues with Marten schema migration detection and delta computation. Marten provides a mechanism to ignore those indexes using `IgnoreIndex(string indexName)`.
 
 <!-- snippet: sample_IgnoreIndex -->
-<a id='snippet-sample_ignoreindex'></a>
+<a id='snippet-sample_IgnoreIndex'></a>
 ```cs
 var store = DocumentStore.For(opts =>
 {
@@ -11,5 +11,5 @@ var store = DocumentStore.For(opts =>
     opts.Schema.For<User>().IgnoreIndex("foo");
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/ignoring_indexes_on_document_table.cs#L27-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ignoreindex' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/ignoring_indexes_on_document_table.cs#L27-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IgnoreIndex' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/documents/indexing/metadata-indexes.md
+++ b/docs/documents/indexing/metadata-indexes.md
@@ -52,7 +52,7 @@ public class TenantIdIndexCustomer
 Or by using the fluent interface:
 
 <!-- snippet: sample_index-tenantId-via-fi -->
-<a id='snippet-sample_index-tenantid-via-fi'></a>
+<a id='snippet-sample_index-tenantId-via-fi'></a>
 ```cs
 DocumentStore.For(_ =>
 {
@@ -60,7 +60,7 @@ DocumentStore.For(_ =>
     _.Schema.For<User>().IndexTenantId();
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MartenRegistryExamples.cs#L32-L38' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_index-tenantid-via-fi' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MartenRegistryExamples.cs#L32-L38' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_index-tenantId-via-fi' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Soft Delete
@@ -69,7 +69,7 @@ If using the [soft deletes](/documents/deletes) functionality you can ask Marten
 to create a partial index on the deleted documents either using `SoftDeletedAttribute`:
 
 <!-- snippet: sample_SoftDeletedWithIndexAttribute -->
-<a id='snippet-sample_softdeletedwithindexattribute'></a>
+<a id='snippet-sample_SoftDeletedWithIndexAttribute'></a>
 ```cs
 [SoftDeleted(Indexed = true)]
 public class IndexedSoftDeletedDoc
@@ -77,7 +77,7 @@ public class IndexedSoftDeletedDoc
     public Guid Id;
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Deleting/configuring_mapping_deletion_style.cs#L45-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_softdeletedwithindexattribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Deleting/configuring_mapping_deletion_style.cs#L45-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_SoftDeletedWithIndexAttribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or by using the fluent interface:

--- a/docs/documents/indexing/unique.md
+++ b/docs/documents/indexing/unique.md
@@ -231,7 +231,7 @@ var store = DocumentStore.For(_ =>
 Same can be configured for Duplicated Field:
 
 <!-- snippet: sample_IndexExamples -->
-<a id='snippet-sample_indexexamples'></a>
+<a id='snippet-sample_IndexExamples'></a>
 ```cs
 var store = DocumentStore.For(options =>
 {
@@ -269,7 +269,7 @@ var store = DocumentStore.For(options =>
     });
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MartenRegistryExamples.cs#L66-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_indexexamples' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MartenRegistryExamples.cs#L66-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IndexExamples' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Unique Index per Tenant

--- a/docs/documents/initial-data.md
+++ b/docs/documents/initial-data.md
@@ -77,7 +77,7 @@ We think it's common that you'll use the `IInitialData` mechanism strictly for t
 a set of baseline data for testing that lives in your test project:
 
 <!-- snippet: sample_MyTestingData -->
-<a id='snippet-sample_mytestingdata'></a>
+<a id='snippet-sample_MyTestingData'></a>
 ```cs
 public class MyTestingData: IInitialData
 {
@@ -88,7 +88,7 @@ public class MyTestingData: IInitialData
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/InitialDataSamples.cs#L57-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_mytestingdata' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/InitialDataSamples.cs#L57-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_MyTestingData' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Now, you'd like to use your exact application Marten configuration, but only for testing, add the `MyTestingData` initial data
@@ -96,7 +96,7 @@ set to the application's Marten configuration. You can do that as of Marten v5.1
 methods as shown in a sample below for a testing project:
 
 <!-- snippet: sample_using_InitializeMartenWith -->
-<a id='snippet-sample_using_initializemartenwith'></a>
+<a id='snippet-sample_using_InitializeMartenWith'></a>
 ```cs
 // Use the configured host builder for your application
 // by calling the Program.CreateHostBuilder() method from
@@ -126,5 +126,5 @@ var store = host.Services.GetRequiredService<IDocumentStore>();
 // MyTestingData:
 await store.Advanced.ResetAllData();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/InitialDataSamples.cs#L23-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_initializemartenwith' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/InitialDataSamples.cs#L23-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_InitializeMartenWith' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/documents/metadata.md
+++ b/docs/documents/metadata.md
@@ -103,7 +103,7 @@ type to a metadata value individually. Let's say that you have a document type l
 this where you want to track metadata:
 
 <!-- snippet: sample_DocWithMetadata -->
-<a id='snippet-sample_docwithmetadata'></a>
+<a id='snippet-sample_DocWithMetadata'></a>
 ```cs
 public class DocWithMetadata
 {
@@ -116,7 +116,7 @@ public class DocWithMetadata
     public bool IsDeleted { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MetadataUsage.cs#L80-L93' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_docwithmetadata' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MetadataUsage.cs#L80-L93' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_DocWithMetadata' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To enable the Marten mapping to metadata values, use this syntax:
@@ -149,7 +149,7 @@ For correlation, causation, and last modified tracking, an easy way to do this i
 just implement the Marten `ITracked` interface as shown below:
 
 <!-- snippet: sample_MyTrackedDoc -->
-<a id='snippet-sample_mytrackeddoc'></a>
+<a id='snippet-sample_MyTrackedDoc'></a>
 ```cs
 public class MyTrackedDoc: ITracked
 {
@@ -159,7 +159,7 @@ public class MyTrackedDoc: ITracked
     public string LastModifiedBy { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Metadata/metadata_marker_interfaces.cs#L163-L173' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_mytrackeddoc' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Metadata/metadata_marker_interfaces.cs#L163-L173' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_MyTrackedDoc' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If your document type implements this interface, Marten will automatically enable the correlation and causation tracking, and set values for correlation, causation, and the last modified data on documents anytime they are loaded or persisted by Marten.
@@ -168,7 +168,7 @@ Likewise, version tracking directly on the document is probably easiest with the
 interface as shown below:
 
 <!-- snippet: sample_MyVersionedDoc -->
-<a id='snippet-sample_myversioneddoc'></a>
+<a id='snippet-sample_MyVersionedDoc'></a>
 ```cs
 public class MyVersionedDoc: IVersioned
 {
@@ -176,7 +176,7 @@ public class MyVersionedDoc: IVersioned
     public Guid Version { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Metadata/metadata_marker_interfaces.cs#L121-L129' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_myversioneddoc' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Metadata/metadata_marker_interfaces.cs#L121-L129' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_MyVersionedDoc' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Implementing `IVersioned` will automatically opt your document type into optimistic concurrency
@@ -187,7 +187,7 @@ checking with mapping of the current version to the `IVersioned.Version` propert
 If you want Marten to run lean, you can omit all metadata fields from Marten with this configuration:
 
 <!-- snippet: sample_DisableAllInformationalFields -->
-<a id='snippet-sample_disableallinformationalfields'></a>
+<a id='snippet-sample_DisableAllInformationalFields'></a>
 ```cs
 var store = DocumentStore.For(opts =>
 {
@@ -198,7 +198,7 @@ var store = DocumentStore.For(opts =>
     opts.Policies.DisableInformationalFields();
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MetadataUsage.cs#L10-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disableallinformationalfields' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MetadataUsage.cs#L10-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_DisableAllInformationalFields' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Querying by Last Modified

--- a/docs/documents/multi-tenancy.md
+++ b/docs/documents/multi-tenancy.md
@@ -484,7 +484,7 @@ To exempt document types from having partitioned tables, such as for tables you 
 even harm by partitioning, you can use either an attribute on the document type:
 
 <!-- snippet: sample_using_DoNotPartitionAttribute -->
-<a id='snippet-sample_using_donotpartitionattribute'></a>
+<a id='snippet-sample_using_DoNotPartitionAttribute'></a>
 ```cs
 [DoNotPartition]
 public class DocThatShouldBeExempted1
@@ -492,7 +492,7 @@ public class DocThatShouldBeExempted1
     public Guid Id { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs#L348-L356' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_donotpartitionattribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs#L348-L356' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_DoNotPartitionAttribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 or exempt a single document type through the fluent interface:

--- a/docs/documents/querying/batched-queries.md
+++ b/docs/documents/querying/batched-queries.md
@@ -62,7 +62,7 @@ As of v0.8.10, Marten allows you to incorporate [compiled queries](/documents/qu
 Say you have a compiled query that finds the first user with a given first name:
 
 <!-- snippet: sample_FindByFirstName -->
-<a id='snippet-sample_findbyfirstname'></a>
+<a id='snippet-sample_FindByFirstName'></a>
 ```cs
 public class FindByFirstName: ICompiledQuery<User, User>
 {
@@ -74,7 +74,7 @@ public class FindByFirstName: ICompiledQuery<User, User>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/BatchedQuerying/batched_querying_acceptance_Tests.cs#L100-L112' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_findbyfirstname' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/BatchedQuerying/batched_querying_acceptance_Tests.cs#L100-L112' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_FindByFirstName' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To use that compiled query class in a batch query, you simply use the `IBatchedQuery.Query(ICompiledQuery)` syntax shown below:

--- a/docs/documents/querying/compiled-queries.md
+++ b/docs/documents/querying/compiled-queries.md
@@ -27,20 +27,20 @@ Fortunately, Marten supports the concept of a _Compiled Query_ that you can use 
 All compiled queries are classes that implement the `ICompiledQuery<TDoc, TResult>` interface shown below:
 
 <!-- snippet: sample_ICompiledQuery -->
-<a id='snippet-sample_icompiledquery'></a>
+<a id='snippet-sample_ICompiledQuery'></a>
 ```cs
 public interface ICompiledQuery<TDoc, TOut> : ICompiledQueryMarker where TDoc: notnull
 {
     Expression<Func<IMartenQueryable<TDoc>, TOut>> QueryIs();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Linq/ICompiledQuery.cs#L29-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_icompiledquery' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Linq/ICompiledQuery.cs#L29-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ICompiledQuery' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In its simplest usage, let's say that we want to find the first user document with a certain first name. That class would look like this:
 
 <!-- snippet: sample_FindByFirstName -->
-<a id='snippet-sample_findbyfirstname'></a>
+<a id='snippet-sample_FindByFirstName'></a>
 ```cs
 public class FindByFirstName: ICompiledQuery<User, User>
 {
@@ -52,7 +52,7 @@ public class FindByFirstName: ICompiledQuery<User, User>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/BatchedQuerying/batched_querying_acceptance_Tests.cs#L100-L112' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_findbyfirstname' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/BatchedQuerying/batched_querying_acceptance_Tests.cs#L100-L112' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_FindByFirstName' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: tip
@@ -173,19 +173,19 @@ To query for multiple results, you need to just return the raw `IQueryable<T>` a
 If you are selecting the whole document without any kind of `Select()` transform, you can use this interface:
 
 <!-- snippet: sample_ICompiledListQuery-with-no-select -->
-<a id='snippet-sample_icompiledlistquery-with-no-select'></a>
+<a id='snippet-sample_ICompiledListQuery-with-no-select'></a>
 ```cs
 public interface ICompiledListQuery<TDoc>: ICompiledListQuery<TDoc, TDoc> where TDoc : notnull
 {
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Linq/ICompiledQuery.cs#L44-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_icompiledlistquery-with-no-select' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Linq/ICompiledQuery.cs#L44-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ICompiledListQuery-with-no-select' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 A sample usage of this type of query is shown below:
 
 <!-- snippet: sample_UsersByFirstName-Query -->
-<a id='snippet-sample_usersbyfirstname-query'></a>
+<a id='snippet-sample_UsersByFirstName-Query'></a>
 ```cs
 public class UsersByFirstName: ICompiledListQuery<User>
 {
@@ -198,25 +198,25 @@ public class UsersByFirstName: ICompiledListQuery<User>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L592-L605' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_usersbyfirstname-query' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L592-L605' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_UsersByFirstName-Query' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If you do want to use a `Select()` transform, use this interface:
 
 <!-- snippet: sample_ICompiledListQuery-with-select -->
-<a id='snippet-sample_icompiledlistquery-with-select'></a>
+<a id='snippet-sample_ICompiledListQuery-with-select'></a>
 ```cs
 public interface ICompiledListQuery<TDoc, TOut>: ICompiledQuery<TDoc, IEnumerable<TOut>> where TDoc : notnull
 {
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Linq/ICompiledQuery.cs#L58-L64' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_icompiledlistquery-with-select' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Linq/ICompiledQuery.cs#L58-L64' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ICompiledListQuery-with-select' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 A sample usage of this type of query is shown below:
 
 <!-- snippet: sample_UserNamesForFirstName -->
-<a id='snippet-sample_usernamesforfirstname'></a>
+<a id='snippet-sample_UserNamesForFirstName'></a>
 ```cs
 public class UserNamesForFirstName: ICompiledListQuery<User, string>
 {
@@ -230,7 +230,7 @@ public class UserNamesForFirstName: ICompiledListQuery<User, string>
     public string FirstName { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L617-L631' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_usernamesforfirstname' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L617-L631' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_UserNamesForFirstName' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Querying for Related Documents with Include()
@@ -426,19 +426,19 @@ we handle Include queries.
 If you are querying for a single document with no transformation, you can use this interface as a convenience:
 
 <!-- snippet: sample_ICompiledQuery-for-single-doc -->
-<a id='snippet-sample_icompiledquery-for-single-doc'></a>
+<a id='snippet-sample_ICompiledQuery-for-single-doc'></a>
 ```cs
 public interface ICompiledQuery<TDoc>: ICompiledQuery<TDoc, TDoc> where TDoc : notnull
 {
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Linq/ICompiledQuery.cs#L71-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_icompiledquery-for-single-doc' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Linq/ICompiledQuery.cs#L71-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ICompiledQuery-for-single-doc' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And an example:
 
 <!-- snippet: sample_FindUserByAllTheThings -->
-<a id='snippet-sample_finduserbyallthethings'></a>
+<a id='snippet-sample_FindUserByAllTheThings'></a>
 ```cs
 public class FindUserByAllTheThings: ICompiledQuery<User>
 {
@@ -455,7 +455,7 @@ public class FindUserByAllTheThings: ICompiledQuery<User>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L376-L393' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_finduserbyallthethings' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L376-L393' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_FindUserByAllTheThings' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Querying for Multiple Results as JSON
@@ -463,7 +463,7 @@ public class FindUserByAllTheThings: ICompiledQuery<User>
 To query for multiple results and have them returned as a Json string, you may run any query on your `IQueryable<T>` (be it ordering or filtering) and then simply finalize the query with `ToJsonArray();` like so:
 
 <!-- snippet: sample_CompiledToJsonArray -->
-<a id='snippet-sample_compiledtojsonarray'></a>
+<a id='snippet-sample_CompiledToJsonArray'></a>
 ```cs
 public class FindJsonOrderedUsersByUsername: ICompiledListQuery<User>
 {
@@ -477,7 +477,7 @@ public class FindJsonOrderedUsersByUsername: ICompiledListQuery<User>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L410-L424' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiledtojsonarray' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L410-L424' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_CompiledToJsonArray' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If you wish to do it asynchronously, you can use the `ToJsonArrayAsync()` method.
@@ -485,7 +485,7 @@ If you wish to do it asynchronously, you can use the `ToJsonArrayAsync()` method
 A sample usage of this type of query is shown below:
 
 <!-- snippet: sample_CompiledToJsonArray -->
-<a id='snippet-sample_compiledtojsonarray'></a>
+<a id='snippet-sample_CompiledToJsonArray'></a>
 ```cs
 public class FindJsonOrderedUsersByUsername: ICompiledListQuery<User>
 {
@@ -499,7 +499,7 @@ public class FindJsonOrderedUsersByUsername: ICompiledListQuery<User>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L410-L424' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiledtojsonarray' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L410-L424' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_CompiledToJsonArray' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note that the result has the documents comma separated and wrapped in angle brackets (as per the Json notation).
@@ -509,7 +509,7 @@ Note that the result has the documents comma separated and wrapped in angle brac
 Finally, if you are querying for a single document as json, you will need to prepend your call to `Single()`, `First()` and so on with a call to `AsJson()`:
 
 <!-- snippet: sample_CompiledAsJson -->
-<a id='snippet-sample_compiledasjson'></a>
+<a id='snippet-sample_CompiledAsJson'></a>
 ```cs
 public class FindJsonUserByUsername: ICompiledQuery<User>
 {
@@ -522,13 +522,13 @@ public class FindJsonUserByUsername: ICompiledQuery<User>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L395-L408' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiledasjson' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L395-L408' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_CompiledAsJson' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And an example:
 
 <!-- snippet: sample_CompiledAsJson -->
-<a id='snippet-sample_compiledasjson'></a>
+<a id='snippet-sample_CompiledAsJson'></a>
 ```cs
 public class FindJsonUserByUsername: ICompiledQuery<User>
 {
@@ -541,7 +541,7 @@ public class FindJsonUserByUsername: ICompiledQuery<User>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L395-L408' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_compiledasjson' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L395-L408' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_CompiledAsJson' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 (our `ToJson()` method simply returns a string representation of the `User` instance in Json notation)
@@ -554,7 +554,7 @@ object to collect the total number of rows in the database when the query is exe
 from the Marten tests:
 
 <!-- snippet: sample_TargetsInOrder -->
-<a id='snippet-sample_targetsinorder'></a>
+<a id='snippet-sample_TargetsInOrder'></a>
 ```cs
 public class TargetsInOrder: ICompiledListQuery<Target>
 {
@@ -572,13 +572,13 @@ public class TargetsInOrder: ICompiledListQuery<Target>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L528-L546' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_targetsinorder' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L528-L546' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_TargetsInOrder' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And when used in the actual test:
 
 <!-- snippet: sample_using_QueryStatistics_with_compiled_query -->
-<a id='snippet-sample_using_querystatistics_with_compiled_query'></a>
+<a id='snippet-sample_using_QueryStatistics_with_compiled_query'></a>
 ```cs
 [Fact]
 public async Task use_compiled_query_with_statistics()
@@ -596,7 +596,7 @@ public async Task use_compiled_query_with_statistics()
     query.Statistics.TotalResults.ShouldBe(100);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L37-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_querystatistics_with_compiled_query' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Compiled/compiled_queries.cs#L37-L55' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_QueryStatistics_with_compiled_query' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Query Plans <Badge type="tip" text="7.25" />
@@ -686,7 +686,7 @@ public static async Task use_query_plan(IQuerySession session, CancellationToken
 There is also a similar interface for usage with [batch querying](/documents/querying/batched-queries):
 
 <!-- snippet: sample_IBatchQueryPlan -->
-<a id='snippet-sample_ibatchqueryplan'></a>
+<a id='snippet-sample_IBatchQueryPlan'></a>
 ```cs
 /// <summary>
 /// Marten's concept of the "Specification" pattern for reusable
@@ -698,7 +698,7 @@ public interface IBatchQueryPlan<T>
     Task<T> Fetch(IBatchedQuery query);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/IQueryPlan.cs#L21-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ibatchqueryplan' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/IQueryPlan.cs#L21-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IBatchQueryPlan' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And because we expect this to be very common, there is convenience base class named `QueryListPlan<T>` for querying lists of `T` data that can be used for both querying directly against an `IQuerySession` and for batch querying. The usage within a batched query is shown below from the Marten tests:

--- a/docs/documents/querying/linq/extending.md
+++ b/docs/documents/querying/linq/extending.md
@@ -9,7 +9,7 @@ Using the (admittedly contrived) example from Marten's tests, say that you want 
 different queries for "IsBlue()." First, write the method you want to be recognized by Marten's Linq support:
 
 <!-- snippet: sample_IsBlue -->
-<a id='snippet-sample_isblue'></a>
+<a id='snippet-sample_IsBlue'></a>
 ```cs
 public class IsBlue: IMethodCallParser
 {
@@ -29,7 +29,7 @@ public class IsBlue: IMethodCallParser
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Acceptance/custom_linq_extensions.cs#L82-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_isblue' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Acceptance/custom_linq_extensions.cs#L82-L102' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IsBlue' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note a couple things here:

--- a/docs/documents/querying/linq/sql.md
+++ b/docs/documents/querying/linq/sql.md
@@ -26,7 +26,7 @@ public async Task query_with_matches_sql()
 Older version of Marten also offer the `MatchesJsonPath()` method which uses the `^` character as a placeholder. This will continue to be supported.
 
 <!-- snippet: sample_using_MatchesJsonPath -->
-<a id='snippet-sample_using_matchesjsonpath'></a>
+<a id='snippet-sample_using_MatchesJsonPath'></a>
 ```cs
 var results2 = await theSession
     .Query<Target>().Where(x => x.MatchesSql('^', "d.data @? '$ ? (@.Children[*] == null || @.Children[*].size() == 0)'"))
@@ -37,5 +37,5 @@ var results3 = await theSession
     .Query<Target>().Where(x => x.MatchesJsonPath("d.data @? '$ ? (@.Children[*] == null || @.Children[*].size() == 0)'"))
     .ToListAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Bugs/Bug_3087_using_JsonPath_with_MatchesSql.cs#L28-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_matchesjsonpath' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Bugs/Bug_3087_using_JsonPath_with_MatchesSql.cs#L28-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_MatchesJsonPath' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/documents/querying/linq/strings.md
+++ b/docs/documents/querying/linq/strings.md
@@ -40,12 +40,12 @@ public void case_insensitive_string_fields(IDocumentSession session)
 A shorthand for case-insensitive string matching is provided through `EqualsIgnoreCase` (string extension method in *Baseline*):
 
 <!-- snippet: sample_sample-linq-EqualsIgnoreCase -->
-<a id='snippet-sample_sample-linq-equalsignorecase'></a>
+<a id='snippet-sample_sample-linq-EqualsIgnoreCase'></a>
 ```cs
 query.Query<User>().Single(x => x.UserName.EqualsIgnoreCase("abc")).Id.ShouldBe(user1.Id);
 query.Query<User>().Single(x => x.UserName.EqualsIgnoreCase("aBc")).Id.ShouldBe(user1.Id);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Acceptance/string_filtering.cs#L225-L230' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sample-linq-equalsignorecase' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Acceptance/string_filtering.cs#L225-L230' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sample-linq-EqualsIgnoreCase' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This defaults to `String.Equals` with `StringComparison.CurrentCultureIgnoreCase` as comparison type.

--- a/docs/documents/querying/query-json.md
+++ b/docs/documents/querying/query-json.md
@@ -93,7 +93,7 @@ public async Task when_get_json_then_raw_json_should_be_returned_async()
 Marten has the ability to combine the `AsJson()` mechanics to the result of a `Select()` transform:
 
 <!-- snippet: sample_AsJson-plus-Select-1 -->
-<a id='snippet-sample_asjson-plus-select-1'></a>
+<a id='snippet-sample_AsJson-plus-Select-1'></a>
 ```cs
 var json = await theSession
     .Query<User>()
@@ -105,13 +105,13 @@ var json = await theSession
 
 json.ShouldBe("{\"Name\": \"Bill\"}");
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/Json/streaming_json_results.cs#L1004-L1014' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asjson-plus-select-1' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/Json/streaming_json_results.cs#L1004-L1014' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AsJson-plus-Select-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And another example, but this time transforming to an anonymous type:
 
 <!-- snippet: sample_AsJson-plus-Select-2 -->
-<a id='snippet-sample_asjson-plus-select-2'></a>
+<a id='snippet-sample_AsJson-plus-Select-2'></a>
 ```cs
 (await theSession
         .Query<User>()
@@ -124,5 +124,5 @@ And another example, but this time transforming to an anonymous type:
         .ToJsonFirstOrDefault())
     .ShouldBe("{\"Name\": \"Bill\"}");
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/Json/streaming_json_results.cs#L977-L989' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_asjson-plus-select-2' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/Json/streaming_json_results.cs#L977-L989' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AsJson-plus-Select-2' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/documents/sessions.md
+++ b/docs/documents/sessions.md
@@ -58,7 +58,7 @@ for reading. The `IServiceCollection.AddMarten()` configuration will set up a DI
 `IQuerySession`, so you can inject that into classes like this sample MVC controller:
 
 <!-- snippet: sample_GetIssueController -->
-<a id='snippet-sample_getissuecontroller'></a>
+<a id='snippet-sample_GetIssueController'></a>
 ```cs
 public class GetIssueController: ControllerBase
 {
@@ -83,7 +83,7 @@ public class GetIssueController: ControllerBase
 
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/IssueController.cs#L55-L80' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_getissuecontroller' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/IssueController.cs#L55-L80' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_GetIssueController' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If you have an `IDocumentStore` object though, you can open a query session like this:
@@ -316,7 +316,7 @@ By default, Marten just uses the underlying timeout configuration from the [Npgs
 You can though, opt to set a different command timeout per session with this syntax:
 
 <!-- snippet: sample_ConfigureCommandTimeout -->
-<a id='snippet-sample_configurecommandtimeout'></a>
+<a id='snippet-sample_ConfigureCommandTimeout'></a>
 ```cs
 public void ConfigureCommandTimeout(IDocumentStore store)
 {
@@ -327,7 +327,7 @@ public void ConfigureCommandTimeout(IDocumentStore store)
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/SessionOptionsTests.cs#L24-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configurecommandtimeout' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/SessionOptionsTests.cs#L24-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ConfigureCommandTimeout' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Unit of Work Mechanics

--- a/docs/documents/storage.md
+++ b/docs/documents/storage.md
@@ -47,7 +47,7 @@ var store = DocumentStore.For(opts =>
 Or by using an attribute on your document type:
 
 <!-- snippet: sample_using_DatabaseSchemaName_attribute -->
-<a id='snippet-sample_using_databaseschemaname_attribute'></a>
+<a id='snippet-sample_using_DatabaseSchemaName_attribute'></a>
 ```cs
 [DatabaseSchemaName("organization")]
 public class Customer
@@ -55,7 +55,7 @@ public class Customer
     [Identity] public string Name { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/DocumentMappingTests.cs#L920-L928' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_databaseschemaname_attribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/DocumentMappingTests.cs#L920-L928' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_DatabaseSchemaName_attribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Type Aliases

--- a/docs/documents/storing.md
+++ b/docs/documents/storing.md
@@ -12,7 +12,7 @@ a previously persisted document with the same identity. Here's that method in ac
 with a sample that shows storing both a brand new document and a modified document:
 
 <!-- snippet: sample_using_DocumentSession_Store -->
-<a id='snippet-sample_using_documentsession_store'></a>
+<a id='snippet-sample_using_DocumentSession_Store'></a>
 ```cs
 using var store = DocumentStore.For("some connection string");
 
@@ -35,7 +35,7 @@ session.Store(newUser, existingUser);
 
 await session.SaveChangesAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/StoringDocuments.cs#L37-L60' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_documentsession_store' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/StoringDocuments.cs#L37-L60' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_DocumentSession_Store' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `Store()` method can happily take a mixed bag of document types at one time, but you'll need to tell Marten to use `Store<object>()` instead of letting it infer the document type as shown below:
@@ -132,7 +132,7 @@ theSession.Query<Target>().Count().ShouldBe(data.Length);
 By default, bulk insert will fail if there are any duplicate id's between the documents being inserted and the existing database data. You can alter this behavior through the `BulkInsertMode` enumeration as shown below:
 
 <!-- snippet: sample_BulkInsertMode_usages -->
-<a id='snippet-sample_bulkinsertmode_usages'></a>
+<a id='snippet-sample_BulkInsertMode_usages'></a>
 ```cs
 // Just say we have an array of documents we want to bulk insert
 var data = Target.GenerateRandomData(100).ToArray();
@@ -151,7 +151,7 @@ await store.BulkInsertDocumentsAsync(data, BulkInsertMode.InsertsOnly);
 // being loaded
 await store.BulkInsertDocumentsAsync(data, BulkInsertMode.OverwriteExisting);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/bulk_loading.cs#L329-L348' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bulkinsertmode_usages' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/bulk_loading.cs#L329-L348' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_BulkInsertMode_usages' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The bulk insert feature can also be used with multi-tenanted documents, but in that
@@ -159,7 +159,7 @@ case you are limited to only loading documents to a single tenant at a time as
 shown below:
 
 <!-- snippet: sample_MultiTenancyWithBulkInsert -->
-<a id='snippet-sample_multitenancywithbulkinsert'></a>
+<a id='snippet-sample_MultiTenancyWithBulkInsert'></a>
 ```cs
 // Just say we have an array of documents we want to bulk insert
 var data = Target.GenerateRandomData(100).ToArray();
@@ -173,5 +173,5 @@ using var store = DocumentStore.For(opts =>
 // If multi-tenanted
 await store.BulkInsertDocumentsAsync("a tenant id", data);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/bulk_loading.cs#L353-L367' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_multitenancywithbulkinsert' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/bulk_loading.cs#L353-L367' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_MultiTenancyWithBulkInsert' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/events/appending.md
+++ b/docs/events/appending.md
@@ -159,7 +159,7 @@ is present in the database:
 To make the stream type markers mandatory, you can use this flag in the configuration:
 
 <!-- snippet: sample_UseMandatoryStreamTypeDeclaration -->
-<a id='snippet-sample_usemandatorystreamtypedeclaration'></a>
+<a id='snippet-sample_UseMandatoryStreamTypeDeclaration'></a>
 ```cs
 var builder = Host.CreateApplicationBuilder();
 builder.Services.AddMarten(opts =>
@@ -171,7 +171,7 @@ builder.Services.AddMarten(opts =>
     opts.Events.UseMandatoryStreamTypeDeclaration = true;
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/mandatory_stream_type_behavior.cs#L151-L163' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_usemandatorystreamtypedeclaration' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/mandatory_stream_type_behavior.cs#L151-L163' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_UseMandatoryStreamTypeDeclaration' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This causes a couple side effects that **force stricter usage of Marten**:
@@ -250,7 +250,7 @@ perfectly safe to delete tombstone events from your database:
   value from the `mt_event_progression` table or through this API call:
 
 <!-- snippet: sample_DaemonDiagnostics -->
-<a id='snippet-sample_daemondiagnostics'></a>
+<a id='snippet-sample_DaemonDiagnostics'></a>
 ```cs
 public static async Task ShowDaemonDiagnostics(IDocumentStore store)
 {
@@ -269,5 +269,5 @@ public static async Task ShowDaemonDiagnostics(IDocumentStore store)
     Console.WriteLine($"The daemon high water sequence mark is {daemonHighWaterMark}");
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L109-L128' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_daemondiagnostics' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L109-L128' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_DaemonDiagnostics' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/events/archiving.md
+++ b/docs/events/archiving.md
@@ -137,7 +137,7 @@ Let's try to make this concrete by building a simple order processing system tha
 aggregate:
 
 <!-- snippet: sample_Order_for_optimized_command_handling -->
-<a id='snippet-sample_order_for_optimized_command_handling'></a>
+<a id='snippet-sample_Order_for_optimized_command_handling'></a>
 ```cs
 public class Item
 {
@@ -175,14 +175,14 @@ public class Order
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs#L24-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_order_for_optimized_command_handling' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs#L24-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_Order_for_optimized_command_handling' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Next, let's say we're having the `Order` aggregate snapshotted so that it's updated every time new events 
 are captured like so:
 
 <!-- snippet: sample_registering_Order_as_Inline -->
-<a id='snippet-sample_registering_order_as_inline'></a>
+<a id='snippet-sample_registering_Order_as_Inline'></a>
 ```cs
 var builder = Host.CreateApplicationBuilder();
 builder.Services.AddMarten(opts =>
@@ -203,7 +203,7 @@ builder.Services.AddMarten(opts =>
 // need that tracking at runtime
 .UseLightweightSessions();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs#L210-L231' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_order_as_inline' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs#L210-L231' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_Order_as_Inline' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Now, let's say as a way to keep our application performing as well as possible, we'd like to be aggressive about archiving

--- a/docs/events/compacting.md
+++ b/docs/events/compacting.md
@@ -59,7 +59,7 @@ There's not yet any default archiver, but we're open to suggestions about what t
 an implementation of this interface:
 
 <!-- snippet: sample_IEventsArchiver -->
-<a id='snippet-sample_ieventsarchiver'></a>
+<a id='snippet-sample_IEventsArchiver'></a>
 ```cs
 /// <summary>
 /// Callback interface for executing event archiving
@@ -70,7 +70,7 @@ public interface IEventsArchiver
         CancellationToken cancellation);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/EventStore.StreamCompacting.cs#L166-L177' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ieventsarchiver' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/EventStore.StreamCompacting.cs#L166-L177' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IEventsArchiver' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 By default, Marten is *not* archiving events in this operation.

--- a/docs/events/metadata.md
+++ b/docs/events/metadata.md
@@ -8,7 +8,7 @@ for causation, correlation, user names, and key/value headers with this syntax a
 Marten:
 
 <!-- snippet: sample_ConfigureEventMetadata -->
-<a id='snippet-sample_configureeventmetadata'></a>
+<a id='snippet-sample_ConfigureEventMetadata'></a>
 ```cs
 var store = DocumentStore.For(opts =>
 {
@@ -22,7 +22,7 @@ var store = DocumentStore.For(opts =>
     opts.Events.MetadataConfig.UserNameEnabled = true;
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MetadataUsage.cs#L118-L132' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configureeventmetadata' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MetadataUsage.cs#L118-L132' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ConfigureEventMetadata' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 By default, Marten runs "lean" by omitting the extra metadata storage on events shown above. Causation, correlation, user name (last modified by), and header fields must be individually enabled. 

--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -29,7 +29,7 @@ be global within your system.
 Let's start with a possible implementation of a single stream projection:
 
 <!-- snippet: sample_SpecialCounterProjection -->
-<a id='snippet-sample_specialcounterprojection'></a>
+<a id='snippet-sample_SpecialCounterProjection'></a>
 ```cs
 public class SpecialCounterProjection: SingleStreamProjection<SpecialCounter, Guid>
 {
@@ -40,13 +40,13 @@ public class SpecialCounterProjection: SingleStreamProjection<SpecialCounter, Gu
 
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/global_tenanted_streams_within_conjoined_tenancy.cs#L395-L406' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_specialcounterprojection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/global_tenanted_streams_within_conjoined_tenancy.cs#L395-L406' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_SpecialCounterProjection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or this equivalent, but see how I'm explicitly registering event types, because that's going to be important:
 
 <!-- snippet: sample_SpecialCounterProjection2 -->
-<a id='snippet-sample_specialcounterprojection2'></a>
+<a id='snippet-sample_SpecialCounterProjection2'></a>
 ```cs
 public class SpecialCounterProjection2: SingleStreamProjection<SpecialCounter, Guid>
 {
@@ -90,7 +90,7 @@ public class SpecialCounterProjection2: SingleStreamProjection<SpecialCounter, G
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/global_tenanted_streams_within_conjoined_tenancy.cs#L410-L454' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_specialcounterprojection2' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/global_tenanted_streams_within_conjoined_tenancy.cs#L410-L454' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_SpecialCounterProjection2' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And finally, let's register our projection within our application's bootstrapping:

--- a/docs/events/projections/aggregate-projections.md
+++ b/docs/events/projections/aggregate-projections.md
@@ -13,7 +13,7 @@ aggregated document representing the state of those events. To jump into a simpl
 view called `QuestParty` that creates an aggregated view of `MembersJoined`, `MembersDeparted`, and `QuestStarted` events related to a group of heroes traveling on a quest in your favorite fantasy novel:
 
 <!-- snippet: sample_QuestParty -->
-<a id='snippet-sample_questparty'></a>
+<a id='snippet-sample_QuestParty'></a>
 ```cs
 public sealed record QuestParty(Guid Id, List<string> Members)
 {
@@ -38,7 +38,7 @@ public sealed record QuestParty(Guid Id, List<string> Members)
         };
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/DocSamples/EventSourcingQuickstart.cs#L27-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_questparty' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/DocSamples/EventSourcingQuickstart.cs#L27-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_QuestParty' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Once again, here's the class diagram of the key projection types inside of Marten, but please note the `SingleStreamProjection<T>`:
@@ -77,7 +77,7 @@ The easiest type of aggregate to create is a document that rolls up the state of
 document that directly mutates itself through method conventions or by sub-classing the `SingleStreamProjection<T>` class like this sample for a fictional `Trip` aggregate document:
 
 <!-- snippet: sample_TripProjection_aggregate -->
-<a id='snippet-sample_tripprojection_aggregate'></a>
+<a id='snippet-sample_TripProjection_aggregate'></a>
 ```cs
 public class TripProjection: SingleStreamProjection<Trip, Guid>
 {
@@ -113,7 +113,7 @@ public class TripProjection: SingleStreamProjection<Trip, Guid>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/TripProjectionWithCustomName.cs#L48-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/TripProjectionWithCustomName.cs#L48-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_TripProjection_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And register that projection like this:
@@ -218,7 +218,7 @@ document type -- which doesn't have to be public by the way.
 You can also use a constructor that takes an event type as shown in this sample of a `Trip` stream aggregation:
 
 <!-- snippet: sample_Trip_stream_aggregation -->
-<a id='snippet-sample_trip_stream_aggregation'></a>
+<a id='snippet-sample_Trip_stream_aggregation'></a>
 ```cs
 public class Trip
 {
@@ -268,13 +268,13 @@ public class Trip
     internal bool ShouldDelete(VacationOver e) => Traveled > 1000;
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/TripProjectionWithCustomName.cs#L123-L173' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_trip_stream_aggregation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/TripProjectionWithCustomName.cs#L123-L173' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_Trip_stream_aggregation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Or finally, you can use a method named `Create()` on a projection type as shown in this sample:
 
 <!-- snippet: sample_TripProjection_aggregate -->
-<a id='snippet-sample_tripprojection_aggregate'></a>
+<a id='snippet-sample_TripProjection_aggregate'></a>
 ```cs
 public class TripProjection: SingleStreamProjection<Trip, Guid>
 {
@@ -310,7 +310,7 @@ public class TripProjection: SingleStreamProjection<Trip, Guid>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/TripProjectionWithCustomName.cs#L48-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/TripProjectionWithCustomName.cs#L48-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_TripProjection_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `Create()` method has to return either the aggregate document type or `Task<T>` where `T` is the aggregate document type. There must be an argument for the specific event type or `IEvent<T>` where `T` is the event type if you need access to event metadata. You can also take in an `IQuerySession` if you need to look up additional data as part of the transformation or `IEvent` in addition to the exact event type just to get at event metadata.
@@ -325,7 +325,7 @@ Marten will apply all those event types that can be cast to the interface or abs
 To make changes to an existing aggregate, you can either use inline Lambda functions per event type with one of the overloads of `ProjectEvent()`:
 
 <!-- snippet: sample_using_ProjectEvent_in_aggregate_projection -->
-<a id='snippet-sample_using_projectevent_in_aggregate_projection'></a>
+<a id='snippet-sample_using_ProjectEvent_in_aggregate_projection'></a>
 ```cs
 public class TripProjection: SingleStreamProjection<Trip, Guid>
 {
@@ -350,13 +350,13 @@ public class TripProjection: SingleStreamProjection<Trip, Guid>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/TripProjectionWithCustomName.cs#L179-L204' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_projectevent_in_aggregate_projection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/TripProjectionWithCustomName.cs#L179-L204' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_ProjectEvent_in_aggregate_projection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 I'm not personally that wild about using lots of inline Lambdas like the example above, and to that end, Marten now supports the `Apply()` method convention. Here's the same `TripProjection`, but this time using methods to mutate the `Trip` document:
 
 <!-- snippet: sample_TripProjection_aggregate -->
-<a id='snippet-sample_tripprojection_aggregate'></a>
+<a id='snippet-sample_TripProjection_aggregate'></a>
 ```cs
 public class TripProjection: SingleStreamProjection<Trip, Guid>
 {
@@ -392,7 +392,7 @@ public class TripProjection: SingleStreamProjection<Trip, Guid>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/TripProjectionWithCustomName.cs#L48-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tripprojection_aggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/TripProjectionWithCustomName.cs#L48-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_TripProjection_aggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `Apply()` methods can accept any combination of these arguments:
@@ -511,7 +511,7 @@ Additionally, `ShouldDelete()` methods should return either a `Boolean` or `Task
 You can use the `SingleStreamProjection<T>` method conventions for stream aggregations, which we just mean to be an aggregate document type that implements its own `Apply()` or `ShouldDelete()` methods to mutate itself. Using that concept, let's take the `TripProjection` we have been using and apply that instead to a `Trip` type:
 
 <!-- snippet: sample_Trip_stream_aggregation -->
-<a id='snippet-sample_trip_stream_aggregation'></a>
+<a id='snippet-sample_Trip_stream_aggregation'></a>
 ```cs
 public class Trip
 {
@@ -561,7 +561,7 @@ public class Trip
     internal bool ShouldDelete(VacationOver e) => Traveled > 1000;
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/TripProjectionWithCustomName.cs#L123-L173' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_trip_stream_aggregation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/TripProjectionWithCustomName.cs#L123-L173' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_Trip_stream_aggregation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Here's an example of using the various ways of doing `Trip` stream aggregation:
@@ -608,7 +608,7 @@ in order to opt into the optimistic concurrency check.
 To start with, let's say we have an `OrderAggregate` defined like this:
 
 <!-- snippet: sample_OrderAggregate_with_version -->
-<a id='snippet-sample_orderaggregate_with_version'></a>
+<a id='snippet-sample_OrderAggregate_with_version'></a>
 ```cs
 public class OrderAggregate
 {
@@ -623,7 +623,7 @@ public class OrderAggregate
     public bool HasShipped { get; private set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/OrderAggregate.cs#L6-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_orderaggregate_with_version' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/OrderAggregate.cs#L6-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_OrderAggregate_with_version' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Notice the `Version` property of that document above. Using a naming convention (we'll talk about how to go around the convention in just a second),
@@ -742,7 +742,7 @@ your aggregate in any way you wish.
 Here's an example of using a custom header value of the events captured to update an aggregate based on the last event encountered:
 
 <!-- snippet: sample_using_ApplyMetadata -->
-<a id='snippet-sample_using_applymetadata'></a>
+<a id='snippet-sample_using_ApplyMetadata'></a>
 ```cs
 public class Item
 {
@@ -794,7 +794,7 @@ public class ItemProjection: SingleStreamProjection<Item, Guid>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/using_apply_metadata.cs#L173-L225' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_applymetadata' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/using_apply_metadata.cs#L173-L225' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_ApplyMetadata' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And the same projection in usage in a unit test to see how it's all put together:
@@ -944,7 +944,7 @@ By default, Marten will only process projection "side effects" during continuous
 wish to use projection side effects while running projections with an `Inline` lifecycle, you can do that with this setting:
 
 <!-- snippet: sample_using_EnableSideEffectsOnInlineProjections -->
-<a id='snippet-sample_using_enablesideeffectsoninlineprojections'></a>
+<a id='snippet-sample_using_EnableSideEffectsOnInlineProjections'></a>
 ```cs
 var builder = Host.CreateApplicationBuilder();
 builder.Services.AddMarten(opts =>
@@ -956,7 +956,7 @@ builder.Services.AddMarten(opts =>
     opts.Events.EnableSideEffectsOnInlineProjections = true;
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/UsingInlineSideEffects.cs#L12-L24' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_enablesideeffectsoninlineprojections' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/UsingInlineSideEffects.cs#L12-L24' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_EnableSideEffectsOnInlineProjections' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This functionality was originally written as a way of sending external messages to a separate system carrying the new state of a single stream projection

--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -204,7 +204,7 @@ You can see the usage below from one of the Marten tests where we use that metho
 daemon has caught up:
 
 <!-- snippet: sample_using_WaitForNonStaleProjectionDataAsync -->
-<a id='snippet-sample_using_waitfornonstaleprojectiondataasync'></a>
+<a id='snippet-sample_using_WaitForNonStaleProjectionDataAsync'></a>
 ```cs
 [Fact]
 public async Task run_simultaneously()
@@ -225,7 +225,7 @@ public async Task run_simultaneously()
     await CheckExpectedResults();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/EventProjections/event_projections_end_to_end.cs#L28-L49' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_waitfornonstaleprojectiondataasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/EventProjections/event_projections_end_to_end.cs#L28-L49' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_WaitForNonStaleProjectionDataAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The basic idea in your tests is to:
@@ -273,7 +273,7 @@ public async Task run_simultaneously()
 The following code shows the diagnostics support for the async daemon as it is today:
 
 <!-- snippet: sample_DaemonDiagnostics -->
-<a id='snippet-sample_daemondiagnostics'></a>
+<a id='snippet-sample_DaemonDiagnostics'></a>
 ```cs
 public static async Task ShowDaemonDiagnostics(IDocumentStore store)
 {
@@ -292,7 +292,7 @@ public static async Task ShowDaemonDiagnostics(IDocumentStore store)
     Console.WriteLine($"The daemon high water sequence mark is {daemonHighWaterMark}");
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L109-L128' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_daemondiagnostics' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L109-L128' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_DaemonDiagnostics' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Command Line Support
@@ -413,7 +413,7 @@ from systems using Marten.
 If your system is configured to export metrics and Open Telemetry data from Marten like this:
 
 <!-- snippet: sample_enabling_open_telemetry_exporting_from_Marten -->
-<a id='snippet-sample_enabling_open_telemetry_exporting_from_marten'></a>
+<a id='snippet-sample_enabling_open_telemetry_exporting_from_Marten'></a>
 ```cs
 // This is passed in by Project Aspire. The exporter usage is a little
 // different for other tools like Prometheus or SigNoz
@@ -432,7 +432,7 @@ builder.Services.AddOpenTelemetry()
         metrics.AddMeter("Marten");
     });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/AspireHeadlessTripService/Program.cs#L21-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_open_telemetry_exporting_from_marten' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/AspireHeadlessTripService/Program.cs#L21-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_open_telemetry_exporting_from_Marten' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 *And* you are running the async daemon in your system, you should see potentially activities for each running projection
@@ -496,7 +496,19 @@ use this information to "know" what streams and projections may be impacted by a
 
 The flag for this is shown below:
 
-snippet: sample_enabling_advanced_tracking
+<!-- snippet: sample_enabling_advanced_tracking -->
+<a id='snippet-sample_enabling_advanced_tracking'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.Services.AddMarten(opts =>
+{
+    opts.Connection(builder.Configuration.GetConnectionString("marten"));
+
+    opts.Events.EnableAdvancedAsyncTracking = true;
+});
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Resiliency/when_skipping_events_in_daemon.cs#L187-L197' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_advanced_tracking' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 ## Querying for Non Stale Data
 

--- a/docs/events/projections/custom-aggregates.md
+++ b/docs/events/projections/custom-aggregates.md
@@ -39,7 +39,7 @@ public class Increment
 And a simple aggregate document type like this:
 
 <!-- snippet: sample_StartAndStopAggregate -->
-<a id='snippet-sample_startandstopaggregate'></a>
+<a id='snippet-sample_StartAndStopAggregate'></a>
 ```cs
 public class StartAndStopAggregate: ISoftDeleted
 {
@@ -57,7 +57,7 @@ public class StartAndStopAggregate: ISoftDeleted
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/explicit_code_for_aggregation_logic.cs#L560-L578' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_startandstopaggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Aggregation/explicit_code_for_aggregation_logic.cs#L560-L578' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_StartAndStopAggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 As you can see, `StartAndStopAggregate` as a `Guid` as its identity and is also [soft-deleted](/documents/deletes.html#soft-deletes) when stored by

--- a/docs/events/projections/custom.md
+++ b/docs/events/projections/custom.md
@@ -3,7 +3,7 @@
 To build your own Marten projection, you just need a class that implements the `Marten.Events.Projections.IProjection` interface shown below:
 
 <!-- snippet: sample_IProjection -->
-<a id='snippet-sample_iprojection'></a>
+<a id='snippet-sample_IProjection'></a>
 ```cs
 /// <summary>
 ///     Interface for all event projections
@@ -12,7 +12,7 @@ To build your own Marten projection, you just need a class that implements the `
 /// </summary>
 public interface IProjection: IJasperFxProjection<IDocumentOperations>, IMartenRegistrable
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Projections/IProjection.cs#L10-L18' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_iprojection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Events/Projections/IProjection.cs#L10-L18' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_IProjection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `StreamAction` aggregates outstanding events by the event stream, which is how Marten tracks events inside of an `IDocumentSession` that has
@@ -20,7 +20,7 @@ yet to be committed. The `IDocumentOperations` interface will give you access to
 or deletions. Here's a sample custom projection from our tests:
 
 <!-- snippet: sample_QuestPatchTestProjection -->
-<a id='snippet-sample_questpatchtestprojection'></a>
+<a id='snippet-sample_QuestPatchTestProjection'></a>
 ```cs
 public class QuestPatchTestProjection: IProjection
 {
@@ -47,7 +47,7 @@ public class QuestPatchTestProjection: IProjection
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/PatchingTests/Patching/patching_api.cs#L1196-L1223' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_questpatchtestprojection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/PatchingTests/Patching/patching_api.cs#L1196-L1223' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_QuestPatchTestProjection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And the custom projection can be registered in your Marten `DocumentStore` like this:

--- a/docs/events/projections/event-projections.md
+++ b/docs/events/projections/event-projections.md
@@ -6,7 +6,7 @@ on individual events. In essence, the `EventProjection` recipe does pattern matc
 To show off what `EventProjection` does, here's a sample that uses most features that `EventProjection` supports:
 
 <!-- snippet: sample_SampleEventProjection -->
-<a id='snippet-sample_sampleeventprojection'></a>
+<a id='snippet-sample_SampleEventProjection'></a>
 ```cs
 public class SampleEventProjection : EventProjection
 {
@@ -62,7 +62,7 @@ public class SampleEventProjection : EventProjection
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/SampleEventProjection.cs#L72-L128' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sampleeventprojection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/SampleEventProjection.cs#L72-L128' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_SampleEventProjection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Do note that at any point you can access event metadata by accepting `IEvent<T>` where `T` is the event type instead of just the event type. You can also take in an additional variable for `IEvent` to just

--- a/docs/events/projections/index.md
+++ b/docs/events/projections/index.md
@@ -38,7 +38,7 @@ The out-of-the box convention is to expose `public Apply(<EventType>)` methods o
 Sticking with the fantasy theme, the `QuestParty` class shown below could be used to aggregate streams of quest data:
 
 <!-- snippet: sample_QuestParty -->
-<a id='snippet-sample_questparty'></a>
+<a id='snippet-sample_QuestParty'></a>
 ```cs
 public sealed record QuestParty(Guid Id, List<string> Members)
 {
@@ -63,7 +63,7 @@ public sealed record QuestParty(Guid Id, List<string> Members)
         };
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/DocSamples/EventSourcingQuickstart.cs#L27-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_questparty' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/DocSamples/EventSourcingQuickstart.cs#L27-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_QuestParty' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Live Aggregation via .Net

--- a/docs/events/projections/inline.md
+++ b/docs/events/projections/inline.md
@@ -4,7 +4,7 @@ An "inline" projection just means that Marten will process the projection agains
 to the event store at the time that `IDocumentSession.SaveChanges()` is called to commit a unit of work. Here's a small example projection:
 
 <!-- snippet: sample_MonsterDefeatedTransform -->
-<a id='snippet-sample_monsterdefeatedtransform'></a>
+<a id='snippet-sample_MonsterDefeatedTransform'></a>
 ```cs
 public class MonsterDefeatedTransform: EventProjection
 {
@@ -20,7 +20,7 @@ public class MonsterDefeated
     public string Monster { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/inline_transformation_of_events.cs#L160-L176' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_monsterdefeatedtransform' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/inline_transformation_of_events.cs#L160-L176' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_MonsterDefeatedTransform' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note that the inline projection is able to use the [event metadata](/events/metadata) at the time the inline projection is executed. That was previously a limitation of Marten that was fixed in Marten V4.

--- a/docs/events/projections/ioc.md
+++ b/docs/events/projections/ioc.md
@@ -14,7 +14,7 @@ Let's say you have a custom aggregation projection like this one below that need
 `IPriceLookup` at runtime:
 
 <!-- snippet: sample_ProductProjection -->
-<a id='snippet-sample_productprojection'></a>
+<a id='snippet-sample_ProductProjection'></a>
 ```cs
 public class ProductProjection: SingleStreamProjection<Product, Guid>
 {
@@ -42,7 +42,7 @@ public class ProductProjection: SingleStreamProjection<Product, Guid>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/ContainerScopedProjectionTests/projections_with_IoC_services.cs#L390-L418' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_productprojection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/ContainerScopedProjectionTests/projections_with_IoC_services.cs#L478-L506' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ProductProjection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Now, we *want* to use this projection at runtime within Marten, and need to register the projection
@@ -71,7 +71,7 @@ using var host = await Host.CreateDefaultBuilder()
     })
     .StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/ContainerScopedProjectionTests/projections_with_IoC_services.cs#L69-L90' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_projection_built_by_services' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/ContainerScopedProjectionTests/projections_with_IoC_services.cs#L78-L99' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_projection_built_by_services' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note that we're having to explicitly specify the projection lifecycle for the projection used within

--- a/docs/events/projections/multi-stream-projections.md
+++ b/docs/events/projections/multi-stream-projections.md
@@ -508,12 +508,12 @@ The `ViewProjection` also provides the ability to "fan out" child events from a 
 create an aggregated view. As an example, a `Travel` event we use in Marten testing contains a list of `Movement` objects:
 
 <!-- snippet: sample_Travel_Movements -->
-<a id='snippet-sample_travel_movements'></a>
+<a id='snippet-sample_Travel_Movements'></a>
 ```cs
 public IList<Movement> Movements { get; set; } = new List<Movement>();
 public List<Stop> Stops { get; set; } = new();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/Travel.cs#L40-L45' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_travel_movements' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/TestingSupport/Travel.cs#L40-L45' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_Travel_Movements' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In a sample `ViewProjection`, we do a "fan out" of the `Travel.Movements` members into separate events being processed through the projection:

--- a/docs/events/projections/testing.md
+++ b/docs/events/projections/testing.md
@@ -308,7 +308,7 @@ See Andrew Lock's blog post [Avoiding flaky tests with TimeProvider and ITimer](
 In the example projection, I've been capturing the timestamp in the `Invoice` document from the Marten event metadata:
 
 <!-- snippet: sample_using_event_metadata_in_Invoice -->
-<a id='snippet-sample_using_event_metadata_in_invoice'></a>
+<a id='snippet-sample_using_event_metadata_in_Invoice'></a>
 ```cs
 public static Invoice Create(IEvent<InvoiceCreated> created)
 {
@@ -324,7 +324,7 @@ public static Invoice Create(IEvent<InvoiceCreated> created)
     };
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/testing_projections.cs#L43-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_event_metadata_in_invoice' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/testing_projections.cs#L43-L59' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_event_metadata_in_Invoice' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 But of course, if that timestamp has some meaning later on and you have any kind of business rules that may need to key

--- a/docs/events/quickstart.md
+++ b/docs/events/quickstart.md
@@ -55,7 +55,7 @@ await session.SaveChangesAsync();
 At some point we would like to know what members are currently part of the quest party. To keep things simple, we're going to use Marten's _live_ stream aggregation feature to model a `QuestParty` that updates itself based on our events:
 
 <!-- snippet: sample_QuestParty -->
-<a id='snippet-sample_questparty'></a>
+<a id='snippet-sample_QuestParty'></a>
 ```cs
 public sealed record QuestParty(Guid Id, List<string> Members)
 {
@@ -80,7 +80,7 @@ public sealed record QuestParty(Guid Id, List<string> Members)
         };
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/DocSamples/EventSourcingQuickstart.cs#L27-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_questparty' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/DocSamples/EventSourcingQuickstart.cs#L27-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_QuestParty' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Next, we'll use the live projection to aggregate the quest stream for a single quest party like this:
@@ -106,7 +106,7 @@ Simple, right? The above code will load the events from the database and run the
 What about the quest itself? On top of seeing our in-progress quest, we also want the ability to query our entire history of past quests. For this, we'll create an _inline_ `SingleStreamProjection` that persists our Quest state to the database as the events are being written:
 
 <!-- snippet: sample_Quest -->
-<a id='snippet-sample_quest'></a>
+<a id='snippet-sample_Quest'></a>
 ```cs
 public sealed record Quest(Guid Id, List<string> Members, List<string> Slayed, string Name, bool isFinished);
 
@@ -136,7 +136,7 @@ public sealed class QuestProjection: SingleStreamProjection<Quest, Guid>
 
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/DocSamples/EventSourcingQuickstart.cs#L54-L83' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_quest' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/DocSamples/EventSourcingQuickstart.cs#L54-L83' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_Quest' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: tip INFO

--- a/docs/events/skipping.md
+++ b/docs/events/skipping.md
@@ -20,7 +20,22 @@ Definitely check out [Rebuilding a Single Stream](/events/projections/rebuilding
 
 To get started, you will first have to enable potential event skipping like this:
 
-snippet: sample_enabling_event_skipping
+<!-- snippet: sample_enabling_event_skipping -->
+<a id='snippet-sample_enabling_event_skipping'></a>
+```cs
+var builder = Host.CreateApplicationBuilder();
+builder.Services.AddMarten(opts =>
+{
+    opts.Connection(builder.Configuration.GetConnectionString("marten"));
+
+    // This is false by default for backwards compatibility,
+    // turning this on will add an extra column and filtering during
+    // various event store operations
+    opts.Events.EnableEventSkippingInProjectionsOrSubscriptions = true;
+});
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/EventSkipping.cs#L14-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_event_skipping' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 That flag just enables the ability to mark events as _skipped_. As you'd imagine, that 
 flag alters Marten behavior by:

--- a/docs/events/subscriptions.md
+++ b/docs/events/subscriptions.md
@@ -26,7 +26,7 @@ events to the Marten event storage.**
 Subscriptions will always be an implementation of the `ISubscription` interface shown below:
 
 <!-- snippet: sample_ISubscription -->
-<a id='snippet-sample_isubscription'></a>
+<a id='snippet-sample_ISubscription'></a>
 ```cs
 /// <summary>
 /// Basic abstraction for custom subscriptions to Marten events through the async daemon. Use this in
@@ -47,7 +47,7 @@ public interface ISubscription
         CancellationToken cancellationToken);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Subscriptions/ISubscription.cs#L11-L32' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_isubscription' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten/Subscriptions/ISubscription.cs#L11-L32' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ISubscription' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 So far, the subscription model gives you these abilities:
@@ -72,7 +72,7 @@ To make this concrete, here's the simplest possible subscription you can make to
 for every event:
 
 <!-- snippet: sample_ConsoleSubscription -->
-<a id='snippet-sample_consolesubscription'></a>
+<a id='snippet-sample_ConsoleSubscription'></a>
 ```cs
 public class ConsoleSubscription: ISubscription
 {
@@ -95,13 +95,13 @@ public class ConsoleSubscription: ISubscription
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L25-L48' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_consolesubscription' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L25-L48' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ConsoleSubscription' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And to register that with our Marten store:
 
 <!-- snippet: sample_register_ConsoleSubscription -->
-<a id='snippet-sample_register_consolesubscription'></a>
+<a id='snippet-sample_register_ConsoleSubscription'></a>
 ```cs
 var builder = Host.CreateApplicationBuilder();
 builder.Services.AddMarten(opts =>
@@ -133,13 +133,13 @@ builder.Services.AddMarten(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L133-L165' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_register_consolesubscription' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L133-L165' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_register_ConsoleSubscription' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Here's a slightly more complicated sample that publishes events to a configured Kafka topic:
 
 <!-- snippet: sample_KafkaSubscription -->
-<a id='snippet-sample_kafkasubscription'></a>
+<a id='snippet-sample_KafkaSubscription'></a>
 ```cs
 public class KafkaSubscription: SubscriptionBase
 {
@@ -199,14 +199,14 @@ public class KafkaProducerConfig
     public string? Topic { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L291-L351' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_kafkasubscription' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L291-L351' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_KafkaSubscription' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This time, it's requiring IoC services injected through its constructor, so we're going to use this mechanism
 to add it to Marten:
 
 <!-- snippet: sample_registering_KafkaSubscription -->
-<a id='snippet-sample_registering_kafkasubscription'></a>
+<a id='snippet-sample_registering_KafkaSubscription'></a>
 ```cs
 var builder = Host.CreateApplicationBuilder();
 builder.Services.AddMarten(opts =>
@@ -230,7 +230,7 @@ builder.Services.AddMarten(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L170-L194' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_kafkasubscription' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L170-L194' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_KafkaSubscription' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Registering Subscriptions
@@ -251,7 +251,7 @@ is a great tool for this.
 Stateless subscriptions can simply be registered like this:
 
 <!-- snippet: sample_register_ConsoleSubscription -->
-<a id='snippet-sample_register_consolesubscription'></a>
+<a id='snippet-sample_register_ConsoleSubscription'></a>
 ```cs
 var builder = Host.CreateApplicationBuilder();
 builder.Services.AddMarten(opts =>
@@ -283,14 +283,14 @@ builder.Services.AddMarten(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L133-L165' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_register_consolesubscription' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L133-L165' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_register_ConsoleSubscription' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 But, if you need to utilize services from your IoC container within your subscription -- and you very likely do --
 you can utilize the `AddSubscriptionWithServices()` mechanisms:
 
 <!-- snippet: sample_registering_KafkaSubscription -->
-<a id='snippet-sample_registering_kafkasubscription'></a>
+<a id='snippet-sample_registering_KafkaSubscription'></a>
 ```cs
 var builder = Host.CreateApplicationBuilder();
 builder.Services.AddMarten(opts =>
@@ -314,7 +314,7 @@ builder.Services.AddMarten(opts =>
 using var host = builder.Build();
 await host.StartAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L170-L194' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_kafkasubscription' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L170-L194' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_KafkaSubscription' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Starting Position of Subscriptions
@@ -412,7 +412,7 @@ the various configuration options for that subscription right into the subscript
 base class is shown below:
 
 <!-- snippet: sample_KafkaSubscription -->
-<a id='snippet-sample_kafkasubscription'></a>
+<a id='snippet-sample_KafkaSubscription'></a>
 ```cs
 public class KafkaSubscription: SubscriptionBase
 {
@@ -472,7 +472,7 @@ public class KafkaProducerConfig
     public string? Topic { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L291-L351' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_kafkasubscription' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L291-L351' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_KafkaSubscription' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Rewinding or Replaying Subscriptions
@@ -526,7 +526,7 @@ that the controller is told.
 The following is an example of using these facilities for error handling:
 
 <!-- snippet: sample_ErrorHandlingSubscription -->
-<a id='snippet-sample_errorhandlingsubscription'></a>
+<a id='snippet-sample_ErrorHandlingSubscription'></a>
 ```cs
 public class ErrorHandlingSubscription: SubscriptionBase
 {
@@ -602,5 +602,5 @@ public class ReallyBadException: Exception
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L50-L127' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_errorhandlingsubscription' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Subscriptions/SubscriptionSamples.cs#L50-L127' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ErrorHandlingSubscription' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ dotnet paket add Marten
 In the startup of your .NET application, make a call to `AddMarten()` to register Marten services like so:
 
 <!-- snippet: sample_StartupConfigureServices -->
-<a id='snippet-sample_startupconfigureservices'></a>
+<a id='snippet-sample_StartupConfigureServices'></a>
 ```cs
 // This is the absolute, simplest way to integrate Marten into your
 // .NET application with Marten's default configuration
@@ -49,7 +49,7 @@ builder.Services.AddMarten(options =>
 // string to Marten
 .UseNpgsqlDataSource();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Program.cs#L16-L37' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_startupconfigureservices' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Program.cs#L16-L37' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_StartupConfigureServices' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 See [Bootstrapping with HostBuilder](/configuration/hostbuilder) for more information and options about this integration.
@@ -70,7 +70,7 @@ Marten uses the [Npgsql](http://www.npgsql.org) library to access PostgreSQL fro
 Now, for your first document type, we'll represent the users in our system:
 
 <!-- snippet: sample_GettingStartedUser -->
-<a id='snippet-sample_gettingstarteduser'></a>
+<a id='snippet-sample_GettingStartedUser'></a>
 ```cs
 public class User
 {
@@ -81,7 +81,7 @@ public class User
     public bool Internal { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/User.cs#L3-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_gettingstarteduser' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/User.cs#L3-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_GettingStartedUser' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 *For more information on document identity, see [identity](/documents/identity).*
@@ -95,7 +95,7 @@ you'll rarely need to interact with that service.
 From here, an instance of `IDocumentStore` or a type of `IDocumentSession` can be injected into the class/controller/endpoint of your choice and we can start persisting and loading user documents:
 
 <!-- snippet: sample_UserEndpoints -->
-<a id='snippet-sample_userendpoints'></a>
+<a id='snippet-sample_UserEndpoints'></a>
 ```cs
 // You can inject the IDocumentStore and open sessions yourself
 app.MapPost("/user",
@@ -131,7 +131,7 @@ app.MapGet("/user/{id:guid}",
     return await session.LoadAsync<User>(id, ct);
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Program.cs#L48-L82' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_userendpoints' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Program.cs#L48-L82' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_UserEndpoints' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ::: tip INFO

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -60,7 +60,7 @@ On the bright side, we believe that the "event slicing" usage in Marten 8 is sig
 The existing "Optimized Artifacts Workflow" was completely removed in V8. Instead though, there is a new option shown below:
 
 <!-- snippet: sample_AddMartenWithCustomSessionCreation -->
-<a id='snippet-sample_addmartenwithcustomsessioncreation'></a>
+<a id='snippet-sample_AddMartenWithCustomSessionCreation'></a>
 ```cs
 var connectionString = Configuration.GetConnectionString("postgres");
 
@@ -81,7 +81,7 @@ services.CritterStackDefaults(x =>
     x.Production.ResourceAutoCreate = AutoCreate.None;
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/ConfiguringSessionCreation/Startup.cs#L56-L75' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_addmartenwithcustomsessioncreation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/AspNetCoreWithMarten/Samples/ConfiguringSessionCreation/Startup.cs#L56-L75' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AddMartenWithCustomSessionCreation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note the usage of `CritterStackDefaults()` above. This will allow you to specify separate behavior for `Development` time vs

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -15,7 +15,7 @@ said, here's a sample of configuring the exporting -- this case just exporting i
 a Project Aspire dashboard in the end:
 
 <!-- snippet: sample_enabling_open_telemetry_exporting_from_Marten -->
-<a id='snippet-sample_enabling_open_telemetry_exporting_from_marten'></a>
+<a id='snippet-sample_enabling_open_telemetry_exporting_from_Marten'></a>
 ```cs
 // This is passed in by Project Aspire. The exporter usage is a little
 // different for other tools like Prometheus or SigNoz
@@ -34,7 +34,7 @@ builder.Services.AddOpenTelemetry()
         metrics.AddMeter("Marten");
     });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/AspireHeadlessTripService/Program.cs#L21-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_open_telemetry_exporting_from_marten' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/samples/AspireHeadlessTripService/Program.cs#L21-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enabling_open_telemetry_exporting_from_Marten' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Note, you'll need a reference to the `OpenTelemetry.Extensions.Hosting` Nuget for that

--- a/docs/scenarios/command_handler_workflow.md
+++ b/docs/scenarios/command_handler_workflow.md
@@ -38,7 +38,7 @@ To that end, Marten has the `FetchForWriting()` operation for optimized command 
 Let's say that you are building an order fulfillment system, so we're naturally going to model our domain as an `Order` aggregate:
 
 <!-- snippet: sample_Order_for_optimized_command_handling -->
-<a id='snippet-sample_order_for_optimized_command_handling'></a>
+<a id='snippet-sample_Order_for_optimized_command_handling'></a>
 ```cs
 public class Item
 {
@@ -76,13 +76,13 @@ public class Order
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs#L24-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_order_for_optimized_command_handling' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs#L24-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_Order_for_optimized_command_handling' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And with some events like these:
 
 <!-- snippet: sample_Order_events_for_optimized_command_handling -->
-<a id='snippet-sample_order_events_for_optimized_command_handling'></a>
+<a id='snippet-sample_Order_events_for_optimized_command_handling'></a>
 ```cs
 public record OrderShipped;
 public record OrderCreated(Item[] Items);
@@ -90,7 +90,7 @@ public record OrderReady;
 
 public record ItemReady(string Name);
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs#L14-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_order_events_for_optimized_command_handling' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs#L14-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_Order_events_for_optimized_command_handling' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Let's jump right into the first sample with simple concurrency handling:
@@ -276,7 +276,7 @@ Lastly, there are several overloads of a method called `IEventStore.WriteToAggre
 over the top of `FetchForWriting()` to simplify the entire workflow. Using that method, our handler versions above becomes:
 
 <!-- snippet: sample_using_WriteToAggregate -->
-<a id='snippet-sample_using_writetoaggregate'></a>
+<a id='snippet-sample_using_WriteToAggregate'></a>
 ```cs
 public Task Handle4(MarkItemReady command, IDocumentSession session)
 {
@@ -303,7 +303,7 @@ public Task Handle4(MarkItemReady command, IDocumentSession session)
     });
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs#L176-L203' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_writetoaggregate' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs#L176-L203' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_WriteToAggregate' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Optimizing FetchForWriting with Inline Aggregates
@@ -311,7 +311,7 @@ public Task Handle4(MarkItemReady command, IDocumentSession session)
 If you are utilizing `FetchForWriting()` for your command handlers -- and you really, really should! -- and at least some of your aggregates are updated `Inline` as shown below:
 
 <!-- snippet: sample_registering_Order_as_Inline -->
-<a id='snippet-sample_registering_order_as_inline'></a>
+<a id='snippet-sample_registering_Order_as_Inline'></a>
 ```cs
 var builder = Host.CreateApplicationBuilder();
 builder.Services.AddMarten(opts =>
@@ -332,7 +332,7 @@ builder.Services.AddMarten(opts =>
 // need that tracking at runtime
 .UseLightweightSessions();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs#L210-L231' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_order_as_inline' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs#L210-L231' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_Order_as_Inline' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can potentially gain some significant performance optimization by using the `UseIdentityMapForInlineAggregates` flag shown above. To be clear, this optimization mostly helps when you have the combination in a command handler that:

--- a/docs/schema/extensions.md
+++ b/docs/schema/extensions.md
@@ -68,7 +68,7 @@ But it **won't apply them** for multi-tenancy per database with **unknown
 Postgresql tables can be modeled with the `Table` class from `Weasel.Postgresql.Tables` as shown in this example below:
 
 <!-- snippet: sample_CustomSchemaTable -->
-<a id='snippet-sample_customschematable'></a>
+<a id='snippet-sample_CustomSchemaTable'></a>
 ```cs
 StoreOptions(opts =>
 {
@@ -82,7 +82,7 @@ StoreOptions(opts =>
 
 await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/adding_custom_schema_objects.cs#L49-L63' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customschematable' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/adding_custom_schema_objects.cs#L49-L63' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_CustomSchemaTable' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Function
@@ -90,7 +90,7 @@ await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 Postgresql functions can be managed by creating a function using `Weasel.Postgresql.Functions.Function` as below:
 
 <!-- snippet: sample_CustomSchemaFunction -->
-<a id='snippet-sample_customschemafunction'></a>
+<a id='snippet-sample_CustomSchemaFunction'></a>
 ```cs
 StoreOptions(opts =>
 {
@@ -112,7 +112,7 @@ $f$  language sql immutable;
 
 await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/adding_custom_schema_objects.cs#L195-L217' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customschemafunction' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/adding_custom_schema_objects.cs#L195-L217' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_CustomSchemaFunction' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Sequence
@@ -120,7 +120,7 @@ await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 [Postgresql sequences](https://www.postgresql.org/docs/10/static/sql-createsequence.html) can be created using `Weasel.Postgresql.Sequence` as below:
 
 <!-- snippet: sample_CustomSchemaSequence -->
-<a id='snippet-sample_customschemasequence'></a>
+<a id='snippet-sample_CustomSchemaSequence'></a>
 ```cs
 StoreOptions(opts =>
 {
@@ -134,7 +134,7 @@ StoreOptions(opts =>
 
 await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/adding_custom_schema_objects.cs#L231-L245' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customschemasequence' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/adding_custom_schema_objects.cs#L231-L245' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_CustomSchemaSequence' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Extension
@@ -142,7 +142,7 @@ await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 Postgresql extensions can be enabled using `Weasel.Postgresql.Extension` as below:
 
 <!-- snippet: sample_CustomSchemaExtension -->
-<a id='snippet-sample_customschemaextension'></a>
+<a id='snippet-sample_CustomSchemaExtension'></a>
 ```cs
 StoreOptions(opts =>
 {
@@ -157,5 +157,5 @@ StoreOptions(opts =>
 
 await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/adding_custom_schema_objects.cs#L76-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_customschemaextension' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/adding_custom_schema_objects.cs#L76-L91' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_CustomSchemaExtension' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/docs/schema/index.md
+++ b/docs/schema/index.md
@@ -8,7 +8,7 @@ As of Marten v0.8, you have much finer grained ability to control the automatic 
 `StoreOptions.AutoCreateSchemaObjects` like so:
 
 <!-- snippet: sample_AutoCreateSchemaObjects -->
-<a id='snippet-sample_autocreateschemaobjects'></a>
+<a id='snippet-sample_AutoCreateSchemaObjects'></a>
 ```cs
 var store = DocumentStore.For(opts =>
 {
@@ -32,7 +32,7 @@ var store = DocumentStore.For(opts =>
     opts.AutoCreateSchemaObjects = AutoCreate.None;
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/StoreOptionsTests.cs#L56-L82' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_autocreateschemaobjects' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/StoreOptionsTests.cs#L56-L82' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AutoCreateSchemaObjects' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To prevent unnecessary loss of data, even in development, on the first usage of a document type, Marten will:

--- a/docs/schema/migrations.md
+++ b/docs/schema/migrations.md
@@ -19,7 +19,7 @@ As long as you have rights to alter your Postgresql database, you can happily se
 modes and not worry about schema changes at all as you happily code new features and change existing document types:
 
 <!-- snippet: sample_AutoCreateSchemaObjects -->
-<a id='snippet-sample_autocreateschemaobjects'></a>
+<a id='snippet-sample_AutoCreateSchemaObjects'></a>
 ```cs
 var store = DocumentStore.For(opts =>
 {
@@ -43,7 +43,7 @@ var store = DocumentStore.For(opts =>
     opts.AutoCreateSchemaObjects = AutoCreate.None;
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/StoreOptionsTests.cs#L56-L82' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_autocreateschemaobjects' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/StoreOptionsTests.cs#L56-L82' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AutoCreateSchemaObjects' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 As long as you're using a permissive auto creation mode (i.e., not _None_), you should be able to code in your application model
@@ -95,12 +95,12 @@ If you'd rather write a database SQL migration file with your own code, bootstra
 want to update, and use:
 
 <!-- snippet: sample_WritePatch -->
-<a id='snippet-sample_writepatch'></a>
+<a id='snippet-sample_WritePatch'></a>
 ```cs
 // All migration code is async now!
 await store.Storage.Database.WriteMigrationFileAsync("1.initial.sql");
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MigrationSamples.cs#L19-L23' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_writepatch' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MigrationSamples.cs#L19-L23' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_WritePatch' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The command above will generate a file called "1.initial.sql" to update the schema, and a second file called
@@ -122,11 +122,11 @@ While there are many options to include these exported scripts in your ci/cd pip
 To programmatically apply all detectable schema changes upfront , you can use this mechanism:
 
 <!-- snippet: sample_ApplyAllConfiguredChangesToDatabase -->
-<a id='snippet-sample_applyallconfiguredchangestodatabase'></a>
+<a id='snippet-sample_ApplyAllConfiguredChangesToDatabase'></a>
 ```cs
 await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MigrationSamples.cs#L25-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_applyallconfiguredchangestodatabase' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MigrationSamples.cs#L25-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ApplyAllConfiguredChangesToDatabase' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 With the [command line tooling](/configuration/cli), it's:
@@ -144,7 +144,7 @@ dotnet run -- marten-apply
 Lastly, Marten V5 adds a new option to have the latest database changes detected and applied on application startup with
 
 <!-- snippet: sample_using_ApplyAllDatabaseChangesOnStartup -->
-<a id='snippet-sample_using_applyalldatabasechangesonstartup'></a>
+<a id='snippet-sample_using_ApplyAllDatabaseChangesOnStartup'></a>
 ```cs
 // The normal Marten configuration
 services.AddMarten(opts =>
@@ -162,7 +162,7 @@ services.AddMarten(opts =>
     // database changes on application startup
     .ApplyAllDatabaseChangesOnStartup();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/bootstrapping_with_service_collection_extensions.cs#L182-L200' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_applyalldatabasechangesonstartup' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/bootstrapping_with_service_collection_extensions.cs#L182-L200' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_ApplyAllDatabaseChangesOnStartup' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 In the option above, Marten is calling the same functionality within an `IHostedService` background task.
@@ -173,11 +173,11 @@ As a possible [environment test](http://codebetter.com/jeremymiller/2006/04/06/e
 by throwing an exception:
 
 <!-- snippet: sample_AssertDatabaseMatchesConfiguration -->
-<a id='snippet-sample_assertdatabasematchesconfiguration'></a>
+<a id='snippet-sample_AssertDatabaseMatchesConfiguration'></a>
 ```cs
 await store.Storage.Database.AssertDatabaseMatchesConfigurationAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MigrationSamples.cs#L29-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_assertdatabasematchesconfiguration' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/MigrationSamples.cs#L29-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_AssertDatabaseMatchesConfiguration' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The exception will list out all the DDL changes that are missing.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,5 @@
+﻿<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+</Project>

--- a/src/DocumentDbTests/Internal/Generated/DocumentStorage/RevisionedDocProvider1212098993.cs
+++ b/src/DocumentDbTests/Internal/Generated/DocumentStorage/RevisionedDocProvider1212098993.cs
@@ -73,7 +73,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(((DocumentDbTests.Concurrency.RevisionedDoc)document).Id);
+            var parameter2 = parameterBuilder.AppendParameter<System.Guid>((document is DocumentDbTests.Concurrency.RevisionedDoc ? ((DocumentDbTests.Concurrency.RevisionedDoc)document).Id : default(System.Guid)));
             setCurrentRevisionParameter(parameterBuilder);
             builder.Append(')');
         }
@@ -137,7 +137,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(((DocumentDbTests.Concurrency.RevisionedDoc)document).Id);
+            var parameter2 = parameterBuilder.AppendParameter<System.Guid>((document is DocumentDbTests.Concurrency.RevisionedDoc ? ((DocumentDbTests.Concurrency.RevisionedDoc)document).Id : default(System.Guid)));
             setCurrentRevisionParameter(parameterBuilder);
             builder.Append(')');
         }
@@ -207,7 +207,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(((DocumentDbTests.Concurrency.RevisionedDoc)document).Id);
+            var parameter2 = parameterBuilder.AppendParameter<System.Guid>((document is DocumentDbTests.Concurrency.RevisionedDoc ? ((DocumentDbTests.Concurrency.RevisionedDoc)document).Id : default(System.Guid)));
             setCurrentRevisionParameter(parameterBuilder);
             builder.Append(')');
         }
@@ -463,7 +463,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(((DocumentDbTests.Concurrency.RevisionedDoc)document).Id);
+            var parameter2 = parameterBuilder.AppendParameter<System.Guid>((document is DocumentDbTests.Concurrency.RevisionedDoc ? ((DocumentDbTests.Concurrency.RevisionedDoc)document).Id : default(System.Guid)));
             setCurrentRevisionParameter(parameterBuilder);
             builder.Append(')');
         }

--- a/src/DocumentDbTests/Internal/Generated/DocumentStorage/RevisionedDocProvider1212098993.cs
+++ b/src/DocumentDbTests/Internal/Generated/DocumentStorage/RevisionedDocProvider1212098993.cs
@@ -73,7 +73,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(document.Id);
+            var parameter2 = parameterBuilder.AppendParameter(((DocumentDbTests.Concurrency.RevisionedDoc)document).Id);
             setCurrentRevisionParameter(parameterBuilder);
             builder.Append(')');
         }
@@ -137,7 +137,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(document.Id);
+            var parameter2 = parameterBuilder.AppendParameter(((DocumentDbTests.Concurrency.RevisionedDoc)document).Id);
             setCurrentRevisionParameter(parameterBuilder);
             builder.Append(')');
         }
@@ -207,7 +207,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(document.Id);
+            var parameter2 = parameterBuilder.AppendParameter(((DocumentDbTests.Concurrency.RevisionedDoc)document).Id);
             setCurrentRevisionParameter(parameterBuilder);
             builder.Append(')');
         }
@@ -463,7 +463,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(document.Id);
+            var parameter2 = parameterBuilder.AppendParameter(((DocumentDbTests.Concurrency.RevisionedDoc)document).Id);
             setCurrentRevisionParameter(parameterBuilder);
             builder.Append(')');
         }
@@ -1077,7 +1077,7 @@ namespace Marten.Generated.DocumentStorage
         public override async System.Threading.Tasks.Task LoadRowAsync(Npgsql.NpgsqlBinaryImporter writer, DocumentDbTests.Concurrency.RevisionedDoc document, Marten.Storage.Tenant tenant, Marten.ISerializer serializer, System.Threading.CancellationToken cancellation)
         {
             await writer.WriteAsync(document.GetType().FullName, NpgsqlTypes.NpgsqlDbType.Varchar, cancellation);
-            await writer.WriteAsync(document.Id, NpgsqlTypes.NpgsqlDbType.Uuid, cancellation);
+            await writer.WriteAsync(((DocumentDbTests.Concurrency.RevisionedDoc)document).Id, NpgsqlTypes.NpgsqlDbType.Uuid, cancellation);
             await writer.WriteAsync(1, NpgsqlTypes.NpgsqlDbType.Integer, cancellation);
             await writer.WriteAsync(serializer.ToJson(document), NpgsqlTypes.NpgsqlDbType.Jsonb, cancellation);
         }

--- a/src/LinqTests/Acceptance/query_with_inheritance.cs
+++ b/src/LinqTests/Acceptance/query_with_inheritance.cs
@@ -43,19 +43,14 @@ public class PapySmurf: Smurf, IPapaSmurf
     public bool IsVillageLeader { get; set; }
 }
 
-public class BrainySmurf: PapaSmurf
-{
-}
+public class BrainySmurf: PapaSmurf;
 
 #endregion
 
 public class sub_class_hierarchies: OneOffConfigurationsContext
 {
-    private readonly ITestOutputHelper _output;
-
-    public sub_class_hierarchies(ITestOutputHelper output)
+    public sub_class_hierarchies()
     {
-        _output = output;
         StoreOptions(_ =>
         {
             #region sample_add-subclass-hierarchy-with-aliases
@@ -67,14 +62,16 @@ public class sub_class_hierarchies: OneOffConfigurationsContext
                     typeof(PapySmurf),
                     typeof(IPapaSmurf),
                     typeof(BrainySmurf)
-                );
+                )
+                .Duplicate<IPapaSmurf>(x => x.IsVillageLeader); // Put a duplicated index on subclass property;
 
             #endregion
 
             _.Connection(ConnectionSource.ConnectionString);
             _.AutoCreateSchemaObjects = AutoCreate.All;
 
-            _.Schema.For<ISmurf>().GinIndexJsonData();
+            _.Schema.For<ISmurf>()
+                .GinIndexJsonData();
         });
     }
 
@@ -96,7 +93,7 @@ public class query_with_inheritance: OneOffConfigurationsContext
 {
     private readonly ITestOutputHelper _output;
 
-    #region sample_add-subclass-hierarchy
+        #region sample_add-subclass-hierarchy
 
     public query_with_inheritance(ITestOutputHelper output)
     {

--- a/src/Marten/Linq/IMartenQueryable.cs
+++ b/src/Marten/Linq/IMartenQueryable.cs
@@ -144,5 +144,23 @@ public interface IMartenQueryable<T>: IQueryable<T>
     IMartenQueryableIncludeBuilder<T, TKey, TInclude> Include<TKey, TInclude>(
         IDictionary<TKey, List<TInclude>> dictionary) where TInclude : notnull where TKey : notnull;
 
+    /// <summary>
+    ///     Filters the query for documents of a given subclass type within a document hierarchy
+    ///     and applies the specified predicate to those subclass documents.
+    /// </summary>
+    /// <typeparam name="TSub">
+    ///     The subclass type to filter on. Must inherit from <typeparamref name="T"/>.
+    /// </typeparam>
+    /// <param name="predicate">
+    ///     A lambda expression representing the filter to apply to documents of type <typeparamref name="TSub"/>.
+    /// </param>
+    /// <returns>
+    ///     An <see cref="IMartenQueryable{T}"/> of the base type <typeparamref name="T"/> with the filter applied
+    ///     only to matching subclass documents.
+    /// </returns>
+    /// <remarks>
+    ///     This method is useful for querying on subclass-specific properties while still returning
+    ///     results as the base type, preserving the hierarchy in the query.
+    /// </remarks>
     IMartenQueryable<T> WhereSub<TSub>(Expression<Func<TSub, bool>> predicate) where TSub : T;
 }

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -196,6 +196,41 @@ public class MartenRegistry
         }
 
         /// <summary>
+        /// Marks a member on a subclass of <typeparamref name="T"/> to be duplicated
+        /// into its own column, enabling fast filtering, sorting and indexing.
+        /// </summary>
+        /// <typeparam name="TSub">
+        /// The subclass of <typeparamref name="T"/> that owns the member to duplicate.
+        /// </typeparam>
+        /// <param name="expression">
+        /// Member selector on <typeparamref name="TSub"/>, for example <c>x => x.Status</c>.
+        /// </param>
+        /// <param name="pgType">
+        /// Optional PostgreSQL column type override, for example <c>"varchar(100)"</c>.
+        /// </param>
+        /// <param name="dbType">
+        /// Optional Npgsql database type override used for parameters.
+        /// </param>
+        /// <param name="configure">
+        /// Optional callback to configure the created index on the duplicated column.
+        /// </param>
+        /// <param name="notNull">
+        /// When true, the duplicated column is created with <c>NOT NULL</c>.
+        /// </param>
+        /// <returns>
+        /// The current mapping expression for chaining.
+        /// </returns>
+        public DocumentMappingExpression<T> Duplicate<TSub>(Expression<Func<TSub, object?>> expression, string? pgType = null,
+            NpgsqlDbType? dbType = null, Action<DocumentIndex>? configure = null, bool notNull = false) where TSub : T
+        {
+            _builder.Alter = mapping =>
+            {
+                mapping.Duplicate(expression, pgType, dbType, configure, notNull);
+            };
+            return this;
+        }
+
+        /// <summary>
         ///     Creates a computed index on this data member within the JSON data storage
         /// </summary>
         /// <param name="expression"></param>

--- a/src/Marten/Schema/Arguments/UpsertArgument.cs
+++ b/src/Marten/Schema/Arguments/UpsertArgument.cs
@@ -137,12 +137,17 @@ END
             }
             else
             {
+                var underlying = rawMemberType;
+                var valueProp = rawMemberType.GetProperty("Value");
+                if (valueProp != null)
+                    underlying = valueProp.PropertyType;
+
                 var guarded = requiresCast
-                    ? $"(document is {DeclaringType!.FullNameInCode()} ? {accessorString} : default({rawMemberType.FullNameInCode()}))"
+                    ? $"(document is {DeclaringType!.FullNameInCode()} ? {accessorString} : default({underlying.FullNameInCode()}))"
                     : accessorString;
 
                 method.Frames.Code(
-                    $"var parameter{i} = {{0}}.{nameof(IGroupedParameterBuilder.AppendParameter)}<{rawMemberType.FullNameInCode()}>({guarded});",
+                    $"var parameter{i} = {{0}}.{nameof(IGroupedParameterBuilder.AppendParameter)}<{underlying.FullNameInCode()}>({guarded});",
                     Use.Type<IGroupedParameterBuilder>());
             }
         }

--- a/src/Marten/Schema/Arguments/UpsertArgument.cs
+++ b/src/Marten/Schema/Arguments/UpsertArgument.cs
@@ -137,13 +137,8 @@ END
             }
             else
             {
-                // value type, veilige access als cast nodig is
-                var safeAccessor = requiresCast
-                    ? $"(document is {DeclaringType!.FullNameInCode()} ? {accessorString} : default({rawMemberType.FullNameInCode()}))"
-                    : accessorString;
-
                 method.Frames.Code(
-                    $"var parameter{i} = {{0}}.{nameof(IGroupedParameterBuilder.AppendParameter)}({safeAccessor});",
+                    $"var parameter{i} = {{0}}.{nameof(IGroupedParameterBuilder.AppendParameter)}({accessorString});",
                     Use.Type<IGroupedParameterBuilder>());
             }
         }

--- a/src/Marten/Schema/Arguments/UpsertArgument.cs
+++ b/src/Marten/Schema/Arguments/UpsertArgument.cs
@@ -58,7 +58,9 @@ public class UpsertArgument
 
                 if (_members.Length == 1)
                 {
-                    DotNetType = _members.Last().GetRawMemberType()!;
+                    var lastMember = _members.Last();
+                    DotNetType = lastMember.GetRawMemberType()!;
+                    DeclaringType = lastMember.DeclaringType;
                 }
                 else
                 {
@@ -79,6 +81,7 @@ public class UpsertArgument
     }
 
     public string ParameterValue { get; set; }
+    public Type? DeclaringType { get; set; }
 
     public Type DotNetType { get; private set; }
 
@@ -97,8 +100,7 @@ public class UpsertArgument
     }
 
     public virtual void GenerateCodeToSetDbParameterValue(GeneratedMethod method, GeneratedType type, int i,
-        Argument parameters,
-        DocumentMapping mapping, StoreOptions options)
+        Argument parameters, DocumentMapping mapping, StoreOptions options)
     {
         var memberPath = _members.Select(x => x.Name).Join("?.");
 
@@ -114,11 +116,18 @@ public class UpsertArgument
                 ? $"{Constant.ForEnum(NpgsqlDbType.Array).Usage} | {Constant.ForEnum(PostgresqlProvider.Instance.ToParameterType(rawMemberType.GetElementType()!)).Usage}"
                 : Constant.ForEnum(DbType).Usage;
 
+            var accessorString = AccessorString(type);
+            var requiresCast = DeclaringType is { } dt && dt != type.BaseType;
+
             if (rawMemberType.IsClass || rawMemberType.IsNullable() || _members.Length > 1)
             {
+                var hasValueGuard = requiresCast
+                    ? $"(document is {DeclaringType!.FullNameInCode()} && {accessorString} != null)"
+                    : $"{accessorString} != null";
+
                 method.Frames.Code($@"
-BLOCK:if (document.{memberPath} != null)
-var parameter{i} = {{0}}.{nameof(IGroupedParameterBuilder.AppendParameter)}(document.{ParameterValue});
+BLOCK:if ({hasValueGuard})
+var parameter{i} = {{0}}.{nameof(IGroupedParameterBuilder.AppendParameter)}({accessorString});
 parameter{i}.{nameof(NpgsqlParameter.NpgsqlDbType)} = {dbTypeString};
 END
 BLOCK:else
@@ -128,7 +137,14 @@ END
             }
             else
             {
-                method.Frames.Code($"var parameter{i} = {{0}}.{nameof(IGroupedParameterBuilder.AppendParameter)}(document.{ParameterValue});",  Use.Type<IGroupedParameterBuilder>());
+                // value type, veilige access als cast nodig is
+                var safeAccessor = requiresCast
+                    ? $"(document is {DeclaringType!.FullNameInCode()} ? {accessorString} : default({rawMemberType.FullNameInCode()}))"
+                    : accessorString;
+
+                method.Frames.Code(
+                    $"var parameter{i} = {{0}}.{nameof(IGroupedParameterBuilder.AppendParameter)}({safeAccessor});",
+                    Use.Type<IGroupedParameterBuilder>());
             }
         }
     }
@@ -231,8 +247,15 @@ END
         }
         else
         {
-            load.Frames.CodeAsync($"await writer.WriteAsync(document.{ParameterValue}, {dbTypeString}, {{0}});",
+            var accessor = AccessorString(type);
+
+            load.Frames.CodeAsync($"await writer.WriteAsync({accessor}, {dbTypeString}, {{0}});",
                 Use.Type<CancellationToken>());
         }
     }
+
+    private string AccessorString(GeneratedType type) =>
+        DeclaringType is { } dt2 && dt2 != type.BaseType
+            ? $"(({DeclaringType.FullNameInCode()})document).{ParameterValue}"
+            : $"document.{ParameterValue}";
 }

--- a/src/Marten/Schema/Arguments/UpsertArgument.cs
+++ b/src/Marten/Schema/Arguments/UpsertArgument.cs
@@ -137,8 +137,12 @@ END
             }
             else
             {
+                var guarded = requiresCast
+                    ? $"(document is {DeclaringType!.FullNameInCode()} ? {accessorString} : default({rawMemberType.FullNameInCode()}))"
+                    : accessorString;
+
                 method.Frames.Code(
-                    $"var parameter{i} = {{0}}.{nameof(IGroupedParameterBuilder.AppendParameter)}({accessorString});",
+                    $"var parameter{i} = {{0}}.{nameof(IGroupedParameterBuilder.AppendParameter)}<{rawMemberType.FullNameInCode()}>({guarded});",
                     Use.Type<IGroupedParameterBuilder>());
             }
         }

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -846,6 +846,32 @@ public class DocumentMapping<T>: DocumentMapping
     /// <returns></returns>
     public void Duplicate(Expression<Func<T, object?>> expression, string? pgType = null, NpgsqlDbType? dbType = null,
         Action<DocumentIndex>? configure = null, bool notNull = false)
+        => Duplicate<T>(expression, pgType, dbType, configure, notNull);
+
+    /// <summary>
+    /// Duplicates a member from a subclass of <typeparamref name="T"/> into a
+    /// dedicated table column, and optionally creates an index on that column.
+    /// </summary>
+    /// <typeparam name="TSub">
+    /// The subclass of <typeparamref name="T"/> that defines the selected member.
+    /// </typeparam>
+    /// <param name="expression">
+    /// Member selector on <typeparamref name="TSub"/>, for example <c>x => x.Code</c>.
+    /// </param>
+    /// <param name="pgType">
+    /// Optional PostgreSQL column type override, for example <c>"timestamp without time zone"</c>.
+    /// </param>
+    /// <param name="dbType">
+    /// Optional Npgsql database type override used for parameters.
+    /// </param>
+    /// <param name="configure">
+    /// Optional callback to configure the index created for the duplicated column.
+    /// </param>
+    /// <param name="notNull">
+    /// When true, the duplicated column is created with <c>NOT NULL</c>.
+    /// </param>
+    public void Duplicate<TSub>(Expression<Func<TSub, object?>> expression, string? pgType = null, NpgsqlDbType? dbType = null,
+        Action<DocumentIndex>? configure = null, bool notNull = false) where TSub : T
     {
         var visitor = new FindMembers();
         visitor.Visit(expression);
@@ -860,7 +886,6 @@ public class DocumentMapping<T>: DocumentMapping
         var indexDefinition = AddIndex(duplicateField.ColumnName);
         configure?.Invoke(indexDefinition);
     }
-
 
     /// <summary>
     ///     Adds a computed index

--- a/src/ValueTypeTests/Internal/Generated/DocumentStorage/GradeProvider907442297.cs
+++ b/src/ValueTypeTests/Internal/Generated/DocumentStorage/GradeProvider907442297.cs
@@ -66,9 +66,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.Grade && ((ValueTypeTests.Grade)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.Grade)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -140,9 +140,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.Grade && ((ValueTypeTests.Grade)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.Grade)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -214,9 +214,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.Grade && ((ValueTypeTests.Grade)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.Grade)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 

--- a/src/ValueTypeTests/Internal/Generated/DocumentStorage/Invoice2Provider479877131.cs
+++ b/src/ValueTypeTests/Internal/Generated/DocumentStorage/Invoice2Provider479877131.cs
@@ -66,9 +66,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.StrongTypedId.Invoice2 && ((ValueTypeTests.StrongTypedId.Invoice2)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.StrongTypedId.Invoice2)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -140,9 +140,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.StrongTypedId.Invoice2 && ((ValueTypeTests.StrongTypedId.Invoice2)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.StrongTypedId.Invoice2)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -214,9 +214,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.StrongTypedId.Invoice2 && ((ValueTypeTests.StrongTypedId.Invoice2)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.StrongTypedId.Invoice2)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 

--- a/src/ValueTypeTests/Internal/Generated/DocumentStorage/Invoice3Provider479877132.cs
+++ b/src/ValueTypeTests/Internal/Generated/DocumentStorage/Invoice3Provider479877132.cs
@@ -65,7 +65,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(document.Id.Value);
+            var parameter2 = parameterBuilder.AppendParameter<System.Guid>((document is ValueTypeTests.StrongTypedId.Invoice3 ? ((ValueTypeTests.StrongTypedId.Invoice3)document).Id.Value : default(System.Guid)));
             setVersionParameter(parameterBuilder);
             builder.Append(')');
         }
@@ -128,7 +128,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(document.Id.Value);
+            var parameter2 = parameterBuilder.AppendParameter<System.Guid>((document is ValueTypeTests.StrongTypedId.Invoice3 ? ((ValueTypeTests.StrongTypedId.Invoice3)document).Id.Value : default(System.Guid)));
             setVersionParameter(parameterBuilder);
             builder.Append(')');
         }
@@ -191,7 +191,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(document.Id.Value);
+            var parameter2 = parameterBuilder.AppendParameter<System.Guid>((document is ValueTypeTests.StrongTypedId.Invoice3 ? ((ValueTypeTests.StrongTypedId.Invoice3)document).Id.Value : default(System.Guid)));
             setVersionParameter(parameterBuilder);
             builder.Append(')');
         }

--- a/src/ValueTypeTests/Internal/Generated/DocumentStorage/InvoiceProvider1724721064.cs
+++ b/src/ValueTypeTests/Internal/Generated/DocumentStorage/InvoiceProvider1724721064.cs
@@ -66,9 +66,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.VogenIds.Invoice && ((ValueTypeTests.VogenIds.Invoice)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.VogenIds.Invoice)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -140,9 +140,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.VogenIds.Invoice && ((ValueTypeTests.VogenIds.Invoice)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.VogenIds.Invoice)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -214,9 +214,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.VogenIds.Invoice && ((ValueTypeTests.VogenIds.Invoice)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.VogenIds.Invoice)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 

--- a/src/ValueTypeTests/Internal/Generated/DocumentStorage/OrderProvider347010495.cs
+++ b/src/ValueTypeTests/Internal/Generated/DocumentStorage/OrderProvider347010495.cs
@@ -65,9 +65,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is FSharpTypes.Order && ((FSharpTypes.Order)document).Id.Item != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Item);
+                var parameter2 = parameterBuilder.AppendParameter(((FSharpTypes.Order)document).Id.Item);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -139,9 +139,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is FSharpTypes.Order && ((FSharpTypes.Order)document).Id.Item != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Item);
+                var parameter2 = parameterBuilder.AppendParameter(((FSharpTypes.Order)document).Id.Item);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -213,9 +213,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is FSharpTypes.Order && ((FSharpTypes.Order)document).Id.Item != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Item);
+                var parameter2 = parameterBuilder.AppendParameter(((FSharpTypes.Order)document).Id.Item);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -815,7 +815,7 @@ namespace Marten.Generated.DocumentStorage
         public override async System.Threading.Tasks.Task LoadRowAsync(Npgsql.NpgsqlBinaryImporter writer, FSharpTypes.Order document, Marten.Storage.Tenant tenant, Marten.ISerializer serializer, System.Threading.CancellationToken cancellation)
         {
             await writer.WriteAsync(document.GetType().FullName, NpgsqlTypes.NpgsqlDbType.Varchar, cancellation);
-            await writer.WriteAsync(document.Id.Item, NpgsqlTypes.NpgsqlDbType.Uuid, cancellation);
+            await writer.WriteAsync(((FSharpTypes.Order)document).Id.Item, NpgsqlTypes.NpgsqlDbType.Uuid, cancellation);
             await writer.WriteAsync(JasperFx.Core.CombGuidIdGeneration.NewGuid(), NpgsqlTypes.NpgsqlDbType.Uuid, cancellation);
             await writer.WriteAsync(serializer.ToJson(document), NpgsqlTypes.NpgsqlDbType.Jsonb, cancellation);
         }

--- a/src/ValueTypeTests/Internal/Generated/DocumentStorage/ReferenceTypeOrderProvider1892982689.cs
+++ b/src/ValueTypeTests/Internal/Generated/DocumentStorage/ReferenceTypeOrderProvider1892982689.cs
@@ -66,9 +66,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.StrongTypedId.ReferenceTypeOrder && ((ValueTypeTests.StrongTypedId.ReferenceTypeOrder)document).Id.Item != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Item);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.StrongTypedId.ReferenceTypeOrder)document).Id.Item);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -140,9 +140,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.StrongTypedId.ReferenceTypeOrder && ((ValueTypeTests.StrongTypedId.ReferenceTypeOrder)document).Id.Item != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Item);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.StrongTypedId.ReferenceTypeOrder)document).Id.Item);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -214,9 +214,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.StrongTypedId.ReferenceTypeOrder && ((ValueTypeTests.StrongTypedId.ReferenceTypeOrder)document).Id.Item != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Item);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.StrongTypedId.ReferenceTypeOrder)document).Id.Item);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -816,7 +816,7 @@ namespace Marten.Generated.DocumentStorage
         public override async System.Threading.Tasks.Task LoadRowAsync(Npgsql.NpgsqlBinaryImporter writer, ValueTypeTests.StrongTypedId.ReferenceTypeOrder document, Marten.Storage.Tenant tenant, Marten.ISerializer serializer, System.Threading.CancellationToken cancellation)
         {
             await writer.WriteAsync(document.GetType().FullName, NpgsqlTypes.NpgsqlDbType.Varchar, cancellation);
-            await writer.WriteAsync(document.Id.Item, NpgsqlTypes.NpgsqlDbType.Uuid, cancellation);
+            await writer.WriteAsync(((ValueTypeTests.StrongTypedId.ReferenceTypeOrder)document).Id.Item, NpgsqlTypes.NpgsqlDbType.Uuid, cancellation);
             await writer.WriteAsync(JasperFx.Core.CombGuidIdGeneration.NewGuid(), NpgsqlTypes.NpgsqlDbType.Uuid, cancellation);
             await writer.WriteAsync(serializer.ToJson(document), NpgsqlTypes.NpgsqlDbType.Jsonb, cancellation);
         }

--- a/src/ValueTypeTests/Internal/Generated/DocumentStorage/TeacherProvider944571072.cs
+++ b/src/ValueTypeTests/Internal/Generated/DocumentStorage/TeacherProvider944571072.cs
@@ -66,9 +66,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.Teacher && ((ValueTypeTests.Teacher)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.Teacher)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -140,9 +140,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.Teacher && ((ValueTypeTests.Teacher)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.Teacher)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 
@@ -214,9 +214,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.Teacher && ((ValueTypeTests.Teacher)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.Teacher)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Uuid;
             }
 

--- a/src/ValueTypeTests/Internal/Generated/DocumentStorage/Team2Provider1170066519.cs
+++ b/src/ValueTypeTests/Internal/Generated/DocumentStorage/Team2Provider1170066519.cs
@@ -66,9 +66,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.StrongTypedId.Team2 && ((ValueTypeTests.StrongTypedId.Team2)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.StrongTypedId.Team2)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Text;
             }
 
@@ -140,9 +140,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.StrongTypedId.Team2 && ((ValueTypeTests.StrongTypedId.Team2)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.StrongTypedId.Team2)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Text;
             }
 
@@ -214,9 +214,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.StrongTypedId.Team2 && ((ValueTypeTests.StrongTypedId.Team2)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.StrongTypedId.Team2)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Text;
             }
 

--- a/src/ValueTypeTests/Internal/Generated/DocumentStorage/Team3Provider396017422.cs
+++ b/src/ValueTypeTests/Internal/Generated/DocumentStorage/Team3Provider396017422.cs
@@ -65,7 +65,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(document.Id.Value);
+            var parameter2 = parameterBuilder.AppendParameter<string>((document is ValueTypeTests.StrongTypedId.Team3 ? ((ValueTypeTests.StrongTypedId.Team3)document).Id.Value : default(string)));
             setVersionParameter(parameterBuilder);
             builder.Append(')');
         }
@@ -128,7 +128,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(document.Id.Value);
+            var parameter2 = parameterBuilder.AppendParameter<string>((document is ValueTypeTests.StrongTypedId.Team3 ? ((ValueTypeTests.StrongTypedId.Team3)document).Id.Value : default(string)));
             setVersionParameter(parameterBuilder);
             builder.Append(')');
         }
@@ -191,7 +191,7 @@ namespace Marten.Generated.DocumentStorage
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
-            var parameter2 = parameterBuilder.AppendParameter(document.Id.Value);
+            var parameter2 = parameterBuilder.AppendParameter<string>((document is ValueTypeTests.StrongTypedId.Team3 ? ((ValueTypeTests.StrongTypedId.Team3)document).Id.Value : default(string)));
             setVersionParameter(parameterBuilder);
             builder.Append(')');
         }

--- a/src/ValueTypeTests/Internal/Generated/DocumentStorage/TeamProvider700129768.cs
+++ b/src/ValueTypeTests/Internal/Generated/DocumentStorage/TeamProvider700129768.cs
@@ -66,9 +66,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.VogenIds.Team && ((ValueTypeTests.VogenIds.Team)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.VogenIds.Team)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Text;
             }
 
@@ -140,9 +140,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.VogenIds.Team && ((ValueTypeTests.VogenIds.Team)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.VogenIds.Team)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Text;
             }
 
@@ -214,9 +214,9 @@ namespace Marten.Generated.DocumentStorage
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
 
-            if (document.Id != null)
+            if ((document is ValueTypeTests.VogenIds.Team && ((ValueTypeTests.VogenIds.Team)document).Id.Value.Value != null))
             {
-                var parameter2 = parameterBuilder.AppendParameter(document.Id.Value.Value);
+                var parameter2 = parameterBuilder.AppendParameter(((ValueTypeTests.VogenIds.Team)document).Id.Value.Value);
                 parameter2.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Text;
             }
 


### PR DESCRIPTION

This change addresses #3896 , where duplicating fields from subclasses (`Duplicate<TSub>`) resulted in unconditional casts in the generated `Upsert`, `Insert`, and `Update` operations.
When saving instances of the base type, this caused an `InvalidCastException`.

Changes include:

* Updated `UpsertArgument.GenerateCodeToSetDbParameterValue` to perform safe type checks before casting to the subclass.
* Applied the same safe access pattern in `GenerateBulkWriterCodeAsync` to avoid runtime cast errors.
* Extended use of `AccessorString` with guards for subtype casting.
* Added XML documentation for both `Duplicate<TSub>` overloads in `DocumentMappingExpression` and `DocumentMapping<T>` to clarify API intent.

Impact:

* Subclass fields can now be safely marked as duplicated fields without causing runtime cast exceptions.
* Generated storage code works correctly for mixed collections of base type and subclass instances.
* API documentation now clearly describes the usage and parameters of `Duplicate<TSub>`.