### PR TITLE
Remove redundant overriding member

### DIFF
--- a/src/EventSourcingTests/Aggregation/explicit_code_for_aggregation_logic.cs
+++ b/src/EventSourcingTests/Aggregation/explicit_code_for_aggregation_logic.cs
@@ -288,10 +288,6 @@ public class MyCustomAggregateWithNoSlicer: CustomProjection<CustomAggregate, in
 
 public class MySingleStreamProjection: SingleStreamProjection<CustomAggregate, Guid>
 {
-    public override CustomAggregate Evolve(CustomAggregate snapshot, Guid id, IEvent e)
-    {
-        return base.Evolve(snapshot, id, e);
-    }
 }
 
 public record struct MyCustomStringId(string Value);

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryValuesMember.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryValuesMember.cs
@@ -57,11 +57,6 @@ internal class DictionaryValuesMember : QueryableMember, ICollectionMember, IVal
 
     }
 
-    public override void PlaceValueInDictionaryForContainment(Dictionary<string, object> dict, ConstantExpression constant)
-    {
-        base.PlaceValueInDictionaryForContainment(dict, constant);
-    }
-
     public Type ElementType { get; }
 
     public SelectManyValueCollection SelectManyUsage { get;}

--- a/src/Marten/Linq/Parsing/SelectParser.cs
+++ b/src/Marten/Linq/Parsing/SelectParser.cs
@@ -29,11 +29,6 @@ internal class SelectParser: ExpressionVisitor
 
     public NewObject NewObject { get; private set; }
 
-    public override Expression Visit(Expression node)
-    {
-        return base.Visit(node);
-    }
-
     protected override Expression VisitBinary(BinaryExpression node)
     {
         if (node.TryToParseConstant(out var constant))

--- a/src/Marten/Linq/Parsing/SelectorVisitor.cs
+++ b/src/Marten/Linq/Parsing/SelectorVisitor.cs
@@ -23,11 +23,6 @@ public class SelectorVisitor: ExpressionVisitor
         _serializer = serializer;
     }
 
-    public override Expression Visit(Expression node)
-    {
-        return base.Visit(node);
-    }
-
     protected override Expression VisitMethodCall(MethodCallExpression node)
     {
         if (node.Method.Name == nameof(QueryableExtensions.ExplicitSql))

--- a/src/Marten/Linq/Parsing/SimpleExpression.cs
+++ b/src/Marten/Linq/Parsing/SimpleExpression.cs
@@ -93,11 +93,6 @@ internal class SimpleExpression: ExpressionVisitor
         }
     }
 
-    public override Expression Visit(Expression node)
-    {
-        return base.Visit(node);
-    }
-
     // Pretend for right now that there's only one of all of these
     // obviously won't be true forever
     public ConstantExpression Constant { get; set; }


### PR DESCRIPTION
Removing overridden methods that are just calling their base correspondent

https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1132/