### PR TITLE
Use nameof operator

### DIFF
--- a/src/LinqTests/Internals/DuplicatedFieldTests.cs
+++ b/src/LinqTests/Internals/DuplicatedFieldTests.cs
@@ -68,7 +68,7 @@ public class DuplicatedFieldTests
 
         var constant = Expression.Constant((int)Colors.Blue);
 
-        field.GetValueForCompiledQueryParameter(constant).ShouldBe(Colors.Blue.ToString());
+        field.GetValueForCompiledQueryParameter(constant).ShouldBe(nameof(Colors.Blue));
     }
 
 

--- a/src/Marten/Events/Schema/EventProgressionTable.cs
+++ b/src/Marten/Events/Schema/EventProgressionTable.cs
@@ -20,7 +20,7 @@ internal class EventProgressionTable: Table
 
         if (eventGraph.UseOptimizedProjectionRebuilds)
         {
-            AddColumn<string>("mode").DefaultValueByString(ShardMode.none.ToString());
+            AddColumn<string>("mode").DefaultValueByString(nameof(ShardMode.none));
             AddColumn<int>("rebuild_threshold").DefaultValueByExpression("0");
             AddColumn<int>("assigned_node").DefaultValueByExpression("0");
         }


### PR DESCRIPTION
Performance improvement as it convert the string to a compile-time const instead of calling `ToString()` method each time