### PR TITLE
Fix issue where existing aggregates could not be rebuilt

### DIFF
--- a/src/Marten/Storage/UpsertFunction.cs
+++ b/src/Marten/Storage/UpsertFunction.cs
@@ -156,7 +156,7 @@ internal class UpsertFunction: Function
 
         if (Arguments.Any(x => x is RevisionArgument) && !_disableConcurrency)
         {
-            whereClauses.Add($"revision > {_tableName.QualifiedName}.{SchemaConstants.VersionColumn}");
+            whereClauses.Add($"revision >= {_tableName.QualifiedName}.{SchemaConstants.VersionColumn}");
         }
 
         if (Arguments.Any(x => x is CurrentVersionArgument) && !_disableConcurrency)


### PR DESCRIPTION
In case of code changes to an aggregate, it may be necesary to rebuild the stored aggregate documents even though they are up to date version-wise.

This is not currently happening because the upsert function only updates data if the version number has strictly increased, which is naturally not the case when rebuilding an existing up-to-date aggregate, since in that case the version number is unchanged.

This PR ensures that the data is updated even when the version number is unchanged.