### PR TITLE
Add (failing) test for using FetchForWriting with identity map across different sessions.

### DIFF
--- a/src/EventSourcingTests/FetchForWriting/fetching_inline_aggregates_for_writing.cs
+++ b/src/EventSourcingTests/FetchForWriting/fetching_inline_aggregates_for_writing.cs
@@ -936,24 +936,24 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
 
         // Start stream using session 1
         await using var session1 = theStore.LightweightSession();
-        var startStream = await session1.Events.FetchForWriting<SimpleAggregate>(streamId);
-        startStream.AppendOne(new AEvent());
+        var firstStreamSession1 = await session1.Events.FetchForWriting<SimpleAggregate>(streamId);
+        firstStreamSession1.AppendOne(new AEvent());
         await session1.SaveChangesAsync();
 
         // Add to stream using session 2
         await using var session2 = theStore.LightweightSession();
-        var stream = await session2.Events.FetchForWriting<SimpleAggregate>(streamId);
-        stream.AppendOne(new AEvent());
+        var secondStreamSession2 = await session2.Events.FetchForWriting<SimpleAggregate>(streamId);
+        secondStreamSession2.AppendOne(new AEvent());
         await session2.SaveChangesAsync();
 
         // Add to stream using session 1 again
-        var stream2 = await session1.Events.FetchForWriting<SimpleAggregate>(streamId);
-        stream2.AppendOne(new AEvent());
+        var thirdStreamSession1 = await session1.Events.FetchForWriting<SimpleAggregate>(streamId);
+        thirdStreamSession1.AppendOne(new AEvent());
         await session1.SaveChangesAsync();
 
         // Verify that all 3 events are projected
-        await using var thirdSession = theStore.LightweightSession();
-        var aggregate = await thirdSession.LoadAsync<SimpleAggregate>(streamId);
+        await using var session3 = theStore.LightweightSession();
+        var aggregate = await session3.LoadAsync<SimpleAggregate>(streamId);
         aggregate.ACount.ShouldBe(3);
     }
 


### PR DESCRIPTION
We have been having this issue with FetchForWriting. It ended up causing duplicated events for us because FetchForWriting returned an outdated version of the aggregate. I don't know if we are abusing Marten here, but we have one command handler that is using FetchForWriting and SaveChangesAsync twice, and then another command handler that got in between and committed an event based on an outdated version of the aggregate.