### PR TITLE
TestCaseForSoftedelete

### DIFF
--- a/src/EventSourcingTests/Aggregation/explicit_code_for_aggregation_logic.cs
+++ b/src/EventSourcingTests/Aggregation/explicit_code_for_aggregation_logic.cs
@@ -585,7 +585,7 @@ public class using_custom_aggregate_with_soft_deletes_and_update_only_events: On
         // soft end state
         var restartState = await theSession.Query<StartAndStopAggregate>().FirstOrDefaultAsync(x => x.Id == streamId);
         Assert.NotNull(restartState);
-        Assert.False(softEndStateByLoadAsync.Deleted);
+        Assert.False(restartState.Deleted);
     }
 }
 


### PR DESCRIPTION
When trying to use a Explicit Aggregation with softdelete and use the UnDeleteAndStore action a not implemented exception is being throwed.

from line => [https://github.com/JasperFx/marten/blob/master/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs#L82](https://github.com/JasperFx/marten/blob/master/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs#L82)


