### PR TITLE
Enhance archiving documentation with event processing details

### DIFF
--- a/docs/events/archiving.md
+++ b/docs/events/archiving.md
@@ -248,8 +248,8 @@ As a result, asynchronous multi-stream projections will no longer process any ot
 
 If you rely on asynchronous multi-stream projections and need all events to be processed before archiving, you can work around this by either:
 
-- Writing the `Archived` event as a side effect within your asynchronous projection, after all other events have been processed, or
-- Delaying the archiving by publishing a scheduled or delayed message (for example, when using Marten together with Wolverine) that appends the `Archived` event after projection completion.
+* Writing the `Archived` event as a side effect within your asynchronous projection, after all other events have been processed, or
+* Delaying the archiving by publishing a scheduled or delayed message (for example, when using Marten together with Wolverine) that appends the `Archived` event after projection completion.
 
 This ensures all prior events are fully projected before the stream is marked as archived.
 :::


### PR DESCRIPTION
Following up on our Discord discussion, I wanted to share this small addition to the documentation to help clarify the behavior of asynchronous projections when working with the Archived event.

There was at least one user who initially had the same misunderstanding, assuming that events appended to a stream would still be processed by asynchronous projections if they appear in the event sequence before the Archived event. That same user later solved the issue by using delayed messages, so I included this approach as one of the suggested workarounds. 
