### PR TITLE
Fixed logger for connections inside EventTracingConnectionLifetime

### DIFF
--- a/src/Marten/Internal/Sessions/EventTracingConnectionLifetime.cs
+++ b/src/Marten/Internal/Sessions/EventTracingConnectionLifetime.cs
@@ -37,9 +37,9 @@ internal class EventTracingConnectionLifetime:
             throw new ArgumentException("The tenant id cannot be null, an empty string or whitespace.", nameof(tenantId));
         }
 
+        InnerConnectionLifetime = innerConnectionLifetime;
         Logger = innerConnectionLifetime.Logger;
         CommandTimeout = innerConnectionLifetime.CommandTimeout;
-        InnerConnectionLifetime = innerConnectionLifetime;
         _telemetryOptions = telemetryOptions;
 
         var currentActivity = Activity.Current ?? null;
@@ -71,7 +71,7 @@ internal class EventTracingConnectionLifetime:
         InnerConnectionLifetime.Dispose();
     }
 
-    public IMartenSessionLogger Logger { get; set; }
+    public IMartenSessionLogger Logger { get => InnerConnectionLifetime.Logger; set => InnerConnectionLifetime.Logger = value; }
     public int CommandTimeout { get; }
     public int Execute(NpgsqlCommand cmd)
     {


### PR DESCRIPTION
Currently, the `EventTracingConnectionLifetime` has it's own `IMartenSessionLogger Logger` property, which is set in it's constructor. This however, does not set the logger of the `InnerConnectionLifetime`. Which causes logs to be written to the default `NulloLogger`. This PR replaces the Logger property from `EventTracingConnectionLifetime` with a proxy for the Logger property from `InnerConnectionLifetime`.