### PR TITLE
Ensure proper usage of NGramSearch call for only allowed scenarios

### DIFF
--- a/src/DocumentDbTests/Indexes/NgramSearchTests.cs
+++ b/src/DocumentDbTests/Indexes/NgramSearchTests.cs
@@ -196,4 +196,79 @@ public class NgramSearchTests : Marten.Testing.Harness.OneOffConfigurationsConte
         result.ShouldContain(x => x.UserName == kierkegaard.UserName);
         result.ShouldContain(x => x.UserName == bjork.UserName);
     }
+
+    [Fact]
+    public async Task test_ngram_search_throws_exception_on_doc_target()
+    {
+        var store = DocumentStore.For(_ =>
+        {
+            _.Connection(Marten.Testing.Harness.ConnectionSource.ConnectionString);
+            _.DatabaseSchemaName = "ngram_test";
+
+            // This creates an ngram index for efficient sub string based matching
+            _.Schema.For<User>().NgramIndex(x => x.UserName.ToLower());
+        });
+
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using var session = store.LightweightSession();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            var result = await session
+                .Query<User>()
+                .Where(x => x.NgramSearch("test"))
+                .ToListAsync();
+        });
+    }
+
+    [Fact]
+    public async Task test_ngram_search_throws_exception_on_computed_prop_value()
+    {
+        var store = DocumentStore.For(_ =>
+        {
+            _.Connection(Marten.Testing.Harness.ConnectionSource.ConnectionString);
+            _.DatabaseSchemaName = "ngram_test";
+
+            // This creates an ngram index for efficient sub string based matching
+            _.Schema.For<User>().NgramIndex(x => x.UserName.ToLower());
+        });
+
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using var session = store.LightweightSession();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            var result = await session
+                .Query<User>()
+                .Where(x => x.UserName.ToLower().NgramSearch("test"))
+                .ToListAsync();
+        });
+    }
+
+    [Fact]
+    public async Task test_ngram_search_throws_exception_on_non_string_prop()
+    {
+        var store = DocumentStore.For(_ =>
+        {
+            _.Connection(Marten.Testing.Harness.ConnectionSource.ConnectionString);
+            _.DatabaseSchemaName = "ngram_test";
+
+            // This creates an ngram index for efficient sub string based matching
+            _.Schema.For<User>().NgramIndex(x => x.UserName.ToLower());
+        });
+
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using var session = store.LightweightSession();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            var result = await session
+                .Query<User>()
+                .Where(x => x.Id.NgramSearch("test"))
+                .ToListAsync();
+        });
+    }
 }

--- a/src/Marten/Linq/Parsing/Methods/FullText/NgramSearch.cs
+++ b/src/Marten/Linq/Parsing/Methods/FullText/NgramSearch.cs
@@ -1,7 +1,9 @@
 #nullable enable
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using Marten.Linq.Members;
+using Npgsql;
 using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Parsing.Methods.FullText;
@@ -17,12 +19,34 @@ public class NgramSearch: IMethodCallParser
     public ISqlFragment Parse(IQueryableMemberCollection memberCollection, IReadOnlyStoreOptions options,
         MethodCallExpression expression)
     {
-        var locator = memberCollection.MemberFor(expression.Arguments[0]).RawLocator;
+        var member = memberCollection.MemberFor(expression.Arguments[0]);
+
+        // check if NGramSearch is called on the doc itself and disallow the operation
+        if (memberCollection.ElementType == member.MemberType)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(NgramSearch)} extension method should target a property and not the document itself.");
+        }
+
+        // check if NGramSearch is performed on a computed property value and disallow the operation
+        if (expression.Arguments[0] is not MemberExpression)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(NgramSearch)} extension method cannot be applied to computed values. It must be applied directly on a string property/field.");
+        }
+
+        // check if NGramSearch is performed on a non-string property and disallow the operation
+        if (member.MemberType != typeof(string))
+        {
+            throw new InvalidOperationException(
+                $"{nameof(NgramSearch)} extension method cannot be applied on non-string property/field.");
+        }
+
         var values = expression.Arguments.Last().Value();
         var useUnaccent = options.Advanced.UseNGramSearchWithUnaccent.ToString().ToUpperInvariant();
 
         return new WhereFragment(
-            $"{options.DatabaseSchemaName}.mt_grams_vector({locator},{useUnaccent}) @@ {options.DatabaseSchemaName}.mt_grams_query(?,{useUnaccent})",
+            $"{options.DatabaseSchemaName}.mt_grams_vector({member.RawLocator},{useUnaccent}) @@ {options.DatabaseSchemaName}.mt_grams_query(?,{useUnaccent})",
             values);
     }
 }


### PR DESCRIPTION
- Targeted on document itself disallow and throw InvalidOperationException
- Targeted on computed property then disallow and throw InvalidOperationException
- Targeted on non-string property then disallow and throw InvalidOperationException
- Add unit tests