### PR TITLE
docs: Fix link to Grate documentation in devops.md

### DIFF
--- a/docs/devops/devops.md
+++ b/docs/devops/devops.md
@@ -46,7 +46,7 @@ Here's what your `Migrations.csproj` could look like:
 
 Note that this is just a shell project that does not contain any classes or code. But some prefer to be able to see the migrations scripts from within the solution. The project directory will contain a folder that contains the SQL scripts for the database migrations: `src\Migrations\scripts\up`
 
-The dockerfile for the migration project does not build anything but uses [grate](https://erikbra.github.io/grate/):
+The dockerfile for the migration project does not build anything but uses [grate](https://grate-devs.github.io/grate/):
 
 ```dockerfile
 FROM erikbra/grate:1.5.4 as migrations


### PR DESCRIPTION
Grate changed to a new GitHub organization a couple of weeks ago. This updates the link to the grate docs to avoid any confusion. 