### PR TITLE
bulkload-with-version-check_v2

### DIFF
--- a/src/Marten/BulkInsertMode.cs
+++ b/src/Marten/BulkInsertMode.cs
@@ -15,5 +15,10 @@ public enum BulkInsertMode
     /// <summary>
     ///     Will overwrite the values of any duplicate documents (last update wins)
     /// </summary>
-    OverwriteExisting
+    OverwriteExisting,
+
+    /// <summary>
+    ///     Will overwrite only when the expected version matches the stored version
+    /// </summary>
+    OverwriteIfVersionMatches
 }

--- a/src/Marten/Internal/CodeGeneration/BulkLoader.cs
+++ b/src/Marten/Internal/CodeGeneration/BulkLoader.cs
@@ -46,7 +46,7 @@ public abstract class BulkLoader<T, TId>: IBulkLoader<T> where TId : notnull whe
         foreach (var document in documents)
         {
             await writer.StartRowAsync(cancellation).ConfigureAwait(false);
-            await LoadRowAsync(writer, document, tenant, serializer, cancellation).ConfigureAwait(false);
+            await LoadTempRowAsync(writer, document, tenant, serializer, cancellation).ConfigureAwait(false);
         }
 
         await writer.CompleteAsync(cancellation).ConfigureAwait(false);
@@ -55,6 +55,11 @@ public abstract class BulkLoader<T, TId>: IBulkLoader<T> where TId : notnull whe
     public abstract string CopyNewDocumentsFromTempTable();
 
     public abstract string OverwriteDuplicatesFromTempTable();
+
+    public virtual string OverwriteDuplicatesFromTempTableWithVersionCheck()
+    {
+        return OverwriteDuplicatesFromTempTable();
+    }
 
     public object GetNullable<TValue>(TValue? value) where TValue : struct
     {
@@ -83,6 +88,12 @@ public abstract class BulkLoader<T, TId>: IBulkLoader<T> where TId : notnull whe
 
     public abstract Task LoadRowAsync(NpgsqlBinaryImporter writer, T document, Tenant tenant,
         ISerializer serializer, CancellationToken cancellation);
+
+    public virtual Task LoadTempRowAsync(NpgsqlBinaryImporter writer, T document, Tenant tenant,
+        ISerializer serializer, CancellationToken cancellation)
+    {
+        return LoadRowAsync(writer, document, tenant, serializer, cancellation);
+    }
 
 
     public abstract string MainLoaderSql();

--- a/src/Marten/Internal/CodeGeneration/SubClassBulkLoader.cs
+++ b/src/Marten/Internal/CodeGeneration/SubClassBulkLoader.cs
@@ -44,4 +44,9 @@ public class SubClassBulkLoader<T, TRoot>: IBulkLoader<T> where T : TRoot
     {
         return _inner.OverwriteDuplicatesFromTempTable();
     }
+
+    public string OverwriteDuplicatesFromTempTableWithVersionCheck()
+    {
+        return _inner.OverwriteDuplicatesFromTempTableWithVersionCheck();
+    }
 }

--- a/src/Marten/Schema/Arguments/ExpectedVersionArgument.cs
+++ b/src/Marten/Schema/Arguments/ExpectedVersionArgument.cs
@@ -1,0 +1,49 @@
+using System.Reflection;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using NpgsqlTypes;
+
+namespace Marten.Schema.Arguments;
+
+internal class ExpectedVersionArgument: UpsertArgument
+{
+    public ExpectedVersionArgument(NpgsqlDbType dbType)
+    {
+        Arg = "expected_version";
+        Column = SchemaConstants.ExpectedVersionColumn;
+        DbType = dbType;
+        PostgresType = dbType == NpgsqlDbType.Integer ? "integer" : "uuid";
+    }
+
+    public override void GenerateBulkWriterCodeAsync(GeneratedType type, GeneratedMethod load, DocumentMapping mapping)
+    {
+        if (mapping.Metadata.Version.Member != null)
+        {
+            writeGuidExpectedVersion(load, mapping.Metadata.Version.Member);
+        }
+        else if (mapping.Metadata.Revision.Member != null)
+        {
+            writeIntExpectedVersion(load, mapping.Metadata.Revision.Member);
+        }
+        else
+        {
+            load.Frames.Code("writer.Write(DBNull.Value, {0});", NpgsqlDbType.Uuid);
+        }
+    }
+
+    private void writeGuidExpectedVersion(GeneratedMethod load, MemberInfo member)
+    {
+        var memberName = member.Name;
+        var dbTypeUsage = Constant.ForEnum(NpgsqlDbType.Uuid).Usage;
+        load.Frames.Code(
+            $"writer.Write(document.{memberName} == Guid.Empty ? (object)DBNull.Value : (object)document.{memberName}, {dbTypeUsage});");
+    }
+
+    private void writeIntExpectedVersion(GeneratedMethod load, MemberInfo member)
+    {
+        var memberName = member.Name;
+        var dbTypeUsage = Constant.ForEnum(NpgsqlDbType.Integer).Usage;
+        load.Frames.Code(
+            $"writer.Write(document.{memberName} <= 0 ? (object)DBNull.Value : (object)document.{memberName}, {dbTypeUsage});");
+    }
+}

--- a/src/Marten/Schema/BulkLoading/IBulkLoader.cs
+++ b/src/Marten/Schema/BulkLoading/IBulkLoader.cs
@@ -23,4 +23,6 @@ public interface IBulkLoader<T>
     string CopyNewDocumentsFromTempTable();
 
     string OverwriteDuplicatesFromTempTable();
+
+    string OverwriteDuplicatesFromTempTableWithVersionCheck();
 }

--- a/src/Marten/Schema/SchemaConstants.cs
+++ b/src/Marten/Schema/SchemaConstants.cs
@@ -13,6 +13,7 @@ internal class SchemaConstants
     public const string LastModifiedColumn = "mt_last_modified";
     public const string DotNetTypeColumn = "mt_dotnet_type";
     public const string VersionColumn = "mt_version";
+    public const string ExpectedVersionColumn = "mt_expected_version";
     public const string CreatedAtColumn = "mt_created_at";
     public const string DeletedColumn = "mt_deleted";
     public const string DeletedAtColumn = "mt_deleted_at";

--- a/src/Marten/Storage/BulkInsertion.cs
+++ b/src/Marten/Storage/BulkInsertion.cs
@@ -190,6 +190,14 @@ internal class BulkInsertion: IDisposable
             await conn.CreateCommand(overwrite + ";" + copy)
                 .ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
         }
+        else if (mode == BulkInsertMode.OverwriteIfVersionMatches)
+        {
+            var overwrite = loader.OverwriteDuplicatesFromTempTableWithVersionCheck();
+            var copy = loader.CopyNewDocumentsFromTempTable();
+
+            await conn.CreateCommand(overwrite + ";" + copy)
+                .ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
+        }
     }
 
     private async Task loadDocumentsAsync<T>(IReadOnlyCollection<T> documents, IBulkLoader<T> loader,


### PR DESCRIPTION
Currently Marten supports 3 bulk insert modes . 

```
// Just say we have an array of documents we want to bulk insert
var data = Target.GenerateRandomData(100).ToArray();

using var store = DocumentStore.For("some connection string");

// Discard any documents that match the identity of an existing document
// in the database
await store.BulkInsertDocumentsAsync(data, BulkInsertMode.IgnoreDuplicates);

// This is the default mode, the bulk insert will fail if any duplicate
// identities with existing data or within the data set being loaded are detected
await store.BulkInsertDocumentsAsync(data, BulkInsertMode.InsertsOnly);

// Overwrite any existing documents with the same identity as the documents
// being loaded
await store.BulkInsertDocumentsAsync(data, BulkInsertMode.OverwriteExisting);
```

It would be great if Marten also supported an additional mode (or a separate BulkUpdate option) that integrates with IVersion optimistic concurrency.

Desired behavior:
	•	For each document in the batch:
	•	insert if it doesn’t exist
	•	update/overwrite only if IVersion matches the current stored version
	•	otherwise skip, rather than overwriting or throwing error

This would be very useful for online JSON migrations/backfills without taking the app down.

Example scenario:
	•	The application performs on-the-fly migrations when a document is loaded/edited after deployment.
	•	At the same time, a background job migrates all documents in bulk for speed.
	•	While processing a batch, some documents might already have been migrated/updated by the app due to live traffic.
	•	In this case, the bulk process should not overwrite those documents — it should skip updates when the stored IVersion has changed since the document was read.


_**IMPORTANT: I'm not familiar with marten internals . Its my first PR on this project and unfortunately I was not able to make the test pass on my machine even before making any changes to master branch (before the changes from this PR). I could only validate that my new tests are passing and the ones related to bulk loading**_

UPDATE: this overlaps a bit with https://github.com/JasperFx/marten/pull/3301 