### PR TITLE
Fix for the "fix" on single tenant aggregations with erroneous tenant ids

### DIFF
--- a/src/Marten/Events/Aggregation/SingleStreamProjection.cs
+++ b/src/Marten/Events/Aggregation/SingleStreamProjection.cs
@@ -42,9 +42,8 @@ public class SingleStreamProjection<TDoc, TId>:
     public override IEventSlicer BuildSlicer(IQuerySession session)
     {
         // This will address https://github.com/JasperFx/wolverine/issues/2053
-        return session.As<QuerySession>().Options.EventGraph.TenancyStyle == TenancyStyle.Conjoined
-            ? new NulloEventSlicer()
-            : base.BuildSlicer(session);
+        var isSingleTenanted = session.As<QuerySession>().Options.EventGraph.TenancyStyle == TenancyStyle.Conjoined;
+        return new TenantedEventSlicer<TDoc, TId>(new ByStream<TDoc, TId>()){ForceSingleTenancy = isSingleTenanted};
     }
 
     public static void Register<TConcrete>(IServiceCollection services, ProjectionLifecycle lifecycle,

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -38,7 +38,7 @@
     <ItemGroup>
         <PackageReference Include="FSharp.Core" Version="9.0.100" />
         <PackageReference Include="JasperFx" Version="1.16.0" />
-        <PackageReference Include="JasperFx.Events" Version="1.15.0" />
+        <PackageReference Include="JasperFx.Events" Version="1.16.0" />
         <PackageReference Include="JasperFx.RuntimeCompiler" Version="4.3.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <!-- This is forced by Npgsql peer dependency -->


### PR DESCRIPTION
Short version: @jeremydmiller is an idiot

Longer version: *Some* usages of Marten & Wolverine resulted in the tenant id being "Main" or "Marten" in *some* permutations of configuration that we still haven't perfectly sorted out. When rebuilding projections, users saw erroneous results because Marten/JasperFx.Events was still slicing on tenant id and therefore, sliced the events incorrectly. 

The first attempt at the "fix" made everything much worse and introduced regression bugs on normal operation. This PR fixes the original issue in a more correct way while also fixing the regression bug. 