### PR TITLE
Add overload for multi-tenanted partitioning configuration

### DIFF
--- a/src/CoreTests/Partitioning/partitioning_configuration.cs
+++ b/src/CoreTests/Partitioning/partitioning_configuration.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Marten.Schema;
 using Marten.Storage;
 using Marten.Storage.Metadata;
 using Marten.Testing.Documents;
@@ -139,7 +140,7 @@ public class partitioning_configuration : OneOffConfigurationsContext
     {
         StoreOptions(opts =>
         {
-            opts.Policies.AllDocumentsAreMultiTenantedWithPartitioning(x => x.ByExternallyManagedListPartitions());
+            opts.Policies.AllDocumentsAreMultiTenantedWithPartitioning(x => x.ByExternallyManagedListPartitions(), PrimaryKeyTenancyOrdering.TenantId_Then_Id);
         });
 
         var table = tableFor<Target>();

--- a/src/CoreTests/Partitioning/querying_against_conjoined_partitioning_with_tenant_id_and_subquery.cs
+++ b/src/CoreTests/Partitioning/querying_against_conjoined_partitioning_with_tenant_id_and_subquery.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Marten;
+using Marten.Schema;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
@@ -31,7 +32,7 @@ public class querying_against_conjoined_partitioning_with_tenant_id_and_subquery
                 x.ByList()
                     .AddPartition("red", "red")
                     .AddPartition("blue", "blue");
-            });
+            }, PrimaryKeyTenancyOrdering.TenantId_Then_Id);
         });
 
         await theStore.BulkInsertAsync("red", reds);

--- a/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs
+++ b/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs
@@ -38,7 +38,7 @@ public class conjoined_multi_tenancy_with_partitioning: OneOffConfigurationsCont
                 x.ByList()
                     .AddPartition("red", "Red")
                     .AddPartition("blue", "Blue");
-            });
+            }, PrimaryKeyTenancyOrdering.Id_Then_TenantId);
         });
     }
 

--- a/src/Marten.Testing/Examples/MultiTenancy.cs
+++ b/src/Marten.Testing/Examples/MultiTenancy.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using JasperFx.MultiTenancy;
+using Marten.Schema;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Xunit;
@@ -140,7 +141,7 @@ public class MultiTenancy
                 // OR use RANGE partitioning with the actual partitions managed
                 // externally
                 x.ByExternallyManagedRangePartitions();
-            });
+            }, PrimaryKeyTenancyOrdering.TenantId_Then_Id);
 
             #endregion
         });


### PR DESCRIPTION
Introduces an overload for AllDocumentsAreMultiTenantedWithPartitioning to allow specifying primary key tenancy ordering. Marks the old method as obsolete and updates internal logic to use the provided ordering, improving flexibility for index management.