### PR TITLE
Add support for prefixing indexes with tenant_id

### DIFF
--- a/docs/documents/multi-tenancy.md
+++ b/docs/documents/multi-tenancy.md
@@ -417,6 +417,24 @@ storeOptions.Schema.For<Target>().SingleTenanted();
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Configuration/document_policies.cs#L76-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-configure-override-with-single-tenancy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### Make all documents start their index by tenant_id
+
+When using conjoined multi tenancy it is often beneficial to have database indexes start with tenant_id. Even when a tenant is specified on the session and PostgreSQL can already restrict queries to the relevant table partition, this does not always fully isolate a single tenant. With hash partitioning, multiple tenants can end up in the same partition, so indexes that do not start with tenant_id may still scan entries belonging to other tenants. By consistently prefixing tenant_id on all indexes, either globally through policies or per document type, Marten allows PostgreSQL to efficiently filter within a partition as well, improving index selectivity and reducing unnecessary index scans in databases with many tenants.
+
+<!-- snippet: sample_tenancy-start_indexes_by_tenant_id -->
+<a id='snippet-sample_tenancy-start_indexes_by_tenant_id'></a>
+```cs
+_.Policies.ForAllDocuments(x =>
+{
+    x.StartIndexesByTenantId = true;
+});
+_.Schema.For<User>()
+    .StartIndexesByTenantId()
+    .Index(x => x.UserName);
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Indexes/computed_tenancy_indexes.cs#L30-L38' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_tenancy-start_indexes_by_tenant_id' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
 ## Marten-Managed Table Partitioning by Tenant <Badge type="tip" text="7.28" />
 
 Man, that's a mouthful! So here's the situation. You have a large number of tenants, use the "conjoined" tenancy model,
@@ -484,7 +502,7 @@ To exempt document types from having partitioned tables, such as for tables you 
 even harm by partitioning, you can use either an attribute on the document type:
 
 <!-- snippet: sample_using_DoNotPartitionAttribute -->
-<a id='snippet-sample_using_donotpartitionattribute'></a>
+<a id='snippet-sample_using_DoNotPartitionAttribute'></a>
 ```cs
 [DoNotPartition]
 public class DocThatShouldBeExempted1
@@ -492,7 +510,7 @@ public class DocThatShouldBeExempted1
     public Guid Id { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs#L348-L356' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_donotpartitionattribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs#L348-L356' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_DoNotPartitionAttribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 or exempt a single document type through the fluent interface:

--- a/src/DocumentDbTests/Indexes/computed_tenancy_indexes.cs
+++ b/src/DocumentDbTests/Indexes/computed_tenancy_indexes.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Schema;
+using Marten.Storage.Metadata;
+using Marten.Testing;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Xunit;
+
+namespace DocumentDbTests.Indexes;
+
+public class computed_tenancy_indexes: OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task create_index_that_includes_tenant_id()
+    {
+        StoreOptions(_ =>
+        {
+            _.Policies.AllDocumentsAreMultiTenantedWithPartitioning(c =>
+            {
+                c.ByHash(Enumerable.Range(0, 4).Select(i => $"h{i:000}").ToArray());
+            });
+            #region sample_tenancy-start_indexes_by_tenant_id
+            _.Policies.ForAllDocuments(x =>
+            {
+                x.StartIndexesByTenantId = true;
+            });
+            _.Schema.For<User>()
+                .StartIndexesByTenantId()
+                .Index(x => x.UserName);
+            #endregion
+            _.Schema.For<Target>()
+                .Index(x => x.Color);
+
+        });
+
+        var data = Target.GenerateRandomData(10).ToArray();
+        await theStore.BulkInsertAsync(data);
+
+        var table = await theStore.Tenancy.Default.Database.ExistingTableFor(typeof(Target));
+        var index = table.IndexFor("mt_doc_target_idx_color");
+
+        index.ToDDL(table).ShouldBe("CREATE INDEX mt_doc_target_idx_color ON computed_tenancy_indexes.mt_doc_target USING btree (tenant_id, CAST(data ->> 'Color' as integer));");
+    }
+
+    [Fact]
+    public async Task create_multi_property_index_that_includes_tenant_id()
+    {
+        StoreOptions(_ =>
+        {
+            _.Policies.AllDocumentsAreMultiTenantedWithPartitioning(c =>
+            {
+                c.ByHash(Enumerable.Range(0, 4).Select(i => $"h{i:000}").ToArray());
+            });
+            _.Schema.For<Target>()
+                .StartIndexesByTenantId()
+                .Index([
+                    x => x.UserId,
+                    x => x.Flag
+                ]);
+        });
+
+        var data = Target.GenerateRandomData(10).ToArray();
+        await theStore.BulkInsertAsync(data);
+
+        var table = await theStore.Tenancy.Default.Database.ExistingTableFor(typeof(Target));
+        var index = table.IndexFor("mt_doc_target_idx_user_idflag");
+
+        index.ToDDL(table).ShouldBe("CREATE INDEX mt_doc_target_idx_user_idflag ON computed_tenancy_indexes.mt_doc_target USING btree (tenant_id, CAST(data ->> 'UserId' as uuid), CAST(data ->> 'Flag' as boolean));");
+    }
+}

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -813,6 +813,15 @@ public class MartenRegistry
         }
 
         /// <summary>
+        ///     All indexes for this document should start by tenant_id />
+        /// </summary>
+        public DocumentMappingExpression<T> StartIndexesByTenantId()
+        {
+            _builder.Alter = m => m.StartIndexesByTenantId = true;
+            return this;
+        }
+
+        /// <summary>
         ///     Opt into the identity key generation strategy
         /// </summary>
         /// <returns></returns>

--- a/src/Marten/Schema/ComputedIndex.cs
+++ b/src/Marten/Schema/ComputedIndex.cs
@@ -74,6 +74,11 @@ public class ComputedIndex: IndexDefinition
 
     private IEnumerable<string> buildColumns()
     {
+        if (_mapping.StartIndexesByTenantId)
+        {
+            yield return TenantIdColumn.Name;
+        }
+
         foreach (var m in _members)
         {
             var member = _mapping.QueryMembers.MemberFor(m);

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -148,6 +148,8 @@ public partial class DocumentMapping: IDocumentMapping, IDocumentType
     public PrimaryKeyTenancyOrdering PrimaryKeyTenancyOrdering { get; set; } =
         PrimaryKeyTenancyOrdering.TenantId_Then_Id;
 
+    public bool StartIndexesByTenantId { get; set; }
+
     public bool DisablePartitioningIfAny { get; set; } = false;
 
     public IPartitionStrategy? Partitioning { get; set; }


### PR DESCRIPTION
Introduces the StartIndexesByTenantId option to allow all document indexes to be prefixed with tenant_id, improving index selectivity for conjoined multi-tenancy scenarios. Updates documentation, adds tests for the new behavior, and implements the option in DocumentMapping, MartenRegistry, and ComputedIndex.