### PR TITLE
Add TryFastForwardVersion() to IEventStream<T> for reusing stream obj…

### DIFF
--- a/src/EventSourcingTests/FetchForWriting/try_fast_forward_version.cs
+++ b/src/EventSourcingTests/FetchForWriting/try_fast_forward_version.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Threading.Tasks;
+using EventSourcingTests.Aggregation;
+using JasperFx.Events.Projections;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.FetchForWriting;
+
+public class try_fast_forward_version : OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task does_no_harm_event_when_called_early()
+    {
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+
+        var stream = await theSession.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        // Should be fine to call this on a brand new stream even though it does nothing
+        stream.TryFastForwardVersion();
+
+        stream.AppendOne(new AEvent());
+        stream.AppendMany(new BEvent(), new BEvent(), new BEvent());
+        stream.AppendMany(new CEvent(), new CEvent());
+
+        await theSession.SaveChangesAsync();
+
+        var document = await theSession.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+        document.ACount.ShouldBe(1);
+        document.BCount.ShouldBe(3);
+        document.CCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task append_successfully_after_initial_save_changes_async()
+    {
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+
+        var stream = await theSession.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        stream.AppendOne(new AEvent());
+        stream.AppendMany(new BEvent(), new BEvent(), new BEvent());
+        stream.AppendMany(new CEvent(), new CEvent());
+
+        await theSession.SaveChangesAsync();
+
+        // Advance the expected version now that we've committed the first batch
+        stream.TryFastForwardVersion();
+
+        stream.AppendOne(new AEvent());
+        stream.AppendOne(new AEvent());
+
+        await theSession.SaveChangesAsync();
+
+        var document = await theSession.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+        document.ACount.ShouldBe(3);
+        document.BCount.ShouldBe(3);
+        document.CCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task append_multiple_times()
+    {
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+
+        var stream = await theSession.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        stream.AppendOne(new AEvent());
+
+        await theSession.SaveChangesAsync();
+
+        stream.TryFastForwardVersion();
+
+        stream.AppendOne(new BEvent());
+
+        await theSession.SaveChangesAsync();
+
+        stream.TryFastForwardVersion();
+
+        stream.AppendOne(new CEvent());
+
+        await theSession.SaveChangesAsync();
+
+        var document = await theSession.Events.AggregateStreamAsync<SimpleAggregate>(streamId);
+        document.ACount.ShouldBe(1);
+        document.BCount.ShouldBe(1);
+        document.CCount.ShouldBe(1);
+    }
+}

--- a/src/Marten/Events/EventStore.FetchForWriting.cs
+++ b/src/Marten/Events/EventStore.FetchForWriting.cs
@@ -39,7 +39,7 @@ internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityS
         action.AggregateType = typeof(TDoc);
         action.ExpectedVersionOnServer = 0;
 
-        return new EventStream<TDoc>(_store.Events, id, document, cancellation, action);
+        return new EventStream<TDoc>(session, _store.Events, id, document, cancellation, action);
     }
 
     IEventStream<TDoc> IEventIdentityStrategy<Guid>.AppendToStream<TDoc>(TDoc? document, DocumentSessionBase session,
@@ -47,7 +47,7 @@ internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityS
     {
         var action = session.Events.Append(id);
         action.ExpectedVersionOnServer = version;
-        return new EventStream<TDoc>(_store.Events, id, document, cancellation, action);
+        return new EventStream<TDoc>(session, _store.Events, id, document, cancellation, action);
     }
 
     IQueryHandler<IReadOnlyList<IEvent>> IEventIdentityStrategy<Guid>.BuildEventQueryHandler(bool isGlobal, Guid id,
@@ -104,7 +104,7 @@ internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityS
         action.AggregateType = typeof(TDoc);
         action.ExpectedVersionOnServer = 0;
 
-        return new EventStream<TDoc>(_store.Events, id, document, cancellation, action);
+        return new EventStream<TDoc>(session, _store.Events, id, document, cancellation, action);
     }
 
     IEventStream<TDoc> IEventIdentityStrategy<string>.AppendToStream<TDoc>(TDoc? document,
@@ -112,7 +112,7 @@ internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityS
     {
         var action = session.Events.Append(id);
         action.ExpectedVersionOnServer = version;
-        return new EventStream<TDoc>(_store.Events, id, document, cancellation, action);
+        return new EventStream<TDoc>(session, _store.Events, id, document, cancellation, action);
     }
 
     IQueryHandler<IReadOnlyList<IEvent>> IEventIdentityStrategy<string>.BuildEventQueryHandler(bool isGlobal, string id,

--- a/src/Marten/Events/StubEventStream.cs
+++ b/src/Marten/Events/StubEventStream.cs
@@ -68,4 +68,12 @@ public class StubEventStream<T> : IEventStream<T> where T : notnull
     public string Key { get; set; } = Guid.NewGuid().ToString();
 
     public IReadOnlyList<IEvent> Events => EventsAppended.Select(x => EventGraph.BuildEvent(x)).ToList();
+
+    /// <summary>
+    /// No-op in the stub. This method is provided to satisfy the interface contract.
+    /// </summary>
+    public void TryFastForwardVersion()
+    {
+        // Intentionally does nothing in the stub
+    }
 }


### PR DESCRIPTION
…ects

Fixes #4114. This allows reusing an IEventStream<T> object across multiple SaveChangesAsync calls by advancing the expected version after each save.