### PR TITLE
Switch to NuGet Central Package Management

### DIFF
--- a/Analysis.Build.props
+++ b/Analysis.Build.props
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
             <PrivateAssets>all</PrivateAssets>
             <ExcludeAssets>none</ExcludeAssets>
             <IncludeAssets>all</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Meziantou.Analyzer" Version="2.0.257">
+        <PackageReference Include="Meziantou.Analyzer">
             <PrivateAssets>all</PrivateAssets>
             <ExcludeAssets>none</ExcludeAssets>
             <IncludeAssets>all</IncludeAssets>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All" />
+        <PackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,83 @@
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageVersion Include="Alba" Version="8.2.0" />
+        <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.2.0" />
+        <PackageVersion Include="BenchmarkDotNet" Version="0.13.10" />
+        <PackageVersion Include="Bogus" Version="35.6.5" />
+        <PackageVersion Include="Confluent.Kafka" Version="2.3.0" />
+        <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+        <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
+        <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+        <PackageVersion Include="FSharp.Core" Version="9.0.100" />
+        <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
+        <PackageVersion Include="JasperFx" Version="1.17.2" />
+        <PackageVersion Include="JasperFx.Events" Version="1.19.1" />
+        <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.3.2" />
+        <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
+        <PackageVersion Include="Lamar" Version="7.1.1" />
+        <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
+        <PackageVersion Include="Marten" Version="8.2.1" />
+        <PackageVersion Include="Meziantou.Analyzer" Version="2.0.257" />
+        <PackageVersion Include="Microsoft.AspNetCore.OData" Version="8.2.5" />
+        <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
+        <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.3.0" />
+        <PackageVersion Include="Microsoft.FeatureManagement" Version="3.2.0" />
+        <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
+        <PackageVersion Include="Neovolve.Logging.Xunit" Version="6.3.0" />
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageVersion Include="NodaTime.Serialization.JsonNet" Version="3.1.0" />
+        <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.1.2" />
+        <PackageVersion Include="Npgsql" Version="9.0.4" />
+        <PackageVersion Include="Npgsql.DependencyInjection" Version="9.0.2" />
+        <PackageVersion Include="Npgsql.Json.NET" Version="9.0.4" />
+        <PackageVersion Include="Npgsql.NodaTime" Version="9.0.2" />
+        <PackageVersion Include="NSubstitute" Version="5.3.0" />
+        <PackageVersion Include="Nuke.Common" Version="10.1.0" />
+        <PackageVersion Include="Ogooreck" Version="0.8.0" />
+        <PackageVersion Include="OpenTelemetry" Version="1.8.1" />
+        <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+        <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.8.0-rc.1" />
+        <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
+        <PackageVersion Include="Shouldly" Version="4.3.0" />
+        <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
+        <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageVersion Include="Vogen" Version="7.0.0" />
+        <PackageVersion Include="Weasel.Postgresql" Version="8.6.0" />
+        <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
+        <PackageVersion Include="xunit" Version="2.9.3" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    </ItemGroup>
+
+    <!-- Framework-specific package versions -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.2" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    </ItemGroup>
+</Project>

--- a/build/build.csproj
+++ b/build/build.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JasperFx" Version="1.11.2" />
-    <PackageReference Include="Npgsql" Version="9.0.4" />
-    <PackageReference Include="Nuke.Common" Version="10.1.0" />
+    <PackageReference Include="JasperFx" />
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="Nuke.Common" />
   </ItemGroup>
 
 </Project>

--- a/docs/src/samples/FreightShipping/FreightShipping.csproj
+++ b/docs/src/samples/FreightShipping/FreightShipping.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Marten" Version="8.2.1" />
-      <PackageReference Include="WolverineFx.Marten" Version="4.2.0" />
+      <PackageReference Include="Marten" />
+      <PackageReference Include="WolverineFx.Marten" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AspNetODataWithMarten/AspNetODataWithMarten.csproj
+++ b/src/AspNetODataWithMarten/AspNetODataWithMarten.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.2.5" />
+      <PackageReference Include="Microsoft.AspNetCore.OData" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ContainerScopedProjectionTests/ContainerScopedProjectionTests.csproj
+++ b/src/ContainerScopedProjectionTests/ContainerScopedProjectionTests.csproj
@@ -12,16 +12,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Jil" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -16,17 +16,17 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Microsoft.FeatureManagement" Version="3.2.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="Npgsql.DependencyInjection" Version="9.0.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Jil" />
+        <PackageReference Include="Microsoft.FeatureManagement" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Npgsql.DependencyInjection" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/DaemonTests.ManualOnly/DaemonTests.ManualOnly.csproj
+++ b/src/DaemonTests.ManualOnly/DaemonTests.ManualOnly.csproj
@@ -4,17 +4,17 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="35.6.5" />
-        <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="Neovolve.Logging.Xunit" Version="6.3.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Bogus" />
+        <PackageReference Include="Confluent.Kafka" />
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Neovolve.Logging.Xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit" />
 
     </ItemGroup>
     <ItemGroup>

--- a/src/DaemonTests/DaemonTests.csproj
+++ b/src/DaemonTests/DaemonTests.csproj
@@ -4,17 +4,17 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="35.6.5" />
-        <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="Neovolve.Logging.Xunit" Version="6.3.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Bogus" />
+        <PackageReference Include="Confluent.Kafka" />
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Neovolve.Logging.Xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit" />
 
     </ItemGroup>
     <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,5 +1,0 @@
-﻿<Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-    </PropertyGroup>
-</Project>

--- a/src/DocumentDbTests/DocumentDbTests.csproj
+++ b/src/DocumentDbTests/DocumentDbTests.csproj
@@ -15,15 +15,15 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Jil" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/EventPublisher/EventPublisher.csproj
+++ b/src/EventPublisher/EventPublisher.csproj
@@ -12,12 +12,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
         <!-- BUG: 1.8.0-rc.1 breaks prometheus exporter so sticking to 1.8.0-beta.1 for now https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1617 -->
-        <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.8.0-rc.1" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
     </ItemGroup>
 </Project>

--- a/src/EventSourcingTests/EventSourcingTests.csproj
+++ b/src/EventSourcingTests/EventSourcingTests.csproj
@@ -6,17 +6,17 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="StronglyTypedId" Version="1.0.0-beta08" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Jil" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="StronglyTypedId" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IssueService/IssueService.csproj
+++ b/src/IssueService/IssueService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
-        <PackageReference Include="StronglyTypedId" Version="1.0.0-beta08" />
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
+        <PackageReference Include="StronglyTypedId" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/LinqTests/LinqTests.csproj
+++ b/src/LinqTests/LinqTests.csproj
@@ -22,16 +22,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FSharp.SystemTextJson" Version="1.3.13" />
-        <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="FSharp.SystemTextJson" />
+        <PackageReference Include="Jil" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/LinqTestsTypes/LinqTestsTypes.csproj
+++ b/src/LinqTestsTypes/LinqTestsTypes.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="FSharp.Core" Version="9.0.100" />
-      <PackageReference Include="JasperFx" Version="1.11.2" />
+      <PackageReference Include="FSharp.Core" />
+      <PackageReference Include="JasperFx" />
     </ItemGroup>
 </Project>

--- a/src/Marten.AspNetCore.Testing/Marten.AspNetCore.Testing.csproj
+++ b/src/Marten.AspNetCore.Testing/Marten.AspNetCore.Testing.csproj
@@ -5,15 +5,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="8.2.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Alba" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Marten.AspNetCore/Marten.AspNetCore.csproj
+++ b/src/Marten.AspNetCore/Marten.AspNetCore.csproj
@@ -22,15 +22,15 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks"/>
     </ItemGroup>
 
     <Import Project="../../Analysis.Build.props"/>

--- a/src/Marten.CommandLine.Tests/Marten.CommandLine.Tests.csproj
+++ b/src/Marten.CommandLine.Tests/Marten.CommandLine.Tests.csproj
@@ -7,15 +7,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
+++ b/src/Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj
@@ -11,12 +11,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit" />
     </ItemGroup>
     <PropertyGroup>
         <NoWarn>xUnit1013</NoWarn>

--- a/src/Marten.NodaTime/Marten.NodaTime.csproj
+++ b/src/Marten.NodaTime/Marten.NodaTime.csproj
@@ -14,9 +14,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.1.0"/>
-        <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.1.2"/>
-        <PackageReference Include="Npgsql.NodaTime" Version="9.0.2" />
+        <PackageReference Include="NodaTime.Serialization.JsonNet"/>
+        <PackageReference Include="NodaTime.Serialization.SystemTextJson"/>
+        <PackageReference Include="Npgsql.NodaTime" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Marten\Marten.csproj"/>

--- a/src/Marten.Testing/Marten.Testing.csproj
+++ b/src/Marten.Testing/Marten.Testing.csproj
@@ -20,16 +20,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Jil" />
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -24,27 +24,27 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FSharp.Core" Version="9.0.100" />
-        <PackageReference Include="JasperFx" Version="1.17.2" />
-        <PackageReference Include="JasperFx.Events" Version="1.19.1" />
-        <PackageReference Include="JasperFx.RuntimeCompiler" Version="4.3.2" />
-        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="FSharp.Core" />
+        <PackageReference Include="JasperFx" />
+        <PackageReference Include="JasperFx.Events" />
+        <PackageReference Include="JasperFx.RuntimeCompiler" />
+        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
+        <PackageReference Include="Newtonsoft.Json" />
         <!-- This is forced by Npgsql peer dependency -->
-        <PackageReference Include="Npgsql.Json.NET" Version="9.0.4" />
-        <PackageReference Include="Weasel.Postgresql" Version="8.6.0" />
+        <PackageReference Include="Npgsql.Json.NET" />
+        <PackageReference Include="Weasel.Postgresql" />
     </ItemGroup>
 
 

--- a/src/MartenBenchmarks/MartenBenchmarks.csproj
+++ b/src/MartenBenchmarks/MartenBenchmarks.csproj
@@ -11,7 +11,7 @@
         <ProjectReference Include="..\Marten\Marten.csproj"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.10"/>
+        <PackageReference Include="BenchmarkDotNet"/>
     </ItemGroup>
     <ItemGroup>
         <Folder Include="Benchmarks"/>

--- a/src/MultiHostTests/MultiHostTests.csproj
+++ b/src/MultiHostTests/MultiHostTests.csproj
@@ -10,10 +10,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="xunit" Version="2.6.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7"/>
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MultiTenancyTests/MultiTenancyTests.csproj
+++ b/src/MultiTenancyTests/MultiTenancyTests.csproj
@@ -16,20 +16,20 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
-        <PackageReference Include="Npgsql.DependencyInjection" Version="9.0.2" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Npgsql.DependencyInjection" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
 
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/PatchingTests/PatchingTests.csproj
+++ b/src/PatchingTests/PatchingTests.csproj
@@ -5,13 +5,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/StressTests/StressTests.csproj
+++ b/src/StressTests/StressTests.csproj
@@ -12,17 +12,17 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Jil" Version="3.0.0-alpha2" />
-        <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Jil" />
+        <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="NSubstitute" Version="5.3.0" />
-        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TestingSupport/TestingSupport.csproj
+++ b/src/TestingSupport/TestingSupport.csproj
@@ -14,11 +14,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0"/>
-        <PackageReference Include="Jil" Version="3.0.0-alpha2"/>
-        <PackageReference Include="Lamar" Version="7.1.1"/>
-        <PackageReference Include="NSubstitute" Version="4.3.0"/>
-        <PackageReference Include="Shouldly" Version="4.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
+        <PackageReference Include="Jil"/>
+        <PackageReference Include="Lamar"/>
+        <PackageReference Include="NSubstitute"/>
+        <PackageReference Include="Shouldly"/>
     </ItemGroup>
 </Project>

--- a/src/ValueTypeTests/ValueTypeTests.csproj
+++ b/src/ValueTypeTests/ValueTypeTests.csproj
@@ -5,19 +5,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FSharp.SystemTextJson" Version="1.3.13" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="Vogen" Version="7.0.0" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="FSharp.SystemTextJson" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Vogen" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="StronglyTypedId" Version="1.0.0-beta08" PrivateAssets="all" ExcludeAssets="runtime" />
+        <PackageReference Include="StronglyTypedId" PrivateAssets="all" ExcludeAssets="runtime" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/AspireHeadlessTripService/AspireHeadlessTripService.csproj
+++ b/src/samples/AspireHeadlessTripService/AspireHeadlessTripService.csproj
@@ -8,11 +8,11 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="OpenTelemetry" Version="1.8.1" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="OpenTelemetry" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/AspireHost/AspireHost.csproj
+++ b/src/samples/AspireHost/AspireHost.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/DocSamples/DocSamples.csproj
+++ b/src/samples/DocSamples/DocSamples.csproj
@@ -10,13 +10,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/samples/Helpdesk/Helpdesk.Api.Tests/Helpdesk.Api.Tests.csproj
+++ b/src/samples/Helpdesk/Helpdesk.Api.Tests/Helpdesk.Api.Tests.csproj
@@ -5,18 +5,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Alba" Version="7.4.1" />
-        <PackageReference Include="FluentAssertions" Version="6.12.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="NSubstitute" Version="5.1.0"/>
-        <PackageReference Include="xunit" Version="2.8.1" />
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0"/>
-        <PackageReference Include="Ogooreck" Version="0.8.0"/>
-        <PackageReference Include="Bogus" Version="35.0.1"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+        <PackageReference Include="Alba" />
+        <PackageReference Include="FluentAssertions"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute"/>
+        <PackageReference Include="xunit" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost"/>
+        <PackageReference Include="Ogooreck"/>
+        <PackageReference Include="Bogus"/>
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/samples/Helpdesk/Helpdesk.Api/Helpdesk.Api.csproj
+++ b/src/samples/Helpdesk/Helpdesk.Api/Helpdesk.Api.csproj
@@ -8,9 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-        <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
+        <PackageReference Include="Confluent.Kafka" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/MinimalAPI/MinimalAPI.csproj
+++ b/src/samples/MinimalAPI/MinimalAPI.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- Centralizes all NuGet package versions into a single root `Directory.Packages.props` file with `ManagePackageVersionsCentrally=true`
- Removes `Version` attributes from all `PackageReference` elements across 30+ csproj and props files
- Standardizes conflicting package versions to the highest version (e.g., xunit 2.9.3, NSubstitute 5.3.0, Shouldly 4.3.0, Microsoft.NET.Test.Sdk 18.0.1)
- Preserves framework-conditional versions for `Microsoft.Extensions.Hosting.Abstractions` and `Microsoft.Extensions.Diagnostics.HealthChecks` (net8.0/net9.0/net10.0)

## Test plan
- [x] `dotnet restore src/Marten.sln` succeeds
- [x] `dotnet build src/Marten.sln` succeeds with 0 errors
- [x] Verified no remaining `Version` attributes on any `PackageReference` in csproj or props files
- [x] Confirmed Helpdesk sample solution failures are pre-existing (identical errors on master)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)