### PR TITLE
Fix null named parameters in raw SQL queries (GH-3045)

### DIFF
--- a/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
@@ -132,8 +132,7 @@ internal abstract class AdvancedSqlQueryHandlerBase<TResult>
 
         if (Parameters.Length == 1 && firstParameter != null && firstParameter.IsAnonymousType())
         {
-            builder.Append(Sql);
-            builder.AddParameters(firstParameter);
+            NamedParameterHelper.AppendSqlWithNamedParameters(builder, Sql, firstParameter);
         }
         else
         {

--- a/src/Marten/Linq/QueryHandlers/NamedParameterHelper.cs
+++ b/src/Marten/Linq/QueryHandlers/NamedParameterHelper.cs
@@ -1,0 +1,108 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using NpgsqlTypes;
+using Weasel.Postgresql;
+
+namespace Marten.Linq.QueryHandlers;
+
+/// <summary>
+/// Converts named-parameter SQL (using anonymous objects) to positional parameters
+/// with proper NpgsqlDbType inference, so that null-valued parameters carry type
+/// information to PostgreSQL. This fixes "42P08: could not determine data type of
+/// parameter" errors when a named parameter's value is null.
+/// </summary>
+internal static class NamedParameterHelper
+{
+    /// <summary>
+    /// Appends the SQL to the builder, replacing :paramName references with positional
+    /// parameters that have proper NpgsqlDbType set based on the property's declared type.
+    /// This ensures null parameter values still carry type information.
+    /// </summary>
+    public static void AppendSqlWithNamedParameters(ICommandBuilder builder, string sql, object parameters)
+    {
+        var properties = parameters.GetType().GetProperties();
+        var propLookup = new Dictionary<string, (object? value, Type propertyType)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var property in properties)
+        {
+            propLookup[property.Name] = (property.GetValue(parameters), property.PropertyType);
+        }
+
+        // Walk through the SQL, find :paramName references, replace with positional parameters
+        var i = 0;
+        while (i < sql.Length)
+        {
+            var c = sql[i];
+
+            // Skip single-quoted strings
+            if (c == '\'')
+            {
+                var end = sql.IndexOf('\'', i + 1);
+                if (end == -1) end = sql.Length - 1;
+                builder.Append(sql.Substring(i, end - i + 1));
+                i = end + 1;
+                continue;
+            }
+
+            // Check for :: (PostgreSQL type cast) - skip it
+            if (c == ':' && i + 1 < sql.Length && sql[i + 1] == ':')
+            {
+                builder.Append("::");
+                i += 2;
+                continue;
+            }
+
+            // Check for :paramName
+            if (c == ':' && i + 1 < sql.Length && IsIdentifierStart(sql[i + 1]))
+            {
+                var nameStart = i + 1;
+                var nameEnd = nameStart;
+                while (nameEnd < sql.Length && IsIdentifierChar(sql[nameEnd]))
+                {
+                    nameEnd++;
+                }
+
+                var paramName = sql.Substring(nameStart, nameEnd - nameStart);
+
+                if (propLookup.TryGetValue(paramName, out var entry))
+                {
+                    var (value, propertyType) = entry;
+                    var underlyingType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+
+                    NpgsqlDbType? dbType = null;
+                    if (value != null && PostgresqlProvider.Instance.HasTypeMapping(value.GetType()))
+                    {
+                        dbType = PostgresqlProvider.Instance.ToParameterType(value.GetType());
+                    }
+                    else if (PostgresqlProvider.Instance.HasTypeMapping(underlyingType))
+                    {
+                        dbType = PostgresqlProvider.Instance.ToParameterType(underlyingType);
+                    }
+
+                    builder.AppendParameter((object?)value ?? DBNull.Value, dbType);
+                }
+                else
+                {
+                    // Unknown parameter name - pass through as-is
+                    builder.Append(sql.Substring(i, nameEnd - i));
+                }
+
+                i = nameEnd;
+                continue;
+            }
+
+            builder.Append(c);
+            i++;
+        }
+    }
+
+    private static bool IsIdentifierStart(char c)
+    {
+        return char.IsLetter(c) || c == '_';
+    }
+
+    private static bool IsIdentifierChar(char c)
+    {
+        return char.IsLetterOrDigit(c) || c == '_';
+    }
+}

--- a/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
@@ -60,8 +60,7 @@ internal class UserSuppliedQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>
 
         if (_parameters.Length == 1 && firstParameter != null && firstParameter.IsAnonymousType())
         {
-            builder.Append(_sql);
-            builder.AddParameters(firstParameter);
+            NamedParameterHelper.AppendSqlWithNamedParameters(builder, _sql, firstParameter);
         }
         else
         {


### PR DESCRIPTION
## Summary
- Fixes #3045 — using named parameters with null values in `QueryAsync`/`AdvancedSqlAsync` caused PostgreSQL error `42P08: could not determine data type of parameter`
- Root cause: when an anonymous object property has a null value, `NpgsqlDbType` was never set on the parameter, so PostgreSQL couldn't infer the type
- New `NamedParameterHelper` converts `:paramName` references to positional `$N` parameters with `NpgsqlDbType` inferred from the property's declared type (handling `Nullable<T>` via `GetUnderlyingType`)

## Test plan
- [x] New test `query_with_null_named_parameter_GH_3045` covers the exact reported scenario (`:param is null or ...` pattern)
- [x] Existing named parameter tests (`query_by_one_named_parameter`, `query_by_two_named_parameters`, `query_two_fields_by_one_named_parameter`) still pass
- [x] Handles edge cases: `::` type casts, single-quoted strings, unknown parameter names

🤖 Generated with [Claude Code](https://claude.com/claude-code)