### PR TITLE
Add session configuration for ancillary stores

### DIFF
--- a/docs/configuration/hostbuilder.md
+++ b/docs/configuration/hostbuilder.md
@@ -711,3 +711,45 @@ public class InvoicingService
 ```
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/MultipleDocumentStores.cs#L73-L96' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_invoicingservice' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+### Session Configuration for Ancillary Stores <Badge type="tip" text="8.x" />
+
+Just like the main store configured with `AddMarten()`, ancillary stores support fluent session configuration
+to control the default `ISessionFactory` used for dependency-injected sessions. The session factory is registered
+as a [keyed service](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection#keyed-services)
+keyed by the store marker interface type (e.g., `typeof(IInvoicingStore)`).
+
+<!-- snippet: sample_bootstrapping_separate_store_with_session_config -->
+<a id='snippet-sample_bootstrapping_separate_store_with_session_config'></a>
+```cs
+using var host = Host.CreateDefaultBuilder()
+    .ConfigureServices(services =>
+    {
+        services.AddMarten("some connection string");
+
+        services.AddMartenStore<IInvoicingStore>(opts =>
+            {
+                opts.Connection("different connection string");
+            })
+            // Use lightweight sessions for this ancillary store
+            .UseLightweightSessions();
+
+        // Or use identity map sessions
+        // .UseIdentitySessions();
+
+        // Or use dirty-tracked sessions
+        // .UseDirtyTrackedSessions();
+
+        // Or use a custom session factory
+        // .BuildSessionsWith<CustomSessionFactory>();
+    }).StartAsync();
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Examples/MultipleDocumentStores.cs#L54-L78' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_bootstrapping_separate_store_with_session_config' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+You can resolve the keyed `ISessionFactory` for an ancillary store directly from the DI container if needed:
+
+```csharp
+var factory = serviceProvider.GetRequiredKeyedService<ISessionFactory>(typeof(IInvoicingStore));
+using var session = factory.OpenSession();
+```

--- a/src/CoreTests/Examples/MultipleDocumentStores.cs
+++ b/src/CoreTests/Examples/MultipleDocumentStores.cs
@@ -50,6 +50,35 @@ public class MultipleDocumentStores
 
         #endregion
     }
+
+    public static async Task bootstrap_with_session_config()
+    {
+        #region sample_bootstrapping_separate_store_with_session_config
+
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten("some connection string");
+
+                services.AddMartenStore<IInvoicingStore>(opts =>
+                    {
+                        opts.Connection("different connection string");
+                    })
+                    // Use lightweight sessions for this ancillary store
+                    .UseLightweightSessions();
+
+                // Or use identity map sessions
+                // .UseIdentitySessions();
+
+                // Or use dirty-tracked sessions
+                // .UseDirtyTrackedSessions();
+
+                // Or use a custom session factory
+                // .BuildSessionsWith<CustomSessionFactory>();
+            }).StartAsync();
+
+        #endregion
+    }
 }
 
 public class DefaultDataSet: IInitialData


### PR DESCRIPTION
## Summary

Closes #4131

- Adds `UseLightweightSessions()`, `UseIdentitySessions()`, `UseDirtyTrackedSessions()`, and `BuildSessionsWith<TFactory>()` to `MartenStoreExpression<T>`, matching the existing `MartenConfigurationExpression` API for `AddMarten()`
- Session factories are registered as keyed DI services (keyed by `typeof(T)`) so they don't conflict with the main store's `ISessionFactory`
- A default `DefaultSessionFactory` keyed registration is added automatically for every ancillary store

## Test plan

- [x] `ancillary_store_use_lightweight_sessions` — resolves `LightweightSessionFactory`, opens `LightweightSession`
- [x] `ancillary_store_use_identity_sessions` — resolves `IdentitySessionFactory`, opens `IdentityMapDocumentSession`
- [x] `ancillary_store_use_dirty_tracked_sessions` — resolves `DirtyTrackedSessionFactory`, opens `DirtyCheckingDocumentSession`
- [x] `ancillary_store_build_sessions_with_custom_factory` — resolves custom `SpecialBuilder` factory
- [x] `ancillary_store_default_session_factory` — default `DefaultSessionFactory` registered without explicit config
- [x] All existing bootstrapping tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)