### PR TITLE
Update JasperFx and Weasel NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,8 +13,8 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="1.19.0" />
-    <PackageVersion Include="JasperFx.Events" Version="1.21.0" />
+    <PackageVersion Include="JasperFx" Version="1.20.0" />
+    <PackageVersion Include="JasperFx.Events" Version="1.21.1" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.0.0" />
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.4.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
@@ -59,7 +59,7 @@
     <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
-    <PackageVersion Include="Weasel.Postgresql" Version="8.7.0" />
+    <PackageVersion Include="Weasel.Postgresql" Version="8.8.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary
- JasperFx 1.19.0 → 1.20.0
- JasperFx.Events 1.21.0 → 1.21.1
- Weasel.Postgresql 8.7.0 → 8.8.0

## Test plan
- [x] Full solution builds successfully across all target frameworks
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)