### PR TITLE
Fix AnyTenant() with child collection Any() in separate Where clauses (GH-4146)

### DIFF
--- a/src/Marten/Linq/SqlGeneration/Filters/SubQueryFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/SubQueryFilter.cs
@@ -32,6 +32,12 @@ internal class SubQueryFilter: ISubQueryFilter
     /// </summary>
     public bool Not { get; set; }
 
+    /// <summary>
+    ///     When true, skips the automatic tenant_id filter in Apply().
+    ///     Set when AnyTenant() is used in the query.
+    /// </summary>
+    internal bool BypassTenantFilter { get; set; }
+
     public ISqlFragment Reverse()
     {
         Not = !Not;
@@ -45,7 +51,7 @@ internal class SubQueryFilter: ISubQueryFilter
             builder.Append("NOT(");
         }
 
-        if (builder.TenantId != StorageConstants.DefaultTenantId && Member is ChildCollectionMember child)
+        if (!BypassTenantFilter && builder.TenantId != StorageConstants.DefaultTenantId && Member is ChildCollectionMember child)
         {
             if (child.Ancestors[0] is DocumentQueryableMemberCollection c && c.TenancyStyle == TenancyStyle.Conjoined)
             {


### PR DESCRIPTION
## Summary
- Fixes #4146 — `AnyTenant()` in a separate `.Where()` clause from a child collection `.Any()` query was still filtering by `tenant_id`
- Root cause: `SubQueryFilter.Apply()` hardcoded a `tenant_id` filter based on `builder.TenantId`, regardless of whether `AnyTenant()` was specified
- Added `BypassTenantFilter` flag to `SubQueryFilter`, set during `compileAnySubQueries` when `AnyTenant()` is detected among the top-level filters

## Test plan
- [x] New test: `any_tenant_with_child_collection_any_in_separate_where_clauses` verifies SQL does not contain `tenant_id`
- [x] Existing tests in `Bug_1884_multi_tenancy_and_Any_query` still pass
- [x] Full LinqTests suite: 1208 passed, 1 skipped, 0 failures
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)