### PR TITLE
Fix ConfigureMarten not being called for projection view types

### DIFF
--- a/src/DocumentDbTests/Configuration/DocumentMappingTests.cs
+++ b/src/DocumentDbTests/Configuration/DocumentMappingTests.cs
@@ -3,7 +3,10 @@ using System.Linq;
 using System.Reflection;
 using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
 using Marten;
+using Marten.Events.Projections;
 using Marten.Exceptions;
 using Marten.Linq.Members;
 using Marten.Linq.Parsing;
@@ -917,6 +920,20 @@ public class DocumentMappingTests
 
     #endregion
 
+    [Fact]
+    public void uses_ConfigureMarten_for_projection_view_type_registered_only_via_projection()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Projections.Add<ProjectionWithConfiguredView>(ProjectionLifecycle.Inline);
+        });
+
+        var mapping = store.Options.Storage.MappingFor(typeof(ProjectionConfiguredView));
+        mapping.ShouldBeOfType<DocumentMapping<ProjectionConfiguredView>>();
+        mapping.Indexes.OfType<ComputedIndex>().Any().ShouldBeTrue();
+    }
+
     #region sample_using_DatabaseSchemaName_attribute
 
     [DatabaseSchemaName("organization")]
@@ -931,4 +948,31 @@ public class DocumentMappingTests
 public class BadDoc
 {
     public string Name { get; set; }
+}
+
+public record SomeProjectionEvent(Guid Id, string ImportantField);
+
+public class ProjectionConfiguredView
+{
+    public string Id { get; set; } = "";
+    public string ImportantField { get; set; } = "";
+
+    public static void ConfigureMarten(DocumentMapping<ProjectionConfiguredView> mapping)
+    {
+        mapping.Index(x => x.ImportantField);
+    }
+}
+
+public class ProjectionWithConfiguredView: MultiStreamProjection<ProjectionConfiguredView, string>
+{
+    public ProjectionWithConfiguredView()
+    {
+        Identity<IEvent<SomeProjectionEvent>>(e => e.Data.Id.ToString());
+    }
+
+    public ProjectionConfiguredView Apply(SomeProjectionEvent @event, ProjectionConfiguredView current)
+    {
+        current.ImportantField = @event.ImportantField;
+        return current;
+    }
 }

--- a/src/Marten/Storage/StorageFeatures.cs
+++ b/src/Marten/Storage/StorageFeatures.cs
@@ -107,7 +107,9 @@ public class StorageFeatures: IFeatureSchema, IDescribeMyself
         }
 
         _buildingList.Value.Remove(type);
-        var m =  new DocumentMapping(type, options);
+        var fallbackBuilder = typeof(DocumentMappingBuilder<>)
+            .CloseAndBuildAs<IDocumentMappingBuilder>(type);
+        var m = fallbackBuilder.Build(options);
         _options.applyPostPolicies(m);
         return m;
     }


### PR DESCRIPTION
## Summary
- Fixes #4156 — the static `ConfigureMarten` method on a view type was never invoked when the type was registered only through a projection (e.g., `MultiStreamProjection<TDoc, TId>`)
- Root cause: `StorageFeatures.Build()` used the non-generic `DocumentMapping(Type, StoreOptions)` constructor as a fallback, which skips the `ConfigureMarten` reflection lookup that only exists in the generic `DocumentMapping<T>` constructor
- Fix: use `DocumentMappingBuilder<T>` (via `CloseAndBuildAs`) in the fallback path, which creates a `DocumentMapping<T>` that properly discovers and invokes `ConfigureMarten`

## Test plan
- [x] Added regression test `uses_ConfigureMarten_for_projection_view_type_registered_only_via_projection` that verifies `ConfigureMarten` is called for a `MultiStreamProjection` view type
- [x] Confirmed test fails without the fix, passes with it
- [x] CoreTests pass (291 passed, 1 skipped)
- [x] DocumentDbTests pass (921 passed, 1 skipped, 4 flaky database failures that reproduce on the base branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)