### PR TITLE
Add tests for partitioned multi-tenant child queries

### DIFF
--- a/src/CoreTests/Partitioning/partitioning_configuration.cs
+++ b/src/CoreTests/Partitioning/partitioning_configuration.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Marten;
 using Marten.Schema;
 using Marten.Schema.Indexing.Unique;
 using Marten.Storage;
@@ -263,5 +264,53 @@ public class partitioning_configuration : OneOffConfigurationsContext
         // This should not throw - PostgreSQL will reject unique indexes
         // that don't include all partition columns
         await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    [Fact]
+    public async Task cannot_query_within_child_collections_across_partition_tenants()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>()
+                .MultiTenantedWithPartitioning(x =>
+                {
+                    x.ByHash(Enumerable.Range(0, 2).Select(i => $"h{i:000}").ToArray());
+                });
+        });
+        var targetBlue1 = Target.Random();
+        targetBlue1.NestedObject = new([Target.Random()]);
+        targetBlue1.NestedObject.Targets[0].String = "not a green list";
+        await using (var blue = theStore.LightweightSession("Blue"))
+        {
+            blue.Store(targetBlue1);
+            await blue.SaveChangesAsync();
+        }
+
+        var targetRed1 = Target.Random();
+        targetRed1.NestedObject = new([Target.Random()]);
+        targetRed1.NestedObject.Targets[0].String = "not a green list";
+        await using(var blue = theStore.LightweightSession("Blue"))
+        {
+            blue.Store(targetRed1);
+            await blue.SaveChangesAsync();
+        }
+
+        await using (var red = theStore.QuerySession("Red"))
+        {
+            (await red.Query<Target>()
+                    .Where(x => x.NestedObject.Targets.Any(i => i.String != null && i.String == "not a green list"))
+                    .ToListAsync())
+                .ShouldHaveSingleItem()
+                .Id.ShouldBe(targetRed1.Id);
+        }
+
+        await using (var blue = theStore.QuerySession("Blue"))
+        {
+            (await blue.Query<Target>()
+                    .Where(x => x.NestedObject.Targets.Any(i => i.String != null && i.String == "not a green list"))
+                    .ToListAsync())
+                .ShouldHaveSingleItem()
+                .Id.ShouldBe(targetBlue1.Id);
+        }
     }
 }

--- a/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs
+++ b/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using JasperFx;
 using Marten;
+using Marten.Linq;
 using Marten.Schema;
 using Marten.Storage;
 using Marten.Testing;
@@ -29,6 +32,10 @@ public class conjoined_multi_tenancy_with_partitioning: OneOffConfigurationsCont
     public conjoined_multi_tenancy_with_partitioning()
     {
 
+        targetBlue1.NestedObject = new([Target.Random()]);
+        targetBlue1.NestedObject.Targets[0].String = "not a green list";
+        targetRed1.NestedObject = new([Target.Random()]);
+        targetRed1.NestedObject.Targets[0].String = "not a green list";
         StoreOptions(opts =>
         {
             opts.Policies.AllDocumentsAreMultiTenantedWithPartitioning(x =>
@@ -81,6 +88,28 @@ public class conjoined_multi_tenancy_with_partitioning: OneOffConfigurationsCont
         {
             (await blue.LoadAsync<Target>(targetBlue1.Id)).ShouldNotBeNull();
             (await blue.LoadAsync<Target>(targetRed1.Id)).ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task cannot_query_within_child_collections_across_tenants()
+    {
+        await using (var red = theStore.QuerySession("Red"))
+        {
+            (await red.Query<Target>()
+                    .Where(x => x.NestedObject.Targets.Any(i => i.String != null && i.String == "not a green list"))
+                    .ToListAsync())
+                .ShouldHaveSingleItem()
+                .Id.ShouldBe(targetRed1.Id);
+        }
+
+        await using (var blue = theStore.QuerySession("Blue"))
+        {
+            (await blue.Query<Target>()
+                    .Where(x => x.NestedObject.Targets.Any(i => i.String != null && i.String == "not a green list"))
+                    .ToListAsync())
+                .ShouldHaveSingleItem()
+                .Id.ShouldBe(targetBlue1.Id);
         }
     }
 


### PR DESCRIPTION
Add tests to verify querying within nested/child collections is correctly scoped per tenant when using partitioning. Updates in:

- src/CoreTests/Partitioning/partitioning_configuration.cs: add Marten using and new test cannot_query_within_child_collections_across_partition_tenants which seeds targets with nested objects in two tenants and asserts queries return only tenant-specific results.
- src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs: add several usings (Collections.Generic, Diagnostics, Marten.Linq), initialize nested objects for test fixtures, and add cannot_query_within_child_collections_across_tenants with similar assertions.

These tests ensure child-collection Any() queries are correctly limited to the active tenant/partition.