### PR TITLE
Add GroupBy, CheckExists, AssignTagWhere, and EventsExistByTags

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -116,6 +116,7 @@ const config: UserConfig<DefaultTheme.Config> = {
             {
               text: 'Querying Documents', link: '/documents/querying/', collapsed: true, items: [
                 { text: 'Loading Documents by Id', link: '/documents/querying/byid' },
+                { text: 'Checking Document Existence', link: '/documents/querying/check-exists' },
                 { text: 'Querying Documents with Linq', link: '/documents/querying/linq/' },
                 { text: 'Supported Linq Operators', link: '/documents/querying/linq/operators' },
                 { text: 'Querying within Child Collections', link: '/documents/querying/linq/child-collections' },

--- a/docs/documents/querying/check-exists.md
+++ b/docs/documents/querying/check-exists.md
@@ -1,0 +1,35 @@
+# Checking Document Existence
+
+Sometimes you only need to know whether a document with a given id exists in the database, without actually loading and deserializing the full document. Marten provides the `CheckExistsAsync` API for this purpose, which issues a lightweight `SELECT EXISTS(...)` query against PostgreSQL. This avoids the overhead of JSON deserialization and object materialization, making it significantly more efficient than loading the document just to check if it's there.
+
+## Usage
+
+`CheckExistsAsync<T>` is available on `IQuerySession` (and therefore also on `IDocumentSession`). It supports all identity types: `Guid`, `int`, `long`, `string`, and strongly-typed identifiers.
+
+<!-- snippet: sample_check_exists_usage -->
+<!-- endSnippet -->
+
+## Supported Identity Types
+
+| Id Type | Supported |
+|---------|-----------|
+| `Guid` | Yes |
+| `int` | Yes |
+| `long` | Yes |
+| `string` | Yes |
+| `object` | Yes (for dynamic id types) |
+| Strong-typed ids (Vogen, record structs, etc.) | Yes (via `object` overload) |
+
+## Batched Queries
+
+`CheckExists<T>` is also available as part of [batched queries](/documents/querying/batched-queries), allowing you to check existence of multiple documents in a single round-trip to the database:
+
+<!-- snippet: sample_check_exists_batch_usage -->
+<!-- endSnippet -->
+
+## Behavior Notes
+
+- Returns `true` if the document exists, `false` otherwise.
+- Respects soft-delete filters: if a document type uses soft deletes, a soft-deleted document will return `false`.
+- Respects multi-tenancy: the check is scoped to the current session's tenant.
+- Does **not** load the document into the identity map or trigger any deserialization.

--- a/docs/documents/querying/linq/operators.md
+++ b/docs/documents/querying/linq/operators.md
@@ -217,10 +217,59 @@ public void using_take_and_skip(IDocumentSession session)
 
 TODO -- link to the paging support
 
-## Grouping Operators
+## GroupBy()
 
-Sorry, but Marten does not yet support `GroupBy()`. You can track [this GitHub issue](https://github.com/JasperFx/marten/issues/569) to follow
-any future work on this Linq operator.
+Marten supports the `GroupBy()` LINQ operator for grouping documents by one or more keys and computing aggregate values. GroupBy translates to SQL `GROUP BY` with aggregate functions like `COUNT`, `SUM`, `MIN`, `MAX`, and `AVG`.
+
+### Simple Key with Aggregates
+
+<!-- snippet: sample_group_by_simple_key_with_count -->
+<!-- endSnippet -->
+
+### Composite Key
+
+You can group by multiple properties using an anonymous type:
+
+```csharp
+var results = await session.Query<Target>()
+    .GroupBy(x => new { x.Color, x.String })
+    .Select(g => new { Color = g.Key.Color, Text = g.Key.String, Count = g.Count() })
+    .ToListAsync();
+```
+
+### Where Before GroupBy
+
+Filter documents before grouping with a standard `Where()` clause:
+
+```csharp
+var results = await session.Query<Target>()
+    .Where(x => x.Number > 20)
+    .GroupBy(x => x.Color)
+    .Select(g => new { Color = g.Key, Count = g.Count() })
+    .ToListAsync();
+```
+
+### HAVING (Where After GroupBy)
+
+Filter groups with a `Where()` clause after `GroupBy()` -- this translates to SQL `HAVING`:
+
+```csharp
+var results = await session.Query<Target>()
+    .GroupBy(x => x.Color)
+    .Where(g => g.Count() > 1)
+    .Select(g => new { Color = g.Key, Count = g.Count() })
+    .ToListAsync();
+```
+
+### Supported Aggregates
+
+The following aggregate methods are supported within GroupBy projections:
+
+- `g.Count()` / `g.LongCount()` -- `COUNT(*)`
+- `g.Sum(x => x.Property)` -- `SUM(property)`
+- `g.Min(x => x.Property)` -- `MIN(property)`
+- `g.Max(x => x.Property)` -- `MAX(property)`
+- `g.Average(x => x.Property)` -- `AVG(property)`
 
 ## Distinct()
 

--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -224,6 +224,17 @@ catch (DcbConcurrencyException ex)
 The consistency check only detects events that match the **same tag query**. Events appended to unrelated tags or streams will not cause a violation.
 :::
 
+## Checking Event Existence
+
+If you only need to know whether any events matching a tag query exist -- without loading or deserializing them -- use `EventsExistAsync`. This is a lightweight `SELECT EXISTS(...)` query that avoids the overhead of fetching and materializing event data:
+
+<!-- snippet: sample_marten_dcb_events_exist_async -->
+<!-- endSnippet -->
+
+This is useful for guard clauses and validation logic in DCB workflows where you need to check preconditions before appending new events.
+
+`EventsExistAsync` is also available in batch queries via `batch.Events.EventsExist(query)`.
+
 ## How It Works
 
 ### Storage

--- a/src/DocumentDbTests/Reading/check_document_exists.cs
+++ b/src/DocumentDbTests/Reading/check_document_exists.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DocumentDbTests.Reading;
+
+public class check_document_exists: IntegrationContext
+{
+    public check_document_exists(DefaultStoreFixture fixture): base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task check_exists_by_guid_id_hit()
+    {
+        var doc = new GuidDoc { Id = Guid.NewGuid() };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        var exists = await theSession.CheckExistsAsync<GuidDoc>(doc.Id);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task check_exists_by_guid_id_miss()
+    {
+        var exists = await theSession.CheckExistsAsync<GuidDoc>(Guid.NewGuid());
+        exists.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_by_int_id_hit()
+    {
+        var doc = new IntDoc { Id = 42 };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        var exists = await theSession.CheckExistsAsync<IntDoc>(42);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task check_exists_by_int_id_miss()
+    {
+        var exists = await theSession.CheckExistsAsync<IntDoc>(999999);
+        exists.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_by_long_id_hit()
+    {
+        var doc = new LongDoc { Id = 200L };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        var exists = await theSession.CheckExistsAsync<LongDoc>(200L);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task check_exists_by_long_id_miss()
+    {
+        var exists = await theSession.CheckExistsAsync<LongDoc>(999999L);
+        exists.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_by_string_id_hit()
+    {
+        var doc = new StringDoc { Id = "test-doc" };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        var exists = await theSession.CheckExistsAsync<StringDoc>("test-doc");
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task check_exists_by_string_id_miss()
+    {
+        var exists = await theSession.CheckExistsAsync<StringDoc>("nonexistent");
+        exists.ShouldBeFalse();
+    }
+
+    #region sample_check_exists_usage
+
+    [Fact]
+    public async Task check_exists_by_object_id()
+    {
+        var doc = new GuidDoc { Id = Guid.NewGuid() };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        // Use the object overload for dynamic id types
+        var exists = await theSession.CheckExistsAsync<GuidDoc>((object)doc.Id);
+        exists.ShouldBeTrue();
+    }
+
+    #endregion
+}
+
+public class check_document_exists_in_batch: IntegrationContext
+{
+    public check_document_exists_in_batch(DefaultStoreFixture fixture): base(fixture)
+    {
+    }
+
+    #region sample_check_exists_batch_usage
+
+    [Fact]
+    public async Task check_exists_in_batch_by_guid_id()
+    {
+        var doc = new GuidDoc { Id = Guid.NewGuid() };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        var batch = theSession.CreateBatchQuery();
+        var existsHit = batch.CheckExists<GuidDoc>(doc.Id);
+        var existsMiss = batch.CheckExists<GuidDoc>(Guid.NewGuid());
+        await batch.Execute();
+
+        (await existsHit).ShouldBeTrue();
+        (await existsMiss).ShouldBeFalse();
+    }
+
+    #endregion
+
+    [Fact]
+    public async Task check_exists_in_batch_by_int_id()
+    {
+        var doc = new IntDoc { Id = 77 };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        var batch = theSession.CreateBatchQuery();
+        var existsHit = batch.CheckExists<IntDoc>(77);
+        var existsMiss = batch.CheckExists<IntDoc>(888888);
+        await batch.Execute();
+
+        (await existsHit).ShouldBeTrue();
+        (await existsMiss).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_in_batch_by_long_id()
+    {
+        var doc = new LongDoc { Id = 300L };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        var batch = theSession.CreateBatchQuery();
+        var existsHit = batch.CheckExists<LongDoc>(300L);
+        var existsMiss = batch.CheckExists<LongDoc>(999999L);
+        await batch.Execute();
+
+        (await existsHit).ShouldBeTrue();
+        (await existsMiss).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_in_batch_by_string_id()
+    {
+        var doc = new StringDoc { Id = "batch-test" };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        var batch = theSession.CreateBatchQuery();
+        var existsHit = batch.CheckExists<StringDoc>("batch-test");
+        var existsMiss = batch.CheckExists<StringDoc>("nope");
+        await batch.Execute();
+
+        (await existsHit).ShouldBeTrue();
+        (await existsMiss).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_in_batch_by_object_id()
+    {
+        var doc = new GuidDoc { Id = Guid.NewGuid() };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        var batch = theSession.CreateBatchQuery();
+        var existsHit = batch.CheckExists<GuidDoc>((object)doc.Id);
+        var existsMiss = batch.CheckExists<GuidDoc>((object)Guid.NewGuid());
+        await batch.Execute();
+
+        (await existsHit).ShouldBeTrue();
+        (await existsMiss).ShouldBeFalse();
+    }
+}

--- a/src/EventSourcingTests/Dcb/assign_tag_where_tests.cs
+++ b/src/EventSourcingTests/Dcb/assign_tag_where_tests.cs
@@ -1,0 +1,207 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+using Marten;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Dcb;
+
+public record RegionId(Guid Value);
+
+public record OrderPlaced(string OrderNumber, decimal Amount);
+public record OrderShipped(string OrderNumber);
+public record OrderCancelled(string OrderNumber, string Reason);
+
+[Collection("OneOffs")]
+public class assign_tag_where_tests : OneOffConfigurationsContext, IAsyncLifetime
+{
+    private RegionId _eastRegion = null!;
+    private RegionId _westRegion = null!;
+
+    public Task InitializeAsync()
+    {
+        _eastRegion = new RegionId(Guid.NewGuid());
+        _westRegion = new RegionId(Guid.NewGuid());
+
+        StoreOptions(opts =>
+        {
+            opts.Events.AddEventType<OrderPlaced>();
+            opts.Events.AddEventType<OrderShipped>();
+            opts.Events.AddEventType<OrderCancelled>();
+
+            opts.Events.RegisterTagType<RegionId>("region");
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task assign_tag_where_by_event_type_name()
+    {
+        // Append events WITHOUT tags
+        var stream1 = Guid.NewGuid();
+        theSession.Events.Append(stream1,
+            new OrderPlaced("ORD-1", 100m),
+            new OrderShipped("ORD-1"));
+        await theSession.SaveChangesAsync();
+
+        // Now retroactively tag all OrderPlaced events with a region
+        await using var session2 = theStore.LightweightSession();
+        var orderPlacedTypeName = theStore.Options.EventGraph.EventMappingFor<OrderPlaced>().EventTypeName;
+        session2.Events.AssignTagWhere(
+            e => e.EventTypeName == orderPlacedTypeName,
+            _eastRegion);
+        await session2.SaveChangesAsync();
+
+        // Query by tag - should find only the OrderPlaced event
+        await using var session3 = theStore.LightweightSession();
+        var query = new EventTagQuery().Or<RegionId>(_eastRegion);
+        var events = await session3.Events.QueryByTagsAsync(query);
+
+        events.Count.ShouldBe(1);
+        events[0].Data.ShouldBeOfType<OrderPlaced>().OrderNumber.ShouldBe("ORD-1");
+    }
+
+    [Fact]
+    public async Task assign_tag_where_by_stream_id()
+    {
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+
+        theSession.Events.Append(stream1,
+            new OrderPlaced("ORD-1", 100m),
+            new OrderShipped("ORD-1"));
+        theSession.Events.Append(stream2,
+            new OrderPlaced("ORD-2", 200m));
+        await theSession.SaveChangesAsync();
+
+        // Tag all events in stream1 only
+        await using var session2 = theStore.LightweightSession();
+        session2.Events.AssignTagWhere(
+            e => e.StreamId == stream1,
+            _eastRegion);
+        await session2.SaveChangesAsync();
+
+        // Query - should find only the 2 events from stream1
+        await using var session3 = theStore.LightweightSession();
+        var query = new EventTagQuery().Or<RegionId>(_eastRegion);
+        var events = await session3.Events.QueryByTagsAsync(query);
+
+        events.Count.ShouldBe(2);
+        events.ShouldAllBe(e => e.StreamId == stream1);
+    }
+
+    [Fact]
+    public async Task assign_tag_where_with_compound_predicate()
+    {
+        var stream1 = Guid.NewGuid();
+
+        theSession.Events.Append(stream1,
+            new OrderPlaced("ORD-1", 100m),
+            new OrderShipped("ORD-1"),
+            new OrderCancelled("ORD-1", "changed mind"));
+        await theSession.SaveChangesAsync();
+
+        // Tag events that are of type OrderPlaced or OrderCancelled
+        await using var session2 = theStore.LightweightSession();
+        var placedType = theStore.Options.EventGraph.EventMappingFor<OrderPlaced>().EventTypeName;
+        var cancelledType = theStore.Options.EventGraph.EventMappingFor<OrderCancelled>().EventTypeName;
+
+        session2.Events.AssignTagWhere(
+            e => e.EventTypeName == placedType || e.EventTypeName == cancelledType,
+            _eastRegion);
+        await session2.SaveChangesAsync();
+
+        // Query - should find 2 events (placed + cancelled, NOT shipped)
+        await using var session3 = theStore.LightweightSession();
+        var query = new EventTagQuery().Or<RegionId>(_eastRegion);
+        var events = await session3.Events.QueryByTagsAsync(query);
+
+        events.Count.ShouldBe(2);
+        events.Select(e => e.Data.GetType()).ShouldContain(typeof(OrderPlaced));
+        events.Select(e => e.Data.GetType()).ShouldContain(typeof(OrderCancelled));
+        events.Select(e => e.Data.GetType()).ShouldNotContain(typeof(OrderShipped));
+    }
+
+    [Fact]
+    public async Task assign_tag_where_is_idempotent()
+    {
+        var stream1 = Guid.NewGuid();
+        theSession.Events.Append(stream1, new OrderPlaced("ORD-1", 100m));
+        await theSession.SaveChangesAsync();
+
+        var placedType = theStore.Options.EventGraph.EventMappingFor<OrderPlaced>().EventTypeName;
+
+        // Assign the same tag twice - should not fail or duplicate
+        await using var session2 = theStore.LightweightSession();
+        session2.Events.AssignTagWhere(
+            e => e.EventTypeName == placedType, _eastRegion);
+        await session2.SaveChangesAsync();
+
+        await using var session3 = theStore.LightweightSession();
+        session3.Events.AssignTagWhere(
+            e => e.EventTypeName == placedType, _eastRegion);
+        await session3.SaveChangesAsync();
+
+        // Should still just find 1 event
+        await using var session4 = theStore.LightweightSession();
+        var query = new EventTagQuery().Or<RegionId>(_eastRegion);
+        var events = await session4.Events.QueryByTagsAsync(query);
+        events.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task assign_tag_where_does_not_affect_unmatched_events()
+    {
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+
+        theSession.Events.Append(stream1, new OrderPlaced("ORD-1", 100m));
+        theSession.Events.Append(stream2, new OrderPlaced("ORD-2", 200m));
+        await theSession.SaveChangesAsync();
+
+        // Only tag events in stream1
+        await using var session2 = theStore.LightweightSession();
+        session2.Events.AssignTagWhere(
+            e => e.StreamId == stream1, _eastRegion);
+        await session2.SaveChangesAsync();
+
+        // Tag events in stream2 with different region
+        await using var session3 = theStore.LightweightSession();
+        session3.Events.AssignTagWhere(
+            e => e.StreamId == stream2, _westRegion);
+        await session3.SaveChangesAsync();
+
+        // Verify east only has stream1
+        await using var session4 = theStore.LightweightSession();
+        var eastEvents = await session4.Events.QueryByTagsAsync(
+            new EventTagQuery().Or<RegionId>(_eastRegion));
+        eastEvents.Count.ShouldBe(1);
+        eastEvents[0].StreamId.ShouldBe(stream1);
+
+        // Verify west only has stream2
+        var westEvents = await session4.Events.QueryByTagsAsync(
+            new EventTagQuery().Or<RegionId>(_westRegion));
+        westEvents.Count.ShouldBe(1);
+        westEvents[0].StreamId.ShouldBe(stream2);
+    }
+
+    [Fact]
+    public async Task assign_tag_where_throws_for_unregistered_tag_type()
+    {
+        var unregisteredTag = new StudentId(Guid.NewGuid());
+
+        Should.Throw<InvalidOperationException>(() =>
+        {
+            theSession.Events.AssignTagWhere(e => e.Sequence > 0, unregisteredTag);
+        });
+    }
+}

--- a/src/EventSourcingTests/Dcb/dcb_tag_query_and_consistency_tests.cs
+++ b/src/EventSourcingTests/Dcb/dcb_tag_query_and_consistency_tests.cs
@@ -517,6 +517,92 @@ public class dcb_tag_query_and_consistency_tests: OneOffConfigurationsContext, I
         });
     }
 
+    #region sample_marten_dcb_events_exist_async
+    [Fact]
+    public async Task events_exist_returns_true_when_matching_events_found()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        var enrolled = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(studentId, courseId);
+        theSession.Events.Append(streamId, enrolled);
+        await theSession.SaveChangesAsync();
+
+        // Check existence -- lightweight, no event loading
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var exists = await theSession.Events.EventsExistAsync(query);
+        exists.ShouldBeTrue();
+    }
+    #endregion
+
+    [Fact]
+    public async Task events_exist_returns_false_when_no_matching_events()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var exists = await theSession.Events.EventsExistAsync(query);
+        exists.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task events_exist_with_event_type_filter()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        var enrolled = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(studentId, courseId);
+        theSession.Events.Append(streamId, enrolled);
+        await theSession.SaveChangesAsync();
+
+        // Should find StudentEnrolled
+        var query1 = new EventTagQuery().Or<StudentEnrolled, StudentId>(studentId);
+        (await theSession.Events.EventsExistAsync(query1)).ShouldBeTrue();
+
+        // Should NOT find AssignmentSubmitted (none appended)
+        var query2 = new EventTagQuery().Or<AssignmentSubmitted, StudentId>(studentId);
+        (await theSession.Events.EventsExistAsync(query2)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task events_exist_via_batch_query_positive()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        var enrolled = theSession.Events.BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(studentId, courseId);
+        theSession.Events.Append(streamId, enrolled);
+        await theSession.SaveChangesAsync();
+
+        await using var session2 = theStore.LightweightSession();
+        var batch = session2.CreateBatchQuery();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var existsTask = batch.Events.EventsExist(query);
+        await batch.Execute();
+
+        (await existsTask).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task events_exist_via_batch_query_negative()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+
+        await using var session2 = theStore.LightweightSession();
+        var batch = session2.CreateBatchQuery();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var existsTask = batch.Events.EventsExist(query);
+        await batch.Execute();
+
+        (await existsTask).ShouldBeFalse();
+    }
+
     [Fact]
     public async Task fetch_for_writing_by_tags_throws_on_empty_query()
     {

--- a/src/LinqTests/Operators/group_by_operator.cs
+++ b/src/LinqTests/Operators/group_by_operator.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+
+namespace LinqTests.Operators;
+
+public class group_by_operator: OneOffConfigurationsContext
+{
+    private IDocumentStore _store;
+    private IDocumentSession _session;
+
+    private async Task SetupTargetData()
+    {
+        _store = StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>();
+        });
+
+        _session = _store.LightweightSession();
+        _disposables.Add(_session);
+
+        // Deterministic data for GroupBy tests
+        var targets = new[]
+        {
+            new Target { Color = Colors.Blue, Number = 10, String = "Alpha", Double = 1.5 },
+            new Target { Color = Colors.Blue, Number = 20, String = "Alpha", Double = 2.5 },
+            new Target { Color = Colors.Green, Number = 30, String = "Beta", Double = 3.5 },
+            new Target { Color = Colors.Green, Number = 40, String = "Beta", Double = 4.5 },
+            new Target { Color = Colors.Green, Number = 50, String = "Gamma", Double = 5.5 },
+            new Target { Color = Colors.Red, Number = 60, String = "Gamma", Double = 6.5 },
+        };
+
+        _session.Store(targets);
+        await _session.SaveChangesAsync();
+    }
+
+    #region sample_group_by_simple_key_with_count
+
+    [Fact]
+    public async Task group_by_simple_key_with_count()
+    {
+        await SetupTargetData();
+
+        var results = await _session.Query<Target>()
+            .GroupBy(x => x.Color)
+            .Select(g => new { Color = g.Key, Count = g.Count() })
+            .ToListAsync();
+
+        results.Count.ShouldBe(3);
+        results.Single(x => x.Color == Colors.Blue).Count.ShouldBe(2);
+        results.Single(x => x.Color == Colors.Green).Count.ShouldBe(3);
+        results.Single(x => x.Color == Colors.Red).Count.ShouldBe(1);
+    }
+
+    #endregion
+
+    [Fact]
+    public async Task group_by_simple_key_with_sum()
+    {
+        await SetupTargetData();
+
+        var results = await _session.Query<Target>()
+            .GroupBy(x => x.Color)
+            .Select(g => new { Color = g.Key, Total = g.Sum(x => x.Number) })
+            .ToListAsync();
+
+        results.Count.ShouldBe(3);
+        results.Single(x => x.Color == Colors.Blue).Total.ShouldBe(30);
+        results.Single(x => x.Color == Colors.Green).Total.ShouldBe(120);
+        results.Single(x => x.Color == Colors.Red).Total.ShouldBe(60);
+    }
+
+    [Fact]
+    public async Task group_by_simple_key_with_multiple_aggregates()
+    {
+        await SetupTargetData();
+
+        var results = await _session.Query<Target>()
+            .GroupBy(x => x.Color)
+            .Select(g => new
+            {
+                Color = g.Key,
+                Count = g.Count(),
+                Total = g.Sum(x => x.Number),
+                Min = g.Min(x => x.Number),
+                Max = g.Max(x => x.Number)
+            })
+            .ToListAsync();
+
+        results.Count.ShouldBe(3);
+
+        var blue = results.Single(x => x.Color == Colors.Blue);
+        blue.Count.ShouldBe(2);
+        blue.Total.ShouldBe(30);
+        blue.Min.ShouldBe(10);
+        blue.Max.ShouldBe(20);
+
+        var green = results.Single(x => x.Color == Colors.Green);
+        green.Count.ShouldBe(3);
+        green.Total.ShouldBe(120);
+        green.Min.ShouldBe(30);
+        green.Max.ShouldBe(50);
+    }
+
+    [Fact]
+    public async Task group_by_string_key()
+    {
+        await SetupTargetData();
+
+        var results = await _session.Query<Target>()
+            .GroupBy(x => x.String)
+            .Select(g => new { Key = g.Key, Count = g.Count() })
+            .ToListAsync();
+
+        results.Count.ShouldBe(3);
+        results.Single(x => x.Key == "Alpha").Count.ShouldBe(2);
+        results.Single(x => x.Key == "Beta").Count.ShouldBe(2);
+        results.Single(x => x.Key == "Gamma").Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task group_by_with_where_before_group()
+    {
+        await SetupTargetData();
+
+        var results = await _session.Query<Target>()
+            .Where(x => x.Number > 20)
+            .GroupBy(x => x.Color)
+            .Select(g => new { Color = g.Key, Count = g.Count() })
+            .ToListAsync();
+
+        // Blue has 10, 20 -> both filtered out
+        // Green has 30, 40, 50 -> 3 pass
+        // Red has 60 -> 1 passes
+        results.Count.ShouldBe(2);
+        results.Single(x => x.Color == Colors.Green).Count.ShouldBe(3);
+        results.Single(x => x.Color == Colors.Red).Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task group_by_with_having()
+    {
+        await SetupTargetData();
+
+        var results = await _session.Query<Target>()
+            .GroupBy(x => x.Color)
+            .Where(g => g.Count() > 1)
+            .Select(g => new { Color = g.Key, Count = g.Count() })
+            .ToListAsync();
+
+        // Blue=2, Green=3, Red=1 -> Red filtered by HAVING
+        results.Count.ShouldBe(2);
+        results.ShouldNotContain(x => x.Color == Colors.Red);
+    }
+
+    [Fact]
+    public async Task group_by_composite_key()
+    {
+        await SetupTargetData();
+
+        var results = await _session.Query<Target>()
+            .GroupBy(x => new { x.Color, x.String })
+            .Select(g => new { Color = g.Key.Color, Text = g.Key.String, Count = g.Count() })
+            .ToListAsync();
+
+        // Blue+Alpha=2, Green+Beta=2, Green+Gamma=1, Red+Gamma=1
+        results.Count.ShouldBe(4);
+        results.Single(x => x.Color == Colors.Blue && x.Text == "Alpha").Count.ShouldBe(2);
+        results.Single(x => x.Color == Colors.Green && x.Text == "Beta").Count.ShouldBe(2);
+        results.Single(x => x.Color == Colors.Green && x.Text == "Gamma").Count.ShouldBe(1);
+        results.Single(x => x.Color == Colors.Red && x.Text == "Gamma").Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task group_by_with_average()
+    {
+        await SetupTargetData();
+
+        var results = await _session.Query<Target>()
+            .GroupBy(x => x.Color)
+            .Select(g => new { Color = g.Key, Avg = g.Average(x => x.Double) })
+            .ToListAsync();
+
+        results.Count.ShouldBe(3);
+        results.Single(x => x.Color == Colors.Blue).Avg.ShouldBe(2.0, tolerance: 0.01);
+        results.Single(x => x.Color == Colors.Green).Avg.ShouldBe(4.5, tolerance: 0.01);
+        results.Single(x => x.Color == Colors.Red).Avg.ShouldBe(6.5, tolerance: 0.01);
+    }
+
+    [Fact]
+    public async Task group_by_select_key_only()
+    {
+        await SetupTargetData();
+
+        var results = await _session.Query<Target>()
+            .GroupBy(x => x.Color)
+            .Select(g => g.Key)
+            .ToListAsync();
+
+        results.Count.ShouldBe(3);
+        results.ShouldContain(Colors.Blue);
+        results.ShouldContain(Colors.Green);
+        results.ShouldContain(Colors.Red);
+    }
+
+    [Fact]
+    public async Task group_by_with_long_count()
+    {
+        await SetupTargetData();
+
+        var results = await _session.Query<Target>()
+            .GroupBy(x => x.Color)
+            .Select(g => new { Color = g.Key, Count = g.LongCount() })
+            .ToListAsync();
+
+        results.Count.ShouldBe(3);
+        results.Single(x => x.Color == Colors.Blue).Count.ShouldBe(2L);
+        results.Single(x => x.Color == Colors.Green).Count.ShouldBe(3L);
+    }
+}

--- a/src/Marten/Events/Dcb/EventsExistByTagsHandler.cs
+++ b/src/Marten/Events/Dcb/EventsExistByTagsHandler.cs
@@ -1,0 +1,130 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Tags;
+using Marten.Internal;
+using Marten.Internal.Sessions;
+using Marten.Linq.QueryHandlers;
+using Weasel.Postgresql;
+
+namespace Marten.Events.Dcb;
+
+internal class EventsExistByTagsHandler: IQueryHandler<bool>
+{
+    private readonly DocumentStore _store;
+    private readonly EventTagQuery _query;
+
+    public EventsExistByTagsHandler(DocumentStore store, EventTagQuery query)
+    {
+        _store = store;
+        _query = query;
+    }
+
+    public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var conditions = _query.Conditions;
+        if (conditions.Count == 0)
+        {
+            throw new ArgumentException("EventTagQuery must have at least one condition.");
+        }
+
+        var distinctTagTypes = conditions.Select(c => c.TagType).Distinct().ToList();
+        var schema = _store.Events.DatabaseSchemaName;
+
+        builder.Append("select exists (select 1 from ");
+
+        var first = true;
+        for (var i = 0; i < distinctTagTypes.Count; i++)
+        {
+            var tagType = distinctTagTypes[i];
+            var registration = _store.Events.FindTagType(tagType)
+                               ?? throw new InvalidOperationException(
+                                   $"Tag type '{tagType.Name}' is not registered. Call RegisterTagType<{tagType.Name}>() first.");
+
+            var alias = $"t{i}";
+            if (first)
+            {
+                builder.Append(schema);
+                builder.Append(".mt_event_tag_");
+                builder.Append(registration.TableSuffix);
+                builder.Append(" ");
+                builder.Append(alias);
+                first = false;
+            }
+            else
+            {
+                builder.Append(" inner join ");
+                builder.Append(schema);
+                builder.Append(".mt_event_tag_");
+                builder.Append(registration.TableSuffix);
+                builder.Append(" ");
+                builder.Append(alias);
+                builder.Append(" on t0.seq_id = ");
+                builder.Append(alias);
+                builder.Append(".seq_id");
+            }
+        }
+
+        // Join to mt_events only if we need event type filtering
+        var hasEventTypeFilter = conditions.Any(c => c.EventType != null);
+        if (hasEventTypeFilter)
+        {
+            builder.Append(" inner join ");
+            builder.Append(schema);
+            builder.Append(".mt_events e on t0.seq_id = e.seq_id");
+        }
+
+        builder.Append(" where (");
+        for (var i = 0; i < conditions.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(" or ");
+            }
+
+            var condition = conditions[i];
+            var tagIndex = distinctTagTypes.IndexOf(condition.TagType);
+            var alias = $"t{tagIndex}";
+
+            builder.Append("(");
+            builder.Append(alias);
+            builder.Append(".value = ");
+
+            var registration = _store.Events.FindTagType(condition.TagType)!;
+            var value = registration.ExtractValue(condition.TagValue);
+            builder.AppendParameter(value);
+
+            if (condition.EventType != null)
+            {
+                builder.Append(" and e.type = ");
+                var eventTypeName = _store.Events.EventMappingFor(condition.EventType).EventTypeName;
+                builder.AppendParameter(eventTypeName);
+            }
+
+            builder.Append(")");
+        }
+
+        builder.Append(") limit 1)");
+    }
+
+    public bool Handle(DbDataReader reader, IMartenSession session)
+    {
+        return reader.Read() && reader.GetBoolean(0);
+    }
+
+    public async Task<bool> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
+    {
+        return await reader.ReadAsync(token).ConfigureAwait(false) &&
+               await reader.GetFieldValueAsync<bool>(0, token).ConfigureAwait(false);
+    }
+
+    public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/src/Marten/Events/EventStore.Dcb.cs
+++ b/src/Marten/Events/EventStore.Dcb.cs
@@ -16,6 +16,14 @@ namespace Marten.Events;
 
 internal partial class EventStore
 {
+    public async Task<bool> EventsExistAsync(EventTagQuery query, CancellationToken cancellation = default)
+    {
+        await _session.Database.EnsureStorageExistsAsync(typeof(IEvent), cancellation).ConfigureAwait(false);
+
+        var handler = new EventsExistByTagsHandler(_store, query);
+        return await _session.ExecuteHandlerAsync(handler, cancellation).ConfigureAwait(false);
+    }
+
     public async Task<IReadOnlyList<IEvent>> QueryByTagsAsync(EventTagQuery query,
         CancellationToken cancellation = default)
     {

--- a/src/Marten/Events/EventStore.cs
+++ b/src/Marten/Events/EventStore.cs
@@ -1,11 +1,17 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Events;
+using Marten.Events.Operations;
 using Marten.Events.Protected;
 using Marten.Internal.Sessions;
+using Marten.Linq.Parsing;
 using Marten.Storage;
+using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Events;
 
@@ -32,5 +38,43 @@ internal partial class EventStore: QueryEventStore, IEventStoreOperations
         _session.QueueOperation(op);
     }
 
+    public void AssignTagWhere(Expression<Func<IEvent, bool>> expression, object tag)
+    {
+        if (expression == null) throw new ArgumentNullException(nameof(expression));
+        if (tag == null) throw new ArgumentNullException(nameof(tag));
 
+        var tagType = tag.GetType();
+        var registration = _store.Events.FindTagType(tagType)
+                           ?? throw new InvalidOperationException(
+                               $"Tag type '{tagType.Name}' is not registered. Call RegisterTagType<{tagType.Name}>() first.");
+
+        var value = registration.ExtractValue(tag);
+        var schema = _store.Events.DatabaseSchemaName;
+
+        // Parse the expression into a SQL WHERE fragment using EventQueryMapping
+        var mapping = new EventQueryMapping(_store.Options);
+        var holder = new SimpleWhereFragmentHolder();
+        var parser = new WhereClauseParser(_store.Options, mapping.QueryMembers, holder);
+        parser.Visit(expression.Body);
+
+        ISqlFragment whereFragment = holder.Fragments.Count switch
+        {
+            0 => throw new ArgumentException("Expression did not produce any WHERE clause."),
+            1 => holder.Fragments[0],
+            _ => CompoundWhereFragment.And(holder.Fragments)
+        };
+
+        var op = new AssignTagWhereOperation(schema, registration, value, whereFragment);
+        _session.QueueOperation(op);
+    }
+
+    private class SimpleWhereFragmentHolder: IWhereFragmentHolder
+    {
+        public List<ISqlFragment> Fragments { get; } = new();
+
+        public void Register(ISqlFragment filter)
+        {
+            if (filter != null) Fragments.Add(filter);
+        }
+    }
 }

--- a/src/Marten/Events/IEventStoreOperations.cs
+++ b/src/Marten/Events/IEventStoreOperations.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Events;
@@ -415,6 +416,20 @@ public interface IEventStoreOperations: IEventOperations, IQueryEventStore
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     Guid CompletelyReplaceEvent<T>(long sequence, T eventBody) where T : class;
+
+    /// <summary>
+    /// Retroactively assign a tag to all events matching the given LINQ predicate.
+    /// The tag must be of a registered tag type. The operation is queued and applied at SaveChangesAsync time.
+    /// </summary>
+    /// <param name="expression">LINQ predicate against IEvent properties (e.g. EventTypeName, StreamId, Timestamp)</param>
+    /// <param name="tag">Tag value whose type must be registered via RegisterTagType</param>
+    void AssignTagWhere(Expression<Func<IEvent, bool>> expression, object tag);
+
+    /// <summary>
+    /// Check whether any events exist that match the given tag query, without loading the events.
+    /// This is a lightweight existence check useful for DCB guard clauses.
+    /// </summary>
+    Task<bool> EventsExistAsync(EventTagQuery query, CancellationToken cancellation = default);
 
     /// <summary>
     /// Query events by their tags using the DCB pattern.

--- a/src/Marten/Events/Operations/AssignTagWhereOperation.cs
+++ b/src/Marten/Events/Operations/AssignTagWhereOperation.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+using Marten.Internal;
+using Marten.Internal.Operations;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Events.Operations;
+
+/// <summary>
+/// Retroactively assigns a tag to all events matching a WHERE clause.
+/// Generates: INSERT INTO schema.mt_event_tag_{suffix} (value, seq_id)
+///            SELECT @value, d.seq_id FROM schema.mt_events as d WHERE {where}
+///            ON CONFLICT DO NOTHING
+/// </summary>
+internal class AssignTagWhereOperation: IStorageOperation
+{
+    private readonly string _schemaName;
+    private readonly ITagTypeRegistration _registration;
+    private readonly object _value;
+    private readonly ISqlFragment _whereFragment;
+
+    public AssignTagWhereOperation(string schemaName, ITagTypeRegistration registration, object value,
+        ISqlFragment whereFragment)
+    {
+        _schemaName = schemaName;
+        _registration = registration;
+        _value = value;
+        _whereFragment = whereFragment;
+    }
+
+    public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        builder.Append("insert into ");
+        builder.Append(_schemaName);
+        builder.Append(".mt_event_tag_");
+        builder.Append(_registration.TableSuffix);
+        builder.Append(" (value, seq_id) select ");
+        builder.AppendParameter(_value);
+        builder.Append(", d.seq_id from ");
+        builder.Append(_schemaName);
+        builder.Append(".mt_events as d where ");
+        _whereFragment.Apply(builder);
+        builder.Append(" on conflict do nothing");
+    }
+
+    public Type DocumentType => typeof(IEvent);
+
+    public void Postprocess(DbDataReader reader, IList<Exception> exceptions)
+    {
+        // No-op
+    }
+
+    public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
+
+    public OperationRole Role() => OperationRole.Events;
+}

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -73,6 +73,56 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     string TenantId { get; }
 
     /// <summary>
+    ///     Check if a document of type T with the given string id exists in the database
+    ///     without loading or deserializing the document
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id"></param>
+    /// <param name="token"></param>
+    /// <returns></returns>
+    Task<bool> CheckExistsAsync<T>(string id, CancellationToken token = default) where T : notnull;
+
+    /// <summary>
+    ///     Check if a document of type T with the given int id exists in the database
+    ///     without loading or deserializing the document
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id"></param>
+    /// <param name="token"></param>
+    /// <returns></returns>
+    Task<bool> CheckExistsAsync<T>(int id, CancellationToken token = default) where T : notnull;
+
+    /// <summary>
+    ///     Check if a document of type T with the given long id exists in the database
+    ///     without loading or deserializing the document
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id"></param>
+    /// <param name="token"></param>
+    /// <returns></returns>
+    Task<bool> CheckExistsAsync<T>(long id, CancellationToken token = default) where T : notnull;
+
+    /// <summary>
+    ///     Check if a document of type T with the given Guid id exists in the database
+    ///     without loading or deserializing the document
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id"></param>
+    /// <param name="token"></param>
+    /// <returns></returns>
+    Task<bool> CheckExistsAsync<T>(Guid id, CancellationToken token = default) where T : notnull;
+
+    /// <summary>
+    ///     Check if a document of type T with the given id exists in the database
+    ///     without loading or deserializing the document
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id"></param>
+    /// <param name="token"></param>
+    /// <returns></returns>
+    Task<bool> CheckExistsAsync<T>(object id, CancellationToken token = default) where T : notnull;
+
+    /// <summary>
     ///     Asynchronously find or load a single document of type T by a string id
     /// </summary>
     /// <typeparam name="T"></typeparam>

--- a/src/Marten/Internal/Sessions/QuerySession.CheckExists.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.CheckExists.cs
@@ -1,0 +1,86 @@
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+using Marten.Exceptions;
+using Marten.Internal.Storage;
+using Marten.Linq.QueryHandlers;
+
+namespace Marten.Internal.Sessions;
+
+public partial class QuerySession
+{
+    public async Task<bool> CheckExistsAsync<T>(string id, CancellationToken token = default) where T : notnull
+    {
+        assertNotDisposed();
+        await Database.EnsureStorageExistsAsync(typeof(T), token).ConfigureAwait(false);
+        var storage = StorageFor<T, string>();
+        var handler = new CheckExistsByIdHandler<T, string>(storage, id);
+        return await ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+    }
+
+    public async Task<bool> CheckExistsAsync<T>(int id, CancellationToken token = default) where T : notnull
+    {
+        assertNotDisposed();
+        await Database.EnsureStorageExistsAsync(typeof(T), token).ConfigureAwait(false);
+        var storage = StorageFor<T>();
+
+        if (storage is IDocumentStorage<T, int> i)
+        {
+            var handler = new CheckExistsByIdHandler<T, int>(i, id);
+            return await ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+        }
+
+        if (storage is IDocumentStorage<T, long> l)
+        {
+            var handler = new CheckExistsByIdHandler<T, long>(l, id);
+            return await ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+        }
+
+        throw new DocumentIdTypeMismatchException(
+            $"The identity type for document type {typeof(T).FullNameInCode()} is not numeric");
+    }
+
+    public async Task<bool> CheckExistsAsync<T>(long id, CancellationToken token = default) where T : notnull
+    {
+        assertNotDisposed();
+        await Database.EnsureStorageExistsAsync(typeof(T), token).ConfigureAwait(false);
+        var storage = StorageFor<T, long>();
+        var handler = new CheckExistsByIdHandler<T, long>(storage, id);
+        return await ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+    }
+
+    public async Task<bool> CheckExistsAsync<T>(Guid id, CancellationToken token = default) where T : notnull
+    {
+        assertNotDisposed();
+        await Database.EnsureStorageExistsAsync(typeof(T), token).ConfigureAwait(false);
+        var storage = StorageFor<T, Guid>();
+        var handler = new CheckExistsByIdHandler<T, Guid>(storage, id);
+        return await ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+    }
+
+    public async Task<bool> CheckExistsAsync<T>(object id, CancellationToken token = default) where T : notnull
+    {
+        assertNotDisposed();
+        await Database.EnsureStorageExistsAsync(typeof(T), token).ConfigureAwait(false);
+        var loader = typeof(ExistsChecker<>).CloseAndBuildAs<IExistsChecker>(id.GetType());
+        return await loader.CheckExistsAsync<T>(id, this, token).ConfigureAwait(false);
+    }
+
+    private interface IExistsChecker
+    {
+        Task<bool> CheckExistsAsync<T>(object id, QuerySession session, CancellationToken token = default) where T : notnull;
+    }
+
+    private class ExistsChecker<TId>: IExistsChecker where TId : notnull
+    {
+        public async Task<bool> CheckExistsAsync<T>(object id, QuerySession session, CancellationToken token = default) where T : notnull
+        {
+            var storage = session.StorageFor<T, TId>();
+            var handler = new CheckExistsByIdHandler<T, TId>(storage, (TId)id);
+            return await session.ExecuteHandlerAsync(handler, token).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -1,7 +1,9 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using JasperFx.Core.Reflection;
 using Marten.Exceptions;
 using Marten.Internal;
@@ -36,6 +38,12 @@ public partial class CollectionUsage
         }
 
         statement.ParseWhereClause(WhereExpressions, session, collection, storage);
+
+        // If this is a GroupBy query, handle it separately
+        if (GroupByData != null)
+        {
+            return CompileGroupBy(session, statement, collection, statistics);
+        }
 
         ParseIncludes(collection, session);
         if (Includes.Any())
@@ -371,6 +379,155 @@ public partial class CollectionUsage
         ProcessSingleValueModeIfAny(joinStatement, session, null, statistics);
 
         return joinStatement;
+    }
+
+    public Statement CompileGroupBy(IMartenSession session,
+        SelectorStatement statement, IQueryableMemberCollection collection, QueryStatistics? statistics)
+    {
+        var groupBy = GroupByData!;
+        var groupingUsage = Inner; // The IGrouping<K,T> usage with SelectExpression and WhereExpressions
+
+        if (groupingUsage?.SelectExpression == null)
+        {
+            throw new BadLinqExpressionException(
+                "GroupBy must be followed by a Select() projection. Marten does not support returning IGrouping<K,T> directly.");
+        }
+
+        // Find the grouping parameter from the select expression
+        // The SelectExpression is the body of the lambda; we need the original lambda's parameter
+        // The grouping parameter was on the Select's lambda: g => new { ... }
+        // We need to find it from the expression tree
+        ParameterExpression groupingParam = FindGroupingParameter(groupingUsage.SelectExpression);
+
+        var parser = new GroupBySelectParser(
+            _options.Serializer(),
+            collection,
+            groupBy.KeySelector,
+            groupingUsage.SelectExpression,
+            groupingParam);
+
+        // Set GROUP BY columns
+        foreach (var col in parser.GroupByColumns)
+        {
+            statement.GroupByColumns.Add(col);
+        }
+
+        // Set SELECT clause
+        if (parser.IsScalar)
+        {
+            var fragment = parser.ScalarFragment;
+            if (fragment is IQueryableMember member)
+            {
+                if (member.MemberType == typeof(string))
+                {
+                    statement.SelectClause =
+                        new NewScalarStringSelectClause(member.RawLocator, statement.SelectClause.FromObject);
+                }
+                else if (member.MemberType.IsSimple() || member.MemberType == typeof(Guid) ||
+                         member.MemberType == typeof(decimal) || member.MemberType == typeof(DateTimeOffset))
+                {
+                    statement.SelectClause =
+                        typeof(NewScalarSelectClause<>).CloseAndBuildAs<ISelectClause>(member,
+                            statement.SelectClause.FromObject,
+                            member.MemberType);
+                }
+            }
+            else if (fragment is LiteralSql literal)
+            {
+                // Aggregate scalar like count(*)
+                statement.SelectClause =
+                    new NewScalarSelectClause<int>(literal.Text, statement.SelectClause.FromObject);
+            }
+        }
+        else
+        {
+            var resultType = groupingUsage.SelectExpression.Type;
+            statement.SelectClause =
+                typeof(SelectDataSelectClause<>).CloseAndBuildAs<ISelectClause>(
+                    statement.SelectClause.FromObject,
+                    parser.NewObject,
+                    resultType);
+        }
+
+        // Process HAVING from the grouping usage's WhereExpressions
+        if (groupingUsage.WhereExpressions.Any())
+        {
+            // Build key member dictionaries for the HAVING resolver
+            var keyMembers = new Dictionary<string, IQueryableMember>();
+            IQueryableMember simpleKeyMember = null;
+            bool isCompositeKey;
+
+            var keyBody = groupBy.KeySelector.Body;
+            if (keyBody is NewExpression newExpr)
+            {
+                isCompositeKey = true;
+                var parameters = newExpr.Constructor!.GetParameters();
+                for (var i = 0; i < parameters.Length; i++)
+                {
+                    keyMembers[parameters[i].Name!] = collection.MemberFor(newExpr.Arguments[i]);
+                }
+            }
+            else
+            {
+                isCompositeKey = false;
+                simpleKeyMember = collection.MemberFor(keyBody);
+            }
+
+            foreach (var whereExpr in groupingUsage.WhereExpressions)
+            {
+                var havingFragment = GroupBySelectParser.ResolveHavingFragment(
+                    whereExpr, collection, groupBy.KeySelector, keyMembers, simpleKeyMember, isCompositeKey);
+                statement.HavingClauses.Add(havingFragment);
+            }
+        }
+
+        // Transfer downstream operators from the grouping usage's Inner (if any)
+        // e.g., OrderBy, Take, Skip after Select
+        var downstream = groupingUsage.Inner;
+        if (downstream != null)
+        {
+            statement.Limit ??= downstream._limit;
+            statement.Offset ??= downstream._offset;
+
+            if (downstream.SingleValueMode.HasValue)
+            {
+                SingleValueMode = downstream.SingleValueMode;
+            }
+
+            if (downstream.IsAny)
+            {
+                IsAny = true;
+            }
+        }
+
+        // Apply single value mode (Count, First, etc. after the GroupBy+Select)
+        ProcessSingleValueModeIfAny(statement, session, collection, statistics);
+
+        return statement.Top();
+    }
+
+    private static ParameterExpression FindGroupingParameter(Expression expression)
+    {
+        var finder = new GroupingParameterFinder();
+        finder.Visit(expression);
+        return finder.Parameter ?? throw new BadLinqExpressionException(
+            "Could not find the IGrouping parameter in the GroupBy Select expression");
+    }
+
+    private class GroupingParameterFinder: ExpressionVisitor
+    {
+        public ParameterExpression? Parameter { get; private set; }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            if (Parameter == null && node.Type.IsGenericType &&
+                node.Type.GetGenericTypeDefinition() == typeof(IGrouping<,>))
+            {
+                Parameter = node;
+            }
+
+            return base.VisitParameter(node);
+        }
     }
 
     public Statement CompileSelectMany(IMartenSession session,

--- a/src/Marten/Linq/CollectionUsage.cs
+++ b/src/Marten/Linq/CollectionUsage.cs
@@ -30,6 +30,7 @@ public partial class CollectionUsage
     public Expression SelectMany { get; set; } = null!;
     public MethodCallExpression? SelectManyCallExpression { get; set; }
     public GroupJoinData? GroupJoinData { get; set; }
+    public GroupByData? GroupByData { get; set; }
 
 
     public void WriteLimit(int limit)

--- a/src/Marten/Linq/GroupByData.cs
+++ b/src/Marten/Linq/GroupByData.cs
@@ -1,0 +1,15 @@
+#nullable enable
+using System.Linq.Expressions;
+
+namespace Marten.Linq;
+
+/// <summary>
+/// Holds parsed GroupBy expression components for LINQ GroupBy translation to SQL GROUP BY.
+/// </summary>
+public class GroupByData
+{
+    /// <summary>
+    /// The key selector lambda (e.g., x => x.Color)
+    /// </summary>
+    public LambdaExpression KeySelector { get; set; } = null!;
+}

--- a/src/Marten/Linq/Parsing/GroupBySelectParser.cs
+++ b/src/Marten/Linq/Parsing/GroupBySelectParser.cs
@@ -1,0 +1,488 @@
+#nullable disable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Marten.Exceptions;
+using Marten.Linq.Members;
+using Marten.Linq.SqlGeneration;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.Parsing;
+
+/// <summary>
+/// Parses the Select() projection on an IGrouping to build the SQL SELECT columns,
+/// GROUP BY keys, and aggregate expressions (COUNT, SUM, MIN, MAX, AVG).
+/// </summary>
+internal class GroupBySelectParser: ExpressionVisitor
+{
+    private readonly ISerializer _serializer;
+    private readonly IQueryableMemberCollection _collection;
+    private readonly LambdaExpression _keySelector;
+    private readonly ParameterExpression _groupingParameter;
+
+    // For composite keys: maps anonymous type member name to IQueryableMember
+    private readonly Dictionary<string, IQueryableMember> _keyMembers = new();
+    // For simple keys: the single key member
+    private IQueryableMember _simpleKeyMember;
+    private bool _isCompositeKey;
+
+    private string _currentField;
+    private bool _hasStarted;
+
+    public NewObject NewObject { get; private set; }
+    public List<string> GroupByColumns { get; } = new();
+
+    // For scalar select (e.g., .Select(g => g.Key) or .Select(g => g.Count()))
+    public ISqlFragment ScalarFragment { get; private set; }
+    public bool IsScalar { get; private set; }
+
+    public GroupBySelectParser(
+        ISerializer serializer,
+        IQueryableMemberCollection collection,
+        LambdaExpression keySelector,
+        Expression selectBody,
+        ParameterExpression groupingParameter)
+    {
+        _serializer = serializer;
+        _collection = collection;
+        _keySelector = keySelector;
+        _groupingParameter = groupingParameter;
+
+        NewObject = new NewObject(serializer);
+        ParseKeySelector();
+        Visit(selectBody);
+    }
+
+    private void ParseKeySelector()
+    {
+        var body = _keySelector.Body;
+
+        if (body is NewExpression newExpr)
+        {
+            // Composite key: x => new { x.Color, x.Number }
+            _isCompositeKey = true;
+            var parameters = newExpr.Constructor!.GetParameters();
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                var member = _collection.MemberFor(newExpr.Arguments[i]);
+                _keyMembers[parameters[i].Name!] = member;
+                GroupByColumns.Add(member.TypedLocator);
+            }
+        }
+        else if (body is MemberInitExpression memberInit)
+        {
+            // Composite key with member init: x => new KeyClass { Color = x.Color }
+            _isCompositeKey = true;
+            foreach (var binding in memberInit.Bindings.OfType<MemberAssignment>())
+            {
+                var member = _collection.MemberFor(binding.Expression);
+                _keyMembers[binding.Member.Name] = member;
+                GroupByColumns.Add(member.TypedLocator);
+            }
+        }
+        else
+        {
+            // Simple key: x => x.Color
+            _isCompositeKey = false;
+            _simpleKeyMember = _collection.MemberFor(body);
+            GroupByColumns.Add(_simpleKeyMember.TypedLocator);
+        }
+    }
+
+    protected override Expression VisitNew(NewExpression node)
+    {
+        if (_hasStarted)
+        {
+            // Nested new expression - not supported for now
+            throw new BadLinqExpressionException(
+                "Marten does not support nested constructors in GroupBy projections");
+        }
+
+        _hasStarted = true;
+
+        var parameters = node.Constructor!.GetParameters();
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            _currentField = parameters[i].Name;
+            Visit(node.Arguments[i]);
+        }
+
+        return node;
+    }
+
+    protected override Expression VisitMemberInit(MemberInitExpression node)
+    {
+        _hasStarted = true;
+
+        // Visit constructor args first
+        var parameters = node.NewExpression.Constructor!.GetParameters();
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            _currentField = parameters[i].Name;
+            Visit(node.NewExpression.Arguments[i]);
+        }
+
+        // Then visit member bindings
+        foreach (var binding in node.Bindings.OfType<MemberAssignment>())
+        {
+            _currentField = binding.Member.Name;
+            Visit(binding.Expression);
+        }
+
+        return node;
+    }
+
+    protected override Expression VisitMember(MemberExpression node)
+    {
+        // Check if this is g.Key
+        if (IsGroupingKeyAccess(node))
+        {
+            if (_isCompositeKey)
+            {
+                // g.Key for composite key - this shouldn't happen directly in a well-formed projection
+                // But if it does, we can't represent the whole anonymous key as a single SQL expression
+                throw new BadLinqExpressionException(
+                    "Cannot select the entire composite GroupBy key directly. Access individual key members like g.Key.Color instead.");
+            }
+
+            if (_currentField != null)
+            {
+                NewObject.Members[_currentField] = _simpleKeyMember;
+                _currentField = null;
+            }
+            else
+            {
+                // Scalar select: .Select(g => g.Key)
+                IsScalar = true;
+                ScalarFragment = _simpleKeyMember;
+            }
+
+            return node;
+        }
+
+        // Check if this is g.Key.PropertyName (composite key member access)
+        if (node.Expression is MemberExpression innerMember && IsGroupingKeyAccess(innerMember))
+        {
+            var memberName = node.Member.Name;
+            if (_keyMembers.TryGetValue(memberName, out var keyMember))
+            {
+                if (_currentField != null)
+                {
+                    NewObject.Members[_currentField] = keyMember;
+                    _currentField = null;
+                }
+                else
+                {
+                    IsScalar = true;
+                    ScalarFragment = keyMember;
+                }
+
+                return node;
+            }
+
+            throw new BadLinqExpressionException(
+                $"Unknown composite key member '{memberName}' in GroupBy projection");
+        }
+
+        return base.VisitMember(node);
+    }
+
+    protected override Expression VisitMethodCall(MethodCallExpression node)
+    {
+        var aggregateSql = TryResolveAggregate(node);
+        if (aggregateSql != null)
+        {
+            if (_currentField != null)
+            {
+                NewObject.Members[_currentField] = new LiteralSql(aggregateSql);
+                _currentField = null;
+            }
+            else
+            {
+                IsScalar = true;
+                ScalarFragment = new LiteralSql(aggregateSql);
+            }
+
+            return node;
+        }
+
+        return base.VisitMethodCall(node);
+    }
+
+    private string TryResolveAggregate(MethodCallExpression node)
+    {
+        var methodName = node.Method.Name;
+
+        // Parameterless: g.Count(), g.LongCount()
+        if (methodName is "Count" or "LongCount")
+        {
+            if (node.Arguments.Count == 1 && IsGroupingParameter(node.Arguments[0]))
+            {
+                return "count(*)";
+            }
+
+            // With predicate: g.Count(x => x.Flag)
+            if (node.Arguments.Count == 2 && IsGroupingParameter(node.Arguments[0]))
+            {
+                var predicateSql = ResolvePredicate(node.Arguments[1]);
+                return $"count(*) filter (where {predicateSql})";
+            }
+        }
+
+        // Aggregate with selector: g.Sum(x => x.Number), g.Min(...), g.Max(...), g.Average(...)
+        if (methodName is "Sum" or "Min" or "Max" or "Average")
+        {
+            if (node.Arguments.Count == 2 && IsGroupingParameter(node.Arguments[0]))
+            {
+                var selectorLambda = ExtractLambda(node.Arguments[1]);
+                if (selectorLambda != null)
+                {
+                    var member = _collection.MemberFor(selectorLambda.Body);
+                    var sqlOp = methodName == "Average" ? "avg" : methodName.ToLowerInvariant();
+                    return $"{sqlOp}({member.TypedLocator})";
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves a HAVING clause predicate from the grouping's Where expression.
+    /// Returns the SQL for the predicate.
+    /// </summary>
+    public static ISqlFragment ResolveHavingFragment(
+        Expression expression,
+        IQueryableMemberCollection collection,
+        LambdaExpression keySelector,
+        Dictionary<string, IQueryableMember> keyMembers,
+        IQueryableMember simpleKeyMember,
+        bool isCompositeKey)
+    {
+        var resolver = new HavingExpressionResolver(collection, keySelector, keyMembers, simpleKeyMember, isCompositeKey);
+        return resolver.Resolve(expression);
+    }
+
+    private bool IsGroupingKeyAccess(MemberExpression node)
+    {
+        return node.Member.Name == "Key"
+               && node.Expression is ParameterExpression param
+               && param == _groupingParameter;
+    }
+
+    private bool IsGroupingParameter(Expression node)
+    {
+        return node is ParameterExpression param && param == _groupingParameter;
+    }
+
+    private static LambdaExpression ExtractLambda(Expression expr)
+    {
+        if (expr is UnaryExpression unary)
+        {
+            expr = unary.Operand;
+        }
+
+        return expr as LambdaExpression;
+    }
+
+    private string ResolvePredicate(Expression expr)
+    {
+        var lambda = ExtractLambda(expr);
+        if (lambda == null)
+        {
+            throw new BadLinqExpressionException("Expected a lambda predicate in GroupBy aggregate");
+        }
+
+        // Simple predicate support: x => x.Flag
+        var member = _collection.MemberFor(lambda.Body);
+        return $"{member.TypedLocator} = True";
+    }
+}
+
+/// <summary>
+/// Translates Where() expressions on IGrouping to SQL HAVING clauses.
+/// Supports aggregate comparisons like g.Count() > 5, g.Sum(x => x.Number) >= 100.
+/// </summary>
+internal class HavingExpressionResolver
+{
+    private readonly IQueryableMemberCollection _collection;
+    private readonly LambdaExpression _keySelector;
+    private readonly Dictionary<string, IQueryableMember> _keyMembers;
+    private readonly IQueryableMember _simpleKeyMember;
+    private readonly bool _isCompositeKey;
+
+    public HavingExpressionResolver(
+        IQueryableMemberCollection collection,
+        LambdaExpression keySelector,
+        Dictionary<string, IQueryableMember> keyMembers,
+        IQueryableMember simpleKeyMember,
+        bool isCompositeKey)
+    {
+        _collection = collection;
+        _keySelector = keySelector;
+        _keyMembers = keyMembers;
+        _simpleKeyMember = simpleKeyMember;
+        _isCompositeKey = isCompositeKey;
+    }
+
+    public ISqlFragment Resolve(Expression expression)
+    {
+        if (expression is BinaryExpression binary)
+        {
+            return ResolveBinary(binary);
+        }
+
+        throw new BadLinqExpressionException(
+            "Marten only supports binary comparison expressions in GroupBy HAVING clauses");
+    }
+
+    private ISqlFragment ResolveBinary(BinaryExpression binary)
+    {
+        // Handle AND/OR
+        if (binary.NodeType == ExpressionType.AndAlso)
+        {
+            var left = Resolve(binary.Left);
+            var right = Resolve(binary.Right);
+            return new CompoundFragment("and", left, right);
+        }
+
+        if (binary.NodeType == ExpressionType.OrElse)
+        {
+            var left = Resolve(binary.Left);
+            var right = Resolve(binary.Right);
+            return new CompoundFragment("or", left, right);
+        }
+
+        var op = binary.NodeType switch
+        {
+            ExpressionType.Equal => "=",
+            ExpressionType.NotEqual => "!=",
+            ExpressionType.GreaterThan => ">",
+            ExpressionType.GreaterThanOrEqual => ">=",
+            ExpressionType.LessThan => "<",
+            ExpressionType.LessThanOrEqual => "<=",
+            _ => throw new BadLinqExpressionException(
+                $"Unsupported comparison operator '{binary.NodeType}' in GroupBy HAVING clause")
+        };
+
+        var leftSql = ResolveOperand(binary.Left);
+        var rightSql = ResolveOperand(binary.Right);
+
+        return new HavingComparisonFragment(leftSql, op, rightSql);
+    }
+
+    private string ResolveOperand(Expression expr)
+    {
+        // Aggregate call: g.Count(), g.Sum(x => x.Number)
+        if (expr is MethodCallExpression method)
+        {
+            return ResolveAggregateCall(method)
+                   ?? throw new BadLinqExpressionException(
+                       $"Unsupported method '{method.Method.Name}' in GroupBy HAVING clause");
+        }
+
+        // Constant
+        if (expr is ConstantExpression constant)
+        {
+            return constant.Value?.ToString() ?? "NULL";
+        }
+
+        // Key access: g.Key
+        if (expr is MemberExpression member && member.Member.Name == "Key")
+        {
+            if (_isCompositeKey)
+            {
+                throw new BadLinqExpressionException(
+                    "Cannot use composite key directly in HAVING clause");
+            }
+
+            return _simpleKeyMember!.TypedLocator;
+        }
+
+        // Try to evaluate as constant
+        if (expr.TryToParseConstant(out var c))
+        {
+            return c.Value?.ToString() ?? "NULL";
+        }
+
+        throw new BadLinqExpressionException(
+            $"Unsupported expression type '{expr.NodeType}' in GroupBy HAVING clause");
+    }
+
+    private string ResolveAggregateCall(MethodCallExpression node)
+    {
+        var methodName = node.Method.Name;
+
+        if (methodName is "Count" or "LongCount")
+        {
+            return "count(*)";
+        }
+
+        if (methodName is "Sum" or "Min" or "Max" or "Average" && node.Arguments.Count >= 2)
+        {
+            var lambda = ExtractLambda(node.Arguments[1]);
+            if (lambda != null)
+            {
+                var member = _collection.MemberFor(lambda.Body);
+                var sqlOp = methodName == "Average" ? "avg" : methodName.ToLowerInvariant();
+                return $"{sqlOp}({member.TypedLocator})";
+            }
+        }
+
+        return null;
+    }
+
+    private static LambdaExpression ExtractLambda(Expression expr)
+    {
+        if (expr is UnaryExpression unary) expr = unary.Operand;
+        return expr as LambdaExpression;
+    }
+}
+
+internal class HavingComparisonFragment: ISqlFragment
+{
+    private readonly string _left;
+    private readonly string _op;
+    private readonly string _right;
+
+    public HavingComparisonFragment(string left, string op, string right)
+    {
+        _left = left;
+        _op = op;
+        _right = right;
+    }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        builder.Append(_left);
+        builder.Append(" ");
+        builder.Append(_op);
+        builder.Append(" ");
+        builder.Append(_right);
+    }
+}
+
+internal class CompoundFragment: ISqlFragment
+{
+    private readonly string _separator;
+    private readonly ISqlFragment _left;
+    private readonly ISqlFragment _right;
+
+    public CompoundFragment(string separator, ISqlFragment left, ISqlFragment right)
+    {
+        _separator = separator;
+        _left = left;
+        _right = right;
+    }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        builder.Append("(");
+        _left.Apply(builder);
+        builder.Append($" {_separator} ");
+        _right.Apply(builder);
+        builder.Append(")");
+    }
+}

--- a/src/Marten/Linq/Parsing/Operators/GroupByOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/GroupByOperator.cs
@@ -1,0 +1,27 @@
+#nullable enable
+using System.Linq.Expressions;
+
+namespace Marten.Linq.Parsing.Operators;
+
+public class GroupByOperator: LinqOperator
+{
+    public GroupByOperator(): base("GroupBy")
+    {
+    }
+
+    public override void Apply(ILinqQuery query, MethodCallExpression expression)
+    {
+        // GroupBy signature: source.GroupBy(keySelector)
+        // expression.Arguments[0] = source
+        // expression.Arguments[1] = key selector
+
+        var usage = query.CollectionUsageFor(expression);
+
+        var keyExpr = expression.Arguments[1].UnBox();
+
+        usage.GroupByData = new GroupByData
+        {
+            KeySelector = (LambdaExpression)keyExpr
+        };
+    }
+}

--- a/src/Marten/Linq/Parsing/Operators/OperatorLibrary.cs
+++ b/src/Marten/Linq/Parsing/Operators/OperatorLibrary.cs
@@ -28,6 +28,7 @@ internal class OperatorLibrary
         Add<SelectManyOperator>();
         Add<GroupJoinOperator>();
         Add<SelectOperator>();
+        Add<GroupByOperator>();
         Add<AnyOperator>();
         Add<DistinctOperator>();
         Add<IncludeOperator>(); // TODO -- is this necessary?

--- a/src/Marten/Linq/QueryHandlers/CheckExistsByIdHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/CheckExistsByIdHandler.cs
@@ -1,0 +1,68 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+using Marten.Internal;
+using Marten.Internal.Storage;
+using Marten.Services;
+using Weasel.Postgresql;
+
+namespace Marten.Linq.QueryHandlers;
+
+internal class CheckExistsByIdHandler<T, TId>: IQueryHandler<bool> where T : notnull where TId : notnull
+{
+    private readonly TId _id;
+    private readonly IDocumentStorage<T> storage;
+    private static readonly Type[] _identityTypes = [typeof(int), typeof(long), typeof(string), typeof(Guid)];
+
+    public CheckExistsByIdHandler(IDocumentStorage<T, TId> documentStorage, TId id)
+    {
+        storage = documentStorage;
+        _id = id;
+    }
+
+    public void ConfigureCommand(ICommandBuilder sql, IMartenSession session)
+    {
+        sql.Append("select exists(select 1 from ");
+        sql.Append(storage.FromObject);
+        sql.Append(" as d where id = ");
+
+        if (_identityTypes.Contains(typeof(TId)))
+        {
+            sql.AppendParameter(_id);
+        }
+        else
+        {
+            var valueType = ValueTypeInfo.ForType(typeof(TId));
+            typeof(Appender<,>).CloseAndBuildAs<IAppender<TId>>(valueType, typeof(TId), valueType.SimpleType)
+                .Append(sql, _id);
+        }
+
+        storage.AddTenancyFilter(sql, session.TenantId);
+        sql.Append(")");
+    }
+
+    public bool Handle(DbDataReader reader, IMartenSession session)
+    {
+        return reader.Read() && reader.GetBoolean(0);
+    }
+
+    public async Task<bool> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
+    {
+        if (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            return reader.GetBoolean(0);
+        }
+
+        return false;
+    }
+
+    public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)
+    {
+        throw new NotSupportedException("StreamJson is not supported for CheckExistsByIdHandler");
+    }
+}

--- a/src/Marten/Linq/SqlGeneration/SelectorStatement.cs
+++ b/src/Marten/Linq/SqlGeneration/SelectorStatement.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using JasperFx.Core;
 using Marten.Internal;
@@ -25,6 +26,9 @@ public class SelectorStatement: Statement, IWhereFragmentHolder
 
     public bool IsDistinct { get; set; }
 
+    public List<string> GroupByColumns { get; } = new();
+    public List<ISqlFragment> HavingClauses { get; } = new();
+
     public void Register(ISqlFragment fragment)
     {
         Wheres.Add(fragment);
@@ -44,6 +48,28 @@ public class SelectorStatement: Statement, IWhereFragmentHolder
             {
                 sql.Append(" and ");
                 Wheres[i].Apply(sql);
+            }
+        }
+
+        if (GroupByColumns.Count > 0)
+        {
+            sql.Append(" GROUP BY ");
+            sql.Append(GroupByColumns[0]);
+            for (var i = 1; i < GroupByColumns.Count; i++)
+            {
+                sql.Append(", ");
+                sql.Append(GroupByColumns[i]);
+            }
+        }
+
+        if (HavingClauses.Count > 0)
+        {
+            sql.Append(" HAVING ");
+            HavingClauses[0].Apply(sql);
+            for (var i = 1; i < HavingClauses.Count; i++)
+            {
+                sql.Append(" and ");
+                HavingClauses[i].Apply(sql);
             }
         }
 

--- a/src/Marten/Services/BatchQuerying/BatchedQuery.Events.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQuery.Events.cs
@@ -183,6 +183,14 @@ internal partial class BatchedQuery: IBatchEvents
         return AddItem(handler);
     }
 
+    public Task<bool> EventsExist(EventTagQuery query)
+    {
+        _documentTypes.Add(typeof(IEvent));
+        var store = (DocumentStore)Parent.DocumentStore;
+        var handler = new EventsExistByTagsHandler(store, query);
+        return AddItem(handler);
+    }
+
     public Task<IEventBoundary<T>> FetchForWritingByTags<T>(EventTagQuery query) where T : class
     {
         Parent.AssertIsDocumentSession();

--- a/src/Marten/Services/BatchQuerying/BatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQuery.cs
@@ -136,6 +136,58 @@ internal partial class BatchedQuery: IBatchedQuery
         return plan.Fetch(this);
     }
 
+    public Task<bool> CheckExists<T>(string id) where T : class
+    {
+        return checkExists<T, string>(id);
+    }
+
+    public Task<bool> CheckExists<T>(int id) where T : class
+    {
+        return checkExists<T, int>(id);
+    }
+
+    public Task<bool> CheckExists<T>(long id) where T : class
+    {
+        return checkExists<T, long>(id);
+    }
+
+    public Task<bool> CheckExists<T>(Guid id) where T : class
+    {
+        return checkExists<T, Guid>(id);
+    }
+
+    public Task<bool> CheckExists<T>(object id) where T : class
+    {
+        var checker = typeof(ExistsChecker<>).CloseAndBuildAs<IExistsChecker>(id.GetType());
+        return checker.CheckExists<T>(id, this);
+    }
+
+    private Task<bool> checkExists<T, TId>(TId id) where T : class where TId : notnull
+    {
+        _documentTypes.Add(typeof(T));
+        var storage = Parent.StorageFor<T>();
+        if (storage is IDocumentStorage<T, TId> s)
+        {
+            var handler = new CheckExistsByIdHandler<T, TId>(s, id);
+            return AddItem(handler);
+        }
+
+        throw new DocumentIdTypeMismatchException(storage, typeof(TId));
+    }
+
+    private interface IExistsChecker
+    {
+        Task<bool> CheckExists<T>(object id, BatchedQuery parent) where T : class;
+    }
+
+    private class ExistsChecker<TId>: IExistsChecker where TId : notnull
+    {
+        public Task<bool> CheckExists<T>(object id, BatchedQuery parent) where T : class
+        {
+            return parent.checkExists<T, TId>((TId)id);
+        }
+    }
+
     private Task<T?> load<T, TId>(TId id) where T : class where TId : notnull
     {
         _documentTypes.Add(typeof(T));

--- a/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/IBatchedQuery.cs
@@ -139,6 +139,14 @@ public interface IBatchEvents
     Task<T?> FetchLatest<T>(string id) where T : class;
 
     /// <summary>
+    ///     Check whether any events exist that match the given tag query, without loading the events.
+    ///     This is a lightweight existence check useful for DCB guard clauses.
+    /// </summary>
+    /// <param name="query"></param>
+    /// <returns></returns>
+    Task<bool> EventsExist(EventTagQuery query);
+
+    /// <summary>
     ///     Fetch events matching a tag query and aggregate them into type T with a DCB consistency boundary.
     ///     At SaveChangesAsync time, will throw DcbConcurrencyException if new matching events were appended.
     /// </summary>
@@ -156,6 +164,51 @@ public interface IBatchedQuery
     IBatchEvents Events { get; }
 
     QuerySession Parent { get; }
+
+    /// <summary>
+    ///     Check if a document of type T with the given string id exists in the database
+    ///     without loading or deserializing the document
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    Task<bool> CheckExists<T>(string id) where T : class;
+
+    /// <summary>
+    ///     Check if a document of type T with the given int id exists in the database
+    ///     without loading or deserializing the document
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    Task<bool> CheckExists<T>(int id) where T : class;
+
+    /// <summary>
+    ///     Check if a document of type T with the given long id exists in the database
+    ///     without loading or deserializing the document
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    Task<bool> CheckExists<T>(long id) where T : class;
+
+    /// <summary>
+    ///     Check if a document of type T with the given Guid id exists in the database
+    ///     without loading or deserializing the document
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    Task<bool> CheckExists<T>(Guid id) where T : class;
+
+    /// <summary>
+    ///     Check if a document of type T with the given id exists in the database
+    ///     without loading or deserializing the document
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    Task<bool> CheckExists<T>(object id) where T : class;
 
     /// <summary>
     ///     Load a single document of Type "T" by id

--- a/src/ValueTypeTests/StrongTypedId/check_exists_with_strong_typed_ids.cs
+++ b/src/ValueTypeTests/StrongTypedId/check_exists_with_strong_typed_ids.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.CodeGeneration;
+using JasperFx.Core;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+
+namespace ValueTypeTests.StrongTypedId;
+
+public class check_exists_with_strong_typed_ids: IDisposable, IAsyncDisposable
+{
+    private readonly DocumentStore theStore;
+    private IDocumentSession theSession;
+
+    public check_exists_with_strong_typed_ids()
+    {
+        theStore = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "strong_typed_exists";
+
+            opts.ApplicationAssembly = GetType().Assembly;
+            opts.GeneratedCodeMode = TypeLoadMode.Auto;
+            opts.GeneratedCodeOutputPath =
+                AppContext.BaseDirectory.ParentDirectory().ParentDirectory().ParentDirectory().AppendPath("Internal", "Generated");
+        });
+
+        theSession = theStore.LightweightSession();
+    }
+
+    public void Dispose()
+    {
+        theStore?.Dispose();
+        theSession?.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (theStore != null)
+        {
+            await theStore.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task check_exists_with_guid_strong_typed_id_hit()
+    {
+        var invoice = new Invoice2();
+        theSession.Store(invoice);
+        await theSession.SaveChangesAsync();
+
+        var exists = await theSession.CheckExistsAsync<Invoice2>((object)invoice.Id!.Value);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task check_exists_with_guid_strong_typed_id_miss()
+    {
+        var exists = await theSession.CheckExistsAsync<Invoice2>((object)new Invoice2Id(Guid.NewGuid()));
+        exists.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_with_int_strong_typed_id_hit()
+    {
+        var order = new Order2 { Id = new Order2Id(42), Name = "Test" };
+        theSession.Store(order);
+        await theSession.SaveChangesAsync();
+
+        var exists = await theSession.CheckExistsAsync<Order2>((object)order.Id!.Value);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task check_exists_with_int_strong_typed_id_miss()
+    {
+        var exists = await theSession.CheckExistsAsync<Order2>((object)new Order2Id(999999));
+        exists.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_with_long_strong_typed_id_hit()
+    {
+        var issue = new Issue2 { Id = new Issue2Id(500L), Name = "Test" };
+        theSession.Store(issue);
+        await theSession.SaveChangesAsync();
+
+        var exists = await theSession.CheckExistsAsync<Issue2>((object)issue.Id!.Value);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task check_exists_with_long_strong_typed_id_miss()
+    {
+        var exists = await theSession.CheckExistsAsync<Issue2>((object)new Issue2Id(999999L));
+        exists.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_with_string_strong_typed_id_hit()
+    {
+        var team = new Team2 { Id = new Team2Id("team-exists-test"), Name = "Test" };
+        theSession.Store(team);
+        await theSession.SaveChangesAsync();
+
+        var exists = await theSession.CheckExistsAsync<Team2>((object)team.Id!.Value);
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task check_exists_with_string_strong_typed_id_miss()
+    {
+        var exists = await theSession.CheckExistsAsync<Team2>((object)new Team2Id("nonexistent"));
+        exists.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_in_batch_with_guid_strong_typed_id()
+    {
+        var invoice = new Invoice2();
+        theSession.Store(invoice);
+        await theSession.SaveChangesAsync();
+
+        var batch = theSession.CreateBatchQuery();
+        var existsHit = batch.CheckExists<Invoice2>((object)invoice.Id!.Value);
+        var existsMiss = batch.CheckExists<Invoice2>((object)new Invoice2Id(Guid.NewGuid()));
+        await batch.Execute();
+
+        (await existsHit).ShouldBeTrue();
+        (await existsMiss).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_in_batch_with_int_strong_typed_id()
+    {
+        var order = new Order2 { Id = new Order2Id(88), Name = "Batch Test" };
+        theSession.Store(order);
+        await theSession.SaveChangesAsync();
+
+        var batch = theSession.CreateBatchQuery();
+        var existsHit = batch.CheckExists<Order2>((object)order.Id!.Value);
+        var existsMiss = batch.CheckExists<Order2>((object)new Order2Id(777777));
+        await batch.Execute();
+
+        (await existsHit).ShouldBeTrue();
+        (await existsMiss).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_in_batch_with_long_strong_typed_id()
+    {
+        var issue = new Issue2 { Id = new Issue2Id(600L), Name = "Batch Test" };
+        theSession.Store(issue);
+        await theSession.SaveChangesAsync();
+
+        var batch = theSession.CreateBatchQuery();
+        var existsHit = batch.CheckExists<Issue2>((object)issue.Id!.Value);
+        var existsMiss = batch.CheckExists<Issue2>((object)new Issue2Id(888888L));
+        await batch.Execute();
+
+        (await existsHit).ShouldBeTrue();
+        (await existsMiss).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task check_exists_in_batch_with_string_strong_typed_id()
+    {
+        var team = new Team2 { Id = new Team2Id("batch-exists-test"), Name = "Batch Test" };
+        theSession.Store(team);
+        await theSession.SaveChangesAsync();
+
+        var batch = theSession.CreateBatchQuery();
+        var existsHit = batch.CheckExists<Team2>((object)team.Id!.Value);
+        var existsMiss = batch.CheckExists<Team2>((object)new Team2Id("not-there"));
+        await batch.Execute();
+
+        (await existsHit).ShouldBeTrue();
+        (await existsMiss).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Add GroupBy LINQ operator support with anonymous type and `IGrouping<TKey, TElement>` result handling
- Add `CheckExistsAsync<T>(id)` for efficient existence checks by document ID (supports Guid, int, long, string, and strong-typed IDs)
- Add `AssignTagWhere` operation for DCB event tagging with arbitrary where clauses
- Add `EventsExistByTags` batch query operation for checking event existence by tags

## Test plan
- [x] GroupBy operator tests (`LinqTests/Operators/group_by_operator.cs`)
- [x] CheckExists tests (`DocumentDbTests/Reading/check_document_exists.cs`)
- [x] CheckExists with strong-typed IDs (`ValueTypeTests/check_exists_with_strong_typed_ids.cs`)
- [x] AssignTagWhere tests (`EventSourcingTests/Dcb/assign_tag_where_tests.cs`)
- [x] EventsExistByTags tests (`EventSourcingTests/Dcb/dcb_tag_query_and_consistency_tests.cs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)