### PR TITLE
Add MCP server for event store configuration

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -100,6 +100,7 @@ const config: UserConfig<DefaultTheme.Config> = {
             { text: 'Multi-Tenancy with Database per Tenant', link: '/configuration/multitenancy' },
             { text: 'Environment Checks', link: '/configuration/environment-checks' },
             { text: 'Custom IoC Integration', link: '/configuration/ioc' },
+            { text: 'MCP Server', link: '/configuration/mcp' },
           ]
         },
         {

--- a/docs/configuration/mcp.md
+++ b/docs/configuration/mcp.md
@@ -1,0 +1,167 @@
+# MCP Server
+
+Marten ships with a built-in [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that exposes your event store configuration as read-only tools. This lets AI assistants and agents introspect your Marten setup for diagnostics, code generation guidance, and operational visibility.
+
+The MCP server uses the **Streamable HTTP** transport (stateless POST-based JSON-RPC) and is implemented as ASP.NET Core Minimal API endpoints in the `Marten.AspNetCore` package.
+
+## Installation
+
+Install the `Marten.AspNetCore` NuGet package:
+
+```bash
+dotnet add package Marten.AspNetCore
+```
+
+## Setup
+
+Register the MCP endpoints in your ASP.NET Core application:
+
+```csharp
+using Marten.AspNetCore;
+
+var app = builder.Build();
+
+app.MapMartenMcp();
+```
+
+This registers a single POST endpoint at `/marten/mcp/` that handles all MCP JSON-RPC requests.
+
+### Custom Route Prefix
+
+You can change the default route prefix:
+
+```csharp
+app.MapMartenMcp("/api/marten-mcp");
+```
+
+## Authorization
+
+`MapMartenMcp()` returns a `RouteGroupBuilder`, so you can chain standard ASP.NET Core endpoint configuration including authorization policies:
+
+```csharp
+app.MapMartenMcp()
+    .RequireAuthorization("AdminPolicy");
+```
+
+Or with a specific authorization policy:
+
+```csharp
+app.MapMartenMcp()
+    .RequireAuthorization(policy =>
+    {
+        policy.RequireRole("admin");
+    });
+```
+
+::: warning
+The MCP endpoints expose internal configuration details about your event store schema, projections, and event types. You **should** apply authorization to these endpoints in production environments.
+:::
+
+## Available Tools
+
+The MCP server exposes five read-only tools:
+
+### get_event_store_configuration
+
+Returns the full event store options snapshot including:
+
+| Property | Description |
+| :--- | :--- |
+| `streamIdentity` | `AsGuid` or `AsString` |
+| `tenancyStyle` | `Single` or `Conjoined` |
+| `appendMode` | `Quick` or `Rich` |
+| `eventNamingStyle` | Event type naming convention |
+| `databaseSchemaName` | Schema for event tables |
+| `enableUniqueIndexOnEventId` | Whether Event.Id has a unique index |
+| `useArchivedStreamPartitioning` | PostgreSQL list partitioning for archived streams |
+| `useOptimizedProjectionRebuilds` | Optimized projection rebuild support |
+| `useMandatoryStreamTypeDeclaration` | Whether stream type is required |
+| `enableAdvancedAsyncTracking` | Advanced async projection tracking |
+| `enableSideEffectsOnInlineProjections` | Side effects on inline projections |
+| `useMonitoredAdvisoryLock` | Advisory lock monitoring for HotCold daemon |
+| `enableEventSkippingInProjectionsOrSubscriptions` | Event skipping support |
+
+### get_event_metadata_configuration
+
+Returns which optional event metadata fields are enabled:
+
+| Property | Description |
+| :--- | :--- |
+| `correlationIdEnabled` | Correlation ID tracking |
+| `causationIdEnabled` | Causation ID tracking |
+| `headersEnabled` | Custom event headers |
+| `userNameEnabled` | User name / "last modified by" tracking |
+
+### list_known_event_types
+
+Lists all event types registered with the event store. Each entry includes:
+
+| Property | Description |
+| :--- | :--- |
+| `eventTypeName` | The alias stored in the database `type` column (e.g. `members_joined`) |
+| `dotNetTypeName` | The full .NET type name |
+
+### list_projections
+
+Lists all projections and subscriptions. Each entry includes:
+
+| Property | Description |
+| :--- | :--- |
+| `name` | Projection class name |
+| `implementationType` | Full .NET type name |
+| `type` | Subscription type (e.g. `Snapshot`, `MultiStream`, `FlatTableProjection`) |
+| `shards` | Array of shard identifiers |
+
+### get_daemon_settings
+
+Returns the async projection daemon configuration:
+
+| Property | Description |
+| :--- | :--- |
+| `asyncMode` | Daemon mode (`Disabled`, `Solo`, `HotCold`) |
+| `slowPollingTime` | Slow polling interval in milliseconds |
+| `fastPollingTime` | Fast polling interval in milliseconds |
+| `healthCheckPollingTime` | Health check polling interval in milliseconds |
+| `staleSequenceThreshold` | Stale sequence detection threshold in milliseconds |
+
+## MCP Protocol Details
+
+The endpoint implements the MCP [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http). All requests are JSON-RPC 2.0 POST requests to the single endpoint.
+
+### Supported Methods
+
+| Method | Description |
+| :--- | :--- |
+| `initialize` | Handshake — returns server capabilities |
+| `tools/list` | Lists available tools with descriptions and input schemas |
+| `tools/call` | Executes a tool by name and returns results |
+
+### Example Request
+
+```bash
+curl -X POST http://localhost:5000/marten/mcp/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": { "name": "get_event_store_configuration" }
+  }'
+```
+
+### Example Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"streamIdentity\":\"AsGuid\",\"tenancyStyle\":\"Single\",\"appendMode\":\"Quick\",...}"
+      }
+    ]
+  }
+}
+```

--- a/src/IssueService/Startup.cs
+++ b/src/IssueService/Startup.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using IssueService.Controllers;
 using JasperFx.Events;
 using Marten;
+using Marten.AspNetCore;
 using Marten.Events.Projections;
 using Marten.Testing.Harness;
 using Microsoft.AspNetCore.Builder;
@@ -82,6 +83,7 @@ public class Startup
         app.UseEndpoints(endpoints =>
         {
             endpoints.MapControllers();
+            endpoints.MapMartenMcp();
         });
     }
 }

--- a/src/Marten.AspNetCore.Testing/mcp_endpoint_tests.cs
+++ b/src/Marten.AspNetCore.Testing/mcp_endpoint_tests.cs
@@ -1,0 +1,223 @@
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Alba;
+using Shouldly;
+using Xunit;
+
+namespace Marten.AspNetCore.Testing;
+
+[Collection("integration")]
+public class mcp_endpoint_tests: IntegrationContext
+{
+    private readonly IAlbaHost theHost;
+
+    public mcp_endpoint_tests(AppFixture fixture) : base(fixture)
+    {
+        theHost = fixture.Host;
+    }
+
+    private async Task<JsonDocument> SendMcpRequest(string method, object? @params = null)
+    {
+        var request = new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method,
+            @params
+        };
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Post.Json(request).ToUrl("/marten/mcp/");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var body = result.ReadAsText();
+        return JsonDocument.Parse(body);
+    }
+
+    [Fact]
+    public async Task can_initialize()
+    {
+        using var doc = await SendMcpRequest("initialize");
+
+        var root = doc.RootElement;
+        root.GetProperty("jsonrpc").GetString().ShouldBe("2.0");
+        root.GetProperty("id").GetInt32().ShouldBe(1);
+
+        var result = root.GetProperty("result");
+        result.GetProperty("protocolVersion").GetString().ShouldNotBeNullOrEmpty();
+
+        var capabilities = result.GetProperty("capabilities");
+        capabilities.TryGetProperty("tools", out _).ShouldBeTrue();
+
+        var serverInfo = result.GetProperty("serverInfo");
+        serverInfo.GetProperty("name").GetString().ShouldBe("marten");
+    }
+
+    [Fact]
+    public async Task can_list_tools()
+    {
+        using var doc = await SendMcpRequest("tools/list");
+
+        var tools = doc.RootElement.GetProperty("result").GetProperty("tools");
+        tools.GetArrayLength().ShouldBeGreaterThanOrEqualTo(5);
+
+        var toolNames = tools.EnumerateArray()
+            .Select(t => t.GetProperty("name").GetString())
+            .ToList();
+
+        toolNames.ShouldContain("get_event_store_configuration");
+        toolNames.ShouldContain("get_event_metadata_configuration");
+        toolNames.ShouldContain("list_known_event_types");
+        toolNames.ShouldContain("list_projections");
+        toolNames.ShouldContain("get_daemon_settings");
+
+        // Each tool should have a description and input schema
+        foreach (var tool in tools.EnumerateArray())
+        {
+            tool.GetProperty("description").GetString().ShouldNotBeNullOrEmpty();
+            tool.GetProperty("inputSchema").GetProperty("type").GetString().ShouldBe("object");
+        }
+    }
+
+    [Fact]
+    public async Task can_get_event_store_configuration()
+    {
+        using var doc = await SendMcpRequest("tools/call",
+            new { name = "get_event_store_configuration" });
+
+        var content = doc.RootElement.GetProperty("result").GetProperty("content");
+        content.GetArrayLength().ShouldBe(1);
+
+        var text = content[0].GetProperty("text").GetString()!;
+        using var config = JsonDocument.Parse(text);
+        var root = config.RootElement;
+
+        root.GetProperty("streamIdentity").GetString().ShouldBe("AsGuid");
+        root.GetProperty("tenancyStyle").GetString().ShouldNotBeNullOrEmpty();
+        root.GetProperty("appendMode").GetString().ShouldNotBeNullOrEmpty();
+        root.GetProperty("eventNamingStyle").GetString().ShouldNotBeNullOrEmpty();
+        root.GetProperty("databaseSchemaName").GetString().ShouldNotBeNullOrEmpty();
+
+        // Boolean flags should be present
+        root.TryGetProperty("enableUniqueIndexOnEventId", out _).ShouldBeTrue();
+        root.TryGetProperty("useArchivedStreamPartitioning", out _).ShouldBeTrue();
+        root.TryGetProperty("useOptimizedProjectionRebuilds", out _).ShouldBeTrue();
+        root.TryGetProperty("useMandatoryStreamTypeDeclaration", out _).ShouldBeTrue();
+        root.TryGetProperty("enableAdvancedAsyncTracking", out _).ShouldBeTrue();
+        root.TryGetProperty("enableSideEffectsOnInlineProjections", out _).ShouldBeTrue();
+        root.TryGetProperty("useMonitoredAdvisoryLock", out _).ShouldBeTrue();
+        root.TryGetProperty("enableEventSkippingInProjectionsOrSubscriptions", out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task can_get_event_metadata_configuration()
+    {
+        using var doc = await SendMcpRequest("tools/call",
+            new { name = "get_event_metadata_configuration" });
+
+        var content = doc.RootElement.GetProperty("result").GetProperty("content");
+        var text = content[0].GetProperty("text").GetString()!;
+        using var config = JsonDocument.Parse(text);
+        var root = config.RootElement;
+
+        root.TryGetProperty("correlationIdEnabled", out _).ShouldBeTrue();
+        root.TryGetProperty("causationIdEnabled", out _).ShouldBeTrue();
+        root.TryGetProperty("headersEnabled", out _).ShouldBeTrue();
+        root.TryGetProperty("userNameEnabled", out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task can_list_known_event_types()
+    {
+        using var doc = await SendMcpRequest("tools/call",
+            new { name = "list_known_event_types" });
+
+        var content = doc.RootElement.GetProperty("result").GetProperty("content");
+        content.GetArrayLength().ShouldBe(1);
+        content[0].GetProperty("type").GetString().ShouldBe("text");
+
+        var text = content[0].GetProperty("text").GetString()!;
+        using var eventTypes = JsonDocument.Parse(text);
+        // Should at minimum have the Archived event type
+        eventTypes.RootElement.GetArrayLength().ShouldBeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task can_list_projections()
+    {
+        using var doc = await SendMcpRequest("tools/call",
+            new { name = "list_projections" });
+
+        var content = doc.RootElement.GetProperty("result").GetProperty("content");
+        var text = content[0].GetProperty("text").GetString()!;
+        using var projections = JsonDocument.Parse(text);
+
+        // IssueService registers a Snapshot<Order> inline projection
+        projections.RootElement.GetArrayLength().ShouldBeGreaterThanOrEqualTo(1);
+
+        var first = projections.RootElement[0];
+        first.TryGetProperty("name", out _).ShouldBeTrue();
+        first.TryGetProperty("implementationType", out _).ShouldBeTrue();
+        first.TryGetProperty("type", out _).ShouldBeTrue();
+        first.TryGetProperty("shards", out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task can_get_daemon_settings()
+    {
+        using var doc = await SendMcpRequest("tools/call",
+            new { name = "get_daemon_settings" });
+
+        var content = doc.RootElement.GetProperty("result").GetProperty("content");
+        var text = content[0].GetProperty("text").GetString()!;
+        using var config = JsonDocument.Parse(text);
+        var root = config.RootElement;
+
+        root.GetProperty("asyncMode").GetString().ShouldNotBeNullOrEmpty();
+        root.GetProperty("slowPollingTime").GetDouble().ShouldBeGreaterThan(0);
+        root.GetProperty("fastPollingTime").GetDouble().ShouldBeGreaterThan(0);
+        root.GetProperty("healthCheckPollingTime").GetDouble().ShouldBeGreaterThan(0);
+        root.GetProperty("staleSequenceThreshold").GetDouble().ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task returns_error_for_unknown_method()
+    {
+        using var doc = await SendMcpRequest("nonexistent/method");
+
+        var error = doc.RootElement.GetProperty("error");
+        error.GetProperty("code").GetInt32().ShouldBe(-32601);
+        error.GetProperty("message").GetString().ShouldContain("Method not found");
+    }
+
+    [Fact]
+    public async Task returns_error_for_unknown_tool()
+    {
+        using var doc = await SendMcpRequest("tools/call",
+            new { name = "nonexistent_tool" });
+
+        var error = doc.RootElement.GetProperty("error");
+        error.GetProperty("code").GetInt32().ShouldBe(-32602);
+        error.GetProperty("message").GetString().ShouldContain("Unknown tool");
+    }
+
+    [Fact]
+    public async Task returns_parse_error_for_invalid_json()
+    {
+        var result = await theHost.Scenario(s =>
+        {
+            s.Post.Text("this is not json").ToUrl("/marten/mcp/");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var body = result.ReadAsText();
+        using var doc = JsonDocument.Parse(body);
+        var error = doc.RootElement.GetProperty("error");
+        error.GetProperty("code").GetInt32().ShouldBe(-32700);
+    }
+}

--- a/src/Marten.AspNetCore/McpEndpointExtensions.cs
+++ b/src/Marten.AspNetCore/McpEndpointExtensions.cs
@@ -1,0 +1,342 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten.Events;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Marten.AspNetCore;
+
+public static class McpEndpointExtensions
+{
+    private const string McpProtocolVersion = "2025-03-26";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// Maps MCP (Model Context Protocol) endpoints that expose read-only event store configuration
+    /// as MCP tools. Returns a <see cref="RouteGroupBuilder"/> so callers can apply authorization
+    /// policies, rate limiting, or other endpoint metadata.
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder</param>
+    /// <param name="pattern">The route prefix for MCP endpoints. Defaults to "/marten/mcp".</param>
+    /// <returns>A <see cref="RouteGroupBuilder"/> for further configuration (e.g. RequireAuthorization)</returns>
+    public static RouteGroupBuilder MapMartenMcp(
+        this IEndpointRouteBuilder endpoints,
+        string pattern = "/marten/mcp")
+    {
+        var group = endpoints.MapGroup(pattern);
+
+        group.MapPost("/", HandleMcpRequest);
+
+        return group;
+    }
+
+    private static async Task HandleMcpRequest(HttpContext context)
+    {
+        JsonRpcRequest? request;
+        try
+        {
+            request = await JsonSerializer.DeserializeAsync<JsonRpcRequest>(
+                context.Request.Body, JsonOptions, context.RequestAborted).ConfigureAwait(false);
+        }
+        catch
+        {
+            await WriteJsonRpcError(context, null, -32700, "Parse error").ConfigureAwait(false);
+            return;
+        }
+
+        if (request == null)
+        {
+            await WriteJsonRpcError(context, null, -32600, "Invalid Request").ConfigureAwait(false);
+            return;
+        }
+
+        switch (request.Method)
+        {
+            case "initialize":
+                await HandleInitialize(context, request).ConfigureAwait(false);
+                break;
+            case "tools/list":
+                await HandleToolsList(context, request).ConfigureAwait(false);
+                break;
+            case "tools/call":
+                await HandleToolsCall(context, request).ConfigureAwait(false);
+                break;
+            default:
+                await WriteJsonRpcError(context, request.Id, -32601, $"Method not found: {request.Method}").ConfigureAwait(false);
+                break;
+        }
+    }
+
+    private static Task HandleInitialize(HttpContext context, JsonRpcRequest request)
+    {
+        var result = new
+        {
+            protocolVersion = McpProtocolVersion,
+            capabilities = new
+            {
+                tools = new { }
+            },
+            serverInfo = new
+            {
+                name = "marten",
+                version = "1.0.0"
+            }
+        };
+
+        return WriteJsonRpcResult(context, request.Id, result);
+    }
+
+    private static Task HandleToolsList(HttpContext context, JsonRpcRequest request)
+    {
+        var tools = new[]
+        {
+            new McpToolDefinition
+            {
+                Name = "get_event_store_configuration",
+                Description =
+                    "Returns the current Marten event store configuration including stream identity, tenancy style, append mode, schema name, and all feature flags.",
+                InputSchema = new McpToolInputSchema
+                {
+                    Type = "object", Properties = new Dictionary<string, object>()
+                }
+            },
+            new McpToolDefinition
+            {
+                Name = "get_event_metadata_configuration",
+                Description =
+                    "Returns which optional event metadata fields are enabled (correlation ID, causation ID, headers, user name).",
+                InputSchema = new McpToolInputSchema
+                {
+                    Type = "object", Properties = new Dictionary<string, object>()
+                }
+            },
+            new McpToolDefinition
+            {
+                Name = "list_known_event_types",
+                Description =
+                    "Lists all event types registered with the Marten event store, including their type name aliases and .NET type names.",
+                InputSchema = new McpToolInputSchema
+                {
+                    Type = "object", Properties = new Dictionary<string, object>()
+                }
+            },
+            new McpToolDefinition
+            {
+                Name = "list_projections",
+                Description =
+                    "Lists all projections and subscriptions configured in the Marten event store, including their lifecycle and shard information.",
+                InputSchema = new McpToolInputSchema
+                {
+                    Type = "object", Properties = new Dictionary<string, object>()
+                }
+            },
+            new McpToolDefinition
+            {
+                Name = "get_daemon_settings",
+                Description =
+                    "Returns the async projection daemon configuration settings.",
+                InputSchema = new McpToolInputSchema
+                {
+                    Type = "object", Properties = new Dictionary<string, object>()
+                }
+            }
+        };
+
+        return WriteJsonRpcResult(context, request.Id, new { tools });
+    }
+
+    private static Task HandleToolsCall(HttpContext context, JsonRpcRequest request)
+    {
+        var store = context.RequestServices.GetRequiredService<IDocumentStore>();
+        var options = store.Options.Events;
+
+        string? toolName = null;
+        if (request.Params is JsonElement paramsElement &&
+            paramsElement.TryGetProperty("name", out var nameElement))
+        {
+            toolName = nameElement.GetString();
+        }
+
+        return toolName switch
+        {
+            "get_event_store_configuration" => HandleGetEventStoreConfiguration(context, request, options),
+            "get_event_metadata_configuration" => HandleGetEventMetadataConfiguration(context, request, options),
+            "list_known_event_types" => HandleListKnownEventTypes(context, request, options),
+            "list_projections" => HandleListProjections(context, request, options),
+            "get_daemon_settings" => HandleGetDaemonSettings(context, request, options),
+            _ => WriteJsonRpcError(context, request.Id, -32602, $"Unknown tool: {toolName}")
+        };
+    }
+
+    private static Task HandleGetEventStoreConfiguration(
+        HttpContext context, JsonRpcRequest request, IReadOnlyEventStoreOptions options)
+    {
+        var config = new Dictionary<string, object>
+        {
+            ["streamIdentity"] = options.StreamIdentity.ToString(),
+            ["tenancyStyle"] = options.TenancyStyle.ToString(),
+            ["appendMode"] = options.AppendMode.ToString(),
+            ["eventNamingStyle"] = options.EventNamingStyle.ToString(),
+            ["databaseSchemaName"] = options.DatabaseSchemaName,
+            ["enableUniqueIndexOnEventId"] = options.EnableUniqueIndexOnEventId,
+            ["useArchivedStreamPartitioning"] = options.UseArchivedStreamPartitioning,
+            ["useOptimizedProjectionRebuilds"] = options.UseOptimizedProjectionRebuilds,
+            ["useMandatoryStreamTypeDeclaration"] = options.UseMandatoryStreamTypeDeclaration,
+            ["enableAdvancedAsyncTracking"] = options.EnableAdvancedAsyncTracking,
+            ["enableSideEffectsOnInlineProjections"] = options.EnableSideEffectsOnInlineProjections,
+            ["useMonitoredAdvisoryLock"] = options.UseMonitoredAdvisoryLock,
+            ["enableEventSkippingInProjectionsOrSubscriptions"] = options.EnableEventSkippingInProjectionsOrSubscriptions
+        };
+
+        var content = new[] { new McpTextContent { Text = JsonSerializer.Serialize(config, JsonOptions) } };
+        return WriteJsonRpcResult(context, request.Id, new { content });
+    }
+
+    private static Task HandleGetEventMetadataConfiguration(
+        HttpContext context, JsonRpcRequest request, IReadOnlyEventStoreOptions options)
+    {
+        var metadata = options.MetadataConfig;
+        var config = new Dictionary<string, object>
+        {
+            ["correlationIdEnabled"] = metadata.CorrelationIdEnabled,
+            ["causationIdEnabled"] = metadata.CausationIdEnabled,
+            ["headersEnabled"] = metadata.HeadersEnabled,
+            ["userNameEnabled"] = metadata.UserNameEnabled
+        };
+
+        var content = new[] { new McpTextContent { Text = JsonSerializer.Serialize(config, JsonOptions) } };
+        return WriteJsonRpcResult(context, request.Id, new { content });
+    }
+
+    private static Task HandleListKnownEventTypes(
+        HttpContext context, JsonRpcRequest request, IReadOnlyEventStoreOptions options)
+    {
+        var eventTypes = options.AllKnownEventTypes().Select(et => new Dictionary<string, string>
+        {
+            ["eventTypeName"] = et.EventTypeName,
+            ["dotNetTypeName"] = et.DotNetTypeName
+        }).ToList();
+
+        var content = new[] { new McpTextContent { Text = JsonSerializer.Serialize(eventTypes, JsonOptions) } };
+        return WriteJsonRpcResult(context, request.Id, new { content });
+    }
+
+    private static Task HandleListProjections(
+        HttpContext context, JsonRpcRequest request, IReadOnlyEventStoreOptions options)
+    {
+        var projections = options.Projections().Select(p => new Dictionary<string, object>
+        {
+            ["name"] = p.ImplementationType.Name,
+            ["implementationType"] = p.ImplementationType.FullName ?? p.ImplementationType.Name,
+            ["type"] = p.Type.ToString(),
+            ["shards"] = p.ShardNames().Select(s => s.Identity).ToArray()
+        }).ToList();
+
+        var content = new[] { new McpTextContent { Text = JsonSerializer.Serialize(projections, JsonOptions) } };
+        return WriteJsonRpcResult(context, request.Id, new { content });
+    }
+
+    private static Task HandleGetDaemonSettings(
+        HttpContext context, JsonRpcRequest request, IReadOnlyEventStoreOptions options)
+    {
+        var daemon = options.Daemon;
+        var config = new Dictionary<string, object>
+        {
+            ["asyncMode"] = daemon.AsyncMode.ToString(),
+            ["slowPollingTime"] = daemon.SlowPollingTime.TotalMilliseconds,
+            ["fastPollingTime"] = daemon.FastPollingTime.TotalMilliseconds,
+            ["healthCheckPollingTime"] = daemon.HealthCheckPollingTime.TotalMilliseconds,
+            ["staleSequenceThreshold"] = daemon.StaleSequenceThreshold.TotalMilliseconds
+        };
+
+        var content = new[] { new McpTextContent { Text = JsonSerializer.Serialize(config, JsonOptions) } };
+        return WriteJsonRpcResult(context, request.Id, new { content });
+    }
+
+    private static async Task WriteJsonRpcResult(HttpContext context, object? id, object result)
+    {
+        context.Response.ContentType = "application/json";
+        context.Response.StatusCode = 200;
+
+        var response = new JsonRpcResponse { Id = id, Result = result };
+        await JsonSerializer.SerializeAsync(context.Response.Body, response, JsonOptions, context.RequestAborted).ConfigureAwait(false);
+    }
+
+    private static async Task WriteJsonRpcError(HttpContext context, object? id, int code, string message)
+    {
+        context.Response.ContentType = "application/json";
+        context.Response.StatusCode = 200;
+
+        var response = new JsonRpcErrorResponse
+        {
+            Id = id,
+            Error = new JsonRpcErrorDetail { Code = code, Message = message }
+        };
+        await JsonSerializer.SerializeAsync(context.Response.Body, response, JsonOptions, context.RequestAborted).ConfigureAwait(false);
+    }
+
+    #region JSON-RPC types
+
+    internal class JsonRpcRequest
+    {
+        [JsonPropertyName("jsonrpc")] public string Jsonrpc { get; set; } = "2.0";
+        [JsonPropertyName("id")] public object? Id { get; set; }
+        [JsonPropertyName("method")] public string Method { get; set; } = "";
+        [JsonPropertyName("params")] public object? Params { get; set; }
+    }
+
+    internal class JsonRpcResponse
+    {
+        [JsonPropertyName("jsonrpc")] public string Jsonrpc { get; set; } = "2.0";
+        [JsonPropertyName("id")] public object? Id { get; set; }
+        [JsonPropertyName("result")] public object? Result { get; set; }
+    }
+
+    internal class JsonRpcErrorResponse
+    {
+        [JsonPropertyName("jsonrpc")] public string Jsonrpc { get; set; } = "2.0";
+        [JsonPropertyName("id")] public object? Id { get; set; }
+        [JsonPropertyName("error")] public JsonRpcErrorDetail? Error { get; set; }
+    }
+
+    internal class JsonRpcErrorDetail
+    {
+        [JsonPropertyName("code")] public int Code { get; set; }
+        [JsonPropertyName("message")] public string Message { get; set; } = "";
+    }
+
+    internal class McpToolDefinition
+    {
+        [JsonPropertyName("name")] public string Name { get; set; } = "";
+        [JsonPropertyName("description")] public string Description { get; set; } = "";
+        [JsonPropertyName("inputSchema")] public McpToolInputSchema InputSchema { get; set; } = new();
+    }
+
+    internal class McpToolInputSchema
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = "object";
+        [JsonPropertyName("properties")] public Dictionary<string, object> Properties { get; set; } = new();
+    }
+
+    internal class McpTextContent
+    {
+        [JsonPropertyName("type")] public string Type { get; set; } = "text";
+        [JsonPropertyName("text")] public string Text { get; set; } = "";
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Add MCP (Model Context Protocol) Streamable HTTP server in `Marten.AspNetCore` via `MapMartenMcp()`
- Exposes `IReadOnlyEventStoreOptions` as 5 read-only MCP tools: event store config, metadata config, known event types, projections, and daemon settings
- Returns `RouteGroupBuilder` for authorization policy chaining
- Hand-rolled JSON-RPC 2.0 implementation with no external MCP SDK dependency

## Test plan
- [x] 10 Alba-based integration tests covering all tools, error handling, and protocol compliance
- [x] All 38 existing AspNetCore tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)