### PR TITLE
feat: PostgreSQL LISTEN/NOTIFY support for async daemon wakeup

### DIFF
--- a/src/Marten/Events/Daemon/HighWater/PostgresqlListenWakeup.cs
+++ b/src/Marten/Events/Daemon/HighWater/PostgresqlListenWakeup.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Daemon.HighWater;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+namespace Marten.Events.Daemon.HighWater;
+
+/// <summary>
+/// Uses PostgreSQL LISTEN/NOTIFY to wake the <see cref="HighWaterAgent"/>
+/// immediately when new events are appended, instead of waiting for the
+/// full polling interval. Falls back to the configured timeout if no
+/// notification arrives.
+/// </summary>
+public sealed class PostgresqlListenWakeup : IHighWaterWakeup
+{
+    /// <summary>
+    /// The default PostgreSQL notification channel name used by Marten
+    /// to signal that new events have been appended to the event store.
+    /// </summary>
+    public const string DefaultChannel = "mt_events_appended";
+
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly ILogger _logger;
+    private readonly string _channel;
+    private NpgsqlConnection? _connection;
+    private readonly SemaphoreSlim _signal = new(0);
+    private bool _disposed;
+
+    public PostgresqlListenWakeup(NpgsqlDataSource dataSource, ILogger logger, string channel = DefaultChannel)
+    {
+        _dataSource = dataSource;
+        _logger = logger;
+        _channel = channel;
+    }
+
+    public async Task WaitAsync(TimeSpan timeout, CancellationToken token)
+    {
+        await ensureListeningAsync(token).ConfigureAwait(false);
+
+        // Wait for either a NOTIFY signal or the timeout
+        try
+        {
+            await _signal.WaitAsync(timeout, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            // Timeout elapsed — this is normal, fall through to let the caller poll
+        }
+    }
+
+    private async Task ensureListeningAsync(CancellationToken token)
+    {
+        if (_connection != null)
+        {
+            return;
+        }
+
+        _connection = await _dataSource.OpenConnectionAsync(token).ConfigureAwait(false);
+        _connection.Notification += onNotification;
+
+        await using var cmd = _connection.CreateCommand();
+        cmd.CommandText = $"LISTEN {_channel}";
+        await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+
+        _logger.LogInformation("Listening on PostgreSQL channel '{Channel}' for event store notifications", _channel);
+
+        // Start a background loop to consume notifications.
+        // Npgsql requires WaitAsync to be called to receive notifications.
+        _ = Task.Run(() => receiveLoop(token), token);
+    }
+
+    private async Task receiveLoop(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested && !_disposed)
+        {
+            try
+            {
+                // WaitAsync blocks until a notification arrives or the timeout elapses.
+                // We use a long timeout here as a keepalive; actual wakeup happens via _signal.
+                await _connection!.WaitAsync(TimeSpan.FromSeconds(30), token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested || _disposed)
+            {
+                return;
+            }
+            catch (NpgsqlException ex)
+            {
+                _logger.LogWarning(ex, "PostgreSQL LISTEN connection error, will attempt to reconnect");
+                await reconnectAsync(token).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error in PostgreSQL LISTEN receive loop");
+                await Task.Delay(TimeSpan.FromSeconds(1), token).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private void onNotification(object sender, NpgsqlNotificationEventArgs e)
+    {
+        _signal.Release();
+    }
+
+    private async Task reconnectAsync(CancellationToken token)
+    {
+        try
+        {
+            if (_connection != null)
+            {
+                _connection.Notification -= onNotification;
+                await _connection.DisposeAsync().ConfigureAwait(false);
+                _connection = null;
+            }
+
+            await ensureListeningAsync(token).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to reconnect PostgreSQL LISTEN connection");
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        if (_connection != null)
+        {
+            _connection.Notification -= onNotification;
+            _connection.Dispose();
+            _connection = null;
+        }
+
+        _signal.Dispose();
+    }
+}

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -201,6 +201,7 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     public bool EnableAdvancedAsyncTracking { get; set; }
     public bool EnableEventSkippingInProjectionsOrSubscriptions { get; set; }
     public bool UseArchivedStreamPartitioning { get; set; }
+    public bool UseListenNotifyForEventAppends { get; set; }
     public IMessageOutbox MessageOutbox { get; set; } = new NulloMessageOutbox();
 
 

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -119,6 +119,14 @@ namespace Marten.Events
         public bool EnableEventSkippingInProjectionsOrSubscriptions { get; set; }
 
         /// <summary>
+        /// When enabled, uses PostgreSQL LISTEN/NOTIFY to wake the async projection daemon
+        /// immediately when new events are appended, instead of relying solely on polling.
+        /// This provides near-instant projection updates while still falling back to polling
+        /// as a safety net. Default is false.
+        /// </summary>
+        public bool UseListenNotifyForEventAppends { get; set; }
+
+        /// <summary>
         ///     Register an event type with Marten. This isn't strictly necessary for normal usage,
         ///     but can help Marten with asynchronous projections where Marten hasn't yet encountered
         ///     the event type. It can also be used for the event namespace migration.

--- a/src/Marten/Events/Schema/QuickAppendEventFunction.cs
+++ b/src/Marten/Events/Schema/QuickAppendEventFunction.cs
@@ -134,6 +134,8 @@ BEGIN
 
 	update {databaseSchema}.mt_streams set version = event_version, timestamp = now() where {streamsWhere};
 
+	PERFORM pg_notify('mt_events_appended', '');
+
 	return return_value;
 END
 $$ LANGUAGE plpgsql;

--- a/src/Marten/Storage/MartenDatabase.EventStorage.cs
+++ b/src/Marten/Storage/MartenDatabase.EventStorage.cs
@@ -288,6 +288,12 @@ select last_value from {Options.Events.DatabaseSchemaName}.mt_events_sequence;
         logger ??= store.Options.LogFactory?.CreateLogger<ProjectionDaemon>() ??
                    store.Options.DotNetLogger ?? NullLogger.Instance;
 
+        if (Options.EventGraph.UseListenNotifyForEventAppends)
+        {
+            store.Options.Projections.Wakeup =
+                new PostgresqlListenWakeup(DataSource, logger);
+        }
+
         var detector = new HighWaterDetector(this, Options.EventGraph, logger);
 
         return new ProjectionDaemon(store, this, logger, detector);


### PR DESCRIPTION
## Summary

- Adds `pg_notify('mt_events_appended', '')` to the `mt_quick_append_events` SQL function so PostgreSQL fires a notification whenever events are appended
- Implements `PostgresqlListenWakeup` (using Npgsql's LISTEN support) that wakes the `HighWaterAgent` immediately on notification, with fallback to the configured polling interval
- Adds `UseListenNotifyForEventAppends` option to `IEventStoreOptions` / `EventGraph` to opt in
- Wires it up automatically in `StartProjectionDaemon` when the option is enabled

### Depends on

This PR requires JasperFx/jasperfx#164 which adds the `IHighWaterWakeup` extension point to the async daemon's `HighWaterAgent`.

### Usage

```csharp
builder.Services.AddMarten(opts =>
{
    opts.Events.UseListenNotifyForEventAppends = true;
    // ... other config
});
```

This reduces async projection latency from the polling interval (default 250ms-1s) to near-zero when events are appended, while maintaining polling as a safety fallback.