### PR TITLE
Fix GroupJoin CTE missing join key columns with QueryOnly storage

### DIFF
--- a/src/LinqTests/Operators/group_join_operator.cs
+++ b/src/LinqTests/Operators/group_join_operator.cs
@@ -549,4 +549,59 @@ public class group_join_operator: OneOffConfigurationsContext
     }
 
     #endregion
+
+    #region QuerySession (QueryOnly storage) Tests
+
+    [Fact]
+    public async Task GroupJoin_left_join_on_id_with_query_session()
+    {
+        await SetupData();
+
+        // Use QuerySession (QueryOnly storage) where IdColumn.ShouldSelect returns false.
+        // This verifies that d.id is included in the CTE SELECT list even though
+        // QueryOnly storage normally excludes it.
+        await using var querySession = _store.QuerySession();
+
+        var results = await querySession.Query<JoinCustomer>()
+            .GroupJoin(
+                querySession.Query<JoinOrder>(),
+                c => c.Id,
+                o => o.CustomerId,
+                (c, orders) => new { c, orders })
+            .SelectMany(
+                x => x.orders.DefaultIfEmpty(),
+                (x, o) => new { CustomerName = x.c.Name, OrderStatus = (string?)o.Status })
+            .ToListAsync();
+
+        results.Count.ShouldBe(4); // Alice(2) + Bob(1) + Charlie(1 null)
+        results.Count(r => r.CustomerName == "Alice").ShouldBe(2);
+        results.Count(r => r.CustomerName == "Bob").ShouldBe(1);
+
+        var charlie = results.Single(r => r.CustomerName == "Charlie");
+        charlie.OrderStatus.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GroupJoin_inner_join_on_id_with_query_session()
+    {
+        await SetupData();
+
+        await using var querySession = _store.QuerySession();
+
+        var results = await querySession.Query<JoinCustomer>()
+            .GroupJoin(
+                querySession.Query<JoinOrder>(),
+                c => c.Id,
+                o => o.CustomerId,
+                (c, orders) => new { c, orders })
+            .SelectMany(
+                x => x.orders,
+                (x, o) => new { x.c.Name, o.Amount })
+            .ToListAsync();
+
+        results.Count.ShouldBe(3);
+        results.Count(r => r.Name == "Alice").ShouldBe(2);
+    }
+
+    #endregion
 }

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -460,7 +460,15 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
 
 internal class DuplicatedFieldSelectClause: ISelectClause, IModifyableFromObject
 {
-    private readonly string[] _selectFields;
+    private string[] _selectFields;
+
+    internal void EnsureColumn(string columnLocator)
+    {
+        if (!_selectFields.Contains(columnLocator))
+        {
+            _selectFields = [.._selectFields, columnLocator];
+        }
+    }
     private readonly IDocumentStorage _parent;
 
     public DuplicatedFieldSelectClause(string fromObject, string selector, string[] selectFields, Type selectedType,

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -303,6 +303,11 @@ public partial class CollectionUsage
         var outerKeyMember = outerCollection.MemberFor(groupJoin.OuterKeySelector.Body);
         var innerKeyMember = innerCollection.MemberFor(groupJoin.InnerKeySelector.Body);
 
+        // Ensure join key columns are present in CTE SELECT lists (they may be
+        // excluded when using QueryOnly storage, e.g. d.id is omitted by IdColumn)
+        EnsureJoinKeyInCte(outerStatement, outerStorage, outerKeyMember.TypedLocator);
+        EnsureJoinKeyInCte(innerStatement, innerStorage, innerKeyMember.TypedLocator);
+
         // Replace d. prefix with CTE aliases for the ON clause
         var outerKeyLocator = outerKeyMember.TypedLocator.Replace("d.", outerCteAlias + ".");
         var innerKeyLocator = innerKeyMember.TypedLocator.Replace("d.", innerCteAlias + ".");
@@ -689,6 +694,30 @@ public partial class CollectionUsage
                     throw new BadLinqExpressionException("See https://github.com/JasperFx/marten/issues/2704");
                 }
             }
+        }
+    }
+
+    private static void EnsureJoinKeyInCte(SelectorStatement statement, IDocumentStorage storage, string keyLocator)
+    {
+        var selectClause = statement.SelectClause;
+        var currentFields = selectClause.SelectFields();
+
+        if (currentFields.Contains(keyLocator))
+        {
+            return;
+        }
+
+        if (selectClause is DuplicatedFieldSelectClause duplicatedClause)
+        {
+            duplicatedClause.EnsureColumn(keyLocator);
+        }
+        else
+        {
+            // When there are no duplicate fields, SelectClauseWithDuplicatedFields returns
+            // the storage itself. Wrap it in a DuplicatedFieldSelectClause to add the column.
+            var fields = currentFields.Append(keyLocator).ToArray();
+            statement.SelectClause = new DuplicatedFieldSelectClause(
+                selectClause.FromObject, string.Empty, fields, selectClause.SelectedType, storage);
         }
     }
 }


### PR DESCRIPTION
Fixes #4188

- When using `GroupJoin` with `IQuerySession` (QueryOnly storage), the generated CTE omitted `d.id` from its SELECT
list because `IdColumn.ShouldSelect()` returns `false` for `StorageStyle.QueryOnly`. This caused a `42703: column does
not exist` PostgreSQL error when the join key referenced the document's `Id`.
- Added `EnsureJoinKeyInCte()` to `CollectionUsage.Compilation.cs` which verifies that join key columns are present in
both CTE SELECT lists before building the JOIN clause, injecting them via
`DuplicatedFieldSelectClause.EnsureColumn()` if missing.
- Added `EnsureColumn()` method to `DuplicatedFieldSelectClause` to allow dynamically adding columns to the select
list.
- Added two regression tests covering left join and inner join on `Id` using `QuerySession`.

## Test plan

- [x] `GroupJoin_left_join_on_id_with_query_session` — verifies left join via `DefaultIfEmpty()` produces correct
results including null for unmatched rows
- [x] `GroupJoin_inner_join_on_id_with_query_session` — verifies inner join produces correct results excluding
unmatched rows
- [ ] Existing `GroupJoin` tests continue to pass (no regression for `IDocumentSession` usage)