### PR TITLE
Fix EventTagTable and NaturalKeyTable FK with UseArchivedStreamPartitioning

### DIFF
--- a/src/CoreTests/Bugs/Bug_4190_archived_partitioning_with_strong_typed_id.cs
+++ b/src/CoreTests/Bugs/Bug_4190_archived_partitioning_with_strong_typed_id.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Tags;
+using Marten;
+using Marten.Events.Schema;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tables;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+public class Bug_4190_archived_partitioning_with_strong_typed_id : BugIntegrationContext
+{
+    // Strongly-typed ID similar to Vogen-generated value types
+    public record EntityId(Guid Value);
+
+    [Fact]
+    public void event_tag_table_fk_correction_should_not_throw_with_archived_partitioning()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.UseArchivedStreamPartitioning = true;
+            opts.Events.RegisterTagType<EntityId>("entity");
+        });
+
+        var events = theStore.Options.EventGraph;
+        var schemaObjects = ((Weasel.Core.Migrations.IFeatureSchema)events).Objects;
+
+        var tagTable = schemaObjects.OfType<Table>()
+            .FirstOrDefault(t => t.Identifier.Name.Contains("mt_event_tag"));
+        tagTable.ShouldNotBeNull();
+
+        var eventsTable = schemaObjects.OfType<Table>()
+            .FirstOrDefault(t => t.Identifier.Name == "mt_events");
+        eventsTable.ShouldNotBeNull();
+
+        // Verify the events table PK includes is_archived when partitioned
+        eventsTable.PrimaryKeyColumns.ShouldContain("is_archived",
+            "mt_events PK should include is_archived when UseArchivedStreamPartitioning is enabled");
+
+        // The tag table should have is_archived column to satisfy the FK correction
+        var isArchivedCol = tagTable.Columns.FirstOrDefault(c => c.Name == "is_archived");
+        isArchivedCol.ShouldNotBeNull(
+            "EventTagTable should have is_archived column when UseArchivedStreamPartitioning is enabled");
+
+        // Explicitly test PostProcess doesn't throw
+        Should.NotThrow(() => tagTable.PostProcess(schemaObjects));
+    }
+
+    [Fact]
+    public async Task can_create_schema_with_archived_partitioning_and_tag_type()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.UseArchivedStreamPartitioning = true;
+            opts.Events.RegisterTagType<EntityId>("entity");
+        });
+
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+        await theStore.Storage.Database.AssertDatabaseMatchesConfigurationAsync();
+    }
+
+    [Fact]
+    public async Task schema_is_idempotent_with_archived_partitioning_and_tag_type()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.UseArchivedStreamPartitioning = true;
+            opts.Events.RegisterTagType<EntityId>("entity");
+        });
+
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var store2 = SeparateStore(opts =>
+        {
+            opts.Events.UseArchivedStreamPartitioning = true;
+            opts.Events.RegisterTagType<EntityId>("entity");
+        });
+
+        await store2.Storage.Database.AssertDatabaseMatchesConfigurationAsync();
+    }
+
+    [Fact]
+    public async Task can_create_schema_with_archived_partitioning_conjoined_tenancy_and_tag_type()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.UseArchivedStreamPartitioning = true;
+            opts.Events.TenancyStyle = Marten.Storage.TenancyStyle.Conjoined;
+            opts.Events.RegisterTagType<EntityId>("entity");
+        });
+
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+        await theStore.Storage.Database.AssertDatabaseMatchesConfigurationAsync();
+    }
+}

--- a/src/Marten/Events/Schema/EventTagTable.cs
+++ b/src/Marten/Events/Schema/EventTagTable.cs
@@ -1,5 +1,6 @@
 using System;
 using JasperFx.Events.Tags;
+using Marten.Events.Archiving;
 using Weasel.Postgresql;
 using Weasel.Postgresql.Tables;
 
@@ -14,8 +15,29 @@ internal class EventTagTable: Table
 
         // Composite primary key with value first for query performance
         AddColumn("value", pgType).NotNull().AsPrimaryKey();
-        AddColumn("seq_id", "bigint").NotNull().AsPrimaryKey()
-            .ForeignKeyTo(new PostgresqlObjectName(events.DatabaseSchemaName, "mt_events"), "seq_id");
+
+        if (events.UseArchivedStreamPartitioning)
+        {
+            // When mt_events is partitioned by is_archived, its PK includes is_archived.
+            // The FK must reference all PK columns, so we need is_archived in this table too.
+            AddColumn("seq_id", "bigint").NotNull().AsPrimaryKey();
+
+            var archiving = AddColumn<IsArchivedColumn>();
+            archiving.AsPrimaryKey();
+            archiving.PartitionByListValues().AddPartition("archived", true);
+
+            ForeignKeys.Add(new ForeignKey($"fkey_mt_event_tag_{registration.TableSuffix}_seq_id_is_archived")
+            {
+                ColumnNames = new[] { "seq_id", "is_archived" },
+                LinkedNames = new[] { "seq_id", "is_archived" },
+                LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, "mt_events")
+            });
+        }
+        else
+        {
+            AddColumn("seq_id", "bigint").NotNull().AsPrimaryKey()
+                .ForeignKeyTo(new PostgresqlObjectName(events.DatabaseSchemaName, "mt_events"), "seq_id");
+        }
 
         PrimaryKeyName = $"pk_mt_event_tag_{registration.TableSuffix}";
     }

--- a/src/Marten/Events/Schema/NaturalKeyTable.cs
+++ b/src/Marten/Events/Schema/NaturalKeyTable.cs
@@ -26,15 +26,6 @@ internal class NaturalKeyTable: Table
 
         AddColumn(streamCol, streamColType).NotNull();
 
-        // FK to mt_streams with CASCADE delete
-        ForeignKeys.Add(new ForeignKey($"fk_{Identifier.Name}_stream")
-        {
-            ColumnNames = new[] { streamCol },
-            LinkedNames = new[] { "id" },
-            LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, StreamsTable.TableName),
-            OnDelete = CascadeAction.Cascade
-        });
-
         // Tenancy support
         if (events.TenancyStyle == TenancyStyle.Conjoined)
         {
@@ -46,6 +37,26 @@ internal class NaturalKeyTable: Table
         if (events.UseArchivedStreamPartitioning)
         {
             archiving.PartitionByListValues().AddPartition("archived", true);
+
+            // FK to mt_streams must include is_archived when streams table is partitioned
+            ForeignKeys.Add(new ForeignKey($"fk_{Identifier.Name}_stream_is_archived")
+            {
+                ColumnNames = new[] { streamCol, "is_archived" },
+                LinkedNames = new[] { "id", "is_archived" },
+                LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, StreamsTable.TableName),
+                OnDelete = CascadeAction.Cascade
+            });
+        }
+        else
+        {
+            // FK to mt_streams with CASCADE delete
+            ForeignKeys.Add(new ForeignKey($"fk_{Identifier.Name}_stream")
+            {
+                ColumnNames = new[] { streamCol },
+                LinkedNames = new[] { "id" },
+                LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, StreamsTable.TableName),
+                OnDelete = CascadeAction.Cascade
+            });
         }
 
         // Index on stream id/key for reverse lookups


### PR DESCRIPTION
## Summary
- Fixes #4190 - `InvalidForeignKeyException` when using strongly-typed IDs with `UseArchivedStreamPartitioning = true`
- When `UseArchivedStreamPartitioning` is enabled, `mt_events` is list-partitioned by `is_archived`, adding it to the primary key. `EventTagTable` and `NaturalKeyTable` must include `is_archived` in their FK references and have the column present
- `EventTagTable`: adds `is_archived` column with list partitioning and includes it in the FK to `mt_events` when partitioning is enabled
- `NaturalKeyTable`: includes `is_archived` in the FK to `mt_streams` when partitioning is enabled (it already had the column)

## Test plan
- [x] Added `Bug_4190_archived_partitioning_with_strong_typed_id` tests verifying schema creation, FK correctness, and idempotency
- [x] All existing partitioning tests pass (30 in CoreTests)
- [x] All tag-related event sourcing tests pass (41 in EventSourcingTests)
- [x] CI should validate full test matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)