### PR TITLE
Add EventProjection alternative to flat table projection docs

### DIFF
--- a/docs/events/projections/flat.md
+++ b/docs/events/projections/flat.md
@@ -1,11 +1,11 @@
 # Flat Table Projections
 
-Marten has yet another projection recipe for writing event data to flat projections. 
+Marten has yet another projection recipe for writing event data to flat projections.
 
-Let’s dive right into a sample usage of this. If you’re a software developer long enough and move around just a little bit, 
-you’re going to get sucked into building a workflow for importing flat files of dubious quality from external partners or 
-customers. I’m going to claim that event sourcing is a good fit for this problem domain (and 
-also suggesting this pretty strongly at work). That being said, here’s what the event types might look like that are 
+Let's dive right into a sample usage of this. If you're a software developer long enough and move around just a little bit,
+you're going to get sucked into building a workflow for importing flat files of dubious quality from external partners or
+customers. I'm going to claim that event sourcing is a good fit for this problem domain (and
+also suggesting this pretty strongly at work). That being said, here's what the event types might look like that are
 recording the progress of a file import:
 
 <!-- snippet: sample_flat_table_events -->
@@ -29,78 +29,14 @@ public record ImportFailed;
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/FlatTableProjection.cs#L14-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_flat_table_events' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-At some point, we’re going to want to apply some metrics to the execution history to understand the average size of the 
-incoming files, what times of the day have more or less traffic, and performance information broken down by file size, 
+At some point, we're going to want to apply some metrics to the execution history to understand the average size of the
+incoming files, what times of the day have more or less traffic, and performance information broken down by file size,
 file type, and who knows what. This sounds to me like a perfect use case for SQL queries against a flat table.
 
-Enter Marten flat table projection functionality. First off, let’s do this simply by writing some explicit SQL in a 
-new projection that we can replay against the existing events when we’re ready. I’m going to use Marten’s 
-`EventProjection` as a base class in this case:
+## Using FlatTableProjection
 
-<!-- snippet: sample_import_sql_projection -->
-<a id='snippet-sample_import_sql_projection'></a>
-```cs
-public partial class ImportSqlProjection: EventProjection
-{
-    public ImportSqlProjection()
-    {
-        // Define the table structure here so that
-        // Marten can manage this for us in its schema
-        // management
-        var table = new Table("import_history");
-        table.AddColumn<Guid>("id").AsPrimaryKey();
-        table.AddColumn<string>("activity_type").NotNull();
-        table.AddColumn<DateTimeOffset>("started").NotNull();
-        table.AddColumn<DateTimeOffset>("finished");
-
-        SchemaObjects.Add(table);
-
-        // Telling Marten to delete the table data as the
-        // first step in rebuilding this projection
-        Options.DeleteDataInTableOnTeardown(table.Identifier);
-    }
-
-    public void Project(IEvent<ImportStarted> e, IDocumentOperations ops)
-    {
-        ops.QueueSqlCommand("insert into import_history (id, activity_type, started) values (?, ?, ?)",
-            e.StreamId, e.Data.ActivityType, e.Data.Started
-        );
-    }
-
-    public void Project(IEvent<ImportFinished> e, IDocumentOperations ops)
-    {
-        ops.QueueSqlCommand("update import_history set finished = ? where id = ?",
-            e.Data.Finished, e.StreamId
-        );
-    }
-
-    public void Project(IEvent<ImportFailed> e, IDocumentOperations ops)
-    {
-        ops.QueueSqlCommand("delete from import_history where id = ?", e.StreamId);
-    }
-}
-```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/FlatTableProjection.cs#L35-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_import_sql_projection' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-A couple notes about the code above:
-
-We’ve invested a huge amount of time in Marten and the related Weasel library building in robust schema management. 
-The `Table` model I’m using up above comes from Weasel, and this allows a Marten application using this projection 
-to manage the table creation in the underlying database for us. This new table would be part of all Marten’s built in 
-schema management functionality.
-
-The `QueueSqlCommand()` functionality gives you the ability to add raw SQL commands to be executed as part of a 
-Marten unit of work transaction. It’s important to note that the QueueSqlCommand() method doesn’t execute inline, 
-rather it adds the SQL you enqueue to be executed in a batch query when you eventually call the holding 
-`IDocumentSession.SaveChangesAsync()`. I can’t stress this enough, it has consistently been a big performance gain in 
-Marten to batch up queries to the database server and reduce the number of network round trips.
-
-The `Project()` methods are a naming convention with Marten’s EventProjection. The first argument is always 
-assumed to be the event type. In this case though, it’s legal to use Marten’s `IEvent<T>` envelope type to 
-allow you access to event metadata like timestamps, version information, and the containing stream identity.
-
-Now, let’s use Marten’s `FlatTableProjection` recipe to do a little more advanced version of the earlier projection:
+Marten's `FlatTableProjection` provides a declarative, fluent API for projecting events to a flat table. This approach
+handles column mapping, upsert generation, and schema management automatically:
 
 <!-- snippet: sample_flat_import_projection -->
 <a id='snippet-sample_flat_import_projection'></a>
@@ -161,17 +97,100 @@ public class FlatImportProjection: FlatTableProjection
 
 A couple notes on this version of the code:
 
-* `FlatTableProjection` is adding columns to its table based on the designated column mappings. 
+* `FlatTableProjection` is adding columns to its table based on the designated column mappings.
   You can happily customize the `FlatTableProjection.Table` object to add indexes, constraints, or defaults.
-* Marten is able to apply schema migrations and manage the table from the `FlatTableProjection` as long as it’s registered with Marten.
-* When you call `Map(x => x.ActivityType)`, Marten is by default mapping that to a snake_cased derivation of the member 
-  name for the column, so “activity_type”. You can explicitly map the column name yourself.
-* The call to `Map(expression)` chains a fluent builder for the table column if you want to further customize the table 
+* Marten is able to apply schema migrations and manage the table from the `FlatTableProjection` as long as it's registered with Marten.
+* When you call `Map(x => x.ActivityType)`, Marten is by default mapping that to a snake_cased derivation of the member
+  name for the column, so "activity_type". You can explicitly map the column name yourself.
+* The call to `Map(expression)` chains a fluent builder for the table column if you want to further customize the table
   column with default values or constraints like the `NotNull()`.
-* In this case, I’m building a database row per event stream. The `FlatTableProjection` can also map to arbitrary 
+* In this case, I'm building a database row per event stream. The `FlatTableProjection` can also map to arbitrary
   members of each event type.
-* The `Project<T>(lambda)` configuration leads to a runtime, code generation of a Postgresql upsert command so 
-  as to not be completely dependent upon events being captured in the exact right order. I think this will be more 
+* The `Project<T>(lambda)` configuration leads to a runtime, code generation of a Postgresql upsert command so
+  as to not be completely dependent upon events being captured in the exact right order. I think this will be more
   robust in real life usage than the first, more explicit version.
 
 The `FlatTableProjection` in its first incarnation is not yet able to use event metadata.
+
+## Using EventProjection for Flat Tables
+
+::: tip
+The `EventProjection` approach shown below is more explicit code than `FlatTableProjection`, but it is also
+more flexible. Use `EventProjection` when you need full control over the SQL being generated, need to access
+event metadata through the `IEvent<T>` envelope, or when the declarative `FlatTableProjection` API does not
+support your use case. The tradeoff is that you are writing raw SQL yourself, so you are responsible for
+getting the SQL correct and handling upsert logic on your own.
+:::
+
+As an alternative to the more rigid `FlatTableProjection` approach, you can use Marten's `EventProjection` as a
+base class and write explicit SQL to project events into a flat table. This gives you complete control over the
+SQL operations and full access to event metadata:
+
+<!-- snippet: sample_import_sql_event_projection -->
+<a id='snippet-sample_import_sql_event_projection'></a>
+```cs
+public partial class ImportSqlProjection: EventProjection
+{
+    public ImportSqlProjection()
+    {
+        // Define the table structure here so that
+        // Marten can manage this for us in its schema
+        // management
+        var table = new Table("import_history");
+        table.AddColumn<Guid>("id").AsPrimaryKey();
+        table.AddColumn<string>("activity_type").NotNull();
+        table.AddColumn<string>("customer_id").NotNull();
+        table.AddColumn<DateTimeOffset>("started").NotNull();
+        table.AddColumn<DateTimeOffset>("finished");
+
+        SchemaObjects.Add(table);
+
+        // Telling Marten to delete the table data as the
+        // first step in rebuilding this projection
+        Options.DeleteDataInTableOnTeardown(table.Identifier);
+    }
+
+    // Use the IEvent<T> envelope to access event metadata
+    // like stream identity and timestamps
+    public void Project(IEvent<ImportStarted> e, IDocumentOperations ops)
+    {
+        ops.QueueSqlCommand(
+            "insert into import_history (id, activity_type, customer_id, started) values (?, ?, ?, ?)",
+            e.StreamId, e.Data.ActivityType, e.Data.CustomerId, e.Data.Started
+        );
+    }
+
+    public void Project(IEvent<ImportFinished> e, IDocumentOperations ops)
+    {
+        ops.QueueSqlCommand(
+            "update import_history set finished = ? where id = ?",
+            e.Data.Finished, e.StreamId
+        );
+    }
+
+    // You can use any SQL operation, including deletes
+    public void Project(IEvent<ImportFailed> e, IDocumentOperations ops)
+    {
+        ops.QueueSqlCommand(
+            "delete from import_history where id = ?",
+            e.StreamId
+        );
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Projections/Flattened/using_event_projection_for_flat_tables.cs#L18-L75' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_import_sql_event_projection' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+A couple notes about the `EventProjection` approach:
+
+* **Schema management** -- The `Table` model comes from the Weasel library. Adding it to `SchemaObjects` allows Marten's
+  built-in schema management to create and migrate the table automatically.
+* **Batched execution** -- The `QueueSqlCommand()` method doesn't execute inline. Instead, it adds the SQL to be executed
+  in a batch query when you call `IDocumentSession.SaveChangesAsync()`. This batching reduces network round trips to the
+  database and is a consistent performance win.
+* **Event metadata access** -- The `Project()` methods use `IEvent<T>` envelope types, giving you access to event metadata
+  like timestamps, version information, and stream identity. This is something the declarative `FlatTableProjection`
+  cannot currently provide.
+* **Full SQL control** -- You can write any SQL you need: inserts, updates, deletes, or even complex statements with
+  subqueries. This is useful when your projection logic doesn't fit the `Map`/`Increment`/`SetValue` patterns of
+  `FlatTableProjection`.

--- a/src/EventSourcingTests/Projections/Flattened/using_event_projection_for_flat_tables.cs
+++ b/src/EventSourcingTests/Projections/Flattened/using_event_projection_for_flat_tables.cs
@@ -1,0 +1,80 @@
+using System;
+using JasperFx.Events;
+using Marten;
+using Marten.Events.Daemon;
+using Marten.Events.Projections;
+using Weasel.Postgresql.Tables;
+
+namespace EventSourcingTests.Projections.Flattened;
+
+#region sample_event_projection_flat_table_events
+
+public record ImportStarted(
+    DateTimeOffset Started,
+    string ActivityType,
+    string CustomerId,
+    int PlannedSteps);
+
+public record ImportProgress(
+    string StepName,
+    int Records,
+    int Invalids);
+
+public record ImportFinished(DateTimeOffset Finished);
+
+public record ImportFailed;
+
+#endregion
+
+#region sample_import_sql_event_projection
+
+public partial class ImportSqlProjection: EventProjection
+{
+    public ImportSqlProjection()
+    {
+        // Define the table structure here so that
+        // Marten can manage this for us in its schema
+        // management
+        var table = new Table("import_history");
+        table.AddColumn<Guid>("id").AsPrimaryKey();
+        table.AddColumn<string>("activity_type").NotNull();
+        table.AddColumn<string>("customer_id").NotNull();
+        table.AddColumn<DateTimeOffset>("started").NotNull();
+        table.AddColumn<DateTimeOffset>("finished");
+
+        SchemaObjects.Add(table);
+
+        // Telling Marten to delete the table data as the
+        // first step in rebuilding this projection
+        Options.DeleteDataInTableOnTeardown(table.Identifier);
+    }
+
+    // Use the IEvent<T> envelope to access event metadata
+    // like stream identity and timestamps
+    public void Project(IEvent<ImportStarted> e, IDocumentOperations ops)
+    {
+        ops.QueueSqlCommand(
+            "insert into import_history (id, activity_type, customer_id, started) values (?, ?, ?, ?)",
+            e.StreamId, e.Data.ActivityType, e.Data.CustomerId, e.Data.Started
+        );
+    }
+
+    public void Project(IEvent<ImportFinished> e, IDocumentOperations ops)
+    {
+        ops.QueueSqlCommand(
+            "update import_history set finished = ? where id = ?",
+            e.Data.Finished, e.StreamId
+        );
+    }
+
+    // You can use any SQL operation, including deletes
+    public void Project(IEvent<ImportFailed> e, IDocumentOperations ops)
+    {
+        ops.QueueSqlCommand(
+            "delete from import_history where id = ?",
+            e.StreamId
+        );
+    }
+}
+
+#endregion


### PR DESCRIPTION
## Summary
- Add new code sample in `EventSourcingTests` demonstrating `EventProjection` with `QueueSqlCommand` for flat table projections
- Reorganize flat table projection docs to show `FlatTableProjection` first, then `EventProjection` as a more flexible alternative
- Stress that `EventProjection` is more explicit code but offers full SQL control and access to event metadata via `IEvent<T>`

## Test plan
- [ ] Verify `EventSourcingTests` project compiles with the new sample code
- [ ] Review documentation renders correctly in VitePress

🤖 Generated with [Claude Code](https://claude.com/claude-code)