### PR TITLE
Update JasperFx and Weasel NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="1.21.3" />
+    <PackageVersion Include="JasperFx" Version="1.21.4" />
     <PackageVersion Include="JasperFx.Events" Version="1.24.1" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.3.0" />
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.4.0" />
@@ -60,8 +60,8 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="8.10.1" />
-    <PackageVersion Include="Weasel.Postgresql" Version="8.10.1" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="8.10.2" />
+    <PackageVersion Include="Weasel.Postgresql" Version="8.10.2" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary
- JasperFx 1.21.3 → 1.21.4 (includes fix for unix socket DatabaseUri, JasperFx/jasperfx#170)
- Weasel.Postgresql 8.10.1 → 8.10.2
- Weasel.EntityFrameworkCore 8.10.1 → 8.10.2

## Test plan
- [x] Marten compiles successfully with updated packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)