### PR TITLE
Fix integer out of range in mt_quick_append_events and mt_get_next_hi SQL functions

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4246_integer_out_of_range_in_quick_append_function.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4246_integer_out_of_range_in_quick_append_function.cs
@@ -1,0 +1,49 @@
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+public class Bug_4246_integer_out_of_range_in_quick_append_function : OneOffConfigurationsContext
+{
+    public Bug_4246_integer_out_of_range_in_quick_append_function()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.AppendMode = EventAppendMode.Quick;
+            opts.Connection(ConnectionSource.ConnectionString);
+        });
+    }
+
+    [Fact]
+    public async Task quick_append_should_handle_sequence_ids_above_int_max_value()
+    {
+        var schemaName = theStore.Options.DatabaseSchemaName;
+        const long expectedFirstSequence = 1L;
+        const long expectedSecondSequence = 2_200_000_000L;
+
+        await using var session = theStore.LightweightSession();
+        var streamId = session.Events.StartStream<Quest>(new QuestStarted { Name = "Test" });
+        await session.SaveChangesAsync();
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await conn.CreateCommand($"ALTER SEQUENCE {schemaName}.mt_events_sequence RESTART WITH {expectedSecondSequence}")
+            .ExecuteNonQueryAsync();
+        await conn.CloseAsync();
+
+        await using var session2 = theStore.LightweightSession();
+        session2.Events.Append(streamId.Id, new MembersJoined { Members = new[] { "Frodo" } });
+        await session2.SaveChangesAsync();
+
+        await using var session3 = theStore.LightweightSession();
+        var events = await session3.Events.FetchStreamAsync(streamId.Id);
+        events.Count.ShouldBe(2);
+        events[0].Sequence.ShouldBe(expectedFirstSequence);
+        events[1].Sequence.ShouldBe(expectedSecondSequence);
+    }
+}

--- a/src/Marten/Events/Schema/QuickAppendEventFunction.cs
+++ b/src/Marten/Events/Schema/QuickAppendEventFunction.cs
@@ -98,16 +98,16 @@ namespace Marten.Events.Schema;
             }
 
             writer.WriteLine($@"
-CREATE OR REPLACE FUNCTION {Identifier}(stream {streamIdType}, stream_type varchar, tenantid varchar, event_ids uuid[], event_types varchar[], dotnet_types varchar[], bodies jsonb[]{metadataParameters}{tagParameters}) RETURNS int[] AS $$
+CREATE OR REPLACE FUNCTION {Identifier}(stream {streamIdType}, stream_type varchar, tenantid varchar, event_ids uuid[], event_types varchar[], dotnet_types varchar[], bodies jsonb[]{metadataParameters}{tagParameters}) RETURNS bigint[] AS $$
 DECLARE
-	event_version int;
+	event_version bigint;
 	event_type varchar;
 	event_id uuid;
 	body jsonb;
 	index int;
-	seq int;
+	seq bigint;
     actual_tenant varchar;
-	return_value int[];
+	return_value bigint[];
 BEGIN
 	select version into event_version from {databaseSchema}.mt_streams where {streamsWhere};
 	if event_version IS NULL then

--- a/src/Marten/Schema/SQL/mt_get_next_hi.sql
+++ b/src/Marten/Schema/SQL/mt_get_next_hi.sql
@@ -1,5 +1,5 @@
 ﻿CREATE
-OR REPLACE FUNCTION {databaseSchema}.mt_get_next_hi(entity varchar) RETURNS integer AS
+OR REPLACE FUNCTION {databaseSchema}.mt_get_next_hi(entity varchar) RETURNS bigint AS
 $$
 DECLARE
 current_value bigint;


### PR DESCRIPTION
The mt_quick_append_events function declared its return type and internal variables as int/int[] while the underlying sequence (mt_events_sequence) and seq_id column use bigint. This causes integer overflow when sequence IDs exceed ~2.1 billion, which was observed in production.

Changed in mt_quick_append_events:
- RETURNS int[] → bigint[]
- event_version int → bigint
- seq int → bigint
- return_value int[] → bigint[]

Also fixed mt_get_next_hi which declared RETURNS integer despite its hi_value column being bigint and its internal variables being bigint.

C# consumers already read these values as long/long[], so no client-side changes are needed. A test is added that advances the event sequence past int.MaxValue and verifies quick append still works correctly.

This fixes bug: https://github.com/JasperFx/marten/issues/4246