### PR TITLE
Regression tests for [JsonPropertyName] on temporal types (closes #4253)

### DIFF
--- a/src/DocumentDbTests/Indexes/computed_indexes.cs
+++ b/src/DocumentDbTests/Indexes/computed_indexes.cs
@@ -371,3 +371,73 @@ public class ApiResponseRecord
     public string Response { get; set; }
     public DateTime RequestTimeUtc { get; set; }
 }
+
+public class computed_indexes_jsonpropertyname : OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task datetimeoffset_index_ddl_uses_json_property_name()
+    {
+        StoreOptions(_ =>
+        {
+            _.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default);
+            _.Schema.For<Bug4253Doc>().Index(x => x.Timestamp, c => c.Name = "idx_b4253_ts");
+            _.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        await theStore.Storage.Database.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.CreateOrUpdate);
+
+        var table = await theStore.Tenancy.Default.Database.ExistingTableFor(typeof(Bug4253Doc));
+        var index = table.IndexFor("idx_b4253_ts");
+
+        index.ShouldNotBeNull();
+        var ddl = index.ToDDL(table);
+
+        // Must reference the JSON key 'ts' from [JsonPropertyName], not the C# name 'Timestamp'
+        ddl.ShouldContain("'ts'");
+        ddl.ShouldNotContain("'Timestamp'");
+    }
+
+    [Fact]
+    public async Task datetimeoffset_required_init_index_ddl_uses_json_property_name()
+    {
+        StoreOptions(_ =>
+        {
+            _.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default);
+            _.Schema.For<Bug4253RequiredInitDoc>().Index(x => x.Timestamp, c => c.Name = "idx_b4253_req_ts");
+            _.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        await theStore.Storage.Database.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.CreateOrUpdate);
+
+        var table = await theStore.Tenancy.Default.Database.ExistingTableFor(typeof(Bug4253RequiredInitDoc));
+        var index = table.IndexFor("idx_b4253_req_ts");
+
+        index.ShouldNotBeNull();
+        var ddl = index.ToDDL(table);
+
+        ddl.ShouldContain("'ts'");
+        ddl.ShouldNotContain("'Timestamp'");
+    }
+}
+
+public class Bug4253Doc
+{
+    public Guid Id { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("ts")]
+    public DateTimeOffset Timestamp { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("auid")]
+    public int ActorUserId { get; set; }
+}
+
+public class Bug4253RequiredInitDoc
+{
+    public Guid Id { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("ts")]
+    public required DateTimeOffset Timestamp { get; init; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("auid")]
+    public required int ActorUserId { get; init; }
+}

--- a/src/LinqTests/Acceptance/json_naming_attributes.cs
+++ b/src/LinqTests/Acceptance/json_naming_attributes.cs
@@ -7,6 +7,7 @@ using Marten.Services;
 using Marten.Testing.Harness;
 using Newtonsoft.Json;
 using Shouldly;
+using Weasel.Core;
 
 namespace LinqTests.Acceptance;
 
@@ -48,6 +49,156 @@ public class json_naming_attributes
         command.CommandText.ShouldBe("select d.id, d.data from atts.mt_doc_stjdoc as d where d.data ->> 'shade' = :p0;");
 
     }
+
+    [Fact]
+    public void recognize_stj_json_property_on_datetimeoffset_in_linq()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "atts";
+            opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default);
+        });
+
+        using var session = store.LightweightSession();
+
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-1);
+        var command = session.Query<StjDateTimeOffsetDoc>()
+            .Where(x => x.Timestamp >= cutoff)
+            .ToCommand();
+
+        // The JSON key 'ts' (from [JsonPropertyName]) must appear; 'Timestamp' (C# name) must not
+        command.CommandText.ShouldContain("'ts'");
+        command.CommandText.ShouldNotContain("'Timestamp'");
+    }
+
+    [Fact]
+    public void recognize_stj_json_property_on_datetimeoffset_required_init_in_linq()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "atts";
+            opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default);
+        });
+
+        using var session = store.LightweightSession();
+
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-1);
+        var command = session.Query<StjRequiredInitDateTimeOffsetDoc>()
+            .Where(x => x.Timestamp >= cutoff)
+            .ToCommand();
+
+        command.CommandText.ShouldContain("'ts'");
+        command.CommandText.ShouldNotContain("'Timestamp'");
+    }
+
+    [Fact]
+    public void recognize_stj_json_property_on_datetime_in_linq()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "atts";
+            opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default);
+        });
+
+        using var session = store.LightweightSession();
+
+        var cutoff = DateTime.UtcNow.AddDays(-1);
+        var command = session.Query<StjTemporalDoc>()
+            .Where(x => x.DateTime >= cutoff)
+            .ToCommand();
+
+        command.CommandText.ShouldContain("'dt'");
+        command.CommandText.ShouldNotContain("'DateTime'");
+    }
+
+    [Fact]
+    public void recognize_stj_json_property_on_dateonly_in_linq()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "atts";
+            opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default);
+        });
+
+        using var session = store.LightweightSession();
+
+        var cutoff = DateOnly.FromDateTime(DateTime.UtcNow);
+        var command = session.Query<StjTemporalDoc>()
+            .Where(x => x.DateOnly >= cutoff)
+            .ToCommand();
+
+        command.CommandText.ShouldContain("'d_only'");
+        command.CommandText.ShouldNotContain("'DateOnly'");
+    }
+
+    [Fact]
+    public void recognize_stj_json_property_on_timeonly_in_linq()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "atts";
+            opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default);
+        });
+
+        using var session = store.LightweightSession();
+
+        var cutoff = TimeOnly.FromDateTime(DateTime.UtcNow);
+        var command = session.Query<StjTemporalDoc>()
+            .Where(x => x.TimeOnly >= cutoff)
+            .ToCommand();
+
+        command.CommandText.ShouldContain("'t_only'");
+        command.CommandText.ShouldNotContain("'TimeOnly'");
+    }
+
+    [Fact]
+    public async Task end_to_end_query_with_datetimeoffset_json_property_name()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "atts_dto_e2e";
+            opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default);
+        });
+
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new StjDateTimeOffsetDoc
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTimeOffset.UtcNow,
+                ActorUserId = 42
+            });
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = store.QuerySession())
+        {
+            var cutoff = DateTimeOffset.UtcNow.AddDays(-1);
+
+            var totalCount = await session.Query<StjDateTimeOffsetDoc>().CountAsync();
+            totalCount.ShouldBe(1);
+
+            // The bug: this silently returns 0 even though the data matches
+            var recent = await session.Query<StjDateTimeOffsetDoc>()
+                .Where(x => x.Timestamp >= cutoff)
+                .CountAsync();
+            recent.ShouldBe(1);
+
+            // Sanity: the int filter with JsonPropertyName works
+            var byActor = await session.Query<StjDateTimeOffsetDoc>()
+                .Where(x => x.ActorUserId == 42)
+                .CountAsync();
+            byActor.ShouldBe(1);
+        }
+    }
 }
 
 public class AttributedDoc
@@ -64,4 +215,43 @@ public class StjDoc
 
     [JsonPropertyName("shade")]
     public string Color { get; set; }
+}
+
+public class StjDateTimeOffsetDoc
+{
+    public Guid Id { get; set; }
+
+    [JsonPropertyName("ts")]
+    public DateTimeOffset Timestamp { get; set; }
+
+    [JsonPropertyName("auid")]
+    public int ActorUserId { get; set; }
+}
+
+public class StjRequiredInitDateTimeOffsetDoc
+{
+    public Guid Id { get; set; }
+
+    [JsonPropertyName("ts")]
+    public required DateTimeOffset Timestamp { get; init; }
+
+    [JsonPropertyName("auid")]
+    public required int ActorUserId { get; init; }
+}
+
+public class StjTemporalDoc
+{
+    public Guid Id { get; set; }
+
+    [JsonPropertyName("dt")]
+    public DateTime DateTime { get; set; }
+
+    [JsonPropertyName("dto")]
+    public DateTimeOffset DateTimeOffset { get; set; }
+
+    [JsonPropertyName("d_only")]
+    public DateOnly DateOnly { get; set; }
+
+    [JsonPropertyName("t_only")]
+    public TimeOnly TimeOnly { get; set; }
 }


### PR DESCRIPTION
Closes #4253

## Summary

The issue reported that `[JsonPropertyName("ts")]` on a `DateTimeOffset` property is ignored by Marten's LINQ provider — SQL emits `(data ->> 'Timestamp')` instead of `(data ->> 'ts')`, and `CREATE INDEX` DDL has the same issue.

After tracing the code paths on master (8.30.0), the obvious candidates all look correct:
- `QueryableMember` base ctor sets `RawLocator` using `member.ToJsonKey(casing)` which honors `[JsonPropertyName]`
- `DateTimeOffsetMember`, `DateTimeMember`, `DateOnlyMember`, `TimeOnlyMember` all inherit this base behavior
- `ComputedIndex` resolves members through the same `MemberFor` path as LINQ

I wrote 8 regression tests mirroring the bug repro exactly. **All 8 pass on master** — the bug does not reproduce on the current code. The reporter may have been on an older build, or there's a reproduction step I'm missing.

Rather than keep the issue open without a reproducible repro, landing these regression tests to prevent future regressions across all temporal types.

## Tests added

LINQ Where SQL (`src/LinqTests/Acceptance/json_naming_attributes.cs`):
- `recognize_stj_json_property_on_datetimeoffset_in_linq`
- `recognize_stj_json_property_on_datetimeoffset_required_init_in_linq` — uses the `required { get; init; }` shape from the bug report
- `recognize_stj_json_property_on_datetime_in_linq`
- `recognize_stj_json_property_on_dateonly_in_linq`
- `recognize_stj_json_property_on_timeonly_in_linq`
- `end_to_end_query_with_datetimeoffset_json_property_name` — end-to-end count query from the bug repro

Index DDL (`src/DocumentDbTests/Indexes/computed_indexes.cs`):
- `datetimeoffset_index_ddl_uses_json_property_name`
- `datetimeoffset_required_init_index_ddl_uses_json_property_name`

## Test plan

- [x] All 6 LINQ tests pass on master (net9.0)
- [x] Both index DDL tests pass on master (net9.0)
- [x] End-to-end integration test with real PostgreSQL passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)