### PR TITLE
Add PostgreSQL Row Level Security for conjoined tenancy (v2)

### DIFF
--- a/docs/documents/multi-tenancy.md
+++ b/docs/documents/multi-tenancy.md
@@ -585,7 +585,7 @@ options.UseRowLevelSecurity("security.tenant");
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/row_level_security_unit_tests.cs#L39-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enable_row_level_security_custom_setting' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-The setting name must be a qualified PostgreSQL custom GUC identifier of the form `prefix.name` using letters, digits, and underscores. Marten validates this at configuration time because the setting name is interpolated into `CREATE POLICY ... current_setting('<name>')` DDL. The *tenant id* is sent as a bound parameter so it accepts any value.
+The setting name must be a qualified PostgreSQL custom GUC identifier of the form `prefix.name` using letters, digits, and underscores. Marten validates this at configuration time because the setting name is interpolated into `CREATE POLICY ... current_setting('<name>')` DDL. The _tenant id_ is sent as a bound parameter so it accepts any value.
 
 ### Per-document overrides
 
@@ -613,7 +613,7 @@ options.Schema.For<Target>().MultiTenanted().UseRowLevelSecurity("app.org_id");
 
 The resolution order per mapping is: explicit mapping-level override, then the store-level setting, falling back to `"app.tenant_id"`.
 
-**Caveat:** Marten only sets the *store-level* GUC on each opened session connection. If you override a mapping to use a different setting name, your application is responsible for populating that GUC itself on any session that queries that document — Marten writes the policy but does not automatically set the custom GUC.
+**Caveat:** Marten only sets the _store-level_ GUC on each opened session connection. If you override a mapping to use a different setting name, your application is responsible for populating that GUC itself on any session that queries that document — Marten writes the policy but does not automatically set the custom GUC.
 
 ### Reconfiguring and rolling back
 

--- a/docs/documents/multi-tenancy.md
+++ b/docs/documents/multi-tenancy.md
@@ -502,7 +502,7 @@ To exempt document types from having partitioned tables, such as for tables you 
 even harm by partitioning, you can use either an attribute on the document type:
 
 <!-- snippet: sample_using_DoNotPartitionAttribute -->
-<a id='snippet-sample_using_donotpartitionattribute'></a>
+<a id='snippet-sample_using_DoNotPartitionAttribute'></a>
 ```cs
 [DoNotPartition]
 public class DocThatShouldBeExempted1
@@ -510,7 +510,7 @@ public class DocThatShouldBeExempted1
     public Guid Id { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs#L296-L304' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_donotpartitionattribute' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs#L296-L304' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_DoNotPartitionAttribute' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 or exempt a single document type through the fluent interface:
@@ -553,6 +553,76 @@ This API will:
 - Delete tenant specific data out of any document table that is configured for `Conjoined` multi-tenancy for that named tenant
 
 This API is able to differentiate between documents that are configured for tenancy and document types that are global.
+
+## Row Level Security <Badge type="tip" text="8.31" />
+
+Conjoined tenancy filters rows by `tenant_id` at Marten's query layer. PostgreSQL [Row Level Security (RLS)](https://www.postgresql.org/docs/current/ddl-rowsecurity.html) adds a database-enforced safety net so any connection — including raw SQL, ad-hoc analytics, or code that bypasses Marten's session — can only see rows belonging to the current tenant.
+
+When you opt in, Marten will:
+
+1. Call `set_config('<setting>', '<tenantId>', false)` on every opened session connection, so PostgreSQL knows which tenant the session is acting as.
+2. On conjoined-tenancy document tables, emit `ENABLE ROW LEVEL SECURITY`, `FORCE ROW LEVEL SECURITY`, and a `marten_tenant_isolation` policy that restricts visible rows to `tenant_id = current_setting('<setting>')`. These are produced through Marten's normal schema migration pipeline.
+
+`FORCE ROW LEVEL SECURITY` ensures the policy applies to the table owner as well. Note that PostgreSQL **superusers always bypass RLS** regardless of the `FORCE` flag — run your application (and any ad-hoc verification) as a non-superuser role to see RLS in effect.
+
+### Enable for the whole store
+
+<!-- snippet: sample_enable_row_level_security -->
+<a id='snippet-sample_enable_row_level_security'></a>
+```cs
+options.UseRowLevelSecurity();
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/row_level_security_unit_tests.cs#L25-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enable_row_level_security' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The default GUC setting name is `app.tenant_id`. Pass a custom name when it conflicts with an existing GUC naming scheme in your database:
+
+<!-- snippet: sample_enable_row_level_security_custom_setting -->
+<a id='snippet-sample_enable_row_level_security_custom_setting'></a>
+```cs
+options.UseRowLevelSecurity("security.tenant");
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/row_level_security_unit_tests.cs#L39-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_enable_row_level_security_custom_setting' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The setting name must be a qualified PostgreSQL custom GUC identifier of the form `prefix.name` using letters, digits, and underscores. Marten validates this at configuration time because the setting name is interpolated into `CREATE POLICY ... current_setting('<name>')` DDL. The *tenant id* is sent as a bound parameter so it accepts any value.
+
+### Per-document overrides
+
+You can selectively exclude individual document types from RLS when it would otherwise apply store-wide — useful for tables such as audit logs, read-only reference data, or anything explicitly intended to be accessible across tenants:
+
+<!-- snippet: sample_disable_row_level_security_per_mapping -->
+<a id='snippet-sample_disable_row_level_security_per_mapping'></a>
+```cs
+options.UseRowLevelSecurity();
+options.Schema.For<Target>().MultiTenanted().DisableRowLevelSecurity();
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/row_level_security_unit_tests.cs#L163-L168' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_disable_row_level_security_per_mapping' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Or use a different GUC setting name for a specific document type:
+
+<!-- snippet: sample_use_row_level_security_per_mapping -->
+<a id='snippet-sample_use_row_level_security_per_mapping'></a>
+```cs
+options.UseRowLevelSecurity();
+options.Schema.For<Target>().MultiTenanted().UseRowLevelSecurity("app.org_id");
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/row_level_security_unit_tests.cs#L182-L187' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_use_row_level_security_per_mapping' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The resolution order per mapping is: explicit mapping-level override, then the store-level setting, falling back to `"app.tenant_id"`.
+
+**Caveat:** Marten only sets the *store-level* GUC on each opened session connection. If you override a mapping to use a different setting name, your application is responsible for populating that GUC itself on any session that queries that document — Marten writes the policy but does not automatically set the custom GUC.
+
+### Reconfiguring and rolling back
+
+Toggling RLS off store-wide, or adding `DisableRowLevelSecurity()` on a mapping that was previously RLS-enabled, produces a `DROP POLICY` delta on the next schema migration. Changing the setting name (globally or per mapping) is detected by comparing the policy expression against `pg_get_expr(polqual, ...)` and triggers a drop-and-recreate.
+
+### Limitations
+
+- RLS applies only to `TenancyStyle.Conjoined` document tables. Single-tenancy and per-database tenancy are unchanged.
+- Event store tables (`mt_events`, `mt_streams`) do not currently get RLS policies.
 
 ## Implementation Details
 

--- a/src/CoreTests/row_level_security_unit_tests.cs
+++ b/src/CoreTests/row_level_security_unit_tests.cs
@@ -1,0 +1,274 @@
+using System;
+using System.IO;
+using System.Linq;
+using Marten;
+using Marten.Schema;
+using Marten.Internal.Sessions;
+using Marten.Internal.Sessions.Rls;
+using Marten.Services;
+using Marten.Storage;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using NSubstitute;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace CoreTests;
+
+public class row_level_security_unit_tests
+{
+    [Fact]
+    public void can_enable_row_level_security_with_default_setting_name()
+    {
+        var options = new StoreOptions();
+
+        #region sample_enable_row_level_security
+
+        options.UseRowLevelSecurity();
+
+        #endregion
+
+        options.RlsTenantSessionSetting.ShouldBe("app.tenant_id");
+    }
+
+    [Fact]
+    public void can_enable_row_level_security_with_custom_setting_name()
+    {
+        var options = new StoreOptions();
+
+        #region sample_enable_row_level_security_custom_setting
+
+        options.UseRowLevelSecurity("security.tenant");
+
+        #endregion
+
+        options.RlsTenantSessionSetting.ShouldBe("security.tenant");
+    }
+
+    [Fact]
+    public void session_options_builds_rls_auto_closing_lifetime_when_enabled()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.UseRowLevelSecurity();
+        });
+
+        var database = Substitute.For<IMartenDatabase>();
+        var sessionOptions = SessionOptions.ForDatabase("tenant_blue", database);
+
+        var lifetime = sessionOptions.Initialize(store, CommandRunnerMode.Transactional,
+            new OpenTelemetryOptions { TrackConnections = TrackLevel.None });
+
+        lifetime.ShouldBeOfType<RlsAutoClosingLifetime>();
+    }
+
+    [Fact]
+    public void session_options_uses_plain_auto_closing_lifetime_when_disabled()
+    {
+        using var store = DocumentStore.For(opts => opts.Connection(ConnectionSource.ConnectionString));
+
+        var database = Substitute.For<IMartenDatabase>();
+        var sessionOptions = SessionOptions.ForDatabase("tenant_blue", database);
+
+        var lifetime = sessionOptions.Initialize(store, CommandRunnerMode.Transactional,
+            new OpenTelemetryOptions { TrackConnections = TrackLevel.None });
+
+        lifetime.ShouldBeOfType<AutoClosingLifetime>();
+        lifetime.ShouldNotBeOfType<RlsAutoClosingLifetime>();
+    }
+
+    [Fact]
+    public void session_options_builds_rls_sticky_transactional_connection_when_sticky_enabled()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.UseRowLevelSecurity();
+            opts.UseStickyConnectionLifetimes = true;
+        });
+
+        var database = Substitute.For<IMartenDatabase>();
+        var sessionOptions = SessionOptions.ForDatabase("tenant_blue", database);
+
+        var lifetime = sessionOptions.Initialize(store, CommandRunnerMode.Transactional,
+            new OpenTelemetryOptions { TrackConnections = TrackLevel.None });
+
+        lifetime.ShouldBeOfType<RlsTransactionalConnection>();
+    }
+
+    [Fact]
+    public void session_options_uses_plain_sticky_transactional_connection_when_rls_disabled()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.UseStickyConnectionLifetimes = true;
+        });
+
+        var database = Substitute.For<IMartenDatabase>();
+        var sessionOptions = SessionOptions.ForDatabase("tenant_blue", database);
+
+        var lifetime = sessionOptions.Initialize(store, CommandRunnerMode.Transactional,
+            new OpenTelemetryOptions { TrackConnections = TrackLevel.None });
+
+        lifetime.ShouldBeOfType<TransactionalConnection>();
+        lifetime.ShouldNotBeOfType<RlsTransactionalConnection>();
+    }
+
+    [Fact]
+    public void use_row_level_security_rejects_invalid_setting_name()
+    {
+        var options = new StoreOptions();
+
+        Should.Throw<ArgumentException>(() => options.UseRowLevelSecurity("app.tenant_id'; drop table users; --"));
+        Should.Throw<ArgumentException>(() => options.UseRowLevelSecurity("no_dot"));
+        Should.Throw<ArgumentException>(() => options.UseRowLevelSecurity(""));
+    }
+
+    [Fact]
+    public void rls_policy_schema_object_writes_expected_create_and_drop_sql()
+    {
+        var schemaObject = new RlsPolicySchemaObject(
+            new PostgresqlObjectName("public", "mt_doc_target", SchemaUtils.IdentifierUsage.General),
+            "app.tenant_id");
+
+        var createWriter = new StringWriter();
+        schemaObject.WriteCreateStatement(new PostgresqlMigrator(), createWriter);
+        var createSql = createWriter.ToString();
+
+        createSql.ShouldContain("ALTER TABLE public.mt_doc_target ENABLE ROW LEVEL SECURITY;");
+        createSql.ShouldContain("ALTER TABLE public.mt_doc_target FORCE ROW LEVEL SECURITY;");
+        createSql.ShouldContain("DROP POLICY IF EXISTS marten_tenant_isolation ON public.mt_doc_target;");
+        createSql.ShouldContain("CREATE POLICY marten_tenant_isolation ON public.mt_doc_target");
+        createSql.ShouldContain("USING (tenant_id = current_setting('app.tenant_id'))");
+        createSql.ShouldContain("WITH CHECK (tenant_id = current_setting('app.tenant_id'));");
+
+        var dropWriter = new StringWriter();
+        schemaObject.WriteDropStatement(new PostgresqlMigrator(), dropWriter);
+        var dropSql = dropWriter.ToString();
+
+        dropSql.ShouldContain("DROP POLICY IF EXISTS marten_tenant_isolation ON public.mt_doc_target;");
+        dropSql.ShouldContain("ALTER TABLE public.mt_doc_target NO FORCE ROW LEVEL SECURITY;");
+        dropSql.ShouldContain("ALTER TABLE public.mt_doc_target DISABLE ROW LEVEL SECURITY;");
+    }
+
+    [Fact]
+    public void document_schema_includes_rls_policy_when_enabled_for_conjoined_tenancy()
+    {
+        var options = new StoreOptions();
+        options.UseRowLevelSecurity();
+        options.Schema.For<Target>().MultiTenanted();
+
+        var mapping = options.Storage.MappingFor(typeof(Target));
+        var schema = new DocumentSchema(mapping);
+
+        schema.Objects.Any(x => x is RlsPolicySchemaObject).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void document_schema_includes_rls_policy_object_when_disabled_for_conjoined_tenancy()
+    {
+        var options = new StoreOptions();
+        options.Schema.For<Target>().MultiTenanted();
+
+        var mapping = options.Storage.MappingFor(typeof(Target));
+        var schema = new DocumentSchema(mapping);
+
+        schema.Objects.Any(x => x is RlsPolicySchemaObject).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void mapping_without_override_inherits_store_rls_setting()
+    {
+        var options = new StoreOptions();
+        options.UseRowLevelSecurity("app.tenant_id");
+        options.Schema.For<Target>().MultiTenanted();
+
+        var (enabled, settingName) = options.Storage.MappingFor(typeof(Target))
+            .ResolveRowLevelSecurity();
+
+        enabled.ShouldBeTrue();
+        settingName.ShouldBe("app.tenant_id");
+    }
+
+    [Fact]
+    public void mapping_disable_override_wins_even_when_store_enabled()
+    {
+        var options = new StoreOptions();
+
+        #region sample_disable_row_level_security_per_mapping
+
+        options.UseRowLevelSecurity();
+        options.Schema.For<Target>().MultiTenanted().DisableRowLevelSecurity();
+
+        #endregion
+
+        var (enabled, settingName) = options.Storage.MappingFor(typeof(Target))
+            .ResolveRowLevelSecurity();
+
+        enabled.ShouldBeFalse();
+        settingName.ShouldBeNull();
+    }
+
+    [Fact]
+    public void mapping_enable_override_uses_explicit_setting()
+    {
+        var options = new StoreOptions();
+
+        #region sample_use_row_level_security_per_mapping
+
+        options.UseRowLevelSecurity();
+        options.Schema.For<Target>().MultiTenanted().UseRowLevelSecurity("app.org_id");
+
+        #endregion
+
+        var (enabled, settingName) = options.Storage.MappingFor(typeof(Target))
+            .ResolveRowLevelSecurity();
+
+        enabled.ShouldBeTrue();
+        settingName.ShouldBe("app.org_id");
+    }
+
+    [Fact]
+    public void mapping_enable_override_with_null_setting_falls_back_to_store_setting()
+    {
+        var options = new StoreOptions();
+        options.UseRowLevelSecurity("security.tenant");
+        options.Schema.For<Target>().MultiTenanted().UseRowLevelSecurity();
+
+        var (enabled, settingName) = options.Storage.MappingFor(typeof(Target))
+            .ResolveRowLevelSecurity();
+
+        enabled.ShouldBeTrue();
+        settingName.ShouldBe("security.tenant");
+    }
+
+    [Fact]
+    public void mapping_enable_override_with_null_setting_and_no_store_setting_falls_back_to_default()
+    {
+        var options = new StoreOptions();
+        options.Schema.For<Target>().MultiTenanted().UseRowLevelSecurity();
+
+        var (enabled, settingName) = options.Storage.MappingFor(typeof(Target))
+            .ResolveRowLevelSecurity();
+
+        enabled.ShouldBeTrue();
+        settingName.ShouldBe("app.tenant_id");
+    }
+
+    [Fact]
+    public void single_tenancy_resolves_disabled_regardless_of_override()
+    {
+        var options = new StoreOptions();
+        options.UseRowLevelSecurity();
+        options.Schema.For<Target>().UseRowLevelSecurity("app.org_id");
+
+        var (enabled, settingName) = options.Storage.MappingFor(typeof(Target))
+            .ResolveRowLevelSecurity();
+
+        enabled.ShouldBeFalse();
+        settingName.ShouldBeNull();
+    }
+}

--- a/src/DocumentDbTests/MultiTenancy/row_level_security_with_conjoined_tenancy.cs
+++ b/src/DocumentDbTests/MultiTenancy/row_level_security_with_conjoined_tenancy.cs
@@ -1,0 +1,567 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Transactions;
+using Marten;
+using Marten.Services;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace DocumentDbTests.MultiTenancy;
+
+public class row_level_security_with_conjoined_tenancy: OneOffConfigurationsContext
+{
+    public row_level_security_with_conjoined_tenancy()
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        _schemaName = $"{GetType().Name}_{suffix}".ToLowerInvariant();
+    }
+
+    [Fact]
+    public async Task applies_rls_policy_during_schema_migration()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted();
+            opts.UseRowLevelSecurity();
+        });
+
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var tableName = theStore.Options.Storage.MappingFor(typeof(Target)).TableName;
+        theStore.Options.DatabaseSchemaName.ShouldBe(_schemaName);
+        tableName.Schema.ShouldBe(_schemaName);
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "select count(*) from pg_policy p " +
+            "join pg_class c on p.polrelid = c.oid " +
+            "join pg_namespace n on c.relnamespace = n.oid " +
+            "where n.nspname = @schema and c.relname = @table and p.polname = 'marten_tenant_isolation'";
+        cmd.Parameters.AddWithValue("schema", tableName.Schema);
+        cmd.Parameters.AddWithValue("table", tableName.Name);
+
+        var policyCount = (long)(await cmd.ExecuteScalarAsync());
+        policyCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task sets_session_tenant_setting_for_auto_closing_lifetime()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted();
+            opts.UseRowLevelSecurity();
+        });
+
+        await using var session = theStore.QuerySession("tenant_red");
+        var value = (await session.QueryAsync<string>("select current_setting('app.tenant_id')")).Single();
+
+        value.ShouldBe("tenant_red");
+    }
+
+    [Fact]
+    public async Task sets_session_tenant_setting_for_sticky_connection_lifetime()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted();
+            opts.UseRowLevelSecurity();
+            opts.UseStickyConnectionLifetimes = true;
+        });
+
+        await using var session = theStore.QuerySession("tenant_blue");
+        var value = (await session.QueryAsync<string>("select current_setting('app.tenant_id')")).Single();
+
+        value.ShouldBe("tenant_blue");
+    }
+
+    [Fact]
+    public async Task sets_session_tenant_setting_for_caller_supplied_transaction()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted();
+            opts.UseRowLevelSecurity();
+        });
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var tx = await conn.BeginTransactionAsync();
+
+        var sessionOptions = SessionOptions.ForTransaction(tx);
+        sessionOptions.TenantId = "tenant_violet";
+
+        await using var session = theStore.QuerySession(sessionOptions);
+        var value = (await session.QueryAsync<string>("select current_setting('app.tenant_id')")).Single();
+
+        value.ShouldBe("tenant_violet");
+    }
+
+    [Fact]
+    public async Task bulk_insert_succeeds_under_rls_for_conjoined_tenant()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted();
+            opts.UseRowLevelSecurity();
+        });
+
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var targets = new[] { Target.Random(), Target.Random(), Target.Random() };
+        await theStore.BulkInsertAsync("tenant_magenta", targets);
+
+        await using var session = theStore.QuerySession("tenant_magenta");
+        var ids = (await session.Query<Target>().ToListAsync()).Select(x => x.Id).OrderBy(x => x).ToList();
+        ids.ShouldBe(targets.Select(x => x.Id).OrderBy(x => x).ToList());
+    }
+
+    [Fact]
+    public async Task sets_session_tenant_setting_for_ambient_dot_net_transaction()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted();
+            opts.UseRowLevelSecurity();
+        });
+
+        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+        var sessionOptions = SessionOptions.ForCurrentTransaction();
+        sessionOptions.TenantId = "tenant_cyan";
+
+        await using (var session = theStore.QuerySession(sessionOptions))
+        {
+            var value = (await session.QueryAsync<string>("select current_setting('app.tenant_id')")).Single();
+            value.ShouldBe("tenant_cyan");
+        }
+
+        scope.Complete();
+    }
+
+    [Fact]
+    public async Task does_not_set_tenant_setting_when_rls_is_disabled()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted();
+        });
+
+        await using var session = theStore.QuerySession("tenant_green");
+        var value = (await session.QueryAsync<string>("select current_setting('app.tenant_id', true)")).Single();
+
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task applies_rls_flags_and_policy_to_document_table()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted();
+            opts.UseRowLevelSecurity();
+        });
+
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var tableName = theStore.Options.Storage.MappingFor(typeof(Target)).TableName;
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "select c.relrowsecurity, c.relforcerowsecurity from pg_class c " +
+            "join pg_namespace n on c.relnamespace = n.oid " +
+            "where n.nspname = @schema and c.relname = @table";
+        cmd.Parameters.AddWithValue("schema", tableName.Schema);
+        cmd.Parameters.AddWithValue("table", tableName.Name);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        (await reader.ReadAsync()).ShouldBeTrue();
+        reader.GetBoolean(0).ShouldBeTrue();
+        reader.GetBoolean(1).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task postgres_blocks_cross_tenant_reads_when_rls_enabled(bool useStickyConnectionLifetimes)
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted();
+            opts.UseRowLevelSecurity();
+            opts.UseStickyConnectionLifetimes = useStickyConnectionLifetimes;
+        });
+
+        var targetA = Target.Random();
+        var targetB = Target.Random();
+
+        await using (var sessionA = theStore.LightweightSession("tenant_a"))
+        {
+            sessionA.Store(targetA);
+            await sessionA.SaveChangesAsync();
+        }
+
+        await using (var sessionB = theStore.LightweightSession("tenant_b"))
+        {
+            sessionB.Store(targetB);
+            await sessionB.SaveChangesAsync();
+        }
+
+        // Marten-layer check: its own conjoined-tenancy filter would satisfy this even without RLS,
+        // but it still verifies the tenant setting does not break regular reads.
+        await using (var sessionA = theStore.QuerySession("tenant_a"))
+        {
+            var rows = await sessionA.Query<Target>().ToListAsync();
+            rows.Select(x => x.Id).ShouldBe([targetA.Id]);
+        }
+
+        // PostgreSQL-layer check: prove it's the RLS policy (not Marten) doing the filtering.
+        // Requires a non-superuser role because superusers bypass RLS regardless of FORCE.
+        var tableName = theStore.Options.Storage.MappingFor(typeof(Target)).TableName;
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using (var setup = conn.CreateCommand())
+        {
+            setup.CommandText = $@"
+                DO $$ BEGIN
+                  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'marten_rls_probe') THEN
+                    CREATE ROLE marten_rls_probe;
+                  END IF;
+                END $$;
+                GRANT USAGE ON SCHEMA {tableName.Schema} TO marten_rls_probe;
+                GRANT SELECT ON {tableName.Schema}.{tableName.Name} TO marten_rls_probe;
+                SET ROLE marten_rls_probe;";
+            await setup.ExecuteNonQueryAsync();
+        }
+
+        await AssertVisibleRowCount(conn, tableName.QualifiedName, "tenant_a", 1);
+        await AssertVisibleRowCount(conn, tableName.QualifiedName, "tenant_b", 1);
+    }
+
+    private static async Task AssertVisibleRowCount(NpgsqlConnection conn, string qualifiedTable, string tenantId, long expected)
+    {
+        await using var setTenant = conn.CreateCommand();
+        setTenant.CommandText = "select set_config('app.tenant_id', @tenant, false)";
+        setTenant.Parameters.AddWithValue("tenant", tenantId);
+        await setTenant.ExecuteNonQueryAsync();
+
+        await using var selectCmd = conn.CreateCommand();
+        selectCmd.CommandText = $"select count(*) from {qualifiedTable}";
+        var actual = (long)await selectCmd.ExecuteScalarAsync();
+        actual.ShouldBe(expected, $"tenant='{tenantId}'");
+    }
+
+    [Fact]
+    public async Task reapplies_policy_when_setting_name_changes()
+    {
+        using var initialStore = SeparateStore(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted();
+            opts.UseRowLevelSecurity();
+        });
+
+        await initialStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        using var updatedStore = SeparateStore(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted();
+            opts.UseRowLevelSecurity("security.tenant");
+        });
+
+        await updatedStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var tableName = updatedStore.Options.Storage.MappingFor(typeof(Target)).TableName;
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "select pg_get_expr(p.polqual, p.polrelid), pg_get_expr(p.polwithcheck, p.polrelid) " +
+            "from pg_policy p " +
+            "join pg_class c on p.polrelid = c.oid " +
+            "join pg_namespace n on c.relnamespace = n.oid " +
+            "where n.nspname = @schema and c.relname = @table and p.polname = 'marten_tenant_isolation'";
+        cmd.Parameters.AddWithValue("schema", tableName.Schema);
+        cmd.Parameters.AddWithValue("table", tableName.Name);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        (await reader.ReadAsync()).ShouldBeTrue();
+
+        var usingExpression = reader.GetString(0);
+        var checkExpression = reader.GetString(1);
+
+        usingExpression.ShouldContain("current_setting('security.tenant'");
+        usingExpression.ShouldNotContain("current_setting('app.tenant_id'");
+        checkExpression.ShouldContain("current_setting('security.tenant'");
+        checkExpression.ShouldNotContain("current_setting('app.tenant_id'");
+    }
+
+    [Fact]
+    public async Task removes_rls_policy_when_configuration_disables_row_level_security()
+    {
+        using var storeWithRls = SeparateStore(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted();
+            opts.UseRowLevelSecurity();
+        });
+
+        await storeWithRls.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        using var storeWithoutRls = SeparateStore(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted();
+        });
+
+        await storeWithoutRls.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var tableName = storeWithoutRls.Options.Storage.MappingFor(typeof(Target)).TableName;
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using var policyCmd = conn.CreateCommand();
+        policyCmd.CommandText =
+            "select count(*) from pg_policy p " +
+            "join pg_class c on p.polrelid = c.oid " +
+            "join pg_namespace n on c.relnamespace = n.oid " +
+            "where n.nspname = @schema and c.relname = @table and p.polname = 'marten_tenant_isolation'";
+        policyCmd.Parameters.AddWithValue("schema", tableName.Schema);
+        policyCmd.Parameters.AddWithValue("table", tableName.Name);
+
+        var policyCount = (long)(await policyCmd.ExecuteScalarAsync());
+        policyCount.ShouldBe(0);
+
+        await using var flagsCmd = conn.CreateCommand();
+        flagsCmd.CommandText =
+            "select c.relrowsecurity, c.relforcerowsecurity from pg_class c " +
+            "join pg_namespace n on c.relnamespace = n.oid " +
+            "where n.nspname = @schema and c.relname = @table";
+        flagsCmd.Parameters.AddWithValue("schema", tableName.Schema);
+        flagsCmd.Parameters.AddWithValue("table", tableName.Name);
+
+        await using var reader = await flagsCmd.ExecuteReaderAsync();
+        (await reader.ReadAsync()).ShouldBeTrue();
+        reader.GetBoolean(0).ShouldBeFalse();
+        reader.GetBoolean(1).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task mapping_opt_out_excludes_only_that_table_when_store_rls_enabled()
+    {
+        StoreOptions(opts =>
+        {
+            opts.UseRowLevelSecurity();
+            opts.Schema.For<Target>().MultiTenanted();
+            opts.Schema.For<User>().MultiTenanted().DisableRowLevelSecurity();
+        });
+
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var targetTable = theStore.Options.Storage.MappingFor(typeof(Target)).TableName;
+        var userTable = theStore.Options.Storage.MappingFor(typeof(User)).TableName;
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        (await PolicyCountAsync(conn, targetTable)).ShouldBe(1);
+        (await PolicyCountAsync(conn, userTable)).ShouldBe(0);
+
+        var (targetRls, targetForce) = await ReadRlsFlagsAsync(conn, targetTable);
+        targetRls.ShouldBeTrue();
+        targetForce.ShouldBeTrue();
+
+        var (userRls, userForce) = await ReadRlsFlagsAsync(conn, userTable);
+        userRls.ShouldBeFalse();
+        userForce.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task mapping_custom_setting_writes_policy_with_that_setting()
+    {
+        StoreOptions(opts =>
+        {
+            opts.UseRowLevelSecurity();
+            opts.Schema.For<Target>().MultiTenanted();
+            opts.Schema.For<User>().MultiTenanted().UseRowLevelSecurity("app.org_id");
+        });
+
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var targetTable = theStore.Options.Storage.MappingFor(typeof(Target)).TableName;
+        var userTable = theStore.Options.Storage.MappingFor(typeof(User)).TableName;
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        (await ReadPolicyExpressionAsync(conn, targetTable)).ShouldContain("current_setting('app.tenant_id'");
+        (await ReadPolicyExpressionAsync(conn, userTable)).ShouldContain("current_setting('app.org_id'");
+    }
+
+    [Fact]
+    public async Task mapping_opt_out_drops_previously_applied_policy_on_next_migration()
+    {
+        using var initialStore = SeparateStore(opts =>
+        {
+            opts.UseRowLevelSecurity();
+            opts.Schema.For<Target>().MultiTenanted();
+        });
+
+        await initialStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        using var updatedStore = SeparateStore(opts =>
+        {
+            opts.UseRowLevelSecurity();
+            opts.Schema.For<Target>().MultiTenanted().DisableRowLevelSecurity();
+        });
+
+        await updatedStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var tableName = updatedStore.Options.Storage.MappingFor(typeof(Target)).TableName;
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        (await PolicyCountAsync(conn, tableName)).ShouldBe(0);
+
+        var (rls, force) = await ReadRlsFlagsAsync(conn, tableName);
+        rls.ShouldBeFalse();
+        force.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task global_setting_switches_to_table_specific_setting_on_next_migration()
+    {
+        using var initialStore = SeparateStore(opts =>
+        {
+            opts.UseRowLevelSecurity();
+            opts.Schema.For<Target>().MultiTenanted();
+        });
+
+        await initialStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        using var updatedStore = SeparateStore(opts =>
+        {
+            opts.UseRowLevelSecurity();
+            opts.Schema.For<Target>().MultiTenanted().UseRowLevelSecurity("app.org_id");
+        });
+
+        await updatedStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var tableName = updatedStore.Options.Storage.MappingFor(typeof(Target)).TableName;
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        var expression = await ReadPolicyExpressionAsync(conn, tableName);
+        expression.ShouldContain("current_setting('app.org_id'");
+        expression.ShouldNotContain("current_setting('app.tenant_id'");
+    }
+
+    [Fact]
+    public async Task table_specific_setting_reverts_to_global_setting_when_override_removed()
+    {
+        using var initialStore = SeparateStore(opts =>
+        {
+            opts.UseRowLevelSecurity();
+            opts.Schema.For<Target>().MultiTenanted().UseRowLevelSecurity("app.org_id");
+        });
+
+        await initialStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        using var updatedStore = SeparateStore(opts =>
+        {
+            opts.UseRowLevelSecurity();
+            opts.Schema.For<Target>().MultiTenanted();
+        });
+
+        await updatedStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var tableName = updatedStore.Options.Storage.MappingFor(typeof(Target)).TableName;
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        var expression = await ReadPolicyExpressionAsync(conn, tableName);
+        expression.ShouldContain("current_setting('app.tenant_id'");
+        expression.ShouldNotContain("current_setting('app.org_id'");
+    }
+
+    [Fact]
+    public async Task mapping_level_opt_in_creates_policy_when_store_rls_is_off()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Target>().MultiTenanted().UseRowLevelSecurity("app.org_id");
+        });
+
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var tableName = theStore.Options.Storage.MappingFor(typeof(Target)).TableName;
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        (await PolicyCountAsync(conn, tableName)).ShouldBe(1);
+
+        var (rls, force) = await ReadRlsFlagsAsync(conn, tableName);
+        rls.ShouldBeTrue();
+        force.ShouldBeTrue();
+
+        (await ReadPolicyExpressionAsync(conn, tableName)).ShouldContain("current_setting('app.org_id'");
+    }
+
+    private static async Task<long> PolicyCountAsync(NpgsqlConnection conn, Weasel.Core.DbObjectName tableName)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "select count(*) from pg_policy p " +
+            "join pg_class c on p.polrelid = c.oid " +
+            "join pg_namespace n on c.relnamespace = n.oid " +
+            "where n.nspname = @schema and c.relname = @table and p.polname = 'marten_tenant_isolation'";
+        cmd.Parameters.AddWithValue("schema", tableName.Schema);
+        cmd.Parameters.AddWithValue("table", tableName.Name);
+        return (long)await cmd.ExecuteScalarAsync();
+    }
+
+    private static async Task<(bool Rls, bool Force)> ReadRlsFlagsAsync(NpgsqlConnection conn, Weasel.Core.DbObjectName tableName)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "select c.relrowsecurity, c.relforcerowsecurity from pg_class c " +
+            "join pg_namespace n on c.relnamespace = n.oid " +
+            "where n.nspname = @schema and c.relname = @table";
+        cmd.Parameters.AddWithValue("schema", tableName.Schema);
+        cmd.Parameters.AddWithValue("table", tableName.Name);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        (await reader.ReadAsync()).ShouldBeTrue();
+        return (reader.GetBoolean(0), reader.GetBoolean(1));
+    }
+
+    private static async Task<string> ReadPolicyExpressionAsync(NpgsqlConnection conn, Weasel.Core.DbObjectName tableName)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "select pg_get_expr(p.polqual, p.polrelid) from pg_policy p " +
+            "join pg_class c on p.polrelid = c.oid " +
+            "join pg_namespace n on c.relnamespace = n.oid " +
+            "where n.nspname = @schema and c.relname = @table and p.polname = 'marten_tenant_isolation'";
+        cmd.Parameters.AddWithValue("schema", tableName.Schema);
+        cmd.Parameters.AddWithValue("table", tableName.Name);
+        var result = await cmd.ExecuteScalarAsync();
+        return (string)result;
+    }
+}

--- a/src/Marten/Events/Daemon/Internals/ProjectionDocumentSession.cs
+++ b/src/Marten/Events/Daemon/Internals/ProjectionDocumentSession.cs
@@ -19,7 +19,7 @@ internal class ProjectionDocumentSession: DocumentSessionBase, ITransactionParti
 
     public ProjectionDocumentSession(DocumentStore store,
         ISessionWorkTracker workTracker,
-        SessionOptions sessionOptions, ShardExecutionMode mode): base(store, sessionOptions, new AutoClosingLifetime(sessionOptions, store.Options), workTracker)
+        SessionOptions sessionOptions, ShardExecutionMode mode): base(store, sessionOptions, sessionOptions.BuildAutoClosingLifetime(store), workTracker)
     {
         Mode = mode;
     }

--- a/src/Marten/Internal/Sessions/AmbientTransactionLifetime.cs
+++ b/src/Marten/Internal/Sessions/AmbientTransactionLifetime.cs
@@ -54,20 +54,26 @@ internal class AmbientTransactionLifetime: ConnectionLifetimeBase, IAlwaysConnec
 
 
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
+        if (_connection is { State: ConnectionState.Open })
+        {
+            await BeforeCloseAsync(_connection, CancellationToken.None).ConfigureAwait(false);
+        }
         if (_connection != null)
         {
-            return _connection.DisposeAsync();
+            await _connection.DisposeAsync().ConfigureAwait(false);
         }
-
-        return new ValueTask();
     }
 
     public void Dispose()
     {
         if (OwnsConnection)
         {
+            if (_connection is { State: ConnectionState.Open })
+            {
+                BeforeClose(_connection);
+            }
             _connection?.Close();
             _connection?.Dispose();
         }
@@ -116,6 +122,7 @@ internal class AmbientTransactionLifetime: ConnectionLifetimeBase, IAlwaysConnec
             _connection = _options.Tenant.Database.CreateConnection();
 #pragma warning restore CS8602
             _connection.Open();
+            AfterOpened(_connection);
             _connection.EnlistTransaction(_options.DotNetTransaction);
         }
     }
@@ -133,8 +140,27 @@ internal class AmbientTransactionLifetime: ConnectionLifetimeBase, IAlwaysConnec
             _connection = _options.Tenant.Database.CreateConnection();
 #pragma warning restore CS8602
             await _connection.OpenAsync(token).ConfigureAwait(false);
+            await AfterOpenedAsync(_connection, token).ConfigureAwait(false);
             _connection.EnlistTransaction(_options.DotNetTransaction);
         }
+    }
+
+    protected virtual void AfterOpened(NpgsqlConnection connection)
+    {
+    }
+
+    protected virtual Task AfterOpenedAsync(NpgsqlConnection connection, CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected virtual void BeforeClose(NpgsqlConnection connection)
+    {
+    }
+
+    protected virtual Task BeforeCloseAsync(NpgsqlConnection connection, CancellationToken token)
+    {
+        return Task.CompletedTask;
     }
 
     public int Execute(NpgsqlCommand cmd)

--- a/src/Marten/Internal/Sessions/AutoClosingLifetime.cs
+++ b/src/Marten/Internal/Sessions/AutoClosingLifetime.cs
@@ -49,11 +49,21 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
 
     }
 
+    protected virtual void AfterOpened(NpgsqlConnection connection)
+    {
+    }
+
+    protected virtual Task AfterOpenedAsync(NpgsqlConnection connection, CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
+
     public int Execute(NpgsqlCommand cmd)
     {
         Logger.OnBeforeExecute(cmd);
         using var conn = _database.CreateConnection();
         conn.Open();
+        AfterOpened(conn);
         try
         {
             cmd.Connection = conn;
@@ -80,6 +90,7 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
         Logger.OnBeforeExecute(command);
         await using var conn = _database.CreateConnection();
         await conn.OpenAsync(token).ConfigureAwait(false);
+        await AfterOpenedAsync(conn, token).ConfigureAwait(false);
 
         try
         {
@@ -108,6 +119,7 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
         // Do NOT use a using block here because we're returning the reader
         var conn = _database.CreateConnection(_readerConnectionUsage);
         conn.Open();
+        AfterOpened(conn);
 
         try
         {
@@ -132,6 +144,7 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
         // Do NOT use a using block here because we're returning the reader
         var conn = _database.CreateConnection(_readerConnectionUsage);
         await conn.OpenAsync(token).ConfigureAwait(false);
+        await AfterOpenedAsync(conn, token).ConfigureAwait(false);
 
         try
         {
@@ -156,6 +169,7 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
         // Do NOT use a using block here because we're returning the reader
         var conn = _database.CreateConnection(_readerConnectionUsage);
         conn.Open();
+        AfterOpened(conn);
 
         try
         {
@@ -179,6 +193,7 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
         // Do NOT use a using block here because we're returning the reader
         var conn = _database.CreateConnection(_readerConnectionUsage);
         await conn.OpenAsync(token).ConfigureAwait(false);
+        await AfterOpenedAsync(conn, token).ConfigureAwait(false);
 
         try
         {
@@ -201,6 +216,7 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
     {
         using var conn = _database.CreateConnection();
         conn.Open();
+        AfterOpened(conn);
 
         try
         {
@@ -290,6 +306,7 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
     {
         await using var conn = _database.CreateConnection();
         await conn.OpenAsync(token).ConfigureAwait(false);
+        await AfterOpenedAsync(conn, token).ConfigureAwait(false);
 
         try
         {
@@ -385,22 +402,22 @@ internal class AutoClosingLifetime: ConnectionLifetimeBase, IConnectionLifetime,
 
     public IAlwaysConnectedLifetime Start()
     {
-        var transaction = _options.Mode == CommandRunnerMode.ReadOnly
-            ? new ReadOnlyTransactionalConnection(_options){Logger = Logger, CommandTimeout = CommandTimeout}
-            : new TransactionalConnection(_options){Logger = Logger, CommandTimeout = CommandTimeout};
+        var transaction = CreateStickyConnection();
         transaction.BeginTransaction();
-
         return transaction;
     }
 
     public async Task<IAlwaysConnectedLifetime> StartAsync(CancellationToken token)
     {
-        var transaction = _options.Mode == CommandRunnerMode.ReadOnly
-            ? new ReadOnlyTransactionalConnection(_options){Logger = Logger, CommandTimeout = CommandTimeout}
-            : new TransactionalConnection(_options){Logger = Logger, CommandTimeout = CommandTimeout };
-
+        var transaction = CreateStickyConnection();
         await transaction.BeginTransactionAsync(token).ConfigureAwait(false);
-
         return transaction;
+    }
+
+    protected virtual TransactionalConnection CreateStickyConnection()
+    {
+        return _options.Mode == CommandRunnerMode.ReadOnly
+            ? new ReadOnlyTransactionalConnection(_options) { Logger = Logger, CommandTimeout = CommandTimeout }
+            : new TransactionalConnection(_options) { Logger = Logger, CommandTimeout = CommandTimeout };
     }
 }

--- a/src/Marten/Internal/Sessions/ExternalTransaction.cs
+++ b/src/Marten/Internal/Sessions/ExternalTransaction.cs
@@ -35,24 +35,24 @@ internal class ExternalTransaction: ConnectionLifetimeBase, IAlwaysConnectedLife
 
     public NpgsqlTransaction Transaction { get; }
 
-    public ValueTask DisposeAsync()
+    public virtual ValueTask DisposeAsync()
     {
         return new ValueTask();
     }
 
-    public void Dispose()
+    public virtual void Dispose()
     {
         // Nothing
     }
 
-    public void Apply(NpgsqlCommand command)
+    public virtual void Apply(NpgsqlCommand command)
     {
         command.Connection = Connection;
         command.Transaction = Transaction;
         command.CommandTimeout = CommandTimeout;
     }
 
-    public Task ApplyAsync(NpgsqlCommand command, CancellationToken token)
+    public virtual Task ApplyAsync(NpgsqlCommand command, CancellationToken token)
     {
         command.Connection = Connection;
         command.Transaction = Transaction;
@@ -61,14 +61,14 @@ internal class ExternalTransaction: ConnectionLifetimeBase, IAlwaysConnectedLife
         return Task.CompletedTask;
     }
 
-    public void Apply(NpgsqlBatch batch)
+    public virtual void Apply(NpgsqlBatch batch)
     {
         batch.Connection = Connection;
         batch.Transaction = Transaction;
         batch.Timeout = CommandTimeout;
     }
 
-    public Task ApplyAsync(NpgsqlBatch batch, CancellationToken token)
+    public virtual Task ApplyAsync(NpgsqlBatch batch, CancellationToken token)
     {
         batch.Connection = Connection;
         batch.Transaction = Transaction;

--- a/src/Marten/Internal/Sessions/Rls/RlsAmbientTransactionLifetime.cs
+++ b/src/Marten/Internal/Sessions/Rls/RlsAmbientTransactionLifetime.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Services;
+using Npgsql;
+
+namespace Marten.Internal.Sessions.Rls;
+
+internal sealed class RlsAmbientTransactionLifetime: AmbientTransactionLifetime
+{
+    private readonly string _tenantId;
+    private readonly string _settingName;
+
+    public RlsAmbientTransactionLifetime(SessionOptions options, string tenantId, string settingName): base(options)
+    {
+        _tenantId = tenantId;
+        _settingName = settingName;
+    }
+
+    protected override void AfterOpened(NpgsqlConnection connection)
+    {
+        RlsSessionVariableApplier.Apply(connection, _settingName, _tenantId);
+    }
+
+    protected override Task AfterOpenedAsync(NpgsqlConnection connection, CancellationToken token)
+    {
+        return RlsSessionVariableApplier.ApplyAsync(connection, _settingName, _tenantId, token);
+    }
+
+    protected override void BeforeClose(NpgsqlConnection connection)
+    {
+        RlsSessionVariableApplier.Reset(connection, _settingName);
+    }
+
+    protected override Task BeforeCloseAsync(NpgsqlConnection connection, CancellationToken token)
+    {
+        return RlsSessionVariableApplier.ResetAsync(connection, _settingName, token);
+    }
+}

--- a/src/Marten/Internal/Sessions/Rls/RlsAutoClosingLifetime.cs
+++ b/src/Marten/Internal/Sessions/Rls/RlsAutoClosingLifetime.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Services;
+using Npgsql;
+
+namespace Marten.Internal.Sessions.Rls;
+
+internal sealed class RlsAutoClosingLifetime: AutoClosingLifetime
+{
+    private readonly SessionOptions _options;
+    private readonly string _tenantId;
+    private readonly string _settingName;
+
+    public RlsAutoClosingLifetime(SessionOptions options, StoreOptions storeOptions, string tenantId, string settingName)
+        : base(options, storeOptions)
+    {
+        _options = options;
+        _tenantId = tenantId;
+        _settingName = settingName;
+    }
+
+    protected override void AfterOpened(NpgsqlConnection connection)
+    {
+        RlsSessionVariableApplier.Apply(connection, _settingName, _tenantId);
+    }
+
+    protected override Task AfterOpenedAsync(NpgsqlConnection connection, CancellationToken token)
+    {
+        return RlsSessionVariableApplier.ApplyAsync(connection, _settingName, _tenantId, token);
+    }
+
+    protected override TransactionalConnection CreateStickyConnection()
+    {
+        return _options.Mode == CommandRunnerMode.ReadOnly
+            ? new RlsReadOnlyTransactionalConnection(_options, _tenantId, _settingName) { Logger = Logger, CommandTimeout = CommandTimeout }
+            : new RlsTransactionalConnection(_options, _tenantId, _settingName) { Logger = Logger, CommandTimeout = CommandTimeout };
+    }
+}

--- a/src/Marten/Internal/Sessions/Rls/RlsExternalTransaction.cs
+++ b/src/Marten/Internal/Sessions/Rls/RlsExternalTransaction.cs
@@ -1,0 +1,77 @@
+#nullable enable
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Services;
+using Npgsql;
+
+namespace Marten.Internal.Sessions.Rls;
+
+internal sealed class RlsExternalTransaction: ExternalTransaction
+{
+    private readonly string _tenantId;
+    private readonly string _settingName;
+    private bool _applied;
+
+    public RlsExternalTransaction(SessionOptions options, string tenantId, string settingName): base(options)
+    {
+        _tenantId = tenantId;
+        _settingName = settingName;
+    }
+
+    public override void Apply(NpgsqlCommand command)
+    {
+        EnsureApplied();
+        base.Apply(command);
+    }
+
+    public override async Task ApplyAsync(NpgsqlCommand command, CancellationToken token)
+    {
+        await EnsureAppliedAsync(token).ConfigureAwait(false);
+        await base.ApplyAsync(command, token).ConfigureAwait(false);
+    }
+
+    public override void Apply(NpgsqlBatch batch)
+    {
+        EnsureApplied();
+        base.Apply(batch);
+    }
+
+    public override async Task ApplyAsync(NpgsqlBatch batch, CancellationToken token)
+    {
+        await EnsureAppliedAsync(token).ConfigureAwait(false);
+        await base.ApplyAsync(batch, token).ConfigureAwait(false);
+    }
+
+    public override void Dispose()
+    {
+        if (_applied)
+        {
+            RlsSessionVariableApplier.Reset(Connection, _settingName);
+        }
+        base.Dispose();
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (_applied)
+        {
+            await RlsSessionVariableApplier.ResetAsync(Connection, _settingName).ConfigureAwait(false);
+        }
+        await base.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private void EnsureApplied()
+    {
+        if (_applied || Connection.State != ConnectionState.Open) return;
+        RlsSessionVariableApplier.Apply(Connection, _settingName, _tenantId);
+        _applied = true;
+    }
+
+    private async ValueTask EnsureAppliedAsync(CancellationToken token)
+    {
+        if (_applied || Connection.State != ConnectionState.Open) return;
+        await RlsSessionVariableApplier.ApplyAsync(Connection, _settingName, _tenantId, token).ConfigureAwait(false);
+        _applied = true;
+    }
+}

--- a/src/Marten/Internal/Sessions/Rls/RlsReadOnlyTransactionalConnection.cs
+++ b/src/Marten/Internal/Sessions/Rls/RlsReadOnlyTransactionalConnection.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Services;
+using Npgsql;
+
+namespace Marten.Internal.Sessions.Rls;
+
+internal sealed class RlsReadOnlyTransactionalConnection: ReadOnlyTransactionalConnection
+{
+    private readonly string _tenantId;
+    private readonly string _settingName;
+
+    public RlsReadOnlyTransactionalConnection(SessionOptions options, string tenantId, string settingName): base(options)
+    {
+        _tenantId = tenantId;
+        _settingName = settingName;
+    }
+
+    protected override void AfterOpened(NpgsqlConnection connection)
+    {
+        RlsSessionVariableApplier.Apply(connection, _settingName, _tenantId);
+    }
+
+    protected override Task AfterOpenedAsync(NpgsqlConnection connection, CancellationToken token)
+    {
+        return RlsSessionVariableApplier.ApplyAsync(connection, _settingName, _tenantId, token);
+    }
+
+    protected override void BeforeClose(NpgsqlConnection connection)
+    {
+        RlsSessionVariableApplier.Reset(connection, _settingName);
+    }
+
+    protected override Task BeforeCloseAsync(NpgsqlConnection connection, CancellationToken token)
+    {
+        return RlsSessionVariableApplier.ResetAsync(connection, _settingName, token);
+    }
+}

--- a/src/Marten/Internal/Sessions/Rls/RlsSessionVariableApplier.cs
+++ b/src/Marten/Internal/Sessions/Rls/RlsSessionVariableApplier.cs
@@ -1,0 +1,50 @@
+#nullable enable
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+
+namespace Marten.Internal.Sessions.Rls;
+
+internal static class RlsSessionVariableApplier
+{
+    private const string SetConfigSql = "SELECT set_config(@name, @value, false)";
+
+    public static void Apply(NpgsqlConnection connection, string settingName, string tenantId)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = SetConfigSql;
+        cmd.Parameters.AddWithValue("name", settingName);
+        cmd.Parameters.AddWithValue("value", tenantId);
+        cmd.ExecuteNonQuery();
+    }
+
+    public static async Task ApplyAsync(NpgsqlConnection connection, string settingName, string tenantId, CancellationToken token)
+    {
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = SetConfigSql;
+        cmd.Parameters.AddWithValue("name", settingName);
+        cmd.Parameters.AddWithValue("value", tenantId);
+        await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+    }
+
+    public static void Reset(NpgsqlConnection connection, string settingName)
+    {
+        if (connection.State != ConnectionState.Open) return;
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT set_config(@name, NULL, false)";
+        cmd.Parameters.AddWithValue("name", settingName);
+        cmd.ExecuteNonQuery();
+    }
+
+    public static async Task ResetAsync(NpgsqlConnection connection, string settingName, CancellationToken token = default)
+    {
+        if (connection.State != ConnectionState.Open) return;
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT set_config(@name, NULL, false)";
+        cmd.Parameters.AddWithValue("name", settingName);
+        await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+    }
+}

--- a/src/Marten/Internal/Sessions/Rls/RlsTransactionalConnection.cs
+++ b/src/Marten/Internal/Sessions/Rls/RlsTransactionalConnection.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Services;
+using Npgsql;
+
+namespace Marten.Internal.Sessions.Rls;
+
+internal class RlsTransactionalConnection: TransactionalConnection
+{
+    private readonly string _tenantId;
+    private readonly string _settingName;
+
+    public RlsTransactionalConnection(SessionOptions options, string tenantId, string settingName): base(options)
+    {
+        _tenantId = tenantId;
+        _settingName = settingName;
+    }
+
+    protected override void AfterOpened(NpgsqlConnection connection)
+    {
+        RlsSessionVariableApplier.Apply(connection, _settingName, _tenantId);
+    }
+
+    protected override Task AfterOpenedAsync(NpgsqlConnection connection, CancellationToken token)
+    {
+        return RlsSessionVariableApplier.ApplyAsync(connection, _settingName, _tenantId, token);
+    }
+
+    protected override void BeforeClose(NpgsqlConnection connection)
+    {
+        RlsSessionVariableApplier.Reset(connection, _settingName);
+    }
+
+    protected override Task BeforeCloseAsync(NpgsqlConnection connection, CancellationToken token)
+    {
+        return RlsSessionVariableApplier.ResetAsync(connection, _settingName, token);
+    }
+}

--- a/src/Marten/Internal/Sessions/TransactionalConnection.cs
+++ b/src/Marten/Internal/Sessions/TransactionalConnection.cs
@@ -49,6 +49,11 @@ internal class TransactionalConnection: ConnectionLifetimeBase, IAlwaysConnected
             await Transaction.DisposeAsync().ConfigureAwait(false);
         }
 
+        if (_connection is { State: ConnectionState.Open })
+        {
+            await BeforeCloseAsync(_connection, CancellationToken.None).ConfigureAwait(false);
+        }
+
         if (_connection != null)
         {
             await _connection.DisposeAsync().ConfigureAwait(false);
@@ -58,6 +63,10 @@ internal class TransactionalConnection: ConnectionLifetimeBase, IAlwaysConnected
     public void Dispose()
     {
         Transaction?.SafeDispose();
+        if (_connection is { State: ConnectionState.Open })
+        {
+            BeforeClose(_connection);
+        }
         _connection?.SafeDispose();
     }
 
@@ -125,6 +134,10 @@ internal class TransactionalConnection: ConnectionLifetimeBase, IAlwaysConnected
         Transaction.Dispose();
         Transaction = null;
 
+        if (_connection is { State: ConnectionState.Open })
+        {
+            BeforeClose(_connection);
+        }
         _connection?.Close();
         _connection = null;
     }
@@ -142,6 +155,10 @@ internal class TransactionalConnection: ConnectionLifetimeBase, IAlwaysConnected
 
         if (_connection != null)
         {
+            if (_connection.State == ConnectionState.Open)
+            {
+                await BeforeCloseAsync(_connection, token).ConfigureAwait(false);
+            }
             await _connection.CloseAsync().ConfigureAwait(false);
             await _connection.DisposeAsync().ConfigureAwait(false);
         }
@@ -157,6 +174,10 @@ internal class TransactionalConnection: ConnectionLifetimeBase, IAlwaysConnected
             Transaction.Dispose();
             Transaction = null;
 
+            if (_connection is { State: ConnectionState.Open })
+            {
+                BeforeClose(_connection);
+            }
             _connection?.Close();
             _connection?.Dispose();
             _connection = null;
@@ -173,6 +194,10 @@ internal class TransactionalConnection: ConnectionLifetimeBase, IAlwaysConnected
 
             if (_connection != null)
             {
+                if (_connection.State == ConnectionState.Open)
+                {
+                    await BeforeCloseAsync(_connection, token).ConfigureAwait(false);
+                }
                 await _connection.CloseAsync().ConfigureAwait(false);
                 await _connection.DisposeAsync().ConfigureAwait(false);
             }
@@ -194,6 +219,7 @@ internal class TransactionalConnection: ConnectionLifetimeBase, IAlwaysConnected
         if (_connection.State == ConnectionState.Closed)
         {
             _connection.Open();
+            AfterOpened(_connection);
         }
     }
 
@@ -209,7 +235,26 @@ internal class TransactionalConnection: ConnectionLifetimeBase, IAlwaysConnected
         if (_connection.State == ConnectionState.Closed)
         {
             await _connection.OpenAsync(token).ConfigureAwait(false);
+            await AfterOpenedAsync(_connection, token).ConfigureAwait(false);
         }
+    }
+
+    protected virtual void AfterOpened(NpgsqlConnection connection)
+    {
+    }
+
+    protected virtual Task AfterOpenedAsync(NpgsqlConnection connection, CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected virtual void BeforeClose(NpgsqlConnection connection)
+    {
+    }
+
+    protected virtual Task BeforeCloseAsync(NpgsqlConnection connection, CancellationToken token)
+    {
+        return Task.CompletedTask;
     }
 
     public int Execute(NpgsqlCommand cmd)

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -788,6 +788,42 @@ public class MartenRegistry
         }
 
         /// <summary>
+        /// Enable PostgreSQL Row Level Security for this document type only, overriding
+        /// any store-level setting. Requires conjoined tenancy. When <paramref name="settingName"/>
+        /// is null the store-level RLS setting is used, falling back to "app.tenant_id".
+        /// <para>
+        /// Note: Marten only sets the store-level GUC on each opened session connection. If this
+        /// override uses a different setting name than the store, the application is responsible
+        /// for populating that GUC on each session; Marten writes the policy but does not set
+        /// the custom GUC automatically.
+        /// </para>
+        /// </summary>
+        public DocumentMappingExpression<T> UseRowLevelSecurity(string? settingName = null)
+        {
+            _builder.Alter = m =>
+            {
+                m.RlsOverride = true;
+                m.RlsSettingOverride = settingName;
+            };
+            return this;
+        }
+
+        /// <summary>
+        /// Explicitly disable PostgreSQL Row Level Security for this document type, even
+        /// when Row Level Security is enabled store-wide. A subsequent schema migration
+        /// drops any previously applied tenant-isolation policy on this table.
+        /// </summary>
+        public DocumentMappingExpression<T> DisableRowLevelSecurity()
+        {
+            _builder.Alter = m =>
+            {
+                m.RlsOverride = false;
+                m.RlsSettingOverride = null;
+            };
+            return this;
+        }
+
+        /// <summary>
         ///     Marks just this document type as being stored with conjoined multi-tenancy
         /// </summary>
         /// <returns></returns>

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -190,6 +190,47 @@ public partial class DocumentMapping: IDocumentMapping, IDocumentType
     // TODO: This should be smarter, maybe nullable option for Schema or some other base type
     internal bool SkipSchemaGeneration { get; set; }
 
+    /// <summary>
+    /// Per-mapping override for Row Level Security.
+    /// Null inherits the store-level <see cref="StoreOptions.RlsTenantSessionSetting"/>;
+    /// true forces RLS on for this mapping; false forces it off.
+    /// </summary>
+    internal bool? RlsOverride { get; set; }
+
+    /// <summary>
+    /// Optional per-mapping GUC setting name. Only relevant when RLS is enabled for the
+    /// mapping (either via <see cref="RlsOverride"/> == true or inherited from the store).
+    /// When null, the store-level setting is used.
+    /// </summary>
+    internal string? RlsSettingOverride { get; set; }
+
+    /// <summary>
+    /// Resolves the effective RLS configuration for this mapping: whether a policy
+    /// should be applied and which GUC setting name it should reference.
+    /// Only returns an enabled result for <see cref="TenancyStyle.Conjoined"/> mappings.
+    /// </summary>
+    internal (bool Enabled, string? SettingName) ResolveRowLevelSecurity()
+    {
+        if (TenancyStyle != TenancyStyle.Conjoined)
+        {
+            return (false, null);
+        }
+
+        var storeSetting = StoreOptions.RlsTenantSessionSetting;
+
+        if (RlsOverride == false)
+        {
+            return (false, null);
+        }
+
+        if (RlsOverride == true)
+        {
+            return (true, RlsSettingOverride ?? storeSetting ?? "app.tenant_id");
+        }
+
+        return storeSetting != null ? (true, storeSetting) : (false, null);
+    }
+
     public MemberInfo IdMember
     {
         get => _idMember;

--- a/src/Marten/Schema/DocumentSchema.cs
+++ b/src/Marten/Schema/DocumentSchema.cs
@@ -84,5 +84,13 @@ internal class DocumentSchema: IFeatureSchema
         {
             yield return Overwrite;
         }
+
+        if (_mapping.TenancyStyle == TenancyStyle.Conjoined)
+        {
+            var (enabled, settingName) = _mapping.ResolveRowLevelSecurity();
+            yield return new RlsPolicySchemaObject(
+                _mapping.TableName,
+                enabled ? settingName : null);
+        }
     }
 }

--- a/src/Marten/Services/SessionOptions.cs
+++ b/src/Marten/Services/SessionOptions.cs
@@ -165,9 +165,9 @@ public sealed class SessionOptions
         {
             if (IsolationLevel == IsolationLevel.Serializable)
             {
-                var transaction = mode == CommandRunnerMode.ReadOnly
+                TransactionalConnection transaction = mode == CommandRunnerMode.ReadOnly
                     ? new RlsReadOnlyTransactionalConnection(this, tenantId, rls) { CommandTimeout = timeout }
-                    : (TransactionalConnection)new RlsTransactionalConnection(this, tenantId, rls) { CommandTimeout = timeout };
+                    : new RlsTransactionalConnection(this, tenantId, rls) { CommandTimeout = timeout };
                 transaction.BeginTransaction();
                 return transaction;
             }

--- a/src/Marten/Services/SessionOptions.cs
+++ b/src/Marten/Services/SessionOptions.cs
@@ -10,6 +10,7 @@ using JasperFx.MultiTenancy;
 using Marten.Exceptions;
 using Marten.Internal.OpenTelemetry;
 using Marten.Internal.Sessions;
+using Marten.Internal.Sessions.Rls;
 using Marten.Storage;
 using Npgsql;
 using IsolationLevel = System.Data.IsolationLevel;
@@ -111,46 +112,97 @@ public sealed class SessionOptions
             Mode = CommandRunnerMode.External;
         }
 
+        if (store.Options.RlsTenantSessionSetting is { } rls && Tenant is not null)
+        {
+            return buildRlsConnectionLifetime(store, mode, rls);
+        }
+
+        var timeout = Timeout ?? store.Options.CommandTimeout;
+
         if (OwnsConnection && OwnsTransactionLifecycle)
         {
             if (IsolationLevel == IsolationLevel.Serializable)
             {
                 var transaction = mode == CommandRunnerMode.ReadOnly
-                    ? new ReadOnlyTransactionalConnection(this) { CommandTimeout = Timeout ?? store.Options.CommandTimeout }
-                    : new TransactionalConnection(this) { CommandTimeout = Timeout ?? store.Options.CommandTimeout };
+                    ? new ReadOnlyTransactionalConnection(this) { CommandTimeout = timeout }
+                    : new TransactionalConnection(this) { CommandTimeout = timeout };
                 transaction.BeginTransaction();
-
                 return transaction;
             }
-            else if (store.Options.UseStickyConnectionLifetimes)
+
+            if (store.Options.UseStickyConnectionLifetimes)
             {
-                return new TransactionalConnection(this) { CommandTimeout = Timeout ?? store.Options.CommandTimeout };
+                return new TransactionalConnection(this) { CommandTimeout = timeout };
             }
 
-            {
-                return new AutoClosingLifetime(this, store.Options);
-            }
+            return new AutoClosingLifetime(this, store.Options);
         }
-
 
         if (Transaction != null)
         {
-            return new ExternalTransaction(this) { CommandTimeout = Timeout ?? store.Options.CommandTimeout };
+            return new ExternalTransaction(this) { CommandTimeout = timeout };
         }
-
 
         if (DotNetTransaction != null)
         {
-            return new AmbientTransactionLifetime(this) { CommandTimeout = Timeout ?? store.Options.CommandTimeout };
+            return new AmbientTransactionLifetime(this) { CommandTimeout = timeout };
         }
 
         if (Connection != null)
         {
-            return new TransactionalConnection(this) { CommandTimeout = Timeout ?? store.Options.CommandTimeout };
+            return new TransactionalConnection(this) { CommandTimeout = timeout };
         }
 
+        throw new NotSupportedException("Invalid combination of SessionOptions");
+    }
+
+    private IConnectionLifetime buildRlsConnectionLifetime(DocumentStore store, CommandRunnerMode mode, string rls)
+    {
+        var tenantId = Tenant!.TenantId;
+        var timeout = Timeout ?? store.Options.CommandTimeout;
+
+        if (OwnsConnection && OwnsTransactionLifecycle)
+        {
+            if (IsolationLevel == IsolationLevel.Serializable)
+            {
+                var transaction = mode == CommandRunnerMode.ReadOnly
+                    ? new RlsReadOnlyTransactionalConnection(this, tenantId, rls) { CommandTimeout = timeout }
+                    : (TransactionalConnection)new RlsTransactionalConnection(this, tenantId, rls) { CommandTimeout = timeout };
+                transaction.BeginTransaction();
+                return transaction;
+            }
+
+            if (store.Options.UseStickyConnectionLifetimes)
+            {
+                return new RlsTransactionalConnection(this, tenantId, rls) { CommandTimeout = timeout };
+            }
+
+            return new RlsAutoClosingLifetime(this, store.Options, tenantId, rls);
+        }
+
+        if (Transaction != null)
+        {
+            return new RlsExternalTransaction(this, tenantId, rls) { CommandTimeout = timeout };
+        }
+
+        if (DotNetTransaction != null)
+        {
+            return new RlsAmbientTransactionLifetime(this, tenantId, rls) { CommandTimeout = timeout };
+        }
+
+        if (Connection != null)
+        {
+            return new RlsTransactionalConnection(this, tenantId, rls) { CommandTimeout = timeout };
+        }
 
         throw new NotSupportedException("Invalid combination of SessionOptions");
+    }
+
+    internal AutoClosingLifetime BuildAutoClosingLifetime(DocumentStore store)
+    {
+        return store.Options.RlsTenantSessionSetting is { } rls && Tenant is not null
+            ? new RlsAutoClosingLifetime(this, store.Options, Tenant.TenantId, rls)
+            : new AutoClosingLifetime(this, store.Options);
     }
 
     internal async Task<IConnectionLifetime> InitializeAsync(DocumentStore store, CommandRunnerMode mode,
@@ -172,11 +224,18 @@ public sealed class SessionOptions
             Mode = CommandRunnerMode.External;
         }
 
+        if (store.Options.RlsTenantSessionSetting is { } rls)
+        {
+            return await buildRlsConnectionLifetimeAsync(store, mode, rls, token).ConfigureAwait(false);
+        }
+
+        var timeout = Timeout ?? store.Options.CommandTimeout;
+
         if (OwnsConnection && OwnsTransactionLifecycle)
         {
             var transaction = mode == CommandRunnerMode.ReadOnly
-                ? new ReadOnlyTransactionalConnection(this)
-                : new TransactionalConnection(this);
+                ? new ReadOnlyTransactionalConnection(this) { CommandTimeout = timeout }
+                : new TransactionalConnection(this) { CommandTimeout = timeout };
 
             if (IsolationLevel == IsolationLevel.Serializable)
             {
@@ -188,12 +247,54 @@ public sealed class SessionOptions
 
         if (Transaction != null)
         {
-            return new ExternalTransaction(this);
+            return new ExternalTransaction(this) { CommandTimeout = timeout };
         }
 
         if (DotNetTransaction != null)
         {
-            return new AmbientTransactionLifetime(this);
+            return new AmbientTransactionLifetime(this) { CommandTimeout = timeout };
+        }
+
+        if (Connection != null)
+        {
+            return new TransactionalConnection(this) { CommandTimeout = timeout };
+        }
+
+        throw new NotSupportedException("Invalid combination of SessionOptions");
+    }
+
+    private async Task<IConnectionLifetime> buildRlsConnectionLifetimeAsync(DocumentStore store, CommandRunnerMode mode, string rls, CancellationToken token)
+    {
+        var tenantId = Tenant!.TenantId;
+        var timeout = Timeout ?? store.Options.CommandTimeout;
+
+        if (OwnsConnection && OwnsTransactionLifecycle)
+        {
+            TransactionalConnection transaction = mode == CommandRunnerMode.ReadOnly
+                ? new RlsReadOnlyTransactionalConnection(this, tenantId, rls) { CommandTimeout = timeout }
+                : new RlsTransactionalConnection(this, tenantId, rls) { CommandTimeout = timeout };
+
+            if (IsolationLevel == IsolationLevel.Serializable)
+            {
+                await transaction.BeginTransactionAsync(token).ConfigureAwait(false);
+            }
+
+            return transaction;
+        }
+
+        if (Transaction != null)
+        {
+            return new RlsExternalTransaction(this, tenantId, rls) { CommandTimeout = timeout };
+        }
+
+        if (DotNetTransaction != null)
+        {
+            return new RlsAmbientTransactionLifetime(this, tenantId, rls) { CommandTimeout = timeout };
+        }
+
+        if (Connection != null)
+        {
+            return new RlsTransactionalConnection(this, tenantId, rls) { CommandTimeout = timeout };
         }
 
         throw new NotSupportedException("Invalid combination of SessionOptions");

--- a/src/Marten/Storage/BulkInsertion.cs
+++ b/src/Marten/Storage/BulkInsertion.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
 using JasperFx.Core.Reflection;
+using Marten.Internal.Sessions.Rls;
 using Marten.Schema.BulkLoading;
 using Npgsql;
 using Weasel.Postgresql;
@@ -14,11 +15,20 @@ namespace Marten.Storage;
 internal class BulkInsertion: IDisposable
 {
     private readonly Tenant _tenant;
+    private readonly string? _rlsSettingName;
 
     public BulkInsertion(Tenant tenant, StoreOptions options)
     {
         _tenant = tenant;
         Serializer = options.Serializer();
+        _rlsSettingName = options.RlsTenantSessionSetting;
+    }
+
+    private Task applyRlsIfEnabledAsync(NpgsqlConnection conn, CancellationToken cancellation)
+    {
+        return _rlsSettingName is null
+            ? Task.CompletedTask
+            : RlsSessionVariableApplier.ApplyAsync(conn, _rlsSettingName, _tenant.TenantId, cancellation);
     }
 
     public ISerializer Serializer { get; }
@@ -41,6 +51,7 @@ internal class BulkInsertion: IDisposable
 
             await using var conn = _tenant.Database.CreateConnection();
             await conn.OpenAsync(cancellation).ConfigureAwait(false);
+            await applyRlsIfEnabledAsync(conn, cancellation).ConfigureAwait(false);
 
             var tx = await conn.BeginTransactionAsync(cancellation).ConfigureAwait(false);
             try
@@ -70,6 +81,7 @@ internal class BulkInsertion: IDisposable
             await _tenant.Database.EnsureStorageExistsAsync(typeof(T), cancellation).ConfigureAwait(false);
             await using var conn = _tenant.Database.CreateConnection();
             await conn.OpenAsync(cancellation).ConfigureAwait(false);
+            await applyRlsIfEnabledAsync(conn, cancellation).ConfigureAwait(false);
             conn.EnlistTransaction(transaction);
             await bulkInsertDocumentsAsync(documents, batchSize, conn, mode, cancellation).ConfigureAwait(false);
         }
@@ -99,6 +111,7 @@ internal class BulkInsertion: IDisposable
         await using var conn = _tenant.Database.CreateConnection();
 
         await conn.OpenAsync(cancellation).ConfigureAwait(false);
+        await applyRlsIfEnabledAsync(conn, cancellation).ConfigureAwait(false);
         var tx = await conn.BeginTransactionAsync(cancellation).ConfigureAwait(false);
 
         try
@@ -132,6 +145,7 @@ internal class BulkInsertion: IDisposable
 
         await using var conn = _tenant.Database.CreateConnection();
         await conn.OpenAsync(cancellation).ConfigureAwait(false);
+        await applyRlsIfEnabledAsync(conn, cancellation).ConfigureAwait(false);
         conn.EnlistTransaction(transaction);
 
         foreach (var group in groups)

--- a/src/Marten/Storage/RlsPolicySchemaObject.cs
+++ b/src/Marten/Storage/RlsPolicySchemaObject.cs
@@ -1,0 +1,126 @@
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Weasel.Core;
+using Weasel.Postgresql;
+using DbCommandBuilder = Weasel.Core.DbCommandBuilder;
+using DbDataReader = System.Data.Common.DbDataReader;
+
+namespace Marten.Storage;
+
+/// <summary>
+/// Schema object that manages the PostgreSQL Row Level Security policy
+/// enforcing tenant isolation on a conjoined-tenancy document table.
+/// </summary>
+internal class RlsPolicySchemaObject: ISchemaObject
+{
+    private const string PolicyName = "marten_tenant_isolation";
+    private readonly DbObjectName _tableName;
+    private readonly string? _settingName;
+    private readonly bool _enabled;
+
+    /// <summary>
+    /// Create a new RLS policy schema object for the given document table.
+    /// </summary>
+    /// <param name="tableName">The document table to attach the policy to.</param>
+    /// <param name="settingName">The PostgreSQL session setting name that holds the current tenant id. Null disables Marten-managed RLS for this table.</param>
+    public RlsPolicySchemaObject(DbObjectName tableName, string? settingName)
+    {
+        _tableName = tableName;
+        _settingName = settingName;
+        _enabled = !string.IsNullOrWhiteSpace(settingName);
+        Identifier = new PostgresqlObjectName(
+            _tableName.Schema,
+            $"{_tableName.Name}_{PolicyName}",
+            SchemaUtils.IdentifierUsage.General);
+    }
+
+    /// <inheritdoc />
+    public DbObjectName Identifier { get; }
+
+    /// <inheritdoc />
+    public void WriteCreateStatement(Migrator migrator, TextWriter writer)
+    {
+        var qualifiedTable = $"{_tableName.Schema}.{_tableName.Name}";
+        if (_enabled)
+        {
+            writer.WriteLine($"ALTER TABLE {qualifiedTable} ENABLE ROW LEVEL SECURITY;");
+            writer.WriteLine($"ALTER TABLE {qualifiedTable} FORCE ROW LEVEL SECURITY;");
+            writer.WriteLine($"DROP POLICY IF EXISTS {PolicyName} ON {qualifiedTable};");
+            writer.WriteLine($"CREATE POLICY {PolicyName} ON {qualifiedTable}");
+            writer.WriteLine($"    USING (tenant_id = current_setting('{_settingName}'))");
+            writer.WriteLine($"    WITH CHECK (tenant_id = current_setting('{_settingName}'));");
+        }
+        else
+        {
+            writer.WriteLine($"DROP POLICY IF EXISTS {PolicyName} ON {qualifiedTable};");
+            writer.WriteLine($"ALTER TABLE {qualifiedTable} NO FORCE ROW LEVEL SECURITY;");
+            writer.WriteLine($"ALTER TABLE {qualifiedTable} DISABLE ROW LEVEL SECURITY;");
+        }
+
+        writer.WriteLine();
+    }
+
+    /// <inheritdoc />
+    public void WriteDropStatement(Migrator rules, TextWriter writer)
+    {
+        var qualifiedTable = $"{_tableName.Schema}.{_tableName.Name}";
+        writer.WriteLine($"DROP POLICY IF EXISTS {PolicyName} ON {qualifiedTable};");
+        writer.WriteLine($"ALTER TABLE {qualifiedTable} NO FORCE ROW LEVEL SECURITY;");
+        writer.WriteLine($"ALTER TABLE {qualifiedTable} DISABLE ROW LEVEL SECURITY;");
+        writer.WriteLine();
+    }
+
+    /// <inheritdoc />
+    public void ConfigureQueryCommand(DbCommandBuilder builder)
+    {
+        // Weasel's AddParameter only binds the value — the caller is responsible
+        // for writing the placeholder. AppendParameter does both, so we use it
+        // rather than interpolating {param.ParameterName} (which emits "p0"
+        // without the "@" prefix and is read by PG as a column identifier).
+        if (_enabled)
+        {
+            // Match both RLS flags AND that the policy's USING / WITH CHECK
+            // clauses reference current_setting('<settingName>'). If the user
+            // reconfigures RLS to use a different setting name, the LIKE fails
+            // and the Create path drops + recreates the policy.
+            builder.Append("SELECT 1 FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid WHERE n.nspname = ");
+            builder.AppendParameter(_tableName.Schema);
+            builder.Append(" AND c.relname = ");
+            builder.AppendParameter(_tableName.Name);
+            builder.Append(" AND c.relrowsecurity = TRUE AND c.relforcerowsecurity = TRUE AND EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid AND p.polname = ");
+            builder.AppendParameter(PolicyName);
+            builder.Append(" AND pg_get_expr(p.polqual, p.polrelid) LIKE ");
+            var expressionPattern = $"%current_setting('{_settingName}'%";
+            builder.AppendParameter(expressionPattern);
+            builder.Append(" AND pg_get_expr(p.polwithcheck, p.polrelid) LIKE ");
+            builder.AppendParameter(expressionPattern);
+            builder.Append(");");
+        }
+        else
+        {
+            builder.Append("SELECT 1 FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid WHERE n.nspname = ");
+            builder.AppendParameter(_tableName.Schema);
+            builder.Append(" AND c.relname = ");
+            builder.AppendParameter(_tableName.Name);
+            builder.Append(" AND c.relrowsecurity = FALSE AND c.relforcerowsecurity = FALSE AND NOT EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid AND p.polname = ");
+            builder.AppendParameter(PolicyName);
+            builder.Append(");");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<ISchemaObjectDelta> CreateDeltaAsync(DbDataReader reader, CancellationToken ct = default)
+    {
+        var exists = await reader.ReadAsync(ct).ConfigureAwait(false);
+        return new SchemaObjectDelta(this, exists ? SchemaPatchDifference.None : SchemaPatchDifference.Create);
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<DbObjectName> AllNames()
+    {
+        yield return Identifier;
+    }
+}

--- a/src/Marten/Storage/RlsPolicySchemaObject.cs
+++ b/src/Marten/Storage/RlsPolicySchemaObject.cs
@@ -33,7 +33,7 @@ internal class RlsPolicySchemaObject: ISchemaObject
         _enabled = !string.IsNullOrWhiteSpace(settingName);
         Identifier = new PostgresqlObjectName(
             _tableName.Schema,
-            $"{_tableName.Name}_{PolicyName}",
+            PostgresqlIdentifier.Shorten($"{_tableName.Name}_{PolicyName}"),
             SchemaUtils.IdentifierUsage.General);
     }
 

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using ImTools;
 using JasperFx;
 using JasperFx.CodeGeneration;
@@ -205,6 +206,43 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
     /// Default is false
     /// </summary>
     public bool UseStickyConnectionLifetimes { get; set; } = false;
+
+    /// <summary>
+    /// The PostgreSQL session setting name used for RLS tenant identification.
+    /// Null means RLS is disabled. Defaults to null.
+    /// </summary>
+    public string? RlsTenantSessionSetting { get; private set; }
+
+    private static readonly Regex RlsSettingNamePattern =
+        new(@"^[a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Enable PostgreSQL Row Level Security. Marten will:
+    /// 1. Call set_config('{settingName}', '{tenantId}', false) on every connection
+    /// 2. Automatically create RLS policies on conjoined-tenancy tables
+    /// </summary>
+    /// <param name="settingName">
+    /// The PostgreSQL session setting name to use. Must be a qualified custom GUC
+    /// identifier of the form "prefix.name" (letters, digits, underscores only).
+    /// Defaults to "app.tenant_id".
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="settingName"/> is not a qualified identifier.
+    /// Required because the setting name is interpolated into <c>current_setting(...)</c>
+    /// inside the generated RLS policy DDL.
+    /// </exception>
+    public void UseRowLevelSecurity(string settingName = "app.tenant_id")
+    {
+        if (!RlsSettingNamePattern.IsMatch(settingName))
+        {
+            throw new ArgumentException(
+                $"Setting name '{settingName}' is not a valid PostgreSQL custom GUC identifier. " +
+                "Expected form: 'prefix.name' using letters, digits, and underscores.",
+                nameof(settingName));
+        }
+
+        RlsTenantSessionSetting = settingName;
+    }
 
     /// <summary>
     /// Polly policies for retries within Marten command execution


### PR DESCRIPTION
## Summary

Opt-in PostgreSQL Row Level Security as a database-enforced safety net on top of Marten's conjoined-tenancy filter — so any connection (raw SQL, ad-hoc analytics, code that bypasses Marten's session) can only see rows belonging to the current tenant.

- `StoreOptions.UseRowLevelSecurity(settingName = "app.tenant_id")` emits `ENABLE` + `FORCE ROW LEVEL SECURITY` and a `marten_tenant_isolation` policy (`tenant_id = current_setting('<setting>')`) on every conjoined-tenancy table via the normal schema migration pipeline. Toggling off, renaming the setting, or overriding per-mapping produces the correct `DROP`/`CREATE` deltas.
- Per-mapping overrides on `DocumentMappingExpression`: `.DisableRowLevelSecurity()` to exempt a table, `.UseRowLevelSecurity("custom.setting")` to use a different GUC for that table. Resolution order: mapping override → store setting → default.
- Marten applies the session GUC (`set_config`) on every opened session connection via RLS-aware subclasses of each `IConnectionLifetime` (`RlsAutoClosingLifetime`, `RlsTransactionalConnection`, `RlsReadOnlyTransactionalConnection`, `RlsAmbientTransactionLifetime`, `RlsExternalTransaction`). Lifetimes expose `AfterOpened` / `BeforeClose` virtual hooks; sticky variants reset the GUC before close so the connection returns clean to the pool.
- Covers every session shape: auto-closing, sticky, serializable, caller-supplied `NpgsqlTransaction`, ambient `System.Transactions`, pre-opened `NpgsqlConnection`, async projection daemon sessions, and `BulkInsertAsync`.

Docs: [docs/documents/multi-tenancy.md § Row Level Security](docs/documents/multi-tenancy.md).

## Caveats

- RLS applies only to `TenancyStyle.Conjoined` document tables. Event store tables (`mt_events`, `mt_streams`) are out of scope and receive no policy.
- PostgreSQL **superusers always bypass RLS** regardless of `FORCE`. Run application and verification under a non-superuser role.
- If you override a mapping with a different setting name than the store, your application is responsible for setting that GUC itself — Marten only applies the store-level setting on each session.
- `IDocumentStore.Advanced.Clean.*` (cross-tenant admin cleanup) will be blocked by RLS + FORCE; use a superuser or `BYPASSRLS` role, or disable RLS temporarily.

## Test plan

- [x] `./build.sh test-core` — includes `row_level_security_unit_tests` (variant selection across all `SessionOptions` shapes, per-mapping override resolution)
- [x] `./build.sh test-document-db` — includes `row_level_security_with_conjoined_tenancy` (schema migration/rollback, GUC application across all lifetime variants, caller-supplied `Transaction` + RLS, `DotNetTransaction` + RLS, bulk insert under RLS, cross-tenant read block via non-superuser probe role)
- [x] Verify against a non-superuser Postgres role that `FORCE ROW LEVEL SECURITY` actually blocks cross-tenant reads
- [x] Smoke: enable `UseRowLevelSecurity()` in an existing conjoined-tenancy app, run one migration, confirm policies exist in `pg_policy` and sessions see only their tenant's rows
