### PR TITLE
Add StreamOne/StreamMany/StreamAggregate typed streaming result types

### DIFF
--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -231,3 +231,82 @@ writes the raw JSON to any `Stream`, which you can use to build your own respons
 var stream = new MemoryStream();
 bool found = await session.Events.StreamLatestJson<Order>(orderId, stream);
 ```
+
+## Typed Streaming Result Types <Badge type="tip" text="8.x" />
+
+For Minimal API endpoints (and for frameworks like [Wolverine.Http](https://wolverinefx.net/guide/http/)
+that dispatch any `IResult` return value), `Marten.AspNetCore` ships three typed
+result wrappers that carry the streaming behavior above as endpoint return values
+while also contributing correct OpenAPI metadata:
+
+| Type                 | Source                                           | Response shape    | 404 on miss? |
+| -------------------- | ------------------------------------------------ | ----------------- | ------------ |
+| `StreamOne<T>`       | `IQueryable<T>` — regular Marten document query  | Single `T`        | yes          |
+| `StreamMany<T>`      | `IQueryable<T>` — regular Marten document query  | JSON array `T[]`  | no (empty array = 200) |
+| `StreamAggregate<T>` | `IDocumentSession` + stream id — event-sourced   | Single `T`        | yes          |
+
+Each type implements both `IResult` (so ASP.NET Minimal API dispatches it via
+`ExecuteAsync`) and `IEndpointMetadataProvider` (so Swashbuckle, NSwag, and the
+built-in OpenAPI generator see the right response shape), while delegating the
+actual body write to `WriteSingle`/`WriteArray`/`WriteLatest`. Returning one
+from an endpoint is a concise, typed alternative to writing the HTTP handshake
+manually.
+
+### `StreamOne<T>` — single document with 404 on miss
+
+```csharp
+app.MapGet("/issues/{id:guid}",
+    (Guid id, IQuerySession session) =>
+        new StreamOne<Issue>(session.Query<Issue>().Where(x => x.Id == id)));
+```
+
+Returns `200 application/json` with the document JSON on a hit, `404` on a miss.
+`Content-Length` and `Content-Type` are set automatically, matching the
+behavior of `WriteSingle<T>`.
+
+### `StreamMany<T>` — JSON array
+
+```csharp
+app.MapGet("/issues/open",
+    (IQuerySession session) =>
+        new StreamMany<Issue>(session.Query<Issue>().Where(x => x.Open)));
+```
+
+Returns `200 application/json` with a JSON array body. An empty result set
+yields `[]`, not a 404 — matching the behavior of `WriteArray<T>`.
+
+### `StreamAggregate<T>` — event-sourced aggregate (latest)
+
+```csharp
+app.MapGet("/orders/{id:guid}",
+    (Guid id, IDocumentSession session) =>
+        new StreamAggregate<Order>(session, id));
+```
+
+Returns `200 application/json` with the JSON of the latest projected aggregate
+state, or `404` if no stream exists. A constructor overload accepts `string`
+ids for stores configured with string-keyed streams.
+
+### StreamOne vs StreamAggregate
+
+- **`StreamOne<T>`** is for regular Marten documents — plain objects persisted
+  via `session.Store()` and queried with `session.Query<T>()`. The query hits
+  the document table directly.
+- **`StreamAggregate<T>`** is for event-sourced aggregates. Marten rebuilds the
+  latest aggregate state by folding events from the event store (or reads a
+  projected snapshot if one is configured). Use this when `T` is an
+  event-sourced aggregate, not a stored document.
+
+### Customizing status code and content type
+
+All three types expose init-only properties:
+
+```csharp
+app.MapPost("/issues",
+    (CreateIssue cmd, IQuerySession session) =>
+        new StreamOne<Issue>(session.Query<Issue>().Where(x => x.Id == cmd.IssueId))
+        {
+            OnFoundStatus = StatusCodes.Status201Created,
+            ContentType = "application/vnd.myapi.issue+json"
+        });
+```

--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -310,3 +310,38 @@ app.MapPost("/issues",
             ContentType = "application/vnd.myapi.issue+json"
         });
 ```
+
+### Compiled query overloads
+
+`StreamOne` and `StreamMany` also accept Marten compiled queries. These overloads
+take an extra generic argument for the query result type and the `IQuerySession`
+alongside the compiled query:
+
+```csharp
+public class IssueById : ICompiledQuery<Issue, Issue>
+{
+    public Guid Id { get; set; }
+    public Expression<Func<IMartenQueryable<Issue>, Issue>> QueryIs()
+        => q => q.FirstOrDefault(x => x.Id == Id);
+}
+
+public class OpenIssues : ICompiledListQuery<Issue>
+{
+    public Expression<Func<IMartenQueryable<Issue>, IEnumerable<Issue>>> QueryIs()
+        => q => q.Where(x => x.Open);
+}
+
+app.MapGet("/issues/{id:guid}",
+    (Guid id, IQuerySession session) =>
+        new StreamOne<Issue, Issue>(session, new IssueById { Id = id }));
+
+app.MapGet("/issues/open",
+    (IQuerySession session) =>
+        new StreamMany<Issue, IEnumerable<Issue>>(session, new OpenIssues()));
+```
+
+These use `WriteOne` / `WriteArray` for compiled queries under the hood. OpenAPI
+metadata advertises `200: TOut` (and `404` for `StreamOne`), where `TOut` is the
+compiled query's declared return type. Prefer compiled queries when the endpoint
+is on a hot path — Marten caches the compiled SQL and bypasses LINQ parsing on
+subsequent calls.

--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -239,11 +239,11 @@ that dispatch any `IResult` return value), `Marten.AspNetCore` ships three typed
 result wrappers that carry the streaming behavior above as endpoint return values
 while also contributing correct OpenAPI metadata:
 
-| Type                 | Source                                           | Response shape    | 404 on miss? |
-| -------------------- | ------------------------------------------------ | ----------------- | ------------ |
-| `StreamOne<T>`       | `IQueryable<T>` — regular Marten document query  | Single `T`        | yes          |
+| Type                 | Source                                           | Response shape    | 404 on miss?           |
+| -------------------- | ------------------------------------------------ | ----------------- | ---------------------- |
+| `StreamOne<T>`       | `IQueryable<T>` — regular Marten document query  | Single `T`        | yes                    |
 | `StreamMany<T>`      | `IQueryable<T>` — regular Marten document query  | JSON array `T[]`  | no (empty array = 200) |
-| `StreamAggregate<T>` | `IDocumentSession` + stream id — event-sourced   | Single `T`        | yes          |
+| `StreamAggregate<T>` | `IDocumentSession` + stream id — event-sourced   | Single `T`        | yes                    |
 
 Each type implements both `IResult` (so ASP.NET Minimal API dispatches it via
 `ExecuteAsync`) and `IEndpointMetadataProvider` (so Swashbuckle, NSwag, and the

--- a/src/IssueService/Startup.cs
+++ b/src/IssueService/Startup.cs
@@ -82,6 +82,7 @@ public class Startup
         app.UseEndpoints(endpoints =>
         {
             endpoints.MapControllers();
+            endpoints.MapStreamingMinimalEndpoints();
         });
     }
 }

--- a/src/IssueService/StreamingMinimalEndpoints.cs
+++ b/src/IssueService/StreamingMinimalEndpoints.cs
@@ -63,6 +63,27 @@ public static class StreamingMinimalEndpoints
             (string id, IDocumentSession session)
                 => new StreamAggregate<NamedOrder>(session, id));
 
+        // --- StreamOne<TDoc, TOut> — compiled query ---
+
+        app.MapGet("/minimal/compiled/issue/{id:guid}",
+            (Guid id, IQuerySession session)
+                => new StreamOne<Issue, Issue>(session, new IssueById { Id = id }));
+
+        // Custom OnFoundStatus for the compiled single overload
+        app.MapGet("/minimal/compiled/issue/{id:guid}/accepted",
+            (Guid id, IQuerySession session)
+                => new StreamOne<Issue, Issue>(session, new IssueById { Id = id })
+                {
+                    OnFoundStatus = StatusCodes.Status202Accepted
+                });
+
+        // --- StreamMany<TDoc, TOut> — compiled list query ---
+
+        app.MapGet("/minimal/compiled/issues/open",
+            (IQuerySession session)
+                => new StreamMany<Issue, System.Collections.Generic.IEnumerable<Issue>>(
+                    session, new OpenIssues()));
+
         return app;
     }
 }

--- a/src/IssueService/StreamingMinimalEndpoints.cs
+++ b/src/IssueService/StreamingMinimalEndpoints.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Linq;
+using IssueService.Controllers;
+using Marten;
+using Marten.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace IssueService;
+
+/// <summary>
+/// Minimal-API endpoint registrations that exercise the
+/// <see cref="StreamOne{T}"/>, <see cref="StreamMany{T}"/>, and
+/// <see cref="StreamAggregate{T}"/> helpers. Used by the Marten.AspNetCore.Testing
+/// Alba tests to prove the helpers work on bare Minimal API (no Wolverine.Http
+/// code generation required).
+/// </summary>
+public static class StreamingMinimalEndpoints
+{
+    public static IEndpointRouteBuilder MapStreamingMinimalEndpoints(this IEndpointRouteBuilder app)
+    {
+        // --- StreamOne<T> ---
+
+        app.MapGet("/minimal/issue/{id:guid}",
+            (Guid id, IQuerySession session)
+                => new StreamOne<Issue>(session.Query<Issue>().Where(x => x.Id == id)));
+
+        // Custom OnFoundStatus (e.g., 202 Accepted to exercise the init property)
+        app.MapGet("/minimal/issue/{id:guid}/accepted",
+            (Guid id, IQuerySession session)
+                => new StreamOne<Issue>(session.Query<Issue>().Where(x => x.Id == id))
+                {
+                    OnFoundStatus = StatusCodes.Status202Accepted
+                });
+
+        // Custom ContentType
+        app.MapGet("/minimal/issue/{id:guid}/vendor-type",
+            (Guid id, IQuerySession session)
+                => new StreamOne<Issue>(session.Query<Issue>().Where(x => x.Id == id))
+                {
+                    ContentType = "application/vnd.marten.issue+json"
+                });
+
+        // --- StreamMany<T> ---
+
+        app.MapGet("/minimal/issues/open",
+            (IQuerySession session)
+                => new StreamMany<Issue>(session.Query<Issue>().Where(x => x.Open)));
+
+        // Known-empty result — exercises the "no 404, empty array" contract
+        app.MapGet("/minimal/issues/none",
+            (IQuerySession session)
+                => new StreamMany<Issue>(session.Query<Issue>().Where(x => x.Id == Guid.Empty)));
+
+        // --- StreamAggregate<T> ---
+
+        app.MapGet("/minimal/order/{id:guid}",
+            (Guid id, IDocumentSession session)
+                => new StreamAggregate<Order>(session, id));
+
+        app.MapGet("/minimal/named-order/{id}",
+            (string id, IDocumentSession session)
+                => new StreamAggregate<NamedOrder>(session, id));
+
+        return app;
+    }
+}

--- a/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
+++ b/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Alba;
+using IssueService.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Marten.AspNetCore.Testing;
+
+/// <summary>
+/// Alba-based tests for <see cref="StreamOne{T}"/>, <see cref="StreamMany{T}"/>,
+/// and <see cref="StreamAggregate{T}"/> executing against plain Minimal API
+/// endpoints (no Wolverine required).
+/// </summary>
+[Collection("integration")]
+public class streaming_result_types_tests: IntegrationContext
+{
+    private readonly IAlbaHost theHost;
+
+    public streaming_result_types_tests(AppFixture fixture) : base(fixture)
+    {
+        theHost = fixture.Host;
+    }
+
+    // ───────────────────────── StreamOne<T> ─────────────────────────
+
+    [Fact]
+    public async Task stream_one_returns_matching_document_as_json()
+    {
+        var issue = new Issue { Description = "stream_one hit", Open = true };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{issue.Id}");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var read = result.ReadAsJson<Issue>();
+        read.Description.ShouldBe(issue.Description);
+    }
+
+    [Fact]
+    public async Task stream_one_sets_content_length_on_hit()
+    {
+        var issue = new Issue { Description = "has-length", Open = false };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{issue.Id}");
+            s.StatusCodeShouldBe(200);
+        });
+
+        // Marten.AspNetCore's WriteSingle buffers the document and sets Content-Length.
+        result.Context.Response.ContentLength.HasValue.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task stream_one_returns_404_when_no_match()
+    {
+        await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{Guid.NewGuid()}");
+            s.StatusCodeShouldBe(404);
+        });
+    }
+
+    [Fact]
+    public async Task stream_one_respects_custom_on_found_status()
+    {
+        var issue = new Issue { Description = "accepted", Open = true };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{issue.Id}/accepted");
+            s.StatusCodeShouldBe(202);
+            s.ContentTypeShouldBe("application/json");
+        });
+    }
+
+    [Fact]
+    public async Task stream_one_respects_custom_content_type()
+    {
+        var issue = new Issue { Description = "vendor", Open = true };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{issue.Id}/vendor-type");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/vnd.marten.issue+json");
+        });
+    }
+
+    // ───────────────────────── StreamMany<T> ─────────────────────────
+
+    [Fact]
+    public async Task stream_many_returns_json_array()
+    {
+        // Seed three open issues with a unique description prefix to assert against
+        var prefix = "many_" + Guid.NewGuid().ToString("N")[..8];
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(new Issue { Description = prefix + "_a", Open = true });
+            session.Store(new Issue { Description = prefix + "_b", Open = true });
+            session.Store(new Issue { Description = prefix + "_c", Open = true });
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/issues/open");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var body = result.ReadAsJson<List<Issue>>();
+        body.Count(x => x.Description.StartsWith(prefix)).ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task stream_many_returns_empty_array_when_no_match_not_404()
+    {
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/issues/none");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        result.ReadAsText().Trim().ShouldBe("[]");
+    }
+
+    // ───────────────────── StreamAggregate<T> ─────────────────────
+
+    [Fact]
+    public async Task stream_aggregate_returns_latest_aggregate_as_json()
+    {
+        var orderId = Guid.NewGuid();
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Events.StartStream<Order>(orderId, new OrderPlaced("Book", 19.99m));
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var order = result.ReadAsJson<Order>();
+        order.Id.ShouldBe(orderId);
+        order.Description.ShouldBe("Book");
+        order.Amount.ShouldBe(19.99m);
+    }
+
+    [Fact]
+    public async Task stream_aggregate_returns_404_for_unknown_id()
+    {
+        await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{Guid.NewGuid()}");
+            s.StatusCodeShouldBe(404);
+        });
+    }
+
+    // ───────────────────────── OpenAPI metadata ─────────────────────────
+
+    [Fact]
+    public void stream_one_endpoint_advertises_produces_T_and_404_in_metadata()
+    {
+        var metadata = EndpointMetadataFor("GET", "/minimal/issue/{id:guid}");
+
+        metadata.OfType<IProducesResponseTypeMetadata>()
+            .ShouldContain(m => m.StatusCode == 200 && m.Type == typeof(Issue));
+        metadata.OfType<IProducesResponseTypeMetadata>()
+            .ShouldContain(m => m.StatusCode == 404);
+    }
+
+    [Fact]
+    public void stream_many_endpoint_advertises_produces_array_in_metadata()
+    {
+        var metadata = EndpointMetadataFor("GET", "/minimal/issues/open");
+
+        metadata.OfType<IProducesResponseTypeMetadata>()
+            .ShouldContain(m => m.StatusCode == 200 && m.Type == typeof(IReadOnlyList<Issue>));
+    }
+
+    [Fact]
+    public void stream_aggregate_endpoint_advertises_produces_T_and_404_in_metadata()
+    {
+        var metadata = EndpointMetadataFor("GET", "/minimal/order/{id:guid}");
+
+        metadata.OfType<IProducesResponseTypeMetadata>()
+            .ShouldContain(m => m.StatusCode == 200 && m.Type == typeof(Order));
+        metadata.OfType<IProducesResponseTypeMetadata>()
+            .ShouldContain(m => m.StatusCode == 404);
+    }
+
+    private EndpointMetadataCollection EndpointMetadataFor(string method, string pattern)
+    {
+        var endpoint = theHost.Services.GetServices<EndpointDataSource>()
+            .SelectMany(x => x.Endpoints)
+            .OfType<RouteEndpoint>()
+            .FirstOrDefault(x =>
+                x.RoutePattern.RawText == pattern &&
+                x.Metadata.GetMetadata<HttpMethodMetadata>()!.HttpMethods.Contains(method));
+
+        endpoint.ShouldNotBeNull($"No endpoint found for {method} {pattern}");
+        return endpoint.Metadata;
+    }
+}

--- a/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
+++ b/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
@@ -224,6 +224,102 @@ public class streaming_result_types_tests: IntegrationContext
             .ShouldContain(m => m.StatusCode == 404);
     }
 
+    // ───────────────── StreamOne<TDoc, TOut> compiled query ─────────────────
+
+    [Fact]
+    public async Task compiled_stream_one_returns_matching_document_as_json()
+    {
+        var issue = new Issue { Description = "compiled stream_one hit", Open = true };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/compiled/issue/{issue.Id}");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var read = result.ReadAsJson<Issue>();
+        read.Description.ShouldBe(issue.Description);
+    }
+
+    [Fact]
+    public async Task compiled_stream_one_returns_404_when_no_match()
+    {
+        await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/compiled/issue/{Guid.NewGuid()}");
+            s.StatusCodeShouldBe(404);
+        });
+    }
+
+    [Fact]
+    public async Task compiled_stream_one_honours_custom_onfound_status()
+    {
+        var issue = new Issue { Description = "compiled custom-status", Open = true };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/compiled/issue/{issue.Id}/accepted");
+            s.StatusCodeShouldBe(202);
+        });
+    }
+
+    [Fact]
+    public void compiled_stream_one_endpoint_advertises_produces_T_and_404_in_metadata()
+    {
+        var metadata = EndpointMetadataFor("GET", "/minimal/compiled/issue/{id:guid}");
+
+        metadata.OfType<IProducesResponseTypeMetadata>()
+            .ShouldContain(m => m.StatusCode == 200 && m.Type == typeof(Issue));
+        metadata.OfType<IProducesResponseTypeMetadata>()
+            .ShouldContain(m => m.StatusCode == 404);
+    }
+
+    // ──────────────── StreamMany<TDoc, TOut> compiled list query ────────────────
+
+    [Fact]
+    public async Task compiled_stream_many_returns_json_array()
+    {
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(new Issue { Description = "compiled-open-1", Open = true });
+            session.Store(new Issue { Description = "compiled-open-2", Open = true });
+            session.Store(new Issue { Description = "compiled-closed", Open = false });
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/compiled/issues/open");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var read = result.ReadAsJson<List<Issue>>();
+        read.ShouldNotBeNull();
+        read.ShouldAllBe(x => x.Open);
+    }
+
+    [Fact]
+    public void compiled_stream_many_endpoint_advertises_produces_enumerable_in_metadata()
+    {
+        var metadata = EndpointMetadataFor("GET", "/minimal/compiled/issues/open");
+
+        // TOut is IEnumerable<Issue> for OpenIssues : ICompiledListQuery<Issue>
+        metadata.OfType<IProducesResponseTypeMetadata>()
+            .ShouldContain(m => m.StatusCode == 200 && m.Type == typeof(IEnumerable<Issue>));
+    }
+
     private EndpointMetadataCollection EndpointMetadataFor(string method, string pattern)
     {
         var endpoint = theHost.Services.GetServices<EndpointDataSource>()

--- a/src/Marten.AspNetCore/StreamAggregate.cs
+++ b/src/Marten.AspNetCore/StreamAggregate.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Marten.AspNetCore;
+
+/// <summary>
+/// Minimal-API / Wolverine.Http endpoint return value that streams the latest projected
+/// JSON of an event-sourced aggregate directly to the <see cref="HttpContext.Response"/>.
+/// Uses <see cref="QueryableExtensions.WriteLatest{T}(Marten.Events.IEventStoreOperations, Guid, HttpContext, string, int)"/>
+/// under the hood, which pulls the latest aggregate state from the event store without a
+/// deserialize/serialize round-trip.
+/// <para>
+/// Returns HTTP <c>404</c> if no aggregate exists for the supplied id,
+/// <see cref="OnFoundStatus"/> (default 200) if it does.
+/// </para>
+/// <para>
+/// <b>StreamAggregate vs StreamOne.</b> Use <see cref="StreamAggregate{T}"/>
+/// for event-sourced aggregates — Marten rebuilds (or reads the snapshot of) the
+/// latest aggregate state from events before streaming. Use <see cref="StreamOne{T}"/>
+/// for regular Marten documents that are stored directly (not event-sourced).
+/// </para>
+/// </summary>
+/// <typeparam name="T">The aggregate type.</typeparam>
+public sealed class StreamAggregate<T> : IResult, IEndpointMetadataProvider where T : class
+{
+    private readonly IDocumentSession _session;
+    private readonly Guid _guidId;
+    private readonly string? _stringId;
+    private readonly bool _useGuid;
+
+    /// <summary>
+    /// Stream the latest aggregate state of type <typeparamref name="T"/> for
+    /// the aggregate whose stream is identified by <paramref name="id"/>.
+    /// </summary>
+    public StreamAggregate(IDocumentSession session, Guid id)
+    {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _guidId = id;
+        _stringId = null;
+        _useGuid = true;
+    }
+
+    /// <summary>
+    /// Stream the latest aggregate state of type <typeparamref name="T"/> for
+    /// the aggregate whose stream is identified by string <paramref name="id"/>
+    /// (for Marten stores configured with string-keyed streams).
+    /// </summary>
+    public StreamAggregate(IDocumentSession session, string id)
+    {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _stringId = id ?? throw new ArgumentNullException(nameof(id));
+        _guidId = Guid.Empty;
+        _useGuid = false;
+    }
+
+    /// <summary>
+    /// Status code written when the aggregate is found. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
+
+        return _useGuid
+            ? _session.Events.WriteLatest<T>(_guidId, httpContext, ContentType, OnFoundStatus)
+            : _session.Events.WriteLatest<T>(_stringId!, httpContext, ContentType, OnFoundStatus);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI correctly advertises a
+    /// <c>200: T</c> and <c>404</c> response for this endpoint.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(T), new[] { "application/json" }));
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status404NotFound, typeof(void), Array.Empty<string>()));
+    }
+}

--- a/src/Marten.AspNetCore/StreamMany.cs
+++ b/src/Marten.AspNetCore/StreamMany.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Marten.AspNetCore;
+
+/// <summary>
+/// Minimal-API / Wolverine.Http endpoint return value that streams a JSON array of
+/// Marten documents directly to the <see cref="HttpContext.Response"/>. Uses
+/// <see cref="QueryableExtensions.WriteArray{T}"/> under the hood — the JSON array is
+/// written straight to the response stream without a deserialize/serialize round-trip.
+/// <para>
+/// Unlike <see cref="StreamOne{T}"/>, this type never returns 404: an empty result
+/// set yields an empty JSON array (<c>[]</c>) with status <see cref="OnFoundStatus"/>
+/// (default 200).
+/// </para>
+/// </summary>
+/// <typeparam name="T">The document type contained in the array.</typeparam>
+public sealed class StreamMany<T> : IResult, IEndpointMetadataProvider
+{
+    private readonly IQueryable<T> _queryable;
+
+    /// <summary>
+    /// Create a <see cref="StreamMany{T}"/> wrapping a Marten <see cref="IQueryable{T}"/>.
+    /// All matching documents are streamed as a JSON array.
+    /// </summary>
+    public StreamMany(IQueryable<T> queryable)
+    {
+        _queryable = queryable ?? throw new ArgumentNullException(nameof(queryable));
+    }
+
+    /// <summary>
+    /// Status code written with the response. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
+        return _queryable.WriteArray(httpContext, ContentType, OnFoundStatus);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI correctly advertises a
+    /// <c>200: T[]</c> response for this endpoint. No 404 is advertised
+    /// because an empty array is a valid response.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(IReadOnlyList<T>), new[] { "application/json" }));
+    }
+}

--- a/src/Marten.AspNetCore/StreamManyCompiled.cs
+++ b/src/Marten.AspNetCore/StreamManyCompiled.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Marten.Linq;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Marten.AspNetCore;
+
+/// <summary>
+/// Minimal-API / Wolverine.Http endpoint return value that streams the JSON array
+/// produced by a Marten <see cref="ICompiledQuery{TDoc, TOut}"/> (typically an
+/// <see cref="ICompiledListQuery{TDoc, TOut}"/>) directly to the
+/// <see cref="HttpContext.Response"/>. Uses
+/// <see cref="QueryableExtensions.WriteArray{TDoc, TOut}"/> under the hood — the JSON
+/// array is written straight to the response stream without a deserialize/serialize
+/// round-trip.
+/// <para>
+/// Unlike <see cref="StreamOne{TDoc, TOut}"/>, this type never returns 404: an empty
+/// result set yields an empty JSON array (<c>[]</c>) with status
+/// <see cref="OnFoundStatus"/> (default 200).
+/// </para>
+/// <para>
+/// This is the <see cref="ICompiledQuery{TDoc, TOut}"/> overload. Use
+/// <see cref="StreamMany{T}"/> (the single-arity version) for regular
+/// <see cref="System.Linq.IQueryable{T}"/>-based queries.
+/// </para>
+/// </summary>
+/// <typeparam name="TDoc">The Marten document type the query runs against.</typeparam>
+/// <typeparam name="TOut">
+/// The projected return type of the compiled query. Typically
+/// <c>IEnumerable&lt;TItem&gt;</c> — e.g. when using
+/// <see cref="ICompiledListQuery{TDoc, TItem}"/>.
+/// </typeparam>
+public sealed class StreamMany<TDoc, TOut> : IResult, IEndpointMetadataProvider where TDoc : notnull
+{
+    private readonly IQuerySession _session;
+    private readonly ICompiledQuery<TDoc, TOut> _query;
+
+    /// <summary>
+    /// Create a <see cref="StreamMany{TDoc, TOut}"/> wrapping a compiled query.
+    /// All matching results are streamed as a JSON array.
+    /// </summary>
+    public StreamMany(IQuerySession session, ICompiledQuery<TDoc, TOut> query)
+    {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _query = query ?? throw new ArgumentNullException(nameof(query));
+    }
+
+    /// <summary>
+    /// Status code written with the response. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
+        return _session.WriteArray(_query, httpContext, ContentType, OnFoundStatus);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI advertises a <c>200: TOut</c> response
+    /// for this endpoint. No 404 is advertised because an empty array is a valid response.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(TOut), new[] { "application/json" }));
+    }
+}

--- a/src/Marten.AspNetCore/StreamOne.cs
+++ b/src/Marten.AspNetCore/StreamOne.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Marten.AspNetCore;
+
+/// <summary>
+/// Minimal-API / Wolverine.Http endpoint return value that streams the first matching
+/// Marten document as raw JSON directly to the <see cref="HttpContext.Response"/>.
+/// Uses <see cref="QueryableExtensions.WriteSingle{T}"/> under the hood — the JSON is
+/// written straight to the response stream without a deserialize/serialize round-trip.
+/// <para>
+/// Returns HTTP <c>404</c> if the query produces no result, <see cref="OnFoundStatus"/>
+/// (default 200) if it does. <see cref="HttpResponse.ContentLength"/> and
+/// <see cref="HttpResponse.ContentType"/> are set automatically.
+/// </para>
+/// <para>
+/// <b>StreamOne vs StreamAggregate.</b> Use <see cref="StreamOne{T}"/> for regular
+/// Marten documents — plain objects persisted via <c>session.Store()</c> and queried
+/// with <c>session.Query&lt;T&gt;()</c>. Use <see cref="StreamAggregate{T}"/> when
+/// the target is an event-sourced aggregate projected live from the event stream
+/// (the "latest" aggregate snapshot).
+/// </para>
+/// </summary>
+/// <typeparam name="T">The document type to stream.</typeparam>
+public sealed class StreamOne<T> : IResult, IEndpointMetadataProvider
+{
+    private readonly IQueryable<T> _queryable;
+
+    /// <summary>
+    /// Create a <see cref="StreamOne{T}"/> wrapping a Marten <see cref="IQueryable{T}"/>.
+    /// The query's first matching document is streamed as JSON; 404 if none.
+    /// </summary>
+    public StreamOne(IQueryable<T> queryable)
+    {
+        _queryable = queryable ?? throw new ArgumentNullException(nameof(queryable));
+    }
+
+    /// <summary>
+    /// Status code written when the query produces a result. Defaults to 200.
+    /// Use 201 (Created) on a POST that returns a freshly-created document, etc.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
+        return _queryable.WriteSingle(httpContext, ContentType, OnFoundStatus);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI correctly advertises a
+    /// <c>200: T</c> and <c>404</c> response for this endpoint.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(T), new[] { "application/json" }));
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status404NotFound, typeof(void), Array.Empty<string>()));
+    }
+}

--- a/src/Marten.AspNetCore/StreamOneCompiled.cs
+++ b/src/Marten.AspNetCore/StreamOneCompiled.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Marten.Linq;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Marten.AspNetCore;
+
+/// <summary>
+/// Minimal-API / Wolverine.Http endpoint return value that streams the first matching
+/// result of a Marten <see cref="ICompiledQuery{TDoc, TOut}"/> as raw JSON directly to
+/// the <see cref="HttpContext.Response"/>. Uses
+/// <see cref="QueryableExtensions.WriteOne{TDoc, TOut}"/> under the hood — the JSON is
+/// written straight to the response stream without a deserialize/serialize round-trip.
+/// <para>
+/// Returns HTTP <c>404</c> if the query produces no result, <see cref="OnFoundStatus"/>
+/// (default 200) if it does. <see cref="HttpResponse.ContentLength"/> and
+/// <see cref="HttpResponse.ContentType"/> are set automatically.
+/// </para>
+/// <para>
+/// This is the <see cref="ICompiledQuery{TDoc, TOut}"/> overload. Use
+/// <see cref="StreamOne{T}"/> (the single-arity version) for regular
+/// <see cref="System.Linq.IQueryable{T}"/>-based queries.
+/// </para>
+/// </summary>
+/// <typeparam name="TDoc">The Marten document type the query runs against.</typeparam>
+/// <typeparam name="TOut">The projected return type of the compiled query.</typeparam>
+public sealed class StreamOne<TDoc, TOut> : IResult, IEndpointMetadataProvider where TDoc : notnull
+{
+    private readonly IQuerySession _session;
+    private readonly ICompiledQuery<TDoc, TOut> _query;
+
+    /// <summary>
+    /// Create a <see cref="StreamOne{TDoc, TOut}"/> wrapping a compiled query.
+    /// The query's single result is streamed as JSON; 404 if none.
+    /// </summary>
+    public StreamOne(IQuerySession session, ICompiledQuery<TDoc, TOut> query)
+    {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _query = query ?? throw new ArgumentNullException(nameof(query));
+    }
+
+    /// <summary>
+    /// Status code written when the query produces a result. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
+        return _session.WriteOne(_query, httpContext, ContentType, OnFoundStatus);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI correctly advertises a
+    /// <c>200: TOut</c> and <c>404</c> response for this endpoint.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(TOut), new[] { "application/json" }));
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status404NotFound, typeof(void), Array.Empty<string>()));
+    }
+}


### PR DESCRIPTION
## Summary

`Marten.AspNetCore` already ships `WriteSingle` / `WriteArray` / `WriteLatest` extension helpers that stream raw JSON directly to an `HttpResponse`. This PR adds three typed endpoint return values that wrap that behavior for Minimal API endpoints (and any framework that dispatches `IResult`, e.g. [Wolverine.Http](https://wolverinefx.net/guide/http/)).

| Type                 | Source                                          | Response shape   | 404 on miss? |
| -------------------- | ----------------------------------------------- | ---------------- | ------------ |
| `StreamOne<T>`       | `IQueryable<T>` — regular Marten document query | Single `T`       | yes          |
| `StreamMany<T>`      | `IQueryable<T>` — regular Marten document query | JSON array `T[]` | no (empty `[]`) |
| `StreamAggregate<T>` | `IDocumentSession` + stream id — event-sourced  | Single `T`       | yes          |

## Why
`WriteSingle(HttpContext)` / `WriteArray(HttpContext)` / `WriteLatest(HttpContext)` are already great at what they do, but endpoint authors have to manually wire the result up and lose typed return values (and therefore lose good OpenAPI metadata). These wrappers give Minimal API and Wolverine.Http users a concise, typed alternative that still gets raw-JSON-from-the-database streaming.

## Design
- Each type implements both `IResult` (so ASP.NET Minimal API dispatches it via `ExecuteAsync`) and `IEndpointMetadataProvider` (so Swashbuckle, NSwag, and the built-in OpenAPI generator see the right response shape — `Produces<T>` / `Produces<IReadOnlyList<T>>` / `Produces(404)`).
- `ExecuteAsync` delegates to the existing extension helpers — zero behavioral drift.
- `OnFoundStatus` (default 200) and `ContentType` (default `application/json`) are init-only properties so endpoints can customize e.g. `201 Created` or a vendor-specific content type.
- `StreamAggregate<T>` requires `IDocumentSession` (mirroring the existing `WriteLatest` constraint).

## Example
\`\`\`csharp
app.MapGet(\"/issues/{id:guid}\",
    (Guid id, IQuerySession session) =>
        new StreamOne<Issue>(session.Query<Issue>().Where(x => x.Id == id)));

app.MapGet(\"/issues/open\",
    (IQuerySession session) =>
        new StreamMany<Issue>(session.Query<Issue>().Where(x => x.Open)));

app.MapGet(\"/orders/{id:guid}\",
    (Guid id, IDocumentSession session) =>
        new StreamAggregate<Order>(session, id));
\`\`\`

## Scope
- **New files**: \`StreamOne.cs\`, \`StreamMany.cs\`, \`StreamAggregate.cs\` in \`Marten.AspNetCore\`
- **IssueService** now also maps Minimal-API endpoints under \`/minimal/...\` so the test host exercises both controllers and Minimal API
- **12 new tests** in \`Marten.AspNetCore.Testing/streaming_result_types_tests.cs\` covering: hit/miss, custom status code, custom content type, empty-array behavior, aggregate with 404, OpenAPI metadata assertions
- **Docs**: new \"Typed Streaming Result Types\" section in \`docs/documents/aspnetcore.md\` with the StreamOne-vs-StreamAggregate distinction called out

## Test plan
- [x] 12 new Alba-driven Minimal-API tests pass
- [x] All 40 existing \`Marten.AspNetCore.Testing\` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)