### PR TITLE
Add NextSequenceValue / NextSequenceValueAsLong on IQuerySession

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,8 +13,8 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="1.23.1" />
-    <PackageVersion Include="JasperFx.Events" Version="1.26.1" />
+    <PackageVersion Include="JasperFx" Version="1.24.1" />
+    <PackageVersion Include="JasperFx.Events" Version="1.28.0" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.4.0" />
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.4.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,8 +14,11 @@
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
     <PackageVersion Include="JasperFx" Version="1.24.1" />
-    <PackageVersion Include="JasperFx.Events" Version="1.28.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.4.0" />
+    <PackageVersion Include="JasperFx.Events" Version="1.28.1" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.4.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -135,6 +135,7 @@ const config: UserConfig<DefaultTheme.Config> = {
             { text: 'Opening Sessions', link: '/documents/sessions' },
             { text: 'Storing Documents', link: '/documents/storing' },
             { text: 'Deleting Documents', link: '/documents/deletes' },
+            { text: 'PostgreSQL Sequences', link: '/documents/sequences' },
             {
               text: 'Querying Documents', link: '/documents/querying/', collapsed: true, items: [
                 { text: 'Loading Documents by Id', link: '/documents/querying/byid' },

--- a/docs/documents/sequences.md
+++ b/docs/documents/sequences.md
@@ -1,0 +1,104 @@
+# PostgreSQL Sequences <Badge type="tip" text="8.x" />
+
+Marten exposes a small helper on `IQuerySession` for fetching the next value of a
+PostgreSQL [sequence](https://www.postgresql.org/docs/current/sql-createsequence.html).
+It's a thin wrapper around `SELECT nextval(<sequence name>)` that keeps the call
+on the session's connection and retry pipeline, so you don't have to drop down to
+raw SQL in your application code.
+
+## Why
+
+Sequences are the idiomatic way to generate monotonically-increasing identifiers
+in Postgres — human-readable reference numbers, ticket numbers, invoice numbers,
+or any other running counter that should not be produced client-side. They're
+transactionally safe, gap-tolerant by design (an uncommitted `nextval` still
+advances the sequence), and decoupled from any particular table.
+
+A common pattern is to define the sequence through Marten's
+[FeatureSchemaBase](/scenarios/using-sequence-for-unique-id) so it's created and
+migrated alongside the rest of your schema, then call into it at runtime with
+the methods described below.
+
+## Fetching the next value
+
+Given a sequence already created in the database, call `NextSequenceValue` on
+any `IQuerySession` (or `IDocumentSession`, which extends it). The name is
+passed as a string and can be schema-qualified:
+
+<!-- snippet: sample_next_sequence_value_by_string -->
+<a id='snippet-sample_next_sequence_value_by_string'></a>
+```cs
+await using var session = theStore.QuerySession();
+
+// Fetch the next value of a PostgreSQL sequence by name.
+// The name can be schema-qualified (e.g. "my_schema.my_sequence").
+var first = await session.NextSequenceValue($"{SchemaName}.seq_int_str");
+var second = await session.NextSequenceValue($"{SchemaName}.seq_int_str");
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/next_sequence_value_tests.cs#L32-L41' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_next_sequence_value_by_string' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+If you already have a `DbObjectName` handle — for example, from a Weasel
+`Sequence` schema object in one of your custom feature schemas — pass it
+directly. Marten uses its `QualifiedName` under the hood:
+
+<!-- snippet: sample_next_sequence_value_by_dbobjectname -->
+<a id='snippet-sample_next_sequence_value_by_dbobjectname'></a>
+```cs
+await using var session = theStore.QuerySession();
+
+// Pass a DbObjectName (here, Weasel's PostgresqlObjectName) when you already have
+// a strongly-typed reference to the sequence — for example, from a Weasel Sequence
+// schema object built by your own FeatureSchemaBase.
+var name = new PostgresqlObjectName(SchemaName, "seq_int_obj");
+var first = await session.NextSequenceValue(name);
+var second = await session.NextSequenceValue(name);
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/next_sequence_value_tests.cs#L55-L66' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_next_sequence_value_by_dbobjectname' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Both overloads return `Task<int>`. The value is narrowed from Postgres's native
+`bigint` with a SQL-side `::int` cast, which will throw if the sequence has
+grown beyond `Int32.MaxValue` (~2.1 billion).
+
+## Long-valued sequences
+
+PostgreSQL sequences are 64-bit by default. For sequences that may exceed the
+range of a signed 32-bit integer — or when you simply prefer to work in `long`
+from the start — use `NextSequenceValueAsLong`:
+
+<!-- snippet: sample_next_sequence_value_as_long -->
+<a id='snippet-sample_next_sequence_value_as_long'></a>
+```cs
+await using var session = theStore.QuerySession();
+
+// Use NextSequenceValueAsLong when the sequence may exceed Int32.MaxValue
+// (roughly 2.1 billion). nextval() is a bigint in Postgres natively.
+var first = await session.NextSequenceValueAsLong($"{SchemaName}.seq_big");
+var second = await session.NextSequenceValueAsLong(new PostgresqlObjectName(SchemaName, "seq_big"));
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/next_sequence_value_tests.cs#L107-L116' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_next_sequence_value_as_long' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+`NextSequenceValueAsLong` returns the `bigint` produced by `nextval()` as-is,
+without any client-side narrowing.
+
+## API summary
+
+```cs
+// On IQuerySession
+Task<int>  NextSequenceValue(string sequenceName, CancellationToken token = default);
+Task<int>  NextSequenceValue(DbObjectName sequenceName, CancellationToken token = default);
+Task<long> NextSequenceValueAsLong(string sequenceName, CancellationToken token = default);
+Task<long> NextSequenceValueAsLong(DbObjectName sequenceName, CancellationToken token = default);
+```
+
+All four overloads share the same implementation: a parameterized
+`select nextval(:seq)` (optionally with an `::int` cast for the `Task<int>`
+overloads) executed through the session's normal connection lifetime.
+
+## Related
+
+For an end-to-end example that combines sequence definition through
+`FeatureSchemaBase` with runtime consumption, see
+[Using sequences for unique and human-readable identifiers](/scenarios/using-sequence-for-unique-id).

--- a/docs/events/archiving.md
+++ b/docs/events/archiving.md
@@ -253,3 +253,28 @@ If you rely on asynchronous multi-stream projections and need all events to be p
 
 This ensures all prior events are fully projected before the stream is marked as archived.
 :::
+
+### Archived in Composite Projections <Badge type="tip" text="8.x" />
+
+When multiple single-stream projections run inside the same
+[composite projection](/events/projections/composite), every child projection
+processes every slice in the batch. An `Archived` event raised on one child's
+stream is therefore *seen* by every sibling. To prevent unintended side effects,
+Marten gates `Archived` handling on whether a given child actually **owns** the
+stream — measured by whether the child has a snapshot for that stream id (either
+loaded before the slice was applied, or materialized by the slice itself):
+
+1. `Archived` can never **create** a new aggregate in a sibling that has no
+   snapshot. If a sibling happens to declare `Create(Archived)` — legal but
+   almost always accidental in a composite — that method is skipped while the
+   snapshot is still null. Once the snapshot exists, `Apply(Archived)` hooks
+   run normally, so `Apply(Archived, current)` patterns on genuine owners keep
+   working.
+2. `mt_archive_stream` is only issued from the child that owns the stream.
+   Siblings that did not materialize anything skip the archival call, avoiding
+   redundant (or phantom) database operations.
+
+In practice: appending `Archived` to a stream that belongs to projection A
+archives that stream from A's perspective, even when A shares a composite group
+with unrelated sibling projections B and C. No documents are created in B or C
+for A's stream id.

--- a/docs/events/archiving.md
+++ b/docs/events/archiving.md
@@ -259,22 +259,25 @@ This ensures all prior events are fully projected before the stream is marked as
 When multiple single-stream projections run inside the same
 [composite projection](/events/projections/composite), every child projection
 processes every slice in the batch. An `Archived` event raised on one child's
-stream is therefore *seen* by every sibling. To prevent unintended side effects,
-Marten gates `Archived` handling on whether a given child actually **owns** the
-stream — measured by whether the child has a snapshot for that stream id (either
-loaded before the slice was applied, or materialized by the slice itself):
+stream is therefore *seen* by every sibling. To avoid redundant stream-archival
+operations, the `mt_archive_stream` call is only issued from the child that
+actually **owns** the stream — measured by whether the child has a snapshot for
+that stream id (either loaded before the slice was applied, or materialized by
+the slice itself). Siblings that did not materialize anything skip the archive.
 
-1. `Archived` can never **create** a new aggregate in a sibling that has no
-   snapshot. If a sibling happens to declare `Create(Archived)` — legal but
-   almost always accidental in a composite — that method is skipped while the
-   snapshot is still null. Once the snapshot exists, `Apply(Archived)` hooks
-   run normally, so `Apply(Archived, current)` patterns on genuine owners keep
-   working.
-2. `mt_archive_stream` is only issued from the child that owns the stream.
-   Siblings that did not materialize anything skip the archival call, avoiding
-   redundant (or phantom) database operations.
+::: tip
+Archiving a stream and deleting the projected document are **independent**
+operations. Marten does not delete projected documents as a side effect of an
+`Archived` event — that's a common and legitimate pattern: keep the read model
+around for historical queries while the underlying event stream moves out of
+the hot table. If you *do* want the document removed when the stream is
+archived, either call `session.Delete<T>(id)` explicitly (see the earlier tip)
+or register the deletion in your projection's `Apply(Archived, current)`
+method by returning `null` (or otherwise opting in).
+:::
 
-In practice: appending `Archived` to a stream that belongs to projection A
-archives that stream from A's perspective, even when A shares a composite group
-with unrelated sibling projections B and C. No documents are created in B or C
-for A's stream id.
+Whether a projection's `Create(Archived)` or `Apply(Archived, current)` method
+runs is entirely governed by the user-defined handlers on that projection —
+`Archived` is just an event and receives no special treatment at the
+`EvolveAsync` level. The ownership guard described above only scopes the
+stream-archival side effect.

--- a/src/CoreTests/next_sequence_value_tests.cs
+++ b/src/CoreTests/next_sequence_value_tests.cs
@@ -1,0 +1,134 @@
+using System.Threading.Tasks;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace CoreTests;
+
+public class next_sequence_value_tests : OneOffConfigurationsContext
+{
+    private async Task ensureSequenceAsync(string sequenceName, long startWith = 1)
+    {
+        // Touch theStore first so OneOffConfigurationsContext's lazy "drop schema"
+        // happens before we create our sequence, not after.
+        _ = theStore;
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await conn.RunSqlAsync(
+            $"CREATE SCHEMA IF NOT EXISTS {SchemaName}",
+            $"DROP SEQUENCE IF EXISTS {SchemaName}.{sequenceName}",
+            $"CREATE SEQUENCE {SchemaName}.{sequenceName} START {startWith}");
+    }
+
+    [Fact]
+    public async Task next_sequence_value_returns_sequential_ints_with_qualified_string_name()
+    {
+        await ensureSequenceAsync("seq_int_str");
+
+        #region sample_next_sequence_value_by_string
+
+        await using var session = theStore.QuerySession();
+
+        // Fetch the next value of a PostgreSQL sequence by name.
+        // The name can be schema-qualified (e.g. "my_schema.my_sequence").
+        var first = await session.NextSequenceValue($"{SchemaName}.seq_int_str");
+        var second = await session.NextSequenceValue($"{SchemaName}.seq_int_str");
+
+        #endregion
+
+        var third = await session.NextSequenceValue($"{SchemaName}.seq_int_str");
+
+        first.ShouldBe(1);
+        second.ShouldBe(2);
+        third.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task next_sequence_value_returns_sequential_ints_with_dbobjectname()
+    {
+        await ensureSequenceAsync("seq_int_obj");
+
+        #region sample_next_sequence_value_by_dbobjectname
+
+        await using var session = theStore.QuerySession();
+
+        // Pass a DbObjectName (here, Weasel's PostgresqlObjectName) when you already have
+        // a strongly-typed reference to the sequence — for example, from a Weasel Sequence
+        // schema object built by your own FeatureSchemaBase.
+        var name = new PostgresqlObjectName(SchemaName, "seq_int_obj");
+        var first = await session.NextSequenceValue(name);
+        var second = await session.NextSequenceValue(name);
+
+        #endregion
+
+        first.ShouldBe(1);
+        second.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task next_sequence_value_as_long_returns_sequential_longs_with_qualified_string_name()
+    {
+        await ensureSequenceAsync("seq_long_str");
+
+        await using var session = theStore.QuerySession();
+        var first = await session.NextSequenceValueAsLong($"{SchemaName}.seq_long_str");
+        var second = await session.NextSequenceValueAsLong($"{SchemaName}.seq_long_str");
+
+        first.ShouldBe(1L);
+        second.ShouldBe(2L);
+    }
+
+    [Fact]
+    public async Task next_sequence_value_as_long_returns_sequential_longs_with_dbobjectname()
+    {
+        await ensureSequenceAsync("seq_long_obj");
+
+        await using var session = theStore.QuerySession();
+        var name = new PostgresqlObjectName(SchemaName, "seq_long_obj");
+
+        var first = await session.NextSequenceValueAsLong(name);
+        var second = await session.NextSequenceValueAsLong(name);
+
+        first.ShouldBe(1L);
+        second.ShouldBe(2L);
+    }
+
+    [Fact]
+    public async Task next_sequence_value_as_long_handles_values_above_int32_max()
+    {
+        // Sequences can exceed Int32.MaxValue (2,147,483,647) — long overload must handle.
+        const long startAboveInt32Max = 3_000_000_000L;
+        await ensureSequenceAsync("seq_big", startAboveInt32Max);
+
+        #region sample_next_sequence_value_as_long
+
+        await using var session = theStore.QuerySession();
+
+        // Use NextSequenceValueAsLong when the sequence may exceed Int32.MaxValue
+        // (roughly 2.1 billion). nextval() is a bigint in Postgres natively.
+        var first = await session.NextSequenceValueAsLong($"{SchemaName}.seq_big");
+        var second = await session.NextSequenceValueAsLong(new PostgresqlObjectName(SchemaName, "seq_big"));
+
+        #endregion
+
+        first.ShouldBe(startAboveInt32Max);
+        second.ShouldBe(startAboveInt32Max + 1);
+    }
+
+    [Fact]
+    public async Task next_sequence_value_honors_start_value()
+    {
+        await ensureSequenceAsync("seq_start", 10_000);
+
+        await using var session = theStore.QuerySession();
+        var first = await session.NextSequenceValue(new PostgresqlObjectName(SchemaName, "seq_start"));
+        first.ShouldBe(10_000);
+
+        var second = await session.NextSequenceValue($"{SchemaName}.seq_start");
+        second.ShouldBe(10_001);
+    }
+}

--- a/src/DaemonTests/Composites/Bug_4093_archived_in_composite_projections.cs
+++ b/src/DaemonTests/Composites/Bug_4093_archived_in_composite_projections.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Core;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DaemonTests.Composites;
+
+/// <summary>
+/// Regression tests for https://github.com/JasperFx/marten/issues/4093.
+///
+/// When multiple single-stream projections run inside the same composite group,
+/// an Archived event that belongs to one child's stream should NOT create
+/// phantom documents in other children, and should not issue redundant
+/// stream-archival operations from children that don't own the stream.
+///
+/// The fix (Option A): only archive from a single-stream projection that actually
+/// has a snapshot for the stream id being archived.
+/// </summary>
+public class Bug_4093_archived_in_composite_projections : DaemonContext
+{
+    public Bug_4093_archived_in_composite_projections(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task archived_does_not_create_phantom_docs_in_other_children_of_composite()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsGuid;
+
+            opts.Projections.CompositeProjectionFor("B4093Group", x =>
+            {
+                // This child owns streams that begin with FooStarted.
+                x.Add<Bug4093FooProjection>();
+
+                // This child "listens" for Archived (a contrived but legal pattern).
+                // Today, when Archived appears in any stream in the composite's batch,
+                // this projection's Create(Archived) fires and writes a phantom
+                // Bug4093BarDoc with the id of the other child's stream.
+                x.Add<Bug4093BarProjection>();
+            });
+        }, true);
+
+        var fooStreamId = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<Bug4093FooDoc>(fooStreamId, new Bug4093FooStarted(), new Archived("done"));
+            await session.SaveChangesAsync();
+        }
+
+        using var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(10.Seconds());
+
+        // The stream itself should be archived (Foo owns it).
+        await using var query = theStore.QuerySession();
+
+        // Bug4093BarDoc must NOT be written for the Foo stream id — Bar doesn't own it,
+        // and even though it has a Create(Archived) handler, the Option A guard
+        // (snapshot != null) should keep Bar's storage untouched.
+        var phantomBar = await query.LoadAsync<Bug4093BarDoc>(fooStreamId);
+        phantomBar.ShouldBeNull(
+            "Bar projection does not own the Foo stream — no phantom Bar doc should be created");
+    }
+
+    [Fact]
+    public async Task owning_child_archives_stream_non_owning_child_is_a_noop()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsGuid;
+
+            opts.Projections.CompositeProjectionFor("B4093Ownership", x =>
+            {
+                x.Add<Bug4093FooProjection>();
+                x.Add<Bug4093BazProjection>();
+            });
+        }, true);
+
+        var fooStreamId = Guid.NewGuid();
+        var bazStreamId = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            // Foo stream with Archived at end — Foo should archive
+            session.Events.StartStream<Bug4093FooDoc>(fooStreamId, new Bug4093FooStarted(), new Archived("done"));
+
+            // Baz stream with only its own events — Baz should have a doc, stream should NOT be archived
+            session.Events.StartStream<Bug4093BazDoc>(bazStreamId, new Bug4093BazStarted());
+
+            await session.SaveChangesAsync();
+        }
+
+        using var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(10.Seconds());
+
+        await using var query = theStore.QuerySession();
+
+        // Foo's doc exists and its stream is archived.
+        var foo = await query.LoadAsync<Bug4093FooDoc>(fooStreamId);
+        foo.ShouldNotBeNull();
+
+        // Baz's doc exists for its own stream; it should NOT have a phantom doc for the Foo stream.
+        var baz = await query.LoadAsync<Bug4093BazDoc>(bazStreamId);
+        baz.ShouldNotBeNull();
+
+        var phantomBaz = await query.LoadAsync<Bug4093BazDoc>(fooStreamId);
+        phantomBaz.ShouldBeNull(
+            "Baz does not own the Foo stream; it must not have a doc under that id");
+    }
+}
+
+// ─────────────────────────── fixtures ───────────────────────────
+
+public record Bug4093FooStarted;
+public record Bug4093BazStarted;
+
+public class Bug4093FooDoc
+{
+    public Guid Id { get; set; }
+}
+
+public class Bug4093BazDoc
+{
+    public Guid Id { get; set; }
+}
+
+public class Bug4093BarDoc
+{
+    public Guid Id { get; set; }
+    public string ArchivedReason { get; set; } = "";
+}
+
+public class Bug4093FooProjection : SingleStreamProjection<Bug4093FooDoc, Guid>
+{
+    public Bug4093FooDoc Create(Bug4093FooStarted _) => new();
+}
+
+public class Bug4093BazProjection : SingleStreamProjection<Bug4093BazDoc, Guid>
+{
+    public Bug4093BazDoc Create(Bug4093BazStarted _) => new();
+}
+
+/// <summary>
+/// Contrived sibling projection that would accidentally create documents
+/// for any stream carrying an Archived event. Used to expose phantom-doc
+/// behavior in composites prior to the Option A guard.
+/// </summary>
+public class Bug4093BarProjection : SingleStreamProjection<Bug4093BarDoc, Guid>
+{
+    public Bug4093BarDoc Create(Archived e) => new() { ArchivedReason = e.Reason };
+}

--- a/src/DaemonTests/Composites/Bug_4093_archived_in_composite_projections.cs
+++ b/src/DaemonTests/Composites/Bug_4093_archived_in_composite_projections.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using DaemonTests.TestingSupport;
 using JasperFx.Core;
@@ -18,60 +17,21 @@ namespace DaemonTests.Composites;
 /// Regression tests for https://github.com/JasperFx/marten/issues/4093.
 ///
 /// When multiple single-stream projections run inside the same composite group,
-/// an Archived event that belongs to one child's stream should NOT create
-/// phantom documents in other children, and should not issue redundant
-/// stream-archival operations from children that don't own the stream.
+/// a stream-archival call (from an <see cref="Archived"/> event) must only be
+/// issued by the child projection that actually owns the stream — i.e., the one
+/// with a snapshot for the id. Sibling projections that don't own the stream
+/// must not issue redundant stream-archival operations.
 ///
-/// The fix (Option A): only archive from a single-stream projection that actually
-/// has a snapshot for the stream id being archived.
+/// Note: whether Archived *creates* or *mutates* a projected document is a
+/// separate concern — it is driven entirely by the user-defined Create/Apply
+/// handlers on the projection. Archiving a stream and deleting the projected
+/// document are independent operations; see the "manually delete any projected
+/// aggregates" note in docs/events/archiving.md.
 /// </summary>
 public class Bug_4093_archived_in_composite_projections : DaemonContext
 {
     public Bug_4093_archived_in_composite_projections(ITestOutputHelper output) : base(output)
     {
-    }
-
-    [Fact]
-    public async Task archived_does_not_create_phantom_docs_in_other_children_of_composite()
-    {
-        StoreOptions(opts =>
-        {
-            opts.Events.StreamIdentity = StreamIdentity.AsGuid;
-
-            opts.Projections.CompositeProjectionFor("B4093Group", x =>
-            {
-                // This child owns streams that begin with FooStarted.
-                x.Add<Bug4093FooProjection>();
-
-                // This child "listens" for Archived (a contrived but legal pattern).
-                // Today, when Archived appears in any stream in the composite's batch,
-                // this projection's Create(Archived) fires and writes a phantom
-                // Bug4093BarDoc with the id of the other child's stream.
-                x.Add<Bug4093BarProjection>();
-            });
-        }, true);
-
-        var fooStreamId = Guid.NewGuid();
-
-        await using (var session = theStore.LightweightSession())
-        {
-            session.Events.StartStream<Bug4093FooDoc>(fooStreamId, new Bug4093FooStarted(), new Archived("done"));
-            await session.SaveChangesAsync();
-        }
-
-        using var daemon = await theStore.BuildProjectionDaemonAsync();
-        await daemon.StartAllAsync();
-        await daemon.WaitForNonStaleData(10.Seconds());
-
-        // The stream itself should be archived (Foo owns it).
-        await using var query = theStore.QuerySession();
-
-        // Bug4093BarDoc must NOT be written for the Foo stream id — Bar doesn't own it,
-        // and even though it has a Create(Archived) handler, the Option A guard
-        // (snapshot != null) should keep Bar's storage untouched.
-        var phantomBar = await query.LoadAsync<Bug4093BarDoc>(fooStreamId);
-        phantomBar.ShouldBeNull(
-            "Bar projection does not own the Foo stream — no phantom Bar doc should be created");
     }
 
     [Fact]
@@ -112,7 +72,7 @@ public class Bug_4093_archived_in_composite_projections : DaemonContext
         var foo = await query.LoadAsync<Bug4093FooDoc>(fooStreamId);
         foo.ShouldNotBeNull();
 
-        // Baz's doc exists for its own stream; it should NOT have a phantom doc for the Foo stream.
+        // Baz's doc exists for its own stream; it should NOT have a doc for the Foo stream.
         var baz = await query.LoadAsync<Bug4093BazDoc>(bazStreamId);
         baz.ShouldNotBeNull();
 
@@ -137,12 +97,6 @@ public class Bug4093BazDoc
     public Guid Id { get; set; }
 }
 
-public class Bug4093BarDoc
-{
-    public Guid Id { get; set; }
-    public string ArchivedReason { get; set; } = "";
-}
-
 public class Bug4093FooProjection : SingleStreamProjection<Bug4093FooDoc, Guid>
 {
     public Bug4093FooDoc Create(Bug4093FooStarted _) => new();
@@ -151,14 +105,4 @@ public class Bug4093FooProjection : SingleStreamProjection<Bug4093FooDoc, Guid>
 public class Bug4093BazProjection : SingleStreamProjection<Bug4093BazDoc, Guid>
 {
     public Bug4093BazDoc Create(Bug4093BazStarted _) => new();
-}
-
-/// <summary>
-/// Contrived sibling projection that would accidentally create documents
-/// for any stream carrying an Archived event. Used to expose phantom-doc
-/// behavior in composites prior to the Option A guard.
-/// </summary>
-public class Bug4093BarProjection : SingleStreamProjection<Bug4093BarDoc, Guid>
-{
-    public Bug4093BarDoc Create(Archived e) => new() { ArchivedReason = e.Reason };
 }

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -13,6 +13,7 @@ using Marten.Services.BatchQuerying;
 using Marten.Storage;
 using Marten.Storage.Metadata;
 using Npgsql;
+using Weasel.Core;
 using Weasel.Postgresql.Tables.Indexes;
 
 namespace Marten;
@@ -593,6 +594,36 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     Task<T> QueryByPlanAsync<T>(IQueryPlan<T> plan, CancellationToken token = default);
+
+    /// <summary>
+    ///     Fetch the next value of a PostgreSQL sequence by name (optionally schema-qualified).
+    ///     The underlying call is the Postgres <c>nextval()</c> function. The returned value is
+    ///     cast to <see cref="int" /> in SQL; use
+    ///     <see cref="NextSequenceValueAsLong(string, CancellationToken)" /> when the sequence
+    ///     may exceed <see cref="int.MaxValue" />.
+    /// </summary>
+    Task<int> NextSequenceValue(string sequenceName, CancellationToken token = default);
+
+    /// <summary>
+    ///     Fetch the next value of a PostgreSQL sequence described by a <see cref="DbObjectName" />.
+    ///     The underlying call is the Postgres <c>nextval()</c> function. The returned value is
+    ///     cast to <see cref="int" /> in SQL; use
+    ///     <see cref="NextSequenceValueAsLong(DbObjectName, CancellationToken)" /> when the sequence
+    ///     may exceed <see cref="int.MaxValue" />.
+    /// </summary>
+    Task<int> NextSequenceValue(DbObjectName sequenceName, CancellationToken token = default);
+
+    /// <summary>
+    ///     Fetch the next value of a PostgreSQL sequence by name (optionally schema-qualified)
+    ///     as a 64-bit integer, matching the native type of <c>nextval()</c>.
+    /// </summary>
+    Task<long> NextSequenceValueAsLong(string sequenceName, CancellationToken token = default);
+
+    /// <summary>
+    ///     Fetch the next value of a PostgreSQL sequence described by a <see cref="DbObjectName" />
+    ///     as a 64-bit integer, matching the native type of <c>nextval()</c>.
+    /// </summary>
+    Task<long> NextSequenceValueAsLong(DbObjectName sequenceName, CancellationToken token = default);
 
 
 }

--- a/src/Marten/Internal/Sessions/QuerySession.Sequences.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Sequences.cs
@@ -1,0 +1,79 @@
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Core;
+
+namespace Marten.Internal.Sessions;
+
+public partial class QuerySession
+{
+    /// <summary>
+    ///     Fetch the next value of a PostgreSQL sequence by name (optionally schema-qualified).
+    ///     The underlying call is the Postgres <c>nextval()</c> function. The returned value
+    ///     is cast to <see cref="int" /> in SQL; use
+    ///     <see cref="NextSequenceValueAsLong(string, CancellationToken)" /> when the sequence
+    ///     may exceed <see cref="int.MaxValue" />.
+    /// </summary>
+    /// <param name="sequenceName">The sequence name. Schema-qualified names are supported.</param>
+    /// <param name="token"></param>
+    public async Task<int> NextSequenceValue(string sequenceName, CancellationToken token = default)
+    {
+        ArgumentNullException.ThrowIfNull(sequenceName);
+
+        await using var cmd = new NpgsqlCommand("select nextval(:seq)::int");
+        cmd.Parameters.Add(new NpgsqlParameter("seq", NpgsqlDbType.Text) { Value = sequenceName });
+
+        await using var reader = await ExecuteReaderAsync(cmd, token).ConfigureAwait(false);
+        await reader.ReadAsync(token).ConfigureAwait(false);
+        return await reader.GetFieldValueAsync<int>(0, token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Fetch the next value of a PostgreSQL sequence described by a <see cref="DbObjectName" />.
+    ///     The underlying call is the Postgres <c>nextval()</c> function. The returned value
+    ///     is cast to <see cref="int" /> in SQL; use
+    ///     <see cref="NextSequenceValueAsLong(DbObjectName, CancellationToken)" /> when the sequence
+    ///     may exceed <see cref="int.MaxValue" />.
+    /// </summary>
+    /// <param name="sequenceName">The sequence identifier including its schema.</param>
+    /// <param name="token"></param>
+    public Task<int> NextSequenceValue(DbObjectName sequenceName, CancellationToken token = default)
+    {
+        ArgumentNullException.ThrowIfNull(sequenceName);
+        return NextSequenceValue(sequenceName.QualifiedName, token);
+    }
+
+    /// <summary>
+    ///     Fetch the next value of a PostgreSQL sequence by name (optionally schema-qualified)
+    ///     as a 64-bit integer, matching the native type of <c>nextval()</c>.
+    /// </summary>
+    /// <param name="sequenceName">The sequence name. Schema-qualified names are supported.</param>
+    /// <param name="token"></param>
+    public async Task<long> NextSequenceValueAsLong(string sequenceName, CancellationToken token = default)
+    {
+        ArgumentNullException.ThrowIfNull(sequenceName);
+
+        await using var cmd = new NpgsqlCommand("select nextval(:seq)");
+        cmd.Parameters.Add(new NpgsqlParameter("seq", NpgsqlDbType.Text) { Value = sequenceName });
+
+        await using var reader = await ExecuteReaderAsync(cmd, token).ConfigureAwait(false);
+        await reader.ReadAsync(token).ConfigureAwait(false);
+        return await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Fetch the next value of a PostgreSQL sequence described by a <see cref="DbObjectName" />
+    ///     as a 64-bit integer, matching the native type of <c>nextval()</c>.
+    /// </summary>
+    /// <param name="sequenceName">The sequence identifier including its schema.</param>
+    /// <param name="token"></param>
+    public Task<long> NextSequenceValueAsLong(DbObjectName sequenceName, CancellationToken token = default)
+    {
+        ArgumentNullException.ThrowIfNull(sequenceName);
+        return NextSequenceValueAsLong(sequenceName.QualifiedName, token);
+    }
+}


### PR DESCRIPTION
## Summary

A small convenience API on \`IQuerySession\` for fetching the next value of a PostgreSQL sequence without dropping to raw SQL from application code.

```cs
Task<int>  NextSequenceValue(string sequenceName, CancellationToken token = default);
Task<int>  NextSequenceValue(DbObjectName sequenceName, CancellationToken token = default);
Task<long> NextSequenceValueAsLong(string sequenceName, CancellationToken token = default);
Task<long> NextSequenceValueAsLong(DbObjectName sequenceName, CancellationToken token = default);
```

Executes \`select nextval(:seq)\` through the session's normal connection lifetime, so it picks up the resilience pipeline, tenancy, and logging for free.

### Design notes

- The int overloads cast in SQL (\`::int\`) so sequences above \`Int32.MaxValue\` surface as a proper overflow exception rather than silently truncating. \`NextSequenceValueAsLong\` returns the native \`bigint\` without client-side narrowing.
- Both the \`string\` and \`DbObjectName\` overloads accept schema-qualified names; the \`DbObjectName\` variant just forwards to \`QualifiedName\`.
- The sequence name is passed as a parameter, not interpolated into the SQL. PostgreSQL's \`regclass\` resolution accepts text for \`nextval()\`.

## Tests

\`src/CoreTests/next_sequence_value_tests.cs\` — 6 tests, all pass on net9.0:

- \`next_sequence_value_returns_sequential_ints_with_qualified_string_name\`
- \`next_sequence_value_returns_sequential_ints_with_dbobjectname\`
- \`next_sequence_value_as_long_returns_sequential_longs_with_qualified_string_name\`
- \`next_sequence_value_as_long_returns_sequential_longs_with_dbobjectname\`
- \`next_sequence_value_as_long_handles_values_above_int32_max\` — asserts a sequence started at 3,000,000,000 (above int32 max) returns the expected long
- \`next_sequence_value_honors_start_value\` — asserts a custom \`START\` value is respected

## Docs

New page at \`docs/documents/sequences.md\` under \"Document DB → PostgreSQL Sequences\" in the sidebar. Cross-links to the existing [Using sequences for unique and human-readable identifiers](/scenarios/using-sequence-for-unique-id) scenario. Snippets are extracted via mdsnippets from the test file. \`npm run docs-build\` completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)