### PR TITLE
NaturalKey on self-aggregating aggregates (closes #4277)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
     <PackageVersion Include="JasperFx" Version="1.26.0" />
-    <PackageVersion Include="JasperFx.Events" Version="1.29.0" />
+    <PackageVersion Include="JasperFx.Events" Version="1.29.1" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EventSourcingTests/Bugs/Bug_4197_fetch_for_writing_natural_key.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4197_fetch_for_writing_natural_key.cs
@@ -92,4 +92,39 @@ public class Bug_4197_fetch_for_writing_natural_key : OneOffConfigurationsContex
         stream.Aggregate.ShouldNotBeNull();
         stream.Aggregate.Key.ShouldBe(aggregateKey);
     }
+
+    // Regression coverage for https://github.com/JasperFx/marten/issues/4277.
+    // Self-aggregating aggregate (record) with a static [NaturalKeySource] factory.
+    public sealed record Bug4277SelfAggregate(Guid Id, [property: NaturalKey] Bug4197AggregateKey Key)
+    {
+        [NaturalKeySource]
+        public static Bug4277SelfAggregate Create(Bug4197AggregateCreatedEvent e)
+            => new(e.Id, new Bug4197AggregateKey(e.Key));
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_with_natural_key_on_self_aggregating_record_with_static_source()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.Snapshot<Bug4277SelfAggregate>(SnapshotLifecycle.Inline);
+        });
+
+        await using var session = theStore.LightweightSession();
+
+        var aggregateId = Guid.NewGuid();
+        var aggregateKey = new Bug4197AggregateKey("another-key-value");
+        var e = new Bug4197AggregateCreatedEvent(aggregateId, aggregateKey.Value);
+
+        session.Events.StartStream<Bug4277SelfAggregate>(aggregateId, e);
+        await session.SaveChangesAsync();
+
+        // Before the fix, the natural-key lookup row was never written, so this
+        // FetchForWriting by natural key returned a null aggregate.
+        var stream = await session.Events.FetchForWriting<Bug4277SelfAggregate, Bug4197AggregateKey>(aggregateKey);
+
+        stream.ShouldNotBeNull();
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Key.ShouldBe(aggregateKey);
+    }
 }


### PR DESCRIPTION
Closes #4277.

## Summary

Adds an end-to-end regression test to \`Bug_4197_fetch_for_writing_natural_key.cs\` matching the exact self-aggregating shape from the issue:

\`\`\`csharp
public sealed record Bug4277SelfAggregate(Guid Id, [property: NaturalKey] Bug4197AggregateKey Key)
{
    [NaturalKeySource]
    public static Bug4277SelfAggregate Create(Bug4197AggregateCreatedEvent e)
        => new(e.Id, new Bug4197AggregateKey(e.Key));
}
\`\`\`

Before the fix, calling \`FetchForWriting<Bug4277SelfAggregate, Bug4197AggregateKey>(key)\` returned a null aggregate because the natural-key lookup row was never written — the discovery scan in JasperFx.Events silently skipped the static \`Create\` method on the aggregate type.

## Upstream fix

Companion PR: [JasperFx/jasperfx#187](https://github.com/JasperFx/jasperfx/pull/187), shipping as **JasperFx.Events 1.29.1**. That PR:

- Widens \`discoverNaturalKey\` to scan static methods on the aggregate type, not just instance methods.
- Teaches \`buildExtractor\` to call a static factory on \`docType\` that returns \`docType\` and read the natural-key property off the returned aggregate.
- Adds three JasperFx-side unit tests that exercise the three \`[NaturalKeySource]\` discovery pathways directly.

## Dependency

This PR bumps \`Directory.Packages.props\` \`JasperFx.Events\` from \`1.29.0\` to \`1.29.1\`. CI on this branch will fail with \`NU1102\` until \`JasperFx.Events 1.29.1\` is published to NuGet.org via the upstream PR. Local verification performed against a packed dev build of \`1.29.1\`:

- \`Bug_4197_fetch_for_writing_natural_key\` — 3/3 pass (including the new test)
- Broader natural-key + aggregation sweep — 283/283 pass on net9.0, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)