### PR TITLE
Support Count/LongCount after GroupBy().Select() (#4278)

### DIFF
--- a/src/LinqTests/Operators/group_by_operator.cs
+++ b/src/LinqTests/Operators/group_by_operator.cs
@@ -222,4 +222,33 @@ public class group_by_operator: OneOffConfigurationsContext
         results.Single(x => x.Color == Colors.Blue).Count.ShouldBe(2L);
         results.Single(x => x.Color == Colors.Green).Count.ShouldBe(3L);
     }
+
+    // https://github.com/JasperFx/marten/issues/4278
+    [Fact]
+    public async Task group_by_count()
+    {
+        await SetupTargetData();
+
+        var count = await _session.Query<Target>()
+            .GroupBy(x => x.Color)
+            .Select(x => x.Key)      // Select must always follow GroupBy
+            .CountAsync();
+
+        // Blue, Green, Red -> three distinct groups
+        count.ShouldBe(3);
+    }
+
+    // https://github.com/JasperFx/marten/issues/4278
+    [Fact]
+    public async Task group_by_long_count()
+    {
+        await SetupTargetData();
+
+        var count = await _session.Query<Target>()
+            .GroupBy(x => x.Color)
+            .Select(x => x.Key)
+            .LongCountAsync();
+
+        count.ShouldBe(3L);
+    }
 }

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -486,6 +486,19 @@ public partial class CollectionUsage
             }
         }
 
+        // Transfer single-value operators applied directly on the grouping usage
+        // itself (e.g., .GroupBy(...).Select(...).CountAsync() / .AnyAsync()).
+        // See https://github.com/JasperFx/marten/issues/4278.
+        if (groupingUsage.SingleValueMode.HasValue)
+        {
+            SingleValueMode ??= groupingUsage.SingleValueMode;
+        }
+
+        if (groupingUsage.IsAny)
+        {
+            IsAny = true;
+        }
+
         // Transfer downstream operators from the grouping usage's Inner (if any)
         // e.g., OrderBy, Take, Skip after Select
         var downstream = groupingUsage.Inner;
@@ -630,6 +643,22 @@ public partial class CollectionUsage
                         return;
                     }
 
+                    if (statement.GroupByColumns.Count > 0)
+                    {
+                        // .GroupBy(...).Select(...).CountAsync() should return the
+                        // number of groups, not count(*) over the grouped rows.
+                        // Wrap the GROUP BY query in a CTE and count its rows.
+                        // See https://github.com/JasperFx/marten/issues/4278.
+                        statement.ConvertToCommonTableExpression(session);
+                        var groupCount = new SelectorStatement
+                        {
+                            SelectClause = new CountClause<int>(statement.ExportName)
+                        };
+
+                        statement.AddToEnd(groupCount);
+                        return;
+                    }
+
                     statement.SelectClause = new CountClause<int>(statement.SelectClause.FromObject);
 
                     break;
@@ -649,6 +678,21 @@ public partial class CollectionUsage
                         };
 
                         statement.AddToEnd(count);
+                        return;
+                    }
+
+                    if (statement.GroupByColumns.Count > 0)
+                    {
+                        // .GroupBy(...).Select(...).LongCountAsync() should return
+                        // the number of groups. See
+                        // https://github.com/JasperFx/marten/issues/4278.
+                        statement.ConvertToCommonTableExpression(session);
+                        var groupLongCount = new SelectorStatement
+                        {
+                            SelectClause = new CountClause<long>(statement.ExportName)
+                        };
+
+                        statement.AddToEnd(groupLongCount);
                         return;
                     }
 


### PR DESCRIPTION
## Summary

`.GroupBy(...).Select(...).CountAsync()` was throwing `System.NotSupportedException: Marten does not know how to use result type int`. Two adjustments in `CollectionUsage.Compilation.cs`:

- Transfer `SingleValueMode` and `IsAny` from the grouping usage itself in `CompileGroupBy`, not just from `groupingUsage.Inner`. Terminal aggregates applied directly after the `Select(...)` projection land on the grouping usage, and were previously dropped.
- In `ProcessSingleValueModeIfAny`, when `Count`/`LongCount` is being applied and the statement already has `GROUP BY` columns, wrap the query in a CTE and count its rows — mirroring the existing `IsDistinct` path. Replacing the SELECT with `count(*)` in-place would have counted rows within each group instead of counting the groups themselves.

Fixes #4278.

## Test plan

- [x] New regression tests `group_by_count` and `group_by_long_count` in `group_by_operator.cs` — both fail on master with `NotSupportedException`, both pass with this fix.
- [x] Full `LinqTests` suite: 1255 passed, 0 failed, 1 skipped (pre-existing skip, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)