### PR TITLE
#4284 Support DI-backed composite projections

### DIFF
--- a/src/DaemonTests/Composites/Feature_4284_composite_projection_with_services.cs
+++ b/src/DaemonTests/Composites/Feature_4284_composite_projection_with_services.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using JasperFx.Events;
+using Marten;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.Composites;
+
+public class Feature_4284_composite_projection_with_services
+{
+    [Fact]
+    public async Task can_use_scoped_services_in_projection_registered_under_composite()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddScoped<ICompositePriceLookup, CompositePriceLookup>();
+
+                services.AddMarten(opts =>
+                    {
+                        opts.Connection(ConnectionSource.ConnectionString);
+                        opts.DatabaseSchemaName = "feature_4284_net" + Environment.Version.Major;
+                        opts.Projections.CompositeProjectionFor("Feature4284Products", projection =>
+                        {
+                            projection.AddProjectionWithServices<CompositeProductProjection>(ServiceLifetime.Scoped);
+                            projection.AddProjectionWithServices<CompositeProductMetricProjection>(ServiceLifetime.Scoped);
+                        });
+                    })
+                    .ApplyAllDatabaseChangesOnStartup();
+            })
+            .StartAsync();
+
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+        await using var session = store.LightweightSession();
+        var streamId = session.Events.StartStream<CompositeProduct>(
+            new CompositeProductRegistered("Ankle Socks", "Socks")).Id;
+        await session.SaveChangesAsync();
+
+        using var daemon = await store.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(10.Seconds());
+        await daemon.StopAllAsync();
+
+        var product = await session.LoadAsync<CompositeProduct>(streamId);
+        product.ShouldNotBeNull();
+        product.Name.ShouldBe("Ankle Socks");
+        product.Category.ShouldBe("Socks");
+        product.Price.ShouldBe(12.5);
+
+        var metric = await session.LoadAsync<CompositeProductMetric>(streamId);
+        metric.ShouldNotBeNull();
+        metric.Price.ShouldBe(12.5);
+    }
+}
+
+public interface ICompositePriceLookup
+{
+    double PriceFor(string category);
+}
+
+public class CompositePriceLookup: ICompositePriceLookup
+{
+    public double PriceFor(string category)
+    {
+        return category == "Socks" ? 12.5 : 5;
+    }
+}
+
+public class CompositeProduct
+{
+    public Guid Id { get; set; }
+    public double Price { get; set; }
+    public string Category { get; set; }
+    public string Name { get; set; }
+}
+
+public record CompositeProductRegistered(string Name, string Category);
+
+public class CompositeProductMetric
+{
+    public Guid Id { get; set; }
+    public double Price { get; set; }
+}
+
+public class CompositeProductProjection: SingleStreamProjection<CompositeProduct, Guid>
+{
+    private readonly ICompositePriceLookup _lookup;
+
+    public CompositeProductProjection(ICompositePriceLookup lookup)
+    {
+        _lookup = lookup;
+        Name = "Feature4284Product";
+    }
+
+    public override CompositeProduct Evolve(CompositeProduct snapshot, Guid id, IEvent e)
+    {
+        snapshot ??= new CompositeProduct { Id = id };
+
+        if (e.Data is CompositeProductRegistered registered)
+        {
+            snapshot.Price = _lookup.PriceFor(registered.Category);
+            snapshot.Name = registered.Name;
+            snapshot.Category = registered.Category;
+        }
+
+        return snapshot;
+    }
+}
+
+public class CompositeProductMetricProjection: IProjection
+{
+    private readonly ICompositePriceLookup _lookup;
+
+    public CompositeProductMetricProjection(ICompositePriceLookup lookup)
+    {
+        _lookup = lookup;
+    }
+
+    public Task ApplyAsync(IDocumentOperations operations, IReadOnlyList<IEvent> events,
+        CancellationToken cancellation)
+    {
+        foreach (var e in events)
+        {
+            if (e.Data is CompositeProductRegistered registered)
+            {
+                operations.Store(new CompositeProductMetric
+                {
+                    Id = e.StreamId,
+                    Price = _lookup.PriceFor(registered.Category)
+                });
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Marten/Events/Projections/CompositeProjection.cs
+++ b/src/Marten/Events/Projections/CompositeProjection.cs
@@ -11,20 +11,38 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Descriptors;
 using JasperFx.Events.Projections;
 using JasperFx.Events.Projections.Composite;
+using JasperFx.Events.Projections.ContainerScoped;
 using JasperFx.Events.Subscriptions;
 using Marten.Events.Aggregation;
 using Marten.Schema;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Marten.Events.Projections;
 
+internal interface ICompositeProjectionServiceSource
+{
+    void AttachServiceProvider(IServiceProvider services);
+}
+
 public class CompositeProjection : CompositeProjection<IDocumentOperations, IQuerySession>
 {
     private readonly StoreOptions _options;
+    private IServiceProvider? _services;
 
     internal CompositeProjection(string name, StoreOptions options, ProjectionOptions parent) : base(name)
     {
         _options = options;
+    }
+
+    internal void AttachServiceProvider(IServiceProvider services)
+    {
+        _services = services;
+
+        foreach (var source in AllProjections().OfType<ICompositeProjectionServiceSource>())
+        {
+            source.AttachServiceProvider(services);
+        }
     }
 
     /// <summary>
@@ -88,6 +106,403 @@ public class CompositeProjection : CompositeProjection<IDocumentOperations, IQue
     public void Add<T>(int stageNumber = 1) where T : IProjectionSource<IDocumentOperations, IQuerySession>, new()
     {
         Add(new T(), stageNumber);
+    }
+
+    /// <summary>
+    /// Add a projection that requires services from the application's IoC container to this composite.
+    /// </summary>
+    /// <param name="lifetime">
+    /// The IoC lifecycle for the projection instance. Note that the Transient lifetime will still be
+    /// treated as Scoped.
+    /// </param>
+    /// <param name="stageNumber">Optionally move the execution to a later stage. The default is 1</param>
+    /// <param name="configure">Optional configuration of the projection name, version, event filtering, and async execution</param>
+    /// <typeparam name="TProjection">The projection type to add</typeparam>
+    public void AddProjectionWithServices<TProjection>(ServiceLifetime lifetime = ServiceLifetime.Scoped,
+        int stageNumber = 1, Action<ProjectionBase>? configure = null) where TProjection : class, IMartenRegistrable
+    {
+        var source = new CompositeProjectionWithServicesSource<TProjection>(lifetime, configure);
+
+        if (_services != null)
+        {
+            source.AttachServiceProvider(_services);
+        }
+
+        StageFor(stageNumber).Add(source);
+    }
+}
+
+internal class CompositeProjectionWithServicesSource<TProjection> :
+    ProjectionBase,
+    IProjectionSource<IDocumentOperations, IQuerySession>,
+    ISubscriptionFactory<IDocumentOperations, IQuerySession>,
+    IAggregateProjection,
+    IMartenAggregateProjection,
+    ICompositeProjectionServiceSource where TProjection : class, IMartenRegistrable
+{
+    private readonly Type? _aggregateType;
+    private readonly Action<ProjectionBase>? _configure;
+    private readonly Type? _identityType;
+    private readonly ServiceLifetime _lifetime;
+    private readonly AggregationScope _scope;
+    private IProjectionSource<IDocumentOperations, IQuerySession>? _inner;
+    private IServiceProvider? _services;
+
+    public CompositeProjectionWithServicesSource(ServiceLifetime lifetime, Action<ProjectionBase>? configure)
+    {
+        _lifetime = lifetime;
+        _configure = configure;
+        Lifecycle = ProjectionLifecycle.Async;
+        Name = typeof(TProjection).Name;
+        Version = 1;
+
+        if (typeof(TProjection).TryGetAttribute<ProjectionVersionAttribute>(out var att))
+        {
+            Version = att.Version;
+        }
+
+        _configure?.Invoke(this);
+
+        if (tryFindAggregateTypes(typeof(TProjection), out var aggregateType, out var identityType, out var scope))
+        {
+            _aggregateType = aggregateType;
+            _identityType = identityType;
+            _scope = scope;
+            RegisterPublishedType(aggregateType);
+        }
+    }
+
+    public SubscriptionType Type => Source.Type;
+    public ShardName[] ShardNames() => Source.ShardNames();
+    public Type ImplementationType => Source.ImplementationType;
+    public SubscriptionDescriptor Describe(IEventStore store) => Source.Describe(store);
+
+    private IProjectionSource<IDocumentOperations, IQuerySession> Source
+    {
+        get
+        {
+            if (_inner != null)
+            {
+                return _inner;
+            }
+
+            if (_services == null)
+            {
+                throw new InvalidOperationException(
+                    $"Projection {typeof(TProjection).FullNameInCode()} requires application services, but no IServiceProvider has been attached. Use this registration through AddMarten() so Marten can resolve the projection from DI.");
+            }
+
+            _inner = buildSource(_services);
+            return _inner;
+        }
+    }
+
+    public void AttachServiceProvider(IServiceProvider services)
+    {
+        _services = services;
+        _inner ??= buildSource(services);
+    }
+
+    private IProjectionSource<IDocumentOperations, IQuerySession> buildSource(IServiceProvider services)
+    {
+        IProjectionSource<IDocumentOperations, IQuerySession> source;
+
+        if (_lifetime == ServiceLifetime.Singleton)
+        {
+            source = buildSingletonSource(services);
+        }
+        else if (typeof(TProjection).CanBeCastTo<IProjection>() &&
+                 !typeof(TProjection).CanBeCastTo<IProjectionSource<IDocumentOperations, IQuerySession>>())
+        {
+            source = typeof(CompositeScopedIProjectionSource<>)
+                .CloseAndBuildAs<ProjectionBase>(services, typeof(TProjection))
+                .As<IProjectionSource<IDocumentOperations, IQuerySession>>();
+        }
+        else if (_aggregateType != null && _identityType != null)
+        {
+            var projectionServices = new ProjectionActivatingServiceProvider<TProjection>(services);
+            source = typeof(ScopedAggregationWrapper<,,,,>)
+                .CloseAndBuildAs<ProjectionBase>(projectionServices, typeof(TProjection), _aggregateType, _identityType,
+                    typeof(IDocumentOperations), typeof(IQuerySession))
+                .As<IProjectionSource<IDocumentOperations, IQuerySession>>();
+        }
+        else
+        {
+            var projectionServices = new ProjectionActivatingServiceProvider<TProjection>(services);
+            source = typeof(ScopedProjectionWrapper<,,>)
+                .CloseAndBuildAs<ProjectionBase>(projectionServices, typeof(TProjection), typeof(IDocumentOperations),
+                    typeof(IQuerySession))
+                .As<IProjectionSource<IDocumentOperations, IQuerySession>>();
+        }
+
+        if (source is ProjectionBase projection)
+        {
+            projection.Lifecycle = ProjectionLifecycle.Async;
+            _configure?.Invoke(projection);
+            projection.Name = Name;
+            projection.OverwriteVersion(Version);
+        }
+
+        return source;
+    }
+
+    private static IProjectionSource<IDocumentOperations, IQuerySession> buildSingletonSource(IServiceProvider services)
+    {
+        var projection = services.GetService<TProjection>() ??
+                         ActivatorUtilities.CreateInstance<TProjection>(services);
+
+        if (projection is IProjection martenProjection &&
+            projection is not IProjectionSource<IDocumentOperations, IQuerySession>)
+        {
+            return new CompositeIProjectionSource(martenProjection);
+        }
+
+        return projection.As<IProjectionSource<IDocumentOperations, IQuerySession>>();
+    }
+
+    private static bool tryFindAggregateTypes(Type projectionType, out Type aggregateType, out Type identityType,
+        out AggregationScope scope)
+    {
+        var type = projectionType;
+        while (type != null && type != typeof(object))
+        {
+            if (type.IsGenericType)
+            {
+                var definition = type.GetGenericTypeDefinition();
+                if (definition == typeof(SingleStreamProjection<,>) ||
+                    definition == typeof(MultiStreamProjection<,>))
+                {
+                    var arguments = type.GetGenericArguments();
+                    aggregateType = arguments[0];
+                    identityType = arguments[1];
+                    scope = definition == typeof(SingleStreamProjection<,>)
+                        ? AggregationScope.SingleStream
+                        : AggregationScope.MultiStream;
+                    return true;
+                }
+            }
+
+            type = type.BaseType;
+        }
+
+        aggregateType = null!;
+        identityType = null!;
+        scope = default;
+        return false;
+    }
+
+    Type IAggregateProjection.IdentityType => _identityType ?? typeof(void);
+    Type IAggregateProjection.AggregateType => _aggregateType ?? typeof(void);
+    AggregationScope IAggregateProjection.Scope => _scope;
+    Type[] IAggregateProjection.AllEventTypes =>
+        _aggregateType == null ? [] : Source.As<IAggregateProjection>().AllEventTypes;
+    NaturalKeyDefinition? IAggregateProjection.NaturalKeyDefinition =>
+        _aggregateType == null ? null : Source.As<IAggregateProjection>().NaturalKeyDefinition;
+
+    void IMartenAggregateProjection.ConfigureAggregateMapping(DocumentMapping mapping, StoreOptions storeOptions)
+    {
+        if (_services != null)
+        {
+            using var scope = _services.CreateScope();
+            var projection = scope.ServiceProvider.GetService<TProjection>() ??
+                             ActivatorUtilities.CreateInstance<TProjection>(scope.ServiceProvider);
+
+            if (projection is IMartenAggregateProjection martenAggregateProjection)
+            {
+                martenAggregateProjection.ConfigureAggregateMapping(mapping, storeOptions);
+                return;
+            }
+        }
+
+        if (_scope == AggregationScope.SingleStream)
+        {
+            mapping.UseVersionFromMatchingStream = true;
+        }
+    }
+
+    public IReadOnlyList<AsyncShard<IDocumentOperations, IQuerySession>> Shards() => Source.Shards();
+
+    public bool TryBuildReplayExecutor(IEventStore<IDocumentOperations, IQuerySession> store, IEventDatabase database,
+        [NotNullWhen(true)] out IReplayExecutor? executor)
+    {
+        return Source.TryBuildReplayExecutor(store, database, out executor);
+    }
+
+    public IInlineProjection<IDocumentOperations> BuildForInline()
+    {
+        throw new NotSupportedException("Composite projections do not support inline execution");
+    }
+
+    public ISubscriptionExecution BuildExecution(IEventStore<IDocumentOperations, IQuerySession> store,
+        IEventDatabase database, ILoggerFactory loggerFactory, ShardName shardName)
+    {
+        return Source.As<ISubscriptionFactory<IDocumentOperations, IQuerySession>>()
+            .BuildExecution(store, database, loggerFactory, shardName);
+    }
+
+    public ISubscriptionExecution BuildExecution(IEventStore<IDocumentOperations, IQuerySession> store,
+        IEventDatabase database, ILogger logger, ShardName shardName)
+    {
+        return Source.As<ISubscriptionFactory<IDocumentOperations, IQuerySession>>()
+            .BuildExecution(store, database, logger, shardName);
+    }
+}
+
+internal class CompositeScopedIProjectionSource<TProjection> :
+    ProjectionBase,
+    IProjectionSource<IDocumentOperations, IQuerySession>,
+    ISubscriptionFactory<IDocumentOperations, IQuerySession> where TProjection : class, IProjection
+{
+    private readonly IServiceProvider _services;
+
+    public CompositeScopedIProjectionSource(IServiceProvider services)
+    {
+        _services = services;
+        Lifecycle = ProjectionLifecycle.Async;
+        Name = typeof(TProjection).Name;
+        Version = 1;
+        if (typeof(TProjection).TryGetAttribute<ProjectionVersionAttribute>(out var att))
+        {
+            Version = att.Version;
+        }
+    }
+
+    public SubscriptionType Type => SubscriptionType.EventProjection;
+    public ShardName[] ShardNames() => [new ShardName(Name, ShardName.All, Version)];
+    public Type ImplementationType => typeof(TProjection);
+    public SubscriptionDescriptor Describe(IEventStore store) => new(this, store);
+
+    public IReadOnlyList<AsyncShard<IDocumentOperations, IQuerySession>> Shards()
+    {
+        return
+        [
+            new AsyncShard<IDocumentOperations, IQuerySession>(Options, ShardRole.Projection,
+                new ShardName(Name, "All", Version), this, this)
+        ];
+    }
+
+    public bool TryBuildReplayExecutor(IEventStore<IDocumentOperations, IQuerySession> store, IEventDatabase database,
+        [NotNullWhen(true)] out IReplayExecutor? executor)
+    {
+        executor = default;
+        return false;
+    }
+
+    public IInlineProjection<IDocumentOperations> BuildForInline()
+    {
+        throw new NotSupportedException("CompositeScopedIProjectionSource does not support inline execution");
+    }
+
+    public ISubscriptionExecution BuildExecution(IEventStore<IDocumentOperations, IQuerySession> store,
+        IEventDatabase database, ILoggerFactory loggerFactory, ShardName shardName)
+    {
+        return new CompositeScopedIProjectionExecution<TProjection>(_services, shardName);
+    }
+
+    public ISubscriptionExecution BuildExecution(IEventStore<IDocumentOperations, IQuerySession> store,
+        IEventDatabase database, ILogger logger, ShardName shardName)
+    {
+        return new CompositeScopedIProjectionExecution<TProjection>(_services, shardName);
+    }
+}
+
+internal class CompositeScopedIProjectionExecution<TProjection> : ISubscriptionExecution where TProjection : class, IProjection
+{
+    private readonly IServiceProvider _services;
+
+    public CompositeScopedIProjectionExecution(IServiceProvider services, ShardName shardName)
+    {
+        _services = services;
+        ShardName = shardName;
+    }
+
+    public ShardName ShardName { get; }
+    public ShardExecutionMode Mode { get; set; }
+
+    public async Task ProcessRangeAsync(EventRange range)
+    {
+        var batch = range.ActiveBatch as IProjectionBatch<IDocumentOperations, IQuerySession>;
+        if (batch == null) return;
+
+        var groups = range.Events.GroupBy(x => x.TenantId).ToArray();
+        foreach (var group in groups)
+        {
+            using var scope = _services.CreateScope();
+            var projection = ActivatorUtilities.GetServiceOrCreateInstance<TProjection>(scope.ServiceProvider);
+
+            await using var session = batch.SessionForTenant(group.Key);
+            await projection.ApplyAsync(session, group.ToList(), CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    public ValueTask EnqueueAsync(EventPage page, ISubscriptionAgent subscriptionAgent) => new();
+    public Task StopAndDrainAsync(CancellationToken token) => Task.CompletedTask;
+    public Task HardStopAsync() => Task.CompletedTask;
+
+    public bool TryBuildReplayExecutor([NotNullWhen(true)] out IReplayExecutor? executor)
+    {
+        executor = default;
+        return false;
+    }
+
+    public Task ProcessImmediatelyAsync(SubscriptionAgent subscriptionAgent, EventPage events,
+        CancellationToken cancellation) => Task.CompletedTask;
+
+    public bool TryGetAggregateCache<TId, TDoc>([NotNullWhen(true)] out IAggregateCaching<TId, TDoc>? caching)
+    {
+        caching = null;
+        return false;
+    }
+
+    public ValueTask DisposeAsync() => new();
+}
+
+internal class ProjectionActivatingServiceProvider<TProjection> : IServiceProvider, IServiceScopeFactory
+    where TProjection : class
+{
+    private readonly IServiceProvider _inner;
+
+    public ProjectionActivatingServiceProvider(IServiceProvider inner)
+    {
+        _inner = inner;
+    }
+
+    public object? GetService(Type serviceType)
+    {
+        if (serviceType == typeof(IServiceScopeFactory))
+        {
+            return this;
+        }
+
+        if (serviceType == typeof(TProjection))
+        {
+            return _inner.GetService(serviceType) ?? ActivatorUtilities.CreateInstance(_inner, serviceType);
+        }
+
+        return _inner.GetService(serviceType);
+    }
+
+    public IServiceScope CreateScope()
+    {
+        return new ProjectionActivatingServiceScope<TProjection>(_inner.CreateScope());
+    }
+}
+
+internal class ProjectionActivatingServiceScope<TProjection> : IServiceScope where TProjection : class
+{
+    private readonly IServiceScope _inner;
+
+    public ProjectionActivatingServiceScope(IServiceScope inner)
+    {
+        _inner = inner;
+        ServiceProvider = new ProjectionActivatingServiceProvider<TProjection>(inner.ServiceProvider);
+    }
+
+    public IServiceProvider ServiceProvider { get; }
+
+    public void Dispose()
+    {
+        _inner.Dispose();
     }
 }
 

--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -71,6 +71,14 @@ public class ProjectionOptions: ProjectionGraph<IProjection, IDocumentOperations
         foreach (var planner in _builtInPlanners) yield return planner;
     }
 
+    internal void AttachServiceProvider(IServiceProvider services)
+    {
+        foreach (var composite in All.OfType<CompositeProjection>())
+        {
+            composite.AttachServiceProvider(services);
+        }
+    }
+
     internal IInlineProjection<IDocumentOperations>[] BuildInlineProjections(DocumentStore store)
     {
         var projections = All

--- a/src/Marten/Internal/SecondaryStoreConfig.cs
+++ b/src/Marten/Internal/SecondaryStoreConfig.cs
@@ -111,6 +111,7 @@ internal class SecondaryStoreConfig<T>: IStoreConfig where T : IDocumentStore
         options.ReadJasperFxOptions(provider.GetService<JasperFxOptions>());
         options.StoreName = typeof(T).Name;
         options.ReadJasperFxOptions(provider.GetService<JasperFxOptions>());
+        options.Projections.AttachServiceProvider(provider);
 
         return options;
     }

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -178,6 +178,7 @@ public static class MartenServiceCollectionExtensions
             options.ReadJasperFxOptions(s.GetService<JasperFxOptions>());
 
             options.InitialData.AddRange(s.GetServices<IInitialData>());
+            options.Projections.AttachServiceProvider(s);
 
             return options;
         });


### PR DESCRIPTION
Add support for registering composite projections that require application services (DI).

- Introduce CompositeProjection.AddProjectionWithServices<T> to register projections resolved from IServiceProvider, honoring ServiceLifetime (Transient treated as Scoped, Singleton uses a single instance).
- Implement internal plumbing: CompositeProjection now accepts an IServiceProvider and propagates it to projections via ICompositeProjectionServiceSource; add CompositeProjectionWithServicesSource, CompositeScopedIProjectionSource, CompositeScopedIProjectionExecution, and ProjectionActivatingServiceProvider/Scope to create/execute projections within scoped service scopes.
- Wire service provider attachment through ProjectionOptions.AttachServiceProvider and call it when building stores (MartenServiceCollectionExtensions and SecondaryStoreConfig) so projections registered in AddMarten can resolve DI services.
- Add an integration test (Feature_4284_composite_projection_with_services) that verifies scoped services are available to composite projections and that projections produce expected documents.

This enables composite projections to depend on scoped/singleton services from the host DI container when registered through AddMarten.

Fixes #4284