### PR TITLE
Ensure ExistingStreamIdCollisionException is thrown when UseArchivedStreamPartitioning is enabled

### DIFF
--- a/src/EventSourcingTests/Bugs/start_stream_should_enforce_that_it_is_a_new_stream_when_UseArchivedStreamPartitioning_is_enabled.cs
+++ b/src/EventSourcingTests/Bugs/start_stream_should_enforce_that_it_is_a_new_stream_when_UseArchivedStreamPartitioning_is_enabled.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+using Marten.Exceptions;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+public class start_stream_should_enforce_that_it_is_a_new_stream_when_UseArchivedStreamPartitioning_is_enabled: OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task throw_exception_if_start_stream_is_called_on_existing_stream_when_UseArchivedStreamPartitioning()
+    {
+        StoreOptions(_ => _.Events.UseArchivedStreamPartitioning = true);
+
+        var stream = Guid.NewGuid();
+
+        using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(stream, new MembersJoined());
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(stream, new MembersJoined());
+
+            await Should.ThrowAsync<ExistingStreamIdCollisionException>(async () =>
+            {
+                await session.SaveChangesAsync();
+            });
+        }
+    }
+}

--- a/src/Marten/Events/Operations/InsertStreamBase.cs
+++ b/src/Marten/Events/Operations/InsertStreamBase.cs
@@ -49,11 +49,16 @@ public abstract class InsertStreamBase: IStorageOperation, IExceptionTransform, 
     }
 
     private static bool matches(Exception e)
-    {
+    {        
         return e is PostgresException
         {
             SqlState: PostgresErrorCodes.UniqueViolation,
             TableName: StreamsTable.TableName
+        }
+        || e is PostgresException
+        {
+            SqlState: PostgresErrorCodes.UniqueViolation,
+            TableName: StreamsTable.DefaultPartionedTableName
         };
     }
 

--- a/src/Marten/Events/Schema/StreamsTable.cs
+++ b/src/Marten/Events/Schema/StreamsTable.cs
@@ -20,6 +20,7 @@ namespace Marten.Events.Schema;
 internal class StreamsTable: Table
 {
     public const string TableName = "mt_streams";
+    public const string DefaultPartionedTableName = $"{TableName}_default";
 
     public StreamsTable(EventGraph events): base(new PostgresqlObjectName(events.DatabaseSchemaName, TableName))
     {


### PR DESCRIPTION
Suggestion on a fix for issue #4286 