### PR TITLE
Fix value type builder selection when a nullable sibling factory is present

### DIFF
--- a/src/Marten/StoreOptions.Identity.cs
+++ b/src/Marten/StoreOptions.Identity.cs
@@ -147,8 +147,14 @@ public partial class StoreOptions
             return valueType;
         }
 
-        var builder = type.GetMethods(BindingFlags.Static | BindingFlags.Public).FirstOrDefault(x =>
-            x.GetParameters().Length == 1 && x.GetParameters()[0].ParameterType == valueProperty.PropertyType);
+        var candidateBuilders = type.GetMethods(BindingFlags.Static | BindingFlags.Public).Where(x =>
+        {
+            var parameters = x.GetParameters();
+            return parameters.Length == 1 && parameters[0].ParameterType == valueProperty.PropertyType;
+        }).ToArray();
+
+        var builder = candidateBuilders.FirstOrDefault(x => x.ReturnType == type)
+                      ?? candidateBuilders.FirstOrDefault();
 
         if (builder != null)
         {

--- a/src/ValueTypeTests/Bugs/Bug_4288_value_type_with_nullable_factory.cs
+++ b/src/ValueTypeTests/Bugs/Bug_4288_value_type_with_nullable_factory.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Vogen;
+
+namespace ValueTypeTests.Bugs;
+
+public class Bug_4288_value_type_with_nullable_factory : BugIntegrationContext
+{
+    [Fact]
+    public void can_generate_ddl_for_index_over_value_type_with_nullable_sibling_factory()
+    {
+        // Adding a `static FromNullable(string?)` sibling to a Vogen value object used to make
+        // Marten select that method as the value type's builder, which then crashed in
+        // ValueTypeInfo.CreateWrapper because the return type is Nullable<Bug4288Value>, not
+        // Bug4288Value. The crash surfaced when generating DDL for any computed index over
+        // the value type.
+        StoreOptions(opts =>
+        {
+            opts.RegisterValueType<Bug4288Value>();
+            opts.Schema.For<Bug4288Doc>().Index(x => x.Value);
+        });
+
+        Should.NotThrow(() => theStore.Storage.ToDatabaseScript());
+    }
+
+    [Fact]
+    public async Task can_round_trip_and_query_value_type_with_nullable_sibling_factory()
+    {
+        StoreOptions(opts =>
+        {
+            opts.RegisterValueType<Bug4288Value>();
+        });
+
+        var doc = new Bug4288Doc { Value = Bug4288Value.From("abc") };
+        theSession.Store(doc);
+        await theSession.SaveChangesAsync();
+
+        var key = Bug4288Value.From("abc");
+        var found = await theSession.Query<Bug4288Doc>()
+            .Where(x => x.Value == key)
+            .ToListAsync();
+
+        found.Count.ShouldBe(1);
+        found.Single().Id.ShouldBe(doc.Id);
+    }
+}
+
+[ValueObject<string>]
+public readonly partial struct Bug4288Value
+{
+    private static Validation Validate(string value)
+        => string.IsNullOrWhiteSpace(value) ? Validation.Invalid("Cannot be empty.") : Validation.Ok;
+
+    public static Bug4288Value? FromNullable(string? value)
+        => value is null ? null : From(value);
+}
+
+public class Bug4288Doc
+{
+    public Guid Id { get; set; }
+    public Bug4288Value? Value { get; set; }
+}

--- a/src/ValueTypeTests/registration.cs
+++ b/src/ValueTypeTests/registration.cs
@@ -26,6 +26,15 @@ public class registration
         value.ValueProperty.Name.ShouldBe("Value");
     }
 
+    [Fact]
+    public void picks_builder_whose_return_type_matches_value_type()
+    {
+        var options = new StoreOptions();
+        var value = options.RegisterValueType(typeof(SpecialValueWithNullableSibling));    
+        value.Builder.Name.ShouldBe("From");
+        value.Builder.ReturnType.ShouldBe(typeof(SpecialValueWithNullableSibling));
+    }
+
     [Theory]
     [InlineData(typeof(NotValidId))]
     [InlineData(typeof(DefinitelyNotValid))]
@@ -51,6 +60,21 @@ public readonly struct SpecialValue
     public string Value { get; }
 
     public static SpecialValue From(string value) => new SpecialValue(value);
+}
+
+public readonly struct SpecialValueWithNullableSibling
+{
+    private SpecialValueWithNullableSibling(string value)
+    {
+        Value = value;
+    }
+
+    public string Value { get; }
+
+    public static SpecialValueWithNullableSibling? FromNullable(string? value)
+        => value is null ? null : From(value);
+
+    public static SpecialValueWithNullableSibling From(string value) => new(value);
 }
 
 public class NotValidId(string Value);


### PR DESCRIPTION
Suggestion on a fix for issue #4288

 ## Why

  `RegisterValueType` selected the static builder method by parameter signature alone (`FirstOrDefault` over public
  static methods with one parameter matching the wrapped value type). When a Vogen value object had a nullable sibling
  factory — e.g. `static T? FromNullable(string?)` alongside `static T From(string)` — `FirstOrDefault` could pick the
  nullable one. That builder's `ReturnType` is `Nullable<T>`, which then blew up inside `ValueTypeInfo.CreateWrapper`,
  which assumes the builder returns `T` itself. The symptom reported in #4288 was a crash when generating DDL for any
  computed index over the value type.

  ## Changes

  - `src/Marten/StoreOptions.Identity.cs` — `RegisterValueType` now collects every candidate with the correct parameter
  signature and prefers the one whose `ReturnType == type`, falling back to the first candidate. Preserves prior
  behaviour for value types that expose only a single matching builder.
  - `src/ValueTypeTests/Bugs/Bug_4288_value_type_with_nullable_factory.cs` — regression test covering (1) DDL generation
   for a computed index over the value type and (2) round-trip + query using `Bug4288Value`, which exposes
  `FromNullable`.
  - `src/ValueTypeTests/registration.cs` — new unit test `picks_builder_whose_return_type_matches_value_type` that pins
  the selection rule, plus a `SpecialValueWithNullableSibling` fixture (with `From` and `FromNullable` side by side).

  ## Verification

  - `dotnet build src/Marten/Marten.csproj` — succeeds.
  - `dotnet test src/ValueTypeTests/ValueTypeTests.csproj` —
  `registration.picks_builder_whose_return_type_matches_value_type` (pure unit test, no Postgres dependency) passes;
  `Bug_4288_value_type_with_nullable_factory`
  (`can_generate_ddl_for_index_over_value_type_with_nullable_sibling_factory` and
  `can_round_trip_and_query_value_type_with_nullable_sibling_factory`) passes against a local Postgres; the existing
  `registration` suite stays green.
  - Behaviour is unchanged for value types with only a single matching builder — the `FirstOrDefault()` fallback returns
   the same method the old code used to pick.