### PR TITLE
FlatTableProjection: honor enum storage + value types + nullable (#4290, #4291)

### DIFF
--- a/docs/events/projections/flat.md
+++ b/docs/events/projections/flat.md
@@ -112,6 +112,57 @@ A couple notes on this version of the code:
 
 The `FlatTableProjection` in its first incarnation is not yet able to use event metadata.
 
+### Enums, Nullable Values, and Registered Value Types <Badge type="tip" text="8.x" />
+
+`FlatTableProjection.Map(...)` honors three things on top of the property type
+itself:
+
+1. **Enum columns** follow `StoreOptions.Advanced.DuplicatedFieldEnumStorage`,
+   which defaults to your serializer's `EnumStorage`. Set it explicitly when
+   you want to lock the column type:
+
+   ```cs
+   var store = DocumentStore.For(opts =>
+   {
+       opts.Connection(connectionString);
+       // Store all duplicated-field-style enums (including FlatTableProjection
+       // columns) as text. The matching table column should be `varchar`/`text`.
+       opts.Advanced.DuplicatedFieldEnumStorage = EnumStorage.AsString;
+
+       opts.Projections.Add<MyFlatProjection>(ProjectionLifecycle.Inline);
+   });
+   ```
+
+   With `EnumStorage.AsString`, `Map(x => x.Status)` writes `Status.ToString()`
+   into a text column. With `EnumStorage.AsInteger` (the default for the
+   built-in JSON serializers), the same call writes the underlying integer
+   value into an int column. Make sure the column type you declare on
+   `Table.AddColumn<T>(...)` matches your `DuplicatedFieldEnumStorage` setting.
+
+2. **Nullable enums and nullable value-typed properties** are handled
+   automatically — when the property value is `null`, Marten writes `DBNull`;
+   otherwise the same enum / value-type projection rules apply. The target
+   column needs to be marked `AllowNulls()` (or otherwise be nullable).
+
+3. **Registered value types** (e.g. Vogen-style single-value wrappers
+   registered through `opts.RegisterValueType<TWrapper>()`) are unwrapped to
+   their inner primitive automatically. `Map(x => x.MyValueObject)` projects
+   the value type's inner property into the column without any manual
+   `cfg.Map(x => x.MyValueObject.Value, "...")` workaround. The column type
+   should match the wrapped primitive (e.g. `Table.AddColumn<int>(...)` for a
+   `record struct WrapperId(int Value)`).
+
+::: warning
+Prior to Marten 8.x, `FlatTableProjection` ignored
+`DuplicatedFieldEnumStorage` and could not handle registered value types or
+nullable wrappers. Mapping a `string` enum column threw
+`Writing values of '<EnumType>' is not supported for parameters having
+NpgsqlDbType 'Integer'`, and mapping a registered value-type property threw
+`Can't infer NpgsqlDbType for type <Wrapper>`. See
+[#4290](https://github.com/JasperFx/marten/issues/4290) and
+[#4291](https://github.com/JasperFx/marten/issues/4291).
+:::
+
 ### Partial-Mapping Events (Update-Only) <Badge type="tip" text="8.x" />
 
 When an event mapped into a `FlatTableProjection` does not populate every non-primary-key

--- a/src/EventSourcingTests/Projections/Flattened/Bug_4290_4291_flat_table_enum_and_value_types.cs
+++ b/src/EventSourcingTests/Projections/Flattened/Bug_4290_4291_flat_table_enum_and_value_types.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Projections.Flattened;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace EventSourcingTests.Projections.Flattened;
+
+/// <summary>
+/// Regression coverage for:
+///  - https://github.com/JasperFx/marten/issues/4291
+///    FlatTableProjection mapping enums as strings throws.
+///  - https://github.com/JasperFx/marten/issues/4290
+///    FlatTableProjection throws when mapping a value object or nullable value
+///    object.
+///
+/// FlatTableProjection now honors StoreOptions.Advanced.DuplicatedFieldEnumStorage
+/// for enum columns, supports nullable enums, and auto-unwraps registered
+/// value types (and nullable value types) to their inner primitive.
+/// </summary>
+public class Bug_4290_4291_flat_table_enum_and_value_types : OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task enum_stored_as_string_when_DuplicatedFieldEnumStorage_is_AsString()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Advanced.DuplicatedFieldEnumStorage = EnumStorage.AsString;
+            opts.Projections.Add<Bug4290StatusProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new Bug4290StatusChanged(Bug4290Status.Active, null));
+        await theSession.SaveChangesAsync();
+
+        await using var conn = theStore.Storage.Database.CreateConnection();
+        await conn.OpenAsync();
+
+        var statusValue = await Weasel.Core.CommandExtensions
+            .CreateCommand(conn,
+                $"select status from {SchemaName}.bug_4290_status where id = :id")
+            .With("id", streamId)
+            .ExecuteScalarAsync();
+
+        statusValue.ShouldBe(Bug4290Status.Active.ToString());
+    }
+
+    [Fact]
+    public async Task enum_stored_as_int_when_DuplicatedFieldEnumStorage_is_AsInteger()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Advanced.DuplicatedFieldEnumStorage = EnumStorage.AsInteger;
+            opts.Projections.Add<Bug4290IntStatusProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new Bug4290StatusChanged(Bug4290Status.Suspended, null));
+        await theSession.SaveChangesAsync();
+
+        await using var conn = theStore.Storage.Database.CreateConnection();
+        await conn.OpenAsync();
+
+        var statusValue = await Weasel.Core.CommandExtensions
+            .CreateCommand(conn,
+                $"select status from {SchemaName}.bug_4290_int_status where id = :id")
+            .With("id", streamId)
+            .ExecuteScalarAsync();
+
+        statusValue.ShouldBe((int)Bug4290Status.Suspended);
+    }
+
+    [Fact]
+    public async Task nullable_enum_stored_as_string_with_value_present()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Advanced.DuplicatedFieldEnumStorage = EnumStorage.AsString;
+            opts.Projections.Add<Bug4290StatusProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new Bug4290StatusChanged(Bug4290Status.Active, Bug4290Status.Suspended));
+        await theSession.SaveChangesAsync();
+
+        await using var conn = theStore.Storage.Database.CreateConnection();
+        await conn.OpenAsync();
+
+        var previous = await Weasel.Core.CommandExtensions
+            .CreateCommand(conn,
+                $"select previous_status from {SchemaName}.bug_4290_status where id = :id")
+            .With("id", streamId)
+            .ExecuteScalarAsync();
+
+        previous.ShouldBe(Bug4290Status.Suspended.ToString());
+    }
+
+    [Fact]
+    public async Task nullable_enum_stored_as_dbnull_when_value_is_null()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Advanced.DuplicatedFieldEnumStorage = EnumStorage.AsString;
+            opts.Projections.Add<Bug4290StatusProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new Bug4290StatusChanged(Bug4290Status.Active, null));
+        await theSession.SaveChangesAsync();
+
+        await using var conn = theStore.Storage.Database.CreateConnection();
+        await conn.OpenAsync();
+
+        var previous = await Weasel.Core.CommandExtensions
+            .CreateCommand(conn,
+                $"select previous_status from {SchemaName}.bug_4290_status where id = :id")
+            .With("id", streamId)
+            .ExecuteScalarAsync();
+
+        previous.ShouldBe(DBNull.Value);
+    }
+
+    [Fact]
+    public async Task value_type_property_is_auto_unwrapped_to_inner_primitive()
+    {
+        StoreOptions(opts =>
+        {
+            opts.RegisterValueType(typeof(Bug4290LegacyId));
+            opts.Projections.Add<Bug4290LegacyProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new Bug4290LegacyAssigned(new Bug4290LegacyId(42), null));
+        await theSession.SaveChangesAsync();
+
+        await using var conn = theStore.Storage.Database.CreateConnection();
+        await conn.OpenAsync();
+
+        var primaryValue = await Weasel.Core.CommandExtensions
+            .CreateCommand(conn,
+                $"select primary_id from {SchemaName}.bug_4290_legacy where id = :id")
+            .With("id", streamId)
+            .ExecuteScalarAsync();
+
+        primaryValue.ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task nullable_value_type_with_value_unwraps_to_inner_primitive()
+    {
+        StoreOptions(opts =>
+        {
+            opts.RegisterValueType(typeof(Bug4290LegacyId));
+            opts.Projections.Add<Bug4290LegacyProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new Bug4290LegacyAssigned(new Bug4290LegacyId(7), new Bug4290LegacyId(99)));
+        await theSession.SaveChangesAsync();
+
+        await using var conn = theStore.Storage.Database.CreateConnection();
+        await conn.OpenAsync();
+
+        var secondaryValue = await Weasel.Core.CommandExtensions
+            .CreateCommand(conn,
+                $"select secondary_id from {SchemaName}.bug_4290_legacy where id = :id")
+            .With("id", streamId)
+            .ExecuteScalarAsync();
+
+        secondaryValue.ShouldBe(99);
+    }
+
+    [Fact]
+    public async Task nullable_value_type_with_null_writes_dbnull()
+    {
+        StoreOptions(opts =>
+        {
+            opts.RegisterValueType(typeof(Bug4290LegacyId));
+            opts.Projections.Add<Bug4290LegacyProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new Bug4290LegacyAssigned(new Bug4290LegacyId(7), null));
+        await theSession.SaveChangesAsync();
+
+        await using var conn = theStore.Storage.Database.CreateConnection();
+        await conn.OpenAsync();
+
+        var secondaryValue = await Weasel.Core.CommandExtensions
+            .CreateCommand(conn,
+                $"select secondary_id from {SchemaName}.bug_4290_legacy where id = :id")
+            .With("id", streamId)
+            .ExecuteScalarAsync();
+
+        secondaryValue.ShouldBe(DBNull.Value);
+    }
+}
+
+// ─────────────────────────── fixtures ───────────────────────────
+
+public enum Bug4290Status
+{
+    Active,
+    Suspended,
+    Closed
+}
+
+public record Bug4290StatusChanged(Bug4290Status Status, Bug4290Status? PreviousStatus);
+
+// Mirrors the Vogen-style "single-value wrapper struct" pattern from #4290 with
+// a single public Value property over an int. Registered with Marten via
+// opts.RegisterValueType(typeof(Bug4290LegacyId)).
+public readonly struct Bug4290LegacyId
+{
+    public Bug4290LegacyId(int value) => Value = value;
+    public int Value { get; }
+}
+
+public record Bug4290LegacyAssigned(Bug4290LegacyId PrimaryId, Bug4290LegacyId? SecondaryId);
+
+// Status column is text — should accept enum-as-string when configured so
+public class Bug4290StatusProjection : FlatTableProjection
+{
+    public Bug4290StatusProjection() : base("bug_4290_status", SchemaNameSource.EventSchema)
+    {
+        Table.AddColumn<Guid>("id").AsPrimaryKey();
+        Table.AddColumn<string>("status");
+        Table.AddColumn<string>("previous_status").AllowNulls();
+
+        Project<Bug4290StatusChanged>(map =>
+        {
+            map.Map(x => x.Status);
+            map.Map(x => x.PreviousStatus);
+        });
+    }
+}
+
+// Status column is int — should accept enum-as-int when configured so
+public class Bug4290IntStatusProjection : FlatTableProjection
+{
+    public Bug4290IntStatusProjection() : base("bug_4290_int_status", SchemaNameSource.EventSchema)
+    {
+        Table.AddColumn<Guid>("id").AsPrimaryKey();
+        Table.AddColumn<int>("status");
+
+        Project<Bug4290StatusChanged>(map =>
+        {
+            map.Map(x => x.Status);
+        });
+    }
+}
+
+public class Bug4290LegacyProjection : FlatTableProjection
+{
+    public Bug4290LegacyProjection() : base("bug_4290_legacy", SchemaNameSource.EventSchema)
+    {
+        Table.AddColumn<Guid>("id").AsPrimaryKey();
+        Table.AddColumn<int>("primary_id");
+        Table.AddColumn<int>("secondary_id").AllowNulls();
+
+        Project<Bug4290LegacyAssigned>(map =>
+        {
+            map.Map(x => x.PrimaryId);
+            map.Map(x => x.SecondaryId);
+        });
+    }
+}

--- a/src/Marten/Events/Projections/Flattened/EventDeleter.cs
+++ b/src/Marten/Events/Projections/Flattened/EventDeleter.cs
@@ -14,24 +14,26 @@ internal class EventDeleter<T> : IEventHandler
 {
     private string _sql;
     private IParameterSetter<IEvent>? _parameter;
+    private readonly MemberInfo[] _pkMembers;
 
     public EventDeleter(MemberInfo[] members, Table table)
     {
-        if (members.Length != 0)
-        {
-            _parameter = FlatTableProjection.BuildPrimaryKeySetter<T>(members);
-        }
+        _pkMembers = members;
     }
 
     public void Compile(EventGraph events, Table table)
     {
-        if (_parameter == null)
+        if (_pkMembers.Length != 0)
+        {
+            _parameter = FlatTableProjection.BuildPrimaryKeySetter<T>(_pkMembers, events.Options);
+        }
+        else
         {
             _parameter = events.StreamIdentity == StreamIdentity.AsGuid
                 ? (IParameterSetter<IEvent>)new ParameterSetter<IEvent, Guid>(e => e.StreamId)
                 : new ParameterSetter<IEvent, string>(e => e.StreamKey);
-
         }
+
         _sql = $"delete from {table.Identifier} where {table.PrimaryKeyColumns[0]} = ?";
     }
 

--- a/src/Marten/Events/Projections/Flattened/FlatTableProjection.cs
+++ b/src/Marten/Events/Projections/Flattened/FlatTableProjection.cs
@@ -17,6 +17,7 @@ using JasperFx.Events.Subscriptions;
 using Marten.Events.Daemon;
 using Marten.Linq.Parsing;
 using Microsoft.Extensions.Logging;
+using NpgsqlTypes;
 using Weasel.Core;
 using Weasel.Postgresql;
 using IReplayExecutor = JasperFx.Events.Daemon.IReplayExecutor;
@@ -220,54 +221,127 @@ public partial class FlatTableProjection: ProjectionBase, IProjectionSource<IDoc
         Options.DeleteDataInTableOnTeardown(Table.Identifier);
     }
 
-    internal static IParameterSetter<IEvent> BuildPrimaryKeySetter<T>(MemberInfo[] members)
+    internal static IParameterSetter<IEvent> BuildPrimaryKeySetter<T>(MemberInfo[] members, StoreOptions storeOptions)
     {
         // It's off of IEvent directly
         if (members.Length == 1)
         {
             if (members[0].DeclaringType == typeof(IEvent))
             {
-                return typeof(ParameterSetter<,>).CloseAndBuildAs<IParameterSetter<IEvent>>(members[0], typeof(IEvent), members[0].GetRawMemberType()!);
+                return (IParameterSetter<IEvent>)BuildLeafParameterSetter(members[0], typeof(IEvent), storeOptions);
             }
 
-            var setter = typeof(ParameterSetter<,>).CloseAndBuildAs<IParameterSetter<T>>(members[0], typeof(T), members[0].GetRawMemberType()!);
-            return new EventForwarder<T>(setter);
+            var setter = BuildLeafParameterSetter(members[0], typeof(T), storeOptions);
+            return new EventForwarder<T>((IParameterSetter<T>)setter);
         }
 
         if (members.Length == 2)
         {
-            var inner = typeof(ParameterSetter<,>).CloseAndBuildAs<IParameterSetter<T>>(members[1], typeof(T),
-                members[1].GetRawMemberType()!);
-
-            return new EventForwarder<T>(inner);
+            var inner = BuildLeafParameterSetter(members[1], typeof(T), storeOptions);
+            return new EventForwarder<T>((IParameterSetter<T>)inner);
         }
 
-        return BuildSetterForMembers<T>(members.Skip(0).ToArray());
+        return BuildSetterForMembers<T>(members.Skip(0).ToArray(), storeOptions);
     }
 
-    internal static IParameterSetter<IEvent> BuildSetterForMembers<T>(MemberInfo[] members)
+    internal static IParameterSetter<IEvent> BuildSetterForMembers<T>(MemberInfo[] members, StoreOptions storeOptions)
     {
         if (members.Length == 1)
         {
             if (members[0].DeclaringType != typeof(IEvent))
             {
-                var inner = typeof(ParameterSetter<,>).CloseAndBuildAs<IParameterSetter<T>>(members[0],typeof(T), members[0].GetRawMemberType()!);
-                return new EventForwarder<T>(inner);
+                var inner = BuildLeafParameterSetter(members[0], typeof(T), storeOptions);
+                return new EventForwarder<T>((IParameterSetter<T>)inner);
             }
         }
 
-        // off of something on the event
-        var outsideToInside = members.Reverse().ToArray();
+        // off of something on the event - MemberFinder.Determine returns the chain
+        // outer-to-leaf, e.g. [Foo, Bar, Value]. Reversing puts the leaf first so
+        // the ParameterSetter at the bottom does the actual parameter write, and
+        // each RelayParameterSetter wraps it with the next level out (handling
+        // intermediate nulls).
+        var leafFirst = members.Reverse().ToArray();
 
-        var dbType = PostgresqlProvider.Instance.ToParameterType(outsideToInside[0].GetRawMemberType()!);
-        var setter = typeof(ParameterSetter<,>).CloseAndBuildAs<object>(outsideToInside[0], outsideToInside[1].GetRawMemberType()!,
-            outsideToInside[0].GetRawMemberType()!);
+        // Leaf decides the storage db type and any value transform (enum->string,
+        // value-type unwrap, etc.). Use that db type all the way up so intermediate
+        // nulls write DBNull with the correct type.
+        var (dbType, _) = ResolveLeafStorage(leafFirst[0].GetRawMemberType()!, storeOptions);
 
-        for (int i = 1; i < outsideToInside.Length; i++)
+        var setter = BuildLeafParameterSetter(leafFirst[0], leafFirst[1].GetRawMemberType()!, storeOptions);
+
+        for (var i = 1; i < leafFirst.Length; i++)
         {
-            setter = typeof(RelayParameterSetter<,>).CloseAndBuildAs<object>(dbType, setter, outsideToInside[i], outsideToInside[i].DeclaringType!, outsideToInside[i].GetRawMemberType()!);
+            setter = typeof(RelayParameterSetter<,>).CloseAndBuildAs<object>(dbType, setter,
+                leafFirst[i], leafFirst[i].DeclaringType!, leafFirst[i].GetRawMemberType()!);
         }
 
         return new EventForwarder<T>((IParameterSetter<T>)setter);
+    }
+
+    /// <summary>
+    /// Build a leaf <see cref="ParameterSetter{TSource,TValue}"/> for a single
+    /// member off of a known source type. Honors <see cref="StoreOptions"/> for
+    /// enum storage, registered value types, and nullable variants of either —
+    /// scenarios <see cref="PostgresqlProvider.ToParameterType(Type)"/> can't
+    /// resolve on its own.
+    /// </summary>
+    private static object BuildLeafParameterSetter(MemberInfo member, Type sourceType, StoreOptions storeOptions)
+    {
+        var memberType = member.GetRawMemberType()!;
+        var (dbType, transform) = ResolveLeafStorage(memberType, storeOptions);
+
+        // Default path (no special handling): preserve historical 1-arg construction
+        // so we don't churn the existing tests / reflection layout.
+        if (transform == null)
+        {
+            return typeof(ParameterSetter<,>).CloseAndBuildAs<object>(member, sourceType, memberType);
+        }
+
+        // Special path (enum / value type / nullable variants): use the explicit
+        // (member, dbType, transform) constructor so PostgresqlProvider never has
+        // to infer a parameter type from the .NET wrapper type.
+        return typeof(ParameterSetter<,>).CloseAndBuildAs<object>(
+            member, dbType, transform,
+            sourceType, memberType);
+    }
+
+    /// <summary>
+    /// Decide the PostgreSQL parameter type and any value-projection function
+    /// needed for a member of the supplied (possibly nullable) .NET type.
+    /// </summary>
+    /// <returns>
+    /// <c>(dbType, transform)</c> where <c>transform</c> is non-null when the
+    /// .NET value needs projection (enum-to-string, value-type-to-inner) before
+    /// being handed to Npgsql.
+    /// </returns>
+    internal static (NpgsqlDbType dbType, Func<object, object?>? transform) ResolveLeafStorage(Type memberType, StoreOptions storeOptions)
+    {
+        // Unwrap Nullable<T> for the type-introspection pass. The runtime setter
+        // sees the nullable type as TValue and writes DBNull whenever the value is null;
+        // only the non-null value hits the transform.
+        var nonNullable = Nullable.GetUnderlyingType(memberType) ?? memberType;
+
+        if (nonNullable.IsEnum)
+        {
+            if (storeOptions.Advanced.DuplicatedFieldEnumStorage == EnumStorage.AsString)
+            {
+                return (NpgsqlDbType.Varchar, raw => raw.ToString());
+            }
+
+            // AsInteger: convert each enum value to its underlying int. Use
+            // Convert.ToInt32 rather than a direct cast so non-Int32-backed enums
+            // (byte, short, long) round-trip into the int column without a runtime cast error.
+            return (NpgsqlDbType.Integer, raw => Convert.ToInt32(raw));
+        }
+
+        var valueTypeInfo = storeOptions.TryFindValueType(nonNullable);
+        if (valueTypeInfo != null)
+        {
+            var innerDbType = PostgresqlProvider.Instance.ToParameterType(valueTypeInfo.SimpleType);
+            var valueProperty = valueTypeInfo.ValueProperty;
+            return (innerDbType, raw => valueProperty.GetValue(raw));
+        }
+
+        return (PostgresqlProvider.Instance.ToParameterType(memberType), null);
     }
 }

--- a/src/Marten/Events/Projections/Flattened/ParameterSetter.cs
+++ b/src/Marten/Events/Projections/Flattened/ParameterSetter.cs
@@ -12,15 +12,39 @@ internal class ParameterSetter<TSource, TValue>: IParameterSetter<TSource>
     private readonly Func<TSource, TValue> _source;
     private readonly NpgsqlDbType _dbType;
 
+    /// <summary>
+    /// Optional value transform applied just before the parameter is written.
+    /// Used to project values like enums-as-strings or value-type wrappers
+    /// onto the inner primitive that PostgreSQL actually expects.
+    /// Receives the raw value boxed to <see cref="object"/> so the construction
+    /// site can build the transform without closing over <typeparamref name="TValue"/>.
+    /// </summary>
+    private readonly Func<object, object?>? _transform;
+
     public ParameterSetter(PropertyInfo member) : this(LambdaBuilder.GetProperty<TSource, TValue>(member))
     {
 
     }
 
     public ParameterSetter(Func<TSource, TValue> source)
+        : this(source, PostgresqlProvider.Instance.ToParameterType(typeof(TValue)), null)
+    {
+    }
+
+    public ParameterSetter(Func<TSource, TValue> source, NpgsqlDbType dbType, Func<object, object?>? transform)
     {
         _source = source;
-        _dbType = PostgresqlProvider.Instance.ToParameterType(typeof(TValue));
+        _dbType = dbType;
+        _transform = transform;
+    }
+
+    /// <summary>
+    /// Convenience overload used when the leaf is built from a <see cref="PropertyInfo"/>
+    /// rather than from a pre-built getter delegate.
+    /// </summary>
+    public ParameterSetter(PropertyInfo member, NpgsqlDbType dbType, Func<object, object?>? transform)
+        : this(LambdaBuilder.GetProperty<TSource, TValue>(member), dbType, transform)
+    {
     }
 
     public void SetValue(NpgsqlParameter parameter, TSource source)
@@ -30,10 +54,15 @@ internal class ParameterSetter<TSource, TValue>: IParameterSetter<TSource>
         if (raw == null)
         {
             parameter.Value = DBNull.Value;
+            return;
         }
-        else
+
+        if (_transform != null)
         {
-            parameter.Value = raw;
+            parameter.Value = _transform(raw) ?? (object)DBNull.Value;
+            return;
         }
+
+        parameter.Value = raw;
     }
 }

--- a/src/Marten/Events/Projections/Flattened/StatementMap.cs
+++ b/src/Marten/Events/Projections/Flattened/StatementMap.cs
@@ -20,10 +20,14 @@ public class StatementMap<T>: IEventHandler
     private readonly MemberInfo[] _pkMembers;
     private DbObjectName _functionIdentifier;
 
-    private readonly List<IParameterSetter<IEvent>> _setters = new();
+    // Setters are realized in Compile() so they can read StoreOptions
+    // (DuplicatedFieldEnumStorage and registered value types) off the EventGraph.
+    // The pending list captures only the member arrays declared via Map / Increment /
+    // Decrement; the leading PK setter is added in Compile.
+    private readonly List<MemberInfo[]> _pendingMemberSetters = new();
+    private IParameterSetter<IEvent>[] _setters = Array.Empty<IParameterSetter<IEvent>>();
     private string _sql;
     private readonly bool _streamIdentified;
-    private bool _hasBuiltPK;
 
     public StatementMap(FlatTableProjection parent, MemberInfo[] pkMembers)
     {
@@ -31,11 +35,6 @@ public class StatementMap<T>: IEventHandler
         _pkMembers = pkMembers;
 
         _streamIdentified = pkMembers.IsEmpty();
-        if (pkMembers.Length != 0)
-        {
-            _setters.Add(FlatTableProjection.BuildSetterForMembers<T>(pkMembers));
-            _hasBuiltPK = true;
-        }
     }
 
     Type IEventHandler.EventType => typeof(T);
@@ -55,24 +54,37 @@ public class StatementMap<T>: IEventHandler
 
     public void Compile(EventGraph events, Table table)
     {
-        if (_streamIdentified && !_hasBuiltPK)
+        var storeOptions = events.Options;
+        var setters = new List<IParameterSetter<IEvent>>(_pendingMemberSetters.Count + 1);
+
+        // Primary-key setter is always at column index 0.
+        if (_streamIdentified)
         {
-            _hasBuiltPK = true;
             var setter = events.StreamIdentity == StreamIdentity.AsGuid
                 ? (IParameterSetter<IEvent>)new ParameterSetter<IEvent, Guid>(e => e.StreamId)
                 : new ParameterSetter<IEvent, string>(e => e.StreamKey);
-
-            _setters.Insert(0, setter);
+            setters.Add(setter);
+        }
+        else
+        {
+            setters.Add(FlatTableProjection.BuildPrimaryKeySetter<T>(_pkMembers, storeOptions));
         }
 
+        foreach (var members in _pendingMemberSetters)
+        {
+            setters.Add(FlatTableProjection.BuildSetterForMembers<T>(members, storeOptions));
+        }
+
+        _setters = setters.ToArray();
+
         createFunctionName(table);
-        var parameters = _setters.Select(x => "?").Join(", ");
+        var parameters = _setters.Select(_ => "?").Join(", ");
         _sql = $"select {_functionIdentifier}({parameters})";
     }
 
     public void Handle(IDocumentOperations operations, IEvent e)
     {
-        var op = new SqlOperation(_sql, e, _setters.ToArray());
+        var op = new SqlOperation(_sql, e, _setters);
         operations.QueueOperation(op);
     }
 
@@ -95,7 +107,7 @@ public class StatementMap<T>: IEventHandler
         var map = new MemberMap<T, TValue>(members, columnName, ColumnMapType.Value);
         _columnMaps.Add(map);
 
-        _setters.Add(FlatTableProjection.BuildSetterForMembers<T>(map.Members));
+        _pendingMemberSetters.Add(map.Members);
 
         return map.ResolveColumn(_parent.Table);
     }
@@ -113,7 +125,7 @@ public class StatementMap<T>: IEventHandler
         var map = new MemberMap<T, TValue>(members, columnName, ColumnMapType.Increment);
         _columnMaps.Add(map);
 
-        _setters.Add(FlatTableProjection.BuildSetterForMembers<T>(map.Members));
+        _pendingMemberSetters.Add(map.Members);
 
         return map.ResolveColumn(_parent.Table);
     }
@@ -141,7 +153,7 @@ public class StatementMap<T>: IEventHandler
         var map = new MemberMap<T, TValue>(members, columnName, ColumnMapType.Decrement);
         _columnMaps.Add(map);
 
-        _setters.Add(FlatTableProjection.BuildSetterForMembers<T>(map.Members));
+        _pendingMemberSetters.Add(map.Members);
 
 
         return map.ResolveColumn(_parent.Table);


### PR DESCRIPTION
## Summary

`FlatTableProjection.Map / Increment / Decrement` built `ParameterSetter`s eagerly via `PostgresqlProvider.ToParameterType`, which left three bug paths:

- **Enum columns ignored `Advanced.DuplicatedFieldEnumStorage`.** Mapping an enum onto a `string` column threw `Writing values of '<EnumType>' is not supported for parameters having NpgsqlDbType 'Integer'`. (#4291)
- **Registered value-type properties** (e.g. Vogen single-value wrappers registered via `RegisterValueType<TWrapper>()`) threw `Can't infer NpgsqlDbType for type <Wrapper>`. (#4290)
- **Nullable enums and nullable value types** were never special-cased.

This PR defers `ParameterSetter` construction from registration time to `Compile`, where `EventGraph` (and therefore `StoreOptions`) is in scope. At `Compile` the leaf member's storage is decided as:

- **enum** → `Varchar` + `.ToString()` **or** `Integer` + `Convert.ToInt32`, chosen by `DuplicatedFieldEnumStorage`. Nullable enums fall through `ParameterSetter`'s null path and write `DBNull`.
- **registered value type** → inner `SimpleType`'s `NpgsqlDbType` + `ValueProperty.GetValue` extraction. Nullable value types share the null path.
- **everything else** → existing `PostgresqlProvider` lookup, no transform.

`ParameterSetter<TSource,TValue>` gains a `(member, dbType, transform)` constructor so the leaf can bind to a DB type the wrapper type wouldn't infer; the existing 1-arg constructor stays untouched. `BuildPrimaryKeySetter<T>` / `BuildSetterForMembers<T>` now require `StoreOptions`; `EventDeleter` and `StatementMap` defer their setter builds to `Compile` to match.

Documentation: `docs/events/projections/flat.md` gets a new **Enums, Nullable Values, and Registered Value Types** section that calls out the `DuplicatedFieldEnumStorage` dependency and the column-type expectation.

Fixes #4290.
Fixes #4291.

## Test plan

- [x] New regression file `Bug_4290_4291_flat_table_enum_and_value_types.cs` (7 facts) — all fail on master, all pass with this fix:
  - enum stored as text under `EnumStorage.AsString`
  - enum stored as int under `EnumStorage.AsInteger`
  - nullable enum with value present
  - nullable enum with `null` (writes `DBNull`)
  - registered value type auto-unwrapped to inner primitive
  - nullable registered value type with value present
  - nullable registered value type with `null` (writes `DBNull`)
- [x] All 40 existing `Flattened` / `FlatTable` tests still pass
- [x] All 164 `Projections` event-sourcing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)