### PR TITLE
Pick up JasperFx 1.27.0 indexed type lookup + trim two SaveChanges allocations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="1.26.0" />
+    <PackageVersion Include="JasperFx" Version="1.27.0" />
     <PackageVersion Include="JasperFx.Events" Version="1.29.1" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.5.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Marten/Events/QuickEventAppender.cs
+++ b/src/Marten/Events/QuickEventAppender.cs
@@ -31,12 +31,15 @@ internal class QuickEventAppender: IEventAppender
             }
         }
 
+        // The quick-append path never reads from this queue (PrepareEvents calls
+        // applyQuickMetadata, not applyRichMetadata, and only the rich variant
+        // dequeues from it). Hoist a single throwaway instance out of the
+        // per-stream loop so we don't allocate one per stream on every save.
+        var sequences = new Queue<long>();
+
         foreach (var stream in session.WorkTracker.Streams.Where(x => x.Events.Any()))
         {
             stream.TenantId ??= session.TenantId;
-
-            // Not really using it, just need a stand in
-            var sequences = new Queue<long>();
             if (stream.ActionType == StreamActionType.Start)
             {
                 stream.PrepareEvents(0, eventGraph, sequences, session);

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
@@ -96,7 +96,20 @@ public abstract partial class DocumentSessionBase
 
     private IEnumerable<Type> operationDocumentTypes()
     {
-        return _workTracker.Operations().Select(x => x.DocumentType).Where(x => x != null).Distinct();
+        // Single-pass HashSet so we don't enumerate Operations() twice (once for
+        // Select, once for the Distinct hash) and don't allocate intermediate
+        // LINQ enumerator chains on every SaveChanges.
+        var types = new HashSet<Type>();
+        foreach (var op in _workTracker.Operations())
+        {
+            var documentType = op.DocumentType;
+            if (documentType != null)
+            {
+                types.Add(documentType);
+            }
+        }
+
+        return types;
     }
 
     internal record PagesExecution(IReadOnlyList<OperationPage> Pages, IConnectionLifetime Connection,


### PR DESCRIPTION
## Summary

Non-breaking cold-start + per-`SaveChanges` allocation cleanup, carved out of the Marten 9.0 umbrella issue ([#4294](https://github.com/JasperFx/marten/issues/4294)) so the simpler wins don't have to wait for 9.0.

### What lands

1. **`JasperFx` package bumped 1.26.0 → 1.27.0**, picking up [JasperFx/jasperfx#192](https://github.com/JasperFx/jasperfx/pull/192) (closes [JasperFx/jasperfx#189](https://github.com/JasperFx/jasperfx/issues/189)). `CodeGenerationExtensions.FindPreGeneratedType` is now O(1) per call after the first lookup per `Assembly`, instead of O(ExportedTypes). Static-mode cold start (Marten with `TypeLoadMode.Static` and pre-generated code in the entry assembly) stops paying an `assembly.ExportedTypes.FirstOrDefault` scan per `ICodeFile.AttachTypes` call.

2. **`QuickEventAppender`**: hoist the per-stream `Queue<long>` allocation out of the `foreach` over `WorkTracker.Streams`. The quick-append path never reads from it (only `applyRichMetadata` dequeues; the quick variant doesn't touch it), so a single throwaway instance is correct. Bulk-append workloads stop paying one allocation per stream.

3. **`DocumentSessionBase.operationDocumentTypes()`**: replace `Operations().Select(...).Where(...).Distinct()` with a single-pass `HashSet<Type>` walk. Same observable behavior, fewer intermediate enumerator/list allocations on every `SaveChanges`.

### What deliberately did **not** land

The bigger cold-start items in #4294 — lazy `BuildAllMappings`, lazy `EventGraph.FeatureSchema.Objects`, `Static`-mode validation skip, `IEnumerable<StreamAction>` widening — are still 9.0 candidates because they each have semantic-change risk or signature implications. Tracked there.

## Test plan

- [x] Build clean (`Marten` + `EventSourcingTests`)
- [x] Targeted event-sourcing sweep (`end_to_end_event_capture_and_fetching_the_stream`, `quick_append_event_capture_and_fetching_the_stream`, `archiving_events`, `start_stream_should_enforce_*`) — 212 tests, all green
- [x] Full `CoreTests` sweep — 327 passed, 1 skipped (pre-existing), 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)