### PR TITLE
Pick up JasperFx.Events 1.30.0 + pre-warm EventGraph._nameToType

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
     <PackageVersion Include="JasperFx" Version="1.27.0" />
-    <PackageVersion Include="JasperFx.Events" Version="1.29.1" />
+    <PackageVersion Include="JasperFx.Events" Version="1.30.0" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -606,10 +606,31 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
 
 
         _tombstones = new RetryBlock<UpdateBatch>(executeTombstoneBlock, logger, _cancellation.Token);
-        foreach (var mapping in _events)
+
+        // Pre-warm name->type so the first read of each event type from the database
+        // doesn't fall through Type.GetType(assemblyQualifiedName) in TypeForDotNetName,
+        // which is itself O(loaded-assemblies). Populate both AssemblyQualifiedName and
+        // FullName since both shapes appear in event metadata over the lifetime of a
+        // store. Done as a single Swap so we don't churn ImHashMap.
+        _nameToType.Swap(map =>
         {
-            mapping.JsonTransformation(null);
-        }
+            foreach (var mapping in _events)
+            {
+                mapping.JsonTransformation(null);
+
+                var docType = mapping.DocumentType;
+                if (docType.AssemblyQualifiedName is { } aqn)
+                {
+                    map = map.AddOrUpdate(aqn, docType);
+                }
+                if (docType.FullName is { } fullName)
+                {
+                    map = map.AddOrUpdate(fullName, docType);
+                }
+            }
+
+            return map;
+        });
 
         autoDiscoverTagTypesFromProjections();
     }


### PR DESCRIPTION
## Summary

Continues the 8.x cold-start trim from [#4295](https://github.com/JasperFx/marten/pull/4295). Two more non-breaking optimizations from the umbrella issue ([#4294](https://github.com/JasperFx/marten/issues/4294)).

### What lands

1. **`JasperFx.Events` bumped 1.29.1 → 1.30.0**, picking up [JasperFx/jasperfx#193](https://github.com/JasperFx/jasperfx/pull/193). `ProjectionGraph.DiscoverGeneratedEvolvers` now (a) skips framework / library assemblies (`System.*`, `Microsoft.*`, `JasperFx.*`, `Marten.*`, `Wolverine.*`, `Weasel.*`, `Npgsql.*`, etc.) before reading custom attributes — they structurally cannot carry user-defined `[GeneratedEvolverAttribute]` — and (b) caches per-assembly results in a process-wide `ConcurrentDictionary`, so multi-store hosts share the work.

2. **`EventGraph._nameToType` pre-warmed in `Initialize`**. `TypeForDotNetName` (`src/Marten/Events/EventGraph.cs:551`) otherwise falls through to `Type.GetType(assemblyQualifiedName)` on first read of each event type from the database, and that fallback is itself O(loaded-assemblies). Pre-populating both the `AssemblyQualifiedName` and `FullName` keys for every registered event type — in a single `ImHashMap.Swap` so we don't churn the map — means the first read of every known event type lands directly in the cache. Lazily-registered types (those discovered via `_events.OnMissing`) still fall through the existing path; behavior unchanged.

## Test plan

- [x] Build clean (`Marten` + `EventSourcingTests`)
- [x] `end_to_end_event_capture_and_fetching_the_stream` + `archiving_events` + `quick_append_event_capture_and_fetching_the_stream` — 208 passed, 0 failed
- [x] Cross-section that exercises event-type discovery / upcasting / multi-store wiring (`Bug_4197`, `Bug_4277`, `SchemaChange.Upcasters`, `Aggregation.global_tenanted_streams`) — 59 passed, 0 failed

## What's still on the 9.0 board

The bigger items on the umbrella issue — lazy `BuildAllMappings`, lazy `EventGraph.FeatureSchema.Objects`, `Static`-mode `AssertValidity` skip, `IEnumerable<StreamAction>` widening, `GenerationRules` caching with mutation isolation, and anything depending on JasperFx [#190](https://github.com/JasperFx/jasperfx/issues/190) (`ITypeLoader`) or [#191](https://github.com/JasperFx/jasperfx/issues/191) (`CloseAndBuildAs` rework) — are still 9.0-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)