### PR TITLE
Honor UseMonitoredAdvisoryLock = false via AdvisoryLockFactory

### DIFF
--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -92,11 +92,15 @@ As of right now, the daemon can run as one of two modes:
    projection on each tenant database and **ensure that each projection is running on exactly one running process**.
 
 ::: tip
-When running in `HotCold` mode, Marten will monitor the Postgres advisory lock by running a `SELECT pg_catalog.pg_sleep(60)` query to detect if the database restarts or fails-over.
-Without this monitoring, Marten will not be aware of the lock loss and multiple async daemons can start running concurrently across multiple nodes, causing application failure.
+In `HotCold` mode, Marten coordinates leader election with a PostgreSQL session-level advisory lock. By default (`UseMonitoredAdvisoryLock = true`) the lock is acquired 
+through [Medallion.Threading.Postgres](https://github.com/madelson/DistributedLock), which detects lock loss after a database restart or fail-over via a `SELECT pg_sleep(60)` 
+keep-alive query and shuts down the affected agents so they do not run concurrently. Some monitoring tools report the keep-alive as load — it is a sleep and does not consume database resources.
+:::
 
-Some monitoring tools erroneously report this query as "load", however this query simply sleeps for 60 seconds and **does not** consume any database resources. 
-If this monitoring is undesirable for your scenario, you can opt-out by setting `options.Events.UseMonitoredAdvisoryLock` to false when configuring Marten.
+::: warning
+Setting `options.Events.UseMonitoredAdvisoryLock = false` switches to a native implementation that issues `pg_try_advisory_lock` directly with no `SET LOCAL` and no keep-alive query. 
+This avoids the `SET LOCAL can only be used in transaction blocks` warnings emitted by the third-party locker under PostgreSQL 18, but **lock loss is no longer detected** — only choose 
+this mode when an external mechanism prevents two daemon instances from staying up simultaneously.
 :::
 
 ## Projection Distribution

--- a/src/DaemonTests.ManualOnly/Coordination/AdvisoryLocksTest.cs
+++ b/src/DaemonTests.ManualOnly/Coordination/AdvisoryLocksTest.cs
@@ -6,6 +6,7 @@ using Marten.Storage;
 using Marten.Testing.Harness;
 using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
+using Weasel.Core;
 using Weasel.Postgresql;
 using Xunit;
 
@@ -13,66 +14,105 @@ namespace DaemonTests.ManualOnly.Coordination;
 
 public class AdvisoryLocksTest
 {
-    [Fact]
-    public async Task get_lock_smoke_test()
+    private static IAdvisoryLock CreateLock(IDocumentStore store, bool monitored)
+    {
+        var database = (MartenDatabase)store.Storage.Database;
+        return AdvisoryLockFactory.Create(
+            database.DataSource,
+            NullLogger.Instance,
+            database.Identifier,
+            new AdvisoryLockOptions { LockMonitoringEnabled = monitored });
+    }
+
+    private static int IdFor(bool monitored, int seed) => (monitored ? 1000 : 2000) + seed;
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task get_lock_smoke_test(bool monitored)
+    {
+        await using var store = DocumentStore.For(ConnectionSource.ConnectionString);
+        await using var locks = CreateLock(store, monitored);
+
+        var lockId = IdFor(monitored, 50);
+
+        locks.HasLock(lockId).ShouldBeFalse();
+
+        (await locks.TryAttainLockAsync(lockId, CancellationToken.None)).ShouldBeTrue();
+
+        locks.HasLock(lockId).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task get_exclusive_lock(bool monitored)
     {
         await using var store = DocumentStore.For(ConnectionSource.ConnectionString);
 
+        await using var locks = CreateLock(store, monitored);
+        await using var locks2 = CreateLock(store, monitored);
 
-        await using var locks = new AdvisoryLock(((MartenDatabase)store.Storage.Database).DataSource, NullLogger.Instance, store.Storage.Database.Identifier, new AdvisoryLockOptions());
+        var lockId = IdFor(monitored, 60);
 
-        locks.HasLock(50).ShouldBeFalse();
+        (await locks.TryAttainLockAsync(lockId, CancellationToken.None)).ShouldBeTrue();
+        (await locks2.TryAttainLockAsync(lockId, CancellationToken.None)).ShouldBeFalse();
 
-        (await locks.TryAttainLockAsync(50, CancellationToken.None)).ShouldBeTrue();
+        await locks.ReleaseLockAsync(lockId);
+        locks.HasLock(lockId).ShouldBeFalse();
 
-        locks.HasLock(50).ShouldBeTrue();
+        (await locks2.TryAttainLockAsync(lockId, CancellationToken.None)).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task get_multiple_locks(bool monitored)
+    {
+        await using var store = DocumentStore.For(ConnectionSource.ConnectionString);
+        await using var locks = CreateLock(store, monitored);
+
+        var first = IdFor(monitored, 70);
+        var second = IdFor(monitored, 71);
+        var third = IdFor(monitored, 72);
+
+        (await locks.TryAttainLockAsync(first, CancellationToken.None)).ShouldBeTrue();
+        (await locks.TryAttainLockAsync(second, CancellationToken.None)).ShouldBeTrue();
+        (await locks.TryAttainLockAsync(third, CancellationToken.None)).ShouldBeTrue();
+
+        locks.HasLock(first).ShouldBeTrue();
+        locks.HasLock(second).ShouldBeTrue();
+        locks.HasLock(third).ShouldBeTrue();
+
+        await using var locks2 = CreateLock(store, monitored);
+        (await locks2.TryAttainLockAsync(first, CancellationToken.None)).ShouldBeFalse();
+        (await locks2.TryAttainLockAsync(second, CancellationToken.None)).ShouldBeFalse();
+        (await locks2.TryAttainLockAsync(third, CancellationToken.None)).ShouldBeFalse();
+
+        await locks.ReleaseLockAsync(first);
+        locks.HasLock(first).ShouldBeFalse();
+
+        locks.HasLock(second).ShouldBeTrue();
+        locks.HasLock(third).ShouldBeTrue();
+
+        (await locks2.TryAttainLockAsync(first, CancellationToken.None)).ShouldBeTrue();
     }
 
     [Fact]
-    public async Task get_exclusive_lock()
+    public async Task factory_returns_native_lock_when_monitoring_disabled()
     {
         await using var store = DocumentStore.For(ConnectionSource.ConnectionString);
+        await using var locks = CreateLock(store, monitored: false);
 
-        await using var locks = new AdvisoryLock(((MartenDatabase)store.Storage.Database).DataSource, NullLogger.Instance, store.Storage.Database.Identifier, new AdvisoryLockOptions());
-        await using var locks2 = new AdvisoryLock(((MartenDatabase)store.Storage.Database).DataSource, NullLogger.Instance, store.Storage.Database.Identifier, new AdvisoryLockOptions());
-
-        (await locks.TryAttainLockAsync(50, CancellationToken.None)).ShouldBeTrue();
-        (await locks2.TryAttainLockAsync(50, CancellationToken.None)).ShouldBeFalse();
-
-        await locks.ReleaseLockAsync(50);
-        locks.HasLock(50).ShouldBeFalse();
-
-        (await locks2.TryAttainLockAsync(50, CancellationToken.None)).ShouldBeTrue();
-
+        locks.ShouldBeOfType<NativeAdvisoryLock>();
     }
 
     [Fact]
-    public async Task get_multiple_locks()
+    public async Task factory_returns_monitored_lock_by_default()
     {
         await using var store = DocumentStore.For(ConnectionSource.ConnectionString);
+        await using var locks = CreateLock(store, monitored: true);
 
-        await using var locks = new AdvisoryLock(((MartenDatabase)store.Storage.Database).DataSource, NullLogger.Instance, store.Storage.Database.Identifier, new AdvisoryLockOptions());
-
-        (await locks.TryAttainLockAsync(50, CancellationToken.None)).ShouldBeTrue();
-        (await locks.TryAttainLockAsync(51, CancellationToken.None)).ShouldBeTrue();
-        (await locks.TryAttainLockAsync(52, CancellationToken.None)).ShouldBeTrue();
-
-        locks.HasLock(50).ShouldBeTrue();
-        locks.HasLock(51).ShouldBeTrue();
-        locks.HasLock(52).ShouldBeTrue();
-
-        await using var locks2 = new AdvisoryLock(((MartenDatabase)store.Storage.Database).DataSource, NullLogger.Instance, store.Storage.Database.Identifier, new AdvisoryLockOptions());
-        (await locks2.TryAttainLockAsync(50, CancellationToken.None)).ShouldBeFalse();
-        (await locks2.TryAttainLockAsync(51, CancellationToken.None)).ShouldBeFalse();
-        (await locks2.TryAttainLockAsync(52, CancellationToken.None)).ShouldBeFalse();
-
-        await locks.ReleaseLockAsync(50);
-        locks.HasLock(50).ShouldBeFalse();
-
-        locks.HasLock(51).ShouldBeTrue();
-        locks.HasLock(52).ShouldBeTrue();
-
-        (await locks2.TryAttainLockAsync(50, CancellationToken.None)).ShouldBeTrue();
-
+        locks.ShouldBeOfType<AdvisoryLock>();
     }
 }

--- a/src/Marten/Events/Daemon/Coordination/MultiTenantedProjectionDistributor.cs
+++ b/src/Marten/Events/Daemon/Coordination/MultiTenantedProjectionDistributor.cs
@@ -7,6 +7,7 @@ using JasperFx.Core;
 using Marten.Storage;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Weasel.Core;
 using Weasel.Postgresql;
 
 namespace Marten.Events.Daemon.Coordination;
@@ -14,16 +15,19 @@ namespace Marten.Events.Daemon.Coordination;
 public class MultiTenantedProjectionDistributor: IProjectionDistributor
 {
     private readonly DocumentStore _store;
-    private readonly Cache<IMartenDatabase, AdvisoryLock> _locks;
+    private readonly Cache<IMartenDatabase, IAdvisoryLock> _locks;
 
     public MultiTenantedProjectionDistributor(DocumentStore store)
     {
         _store = store;
 
-        var logger = _store.Options.LogFactory?.CreateLogger<AdvisoryLock>() ??
-                     _store.Options.DotNetLogger ?? NullLogger<AdvisoryLock>.Instance;
+        var useMonitoredAdvisoryLock = store.Options.Events.UseMonitoredAdvisoryLock;
+        var logger = useMonitoredAdvisoryLock ? Logger<AdvisoryLock>() : Logger<NativeAdvisoryLock>();
 
-        _locks = new(db => new AdvisoryLock(((MartenDatabase)db).DataSource, logger, db.Id.Identity, new AdvisoryLockOptions { LockMonitoringEnabled = store.Options.Events.UseMonitoredAdvisoryLock }));
+        _locks = new(db => AdvisoryLockFactory.Create(((MartenDatabase)db).DataSource, logger, db.Id.Identity, new AdvisoryLockOptions { LockMonitoringEnabled = useMonitoredAdvisoryLock }));
+
+        ILogger Logger<T>() =>
+            store.Options.LogFactory?.CreateLogger<T>() ?? store.Options.DotNetLogger ?? NullLogger<T>.Instance;
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Marten/Events/Daemon/Coordination/SingleTenantProjectionDistributor.cs
+++ b/src/Marten/Events/Daemon/Coordination/SingleTenantProjectionDistributor.cs
@@ -7,6 +7,7 @@ using JasperFx.Core;
 using Marten.Storage;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Weasel.Core;
 using Weasel.Postgresql;
 
 namespace Marten.Events.Daemon.Coordination;
@@ -14,16 +15,19 @@ namespace Marten.Events.Daemon.Coordination;
 public class SingleTenantProjectionDistributor : IProjectionDistributor
 {
     private readonly DocumentStore _store;
-    private readonly Cache<IMartenDatabase, AdvisoryLock> _locks;
+    private readonly Cache<IMartenDatabase, IAdvisoryLock> _locks;
 
     public SingleTenantProjectionDistributor(DocumentStore store)
     {
         _store = store;
 
-        var logger = _store.Options.LogFactory?.CreateLogger<AdvisoryLock>() ??
-                     _store.Options.DotNetLogger ?? NullLogger<AdvisoryLock>.Instance;
+        var useMonitoredAdvisoryLock = store.Options.Events.UseMonitoredAdvisoryLock;
+        var logger = useMonitoredAdvisoryLock ? Logger<AdvisoryLock>() : Logger<NativeAdvisoryLock>();
 
-        _locks = new(db => new AdvisoryLock(((MartenDatabase)db).DataSource, logger, db.Id.Identity, new AdvisoryLockOptions { LockMonitoringEnabled = store.Options.Events.UseMonitoredAdvisoryLock }));
+        _locks = new(db => AdvisoryLockFactory.Create(((MartenDatabase)db).DataSource, logger, db.Id.Identity, new AdvisoryLockOptions { LockMonitoringEnabled = useMonitoredAdvisoryLock }));
+
+        ILogger Logger<T>() =>
+            store.Options.LogFactory?.CreateLogger<T>() ?? store.Options.DotNetLogger ?? NullLogger<T>.Instance;
     }
 
     public ValueTask<IReadOnlyList<IProjectionSet>> BuildDistributionAsync()


### PR DESCRIPTION
# Honour `UseMonitoredAdvisoryLock = false` end-to-end

Draft. Closes [#4195](https://github.com/JasperFx/marten/discussions/4195).

> **Blocked on the companion Weasel PR.** This PR cannot compile until the Weasel PR adding `NativeAdvisoryLock` and `AdvisoryLockFactory` is merged and shipped (release or pre-release). Marked Draft until then; intended to be reviewed in parallel with the Weasel PR.

## Problem

`StoreOptions.Events.UseMonitoredAdvisoryLock = false` is documented as an opt-out from advisory-lock monitoring, but only changed `AdvisoryLock.HasLock()` semantics. The Medallion-backed acquisition path stayed in use, so the `SET LOCAL` warnings under PostgreSQL 18 reported in #4195 persisted regardless of the flag value.

## Change

- `SingleTenantProjectionDistributor` and `MultiTenantedProjectionDistributor` now build their lock through `AdvisoryLockFactory.Create(...)` instead of `new AdvisoryLock(...)`. Their `_locks` cache is typed as `Cache<IMartenDatabase, IAdvisoryLock>`.
- `Weasel.Postgresql` package reference bumped to the version that ships `NativeAdvisoryLock` / `AdvisoryLockFactory`.
- `AdvisoryLocksTest` (in `DaemonTests.ManualOnly`) — the three existing facts are promoted to `[Theory]` parametrised on `LockMonitoringEnabled`, asserting both engines pass the same contract. Two new facts (`factory_returns_native_lock_when_monitoring_disabled`, `factory_returns_monitored_lock_by_default`) lock in the factory's branching.
- `docs/events/projections/async-daemon.md` HotCold tip rewritten to describe both modes accurately, attribute the keep-alive to Medallion, and explain when each mode is appropriate.

## Behaviour

- Default (`UseMonitoredAdvisoryLock = true`) — unchanged. Lock is acquired through Medallion, lock-loss detection works as before, `SET LOCAL` warnings still appear on PG 18 (this is upstream Medallion behaviour and unchanged).
- Opt-out (`UseMonitoredAdvisoryLock = false`) — now uses `NativeAdvisoryLock`: plain `pg_try_advisory_lock` over a dedicated connection, no `SET LOCAL`, no keep-alive. The trade-off is documented: lock loss caused by a silent connection drop is only surfaced on the next acquisition attempt.

## Tests

```
dotnet test src/DaemonTests.ManualOnly/DaemonTests.ManualOnly.csproj --filter "FullyQualifiedName~AdvisoryLocksTest"
```

## Migration notes

Pure opt-in. No public API changed. Users who never set the flag get exactly the previous behaviour. Users who had set it to `false` gain the behaviour the documentation already promised.
