### PR TITLE
Fix ProjectionVersion suffix being overwritten by explicit DocumentAlias

### DIFF
--- a/src/EventSourcingTests/Aggregation/blue_green_deployment_of_aggregates.cs
+++ b/src/EventSourcingTests/Aggregation/blue_green_deployment_of_aggregates.cs
@@ -38,6 +38,20 @@ public class blue_green_deployment_of_aggregates
         var mapping = store.Options.Storage.MappingFor(typeof(OtherAggregate));
         mapping.Alias.ShouldBe("otheraggregate_3");
     }
+
+    [Fact]
+    public void apply_the_version_suffix_when_document_alias_is_set_via_fluent_api()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Projections.Add<Version2>(ProjectionLifecycle.Async);
+            opts.Schema.For<MyAggregate>().DocumentAlias("custom_alias");
+        });
+
+        var mapping = store.Options.Storage.MappingFor(typeof(MyAggregate));
+        mapping.Alias.ShouldBe("custom_alias_2");
+    }
 }
 
 public class Version2: SingleStreamProjection<MyAggregate, Guid>

--- a/src/Marten/Events/Projections/ProjectionDocumentPolicy.cs
+++ b/src/Marten/Events/Projections/ProjectionDocumentPolicy.cs
@@ -14,11 +14,6 @@ internal class ProjectionDocumentPolicy : IDocumentPolicy
 
         if (mapping.StoreOptions.Projections.TryFindAggregate(mapping.DocumentType, out var projection))
         {
-            if (projection.Version > 1)
-            {
-                mapping.Alias += "_" + projection.Version;
-            }
-
             mapping.UseOptimisticConcurrency = false;
             mapping.Metadata.Version.Enabled = false;
             mapping.UseNumericRevisions = true;
@@ -28,7 +23,26 @@ internal class ProjectionDocumentPolicy : IDocumentPolicy
             {
                 m.ConfigureAggregateMapping(mapping, mapping.StoreOptions);
             }
+        }
+    }
+}
 
+internal class ProjectionVersionAliasPolicy : IDocumentPolicy
+{
+    public void Apply(DocumentMapping mapping)
+    {
+        if (mapping.StoreOptions.Projections == null) return;
+
+        if (mapping.StoreOptions.Projections.TryFindAggregate(mapping.DocumentType, out var projection))
+        {
+            if (projection.Version > 1)
+            {
+                var suffix = "_" + projection.Version;
+                if (!mapping.Alias.EndsWith(suffix))
+                {
+                    mapping.Alias += suffix;
+                }
+            }
         }
     }
 }

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -72,7 +72,7 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
         new ProjectionDocumentPolicy()
     ];
 
-    private readonly List<IDocumentPolicy> _postPolicies = new();
+    private readonly List<IDocumentPolicy> _postPolicies = new() { new ProjectionVersionAliasPolicy() };
 
     /// <summary>
     ///     Register "initial data loads" that will be applied to the DocumentStore when it is


### PR DESCRIPTION
When a projection sets ProjectionVersion > 1, the document alias should be suffixed with "_N" so the new version is rebuilt into a parallel mt_doc_xxx_N table (per the documented blue/green deployment pattern). However, when the user supplies an explicit alias via Schema.For<T>().DocumentAlias("...") or [DocumentAlias("...")], that alias was applied AFTER the policy ran, silently overwriting the version suffix. The new shard would then attempt to rebuild into the v1 table and crash on existing v1 documents that lack newly-added fields.

Split the alias-suffix step out of ProjectionDocumentPolicy into a new ProjectionVersionAliasPolicy registered as a post-policy. Post-policies run from StorageFeatures.MappingFor AFTER the fluent builder alterations, so the suffix lands on whatever alias the user actually configured. The remaining Marten-managed defaults (UseOptimisticConcurrency=false, UseNumericRevisions=true, ConfigureAggregateMapping) stay in the pre-policy and continue to win against earlier user-supplied policies.