### PR TITLE
Pre-warm EventGraph._byEventName and _aggregateTypeByName at Initialize

### DIFF
--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -614,7 +614,9 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
         // doesn't fall through Type.GetType(assemblyQualifiedName) in TypeForDotNetName,
         // which is itself O(loaded-assemblies). Populate both AssemblyQualifiedName and
         // FullName since both shapes appear in event metadata over the lifetime of a
-        // store. Done as a single Swap so we don't churn ImHashMap.
+        // store. Done as a single Swap so we don't churn ImHashMap. Also pre-fill
+        // _byEventName so EventMappingFor(string) skips its O(n) AllEvents() walk on
+        // first lookup of every registered event-type alias.
         _nameToType.Swap(map =>
         {
             foreach (var mapping in _events)
@@ -630,10 +632,24 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
                 {
                     map = map.AddOrUpdate(fullName, docType);
                 }
+
+                _byEventName.Fill(mapping.EventTypeName, mapping);
             }
 
             return map;
         });
+
+        // Pre-warm the aggregate-name -> aggregate-type cache so AggregateTypeFor
+        // (and therefore the LINQ-from-aggregate-alias path) doesn't pay the linear
+        // AllAggregateTypes() walk on the first lookup of each aggregate alias.
+        // findAggregateType is the OnMissing on _aggregateTypeByName and would do
+        // exactly this work lazily; pre-populating moves the cost off the request
+        // path and into the once-per-store Initialize.
+        foreach (var aggregateType in Options.Projections.AllAggregateTypes())
+        {
+            var alias = _aggregateNameByType[aggregateType];
+            _aggregateTypeByName.Fill(alias, aggregateType);
+        }
 
         autoDiscoverTagTypesFromProjections();
     }


### PR DESCRIPTION
## Summary

Round 3 of the 8.x cold-start trim begun in [#4295](https://github.com/JasperFx/marten/pull/4295) and [#4296](https://github.com/JasperFx/marten/pull/4296). Two more lazy caches in `EventGraph` paid an O(n) linear walk on first lookup of each name; pre-populating them at `Initialize` from already-known data lands the first request on a cache hit.

### What lands

- **`_byEventName` pre-warm.** `OnMissing = name => AllEvents().FirstOrDefault(x => x.EventTypeName == name)` did a full event-list scan per miss. Now we `Fill(mapping.EventTypeName, mapping)` for every registered event type in the same loop that already walks `_events` for `JsonTransformation` and the `_nameToType` pre-warm landed in #4296.
- **`_aggregateTypeByName` pre-warm.** `OnMissing = findAggregateType` iterated `Options.Projections.AllAggregateTypes()` per call and read `_aggregateNameByType[aggregateType]` to compare. Walk that collection once at `Initialize` and `Fill` the entries up front.

Behavior unchanged: the existing `OnMissing`/`Fill` paths remain intact for any name that wasn't registered at `Initialize` time (e.g. types added later via `_events.OnMissing`).

## Test plan

- [x] Build clean
- [x] 174 event-sourcing + aggregation tests across `end_to_end_event_capture`, `archiving_events`, `SchemaChange.Upcasters`, `Aggregation.global_tenanted_streams`, `aggregate_alias`, `AggregateAliasFor` — all pass

## What's still on the 9.0 board

The remaining cold-start, runtime-perf, and AOT items are 9.0-scope. Each is now tracked under its own issue on the **Marten 9.0** milestone for triage / assignment; the umbrella issue [#4294](https://github.com/JasperFx/marten/issues/4294) is being updated to link them. They are: lazy `BuildAllMappings`, lazy `EventGraph.FeatureSchema.Objects`, `Static`-mode `AssertValidity` skip, `IEnumerable<StreamAction>` widening, `GenerationRules` mutation isolation, the LINQ `Activator.CreateInstance` factory cache (depends on JasperFx [#191](https://github.com/JasperFx/jasperfx/issues/191)), and AOT-friendly mode (depends on JasperFx [#190](https://github.com/JasperFx/jasperfx/issues/190)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)