### PR TITLE
Bump JasperFx 1.27 → 1.28.1 + JasperFx.Events 1.30 → 1.31.0 (replaces #4003)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,13 +13,13 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="1.27.0" />
-    <PackageVersion Include="JasperFx.Events" Version="1.30.0" />
+    <PackageVersion Include="JasperFx" Version="1.28.1" />
+    <PackageVersion Include="JasperFx.Events" Version="1.31.0" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.4.0" />
+    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="4.5.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/Marten/DocumentStore.CompiledQueryCollection.cs
+++ b/src/Marten/DocumentStore.CompiledQueryCollection.cs
@@ -48,7 +48,14 @@ internal class CompiledQueryCollection
         var rules = _store.Options.CreateGenerationRules();
         rules.ReferenceTypes(typeof(TDoc), typeof(TOut), query.GetType());
 
-        file.InitializeSynchronously(rules, _store, null);
+        // Disambiguated against JasperFx 1.28's new
+        // JasperFx.CodeGeneration.CodeFileExtensions.InitializeSynchronously,
+        // which requires IAssemblyGenerator registered in DI. Marten passes a
+        // null IServiceProvider here, so we explicitly call the obsolete
+        // JasperFx.RuntimeCompiler overload that still falls back to a fresh
+        // AssemblyGenerator. Tracked for proper migration in Marten 9.0
+        // (see issue #4309 — AOT-friendly mode).
+        JasperFx.RuntimeCompiler.CodeFileExtensions.InitializeSynchronously(file, rules, _store, null);
 
         source = file.Build(rules);
         _querySources = _querySources.AddOrUpdate(query.GetType(), source);

--- a/src/Marten/Internal/ProviderGraph.cs
+++ b/src/Marten/Internal/ProviderGraph.cs
@@ -59,7 +59,13 @@ public class ProviderGraph: IProviderGraph
         if (documentType == typeof(IEvent))
         {
             var rules = _options.CreateGenerationRules();
-            _options.EventGraph.InitializeSynchronously(rules, _options.EventGraph, null);
+            // Disambiguated against JasperFx 1.28's new
+            // JasperFx.CodeGeneration.CodeFileExtensions.InitializeSynchronously
+            // which requires IAssemblyGenerator in DI. We pass null services here
+            // so we deliberately route through the obsolete RuntimeCompiler
+            // overload that constructs a fresh AssemblyGenerator. Proper
+            // migration tracked under Marten 9.0 issue #4309.
+            JasperFx.RuntimeCompiler.CodeFileExtensions.InitializeSynchronously(_options.EventGraph, rules, _options.EventGraph, null);
 
             _storage = _storage.AddOrUpdate(documentType, _options.EventGraph.Provider);
 
@@ -78,7 +84,8 @@ public class ProviderGraph: IProviderGraph
 
                     var rules = _options.CreateGenerationRules();
                     rules.ReferenceTypes(m.DocumentType);
-                    builder.InitializeSynchronously(rules, _options, null);
+                    // See note above for the disambiguation rationale.
+                    JasperFx.RuntimeCompiler.CodeFileExtensions.InitializeSynchronously(builder, rules, _options, null);
                     var slot = builder.BuildProvider<T>();
 
                     _storage = _storage.AddOrUpdate(documentType, slot);

--- a/src/Marten/Internal/SecondaryStoreConfig.cs
+++ b/src/Marten/Internal/SecondaryStoreConfig.cs
@@ -127,7 +127,14 @@ internal class SecondaryStoreConfig<T>: IStoreConfig where T : IDocumentStore
         // ParentDirectory(). Align the paths to avoid writing duplicate files
         // with the same namespace and class name to different directories (#4185)
         rules.GeneratedCodeOutputPath = rules.GeneratedCodeOutputPath.ParentDirectory();
-        this.InitializeSynchronously(rules, Parent, provider);
+        // Disambiguated against JasperFx 1.28's new
+        // JasperFx.CodeGeneration.CodeFileExtensions.InitializeSynchronously.
+        // The 'provider' here may be non-null (it's the host IServiceProvider)
+        // but it isn't required to have IAssemblyGenerator registered, so we
+        // route through the obsolete RuntimeCompiler overload that uses a
+        // fresh AssemblyGenerator. Proper migration tracked under Marten 9.0
+        // issue #4309.
+        JasperFx.RuntimeCompiler.CodeFileExtensions.InitializeSynchronously(this, rules, Parent, provider);
 
         var store = (T)Activator.CreateInstance(_storeType!, options)!;
         store.As<DocumentStore>().Subject = new Uri("marten://" + typeof(T).Name.ToLowerInvariant());


### PR DESCRIPTION
## Summary

Picks up the latest JasperFx + JasperFx.Events; also bumps `JasperFx.RuntimeCompiler` to 4.5.0 so the transitive set is consistent. **Closes [#4003](https://github.com/JasperFx/marten/pull/4003)** — the test additions in that PR were already brought into master via [`8ee1d2348`](https://github.com/JasperFx/marten/commit/8ee1d2348) (`Add test reproductions from PR #4155 and #4003`), so the only remaining work was the package bump.

### One required call-site fix

JasperFx 1.28 moved the `ICodeFile` codegen extension methods — notably `InitializeSynchronously` — into the `JasperFx.CodeGeneration` namespace ([JasperFx/jasperfx#194](https://github.com/JasperFx/jasperfx/pull/194)) and marked the `JasperFx.RuntimeCompiler` copies `[Obsolete]`. The new method requires `IAssemblyGenerator` to be registered in DI, which is part of the deliberate AOT-prep work.

Marten currently calls `InitializeSynchronously` with `services: null` at four sites:
- `src/Marten/DocumentStore.CompiledQueryCollection.cs:51`
- `src/Marten/Internal/ProviderGraph.cs:62, 81`
- `src/Marten/Internal/SecondaryStoreConfig.cs:130`

The new method's runtime path would throw `InvalidOperationException` on those null-services calls. To avoid behavior change in 8.x, this PR fully-qualifies those four calls to the `JasperFx.RuntimeCompiler.CodeFileExtensions.InitializeSynchronously` overload (which still falls back to `new AssemblyGenerator()`). `Directory.Build.props` already suppresses CS0618 (Obsolete), so the explicit qualification doesn't generate noise.

Proper migration — registering `IAssemblyGenerator` in Marten's DI graph and switching to the new namespace's method — is tracked as part of the AOT-friendly mode work in [#4309](https://github.com/JasperFx/marten/issues/4309).

## Test plan

- [x] Build clean (Marten + StressTests + CoreTests)
- [x] StressTests sweep including the test originally proposed in #4003 (`use_a_single_tenanted_document_in_multi_tenancy_ancillary_store`) — 8 passed
- [x] CoreTests — 327 passed, 1 pre-existing skip
- [x] Event-sourcing smoke (118 tests across `end_to_end_event_capture_and_fetching_the_stream` + `archiving_events`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)