### PR TITLE
Bump JasperFx 1.28.2 to fix List<T> duplicate-field codegen (closes #3702)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="1.28.1" />
+    <PackageVersion Include="JasperFx" Version="1.28.2" />
     <PackageVersion Include="JasperFx.Events" Version="1.31.0" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.5.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/DocumentDbTests/Bugs/Bug_PR_3702_list_index_compile_error.cs
+++ b/src/DocumentDbTests/Bugs/Bug_PR_3702_list_index_compile_error.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Linq.MatchesSql;
+using Marten.Schema;
+using Marten.Testing.Harness;
+using NpgsqlTypes;
+using Weasel.Postgresql.Tables;
+using Xunit;
+
+namespace DocumentDbTests.Bugs;
+
+public class Bug_PR_3702_list_index_compile_error : BugIntegrationContext
+{
+    [Fact]
+    public async Task can_create_array_duplicate_column_on_a_list_field()
+    {
+        StoreOptions(opts =>
+        {
+            opts.RegisterDocumentType<DocWithIndexOnList>();
+        });
+
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var newDoc = new DocWithIndexOnList { Id = Guid.NewGuid(), ListOfStrings = ["foo", "bar", "baz"] };
+        theSession.Store(newDoc);
+        await theSession.SaveChangesAsync();
+
+        List<string> arrayFilter = ["foo", "baz"];
+        var queriedDoc = await theSession.Query<DocWithIndexOnList>()
+            .Where(x => x.MatchesSql("d.list_of_strings @> ?", arrayFilter))
+            .FirstOrDefaultAsync();
+
+        Assert.Equal(newDoc.Id, queriedDoc.Id);
+    }
+
+    public class DocWithIndexOnList
+    {
+        public Guid Id { get; set; }
+
+        [DuplicateField(DbType = NpgsqlDbType.Array | NpgsqlDbType.Text, PgType = "text[]", IndexMethod = IndexMethod.gin)]
+        public List<string> ListOfStrings { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- Bumps JasperFx 1.28.1 → 1.28.2.
- 1.28.2 ships a `CodeFormatter.Write` fix (JasperFx/jasperfx#197) that emits **safe C#** for any enum value — including bit-OR'd combinations on non-`[Flags]` enums like `Npgsql.NpgsqlDbType`.
- Adds the reproduction test from @elexisvenator's #3702 verbatim. With the upstream fix it passes unchanged.

## Why this supersedes #3702

A document with

```csharp
[DuplicateField(DbType = NpgsqlDbType.Array | NpgsqlDbType.Text,
                PgType = "text[]", IndexMethod = IndexMethod.gin)]
public List<string> ListOfStrings { get; set; }
```

caused Marten codegen to emit:

```csharp
parameter0.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.-2147483629;
```

— an `Enum.ToString()` of an undefined enum value yielding an integer literal. Roslyn rejected it (`CS1001 Identifier expected`).

#3702 patched two call sites in `UpsertArgument.cs`. The root cause was actually in JasperFx's `CodeFormatter.Write`, which used `value.GetType().FullNameInCode() + "." + value` (implicit `ToString()`) for every enum. Fixing it there handles every other call-site too — past and future.

The 1.28.2 fix:
- Defined single member ⇒ `Type.Name` *(unchanged)*
- `[Flags]` combo ⇒ `Type.A | Type.B`
- Any other value (incl. non-Flags bit-OR'd values) ⇒ `((Type)(rawIntegerLiteral))`

Closes #3702. Anne — er, Ben Edwards (@elexisvenator) — kept as co-author on the reproduction test.

## Test plan
- [x] `dotnet test src/DocumentDbTests --filter Bug_PR_3702 -f net9.0` passes locally
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)