### PR TITLE
Fix #4318: ScopedSubscriptionServiceWrapper drops Options/Name/Version

### DIFF
--- a/src/DaemonTests/Subscriptions/subscriptions_end_to_end.cs
+++ b/src/DaemonTests/Subscriptions/subscriptions_end_to_end.cs
@@ -674,6 +674,43 @@ public class using_simple_subscription_registrations: OneOffConfigurationsContex
         wrapper.IncludedEventTypes.ShouldContain(typeof(MTAEvent));
         wrapper.IncludedEventTypes.ShouldContain(typeof(MTBEvent));
     }
+
+    // Regression for #4318: any Options / Name / Version configured in
+    // the subscriber's constructor used to be silently dropped on the
+    // Scoped registration path. They must surface on the wrapper because
+    // it's the wrapper the daemon reads from at runtime.
+    [Fact]
+    public void scoped_subscription_wrapper_propagates_constructor_configured_options_4318()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<ConstructorConfiguredSubscription>();
+
+        var provider = services.BuildServiceProvider();
+
+        var wrapper = new ScopedSubscriptionServiceWrapper<ConstructorConfiguredSubscription>(provider);
+
+        wrapper.Options.BatchSize.ShouldBe(123);
+        wrapper.Options.MaximumHopperSize.ShouldBe(7777);
+        wrapper.Name.ShouldBe("custom-subscription-name");
+        wrapper.Version.ShouldBe(7u);
+    }
+}
+
+public class ConstructorConfiguredSubscription: SubscriptionBase
+{
+    public ConstructorConfiguredSubscription()
+    {
+        Options.BatchSize = 123;
+        Options.MaximumHopperSize = 7777;
+        Name = "custom-subscription-name";
+        Version = 7;
+    }
+
+    public override Task<IChangeListener> ProcessEventsAsync(EventRange page, ISubscriptionController controller,
+        IDocumentOperations operations, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(Substitute.For<IChangeListener>());
+    }
 }
 
 public class FilteredSubscription: SubscriptionBase, IDisposable

--- a/src/Marten/Subscriptions/SubscriptionWrapper.cs
+++ b/src/Marten/Subscriptions/SubscriptionWrapper.cs
@@ -46,6 +46,19 @@ internal class ScopedSubscriptionServiceWrapper<T>: SubscriptionBase where T : I
             IncludedEventTypes.AddRange(subscription.IncludedEventTypes);
             StreamType = subscription.StreamType;
             IncludeArchivedEvents = subscription.IncludeArchivedEvents;
+
+            // #4318: also propagate Name, Version, and Options that the inner
+            // subscriber set in its constructor. Before this, settings like
+            // `Options.BatchSize = 100` or `Options.SubscribeFromPresent()`
+            // configured inside the user's SubscriptionBase ctor were silently
+            // dropped on the Scoped registration path. The Singleton path
+            // already worked because the registration's `configure` lambda
+            // was applied directly to the resolved instance; for Scoped, the
+            // wrapper itself is what the daemon reads, so its Options must
+            // start from the inner subscriber's configured state.
+            Options = subscription.Options;
+            Name = subscription.Name;
+            Version = subscription.Version;
         }
         scope.SafeDispose();
     }


### PR DESCRIPTION
Closes #4318.

## Summary
When a subscriber registered via `AddSubscriptionWithServices<T>(ServiceLifetime.Scoped, configure)` sets `Options.BatchSize`, `Options.SubscribeFromPresent()`, `Name`, or `Version` in its constructor, those values are silently lost. Only `IncludedEventTypes`, `StreamType`, and `IncludeArchivedEvents` are copied from the resolved inner `T` to the wrapper.

The Singleton path is unaffected because `configure` is applied directly to the resolved `SubscriptionBase`. For Scoped, the wrapper itself is what the daemon reads at runtime, so constructor-time state must surface on the wrapper too.

## Fix
Also copy `Options`, `Name`, and `Version` from the inner subscriber in `ScopedSubscriptionServiceWrapper<T>`.

## Test plan
- [x] New unit-level regression test `scoped_subscription_wrapper_propagates_constructor_configured_options_4318` next to the existing `subscription_wrapper_copies_the_filters_from_subscription_base`. Asserts `BatchSize`, `MaximumHopperSize`, `Name`, and `Version` survive the resolve-and-copy.
- [x] Both pass locally on net10.

Thanks to @Casper-Olsen for the root-cause analysis in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)