### PR TITLE
Bump JasperFx.Events 1.31.0 -> 1.31.1 (CultureNotFoundException fix)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
     <PackageVersion Include="JasperFx" Version="1.28.2" />
-    <PackageVersion Include="JasperFx.Events" Version="1.31.0" />
+    <PackageVersion Include="JasperFx.Events" Version="1.31.1" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="1.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Picks up [JasperFx PR #200](https://github.com/JasperFx/jasperfx/pull/200) — the cold-start prefilter in `ProjectionGraph.IsAssemblyKnownToHaveNoEvolvers` was reading `assembly.GetName().Name`, which under `<InvariantGlobalization>true</InvariantGlobalization>` (implied by `<PublishAot>true</PublishAot>`) throws `CultureNotFoundException` for any culture-tagged satellite assembly such as `pt-br`. The bug surfaces as a crash at `DocumentStore..ctor`.

Reported today against the cold-start optimization changes.

## What this PR does
- Bumps `JasperFx.Events` 1.31.0 → 1.31.1 in `Directory.Packages.props`
- That's it. The fix lives in JasperFx.

## Sequence
This is the first of two PRs landing the fix:
1. **This PR** — bumps the dependency.
2. [#4320](https://github.com/JasperFx/marten/pull/4320) — once this lands, that PR will be rebased onto master so #4320's `Fix #4318` lands on top of the bumped `JasperFx.Events`.

After both merge, Marten cuts a 8.34.1 patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)