### PR TITLE
Fix multi-property record structs misclassified as strong-typed-id wrappers

### DIFF
--- a/src/LinqTests/Bugs/Bug_money_value_object_misdetected_as_strong_typed_id.cs
+++ b/src/LinqTests/Bugs/Bug_money_value_object_misdetected_as_strong_typed_id.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+// Multi-property record structs (e.g. Money(decimal Amount, Guid CurrencyId)) used as
+// document properties were being mis-classified as strong-typed-id wrappers by
+// ValueTypeIdGeneration.IsCandidate. The candidate filter only counted properties whose
+// type is in DocumentMapping.ValidIdTypes (Guid/int/long/string), so it saw only
+// CurrencyId, matched a static `Money Zero(Guid)` builder, and as a side effect called
+// PostgresqlProvider.Instance.RegisterMapping(typeof(Money), "uuid", ...) — globally
+// poisoning Weasel's type map. LINQ resolution then treated Money as a scalar
+// (SimpleCastMember) instead of a JSONB document (ChildDocument), so any nested member
+// access like `x.UnappliedAmount.Amount` threw BadLinqExpressionException.
+//
+// Each test uses its own unique record-struct type to avoid cross-test pollution of
+// the process-wide PostgresqlProvider.Instance singleton.
+public class Bug_money_value_object_misdetected_as_strong_typed_id
+{
+    [Fact]
+    public void multi_property_record_struct_does_not_pollute_global_pg_type_mapping()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Schema.For<MoneyDocA>();
+        });
+
+        var pgType = PostgresqlProvider.Instance.GetDatabaseType(
+            typeof(MoneyA), store.Options.Serializer().EnumStorage);
+
+        pgType.ShouldBe("jsonb");
+    }
+
+    [Fact]
+    public void linq_can_resolve_nested_member_access_on_multi_property_record_struct()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Schema.For<MoneyDocB>();
+        });
+
+        using var session = store.QuerySession();
+        var queryable = session.Query<MoneyDocB>()
+            .Where(x => x.Amount.Value > 0m && x.Amount.CurrencyId == Guid.Empty);
+
+        Should.NotThrow(() => queryable.ToCommand());
+    }
+}
+
+public readonly record struct MoneyA(decimal Value, Guid CurrencyId)
+{
+    public static MoneyA Zero(Guid currencyId) => new(0m, currencyId);
+}
+
+public class MoneyDocA
+{
+    public Guid Id { get; set; }
+    public MoneyA Amount { get; set; }
+}
+
+public readonly record struct MoneyB(decimal Value, Guid CurrencyId)
+{
+    public static MoneyB Zero(Guid currencyId) => new(0m, currencyId);
+}
+
+public class MoneyDocB
+{
+    public Guid Id { get; set; }
+    public MoneyB Amount { get; set; }
+}

--- a/src/Marten/Schema/Identity/ValueTypeIdGeneration.cs
+++ b/src/Marten/Schema/Identity/ValueTypeIdGeneration.cs
@@ -154,6 +154,18 @@ public class ValueTypeIdGeneration: ValueTypeInfo, IIdGeneration, IStrongTypedId
             return false;
         }
 
+        // Reject multi-property value objects (e.g. `Money(decimal Amount, Guid CurrencyId)`)
+        // before any further matching. Such types' canonical constructors take more than one
+        // argument; a strong-typed-id wrapper takes at most one. Without this guard the
+        // ValidIdTypes filter below would silently drop the non-id-typed property, see only
+        // the Guid one, match a static `Zero(Guid)` builder, and — as a side effect — register
+        // the entire value object as a `uuid` column on the global PostgresqlProvider singleton,
+        // breaking LINQ resolution for any document that uses it as a property.
+        if (idType.GetConstructors().Any(c => c.GetParameters().Length > 1))
+        {
+            return false;
+        }
+
         var properties = idType.GetProperties()
             .Where(x => DocumentMapping.ValidIdTypes.Contains(x.PropertyType))
             .ToArray();


### PR DESCRIPTION
## Problem
When a document property's type is a multi-field record struct like `Money(decimal Value, Guid CurrencyId)`, the LINQ resolver throws on nested member access:

```
'Marten.Exceptions.BadLinqExpressionException' ... 'Marten does not (yet) support member Money.Value'
```

## Root cause
In `ValueTypeIdGeneration.IsCandidate`, the property filter only counts properties whose type is in `DocumentMapping.ValidIdTypes` (Guid/int/long/string). For a `Money` struct with `Value: decimal` and `CurrencyId: Guid`, it sees only the `CurrencyId` property — a single match. A static `Money Zero(Guid)` builder method then satisfies the 1-arg signature requirement, and the type is wrongly classified as a strong-typed-id wrapper.

Worse, the candidate check has a side effect: it calls

```csharp
PostgresqlProvider.Instance.RegisterMapping(typeof(Money), "uuid", NpgsqlDbType.Uuid);
```

on the **global Weasel singleton**, poisoning the type map for the rest of the process. Subsequent LINQ resolution treats `Money` as a uuid scalar (`SimpleCastMember`) instead of a JSONB document (`ChildDocument`), so any `x.MoneyProp.Amount > 0` style query throws.

## Fix
Reject types whose canonical constructor takes more than one parameter before any further matching. A strong-typed-id wrapper takes exactly one argument by definition; a multi-property record struct's primary ctor (`Money(decimal, Guid)`) signals "data-carrying value object", not "id wrapper".

Single-arg strong-typed-ids — including those with additional convenience computed properties — continue to be detected normally. Verified: `dotnet test src/ValueTypeTests` passes 339/339.

## Tests
Two regression tests in `src/LinqTests/Bugs/`:

1. `multi_property_record_struct_does_not_pollute_global_pg_type_mapping` — asserts `PostgresqlProvider.Instance.GetDatabaseType(typeof(Money), ...)` returns `"jsonb"` (the document-storage default) rather than `"uuid"`.
2. `linq_can_resolve_nested_member_access_on_multi_property_record_struct` — end-to-end check that `session.Query<Doc>().Where(x => x.Amount.Value > 0m && x.Amount.CurrencyId == Guid.Empty).ToCommand()` no longer throws.

Each test uses its own unique record-struct type to avoid cross-test pollution of the process-wide `PostgresqlProvider.Instance` singleton.

## Reported by
@mmidkiff, with full root-cause analysis pre-attached. Thanks!

## Test plan
- [x] New regression tests pass on net9.0
- [x] `dotnet test src/ValueTypeTests` 339/339 — no regression on legit strong-typed-id detection
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)