### PR TITLE
Fix silent write-loss in mt_upsert_<doc> for numeric-revisioned documents

### DIFF
--- a/src/DocumentDbTests/Concurrency/numeric_revisioning.cs
+++ b/src/DocumentDbTests/Concurrency/numeric_revisioning.cs
@@ -1,9 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Castle.Components.DictionaryAdapter;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.Core;
+using Marten;
 using Marten.Exceptions;
 using Marten.Schema;
 using Marten.Services;
@@ -445,8 +449,123 @@ public class numeric_revisioning: OneOffConfigurationsContext
         });
     }
 
+    [Fact]
+    public async Task concurrent_update_revision_does_not_silently_lose_writes()
+    {
+        // Regression: under READ COMMITTED contention, mt_upsert_* for a numeric-revisioned
+        // document could return a non-zero final_version even when its ON CONFLICT ... DO UPDATE
+        // ... WHERE revision > mt_version clause silently skipped the row update because a
+        // concurrent transaction had already bumped mt_version. SaveChangesAsync would not throw,
+        // AfterCommitAsync would fire, and the caller would believe the write landed.
+        //
+        // Invariant: when N sessions all load the same doc at v=1 and race UpdateRevision(doc, 2),
+        // exactly one SaveChanges should succeed and the rest must throw ConcurrencyException.
+
+        var listener = new CommitCountingListener();
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<RevisionedDoc>().UseNumericRevisions(true);
+            opts.Listeners.Add(listener);
+        });
+
+        const int N = 50;
+
+        var doc = new RevisionedDoc { Name = "Initial" };
+        await using (var seed = theStore.LightweightSession())
+        {
+            seed.Store(doc);
+            await seed.SaveChangesAsync();
+        }
+
+        // Warm the connection pool so all N connectors are established before the race.
+        // With a cold pool, connection setup serializes and stretches the timing so the
+        // race window doesn't open; once warm, every run reproduces.
+        await Task.WhenAll(Enumerable.Range(0, N).Select(async _ =>
+        {
+            await using var warm = theStore.QuerySession();
+            await warm.LoadAsync<RevisionedDoc>(doc.Id);
+        }));
+        listener.Reset();
+
+        var sessions = new List<IDocumentSession>(N);
+        try
+        {
+            for (var i = 0; i < N; i++)
+            {
+                var session = theStore.LightweightSession();
+                var loaded = await session.LoadAsync<RevisionedDoc>(doc.Id);
+                loaded.Version.ShouldBe(1);
+                loaded.Name = $"session {i}";
+                session.UpdateRevision(loaded, 2);
+                sessions.Add(session);
+            }
+
+            var successes = 0;
+            var concurrencyFailures = 0;
+            await Parallel.ForEachAsync(sessions,
+                new ParallelOptions { MaxDegreeOfParallelism = N },
+                async (session, ct) =>
+                {
+                    try
+                    {
+                        await Task.Delay(Random.Shared.Next(0, 10), ct);
+                        await session.SaveChangesAsync(ct);
+                        Interlocked.Increment(ref successes);
+                    }
+                    catch (ConcurrencyException)
+                    {
+                        Interlocked.Increment(ref concurrencyFailures);
+                    }
+                });
+
+            await using var verify = theStore.QuerySession();
+            var persisted = await verify.LoadAsync<RevisionedDoc>(doc.Id);
+            persisted.Version.ShouldBe(2);
+
+            // Only one writer can move v=1 → v=2. Every other SaveChanges must surface
+            // as a ConcurrencyException, never as a silent success.
+            successes.ShouldBe(1, "silent writes detected");
+            concurrencyFailures.ShouldBe(N - 1);
+
+            // AfterCommitAsync must not fire for sessions whose write was silently dropped.
+            listener.AfterCommit.ShouldBe(successes);
+            listener.BeforeSave.ShouldBe(N);
+        }
+        finally
+        {
+            foreach (var session in sessions) session.Dispose();
+        }
+    }
 
 
+
+}
+
+internal class CommitCountingListener: DocumentSessionListenerBase
+{
+    private int _beforeSave;
+    private int _afterCommit;
+
+    public int BeforeSave => _beforeSave;
+    public int AfterCommit => _afterCommit;
+
+    public void Reset()
+    {
+        Interlocked.Exchange(ref _beforeSave, 0);
+        Interlocked.Exchange(ref _afterCommit, 0);
+    }
+
+    public override Task BeforeSaveChangesAsync(IDocumentSession session, CancellationToken token)
+    {
+        Interlocked.Increment(ref _beforeSave);
+        return Task.CompletedTask;
+    }
+
+    public override Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+    {
+        Interlocked.Increment(ref _afterCommit);
+        return Task.CompletedTask;
+    }
 }
 
 

--- a/src/Marten/Storage/UpsertFunction.cs
+++ b/src/Marten/Storage/UpsertFunction.cs
@@ -222,6 +222,7 @@ CREATE OR REPLACE FUNCTION {Identifier.QualifiedName}({argList}) RETURNS INTEGER
 DECLARE
   final_version INTEGER;
   current_version INTEGER;
+  rows_affected INTEGER;
 BEGIN
 
 SELECT {_versionColumnName} into current_version FROM {_versionSourceTable} WHERE id = docId {_andTenantVersionWhereClause}{_andPartitionWhereClause};
@@ -242,6 +243,11 @@ end if;
 INSERT INTO {_tableName.QualifiedName} ({inserts}) VALUES ({valueList})
   ON CONFLICT ({_primaryKeyFields})
   DO UPDATE SET {updates};
+
+  GET DIAGNOSTICS rows_affected = ROW_COUNT;
+  if rows_affected = 0 then
+    return 0;
+  end if;
 
   SELECT mt_version into final_version FROM {_tableName.QualifiedName} WHERE id = docId {_andTenantWhereClause}{_andPartitionWhereClause};
   RETURN final_version;

--- a/src/Marten/Storage/UpsertFunction.cs
+++ b/src/Marten/Storage/UpsertFunction.cs
@@ -222,7 +222,6 @@ CREATE OR REPLACE FUNCTION {Identifier.QualifiedName}({argList}) RETURNS INTEGER
 DECLARE
   final_version INTEGER;
   current_version INTEGER;
-  rows_affected INTEGER;
 BEGIN
 
 SELECT {_versionColumnName} into current_version FROM {_versionSourceTable} WHERE id = docId {_andTenantVersionWhereClause}{_andPartitionWhereClause};
@@ -242,15 +241,10 @@ end if;
 
 INSERT INTO {_tableName.QualifiedName} ({inserts}) VALUES ({valueList})
   ON CONFLICT ({_primaryKeyFields})
-  DO UPDATE SET {updates};
+  DO UPDATE SET {updates}
+  RETURNING mt_version INTO final_version;
 
-  GET DIAGNOSTICS rows_affected = ROW_COUNT;
-  if rows_affected = 0 then
-    return 0;
-  end if;
-
-  SELECT mt_version into final_version FROM {_tableName.QualifiedName} WHERE id = docId {_andTenantWhereClause}{_andPartitionWhereClause};
-  RETURN final_version;
+  RETURN COALESCE(final_version, 0);
 END;
 $function$;
 ");


### PR DESCRIPTION
## Summary

- The generated `mt_upsert_<doc>` function for documents with `UseNumericRevisions = true` could silently drop a concurrent update under READ COMMITTED contention. The `INSERT ... ON CONFLICT ... DO UPDATE ... WHERE revision > mt_version` clause skipped the row when another transaction had already bumped `mt_version`, but the function still returned the (now-bumped) `final_version`. Marten read the non-zero return as success, `SaveChangesAsync` did not throw, and `AfterCommitAsync` fired for a write that never landed.
- Fix: capture `GET DIAGNOSTICS rows_affected = ROW_COUNT` after the INSERT/UPDATE and `RETURN 0` when no row was actually written, so the caller surfaces a `ConcurrencyException` instead of silently succeeding.
- Adds a regression test that races 50 sessions all calling `UpdateRevision(doc, 2)` from `v=1`. Exactly one must succeed; every other must throw `ConcurrencyException`.

## Test plan

- [x] New regression test fails on `master` (8.34.2) without the fix — 6 silent successes instead of 1.
- [x] New regression test passes with the fix on net8.0, net9.0, and net10.0.
- [ ] Existing `numeric_revisioning` and concurrency suites pass.
