### PR TITLE
Fix silent write-loss in mt_upsert_<doc> + ProjectLatest double-store regression

### DIFF
--- a/src/DocumentDbTests/Concurrency/numeric_revisioning.cs
+++ b/src/DocumentDbTests/Concurrency/numeric_revisioning.cs
@@ -1,9 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Castle.Components.DictionaryAdapter;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.Core;
+using Marten;
 using Marten.Exceptions;
 using Marten.Schema;
 using Marten.Services;
@@ -445,8 +449,123 @@ public class numeric_revisioning: OneOffConfigurationsContext
         });
     }
 
+    [Fact]
+    public async Task concurrent_update_revision_does_not_silently_lose_writes()
+    {
+        // Regression: under READ COMMITTED contention, mt_upsert_* for a numeric-revisioned
+        // document could return a non-zero final_version even when its ON CONFLICT ... DO UPDATE
+        // ... WHERE revision > mt_version clause silently skipped the row update because a
+        // concurrent transaction had already bumped mt_version. SaveChangesAsync would not throw,
+        // AfterCommitAsync would fire, and the caller would believe the write landed.
+        //
+        // Invariant: when N sessions all load the same doc at v=1 and race UpdateRevision(doc, 2),
+        // exactly one SaveChanges should succeed and the rest must throw ConcurrencyException.
+
+        var listener = new CommitCountingListener();
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<RevisionedDoc>().UseNumericRevisions(true);
+            opts.Listeners.Add(listener);
+        });
+
+        const int N = 50;
+
+        var doc = new RevisionedDoc { Name = "Initial" };
+        await using (var seed = theStore.LightweightSession())
+        {
+            seed.Store(doc);
+            await seed.SaveChangesAsync();
+        }
+
+        // Warm the connection pool so all N connectors are established before the race.
+        // With a cold pool, connection setup serializes and stretches the timing so the
+        // race window doesn't open; once warm, every run reproduces.
+        await Task.WhenAll(Enumerable.Range(0, N).Select(async _ =>
+        {
+            await using var warm = theStore.QuerySession();
+            await warm.LoadAsync<RevisionedDoc>(doc.Id);
+        }));
+        listener.Reset();
+
+        var sessions = new List<IDocumentSession>(N);
+        try
+        {
+            for (var i = 0; i < N; i++)
+            {
+                var session = theStore.LightweightSession();
+                var loaded = await session.LoadAsync<RevisionedDoc>(doc.Id);
+                loaded.Version.ShouldBe(1);
+                loaded.Name = $"session {i}";
+                session.UpdateRevision(loaded, 2);
+                sessions.Add(session);
+            }
+
+            var successes = 0;
+            var concurrencyFailures = 0;
+            await Parallel.ForEachAsync(sessions,
+                new ParallelOptions { MaxDegreeOfParallelism = N },
+                async (session, ct) =>
+                {
+                    try
+                    {
+                        await Task.Delay(Random.Shared.Next(0, 10), ct);
+                        await session.SaveChangesAsync(ct);
+                        Interlocked.Increment(ref successes);
+                    }
+                    catch (ConcurrencyException)
+                    {
+                        Interlocked.Increment(ref concurrencyFailures);
+                    }
+                });
+
+            await using var verify = theStore.QuerySession();
+            var persisted = await verify.LoadAsync<RevisionedDoc>(doc.Id);
+            persisted.Version.ShouldBe(2);
+
+            // Only one writer can move v=1 → v=2. Every other SaveChanges must surface
+            // as a ConcurrencyException, never as a silent success.
+            successes.ShouldBe(1, "silent writes detected");
+            concurrencyFailures.ShouldBe(N - 1);
+
+            // AfterCommitAsync must not fire for sessions whose write was silently dropped.
+            listener.AfterCommit.ShouldBe(successes);
+            listener.BeforeSave.ShouldBe(N);
+        }
+        finally
+        {
+            foreach (var session in sessions) session.Dispose();
+        }
+    }
 
 
+
+}
+
+internal class CommitCountingListener: DocumentSessionListenerBase
+{
+    private int _beforeSave;
+    private int _afterCommit;
+
+    public int BeforeSave => _beforeSave;
+    public int AfterCommit => _afterCommit;
+
+    public void Reset()
+    {
+        Interlocked.Exchange(ref _beforeSave, 0);
+        Interlocked.Exchange(ref _afterCommit, 0);
+    }
+
+    public override Task BeforeSaveChangesAsync(IDocumentSession session, CancellationToken token)
+    {
+        Interlocked.Increment(ref _beforeSave);
+        return Task.CompletedTask;
+    }
+
+    public override Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+    {
+        Interlocked.Increment(ref _afterCommit);
+        return Task.CompletedTask;
+    }
 }
 
 

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.ForReading.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.ForReading.cs
@@ -57,11 +57,10 @@ internal partial class FetchInlinedPlan<TDoc, TId>
         snapshot = await aggregator.BuildAsync(pendingEvents, session, snapshot, id, storage, cancellation)
             .ConfigureAwait(false);
 
-        // Store the updated document so it persists when the session commits
-        if (snapshot != null)
-        {
-            session.Store(snapshot);
-        }
+        // The configured inline projection itself will persist the projected
+        // document during SaveChangesAsync. Calling session.Store(snapshot) here
+        // would queue a redundant upsert at the same revision, which now surfaces
+        // as a ConcurrencyException after the mt_upsert_<doc> write-loss fix.
 
         return snapshot;
     }

--- a/src/Marten/Storage/UpsertFunction.cs
+++ b/src/Marten/Storage/UpsertFunction.cs
@@ -222,6 +222,7 @@ CREATE OR REPLACE FUNCTION {Identifier.QualifiedName}({argList}) RETURNS INTEGER
 DECLARE
   final_version INTEGER;
   current_version INTEGER;
+  rows_affected INTEGER;
 BEGIN
 
 SELECT {_versionColumnName} into current_version FROM {_versionSourceTable} WHERE id = docId {_andTenantVersionWhereClause}{_andPartitionWhereClause};
@@ -242,6 +243,11 @@ end if;
 INSERT INTO {_tableName.QualifiedName} ({inserts}) VALUES ({valueList})
   ON CONFLICT ({_primaryKeyFields})
   DO UPDATE SET {updates};
+
+  GET DIAGNOSTICS rows_affected = ROW_COUNT;
+  if rows_affected = 0 then
+    return 0;
+  end if;
 
   SELECT mt_version into final_version FROM {_tableName.QualifiedName} WHERE id = docId {_andTenantWhereClause}{_andPartitionWhereClause};
   RETURN final_version;

--- a/src/Marten/Storage/UpsertFunction.cs
+++ b/src/Marten/Storage/UpsertFunction.cs
@@ -222,7 +222,6 @@ CREATE OR REPLACE FUNCTION {Identifier.QualifiedName}({argList}) RETURNS INTEGER
 DECLARE
   final_version INTEGER;
   current_version INTEGER;
-  rows_affected INTEGER;
 BEGIN
 
 SELECT {_versionColumnName} into current_version FROM {_versionSourceTable} WHERE id = docId {_andTenantVersionWhereClause}{_andPartitionWhereClause};
@@ -242,15 +241,10 @@ end if;
 
 INSERT INTO {_tableName.QualifiedName} ({inserts}) VALUES ({valueList})
   ON CONFLICT ({_primaryKeyFields})
-  DO UPDATE SET {updates};
+  DO UPDATE SET {updates}
+  RETURNING mt_version INTO final_version;
 
-  GET DIAGNOSTICS rows_affected = ROW_COUNT;
-  if rows_affected = 0 then
-    return 0;
-  end if;
-
-  SELECT mt_version into final_version FROM {_tableName.QualifiedName} WHERE id = docId {_andTenantWhereClause}{_andPartitionWhereClause};
-  RETURN final_version;
+  RETURN COALESCE(final_version, 0);
 END;
 $function$;
 ");


### PR DESCRIPTION
Supersedes #4325. Picks up @ArieGato's three commits unchanged and adds one
follow-up commit that fixes the regression those changes expose in
`project_latest_tests.inline_projection_stores_document_on_project_latest`.

## What #4325 fixes

The generated `mt_upsert_<doc>` for documents with `UseNumericRevisions = true`
ran `INSERT ... ON CONFLICT ... DO UPDATE ... WHERE revision > mt_version`
and then unconditionally re-read `mt_version`. Under READ COMMITTED contention
the conditional UPDATE could match zero rows while the function still returned
the now-bumped `mt_version`, so Marten saw a non-zero return as success,
`SaveChangesAsync` did not throw, and `AfterCommitAsync` fired for a write that
never landed.

The fix folds the read into the same statement
(`DO UPDATE SET ... RETURNING mt_version INTO final_version`) and
`RETURN COALESCE(final_version, 0)` so that a filtered conflict update produces
0, which Marten already treats as `ConcurrencyException`.

Regression test in `numeric_revisioning.cs` (`concurrent_update_revision_does_not_silently_lose_writes`)
fails on master, passes here.

## What this PR adds on top

`FetchInlinedPlan.ProjectLatest` was queueing an upsert at the projected
revision via `session.Store(snapshot)`, and the configured inline projection
queued a second upsert at the same revision during `SaveChangesAsync`. Under
the old write-loss behaviour the second write silently became a no-op. With
the upsert function now reporting 0 when its `WHERE` filter skips the row,
the second upsert correctly surfaces as `ConcurrencyException` — and the
existing test `inline_projection_stores_document_on_project_latest` started
to fail in CI.

The inline projection persists the projected document itself during
`SaveChangesAsync`, so the explicit `Store` in the inline fetch plan was
always redundant; it just happened to be harmless under the buggy upsert
function. `FetchAsyncPlan` keeps its `session.Store` because async
projections don't run inline.

## Test plan

Run on net10.0 against PostgreSQL 16:

- [x] `EventSourcingTests` filter `project_latest_tests` — 6/6 pass (was 5 pass / 1 fail on the previous PR head)
- [x] `DocumentDbTests` filter `numeric_revisioning|Concurrency` — 66/66 (includes the new race regression test from #4325)
- [x] `EventSourcingTests` filter `numeric_revisioning|Concurrency` — 21/21
- [x] `EventSourcingTests` filter `Aggregation|Projection` — 409/409
- [x] `EventSourcingTests` filter `FetchForWriting|FetchLatest|ProjectLatest|InlineProjection|inline_aggregation` — 212/212
- [x] `EventSourcingTests` filter `Bug_3310_inline_projections|SubscriptionScopedSession|MultiStream` — 22/22
- [x] `PatchingTests` — 114/115 (1 pre-existing skip)
- [x] `MultiTenancyTests` filter `revisioning|Concurrency|Aggregation` — 1/1
- [x] `CoreTests` filter `migrate_from_guid_to_int_based_revisions` — 1/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)