### PR TITLE
Honor `Where` clauses on the inner source of `GroupJoin`

### DIFF
--- a/docs/documents/querying/linq/group-join.md
+++ b/docs/documents/querying/linq/group-join.md
@@ -99,6 +99,40 @@ var results = await session.Query<Customer>()
     .ToListAsync();
 ```
 
+## Filtering Before the Join
+
+`Where` clauses on either side of the join are pushed into the corresponding CTE so filtering happens **before** the join. This applies both to a `Where` applied to the outer source and to a `Where` chained onto the inner `IQueryable` passed as the second argument to `GroupJoin`.
+
+```cs
+var results = await session.Query<Customer>()
+    .Where(c => c.City == "Seattle")                        // filters outer CTE
+    .GroupJoin(
+        session.Query<Order>().Where(o => o.Status == "Shipped"), // filters inner CTE
+        c => c.Id,
+        o => o.CustomerId,
+        (c, orders) => new { c, orders })
+    .SelectMany(
+        x => x.orders,
+        (x, o) => new { CustomerName = x.c.Name, OrderAmount = o.Amount })
+    .ToListAsync();
+```
+
+The generated SQL applies each `Where` to its own CTE so the join only sees pre-filtered rows from both sides:
+
+```sql
+WITH outer_cte AS (
+    SELECT d.id, d.data FROM public.mt_doc_customer AS d
+    WHERE d.data ->> 'City' = 'Seattle'
+),
+inner_cte AS (
+    SELECT d.id, d.data FROM public.mt_doc_order AS d
+    WHERE d.data ->> 'Status' = 'Shipped'
+)
+SELECT ... FROM outer_cte INNER JOIN inner_cte ON ...;
+```
+
+Multiple `Where` calls on either source are supported and are AND-ed together.
+
 ## Left Join (GroupJoin + SelectMany + DefaultIfEmpty)
 
 To include outer rows that have no matching inner rows (a SQL `LEFT JOIN`), add `.DefaultIfEmpty()` to the collection selector in `SelectMany()`:

--- a/src/LinqTests/Operators/group_join_operator.cs
+++ b/src/LinqTests/Operators/group_join_operator.cs
@@ -604,4 +604,79 @@ public class group_join_operator: OneOffConfigurationsContext
     }
 
     #endregion
+
+    #region Inner Source Where Filter Tests
+
+    [Fact]
+    public async Task GroupJoin_inner_join_with_where_on_inner_source()
+    {
+        await SetupData();
+
+        // Filter the inner IQueryable before GroupJoin: only Active orders should
+        // participate in the join.
+        var results = await _session.Query<JoinCustomer>()
+            .GroupJoin(
+                _session.Query<JoinOrder>().Where(o => o.Status == "Active"),
+                c => c.Id,
+                o => o.CustomerId,
+                (c, orders) => new { c, orders })
+            .SelectMany(
+                x => x.orders,
+                (x, o) => new { x.c.Name, o.Status, o.Amount })
+            .ToListAsync();
+
+        results.Count.ShouldBe(2);
+        results.ShouldAllBe(r => r.Status == "Active");
+        results.Count(r => r.Name == "Alice").ShouldBe(1);
+        results.Count(r => r.Name == "Bob").ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GroupJoin_left_join_with_where_on_inner_source()
+    {
+        await SetupData();
+
+        // LEFT JOIN: customers without matching (Active) orders should still appear with null status.
+        var results = await _session.Query<JoinCustomer>()
+            .GroupJoin(
+                _session.Query<JoinOrder>().Where(o => o.Status == "Active"),
+                c => c.Id,
+                o => o.CustomerId,
+                (c, orders) => new { c, orders })
+            .SelectMany(
+                x => x.orders.DefaultIfEmpty(),
+                (x, o) => new { x.c.Name, OrderStatus = (string?)(o == null ? null : o.Status) })
+            .ToListAsync();
+
+        // Alice(1 Active) + Bob(1 Active) + Charlie(no orders -> null)
+        results.Count.ShouldBe(3);
+        results.Count(r => r.OrderStatus == "Active").ShouldBe(2);
+        results.Count(r => r.OrderStatus == null).ShouldBe(1);
+        results.Single(r => r.OrderStatus == null).Name.ShouldBe("Charlie");
+    }
+
+    [Fact]
+    public async Task GroupJoin_inner_join_with_multiple_wheres_on_inner_source()
+    {
+        await SetupData();
+
+        // Two Where calls chained on the inner source: Active AND Amount > 200.
+        var results = await _session.Query<JoinCustomer>()
+            .GroupJoin(
+                _session.Query<JoinOrder>().Where(o => o.Status == "Active").Where(o => o.Amount > 200m),
+                c => c.Id,
+                o => o.CustomerId,
+                (c, orders) => new { c, orders })
+            .SelectMany(
+                x => x.orders,
+                (x, o) => new { x.c.Name, o.Amount })
+            .ToListAsync();
+
+        // Only Bob's Active order with Amount=300 qualifies.
+        results.Count.ShouldBe(1);
+        results.Single().Name.ShouldBe("Bob");
+        results.Single().Amount.ShouldBe(300m);
+    }
+
+    #endregion
 }

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -292,9 +292,9 @@ public partial class CollectionUsage
         };
         var innerCteAlias = innerStatement.ExportName;
 
-        // Apply default filters (soft delete, tenancy) to inner CTE
+        // Apply extracted Where clauses and default filters (soft delete, tenancy) to inner CTE.
         innerStatement.ParseWhereClause(
-            Array.Empty<System.Linq.Expressions.Expression>(),
+            groupJoin.InnerCollectionUsage.WhereExpressions,
             session, innerCollection, innerStorage);
 
         // Chain the inner CTE after the outer CTE

--- a/src/Marten/Linq/GroupJoinData.cs
+++ b/src/Marten/Linq/GroupJoinData.cs
@@ -44,4 +44,12 @@ public class GroupJoinData
     /// (e.g., (c, o) => new { c.Name, o.Amount })
     /// </summary>
     public LambdaExpression? FlattenedResultSelector { get; set; }
+
+    /// <summary>
+    /// CollectionUsage representing the inner IQueryable source. Holds Where
+    /// predicate bodies extracted from the inner source (e.g.
+    /// <c>session.Query&lt;Result&gt;().Where(r => r.Score &gt; 10)</c>) so they can
+    /// be applied to the inner CTE before the join.
+    /// </summary>
+    public CollectionUsage InnerCollectionUsage { get; set; } = null!;
 }

--- a/src/Marten/Linq/Parsing/Operators/GroupJoinOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/GroupJoinOperator.cs
@@ -1,6 +1,5 @@
 #nullable enable
-using System;
-using System.Linq;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace Marten.Linq.Parsing.Operators;
@@ -33,13 +32,18 @@ public class GroupJoinOperator: LinqOperator
         // Determine inner element type from the inner source's IQueryable<T> generic arg
         var innerElementType = innerSource.Type.GetGenericArguments()[0];
 
+        // Build a CollectionUsage for the inner source so its Where clauses are captured
+        var innerUsage = new CollectionUsage(usage.Options, innerElementType);
+        ExtractInnerWhereExpressions(innerSource, innerUsage);
+
         var groupJoinData = new GroupJoinData
         {
             InnerSourceExpression = innerSource,
             OuterKeySelector = (LambdaExpression)outerKeyExpr,
             InnerKeySelector = (LambdaExpression)innerKeyExpr,
             ResultSelector = (LambdaExpression)resultSelectorExpr,
-            InnerElementType = innerElementType
+            InnerElementType = innerElementType,
+            InnerCollectionUsage = innerUsage
         };
 
         // If SelectMany was processed before us (it's the outermost operator),
@@ -99,6 +103,35 @@ public class GroupJoinOperator: LinqOperator
         }
 
         return false;
+    }
+
+    private static void ExtractInnerWhereExpressions(Expression innerSource, CollectionUsage innerUsage)
+    {
+        // Collect Where calls from outer-most to inner-most, then forward them to
+        // CollectionUsage.AddWhereClause in source order so the predicates land on
+        // the inner usage's WhereExpressions in the same order they appear in the
+        // LINQ chain.
+        var collected = new List<MethodCallExpression>();
+        var current = innerSource;
+        while (current is MethodCallExpression call)
+        {
+            if (call.Method.Name == "Where")
+            {
+                collected.Add(call);
+            }
+
+            if (call.Arguments.Count == 0)
+            {
+                break;
+            }
+
+            current = call.Arguments[0];
+        }
+
+        for (var i = collected.Count - 1; i >= 0; i--)
+        {
+            innerUsage.AddWhereClause(collected[i]);
+        }
     }
 }
 


### PR DESCRIPTION
`Where` predicates chained onto the inner `IQueryable` passed to `GroupJoin` were silently dropped during SQL compilation. They are now extracted from the inner source expression tree and applied to the inner CTE so filtering happens **before** the join.

## Problem

Given a query like:

```csharp
await session.Query<Customer>()
    .GroupJoin(
        session.Query<Order>().Where(o => o.Status == "Shipped"),
        c => c.Id,
        o => o.CustomerId,
        (c, orders) => new { c, orders })
    .SelectMany(x => x.orders, (x, o) => new { x.c.Name, o.Amount })
    .ToListAsync();
```

The `Where(o => o.Status == "Shipped")` was completely ignored — the inner CTE was built straight from `Order` storage with only the default tenant/soft-delete filters.
