### PR TITLE
Pin JasperFx 1.35.0 cache fix to the TeleHealth scenario (#4329)

### DIFF
--- a/src/DaemonTests/Composites/multi_stage_projections.cs
+++ b/src/DaemonTests/Composites/multi_stage_projections.cs
@@ -353,6 +353,60 @@ public class multi_stage_projections(ITestOutputHelper output): DaemonContext(ou
 
     }
 
+    [Fact]
+    public async Task downstream_lookups_survive_tiny_upstream_cache()
+    {
+        // Regression for the second symptom diagnosed in
+        // https://github.com/JasperFx/marten/issues/4329 — with a small
+        // CacheLimitPerTenant on the upstream AppointmentProjection, every
+        // AppointmentByExternalIdentifier slice's EnrichWith<Appointment>.AddReferences
+        // lookup previously fell through to a SQL load that couldn't see the
+        // upstream's queued in-flight writes, so the downstream document never
+        // materialised. JasperFx.Events 1.35.0 keeps the upstream cache at full
+        // size for the duration of the composite batch, fixing it.
+        StoreOptions(opts =>
+        {
+            opts.Projections.CompositeProjectionFor("TeleHealth", projection =>
+            {
+                projection.Add<ProviderShiftProjection>();
+
+                // Force the failure mode: the upstream Appointment cache holds 1 entry,
+                // but the batch produces many appointments at once, so anything past
+                // the survivor would previously be evicted.
+                var appointments = new AppointmentProjection();
+                appointments.Options.CacheLimitPerTenant = 1;
+                projection.Add(appointments);
+
+                projection.Snapshot<Board>();
+                projection.Add(new AppointmentMetricsProjection());
+
+                // 2nd stage projections — AppointmentByExternalIdentifierProjection is
+                // the one that uses EnrichWith<Appointment>().AddReferences(), so it's
+                // the canary for the eviction bug.
+                projection.Add<AppointmentDetailsProjection>(2);
+                projection.Add<BoardSummaryProjection>(2);
+                projection.Add<AppointmentByExternalIdentifierProjection>(2);
+            });
+        });
+
+        var tenantId = TenantId.DefaultTenantId;
+        _compositeSession = theStore.LightweightSession(tenantId);
+
+        await setUpData(tenantId);
+
+        using var daemon = await StartDaemon();
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(30.Seconds());
+
+        await startAppointments();
+        await daemon.WaitForNonStaleData(30.Seconds());
+
+        // The downstream lookup-by-id projection should be fully populated, even
+        // though the upstream cache is squeezed to 1 entry.
+        (await _compositeSession.Query<Appointment>().CountAsync()).ShouldBeGreaterThan(0);
+        (await _compositeSession.Query<AppointmentByExternalIdentifier>().CountAsync()).ShouldBeGreaterThan(0);
+    }
+
     private static void verifyDescription(EventStoreUsage usage)
     {
         usage.ShouldNotBeNull();


### PR DESCRIPTION
## Summary

Followup coverage for [#4329](https://github.com/JasperFx/marten/issues/4329).

[`multi_stage_projections.end_to_end`](src/DaemonTests/Composites/multi_stage_projections.cs) already covers the composite projection happy path under default cache sizes. This PR adds a focused regression test against the exact reproduction Jeremy [diagnosed in the issue](https://github.com/JasperFx/marten/issues/4329#issuecomment-4390826711):

> with `CacheLimitPerTenant = 1` on `AppointmentProjection`, every `AppointmentByExternalIdentifier` slice's `EnrichWith<Appointment>.AddReferences` lookup falls through to a SQL load that can't see the upstream's queued in-flight writes, so the downstream document never materialises.

[JasperFx.Events 1.35.0 (jasperfx#206)](https://github.com/JasperFx/jasperfx/pull/206) keeps the upstream cache at full size for the duration of the composite batch, which fixes this. [Marten #4338](https://github.com/JasperFx/marten/pull/4338) added a small synthetic `Bug_4329_fan_out_and_cache_limit` test for the cache fix; this PR adds the matching regression *at the original real-world scenario*, so a future change that re-introduces mid-composite compaction would fail loudly here, not just on the smaller synthetic test.

## What changes

- New `[Fact] downstream_lookups_survive_tiny_upstream_cache` in [`multi_stage_projections.cs`](src/DaemonTests/Composites/multi_stage_projections.cs).
- Builds the same TeleHealth composite as `end_to_end`, but registers `AppointmentProjection` as an instance with `Options.CacheLimitPerTenant = 1` instead of the type-only `Add<AppointmentProjection>()`.
- Asserts that both `Appointment` and `AppointmentByExternalIdentifier` have rows after the daemon catches up — the latter being the canary that previously hit zero under the cache eviction bug.

## Test plan

- [x] `downstream_lookups_survive_tiny_upstream_cache` passes on net10.0 (3s).
- [x] All 9 `DaemonTests/Composites/*` tests pass on net10.0 with the new test added (the existing 8 plus the new regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)