### PR TITLE
Add IEventStoreOptions.IgnoreIndex(name)

### DIFF
--- a/docs/events/configuration.md
+++ b/docs/events/configuration.md
@@ -96,3 +96,29 @@ normal schema migration tooling will handle this automatically.
 The `EnableBigIntEvents` flag is `false` by default in Marten 8.x for backward compatibility. Starting
 in **Marten 9.0**, this flag will default to `true`.
 :::
+
+## Ignoring Custom Indexes
+
+If you add an index on one of Marten's event-store tables (`mt_events`, `mt_streams`, or
+`mt_event_progression`) outside of Marten's own schema configuration — for example, via a custom
+`IFeatureSchema` that declares a GIN index — you need to tell Marten's schema migration to leave that
+index alone. Otherwise the diff will see an unmanaged index on a managed table and try to drop it on
+the next `ApplyAllDatabaseChangesOnStartup()`.
+
+`IEventStoreOptions.IgnoreIndex(name)` adds an index name to the ignore list, mirroring the existing
+`DocumentMapping.IgnoreIndex(name)` for document tables:
+
+<!-- snippet: sample_event_store_ignore_index -->
+<a id='snippet-sample_event_store_ignore_index'></a>
+```cs
+var store = DocumentStore.For(opts =>
+{
+    opts.Connection(ConnectionSource.ConnectionString);
+    opts.Events.IgnoreIndex("mt_events_headers_gin_idx");
+});
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/ignoring_indexes_on_event_store_tables.cs#L47-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_event_store_ignore_index' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The ignore list is consulted by all three event-store tables, so a single name will be treated as
+"ignored" wherever it might appear.

--- a/src/EventSourcingTests/ignoring_indexes_on_event_store_tables.cs
+++ b/src/EventSourcingTests/ignoring_indexes_on_event_store_tables.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using Marten;
+using Marten.Events;
+using Marten.Events.Schema;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests;
+
+public class ignoring_indexes_on_event_store_tables
+{
+    [Fact]
+    public void ignored_index_is_propagated_to_events_table()
+    {
+        var graph = new StoreOptions().EventGraph;
+        graph.IgnoreIndex("custom_idx");
+
+        var table = new EventsTable(graph);
+        table.IgnoredIndexes.ShouldContain("custom_idx");
+    }
+
+    [Fact]
+    public void ignored_index_is_propagated_to_streams_table()
+    {
+        var graph = new StoreOptions().EventGraph;
+        graph.IgnoreIndex("custom_idx");
+
+        var table = new StreamsTable(graph);
+        table.IgnoredIndexes.ShouldContain("custom_idx");
+    }
+
+    [Fact]
+    public void ignored_index_is_propagated_to_event_progression_table()
+    {
+        var graph = new StoreOptions().EventGraph;
+        graph.IgnoreIndex("custom_idx");
+
+        var table = new EventProgressionTable(graph);
+        table.IgnoredIndexes.ShouldContain("custom_idx");
+    }
+
+    [Fact]
+    public void ignore_index_through_configuration()
+    {
+        #region sample_event_store_ignore_index
+        var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Events.IgnoreIndex("mt_events_headers_gin_idx");
+        });
+        #endregion
+
+        store.Options.Events.IgnoredIndexes.ShouldContain("mt_events_headers_gin_idx");
+    }
+
+    [Fact]
+    public void ignore_index_is_idempotent()
+    {
+        var graph = new StoreOptions().EventGraph;
+        graph.IgnoreIndex("custom_idx");
+        graph.IgnoreIndex("custom_idx");
+
+        graph.IgnoredIndexes.Count(x => x == "custom_idx").ShouldBe(1);
+    }
+
+    [Fact]
+    public void ignore_index_returns_options_for_chaining()
+    {
+        var graph = new StoreOptions().EventGraph;
+        var result = graph.IgnoreIndex("custom_idx");
+
+        result.ShouldBeSameAs(graph);
+    }
+
+    [Fact]
+    public void ignore_index_rejects_blank_names()
+    {
+        var graph = new StoreOptions().EventGraph;
+        Should.Throw<ArgumentException>(() => graph.IgnoreIndex(""));
+        Should.Throw<ArgumentException>(() => graph.IgnoreIndex("   "));
+    }
+}

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -228,6 +228,21 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
 
     public bool EnableUniqueIndexOnEventId { get; set; } = false;
 
+    private readonly List<string> _ignoredIndexes = new();
+
+    public IReadOnlyList<string> IgnoredIndexes => _ignoredIndexes;
+
+    public IEventStoreOptions IgnoreIndex(string indexName)
+    {
+        if (string.IsNullOrWhiteSpace(indexName))
+            throw new ArgumentException("Index name must be supplied", nameof(indexName));
+
+        if (!_ignoredIndexes.Contains(indexName))
+            _ignoredIndexes.Add(indexName);
+
+        return this;
+    }
+
     /// <summary>
     /// Opt into adding a composite index on (type, seq_id) to the mt_events table.
     /// This can dramatically improve performance for projection rebuilds and async

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -149,6 +149,21 @@ namespace Marten.Events
         public bool EnableEventSkippingInProjectionsOrSubscriptions { get; set; }
 
         /// <summary>
+        ///     Directs the schema migration functionality to ignore the presence of the named index
+        ///     on the event-store tables (<c>mt_events</c>, <c>mt_streams</c>, <c>mt_event_progression</c>).
+        ///     Use this when an external mechanism (e.g. a custom <c>IFeatureSchema</c>) declares an index
+        ///     on a Marten-managed event-store table that Marten itself shouldn't try to manage.
+        /// </summary>
+        /// <param name="indexName">The PostgreSQL index name to ignore</param>
+        /// <returns>Event store options, to allow fluent definition</returns>
+        IEventStoreOptions IgnoreIndex(string indexName);
+
+        /// <summary>
+        ///     Index names that the schema migration functionality should ignore on the event-store tables.
+        /// </summary>
+        IReadOnlyList<string> IgnoredIndexes { get; }
+
+        /// <summary>
         ///     Register an event type with Marten. This isn't strictly necessary for normal usage,
         ///     but can help Marten with asynchronous projections where Marten hasn't yet encountered
         ///     the event type. It can also be used for the event namespace migration.

--- a/src/Marten/Events/IReadOnlyEventStoreOptions.cs
+++ b/src/Marten/Events/IReadOnlyEventStoreOptions.cs
@@ -128,4 +128,9 @@ public interface IReadOnlyEventStoreOptions
     /// meaning that they do not apply to projections or subscriptions. Use this to "cure" bad events
     /// </summary>
     bool EnableEventSkippingInProjectionsOrSubscriptions { get; set; }
+
+    /// <summary>
+    /// Index names that the schema migration functionality should ignore on the event-store tables.
+    /// </summary>
+    IReadOnlyList<string> IgnoredIndexes { get; }
 }

--- a/src/Marten/Events/Schema/EventProgressionTable.cs
+++ b/src/Marten/Events/Schema/EventProgressionTable.cs
@@ -13,6 +13,9 @@ internal class EventProgressionTable: Table
 
     public EventProgressionTable(EventGraph eventGraph): base(new PostgresqlObjectName(eventGraph.DatabaseSchemaName, Name))
     {
+        foreach (var index in eventGraph.IgnoredIndexes)
+            IgnoredIndexes.Add(index);
+
         AddColumn<string>("name").AsPrimaryKey();
         AddColumn("last_seq_id", "bigint").AllowNulls();
         AddColumn("last_updated", "timestamp with time zone")

--- a/src/Marten/Events/Schema/EventsTable.cs
+++ b/src/Marten/Events/Schema/EventsTable.cs
@@ -15,6 +15,9 @@ internal class EventsTable: Table
 {
     public EventsTable(EventGraph events): base(new PostgresqlObjectName(events.DatabaseSchemaName, "mt_events"))
     {
+        foreach (var index in events.IgnoredIndexes)
+            IgnoredIndexes.Add(index);
+
         AddColumn(new SequenceColumn()).AsPrimaryKey();
         AddColumn(new EventTableColumn("id", x => x.Id)).NotNull();
         AddColumn(new StreamIdColumn(events));

--- a/src/Marten/Events/Schema/StreamsTable.cs
+++ b/src/Marten/Events/Schema/StreamsTable.cs
@@ -23,6 +23,9 @@ internal class StreamsTable: Table
 
     public StreamsTable(EventGraph events): base(new PostgresqlObjectName(events.DatabaseSchemaName, TableName))
     {
+        foreach (var index in events.IgnoredIndexes)
+            IgnoredIndexes.Add(index);
+
         // Per https://github.com/JasperFx/marten/issues/2430, this needs to be first in the PK
         if (events.TenancyStyle == TenancyStyle.Conjoined)
         {


### PR DESCRIPTION
Closes #4341.

### What

Adds `IEventStoreOptions.IgnoreIndex(string indexName)`, mirroring the existing `DocumentMapping.IgnoreIndex(string indexName)` for document tables. The ignore list is consulted by all three event-store tables (`mt_events`, `mt_streams`, `mt_event_progression`) so a single `IgnoreIndex("foo")` covers any of them.

### Why

If you add an index on a Marten-managed event-store table outside Marten's own schema (e.g. a custom `IFeatureSchema` declaring `CREATE INDEX ... ON mt_events USING GIN (headers jsonb_path_ops)`), the schema diff sees an unmanaged index on a managed table and drops it on the next `ApplyAllDatabaseChangesOnStartup()`. The same gap was already solved for documents — this PR brings the event-store side to parity.

### Usage

```csharp
services.AddMarten(opts =>
{
    opts.Events.IgnoreIndex("mt_events_headers_gin_idx");
    opts.Events.IgnoreIndex("mt_events_data_gin_idx");
    opts.Storage.Add<EventQueryIndexFeature>();
});
```

### Changes

- `IEventStoreOptions`: new `IgnoreIndex(string)` method + `IReadOnlyList<string> IgnoredIndexes { get; }`.
- `IReadOnlyEventStoreOptions`: same `IgnoredIndexes` property.
- `EventGraph`: backing list + idempotent add + null/whitespace guard.
- `EventsTable`, `StreamsTable`, `EventProgressionTable`: copy `events.IgnoredIndexes` onto the Weasel base `Table.IgnoredIndexes` (mirrors `DocumentTable.cs:25-26`).
- New tests under `src/EventSourcingTests/ignoring_indexes_on_event_store_tables.cs` (7 tests, all passing on net8/9/10 — no DB required).
- Doc snippet + section in `docs/events/configuration.md`.

Opened as draft per the discussion in #4341 — happy to adjust scope or naming.
