### PR TITLE
Security: reject non-identifier regConfig values in full-text search

### DIFF
--- a/src/LinqTests/Bugs/full_text_regconfig_sql_injection.cs
+++ b/src/LinqTests/Bugs/full_text_regconfig_sql_injection.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using JasperFx;
+using Marten;
+using Marten.Linq;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+// Reproduces and locks down the SQL injection vector reported against the
+// regConfig parameter on Marten's full-text search APIs. Pre-fix, the regConfig
+// string was interpolated directly into the generated SQL by
+// FullTextWhereFragment, making every overload below a sink for arbitrary
+// PostgreSQL syntax: time-based blind, information disclosure, DDL, etc.
+//
+// The tests below assert that a regConfig value containing an obvious payload
+// (single quote, semicolon, comment marker, sleep call) does NOT survive into
+// the generated SQL — either by being rejected at query-construction time
+// (preferred) or by being stripped/escaped. Either outcome breaks the
+// injection vector.
+public class full_text_regconfig_sql_injection
+{
+    private const string TimeBasedBlindPayload = "english'::text); SELECT pg_sleep(5); --";
+    private const string ExfiltrationPayload = "english'; SELECT version(); --";
+    private const string DdlPayload = "english'; DROP TABLE mt_doc_article; --";
+
+    public class Article
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Body { get; set; } = string.Empty;
+    }
+
+    private static IDocumentStore BuildStore() => DocumentStore.For(opts =>
+    {
+        opts.Connection(ConnectionSource.ConnectionString);
+        opts.AutoCreateSchemaObjects = AutoCreate.None;
+    });
+
+    // The full set of full-text search overloads that take a user-controllable
+    // regConfig argument and route through FullTextWhereFragment.
+    public static TheoryData<string, Func<IQueryable<Article>, string, IQueryable<Article>>> Overloads => new()
+    {
+        { nameof(LinqExtensions.Search),          (q, rc) => q.Where(x => x.Search("term", rc)) },
+        { nameof(LinqExtensions.PlainTextSearch), (q, rc) => q.Where(x => x.PlainTextSearch("term", rc)) },
+        { nameof(LinqExtensions.PhraseSearch),    (q, rc) => q.Where(x => x.PhraseSearch("term", rc)) },
+        { nameof(LinqExtensions.WebStyleSearch),  (q, rc) => q.Where(x => x.WebStyleSearch("term", rc)) },
+        { nameof(LinqExtensions.PrefixSearch),    (q, rc) => q.Where(x => x.PrefixSearch("term", rc)) },
+    };
+
+    private static readonly string[] InjectionPayloads =
+    [
+        TimeBasedBlindPayload,
+        ExfiltrationPayload,
+        DdlPayload,
+    ];
+
+    [Theory]
+    [MemberData(nameof(Overloads))]
+    public void rejects_injection_payloads_in_regConfig(
+        string overloadName,
+        Func<IQueryable<Article>, string, IQueryable<Article>> apply)
+    {
+        _ = overloadName;
+        using var store = BuildStore();
+        using var session = store.LightweightSession();
+
+        foreach (var payload in InjectionPayloads)
+        {
+            var query = apply(session.Query<Article>(), payload);
+
+            // Either the query refuses to materialise (validation throws), or
+            // the rendered SQL must NOT contain the raw payload. Both outcomes
+            // close the injection vector; we accept either.
+            string? sql = null;
+            try
+            {
+                sql = query.ToCommand(FetchType.FetchMany).CommandText;
+            }
+            catch (ArgumentException)
+            {
+                // Acceptable: validation rejected the input before SQL was generated.
+                continue;
+            }
+
+            // None of these tokens should ever appear in SQL generated from a
+            // legitimate full-text search; their presence means the payload was
+            // interpolated verbatim. The matched substring is what would
+            // otherwise execute on the database.
+            sql.ShouldNotContain("pg_sleep", Case.Insensitive);
+            sql.ShouldNotContain("DROP TABLE", Case.Insensitive);
+            sql.ShouldNotContain("SELECT version", Case.Insensitive);
+            sql.ShouldNotContain("--");
+        }
+    }
+
+    [Theory]
+    [InlineData("english")]
+    [InlineData("french")]
+    [InlineData("simple")]
+    [InlineData("pg_catalog.english")]
+    public void accepts_known_safe_regConfig_values(string regConfig)
+    {
+        using var store = BuildStore();
+        using var session = store.LightweightSession();
+
+        // None of these should throw; all should produce valid SQL referencing
+        // the regconfig name (so we know the parameter is still being honored).
+        var sql = session.Query<Article>()
+            .Where(x => x.PlainTextSearch("term", regConfig))
+            .ToCommand(FetchType.FetchMany)
+            .CommandText;
+
+        sql.ShouldContain(regConfig);
+    }
+}

--- a/src/Marten/Linq/SqlGeneration/Filters/FullTextWhereFragment.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/FullTextWhereFragment.cs
@@ -1,5 +1,7 @@
 #nullable enable
+using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Marten.Linq.Parsing.Methods.FullText;
 using Marten.Schema;
 using Weasel.Postgresql;
@@ -10,6 +12,17 @@ namespace Marten.Linq.SqlGeneration.Filters;
 
 internal class FullTextWhereFragment: ISqlFragment
 {
+    // PostgreSQL text-search configuration names are stored as identifiers in
+    // pg_ts_config (see https://www.postgresql.org/docs/current/textsearch-configuration.html).
+    // We allow simple unquoted identifiers — optionally schema-qualified — so values
+    // like "english", "french", or "pg_catalog.english" pass through, while anything
+    // containing whitespace, quotes, semicolons, or other punctuation is rejected.
+    // This is a security-critical check: regConfig is interpolated into SQL by Sql below,
+    // so any value that escapes this pattern would be a SQL injection sink.
+    private static readonly Regex _regConfigPattern = new(
+        @"^[a-zA-Z_][a-zA-Z0-9_]{0,62}(\.[a-zA-Z_][a-zA-Z0-9_]{0,62})?$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private readonly string _dataConfig;
     private readonly string _regConfig;
     private readonly FullTextSearchFunction _searchFunction;
@@ -18,11 +31,30 @@ internal class FullTextWhereFragment: ISqlFragment
     public FullTextWhereFragment(DocumentMapping? mapping, FullTextSearchFunction searchFunction, string searchTerm,
         string regConfig = FullTextIndexDefinition.DefaultRegConfig)
     {
+        ValidateRegConfig(regConfig);
+
         _regConfig = regConfig;
 
         _dataConfig = GetDataConfig(mapping, regConfig).Replace("data", "d.data");
         _searchFunction = searchFunction;
         _searchTerm = searchTerm;
+    }
+
+    private static void ValidateRegConfig(string regConfig)
+    {
+        if (regConfig is null)
+        {
+            throw new ArgumentNullException(nameof(regConfig));
+        }
+
+        if (!_regConfigPattern.IsMatch(regConfig))
+        {
+            throw new ArgumentException(
+                $"Invalid PostgreSQL text-search configuration name '{regConfig}'. " +
+                "regConfig must be a simple PostgreSQL identifier (optionally schema-qualified), " +
+                "matching ^[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)?$.",
+                nameof(regConfig));
+        }
     }
 
     // don't parameterize full-text search config as it ruins the performance with the query plan in PG


### PR DESCRIPTION
## Summary

**Security fix.** The \`regConfig\` parameter on every full-text search API path —

- \`IQuerySession.SearchAsync<T>(string searchTerm, string regConfig)\`
- \`IQuerySession.PlainTextSearchAsync<T>(...)\`
- \`IQuerySession.PhraseSearchAsync<T>(...)\`
- \`IQuerySession.WebStyleSearchAsync<T>(...)\`
- \`IQuerySession.PrefixSearchAsync<T>(...)\`
- \`IQueryable<T>.Where(x => x.Search(term, regConfig))\` and the matching \`PlainTextSearch\` / \`PhraseSearch\` / \`WebStyleSearch\` / \`PrefixSearch\` extensions

— flowed unchanged into [\`FullTextWhereFragment.Sql\`](src/Marten/Linq/SqlGeneration/Filters/FullTextWhereFragment.cs), which interpolated it directly into the generated SQL inside single quotes:

\`\`\`sql
to_tsvector('{_regConfig}'::regconfig, {_dataConfig})
    @@ {_searchFunction}('{_regConfig}'::regconfig, ?)
\`\`\`

Any \`regConfig\` value carrying a single quote terminated the literal and let an attacker append arbitrary PostgreSQL. Confirmed payloads:

- Time-based blind: \`english'::text); SELECT pg_sleep(5); --\`
- Information disclosure: \`english'; SELECT version(); --\`
- DDL: \`english'; DROP TABLE mt_doc_article; --\`

The reported impact requires the application to forward attacker-controlled input into \`regConfig\` (e.g. \`?lang=…\`), but the API shape strongly invites that pattern.

## Fix

PostgreSQL text-search configuration names are stored as identifiers in \`pg_ts_config\`, so the legitimate value space is narrow. \`FullTextWhereFragment\` now validates \`regConfig\` against \`^[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)?$\` — a simple unquoted PG identifier, optionally schema-qualified, capped at \`NAMEDATALEN-1\` (63) per side — and throws \`ArgumentException\` for anything else. Defaults (\`"english"\`), schema-qualified configs (\`"pg_catalog.english"\`), and the standard PG configurations (\`french\`, \`simple\`, etc.) all pass; injection payloads never reach the SQL generator.

Validating once at fragment construction covers every affected entry point since every code path (LINQ parser via \`FullTextSearchMethodCallParser\` and the \`QuerySession.FullTextSearch\` async helpers) constructs a \`FullTextWhereFragment\` to render the WHERE clause.

The pre-existing \`// don't parameterize full-text search config as it ruins the performance with the query plan in PG\` comment in the fragment is preserved as the rationale for keeping this an interpolated literal rather than a bound parameter — the validation is what now makes that interpolation safe.

## Test plan

New file [\`src/LinqTests/Bugs/full_text_regconfig_sql_injection.cs\`](src/LinqTests/Bugs/full_text_regconfig_sql_injection.cs):

- \`rejects_injection_payloads_in_regConfig\` — Theory across all 5 overloads × 3 payloads (sleep / version / DDL). Asserts that the rendered SQL does **not** contain \`pg_sleep\` / \`DROP TABLE\` / \`SELECT version\` / \`--\`, and accepts an \`ArgumentException\` thrown at construction as an equivalent outcome (both close the vector). **Fails on master, passes after the fix.**
- \`accepts_known_safe_regConfig_values\` — guards that \`"english"\`, \`"french"\`, \`"simple"\`, and \`"pg_catalog.english"\` still produce valid SQL containing the regconfig name.

Run results on net10.0:

- New tests: 9/9 pass after the fix; 5/9 fail on \`master\` (one per affected overload).
- All other LINQ full-text tests: 29/29 pass.
- All \`DocumentDbTests/Indexes\` tests (covers the existing FTS index/search integration tests): 58/58 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)