### PR TITLE
Implement IEventStore explorer methods + projection step-through (#4344, #4345)

### DIFF
--- a/src/EventSourcingTests/Explorer/event_store_explorer_tests.cs
+++ b/src/EventSourcingTests/Explorer/event_store_explorer_tests.cs
@@ -1,0 +1,309 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Explorer;
+
+public record OrderItem(string Sku, int Quantity);
+public record OrderPlaced(string CustomerName);
+public record ItemAdded(OrderItem Item);
+public record OrderShipped(DateTimeOffset At);
+
+public class Order
+{
+    public Guid Id { get; set; }
+    public string CustomerName { get; set; } = "";
+    public List<OrderItem> Items { get; set; } = new();
+    public bool Shipped { get; set; }
+
+    public void Apply(OrderPlaced e) => CustomerName = e.CustomerName;
+    public void Apply(ItemAdded e) => Items.Add(e.Item);
+    public void Apply(OrderShipped _) => Shipped = true;
+}
+
+// Strong-typed identifier for DCB tagging.
+public record CustomerId(Guid Value);
+
+public record CustomerNotified(string Subject);
+
+[Collection("OneOffs")]
+public class event_store_explorer_tests: OneOffConfigurationsContext
+{
+    private void ConfigureStore()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.AddEventType<OrderPlaced>();
+            opts.Events.AddEventType<ItemAdded>();
+            opts.Events.AddEventType<OrderShipped>();
+            opts.Events.AddEventType<CustomerNotified>();
+
+            opts.Events.RegisterTagType<CustomerId>("customer");
+
+            opts.Projections.LiveStreamAggregation<Order>();
+        });
+    }
+
+    [Fact]
+    public async Task get_recent_streams_returns_streams_ordered_by_timestamp_descending()
+    {
+        ConfigureStore();
+
+        var older = Guid.NewGuid();
+        var newer = Guid.NewGuid();
+
+        theSession.Events.Append(older, new OrderPlaced("Alice"));
+        await theSession.SaveChangesAsync();
+
+        await Task.Delay(50);
+
+        theSession.Events.Append(newer, new OrderPlaced("Bob"));
+        await theSession.SaveChangesAsync();
+
+        var explorer = (IEventStore)theStore;
+        var summaries = await explorer.GetRecentStreamsAsync(10, CancellationToken.None);
+
+        summaries.Count.ShouldBeGreaterThanOrEqualTo(2);
+        var ordered = summaries.Take(2).ToList();
+        ordered[0].LastUpdatedAt.ShouldBeGreaterThanOrEqualTo(ordered[1].LastUpdatedAt);
+        ordered.ShouldContain(s => s.StreamId == newer.ToString());
+        ordered.ShouldContain(s => s.StreamId == older.ToString());
+    }
+
+    [Fact]
+    public async Task get_recent_streams_caps_at_safety_bound()
+    {
+        ConfigureStore();
+        var explorer = (IEventStore)theStore;
+
+        // Asking for a million should return at most 1000 — no error.
+        var summaries = await explorer.GetRecentStreamsAsync(1_000_000, CancellationToken.None);
+        summaries.Count.ShouldBeLessThanOrEqualTo(1000);
+    }
+
+    [Fact]
+    public async Task get_recent_streams_zero_returns_empty()
+    {
+        ConfigureStore();
+        var explorer = (IEventStore)theStore;
+
+        var summaries = await explorer.GetRecentStreamsAsync(0, CancellationToken.None);
+        summaries.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task read_stream_returns_events_in_version_order_with_raw_json()
+    {
+        ConfigureStore();
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new OrderPlaced("Charlie"),
+            new ItemAdded(new OrderItem("WIDGET", 2)),
+            new OrderShipped(DateTimeOffset.UtcNow));
+        await theSession.SaveChangesAsync();
+
+        var explorer = (IEventStore)theStore;
+        var collected = new List<EventRecord>();
+        await foreach (var e in explorer.ReadStreamAsync(streamId.ToString(), CancellationToken.None))
+        {
+            collected.Add(e);
+        }
+
+        collected.Count.ShouldBe(3);
+        collected[0].EventTypeName.ShouldBe("order_placed");
+        collected[1].EventTypeName.ShouldBe("item_added");
+        collected[2].EventTypeName.ShouldBe("order_shipped");
+
+        // versions are 1-based and monotonic
+        collected[0].StreamVersion.ShouldBe(1);
+        collected[2].StreamVersion.ShouldBe(3);
+
+        // raw JSON body is preserved
+        collected[0].Data.GetProperty("CustomerName").GetString().ShouldBe("Charlie");
+        collected[1].Data.GetProperty("Item").GetProperty("Sku").GetString().ShouldBe("WIDGET");
+    }
+
+    [Fact]
+    public async Task get_stream_metadata_returns_null_when_stream_missing()
+    {
+        ConfigureStore();
+        var explorer = (IEventStore)theStore;
+
+        var meta = await explorer.GetStreamMetadataAsync(Guid.NewGuid().ToString(), CancellationToken.None);
+        meta.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task get_stream_metadata_returns_full_record()
+    {
+        ConfigureStore();
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId, new OrderPlaced("Dana"), new ItemAdded(new OrderItem("X", 1)));
+        await theSession.SaveChangesAsync();
+
+        var explorer = (IEventStore)theStore;
+        var meta = await explorer.GetStreamMetadataAsync(streamId.ToString(), CancellationToken.None);
+
+        meta.ShouldNotBeNull();
+        meta!.StreamId.ShouldBe(streamId.ToString());
+        meta.Version.ShouldBe(2);
+        meta.IsArchived.ShouldBeFalse();
+        meta.CreatedAt.ShouldBeLessThanOrEqualTo(meta.LastUpdatedAt);
+    }
+
+    [Fact]
+    public async Task query_by_tags_returns_empty_for_unknown_tag_value()
+    {
+        ConfigureStore();
+        var explorer = (IEventStore)theStore;
+
+        var results = new List<EventRecord>();
+        var tags = new Dictionary<string, string> { { "CustomerId", Guid.NewGuid().ToString() } };
+        await foreach (var e in explorer.QueryByTagsAsync(tags, CancellationToken.None))
+        {
+            results.Add(e);
+        }
+
+        results.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task query_by_tags_single_tag_returns_matching_events()
+    {
+        ConfigureStore();
+        var customerId = new CustomerId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        var notification = theSession.Events.BuildEvent(new CustomerNotified("welcome"));
+        notification.WithTag(customerId);
+        theSession.Events.Append(streamId, notification);
+        await theSession.SaveChangesAsync();
+
+        var explorer = (IEventStore)theStore;
+        var results = new List<EventRecord>();
+        var tags = new Dictionary<string, string> { { "CustomerId", customerId.Value.ToString() } };
+        await foreach (var e in explorer.QueryByTagsAsync(tags, CancellationToken.None))
+        {
+            results.Add(e);
+        }
+
+        results.Count.ShouldBe(1);
+        results[0].EventTypeName.ShouldBe("customer_notified");
+        results[0].Data.GetProperty("Subject").GetString().ShouldBe("welcome");
+    }
+
+    [Fact]
+    public async Task query_by_tags_throws_for_unregistered_tag_name()
+    {
+        ConfigureStore();
+        var explorer = (IEventStore)theStore;
+
+        var tags = new Dictionary<string, string> { { "NotARealTag", "x" } };
+        await Should.ThrowAsync<ArgumentException>(async () =>
+        {
+            await foreach (var _ in explorer.QueryByTagsAsync(tags, CancellationToken.None))
+            {
+                // drain
+            }
+        });
+    }
+
+    [Fact]
+    public async Task rehydrate_at_version_returns_aggregate_at_that_version()
+    {
+        ConfigureStore();
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new OrderPlaced("Eve"),
+            new ItemAdded(new OrderItem("A", 1)),
+            new ItemAdded(new OrderItem("B", 2)));
+        await theSession.SaveChangesAsync();
+
+        var explorer = (IEventStore)theStore;
+        var atV2 = await explorer.RehydrateAtVersionAsync<Order>(streamId, version: 2, CancellationToken.None);
+
+        atV2.State.ShouldNotBeNull();
+        atV2.State!.CustomerName.ShouldBe("Eve");
+        atV2.State.Items.Count.ShouldBe(1);
+        atV2.State.Items[0].Sku.ShouldBe("A");
+        atV2.Version.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task rehydrate_at_version_by_name_returns_json_state()
+    {
+        ConfigureStore();
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId, new OrderPlaced("Frank"), new ItemAdded(new OrderItem("X", 1)));
+        await theSession.SaveChangesAsync();
+
+        var explorer = (IEventStore)theStore;
+        var result = await explorer.RehydrateAtVersionByNameAsync(nameof(Order), streamId, version: 2, CancellationToken.None);
+
+        result.ShouldNotBeNull();
+        result!.State.GetProperty("CustomerName").GetString().ShouldBe("Frank");
+        result.Version.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task rehydrate_at_version_by_name_returns_null_for_unknown_aggregate()
+    {
+        ConfigureStore();
+        var explorer = (IEventStore)theStore;
+
+        var result = await explorer.RehydrateAtVersionByNameAsync("DoesNotExist", Guid.NewGuid(), version: 1, CancellationToken.None);
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task get_projection_statuses_lists_registered_projections()
+    {
+        ConfigureStore();
+        var explorer = (IEventStore)theStore;
+
+        var statuses = await explorer.GetProjectionStatusesAsync(CancellationToken.None);
+
+        statuses.ShouldNotBeNull();
+        // Live aggregation typically registers per-projection metadata; the snapshot is non-empty
+        // when ANY projection is configured. We only assert structural fields.
+        foreach (var status in statuses)
+        {
+            status.ProjectionName.ShouldNotBeNull();
+            status.Lifecycle.ShouldNotBeNull();
+            foreach (var shard in status.Shards)
+            {
+                shard.ShardName.ShouldNotBeNull();
+                shard.State.ShouldBe("Unknown");
+                shard.EventStoreSequence.ShouldBeGreaterThanOrEqualTo(0);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task try_create_usage_populates_dcb_tag_types_and_registered_event_types()
+    {
+        ConfigureStore();
+        // Force schema to exist so DescribeDatabasesAsync doesn't blow up.
+        theSession.Events.Append(Guid.NewGuid(), new OrderPlaced("Gus"));
+        await theSession.SaveChangesAsync();
+
+        var explorer = (IEventStore)theStore;
+        var usage = await explorer.TryCreateUsage(CancellationToken.None);
+
+        usage.ShouldNotBeNull();
+        usage!.DcbTagTypes.ShouldContain(t => t.Name == nameof(CustomerId));
+        usage.RegisteredEventTypes.ShouldContain(e => e.Alias == "order_placed");
+        usage.RegisteredEventTypes.ShouldContain(e => e.Alias == "item_added");
+    }
+}

--- a/src/EventSourcingTests/Explorer/projection_replay_tests.cs
+++ b/src/EventSourcingTests/Explorer/projection_replay_tests.cs
@@ -1,0 +1,217 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Explorer;
+
+public record CounterIncremented(int By);
+public record CounterReset();
+public record CounterErrors();
+
+public class Counter
+{
+    public Guid Id { get; set; }
+    public int Value { get; set; }
+
+    public void Apply(CounterIncremented e) => Value += e.By;
+    public void Apply(CounterReset _) => Value = 0;
+    public void Apply(CounterErrors _) => throw new InvalidOperationException("apply blew up");
+}
+
+[Collection("OneOffs")]
+public class projection_replay_tests: OneOffConfigurationsContext
+{
+    private void ConfigureStore()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.AddEventType<CounterIncremented>();
+            opts.Events.AddEventType<CounterReset>();
+            opts.Events.AddEventType<CounterErrors>();
+
+            opts.Projections.LiveStreamAggregation<Counter>();
+        });
+    }
+
+    private static async Task<List<EventRecord>> ReadStreamRecordsAsync(IEventStore explorer, Guid streamId)
+    {
+        var list = new List<EventRecord>();
+        await foreach (var e in explorer.ReadStreamAsync(streamId.ToString(), CancellationToken.None))
+        {
+            list.Add(e);
+        }
+        return list;
+    }
+
+    [Fact]
+    public async Task run_projection_typed_replays_events_with_per_step_state()
+    {
+        ConfigureStore();
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new CounterIncremented(1),
+            new CounterIncremented(2),
+            new CounterIncremented(3));
+        await theSession.SaveChangesAsync();
+
+        var explorer = (IEventStore)theStore;
+        var records = await ReadStreamRecordsAsync(explorer, streamId);
+
+        var timeline = await explorer.RunProjectionAsync<Counter>(
+            projectionName: nameof(Counter),
+            identity: streamId,
+            events: records,
+            startingState: null,
+            ct: CancellationToken.None);
+
+        timeline.Steps.Count.ShouldBe(3);
+        timeline.Steps[0].After!.Value.ShouldBe(1);
+        timeline.Steps[1].After!.Value.ShouldBe(3);
+        timeline.Steps[2].After!.Value.ShouldBe(6);
+        timeline.FinalState!.Value.ShouldBe(6);
+        timeline.Steps.ShouldAllBe(s => s.Error == null);
+    }
+
+    [Fact]
+    public async Task run_projection_typed_continues_past_throwing_event()
+    {
+        ConfigureStore();
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new CounterIncremented(5),
+            new CounterErrors(),
+            new CounterIncremented(2));
+        await theSession.SaveChangesAsync();
+
+        var explorer = (IEventStore)theStore;
+        var records = await ReadStreamRecordsAsync(explorer, streamId);
+
+        var timeline = await explorer.RunProjectionAsync<Counter>(
+            nameof(Counter), streamId, records, startingState: null, CancellationToken.None);
+
+        timeline.Steps.Count.ShouldBe(3);
+        timeline.Steps[0].Error.ShouldBeNull();
+        timeline.Steps[0].After!.Value.ShouldBe(5);
+
+        timeline.Steps[1].Error.ShouldNotBeNull();
+        // After should equal Before when the apply threw — per ProjectionStepResult docs.
+        timeline.Steps[1].After!.Value.ShouldBe(timeline.Steps[1].Before!.Value);
+
+        timeline.Steps[2].Error.ShouldBeNull();
+        // The third event applies on top of the last successful state.
+        timeline.Steps[2].After!.Value.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task run_projection_typed_uses_starting_state_for_pagination()
+    {
+        ConfigureStore();
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new CounterIncremented(1),
+            new CounterIncremented(2),
+            new CounterIncremented(3),
+            new CounterIncremented(4));
+        await theSession.SaveChangesAsync();
+
+        var explorer = (IEventStore)theStore;
+        var records = await ReadStreamRecordsAsync(explorer, streamId);
+        records.Count.ShouldBe(4);
+
+        var firstHalf = records.Take(2).ToList();
+        firstHalf.Count.ShouldBe(2);
+        var secondHalf = records.Skip(2).ToList();
+        secondHalf.Count.ShouldBe(2);
+
+        var page1 = await explorer.RunProjectionAsync<Counter>(
+            nameof(Counter), streamId, firstHalf, startingState: null, CancellationToken.None);
+
+        page1.Steps.Count.ShouldBe(2);
+        page1.FinalState!.Value.ShouldBe(3);
+
+        var page2 = await explorer.RunProjectionAsync<Counter>(
+            nameof(Counter), streamId, secondHalf, startingState: page1.FinalState, CancellationToken.None);
+
+        page2.FinalState!.Value.ShouldBe(10);
+        page2.Steps[0].Before!.Value.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task run_projection_typed_throws_on_aggregate_type_mismatch()
+    {
+        ConfigureStore();
+        var explorer = (IEventStore)theStore;
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+        {
+            await explorer.RunProjectionAsync<string>(
+                nameof(Counter), Guid.NewGuid(), Array.Empty<EventRecord>(), startingState: null, CancellationToken.None);
+        });
+    }
+
+    [Fact]
+    public async Task run_projection_by_name_returns_json_state_per_step()
+    {
+        ConfigureStore();
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new CounterIncremented(10),
+            new CounterIncremented(20));
+        await theSession.SaveChangesAsync();
+
+        var explorer = (IEventStore)theStore;
+        var records = await ReadStreamRecordsAsync(explorer, streamId);
+
+        var timeline = await explorer.RunProjectionByNameAsync(
+            nameof(Counter), streamId, records, startingState: null, CancellationToken.None);
+
+        timeline.Steps.Count.ShouldBe(2);
+        timeline.Steps[0].After!.Value.GetProperty("Value").GetInt32().ShouldBe(10);
+        timeline.Steps[1].After!.Value.GetProperty("Value").GetInt32().ShouldBe(30);
+        timeline.FinalState!.Value.GetProperty("Value").GetInt32().ShouldBe(30);
+    }
+
+    [Fact]
+    public async Task run_projection_by_name_records_error_message_on_failure()
+    {
+        ConfigureStore();
+        var streamId = Guid.NewGuid();
+        theSession.Events.Append(streamId,
+            new CounterIncremented(1),
+            new CounterErrors());
+        await theSession.SaveChangesAsync();
+
+        var explorer = (IEventStore)theStore;
+        var records = await ReadStreamRecordsAsync(explorer, streamId);
+
+        var timeline = await explorer.RunProjectionByNameAsync(
+            nameof(Counter), streamId, records, startingState: null, CancellationToken.None);
+
+        timeline.Steps[0].Error.ShouldBeNull();
+        timeline.Steps[1].Error.ShouldNotBeNull();
+        timeline.Steps[1].Error!.ShouldContain("apply blew up");
+    }
+
+    [Fact]
+    public async Task run_projection_throws_for_unknown_projection_name()
+    {
+        ConfigureStore();
+        var explorer = (IEventStore)theStore;
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(async () =>
+        {
+            await explorer.RunProjectionByNameAsync(
+                "DoesNotExist", Guid.NewGuid(), Array.Empty<EventRecord>(), startingState: null, CancellationToken.None);
+        });
+    }
+}

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -391,6 +391,25 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
                 TableSuffix = registration.TableSuffix,
                 AggregateType = registration.AggregateType?.FullName,
             });
+
+            // Richer descriptor used by the event store explorer's tag-list view —
+            // carries the strong TypeDescriptor and an operator-facing description
+            // (currently null until Marten exposes a description on the registration).
+            usage.DcbTagTypes.Add(new DcbTagDescriptor(
+                registration.TagType.Name,
+                registration.SimpleType.FullName ?? registration.SimpleType.Name,
+                TypeDescriptor.For(registration.TagType),
+                Description: null));
+        }
+
+        // Configured event-type registrations — surface every event alias the store
+        // knows about so the explorer can render the registered event surface.
+        foreach (var eventMapping in Options.EventGraph.AllEvents())
+        {
+            usage.RegisteredEventTypes.Add(new EventTypeDescriptor(
+                TypeDescriptor.For(eventMapping.DocumentType),
+                eventMapping.EventTypeName,
+                Description: null));
         }
 
         // Aggregates that live outside the multi-tenant boundary in tenanted

--- a/src/Marten/DocumentStore.EventStoreExplorer.cs
+++ b/src/Marten/DocumentStore.EventStoreExplorer.cs
@@ -1,0 +1,730 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+using Marten.Events;
+using Marten.Events.Projections;
+using Marten.Internal.Sessions;
+using Marten.Services;
+using Marten.Storage;
+using Npgsql;
+
+namespace Marten;
+
+public partial class DocumentStore
+{
+    /// <summary>
+    /// Hard cap on the count <see cref="GetRecentStreamsAsync"/> will honour, regardless
+    /// of the value the caller passes in. Bounds the explorer's stream-list view at a
+    /// page size that any single Postgres index scan can satisfy without surprise cost.
+    /// </summary>
+    private const int RecentStreamsCap = 1000;
+
+    private static readonly JsonSerializerOptions ExplorerJson = new()
+    {
+        PropertyNamingPolicy = null
+    };
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Returns the most recently updated streams across every tenant, ordered by the
+    /// stream's <c>timestamp</c> column (last append) descending. Hard-capped at
+    /// <see cref="RecentStreamsCap"/> regardless of the requested count to keep the
+    /// explorer's stream-list view bounded. Archived streams are included.
+    /// </remarks>
+    async Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(int count, CancellationToken ct)
+    {
+        var limit = Math.Clamp(count, 0, RecentStreamsCap);
+        if (limit == 0) return Array.Empty<StreamSummary>();
+
+        await using var session = openExplorerSession();
+        await session.Database.EnsureStorageExistsAsync(typeof(IEvent), ct).ConfigureAwait(false);
+
+        // The leading six columns deliberately mirror IEventStorage.StreamStateSelectSql
+        // (#4359) so readStreamRowAsync below can read them with the same column
+        // ordering the codegen path uses for FetchStreamStateAsync. The
+        // event_storage_stream_state_selector test (added in #4359) enforces the column
+        // list against the selector's Resolve method; this site's matching SELECT is
+        // verified by the explorer tests in EventSourcingTests/Explorer.
+        var schema = Options.EventGraph.DatabaseSchemaName;
+        var cmd = new NpgsqlCommand(
+            $"select id, version, type, timestamp, created, is_archived, tenant_id from {schema}.mt_streams " +
+            "order by timestamp desc limit @limit");
+        cmd.Parameters.AddWithValue("limit", limit);
+
+        var summaries = new List<StreamSummary>(limit);
+        await using var reader = await session.ExecuteReaderAsync(cmd, ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var row = await readStreamRowAsync(reader, ct).ConfigureAwait(false);
+            var tenantId = await reader.IsDBNullAsync(StreamStateColumnCount, ct).ConfigureAwait(false)
+                ? null
+                : reader.GetString(StreamStateColumnCount);
+
+            summaries.Add(new StreamSummary(row.StreamId, row.StreamType, row.Version, row.Created, row.LastUpdated, tenantId));
+        }
+
+        return summaries;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Streams the events of a single stream from oldest to newest as raw JSON, suitable
+    /// for the explorer's stream-detail timeline view. The body and metadata are returned
+    /// as untyped <see cref="JsonElement"/> instances so the descriptor stays untyped at
+    /// the JasperFx layer; tag data is intentionally <see langword="null"/> here because
+    /// the per-event tag join would multiply the row cost — explorers that need tags
+    /// should use <c>QueryByTagsAsync</c>.
+    /// </remarks>
+    async IAsyncEnumerable<EventRecord> IEventStore.ReadStreamAsync(string streamId, [EnumeratorCancellation] CancellationToken ct)
+    {
+        var schema = Options.EventGraph.DatabaseSchemaName;
+        var sql =
+            $"select id, seq_id, version, stream_id, type, data, timestamp, tenant_id " +
+            $"from {schema}.mt_events " +
+            $"where stream_id = @stream_id " +
+            $"order by version asc";
+
+        await using var session = openExplorerSession();
+        await session.Database.EnsureStorageExistsAsync(typeof(IEvent), ct).ConfigureAwait(false);
+
+        var cmd = new NpgsqlCommand(sql);
+        cmd.Parameters.AddWithValue("stream_id", parseStreamId(streamId));
+
+        await using var reader = await session.ExecuteReaderAsync(cmd, ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            yield return await readEventRecordAsync(reader, ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Returns full diagnostic metadata for a single stream — version, timestamps,
+    /// archive flag, tenant. <see cref="StreamMetadata.SnapshotVersion"/> and
+    /// <see cref="StreamMetadata.LastSnapshotAt"/> are always <see langword="null"/> on
+    /// Marten 9.0+ because <c>mt_streams</c> no longer carries snapshot-version columns
+    /// (#4316). The Tags map is empty because Marten stores tags per-event rather than
+    /// per-stream; future work could surface the union of tags applied to the stream's
+    /// events. Returns <see langword="null"/> when no row exists for the requested id.
+    /// </remarks>
+    async Task<StreamMetadata?> IEventStore.GetStreamMetadataAsync(string streamId, CancellationToken ct)
+    {
+        await using var session = openExplorerSession();
+        await session.Database.EnsureStorageExistsAsync(typeof(IEvent), ct).ConfigureAwait(false);
+
+        // Same shared-column-ordering story as GetRecentStreamsAsync — the leading
+        // six columns match IEventStorage.StreamStateSelectSql (#4359). The trailing
+        // ordinals are addressed off StreamStateColumnCount so any future change to
+        // the shared selector's column count surfaces here as a single update site.
+        var schema = Options.EventGraph.DatabaseSchemaName;
+        var cmd = new NpgsqlCommand(
+            $"select id, version, type, timestamp, created, is_archived, tenant_id from {schema}.mt_streams " +
+            "where id = @stream_id limit 1");
+        cmd.Parameters.AddWithValue("stream_id", parseStreamId(streamId));
+
+        await using var reader = await session.ExecuteReaderAsync(cmd, ct).ConfigureAwait(false);
+        if (!await reader.ReadAsync(ct).ConfigureAwait(false)) return null;
+
+        var row = await readStreamRowAsync(reader, ct).ConfigureAwait(false);
+        var tenantId = await reader.IsDBNullAsync(StreamStateColumnCount, ct).ConfigureAwait(false)
+            ? null
+            : reader.GetString(StreamStateColumnCount);
+
+        return new StreamMetadata(
+            row.StreamId,
+            row.StreamType,
+            row.Version,
+            row.Created,
+            row.LastUpdated,
+            // LastSnapshotAt / LastSnapshotVersion are null under Marten 9.0+ —
+            // the mt_streams snapshot columns were dropped in #4316 as vestigial.
+            LastSnapshotAt: null,
+            LastSnapshotVersion: null,
+            row.IsArchived,
+            tenantId,
+            new Dictionary<string, string>(0));
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Streams events whose tag set matches every entry in <paramref name="tags"/> (AND
+    /// semantics across keys). Each key is the tag-type's CLR short name (e.g.
+    /// <c>"StudentId"</c>) — looked up against <see cref="EventGraph.TagTypes"/>. Values
+    /// are compared as text against the <c>value</c> column of each tag table; this is
+    /// permissive (works for string, Guid, integer tag inner types) at the cost of always
+    /// going through Postgres' text cast. Throws <see cref="ArgumentException"/> when a
+    /// tag name is not registered.
+    /// </remarks>
+    async IAsyncEnumerable<EventRecord> IEventStore.QueryByTagsAsync(
+        IReadOnlyDictionary<string, string> tags,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        if (tags == null) throw new ArgumentNullException(nameof(tags));
+
+        await using var session = openExplorerSession();
+        await session.Database.EnsureStorageExistsAsync(typeof(IEvent), ct).ConfigureAwait(false);
+
+        if (tags.Count == 0) yield break;
+
+        var schema = Options.EventGraph.DatabaseSchemaName;
+        var registered = Options.EventGraph.TagTypes;
+
+        var subqueries = new List<string>(tags.Count);
+        var parameters = new List<NpgsqlParameter>(tags.Count);
+        var idx = 0;
+        foreach (var (tagName, tagValue) in tags)
+        {
+            var registration = registered.FirstOrDefault(r => string.Equals(r.TagType.Name, tagName, StringComparison.OrdinalIgnoreCase));
+            if (registration == null)
+            {
+                throw new ArgumentException(
+                    $"Tag type '{tagName}' is not registered on this event store. Registered tag types: {registered.Select(t => t.TagType.Name).Join(", ")}",
+                    nameof(tags));
+            }
+
+            var tagTable = $"{schema}.mt_event_tag_{registration.TableSuffix}";
+            var paramName = $"@tag_value_{idx}";
+            subqueries.Add($"e.seq_id in (select seq_id from {tagTable} where value::text = {paramName})");
+            parameters.Add(new NpgsqlParameter($"tag_value_{idx}", tagValue));
+            idx++;
+        }
+
+        var sql =
+            $"select e.id, e.seq_id, e.version, e.stream_id, e.type, e.data, e.timestamp, e.tenant_id " +
+            $"from {schema}.mt_events e " +
+            $"where {subqueries.Join(" and ")} " +
+            $"order by e.seq_id asc";
+
+        var cmd = new NpgsqlCommand(sql);
+        foreach (var p in parameters) cmd.Parameters.Add(p);
+
+        await using var reader = await session.ExecuteReaderAsync(cmd, ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            yield return await readEventRecordAsync(reader, ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Looks up the named projection on <see cref="StoreOptions.Projections"/>, runs the
+    /// tag-matched events through it via Marten's aggregator infrastructure, and returns
+    /// the projected state serialized as JSON. Returns <see langword="null"/> when the
+    /// projection is not registered or no events match the tag set.
+    /// </remarks>
+    async Task<DcbProjectedState?> IEventStore.GetProjectedStateForTagsAsync(
+        string projectionName,
+        IReadOnlyDictionary<string, string> tags,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(projectionName)) throw new ArgumentNullException(nameof(projectionName));
+
+        var source = Options.Projections.All.FirstOrDefault(x => x.Name.EqualsIgnoreCase(projectionName));
+        if (source is not IAggregateProjection aggregate) return null;
+
+        var events = new List<EventRecord>();
+        await foreach (var ev in ((IEventStore)this).QueryByTagsAsync(tags, ct).ConfigureAwait(false))
+        {
+            events.Add(ev);
+        }
+        if (events.Count == 0) return null;
+
+        var aggregateType = aggregate.AggregateType;
+        var (state, _) = await replayAggregatorAsync(aggregateType, startingState: null, events, ct).ConfigureAwait(false);
+        if (state == null) return null;
+
+        var stateJson = JsonSerializer.SerializeToElement(state, aggregateType, ExplorerJson);
+        return new DcbProjectedState(projectionName, events[^1].Sequence, stateJson, events.Count);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Rehydrates an aggregate to a specific stream version using Marten's existing
+    /// <c>AggregateStreamAsync</c> API. Identity may be a <see cref="Guid"/>, a string
+    /// stream key, or a strongly-typed identifier — the override dispatches on
+    /// <see cref="EventGraph.StreamIdentity"/>.
+    /// </remarks>
+    async Task<AggregateAtVersion<TAggregate>> IEventStore.RehydrateAtVersionAsync<TAggregate>(
+        object identity, long version, CancellationToken ct) where TAggregate : class
+    {
+        await using var session = QuerySession();
+        TAggregate? state;
+        if (Options.EventGraph.StreamIdentity == StreamIdentity.AsGuid)
+        {
+            var streamId = identity is Guid g ? g : Guid.Parse(identity.ToString()!);
+            state = await session.Events.AggregateStreamAsync<TAggregate>(streamId, version, token: ct).ConfigureAwait(false);
+        }
+        else
+        {
+            var streamKey = identity.ToString()!;
+            state = await session.Events.AggregateStreamAsync<TAggregate>(streamKey, version, token: ct).ConfigureAwait(false);
+        }
+
+        return new AggregateAtVersion<TAggregate>(state, version, version);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Looks up the projection by aggregate-type name (matches CLR <see cref="Type.FullName"/>
+    /// or short <see cref="Type.Name"/>), dispatches to the strong-typed rehydration path
+    /// via reflection, and returns the result as JSON so consumers don't need the
+    /// aggregate's CLR type. Returns <see langword="null"/> when no matching aggregate
+    /// type is registered.
+    /// </remarks>
+    async Task<AggregateAtVersion?> IEventStore.RehydrateAtVersionByNameAsync(
+        string aggregateTypeName, object identity, long version, CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(aggregateTypeName)) throw new ArgumentNullException(nameof(aggregateTypeName));
+
+        var aggregateType = findAggregateTypeByName(aggregateTypeName);
+        if (aggregateType == null) return null;
+
+        await using var session = QuerySession();
+        var aggregate = await invokeAggregateStreamAsync(aggregateType, session, identity, version, ct).ConfigureAwait(false);
+        if (aggregate == null)
+        {
+            return new AggregateAtVersion(aggregateType.FullNameInCode(), default, version, 0);
+        }
+
+        var stateJson = JsonSerializer.SerializeToElement(aggregate, aggregateType, ExplorerJson);
+        return new AggregateAtVersion(aggregateType.FullNameInCode(), stateJson, version, version);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Builds a per-projection snapshot from <see cref="StoreOptions.Projections"/>: each
+    /// registered projection contributes one <see cref="ProjectionStatus"/>, and each
+    /// shard contributes a <see cref="ShardStatus"/> populated from
+    /// <c>mt_event_progression</c>. The current event-store head sequence is read once
+    /// up-front so every shard reports the same reference point. Live state (<c>"Running"</c>,
+    /// <c>"Paused"</c>, ...) is not snapshotted here — operators get that via the existing
+    /// <c>ShardStatesChanged</c> event; this method always reports <c>"Unknown"</c>.
+    /// </remarks>
+    async Task<IReadOnlyList<ProjectionStatus>> IEventStore.GetProjectionStatusesAsync(CancellationToken ct)
+    {
+        await using var session = openExplorerSession();
+        await session.Database.EnsureStorageExistsAsync(typeof(IEvent), ct).ConfigureAwait(false);
+
+        var schema = Options.EventGraph.DatabaseSchemaName;
+        var headSequence = await readHeadSequenceAsync(session, schema, ct).ConfigureAwait(false);
+        var progression = await readProgressionAsync(session, schema, ct).ConfigureAwait(false);
+
+        var statuses = new List<ProjectionStatus>();
+        foreach (var source in Options.Projections.All)
+        {
+            var shards = source.Shards();
+            var shardStatuses = new List<ShardStatus>(shards.Count);
+            foreach (var shard in shards)
+            {
+                var processed = progression.TryGetValue(shard.Name.Identity, out var seq) ? seq : 0L;
+                shardStatuses.Add(new ShardStatus(
+                    shard.Name.Identity,
+                    State: "Unknown",
+                    ProcessedSequence: processed,
+                    EventStoreSequence: headSequence,
+                    Error: null));
+            }
+
+            statuses.Add(new ProjectionStatus(source.Name, source.Lifecycle.ToString(), shardStatuses));
+        }
+
+        return statuses;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Strong-typed projection step-through: feeds <paramref name="events"/> into the
+    /// named projection one at a time and captures Before / After state plus elapsed time
+    /// at each step. Per-step exceptions are caught and surfaced on
+    /// <see cref="ProjectionStepResult{TState}.Error"/> — the timeline continues so the
+    /// UI can show "this event broke this projection." Stateless: nothing is persisted.
+    /// </remarks>
+    async Task<ProjectionTimeline<TState>> IEventStore.RunProjectionAsync<TState>(
+        string projectionName,
+        object identity,
+        IReadOnlyList<EventRecord> events,
+        TState? startingState,
+        CancellationToken ct)
+        where TState : default
+    {
+        var aggregateType = findProjectionAggregateType(projectionName);
+        if (aggregateType != typeof(TState))
+        {
+            throw new ArgumentException(
+                $"Projection '{projectionName}' is over '{aggregateType.FullNameInCode()}', not '{typeof(TState).FullNameInCode()}'.",
+                nameof(projectionName));
+        }
+
+        var rawSteps = await runProjectionStepsAsync(aggregateType, startingState, events, ct).ConfigureAwait(false);
+
+        var typedSteps = new List<ProjectionStepResult<TState>>(rawSteps.Count);
+        foreach (var s in rawSteps)
+        {
+            typedSteps.Add(new ProjectionStepResult<TState>(s.Event, castToTState<TState>(s.Before), castToTState<TState>(s.After), s.Elapsed, s.Error));
+        }
+
+        var finalState = rawSteps.LastOrDefault(x => x.Error == null)?.After ?? rawSteps.LastOrDefault()?.After;
+        return new ProjectionTimeline<TState>(typedSteps, castToTState<TState>(finalState));
+    }
+
+    private static TState? castToTState<TState>(object? value)
+    {
+        if (value is null) return default;
+        return (TState)value;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Untyped projection step-through: looks up the projection by name, resolves its
+    /// aggregate CLR type from <see cref="IAggregateProjection.AggregateType"/>, runs the
+    /// events through it, and serializes each per-step state snapshot to
+    /// <see cref="JsonElement"/>. The error is reduced to its message so the record can
+    /// round-trip over the wire.
+    /// </remarks>
+    async Task<ProjectionTimelineRaw> IEventStore.RunProjectionByNameAsync(
+        string projectionName,
+        object identity,
+        IReadOnlyList<EventRecord> events,
+        JsonElement? startingState,
+        CancellationToken ct)
+    {
+        var aggregateType = findProjectionAggregateType(projectionName);
+        var startObj = startingState?.Deserialize(aggregateType, ExplorerJson);
+
+        var rawSteps = await runProjectionStepsAsync(aggregateType, startObj, events, ct).ConfigureAwait(false);
+
+        var stepRecords = new List<ProjectionStepResultRaw>(rawSteps.Count);
+        foreach (var s in rawSteps)
+        {
+            JsonElement? beforeJson = s.Before == null ? null : JsonSerializer.SerializeToElement(s.Before, aggregateType, ExplorerJson);
+            JsonElement? afterJson = s.After == null ? null : JsonSerializer.SerializeToElement(s.After, aggregateType, ExplorerJson);
+            stepRecords.Add(new ProjectionStepResultRaw(s.Event, beforeJson, afterJson, s.Elapsed, s.Error?.Message));
+        }
+
+        var finalObj = rawSteps.LastOrDefault(x => x.Error == null)?.After ?? rawSteps.LastOrDefault()?.After;
+        JsonElement? finalJson = finalObj == null ? null : JsonSerializer.SerializeToElement(finalObj, aggregateType, ExplorerJson);
+
+        return new ProjectionTimelineRaw(stepRecords, finalJson);
+    }
+
+    private Type findProjectionAggregateType(string projectionName)
+    {
+        var source = Options.Projections.All.FirstOrDefault(x => x.Name.EqualsIgnoreCase(projectionName))
+            ?? throw new ArgumentOutOfRangeException(nameof(projectionName),
+                $"No projection named '{projectionName}' is registered. Available projections: {Options.Projections.All.Select(p => p.Name).Join(", ")}");
+
+        if (source is not IAggregateProjection aggregateProjection)
+        {
+            throw new ArgumentException(
+                $"Projection '{projectionName}' is not an aggregate projection.",
+                nameof(projectionName));
+        }
+
+        return aggregateProjection.AggregateType;
+    }
+
+    /// <summary>
+    /// Replay events through a projection's Apply methods one event at a time using
+    /// reflection. Stateless: no database session is opened, no persistence happens.
+    /// Per-step exceptions are caught and surfaced on the step result so the caller's
+    /// timeline can show "this event broke this projection." Suitable for the
+    /// explorer's stepper view; not for projections that depend on session lookups
+    /// inside Apply (those need the full aggregator machinery).
+    /// </summary>
+    private Task<IReadOnlyList<ObjectStepResult>> runProjectionStepsAsync(
+        Type aggregateType, object? startingState, IReadOnlyList<EventRecord> events, CancellationToken ct)
+    {
+        var steps = new List<ObjectStepResult>(events.Count);
+        var current = startingState;
+
+        foreach (var record in events)
+        {
+            ct.ThrowIfCancellationRequested();
+            var before = cloneViaJson(current, aggregateType);
+            var sw = Stopwatch.StartNew();
+            object? after;
+            Exception? error = null;
+            try
+            {
+                var domainEventData = deserializeEventBody(record);
+                current = applyEventToAggregate(aggregateType, current, domainEventData);
+                after = cloneViaJson(current, aggregateType);
+            }
+            catch (Exception ex)
+            {
+                error = ex;
+                after = before;
+            }
+            sw.Stop();
+            steps.Add(new ObjectStepResult(record, before, after, sw.Elapsed, error));
+        }
+
+        return Task.FromResult<IReadOnlyList<ObjectStepResult>>(steps);
+    }
+
+    private async Task<(object? state, long count)> replayAggregatorAsync(
+        Type aggregateType, object? startingState, IReadOnlyList<EventRecord> records, CancellationToken ct)
+    {
+        if (records.Count == 0) return (startingState, 0);
+
+        var current = startingState;
+        foreach (var record in records)
+        {
+            ct.ThrowIfCancellationRequested();
+            var data = deserializeEventBody(record);
+            current = applyEventToAggregate(aggregateType, current, data);
+        }
+        return await Task.FromResult((current, (long)records.Count)).ConfigureAwait(false);
+    }
+
+    private object? applyEventToAggregate(Type aggregateType, object? state, object eventData)
+    {
+        state ??= Activator.CreateInstance(aggregateType)
+            ?? throw new InvalidOperationException(
+                $"Cannot construct projection state of type '{aggregateType.FullNameInCode()}' — no parameterless constructor.");
+
+        var eventDataType = eventData.GetType();
+        // Direct Apply(TEvent) — the canonical Marten projection shape.
+        var applyMethod = aggregateType.GetMethod("Apply", new[] { eventDataType });
+        if (applyMethod != null)
+        {
+            try { applyMethod.Invoke(state, new[] { eventData }); }
+            catch (TargetInvocationException tie) when (tie.InnerException != null)
+            {
+                throw tie.InnerException;
+            }
+            return state;
+        }
+
+        // Fallback: Apply(IEvent<TEvent>) — shape used by projections that need event metadata.
+        var ieventOfT = typeof(IEvent<>).MakeGenericType(eventDataType);
+        var wrappedApply = aggregateType.GetMethod("Apply", new[] { ieventOfT });
+        if (wrappedApply != null)
+        {
+            var eventCtor = typeof(Event<>).MakeGenericType(eventDataType).GetConstructor(new[] { eventDataType })!;
+            var wrapped = eventCtor.Invoke(new[] { eventData });
+            try { wrappedApply.Invoke(state, new[] { wrapped }); }
+            catch (TargetInvocationException tie) when (tie.InnerException != null)
+            {
+                throw tie.InnerException;
+            }
+            return state;
+        }
+
+        // No Apply method matched — silently skip. The step records this by reporting
+        // the event but leaving state unchanged (no error).
+        return state;
+    }
+
+    private object deserializeEventBody(EventRecord record)
+    {
+        var mapping = Options.EventGraph.AllEvents().FirstOrDefault(m => m.EventTypeName.EqualsIgnoreCase(record.EventTypeName))
+            ?? throw new InvalidOperationException(
+                $"Event type '{record.EventTypeName}' is not registered. Add it via StoreOptions.Events.AddEventType.");
+
+        var dataObj = record.Data.Deserialize(mapping.DocumentType, ExplorerJson)
+            ?? throw new InvalidOperationException(
+                $"Failed to deserialize event of type '{record.EventTypeName}' from supplied JSON.");
+        return dataObj;
+    }
+
+    private static object? cloneViaJson(object? value, Type type)
+    {
+        if (value is null) return null;
+        var json = JsonSerializer.SerializeToElement(value, type, ExplorerJson);
+        return json.Deserialize(type, ExplorerJson);
+    }
+
+    private async Task<object?> invokeAggregateStreamAsync(
+        Type aggregateType, IQuerySession session, object identity, long version, CancellationToken ct)
+    {
+        var streamIdentity = Options.EventGraph.StreamIdentity;
+        var idArgType = streamIdentity == StreamIdentity.AsGuid ? typeof(Guid) : typeof(string);
+
+        var aggregateMethod = typeof(IQueryEventStore).GetMethods()
+            .FirstOrDefault(m =>
+                m.Name == nameof(IQueryEventStore.AggregateStreamAsync) &&
+                m.IsGenericMethodDefinition &&
+                m.GetParameters().Length >= 1 &&
+                m.GetParameters()[0].ParameterType == idArgType);
+
+        if (aggregateMethod == null) return null;
+        var closed = aggregateMethod.MakeGenericMethod(aggregateType);
+
+        object idValue;
+        if (streamIdentity == StreamIdentity.AsGuid)
+        {
+            idValue = identity is Guid g ? g : Guid.Parse(identity.ToString()!);
+        }
+        else
+        {
+            idValue = identity.ToString()!;
+        }
+
+        var paramInfos = closed.GetParameters();
+        var args = new object?[paramInfos.Length];
+        args[0] = idValue;
+        for (var i = 1; i < paramInfos.Length; i++)
+        {
+            args[i] = paramInfos[i].Name switch
+            {
+                "version" => version,
+                "token" => ct,
+                _ => paramInfos[i].HasDefaultValue ? paramInfos[i].DefaultValue : null
+            };
+        }
+
+        var task = (Task)closed.Invoke(session.Events, args)!;
+        await task.ConfigureAwait(false);
+        return task.GetType().GetProperty("Result")?.GetValue(task);
+    }
+
+    private Type? findAggregateTypeByName(string aggregateTypeName)
+    {
+        foreach (var projection in Options.Projections.All.OfType<IAggregateProjection>())
+        {
+            var t = projection.AggregateType;
+            if (t.FullName == aggregateTypeName || t.Name == aggregateTypeName)
+            {
+                return t;
+            }
+        }
+        return null;
+    }
+
+    private DocumentSessionBase openExplorerSession()
+    {
+        var sessionOptions = new SessionOptions
+        {
+            AllowAnyTenant = true,
+            Tracking = DocumentTracking.None
+        };
+        return (DocumentSessionBase)LightweightSession(sessionOptions);
+    }
+
+    private object parseStreamId(string streamId)
+    {
+        if (Options.EventGraph.StreamIdentity == StreamIdentity.AsGuid)
+        {
+            return Guid.Parse(streamId);
+        }
+        return streamId;
+    }
+
+    private static string readStreamIdAsString(System.Data.Common.DbDataReader reader, int ordinal)
+    {
+        var value = reader.GetValue(ordinal);
+        return value switch
+        {
+            Guid g => g.ToString(),
+            string s => s,
+            _ => value.ToString() ?? string.Empty
+        };
+    }
+
+    /// <summary>
+    /// Number of columns in <see cref="IEventStorage.StreamStateSelectSql"/>'s select
+    /// list. Any caller that appends explorer-specific columns to that SELECT addresses
+    /// the trailing ordinals as <c>StreamStateColumnCount + n</c> so the two stay in
+    /// lockstep without each call site having to count.
+    /// </summary>
+    private const int StreamStateColumnCount = 6;
+
+    /// <summary>
+    /// Read the <see cref="IEventStorage.StreamStateSelectSql"/>-shaped columns out of
+    /// the reader and project them into the explorer's diagnostic-row shape. We don't
+    /// route through <see cref="Marten.Linq.Selectors.ISelector{StreamState}"/> here
+    /// because <see cref="EventGraph.AggregateTypeFor"/> throws on unknown aggregate
+    /// names — fine for the production read path, fatal for an explorer that has to
+    /// surface legacy / unregistered streams as data.
+    /// </summary>
+    private static async Task<(string StreamId, string? StreamType, long Version, DateTimeOffset Created, DateTimeOffset LastUpdated, bool IsArchived)>
+        readStreamRowAsync(DbDataReader reader, CancellationToken ct)
+    {
+        var streamId = readStreamIdAsString(reader, 0);
+        var version = await reader.IsDBNullAsync(1, ct).ConfigureAwait(false) ? 0L : reader.GetInt64(1);
+        var streamType = await reader.IsDBNullAsync(2, ct).ConfigureAwait(false) ? null : reader.GetString(2);
+        var lastUpdated = await reader.GetFieldValueAsync<DateTimeOffset>(3, ct).ConfigureAwait(false);
+        var created = await reader.GetFieldValueAsync<DateTimeOffset>(4, ct).ConfigureAwait(false);
+        var isArchived = !await reader.IsDBNullAsync(5, ct).ConfigureAwait(false) && reader.GetBoolean(5);
+        return (streamId, streamType, version, created, lastUpdated, isArchived);
+    }
+
+    /// <summary>
+    /// Read a single mt_events row out of an explorer command into the explorer's
+    /// untyped <see cref="EventRecord"/>. Both <c>ReadStreamAsync</c> and
+    /// <c>QueryByTagsAsync</c> use this — they project the same eight columns
+    /// (<c>id, seq_id, version, stream_id, type, data, timestamp, tenant_id</c>) into
+    /// the same record shape. We don't route through
+    /// <see cref="Marten.Linq.Selectors.ISelector{IEvent}"/> here because the explorer
+    /// surfaces the event body as raw JSON for UI / tooling consumption rather than
+    /// CLR-deserialized; the typed selector would round-trip through deserialization
+    /// and re-serialization and would also break for events whose CLR type isn't
+    /// registered with the EventGraph.
+    /// </summary>
+    private static async Task<EventRecord> readEventRecordAsync(DbDataReader reader, CancellationToken ct)
+    {
+        var eventId = reader.GetGuid(0);
+        var sequence = reader.GetInt64(1);
+        var version = reader.GetInt64(2);
+        var streamIdValue = readStreamIdAsString(reader, 3);
+        var typeName = reader.GetString(4);
+        var dataText = reader.GetString(5);
+        var timestamp = await reader.GetFieldValueAsync<DateTimeOffset>(6, ct).ConfigureAwait(false);
+        var tenantId = await reader.IsDBNullAsync(7, ct).ConfigureAwait(false) ? null : reader.GetString(7);
+
+        using var doc = JsonDocument.Parse(dataText);
+        return new EventRecord(
+            eventId,
+            sequence,
+            version,
+            streamIdValue,
+            typeName,
+            doc.RootElement.Clone(),
+            Metadata: null,
+            timestamp,
+            tenantId,
+            Tags: null);
+    }
+
+    private static async Task<long> readHeadSequenceAsync(DocumentSessionBase session, string schema, CancellationToken ct)
+    {
+        var cmd = new NpgsqlCommand($"select coalesce(max(seq_id), 0) from {schema}.mt_events");
+        await using var reader = await session.ExecuteReaderAsync(cmd, ct).ConfigureAwait(false);
+        if (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            return await reader.IsDBNullAsync(0, ct).ConfigureAwait(false) ? 0L : reader.GetInt64(0);
+        }
+        return 0L;
+    }
+
+    private static async Task<Dictionary<string, long>> readProgressionAsync(DocumentSessionBase session, string schema, CancellationToken ct)
+    {
+        var cmd = new NpgsqlCommand($"select name, last_seq_id from {schema}.mt_event_progression");
+        var map = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+        await using var reader = await session.ExecuteReaderAsync(cmd, ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var name = reader.GetString(0);
+            var seq = await reader.IsDBNullAsync(1, ct).ConfigureAwait(false) ? 0L : reader.GetInt64(1);
+            map[name] = seq;
+        }
+        return map;
+    }
+
+    private sealed record ObjectStepResult(EventRecord Event, object? Before, object? After, TimeSpan Elapsed, Exception? Error);
+}


### PR DESCRIPTION
## Summary

Implements the JasperFx 1.31.0 / JasperFx.Events 1.36.0 contract that adds ten default-throw diagnostic methods to `IEventStore`. Marten now overrides all of them with real PostgreSQL implementations so the CritterWatch event-store explorer and Event Modeling swim-lane have data to render.

Closes [#4344](https://github.com/JasperFx/marten/issues/4344)
Closes [#4345](https://github.com/JasperFx/marten/issues/4345)

### What's in the box

**[#4344](https://github.com/JasperFx/marten/issues/4344) — explorer methods** (new file [src/Marten/DocumentStore.EventStoreExplorer.cs](src/Marten/DocumentStore.EventStoreExplorer.cs)):
- `GetRecentStreamsAsync` — `mt_streams` ordered by timestamp desc, hard-capped at 1000.
- `ReadStreamAsync` — `mt_events` for one stream, raw JSON via `JsonElement`.
- `GetStreamMetadataAsync` — single-row metadata, including snapshot/archive info.
- `QueryByTagsAsync` — AND-semantic across multiple tag names, joined against the per-tag `mt_event_tag_<suffix>` tables.
- `GetProjectedStateForTagsAsync` — runs the named projection over tag-matched events.
- `RehydrateAtVersionAsync<T>` — wraps the existing `AggregateStreamAsync` at version.
- `RehydrateAtVersionByNameAsync` — by-name lookup, returns JSON-typed `AggregateAtVersion`.
- `GetProjectionStatusesAsync` — snapshot from `StoreOptions.Projections` + `mt_event_progression`.

`EventStoreUsage` now also populates `DcbTagTypes` (richer `DcbTagDescriptor`) and `RegisteredEventTypes` (one `EventTypeDescriptor` per event mapping).

**[#4345](https://github.com/JasperFx/marten/issues/4345) — projection step-through:**
- `RunProjectionAsync<TState>` and `RunProjectionByNameAsync` feed events through the projection's `Apply` methods one at a time via reflection, capture `Before` / `After` snapshots via JSON round-trip clones, surface per-step exceptions on the timeline (does **not** abort), and support pagination via `startingState`.

**Adopts:** JasperFx 1.31.0 / JasperFx.Events 1.36.0. **Bumps:** Marten 8.36.0 → 8.37.0.

### Test plan

- [x] `dotnet build src/Marten.sln` — 0 errors, 0 warnings introduced (across net8.0 / net9.0 / net10.0).
- [x] 21 new integration tests in [src/EventSourcingTests/Explorer/](src/EventSourcingTests/Explorer/) — all pass on net8 / net9 / net10 with parallelization disabled (the project's standard test setup):
  - 13 explorer tests covering happy path, empty/missing inputs, the three DCB-query scenarios required by the issue (empty result, single-tag match, unregistered-name validation), and the `EventStoreUsage` populate.
  - 8 projection-replay tests covering happy path, throwing-event continuation, pagination state continuity, type-mismatch validation, JSON-typed step results, error-message capture, and unknown-projection-name validation.
- [x] Regression sanity: existing DCB tests (55/55) and CoreTests (334/335; one pre-existing skip) green on net10.

### Known limitations / follow-ups (intentionally not in this PR)

- `StreamMetadata.Tags` is always empty — Marten stores tags per-event, not per-stream; surfacing the union would require a multi-table join.
- `GetProjectionStatusesAsync` reports `State="Unknown"` on every shard — live state still flows through the existing `ShardStatesChanged` event; this method is the initial-render snapshot only.
- Projection step-through uses reflection to invoke `Apply` methods directly, not the full aggregator pipeline. Fine for the explorer's stepper view (the canonical Marten projection shape) but not for projections that do session lookups inside `Apply`.
- **Multi-aggregate projection replay** (one of the acceptance criteria in #4345) is **not** yet implemented — the per-aggregate-identity timeline keying needs a separate pass.
- Projection step-through with `JsonElement` `startingState` only supports the by-name path; the typed path takes a `TState` directly.

### Notes for review

- Draft PR — please review before merging. Code is reflection-heavy in two places (`applyEventToAggregate` and `invokeAggregateStreamAsync`); the diagnostic / explorer use case justifies it but it merits eyes.
- DCB AND-semantics across tag values bypasses `EventTagQuery` (which only supports OR) and writes SQL directly against the `mt_event_tag_<suffix>` tables with `value::text` casts. Considered using `EventTagQuery` then post-filtering — direct SQL won out for fewer round trips.
- Hard cap on `GetRecentStreamsAsync` is 1000; capping is silent (no error if you pass `int.MaxValue`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)