### PR TITLE
Cache LINQ handler factories via GenericFactoryCache (#4308)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.1" />
+    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.3" />
     <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.2" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -323,16 +323,23 @@ public partial class CollectionUsage
             groupJoin.FlattenedResultSelector);
 
         // 5. Create the JoinSelectClause and final SelectorStatement
+        // 9.0 (#4308): use GenericFactoryCache's object[] overload — the
+        // 6-arg ctor doesn't fit the fixed-arity overloads, so we pay an
+        // array allocation per call in exchange for skipping MakeGenericType.
         var resultType = groupJoin.FlattenedResultSelector.ReturnType;
-        var closedJoinSelectType = typeof(JoinSelectClause<>).MakeGenericType(resultType);
-        var joinSelectClause = (ISelectClause)Activator.CreateInstance(
-            closedJoinSelectType,
-            joinParser.NewObject,
-            outerCteAlias,
-            innerCteAlias,
-            groupJoin.IsLeftJoin,
-            outerKeyLocator,
-            innerKeyLocator)!;
+        var joinSelectClause = (ISelectClause)GenericFactoryCache.BuildAs<object>(
+            typeof(JoinSelectClause<>),
+            resultType,
+            new object[]
+            {
+                joinParser.NewObject,
+                outerCteAlias,
+                innerCteAlias,
+                groupJoin.IsLeftJoin,
+                outerKeyLocator,
+                innerKeyLocator
+            },
+            static closed => args => Activator.CreateInstance(closed, args)!);
 
         var joinStatement = new SelectorStatement
         {

--- a/src/Marten/Linq/CollectionUsage.Includes.cs
+++ b/src/Marten/Linq/CollectionUsage.Includes.cs
@@ -31,13 +31,23 @@ public partial class CollectionUsage
             var receiver = expression.Arguments[startingIndex + 1].Value();
 
             var genericArguments = receiver.GetType().GetGenericArguments();
+            // 9.0 (#4308): replace per-call MakeGenericType + Activator.CreateInstance
+            // with delegate-cached factories via GenericFactoryCache. The first call
+            // for a given (open type, type args) pair builds + caches an
+            // Activator-backed factory; subsequent calls reuse the cached delegate
+            // and skip the MakeGenericType cost.
             if (receiver.GetType().Closes(typeof(IList<>)))
             {
                 var includedType = genericArguments[0];
                 var storage = session.StorageFor(includedType);
 
-                var type = typeof(ListIncludePlan<>).MakeGenericType(includedType);
-                var plan = (IIncludePlan)Activator.CreateInstance(type, storage, member, receiver)!;
+                var plan = (IIncludePlan)GenericFactoryCache.BuildAs<object>(
+                    typeof(ListIncludePlan<>),
+                    includedType,
+                    storage,
+                    member,
+                    receiver,
+                    static closed => (a, b, c) => Activator.CreateInstance(closed, a, b, c)!);
 
                 if (expression.Arguments.Count == 3)
                 {
@@ -51,8 +61,13 @@ public partial class CollectionUsage
                 var includedType = genericArguments[0];
                 var storage = session.StorageFor(includedType);
 
-                var type = typeof(IncludePlan<>).MakeGenericType(includedType);
-                var plan = (IIncludePlan)Activator.CreateInstance(type, storage, member, receiver)!;
+                var plan = (IIncludePlan)GenericFactoryCache.BuildAs<object>(
+                    typeof(IncludePlan<>),
+                    includedType,
+                    storage,
+                    member,
+                    receiver,
+                    static closed => (a, b, c) => Activator.CreateInstance(closed, a, b, c)!);
 
                 if (expression.Arguments.Count == 3)
                 {
@@ -67,8 +82,14 @@ public partial class CollectionUsage
                 var includedType = genericArguments[1];
                 var storage = session.StorageFor(includedType);
 
-                var type = typeof(DictionaryIncludePlan<,>).MakeGenericType(includedType, idType);
-                var plan = (IIncludePlan)Activator.CreateInstance(type, storage, member, receiver)!;
+                var plan = (IIncludePlan)GenericFactoryCache.BuildAs<object>(
+                    typeof(DictionaryIncludePlan<,>),
+                    includedType,
+                    idType,
+                    storage,
+                    member,
+                    receiver,
+                    static closed => (a, b, c) => Activator.CreateInstance(closed, a, b, c)!);
 
                 if (expression.Arguments.Count == 3)
                 {

--- a/src/Marten/Linq/Parsing/LinqQueryParser.Handlers.cs
+++ b/src/Marten/Linq/Parsing/LinqQueryParser.Handlers.cs
@@ -31,9 +31,21 @@ internal partial class LinqQueryParser
                                          typeof(TResult).FullNameInCode());
         }
 
-        var nullableSelector = Activator.CreateInstance(typeof(NullableSelector<>).MakeGenericType(typeof(TDocument)), selector);
-        var handlerType = typeof(ListQueryHandler<>).MakeGenericType(itemType!);
-        return (IQueryHandler<TResult>)Activator.CreateInstance(handlerType, statement, nullableSelector)!;
+        // 9.0 (#4308): replace per-call MakeGenericType + Activator.CreateInstance
+        // on the LINQ hot path with delegate-cached factories via
+        // JasperFx.Core.Reflection.GenericFactoryCache.
+        var nullableSelector = GenericFactoryCache.BuildAs<object>(
+            typeof(NullableSelector<>),
+            typeof(TDocument),
+            selector,
+            static closed => arg => Activator.CreateInstance(closed, arg)!);
+
+        return (IQueryHandler<TResult>)GenericFactoryCache.BuildAs<object>(
+            typeof(ListQueryHandler<>),
+            itemType!,
+            statement,
+            nullableSelector,
+            static closed => (a, b) => Activator.CreateInstance(closed, a, b)!);
     }
 
     private static Type? TryGetEnumerableElementType(Type t)


### PR DESCRIPTION
## Summary

Six LINQ hot-path call sites previously did `MakeGenericType + Activator.CreateInstance` on every query execution to build handler tuples keyed on runtime-known document and result types. This migrates them to `JasperFx.Core.Reflection.GenericFactoryCache` (extended in JasperFx 2.0.0-alpha.3 — [jasperfx#223](https://github.com/JasperFx/jasperfx/issues/223)) so the per-call cost collapses to a cache lookup plus a cached-delegate invocation.

| Site | Closed type | Type args | Ctor args | Overload used |
|---|---|---|---|---|
| `LinqQueryParser.Handlers.cs` | `NullableSelector<T>` | 1 | 1 | existing 1-type/1-ctor |
| `LinqQueryParser.Handlers.cs` | `ListQueryHandler<T>` | 1 | 2 | new 1-type/2-ctor |
| `CollectionUsage.Includes.cs` | `ListIncludePlan<T>` | 1 | 3 | new 1-type/3-ctor |
| `CollectionUsage.Includes.cs` | `IncludePlan<T>` | 1 | 3 | new 1-type/3-ctor |
| `CollectionUsage.Includes.cs` | `DictionaryIncludePlan<T, TKey>` | 2 | 3 | new 2-type/3-ctor |
| `CollectionUsage.Compilation.cs` | `JoinSelectClause<T>` | 1 | 6 | new 1-type/object[] |

Bumps the central `JasperFx` package reference to `2.0.0-alpha.3`.

The factory delegates use `Activator.CreateInstance(closed, args)` internally — the cache wins back the `MakeGenericType` cost per call. A follow-up PR can replace `Activator.CreateInstance` with `Expression.Compile`-built delegates for the hottest sites if benchmarks warrant; the current change is the foundation that makes that incremental.

Closes #4308.

## Test plan

- [x] `dotnet build src/Marten.slnx` succeeds with 0 errors.
- [ ] CI green on `test-linq` (covers the migrated sites).
- [ ] CI green on `test-event-sourcing`, `test-core`, `test-document-db`.
- [ ] Benchmark follow-up (not in this PR): confirm per-query handler-construction cost drops measurably on `CollectionUsage.Includes` workloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)