### PR TITLE
Fix TestCodeGen: route through AutoTypeLoader under codegen-write

### DIFF
--- a/src/Marten/Internal/CodeGeneration/StaticOnlyCodeFileLoader.cs
+++ b/src/Marten/Internal/CodeGeneration/StaticOnlyCodeFileLoader.cs
@@ -61,6 +61,28 @@ internal static class StaticOnlyCodeFileLoader
             // pre-9.0 behavior under Dynamic mode without requiring every
             // consuming app to do a manual DI registration.
             var effectiveServices = services ?? RuntimeCompilerFallback.Instance;
+
+            // 9.0: under `dotnet run -- codegen write/test/preview`, the user is
+            // generating the pre-built code so their TypeLoadMode=Static
+            // preference (which applies to runtime loading, not to the act of
+            // generation) must not be honoured here. JasperFx 2.0's
+            // StaticTypeLoader silently no-ops when WithinCodegenCommand is true,
+            // assuming the codegen command will write all needed files itself.
+            // That assumption breaks for *transitive* document storage needs:
+            // compiled-query plan building (CompiledQueryCollection.BuildFiles)
+            // calls session.StorageFor<T>() for a TARGET that isn't necessarily
+            // a registered document of this store, which lands in
+            // ProviderGraph.CreateDocumentProvider<T>() -> BuildProvider<T>()
+            // and that path needs _providerType set NOW, not later. Route the
+            // call through an AutoTypeLoader explicitly so we get the
+            // try-pre-built-then-compile-on-miss behaviour during codegen.
+            // See JasperFx/marten#4360.
+            if (DynamicCodeBuilder.WithinCodegenCommand && rules.Loader is StaticTypeLoader)
+            {
+                new AutoTypeLoader().Initialize(file, rules, parent, effectiveServices);
+                return;
+            }
+
             file.InitializeSynchronously(rules, parent, effectiveServices);
             return;
         }


### PR DESCRIPTION
## Summary

Fixes the \`TestCodeGen\` failure that's been red on every master CI run since ~2026-05-10 23:13Z (last green was \`25612695142\` at 2026-05-09 21:51Z, first red was \`25642444020\`). Symptom on master and every PR that runs against master:

\`\`\`
ERROR:
System.ArgumentNullException: Value cannot be null. (Parameter 'type')
  at System.Activator.CreateInstance(Type type, …)
  at Marten.Internal.CodeGeneration.DocumentProviderBuilder.BuildProvider<T>() in
     src/Marten/Internal/CodeGeneration/DocumentProviderBuilder.cs:line 83
\`\`\`

## Root cause

JasperFx 2.0's \`StaticTypeLoader.Initialize\` silently no-ops when \`DynamicCodeBuilder.WithinCodegenCommand\` is true — its contract assumes the codegen command will itself write every required file via its own pipeline. That assumption holds for document types a store *explicitly registers*, but breaks for **transitive document storage needs surfaced during codegen**.

Concretely: [\`CompiledQueryCollection.BuildFiles\`](src/Marten/DocumentStore.CompiledQueryCollection.cs#L74) opens a session and walks \`QueryCompiler.BuildQueryPlan\` for each registered compiled query. The plan builder calls \`session.StorageFor<T>()\` on the compiled query's *target* type, which may not be a registered document of that store. CommandLineRunner's setup hits this exactly: \`IOtherStore\` registers \`FindUserOtherThings : ICompiledQuery<User>\` but never \`RegisterDocumentType<User>()\`. The \`StorageFor<User>()\` call lands in \`ProviderGraph.CreateDocumentProvider<User>()\`, which expects \`_providerType\` to be set after \`StaticOnlyCodeFileLoader.Initialize\` returns and dereferences it via \`Activator.CreateInstance\` — crash with \`ArgumentNullException\` when \`StaticTypeLoader\`'s no-op left it null.

Pre-9.0 didn't hit this: \`JasperFx.RuntimeCompiler.CodeFileExtensions.InitializeSynchronously\` had a \`?? new AssemblyGenerator()\` fallback that always compiled. JasperFx 2.0's package-level split removed that fallback. The 9.0 rewrite of \`StaticOnlyCodeFileLoader.Initialize\` ([\`55bfd20b6\`](https://github.com/JasperFx/marten/commit/55bfd20b6)) preserved the *always-compile under Dynamic* behaviour but not the *compile-on-miss under Static during codegen* behaviour.

## Fix

In \`StaticOnlyCodeFileLoader.Initialize\`, when \`allowRuntimeCodeGeneration\` is true AND \`WithinCodegenCommand\` AND \`rules.Loader is StaticTypeLoader\`, route through a fresh \`AutoTypeLoader\` (try-static-then-compile semantics). The user's \`Static\` preference still governs runtime loading outside of codegen-write — this only intervenes for the act of generation itself.

\`\`\`csharp
if (DynamicCodeBuilder.WithinCodegenCommand && rules.Loader is StaticTypeLoader)
{
    new AutoTypeLoader().Initialize(file, rules, parent, effectiveServices);
    return;
}
\`\`\`

## Test plan

- [x] **Before:** \`./build.sh test-code-gen\` on plain \`origin/master\` (bed5d0648) — **failed in 0:09 with ArgumentNullException** (proved this is a pre-existing master regression, not specific to any PR).
- [x] **Before:** Same command on PR #4359 — failed identically.
- [x] **After:** \`./build.sh test-code-gen\` on this branch — **succeeds in 0:15**. All four codegen subcommands (\`delete\` → \`write\` → \`test\` → \`write\`) complete green.

## Followup

Once this lands, [#4359](https://github.com/JasperFx/marten/pull/4359) rebases on top of master and its \`TestCodeGen\` job should clear automatically. The companion EventSourcing CREATE-SCHEMA flake on #4359 was unrelated and triaged in that PR's comment thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)