### PR TITLE
Bump JasperFx 2.0.0-alpha.3 → 2.0.0-alpha.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.3" />
+    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.4" />
     <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.2" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Picks up [jasperfx#226](https://github.com/JasperFx/jasperfx/issues/226) — `RecentlyUsedCache` thread-safety fix. The projection daemon's per-tenant aggregate cache (used by `JasperFx.Events.Daemon.AggregationRunner` with 10-way Block parallelism) was racing on field-level updates; alpha.4 serialises `Store` / `TryFind` / `CompactIfNecessary` / `TryRemove` under a single lock. Also fixes a typo in `CompactIfNecessary` that was leaking the LRU timestamp map.

Drive-by bump alongside Polecat's [polecat#59](https://github.com/JasperFx/polecat/pull/59) (un-skip of the composite-upstream-cache test that surfaced the race).

## Test plan

- [x] `dotnet build src/Marten/Marten.csproj` succeeds.
- [ ] CI green across all Marten test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)