### PR TITLE
Bump JasperFx 2.0.0-alpha.4 → 2.0.0-alpha.5 (closes #4354)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.4" />
+    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.5" />
     <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.2" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Closes **#4354** — the `test-code-gen` ArgumentNullException cascade failure on master.

Picks up the [StaticTypeLoader codegen-command fallback fix](https://github.com/JasperFx/jasperfx/pull/230) shipped in JasperFx **2.0.0-alpha.5**. Before alpha.5: `CommandLineRunner`'s `IOtherStore` (TypeLoadMode.Static + registered compiled query `FindUserOtherThings`) caused the codegen-write pipeline's `CompiledQueryCollection.BuildFiles` to trigger `ProviderGraph.CreateDocumentProvider<T>`, where StaticTypeLoader was silently returning instead of providing an attached type — and `Activator.CreateInstance` then threw on the null `_providerType`. After alpha.5: StaticTypeLoader falls back to `DynamicTypeLoader.CompileAndAttach` when `WithinCodegenCommand=true` and the pre-built type is missing.

AOT contract preserved: `WithinCodegenCommand` is only set by JasperFx's command-line codegen targets (tool-time). Production runtime always sees it as false, so the fallback branch is unreachable in a `PublishAot=true` deployment.

## Test plan

- [x] `dotnet build src/Marten/Marten.csproj` succeeds.
- [ ] `test-code-gen` CI step succeeds on master without admin-merge bypass — the primary signal that #4354 is closed.
- [ ] All other Marten CI suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)