### PR TITLE
Bump JasperFx to 2.0.0-alpha.6, absorb #201 IAggregateGrouper signature

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,14 +13,14 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.5" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.2" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.1">
+    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.6" />
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.3" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="2.0.0-alpha.1" />
-    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-alpha.1" />
+    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="2.0.0-alpha.2" />
+    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-alpha.2" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/docs/events/projections/multi-stream-projections.md
+++ b/docs/events/projections/multi-stream-projections.md
@@ -298,7 +298,7 @@ As simpler mechanism to group events to aggregate documents is to supply a custo
 ```cs
 public class LicenseFeatureToggledEventGrouper: IAggregateGrouper<Guid>
 {
-    public async Task Group(IQuerySession session, IEnumerable<IEvent> events, IEventGrouping<Guid> grouping)
+    public async Task Group(IQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<Guid> grouping)
     {
         var licenseFeatureTogglesEvents = events
             .OfType<IEvent<LicenseFeatureToggled>>()
@@ -433,7 +433,7 @@ Custom grouper that resolves `CustomerId` in bulk per event range:
 ```cs
 public class ExternalAccountToCustomerGrouper: IAggregateGrouper<Guid>
 {
-    public async Task Group(IQuerySession session, IEnumerable<IEvent> events, IEventGrouping<Guid> grouping)
+    public async Task Group(IQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<Guid> grouping)
     {
         var usageEvents = events
             .Where(e => e.Data is IExternalAccountEvent)
@@ -534,7 +534,7 @@ the projection being built.
 If you must keep this shape (because you genuinely need the bounded linked-id list
 on the projected document), the grouper has to be coded defensively:
 
-1. Scan the current batch's `IEnumerable<IEvent>` for in-flight link events and seed
+1. Scan the current batch's `IReadOnlyList<IEvent>` for in-flight link events and seed
    an in-memory lookup from those first.
 2. Then query the projected document (or a dedicated lookup) to cover links committed
    by an earlier batch.
@@ -626,7 +626,7 @@ link events and usage events can appear in a single `SaveChangesAsync` batch.
 
 The idea is:
 
-1. The grouper scans the current batch's `IEnumerable<IEvent>` for in-flight link
+1. The grouper scans the current batch's `IReadOnlyList<IEvent>` for in-flight link
    events first, seeding an in-memory map from external id to aggregate id.
 2. For any usage events whose external id is not in the map, the grouper queries
    a dedicated lookup document (the same one Pattern 1 uses) to pick up links
@@ -677,15 +677,13 @@ public class BatchAwareExternalAccountGrouper: IAggregateGrouper<Guid>
 {
     private readonly ConcurrentDictionary<string, Guid> _cache = new();
 
-    public async Task Group(IQuerySession session, IEnumerable<IEvent> events, IEventGrouping<Guid> grouping)
+    public async Task Group(IQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<Guid> grouping)
     {
-        var materialized = events as IReadOnlyCollection<IEvent> ?? events.ToList();
-
-        var labelEvents = materialized.OfType<IEvent<ShippingLabelCreated>>().ToList();
+        var labelEvents = events.OfType<IEvent<ShippingLabelCreated>>().ToList();
         if (labelEvents.Count == 0) return;
 
         // 1) Pick up any link events that share THIS batch.
-        foreach (var linkEvent in materialized.OfType<IEvent<CustomerLinkedToExternalAccount>>())
+        foreach (var linkEvent in events.OfType<IEvent<CustomerLinkedToExternalAccount>>())
         {
             _cache[linkEvent.Data.ExternalAccountId] = linkEvent.Data.CustomerId;
         }
@@ -1047,7 +1045,7 @@ The custom grouper, `MonthlyAllocationGrouper`, is responsible for the logic of 
 ```cs
 public class MonthlyAllocationGrouper: IAggregateGrouper<string>
 {
-    public Task Group(IQuerySession session, IEnumerable<IEvent> events, IEventGrouping<string> grouping)
+    public Task Group(IQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<string> grouping)
     {
         var allocations = events
             .OfType<IEvent<EmployeeAllocated>>();

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -20,6 +20,14 @@
 
   This is purely cosmetic — leaving the columns in place is harmless. New databases created by Marten 9 will not have them. See [#4316](https://github.com/JasperFx/marten/issues/4316).
 
+### `IAggregateGrouper<T>.Group` parameter type tightened
+
+* The `events` parameter on `IAggregateGrouper<T>.Group(...)` changed from `IEnumerable<IEvent>` to `IReadOnlyList<IEvent>`. Implementations frequently need two or more passes over the same batch — partition events by type first, then resolve related document IDs from the database — and the prior `IEnumerable<IEvent>` signature gave no guarantee that re-iteration was safe or cheap. Static analysers correctly flagged it as possible-multiple-enumeration, forcing every implementor to either eat the warning or do a defensive `.ToList()` at the top of `Group`.
+
+  Update the parameter type in your `Group` implementations and drop any defensive `events.ToList()` / `events as IReadOnlyCollection<IEvent>` materialization — `Count`, indexed access, and repeat iteration are first-class on `IReadOnlyList<IEvent>`. No logic change required. The same change applies to the lambda-form `CustomGrouping(Func<IQuerySession, IReadOnlyList<IEvent>, IEventGrouping<TId>, Task>)` overload; lambda call sites usually need no edit because `IReadOnlyList<IEvent>` is also an `IEnumerable<IEvent>` and type inference handles the rest.
+
+  See [jasperfx#201](https://github.com/JasperFx/jasperfx/issues/201) / [jasperfx#202](https://github.com/JasperFx/jasperfx/pull/202).
+
 ## Key Changes in 8.0.0
 
 The V8 release was much smaller than the preceding V7 release, but there are some significant changes to be aware of.

--- a/src/EventSourcingTests/Bugs/Bug_2296_tenant_session_in_grouper.cs
+++ b/src/EventSourcingTests/Bugs/Bug_2296_tenant_session_in_grouper.cs
@@ -101,7 +101,7 @@ public class Bug_2296_tenant_session_in_grouper: OneOffConfigurationsContext
 
         public class EventGrouper: IAggregateGrouper<string>
         {
-            public async Task Group(IQuerySession session, IEnumerable<IEvent> events, IEventGrouping<string> grouping)
+            public async Task Group(IQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<string> grouping)
             {
                 var resetEvents = events.OfType<IEvent<ResetEvent>>().ToList();
                 if (!resetEvents.Any())

--- a/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/Bug_4261_multistream_sample_coverage.cs
+++ b/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/Bug_4261_multistream_sample_coverage.cs
@@ -418,7 +418,7 @@ public class Bug_4261_multistream_sample_coverage
 
         public class ExternalAccountToCustomerGrouper : IAggregateGrouper<Guid>
         {
-            public async Task Group(IQuerySession session, IEnumerable<IEvent> events, IEventGrouping<Guid> grouping)
+            public async Task Group(IQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<Guid> grouping)
             {
                 var usageEvents = events.Where(e => e.Data is IExternalAccountEvent).ToList();
                 if (usageEvents.Count == 0) return;
@@ -587,15 +587,16 @@ public class Bug_4261_multistream_sample_coverage
         {
             private readonly System.Collections.Concurrent.ConcurrentDictionary<string, Guid> _cache = new();
 
-            public async Task Group(IQuerySession session, IEnumerable<IEvent> events, IEventGrouping<Guid> grouping)
+            public async Task Group(IQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<Guid> grouping)
             {
-                var materialized = events as IReadOnlyCollection<IEvent> ?? events.ToList();
-
-                var labelEvents = materialized.OfType<IEvent<ShippingLabelCreated>>().ToList();
+                // events is now IReadOnlyList<IEvent> per jasperfx#201 — drop the
+                // defensive materialize-or-ToList() that was needed when the
+                // parameter was a bare IEnumerable<IEvent>.
+                var labelEvents = events.OfType<IEvent<ShippingLabelCreated>>().ToList();
                 if (labelEvents.Count == 0) return;
 
                 // 1) Pick up any link events that share THIS batch.
-                foreach (var linkEvent in materialized.OfType<IEvent<CustomerLinkedToExternalAccount>>())
+                foreach (var linkEvent in events.OfType<IEvent<CustomerLinkedToExternalAccount>>())
                 {
                     _cache[linkEvent.Data.ExternalAccountId] = linkEvent.Data.CustomerId;
                 }

--- a/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/custom_grouper_with_document_session.cs
+++ b/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/custom_grouper_with_document_session.cs
@@ -18,7 +18,7 @@ namespace EventSourcingTests.Projections.MultiStreamProjections.CustomGroupers;
 #region sample_view-projection-custom-grouper-with-querysession
 public class LicenseFeatureToggledEventGrouper: IAggregateGrouper<Guid>
 {
-    public async Task Group(IQuerySession session, IEnumerable<IEvent> events, IEventGrouping<Guid> grouping)
+    public async Task Group(IQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<Guid> grouping)
     {
         var licenseFeatureTogglesEvents = events
             .OfType<IEvent<LicenseFeatureToggled>>()

--- a/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/custom_grouper_with_events_transformation.cs
+++ b/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/custom_grouper_with_events_transformation.cs
@@ -69,7 +69,7 @@ namespace EventSourcingTests.Projections.ViewProjections.CustomGroupers
 
     public class MonthlyAllocationGrouper: IAggregateGrouper<string>
     {
-        public Task Group(IQuerySession session, IEnumerable<IEvent> events, IEventGrouping<string> grouping)
+        public Task Group(IQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<string> grouping)
         {
             var allocations = events
                 .OfType<IEvent<EmployeeAllocated>>();

--- a/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/grouping_examples_for_unknown_ids.cs
+++ b/src/EventSourcingTests/Projections/MultiStreamProjections/CustomGroupers/grouping_examples_for_unknown_ids.cs
@@ -56,7 +56,7 @@ public class GroupingForUnknownIdsByLookupExample: OneOffConfigurationsContext
 
     public class ExternalAccountToCustomerGrouper: IAggregateGrouper<Guid>
     {
-        public async Task Group(IQuerySession session, IEnumerable<IEvent> events, IEventGrouping<Guid> grouping)
+        public async Task Group(IQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<Guid> grouping)
         {
             var usageEvents = events
                 .Where(e => e.Data is IExternalAccountEvent)
@@ -249,15 +249,16 @@ public class GroupingForUnknownIdsBatchAwareExample: OneOffConfigurationsContext
     {
         private readonly ConcurrentDictionary<string, Guid> _cache = new();
 
-        public async Task Group(IQuerySession session, IEnumerable<IEvent> events, IEventGrouping<Guid> grouping)
+        public async Task Group(IQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<Guid> grouping)
         {
-            var materialized = events as IReadOnlyCollection<IEvent> ?? events.ToList();
-
-            var labelEvents = materialized.OfType<IEvent<ShippingLabelCreated>>().ToList();
+            // events is now IReadOnlyList<IEvent> per jasperfx#201 — drop the
+            // defensive materialize-or-ToList() that used to be required when
+            // the parameter was a bare IEnumerable<IEvent>.
+            var labelEvents = events.OfType<IEvent<ShippingLabelCreated>>().ToList();
             if (labelEvents.Count == 0) return;
 
             // 1) Pick up any link events that share THIS batch.
-            foreach (var linkEvent in materialized.OfType<IEvent<CustomerLinkedToExternalAccount>>())
+            foreach (var linkEvent in events.OfType<IEvent<CustomerLinkedToExternalAccount>>())
             {
                 _cache[linkEvent.Data.ExternalAccountId] = linkEvent.Data.CustomerId;
             }

--- a/src/samples/Helpdesk/Helpdesk.Api/Incidents/GetCustomerIncidentsSummary/IncidentSummary.cs
+++ b/src/samples/Helpdesk/Helpdesk.Api/Incidents/GetCustomerIncidentsSummary/IncidentSummary.cs
@@ -54,7 +54,7 @@ public class CustomerIncidentsSummaryGrouper: IAggregateGrouper<Guid>
         typeof(IncidentClosed)
     };
 
-    public async Task Group(IQuerySession session, IEnumerable<IEvent> events, ITenantSliceGroup<Guid> grouping)
+    public async Task Group(IQuerySession session, IReadOnlyList<IEvent> events, ITenantSliceGroup<Guid> grouping)
     {
         var filteredEvents = events
             .Where(ev => eventTypes.Contains(ev.EventType))


### PR DESCRIPTION
## Summary
- Bump JasperFx 2.0.0-alpha.5 → alpha.6 (4 fixes), JasperFx.Events alpha.2 → alpha.3 (#201 breaking change), JasperFx.RuntimeCompiler alpha.1 → alpha.2, source generators alpha.1 → alpha.2 (metadata refresh).
- Absorb the [jasperfx#201](https://github.com/JasperFx/jasperfx/issues/201) breaking change to `IAggregateGrouper.Group`: parameter type promoted from `IEnumerable<IEvent>` to `IReadOnlyList<IEvent>`.
- Closes #4368 — docs sweep: 6 code samples + 2 prose mentions in `multi-stream-projections.md` + a new migration-guide bullet under "Key Changes in 9.0.0".

## What changed

### Pin bumps in `Directory.Packages.props`
| Package | Before | After |
|---|---|---|
| JasperFx | 2.0.0-alpha.5 | 2.0.0-alpha.6 |
| JasperFx.Events | 2.0.0-alpha.2 | 2.0.0-alpha.3 |
| JasperFx.RuntimeCompiler | 2.0.0-alpha.1 | 2.0.0-alpha.2 |
| JasperFx.Events.SourceGenerator | 2.0.0-alpha.1 | 2.0.0-alpha.2 |
| JasperFx.SourceGeneration | 2.0.0-alpha.1 | 2.0.0-alpha.2 |

### #201 absorption — `IAggregateGrouper.Group` signature
8 implementations swept from `IEnumerable<IEvent>` → `IReadOnlyList<IEvent>`:
- Helpdesk sample: `CustomerIncidentsSummaryGrouper`
- EventSourcingTests: `Bug_2296_tenant_session_in_grouper.EventGrouper`, two groupers in `grouping_examples_for_unknown_ids.cs`, `LicenseFeatureToggledEventGrouper`, two groupers in `Bug_4261_multistream_sample_coverage.cs`, `MonthlyAllocationGrouper`.

Two test groupers had a defensive `events as IReadOnlyCollection<IEvent> ?? events.ToList()` that is now noise — dropped. Lambda-form `CustomGrouping(async (session, events, ...) => ...)` callers needed no edits (type inference + `IReadOnlyList<T> : IEnumerable<T>`).

### Docs (closes #4368)
- `docs/events/projections/multi-stream-projections.md` — six grouper code samples + two prose lines (`Scan the current batch's IReadOnlyList<IEvent>...`) swept, defensive-materialize pattern in `BatchAwareExternalAccountGrouper` cleaned up to mirror the matching test file.
- `docs/migration-guide.md` — new "IAggregateGrouper<T>.Group parameter type tightened" bullet under Key Changes in 9.0.0.

## Verification
- `dotnet build src/Marten/Marten.csproj` — clean
- `dotnet build src/EventSourcingTests/EventSourcingTests.csproj` — clean
- `grep -rn "IEnumerable<IEvent>.*IEventGrouping\|IEnumerable<IEvent>.*ITenantSliceGroup"` across `docs/` and `src/` → no hits

## Out of scope (pre-existing breakage)
`src/CommandLineRunner/Internal/Generated/IThingStore/EventStore/EventStorage.cs` has two `CS0115` overrides that reproduce on clean `origin/master` (stale pre-generated codegen output vs current `IStorageOperations.Resolve` / `ResolveAsync` signatures). Unrelated to this bump — flagging here only so the failing CommandLineRunner build doesn't get misattributed to JasperFx 2.0.0-alpha.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)