### PR TITLE
9.0: cold-start + runtime-perf Tier A fixes (#4294 Lens 1 + Lens 3)

### DIFF
--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -65,7 +65,16 @@ public partial class DocumentStore: IDocumentStore, IDescribeMyself
 
         StorageFeatures.PostProcessConfiguration();
         Events.Initialize(this);
-        Options.Projections.DiscoverGeneratedEvolvers(AppDomain.CurrentDomain.GetAssemblies());
+        // #4294 Lens-1 Row 1: discovery is gated on an opt-out flag and consumes a
+        // process-wide cached assembly snapshot to keep multi-tenanted host
+        // construction off the hot path. JasperFx already caches per-assembly
+        // evolver results inside DiscoverGeneratedEvolvers; the remaining wasted
+        // work was the per-construction AppDomain.CurrentDomain.GetAssemblies()
+        // call and the per-assembly framework-filter loop.
+        if (Options.Projections.DiscoverGeneratedEvolversOnStartup)
+        {
+            Options.Projections.DiscoverGeneratedEvolvers(ProjectionOptions.CachedLoadedAssemblies);
+        }
         // Note: Natural key aggregates are discovered lazily when FetchForWriting
         // is called with a type that has [NaturalKey]. Assembly-level scanning was
         // removed because it caused spurious InvalidProjectionException failures

--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using JasperFx;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
@@ -55,6 +56,31 @@ public class ProjectionOptions: ProjectionGraph<IProjection, IDocumentOperations
         get => _options.Events.UseIdentityMapForAggregates;
         set => _options.Events.UseIdentityMapForAggregates = value;
     }
+
+    /// <summary>
+    ///     Controls whether DocumentStore construction scans loaded assemblies for
+    ///     <c>[GeneratedEvolverAttribute]</c> markers emitted by Marten's source generator
+    ///     (Lens 1 cold-start optimization for #4294). Default is <see langword="true"/>;
+    ///     apps that do not use source-generated aggregate evolvers can set this to
+    ///     <see langword="false"/> to skip the discovery walk and the AppDomain
+    ///     assembly enumeration that drives it. Has no effect on runtime behavior
+    ///     (evolver dispatch is unrelated); only affects construction-time cost.
+    /// </summary>
+    public bool DiscoverGeneratedEvolversOnStartup { get; set; } = true;
+
+    // Snapshot of AppDomain.CurrentDomain.GetAssemblies() taken on first construction
+    // of any DocumentStore in the process. The audit row #4294/Lens-1/#1 calls this out
+    // as a top-fix candidate — multiple DocumentStore instances (multi-database tenancy)
+    // each pay for re-enumerating the full loaded-assembly set otherwise. Trade-off:
+    // assemblies loaded *after* the first DocumentStore construction won't be scanned
+    // for evolvers; in practice the loaded-assembly set is stable once host startup
+    // completes, so this matches typical evolver-discovery semantics. Race on first
+    // assignment is benign (both racers get a valid array; the late writer's array
+    // is discarded).
+    private static Assembly[]? _cachedLoadedAssemblies;
+
+    internal static Assembly[] CachedLoadedAssemblies =>
+        _cachedLoadedAssemblies ??= AppDomain.CurrentDomain.GetAssemblies();
 
     protected override void onAddProjection(object projection)
     {

--- a/src/Marten/Events/QuickEventAppender.cs
+++ b/src/Marten/Events/QuickEventAppender.cs
@@ -12,6 +12,15 @@ namespace Marten.Events;
 
 internal class QuickEventAppender: IEventAppender
 {
+    // #4294 Lens-3 Row 3: PrepareEvents takes a Queue<long> that only the Rich
+    // metadata branch (applyRichMetadata) consumes. QuickEventAppender is only
+    // reached when AppendMode == Quick, at which point PrepareEvents routes to
+    // applyQuickMetadata, which never touches the queue. Replace the per-save
+    // allocation with a process-wide unused sentinel. Static readonly so even
+    // if the invariant ever breaks the shared instance is at least obvious in
+    // diffs / crash dumps.
+    private static readonly Queue<long> _unusedSequencesSentinel = new();
+
     private static void registerOperationsForStreams(EventGraph eventGraph, DocumentSessionBase session)
     {
         var storage = session.EventStorage();
@@ -31,11 +40,10 @@ internal class QuickEventAppender: IEventAppender
             }
         }
 
-        // The quick-append path never reads from this queue (PrepareEvents calls
-        // applyQuickMetadata, not applyRichMetadata, and only the rich variant
-        // dequeues from it). Hoist a single throwaway instance out of the
-        // per-stream loop so we don't allocate one per stream on every save.
-        var sequences = new Queue<long>();
+        // See _unusedSequencesSentinel comment: the queue parameter on
+        // PrepareEvents is dead in this code path; share a single instance
+        // across all saves rather than allocating per-save.
+        var sequences = _unusedSequencesSentinel;
 
         foreach (var stream in session.WorkTracker.Streams.Where(x => x.Events.Any()))
         {


### PR DESCRIPTION
## Summary

Last remaining items from the [#4294 cold-start / runtime-perf audit umbrella](https://github.com/JasperFx/marten/issues/4294) after the bigger pieces shipped in #4303 / #4304 / #4307 / #4309. Two new fixes, plus a confirmation pass on what's already done.

## New work

### Lens 1 Row 1 — \`AppDomain.CurrentDomain.GetAssemblies()\` per DocumentStore construction
Two-part fix in \`ProjectionOptions\` + \`DocumentStore\`:
- **Process-wide \`ProjectionOptions.CachedLoadedAssemblies\` snapshot.** First construction snapshots; later constructions reuse. Trade-off documented inline: assemblies loaded after the first construction won't be scanned for evolvers, which matches typical evolver-discovery semantics where the loaded-assembly set is stable after host startup. Multi-database / multi-tenant hosts that build per-tenant DocumentStores benefit most.
- **\`ProjectionOptions.DiscoverGeneratedEvolversOnStartup\` opt-out flag** (default \`true\`). Apps that don't use source-generated aggregate evolvers can set to \`false\` to skip the discovery walk entirely. Has no effect on runtime behavior; only affects construction-time cost.

### Lens 3 Row 3 — \`Queue<long>\` allocation per save in \`QuickEventAppender\`
The existing comment already admitted the queue was dead in this code path (\`PrepareEvents\` routes to \`applyQuickMetadata\` when \`AppendMode == Quick\`, the only mode that reaches \`QuickEventAppender\`; \`applyQuickMetadata\` never reads the queue). The previous mitigation hoisted the allocation out of the per-stream loop. This goes one more step: a process-wide \`_unusedSequencesSentinel\` so even the per-save allocation goes away. Static readonly so the shared instance is obvious in diffs / crash dumps if the invariant ever breaks.

## Already done (confirmed on the way)

| Audit row | Status |
|---|---|
| Lens 1 Row 3 — lazy \`BuildAllMappings\` | ✅ #4303 |
| Lens 1 Row 4 — skip \`AssertValidity\` in Static mode | ✅ #4309 |
| Lens 1 Row 5 — \`Lazy<ISchemaObject[]>\` for \`EventGraph.FeatureSchema.Objects\` | ✅ #4304 |
| Lens 1 smaller win 1 — \`ProviderGraph\` cache \`GenerationRules\` | ✅ #4307 |
| Lens 1 smaller win 2 — \`EventGraph._nameToType\` pre-warm | ✅ #4307 area |
| Lens 1 smaller win 3 — \`GenerationRules.ApplicationAssembly\` cache \`GetEntryAssembly()\` | ✅ #4307 |
| Lens 3 Row 4 — \`operationDocumentTypes()\` single-pass \`HashSet\` | ✅ already in master |

## Deferred follow-ups

- **Lens 1 Row 2** — indexed pre-generated type lookup. Tracked at [jasperfx#189](https://github.com/JasperFx/jasperfx/issues/189) on the JasperFx side.
- **Lens 3 Row 1** — \`SaveChangesAsync\` \`WorkTracker.Streams\` re-enumeration. Already partly addressed by the \`IInlineProjection.ApplyAsync\` widening shipped in JasperFx.Events (#4306). No Marten-side action remaining.
- **Lens 3 Row 2** — LINQ handler \`Activator.CreateInstance\` caching. Needs the JasperFx \`GenericFactoryCache\` applied at each LINQ site (\`LinqQueryParser.Handlers.cs\`, \`CollectionUsage.Compilation.cs\`). Meaningful refactor; warrants its own PR.

## Test plan
- [x] \`dotnet build src/Marten/Marten.csproj\` — clean (only pre-existing warnings).
- [x] \`dotnet build src/EventSourcingTests/EventSourcingTests.csproj\` — clean.
- [ ] CI runs the full Postgres test matrix; my workstation has no Postgres so local \`dotnet test\` has 158 \`Failed to connect to 127.0.0.1:5432\` failures unrelated to this PR (rest pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)