### PR TITLE
Bump JasperFx 2.0.0-alpha.6 → 2.0.0-alpha.8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.6" />
+    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.8" />
     <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.3" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
Pin bump only. Picks up two alphas since #4369 landed alpha.6:

- **2.0.0-alpha.7** — [jasperfx#240](https://github.com/JasperFx/jasperfx/pull/240): \`UnknownTenantIdException\` exposes \`TenantId\` as a property. Additive — single-arg ctor signature unchanged. Closes the JasperFx companion of the multi-tenancy dedup audit slice [jasperfx#224](https://github.com/JasperFx/jasperfx/issues/224).
- **2.0.0-alpha.8** — [jasperfx#241](https://github.com/JasperFx/jasperfx/pull/241): FastExpressionCompiler 5.3.0 → 5.4.1 (transitive). ImTools was already at latest stable 4.0.0.

Other pins (Events alpha.3, RuntimeCompiler alpha.2, SourceGeneration alpha.2, Events.SourceGenerator alpha.2) stay where they are — no newer alphas to absorb.

## Test plan
- [x] \`dotnet build src/Marten/Marten.csproj\` — clean
- [x] \`dotnet build src/EventSourcingTests/EventSourcingTests.csproj\` — clean
- [x] \`dotnet build src/CoreTests/CoreTests.csproj\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)