### PR TITLE
9.0: widen document Revision int → long (#3733)

### DIFF
--- a/docs/documents/concurrency.md
+++ b/docs/documents/concurrency.md
@@ -173,7 +173,7 @@ public class Reservation: IRevisioned
 
     // other properties
 
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 ```
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/RevisionedDocuments.cs#L83-L99' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_versioned_reservation' title='Start of snippet'>anchor</a></sup>
@@ -200,11 +200,11 @@ public class Order
 {
     public Guid Id { get; set; }
 
-    // Marking an integer as the "version"
+    // Marking a long as the "version"
     // of the document, and making Marten
     // opt this document into the numeric revisioning
     [Version]
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 ```
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/RevisionedDocuments.cs#L68-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_versioned_order' title='Start of snippet'>anchor</a></sup>

--- a/src/DaemonTests/Aggregations/converting_projection_from_inline_to_async.cs
+++ b/src/DaemonTests/Aggregations/converting_projection_from_inline_to_async.cs
@@ -81,7 +81,7 @@ public class converting_projection_from_inline_to_async : OneOffConfigurationsCo
 public class SimpleAggregate : IRevisioned
 {
     // This will be the aggregate version
-    public int Version { get; set; }
+    public long Version { get; set; }
 
     public Guid Id { get; set; }
 

--- a/src/DaemonTests/Aggregations/side_effects_in_aggregations.cs
+++ b/src/DaemonTests/Aggregations/side_effects_in_aggregations.cs
@@ -400,7 +400,7 @@ public class SideEffects1: IRevisioned
     public int B { get; set; }
     public int C { get; set; }
     public int D { get; set; }
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 
 public record WasDeleted(Guid Id);
@@ -460,7 +460,7 @@ public class SideEffects2: IRevisioned
     public int B { get; set; }
     public int C { get; set; }
     public int D { get; set; }
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 
 public class RecordingMessageOutbox: IMessageOutbox

--- a/src/DaemonTests/TeleHealth/Appointments.cs
+++ b/src/DaemonTests/TeleHealth/Appointments.cs
@@ -26,7 +26,7 @@ public class Appointment
 {
     public Guid Id { get; set; }
 
-    public int Version { get; set; }
+    public long Version { get; set; }
     public DateTimeOffset Created { get; set; }
     public string SpecialtyCode { get; set; }
 

--- a/src/DaemonTests/TeleHealth/ProviderShift.cs
+++ b/src/DaemonTests/TeleHealth/ProviderShift.cs
@@ -13,7 +13,7 @@ namespace DaemonTests.TeleHealth;
 public class ProviderShift(Guid boardId, Provider provider)
 {
     public Guid Id { get; set; }
-    public int Version { get; set; }
+    public long Version { get; set; }
     public Guid BoardId { get; private set; } = boardId;
     public Guid ProviderId => Provider.Id;
     public ProviderStatus Status { get; set; } = ProviderStatus.Paused;

--- a/src/DaemonTests/TestingSupport/Trip.cs
+++ b/src/DaemonTests/TestingSupport/Trip.cs
@@ -44,7 +44,7 @@ public class Trip : Activity, IRevisioned
         return $"{nameof(Id)}: {Id}, {nameof(EndedOn)}: {EndedOn}, {nameof(Traveled)}: {Traveled}, {nameof(State)}: {State}, {nameof(Active)}: {Active}, {nameof(StartedOn)}: {StartedOn}";
     }
 
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 
 

--- a/src/DocumentDbTests/Bugs/Bug_3778_schema_name_issue.cs
+++ b/src/DocumentDbTests/Bugs/Bug_3778_schema_name_issue.cs
@@ -45,4 +45,4 @@ public class Bug_3778_schema_name__ending_with_d_issue: OneOffConfigurationsCont
 }
 
 public record User3778(Guid Id, string Name, DateTimeOffset D1, DateOnly D2, User3778 Manager,
-    DateTimeOffset LastModifiedOn, DateTimeOffset CreatedOn, int Version, bool IsArchived);
+    DateTimeOffset LastModifiedOn, DateTimeOffset CreatedOn, long Version, bool IsArchived);

--- a/src/DocumentDbTests/Concurrency/numeric_revisioning.cs
+++ b/src/DocumentDbTests/Concurrency/numeric_revisioning.cs
@@ -575,7 +575,7 @@ public class RevisionedDoc: IRevisioned
     public Guid Id { get; set; }
     public string Name { get; set; }
 
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 
 public class OtherRevisionedDoc
@@ -584,7 +584,7 @@ public class OtherRevisionedDoc
     public string Name { get; set; }
 
     [Version]
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 
 public class UnconventionallyVersionedDoc
@@ -593,5 +593,5 @@ public class UnconventionallyVersionedDoc
 
     public string Name { get; set; }
 
-    public int UnconventionalVersion { get; set; }
+    public long UnconventionalVersion { get; set; }
 }

--- a/src/DocumentDbTests/Internal/Generated/DocumentStorage/RevisionedDocProvider1212098993.cs
+++ b/src/DocumentDbTests/Internal/Generated/DocumentStorage/RevisionedDocProvider1212098993.cs
@@ -237,7 +237,7 @@ namespace Marten.Generated.DocumentStorage
 
             DocumentDbTests.Concurrency.RevisionedDoc document;
             document = _serializer.FromJson<DocumentDbTests.Concurrency.RevisionedDoc>(reader, 0);
-            var version = reader.GetFieldValue<int>(1);
+            var version = reader.GetFieldValue<long>(1);
             document.Version = version;
             return document;
         }
@@ -248,7 +248,7 @@ namespace Marten.Generated.DocumentStorage
 
             DocumentDbTests.Concurrency.RevisionedDoc document;
             document = await _serializer.FromJsonAsync<DocumentDbTests.Concurrency.RevisionedDoc>(reader, 0, token).ConfigureAwait(false);
-            var version = await reader.GetFieldValueAsync<int>(1, token);
+            var version = await reader.GetFieldValueAsync<long>(1, token);
             document.Version = version;
             return document;
         }
@@ -279,7 +279,7 @@ namespace Marten.Generated.DocumentStorage
 
             DocumentDbTests.Concurrency.RevisionedDoc document;
             document = _serializer.FromJson<DocumentDbTests.Concurrency.RevisionedDoc>(reader, 1);
-            var version = reader.GetFieldValue<int>(2);
+            var version = reader.GetFieldValue<long>(2);
             document.Version = version;
             _session.MarkAsDocumentLoaded(id, document);
             return document;
@@ -292,7 +292,7 @@ namespace Marten.Generated.DocumentStorage
 
             DocumentDbTests.Concurrency.RevisionedDoc document;
             document = await _serializer.FromJsonAsync<DocumentDbTests.Concurrency.RevisionedDoc>(reader, 1, token).ConfigureAwait(false);
-            var version = await reader.GetFieldValueAsync<int>(2, token);
+            var version = await reader.GetFieldValueAsync<long>(2, token);
             document.Version = version;
             _session.MarkAsDocumentLoaded(id, document);
             return document;
@@ -325,7 +325,7 @@ namespace Marten.Generated.DocumentStorage
 
             DocumentDbTests.Concurrency.RevisionedDoc document;
             document = _serializer.FromJson<DocumentDbTests.Concurrency.RevisionedDoc>(reader, 1);
-            var version = reader.GetFieldValue<int>(2);
+            var version = reader.GetFieldValue<long>(2);
             document.Version = version;
             _session.MarkAsDocumentLoaded(id, document);
             _identityMap[id] = document;
@@ -340,7 +340,7 @@ namespace Marten.Generated.DocumentStorage
 
             DocumentDbTests.Concurrency.RevisionedDoc document;
             document = await _serializer.FromJsonAsync<DocumentDbTests.Concurrency.RevisionedDoc>(reader, 1, token).ConfigureAwait(false);
-            var version = await reader.GetFieldValueAsync<int>(2, token);
+            var version = await reader.GetFieldValueAsync<long>(2, token);
             document.Version = version;
             _session.MarkAsDocumentLoaded(id, document);
             _identityMap[id] = document;
@@ -374,7 +374,7 @@ namespace Marten.Generated.DocumentStorage
 
             DocumentDbTests.Concurrency.RevisionedDoc document;
             document = _serializer.FromJson<DocumentDbTests.Concurrency.RevisionedDoc>(reader, 1);
-            var version = reader.GetFieldValue<int>(2);
+            var version = reader.GetFieldValue<long>(2);
             document.Version = version;
             _session.MarkAsDocumentLoaded(id, document);
             _identityMap[id] = document;
@@ -390,7 +390,7 @@ namespace Marten.Generated.DocumentStorage
 
             DocumentDbTests.Concurrency.RevisionedDoc document;
             document = await _serializer.FromJsonAsync<DocumentDbTests.Concurrency.RevisionedDoc>(reader, 1, token).ConfigureAwait(false);
-            var version = await reader.GetFieldValueAsync<int>(2, token);
+            var version = await reader.GetFieldValueAsync<long>(2, token);
             document.Version = version;
             _session.MarkAsDocumentLoaded(id, document);
             _identityMap[id] = document;
@@ -1055,7 +1055,7 @@ namespace Marten.Generated.DocumentStorage
 
         public const string OVERWRITE_WITH_VERSION_SQL = "update numeric_revisioning.mt_doc_revisioneddoc target SET data = source.data, mt_dotnet_type = source.mt_dotnet_type, mt_version = source.mt_version, mt_last_modified = transaction_timestamp() FROM mt_doc_revisioneddoc_temp source WHERE source.id = target.id and target.mt_version = source.mt_expected_version";
 
-        public const string CREATE_TEMP_TABLE_FOR_COPYING_SQL = "create temporary table mt_doc_revisioneddoc_temp (like numeric_revisioning.mt_doc_revisioneddoc including defaults, \"mt_expected_version\" integer)";
+        public const string CREATE_TEMP_TABLE_FOR_COPYING_SQL = "create temporary table mt_doc_revisioneddoc_temp (like numeric_revisioning.mt_doc_revisioneddoc including defaults, \"mt_expected_version\" bigint)";
 
 
         public override string CreateTempTableForCopying()
@@ -1086,7 +1086,7 @@ namespace Marten.Generated.DocumentStorage
         {
             await writer.WriteAsync(document.GetType().FullName, NpgsqlTypes.NpgsqlDbType.Varchar, cancellation);
             await writer.WriteAsync(((DocumentDbTests.Concurrency.RevisionedDoc)document).Id, NpgsqlTypes.NpgsqlDbType.Uuid, cancellation);
-            await writer.WriteAsync(1, NpgsqlTypes.NpgsqlDbType.Integer, cancellation);
+            await writer.WriteAsync((long)1, NpgsqlTypes.NpgsqlDbType.Bigint, cancellation);
             await writer.WriteAsync(serializer.ToJson(document), NpgsqlTypes.NpgsqlDbType.Jsonb, cancellation);
         }
 
@@ -1095,8 +1095,8 @@ namespace Marten.Generated.DocumentStorage
         {
             await writer.WriteAsync(document.GetType().FullName, NpgsqlTypes.NpgsqlDbType.Varchar, cancellation);
             await writer.WriteAsync(((DocumentDbTests.Concurrency.RevisionedDoc)document).Id, NpgsqlTypes.NpgsqlDbType.Uuid, cancellation);
-            writer.Write(document.Version <= 0 ? (object)System.DBNull.Value : (object)document.Version, NpgsqlTypes.NpgsqlDbType.Integer);
-            await writer.WriteAsync(1, NpgsqlTypes.NpgsqlDbType.Integer, cancellation);
+            writer.Write(document.Version <= 0 ? (object)System.DBNull.Value : (object)(long)document.Version, NpgsqlTypes.NpgsqlDbType.Bigint);
+            await writer.WriteAsync((long)1, NpgsqlTypes.NpgsqlDbType.Bigint, cancellation);
             await writer.WriteAsync(serializer.ToJson(document), NpgsqlTypes.NpgsqlDbType.Jsonb, cancellation);
         }
 

--- a/src/DocumentDbTests/Writing/bulk_loading.cs
+++ b/src/DocumentDbTests/Writing/bulk_loading.cs
@@ -707,6 +707,6 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
     {
         public Guid Id { get; set; }
         public string Name { get; set; } = string.Empty;
-        public int Version { get; set; }
+        public long Version { get; set; }
     }
 }

--- a/src/EventSourcingTests/Aggregation/AggregationTestingSupport.cs
+++ b/src/EventSourcingTests/Aggregation/AggregationTestingSupport.cs
@@ -95,7 +95,7 @@ public class MyAggregate
 
 
     // This will be the aggregate version
-    public int Version { get; set; }
+    public long Version { get; set; }
 
 
     public Guid Id { get; set; }

--- a/src/EventSourcingTests/Aggregation/OrderAggregate.cs
+++ b/src/EventSourcingTests/Aggregation/OrderAggregate.cs
@@ -12,7 +12,7 @@ public class OrderAggregate
 
     // This would be set automatically by Marten if
     // used as the target of a SingleStreamAggregation
-    public int Version { get; set; }
+    public long Version { get; set; }
 
     public void Apply(OrderShipped shipped) => HasShipped = true;
     public bool HasShipped { get; private set; }

--- a/src/EventSourcingTests/Aggregation/setting_version_number_on_aggregate.cs
+++ b/src/EventSourcingTests/Aggregation/setting_version_number_on_aggregate.cs
@@ -132,7 +132,7 @@ public class setting_version_number_on_aggregate : OneOffConfigurationsContext
     public class MyAggregateWithDifferentVersionProperty
     {
         [Version]
-        public int SpecialVersion { get; set; }
+        public long SpecialVersion { get; set; }
 
 
         public Guid Id { get; set; }

--- a/src/EventSourcingTests/Aggregation/stream_compacting.cs
+++ b/src/EventSourcingTests/Aggregation/stream_compacting.cs
@@ -361,7 +361,7 @@ public class Letters : IRevisioned
     public int BCount { get; set; }
     public int CCount { get; set; }
     public int DCount { get; set; }
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 
 public class LetterCounts: IRevisioned
@@ -371,7 +371,7 @@ public class LetterCounts: IRevisioned
     public int BCount { get; set; }
     public int CCount { get; set; }
     public int DCount { get; set; }
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 
 public class LetterCountsByString: IRevisioned
@@ -381,7 +381,7 @@ public class LetterCountsByString: IRevisioned
     public int BCount { get; set; }
     public int CCount { get; set; }
     public int DCount { get; set; }
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 
 public class LetterCountsByStringProjection: SingleStreamProjection<LetterCountsByString, string>

--- a/src/EventSourcingTests/Aggregation/using_apply_metadata.cs
+++ b/src/EventSourcingTests/Aggregation/using_apply_metadata.cs
@@ -182,7 +182,7 @@ public class Item
     public string LastModifiedBy { get; set; }
     public DateTimeOffset? LastModified { get; set; }
 
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 
 public record ItemStarted(string Description);

--- a/src/EventSourcingTests/Aggregation/when_finding_the_last_good_aggregation.cs
+++ b/src/EventSourcingTests/Aggregation/when_finding_the_last_good_aggregation.cs
@@ -82,10 +82,10 @@ public class when_finding_the_last_good_aggregation : IntegrationContext
 
 public record DeleteYourself;
 
-public class SimpleMaybeDeletedAggregate : IRevisioned
+public class SimpleMaybeDeletedAggregate : Marten.Metadata.IRevisioned
 {
     // This will be the aggregate version
-    public int Version { get; set; }
+    public long Version { get; set; }
 
     public bool ShouldDelete(DeleteYourself _) => true;
 
@@ -160,7 +160,7 @@ public class SimpleMaybeDeletedAggregate : IRevisioned
     }
 }
 
-public class SimpleAsStringMaybeDeletedAggregate : IRevisioned
+public class SimpleAsStringMaybeDeletedAggregate : Marten.Metadata.IRevisioned
 {
     protected bool Equals(SimpleAsStringMaybeDeletedAggregate other)
     {
@@ -193,7 +193,7 @@ public class SimpleAsStringMaybeDeletedAggregate : IRevisioned
     }
 
     // This will be the aggregate version
-    public int Version { get; set; }
+    public long Version { get; set; }
 
     public bool ShouldDelete(DeleteYourself _) => true;
 

--- a/src/EventSourcingTests/Bugs/Bug_3310_inline_projections_with_quick_append.cs
+++ b/src/EventSourcingTests/Bugs/Bug_3310_inline_projections_with_quick_append.cs
@@ -213,7 +213,7 @@ public class Bug_3310_inline_projections_with_quick_append : BugIntegrationConte
         public Guid LastValue { get; init; }
         public long Sum { get; init; }
         [Version]
-        public int Version { get; set; }
+        public long Version { get; set; }
 
         public LoadTestInlineProjection Apply(LoadTestEvent @event, LoadTestInlineProjection current)
         {
@@ -228,7 +228,7 @@ public class Bug_3310_inline_projections_with_quick_append : BugIntegrationConte
         public string StreamKey { get; init; }
         public long Count { get; init; }
         [Version]
-        public int Version { get; set; }
+        public long Version { get; set; }
 
         public LoadTestUnrelatedInlineProjection Apply(LoadTestUnrelatedEvent @event, LoadTestUnrelatedInlineProjection current)
         {

--- a/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs
+++ b/src/EventSourcingTests/Examples/OptimizedCommandHandling.cs
@@ -36,7 +36,7 @@ public class Order
 
     // This is important, by Marten convention this would
     // be the
-    public int Version { get; set; }
+    public long Version { get; set; }
 
     public Order(OrderCreated created)
     {

--- a/src/EventSourcingTests/FetchForWriting/fetch_for_writing_and_projection_metadata_for_inline_projections.cs
+++ b/src/EventSourcingTests/FetchForWriting/fetch_for_writing_and_projection_metadata_for_inline_projections.cs
@@ -164,5 +164,5 @@ public class VersionedGuy
     public int CCount { get; set; }
     public int DCount { get; set; }
 
-    public int Version { get; set; }
+    public long Version { get; set; }
 }

--- a/src/EventSourcingTests/FetchForWriting/fetching_live_aggregates_for_writing.cs
+++ b/src/EventSourcingTests/FetchForWriting/fetching_live_aggregates_for_writing.cs
@@ -776,7 +776,7 @@ public class fetching_live_aggregates_for_writing: IntegrationContext
 public class SimpleAggregate : IRevisioned
 {
     // This will be the aggregate version
-    public int Version { get; set; }
+    public long Version { get; set; }
 
     public Guid Id { get;
         set; }
@@ -848,7 +848,7 @@ public class SimpleAggregate : IRevisioned
 public class SimpleAggregate2
 {
     // This will be the aggregate version
-    public int Version { get; set; }
+    public long Version { get; set; }
 
     public Guid Id { get; set; }
 
@@ -987,7 +987,7 @@ public class SomeProjection : IRevisioned
     public Guid Id { get; set; }
     public int A { get; set; }
     public void Apply(EventA e) => A++;
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 
 public class SomeOtherProjection : IRevisioned
@@ -995,5 +995,5 @@ public class SomeOtherProjection : IRevisioned
     public Guid Id { get; set; }
     public int A { get; set; }
     public void Apply(EventA e) => A++;
-    public int Version { get; set; }
+    public long Version { get; set; }
 }

--- a/src/EventSourcingTests/Projections/Flattened/flat_table_projection_with_event_member_identifier_end_to_end.cs
+++ b/src/EventSourcingTests/Projections/Flattened/flat_table_projection_with_event_member_identifier_end_to_end.cs
@@ -52,7 +52,7 @@ public class flat_table_projection_with_event_member_identifier_end_to_end: OneO
         public int C { get; set; }
         public int D { get; set; }
         public string Status { get; set; }
-        public int Version { get; set; }
+        public long Version { get; set; }
         public Guid Guid { get; set; }
         public DateTimeOffset Time { get; set; }
     }

--- a/src/EventSourcingTests/Projections/Flattened/flat_table_projection_with_stream_id_identifier_end_to_end.cs
+++ b/src/EventSourcingTests/Projections/Flattened/flat_table_projection_with_stream_id_identifier_end_to_end.cs
@@ -51,7 +51,7 @@ public class flat_table_projection_with_stream_id_identifier_end_to_end: OneOffC
         public int C { get; set; }
         public int D { get; set; }
         public string Status { get; set; }
-        public int Version { get; set; }
+        public long Version { get; set; }
     }
 
     private async Task<Data> readData(DbDataReader reader)

--- a/src/EventSourcingTests/Projections/Flattened/flat_table_projection_with_stream_key_identifier_end_to_end.cs
+++ b/src/EventSourcingTests/Projections/Flattened/flat_table_projection_with_stream_key_identifier_end_to_end.cs
@@ -52,7 +52,7 @@ public class flat_table_projection_with_stream_key_identifier_end_to_end: OneOff
         public int C { get; set; }
         public int D { get; set; }
         public string Status { get; set; }
-        public int Version { get; set; }
+        public long Version { get; set; }
     }
 
     private async Task<Data> readData(DbDataReader reader)

--- a/src/EventSourcingTests/Projections/testing_projections.cs
+++ b/src/EventSourcingTests/Projections/testing_projections.cs
@@ -58,7 +58,7 @@ public class Invoice
 
     #endregion
 
-    public int Version { get; set; }
+    public long Version { get; set; }
 
     public decimal Amount { get; set; }
     public string Description { get; set; }

--- a/src/EventSourcingTests/Projections/using_explicit_code_for_live_aggregation.cs
+++ b/src/EventSourcingTests/Projections/using_explicit_code_for_live_aggregation.cs
@@ -97,10 +97,10 @@ public class using_explicit_code_for_live_aggregation : OneOffConfigurationsCont
 
 #region sample_using_simple_explicit_code_for_live_aggregation
 
-public class CountedAggregate: IRevisioned
+public class CountedAggregate: Marten.Metadata.IRevisioned
 {
     // This will be the aggregate version
-    public int Version { get; set; }
+    public long Version { get; set; }
 
     public Guid Id
     {

--- a/src/EventSourcingTests/archiving_events.cs
+++ b/src/EventSourcingTests/archiving_events.cs
@@ -631,7 +631,7 @@ public readonly partial struct GuidId;
 public class SimpleAggregateStrongTypedGuid
 {
     // This will be the aggregate version
-    public int Version { get; set; }
+    public long Version { get; set; }
 
     public GuidId? Id { get; set; }
 
@@ -674,7 +674,7 @@ public readonly partial struct StringId;
 public class SimpleAggregateStrongTypedString
 {
     // This will be the aggregate version
-    public int Version { get; set; }
+    public long Version { get; set; }
 
     public StringId? Id { get; set; }
 

--- a/src/Marten.Testing/Examples/RevisionedDocuments.cs
+++ b/src/Marten.Testing/Examples/RevisionedDocuments.cs
@@ -71,11 +71,11 @@ public class Order
 {
     public Guid Id { get; set; }
 
-    // Marking an integer as the "version"
+    // Marking a long as the "version"
     // of the document, and making Marten
     // opt this document into the numeric revisioning
     [Version]
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 
 #endregion
@@ -93,7 +93,7 @@ public class Reservation: IRevisioned
 
     // other properties
 
-    public int Version { get; set; }
+    public long Version { get; set; }
 }
 
 #endregion

--- a/src/Marten/Events/EventDocumentStorage.cs
+++ b/src/Marten/Events/EventDocumentStorage.cs
@@ -193,7 +193,7 @@ public abstract class EventDocumentStorage: IEventStorage
         // Nothing
     }
 
-    public void Store(IMartenSession session, IEvent document, int revision)
+    public void Store(IMartenSession session, IEvent document, long revision)
     {
         // Nothing
     }

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -272,7 +272,7 @@ public class EventMapping<T>: EventMapping, IDocumentStorage<T> where T : class
         throw new NotSupportedException();
     }
 
-    public void Store(IMartenSession session, T document, int revision)
+    public void Store(IMartenSession session, T document, long revision)
     {
         throw new NotSupportedException();
     }

--- a/src/Marten/IDocumentOperations.cs
+++ b/src/Marten/IDocumentOperations.cs
@@ -111,7 +111,7 @@ public interface IDocumentOperations: IQuerySession, IStorageOperations
     /// <typeparam name="T"></typeparam>
     /// <param name="entity"></param>
     /// <param name="revision"></param>
-    void UpdateRevision<T>(T entity, int revision) where T : notnull;
+    void UpdateRevision<T>(T entity, long revision) where T : notnull;
 
     /// <summary>
     /// Explicitly marks a document as needing to be updated and supplies the
@@ -122,7 +122,7 @@ public interface IDocumentOperations: IQuerySession, IStorageOperations
     /// <param name="entity"></param>
     /// <param name="revision"></param>
     /// <typeparam name="T"></typeparam>
-    void TryUpdateRevision<T>(T entity, int revision) where T : notnull;
+    void TryUpdateRevision<T>(T entity, long revision) where T : notnull;
 
     /// <summary>
     ///     Store an enumerable of potentially mixed documents

--- a/src/Marten/Internal/CodeGeneration/BulkLoaderBuilder.cs
+++ b/src/Marten/Internal/CodeGeneration/BulkLoaderBuilder.cs
@@ -92,7 +92,7 @@ public class BulkLoaderBuilder
 
         if (includeExpectedVersion && needsExpectedVersion())
         {
-            var dbType = _mapping.UseNumericRevisions ? NpgsqlDbType.Integer : NpgsqlDbType.Uuid;
+            var dbType = _mapping.UseNumericRevisions ? NpgsqlDbType.Bigint : NpgsqlDbType.Uuid;
             var expectedArgument = new ExpectedVersionArgument(dbType);
             var insertIndex = arguments.FindIndex(x => x is VersionArgument || x is RevisionArgument);
             if (insertIndex < 0)
@@ -184,7 +184,7 @@ public class BulkLoaderBuilder
             return $"create temporary table {_tempTable} (like {_mapping.TableName.QualifiedName} including defaults)";
         }
 
-        var expectedType = _mapping.UseNumericRevisions ? "integer" : "uuid";
+        var expectedType = _mapping.UseNumericRevisions ? "bigint" : "uuid";
         return $"create temporary table {_tempTable} (like {_mapping.TableName.QualifiedName} including defaults, \"{SchemaConstants.ExpectedVersionColumn}\" {expectedType})";
     }
 

--- a/src/Marten/Internal/CodeGeneration/DocumentSelectorWithDirtyChecking.cs
+++ b/src/Marten/Internal/CodeGeneration/DocumentSelectorWithDirtyChecking.cs
@@ -45,7 +45,7 @@ public abstract class RevisionedDocumentSelectorWithDirtyChecking<T, TId>: IDocu
     protected readonly DocumentMapping _mapping;
     protected readonly ISerializer _serializer;
     protected readonly IMartenSession _session;
-    protected readonly Dictionary<TId, int> _versions;
+    protected readonly Dictionary<TId, long> _versions;
 
     public RevisionedDocumentSelectorWithDirtyChecking(IMartenSession session, DocumentMapping mapping)
     {

--- a/src/Marten/Internal/CodeGeneration/DocumentSelectorWithIdentityMap.cs
+++ b/src/Marten/Internal/CodeGeneration/DocumentSelectorWithIdentityMap.cs
@@ -34,7 +34,7 @@ public abstract class RevisionedDocumentSelectorWithIdentityMap<T, TId>: IDocume
     protected readonly Dictionary<TId, T> _identityMap;
     protected readonly DocumentMapping _mapping;
     protected readonly ISerializer _serializer;
-    protected readonly Dictionary<TId, int> _versions;
+    protected readonly Dictionary<TId, long> _versions;
 
     public RevisionedDocumentSelectorWithIdentityMap(IMartenSession session, DocumentMapping mapping)
     {

--- a/src/Marten/Internal/Operations/StorageOperation.cs
+++ b/src/Marten/Internal/Operations/StorageOperation.cs
@@ -19,7 +19,7 @@ namespace Marten.Internal.Operations;
 
 public interface IRevisionedOperation
 {
-    int Revision { get; set; }
+    long Revision { get; set; }
     bool IgnoreConcurrencyViolation { get; set; }
 }
 
@@ -40,7 +40,7 @@ public abstract class StorageOperation<T, TId>: IDocumentStorageOperation, IExce
     }
 
     // Using 0 as the default so that inserts "just work"
-    public int Revision { get; set; } = 0;
+    public long Revision { get; set; } = 0;
 
     public bool IgnoreConcurrencyViolation { get; set; }
 
@@ -106,7 +106,7 @@ public abstract class StorageOperation<T, TId>: IDocumentStorageOperation, IExce
     protected void setCurrentRevisionParameter(IGroupedParameterBuilder builder)
     {
         var parameter = builder.AppendParameter(Revision);
-        parameter.NpgsqlDbType = NpgsqlDbType.Integer;
+        parameter.NpgsqlDbType = NpgsqlDbType.Bigint;
     }
 
     protected bool postprocessConcurrency(DbDataReader reader, IList<Exception> exceptions)
@@ -130,7 +130,7 @@ public abstract class StorageOperation<T, TId>: IDocumentStorageOperation, IExce
         var success = true;
         if (reader.Read())
         {
-            var revision = reader.GetFieldValue<int>(0);
+            var revision = reader.GetFieldValue<long>(0);
             if (revision == 0)
             {
                 exceptions.Add(new ConcurrencyException(typeof(T), _id));
@@ -162,7 +162,7 @@ public abstract class StorageOperation<T, TId>: IDocumentStorageOperation, IExce
         var success = true;
         if (await reader.ReadAsync(token).ConfigureAwait(false))
         {
-            var revision = await reader.GetFieldValueAsync<int>(0, token).ConfigureAwait(false);
+            var revision = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
             if (revision == 0)
             {
                 exceptions.Add(new ConcurrencyException(typeof(T), _id));

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -89,7 +89,7 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
         _workTracker.Add(op);
     }
 
-    public void UpdateRevision<T>(T entity, int revision) where T : notnull
+    public void UpdateRevision<T>(T entity, long revision) where T : notnull
     {
         assertNotDisposed();
 
@@ -104,7 +104,7 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
         _workTracker.Add(op);
     }
 
-    public void TryUpdateRevision<T>(T entity, int revision) where T : notnull
+    public void TryUpdateRevision<T>(T entity, long revision) where T : notnull
     {
         assertNotDisposed();
 

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -277,7 +277,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
 
     public abstract void Store(IMartenSession session, T document);
     public abstract void Store(IMartenSession session, T document, Guid? version);
-    public abstract void Store(IMartenSession session, T document, int revision);
+    public abstract void Store(IMartenSession session, T document, long revision);
     public abstract void Eject(IMartenSession session, T document);
     public abstract IStorageOperation Update(T document, IMartenSession session, string tenant);
     public abstract IStorageOperation Insert(T document, IMartenSession session, string tenant);

--- a/src/Marten/Internal/Storage/IDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IDocumentStorage.cs
@@ -104,7 +104,7 @@ public interface IDocumentStorage<T>: IDocumentStorage where T : notnull
 
     void Store(IMartenSession session, T document);
     void Store(IMartenSession session, T document, Guid? version);
-    void Store(IMartenSession session, T document, int revision);
+    void Store(IMartenSession session, T document, long revision);
 
     void Eject(IMartenSession session, T document);
 

--- a/src/Marten/Internal/Storage/IdentityMapDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IdentityMapDocumentStorage.cs
@@ -86,7 +86,7 @@ public abstract class IdentityMapDocumentStorage<T, TId>: DocumentStorage<T, TId
         }
     }
 
-    public sealed override void Store(IMartenSession session, T document, int revision)
+    public sealed override void Store(IMartenSession session, T document, long revision)
     {
         store(session, document, out var id);
 

--- a/src/Marten/Internal/Storage/LightweightDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/LightweightDocumentStorage.cs
@@ -36,7 +36,7 @@ public abstract class LightweightDocumentStorage<T, TId>: DocumentStorage<T, TId
         }
     }
 
-    public sealed override void Store(IMartenSession session, T document, int revision)
+    public sealed override void Store(IMartenSession session, T document, long revision)
     {
         var id = AssignIdentity(document, session.TenantId, session.Database);
         session.MarkAsAddedForStorage(id, document);

--- a/src/Marten/Internal/Storage/QueryOnlyDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/QueryOnlyDocumentStorage.cs
@@ -33,7 +33,7 @@ public abstract class QueryOnlyDocumentStorage<T, TId>: DocumentStorage<T, TId>,
     {
     }
 
-    public sealed override void Store(IMartenSession session, T document, int revision)
+    public sealed override void Store(IMartenSession session, T document, long revision)
     {
     }
 

--- a/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
@@ -137,7 +137,7 @@ internal class SubClassDocumentStorage<T, TRoot, TId>: IDocumentStorage<T, TId>,
         _parent.Store(session, document, version);
     }
 
-    public void Store(IMartenSession session, T document, int revision)
+    public void Store(IMartenSession session, T document, long revision)
     {
         _parent.Store(session, document, revision);
     }

--- a/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
+++ b/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
@@ -117,7 +117,7 @@ internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: ID
 
     public void Store(IMartenSession session, TDoc document, Guid? version) => Inner.Store(session, document, version);
 
-    public void Store(IMartenSession session, TDoc document, int revision) => Inner.Store(session, document, revision);
+    public void Store(IMartenSession session, TDoc document, long revision) => Inner.Store(session, document, revision);
 
     public void Eject(IMartenSession session, TDoc document) => Inner.Eject(session, document);
 

--- a/src/Marten/Internal/VersionTracker.cs
+++ b/src/Marten/Internal/VersionTracker.cs
@@ -8,11 +8,11 @@ public class VersionTracker
 {
     private readonly Dictionary<Type, object> _byType = new();
 
-    public Dictionary<TId, int> RevisionsFor<TDoc, TId>() where TId : notnull
+    public Dictionary<TId, long> RevisionsFor<TDoc, TId>() where TId : notnull
     {
         if (_byType.TryGetValue(typeof(TDoc), out var item))
         {
-            if (item is Dictionary<TId, int> d)
+            if (item is Dictionary<TId, long> d)
             {
                 return d;
             }
@@ -20,7 +20,7 @@ public class VersionTracker
             throw new DocumentIdTypeMismatchException(typeof(TDoc), typeof(TId));
         }
 
-        var dict = new Dictionary<TId, int>();
+        var dict = new Dictionary<TId, long>();
         _byType[typeof(TDoc)] = dict;
 
         return dict;
@@ -62,11 +62,11 @@ public class VersionTracker
         return null;
     }
 
-    public int? RevisionFor<TDoc, TId>(TId id) where TId : notnull
+    public long? RevisionFor<TDoc, TId>(TId id) where TId : notnull
     {
         if (_byType.TryGetValue(typeof(TDoc), out var item))
         {
-            if (item is Dictionary<TId, int> dict)
+            if (item is Dictionary<TId, long> dict)
             {
                 if (dict.TryGetValue(id, out var version))
                 {
@@ -100,11 +100,11 @@ public class VersionTracker
         }
     }
 
-    public void StoreRevision<TDoc, TId>(TId id, int revision) where TId : notnull
+    public void StoreRevision<TDoc, TId>(TId id, long revision) where TId : notnull
     {
         if (_byType.TryGetValue(typeof(TDoc), out var item))
         {
-            if (item is Dictionary<TId, int> d)
+            if (item is Dictionary<TId, long> d)
             {
                 d[id] = revision;
             }
@@ -115,7 +115,7 @@ public class VersionTracker
         }
         else
         {
-            var dict = new Dictionary<TId, int> { [id] = revision };
+            var dict = new Dictionary<TId, long> { [id] = revision };
             _byType.Add(typeof(TDoc), dict);
         }
     }
@@ -135,7 +135,7 @@ public class VersionTracker
     {
         if (_byType.TryGetValue(typeof(TDoc), out var item))
         {
-            if (item is Dictionary<TId, int> dict)
+            if (item is Dictionary<TId, long> dict)
             {
                 dict.Remove(id);
             }

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -913,7 +913,7 @@ public class MartenRegistry
             /// <summary>
             ///     The current numeric version of this document in the database
             /// </summary>
-            public Column<int> Revision => new(_parent, m => m.Revision);
+            public Column<long> Revision => new(_parent, m => m.Revision);
 
             /// <summary>
             ///     Timestamp of the last time this document was modified

--- a/src/Marten/Metadata/IRevisioned.cs
+++ b/src/Marten/Metadata/IRevisioned.cs
@@ -11,5 +11,5 @@ public interface IRevisioned
     /// <summary>
     ///     Marten's version for this document
     /// </summary>
-    int Version { get; set; }
+    long Version { get; set; }
 }

--- a/src/Marten/Schema/Arguments/ExpectedVersionArgument.cs
+++ b/src/Marten/Schema/Arguments/ExpectedVersionArgument.cs
@@ -14,7 +14,7 @@ internal class ExpectedVersionArgument: UpsertArgument
         Arg = "expected_version";
         Column = SchemaConstants.ExpectedVersionColumn;
         DbType = dbType;
-        PostgresType = dbType == NpgsqlDbType.Integer ? "integer" : "uuid";
+        PostgresType = dbType == NpgsqlDbType.Bigint ? "bigint" : "uuid";
     }
 
     public override void GenerateBulkWriterCodeAsync(GeneratedType type, GeneratedMethod load, DocumentMapping mapping)
@@ -25,7 +25,7 @@ internal class ExpectedVersionArgument: UpsertArgument
         }
         else if (mapping.Metadata.Revision.Member != null)
         {
-            writeIntExpectedVersion(load, mapping.Metadata.Revision.Member);
+            writeLongExpectedVersion(load, mapping.Metadata.Revision.Member);
         }
         else
         {
@@ -41,11 +41,11 @@ internal class ExpectedVersionArgument: UpsertArgument
             $"writer.Write(document.{memberName} == Guid.Empty ? (object){typeof(DBNull).FullNameInCode()}.Value : (object)document.{memberName}, {dbTypeUsage});");
     }
 
-    private void writeIntExpectedVersion(GeneratedMethod load, MemberInfo member)
+    private void writeLongExpectedVersion(GeneratedMethod load, MemberInfo member)
     {
         var memberName = member.Name;
-        var dbTypeUsage = Constant.ForEnum(NpgsqlDbType.Integer).Usage;
+        var dbTypeUsage = Constant.ForEnum(NpgsqlDbType.Bigint).Usage;
         load.Frames.Code(
-            $"writer.Write(document.{memberName} <= 0 ? (object){typeof(DBNull).FullNameInCode()}.Value : (object)document.{memberName}, {dbTypeUsage});");
+            $"writer.Write(document.{memberName} <= 0 ? (object){typeof(DBNull).FullNameInCode()}.Value : (object)(long)document.{memberName}, {dbTypeUsage});");
     }
 }

--- a/src/Marten/Schema/Arguments/RevisionArgument.cs
+++ b/src/Marten/Schema/Arguments/RevisionArgument.cs
@@ -11,8 +11,8 @@ internal class RevisionArgument: UpsertArgument
     public RevisionArgument()
     {
         Arg = "revision";
-        PostgresType = "integer";
-        DbType = NpgsqlDbType.Integer;
+        PostgresType = "bigint";
+        DbType = NpgsqlDbType.Bigint;
         Column = SchemaConstants.VersionColumn;
     }
 
@@ -26,7 +26,7 @@ internal class RevisionArgument: UpsertArgument
     public override void GenerateBulkWriterCodeAsync(GeneratedType type, GeneratedMethod load, DocumentMapping mapping)
     {
         load.Frames.CodeAsync(
-            "await writer.WriteAsync(1, {0}, {1});",
-            NpgsqlDbType.Integer, Use.Type<CancellationToken>());
+            "await writer.WriteAsync((long)1, {0}, {1});",
+            NpgsqlDbType.Bigint, Use.Type<CancellationToken>());
     }
 }

--- a/src/Marten/Schema/VersionAttribute.cs
+++ b/src/Marten/Schema/VersionAttribute.cs
@@ -19,7 +19,7 @@ public class VersionAttribute: MartenAttribute, IVersionAttribute
         var memberType = member.GetMemberType();
         if (memberType != typeof(Guid) && memberType != typeof(Guid?))
         {
-            if (memberType == typeof(int) || memberType == typeof(long))
+            if (memberType == typeof(long))
             {
                 mapping.UseNumericRevisions = true;
                 mapping.Metadata.Revision.Enabled = true;
@@ -29,8 +29,14 @@ public class VersionAttribute: MartenAttribute, IVersionAttribute
                 return;
             }
 
+            if (memberType == typeof(int))
+            {
+                throw new ArgumentOutOfRangeException(nameof(member),
+                    $"The [Version] attribute on {member.DeclaringType?.FullName ?? "(unknown)"}.{member.Name} is annotated on an int. As of Marten 9, numeric document revisions are widened to long. Change the property type to long. See https://martendb.io/migration-guide.html#numeric-document-revisions-widened-from-int-to-long");
+            }
+
             throw new ArgumentOutOfRangeException(nameof(member),
-                "The [Version] attribute is only valid on properties or fields of type Guid/Guid for optimistic concurrency, or int/long for projected aggregate version");
+                "The [Version] attribute is only valid on properties or fields of type Guid/Guid? for optimistic concurrency, or long for projected aggregate version");
         }
 
         mapping.UseOptimisticConcurrency = true;

--- a/src/Marten/Storage/Metadata/DocumentMetadata.cs
+++ b/src/Marten/Storage/Metadata/DocumentMetadata.cs
@@ -28,7 +28,7 @@ public class DocumentMetadata
     /// <summary>
     ///     The current version of this document in the database if using numeric revisions
     /// </summary>
-    public int CurrentRevision { get; internal set; }
+    public long CurrentRevision { get; internal set; }
 
     /// <summary>
     ///     Timestamp of the last time this document was modified

--- a/src/Marten/Storage/Metadata/MetadataColumn.cs
+++ b/src/Marten/Storage/Metadata/MetadataColumn.cs
@@ -122,7 +122,7 @@ internal abstract class MetadataColumn<T>: MetadataColumn
                 if (value.GetRawMemberType() != typeof(T))
                 {
                     throw new ArgumentOutOfRangeException(nameof(value),
-                        $"The {_memberName} member of {_member.DeclaringType?.NameInCode() ?? "null"} has to be of type {typeof(T).NameInCode()}");
+                        $"The {_memberName} member of {value.DeclaringType?.NameInCode() ?? "null"} has to be of type {typeof(T).NameInCode()}");
                 }
 
                 _member = value;

--- a/src/Marten/Storage/Metadata/RevisionColumn.cs
+++ b/src/Marten/Storage/Metadata/RevisionColumn.cs
@@ -9,7 +9,7 @@ using Weasel.Postgresql.Tables;
 
 namespace Marten.Storage.Metadata;
 
-internal class RevisionColumn: MetadataColumn<int>, ISelectableColumn
+internal class RevisionColumn: MetadataColumn<long>, ISelectableColumn
 {
     public RevisionColumn(): base(SchemaConstants.VersionColumn, x => x.CurrentRevision)
     {
@@ -31,8 +31,8 @@ internal class RevisionColumn: MetadataColumn<int>, ISelectableColumn
         var versionPosition = index; //mapping.IsHierarchy() ? 3 : 2;
 
         async.Frames.CodeAsync(
-            $"var version = await reader.GetFieldValueAsync<int>({versionPosition}, token);");
-        sync.Frames.Code($"var version = reader.GetFieldValue<int>({versionPosition});");
+            $"var version = await reader.GetFieldValueAsync<long>({versionPosition}, token);");
+        sync.Frames.Code($"var version = reader.GetFieldValue<long>({versionPosition});");
 
         if (Member != null)
         {
@@ -53,12 +53,21 @@ internal class RevisionColumn: MetadataColumn<int>, ISelectableColumn
 
     public override string AlterColumnTypeSql(Table table, TableColumn changeActual)
     {
+        // Non-destructive widening from the Marten 8 schema (integer) to Marten 9 (bigint).
+        // Existing revision values are preserved.
+        if (changeActual.Type.EqualsIgnoreCase("integer"))
+        {
+            return $"ALTER TABLE {table.Identifier.QualifiedName} ALTER COLUMN {Name} TYPE bigint;";
+        }
+
+        // Falling through here means the existing column is a Guid concurrency column (uuid)
+        // and the user is switching to numeric revisions: drop and recreate.
         return $"ALTER TABLE {table.Identifier.QualifiedName} DROP COLUMN {Name};{AddColumnSql(table)}";
     }
 
     public override bool CanAlter(TableColumn actual)
     {
-        return actual.Type.EqualsIgnoreCase("uuid");
+        return actual.Type.EqualsIgnoreCase("uuid") || actual.Type.EqualsIgnoreCase("integer");
     }
 
     public override void WriteMetadataInUpdateStatement(ICommandBuilder builder, DocumentSessionBase session)

--- a/src/Marten/Storage/OverwriteFunction.cs
+++ b/src/Marten/Storage/OverwriteFunction.cs
@@ -16,12 +16,12 @@ internal class OverwriteFunction: UpsertFunction
         if (_mapping.Metadata.Revision.Enabled)
         {
             writer.WriteLine($@"
-CREATE OR REPLACE FUNCTION {Identifier.QualifiedName}({argList}) RETURNS INTEGER LANGUAGE plpgsql {
+CREATE OR REPLACE FUNCTION {Identifier.QualifiedName}({argList}) RETURNS BIGINT LANGUAGE plpgsql {
     securityDeclaration
 } AS $function$
 DECLARE
-  final_version INTEGER;
-  current_version INTEGER;
+  final_version BIGINT;
+  current_version BIGINT;
 BEGIN
 
   if revision = 0 then

--- a/src/Marten/Storage/UpdateFunction.cs
+++ b/src/Marten/Storage/UpdateFunction.cs
@@ -21,12 +21,12 @@ internal class UpdateFunction: UpsertFunction
         if (_mapping.Metadata.Revision.Enabled)
         {
             writer.WriteLine($@"
-CREATE OR REPLACE FUNCTION {Identifier.QualifiedName}({argList}) RETURNS INTEGER LANGUAGE plpgsql {
+CREATE OR REPLACE FUNCTION {Identifier.QualifiedName}({argList}) RETURNS BIGINT LANGUAGE plpgsql {
     securityDeclaration
 } AS $function$
 DECLARE
-  final_version INTEGER;
-  current_version INTEGER;
+  final_version BIGINT;
+  current_version BIGINT;
 BEGIN
   if revision <= 1 then
     SELECT mt_version FROM {_tableName.QualifiedName} into current_version WHERE id = docId {_andTenantWhereClause}{_andPartitionWhereClause};

--- a/src/Marten/Storage/UpsertFunction.cs
+++ b/src/Marten/Storage/UpsertFunction.cs
@@ -216,12 +216,12 @@ internal class UpsertFunction: Function
         if (_mapping.Metadata.Revision.Enabled)
         {
             writer.WriteLine($@"
-CREATE OR REPLACE FUNCTION {Identifier.QualifiedName}({argList}) RETURNS INTEGER LANGUAGE plpgsql {
+CREATE OR REPLACE FUNCTION {Identifier.QualifiedName}({argList}) RETURNS BIGINT LANGUAGE plpgsql {
     securityDeclaration
 } AS $function$
 DECLARE
-  final_version INTEGER;
-  current_version INTEGER;
+  final_version BIGINT;
+  current_version BIGINT;
 BEGIN
 
 SELECT {_versionColumnName} into current_version FROM {_versionSourceTable} WHERE id = docId {_andTenantVersionWhereClause}{_andPartitionWhereClause};

--- a/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs
+++ b/src/MultiTenancyTests/marten_managed_tenant_id_partitioning.cs
@@ -311,7 +311,7 @@ public class DocThatShouldBeExempted2
 public class SimpleAggregate : IRevisioned
 {
     // This will be the aggregate version
-    public int Version { get; set; }
+    public long Version { get; set; }
 
     public Guid Id { get; set; }
 

--- a/src/PatchingTests/Patching/Bug_3261_patch_plus_revisions.cs
+++ b/src/PatchingTests/Patching/Bug_3261_patch_plus_revisions.cs
@@ -30,5 +30,5 @@ public class DocDto
 {
     public long Id { get; set; }
     public string Name { get; set; }
-    public int Version { get; set; }
+    public long Version { get; set; }
 }


### PR DESCRIPTION
Closes #3733.

Breaking change for Marten 9.0. The numeric revision tracking column (`mt_version` when `UseNumericRevisions` is enabled) widens from `integer` to `bigint`, and every .NET-side surface that carries a document revision moves from `int` to `long`.

## Why

`int` capped Marten's numeric-revision tracking at ~2.1B updates per document — well within reach for high-throughput inline projections and event-sourced aggregates that snapshot per event. `long` removes the ceiling without changing the public surface beyond the type widening.

## What changed (Marten core)

| Surface | Before | After |
|---|---|---|
| `Marten.Metadata.IRevisioned.Version` | `int` | `long` |
| `DocumentMetadata.CurrentRevision` | `int` | `long` |
| `IRevisionedOperation.Revision` | `int` | `long` |
| `IDocumentSession.UpdateRevision<T>(entity, revision)` | `int revision` | `long revision` |
| `IDocumentSession.TryUpdateRevision<T>(entity, revision)` | `int revision` | `long revision` |
| `IDocumentStorage<T>.Store(IMartenSession, T, int)` | `int` | `long` |
| `VersionTracker.RevisionFor` / `StoreRevision` / `RevisionsFor` | `int` | `long` |
| `MetadataColumn<int>` for `RevisionColumn` | `<int>` | `<long>` |
| `MartenRegistry.MetadataConfig.Revision` | `Column<int>` | `Column<long>` |
| `mt_doc_*.mt_version` (numeric revisions) | `integer` | `bigint` |
| `mt_upsert_*` / `mt_update_*` / `mt_overwrite_*` revision arg + return + locals | `INTEGER` | `BIGINT` |
| Bulk-loader expected-version column / param | `NpgsqlDbType.Integer` | `NpgsqlDbType.Bigint` |

## Schema migration

Non-destructive widening from a Marten 8 deployment: `RevisionColumn.AlterColumnTypeSql` now emits `ALTER TABLE … ALTER COLUMN mt_version TYPE bigint;` when it sees an existing `integer` column. Existing revision values are preserved. Switching from a Guid-versioned column (uuid) to numeric revisions still drops and recreates the column as before.

## Bonus

- Fixed an NRE in `MetadataColumn<T>.Member.set` when the diagnostic message for a type-mismatched member ran on the first assignment (the message referenced the still-null `_member` field — now references the incoming `value`).

## What user code needs to do

- Any `: IRevisioned` implementation: widen the `Version` property to `long`.
- Any `[Version]`-annotated numeric property used with `UseNumericRevisions`: widen to `long`.
- Any `m.Revision.MapTo(x => x.SomeProperty)` configuration: the target property must be `long`.

This is the documented Marten 8 → 9 migration shape; the migration guide section is being tracked in #4355.

## Verification

- Full `DocumentDbTests` on net9.0: **968 passed, 1 skipped, 0 failed** (~58s)
- `EventSourcingTests` subset that touches `IRevisioned` (`when_finding_the_last_good_aggregation`, `using_explicit_code_for_live_aggregation`, `stream_compacting`, `fetching_live_aggregates`, `fetching_inline_aggregates`): **81 passed**
- `PatchingTests` (`Bug_3261_patch_plus_revisions`): **1 passed**
- `CoreTests` revision-related: **6 passed**
- `DocumentDbTests/Concurrency/numeric_revisioning`: **22 passed**
- `DocumentDbTests/Writing/bulk_loading_Tests.overwrite_if_version_matches_respects_expected_revision`: **passed**

The committed TestCodeGen-validated `RevisionedDocProvider1212098993.cs` was regenerated from this widening (now reads `long`).

## Out of scope

- `JasperFx.IRevisioned` (a duplicate of `Marten.Metadata.IRevisioned` in the JasperFx package) still has `int Version`. The three test classes that resolved to JasperFx's interface via `using JasperFx;` are now explicitly qualified to `Marten.Metadata.IRevisioned`. Deduplicating the two interfaces is a follow-up for the Marten 9.0 dedupe-with-JasperFx pass (umbrella #4349).
- Migration guide language: tracked in #4355 as its own PR.

## Test plan

- [ ] CI green across the test matrix (net9.0 / net10.0, both serializers)
- [ ] `TestCodeGen` nuke task passes (the committed regen file matches the widened codegen output)
- [ ] Docs CI passes (`docs/documents/concurrency.md` `int Version` snippets updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)