### PR TITLE
Fix NgramIndex captures TableName at construction time (#4367)

### DIFF
--- a/src/DocumentDbTests/Bugs/Bug_4367_ngram_index_tracks_versioned_alias.cs
+++ b/src/DocumentDbTests/Bugs/Bug_4367_ngram_index_tracks_versioned_alias.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using Marten;
+using Marten.Schema;
+using Shouldly;
+using Xunit;
+
+namespace DocumentDbTests.Bugs;
+
+/// <summary>
+/// Regression for #4367. <see cref="NgramIndex"/> used to capture the
+/// <c>DocumentMapping.TableName</c> snapshot in its constructor, so any
+/// post-construction alias mutation (most importantly the <c>_{Version}</c>
+/// suffix appended by <c>ProjectionVersionAliasPolicy</c> when a document is
+/// owned by a versioned aggregate projection) wasn't reflected in the derived
+/// index name. The index would end up named after the original alias while the
+/// table itself carried the versioned alias — bumping the projection version
+/// would then fail with <c>Npgsql.PostgresException 42P07: relation
+/// "mt_doc_..._idx_ngram_..." already exists</c> on the second deployment
+/// because the old (un-versioned) index still occupied the namespace.
+///
+/// The fix has <see cref="NgramIndex"/> hold a reference to the parent
+/// <see cref="DocumentMapping"/> and resolve <c>TableName.Name</c> lazily,
+/// matching <see cref="DocumentIndex"/> / <see cref="ComputedIndex"/>.
+/// </summary>
+public class Bug_4367_ngram_index_tracks_versioned_alias
+{
+    public class Bug4367Doc
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    [Fact]
+    public void ngram_index_name_picks_up_alias_mutation_after_construction()
+    {
+        var mapping = DocumentMapping.For<Bug4367Doc>();
+        mapping.NgramIndex(x => x.Name);
+
+        var ngram = mapping.Indexes.OfType<NgramIndex>().Single();
+        var preMutationName = ngram.Name;
+        preMutationName.ShouldContain(mapping.TableName.Name);
+
+        // Mirror what ProjectionVersionAliasPolicy.Apply does for a versioned
+        // aggregate projection (Version > 1).
+        mapping.Alias += "_2";
+
+        var postMutationName = ngram.Name;
+        postMutationName.ShouldContain(mapping.TableName.Name);
+        postMutationName.ShouldEndWith("_2_idx_ngram_name");
+        postMutationName.ShouldNotBe(preMutationName);
+    }
+}

--- a/src/Marten/Schema/NgramIndex.cs
+++ b/src/Marten/Schema/NgramIndex.cs
@@ -17,16 +17,22 @@ public class NgramIndex: IndexDefinition
 {
     public const string DefaultRegConfig = "english";
     public const string DefaultDataConfig = "data";
-    private readonly DbObjectName _table;
-    private readonly string _databaseSchemaName;
+
+    // Hold a reference to the DocumentMapping (not a snapshot of TableName or
+    // DatabaseSchemaName) so the index name we derive in deriveIndexName()
+    // tracks any post-construction mutation of the mapping's alias — most
+    // notably the `_{Version}` suffix that ProjectionVersionAliasPolicy
+    // appends to documents owned by a versioned aggregate projection (#4367).
+    // DocumentIndex / ComputedIndex follow the same lazy pattern; NgramIndex
+    // was the outlier capturing TableName at construction time.
+    private readonly DocumentMapping _parent;
 
     private string _dataConfig = null!;
     private readonly string? _indexName;
 
     public NgramIndex(DocumentMapping mapping, string? dataConfig = null, string? indexName = null)
     {
-        _databaseSchemaName = mapping.DatabaseSchemaName;
-        _table = mapping.TableName;
+        _parent = mapping;
         DataConfig = dataConfig;
         _indexName = indexName;
 
@@ -47,7 +53,7 @@ public class NgramIndex: IndexDefinition
         set => _dataConfig = value ?? DefaultDataConfig;
     }
 
-    public override string[] Columns => [$"{_databaseSchemaName}.mt_grams_vector( {_dataConfig})"];
+    public override string[] Columns => [$"{_parent.DatabaseSchemaName}.mt_grams_vector( {_dataConfig})"];
     protected override string deriveIndexName()
     {
         var lowerValue = _indexName?.ToLowerInvariant();
@@ -71,7 +77,7 @@ public class NgramIndex: IndexDefinition
             .Replace("->>", string.Empty)
             .Replace("->", string.Empty);
 
-        return $"{_table.Name}_idx_ngram_{indexFieldName}";
+        return $"{_parent.TableName.Name}_idx_ngram_{indexFieldName}";
     }
 
     private static string GetDataConfig(DocumentMapping mapping, MemberInfo[] members)


### PR DESCRIPTION
Closes #4367.

## Bug

`NgramIndex` snapshotted `mapping.TableName` into a private field in its constructor. Any post-construction mutation of `mapping.Alias` — most notably the `_{Version}` suffix that `ProjectionVersionAliasPolicy` appends to documents owned by a versioned aggregate projection — was invisible to `NgramIndex.deriveIndexName()`.

Concrete failure: a `CompositeProjectionFor(..., projection => projection.Version = 2)` whose owned document carries an ngram index gets a versioned table (`mt_doc_my_doc_2`) but an un-versioned ngram index name (`mt_doc_my_doc_idx_ngram_name`). On the second app start, that name collides with the leftover index on the previous version's table:

```
Npgsql.PostgresException 42P07: relation "mt_doc_my_doc_idx_ngram_name" already exists
```

## Fix

`DocumentIndex` and `ComputedIndex` already read `_parent.TableName.Name` lazily; `NgramIndex` was the outlier capturing at construction time. This patch has `NgramIndex` hold a `DocumentMapping` reference (mirroring `DocumentIndex`) and resolve table name + database schema lazily in `Columns` / `deriveIndexName()`.

```diff
- private readonly DbObjectName _table;
- private readonly string _databaseSchemaName;
+ private readonly DocumentMapping _parent;

  public NgramIndex(DocumentMapping mapping, ...)
  {
-     _databaseSchemaName = mapping.DatabaseSchemaName;
-     _table = mapping.TableName;
+     _parent = mapping;
      ...
  }

  public override string[] Columns =>
-     [$"{_databaseSchemaName}.mt_grams_vector( {_dataConfig})"];
+     [$"{_parent.DatabaseSchemaName}.mt_grams_vector( {_dataConfig})"];

  protected override string deriveIndexName() => ...
-     $"{_table.Name}_idx_ngram_{indexFieldName}";
+     $"{_parent.TableName.Name}_idx_ngram_{indexFieldName}";
```

## Regression test

`Bug_4367_ngram_index_tracks_versioned_alias.cs` — builds a `DocumentMapping` with an `NgramIndex`, then mutates `mapping.Alias` to mimic `ProjectionVersionAliasPolicy.Apply` and asserts the index name picks up the new alias (containing the `_2` version suffix).

## Verification

- New regression test passes.
- All 13 existing `Ngram`/`NGram` tests still pass on net9.0.

## Test plan

- [ ] CI green across the test matrix