### PR TITLE
Fix WaitForNonStaleProjectionDataAsync under sharded multi-tenancy (#4366)

### DIFF
--- a/src/Marten/Events/AsyncProjectionTestingExtensions.cs
+++ b/src/Marten/Events/AsyncProjectionTestingExtensions.cs
@@ -61,19 +61,40 @@ public static class TestingExtensions
 
     /// <summary>
     ///     Wait for any running async daemons to catch up to the latest event sequence at the time
-    ///     this method is invoked for all projections. This method is meant to aid in automated testing
+    ///     this method is invoked for all projections. This method is meant to aid in automated testing.
+    ///     Under multi-tenancy with separate databases (including
+    ///     <c>MultiTenantedWithShardedDatabases</c>), this iterates every database produced by
+    ///     <c>IMartenStorage.AllDatabases()</c> and waits on each shard's daemon — mirroring the
+    ///     <c>IHost.ForceAllMartenDaemonActivityToCatchUpAsync()</c> shape so test fixtures that
+    ///     construct an <see cref="IDocumentStore"/> directly (no <c>IHost</c>) can still use this
+    ///     method against sharded stores. See <a href="https://github.com/JasperFx/marten/issues/4366">#4366</a>.
     /// </summary>
     /// <param name="store"></param>
     /// <param name="timeout"></param>
-    public static Task WaitForNonStaleProjectionDataAsync(this IDocumentStore store, TimeSpan timeout)
+    public static async Task WaitForNonStaleProjectionDataAsync(this IDocumentStore store, TimeSpan timeout)
     {
         if (store.As<DocumentStore>().Tenancy is DefaultTenancy)
         {
-            return store.Storage.Database.WaitForNonStaleProjectionDataAsync(timeout);
+            await store.Storage.Database.WaitForNonStaleProjectionDataAsync(timeout).ConfigureAwait(false);
+            return;
         }
 
-        throw new InvalidOperationException(
-            "If using multi-tenancy through any kind of separate databases per tenant, please specify a tenant id or database name");
+        // Multi-tenancy through separate databases (sharded, conjoined, single-server, etc.):
+        // there is no single "default" database to wait on. Iterate every database the store
+        // knows about and wait on each. Each call gets its own copy of the timeout because the
+        // waits run sequentially; in practice the high-water-mark check is cheap when projections
+        // are already caught up.
+        var databases = await store.Storage.AllDatabases().ConfigureAwait(false);
+        if (databases.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "The document store has no databases registered with its tenancy. Either configure a tenancy strategy that exposes databases (e.g. MultiTenantedWithShardedDatabases) or invoke a specific tenant id / database name overload.");
+        }
+
+        foreach (var database in databases)
+        {
+            await database.WaitForNonStaleProjectionDataAsync(timeout).ConfigureAwait(false);
+        }
     }
 
     /// <summary>

--- a/src/MultiTenancyTests/sharded_tenancy_tests.cs
+++ b/src/MultiTenancyTests/sharded_tenancy_tests.cs
@@ -460,3 +460,82 @@ public class ShardedTestEvent
 {
     public string Value { get; set; } = "";
 }
+
+/// <summary>
+/// Regression for #4366. `IDocumentStore.WaitForNonStaleProjectionDataAsync(TimeSpan)`
+/// used to throw <see cref="InvalidOperationException"/> when the store was configured
+/// with sharded multi-tenancy (or any multi-tenant DB strategy) because the no-arg
+/// overload tried to read `Storage.Database`, which is null in that mode. Test fixtures
+/// without an <c>IHost</c> (constructing <see cref="DocumentStore"/> directly) had no
+/// way to reach `IHost.ForceAllMartenDaemonActivityToCatchUpAsync()` to work around it.
+/// The fix has the no-arg overload iterate `Storage.AllDatabases()` when not running
+/// under <see cref="DefaultTenancy"/> and wait on each shard's daemon.
+/// </summary>
+[Collection("sharded-tenancy")]
+public class Bug_4366_wait_for_non_stale_under_sharded_multitenancy: IAsyncLifetime
+{
+    private readonly ShardedTenancyFixture _fixture;
+    private IDocumentStore _store = null!;
+
+    public Bug_4366_wait_for_non_stale_under_sharded_multitenancy(ShardedTenancyFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded_4366"); } catch { }
+
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants_4366"); } catch { }
+            await ShardedTenancyFixture.cleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        _store?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task wait_for_non_stale_projection_data_does_not_throw_under_sharded_multitenancy()
+    {
+        _store = DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded_4366";
+                x.PartitionSchemaName = "tenants_4366";
+
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+            });
+
+            opts.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+            opts.RegisterDocumentType<Target>();
+        });
+
+        // Apply schema to every shard so daemon high-water-mark fetches don't blow up
+        // for missing event-store storage. No projections are registered, so each shard's
+        // WaitForNonStaleProjectionDataAsync(timeout) short-circuits immediately when
+        // projectionsCount == 1 (only the high-water mark).
+        var databases = await _store.Options.Tenancy.BuildDatabases();
+        foreach (var db in databases.OfType<IMartenDatabase>())
+        {
+            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+        }
+
+        // Pre-fix: throws InvalidOperationException because Storage.Database is null
+        // under sharded multi-tenancy. Post-fix: iterates every shard and returns.
+        await _store.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(30));
+    }
+}


### PR DESCRIPTION
Closes #4366.

## Bug

`IDocumentStore.WaitForNonStaleProjectionDataAsync(TimeSpan)` (the no-arg overload) threw `InvalidOperationException` when the store was configured with `MultiTenantedWithShardedDatabases` (or any tenancy strategy where `Storage.Database` is null because there is no default tenant DB):

```csharp
var options = new StoreOptions();
options.MultiTenantedWithShardedDatabases(x => { ... });
var store = new DocumentStore(options);

// Throws: "If using multi-tenancy through any kind of separate databases per
// tenant, please specify a tenant id or database name"
await store.WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(30));
```

`IHost.ForceAllMartenDaemonActivityToCatchUpAsync()` already iterates every database under the store and works correctly, but:

- Test fixtures that construct `DocumentStore` directly (no `IHost`) have no equivalent.
- `Wolverine.Marten`'s `WaitForNonStaleDaemonDataAfterExecution` calls the single-DB wait under the hood, so every sharded Wolverine + Marten integration test has to bypass it with `IHost.ForceAllMartenDaemonActivityToCatchUpAsync()`.

## Fix

When the store's tenancy isn't `DefaultTenancy`, iterate `Storage.AllDatabases()` and wait on each shard's daemon sequentially — mirroring the shape of `ForceAllMartenDaemonActivityToCatchUpAsync` so a direct-`DocumentStore` consumer gets the same behavior as an `IHost`-based one.

```diff
- public static Task WaitForNonStaleProjectionDataAsync(this IDocumentStore store, TimeSpan timeout)
+ public static async Task WaitForNonStaleProjectionDataAsync(this IDocumentStore store, TimeSpan timeout)
  {
      if (store.As<DocumentStore>().Tenancy is DefaultTenancy)
      {
-         return store.Storage.Database.WaitForNonStaleProjectionDataAsync(timeout);
+         await store.Storage.Database.WaitForNonStaleProjectionDataAsync(timeout).ConfigureAwait(false);
+         return;
      }

-     throw new InvalidOperationException(
-         "If using multi-tenancy through any kind of separate databases per tenant, please specify a tenant id or database name");
+     var databases = await store.Storage.AllDatabases().ConfigureAwait(false);
+     if (databases.Count == 0)
+     {
+         throw new InvalidOperationException(
+             "The document store has no databases registered with its tenancy. " +
+             "Either configure a tenancy strategy that exposes databases (e.g. " +
+             "MultiTenantedWithShardedDatabases) or invoke a specific tenant id / " +
+             "database name overload.");
+     }
+
+     foreach (var database in databases)
+     {
+         await database.WaitForNonStaleProjectionDataAsync(timeout).ConfigureAwait(false);
+     }
  }
```

The empty-databases case (configured with no `AddDatabase` calls yet) keeps a clear `InvalidOperationException` so misconfigurations don't silently no-op.

## Regression test

`Bug_4366_wait_for_non_stale_under_sharded_multitenancy` in `sharded_tenancy_tests.cs` — builds a sharded store with three shard databases, applies schema to each, then calls the no-arg `WaitForNonStaleProjectionDataAsync` and asserts it doesn't throw.

## Verification

- New regression test passes.
- All 12 existing `sharded_tenancy_tests` still pass on net9.0.

## Test plan

- [ ] CI green across the test matrix
- [ ] Wolverine.Marten's `WaitForNonStaleDaemonDataAfterExecution` works under sharded multi-tenancy (downstream check)