### PR TITLE
Fix CascadeAction deprecated namespace in ForeignKey configuration (#4330)

### DIFF
--- a/docs/documents/indexing/foreign-keys.md
+++ b/docs/documents/indexing/foreign-keys.md
@@ -117,7 +117,7 @@ var store = DocumentStore
     {
         _.Connection("some database connection");
 
-        _.Schema.For<Issue>().ForeignKey<User>(x => x.AssigneeId, fkd => fkd.OnDelete = CascadeAction.Cascade);
+        _.Schema.For<Issue>().ForeignKey<User>(x => x.AssigneeId, fkd => fkd.DeleteAction = CascadeAction.Cascade);
     });
 ```
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/ForeignKeyExamples.cs#L44-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_cascade_deletes_with_config_func' title='Start of snippet'>anchor</a></sup>

--- a/src/CoreTests/ForeignKeys/foreign_keys.cs
+++ b/src/CoreTests/ForeignKeys/foreign_keys.cs
@@ -6,7 +6,7 @@ using Marten.Exceptions;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
-using Weasel.Postgresql;
+using Weasel.Core;
 using Xunit;
 
 namespace CoreTests.ForeignKeys;
@@ -216,7 +216,7 @@ public class foreign_keys: OneOffConfigurationsContext
     {
         StoreOptions(options =>
         {
-            options.Schema.For<Issue>().ForeignKey<User>(x => x.AssigneeId, fkd => fkd.OnDelete = onDelete);
+            options.Schema.For<Issue>().ForeignKey<User>(x => x.AssigneeId, fkd => fkd.DeleteAction = onDelete);
         });
     }
 
@@ -363,7 +363,7 @@ public class foreign_keys: OneOffConfigurationsContext
     {
         StoreOptions(_ =>
         {
-            _.Schema.For<Node2>().ForeignKey<Node1>(x => x.Id, fkc => fkc.OnDelete = CascadeAction.Cascade);
+            _.Schema.For<Node2>().ForeignKey<Node1>(x => x.Id, fkc => fkc.DeleteAction = CascadeAction.Cascade);
         });
 
         var node1 = new Node1 { Id = Guid.NewGuid() };
@@ -399,7 +399,7 @@ public class foreign_keys: OneOffConfigurationsContext
         {
             _.Schema.For<Node2>()
                 .Identity(x => x.NonStandardId)
-                .ForeignKey<Node1>(x => x.NonStandardId, fkc => fkc.OnDelete = CascadeAction.Cascade);
+                .ForeignKey<Node1>(x => x.NonStandardId, fkc => fkc.DeleteAction = CascadeAction.Cascade);
         });
 
         var node1 = new Node1 { Id = Guid.NewGuid() };

--- a/src/Marten.Testing/Examples/ForeignKeyExamples.cs
+++ b/src/Marten.Testing/Examples/ForeignKeyExamples.cs
@@ -1,5 +1,5 @@
 ﻿using Marten.Testing.Documents;
-using Weasel.Postgresql;
+using Weasel.Core;
 using Weasel.Postgresql.Tables;
 
 namespace Marten.Testing.Examples;
@@ -47,7 +47,7 @@ public class ForeignKeyExamples
             {
                 _.Connection("some database connection");
 
-                _.Schema.For<Issue>().ForeignKey<User>(x => x.AssigneeId, fkd => fkd.OnDelete = CascadeAction.Cascade);
+                _.Schema.For<Issue>().ForeignKey<User>(x => x.AssigneeId, fkd => fkd.DeleteAction = CascadeAction.Cascade);
             });
         #endregion
     }

--- a/src/Marten/Events/Schema/EventsTable.cs
+++ b/src/Marten/Events/Schema/EventsTable.cs
@@ -96,7 +96,7 @@ internal class EventsTable: Table
                     ColumnNames = new[] { "stream_id", "is_archived" },
                     LinkedNames = new[] { "id", "is_archived" },
                     LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, "mt_streams"),
-                    OnDelete = CascadeAction.Cascade
+                    DeleteAction = Weasel.Core.CascadeAction.Cascade
                 });
 
                 Indexes.Add(new IndexDefinition("pk_mt_events_stream_and_version")
@@ -111,7 +111,7 @@ internal class EventsTable: Table
                     ColumnNames = new[] { "stream_id" },
                     LinkedNames = new[] { "id" },
                     LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, "mt_streams"),
-                    OnDelete = CascadeAction.Cascade
+                    DeleteAction = Weasel.Core.CascadeAction.Cascade
                 });
 
                 Indexes.Add(new IndexDefinition("pk_mt_events_stream_and_version")

--- a/src/Marten/Events/Schema/NaturalKeyTable.cs
+++ b/src/Marten/Events/Schema/NaturalKeyTable.cs
@@ -50,7 +50,7 @@ internal class NaturalKeyTable: Table, ISchemaObject
                     ColumnNames = new[] { streamCol, TenantIdColumn.Name, "is_archived" },
                     LinkedNames = new[] { "id", TenantIdColumn.Name, "is_archived" },
                     LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, StreamsTable.TableName),
-                    OnDelete = Weasel.Postgresql.CascadeAction.Cascade
+                    DeleteAction = Weasel.Core.CascadeAction.Cascade
                 });
             }
             else
@@ -61,7 +61,7 @@ internal class NaturalKeyTable: Table, ISchemaObject
                     ColumnNames = new[] { streamCol, "is_archived" },
                     LinkedNames = new[] { "id", "is_archived" },
                     LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, StreamsTable.TableName),
-                    OnDelete = Weasel.Postgresql.CascadeAction.Cascade
+                    DeleteAction = Weasel.Core.CascadeAction.Cascade
                 });
             }
         }
@@ -73,7 +73,7 @@ internal class NaturalKeyTable: Table, ISchemaObject
                 ColumnNames = new[] { streamCol, TenantIdColumn.Name },
                 LinkedNames = new[] { "id", TenantIdColumn.Name },
                 LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, StreamsTable.TableName),
-                OnDelete = Weasel.Postgresql.CascadeAction.Cascade
+                DeleteAction = Weasel.Core.CascadeAction.Cascade
             });
         }
         else
@@ -84,7 +84,7 @@ internal class NaturalKeyTable: Table, ISchemaObject
                 ColumnNames = new[] { streamCol },
                 LinkedNames = new[] { "id" },
                 LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, StreamsTable.TableName),
-                OnDelete = Weasel.Postgresql.CascadeAction.Cascade
+                DeleteAction = Weasel.Core.CascadeAction.Cascade
             });
         }
 


### PR DESCRIPTION
Closes #4330.

## Bug

`Weasel.Postgresql.CascadeAction` is marked `[Obsolete]` in Weasel 9.x — it's a shim that converts to the canonical `Weasel.Core.CascadeAction` via `ToCoreAction` / `ToLocalCascadeAction` helpers on `ForeignKey`. The legacy `ForeignKey.OnDelete` / `OnUpdate` properties on `Weasel.Postgresql.Tables.ForeignKey` (which Marten's `DocumentForeignKey` inherits) are typed against the obsolete shim, so any user writing

```csharp
options.Schema.For<Issue>().ForeignKey<User>(
    x => x.AssigneeId,
    fkd => fkd.OnDelete = CascadeAction.Cascade);
```

against the documented sample gets a deprecation warning.

## Fix

The canonical replacement already exists on `ForeignKeyBase`: the `DeleteAction` / `UpdateAction` properties, typed as `Weasel.Core.CascadeAction`. This PR swaps every internal Marten reference (and the public documentation sample) from `OnDelete = ...` (deprecated) to `DeleteAction = ...` (canonical).

Files touched:

| File | Change |
|---|---|
| `src/Marten/Events/Schema/EventsTable.cs` | `OnDelete = CascadeAction.Cascade` → `DeleteAction = Weasel.Core.CascadeAction.Cascade` (×2) |
| `src/Marten/Events/Schema/NaturalKeyTable.cs` | `OnDelete = Weasel.Postgresql.CascadeAction.Cascade` → `DeleteAction = Weasel.Core.CascadeAction.Cascade` (×4) |
| `src/CoreTests/ForeignKeys/foreign_keys.cs` | `using Weasel.Postgresql;` → `using Weasel.Core;`; `fkd.OnDelete = …` → `fkd.DeleteAction = …` |
| `src/Marten.Testing/Examples/ForeignKeyExamples.cs` | Same pattern. This is the source of the `sample_cascade_deletes_with_config_func` snippet that appears in `docs/documents/indexing/foreign-keys.md`. |
| `docs/documents/indexing/foreign-keys.md` | Snippet body updated to mirror the source. |

The explicit `Weasel.Core.CascadeAction.Cascade` qualification on the Marten internals avoids ambiguity in files that import both `Weasel.Core` and `Weasel.Postgresql` (both define a `CascadeAction` until the legacy shim is removed).

## User-visible migration

A Marten 9 upgrader who previously wrote `fkd.OnDelete = CascadeAction.Cascade` should switch to `fkd.DeleteAction = CascadeAction.Cascade` (and `using Weasel.Core;` instead of `using Weasel.Postgresql;`). The behavior is identical. The migration guide entry for this lives alongside the other Marten 8 → 9 documentation in the existing migration-guide rollup.

## Verification

- **20** `foreign_keys` integration tests pass on net9.0.
- Full `Marten.slnx` build is clean — no `CascadeAction`-related obsolete warnings remain.

## Test plan

- [ ] CI green across the test matrix
- [ ] Docs CI accepts the snippet update