### PR TITLE
Phase 1 perf: ISerializer.WriteTo(IBufferWriter<byte>) overhaul (#4372)

### DIFF
--- a/src/CoreTests/Internal/Generated/fingerprint.json
+++ b/src/CoreTests/Internal/Generated/fingerprint.json
@@ -1,0 +1,7 @@
+{
+  "ProductName": "marten",
+  "ProductVersion": "9.0.0.0",
+  "JasperFxVersion": "2.0.0.0",
+  "ConfigHash": "e5c940e295a82c0b930a7c8367cf6832f367f37d98480901d8535cfa2b036a66",
+  "SchemaVersion": 1
+}

--- a/src/DocumentDbTests/Internal/Generated/DocumentStorage/RevisionedDocProvider1212098993.cs
+++ b/src/DocumentDbTests/Internal/Generated/DocumentStorage/RevisionedDocProvider1212098993.cs
@@ -68,8 +68,8 @@ namespace Marten.Generated.DocumentStorage
         {
             if (document.Version > 0 && Revision == 1) Revision = document.Version;
             builder.Append("select numeric_revisioning.mt_upsert_revisioneddoc(");
-            var parameter0 = parameterBuilder.AppendParameter(session.Serializer.ToJson(_document));
-            parameter0.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Jsonb;
+            var parameter0 = parameterBuilder.AppendParameter<object>(System.DBNull.Value);
+            session.Serializer.WriteToParameter(parameter0, _document);
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
@@ -132,8 +132,8 @@ namespace Marten.Generated.DocumentStorage
         {
             if (document.Version > 0 && Revision == 1) Revision = document.Version;
             builder.Append("select numeric_revisioning.mt_insert_revisioneddoc(");
-            var parameter0 = parameterBuilder.AppendParameter(session.Serializer.ToJson(_document));
-            parameter0.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Jsonb;
+            var parameter0 = parameterBuilder.AppendParameter<object>(System.DBNull.Value);
+            session.Serializer.WriteToParameter(parameter0, _document);
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
@@ -202,8 +202,8 @@ namespace Marten.Generated.DocumentStorage
         {
             if (document.Version > 0 && Revision == 1) Revision = document.Version;
             builder.Append("select numeric_revisioning.mt_update_revisioneddoc(");
-            var parameter0 = parameterBuilder.AppendParameter(session.Serializer.ToJson(_document));
-            parameter0.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Jsonb;
+            var parameter0 = parameterBuilder.AppendParameter<object>(System.DBNull.Value);
+            session.Serializer.WriteToParameter(parameter0, _document);
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
@@ -458,8 +458,8 @@ namespace Marten.Generated.DocumentStorage
         {
             if (document.Version > 0 && Revision == 1) Revision = document.Version;
             builder.Append("select numeric_revisioning.mt_overwrite_revisioneddoc(");
-            var parameter0 = parameterBuilder.AppendParameter(session.Serializer.ToJson(_document));
-            parameter0.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Jsonb;
+            var parameter0 = parameterBuilder.AppendParameter<object>(System.DBNull.Value);
+            session.Serializer.WriteToParameter(parameter0, _document);
             // .Net Class Type
             var parameter1 = parameterBuilder.AppendParameter(_document.GetType().FullName);
             parameter1.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Varchar;
@@ -1087,7 +1087,7 @@ namespace Marten.Generated.DocumentStorage
             await writer.WriteAsync(document.GetType().FullName, NpgsqlTypes.NpgsqlDbType.Varchar, cancellation);
             await writer.WriteAsync(((DocumentDbTests.Concurrency.RevisionedDoc)document).Id, NpgsqlTypes.NpgsqlDbType.Uuid, cancellation);
             await writer.WriteAsync((long)1, NpgsqlTypes.NpgsqlDbType.Bigint, cancellation);
-            await writer.WriteAsync(serializer.ToJson(document), NpgsqlTypes.NpgsqlDbType.Jsonb, cancellation);
+            await writer.WriteAsync(Marten.Services.SerializerExtensions.SerializeToUtf8(serializer, document), NpgsqlTypes.NpgsqlDbType.Jsonb, cancellation);
         }
 
 
@@ -1097,7 +1097,7 @@ namespace Marten.Generated.DocumentStorage
             await writer.WriteAsync(((DocumentDbTests.Concurrency.RevisionedDoc)document).Id, NpgsqlTypes.NpgsqlDbType.Uuid, cancellation);
             writer.Write(document.Version <= 0 ? (object)System.DBNull.Value : (object)(long)document.Version, NpgsqlTypes.NpgsqlDbType.Bigint);
             await writer.WriteAsync((long)1, NpgsqlTypes.NpgsqlDbType.Bigint, cancellation);
-            await writer.WriteAsync(serializer.ToJson(document), NpgsqlTypes.NpgsqlDbType.Jsonb, cancellation);
+            await writer.WriteAsync(Marten.Services.SerializerExtensions.SerializeToUtf8(serializer, document), NpgsqlTypes.NpgsqlDbType.Jsonb, cancellation);
         }
 
 

--- a/src/DocumentDbTests/Internal/Generated/fingerprint.json
+++ b/src/DocumentDbTests/Internal/Generated/fingerprint.json
@@ -1,0 +1,7 @@
+{
+  "ProductName": "marten",
+  "ProductVersion": "9.0.0.0",
+  "JasperFxVersion": "2.0.0.0",
+  "ConfigHash": "1cb7b80c31f7f9258288ea807e0a42896fe7eac77775cc687737acac2a3cdc77",
+  "SchemaVersion": 1
+}

--- a/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
+++ b/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
@@ -408,5 +408,15 @@ public class noda_time_acceptance: OneOffConfigurationsContext
         {
             throw new NotSupportedException();
         }
+
+        public void WriteTo(System.Buffers.IBufferWriter<byte> writer, object document)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void WriteToParameter(Npgsql.NpgsqlParameter parameter, object document)
+        {
+            throw new NotSupportedException();
+        }
     }
 }

--- a/src/Marten/Events/BulkEventAppender.cs
+++ b/src/Marten/Events/BulkEventAppender.cs
@@ -308,9 +308,9 @@ internal class BulkEventAppender
         // version
         await writer.WriteAsync(e.Version, NpgsqlDbType.Bigint, cancellation).ConfigureAwait(false);
 
-        // data (jsonb)
-        var json = _serializer.ToJson(e.Data);
-        await writer.WriteAsync(json, NpgsqlDbType.Jsonb, cancellation).ConfigureAwait(false);
+        // data (jsonb) — direct UTF-8 serialization, no intermediate string allocation.
+        var dataBytes = SerializeToUtf8(_serializer, e.Data);
+        await writer.WriteAsync(dataBytes, NpgsqlDbType.Jsonb, cancellation).ConfigureAwait(false);
 
         // type
         await writer.WriteAsync(e.EventTypeName, NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
@@ -365,8 +365,8 @@ internal class BulkEventAppender
         {
             if (e.Headers != null)
             {
-                var headersJson = _serializer.ToJson(e.Headers);
-                await writer.WriteAsync(headersJson, NpgsqlDbType.Jsonb, cancellation).ConfigureAwait(false);
+                var headersBytes = SerializeToUtf8(_serializer, e.Headers);
+                await writer.WriteAsync(headersBytes, NpgsqlDbType.Jsonb, cancellation).ConfigureAwait(false);
             }
             else
             {
@@ -406,5 +406,17 @@ ON CONFLICT (name) DO UPDATE SET last_seq_id = GREATEST({schema}.mt_event_progre
         cmd.CommandText = sql;
         cmd.Parameters.AddWithValue("seq", maxSequence);
         await cmd.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Serialize <paramref name="value"/> to a sized UTF-8 byte[] via the serializer's
+    /// buffer-writer path. Avoids the intermediate <see cref="string"/> allocation that
+    /// <see cref="ISerializer.ToJson"/> produces — meaningful across long bulk imports.
+    /// </summary>
+    private static byte[] SerializeToUtf8(ISerializer serializer, object? value)
+    {
+        using var buffer = new Services.PooledByteBufferWriter();
+        serializer.WriteTo(buffer, value);
+        return buffer.ToSizedArray();
     }
 }

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.ForReading.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.ForReading.cs
@@ -144,8 +144,11 @@ internal partial class FetchAsyncPlan<TDoc, TId>
         if (document == null) return false;
 
         _storage.SetIdentity(document, id);
-        var json = session.Serializer.ToJson(document);
-        await destination.WriteAsync(Encoding.UTF8.GetBytes(json), cancellation).ConfigureAwait(false);
+        // Direct UTF-8 serialization into a pooled buffer, then a single async write —
+        // avoids ToJson → string → UTF-8 GetBytes → write round-trip.
+        using var buffer = new Services.PooledByteBufferWriter();
+        session.Serializer.WriteTo(buffer, document);
+        await destination.WriteAsync(buffer.WrittenMemory, cancellation).ConfigureAwait(false);
         return true;
     }
 

--- a/src/Marten/Events/Fetching/FetchLivePlan.ForReading.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.ForReading.cs
@@ -64,8 +64,13 @@ internal partial class FetchLivePlan<TDoc, TId>
         var aggregate = await FetchForReading(session, id, cancellation).ConfigureAwait(false);
         if (aggregate == null) return false;
 
-        var json = session.Serializer.ToJson(aggregate);
-        await destination.WriteAsync(Encoding.UTF8.GetBytes(json), cancellation).ConfigureAwait(false);
+        // Direct UTF-8 serialization into a pooled buffer then a single async write to
+        // the destination stream. Previously: ToJson → string → UTF-8 GetBytes → write
+        // (three allocations + a UTF-16↔UTF-8 round-trip per AspNetCore stream endpoint
+        // response). Now: one serializer pass, one snapshot, one write.
+        using var buffer = new Services.PooledByteBufferWriter();
+        session.Serializer.WriteTo(buffer, aggregate);
+        await destination.WriteAsync(buffer.WrittenMemory, cancellation).ConfigureAwait(false);
         return true;
     }
 

--- a/src/Marten/Events/Operations/QuickAppendEventsOperationBase.cs
+++ b/src/Marten/Events/Operations/QuickAppendEventsOperationBase.cs
@@ -96,7 +96,11 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
         var ids = new Guid[count];
         var typeNames = new string[count];
         var dotNetTypeNames = new string[count];
-        var jsonBodies = new string[count];
+        // jsonBodies is byte[][] so each element is serialized directly to UTF-8 via
+        // ISerializer.WriteToParameter-style emission, skipping the intermediate UTF-16
+        // string materialization that ToJson() would do. Npgsql 9 accepts byte[][] for
+        // Array|Jsonb and writes each element's raw bytes to the wire.
+        var jsonBodies = new byte[count][];
 
         for (int i = 0; i < count; i++)
         {
@@ -104,7 +108,7 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
             ids[i] = e.Id;
             typeNames[i] = e.EventTypeName;
             dotNetTypeNames[i] = e.DotNetTypeName;
-            jsonBodies[i] = session.Serializer.ToJson(e.Data);
+            jsonBodies[i] = SerializeToUtf8(session.Serializer, e.Data);
         }
 
         var param3 = builder.AppendParameter(ids);
@@ -118,6 +122,18 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
 
         var param6 = builder.AppendParameter(jsonBodies);
         param6.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Jsonb;
+    }
+
+    /// <summary>
+    /// Serialize <paramref name="value"/> to a sized UTF-8 byte[] via the serializer's
+    /// <see cref="ISerializer.WriteTo"/> + a pooled staging buffer. Avoids the intermediate
+    /// <see cref="string"/> allocation that <see cref="ISerializer.ToJson"/> produces.
+    /// </summary>
+    private static byte[] SerializeToUtf8(ISerializer serializer, object? value)
+    {
+        using var buffer = new Services.PooledByteBufferWriter();
+        serializer.WriteTo(buffer, value);
+        return buffer.ToSizedArray();
     }
 
     protected void writeCausationIds(IGroupedParameterBuilder builder)
@@ -146,8 +162,8 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
     {
         var events = Stream.Events;
         var count = events.Count;
-        var headers = new string[count];
-        for (int i = 0; i < count; i++) headers[i] = session.Serializer.ToJson(events[i].Headers);
+        var headers = new byte[count][];
+        for (int i = 0; i < count; i++) headers[i] = SerializeToUtf8(session.Serializer, events[i].Headers);
 
         var param = builder.AppendParameter(headers);
         param.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Jsonb;

--- a/src/Marten/Events/Protected/OverwriteEventOperation.cs
+++ b/src/Marten/Events/Protected/OverwriteEventOperation.cs
@@ -25,26 +25,23 @@ internal class OverwriteEventOperation : IStorageOperation
 
     public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
     {
+        // Bind both data and headers as direct UTF-8 bytes via WriteToParameter so we
+        // skip the intermediate string allocations Serializer.ToJson would produce.
         if (_graph.MetadataConfig.HeadersEnabled)
         {
             var parameters = builder.AppendWithParameters($"update {_graph.DatabaseSchemaName}.mt_events set data = ?, headers = ? where seq_id = ?");
-            parameters[0].NpgsqlDbType = NpgsqlDbType.Jsonb;
-            parameters[0].Value = session.Serializer.ToJson(_e.Data);
-            parameters[1].NpgsqlDbType = NpgsqlDbType.Jsonb;
-            parameters[1].Value = session.Serializer.ToJson(_e.Headers);
+            session.Serializer.WriteToParameter(parameters[0], _e.Data);
+            session.Serializer.WriteToParameter(parameters[1], _e.Headers);
             parameters[2].NpgsqlDbType = NpgsqlDbType.Bigint;
             parameters[2].Value = _e.Sequence;
         }
         else
         {
             var parameters = builder.AppendWithParameters($"update {_graph.DatabaseSchemaName}.mt_events set data = ? where seq_id = ?");
-            parameters[0].NpgsqlDbType = NpgsqlDbType.Jsonb;
-            parameters[0].Value = session.Serializer.ToJson(_e.Data);
+            session.Serializer.WriteToParameter(parameters[0], _e.Data);
             parameters[1].NpgsqlDbType = NpgsqlDbType.Bigint;
             parameters[1].Value = _e.Sequence;
         }
-
-
     }
 
     public Type DocumentType => typeof(IEvent);

--- a/src/Marten/Events/Protected/ReplaceEventOperation.cs
+++ b/src/Marten/Events/Protected/ReplaceEventOperation.cs
@@ -37,7 +37,11 @@ internal class ReplaceEventOperation<T> : IStorageOperation where T : class
     public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
     {
         builder.Append($"update {_graph.DatabaseSchemaName}.mt_events set data = ");
-        builder.AppendParameter(session.Serializer.ToJson(_eventBody), NpgsqlDbType.Jsonb);
+        using (var buffer = new Services.PooledByteBufferWriter())
+        {
+            session.Serializer.WriteTo(buffer, _eventBody);
+            builder.AppendParameter(buffer.ToSizedArray(), NpgsqlDbType.Jsonb);
+        }
         builder.Append(", timestamp = now() at time zone 'utc', type = ");
         builder.AppendParameter(_eventTypeName, NpgsqlDbType.Varchar);
         builder.Append(", mt_dotnet_type = ");

--- a/src/Marten/Events/Schema/EventJsonDataColumn.cs
+++ b/src/Marten/Events/Schema/EventJsonDataColumn.cs
@@ -28,10 +28,15 @@ internal class EventJsonDataColumn: TableColumn, IEventTableColumn
 
     public void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full)
     {
-        method.Frames.Code($"var parameter{index} = parameterBuilder.{nameof(IGroupedParameterBuilder.AppendParameter)}({{0}}.Serializer.ToJson({{1}}.{nameof(IEvent.Data)}));",
-             Use.Type<IMartenSession>(), Use.Type<IEvent>());
-
-        method.Frames.Code($"parameter{index}.NpgsqlDbType = {{0}};", NpgsqlDbType.Jsonb);
+        // Generated equivalent of:
+        //   var parameter{i} = parameterBuilder.AppendParameter<object>(DBNull.Value);
+        //   session.Serializer.WriteToParameter(parameter{i}, evt.Data);
+        // Skips the intermediate UTF-16 string allocation that Serializer.ToJson(evt.Data)
+        // would emit, instead serializing directly to a sized UTF-8 byte[] bound to the
+        // parameter.
+        method.Frames.Code($"var parameter{index} = parameterBuilder.{nameof(IGroupedParameterBuilder.AppendParameter)}<object>({typeof(DBNull).FullName}.Value);");
+        method.Frames.Code($"{{0}}.Serializer.{nameof(ISerializer.WriteToParameter)}(parameter{index}, {{1}}.{nameof(IEvent.Data)});",
+            Use.Type<IMartenSession>(), Use.Type<IEvent>());
     }
 
     public string ValueSql(EventGraph graph, AppendMode mode)

--- a/src/Marten/ISerializer.cs
+++ b/src/Marten/ISerializer.cs
@@ -1,9 +1,11 @@
 #nullable enable
 using System;
+using System.Buffers;
 using System.Data.Common;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Npgsql;
 using Weasel.Core;
 
 namespace Marten;
@@ -54,6 +56,27 @@ public interface ISerializer
     /// <param name="document"></param>
     /// <returns></returns>
     string ToJson(object? document);
+
+    /// <summary>
+    ///     Serialize <paramref name="value"/> directly into the supplied buffer writer as UTF-8 JSON.
+    ///     Skips the intermediate string materialization that <see cref="ToJson"/> round-trips through —
+    ///     prefer this on append / write hot paths.
+    /// </summary>
+    /// <remarks>
+    ///     Implementations must produce identical bytes to what <c>Encoding.UTF8.GetBytes(ToJson(value))</c>
+    ///     would emit, modulo whitespace/formatting decisions already baked into the serializer's options.
+    /// </remarks>
+    void WriteTo(IBufferWriter<byte> writer, object? value);
+
+    /// <summary>
+    ///     Convenience for the most common append-path use of <see cref="WriteTo"/>: serialize
+    ///     <paramref name="value"/> as UTF-8 JSON and bind the resulting bytes to <paramref name="parameter"/>
+    ///     with <c>NpgsqlDbType.Jsonb</c>. Skips the round-trip through a .NET <see cref="string"/> that
+    ///     <c>AppendParameter(ToJson(value))</c> incurs.
+    /// </summary>
+    /// <param name="parameter">The Npgsql parameter the JSON bytes will bind to.</param>
+    /// <param name="value">The value to serialize; <c>null</c> binds <see cref="DBNull"/>.</param>
+    void WriteToParameter(NpgsqlParameter parameter, object? value);
 
     /// <summary>
     ///     Deserialize a JSON string stream into an object of type T

--- a/src/Marten/Internal/Operations/StorageOperation.cs
+++ b/src/Marten/Internal/Operations/StorageOperation.cs
@@ -275,15 +275,36 @@ public abstract class StorageOperation<T, TId>: IDocumentStorageOperation, IExce
 
     protected void setHeaderParameter(IGroupedParameterBuilder builder, IMartenSession session)
     {
-        if (session.Headers == null)
+        // Skip the intermediate JSON string. DocumentSessionBase keeps a per-session cached
+        // byte[] of the serialized headers, invalidated whenever SetHeader mutates the
+        // dictionary — so under load N storage ops in one batch reuse one serialization.
+        if (session is Sessions.DocumentSessionBase docSession)
+        {
+            var cachedBytes = docSession.GetCachedSerializedHeaders();
+            if (cachedBytes is null)
+            {
+                var parameter = builder.AppendParameter<object>(DBNull.Value);
+                parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+            }
+            else
+            {
+                var parameter = builder.AppendParameter(cachedBytes);
+                parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+            }
+            return;
+        }
+
+        // Fallback for any IMartenSession implementation that isn't a DocumentSessionBase
+        // (very rare — primarily test doubles): direct UTF-8 serialization via WriteToParameter.
+        if (session.Headers is null)
         {
             var parameter = builder.AppendParameter<object>(DBNull.Value);
             parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
         }
         else
         {
-            var parameter = builder.AppendParameter(session.Serializer.ToJson(session.Headers));
-            parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+            var parameter = builder.AppendParameter<object>(DBNull.Value);
+            session.Serializer.WriteToParameter(parameter, session.Headers);
         }
     }
 }

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -277,11 +277,37 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
         ChangeTrackers.RemoveAll(x => x.Document.GetType().CanBeCastTo(type));
     }
 
+    /// <summary>
+    /// Lazily-computed per-session cache of the JSON-encoded <see cref="Headers"/> dictionary,
+    /// invalidated whenever <see cref="SetHeader"/> mutates the contents. Storage operations
+    /// that bind the headers as a JSONB parameter use this to skip re-serializing on every
+    /// queued op in a batch — under load a single SaveChanges with N tagged operations can
+    /// otherwise serialize the same dictionary N times. See <see cref="GetCachedSerializedHeaders"/>.
+    /// </summary>
+    private byte[]? _serializedHeadersCache;
+
     public void SetHeader(string key, object value)
     {
         Headers ??= new Dictionary<string, object>();
 
         Headers[key] = value;
+        _serializedHeadersCache = null; // invalidate cached bytes
+    }
+
+    /// <summary>
+    /// Returns the JSON bytes for the session's current <see cref="Headers"/> dictionary,
+    /// computing and caching on first call. Returns <c>null</c> when there are no headers.
+    /// </summary>
+    internal byte[]? GetCachedSerializedHeaders()
+    {
+        if (Headers is null || Headers.Count == 0) return null;
+
+        if (_serializedHeadersCache is not null) return _serializedHeadersCache;
+
+        using var buffer = new Services.PooledByteBufferWriter();
+        Serializer.WriteTo(buffer, Headers);
+        _serializedHeadersCache = buffer.ToSizedArray();
+        return _serializedHeadersCache;
     }
 
     public object? GetHeader(string key)

--- a/src/Marten/Schema/Arguments/DocJsonBodyArgument.cs
+++ b/src/Marten/Schema/Arguments/DocJsonBodyArgument.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Threading;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using Marten.Internal;
+using Marten.Services;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 
@@ -20,8 +22,11 @@ internal class DocJsonBodyArgument: UpsertArgument
 
     public override void GenerateBulkWriterCodeAsync(GeneratedType type, GeneratedMethod load, DocumentMapping mapping)
     {
+        // Direct UTF-8 serialization via SerializerExtensions.SerializeToUtf8 — internally
+        // a pooled buffer writer + sized byte[] snapshot. Skips the string materialization
+        // that serializer.ToJson(document) would emit on the bulk-loader hot path.
         load.Frames.CodeAsync(
-            "await writer.WriteAsync(serializer.ToJson(document), {0}, {1});",
+            $"await writer.WriteAsync({typeof(SerializerExtensions).FullName}.{nameof(SerializerExtensions.SerializeToUtf8)}(serializer, document), {{0}}, {{1}});",
             NpgsqlDbType.Jsonb, Use.Type<CancellationToken>());
     }
 
@@ -29,7 +34,9 @@ internal class DocJsonBodyArgument: UpsertArgument
         Argument parameters,
         DocumentMapping mapping, StoreOptions options)
     {
-        method.Frames.Code($"var parameter{i} = {{0}}.{nameof(IGroupedParameterBuilder.AppendParameter)}({{1}}.Serializer.ToJson(_document));", Use.Type<IGroupedParameterBuilder>(), Use.Type<IMartenSession>());
-        method.Frames.Code($"parameter{i}.NpgsqlDbType = {{0}};", NpgsqlDbType.Jsonb);
+        // Use Serializer.WriteToParameter for direct UTF-8 serialization into the
+        // parameter; skips the intermediate string round-trip.
+        method.Frames.Code($"var parameter{i} = {{0}}.{nameof(IGroupedParameterBuilder.AppendParameter)}<object>({typeof(DBNull).FullName}.Value);", Use.Type<IGroupedParameterBuilder>());
+        method.Frames.Code($"{{0}}.Serializer.{nameof(ISerializer.WriteToParameter)}(parameter{i}, _document);", Use.Type<IMartenSession>());
     }
 }

--- a/src/Marten/Services/BufferWriterStream.cs
+++ b/src/Marten/Services/BufferWriterStream.cs
@@ -1,0 +1,67 @@
+#nullable enable
+using System;
+using System.Buffers;
+using System.IO;
+
+namespace Marten.Services;
+
+/// <summary>
+/// Write-only <see cref="Stream"/> facade over an <see cref="IBufferWriter{T}"/>. Used so
+/// Newtonsoft.Json's <c>JsonTextWriter</c>, which writes through a <see cref="TextWriter"/>
+/// on top of a <see cref="Stream"/>, can deliver UTF-8 bytes directly into a pooled buffer
+/// without an intermediate <c>MemoryStream</c> or <c>StringBuilder</c>.
+/// </summary>
+internal sealed class BufferWriterStream: Stream
+{
+    private readonly IBufferWriter<byte> _writer;
+
+    public BufferWriterStream(IBufferWriter<byte> writer)
+    {
+        _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+    }
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+        if (count <= 0) return;
+        var span = _writer.GetSpan(count);
+        buffer.AsSpan(offset, count).CopyTo(span);
+        _writer.Advance(count);
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        if (buffer.IsEmpty) return;
+        var span = _writer.GetSpan(buffer.Length);
+        buffer.CopyTo(span);
+        _writer.Advance(buffer.Length);
+    }
+
+    public override void WriteByte(byte value)
+    {
+        var span = _writer.GetSpan(1);
+        span[0] = value;
+        _writer.Advance(1);
+    }
+}

--- a/src/Marten/Services/JsonNetSerializer.cs
+++ b/src/Marten/Services/JsonNetSerializer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Buffers;
 using System.Data.Common;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core;
@@ -11,6 +12,8 @@ using Marten.Util;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
+using Npgsql;
+using NpgsqlTypes;
 using Weasel.Core;
 
 namespace Marten.Services;
@@ -116,6 +119,52 @@ public class JsonNetSerializer: ISerializer
 
         return writer.ToString();
     }
+
+    public void WriteTo(IBufferWriter<byte> writer, object? value)
+    {
+        if (writer is null) throw new ArgumentNullException(nameof(writer));
+
+        // JsonTextWriter writes chars to a TextWriter — wrap the IBufferWriter<byte> in a
+        // BufferWriterStream and let a UTF-8 StreamWriter do the char→byte transcoding.
+        // The leaveOpen flag on StreamWriter doesn't matter here because the surrounding
+        // stream is a no-op on Dispose; the explicit Flush calls below guarantee bytes
+        // are pushed to the IBufferWriter before WriteTo returns.
+        using var stream = new BufferWriterStream(writer);
+        // Skip the BOM by passing a UTF8Encoding(false) — we don't want a 0xEF 0xBB 0xBF
+        // prefix in the middle of our JSON byte stream.
+        using var streamWriter = new StreamWriter(stream, _utf8NoBom, bufferSize: 1024, leaveOpen: true);
+        using var jsonWriter = new JsonTextWriter(streamWriter)
+        {
+            ArrayPool = _jsonArrayPool, CloseOutput = false, AutoCompleteOnClose = false
+        };
+
+        _serializer.Value.Serialize(jsonWriter, value);
+        jsonWriter.Flush();
+        streamWriter.Flush();
+    }
+
+    public void WriteToParameter(NpgsqlParameter parameter, object? value)
+    {
+        if (parameter is null) throw new ArgumentNullException(nameof(parameter));
+
+        parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+        if (value is null)
+        {
+            parameter.Value = DBNull.Value;
+            return;
+        }
+
+        // Serialize into a pooled buffer to avoid the intermediate StringWriter+char[]
+        // path that ToJson takes, then snapshot a sized byte[] for Npgsql to retain
+        // (the pooled buffer is returned on Dispose at end of method scope).
+        using var buffer = new PooledByteBufferWriter();
+        WriteTo(buffer, value);
+        parameter.Value = buffer.ToSizedArray();
+    }
+
+    // UTF8Encoding(false) suppresses the BOM. Cached on the type because StreamWriter
+    // copies the encoding's flags but doesn't keep a reference.
+    private static readonly UTF8Encoding _utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
 
     public T FromJson<T>(Stream stream)
     {

--- a/src/Marten/Services/PooledByteBufferWriter.cs
+++ b/src/Marten/Services/PooledByteBufferWriter.cs
@@ -1,0 +1,78 @@
+#nullable enable
+using System;
+using System.Buffers;
+
+namespace Marten.Services;
+
+/// <summary>
+/// Pooled <see cref="IBufferWriter{T}"/> over <see cref="ArrayPool{T}.Shared"/>. Used as the
+/// staging buffer when serializing JSON to UTF-8 bytes for Npgsql parameter binding: the
+/// caller writes through <see cref="IBufferWriter{T}"/>, snapshots the written segment, and
+/// returns the rented array on <see cref="Dispose"/>. Not thread-safe; intended for a single
+/// stack-scoped serialize-then-bind round-trip.
+/// </summary>
+internal sealed class PooledByteBufferWriter: IBufferWriter<byte>, IDisposable
+{
+    private byte[] _buffer;
+    private int _written;
+    private bool _disposed;
+
+    public PooledByteBufferWriter(int initialCapacity = 1024)
+    {
+        if (initialCapacity < 256) initialCapacity = 256;
+        _buffer = ArrayPool<byte>.Shared.Rent(initialCapacity);
+    }
+
+    public int WrittenCount => _written;
+
+    public ReadOnlyMemory<byte> WrittenMemory => _buffer.AsMemory(0, _written);
+
+    public ReadOnlySpan<byte> WrittenSpan => _buffer.AsSpan(0, _written);
+
+    public void Advance(int count)
+    {
+        if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
+        if (_written + count > _buffer.Length) throw new InvalidOperationException("Advance past buffer end");
+        _written += count;
+    }
+
+    public Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return _buffer.AsMemory(_written);
+    }
+
+    public Span<byte> GetSpan(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return _buffer.AsSpan(_written);
+    }
+
+    private void EnsureCapacity(int sizeHint)
+    {
+        if (sizeHint < 0) throw new ArgumentOutOfRangeException(nameof(sizeHint));
+        if (sizeHint == 0) sizeHint = 64;
+        var remaining = _buffer.Length - _written;
+        if (remaining >= sizeHint) return;
+
+        var newSize = Math.Max(_buffer.Length * 2, _written + sizeHint);
+        var newer = ArrayPool<byte>.Shared.Rent(newSize);
+        Buffer.BlockCopy(_buffer, 0, newer, 0, _written);
+        ArrayPool<byte>.Shared.Return(_buffer);
+        _buffer = newer;
+    }
+
+    /// <summary>
+    /// Allocates a fresh <c>byte[]</c> sized exactly to the JSON payload. Used to detach the
+    /// payload from the pooled buffer's lifetime — the returned array is safe to hand to
+    /// Npgsql which retains the reference past the buffer's <see cref="Dispose"/>.
+    /// </summary>
+    public byte[] ToSizedArray() => WrittenMemory.ToArray();
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        ArrayPool<byte>.Shared.Return(_buffer);
+    }
+}

--- a/src/Marten/Services/SerializerExtensions.cs
+++ b/src/Marten/Services/SerializerExtensions.cs
@@ -1,0 +1,25 @@
+#nullable enable
+namespace Marten.Services;
+
+/// <summary>
+/// Shared helpers for <see cref="ISerializer"/> that wrap the common UTF-8
+/// serialization patterns (pooled buffer + sized byte[]). These are intentionally
+/// static methods rather than instance ones on <see cref="ISerializer"/> so the
+/// public interface stays minimal.
+/// </summary>
+public static class SerializerExtensions
+{
+    /// <summary>
+    /// Serialize <paramref name="value"/> directly to a sized UTF-8 <c>byte[]</c>
+    /// using the serializer's <see cref="ISerializer.WriteTo"/> path. Avoids the
+    /// intermediate string allocation that <see cref="ISerializer.ToJson"/> emits.
+    /// Used by the event-store / bulk-loader codegen + any non-codegen call site
+    /// that needs to hand UTF-8 bytes to Npgsql.
+    /// </summary>
+    public static byte[] SerializeToUtf8(this ISerializer serializer, object? value)
+    {
+        using var buffer = new PooledByteBufferWriter();
+        serializer.WriteTo(buffer, value);
+        return buffer.ToSizedArray();
+    }
+}

--- a/src/Marten/Services/SystemTextJsonSerializer.cs
+++ b/src/Marten/Services/SystemTextJsonSerializer.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Buffers;
 using System.Data.Common;
 using System.IO;
 using System.Text.Json;
@@ -11,6 +12,7 @@ using JasperFx.Core.Reflection;
 using Marten.Services.Json;
 using Marten.Util;
 using Npgsql;
+using NpgsqlTypes;
 using Weasel.Core;
 
 namespace Marten.Services;
@@ -67,6 +69,38 @@ public class SystemTextJsonSerializer: ISerializer
         }
 
         return JsonSerializer.Serialize(document, document.GetType(), _options);
+    }
+
+    public void WriteTo(IBufferWriter<byte> writer, object? value)
+    {
+        if (writer is null) throw new ArgumentNullException(nameof(writer));
+
+        using var jsonWriter = new Utf8JsonWriter(writer);
+        if (value is null)
+        {
+            jsonWriter.WriteNullValue();
+        }
+        else
+        {
+            JsonSerializer.Serialize(jsonWriter, value, value.GetType(), _options);
+        }
+    }
+
+    public void WriteToParameter(NpgsqlParameter parameter, object? value)
+    {
+        if (parameter is null) throw new ArgumentNullException(nameof(parameter));
+
+        parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+        if (value is null)
+        {
+            parameter.Value = DBNull.Value;
+            return;
+        }
+
+        // SerializeToUtf8Bytes does the same thing the JSON-string round-trip would do
+        // but without the UTF-16 string allocation. Allocates one sized byte[] whose
+        // lifetime is owned by the Npgsql parameter — safe to keep past method scope.
+        parameter.Value = JsonSerializer.SerializeToUtf8Bytes(value, value.GetType(), _options);
     }
 
     public T FromJson<T>(Stream stream)

--- a/src/Marten/Storage/Metadata/HeadersColumn.cs
+++ b/src/Marten/Storage/Metadata/HeadersColumn.cs
@@ -47,8 +47,12 @@ internal class HeadersColumn: MetadataColumn<Dictionary<string, object>>, IEvent
 
     public void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full)
     {
-        method.Frames.Code($"var parameter{index} = parameterBuilder.{nameof(IGroupedParameterBuilder.AppendParameter)}({{0}}.Serializer.ToJson({{1}}.{nameof(IEvent.Headers)}));", Use.Type<IMartenSession>(), Use.Type<IEvent>());
-        method.Frames.Code($"parameter{index}.NpgsqlDbType = {{0}};", NpgsqlDbType.Jsonb);
+        // Use Serializer.WriteToParameter to skip the intermediate UTF-16 string
+        // allocation that Serializer.ToJson(evt.Headers) would emit; the resulting
+        // sized UTF-8 byte[] binds directly to the parameter.
+        method.Frames.Code($"var parameter{index} = parameterBuilder.{nameof(IGroupedParameterBuilder.AppendParameter)}<object>({typeof(DBNull).FullName}.Value);");
+        method.Frames.Code($"{{0}}.Serializer.{nameof(ISerializer.WriteToParameter)}(parameter{index}, {{1}}.{nameof(IEvent.Headers)});",
+            Use.Type<IMartenSession>(), Use.Type<IEvent>());
     }
 
     internal override async Task ApplyAsync(IMartenSession martenSession, DocumentMetadata metadata, int index,


### PR DESCRIPTION
Closes #4372. First of four Marten 9.0 perf phases.

Replaces the JSON-string-then-Npgsql-encode round-trip on every event-store / document write site with direct UTF-8 serialization into pooled byte buffers — removes intermediate string allocations and the UTF-16↔UTF-8 transcoding inside Npgsql.

## New API on \`ISerializer\`

\`\`\`csharp
void WriteTo(IBufferWriter<byte> writer, object? value);
void WriteToParameter(NpgsqlParameter parameter, object? value);
\`\`\`

Plus a static \`SerializerExtensions.SerializeToUtf8(serializer, value)\` helper for non-parameter call sites.

\`ToJson\` / \`ToCleanJson\` / \`ToJsonWithTypes\` **stay** — still used by tools, tests, and any caller that genuinely wants the string form.

## Implementations

| Serializer | Path |
|---|---|
| \`SystemTextJsonSerializer\` | \`JsonSerializer.Serialize(Utf8JsonWriter,...)\` + \`SerializeToUtf8Bytes\` — native STJ. |
| \`JsonNetSerializer\` | \`BufferWriterStream\` (write-only \`Stream\` over \`IBufferWriter<byte>\`) + UTF-8 \`StreamWriter\` (no BOM) + \`JsonTextWriter\`. |

## Helpers

| File | Purpose |
|---|---|
| \`PooledByteBufferWriter.cs\` | \`IBufferWriter<byte>\` over \`ArrayPool<byte>.Shared\`, \`IDisposable\`, \`ToSizedArray()\` detaches an Npgsql-safe \`byte[]\`. |
| \`BufferWriterStream.cs\` | Write-only \`Stream\` facade for the Newtonsoft path. |
| \`SerializerExtensions.cs\` | Static \`SerializeToUtf8(serializer, value)\` wraps the pooled-buffer dance. |

## Write sites migrated (per the spec)

| Site | Change |
|---|---|
| \`QuickAppendEventsOperationBase.writeBasicParameters\` / \`writeHeaders\` | \`string[]\` → \`byte[][]\` bound as \`NpgsqlDbType.Array \| Jsonb\`. Npgsql accepts \`byte[][]\` directly; no UTF-16 round-trip per event. |
| \`BulkEventAppender.WriteEventAsync\` | data + headers serialized to sized \`byte[]\` before \`WriteAsync(NpgsqlDbType.Jsonb)\`. |
| \`StorageOperation.setHeaderParameter\` | \`DocumentSessionBase\` now keeps a per-session cached \`byte[]\` of the serialized Headers, invalidated on \`SetHeader\`. **N ops in a batch reuse one serialization.** |
| \`EventJsonDataColumn\` + \`HeadersColumn\` + \`DocJsonBodyArgument\` codegen | Emits \`WriteToParameter\` against the appended parameter; bulk-loader codegen uses \`SerializerExtensions.SerializeToUtf8\`. |
| \`ReplaceEventOperation\` + \`OverwriteEventOperation\` | Direct \`WriteToParameter\` for data and headers. |
| \`FetchAsyncPlan.ForReading\` + \`FetchLivePlan.ForReading\` (Marten.AspNetCore) | Serialize straight into a pooled buffer and \`destination.WriteAsync(buffer.WrittenMemory, ...)\` — eliminates the \`ToJson → string → UTF-8 GetBytes → write\` triple-allocation per stream-aggregate endpoint response. |

## Deferred to Phase 1 follow-ups (filed)

- **#4384** — \`PatchOperation.PatchFragment.Apply\` was identified as the densest allocation cluster in the spec but doesn't cleanly fit the direct-UTF-8 rewrite (sentinel-substitution dance for polymorphic value injection). The refactor needs an \`ISerializer.WriteRawJson\` primitive — filed separately.
- **#4385** — Pool the parallel \`Guid[]\` / \`string[]\` / \`DateTimeOffset[]\` column arrays in \`QuickAppendEventsOperationBase\` via a \`PooledList<T>\` (Npgsql's array binding reads \`.Length\` on \`T[]\`, so \`ArrayPool<T>.Shared.Rent\` can't be used directly).

## Verification

| Suite | Result |
|---|---:|
| \`EventSourcingTests\` (net9.0) | **1331 passed**, 2 skipped, 0 failed |
| \`CoreTests\` (net9.0) | **355 passed**, 1 skipped, 0 failed |
| \`DocumentDbTests\` (net9.0) | **969 passed**, 1 skipped, 0 failed |
| \`PatchingTests\` (net9.0) | **114 passed**, 1 skipped, 0 failed |
| \`Marten.AspNetCore.Testing\` (net9.0) | **46 passed**, 0 failed — proves the direct-UTF-8 \`StreamForReading\` path works end-to-end against a real ASP.NET endpoint |

## Test plan

- [ ] CI green across the test matrix (net9.0 / net10.0, both serializers)
- [ ] BenchmarkDotNet shows Gen0 allocation reduction on event-append / projection-replay (qualitative target: ≥30% per the spec)
- [ ] Newtonsoft + STJ both round-trip cleanly through the new \`WriteTo\` paths