### PR TITLE
Phase 2 perf: reflection sweep with compiled-delegate caches (#4373)

### DIFF
--- a/src/Marten/Internal/Sessions/DocumentSessionBase.Deletes.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.Deletes.cs
@@ -76,7 +76,12 @@ public abstract partial class DocumentSessionBase
 
     public void Delete<T>(object id) where T : notnull
     {
-        var deleter = typeof(ByIdDeleter<>).CloseAndBuildAs<IByIdDeleter>(this, id.GetType());
+        // 9.0 (#4373): delegate-cached factory keyed on id.GetType().
+        var deleter = GenericFactoryCache.BuildAs<IByIdDeleter>(
+            typeof(ByIdDeleter<>),
+            id.GetType(),
+            this,
+            static closed => session => (IByIdDeleter)Activator.CreateInstance(closed, session)!);
         deleter.Delete<T>(id);
     }
 
@@ -160,7 +165,11 @@ public abstract partial class DocumentSessionBase
 
         foreach (var group in documentsGroupedByType)
         {
-            var handler = typeof(DeleteHandler<>).CloseAndBuildAs<IObjectHandler>(group.Key);
+            // 9.0 (#4373): delegate-cached factory keyed on document type.
+            var handler = GenericFactoryCache.BuildAs<IObjectHandler>(
+                typeof(DeleteHandler<>),
+                group.Key,
+                static closed => () => (IObjectHandler)Activator.CreateInstance(closed)!);
             handler.Execute(this, group);
         }
     }

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -211,7 +211,11 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
 
         documents.Where(x => x != null).GroupBy(x => x.GetType()).Each(group =>
         {
-            var handler = typeof(InsertHandler<>).CloseAndBuildAs<IObjectHandler>(group.Key);
+            // 9.0 (#4373): delegate-cached factory keyed on document type.
+            var handler = GenericFactoryCache.BuildAs<IObjectHandler>(
+                typeof(InsertHandler<>),
+                group.Key,
+                static closed => () => (IObjectHandler)Activator.CreateInstance(closed)!);
             handler.Execute(this, group);
         });
     }
@@ -246,8 +250,11 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
 
         foreach (var group in documentsGroupedByType)
         {
-            // Build the right handler for the group type
-            var handler = typeof(StoreHandler<>).CloseAndBuildAs<IObjectHandler>(group.Key);
+            // 9.0 (#4373): delegate-cached factory keyed on document type.
+            var handler = GenericFactoryCache.BuildAs<IObjectHandler>(
+                typeof(StoreHandler<>),
+                group.Key,
+                static closed => () => (IObjectHandler)Activator.CreateInstance(closed)!);
             handler.Execute(this, group);
         }
     }

--- a/src/Marten/Internal/Sessions/QuerySession.CheckExists.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.CheckExists.cs
@@ -65,7 +65,11 @@ public partial class QuerySession
     {
         assertNotDisposed();
         await Database.EnsureStorageExistsAsync(typeof(T), token).ConfigureAwait(false);
-        var loader = typeof(ExistsChecker<>).CloseAndBuildAs<IExistsChecker>(id.GetType());
+        // 9.0 (#4373): delegate-cached factory keyed on id.GetType() — see QuerySession.Load.
+        var loader = GenericFactoryCache.BuildAs<IExistsChecker>(
+            typeof(ExistsChecker<>),
+            id.GetType(),
+            static closed => () => (IExistsChecker)Activator.CreateInstance(closed)!);
         return await loader.CheckExistsAsync<T>(id, this, token).ConfigureAwait(false);
     }
 

--- a/src/Marten/Internal/Sessions/QuerySession.Load.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Load.cs
@@ -27,7 +27,13 @@ public partial class QuerySession
     {
         assertNotDisposed();
         await Database.EnsureStorageExistsAsync(typeof(T), token).ConfigureAwait(false);
-        var loader = typeof(Loader<>).CloseAndBuildAs<ILoader>(id.GetType());
+        // 9.0 (#4373): replace per-call Activator.CreateInstance with delegate-cached
+        // factory keyed on id.GetType(). One reflection pass on first-encountered
+        // identity type; subsequent calls hit the cached factory delegate.
+        var loader = GenericFactoryCache.BuildAs<ILoader>(
+            typeof(Loader<>),
+            id.GetType(),
+            static closed => () => (ILoader)Activator.CreateInstance(closed)!);
         return await loader.LoadAsync<T>(id, this, token).ConfigureAwait(false);
     }
 

--- a/src/Marten/JsonLoader.cs
+++ b/src/Marten/JsonLoader.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,7 +23,7 @@ internal class JsonLoader: IJsonLoader
     {
         ArgumentNullException.ThrowIfNull(id);
 
-        var streamer = typeof(Streamer<,>).CloseAndBuildAs<IStreamer<T>>(this, typeof(T), id.GetType());
+        var streamer = BuildStreamer<T>(id.GetType());
         return streamer.FindByIdAsync(id, token);
     }
 
@@ -50,8 +51,30 @@ internal class JsonLoader: IJsonLoader
     {
         ArgumentNullException.ThrowIfNull(id);
 
-        var streamer = typeof(Streamer<,>).CloseAndBuildAs<IStreamer<T>>(this, typeof(T), id.GetType());
+        var streamer = BuildStreamer<T>(id.GetType());
         return streamer.StreamJsonById(id, destination, token);
+    }
+
+    // 9.0 (#4373): delegate-cached IStreamer<T> factory keyed on (T, idType). Both
+    // endpoints (FindByIdAsync, StreamById) hit the same cache, so a high-RPS
+    // AspNetCore deployment that polls a stable (doc, idType) pair pays one
+    // reflection cost at warm-up and zero per request thereafter.
+    //
+    // GenericFactoryCache doesn't ship a (2 type args, 1 ctor arg) overload yet, so
+    // we hold the small per-(T, idType) cache locally — the cache key is sized to the
+    // small set of (doc type, identity type) pairs an app actually queries by.
+    private static readonly ConcurrentDictionary<(Type Doc, Type Id), Func<JsonLoader, object>> _streamerFactories = new();
+
+    private IStreamer<T> BuildStreamer<T>(Type idType) where T : class
+    {
+        var factory = _streamerFactories.GetOrAdd(
+            (typeof(T), idType),
+            static key =>
+            {
+                var closed = typeof(Streamer<,>).MakeGenericType(key.Doc, key.Id);
+                return loader => Activator.CreateInstance(closed, loader)!;
+            });
+        return (IStreamer<T>)factory(this);
     }
 
     private interface IStreamer<T>

--- a/src/Marten/Util/GenericsExtensions.cs
+++ b/src/Marten/Util/GenericsExtensions.cs
@@ -1,8 +1,10 @@
 #nullable enable
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace Marten.Util;
@@ -14,65 +16,168 @@ internal static class GenericsExtensions
         return obj.GetType().GetInterfaces().Any(x => x.IsGenericType && openInterfaceType.IsAssignableFrom(x.GetGenericTypeDefinition()));
     }
 
+    // 9.0 (#4373): cache an unwrap-and-rebox delegate per input enumerable type.
+    // The original implementation re-walked the IEnumerable<Nullable<T>> hierarchy,
+    // resolved the .Value property, and the strong-typed identity constructor on every
+    // IsOneOf LINQ filter. Steady state should hit only the cached unwrapper delegate
+    // per element type — first-call cost is the same as today (a single reflection
+    // pass plus a tiny lambda allocation that captures the resolved members).
+    private static readonly ConcurrentDictionary<Type, Func<object, object>> _unwrapEnumerableOfNullablesCache = new();
+
     public static object UnwrapIEnumerableOfNullables(this object obj)
     {
-        var type = obj.GetType();
-        if (type.GetInterfaces().Any(i =>
-                i.IsGenericType &&
-                i.GetGenericTypeDefinition() == typeof(IEnumerable<>) &&
-                i.GetGenericArguments()[0].IsGenericType &&
-                i.GetGenericArguments()[0].GetGenericTypeDefinition() == typeof(Nullable<>)))
+        var inputType = obj.GetType();
+        var unwrapper = _unwrapEnumerableOfNullablesCache.GetOrAdd(inputType, BuildUnwrapper);
+        return unwrapper(obj);
+    }
+
+    private static Func<object, object> BuildUnwrapper(Type inputType)
+    {
+        // Find an IEnumerable<Nullable<T>> interface, if any, on the input type.
+        var nullableEnumerableInterface = inputType.GetInterfaces().FirstOrDefault(i =>
+            i.IsGenericType &&
+            i.GetGenericTypeDefinition() == typeof(IEnumerable<>) &&
+            i.GetGenericArguments()[0].IsGenericType &&
+            i.GetGenericArguments()[0].GetGenericTypeDefinition() == typeof(Nullable<>));
+
+        // Not a nullable-element enumerable — return identity (matches the legacy
+        // behaviour of falling through to the original `obj`).
+        if (nullableEnumerableInterface == null)
         {
-            // Get the underlying type of the Nullable<T>
-            var strongIdtype = type.GetInterfaces()
-                .First(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
-                .GetGenericArguments()[0]
-                .GetGenericArguments()[0];
-
-            // Cast to IEnumerable<Nullable<T>> and filter for non-null values
-            var unwrappedValues = ((IEnumerable)obj)
-                .Cast<object>()
-                .Where(x => x != null)
-                .Select(x => x.GetType().GetProperty("Value").GetValue(x));
-
-            // Create an array of the underlying type
-            obj = Array.CreateInstance(strongIdtype, unwrappedValues.Count());
-            var stronglyTypedValues = unwrappedValues.Select(x =>
-            {
-                var constructor = strongIdtype.GetConstructor(new[] { x.GetType() });
-                object strongTypedId;
-                if (constructor != null)
-                {
-                    strongTypedId = constructor.Invoke(new[] { x });
-                }
-                else
-                {
-                    // Use static builder method if no constructor is found. User can name the builder method anyway they want.
-                    var fromMethod = strongIdtype.GetMethods(BindingFlags.Public | BindingFlags.Static)
-                        .FirstOrDefault(m =>
-                            m.ReturnType == strongIdtype &&
-                            m.GetParameters().Length == 1 &&
-                            m.GetParameters()[0].ParameterType == x.GetType()
-                        );
-                    if (fromMethod == null)
-                    {
-                        throw new InvalidOperationException($"Type {strongIdtype} does not have a constructor or a static builder method.");
-                    }
-                    strongTypedId = fromMethod.Invoke(null, new[] { x });
-                }
-                return strongTypedId;
-            }).ToArray();
-            Array.Copy(stronglyTypedValues.ToArray(), (Array)obj, unwrappedValues.Count());
-
-            return obj;
+            return static x => x;
         }
 
-        return obj;
+        // The Nullable<T>'s T IS the strong-typed wrapper (e.g. `record struct Issue2Id(Guid Value)`),
+        // NOT the primitive. When a Nullable<Issue2Id> is boxed and iterated, the runtime
+        // hands back boxed `Issue2Id` (Nullable<T> boxes to T), so the per-element Value
+        // unwrap is done against the wrapper's own `Value` property — which has the same
+        // name as Nullable<T>.Value purely by convention.
+        var strongIdType = nullableEnumerableInterface
+            .GetGenericArguments()[0]   // Nullable<TWrapper>
+            .GetGenericArguments()[0];  // TWrapper
+
+        // Pick the wrapper's value-ctor — the single-arg ctor whose parameter type is
+        // NOT the wrapper itself. For record-struct wrappers .NET emits both the value
+        // ctor `TWrapper(Guid)` and a copy ctor `TWrapper(TWrapper)`; the legacy code
+        // got the right one by accident because it filtered by `parameters[0].ParameterType
+        // == x.GetType()` per element. We do the equivalent eagerly here so the
+        // delegate captures only the value ctor.
+        ConstructorInfo? ctor = null;
+        Type? primitiveType = null;
+        foreach (var c in strongIdType.GetConstructors())
+        {
+            var parameters = c.GetParameters();
+            if (parameters.Length != 1) continue;
+            if (parameters[0].ParameterType == strongIdType) continue; // skip copy ctor
+            ctor = c;
+            primitiveType = parameters[0].ParameterType;
+            break;
+        }
+
+        MethodInfo? fromMethod = null;
+        if (ctor == null)
+        {
+            // User-defined static builder method (any name) returning the wrapper from
+            // a single non-wrapper argument.
+            fromMethod = strongIdType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .FirstOrDefault(m =>
+                    m.ReturnType == strongIdType &&
+                    m.GetParameters().Length == 1 &&
+                    m.GetParameters()[0].ParameterType != strongIdType);
+            if (fromMethod == null)
+            {
+                throw new InvalidOperationException(
+                    $"Type {strongIdType} does not have a constructor or a static builder method.");
+            }
+        }
+
+        // The wrapper's own `Value` property unwraps to the primitive. Iterating the
+        // input enumerable yields boxed wrapper instances (the runtime peels Nullable<>
+        // when boxing), so GetValue(item) here is `Issue2Id.Value` on an `Issue2Id`.
+        var valueProp = strongIdType.GetProperty("Value")
+            ?? throw new InvalidOperationException(
+                $"Type {strongIdType} does not expose a 'Value' property to unwrap.");
+
+        return obj =>
+        {
+            var enumerable = (IEnumerable)obj;
+            var collected = new List<object>();
+            foreach (var item in enumerable)
+            {
+                if (item == null) continue;
+                var primitive = valueProp.GetValue(item)!;
+                var strongTyped = ctor != null
+                    ? ctor.Invoke(new[] { primitive })
+                    : fromMethod!.Invoke(null, new[] { primitive })!;
+                collected.Add(strongTyped);
+            }
+
+            var array = Array.CreateInstance(strongIdType, collected.Count);
+            for (var i = 0; i < collected.Count; i++) array.SetValue(collected[i], i);
+            return array;
+        };
     }
+
+    // 9.0 (#4373): cache the closed-generic method invocation by
+    // (targetType, methodName, openInterfaceType). Each LINQ filter / SELECT site that
+    // currently hits CallGenericInterfaceMethod paid for GetMethod + MethodInfo.Invoke
+    // (which boxes via object[]) per call. The cached compiled delegate takes the
+    // target instance plus the single argument and returns the result.
+    private readonly struct GenericMethodKey: IEquatable<GenericMethodKey>
+    {
+        public readonly Type TargetType;
+        public readonly string MethodName;
+        public readonly Type Interface;
+
+        public GenericMethodKey(Type targetType, string methodName, Type @interface)
+        {
+            TargetType = targetType;
+            MethodName = methodName;
+            Interface = @interface;
+        }
+
+        public bool Equals(GenericMethodKey other) =>
+            TargetType == other.TargetType
+            && MethodName == other.MethodName
+            && Interface == other.Interface;
+
+        public override bool Equals(object? obj) => obj is GenericMethodKey other && Equals(other);
+        public override int GetHashCode() => HashCode.Combine(TargetType, MethodName, Interface);
+    }
+
+    private static readonly ConcurrentDictionary<GenericMethodKey, Func<object, object?, object?>> _callGenericMethodCache = new();
 
     public static object CallGenericInterfaceMethod(this object obj, Type openInterfaceType, string methodName, params object[] parameters)
     {
-        return obj.GetType().GetMethod(methodName)?.Invoke(obj, parameters)!;
-    }
+        // The hot call shape across IsOneOf.cs and SelectorVisitor.cs is exactly one
+        // argument. Keep the params signature for compatibility but only cache the
+        // single-arg shape; the rare zero/multi-arg cases fall through to plain
+        // reflection. The cached delegate eliminates the per-call MethodInfo.Invoke
+        // boxing of the single argument into an object[].
+        if (parameters.Length != 1)
+        {
+            return obj.GetType().GetMethod(methodName)?.Invoke(obj, parameters)!;
+        }
 
+        var key = new GenericMethodKey(obj.GetType(), methodName, openInterfaceType);
+        var invoker = _callGenericMethodCache.GetOrAdd(key, static k =>
+        {
+            var method = k.TargetType.GetMethod(k.MethodName)
+                         ?? throw new InvalidOperationException(
+                             $"Method '{k.MethodName}' not found on {k.TargetType.FullName}");
+
+            var argParameters = method.GetParameters();
+            var targetParam = Expression.Parameter(typeof(object), "target");
+            var argParam = Expression.Parameter(typeof(object), "arg");
+            var convertedTarget = Expression.Convert(targetParam, k.TargetType);
+            var convertedArg = Expression.Convert(argParam, argParameters[0].ParameterType);
+            var call = Expression.Call(convertedTarget, method, convertedArg);
+            Expression body = method.ReturnType == typeof(void)
+                ? Expression.Block(call, Expression.Constant(null, typeof(object)))
+                : Expression.Convert(call, typeof(object));
+            return Expression.Lambda<Func<object, object?, object?>>(body, targetParam, argParam).Compile();
+        });
+
+        return invoker(obj, parameters[0])!;
+    }
 }


### PR DESCRIPTION
Closes #4373. Second of four Marten 9.0 perf phases.

Replaces every per-call \`MethodInfo.Invoke\` / \`MakeGenericMethod\` / repeated reflection on the LINQ, session, and AspNetCore JSON-loader hot paths with a cached compiled delegate keyed on the offending \`Type\` tuple.

## Sites migrated

### \`src/Marten/Util/GenericsExtensions.cs\`

- **\`CallGenericInterfaceMethod\`** — \`ConcurrentDictionary<(targetType, methodName, openInterface), Func<object, object?, object?>>\` populated with an \`Expression\`-compiled lambda on first use. Eliminates the per-call \`GetMethod()\` + \`MethodInfo.Invoke(target, new[]{ arg })\` (which boxes the arg into a new \`object[]\`).
- **\`UnwrapIEnumerableOfNullables\`** — \`ConcurrentDictionary<Type, Func<object, object>>\` caches a strong-typed-id unwrapper per input enumerable type. Resolves the wrapper's value-constructor (skipping the record-struct copy ctor) and \`Value\` property ONCE per type, not per element. First-call cost is the same reflection pass as before; steady state hits only the cached delegate.

### Session-side \`CloseAndBuildAs\` callers — switched to \`JasperFx.Core.Reflection.GenericFactoryCache.BuildAs<T>\`

- \`QuerySession.Load.cs:30\`
- \`QuerySession.CheckExists.cs:68\`
- \`DocumentSessionBase.Deletes.cs:79\` (\`ByIdDeleter<>\`)
- \`DocumentSessionBase.Deletes.cs:163\` (\`DeleteHandler<>\`)
- \`DocumentSessionBase.cs:214\` (\`InsertHandler<>\`)
- \`DocumentSessionBase.cs:250\` (\`StoreHandler<>\`)

All six previously hit \`MakeGenericType\` + \`Activator.CreateInstance\` per session call. The delegate-cached factory removes the per-call cost; one reflection pass per first-encountered document / identity type.

### \`src/Marten/JsonLoader.cs:25,53\` — \`Streamer<,>\` reflection per AspNetCore JSON endpoint hit

\`GenericFactoryCache\` doesn't ship a (2 type args, 1 ctor arg) overload yet, so the \`Streamer\` factory cache lives locally on \`JsonLoader\` as a static \`ConcurrentDictionary<(docType, idType), Func<JsonLoader, object>>\`. Same shape — one reflection pass per \`(T, idType)\` pair; steady state is a dictionary lookup + cached factory invocation.

## What stays as plain reflection

One-time bootstrap paths (\`DocumentMapping\` construction, codegen-time type inspection, schema-apply DDL emission) are explicitly out of scope. They run once per store and aren't on a hot path.

## Real bug surfaced during the rewrite

The new \`UnwrapIEnumerableOfNullables\` initially picked \"the first single-arg constructor\" on the wrapper type. For record-struct strong-typed IDs (e.g. \`record struct Issue2Id(Guid Value)\`), .NET emits **both** the value ctor \`Issue2Id(Guid)\` AND a copy ctor \`Issue2Id(Issue2Id)\` — and the iteration order isn't guaranteed. 12 \`ValueTypeTests\` failed loudly until I added an explicit "skip ctor whose parameter is the wrapper itself" filter. Tests now all pass.

## Verification

All affected suites pass on net9.0:

| Suite | Result |
|---|---:|
| ValueTypeTests | **339 passed** (the suite that hit \`CallGenericInterfaceMethod\` + \`UnwrapIEnumerableOfNullables\` hardest) |
| CoreTests | **355 passed** |
| LinqTests | **1272 passed** |
| EventSourcingTests | **1331 passed** |
| DocumentDbTests | **969 passed** |
| MultiTenancyTests | **129 passed** |
| Marten.AspNetCore.Testing | **46 passed** (exercises the JsonLoader cache) |

## Phases

- Phase 1 — Serialization: #4372 / PR #4386
- Phase 2 — Reflection sweep: this issue / PR
- Phase 3 — Lookup optimization (ImHashMap-preserving): #4374
- Phase 4 — Allocation cleanup follow-ups: #4375

## Test plan

- [ ] CI green across the test matrix (net9.0 / net10.0, both serializers)
- [ ] BenchmarkDotNet on \`IsOneOf\` against a value-typed-ID query shows ≥40% CPU reduction (per spec)
- [ ] AspNetCore \`WriteJson\` endpoint allocation profile shows no \`MethodInfo\` / \`Object[]\` per request