### PR TITLE
Phase 3 perf: ImHashMap-preserving lookup optimizations (#4374)

### DIFF
--- a/src/Marten/Events/EventStore.FetchForWriting.cs
+++ b/src/Marten/Events/EventStore.FetchForWriting.cs
@@ -27,7 +27,30 @@ namespace Marten.Events;
 
 internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityStrategy<string>
 {
-    private ImHashMap<(Type, Type), object> _fetchStrategies = ImHashMap<(Type, Type), object>.Empty;
+    // 9.0 (#4374): cache fetch plans by a small readonly struct key with stable
+    // RuntimeTypeHandle-based hashing rather than a value tuple. The ImHashMap node
+    // comparison would otherwise route through ValueTuple<,>.Equals which compares
+    // Type references via object.Equals + boxes; this dedicated key uses reference
+    // equality directly and combines the two RuntimeTypeHandle hashes for the lookup.
+    private readonly struct AggregateFetchKey: IEquatable<AggregateFetchKey>
+    {
+        public readonly Type Aggregate;
+        public readonly Type Id;
+
+        public AggregateFetchKey(Type aggregate, Type id)
+        {
+            Aggregate = aggregate;
+            Id = id;
+        }
+
+        public bool Equals(AggregateFetchKey other) => Aggregate == other.Aggregate && Id == other.Id;
+        public override bool Equals(object? obj) => obj is AggregateFetchKey other && Equals(other);
+        public override int GetHashCode() =>
+            HashCode.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Aggregate),
+                System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(Id));
+    }
+
+    private ImHashMap<AggregateFetchKey, object> _fetchStrategies = ImHashMap<AggregateFetchKey, object>.Empty;
 
     async Task<IEventStorage> IEventIdentityStrategy<Guid>.EnsureEventStorageExists<T>(
         DocumentSessionBase session, CancellationToken cancellation)
@@ -244,7 +267,7 @@ internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityS
         // else: natural key type — event storage initialization deferred to the plan
 
         // Use (TDoc, TId) as cache key to support both stream id and natural key lookups
-        var cacheKey = (typeof(TDoc), typeof(TId));
+        var cacheKey = new AggregateFetchKey(typeof(TDoc), typeof(TId));
         if (_fetchStrategies.TryFind(cacheKey, out var stored))
         {
             return (IAggregateFetchPlan<TDoc, TId>)stored;

--- a/src/Marten/Internal/ProviderGraph.cs
+++ b/src/Marten/Internal/ProviderGraph.cs
@@ -36,7 +36,14 @@ public class ProviderGraph: IProviderGraph
     {
         var documentType = typeof(T);
 
-        if (_storage.TryFind(documentType, out var stored))
+        // 9.0 (#4374): hoist _storage into a local for the unlocked fast path. The
+        // JIT can't prove the second read sees the same ImHashMap reference as the
+        // first (it isn't volatile), so it re-emits a field load on every TryFind.
+        // Reading into a local gives the JIT a stable snapshot to work against and
+        // shortens the fast path; the locked branch re-reads _storage on purpose
+        // because Append() may have published a newer map.
+        var snapshot = _storage;
+        if (snapshot.TryFind(documentType, out var stored))
         {
             return stored.As<DocumentProvider<T>>();
         }

--- a/src/Marten/LinqParsing.cs
+++ b/src/Marten/LinqParsing.cs
@@ -144,20 +144,24 @@ public class LinqParsing: IReadOnlyLinqParsing
     {
         var module = expression.Method.Module;
 
+        // 9.0 (#4374): consolidate the per-module map mutation into one AddOrUpdate.
+        // The previous code stored an empty inner map under `module`, then on the
+        // very next mutation overwrote it with the parser-populated map — wasted a
+        // write and the transient empty ImHashMap instance.
         if (!_methodParsersByModule.TryFind(module, out var methodParsers))
         {
             methodParsers = ImHashMap<int, IMethodCallParser>.Empty;
-            _methodParsersByModule = _methodParsersByModule.AddOrUpdate(module, methodParsers);
         }
-
-        if (methodParsers.TryFind(expression.Method.MetadataToken, out var parser))
+        else if (methodParsers.TryFind(expression.Method.MetadataToken, out var cached))
         {
-            return parser;
+            return cached;
         }
 
-        parser = determineMethodParser(expression);
+        var parser = determineMethodParser(expression);
 
-        _methodParsersByModule = _methodParsersByModule.AddOrUpdate(module, methodParsers.AddOrUpdate(expression.Method.MetadataToken, parser));
+        _methodParsersByModule = _methodParsersByModule.AddOrUpdate(
+            module,
+            methodParsers.AddOrUpdate(expression.Method.MetadataToken, parser));
 
         return parser;
     }

--- a/src/Marten/Services/Json/JsonNetObjectContractProvider.cs
+++ b/src/Marten/Services/Json/JsonNetObjectContractProvider.cs
@@ -14,20 +14,25 @@ namespace Marten.Services.Json
     {
         private static readonly Type ConstructorAttributeType = typeof(JsonConstructorAttribute);
 
-        private static readonly Ref<ImHashMap<string, JsonObjectContract>> Constructors =
-            Ref.Of(ImHashMap<string, JsonObjectContract>.Empty);
+        // 9.0 (#4374): key the JsonObjectContract cache directly on Type rather than
+        // on type.AssemblyQualifiedName. Type equality is reference equality post-load,
+        // and Type.GetHashCode falls through to RuntimeTypeHandle — both meaningfully
+        // cheaper than the AQN string allocation+hash that fired on every contract
+        // lookup. The map's key is also no longer a per-call allocation; AQN was a
+        // freshly-materialized string for every miss-path call before this change.
+        private static readonly Ref<ImHashMap<Type, JsonObjectContract>> Constructors =
+            Ref.Of(ImHashMap<Type, JsonObjectContract>.Empty);
 
         public static JsonObjectContract UsingNonDefaultConstructor(
             JsonObjectContract contract,
             Type objectType,
             Func<ConstructorInfo, JsonPropertyCollection, IList<JsonProperty>> createConstructorParameters)
         {
-            var typeName = objectType.AssemblyQualifiedName!;
-            if (Constructors.Value!.TryFind(typeName, out var value))
+            if (Constructors.Value!.TryFind(objectType, out var value))
                 return value;
 
             value = OnUsingNonDefaultConstructor(contract, objectType, createConstructorParameters);
-            Constructors.Swap(d => d.AddOrUpdate(typeName, value));
+            Constructors.Swap(d => d.AddOrUpdate(objectType, value));
 
             return value;
         }


### PR DESCRIPTION
Closes #4374. Third of four Marten 9.0 perf phases.

Tightens existing \`ImHashMap\` usage on hot paths without swapping to \`FrozenDictionary\` (per project direction: \`ImHashMap\` stays).

## Changes

| File | Change |
|---|---|
| \`Events/EventStore.FetchForWriting.cs\` | Replace \`ImHashMap<(Type, Type), object>\` cache key with a \`readonly struct AggregateFetchKey\` that hashes via \`RuntimeHelpers.GetHashCode\` per Type and compares by reference equality. Eliminates the value-tuple boxing the ImHashMap node comparator paid per \`FetchForWriting<T>\` / \`FetchLatest<T>\` call. |
| \`LinqParsing.cs\` | Consolidate \`FindMethodParser\`'s double \`AddOrUpdate\` into one. The previous code stored an empty inner map under the module key, then on the very next mutation overwrote it with the parser-populated map — wasted write + transient empty ImHashMap instance per first-seen module. |
| \`Services/Json/JsonNetObjectContractProvider.cs\` | Key the \`JsonObjectContract\` cache on \`Type\` directly instead of \`type.AssemblyQualifiedName\`. \`Type\` equality is reference equality post-load and \`Type.GetHashCode\` falls through to \`RuntimeTypeHandle\` — both cheaper than the AQN string allocation+hash. |
| \`Internal/ProviderGraph.cs\` | Hoist \`_storage\` into a local for the unlocked fast path. The field isn't volatile, so the JIT re-emits a field load on every \`TryFind\`; reading into a local gives a stable snapshot. The locked branch still re-reads \`_storage\` because \`Append()\` may have published a newer map between the unlocked read and the lock. |

## Deferred from the spec

- **\`EventGraph.cs:651\` "redundant double-fill inside Swap lambda"** — the affected Swap runs once during \`EventGraph\` construction (single-threaded init), so the Swap-retry-on-contention concern doesn't fire in practice. Marginal benefit doesn't justify the TOCTOU risk of restructuring around an external \`CompareExchange\`.
- **\`StorageFeatures._mappings\` and \`OperatorLibrary\`** — spec marks these optional ("consider hoisted reads or struct keys only if profiling shows hot"). No profile data yet to motivate the change.

## Out of scope

- Swapping any \`ImHashMap\` / \`ConcurrentDictionary\` to \`FrozenDictionary\`.
- Restructuring \`EventGraph\` storage beyond the swap-lambda fix (deferred above).
- Changing public API on any of the affected services.

## Verification

All affected suites pass on net9.0:

| Suite | Result |
|---|---:|
| CoreTests | **355 passed** |
| EventSourcingTests | **1331 passed** |
| LinqTests | **1272 passed** |
| DocumentDbTests | **969 passed** |

## Phases

- Phase 1 — Serialization: #4372 / PR #4386
- Phase 2 — Reflection sweep: #4373 / PR #4387
- Phase 3 — Lookup optimization: this issue / PR
- Phase 4 — Allocation cleanup follow-ups: #4375

## Test plan

- [ ] CI green across the test matrix
- [ ] BenchmarkDotNet on \`FetchForWriting<T>\` loop shows zero per-call allocations from the cache lookup itself