### PR TITLE
Perf #4375: structural allocation cleanup follow-ups (Phase 4)

### DIFF
--- a/src/Marten/Events/EventGraph.Actions.cs
+++ b/src/Marten/Events/EventGraph.Actions.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Linq;
 using JasperFx.Events;
-using Marten.Exceptions;
 using Marten.Internal.Sessions;
 
 namespace Marten.Events;
@@ -17,12 +15,15 @@ public partial class EventGraph
             throw new ArgumentOutOfRangeException(nameof(stream), "Cannot use an empty Guid as the stream id");
         }
 
-        var wrapped = events.Select(o =>
+        // 9.0 (#4375): manual loop avoids the Select/iterator + per-call closure allocation
+        // (the previous lambda captured `stream` so the closure object was created per Append).
+        var wrapped = new IEvent[events.Length];
+        for (var i = 0; i < events.Length; i++)
         {
-            var e = BuildEvent(o);
+            var e = BuildEvent(events[i]);
             e.StreamId = stream;
-            return e;
-        }).ToArray();
+            wrapped[i] = e;
+        }
 
         if (session.WorkTracker.TryFindStream(stream, out var eventStream))
         {
@@ -48,12 +49,14 @@ public partial class EventGraph
             throw new ArgumentOutOfRangeException(nameof(stream), "The stream key cannot be null or empty");
         }
 
-        var wrapped = events.Select(o =>
+        // 9.0 (#4375): see EventGraph.Append(Guid …) above — manual loop, no Select/closure.
+        var wrapped = new IEvent[events.Length];
+        for (var i = 0; i < events.Length; i++)
         {
-            var e = BuildEvent(o);
+            var e = BuildEvent(events[i]);
             e.StreamKey = stream;
-            return e;
-        }).ToArray();
+            wrapped[i] = e;
+        }
 
         if (session.WorkTracker.TryFindStream(stream, out var eventStream))
         {

--- a/src/Marten/Internal/Sessions/OperationPage.cs
+++ b/src/Marten/Internal/Sessions/OperationPage.cs
@@ -68,7 +68,9 @@ public class OperationPage
     public void ApplyCallbacks(DbDataReader reader,
         IList<Exception> exceptions)
     {
-        var first = _operations.First();
+        // 9.0 (#4375): indexed loop avoids the SkipIterator + List enumerator allocations
+        // the old `_operations.First()` + `_operations.Skip(1)` pattern triggered per page.
+        var first = _operations[0];
 
         if (first is not NoDataReturnedCall)
         {
@@ -88,8 +90,9 @@ public class OperationPage
             }
         }
 
-        foreach (var operation in _operations.Skip(1))
+        for (var i = 1; i < _operations.Count; i++)
         {
+            var operation = _operations[i];
             if (operation is NoDataReturnedCall)
             {
                 continue;
@@ -117,7 +120,8 @@ public class OperationPage
         IList<Exception> exceptions,
         CancellationToken token)
     {
-        var first = _operations.First();
+        // 9.0 (#4375): see comment in ApplyCallbacks above.
+        var first = _operations[0];
 
         if (first is not NoDataReturnedCall)
         {
@@ -141,8 +145,9 @@ public class OperationPage
             await first.PostprocessAsync(reader, exceptions, token).ConfigureAwait(false);
         }
 
-        foreach (var operation in _operations.Skip(1))
+        for (var i = 1; i < _operations.Count; i++)
         {
+            var operation = _operations[i];
             if (operation is NoDataReturnedCall)
             {
                 continue;

--- a/src/Marten/Internal/UpdateBatch.cs
+++ b/src/Marten/Internal/UpdateBatch.cs
@@ -38,39 +38,42 @@ public class UpdateBatch: IUpdateBatch
 
     public IReadOnlyList<OperationPage> BuildPages(IMartenSession session)
     {
-        return buildPages(session).ToList();
-    }
-
-    private IEnumerable<OperationPage> buildPages(IMartenSession session)
-    {
-        if (!_operations.Any())
+        // 9.0 (#4375): single-page fast path avoids allocating the iterator state machine
+        // + intermediate List<OperationPage> for the common single-batch SaveChanges case.
+        if (_operations.Count == 0)
         {
-            yield break;
+            return Array.Empty<OperationPage>();
         }
 
         if (_operations.Count < session.Options.UpdateBatchSize)
         {
-            yield return new OperationPage(session, _operations);
+            return new[] { new OperationPage(session, _operations) };
         }
-        else
+
+        return buildMultiplePages(session);
+    }
+
+    private List<OperationPage> buildMultiplePages(IMartenSession session)
+    {
+        var batchSize = session.Options.UpdateBatchSize;
+        var pageCount = (_operations.Count + batchSize - 1) / batchSize;
+        var pages = new List<OperationPage>(pageCount);
+
+        var count = 0;
+        while (count < _operations.Count)
         {
-            var count = 0;
-            var batchSize = session.Options.UpdateBatchSize;
-
-            while (count < _operations.Count)
+            var remaining = Math.Min(batchSize, _operations.Count - count);
+            var operations = new IStorageOperation[remaining];
+            for (int i = 0; i < remaining; i++)
             {
-                var remaining = Math.Min(batchSize, _operations.Count - count);
-                var operations = new IStorageOperation[remaining];
-                for (int i = 0; i < remaining; i++)
-                {
-                    operations[i] = _operations[count + i];
-                }
-
-                var page = new OperationPage(session, operations);
-                yield return page;
-
-                count += batchSize;
+                operations[i] = _operations[count + i];
             }
+
+            pages.Add(new OperationPage(session, operations));
+
+            count += batchSize;
         }
+
+        return pages;
     }
 }

--- a/src/Marten/Services/BatchQuerying/BatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQuery.cs
@@ -98,9 +98,8 @@ internal partial class BatchedQuery: IBatchedQuery
         await using var reader = await Parent.ExecuteReaderAsync(command, token).ConfigureAwait(false);
         await _items[0].ReadAsync(reader, Parent, token).ConfigureAwait(false);
 
-        var others = _items.Skip(1).ToArray();
-
-        foreach (var item in others)
+        // 9.0 (#4375): indexed loop avoids the Skip+ToArray buffer allocation per batch query.
+        for (var i = 1; i < _items.Count; i++)
         {
             var hasNext = await reader.NextResultAsync(token).ConfigureAwait(false);
 
@@ -109,7 +108,7 @@ internal partial class BatchedQuery: IBatchedQuery
                 throw new InvalidOperationException("There is no next result to read over.");
             }
 
-            await item.ReadAsync(reader, Parent, token).ConfigureAwait(false);
+            await _items[i].ReadAsync(reader, Parent, token).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
Closes #4375. Phase 4 of the 9.0 perf series (#4372–#4375).

## Summary

- Targets remaining structural allocation hotspots that don't require pooling. Pooling-style refactors that touch lifetime semantics (CommandBuilder, MemberFinder/LinqQueryParser visitors, UnitOfWork buffers, EventDocumentStorage.IdentityFor boxing) are deferred to follow-up issues so this PR stays bounded.

## Changes

- **`UpdateBatch.BuildPages`** — single-page fast path returns `Array.Empty<OperationPage>()` or a one-element array instead of going through a yield iterator + materializing `.ToList()`. The multi-page path now goes through a pre-sized `List<OperationPage>`.
- **`OperationPage.ApplyCallbacks(Async)`** — replaced `_operations.First()` + `_operations.Skip(1)` with `_operations[0]` + indexed `for` loop. Drops the `SkipIterator` + List enumerator allocations per batch page apply.
- **`BatchedQuery.ExecuteAsync`** — replaced `_items.Skip(1).ToArray()` with an indexed `for` loop.
- **`EventGraph.Append`** (Guid and string overloads) — replaced `events.Select(o => …).ToArray()` with a manual `IEvent[]` fill. Drops the Select-iterator allocation and the per-call closure object that captured `stream`.

## Deferred to follow-ups

- **#4389** — CommandBuilder pooling. High-risk because of parameter-list lifetime; needs profile data first.
- **#4390** — MemberFinder + LinqQueryParser visitor pooling, plus `Insert(0)` → `Add+Reverse` cleanup. Touches public visitor surface; needs staged refactor.
- **#4391** — UnitOfWork change-set buffer pre-sizing / pooling.
- **#4392** — `EventDocumentStorage.IdentityFor` boxing. Deferred because actual call sites don't appear to hit on QuickAppend / bulk append the way the spec assumed — needs a profile confirmation before refactoring the `IDocumentStorage<T>` interface.

## Test plan

- [x] `dotnet build src/Marten.slnx` — clean on net9.0 / net10.0, 0 errors.
- [x] `CoreTests` (355 passed / 1 skipped)
- [x] `EventSourcingTests` (1331 passed / 2 skipped)
- [x] `LinqTests` (1272 passed / 1 skipped)
- [x] `DocumentDbTests` (969 passed / 1 skipped)
- [ ] Combined Phase 1–4 BenchmarkDotNet pass — track separately once all four PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)