### PR TITLE
Perf #4390: thread-static MemberFinder pool for LINQ parse path

### DIFF
--- a/src/Marten/Linq/Parsing/MemberFinder.cs
+++ b/src/Marten/Linq/Parsing/MemberFinder.cs
@@ -17,6 +17,43 @@ public class MemberFinder: ExpressionVisitor
 
     public bool FoundParameterAtFront { get; private set; }
 
+    // 9.0 (#4390): one-deep per-thread pool for the LINQ-parse hot path. Determine() is
+    // called once per LINQ member-chain visit during query parsing; pooling drops the
+    // visitor allocation on the second-and-later LINQ call per thread. Subclasses
+    // (PatchingMemberFinder) intentionally bypass this — the pool is type-specific.
+    [System.ThreadStatic] private static MemberFinder? _pooled;
+
+    internal static MemberFinder Rent()
+    {
+        var finder = _pooled;
+        if (finder is null)
+        {
+            return new MemberFinder();
+        }
+
+        _pooled = null;
+        finder.ResetState();
+        return finder;
+    }
+
+    internal static void Return(MemberFinder finder)
+    {
+        // The pool only ever holds a single instance. Recursive Determine calls on the
+        // same thread (rare but possible — a visitor's expression could indirectly call
+        // back into Determine) get a fresh allocation on the inner call rather than
+        // reusing the still-in-flight pooled visitor. The outer call's return wins the
+        // pool slot. This is fine because the cost is bounded by recursion depth.
+        finder.ResetState();
+        _pooled = finder;
+    }
+
+    private void ResetState()
+    {
+        Members.Clear();
+        InvalidNodeTypes.Clear();
+        FoundParameterAtFront = false;
+    }
+
     protected override Expression VisitMember(MemberExpression node)
     {
         Members.Insert(0, node.Member);
@@ -76,29 +113,40 @@ public class MemberFinder: ExpressionVisitor
 
     public static MemberInfo[] Determine(Expression expression)
     {
-        var visitor = new MemberFinder();
-
-        visitor.Visit(expression);
-
-        return visitor.Members.ToArray();
+        var visitor = Rent();
+        try
+        {
+            visitor.Visit(expression);
+            return visitor.Members.ToArray();
+        }
+        finally
+        {
+            Return(visitor);
+        }
     }
 
     public static MemberInfo[] Determine(Expression expression, string invalidMessage)
     {
-        var visitor = new MemberFinder();
-
-        visitor.Visit(expression);
-
-        if (!visitor.FoundParameterAtFront)
+        var visitor = Rent();
+        try
         {
-            throw new BadLinqExpressionException($"{invalidMessage}: '{expression}'");
-        }
+            visitor.Visit(expression);
 
-        if (visitor.InvalidNodeTypes.Any())
+            if (!visitor.FoundParameterAtFront)
+            {
+                throw new BadLinqExpressionException($"{invalidMessage}: '{expression}'");
+            }
+
+            if (visitor.InvalidNodeTypes.Any())
+            {
+                throw new BadLinqExpressionException($"{invalidMessage}: '{expression}'");
+            }
+
+            return visitor.Members.ToArray();
+        }
+        finally
         {
-            throw new BadLinqExpressionException($"{invalidMessage}: '{expression}'");
+            Return(visitor);
         }
-
-        return visitor.Members.ToArray();
     }
 }

--- a/src/Marten/Linq/Parsing/SimpleExpression.cs
+++ b/src/Marten/Linq/Parsing/SimpleExpression.cs
@@ -342,11 +342,19 @@ internal class SimpleExpression: ExpressionVisitor
             {
                 Members.Insert(0, LinqConstants.ArrayLength);
 
-                var finder = new MemberFinder();
-                finder.Visit(node.Arguments[0]);
+                // 9.0 (#4390): pooled MemberFinder via thread-static; see MemberFinder.Rent/Return.
+                var finder = MemberFinder.Rent();
+                try
+                {
+                    finder.Visit(node.Arguments[0]);
 
-                FoundParameterAtStart = finder.FoundParameterAtFront;
-                Members = finder.Members.Concat(Members).ToList();
+                    FoundParameterAtStart = finder.FoundParameterAtFront;
+                    Members = finder.Members.Concat(Members).ToList();
+                }
+                finally
+                {
+                    MemberFinder.Return(finder);
+                }
                 return null;
             }
 


### PR DESCRIPTION
Closes #4390. Deferred follow-up from #4375 Phase 4.

## Summary

Drops the per-call `new MemberFinder()` allocation on the LINQ parse hot path. `MemberFinder.Determine(Expression[, string])` is invoked multiple times per query compilation — every `Where` / `OrderBy` member-chain walk allocates a fresh visitor plus its `List<MemberInfo>` + `List<ExpressionType>` backing fields. The visitor's state is fully copied out (`Members.ToArray()`) before each `Determine` returns, so a one-deep thread-static pool reclaims them safely.

## Changes

- **`MemberFinder.Rent` / `Return` / `ResetState`** — internal one-slot thread-static pool. Recursive `Determine` calls on the same thread (rare, but possible if a visitor's expression indirectly triggers another `Determine`) get a fresh allocation on the inner call; the outer call's return wins the pool slot. Recursion depth bounds the worst case.
- **`MemberFinder.Determine` (both overloads)** — rent/return via `try`/`finally` so the pool is repopulated even when validation throws `BadLinqExpressionException`.
- **`SimpleExpression.VisitMethodCall("Count")`** — also rents via the pool. This site copies `FoundParameterAtFront` and merges `Members` into the `SimpleExpression`'s own list before returning, so the visitor's state is fully extracted before `Return`.

Subclass allocations (`PatchingMemberFinder`) intentionally bypass the pool — the pool is type-specific. The `MartenRegistry` direct `new MemberFinder()` (config-time, rare) is left alone.

## What this PR does NOT include

The original #4390 scope also covered `Insert(0)` → `Add+Reverse` refactoring inside both `MemberFinder` and `LinqQueryParser._collectionUsages`. After investigating, that refactor is:

1. **CPU cost, not allocation** — `List<T>.Insert(0, item)` shifts the backing array but doesn't allocate beyond initial capacity growth.
2. **Tangled with `PatchingMemberFinder`** — the subclass also calls `Insert(0)` and the ordering rules don't compose cleanly across the inheritance.
3. **Tangled with `LinqQueryParser._collectionUsages`** — multiple read sites depend on `_collectionUsages[0]` being the newest insertion; flipping to `Add+Reverse` would require updating every reader semantic.

Both items are bounded CPU costs on small lists (typically ≤5 elements per query). Defer pending profile data justifying the refactor risk.

## Test plan

- [x] `dotnet build src/Marten/Marten.csproj` — clean, no new warnings.
- [x] `LinqTests` (1272 passed / 1 skipped) — covers the pooled `Determine` path across `Where` / `OrderBy` / `Select` / member-chain queries.
- [x] `PatchingTests` (114 passed / 1 skipped) — regression coverage for the un-pooled `PatchingMemberFinder` subclass path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)