### PR TITLE
Perf #4385: ArrayPool the QuickAppend per-batch column arrays

### DIFF
--- a/src/Marten/Events/Operations/QuickAppendEventsOperationBase.cs
+++ b/src/Marten/Events/Operations/QuickAppendEventsOperationBase.cs
@@ -10,6 +10,7 @@ using JasperFx.Events;
 using Marten.Exceptions;
 using Marten.Internal;
 using Marten.Internal.Operations;
+using Marten.Services;
 using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
@@ -18,6 +19,14 @@ namespace Marten.Events.Operations;
 
 public abstract class QuickAppendEventsOperationBase : IStorageOperation
 {
+    // 9.0 (#4385): per-batch column-array rentals from ArrayPool<T>.Shared, returned in
+    // Postprocess / PostprocessAsync once Npgsql has written the parameters to the wire.
+    // Capacity 12 covers writeBasicParameters (4) + writeCausationIds + writeCorrelationIds
+    // + writeHeaders + writeUserNames + writeTimestamps + up-to-N tag-type arrays without
+    // a List growth. Lazily-allocated so subclasses that override ConfigureCommand without
+    // calling any of the helpers pay nothing.
+    private List<IDisposable>? _rentals;
+
     public QuickAppendEventsOperationBase(StreamAction stream)
     {
         Stream = stream;
@@ -41,33 +50,58 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
 
     public abstract void ConfigureCommand(ICommandBuilder builder, IMartenSession session);
 
+    private PooledList<T> rentColumn<T>(int count)
+    {
+        _rentals ??= new List<IDisposable>(12);
+        var list = new PooledList<T>(count);
+        _rentals.Add(list);
+        return list;
+    }
+
+    private void releaseColumnRentals()
+    {
+        if (_rentals is null) return;
+        for (var i = 0; i < _rentals.Count; i++) _rentals[i].Dispose();
+        _rentals.Clear();
+    }
+
     public void Postprocess(DbDataReader reader, IList<Exception> exceptions)
     {
-        if (reader.Read())
+        try
         {
-            var values = reader.GetFieldValue<long[]>(0);
-
-            var finalVersion = values[0];
-            var events = Stream.Events;
-            for (int i = events.Count - 1; i >= 0; i--)
+            if (reader.Read())
             {
-                events[i].Version = finalVersion;
-                finalVersion--;
-            }
+                var values = reader.GetFieldValue<long[]>(0);
 
-            // Ignore the first value
-            for (int i = 1; i < values.Length; i++)
-            {
-                // Only setting the sequence to aid in tombstone processing
-                events[i - 1].Sequence = values[i];
-            }
+                var finalVersion = values[0];
+                var events = Stream.Events;
+                for (int i = events.Count - 1; i >= 0; i--)
+                {
+                    events[i].Version = finalVersion;
+                    finalVersion--;
+                }
 
-            if (Events is { UseMandatoryStreamTypeDeclaration: true } && events[0].Version == 1)
-            {
-                throw new NonExistentStreamException(Events.StreamIdentity == StreamIdentity.AsGuid
-                    ? Stream.Id
-                    : Stream.Key);
+                // Ignore the first value
+                for (int i = 1; i < values.Length; i++)
+                {
+                    // Only setting the sequence to aid in tombstone processing
+                    events[i - 1].Sequence = values[i];
+                }
+
+                if (Events is { UseMandatoryStreamTypeDeclaration: true } && events[0].Version == 1)
+                {
+                    throw new NonExistentStreamException(Events.StreamIdentity == StreamIdentity.AsGuid
+                        ? Stream.Id
+                        : Stream.Key);
+                }
             }
+        }
+        finally
+        {
+            // Always release the rentals — the parameter bytes have been on the wire since
+            // ExecuteReader returned, so they're safe to return to the pool whether
+            // Postprocess succeeded or threw.
+            releaseColumnRentals();
         }
     }
 
@@ -93,14 +127,16 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
 
         var events = Stream.Events;
         var count = events.Count;
-        var ids = new Guid[count];
-        var typeNames = new string[count];
-        var dotNetTypeNames = new string[count];
+        // 9.0 (#4385): rent the parallel column buffers from ArrayPool<T>.Shared via
+        // PooledList<T>, which surfaces the user-supplied length via ICollection<T>.Count
+        // so Npgsql sends exactly `count` elements (the rented array is typically longer).
         // jsonBodies is byte[][] so each element is serialized directly to UTF-8 via
-        // ISerializer.WriteToParameter-style emission, skipping the intermediate UTF-16
-        // string materialization that ToJson() would do. Npgsql 9 accepts byte[][] for
-        // Array|Jsonb and writes each element's raw bytes to the wire.
-        var jsonBodies = new byte[count][];
+        // ISerializer.WriteTo emission, skipping the intermediate UTF-16 string
+        // materialization that ToJson() would do (#4372 Phase 1).
+        var ids = rentColumn<Guid>(count);
+        var typeNames = rentColumn<string>(count);
+        var dotNetTypeNames = rentColumn<string>(count);
+        var jsonBodies = rentColumn<byte[]>(count);
 
         for (int i = 0; i < count; i++)
         {
@@ -111,16 +147,16 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
             jsonBodies[i] = SerializeToUtf8(session.Serializer, e.Data);
         }
 
-        var param3 = builder.AppendParameter(ids);
+        var param3 = builder.AppendParameter<IList<Guid>>(ids);
         param3.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Uuid;
 
-        var param4 = builder.AppendParameter(typeNames);
+        var param4 = builder.AppendParameter<IList<string>>(typeNames);
         param4.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Varchar;
 
-        var param5 = builder.AppendParameter(dotNetTypeNames);
+        var param5 = builder.AppendParameter<IList<string>>(dotNetTypeNames);
         param5.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Varchar;
 
-        var param6 = builder.AppendParameter(jsonBodies);
+        var param6 = builder.AppendParameter<IList<byte[]>>(jsonBodies);
         param6.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Jsonb;
     }
 
@@ -140,10 +176,10 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
     {
         var events = Stream.Events;
         var count = events.Count;
-        var causationIds = new string[count];
+        var causationIds = rentColumn<string>(count);
         for (int i = 0; i < count; i++) causationIds[i] = events[i].CausationId;
 
-        var param = builder.AppendParameter(causationIds);
+        var param = builder.AppendParameter<IList<string>>(causationIds);
         param.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Varchar;
     }
 
@@ -151,10 +187,10 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
     {
         var events = Stream.Events;
         var count = events.Count;
-        var correlationIds = new string[count];
+        var correlationIds = rentColumn<string>(count);
         for (int i = 0; i < count; i++) correlationIds[i] = events[i].CorrelationId;
 
-        var param = builder.AppendParameter(correlationIds);
+        var param = builder.AppendParameter<IList<string>>(correlationIds);
         param.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Varchar;
     }
 
@@ -162,10 +198,10 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
     {
         var events = Stream.Events;
         var count = events.Count;
-        var headers = new byte[count][];
+        var headers = rentColumn<byte[]>(count);
         for (int i = 0; i < count; i++) headers[i] = SerializeToUtf8(session.Serializer, events[i].Headers);
 
-        var param = builder.AppendParameter(headers);
+        var param = builder.AppendParameter<IList<byte[]>>(headers);
         param.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Jsonb;
     }
 
@@ -173,10 +209,10 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
     {
         var events = Stream.Events;
         var count = events.Count;
-        var userNames = new string[count];
+        var userNames = rentColumn<string>(count);
         for (int i = 0; i < count; i++) userNames[i] = events[i].UserName;
 
-        var param = builder.AppendParameter(userNames);
+        var param = builder.AppendParameter<IList<string>>(userNames);
         param.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Varchar;
     }
 
@@ -184,10 +220,10 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
     {
         var events = Stream.Events;
         var count = events.Count;
-        var timestamps = new DateTimeOffset[count];
+        var timestamps = rentColumn<DateTimeOffset>(count);
         for (int i = 0; i < count; i++) timestamps[i] = events[i].Timestamp;
 
-        var param = builder.AppendParameter(timestamps);
+        var param = builder.AppendParameter<IList<DateTimeOffset>>(timestamps);
         param.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.TimestampTz;
     }
 
@@ -199,7 +235,7 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
 
         foreach (var registration in tagTypes)
         {
-            var values = new string?[count];
+            var values = rentColumn<string?>(count);
             for (int i = 0; i < count; i++)
             {
                 var tags = events[i].Tags;
@@ -216,38 +252,48 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation
                 }
             }
 
-            var param = builder.AppendParameter(values);
+            var param = builder.AppendParameter<IList<string?>>(values);
             param.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Varchar;
         }
     }
 
     public async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
     {
-        if (await reader.ReadAsync(token).ConfigureAwait(false))
+        try
         {
-            var values = await reader.GetFieldValueAsync<long[]>(0, token).ConfigureAwait(false);
-
-            var finalVersion = values[0];
-            var events = Stream.Events;
-            for (int i = events.Count - 1; i >= 0; i--)
+            if (await reader.ReadAsync(token).ConfigureAwait(false))
             {
-                events[i].Version = finalVersion;
-                finalVersion--;
-            }
+                var values = await reader.GetFieldValueAsync<long[]>(0, token).ConfigureAwait(false);
 
-            // Ignore the first value
-            for (int i = 1; i < values.Length; i++)
-            {
-                // Only setting the sequence to aid in tombstone processing
-                events[i - 1].Sequence = values[i];
-            }
+                var finalVersion = values[0];
+                var events = Stream.Events;
+                for (int i = events.Count - 1; i >= 0; i--)
+                {
+                    events[i].Version = finalVersion;
+                    finalVersion--;
+                }
 
-            if (Events is { UseMandatoryStreamTypeDeclaration: true } && events[0].Version == 1)
-            {
-                throw new NonExistentStreamException(Events.StreamIdentity == StreamIdentity.AsGuid
-                    ? Stream.Id
-                    : Stream.Key);
+                // Ignore the first value
+                for (int i = 1; i < values.Length; i++)
+                {
+                    // Only setting the sequence to aid in tombstone processing
+                    events[i - 1].Sequence = values[i];
+                }
+
+                if (Events is { UseMandatoryStreamTypeDeclaration: true } && events[0].Version == 1)
+                {
+                    throw new NonExistentStreamException(Events.StreamIdentity == StreamIdentity.AsGuid
+                        ? Stream.Id
+                        : Stream.Key);
+                }
             }
+        }
+        finally
+        {
+            // See Postprocess(reader, exceptions) above for the lifetime rationale —
+            // parameter bytes hit the wire before ExecuteReaderAsync returned, so the
+            // rentals are safe to release here regardless of whether the body threw.
+            releaseColumnRentals();
         }
     }
 }

--- a/src/Marten/Services/PooledList.cs
+++ b/src/Marten/Services/PooledList.cs
@@ -1,0 +1,140 @@
+#nullable enable
+using System;
+using System.Buffers;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Marten.Services;
+
+/// <summary>
+/// Fixed-size pooled <see cref="IList{T}"/> over <see cref="ArrayPool{T}.Shared"/>. Used to
+/// stage per-batch column arrays for Npgsql <c>NpgsqlDbType.Array | …</c> parameters without
+/// allocating a fresh <c>T[]</c> per Save. The rented buffer's length is typically larger
+/// than the requested count — <see cref="Count"/> reports the user-supplied length so Npgsql
+/// (which reads from <see cref="ICollection{T}.Count"/> when binding via the generic
+/// <see cref="IList{T}"/> path) sends exactly the right element count to the wire.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Lifetime.</b> The buffer must remain valid until Npgsql has finished writing the
+/// parameter to the wire (synchronously during <c>ExecuteReader</c> /
+/// <c>ExecuteReaderAsync</c>). Dispose AFTER the reader has consumed the parameter set —
+/// typically in <c>Postprocess</c> / <c>PostprocessAsync</c>. Disposing earlier corrupts the
+/// payload.
+/// </para>
+/// <para>
+/// <b>Not thread-safe.</b> Caller owns the rental until <see cref="Dispose"/>.
+/// </para>
+/// </remarks>
+internal sealed class PooledList<T>: IList<T>, IReadOnlyList<T>, IDisposable
+{
+    private T[]? _buffer;
+    private int _count;
+
+    public PooledList(int count)
+    {
+        if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
+        _buffer = count == 0 ? Array.Empty<T>() : ArrayPool<T>.Shared.Rent(count);
+        _count = count;
+    }
+
+    public int Count => _count;
+
+    public bool IsReadOnly => false;
+
+    public T this[int index]
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            if ((uint)index >= (uint)_count) throw new ArgumentOutOfRangeException(nameof(index));
+            return _buffer![index];
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set
+        {
+            if ((uint)index >= (uint)_count) throw new ArgumentOutOfRangeException(nameof(index));
+            _buffer![index] = value;
+        }
+    }
+
+    public bool Contains(T item) => IndexOf(item) >= 0;
+
+    public int IndexOf(T item)
+    {
+        if (_buffer is null || _count == 0) return -1;
+        return Array.IndexOf(_buffer, item, 0, _count);
+    }
+
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        if (_buffer is null) return;
+        Array.Copy(_buffer, 0, array, arrayIndex, _count);
+    }
+
+    // Mutating IList<T> members aren't meaningful for a fixed-size pooled buffer — the
+    // class is intentionally write-once-via-indexer. Callers staging Npgsql parameters
+    // never need these.
+    void ICollection<T>.Add(T item) => throw new NotSupportedException();
+    void ICollection<T>.Clear() => throw new NotSupportedException();
+    bool ICollection<T>.Remove(T item) => throw new NotSupportedException();
+    void IList<T>.Insert(int index, T item) => throw new NotSupportedException();
+    void IList<T>.RemoveAt(int index) => throw new NotSupportedException();
+
+    public Enumerator GetEnumerator() => new(_buffer, _count);
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public void Dispose()
+    {
+        var buffer = _buffer;
+        _buffer = null;
+        var count = _count;
+        _count = 0;
+
+        if (buffer is null || buffer.Length == 0) return;
+
+        // Clear reference slots so the pooled buffer doesn't pin the prior payload past
+        // the return. Value-type buffers skip this — the trimmer / JIT folds the call away.
+        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>() && count > 0)
+        {
+            Array.Clear(buffer, 0, count);
+        }
+        ArrayPool<T>.Shared.Return(buffer);
+    }
+
+    /// <summary>
+    /// Struct enumerator so <c>foreach</c> over a <see cref="PooledList{T}"/> doesn't box —
+    /// matters when Npgsql binds via <see cref="IEnumerable{T}"/> rather than the indexer.
+    /// </summary>
+    public struct Enumerator: IEnumerator<T>
+    {
+        private readonly T[]? _buffer;
+        private readonly int _count;
+        private int _index;
+
+        internal Enumerator(T[]? buffer, int count)
+        {
+            _buffer = buffer;
+            _count = count;
+            _index = -1;
+        }
+
+        public T Current => _buffer![_index];
+
+        object? IEnumerator.Current => Current;
+
+        public bool MoveNext()
+        {
+            var next = _index + 1;
+            if (next >= _count) return false;
+            _index = next;
+            return true;
+        }
+
+        public void Reset() => _index = -1;
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
Closes #4385. Phase 1 follow-up (#4372).

## Summary

The Phase 1 sweep couldn't pool the parallel column buffers in `QuickAppendEventsOperationBase` because Npgsql's `NpgsqlDbType.Array | T` binding reads `.Length` on `T[]` — and `ArrayPool<T>.Shared.Rent(N)` returns an array whose `Length >= N`, which would silently send trailing slots as garbage.

This PR adds a small `PooledList<T>` that surfaces `Count` (the user-supplied length) via `ICollection<T>.Count`, so Npgsql binds via the `IList<T>` path and sends exactly the right element count to the wire.

## Changes

- **`src/Marten/Services/PooledList.cs`** (new) — fixed-size pooled buffer over `ArrayPool<T>.Shared`:
  - Implements `IList<T>` + `IReadOnlyList<T>` + `IDisposable`.
  - Reports `Count` as the user-supplied length, not the rented array's length.
  - Provides a struct `Enumerator` so `foreach` doesn't box on Npgsql's enumeration path.
  - Clears reference slots on `Dispose` (`RuntimeHelpers.IsReferenceOrContainsReferences<T>` gates this so value-type buffers skip the cost).
  - Mutating `IList<T>` members throw — the buffer is intentionally write-once-via-indexer.

- **`src/Marten/Events/Operations/QuickAppendEventsOperationBase.cs`** — all seven `write*` helpers migrate to `rentColumn<T>(count)`:

  | Helper | Pooled columns |
  |---|---|
  | `writeBasicParameters` | `Guid` ids, `string` typeNames, `string` dotNetTypeNames, `byte[]` jsonBodies |
  | `writeCausationIds` | `string` causationIds |
  | `writeCorrelationIds` | `string` correlationIds |
  | `writeHeaders` | `byte[]` headers |
  | `writeUserNames` | `string` userNames |
  | `writeTimestamps` | `DateTimeOffset` timestamps |
  | `writeAllTagValues` | `string?` values per registered tag type |

  Rentals tracked on a lazily-allocated `_rentals` list (initial capacity 12 — fits the common case without a list-growth allocation). Released in `Postprocess` / `PostprocessAsync` via `try`/`finally`. Parameter bytes hit the wire synchronously during `ExecuteReader[Async]`, so by the time `Postprocess` fires releasing the rentals is safe whether the body succeeded or threw.

## Allocation savings

Per Save with N events: 4–8× length-N column arrays per stream are now pooled buffers instead of fresh allocations, against a single shared `_rentals` `List<IDisposable>` overhead per operation. Net positive at any reasonable batch size.

## Test plan

- [x] `dotnet build src/Marten/Marten.csproj` — clean on net9.0/net10.0.
- [x] `EventSourcingTests` — 1331 passed / 2 skipped. Exercises every `write*` helper:
  - `mandatory_stream_type_behavior` (12 tests) — basic QuickAppend
  - `Dcb` (112 tests) — `writeAllTagValues` via hstore + classic TagTables
  - Full suite covers `writeBasicParameters` / `writeHeaders` / `writeCausationIds` / etc. across multi-event streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)