### PR TITLE
Perf #4384: direct-UTF-8 PatchFragment emission with byte-equivalence test

### DIFF
--- a/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
+++ b/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
@@ -414,6 +414,16 @@ public class noda_time_acceptance: OneOffConfigurationsContext
             throw new NotSupportedException();
         }
 
+        public void WriteToCleanJson(System.Buffers.IBufferWriter<byte> writer, object document)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void WriteToJsonWithTypes(System.Buffers.IBufferWriter<byte> writer, object document)
+        {
+            throw new NotSupportedException();
+        }
+
         public void WriteToParameter(Npgsql.NpgsqlParameter parameter, object document)
         {
             throw new NotSupportedException();

--- a/src/Marten/ISerializer.cs
+++ b/src/Marten/ISerializer.cs
@@ -128,6 +128,16 @@ public interface ISerializer
     string ToCleanJson(object? document);
 
     /// <summary>
+    ///     UTF-8 / buffer-writer counterpart to <see cref="ToCleanJson"/>. Skips the
+    ///     intermediate <see cref="string"/> allocation on the patch-emission hot path.
+    /// </summary>
+    /// <remarks>
+    ///     Implementations must produce identical bytes to what
+    ///     <c>Encoding.UTF8.GetBytes(ToCleanJson(value))</c> would emit.
+    /// </remarks>
+    void WriteToCleanJson(IBufferWriter<byte> writer, object? value);
+
+    /// <summary>
     ///     Write the JSON for a document with embedded
     ///     type information. This is used inside the patching API
     ///     to handle polymorphic collections
@@ -135,6 +145,17 @@ public interface ISerializer
     /// <param name="document"></param>
     /// <returns></returns>
     string ToJsonWithTypes(object document);
+
+    /// <summary>
+    ///     UTF-8 / buffer-writer counterpart to <see cref="ToJsonWithTypes"/>. Skips the
+    ///     intermediate <see cref="string"/> allocation when emitting the polymorphic
+    ///     value payload in a patch operation.
+    /// </summary>
+    /// <remarks>
+    ///     Implementations must produce identical bytes to what
+    ///     <c>Encoding.UTF8.GetBytes(ToJsonWithTypes(value))</c> would emit.
+    /// </remarks>
+    void WriteToJsonWithTypes(IBufferWriter<byte> writer, object value);
 }
 
 #endregion

--- a/src/Marten/Patching/PatchOperation.cs
+++ b/src/Marten/Patching/PatchOperation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using Marten.Internal.Operations;
@@ -17,6 +18,13 @@ namespace Marten.Patching;
 
 internal class PatchFragment: IOperationFragment
 {
+    // 9.0 (#4384): the sentinel byte pattern that ISerializer emits for the string
+    // VALUE_LOOKUP when serializing the wrapper dictionary. We splice the pre-serialized
+    // value bytes in at this exact boundary, preserving byte-equivalence with the
+    // legacy string.Replace path. The bytes are: " _ _ _ V A L U E _ _ _ " (13 bytes,
+    // ASCII / UTF-8 identical).
+    private static ReadOnlySpan<byte> SentinelBytes => "\"___VALUE___\""u8;
+
     private const string VALUE_LOOKUP = "___VALUE___";
     private readonly ISerializer _serializer;
     private readonly IDocumentStorage _storage;
@@ -30,7 +38,6 @@ internal class PatchFragment: IOperationFragment
     {
         _session = session;
         _patchSet = patchSet;
-        _patchSet = patchSet;
         _serializer = serializer;
         _function = function;
         _storage = storage;
@@ -38,32 +45,22 @@ internal class PatchFragment: IOperationFragment
 
     public void Apply(ICommandBuilder builder)
     {
-        var patchSetStr = new List<string>();
-        foreach (var patch in _patchSet)
-        {
-            var json = _serializer.ToCleanJson(patch.Items);
-            if (patch.Items.TryGetValue("value", out var document))
-            {
-                var value = patch.PossiblyPolymorphic ? _serializer.ToJsonWithTypes(document) : _serializer.ToJson(document);
-                var copy = new Dictionary<string, object>();
-                foreach (var item in patch.Items) copy.Add(item.Key, item.Value);
-
-                copy["value"] = VALUE_LOOKUP;
-
-                var patchJson = _serializer.ToJson(copy);
-                var replacedValue = patchJson.Replace($"\"{VALUE_LOOKUP}\"", value);
-
-                json = replacedValue;
-            }
-            patchSetStr.Add(json);
-        }
-
         builder.Append("update ");
         builder.Append(_storage.TableName.QualifiedName);
         builder.Append(" as d set data = ");
         builder.Append(_function.QualifiedName);
         builder.Append("(data, ");
-        builder.AppendParameter("[" + string.Join(",", patchSetStr.ToArray()) + "]", NpgsqlDbType.Jsonb);
+
+        // 9.0 (#4384): build the JSON array body directly into a pooled UTF-8 buffer and
+        // bind as byte[]. Replaces a 4-5-string-per-patch + dict-copy + string.Replace
+        // sentinel-substitution pipeline. Byte-equivalent with the prior string-based
+        // emission — guarded by PatchFragmentByteEquivalenceTests.
+        using (var body = new PooledByteBufferWriter(initialCapacity: 1024))
+        {
+            writePatchArray(body);
+            builder.AppendParameter(body.ToSizedArray(), NpgsqlDbType.Jsonb);
+        }
+
         builder.Append(")");
 
         if (_storage is IHaveMetadataColumns metadata)
@@ -74,6 +71,89 @@ internal class PatchFragment: IOperationFragment
                 column.WriteMetadataInUpdateStatement(builder, _session);
             }
         }
+    }
+
+    /// <summary>
+    /// Emit the patch-set JSON array directly into <paramref name="body"/> as UTF-8 bytes,
+    /// reproducing what the prior implementation would have produced via the
+    /// <c>"[" + string.Join(",", patchSetStr) + "]"</c> string concatenation but without
+    /// the per-patch intermediate string allocations.
+    /// </summary>
+    /// <remarks>
+    /// Internal so the byte-equivalence test (which lives in CoreTests) can drive this
+    /// method directly without re-walking the SQL fragment emission.
+    /// </remarks>
+    internal void writePatchArray(IBufferWriter<byte> body)
+    {
+        body.GetSpan(1)[0] = (byte)'[';
+        body.Advance(1);
+        for (var i = 0; i < _patchSet.Count; i++)
+        {
+            if (i > 0)
+            {
+                body.GetSpan(1)[0] = (byte)',';
+                body.Advance(1);
+            }
+            writePatchJson(body, _patchSet[i]);
+        }
+        body.GetSpan(1)[0] = (byte)']';
+        body.Advance(1);
+    }
+
+    private void writePatchJson(IBufferWriter<byte> body, PatchData patch)
+    {
+        if (!patch.Items.TryGetValue("value", out var document))
+        {
+            // No "value" key — emit the items as clean JSON (no $type metadata), matching
+            // the legacy `_serializer.ToCleanJson(patch.Items)` byte output.
+            _serializer.WriteToCleanJson(body, patch.Items);
+            return;
+        }
+
+        // The legacy flow:
+        //   1. value = ToJsonWithTypes(document) | ToJson(document)   (depending on polymorphism)
+        //   2. copy = clone of patch.Items with value=VALUE_LOOKUP
+        //   3. patchJson = ToJson(copy)                                 // wrapper with sentinel
+        //   4. final = patchJson.Replace("\"___VALUE___\"", value)
+        //
+        // The new flow stages (1) into one pooled buffer, stages (3) into a second pooled
+        // buffer, then writes pre-sentinel | value-bytes | post-sentinel into the body
+        // buffer. Byte boundaries match because the sentinel splice happens at the same
+        // position the string.Replace would have used.
+        using var valueBuffer = new PooledByteBufferWriter(initialCapacity: 256);
+        if (patch.PossiblyPolymorphic)
+        {
+            _serializer.WriteToJsonWithTypes(valueBuffer, document);
+        }
+        else
+        {
+            _serializer.WriteTo(valueBuffer, document);
+        }
+
+        using var wrapperBuffer = new PooledByteBufferWriter(initialCapacity: 256);
+        // Reuse patch.Items shape with the sentinel substituted for value. A copy is
+        // required because patch.Items is owned by the caller and mutating it would leak
+        // the sentinel into reuse scenarios (the PatchExpression is held across Apply
+        // calls in some configurations).
+        var copy = new Dictionary<string, object>(patch.Items.Count);
+        foreach (var item in patch.Items) copy[item.Key] = item.Value;
+        copy["value"] = VALUE_LOOKUP;
+        _serializer.WriteTo(wrapperBuffer, copy);
+
+        var wrapperSpan = wrapperBuffer.WrittenSpan;
+        var sentinelIdx = wrapperSpan.IndexOf(SentinelBytes);
+        if (sentinelIdx < 0)
+        {
+            // Sentinel not present (theoretical safety net — the serializer should always
+            // emit the literal "___VALUE___" string for the substituted value). Emit the
+            // wrapper unmodified rather than corrupting the output silently.
+            body.Write(wrapperSpan);
+            return;
+        }
+
+        body.Write(wrapperSpan.Slice(0, sentinelIdx));
+        body.Write(valueBuffer.WrittenSpan);
+        body.Write(wrapperSpan.Slice(sentinelIdx + SentinelBytes.Length));
     }
 
     public OperationRole Role()

--- a/src/Marten/Services/JsonNetSerializer.cs
+++ b/src/Marten/Services/JsonNetSerializer.cs
@@ -226,6 +226,24 @@ public class JsonNetSerializer: ISerializer
         return writer.ToString();
     }
 
+    public void WriteToCleanJson(IBufferWriter<byte> writer, object? value)
+    {
+        if (writer is null) throw new ArgumentNullException(nameof(writer));
+
+        // Mirror WriteTo's transport but use _clean instead of _serializer so the
+        // emitted bytes match ToCleanJson byte-for-byte.
+        using var stream = new BufferWriterStream(writer);
+        using var streamWriter = new StreamWriter(stream, _utf8NoBom, bufferSize: 1024, leaveOpen: true);
+        using var jsonWriter = new JsonTextWriter(streamWriter)
+        {
+            ArrayPool = _jsonArrayPool, CloseOutput = false, AutoCompleteOnClose = false
+        };
+
+        _clean.Value.Serialize(jsonWriter, value);
+        jsonWriter.Flush();
+        streamWriter.Flush();
+    }
+
     public string ToJsonWithTypes(object document)
     {
         var writer = new StringWriter();
@@ -233,6 +251,25 @@ public class JsonNetSerializer: ISerializer
         _withTypes.Value.Serialize(writer, document);
 
         return writer.ToString();
+    }
+
+    public void WriteToJsonWithTypes(IBufferWriter<byte> writer, object value)
+    {
+        if (writer is null) throw new ArgumentNullException(nameof(writer));
+        if (value is null) throw new ArgumentNullException(nameof(value));
+
+        // Mirror WriteTo's transport but use _withTypes so the emitted bytes match
+        // ToJsonWithTypes byte-for-byte (TypeNameHandling.Objects $type metadata).
+        using var stream = new BufferWriterStream(writer);
+        using var streamWriter = new StreamWriter(stream, _utf8NoBom, bufferSize: 1024, leaveOpen: true);
+        using var jsonWriter = new JsonTextWriter(streamWriter)
+        {
+            ArrayPool = _jsonArrayPool, CloseOutput = false, AutoCompleteOnClose = false
+        };
+
+        _withTypes.Value.Serialize(jsonWriter, value);
+        jsonWriter.Flush();
+        streamWriter.Flush();
     }
 
     /// <summary>

--- a/src/Marten/Services/SystemTextJsonSerializer.cs
+++ b/src/Marten/Services/SystemTextJsonSerializer.cs
@@ -161,9 +161,33 @@ public class SystemTextJsonSerializer: ISerializer
         return JsonSerializer.Serialize(document, _clean);
     }
 
+    public void WriteToCleanJson(IBufferWriter<byte> writer, object? value)
+    {
+        if (writer is null) throw new ArgumentNullException(nameof(writer));
+
+        using var jsonWriter = new Utf8JsonWriter(writer);
+        if (value is null)
+        {
+            jsonWriter.WriteNullValue();
+        }
+        else
+        {
+            JsonSerializer.Serialize(jsonWriter, value, value.GetType(), _clean);
+        }
+    }
+
     public string ToJsonWithTypes(object document)
     {
         return JsonSerializer.Serialize(document, _withTypes);
+    }
+
+    public void WriteToJsonWithTypes(IBufferWriter<byte> writer, object value)
+    {
+        if (writer is null) throw new ArgumentNullException(nameof(writer));
+        if (value is null) throw new ArgumentNullException(nameof(value));
+
+        using var jsonWriter = new Utf8JsonWriter(writer);
+        JsonSerializer.Serialize(jsonWriter, value, value.GetType(), _withTypes);
     }
 
     public ValueCasting ValueCasting => ValueCasting.Strict;

--- a/src/PatchingTests/Patching/PatchFragmentByteEquivalenceTests.cs
+++ b/src/PatchingTests/Patching/PatchFragmentByteEquivalenceTests.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using System.Text;
+using Marten;
+using Marten.Patching;
+using Marten.Services;
+using Marten.Services.Json;
+using Shouldly;
+using Xunit;
+
+namespace PatchingTests.Patching;
+
+/// <summary>
+/// Trust-gate for #4384's PatchFragment refactor: prove the new direct-UTF-8 emission
+/// produces byte-identical output to the legacy <c>string + string.Replace</c> pipeline.
+/// The patch fragment is the input to the PostgreSQL patch-doc SQL function, so the bytes
+/// have to match exactly or the patch will mis-execute silently.
+/// </summary>
+public class PatchFragmentByteEquivalenceTests
+{
+    /// <summary>
+    /// Sentinel used by the legacy <see cref="PatchFragment"/> to placeholder the polymorphic
+    /// "value" key prior to a <c>string.Replace</c> substitution. Mirrored here so the test
+    /// can compute the legacy bytes without depending on the production constant.
+    /// </summary>
+    private const string VALUE_LOOKUP = "___VALUE___";
+
+    public static IEnumerable<object[]> Serializers()
+    {
+        yield return new object[] { new JsonNetSerializer() };
+        yield return new object[] { new SystemTextJsonSerializer() };
+    }
+
+    [Theory]
+    [MemberData(nameof(Serializers))]
+    public void no_value_patch_emits_clean_json_bytes(ISerializer serializer)
+    {
+        // Set / Increment / Duplicate / Remove patches — no "value" key. Legacy uses
+        // ToCleanJson; new path uses WriteToCleanJson.
+        var patch = new Dictionary<string, object>
+        {
+            ["type"] = "increment",
+            ["increment"] = 7,
+            ["path"] = "Count"
+        };
+        var legacy = legacyBytesFor(serializer, new List<PatchData> { new(patch, false) });
+        var fresh = freshBytesFor(serializer, new List<PatchData> { new(patch, false) });
+
+        fresh.ShouldBe(legacy);
+    }
+
+    [Theory]
+    [MemberData(nameof(Serializers))]
+    public void value_patch_non_polymorphic_emits_spliced_bytes(ISerializer serializer)
+    {
+        // Set value patch — has "value" key with a concrete (non-polymorphic) type.
+        // Legacy emits ToJson(copy) with VALUE_LOOKUP sentinel and string.Replace.
+        // New emits the wrapper via WriteTo + splices in the value bytes (also WriteTo).
+        var patch = new Dictionary<string, object>
+        {
+            ["type"] = "set",
+            ["path"] = "Name",
+            ["value"] = "Bob"
+        };
+        var legacy = legacyBytesFor(serializer, new List<PatchData> { new(patch, false) });
+        var fresh = freshBytesFor(serializer, new List<PatchData> { new(patch, false) });
+
+        fresh.ShouldBe(legacy);
+    }
+
+    [Theory]
+    [MemberData(nameof(Serializers))]
+    public void value_patch_polymorphic_emits_with_types_bytes(ISerializer serializer)
+    {
+        // Append-element-polymorphic patch — "value" is a derived type stored under a
+        // base-type collection slot. Legacy emits the value via ToJsonWithTypes (so the
+        // $type metadata is present), then splices into the wrapper. New does the same
+        // via WriteToJsonWithTypes for the value plus WriteTo for the wrapper.
+        Animal value = new Dog { Name = "Rex", BarkVolume = 11 };
+        var patch = new Dictionary<string, object>
+        {
+            ["type"] = "append",
+            ["path"] = "Pets",
+            ["value"] = value
+        };
+        var legacy = legacyBytesFor(serializer, new List<PatchData> { new(patch, true) });
+        var fresh = freshBytesFor(serializer, new List<PatchData> { new(patch, true) });
+
+        fresh.ShouldBe(legacy);
+    }
+
+    [Theory]
+    [MemberData(nameof(Serializers))]
+    public void mixed_patch_set_emits_byte_identical_array(ISerializer serializer)
+    {
+        // The patch fragment is a JSON array of patches — exercising mixed entries
+        // (no-value + non-polymorphic-value + polymorphic-value) catches comma-placement
+        // regressions and ordering / boundary bugs that single-entry tests would miss.
+        var noValue = new Dictionary<string, object>
+        {
+            ["type"] = "increment", ["increment"] = 1, ["path"] = "Count"
+        };
+        var valueSimple = new Dictionary<string, object>
+        {
+            ["type"] = "set", ["path"] = "Name", ["value"] = "Bob"
+        };
+        Animal poly = new Dog { Name = "Rex", BarkVolume = 11 };
+        var valuePoly = new Dictionary<string, object>
+        {
+            ["type"] = "append", ["path"] = "Pets", ["value"] = poly
+        };
+
+        var patchSet = new List<PatchData>
+        {
+            new(noValue, false),
+            new(valueSimple, false),
+            new(valuePoly, true)
+        };
+
+        var legacy = legacyBytesFor(serializer, patchSet);
+        var fresh = freshBytesFor(serializer, patchSet);
+
+        fresh.ShouldBe(legacy);
+    }
+
+    /// <summary>
+    /// Reproduce the legacy <c>PatchFragment.Apply</c> string-based emission inline and
+    /// return its UTF-8 byte encoding. Mirrors the pre-#4384 code exactly so the test
+    /// catches any drift between the legacy logic the issue body documents and the new
+    /// direct-UTF-8 path.
+    /// </summary>
+    private static byte[] legacyBytesFor(ISerializer serializer, List<PatchData> patchSet)
+    {
+        var patchSetStr = new List<string>();
+        foreach (var patch in patchSet)
+        {
+            var json = serializer.ToCleanJson(patch.Items);
+            if (patch.Items.TryGetValue("value", out var document))
+            {
+                var value = patch.PossiblyPolymorphic
+                    ? serializer.ToJsonWithTypes(document)
+                    : serializer.ToJson(document);
+                var copy = new Dictionary<string, object>();
+                foreach (var item in patch.Items) copy.Add(item.Key, item.Value);
+                copy["value"] = VALUE_LOOKUP;
+
+                var patchJson = serializer.ToJson(copy);
+                var replacedValue = patchJson.Replace($"\"{VALUE_LOOKUP}\"", value);
+
+                json = replacedValue;
+            }
+            patchSetStr.Add(json);
+        }
+
+        return Encoding.UTF8.GetBytes("[" + string.Join(",", patchSetStr.ToArray()) + "]");
+    }
+
+    /// <summary>
+    /// Drive the new <see cref="PatchFragment.writePatchArray"/> path. We construct
+    /// PatchFragment with a null storage / session / function — none of those are read
+    /// from <c>writePatchArray</c> (they live on the outer <c>Apply</c> SQL emission).
+    /// </summary>
+    private static byte[] freshBytesFor(ISerializer serializer, List<PatchData> patchSet)
+    {
+        var fragment = new PatchFragment(
+            session: null,
+            patchSet: patchSet,
+            serializer: serializer,
+            function: null,
+            storage: null);
+
+        using var buffer = new PooledByteBufferWriter(initialCapacity: 256);
+        fragment.writePatchArray(buffer);
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    public abstract class Animal
+    {
+        public string Name { get; set; }
+    }
+
+    public class Dog : Animal
+    {
+        public int BarkVolume { get; set; }
+    }
+}


### PR DESCRIPTION
Closes #4384. Phase 1 follow-up (#4372).

## Summary

`PatchFragment.Apply` was the densest allocation cluster the Phase 1 sweep identified but couldn't cleanly refactor — each patch went through 4–5 string allocations + a dictionary copy + a `string.Replace` sentinel substitution, then a final `string.Join` into the SQL parameter.

This PR stages everything into pooled `PooledByteBufferWriter` instances and binds a `byte[]` parameter, while preserving byte-equivalence with the legacy output. The patch bytes feed a PostgreSQL patch-doc SQL function, so any drift would silently mis-execute patches — hence the dedicated byte-equivalence test.

## ISerializer additions (2 new methods)

| Method | Mirrors | Used for |
|---|---|---|
| `WriteToCleanJson(IBufferWriter<byte>, object?)` | `ToCleanJson` | no-value patches (Set, Increment, Duplicate, Remove…) |
| `WriteToJsonWithTypes(IBufferWriter<byte>, object)` | `ToJsonWithTypes` | polymorphic value payload in Append / Insert / AppendIfNotExists |

Both implementations (`SystemTextJsonSerializer` + `JsonNetSerializer`) reuse the existing `WriteTo` transport but route through the `_clean` / `_withTypes` serializer configuration so the emitted bytes match `ToCleanJson` / `ToJsonWithTypes` byte-for-byte.

## PatchFragment refactor

`Apply` writes the SQL prefix directly, then builds the patch-set JSON array into a `PooledByteBufferWriter`:
- Opens `[`, writes each patch (comma-delimited), closes `]`.
- **No-value patches:** `WriteToCleanJson(body, patch.Items)` — one call, no intermediate string.
- **Value patches:** pre-serialize the value into one pooled buffer (`WriteToJsonWithTypes` or `WriteTo` depending on `PossiblyPolymorphic`), serialize the wrapper-with-sentinel into a second pooled buffer (`WriteTo`), then splice via byte-level `IndexOf("\"___VALUE___\""u8)` of the sentinel. Byte boundaries match the legacy `string.Replace` exactly.

Binds `body.ToSizedArray()` to the SQL parameter as `NpgsqlDbType.Jsonb`.

Per-patch allocations drop from **4–5 strings + dict copy** to **1 dict copy + 2 pooled byte buffers** (the dict copy is still required to swap value→sentinel without mutating caller-owned `patch.Items`).

## Byte-equivalence test

`PatchFragmentByteEquivalenceTests` is a trust-gate test that runs both the legacy emission (mirrored inline) and the new `writePatchArray` path for the same inputs and asserts `ShouldBe(legacy)` byte-for-byte. Theory across both serializers (`JsonNetSerializer` + `SystemTextJsonSerializer`) × four scenarios:

- **no-value patch** — Set / Increment / Duplicate / Remove shape
- **value-patch non-polymorphic** — Set with concrete value
- **value-patch polymorphic** — Append with `Animal`/`Dog` hierarchy, verifies `$type` metadata flows through both legacy and new paths
- **mixed patch-set** — all three in one array; catches comma-placement and boundary regressions that single-entry tests would miss

8 tests total, 8 pass.

## Test plan

- [x] `dotnet build src/Marten/Marten.csproj` — clean on net9.0/net10.0.
- [x] `dotnet build src/PatchingTests/PatchingTests.csproj` — clean.
- [x] `PatchFragmentByteEquivalenceTests` — 8/8 pass on net9.0 (both serializers × four scenarios).
- [x] Full `PatchingTests` — 122 passed / 1 skipped on net9.0 (114 existing + 8 new).

Extends the existing `noda_time_acceptance.cs` custom `ISerializer` stub with `WriteToCleanJson` / `WriteToJsonWithTypes` overrides (throw `NotSupportedException`, same pattern as the existing `WriteTo` / `WriteToParameter`) so the extension test compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)