### PR TITLE
Flip V9 StoreOptions defaults + add RestoreV8Defaults() escape hatch

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -187,7 +187,7 @@ var store = DocumentStore.For(opts =>
 `RestoreV8Defaults()` reverts every setting flipped in this release:
 
 | Setting | V8 default it restores |
-|---|---|
+| --- | --- |
 | `Events.AppendMode` | `EventAppendMode.Rich` — [Event Appending](events/appending.md) |
 | `Events.EnableAdvancedAsyncTracking` | `false` — [Async Projection Daemon](events/projections/async-daemon.md) |
 | `Events.EnableEventSkippingInProjectionsOrSubscriptions` | `false` — [Async Projection Daemon](events/projections/async-daemon.md) |

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -102,6 +102,104 @@
 
   The full trade-off table and measured per-op numbers live in the [DCB documentation → Choosing a Storage Mode](events/dcb.md#choosing-a-storage-mode) section. See [#4238](https://github.com/JasperFx/marten/issues/4238) / [#4379](https://github.com/JasperFx/marten/pull/4379).
 
+### Flipped defaults in Marten 9 — read this section
+
+Marten 9 ships a handful of `StoreOptions` defaults flipped to the values recommended for a greenfield project in [Jeremy's "Building a Greenfield System with the Critter Stack" post](https://jeremydmiller.com/2026/02/02/building-a-greenfield-system-with-the-critter-stack/). The full set is summarized in the [Restoring V8 Defaults](#restoring-v8-defaults) section at the end — call `opts.RestoreV8Defaults()` to revert every flip in one line if you're upgrading an existing Marten 8 application and not ready to opt in piecemeal. Each individual flip is detailed below.
+
+#### **`Events.AppendMode` now defaults to `EventAppendMode.QuickWithServerTimestamps`**
+
+* **Was `EventAppendMode.Rich` in Marten 8.x.** The `Quick`/`QuickWithServerTimestamps` append path delivers roughly 50% higher throughput and reduces event-skipping under contention; `QuickWithServerTimestamps` is preferred over `Quick` because it preserves database-side timestamps that most applications rely on.
+* **Restore the V8 default:** `opts.Events.AppendMode = EventAppendMode.Rich;` (or `opts.RestoreV8Defaults();`).
+* See the [Event Appending modes](events/appending.md) and [Optimizing the Event Store](events/optimizing.md) docs.
+
+#### **`Events.EnableAdvancedAsyncTracking` now defaults to `true`**
+
+* **Was `false` in Marten 8.x.** Enabling this adds extra columns to the projection-progression table that let the async daemon and CritterWatch observability heal a system that's hit projection lag or shard failures. The schema change is non-destructive — Marten 9's automatic migration adds the columns on first boot.
+* **Restore the V8 default:** `opts.Events.EnableAdvancedAsyncTracking = false;` (or `opts.RestoreV8Defaults();`).
+* See the [Async Projection Daemon](events/projections/async-daemon.md) docs.
+
+#### **`Events.EnableEventSkippingInProjectionsOrSubscriptions` now defaults to `true`**
+
+* **Was `false` in Marten 8.x.** Enables marking individual events as "plain bad" so a stuck projection or subscription can skip them on subsequent attempts instead of jamming the shard.
+* **Restore the V8 default:** `opts.Events.EnableEventSkippingInProjectionsOrSubscriptions = false;` (or `opts.RestoreV8Defaults();`).
+* See the [Async Projection Daemon](events/projections/async-daemon.md) docs.
+
+#### **`Events.UseIdentityMapForAggregates` now defaults to `true` — read carefully**
+
+* **Was `false` in Marten 8.x.** This optimizes inline aggregate projections by keeping a session-local identity map of in-flight aggregates so multiple events in the same `SaveChangesAsync` resolve against a single aggregate instance.
+* **⚠️ Behavior change risk if your code self-mutates aggregates.** The optimization assumes you obtain aggregates via `IDocumentSession.Events.FetchForWriting()` and use the *decider pattern* (event-handler methods return events; the aggregate is rebuilt from them) rather than mutating fields directly inside the projection's `Apply` methods. If your aggregate handlers self-mutate the aggregate instance, mutations will leak across events within the same batch under the new default and you can see corrupted projections or incorrect optimistic-concurrency comparisons.
+* **What to do:** Either (a) migrate your aggregate handlers to the decider pattern + `FetchForWriting`, or (b) keep the V8 default explicitly: `opts.Events.UseIdentityMapForAggregates = false;` (or call `opts.RestoreV8Defaults();`).
+* See the [Aggregate Projections](events/projections/aggregate-projections.md) and [FetchForWriting](events/projections/aggregate-projections.md#rehydrating-aggregates-for-writes) docs.
+
+#### **`Events.EnableBigIntEvents` now defaults to `true`**
+
+* **Was `false` in Marten 8.x.** Switches the `mt_quick_append_events` and `mt_get_next_hi` PostgreSQL functions to use `bigint` (64-bit) for event version, sequence, and hi-lo return values. Eliminates the ~2.1B-events overflow ceiling that 32-bit columns imposed.
+* **⚠️ Schema impact.** Marten 9's automatic schema migration alters the relevant columns and function signatures from `integer` to `bigint`. The migration is data-preserving (all existing sequence values are kept verbatim — `bigint` is a strict superset of `integer`) and runs once on first boot. Existing rows are not rewritten.
+* **Restore the V8 default:** `opts.Events.EnableBigIntEvents = false;` (or `opts.RestoreV8Defaults();`).
+* See the [Event Store](events/index.md) docs.
+
+#### **`DisableNpgsqlLogging` now defaults to `true`**
+
+* **Was `false` in Marten 8.x.** Suppresses the (very noisy) Npgsql-internal logger that V8 forwarded to your `ILogger<Marten>`. Marten's own structured logs are unaffected.
+* **Restore the V8 default:** `opts.DisableNpgsqlLogging = false;` (or `opts.RestoreV8Defaults();`).
+* See the [StoreOptions](configuration/storeoptions.md) reference.
+
+### Default `IDocumentSession` from DI is now lightweight
+
+* When you call `services.AddMarten(...)` and inject `IDocumentSession`, Marten 9 hands you a **lightweight session** by default. Marten 8 returned an **identity-map session**.
+* **Lightweight sessions do not de-duplicate loaded documents within a session.** If your V8 code relied on `await session.LoadAsync<T>(id)` returning the same instance across repeated calls within a single session, you'll see distinct instances after upgrading. The same applies to documents loaded into queries and aggregates.
+* **What to do:** If you depend on identity-map behavior, restore it on the DI side — `RestoreV8Defaults()` on `StoreOptions` cannot reach the DI session factory:
+  ```csharp
+  services.AddMarten(opts =>
+  {
+      opts.Connection(connectionString);
+      // opts.RestoreV8Defaults();  // restores StoreOptions defaults only
+  })
+  .UseIdentitySessions();          // <-- restores the V8 DI default
+  ```
+* See [Document Sessions](documents/sessions.md) for the full session-type comparison.
+
+### Default serializer is now `System.Text.Json`
+
+* Marten 8 used `Newtonsoft.Json` by default. Marten 9 uses `System.Text.Json` by default, and the Newtonsoft integration moved to a **separate `Marten.Newtonsoft` NuGet package**. Marten core no longer depends on `Newtonsoft.Json`.
+* **What to do if you want the V8 Newtonsoft default back:**
+  1. Add the `Marten.Newtonsoft` NuGet package: `dotnet add package Marten.Newtonsoft`.
+  2. Add `using Marten.Newtonsoft;` at the call site.
+  3. Call `opts.UseNewtonsoftForSerialization(...)` (now an extension method) yourself — `RestoreV8Defaults()` does not touch the serializer, by design (it cannot reach across the package boundary).
+* See [JSON Serialization](configuration/json.md) for the full migration details and per-serializer trade-offs.
+
+### Restoring V8 defaults
+
+Migrating from Marten 8? Call `StoreOptions.RestoreV8Defaults()` first, then layer your own configuration on top:
+
+```csharp
+var store = DocumentStore.For(opts =>
+{
+    opts.Connection(connectionString);
+
+    // Reverts every `StoreOptions` default that Marten 9 flipped.
+    opts.RestoreV8Defaults();
+
+    // ...your usual configuration, document mappings, projections...
+});
+```
+
+`RestoreV8Defaults()` reverts every setting flipped in this release:
+
+| Setting | V8 default it restores |
+|---|---|
+| `Events.AppendMode` | `EventAppendMode.Rich` — [Event Appending](events/appending.md) |
+| `Events.EnableAdvancedAsyncTracking` | `false` — [Async Projection Daemon](events/projections/async-daemon.md) |
+| `Events.EnableEventSkippingInProjectionsOrSubscriptions` | `false` — [Async Projection Daemon](events/projections/async-daemon.md) |
+| `Events.UseIdentityMapForAggregates` | `false` — [Aggregate Projections](events/projections/aggregate-projections.md) |
+| `Events.EnableBigIntEvents` | `false` — [Event Store](events/index.md) |
+| `DisableNpgsqlLogging` | `false` — [StoreOptions](configuration/storeoptions.md) |
+
+`RestoreV8Defaults()` **does not** cover two cross-cutting V9 changes — handle them explicitly:
+
+* **Default serializer.** Add the `Marten.Newtonsoft` NuGet package, `using Marten.Newtonsoft;`, and call `opts.UseNewtonsoftForSerialization(...)`. See [JSON Serialization](configuration/json.md).
+* **Default injected `IDocumentSession`.** Chain `.UseIdentitySessions()` after `AddMarten(...)`. See [Document Sessions](documents/sessions.md).
+
 ## Key Changes in 8.0.0
 
 The V8 release was much smaller than the preceding V7 release, but there are some significant changes to be aware of.

--- a/src/CoreTests/V9DefaultsAndRestoreV8DefaultsTests.cs
+++ b/src/CoreTests/V9DefaultsAndRestoreV8DefaultsTests.cs
@@ -1,0 +1,160 @@
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests;
+
+/// <summary>
+///     Trust-gate for the Marten 9.0 default flips and <see cref="StoreOptions.RestoreV8Defaults"/>.
+///     Every setting whose default changed between Marten 8 and Marten 9 gets one test asserting
+///     the new V9 default, plus one test asserting <c>RestoreV8Defaults()</c> returns it to the V8
+///     value. The closing test pins down that <c>RestoreV8Defaults()</c> does <i>not</i> touch
+///     settings whose default didn't change — so users who chained their own configuration after
+///     the call don't have non-flipped fields stomped.
+/// </summary>
+public class V9DefaultsAndRestoreV8DefaultsTests
+{
+    // ---------- V9 defaults ----------
+
+    [Fact]
+    public void v9_default_for_events_append_mode_is_quick_with_server_timestamps()
+    {
+        new StoreOptions().Events.AppendMode.ShouldBe(EventAppendMode.QuickWithServerTimestamps);
+    }
+
+    [Fact]
+    public void v9_default_for_enable_advanced_async_tracking_is_true()
+    {
+        new StoreOptions().Events.EnableAdvancedAsyncTracking.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void v9_default_for_enable_event_skipping_in_projections_or_subscriptions_is_true()
+    {
+        new StoreOptions().Events.EnableEventSkippingInProjectionsOrSubscriptions.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void v9_default_for_use_identity_map_for_aggregates_is_true()
+    {
+        new StoreOptions().Events.UseIdentityMapForAggregates.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void v9_default_for_enable_big_int_events_is_true()
+    {
+        new StoreOptions().Events.EnableBigIntEvents.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void v9_default_for_disable_npgsql_logging_is_true()
+    {
+        new StoreOptions().DisableNpgsqlLogging.ShouldBeTrue();
+    }
+
+    // ---------- RestoreV8Defaults reverts every flip ----------
+
+    [Fact]
+    public void restore_v8_defaults_reverts_append_mode_to_rich()
+    {
+        var opts = new StoreOptions();
+        opts.RestoreV8Defaults();
+        opts.Events.AppendMode.ShouldBe(EventAppendMode.Rich);
+    }
+
+    [Fact]
+    public void restore_v8_defaults_reverts_enable_advanced_async_tracking_to_false()
+    {
+        var opts = new StoreOptions();
+        opts.RestoreV8Defaults();
+        opts.Events.EnableAdvancedAsyncTracking.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void restore_v8_defaults_reverts_enable_event_skipping_in_projections_or_subscriptions_to_false()
+    {
+        var opts = new StoreOptions();
+        opts.RestoreV8Defaults();
+        opts.Events.EnableEventSkippingInProjectionsOrSubscriptions.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void restore_v8_defaults_reverts_use_identity_map_for_aggregates_to_false()
+    {
+        var opts = new StoreOptions();
+        opts.RestoreV8Defaults();
+        opts.Events.UseIdentityMapForAggregates.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void restore_v8_defaults_reverts_enable_big_int_events_to_false()
+    {
+        var opts = new StoreOptions();
+        opts.RestoreV8Defaults();
+        opts.Events.EnableBigIntEvents.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void restore_v8_defaults_reverts_disable_npgsql_logging_to_false()
+    {
+        var opts = new StoreOptions();
+        opts.RestoreV8Defaults();
+        opts.DisableNpgsqlLogging.ShouldBeFalse();
+    }
+
+    // ---------- RestoreV8Defaults leaves non-flipped settings alone ----------
+    //
+    // The greenfield post calls out additional settings that V9 deliberately did *not* flip
+    // (UseArchivedStreamPartitioning, UseMandatoryStreamTypeDeclaration). RestoreV8Defaults
+    // must not stomp them — a user who calls RestoreV8Defaults then explicitly opts into one
+    // of those should not have their explicit choice reverted.
+
+    [Fact]
+    public void restore_v8_defaults_does_not_touch_use_archived_stream_partitioning()
+    {
+        var opts = new StoreOptions();
+        opts.Events.UseArchivedStreamPartitioning = true;
+        opts.RestoreV8Defaults();
+        opts.Events.UseArchivedStreamPartitioning.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void restore_v8_defaults_does_not_touch_use_mandatory_stream_type_declaration()
+    {
+        var opts = new StoreOptions();
+        opts.Events.UseMandatoryStreamTypeDeclaration = true;
+        opts.RestoreV8Defaults();
+        opts.Events.UseMandatoryStreamTypeDeclaration.ShouldBeTrue();
+    }
+
+    // ---------- Chaining behavior: user overrides after RestoreV8Defaults stick ----------
+
+    [Fact]
+    public void user_overrides_after_restore_v8_defaults_win()
+    {
+        var opts = new StoreOptions();
+        opts.RestoreV8Defaults();
+        opts.Events.AppendMode = EventAppendMode.Quick;
+        opts.DisableNpgsqlLogging = true;
+
+        // The user's explicit per-setting overrides land on top of the V8-default reset.
+        opts.Events.AppendMode.ShouldBe(EventAppendMode.Quick);
+        opts.DisableNpgsqlLogging.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void restore_v8_defaults_after_user_overrides_still_resets_flipped_settings()
+    {
+        // Inverse direction — the user touched some flipped settings explicitly and then
+        // calls RestoreV8Defaults at the bottom. The reset still wins (because it ran last).
+        var opts = new StoreOptions();
+        opts.Events.UseIdentityMapForAggregates = true;
+        opts.Events.EnableBigIntEvents = true;
+        opts.RestoreV8Defaults();
+
+        opts.Events.UseIdentityMapForAggregates.ShouldBeFalse();
+        opts.Events.EnableBigIntEvents.ShouldBeFalse();
+    }
+}

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -79,6 +79,15 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
 
         AddEventType<Archived>();
 
+        // 9.0 (#default-flips): apply V9 default flips for new StoreOptions instances.
+        // Callers wanting V8 semantics call StoreOptions.RestoreV8Defaults() to revert
+        // these. Anything not listed here kept its V8 default. See docs/migration-guide.md
+        // for the per-setting rationale + the consolidated RestoreV8Defaults recipe.
+        AppendMode = EventAppendMode.QuickWithServerTimestamps;
+        EnableAdvancedAsyncTracking = true;
+        EnableEventSkippingInProjectionsOrSubscriptions = true;
+        UseIdentityMapForAggregates = true;
+        EnableBigIntEvents = true;
     }
 
     /// <summary>

--- a/src/Marten/Events/Schema/QuickAppendEventFunction.cs
+++ b/src/Marten/Events/Schema/QuickAppendEventFunction.cs
@@ -70,7 +70,12 @@ namespace Marten.Events.Schema;
             if (_events.AppendMode == EventAppendMode.QuickWithServerTimestamps)
             {
                 timestampValue = "timestamps[index]";
-                metadataParameters += ", timestamps timestamptz[]";
+                // 9.0 (#default-flips): emit `timestamp with time zone[]` rather than
+                // `timestamptz[]` because PG normalizes function-parameter types to the
+                // canonical long form, and Weasel's schema-diff comparator is string-based
+                // — using the canonical spelling here avoids false-positive "function
+                // changed" diffs on every AssertDatabaseMatchesConfigurationAsync call.
+                metadataParameters += ", timestamps timestamp with time zone[]";
             }
 
             // Add tag type parameters. In DcbStorageMode.HStore the function does NOT

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -13,6 +13,7 @@ using JasperFx.CodeGeneration;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.Descriptors;
+using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.MultiTenancy;
 using Marten.Events;
@@ -170,9 +171,11 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
     }
 
     /// <summary>
-    /// Npgsql logging is absurdly noisy, you may want to disable the logging. Default is false
+    /// Npgsql logging is absurdly noisy. <b>Marten 9 flipped the default to <c>true</c></b> —
+    /// set this back to <c>false</c> (or call <see cref="RestoreV8Defaults"/>) to restore the
+    /// V8-era behavior of forwarding Npgsql's internal logger.
     /// </summary>
-    public bool DisableNpgsqlLogging { get; set; }
+    public bool DisableNpgsqlLogging { get; set; } = true;
 
     /// <summary>
     /// Configure and override the Polly error handling policies for this DocumentStore
@@ -695,6 +698,52 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
         {
             configuration(_serializer);
         }
+    }
+
+    /// <summary>
+    ///     Reset every <see cref="StoreOptions"/> default that Marten 9 flipped from its V8
+    ///     value back to the V8 value. Intended as a migration-path escape hatch — call
+    ///     this first and add your own overrides afterward.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Affected settings (see <c>docs/migration-guide.md</c> for the per-setting rationale
+    ///     and linked option documentation):
+    ///     <list type="bullet">
+    ///       <item><see cref="EventGraph.AppendMode"/> &rarr; <see cref="EventAppendMode.Rich"/></item>
+    ///       <item><see cref="EventGraph.EnableAdvancedAsyncTracking"/> &rarr; <c>false</c></item>
+    ///       <item><see cref="EventGraph.EnableEventSkippingInProjectionsOrSubscriptions"/> &rarr; <c>false</c></item>
+    ///       <item><see cref="EventGraph.UseIdentityMapForAggregates"/> &rarr; <c>false</c></item>
+    ///       <item><see cref="EventGraph.EnableBigIntEvents"/> &rarr; <c>false</c></item>
+    ///       <item><see cref="DisableNpgsqlLogging"/> &rarr; <c>false</c></item>
+    ///     </list>
+    ///     </para>
+    ///     <para>
+    ///     <b>NOT covered by this method</b> (require explicit follow-up):
+    ///     <list type="bullet">
+    ///       <item>
+    ///         <b>Serializer.</b> The V9 default is <see cref="SystemTextJsonSerializer"/>. To
+    ///         restore the V8 default, add the <c>Marten.Newtonsoft</c> NuGet package and
+    ///         call <c>opts.UseNewtonsoftForSerialization()</c> yourself.
+    ///       </item>
+    ///       <item>
+    ///         <b>Injected <c>IDocumentSession</c> default.</b> V9 defaults to lightweight
+    ///         sessions when using <c>AddMarten()</c>. Call
+    ///         <c>services.AddMarten(...).UseIdentitySessions()</c> on the DI builder to
+    ///         restore the V8 identity-map behavior; <see cref="StoreOptions"/> alone
+    ///         cannot reach the DI session factory.
+    ///       </item>
+    ///     </list>
+    ///     </para>
+    /// </remarks>
+    public void RestoreV8Defaults()
+    {
+        Events.AppendMode = EventAppendMode.Rich;
+        Events.EnableAdvancedAsyncTracking = false;
+        Events.EnableEventSkippingInProjectionsOrSubscriptions = false;
+        Events.UseIdentityMapForAggregates = false;
+        Events.EnableBigIntEvents = false;
+        DisableNpgsqlLogging = false;
     }
 
     /// <summary>


### PR DESCRIPTION
Implements the V9 greenfield defaults from [Jeremy's "Building a Greenfield System with the Critter Stack" post](https://jeremydmiller.com/2026/02/02/building-a-greenfield-system-with-the-critter-stack/) and ships `StoreOptions.RestoreV8Defaults()` as the migration escape hatch — every flip can be reverted in one call.

## Flipped defaults

| Setting | V8 default | V9 default |
|---|---|---|
| `Events.AppendMode` | `Rich` | **`QuickWithServerTimestamps`** |
| `Events.EnableAdvancedAsyncTracking` | `false` | **`true`** |
| `Events.EnableEventSkippingInProjectionsOrSubscriptions` | `false` | **`true`** |
| `Events.UseIdentityMapForAggregates` | `false` | **`true`** |
| `Events.EnableBigIntEvents` | `false` | **`true`** |
| `DisableNpgsqlLogging` | `false` | **`true`** |

The `Events.*` flips are applied in the `EventGraph` constructor (after the base `EventRegistry` init) so they take effect for every new `StoreOptions` instance. `DisableNpgsqlLogging` is flipped via the property initializer on `StoreOptions` itself.

Two greenfield recommendations from the post are intentionally **not** flipped:
- `Events.UseArchivedStreamPartitioning` — the post itself qualifies as "users need to code a certain way to take advantage of it."
- `Events.UseMandatoryStreamTypeDeclaration` — deferred until the optimized rebuild store lands and actually needs it.

## `RestoreV8Defaults()` — the migration escape hatch

```csharp
var store = DocumentStore.For(opts =>
{
    opts.Connection(connectionString);
    opts.RestoreV8Defaults();   // revert every V9 default flip
    // ...the rest of your usual config...
});
```

**Out-of-scope by design** (documented in the migration guide):

- **Default serializer (Newtonsoft → STJ).** `RestoreV8Defaults` does not reach across the `Marten.Newtonsoft` package boundary. Users wanting the V8 Newtonsoft default must add `Marten.Newtonsoft` + `using Marten.Newtonsoft;` + call `UseNewtonsoftForSerialization()` themselves.
- **Default injected `IDocumentSession` (lightweight → identity-map).** `StoreOptions` cannot reach the DI session factory. Users must chain `.UseIdentitySessions()` on `AddMarten(...)`.

## Schema-diff fix surfaced by the `AppendMode` flip

The V9 `AppendMode` flip means the `mt_quick_append_events` PG function now ships with a `timestamps timestamptz[]` parameter for every fresh store. PG canonicalizes function-parameter types when storing them in `pg_proc` (`timestamptz` → `timestamp with time zone`), and Weasel's schema-diff comparator is string-based — so every `AssertDatabaseMatchesConfigurationAsync` call would have reported a false-positive "function changed" diff.

**Fix:** emit the canonical long form in `QuickAppendEventFunction.cs` so the diff comparator sees identical strings on both sides. `Bug_2103_able_to_add_metadata_tables_in_migrations_to_events_table` was the test that caught this regression.

## Migration guide

`docs/migration-guide.md` gets a new **"Flipped defaults in Marten 9 — read this section"** subsection in the "Key Changes in 9.0.0" area, with:
- One bold-lead callout per flipped default, including the per-setting rationale + link to its documentation.
- A **prominent risk callout** for `UseIdentityMapForAggregates = true` — the post calls out that this only works correctly when consumers use `FetchForWriting` + the decider pattern; self-mutating aggregate handlers can see corrupted state under the new default.
- A consolidated **"Restoring V8 Defaults"** subsection at the bottom that lists every setting `RestoreV8Defaults()` touches with doc links, plus the two out-of-scope caveats (serializer + DI session default) with example code.

## Tests

`src/CoreTests/V9DefaultsAndRestoreV8DefaultsTests.cs` — **16 facts** split into four sections:

1. **V9 defaults** — one assertion per flipped setting that fresh `StoreOptions` surfaces the new V9 value (6 tests).
2. **`RestoreV8Defaults` reverts** — one assertion per flipped setting that the method puts the value back to its V8 default (6 tests).
3. **Non-flipped settings untouched** — `UseArchivedStreamPartitioning` and `UseMandatoryStreamTypeDeclaration` set explicitly survive a `RestoreV8Defaults` call (2 tests; method only touches what V9 flipped).
4. **Chaining** — user overrides after `RestoreV8Defaults` take precedence (forward direction), and `RestoreV8Defaults` at the end reverts everything the user had set on the flipped settings (reverse direction; 2 tests).

## Test plan

- [x] `dotnet build src/Marten.slnx` — clean on net9.0 and net10.0.
- [x] `CoreTests` (372 tests / 1 skip) — 371 passed including the 16 new defaults tests + `Bug_2103` (passing again thanks to the canonical-form fix).
- [ ] CI to run the full `EventSourcingTests` / `DocumentDbTests` / `LinqTests` / `PatchingTests` matrix on both serializers (CI handles this; my local PG harness is one PG version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)