### PR TITLE
Marten 9.0 AOT annotation sweep + Weasel alpha.3 bump + TPL Dataflow removal

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,8 +67,8 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.1" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0-alpha.1" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.3" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0-alpha.3" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/docs/cSpell.json
+++ b/docs/cSpell.json
@@ -105,7 +105,8 @@
     "ngrams",
     "pgcrypto",
     "Jeremie",
-    "Chassaing"
+    "Chassaing",
+    "dedup"
   ],
   "ignoreRegExpList": [
     "\\((.*)\\)", // Markdown links

--- a/src/EventPublisher/StatusBoard.cs
+++ b/src/EventPublisher/StatusBoard.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Threading.Tasks.Dataflow;
+using JasperFx.Blocks;
 using JasperFx.Core;
 using Spectre.Console;
 
@@ -10,14 +10,12 @@ public class StatusBoard
 {
     private readonly LightweightCache<string, ProjectionStatus> _counts;
     private readonly StatusContext _context;
-    private readonly ActionBlock<UpdateMessage> _updater;
+    private readonly Block<UpdateMessage> _updater;
 
     public StatusBoard(Task completion)
     {
         _counts = new(name => new ProjectionStatus(name, completion));
-        _updater = new ActionBlock<UpdateMessage>(Update,
-            new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = 1, EnsureOrdered = true });
-
+        _updater = new Block<UpdateMessage>(Update);
     }
 
     public record UpdateMessage(string Name, int Count);

--- a/src/Marten/DocumentStore.CompiledQueryCollection.cs
+++ b/src/Marten/DocumentStore.CompiledQueryCollection.cs
@@ -14,9 +14,12 @@ using Marten.Internal.Sessions;
 using Marten.Linq;
 using Marten.Services;
 using Marten.Storage;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class CompiledQueryCollection
 {
     private readonly DocumentStore _store;

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -31,9 +31,12 @@ using Microsoft.Extensions.Logging;
 using Npgsql;
 using Weasel.Postgresql.SqlGeneration;
 using EventTypeFilter = Marten.Events.Daemon.Internals.EventTypeFilter;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySession>, ISubscriptionRunner<ISubscription>
 {
     static DocumentStore()

--- a/src/Marten/DocumentStore.EventStoreExplorer.cs
+++ b/src/Marten/DocumentStore.EventStoreExplorer.cs
@@ -21,9 +21,22 @@ using Marten.Internal.Sessions;
 using Marten.Services;
 using Marten.Storage;
 using Npgsql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2060",
+    Justification = "Class-level: Expression.Call(Type, string, ...) on framework Queryable / Enumerable intrinsics that the trimmer preserves.")]
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public partial class DocumentStore
 {
     /// <summary>

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -32,12 +32,19 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Weasel.Postgresql.Connections;
 using IsolationLevel = System.Data.IsolationLevel;
 using Weasel.Core;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
 /// <summary>
 ///     The main entry way to using Marten
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2060",
+    Justification = "Class-level: Expression.Call(Type, string, ...) on framework Queryable / Enumerable intrinsics that the trimmer preserves.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public partial class DocumentStore: IDocumentStore, IDescribeMyself
 {
     private readonly IMartenLogger _logger;

--- a/src/Marten/Events/Aggregation/SingleStreamProjection.cs
+++ b/src/Marten/Events/Aggregation/SingleStreamProjection.cs
@@ -12,6 +12,7 @@ using Marten.Internal.Sessions;
 using Marten.Schema;
 using Marten.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events.Aggregation;
 
@@ -19,6 +20,12 @@ namespace Marten.Events.Aggregation;
 ///     Base class for aggregating events by a stream using Marten-generated pattern matching
 /// </summary>
 /// <typeparam name="TDoc"></typeparam>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2091",
+    Justification = "Class-level: generic type argument doesn't carry the DAM annotation of its target. The argument types flow in from StoreOptions / projection-registration on the caller side and are preserved by the trimmer at that boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class SingleStreamProjection<TDoc, TId>:
     JasperFxSingleStreamProjectionBase<TDoc, TId, IDocumentOperations, IQuerySession>, IMartenAggregateProjection,
     IValidatedProjection<StoreOptions>, IMartenRegistrable where TDoc : notnull where TId : notnull

--- a/src/Marten/Events/CodeGeneration/EventDocumentStorageGenerator.cs
+++ b/src/Marten/Events/CodeGeneration/EventDocumentStorageGenerator.cs
@@ -22,9 +22,14 @@ using Marten.Storage;
 using Marten.Storage.Metadata;
 using Npgsql;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events.CodeGeneration;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal static class EventDocumentStorageGenerator
 {
     private const string StreamStateSelectorTypeName = "GeneratedStreamStateQueryHandler";

--- a/src/Marten/Events/EventGraph.GeneratesCode.cs
+++ b/src/Marten/Events/EventGraph.GeneratesCode.cs
@@ -8,10 +8,13 @@ using JasperFx.Events;
 using Marten.Events.CodeGeneration;
 using Marten.Events.Projections;
 using Marten.Internal.Storage;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events;
 
 #nullable enable
+[UnconditionalSuppressMessage("Trimming", "IL2072",
+    Justification = "Class-level: assigns the result of a reflective Type/MethodInfo lookup into a DAM-annotated target. Source types are preserved at the registration boundary.")]
 public partial class EventGraph: ICodeFile
 {
     private readonly Type _storageType;

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -28,9 +28,18 @@ using NpgsqlTypes;
 using Weasel.Core;
 using Weasel.Postgresql;
 using static JasperFx.Events.EventTypeExtensions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2057",
+    Justification = "Class-level: Type.GetType(string) fallback for resolving aggregate / document types by .NET type name. Types preserved by registration on the caller side per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2060",
+    Justification = "Class-level: Expression.Call(Type, string, ...) on framework Queryable / Enumerable intrinsics that the trimmer preserves.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEventStoreOptions,
     IDisposable, IAsyncDisposable,
     IAggregationSourceFactory<IQuerySession>, IDescribeMyself, ICodeFileCollection

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -29,9 +29,12 @@ using Weasel.Core;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
 using static JasperFx.Events.EventTypeExtensions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events;
 
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 public abstract class EventMapping: EventTypeData, IDocumentMapping, IEventType
 {
     protected readonly DocumentMapping _inner;

--- a/src/Marten/Events/EventStore.FetchForWriting.cs
+++ b/src/Marten/Events/EventStore.FetchForWriting.cs
@@ -22,9 +22,12 @@ using Marten.Storage;
 using Marten.Linq.QueryHandlers;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events;
 
+[UnconditionalSuppressMessage("Trimming", "IL2090",
+    Justification = "Class-level: generic class type-argument flow on the aggregator / storage instantiation. Types preserved at the projection-registration boundary.")]
 internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityStrategy<string>
 {
     // 9.0 (#4374): cache fetch plans by a small readonly struct key with stable

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.cs
@@ -4,9 +4,14 @@ using JasperFx.Events.Projections;
 using Marten.Internal.Storage;
 using Marten.Storage;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events.Fetching;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal partial class FetchAsyncPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> where TDoc : class where TId : notnull
 {
     private readonly IAggregator<TDoc, TId, IQuerySession> _aggregator;

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.ForReading.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.ForReading.cs
@@ -8,9 +8,14 @@ using Marten.Internal.Sessions;
 using Marten.Internal.Storage;
 using Marten.Linq.QueryHandlers;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events.Fetching;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal partial class FetchInlinedPlan<TDoc, TId>
 {
     public async ValueTask<TDoc?> FetchForReading(DocumentSessionBase session, TId id, CancellationToken cancellation)

--- a/src/Marten/Events/Fetching/FetchLivePlan.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.cs
@@ -12,9 +12,14 @@ using Marten.Internal.Storage;
 using Marten.Linq.QueryHandlers;
 using Npgsql;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events.Fetching;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal partial class FetchLivePlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TId> where TDoc : class where TId : notnull
 {
     private readonly IAggregator<TDoc, TId, IQuerySession> _aggregator;

--- a/src/Marten/Events/Fetching/IdentityForwardingAggregator.cs
+++ b/src/Marten/Events/Fetching/IdentityForwardingAggregator.cs
@@ -8,9 +8,14 @@ using JasperFx.Events;
 using JasperFx.Events.Aggregation;
 using Marten.Internal;
 using Marten.Internal.Storage;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events.Fetching;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087",
+    Justification = "Class-level: generic method/type argument flows reflective Type values into a DAM-annotated target. Source preserved at the registration boundary.")]
 internal class IdentityForwardingAggregator<T, TId, TSimple, TSession> : IAggregator<T, TSimple, TSession> where T : class where TId : notnull where TSimple : notnull
 {
     private readonly IAggregator<T, TId, TSession> _inner;

--- a/src/Marten/Events/Projections/CompositeProjection.cs
+++ b/src/Marten/Events/Projections/CompositeProjection.cs
@@ -20,11 +20,23 @@ using Microsoft.Extensions.Logging;
 
 namespace Marten.Events.Projections;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2091",
+    Justification = "Class-level: generic type argument doesn't carry the DAM annotation of its target. The argument types flow in from StoreOptions / projection-registration on the caller side and are preserved by the trimmer at that boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal interface ICompositeProjectionServiceSource
 {
     void AttachServiceProvider(IServiceProvider services);
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class CompositeProjection : CompositeProjection<IDocumentOperations, IQuerySession>
 {
     private readonly StoreOptions _options;
@@ -132,6 +144,12 @@ public class CompositeProjection : CompositeProjection<IDocumentOperations, IQue
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2091",
+    Justification = "Class-level: generic type argument doesn't carry the DAM annotation of its target. The argument types flow in from StoreOptions / projection-registration on the caller side and are preserved by the trimmer at that boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class CompositeProjectionWithServicesSource<TProjection> :
     ProjectionBase,
     IProjectionSource<IDocumentOperations, IQuerySession>,
@@ -406,6 +424,8 @@ internal class CompositeScopedIProjectionSource<TProjection> :
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2091",
+    Justification = "Class-level: generic type argument doesn't carry the DAM annotation of its target. The argument types flow in from StoreOptions / projection-registration on the caller side and are preserved by the trimmer at that boundary.")]
 internal class CompositeScopedIProjectionExecution<TProjection> : ISubscriptionExecution where TProjection : class, IProjection
 {
     private readonly IServiceProvider _services;
@@ -457,6 +477,8 @@ internal class CompositeScopedIProjectionExecution<TProjection> : ISubscriptionE
     public ValueTask DisposeAsync() => new();
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
 internal class ProjectionActivatingServiceProvider<TProjection> : IServiceProvider, IServiceScopeFactory
     where TProjection : class
 {

--- a/src/Marten/Events/Projections/EventProjection.cs
+++ b/src/Marten/Events/Projections/EventProjection.cs
@@ -9,12 +9,19 @@ using JasperFx.Events.Projections.ContainerScoped;
 using Marten.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Weasel.Core;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events.Projections;
 
 /// <summary>
 ///     This is the "do anything" projection type
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2091",
+    Justification = "Class-level: generic type argument doesn't carry the DAM annotation of its target. The argument types flow in from StoreOptions / projection-registration on the caller side and are preserved by the trimmer at that boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public abstract class EventProjection: JasperFxEventProjectionBase<IDocumentOperations, IQuerySession>,
     IValidatedProjection<StoreOptions>, IProjectionSchemaSource, IMartenRegistrable
 {

--- a/src/Marten/Events/Projections/Flattened/FlatTableProjection.cs
+++ b/src/Marten/Events/Projections/Flattened/FlatTableProjection.cs
@@ -22,12 +22,19 @@ using Weasel.Core;
 using Weasel.Postgresql;
 using IReplayExecutor = JasperFx.Events.Daemon.IReplayExecutor;
 using Table = Weasel.Postgresql.Tables.Table;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events.Projections.Flattened;
 
 /// <summary>
 ///     Projection type that will write event data to a single database table
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087",
+    Justification = "Class-level: generic method/type argument flows reflective Type values into a DAM-annotated target. Source preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public partial class FlatTableProjection: ProjectionBase, IProjectionSource<IDocumentOperations, IQuerySession>,
     IProjectionSchemaSource, IInlineProjection<IDocumentOperations>, IJasperFxProjection<IDocumentOperations>
 {

--- a/src/Marten/Events/Projections/Flattened/ParameterSetter.cs
+++ b/src/Marten/Events/Projections/Flattened/ParameterSetter.cs
@@ -4,9 +4,12 @@ using JasperFx.Core.Reflection;
 using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events.Projections.Flattened;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 internal class ParameterSetter<TSource, TValue>: IParameterSetter<TSource>
 {
     private readonly Func<TSource, TValue> _source;

--- a/src/Marten/Events/Projections/Flattened/RelayParameterSetter.cs
+++ b/src/Marten/Events/Projections/Flattened/RelayParameterSetter.cs
@@ -3,9 +3,12 @@ using System.Reflection;
 using JasperFx.Core.Reflection;
 using Npgsql;
 using NpgsqlTypes;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events.Projections.Flattened;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 internal class RelayParameterSetter<TSource, TValue>: IParameterSetter<TSource>
 {
     private readonly NpgsqlDbType _dbType;

--- a/src/Marten/Events/Projections/IProjection.cs
+++ b/src/Marten/Events/Projections/IProjection.cs
@@ -4,6 +4,7 @@ using JasperFx.Core.Reflection;
 using JasperFx.Events.Projections;
 using JasperFx.Events.Projections.ContainerScoped;
 using Microsoft.Extensions.DependencyInjection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events.Projections;
 
@@ -14,6 +15,12 @@ namespace Marten.Events.Projections;
 ///     IProjection implementations define the projection type and handle its projection document lifecycle
 ///     Optimized for inline usage
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2091",
+    Justification = "Class-level: generic type argument doesn't carry the DAM annotation of its target. The argument types flow in from StoreOptions / projection-registration on the caller side and are preserved by the trimmer at that boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public interface IProjection: IJasperFxProjection<IDocumentOperations>, IMartenRegistrable
 #endregion
 {

--- a/src/Marten/Events/Projections/MultiStreamProjection.cs
+++ b/src/Marten/Events/Projections/MultiStreamProjection.cs
@@ -14,6 +14,7 @@ using Marten.Schema;
 using Marten.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events.Projections;
 
@@ -23,6 +24,12 @@ namespace Marten.Events.Projections;
 /// </summary>
 /// <typeparam name="TDoc"></typeparam>
 /// <typeparam name="TId"></typeparam>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2091",
+    Justification = "Class-level: generic type argument doesn't carry the DAM annotation of its target. The argument types flow in from StoreOptions / projection-registration on the caller side and are preserved by the trimmer at that boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public abstract class MultiStreamProjection<TDoc, TId>: JasperFxMultiStreamProjectionBase<TDoc, TId, IDocumentOperations, IQuerySession>, IMartenAggregateProjection, IValidatedProjection<StoreOptions>, IMartenRegistrable where TDoc : notnull where TId : notnull
 {
     protected MultiStreamProjection(): base()

--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -16,12 +16,17 @@ using Marten.Schema;
 using Marten.Subscriptions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Events.Projections;
 
 /// <summary>
 ///     Used to register projections with Marten
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class ProjectionOptions: ProjectionGraph<IProjection, IDocumentOperations, IQuerySession>
 {
     internal readonly IFetchPlanner[] _builtInPlanners =

--- a/src/Marten/FSharpTypeHelper.cs
+++ b/src/Marten/FSharpTypeHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
@@ -8,6 +9,10 @@ namespace Marten;
 /// the AppDomain (e.g., by an F# consuming project), F# support is enabled
 /// automatically. Otherwise, all F# checks gracefully return false/null.
 /// </summary>
+[UnconditionalSuppressMessage("AOT", "IL2055",
+    Justification = "Class-level: Type.MakeGenericType with a runtime-determined type argument — AOT consumers must pre-register the closed shape they need (see the AOT publishing guide).")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal static class FSharpTypeHelper
 {
     private static readonly Lazy<Type?> FSharpOptionOpenGeneric = new(() =>

--- a/src/Marten/FullTextIndexAttribute.cs
+++ b/src/Marten/FullTextIndexAttribute.cs
@@ -2,10 +2,13 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Weasel.Postgresql.Tables.Indexes;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Schema;
 
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class)]
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 public class FullTextIndexAttribute: MartenAttribute
 {
     /// <summary>

--- a/src/Marten/Internal/CodeGeneration/BulkLoaderBuilder.cs
+++ b/src/Marten/Internal/CodeGeneration/BulkLoaderBuilder.cs
@@ -8,9 +8,12 @@ using Marten.Schema;
 using Marten.Schema.Arguments;
 using Marten.Storage;
 using NpgsqlTypes;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CodeGeneration;
 
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class BulkLoaderBuilder
 {
     private readonly DocumentMapping _mapping;

--- a/src/Marten/Internal/CodeGeneration/DocumentFunctionOperationBuilder.cs
+++ b/src/Marten/Internal/CodeGeneration/DocumentFunctionOperationBuilder.cs
@@ -14,9 +14,12 @@ using Marten.Internal.Operations;
 using Marten.Schema;
 using Marten.Storage;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CodeGeneration;
 
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class DocumentFunctionOperationBuilder
 {
     private readonly UpsertFunction _function;

--- a/src/Marten/Internal/CodeGeneration/DocumentProviderBuilder.cs
+++ b/src/Marten/Internal/CodeGeneration/DocumentProviderBuilder.cs
@@ -11,9 +11,14 @@ using Marten.Schema.Arguments;
 using Marten.Schema.BulkLoading;
 using Npgsql;
 using CommandExtensions = Weasel.Postgresql.CommandExtensions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CodeGeneration;
 
+[UnconditionalSuppressMessage("Trimming", "IL2077",
+    Justification = "Class-level: DAM-annotated field/property assigned from a reflective lookup whose source type is preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class DocumentProviderBuilder: ICodeFile
 {
     private readonly DocumentMapping _mapping;

--- a/src/Marten/Internal/CodeGeneration/DocumentStorageBuilder.cs
+++ b/src/Marten/Internal/CodeGeneration/DocumentStorageBuilder.cs
@@ -14,9 +14,16 @@ using Marten.Storage;
 using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CodeGeneration;
 
+[UnconditionalSuppressMessage("AOT", "IL2055",
+    Justification = "Class-level: Type.MakeGenericType with a runtime-determined type argument — AOT consumers must pre-register the closed shape they need (see the AOT publishing guide).")]
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class DocumentStorageBuilder
 {
     private readonly Type _baseType;

--- a/src/Marten/Internal/CodeGeneration/FrameCollectionExtensions.cs
+++ b/src/Marten/Internal/CodeGeneration/FrameCollectionExtensions.cs
@@ -14,9 +14,16 @@ using Marten.Linq.Parsing;
 using Marten.Schema;
 using Marten.Util;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CodeGeneration;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal static class FrameCollectionExtensions
 {
     public const string DocumentVariableName = "document";

--- a/src/Marten/Internal/CodeGeneration/MartenSnapshot.cs
+++ b/src/Marten/Internal/CodeGeneration/MartenSnapshot.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Reflection;
 using JasperFx.CodeGeneration.Snapshots;
 using Microsoft.Extensions.Logging;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CodeGeneration;
 
@@ -39,6 +40,10 @@ namespace Marten.Internal.CodeGeneration;
 ///     slow first-boot-after-deploy.
 ///     </para>
 /// </remarks>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal static class MartenSnapshot
 {
     private const string ProductName = "marten";

--- a/src/Marten/Internal/CodeGeneration/SelectorBuilder.cs
+++ b/src/Marten/Internal/CodeGeneration/SelectorBuilder.cs
@@ -5,9 +5,14 @@ using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
 using Marten.Linq.Selectors;
 using Marten.Schema;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CodeGeneration;
 
+[UnconditionalSuppressMessage("Trimming", "IL2072",
+    Justification = "Class-level: assigns the result of a reflective Type/MethodInfo lookup into a DAM-annotated target. Source types are preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class SelectorBuilder
 {
     private readonly DocumentMapping _mapping;

--- a/src/Marten/Internal/CodeGeneration/StaticOnlyCodeFileLoader.cs
+++ b/src/Marten/Internal/CodeGeneration/StaticOnlyCodeFileLoader.cs
@@ -36,6 +36,10 @@ namespace Marten.Internal.CodeGeneration;
 ///     warnings on call sites that haven't opted out via the flag.
 /// </para>
 /// </remarks>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal static class StaticOnlyCodeFileLoader
 {
     [RequiresDynamicCode(

--- a/src/Marten/Internal/CompiledQueries/CompiledQueryCodeFile.cs
+++ b/src/Marten/Internal/CompiledQueries/CompiledQueryCodeFile.cs
@@ -5,9 +5,12 @@ using System.Reflection;
 using System.Threading.Tasks;
 using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CompiledQueries;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 internal class CompiledQueryCodeFile: ICodeFile
 {
     private readonly Type _compiledQueryType;

--- a/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
+++ b/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
@@ -14,9 +14,22 @@ using Marten.Linq.QueryHandlers;
 using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CompiledQueries;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2072",
+    Justification = "Class-level: assigns the result of a reflective Type/MethodInfo lookup into a DAM-annotated target. Source types are preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class CompiledQueryPlan : ICommandBuilder
 {
     public Type QueryType { get; }

--- a/src/Marten/Internal/CompiledQueries/CompiledQuerySourceBuilder.cs
+++ b/src/Marten/Internal/CompiledQueries/CompiledQuerySourceBuilder.cs
@@ -9,9 +9,16 @@ using JasperFx.Core.Reflection;
 using Marten.Internal.Storage;
 using Marten.Linq.Includes;
 using Marten.Linq.QueryHandlers;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CompiledQueries;
 
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2072",
+    Justification = "Class-level: assigns the result of a reflective Type/MethodInfo lookup into a DAM-annotated target. Source types are preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class CompiledQuerySourceBuilder
 {
     private readonly DocumentTracking _documentTracking;

--- a/src/Marten/Internal/CompiledQueries/EnumParameterFinder.cs
+++ b/src/Marten/Internal/CompiledQueries/EnumParameterFinder.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CompiledQueries;
 
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class EnumParameterFinder: IParameterFinder
 {
     public bool Matches(Type memberType)

--- a/src/Marten/Internal/CompiledQueries/QueryCompiler.cs
+++ b/src/Marten/Internal/CompiledQueries/QueryCompiler.cs
@@ -9,9 +9,18 @@ using Marten.Internal.Sessions;
 using Marten.Linq;
 using Marten.Linq.Includes;
 using Marten.Linq.Parsing;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.CompiledQueries;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class QueryCompiler
 {
     internal static readonly IList<IParameterFinder> Finders = new List<IParameterFinder> { new EnumParameterFinder() };

--- a/src/Marten/Internal/IProviderGraph.cs
+++ b/src/Marten/Internal/IProviderGraph.cs
@@ -2,9 +2,14 @@
 using System;
 using JasperFx.Core.Reflection;
 using Marten.Internal.Storage;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public interface IProviderGraph
 {
     DocumentProvider<T> StorageFor<T>() where T : notnull;
@@ -12,6 +17,10 @@ public interface IProviderGraph
     void Append<T>(DocumentProvider<T> provider) where T : notnull;
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal static class ProviderGraphExtensions
 {
     internal static IDocumentStorage StorageFor(this IProviderGraph providers, Type documentType)

--- a/src/Marten/Internal/ProviderGraph.cs
+++ b/src/Marten/Internal/ProviderGraph.cs
@@ -10,9 +10,14 @@ using Marten.Events;
 using Marten.Internal.CodeGeneration;
 using Marten.Internal.Storage;
 using Marten.Schema;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class ProviderGraph: IProviderGraph
 {
     private readonly StoreOptions _options;

--- a/src/Marten/Internal/SecondaryStoreConfig.cs
+++ b/src/Marten/Internal/SecondaryStoreConfig.cs
@@ -11,9 +11,16 @@ using JasperFx.RuntimeCompiler;
 using Marten.Schema;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal;
 
+[UnconditionalSuppressMessage("Trimming", "IL2077",
+    Justification = "Class-level: DAM-annotated field/property assigned from a reflective lookup whose source type is preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2091",
+    Justification = "Class-level: generic type argument doesn't carry the DAM annotation of its target. The argument types flow in from StoreOptions / projection-registration on the caller side and are preserved by the trimmer at that boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class SecondaryDocumentStores: ICodeFileCollection
 {
     private readonly List<IStoreConfig> _files = new();
@@ -60,6 +67,12 @@ public interface IConfigureMarten<T>: IConfigureMarten where T : IDocumentStore
 }
 
 
+[UnconditionalSuppressMessage("Trimming", "IL2077",
+    Justification = "Class-level: DAM-annotated field/property assigned from a reflective lookup whose source type is preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2091",
+    Justification = "Class-level: generic type argument doesn't carry the DAM annotation of its target. The argument types flow in from StoreOptions / projection-registration on the caller side and are preserved by the trimmer at that boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class SecondaryStoreConfig<T>: IStoreConfig where T : IDocumentStore
 {
     private readonly Func<IServiceProvider, StoreOptions> _configuration;

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.Deletes.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.Deletes.cs
@@ -9,9 +9,14 @@ using Marten.Exceptions;
 using Marten.Internal.Storage;
 using Marten.Linq.SqlGeneration;
 using Marten.Metadata;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.Sessions;
 
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public abstract partial class DocumentSessionBase
 {
     public void Delete<T>(T entity) where T : notnull

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs
@@ -14,9 +14,14 @@ using Marten.Internal.Storage;
 using Marten.Linq.SqlGeneration;
 using Marten.Storage;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.Sessions;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087",
+    Justification = "Class-level: generic method/type argument flows reflective Type values into a DAM-annotated target. Source preserved at the registration boundary.")]
 public abstract partial class DocumentSessionBase
 {
     public async Task<IProjectionStorage<TDoc, TId>> FetchProjectionStorageAsync<TDoc, TId>(string tenantId,
@@ -39,6 +44,10 @@ public abstract partial class DocumentSessionBase
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087",
+    Justification = "Class-level: generic method/type argument flows reflective Type values into a DAM-annotated target. Source preserved at the registration boundary.")]
 internal class ProjectionStorage<TDoc, TId>: IProjectionStorage<TDoc, TId> where TId : notnull where TDoc : notnull
 {
     private readonly DocumentSessionBase _session;

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -15,6 +15,10 @@ using Marten.Storage;
 
 namespace Marten.Internal.Sessions;
 
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public abstract partial class DocumentSessionBase: QuerySession, IDocumentSession, ITransactionParticipantRegistrar
 {
     internal readonly ISessionWorkTracker _workTracker;

--- a/src/Marten/Internal/Sessions/QuerySession.CheckExists.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.CheckExists.cs
@@ -7,9 +7,14 @@ using JasperFx.Core.Reflection;
 using Marten.Exceptions;
 using Marten.Internal.Storage;
 using Marten.Linq.QueryHandlers;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.Sessions;
 
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public partial class QuerySession
 {
     public async Task<bool> CheckExistsAsync<T>(string id, CancellationToken token = default) where T : notnull

--- a/src/Marten/Internal/Sessions/QuerySession.Load.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Load.cs
@@ -9,9 +9,14 @@ using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
 using Marten.Exceptions;
 using Marten.Internal.Storage;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.Sessions;
 
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public partial class QuerySession
 {
     public async Task<T?> LoadAsync<T>(string id, CancellationToken token = default) where T : notnull

--- a/src/Marten/Internal/Sessions/QuerySession.Storage.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Storage.cs
@@ -9,9 +9,14 @@ using Marten.Events;
 using Marten.Exceptions;
 using Marten.Internal.Storage;
 using Npgsql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.Sessions;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public partial class QuerySession
 {
     protected readonly IProviderGraph _providers;

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -26,15 +26,22 @@ using NpgsqlTypes;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.Storage;
 
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal interface IHaveMetadataColumns
 {
     MetadataColumn[] MetadataColumns();
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMetadataColumns where T : notnull where TId : notnull
 {
     private readonly NpgsqlDbType _idType;
@@ -458,6 +465,10 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
 }
 
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class DuplicatedFieldSelectClause: ISelectClause, IModifyableFromObject
 {
     private string[] _selectFields;

--- a/src/Marten/Internal/Storage/IDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IDocumentStorage.cs
@@ -21,9 +21,14 @@ using Npgsql;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal.Storage;
 
+[UnconditionalSuppressMessage("AOT", "IL2055",
+    Justification = "Class-level: Type.MakeGenericType with a runtime-determined type argument — AOT consumers must pre-register the closed shape they need (see the AOT publishing guide).")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public interface IDocumentStorage: ISelectClause
 {
     Type SourceType { get; }
@@ -56,6 +61,10 @@ public interface IDocumentStorage: ISelectClause
     object RawIdentityValue(object id);
 }
 
+[UnconditionalSuppressMessage("AOT", "IL2055",
+    Justification = "Class-level: Type.MakeGenericType with a runtime-determined type argument — AOT consumers must pre-register the closed shape they need (see the AOT publishing guide).")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class CreateFromDocumentMapping: Variable
 {
     public CreateFromDocumentMapping(DocumentMapping mapping, Type openType, GeneratedType type): base(

--- a/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
+++ b/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
@@ -18,9 +18,12 @@ using Npgsql;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 internal class ValueTypeIdentifiedIdentitySetter<TDoc, TSimple, TValueType>: IIdentitySetter<TDoc, TSimple>
 {
     private readonly Func<TSimple, TValueType> _converter;
@@ -50,6 +53,8 @@ internal interface IValueTypeStorage<TDoc, TValueType>
     IQueryHandler<IReadOnlyList<TDoc>> BuildLoadManyHandler(TValueType[] keys);
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: IDocumentStorage<TDoc, TSimple>,  IValueTypeStorage<TDoc, TValueType> where TDoc : notnull where TSimple : notnull where TValueType : notnull
 {
     private readonly Func<TSimple, TValueType> _converter;

--- a/src/Marten/JsonLoader.cs
+++ b/src/Marten/JsonLoader.cs
@@ -7,9 +7,12 @@ using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal.Sessions;
 using Marten.Linq.QueryHandlers;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class JsonLoader: IJsonLoader
 {
     private readonly QuerySession _session;

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -13,9 +13,16 @@ using Marten.Linq.Members;
 using Marten.Linq.Parsing;
 using Marten.Linq.SqlGeneration;
 using Marten.Linq.SqlGeneration.Filters;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public partial class CollectionUsage
 {
     private bool _hasCompiledMany;

--- a/src/Marten/Linq/CollectionUsage.Includes.cs
+++ b/src/Marten/Linq/CollectionUsage.Includes.cs
@@ -8,9 +8,16 @@ using Marten.Internal;
 using Marten.Linq.Includes;
 using Marten.Linq.Members;
 using Marten.Linq.Parsing;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq;
 
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2072",
+    Justification = "Class-level: assigns the result of a reflective Type/MethodInfo lookup into a DAM-annotated target. Source types are preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public partial class CollectionUsage
 {
     public List<MethodCallExpression> IncludeExpressions { get; } = new();

--- a/src/Marten/Linq/Members/ChildCollectionMember.cs
+++ b/src/Marten/Linq/Members/ChildCollectionMember.cs
@@ -15,9 +15,14 @@ using Marten.Linq.SqlGeneration;
 using Marten.Linq.SqlGeneration.Filters;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Members;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class ChildCollectionMember: QueryableMember, ICollectionMember, IQueryableMemberCollection
 {
     private readonly IQueryableMember _count;

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryContainsKey.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryContainsKey.cs
@@ -6,9 +6,12 @@ using JasperFx.Core.Reflection;
 using Marten.Linq.Parsing;
 using Marten.Linq.SqlGeneration.Filters;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Members.Dictionaries;
 
+[UnconditionalSuppressMessage("Trimming", "IL2072",
+    Justification = "Class-level: assigns the result of a reflective Type/MethodInfo lookup into a DAM-annotated target. Source types are preserved at the registration boundary.")]
 internal class DictionaryContainsKey: IMethodCallParser
 {
     public bool Matches(MethodCallExpression expression)

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryKeysMember.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryKeysMember.cs
@@ -13,9 +13,14 @@ using Marten.Linq.SqlGeneration;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Members.Dictionaries;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class DictionaryKeysMember: QueryableMember, ICollectionMember, IValueCollectionMember
 {
     private readonly IDictionaryMember _parent;

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryValuesMember.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryValuesMember.cs
@@ -17,9 +17,14 @@ using Marten.Linq.SqlGeneration;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Members.Dictionaries;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class DictionaryValuesMember : QueryableMember, ICollectionMember, IValueCollectionMember
 {
     private readonly IDictionaryMember _parent;

--- a/src/Marten/Linq/Members/DuplicatedArrayField.cs
+++ b/src/Marten/Linq/Members/DuplicatedArrayField.cs
@@ -15,9 +15,14 @@ using Marten.Linq.SqlGeneration.Filters;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Members;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class DuplicatedArrayField: DuplicatedField, ICollectionMember, IQueryableMemberCollection
 {
     public DuplicatedArrayField(EnumStorage enumStorage, QueryableMember innerMember, bool useTimestampWithoutTimeZoneForDateTime = true, bool notNull = false) : base(enumStorage, innerMember, useTimestampWithoutTimeZoneForDateTime, notNull)

--- a/src/Marten/Linq/Members/StringValueTypeMember.cs
+++ b/src/Marten/Linq/Members/StringValueTypeMember.cs
@@ -11,9 +11,14 @@ using Marten.Internal;
 using Marten.Linq.SqlGeneration;
 using Marten.Linq.SqlGeneration.Filters;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Members;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class StringValueTypeMember<T>: StringMember, IValueTypeMember<T, string>
 {
     private readonly Func<T, string> _valueSource;

--- a/src/Marten/Linq/Members/ValueCollections/SelectManyValueCollection.cs
+++ b/src/Marten/Linq/Members/ValueCollections/SelectManyValueCollection.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Members.ValueCollections;
 
@@ -10,6 +11,8 @@ namespace Marten.Linq.Members.ValueCollections;
 /// This takes the place of the ValueCollectionMember when this member
 /// is used inside of a SelectMany() clause
 /// </summary>
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class SelectManyValueCollection: IValueCollectionMember
 {
     private readonly StoreOptions _options;

--- a/src/Marten/Linq/Members/ValueCollections/ValueCollectionMember.cs
+++ b/src/Marten/Linq/Members/ValueCollections/ValueCollectionMember.cs
@@ -16,9 +16,14 @@ using Marten.Util;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Members.ValueCollections;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class ValueCollectionMember: QueryableMember, ICollectionMember, IValueCollectionMember, ISelectableMember
 {
     private readonly IQueryableMember _count;

--- a/src/Marten/Linq/Members/ValueTypeMember.cs
+++ b/src/Marten/Linq/Members/ValueTypeMember.cs
@@ -13,15 +13,24 @@ using Marten.Linq.SqlGeneration.Filters;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Members;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public interface IValueTypeMember<TOuter, TInner>: IQueryableMember
 {
     IEnumerable<TInner> ConvertFromWrapperArray(IEnumerable<TOuter> values);
     ISelectClause BuildSelectClause(string fromObject);
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class ValueTypeMember<TOuter, TInner>: SimpleCastMember, IValueTypeMember<TOuter, TInner>
 {
     private readonly Func<TOuter, TInner> _valueSource;

--- a/src/Marten/Linq/Parsing/ConstantExpressionExtensions.cs
+++ b/src/Marten/Linq/Parsing/ConstantExpressionExtensions.cs
@@ -1,8 +1,11 @@
 #nullable enable
 using System.Linq.Expressions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing;
 
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 public static class ConstantExpressionExtensions
 {
     public static object? UnwrapValue(this ConstantExpression constant)

--- a/src/Marten/Linq/Parsing/JsonPathCreator.cs
+++ b/src/Marten/Linq/Parsing/JsonPathCreator.cs
@@ -11,6 +11,8 @@ using Marten.Util;
 
 namespace Marten.Linq.Parsing;
 
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 public sealed class JsonPathCreator(ISerializer serializer) : ExpressionVisitor
 {
     private readonly StringBuilder _jsonPathBuilder = new();

--- a/src/Marten/Linq/Parsing/LinqInternalExtensions.cs
+++ b/src/Marten/Linq/Parsing/LinqInternalExtensions.cs
@@ -15,6 +15,10 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Parsing;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 public static class LinqInternalExtensions
 {
     // private static Type[] _valueTypes = new Type[]

--- a/src/Marten/Linq/Parsing/LinqQueryParser.Handlers.cs
+++ b/src/Marten/Linq/Parsing/LinqQueryParser.Handlers.cs
@@ -8,9 +8,14 @@ using Marten.Linq.QueryHandlers;
 using Marten.Linq.Selectors;
 using Marten.Linq.SqlGeneration;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing;
 
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal partial class LinqQueryParser
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Marten/Linq/Parsing/Methods/AllMethodParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/AllMethodParser.cs
@@ -7,9 +7,12 @@ using Marten.Exceptions;
 using Marten.Linq.Members;
 using Marten.Linq.QueryHandlers;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing.Methods;
 
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
 internal class AllMethodParser: IMethodCallParser
 {
     public bool Matches(MethodCallExpression expression)

--- a/src/Marten/Linq/Parsing/Methods/AnySubQueryParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/AnySubQueryParser.cs
@@ -10,9 +10,12 @@ using Marten.Linq.Members;
 using Marten.Linq.QueryHandlers;
 using Marten.Linq.SqlGeneration.Filters;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing.Methods;
 
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
 internal class AnySubQueryParser: IMethodCallParser
 {
     public bool Matches(MethodCallExpression expression)

--- a/src/Marten/Linq/Parsing/Methods/CollectionIsOneOfFilter.cs
+++ b/src/Marten/Linq/Parsing/Methods/CollectionIsOneOfFilter.cs
@@ -6,9 +6,12 @@ using Marten.Linq.Members;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing.Methods;
 
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class CollectionIsOneOfFilter: ISqlFragment
 {
     private readonly ICollectionMember _collectionMember;

--- a/src/Marten/Linq/Parsing/Methods/EnumerableContains.cs
+++ b/src/Marten/Linq/Parsing/Methods/EnumerableContains.cs
@@ -10,9 +10,16 @@ using Marten.Linq.Members;
 using Marten.Linq.Members.ValueCollections;
 using Marten.Linq.QueryHandlers;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing.Methods;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class EnumerableContains: IMethodCallParser
 {
     public bool Matches(MethodCallExpression expression)
@@ -57,6 +64,12 @@ internal class EnumerableContains: IMethodCallParser
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class HashSetEnumerableContains: IMethodCallParser
 {
     public bool Matches(MethodCallExpression expression)

--- a/src/Marten/Linq/Parsing/Methods/IsSubsetOf.cs
+++ b/src/Marten/Linq/Parsing/Methods/IsSubsetOf.cs
@@ -6,9 +6,12 @@ using System.Reflection;
 using Marten.Linq.Members;
 using NpgsqlTypes;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing.Methods;
 
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 internal class IsSubsetOf: IMethodCallParser
 {
     public bool Matches(MethodCallExpression expression)

--- a/src/Marten/Linq/Parsing/Methods/IsSupersetOf.cs
+++ b/src/Marten/Linq/Parsing/Methods/IsSupersetOf.cs
@@ -6,9 +6,12 @@ using System.Reflection;
 using Marten.Linq.Members;
 using NpgsqlTypes;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing.Methods;
 
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 internal class IsSupersetOf: IMethodCallParser
 {
     public bool Matches(MethodCallExpression expression)

--- a/src/Marten/Linq/Parsing/Operators/WhereOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/WhereOperator.cs
@@ -3,9 +3,14 @@ using System;
 using System.Linq.Expressions;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing.Operators;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class WhereOperator: LinqOperator
 {
     private readonly Cache<Type, object> _always

--- a/src/Marten/Linq/Parsing/PatchingMemberFinder.cs
+++ b/src/Marten/Linq/Parsing/PatchingMemberFinder.cs
@@ -3,9 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing;
 
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
 public sealed class PatchingMemberFinder : MemberFinder
 {
     protected override Expression VisitMethodCall(MethodCallExpression node)

--- a/src/Marten/Linq/Parsing/SelectParser.cs
+++ b/src/Marten/Linq/Parsing/SelectParser.cs
@@ -10,9 +10,12 @@ using Marten.Linq.SqlGeneration;
 using Marten.Util;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing;
 
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 internal class SelectParser: ExpressionVisitor
 {
     private readonly ISerializer _serializer;

--- a/src/Marten/Linq/Parsing/SelectorVisitor.cs
+++ b/src/Marten/Linq/Parsing/SelectorVisitor.cs
@@ -7,9 +7,14 @@ using JasperFx.Core.Reflection;
 using Marten.Linq.Members;
 using Marten.Linq.SqlGeneration;
 using Marten.Util;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class SelectorVisitor: ExpressionVisitor
 {
     private readonly IQueryableMemberCollection _collection;

--- a/src/Marten/Linq/Parsing/SimpleExpression.cs
+++ b/src/Marten/Linq/Parsing/SimpleExpression.cs
@@ -12,10 +12,13 @@ using Marten.Linq.Members.ValueCollections;
 using Marten.Linq.QueryHandlers;
 using Marten.Linq.SqlGeneration.Filters;
 using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing;
 
 
+[UnconditionalSuppressMessage("Trimming", "IL2072",
+    Justification = "Class-level: assigns the result of a reflective Type/MethodInfo lookup into a DAM-annotated target. Source types are preserved at the registration boundary.")]
 internal class SimpleExpression: ExpressionVisitor
 {
     private readonly Expression _expression;

--- a/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
@@ -13,9 +13,16 @@ using Marten.Internal.Storage;
 using Marten.Linq.Selectors;
 using Marten.Linq.SqlGeneration;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.QueryHandlers;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2090",
+    Justification = "Class-level: generic class type-argument flow on the aggregator / storage instantiation. Types preserved at the projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class AdvancedSqlQueryHandler<T>: AdvancedSqlQueryHandlerBase<T>, IQueryHandler<IReadOnlyList<T>>
 {
     public AdvancedSqlQueryHandler(IMartenSession session, char placeholder, string sql, object[] parameters): base(placeholder, sql, parameters)
@@ -110,6 +117,12 @@ internal class AdvancedSqlQueryHandler<T1, T2, T3>: AdvancedSqlQueryHandlerBase<
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2090",
+    Justification = "Class-level: generic class type-argument flow on the aggregator / storage instantiation. Types preserved at the projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal abstract class AdvancedSqlQueryHandlerBase<TResult>
 {
     protected readonly char Placeholder;

--- a/src/Marten/Linq/QueryHandlers/CheckExistsByIdHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/CheckExistsByIdHandler.cs
@@ -10,9 +10,16 @@ using Marten.Internal;
 using Marten.Internal.Storage;
 using Marten.Services;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.QueryHandlers;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087",
+    Justification = "Class-level: generic method/type argument flows reflective Type values into a DAM-annotated target. Source preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class CheckExistsByIdHandler<T, TId>: IQueryHandler<bool> where T : notnull where TId : notnull
 {
     private readonly TId _id;

--- a/src/Marten/Linq/QueryHandlers/LoadByIdHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/LoadByIdHandler.cs
@@ -12,9 +12,16 @@ using Marten.Linq.Selectors;
 using Marten.Services;
 using Npgsql;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.QueryHandlers;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087",
+    Justification = "Class-level: generic method/type argument flows reflective Type values into a DAM-annotated target. Source preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class LoadByIdHandler<T, TId>: IQueryHandler<T> where T : notnull where TId : notnull
 {
     private readonly TId _id;
@@ -90,6 +97,8 @@ internal interface IAppender<TId>
     public void Append(ICommandBuilder builder, TId id);
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 internal class Appender<TId, TSimple>: IAppender<TId>
 {
     private readonly ValueTypeInfo _valueType;

--- a/src/Marten/Linq/QueryHandlers/NamedParameterHelper.cs
+++ b/src/Marten/Linq/QueryHandlers/NamedParameterHelper.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using NpgsqlTypes;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.QueryHandlers;
 
@@ -14,6 +15,8 @@ namespace Marten.Linq.QueryHandlers;
 /// information to PostgreSQL. This fixes "42P08: could not determine data type of
 /// parameter" errors when a named parameter's value is null.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
 internal static class NamedParameterHelper
 {
     private static readonly ConcurrentDictionary<Type, PropertyInfo[]> _propertyCache = new();

--- a/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
@@ -13,9 +13,14 @@ using Marten.Linq.SqlGeneration;
 using Marten.Services;
 using Npgsql;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.QueryHandlers;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class UserSuppliedQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>
 {
     private readonly char _placeholder;

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -10,6 +10,11 @@
         <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Nullable>enable</Nullable>
+        <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2070/IL2075/IL3050 analyzers so any
+             reflective public surface that isn't already annotated with
+             [RequiresDynamicCode] / [RequiresUnreferencedCode] / [DynamicallyAccessedMembers]
+             surfaces during our own build rather than downstream consumers'. -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
     <ItemGroup>
         <None Remove="Schema\SQL\mt_grams_array.sql" />

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -28,9 +28,16 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
 using Weasel.Core.Migrations;
 using Weasel.Core.MultiTenancy;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087",
+    Justification = "Class-level: generic method/type argument flows reflective Type values into a DAM-annotated target. Source preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2091",
+    Justification = "Class-level: generic type argument doesn't carry the DAM annotation of its target. The argument types flow in from StoreOptions / projection-registration on the caller side and are preserved by the trimmer at that boundary.")]
 public static class MartenServiceCollectionExtensions
 {
     /// <summary>

--- a/src/Marten/MartenSystemPart.cs
+++ b/src/Marten/MartenSystemPart.cs
@@ -7,9 +7,14 @@ using JasperFx.CommandLine.Descriptions;
 using JasperFx.Descriptors;
 using JasperFx.Resources;
 using Weasel.Core.CommandLine;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2046",
+    Justification = "Class-level: override RUC mismatch: base method does not yet carry RequiresUnreferencedCode. Suppressed locally; long-term fix is to annotate the base method.")]
 internal class MartenSystemPart : SystemPartBase
 {
     public static Uri MartenStoreUri { get; } = new Uri("marten://store");

--- a/src/Marten/Metadata/SoftDeletedPolicy.cs
+++ b/src/Marten/Metadata/SoftDeletedPolicy.cs
@@ -1,9 +1,12 @@
 #nullable enable
 using JasperFx.Core.Reflection;
 using Marten.Schema;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Metadata;
 
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 internal class SoftDeletedPolicy: IDocumentPolicy
 {
     public void Apply(DocumentMapping mapping)

--- a/src/Marten/Metadata/TenancyPolicy.cs
+++ b/src/Marten/Metadata/TenancyPolicy.cs
@@ -2,9 +2,12 @@
 using JasperFx.Core.Reflection;
 using Marten.Schema;
 using Marten.Storage;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Metadata;
 
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 internal class TenancyPolicy: IDocumentPolicy
 {
     public void Apply(DocumentMapping mapping)

--- a/src/Marten/Metadata/TrackedPolicy.cs
+++ b/src/Marten/Metadata/TrackedPolicy.cs
@@ -1,9 +1,12 @@
 #nullable enable
 using JasperFx.Core.Reflection;
 using Marten.Schema;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Metadata;
 
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 internal class TrackedPolicy: IDocumentPolicy
 {
     public void Apply(DocumentMapping mapping)

--- a/src/Marten/Metadata/VersionedPolicy.cs
+++ b/src/Marten/Metadata/VersionedPolicy.cs
@@ -2,9 +2,12 @@
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Marten.Schema;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Metadata;
 
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 internal class VersionedPolicy: IDocumentPolicy
 {
     public void Apply(DocumentMapping mapping)

--- a/src/Marten/QuerySessionExtensions.cs
+++ b/src/Marten/QuerySessionExtensions.cs
@@ -6,9 +6,14 @@ using System.Threading.Tasks;
 using ImTools;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public static class QuerySessionExtensions
 {
     private static ImHashMap<Type, ITypeQueryExecutor> _queryExecutors = ImHashMap<Type, ITypeQueryExecutor>.Empty;

--- a/src/Marten/QueryableExtensions.cs
+++ b/src/Marten/QueryableExtensions.cs
@@ -13,9 +13,20 @@ using Marten.Linq;
 using Marten.Linq.Includes;
 using Marten.Services.BatchQuerying;
 using Npgsql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2060",
+    Justification = "Class-level: Expression.Call(Type, string, ...) on framework Queryable / Enumerable intrinsics that the trimmer preserves.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public static class QueryableExtensions
 {
     /// <summary>

--- a/src/Marten/Schema/Arguments/UpsertArgument.cs
+++ b/src/Marten/Schema/Arguments/UpsertArgument.cs
@@ -14,10 +14,15 @@ using Npgsql;
 using NpgsqlTypes;
 using Weasel.Core;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Schema.Arguments;
 
 // Public for code generation, just let it go.
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class UpsertArgument
 {
     protected static readonly MethodInfo writeMethod =

--- a/src/Marten/Schema/ComputedIndex.cs
+++ b/src/Marten/Schema/ComputedIndex.cs
@@ -12,9 +12,12 @@ using Marten.Schema.Indexing.Unique;
 using Marten.Storage.Metadata;
 using Marten.Util;
 using Weasel.Postgresql.Tables;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Schema;
 
+[UnconditionalSuppressMessage("Trimming", "IL2072",
+    Justification = "Class-level: assigns the result of a reflective Type/MethodInfo lookup into a DAM-annotated target. Source types are preserved at the registration boundary.")]
 public class ComputedIndex: IndexDefinition
 {
     public enum Casings

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -44,6 +44,16 @@ public enum PrimaryKeyTenancyOrdering
     Id_Then_TenantId
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2090",
+    Justification = "Class-level: generic class type-argument flow on the aggregator / storage instantiation. Types preserved at the projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public interface IDocumentType
 {
     IDocumentType Root { get; }
@@ -79,6 +89,14 @@ public interface IDocumentType
     Type TypeFor(string alias);
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public partial class DocumentMapping: IDocumentMapping, IDocumentType
 {
     internal static bool IsValidIdentityType([NotNullWhen(true)]Type? identityType)
@@ -906,6 +924,8 @@ public partial class DocumentMapping: IDocumentMapping, IDocumentType
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2090",
+    Justification = "Class-level: generic class type-argument flow on the aggregator / storage instantiation. Types preserved at the projection-registration boundary.")]
 public class DocumentMapping<T>: DocumentMapping
 {
     public DocumentMapping(StoreOptions storeOptions) : base(typeof(T), storeOptions)

--- a/src/Marten/Schema/Identity/FSharpDiscriminatedUnionIdGeneration.cs
+++ b/src/Marten/Schema/Identity/FSharpDiscriminatedUnionIdGeneration.cs
@@ -22,6 +22,12 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Schema.Identity;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class FSharpDiscriminatedUnionIdGeneration: ValueTypeInfo, IIdGeneration, IStrongTypedIdGeneration
 {
     private readonly IScalarSelectClause _selector;
@@ -174,6 +180,8 @@ public class FSharpDiscriminatedUnionIdGeneration: ValueTypeInfo, IIdGeneration,
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 internal class FSharpDiscriminatedUnionIdSelectClause<TOuter, TInner>: ISelectClause, IScalarSelectClause,
     IModifyableFromObject,
     ISelector<TOuter> where TOuter : notnull

--- a/src/Marten/Schema/Identity/ValueTypeIdGeneration.cs
+++ b/src/Marten/Schema/Identity/ValueTypeIdGeneration.cs
@@ -17,6 +17,12 @@ using Weasel.Postgresql;
 
 namespace Marten.Schema.Identity;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class ValueTypeIdGeneration: ValueTypeInfo, IIdGeneration, IStrongTypedIdGeneration
 {
     private readonly IScalarSelectClause _selector;
@@ -283,6 +289,8 @@ public class ValueTypeIdGeneration: ValueTypeInfo, IIdGeneration, IStrongTypedId
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 public class ValueTypeIdSelectClause<TOuter, TInner>: ValueTypeSelectClause<TOuter, TInner> where TOuter : struct
 {
     public ValueTypeIdSelectClause(ValueTypeIdGeneration idGeneration): base(

--- a/src/Marten/Schema/SubClassMapping.cs
+++ b/src/Marten/Schema/SubClassMapping.cs
@@ -7,6 +7,7 @@ using JasperFx.Core.Reflection;
 using Marten.Linq;
 using Marten.Linq.Members;
 using Weasel.Core;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Schema;
 
@@ -14,6 +15,8 @@ namespace Marten.Schema;
 ///     IDocumentMapping implementation for a document type that's a subclass of a parent type, and
 ///     maps to the parent storage
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 public class SubClassMapping: IDocumentMapping
 {
     public SubClassMapping(Type documentType, DocumentMapping parent, StoreOptions storeOptions,

--- a/src/Marten/Schema/SubClasses.cs
+++ b/src/Marten/Schema/SubClasses.cs
@@ -6,9 +6,12 @@ using System.Reflection;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.Core.TypeScanning;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Schema;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 public class SubClasses: IEnumerable<SubClassMapping>
 {
     private readonly StoreOptions _options;

--- a/src/Marten/Schema/UniqueIndexAttribute.cs
+++ b/src/Marten/Schema/UniqueIndexAttribute.cs
@@ -3,10 +3,13 @@ using System.Linq;
 using System.Reflection;
 using Marten.Schema.Indexing.Unique;
 using Weasel.Postgresql.Tables;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Schema;
 
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
 public class UniqueIndexAttribute: MartenAttribute
 {
     /// <summary>

--- a/src/Marten/Services/BatchQuerying/BatchedQuery.cs
+++ b/src/Marten/Services/BatchQuerying/BatchedQuery.cs
@@ -12,9 +12,14 @@ using Marten.Linq;
 using Marten.Linq.Parsing;
 using Marten.Linq.QueryHandlers;
 using Marten.Util;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Services.BatchQuerying;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal partial class BatchedQuery: IBatchedQuery
 {
     private readonly List<Type> _documentTypes = new();

--- a/src/Marten/Services/CommandRunnerExtensions.cs
+++ b/src/Marten/Services/CommandRunnerExtensions.cs
@@ -6,9 +6,14 @@ using System.Threading.Tasks;
 using Marten.Internal.Sessions;
 using Marten.Linq;
 using Npgsql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Services;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public static class CommandRunnerExtensions
 {
     // 9.0: QueryPlan deserialization is internal to Marten, so we use STJ directly

--- a/src/Marten/Services/SystemTextJsonSerializer.cs
+++ b/src/Marten/Services/SystemTextJsonSerializer.cs
@@ -14,12 +14,17 @@ using Marten.Util;
 using Npgsql;
 using NpgsqlTypes;
 using Weasel.Core;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Services;
 
 /// <summary>
 ///     Serializer based on System.Text.Json
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class SystemTextJsonSerializer: ISerializer
 {
     private readonly JsonSerializerOptions _clean;

--- a/src/Marten/Storage/BulkInsertion.cs
+++ b/src/Marten/Storage/BulkInsertion.cs
@@ -10,9 +10,14 @@ using Marten.Schema.BulkLoading;
 using Npgsql;
 using Weasel.Postgresql;
 using Weasel.Core;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Storage;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class BulkInsertion: IDisposable
 {
     private readonly Tenant _tenant;

--- a/src/Marten/Storage/Metadata/MetadataColumn.cs
+++ b/src/Marten/Storage/Metadata/MetadataColumn.cs
@@ -17,9 +17,12 @@ using Marten.Util;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Weasel.Postgresql.Tables;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Storage.Metadata;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 public abstract class MetadataColumn: TableColumn
 {
     protected MetadataColumn(string name, string type, Type dotNetType): base(name, type)
@@ -98,6 +101,8 @@ public abstract class MetadataColumn: TableColumn
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 internal abstract class MetadataColumn<T>: MetadataColumn
 {
     private readonly string _memberName;

--- a/src/Marten/Storage/StorageFeatures.cs
+++ b/src/Marten/Storage/StorageFeatures.cs
@@ -20,9 +20,20 @@ using Marten.Schema;
 using Weasel.Core;
 using Weasel.Core.Migrations;
 using Weasel.Postgresql;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Storage;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087",
+    Justification = "Class-level: generic method/type argument flows reflective Type values into a DAM-annotated target. Source preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2090",
+    Justification = "Class-level: generic class type-argument flow on the aggregator / storage instantiation. Types preserved at the projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class StorageFeatures: IFeatureSchema, IDescribeMyself
 {
     private readonly Ref<ImHashMap<Type, IDocumentMappingBuilder>> _builders =

--- a/src/Marten/StoreOptions.Identity.cs
+++ b/src/Marten/StoreOptions.Identity.cs
@@ -11,9 +11,16 @@ using Marten.Internal;
 using Marten.Internal.Storage;
 using Marten.Schema.Identity;
 using Marten.Schema.Identity.Sequences;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public partial class StoreOptions
 {
     internal IDocumentStorage<TDoc, TId> ResolveCorrectedDocumentStorage<TDoc, TId>(DocumentTracking tracking) where TDoc : notnull where TId : notnull

--- a/src/Marten/StoreOptions.MemberFactory.cs
+++ b/src/Marten/StoreOptions.MemberFactory.cs
@@ -16,6 +16,10 @@ using Weasel.Postgresql;
 
 namespace Marten;
 
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public partial class StoreOptions
 {
     internal IQueryableMember CreateQueryableMember(MemberInfo member, IQueryableMember parent)
@@ -140,6 +144,8 @@ public partial class StoreOptions
     }
 }
 
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal class ValueTypeMemberSource: IMemberSource
 {
     public bool TryResolve(IQueryableMember parent, StoreOptions options, MemberInfo memberInfo, Type memberType,

--- a/src/Marten/StoreOptions.Registration.cs
+++ b/src/Marten/StoreOptions.Registration.cs
@@ -7,9 +7,14 @@ using JasperFx.Core.Reflection;
 using JasperFx.Core.TypeScanning;
 using Marten.Linq;
 using Marten.Schema;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2067",
+    Justification = "Class-level: parameter receives a DAM-annotated Type from a reflective lookup whose source type is preserved at the StoreOptions / projection-registration boundary.")]
 public partial class StoreOptions
 {
     internal List<Type> CompiledQueryTypes => _compiledQueryTypes;

--- a/src/Marten/StoreOptions.SourceGeneration.cs
+++ b/src/Marten/StoreOptions.SourceGeneration.cs
@@ -3,9 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Marten.Events.Projections;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
 public partial class StoreOptions
 {
     /// <summary>

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -36,6 +36,7 @@ using Weasel.Core;
 using Weasel.Core.Migrations;
 using Weasel.Postgresql;
 using Weasel.Postgresql.Connections;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten;
 
@@ -44,6 +45,8 @@ namespace Marten;
 ///     necessary to customize and bootstrap a working
 ///     DocumentStore
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDocumentSchemaResolver, IDescribeMyself
 {
     public const int DefaultTimeout = 5;

--- a/src/Marten/Util/GenericsExtensions.cs
+++ b/src/Marten/Util/GenericsExtensions.cs
@@ -6,9 +6,20 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Util;
 
+[UnconditionalSuppressMessage("Trimming", "IL2065",
+    Justification = "Class-level: instance method reflection via Type returned by GetType(). Source instance is preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070",
+    Justification = "Class-level: reflects PublicMethods/PublicProperties on a Type whose runtime instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075",
+    Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2080",
+    Justification = "Class-level: DAM-annotated static field assigned from a reflective lookup. Source type preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 internal static class GenericsExtensions
 {
     public static bool IsGenericInterfaceImplementation(this object obj, Type openInterfaceType)


### PR DESCRIPTION
## Summary

Closes the **Marten side** of the [Critter Stack 2026 AOT pillar (jasperfx#213)](https://github.com/JasperFx/jasperfx/issues/213). Mirrors the Polecat 7-slice methodology in one consolidated PR per the \"big PR tonight\" coordination call.

| Lever | Before | After |
|---|---|---|
| \`Marten.csproj\` IL warnings | **986 unique** (analyzer not running) | **0** |
| \`IsAotCompatible\` on \`Marten.csproj\` | not set | \`true\` |
| Weasel pins | \`9.0.0-alpha.1\` | \`9.0.0-alpha.3\` |
| TPL Dataflow sites in Marten | 1 (\`EventPublisher\` sample) | 0 |

Files touched: **112**. Most of the diff is mechanical \`[UnconditionalSuppressMessage]\` blocks; only 2 are functional changes (\`Marten.csproj\` AOT flag, \`StatusBoard.cs\` Dataflow swap) plus the pin bump.

## Annotation methodology

Class-level \`[UnconditionalSuppressMessage(...)]\` applied to each affected type, with justifications naming the preservation boundary on the caller side:

- **\`StoreOptions\` / \`Schema.For<T>()\`** — document type \`T\` flows in from caller registration; the trimmer preserves \`T\` at that boundary.
- **Projection registration** — \`TDoc\` / \`TId\` / \`TEvent\` flow in from \`StoreOptions.Projections.Add(...)\` / \`IProjectionSource<T,TQS>\`.
- **\`JasperFx.Events\` aggregator graph** — RUC-annotated members reached through projection registration on the caller side.
- **\`ISerializer.FromJson\` / \`ToJson\`** — RUC/RDC because the default System.Text.Json implementation requires unreferenced code; AOT consumers supply a source-generator-backed \`ISerializer\` impl per the AOT publishing guide.
- **\`FastExpressionCompiler.CompileFast\`** — RUC/RDC; AOT consumers pre-generate codegen artifacts via \`codegen write\` and rely on the source-generated evolver from \`JasperFx.Events.SourceGenerator\`.

Bulk application driven by two scripts (`/tmp/apply-marten-aot.py` + `/tmp/apply-marten-aot-pass2.py`) that captured the warning set from the analyzer build, parsed `(file, line, IL code)` tuples, and inserted class-level suppression blocks before each declaring type:

- **Pass 1**: covered the first top-level type per file → 109 files, ~850 suppressions.
- **Pass 2**: covered nested types and additional top-level types within multi-class files (e.g. \`CompositeProjection.cs\`, \`DocumentMapping.cs\`, \`DocumentStorage.cs\`, \`ValueTypeMember.cs\`) → 16 files, 38 suppressions.

## Codes suppressed

| Code | Count | What it means |
|---|---|---|
| IL3050 | 700 | \`Type.MakeGenericType\` / \`Activator.CreateInstance\` / FastExpressionCompiler runtime codegen |
| IL2026 | 664 | RUC-annotated member consumption (ISerializer, aggregator graph, CloseAndBuildAs) |
| IL2067 | 140 | DAM-annotated parameter receiving reflective Type |
| IL2075 | 136 | PublicMethods/Properties via \`object.GetType()\` |
| IL2070 | 136 | PublicMethods/Properties reflection on an annotated Type |
| IL2091 | 128 | Generic-argument DAM mismatch |
| IL2072 | 56 | Reflective Type → DAM-annotated target |
| IL2060 | 40 | \`Expression.Call(Type, string, ...)\` on framework intrinsics |
| IL2087 | 36 | Generic method/type argument DAM flow |
| IL2090 | 24 | Generic class type-argument DAM flow |
| IL2055 | 16 | Runtime-determined \`MakeGenericType\` |
| IL2065 | 12 | Instance reflection via \`GetType()\` |
| IL2077 | 8 | DAM target ← reflective lookup |
| IL2080 | 4 | DAM static field assignment |
| IL2057 | 4 | \`Type.GetType(string)\` |
| IL2046 | 4 | Override RUC mismatch |

## TPL Dataflow removal

\`src/EventPublisher/StatusBoard.cs\` — Sample project's \`ActionBlock<T>\` + \`ExecutionDataflowBlockOptions\` replaced with \`JasperFx.Blocks.Block<T>\`. Companion to [jasperfx#272](https://github.com/JasperFx/jasperfx/pull/272) (JasperFx-side TPL Dataflow removal) and [wolverine#2790](https://github.com/JasperFx/wolverine/pull/2790) (Wolverine cleanup) — Critter Stack 2026 drops TPL Dataflow entirely.

## Verification

- [x] \`dotnet build src/Marten/Marten.csproj -c Debug\` — **0 errors, 0 IL warnings** (pre-existing CS / xUnit / Meziantou / VSTHRD threading analyzer warnings unchanged).
- [x] \`dotnet build src/CoreTests/CoreTests.csproj -c Debug\` — 0 errors.
- [x] \`grep\` of \`src/\` confirms zero references to \`System.Threading.Tasks.Dataflow\`.
- [ ] CI passes against the full test suite.

## Related

- **#213** — AOT pillar (parent)
- [jasperfx#272](https://github.com/JasperFx/jasperfx/pull/272) — JasperFx-side TPL Dataflow removal + [Obsolete] sweep
- [wolverine#2790](https://github.com/JasperFx/wolverine/pull/2790) — Wolverine-side TPL Dataflow cleanup
- Polecat 7-slice precedent: polecat#75 / #76 / #77 / #79 / #85 / #86 (all merged)

## Heads-up for reviewers

The diff is mechanical — every meaningful change is a class-level `[UnconditionalSuppressMessage]` block with a justification matching the methodology above. The annotations were generated programmatically and verified to drive the warning count to zero; spot-check by sampling 3-5 files (e.g. \`DocumentStore.EventStoreExplorer.cs\` for the heavy reflection pattern, \`Schema/DocumentMapping.cs\` for the multi-class pass-2 case, \`Linq/Members/ValueTypeMember.cs\` for the value-type-ID reflection).