### PR TITLE
Eliminate synchronous query APIs in Marten 9.0 (#4420)

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -272,6 +272,45 @@ The runtime falls back to the existing codegen path in three documented cases �
 
 Tracked at [#4405](https://github.com/JasperFx/marten/issues/4405). Removing the codegen-fallback bridge entirely is a follow-up to that issue.
 
+### Synchronous query APIs removed
+
+**Marten 9 fully removes the synchronous data-access path.** Every database-bound synchronous LINQ terminal operator, `IQuerySession`/`IDocumentSession` sync helper, and the `IQueryHandler<T>.Handle(DbDataReader, IMartenSession)` extensibility hook now either no longer exist or throw at runtime:
+
+```text
+NotSupportedException: As of Marten 9.0, only asynchronous data access is supported
+```
+
+Async-only was the recommended path for several releases — the sync methods have been carrying an `[Obsolete]` warning since Marten 7. They're gone now.
+
+**What you have to change:**
+
+* Replace every sync LINQ terminal operator on a Marten `IQueryable<T>` with its async equivalent (the message above will surface at runtime if you miss one):
+
+  | Before (Marten 8 — `[Obsolete]`) | After (Marten 9) |
+  | --- | --- |
+  | `session.Query<Foo>().ToList()` | `await session.Query<Foo>().ToListAsync()` |
+  | `session.Query<Foo>().ToArray()` | `(await session.Query<Foo>().ToListAsync()).ToArray()` |
+  | `session.Query<Foo>().First()` | `await session.Query<Foo>().FirstAsync()` |
+  | `session.Query<Foo>().FirstOrDefault()` | `await session.Query<Foo>().FirstOrDefaultAsync()` |
+  | `session.Query<Foo>().Single()` | `await session.Query<Foo>().SingleAsync()` |
+  | `session.Query<Foo>().SingleOrDefault()` | `await session.Query<Foo>().SingleOrDefaultAsync()` |
+  | `session.Query<Foo>().Count()` | `await session.Query<Foo>().CountAsync()` |
+  | `session.Query<Foo>().LongCount()` | `await session.Query<Foo>().CountLongAsync()` |
+  | `session.Query<Foo>().Any()` | `await session.Query<Foo>().AnyAsync()` |
+  | `session.Query<Foo>().Min(x => x.N)` | `await session.Query<Foo>().MinAsync(x => x.N)` |
+  | `session.Query<Foo>().Max(x => x.N)` | `await session.Query<Foo>().MaxAsync(x => x.N)` |
+  | `session.Query<Foo>().Sum(x => x.N)` | `await session.Query<Foo>().SumAsync(x => x.N)` |
+  | `session.Query<Foo>().Average(x => x.N)` | `await session.Query<Foo>().AverageAsync(x => x.N)` |
+  | `foreach (var f in session.Query<Foo>())` | `await foreach (var f in session.Query<Foo>().ToAsyncEnumerable(ct))` |
+
+* Replace every `Load<T>`, `LoadMany<T>`, `Query<T>(sql, ...)`, `Json.*` sync call on `IQuerySession` with the corresponding `LoadAsync`, `LoadManyAsync`, `QueryAsync`, `Json.*Async` equivalent.
+
+* If you implement `IQueryHandler<T>` (a fairly advanced extensibility hook used by user-supplied SQL plans and custom selectors), the interface no longer has a synchronous `Handle(DbDataReader reader, IMartenSession session)` method — implement only `HandleAsync(DbDataReader, IMartenSession, CancellationToken)`. Delete any existing sync `Handle` override; it isn't satisfying anything anymore.
+
+There is **no escape hatch.** The internal `QuerySession.ExecuteHandler<T>(IQueryHandler<T>)` overload remains for now to preserve the type surface but throws the same `NotSupportedException` — use `ExecuteHandlerAsync(handler, cancellationToken)` instead. If you have a code path that genuinely needs blocking execution (e.g. interop with a non-async legacy framework), wrap the async call with `.GetAwaiter().GetResult()` at your own risk.
+
+See [#4420](https://github.com/JasperFx/marten/issues/4420).
+
 ### Obsolete API sweep
 
 Marten 9 retires obsolete types and members deprecated in Marten 8.x:

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -295,7 +295,7 @@ Async-only was the recommended path for several releases — the sync methods ha
   | `session.Query<Foo>().Single()` | `await session.Query<Foo>().SingleAsync()` |
   | `session.Query<Foo>().SingleOrDefault()` | `await session.Query<Foo>().SingleOrDefaultAsync()` |
   | `session.Query<Foo>().Count()` | `await session.Query<Foo>().CountAsync()` |
-  | `session.Query<Foo>().LongCount()` | `await session.Query<Foo>().CountLongAsync()` |
+  | `session.Query<Foo>().LongCount()` | `await session.Query<Foo>().LongCountAsync()` |
   | `session.Query<Foo>().Any()` | `await session.Query<Foo>().AnyAsync()` |
   | `session.Query<Foo>().Min(x => x.N)` | `await session.Query<Foo>().MinAsync(x => x.N)` |
   | `session.Query<Foo>().Max(x => x.N)` | `await session.Query<Foo>().MaxAsync(x => x.N)` |
@@ -304,6 +304,8 @@ Async-only was the recommended path for several releases — the sync methods ha
   | `foreach (var f in session.Query<Foo>())` | `await foreach (var f in session.Query<Foo>().ToAsyncEnumerable(ct))` |
 
 * Replace every `Load<T>`, `LoadMany<T>`, `Query<T>(sql, ...)`, `Json.*` sync call on `IQuerySession` with the corresponding `LoadAsync`, `LoadManyAsync`, `QueryAsync`, `Json.*Async` equivalent.
+
+* The sync `IQueryable<T>.ToPagedList(pageNumber, pageSize)` extension method (and the matching `PagedList<T>.Create(...)` / `PagedList<T>.Init(...)`) now throw the same `NotSupportedException` because their implementations called sync `LongCount()` / `ToList()` underneath. Switch to `await queryable.ToPagedListAsync(pageNumber, pageSize, token)` (the async variant has been there since Marten 4).
 
 * If you implement `IQueryHandler<T>` (a fairly advanced extensibility hook used by user-supplied SQL plans and custom selectors), the interface no longer has a synchronous `Handle(DbDataReader reader, IMartenSession session)` method — implement only `HandleAsync(DbDataReader, IMartenSession, CancellationToken)`. Delete any existing sync `Handle` override; it isn't satisfying anything anymore.
 

--- a/src/CoreTests/Bugs/Bug_1258_cannot_derive_updates_for_objects.cs
+++ b/src/CoreTests/Bugs/Bug_1258_cannot_derive_updates_for_objects.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using JasperFx;
+using Marten;
 using Marten.Testing.Harness;
 using Npgsql;
 using Shouldly;
@@ -182,7 +183,7 @@ public class Bug_1258_cannot_derive_updates_for_objects: BugIntegrationContext
         {
             var userList = new List<UserWithCustomType>();
 
-            var issues = query.Query<IssueForUserWithCustomType>().Include<UserWithCustomType>(x => x.UserId, userList).ToArray();
+            var issues = await query.Query<IssueForUserWithCustomType>().Include<UserWithCustomType>(x => x.UserId, userList).ToListAsync();
 
             userList.Count.ShouldBe(2);
 
@@ -190,7 +191,7 @@ public class Bug_1258_cannot_derive_updates_for_objects: BugIntegrationContext
             userList.Any(x => x.Id == guyWithCustomType2.Id);
             userList.Any(x => x == null);
 
-            issues.Length.ShouldBe(3);
+            issues.Count.ShouldBe(3);
         }
 
         var secondStore = SeparateStore(_ =>
@@ -210,7 +211,7 @@ public class Bug_1258_cannot_derive_updates_for_objects: BugIntegrationContext
         {
             var userList = new List<UserWithCustomType>();
 
-            var issues = query.Query<IssueForUserWithCustomType>().Include<UserWithCustomType>(x => x.UserId, userList).ToArray();
+            var issues = (await query.Query<IssueForUserWithCustomType>().Include<UserWithCustomType>(x => x.UserId, userList).ToListAsync());
 
             userList.Count.ShouldBe(2);
 
@@ -218,7 +219,7 @@ public class Bug_1258_cannot_derive_updates_for_objects: BugIntegrationContext
             userList.Any(x => x.Id == guyWithCustomType2.Id);
             userList.Any(x => x == null);
 
-            issues.Length.ShouldBe(3);
+            issues.Count.ShouldBe(3);
         }
     }
 

--- a/src/CoreTests/DocumentCleanerTests.cs
+++ b/src/CoreTests/DocumentCleanerTests.cs
@@ -36,7 +36,7 @@ public class DocumentCleanerTests: OneOffConfigurationsContext
         await theCleaner.DeleteDocumentsByTypeAsync(typeof(Target));
 
         await using var session = theStore.QuerySession();
-        session.Query<Target>().Count().ShouldBe(0);
+        (await session.Query<Target>().CountAsync()).ShouldBe(0);
     }
 
     [Fact]
@@ -54,10 +54,10 @@ public class DocumentCleanerTests: OneOffConfigurationsContext
         await theCleaner.DeleteAllDocumentsAsync();
 
         await using var session = theStore.QuerySession();
-        session.Query<Target>().Count().ShouldBe(0);
-        session.Query<User>().Count().ShouldBe(0);
-        session.Query<Issue>().Count().ShouldBe(0);
-        session.Query<Company>().Count().ShouldBe(0);
+        (await session.Query<Target>().CountAsync()).ShouldBe(0);
+        (await session.Query<User>().CountAsync()).ShouldBe(0);
+        (await session.Query<Issue>().CountAsync()).ShouldBe(0);
+        (await session.Query<Company>().CountAsync()).ShouldBe(0);
     }
 
     [Fact]
@@ -180,12 +180,12 @@ public class DocumentCleanerTests: OneOffConfigurationsContext
 
         await using var session = theStore.LightweightSession();
         // Not cleaned off
-        session.Query<Target>().Count().ShouldBe(2);
-        session.Query<User>().Count().ShouldBe(1);
+        (await session.Query<Target>().CountAsync()).ShouldBe(2);
+        (await session.Query<User>().CountAsync()).ShouldBe(1);
 
         // Should be cleaned off
-        session.Query<Issue>().Count().ShouldBe(0);
-        session.Query<Company>().Count().ShouldBe(0);
+        (await session.Query<Issue>().CountAsync()).ShouldBe(0);
+        (await session.Query<Company>().CountAsync()).ShouldBe(0);
     }
 
     [Fact]
@@ -204,12 +204,12 @@ public class DocumentCleanerTests: OneOffConfigurationsContext
 
         await using var session = theStore.LightweightSession();
         // Not cleaned off
-        session.Query<Target>().Count().ShouldBe(2);
-        session.Query<User>().Count().ShouldBe(1);
+        (await session.Query<Target>().CountAsync()).ShouldBe(2);
+        (await session.Query<User>().CountAsync()).ShouldBe(1);
 
         // Should be cleaned off
-        session.Query<Issue>().Count().ShouldBe(0);
-        session.Query<Company>().Count().ShouldBe(0);
+        (await session.Query<Issue>().CountAsync()).ShouldBe(0);
+        (await session.Query<Company>().CountAsync()).ShouldBe(0);
     }
 
     [Fact]

--- a/src/CoreTests/DocumentCleanerTests.cs
+++ b/src/CoreTests/DocumentCleanerTests.cs
@@ -130,7 +130,7 @@ public class DocumentCleanerTests: OneOffConfigurationsContext
 
         await theCleaner.DeleteAllEventDataAsync();
 
-        theSession.Events.QueryRawEventDataOnly<QuestStarted>().ShouldBeEmpty();
+        (await theSession.Events.QueryRawEventDataOnly<QuestStarted>().ToListAsync()).ShouldBeEmpty();
         (await theSession.Events.FetchStreamAsync(streamId)).ShouldBeEmpty();
     }
 
@@ -151,7 +151,7 @@ public class DocumentCleanerTests: OneOffConfigurationsContext
 
         await theCleaner.DeleteAllEventDataAsync();
 
-        theSession.Events.QueryRawEventDataOnly<QuestStarted>().ShouldBeEmpty();
+        (await theSession.Events.QueryRawEventDataOnly<QuestStarted>().ToListAsync()).ShouldBeEmpty();
         (await theSession.Events.FetchStreamAsync(streamId)).ShouldBeEmpty();
 
         var progress = await theStore.Advanced.AllProjectionProgress();

--- a/src/CoreTests/bootstrapping_with_service_collection_extensions.cs
+++ b/src/CoreTests/bootstrapping_with_service_collection_extensions.cs
@@ -341,8 +341,8 @@ public class bootstrapping_with_service_collection_extensions
         var serviceProvider = services.BuildServiceProvider();
 
         await using var session = serviceProvider.GetService<IDocumentSession>();
-        Func<bool> Call(IDocumentSession s) => () => s.Query<Target>().Any();
-        Call(session).ShouldNotThrow();
+        Func<Task<bool>> Call(IDocumentSession s) => async () => await s.Query<Target>().AnyAsync();
+        await Call(session).ShouldNotThrowAsync();
     }
 
     [Fact]
@@ -367,8 +367,8 @@ public class bootstrapping_with_service_collection_extensions
         var serviceProvider = services.BuildServiceProvider();
 
         await using var session = serviceProvider.GetService<IDocumentSession>();
-        Func<bool> Call(IDocumentSession s) => () => s.Query<Target>().Any();
-        Call(session).ShouldNotThrow();
+        Func<Task<bool>> Call(IDocumentSession s) => async () => await s.Query<Target>().AnyAsync();
+        await Call(session).ShouldNotThrowAsync();
     }
 
 
@@ -393,8 +393,8 @@ public class bootstrapping_with_service_collection_extensions
         var serviceProvider = services.BuildServiceProvider();
 
         await using var session = serviceProvider.GetService<IDocumentSession>();
-        Func<bool> Call(IDocumentSession s) => () => s.Query<Target>().Any();
-        Call(session).ShouldNotThrow();
+        Func<Task<bool>> Call(IDocumentSession s) => async () => await s.Query<Target>().AnyAsync();
+        await Call(session).ShouldNotThrowAsync();
     }
 
     [Fact]

--- a/src/CoreTests/working_with_initial_data.cs
+++ b/src/CoreTests/working_with_initial_data.cs
@@ -270,7 +270,7 @@ public class working_with_initial_data : OneOffConfigurationsContext
         {
             foreach (var initialAggregate in InitialWithQueryDatasets.Aggregates)
             {
-                var aggregate = session.Query<Aggregate1495>().First(x => x.Name == initialAggregate.Name);
+                var aggregate = (await session.Query<Aggregate1495>().FirstAsync(x => x.Name == initialAggregate.Name));
                 aggregate.Name.ShouldBe(initialAggregate.Name);
             }
         }
@@ -290,7 +290,7 @@ public class InitialDataWithQuery: IInitialData
     public async Task Populate(IDocumentStore store, CancellationToken cancellation)
     {
         await using var session = store.LightweightSession();
-        if (!session.Query<Aggregate1495>().Any())
+        if (!(await session.Query<Aggregate1495>().AnyAsync()))
         {
             session.Store(_initialData);
             await session.SaveChangesAsync(cancellation);

--- a/src/DaemonTests/Aggregations/build_aggregate_multiple_projections.cs
+++ b/src/DaemonTests/Aggregations/build_aggregate_multiple_projections.cs
@@ -145,8 +145,8 @@ public class build_aggregate_multiple_projections: DaemonContext
         //Assert results are latest
         await using (var session = theStore.QuerySession())
         {
-            var carName = session.Query<CarView>().FirstOrDefault()?.Name;
-            var truckName = session.Query<TruckView>().FirstOrDefault()?.Name;
+            var carName = (await session.Query<CarView>().FirstOrDefaultAsync())?.Name;
+            var truckName = (await session.Query<TruckView>().FirstOrDefaultAsync())?.Name;
 
             carName.ShouldBe("car-name-2");
             truckName.ShouldBe("truck-name-2");

--- a/src/DocumentDbTests/Bugs/Bug_1060_invalid_cast_exception_on_doc_with_subclass.cs
+++ b/src/DocumentDbTests/Bugs/Bug_1060_invalid_cast_exception_on_doc_with_subclass.cs
@@ -5,6 +5,7 @@ using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
+using Marten;
 
 namespace DocumentDbTests.Bugs;
 
@@ -36,13 +37,13 @@ public class Bug_1060_invalid_cast_exception_on_doc_with_subclass: BugIntegratio
         var users = new List<User>();
         var admins = new List<AdminUser>();
 
-        var userIssues = session.Query<Issue>()
+        var userIssues = (await session.Query<Issue>()
             .Include(i => i.ReporterId, users)
-            .ToList();
+            .ToListAsync());
 
-        var adminIssues = session.Query<Issue>()
+        var adminIssues = (await session.Query<Issue>()
             .Include(i => i.ReporterId, admins)
-            .ToList();
+            .ToListAsync());
 
         // validate for parent document (base class)
         users.Count(p => p != null).ShouldBe(2);

--- a/src/DocumentDbTests/Bugs/Bug_1061_string_enum_serialization_does_not_work_with_ginindexjsondata.cs
+++ b/src/DocumentDbTests/Bugs/Bug_1061_string_enum_serialization_does_not_work_with_ginindexjsondata.cs
@@ -59,7 +59,7 @@ public class Bug_1061_string_enum_serialization_does_not_work_with_ginindexjsond
 
         await using (var session = store2.LightweightSession())
         {
-            var items = session.Query<Bug_1061_Class>().Where(x => x.Enum == Bug_1061_Enum.One).ToList();
+            var items = (await session.Query<Bug_1061_Class>().Where(x => x.Enum == Bug_1061_Enum.One).ToListAsync());
             Assert.Single(items);
         }
     }

--- a/src/DocumentDbTests/Bugs/Bug_1155_null_duplicate_fields.cs
+++ b/src/DocumentDbTests/Bugs/Bug_1155_null_duplicate_fields.cs
@@ -6,6 +6,7 @@ using Marten.Testing.Harness;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Xunit;
+using Marten;
 
 namespace DocumentDbTests.Bugs;
 
@@ -32,9 +33,9 @@ public class Bug_1155_null_duplicate_fields: BugIntegrationContext
         }
 
         using (var session = theStore.QuerySession())
-        {
+        {(await 
             session.Query<Target>().Where(x => x.Number == 1)
-                .ToArray()
+                .ToListAsync())
                 .Select(x => x.Number)
                 .ShouldHaveTheSameElementsAs(1);
         }
@@ -61,9 +62,9 @@ public class Bug_1155_null_duplicate_fields: BugIntegrationContext
         }
 
         using (var session = theStore.QuerySession())
-        {
+        {(await 
             session.Query<Target>().Where(x => x.Number == 1)
-                .ToArray()
+                .ToListAsync())
                 .Select(x => x.Number)
                 .ShouldHaveTheSameElementsAs(1);
         }
@@ -90,9 +91,9 @@ public class Bug_1155_null_duplicate_fields: BugIntegrationContext
         }
 
         using (var session = theStore.QuerySession())
-        {
+        {(await 
             session.Query<Target>().Where(x => x.Number == 1)
-                .ToArray()
+                .ToListAsync())
                 .Select(x => x.Number)
                 .ShouldHaveTheSameElementsAs(1);
         }
@@ -119,9 +120,9 @@ public class Bug_1155_null_duplicate_fields: BugIntegrationContext
         }
 
         using (var session = theStore.QuerySession())
-        {
+        {(await 
             session.Query<Target>().Where(x => x.Number == 1)
-                .ToArray()
+                .ToListAsync())
                 .Select(x => x.Number)
                 .ShouldHaveTheSameElementsAs(1);
         }
@@ -144,9 +145,9 @@ public class Bug_1155_null_duplicate_fields: BugIntegrationContext
         }
 
         using (var session = theStore.QuerySession())
-        {
+        {(await 
             session.Query<Target>().Where(x => x.Number == 1)
-                .ToArray()
+                .ToListAsync())
                 .Select(x => x.Number)
                 .ShouldHaveTheSameElementsAs(1);
         }
@@ -169,9 +170,9 @@ public class Bug_1155_null_duplicate_fields: BugIntegrationContext
         }
 
         using (var session = theStore.QuerySession())
-        {
+        {(await 
             session.Query<Target>().Where(x => x.Number == 1)
-                .ToArray()
+                .ToListAsync())
                 .Select(x => x.Number)
                 .ShouldHaveTheSameElementsAs(1);
         }
@@ -191,9 +192,9 @@ public class Bug_1155_null_duplicate_fields: BugIntegrationContext
             }
         });
 
-        using var session = theStore.QuerySession();
+        using var session = theStore.QuerySession();(await 
         session.Query<Target>().Where(x => x.Number == 1)
-            .ToArray()
+            .ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1);
     }

--- a/src/DocumentDbTests/Bugs/Bug_127_do_not_recreate_a_table_with_duplicated_string_field_Tests.cs
+++ b/src/DocumentDbTests/Bugs/Bug_127_do_not_recreate_a_table_with_duplicated_string_field_Tests.cs
@@ -8,6 +8,7 @@ using Shouldly;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Xunit;
+using Marten;
 
 namespace DocumentDbTests.Bugs;
 
@@ -31,7 +32,7 @@ public class Bug_127_do_not_recreate_a_table_with_duplicated_string_field_Tests 
 
             await session1.SaveChangesAsync();
 
-            session1.Query<Team>().Count().ShouldBe(3);
+            (await session1.Query<Team>().CountAsync()).ShouldBe(3);
         }
 
         var store2 = SeparateStore(_ =>
@@ -41,7 +42,7 @@ public class Bug_127_do_not_recreate_a_table_with_duplicated_string_field_Tests 
 
         using (var session2 = store2.QuerySession())
         {
-            session2.Query<Team>().Count().ShouldBe(3);
+            (await session2.Query<Team>().CountAsync()).ShouldBe(3);
         }
     }
 }

--- a/src/DocumentDbTests/Bugs/Bug_1454_comparison_between_data_offset_in_child_collection.cs
+++ b/src/DocumentDbTests/Bugs/Bug_1454_comparison_between_data_offset_in_child_collection.cs
@@ -4,6 +4,8 @@ using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
+using System.Threading.Tasks;
+using Marten;
 
 namespace DocumentDbTests.Bugs;
 
@@ -14,18 +16,18 @@ public class Bug_1454_comparison_between_data_offset_in_child_collection : Integ
     }
 
     [Fact]
-    public void can_query_against_DateTime()
+    public async Task can_query_against_DateTime()
     {
-        theSession.Query<Target>().SelectMany(x => x.Children)
+        (await theSession.Query<Target>().SelectMany(x => x.Children)
             .Where(x => x.Date == DateTime.Today.AddDays(-3))
-            .ToList().ShouldNotBeNull();
+            .ToListAsync()).ShouldNotBeNull();
     }
 
     [Fact]
-    public void can_query_against_DateTimeOffset()
+    public async Task can_query_against_DateTimeOffset()
     {
-        theSession.Query<Target>().SelectMany(x => x.Children)
+        (await theSession.Query<Target>().SelectMany(x => x.Children)
             .Where(x => x.DateOffset == DateTimeOffset.UtcNow)
-            .ToList().ShouldNotBeNull();
+            .ToListAsync()).ShouldNotBeNull();
     }
 }

--- a/src/DocumentDbTests/Bugs/Bug_187_not_assigning_id_in_BulkInsert_Tests.cs
+++ b/src/DocumentDbTests/Bugs/Bug_187_not_assigning_id_in_BulkInsert_Tests.cs
@@ -4,6 +4,7 @@ using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
+using Marten;
 
 namespace DocumentDbTests.Bugs;
 
@@ -22,7 +23,7 @@ public class Bug_187_not_assigning_id_in_BulkInsert_Tests: IntegrationContext
 
         using (var session = theStore.QuerySession())
         {
-            session.Query<IntDoc>().Count().ShouldBe(50);
+            (await session.Query<IntDoc>().CountAsync()).ShouldBe(50);
         }
     }
 

--- a/src/DocumentDbTests/Bugs/Bug_382_bulk_insert_that_causes_multiple_batches.cs
+++ b/src/DocumentDbTests/Bugs/Bug_382_bulk_insert_that_causes_multiple_batches.cs
@@ -24,7 +24,7 @@ public class Bug_382_bulk_insert_that_causes_multiple_batches: BugIntegrationCon
 
         await theStore.BulkInsertAsync(data, BulkInsertMode.OverwriteExisting, batchSize: 10);
 
-        theSession.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
     }
 
 

--- a/src/DocumentDbTests/Bugs/Bug_621_bulk_insert_with_optimistic_concurrency.cs
+++ b/src/DocumentDbTests/Bugs/Bug_621_bulk_insert_with_optimistic_concurrency.cs
@@ -4,6 +4,7 @@ using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
+using Marten;
 
 namespace DocumentDbTests.Bugs;
 
@@ -23,7 +24,7 @@ public class Bug_621_bulk_insert_with_optimistic_concurrency: BugIntegrationCont
 
         using (var query = theStore.QuerySession())
         {
-            query.Query<Target>().Count().ShouldBe(1000);
+            (await query.Query<Target>().CountAsync()).ShouldBe(1000);
         }
     }
 

--- a/src/DocumentDbTests/Bugs/Bug_635_operations_order_in_same_session.cs
+++ b/src/DocumentDbTests/Bugs/Bug_635_operations_order_in_same_session.cs
@@ -6,6 +6,7 @@ using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
+using Marten;
 
 namespace DocumentDbTests.Bugs;
 
@@ -43,7 +44,7 @@ public class Bug_635_operations_order_in_same_session: IntegrationContext
 
         using (var querySession = theStore.QuerySession())
         {
-            var count = querySession.Query<User>().Count(x => x.LastName == "batch-id1");
+            var count = (await querySession.Query<User>().CountAsync(x => x.LastName == "batch-id1"));
 
             //This fails as the DeleteWhere gets executed after the Store(...) in the replaceSession
             count.ShouldBe(newBatchSize);

--- a/src/DocumentDbTests/Bugs/Bug_837_missing_func_mt_immutable_timestamp_when_initializing_with_new_Schema.cs
+++ b/src/DocumentDbTests/Bugs/Bug_837_missing_func_mt_immutable_timestamp_when_initializing_with_new_Schema.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using JasperFx;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
@@ -7,13 +8,14 @@ using Shouldly;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Xunit;
+using Marten;
 
 namespace DocumentDbTests.Bugs;
 
 public class Bug_837_missing_func_mt_immutable_timestamp_when_initializing_with_new_Schema: BugIntegrationContext
 {
     [Fact]
-    public void missing_func_mt_immutable_timestamp_when_initializing_with_new_Schema()
+    public async Task missing_func_mt_immutable_timestamp_when_initializing_with_new_Schema()
     {
         var store = SeparateStore(_ =>
         {
@@ -22,7 +24,7 @@ public class Bug_837_missing_func_mt_immutable_timestamp_when_initializing_with_
         });
 
         using var session = store.QuerySession();
-        session.Query<Target>().FirstOrDefault(m => m.DateOffset > DateTimeOffset.UtcNow)
+        (await session.Query<Target>().FirstOrDefaultAsync(m => m.DateOffset > DateTimeOffset.UtcNow))
             .ShouldBeNull();
     }
 

--- a/src/DocumentDbTests/Bugs/Bug_964_optimistic_concurrency_with_subclass.cs
+++ b/src/DocumentDbTests/Bugs/Bug_964_optimistic_concurrency_with_subclass.cs
@@ -8,6 +8,7 @@ using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
+using Marten;
 
 namespace DocumentDbTests.Bugs;
 
@@ -73,7 +74,7 @@ public class Bug_964_optimistic_concurrency_with_subclass: BugIntegrationContext
 
         using (var session = theStore.LightweightSession())
         {
-            var discardedResult = session.Query<CloudStorageMinio>().SingleOrDefault(p => p.Id == minio1.Id);
+            var discardedResult = (await session.Query<CloudStorageMinio>().SingleOrDefaultAsync(p => p.Id == minio1.Id));
 
             // Because I have loaded the record above, all exceptions go away - even when I still expect them
 

--- a/src/DocumentDbTests/Bugs/Bug_980_bulk_insert_with_subclass.cs
+++ b/src/DocumentDbTests/Bugs/Bug_980_bulk_insert_with_subclass.cs
@@ -4,6 +4,7 @@ using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
+using Marten;
 
 namespace DocumentDbTests.Bugs;
 
@@ -29,8 +30,8 @@ public class Bug_980_bulk_insert_with_subclass: BugIntegrationContext
         await theStore.BulkInsertAsync(users);
 
         await using var query = theStore.LightweightSession();
-        query.Query<AdminUser>().Count().ShouldBe(1);
-        query.Query<SuperUser>().Count().ShouldBe(2);
+        (await query.Query<AdminUser>().CountAsync()).ShouldBe(1);
+        (await query.Query<SuperUser>().CountAsync()).ShouldBe(2);
     }
 
     [Fact]
@@ -54,7 +55,7 @@ public class Bug_980_bulk_insert_with_subclass: BugIntegrationContext
         await theStore.BulkInsertAsync(users);
 
         await using var query = theStore.LightweightSession();
-        query.Query<SuperUser>().Count().ShouldBe(4);
+        (await query.Query<SuperUser>().CountAsync()).ShouldBe(4);
     }
 
 }

--- a/src/DocumentDbTests/Deleting/delete_many_documents_by_query.cs
+++ b/src/DocumentDbTests/Deleting/delete_many_documents_by_query.cs
@@ -22,7 +22,7 @@ public class delete_many_documents_by_query : IntegrationContext
 
         await theStore.BulkInsertAsync(targets);
 
-        var initialCount = theSession.Query<Target>().Count(x => x.Double == 578);
+        var initialCount = (await theSession.Query<Target>().CountAsync(x => x.Double == 578));
 
         #region sample_deletewhere
         theSession.DeleteWhere<Target>(x => x.Double == 578);
@@ -30,9 +30,9 @@ public class delete_many_documents_by_query : IntegrationContext
         await theSession.SaveChangesAsync();
         #endregion
 
-        theSession.Query<Target>().Count().ShouldBe(50 - initialCount);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(50 - initialCount);
 
-        theSession.Query<Target>().Count(x => x.Double == 578)
+        (await theSession.Query<Target>().CountAsync(x => x.Double == 578))
             .ShouldBe(0);
 
     }
@@ -74,7 +74,7 @@ public class delete_many_documents_by_query : IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Count(x => x.Double == 578 && x.Number == current.Id)
+        (await theSession.Query<Target>().CountAsync(x => x.Double == 578 && x.Number == current.Id))
             .ShouldBe(0);
 
     }
@@ -93,18 +93,18 @@ public class delete_many_documents_by_query : IntegrationContext
 
         await theStore.BulkInsertAsync(targets);
 
-        var initialCount = theSession.Query<Target>().Count(x => x.Double == 578);
+        var initialCount = (await theSession.Query<Target>().CountAsync(x => x.Double == 578));
 
         theSession.Store(new User(), new User(), new User());
         theSession.DeleteWhere<Target>(x => x.Double == 578);
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Count().ShouldBe(50 - initialCount);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(50 - initialCount);
 
-        theSession.Query<Target>().Count(x => x.Double == 578)
+        (await theSession.Query<Target>().CountAsync(x => x.Double == 578))
             .ShouldBe(0);
 
-        theSession.Query<User>().Count().ShouldBe(3);
+        (await theSession.Query<User>().CountAsync()).ShouldBe(3);
     }
 
     public class FailureInLife
@@ -126,7 +126,7 @@ public class delete_many_documents_by_query : IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<FailureInLife>().Count().ShouldBe(0);
+        (await theSession.Query<FailureInLife>().CountAsync()).ShouldBe(0);
 
     }
 

--- a/src/DocumentDbTests/Deleting/soft_deletes.cs
+++ b/src/DocumentDbTests/Deleting/soft_deletes.cs
@@ -299,12 +299,12 @@ public class soft_deletes: StoreContext<SoftDeletedFixture>, IClassFixture<SoftD
         await session.SaveChangesAsync();
 
         // no where clause, deleted docs should be filtered out
-        session.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("foo", "jack");
+        (await session.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("foo", "jack");
 
         // with a where clause
-        session.Query<User>().Where(x => x.UserName != "jack")
-            .ToList().Single().UserName.ShouldBe("foo");
+        (await session.Query<User>().Where(x => x.UserName != "jack")
+            .ToListAsync()).Single().UserName.ShouldBe("foo");
     }
 
     #endregion
@@ -326,13 +326,13 @@ public class soft_deletes: StoreContext<SoftDeletedFixture>, IClassFixture<SoftD
         await session.SaveChangesAsync();
 
         // no where clause, all documents are returned
-        session.Query<User>().Where(x => x.MaybeDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("bar", "baz", "foo", "jack");
+        (await session.Query<User>().Where(x => x.MaybeDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("bar", "baz", "foo", "jack");
 
         // with a where clause, all documents are returned
-        session.Query<User>().Where(x => x.UserName != "jack" && x.MaybeDeleted())
+        (await session.Query<User>().Where(x => x.UserName != "jack" && x.MaybeDeleted())
             .OrderBy(x => x.UserName)
-            .ToList()
+            .ToListAsync())
             .Select(x => x.UserName)
             .ShouldHaveTheSameElementsAs("bar", "baz", "foo");
     }
@@ -356,13 +356,13 @@ public class soft_deletes: StoreContext<SoftDeletedFixture>, IClassFixture<SoftD
         await session.SaveChangesAsync();
 
         // no where clause
-        session.Query<User>().Where(x => x.IsDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("bar", "baz");
+        (await session.Query<User>().Where(x => x.IsDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("bar", "baz");
 
         // with a where clause
-        session.Query<User>().Where(x => x.UserName != "baz" && x.IsDeleted())
+        (await session.Query<User>().Where(x => x.UserName != "baz" && x.IsDeleted())
             .OrderBy(x => x.UserName)
-            .ToList()
+            .ToListAsync())
             .Select(x => x.UserName)
             .Single().ShouldBe("bar");
     }
@@ -389,8 +389,8 @@ public class soft_deletes: StoreContext<SoftDeletedFixture>, IClassFixture<SoftD
         session.Delete(user4);
         await session.SaveChangesAsync();
 
-        session.Query<User>().Where(x => x.DeletedSince(epoch.Value)).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("jack");
+        (await session.Query<User>().Where(x => x.DeletedSince(epoch.Value)).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("jack");
     }
 
     #endregion
@@ -415,8 +415,8 @@ public class soft_deletes: StoreContext<SoftDeletedFixture>, IClassFixture<SoftD
 
         var epoch = (await session.MetadataForAsync(user4)).DeletedAt;
 
-        session.Query<User>().Where(x => x.DeletedBefore(epoch.Value)).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("baz");
+        (await session.Query<User>().Where(x => x.DeletedBefore(epoch.Value)).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("baz");
     }
 
     [Fact]
@@ -437,12 +437,12 @@ public class soft_deletes: StoreContext<SoftDeletedFixture>, IClassFixture<SoftD
         await session.SaveChangesAsync();
 
         // no where clause
-        session.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("foo", "jack");
+        (await session.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("foo", "jack");
 
         // with a where clause
-        session.Query<User>().Where(x => x.UserName != "jack")
-            .ToList().Single().UserName.ShouldBe("foo");
+        (await session.Query<User>().Where(x => x.UserName != "jack")
+            .ToListAsync()).Single().UserName.ShouldBe("foo");
     }
 
     [Fact]
@@ -463,12 +463,12 @@ public class soft_deletes: StoreContext<SoftDeletedFixture>, IClassFixture<SoftD
         await session.SaveChangesAsync();
 
         // no where clause
-        session.Query<SuperUser>().OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("foo", "jack");
+        (await session.Query<SuperUser>().OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("foo", "jack");
 
         // with a where clause
-        session.Query<SuperUser>().Where(x => x.UserName != "jack")
-            .ToList().Single().UserName.ShouldBe("foo");
+        (await session.Query<SuperUser>().Where(x => x.UserName != "jack")
+            .ToListAsync()).Single().UserName.ShouldBe("foo");
     }
 
     [Fact]
@@ -489,14 +489,14 @@ public class soft_deletes: StoreContext<SoftDeletedFixture>, IClassFixture<SoftD
         await session.SaveChangesAsync();
 
         // no where clause
-        session.Query<SuperUser>().Where(x => x.MaybeDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("bar", "baz", "foo", "jack");
+        (await session.Query<SuperUser>().Where(x => x.MaybeDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("bar", "baz", "foo", "jack");
 
         // with a where clause
-        session.Query<SuperUser>().Where(x => x.UserName != "jack" && x.MaybeDeleted())
+        (await session.Query<SuperUser>().Where(x => x.UserName != "jack" && x.MaybeDeleted())
             .OrderBy(x => x.UserName)
             .Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("bar", "baz", "foo");
+            .ToListAsync()).ShouldHaveTheSameElementsAs("bar", "baz", "foo");
     }
 
     [Fact]
@@ -517,14 +517,14 @@ public class soft_deletes: StoreContext<SoftDeletedFixture>, IClassFixture<SoftD
         await session.SaveChangesAsync();
 
         // no where clause
-        session.Query<SuperUser>().Where(x => x.IsDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("bar", "baz");
+        (await session.Query<SuperUser>().Where(x => x.IsDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("bar", "baz");
 
         // with a where clause
-        session.Query<SuperUser>().Where(x => x.UserName != "bar" && x.IsDeleted())
+        (await session.Query<SuperUser>().Where(x => x.UserName != "bar" && x.IsDeleted())
             .OrderBy(x => x.UserName)
             .Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("baz");
+            .ToListAsync()).ShouldHaveTheSameElementsAs("baz");
     }
 
     [Fact]
@@ -1001,12 +1001,12 @@ public class soft_deletes_with_partitioning: OneOffConfigurationsContext, IAsync
         await session.SaveChangesAsync();
 
         // no where clause, deleted docs should be filtered out
-        session.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("foo", "jack");
+        (await session.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("foo", "jack");
 
         // with a where clause
-        session.Query<User>().Where(x => x.UserName != "jack")
-            .ToList().Single().UserName.ShouldBe("foo");
+        (await session.Query<User>().Where(x => x.UserName != "jack")
+            .ToListAsync()).Single().UserName.ShouldBe("foo");
     }
 
     #endregion
@@ -1028,13 +1028,13 @@ public class soft_deletes_with_partitioning: OneOffConfigurationsContext, IAsync
         await session.SaveChangesAsync();
 
         // no where clause, all documents are returned
-        session.Query<User>().Where(x => x.MaybeDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("bar", "baz", "foo", "jack");
+        (await session.Query<User>().Where(x => x.MaybeDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("bar", "baz", "foo", "jack");
 
         // with a where clause, all documents are returned
-        session.Query<User>().Where(x => x.UserName != "jack" && x.MaybeDeleted())
+        (await session.Query<User>().Where(x => x.UserName != "jack" && x.MaybeDeleted())
             .OrderBy(x => x.UserName)
-            .ToList()
+            .ToListAsync())
             .Select(x => x.UserName)
             .ShouldHaveTheSameElementsAs("bar", "baz", "foo");
     }
@@ -1058,13 +1058,13 @@ public class soft_deletes_with_partitioning: OneOffConfigurationsContext, IAsync
         await session.SaveChangesAsync();
 
         // no where clause
-        session.Query<User>().Where(x => x.IsDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("bar", "baz");
+        (await session.Query<User>().Where(x => x.IsDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("bar", "baz");
 
         // with a where clause
-        session.Query<User>().Where(x => x.UserName != "baz" && x.IsDeleted())
+        (await session.Query<User>().Where(x => x.UserName != "baz" && x.IsDeleted())
             .OrderBy(x => x.UserName)
-            .ToList()
+            .ToListAsync())
             .Select(x => x.UserName)
             .Single().ShouldBe("bar");
     }
@@ -1091,8 +1091,8 @@ public class soft_deletes_with_partitioning: OneOffConfigurationsContext, IAsync
         session.Delete(user4);
         await session.SaveChangesAsync();
 
-        session.Query<User>().Where(x => x.DeletedSince(epoch.Value)).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("jack");
+        (await session.Query<User>().Where(x => x.DeletedSince(epoch.Value)).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("jack");
     }
 
     #endregion
@@ -1117,8 +1117,8 @@ public class soft_deletes_with_partitioning: OneOffConfigurationsContext, IAsync
 
         var epoch = (await session.MetadataForAsync(user4)).DeletedAt;
 
-        session.Query<User>().Where(x => x.DeletedBefore(epoch.Value)).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("baz");
+        (await session.Query<User>().Where(x => x.DeletedBefore(epoch.Value)).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("baz");
     }
 
     [Fact]
@@ -1139,12 +1139,12 @@ public class soft_deletes_with_partitioning: OneOffConfigurationsContext, IAsync
         await session.SaveChangesAsync();
 
         // no where clause
-        session.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("foo", "jack");
+        (await session.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("foo", "jack");
 
         // with a where clause
-        session.Query<User>().Where(x => x.UserName != "jack")
-            .ToList().Single().UserName.ShouldBe("foo");
+        (await session.Query<User>().Where(x => x.UserName != "jack")
+            .ToListAsync()).Single().UserName.ShouldBe("foo");
     }
 
     [Fact]
@@ -1165,12 +1165,12 @@ public class soft_deletes_with_partitioning: OneOffConfigurationsContext, IAsync
         await session.SaveChangesAsync();
 
         // no where clause
-        session.Query<SuperUser>().OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("foo", "jack");
+        (await session.Query<SuperUser>().OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("foo", "jack");
 
         // with a where clause
-        session.Query<SuperUser>().Where(x => x.UserName != "jack")
-            .ToList().Single().UserName.ShouldBe("foo");
+        (await session.Query<SuperUser>().Where(x => x.UserName != "jack")
+            .ToListAsync()).Single().UserName.ShouldBe("foo");
     }
 
     [Fact]
@@ -1191,14 +1191,14 @@ public class soft_deletes_with_partitioning: OneOffConfigurationsContext, IAsync
         await session.SaveChangesAsync();
 
         // no where clause
-        session.Query<SuperUser>().Where(x => x.MaybeDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("bar", "baz", "foo", "jack");
+        (await session.Query<SuperUser>().Where(x => x.MaybeDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("bar", "baz", "foo", "jack");
 
         // with a where clause
-        session.Query<SuperUser>().Where(x => x.UserName != "jack" && x.MaybeDeleted())
+        (await session.Query<SuperUser>().Where(x => x.UserName != "jack" && x.MaybeDeleted())
             .OrderBy(x => x.UserName)
             .Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("bar", "baz", "foo");
+            .ToListAsync()).ShouldHaveTheSameElementsAs("bar", "baz", "foo");
     }
 
     [Fact]
@@ -1219,14 +1219,14 @@ public class soft_deletes_with_partitioning: OneOffConfigurationsContext, IAsync
         await session.SaveChangesAsync();
 
         // no where clause
-        session.Query<SuperUser>().Where(x => x.IsDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("bar", "baz");
+        (await session.Query<SuperUser>().Where(x => x.IsDeleted()).OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("bar", "baz");
 
         // with a where clause
-        session.Query<SuperUser>().Where(x => x.UserName != "bar" && x.IsDeleted())
+        (await session.Query<SuperUser>().Where(x => x.UserName != "bar" && x.IsDeleted())
             .OrderBy(x => x.UserName)
             .Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("baz");
+            .ToListAsync()).ShouldHaveTheSameElementsAs("baz");
     }
 
     [Fact]

--- a/src/DocumentDbTests/Deleting/soft_deletes.cs
+++ b/src/DocumentDbTests/Deleting/soft_deletes.cs
@@ -543,12 +543,12 @@ public class soft_deletes: StoreContext<SoftDeletedFixture>, IClassFixture<SoftD
         await session.SaveChangesAsync();
 
         var users = new List<User>();
-        var files = session.Query<File>().Include(u => u.UserId, users).ToList();
+        var files = (await session.Query<File>().Include(u => u.UserId, users).ToListAsync());
         files.Count.ShouldBe(1);
         users.Count.ShouldBe(1);
-        files = session.Query<File>().Where(f => f.MaybeDeleted()).Include(u => u.UserId, users).ToList();
+        files = (await session.Query<File>().Where(f => f.MaybeDeleted()).Include(u => u.UserId, users).ToListAsync());
         files.Count.ShouldBe(2);
-        files = session.Query<File>().Where(f => f.IsDeleted()).Include(u => u.UserId, users).ToList();
+        files = (await session.Query<File>().Where(f => f.IsDeleted()).Include(u => u.UserId, users).ToListAsync());
         files.Count.ShouldBe(1);
     }
 
@@ -1245,12 +1245,12 @@ public class soft_deletes_with_partitioning: OneOffConfigurationsContext, IAsync
         await session.SaveChangesAsync();
 
         var users = new List<User>();
-        var files = session.Query<File>().Include(u => u.UserId, users).ToList();
+        var files = (await session.Query<File>().Include(u => u.UserId, users).ToListAsync());
         files.Count.ShouldBe(1);
         users.Count.ShouldBe(1);
-        files = session.Query<File>().Where(f => f.MaybeDeleted()).Include(u => u.UserId, users).ToList();
+        files = (await session.Query<File>().Where(f => f.MaybeDeleted()).Include(u => u.UserId, users).ToListAsync());
         files.Count.ShouldBe(2);
-        files = session.Query<File>().Where(f => f.IsDeleted()).Include(u => u.UserId, users).ToList();
+        files = (await session.Query<File>().Where(f => f.IsDeleted()).Include(u => u.UserId, users).ToListAsync());
         files.Count.ShouldBe(1);
     }
 

--- a/src/DocumentDbTests/HierarchicalStorage/Bug_1247_end_to_end_query_with_include_and_document_hierarchy_Tests.cs
+++ b/src/DocumentDbTests/HierarchicalStorage/Bug_1247_end_to_end_query_with_include_and_document_hierarchy_Tests.cs
@@ -31,14 +31,14 @@ public class Bug_1247_query_with_include_and_document_hierarchy_Tests: end_to_en
         using var query = theStore.QuerySession();
         var list = new List<User>();
 
-        var issues = query.Query<Issue>().Include<User>(x => x.AssigneeId, list).ToArray();
+        var issues = (await query.Query<Issue>().Include<User>(x => x.AssigneeId, list).ToListAsync());
 
         list.Count.ShouldBe(2);
 
         list.Any(x => x.Id == user1.Id).ShouldBeTrue();
         list.Any(x => x.Id == user2.Id).ShouldBeTrue();
 
-        issues.Length.ShouldBe(4);
+        issues.Count.ShouldBe(4);
     }
 
     // [Fact] flaky in CI

--- a/src/DocumentDbTests/HierarchicalStorage/Bug_1484_store_overloads_Tests.cs
+++ b/src/DocumentDbTests/HierarchicalStorage/Bug_1484_store_overloads_Tests.cs
@@ -16,7 +16,7 @@ public class Bug_1484_store_overloads_Tests: end_to_end_document_hierarchy_usage
         session.Store(admin1);
         await session.SaveChangesAsync();
 
-        session.Query<AdminUser>().Count().ShouldBe(1);
+        (await session.Query<AdminUser>().CountAsync()).ShouldBe(1);
     }
 
     [Fact]
@@ -26,7 +26,7 @@ public class Bug_1484_store_overloads_Tests: end_to_end_document_hierarchy_usage
         session.Store(admin1, admin2);
         await session.SaveChangesAsync();
 
-        session.Query<AdminUser>().Count().ShouldBe(2);
+        (await session.Query<AdminUser>().CountAsync()).ShouldBe(2);
     }
 
     [Fact]
@@ -36,7 +36,7 @@ public class Bug_1484_store_overloads_Tests: end_to_end_document_hierarchy_usage
         session.Store(new[] { admin1, admin2 });
         await session.SaveChangesAsync();
 
-        session.Query<AdminUser>().Count().ShouldBe(2);
+        (await session.Query<AdminUser>().CountAsync()).ShouldBe(2);
     }
 
     [Fact]
@@ -46,6 +46,6 @@ public class Bug_1484_store_overloads_Tests: end_to_end_document_hierarchy_usage
         session.Store(new[] { admin1, admin2 }.AsEnumerable());
         await session.SaveChangesAsync();
 
-        session.Query<AdminUser>().Count().ShouldBe(2);
+        (await session.Query<AdminUser>().CountAsync()).ShouldBe(2);
     }
 }

--- a/src/DocumentDbTests/HierarchicalStorage/delete_by_where_for_hierarchy_Tests.cs
+++ b/src/DocumentDbTests/HierarchicalStorage/delete_by_where_for_hierarchy_Tests.cs
@@ -5,6 +5,7 @@ using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
+using Marten;
 
 namespace DocumentDbTests.HierarchicalStorage;
 
@@ -18,9 +19,9 @@ public class delete_by_where_for_hierarchy_Tests: end_to_end_document_hierarchy_
         theSession.DeleteWhere<SuperUser>(x => true);
         await theSession.SaveChangesAsync();
 
-        theSession.Query<SuperUser>().Count().ShouldBe(0);
-        theSession.Query<AdminUser>().Count().ShouldBe(2);
-        theSession.Query<User>().Count().ShouldBe(4);
+        (await theSession.Query<SuperUser>().CountAsync()).ShouldBe(0);
+        (await theSession.Query<AdminUser>().CountAsync()).ShouldBe(2);
+        (await theSession.Query<User>().CountAsync()).ShouldBe(4);
     }
 
     [Fact]
@@ -31,9 +32,9 @@ public class delete_by_where_for_hierarchy_Tests: end_to_end_document_hierarchy_
         theSession.DeleteWhere<SuperUser>(x => x.FirstName.StartsWith("D"));
         await theSession.SaveChangesAsync();
 
-        theSession.Query<SuperUser>().Count().ShouldBe(1);
-        theSession.Query<AdminUser>().Count().ShouldBe(2);
-        theSession.Query<User>().Count().ShouldBe(5);
+        (await theSession.Query<SuperUser>().CountAsync()).ShouldBe(1);
+        (await theSession.Query<AdminUser>().CountAsync()).ShouldBe(2);
+        (await theSession.Query<User>().CountAsync()).ShouldBe(5);
     }
 
     [Fact]
@@ -45,8 +46,8 @@ public class delete_by_where_for_hierarchy_Tests: end_to_end_document_hierarchy_
         await theSession.SaveChangesAsync();
 
         // Should delete one SuperUser and one AdminUser
-        theSession.Query<SuperUser>().Count().ShouldBe(1);
-        theSession.Query<AdminUser>().Count().ShouldBe(1);
-        theSession.Query<User>().Count().ShouldBe(4);
+        (await theSession.Query<SuperUser>().CountAsync()).ShouldBe(1);
+        (await theSession.Query<AdminUser>().CountAsync()).ShouldBe(1);
+        (await theSession.Query<User>().CountAsync()).ShouldBe(4);
     }
 }

--- a/src/DocumentDbTests/HierarchicalStorage/end_to_end_document_hierarchy_with_interface_tests.cs
+++ b/src/DocumentDbTests/HierarchicalStorage/end_to_end_document_hierarchy_with_interface_tests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
+using Marten;
 
 namespace DocumentDbTests.HierarchicalStorage;
 
@@ -65,7 +66,7 @@ public class end_to_end_document_hierarchy_with_interface_tests: OneOffConfigura
 
         using (var session = theStore.LightweightSession())
         {
-            session.Query<IPolicy>().Single(p => p.VersionId == policy.VersionId)
+            (await session.Query<IPolicy>().SingleAsync(p => p.VersionId == policy.VersionId))
                 .VersionId.ShouldBe(policy.VersionId);
         }
     }

--- a/src/DocumentDbTests/HierarchicalStorage/query_through_mixed_population_Tests.cs
+++ b/src/DocumentDbTests/HierarchicalStorage/query_through_mixed_population_Tests.cs
@@ -37,7 +37,7 @@ public class query_through_mixed_population_Tests: end_to_end_document_hierarchy
     public async Task identity_map_usage_from_select()
     {
         using var session = await identitySessionWithData();
-        var users = session.Query<User>().OrderBy(x => x.FirstName).ToArray();
+        var users = (await session.Query<User>().OrderBy(x => x.FirstName).ToListAsync());
         users[0].ShouldBeSameAs(admin1);
         users[1].ShouldBeSameAs(super1);
         users[5].ShouldBeSameAs(user2);
@@ -107,10 +107,10 @@ public class query_through_mixed_population_Tests: end_to_end_document_hierarchy
     }
 
     [Fact]
-    public void query_against_all_with_no_where()
+    public async Task query_against_all_with_no_where()
     {
         using var session = theStore.IdentitySession();
-        var users = session.Query<User>().OrderBy(x => x.FirstName).ToArray();
+        var users = (await session.Query<User>().OrderBy(x => x.FirstName).ToListAsync());
         users
             .Select(x => x.Id)
             .ShouldHaveTheSameElementsAs(admin1.Id, super1.Id, admin2.Id, user1.Id, super2.Id, user2.Id);
@@ -130,10 +130,10 @@ public class query_through_mixed_population_Tests: end_to_end_document_hierarchy
     }
 
     [Fact]
-    public void query_for_only_a_subclass_with_no_where_clause()
+    public async Task query_for_only_a_subclass_with_no_where_clause()
     {
         using var session = theStore.IdentitySession();
-        session.Query<AdminUser>().OrderBy(x => x.FirstName).ToArray()
+        (await session.Query<AdminUser>().OrderBy(x => x.FirstName).ToListAsync())
             .Select(x => x.Id).ShouldHaveTheSameElementsAs(admin1.Id, admin2.Id);
     }
 

--- a/src/DocumentDbTests/HierarchicalStorage/query_through_mixed_population_Tests.cs
+++ b/src/DocumentDbTests/HierarchicalStorage/query_through_mixed_population_Tests.cs
@@ -121,11 +121,11 @@ public class query_through_mixed_population_Tests: end_to_end_document_hierarchy
     }
 
     [Fact]
-    public void query_against_all_with_where_clause()
+    public async Task query_against_all_with_where_clause()
     {
-        using var session = theStore.IdentitySession();
-        session.Query<User>().OrderBy(x => x.FirstName).Where(x => x.UserName.StartsWith("A"))
-            .ToArray().Select(x => x.Id)
+        await using var session = theStore.IdentitySession();
+        (await session.Query<User>().OrderBy(x => x.FirstName).Where(x => x.UserName.StartsWith("A"))
+            .ToListAsync()).Select(x => x.Id)
             .ShouldHaveTheSameElementsAs(admin1.Id, super1.Id, user1.Id);
     }
 

--- a/src/DocumentDbTests/HierarchicalStorage/query_through_mixed_population_Tests.cs
+++ b/src/DocumentDbTests/HierarchicalStorage/query_through_mixed_population_Tests.cs
@@ -26,10 +26,10 @@ public class query_through_mixed_population_Tests: end_to_end_document_hierarchy
         await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(AdminUser));
 
         using var session = theStore.IdentitySession();
-        session.Query<User>().Any().ShouldBeTrue();
-        session.Query<SuperUser>().Any().ShouldBeTrue();
+        (await session.Query<User>().AnyAsync()).ShouldBeTrue();
+        (await session.Query<SuperUser>().AnyAsync()).ShouldBeTrue();
 
-        session.Query<AdminUser>().Any().ShouldBeFalse();
+        (await session.Query<AdminUser>().AnyAsync()).ShouldBeFalse();
     }
 
 
@@ -138,10 +138,10 @@ public class query_through_mixed_population_Tests: end_to_end_document_hierarchy
     }
 
     [Fact]
-    public void query_for_only_a_subclass_with_where_clause()
+    public async Task query_for_only_a_subclass_with_where_clause()
     {
         using var session = theStore.IdentitySession();
-        session.Query<AdminUser>().Where(x => x.FirstName == "Eric").Single()
+        (await session.Query<AdminUser>().Where(x => x.FirstName == "Eric").SingleAsync())
             .Id.ShouldBe(admin2.Id);
     }
 }

--- a/src/DocumentDbTests/HierarchicalStorage/query_through_mixed_population_multi_tenanted.cs
+++ b/src/DocumentDbTests/HierarchicalStorage/query_through_mixed_population_multi_tenanted.cs
@@ -36,10 +36,10 @@ public class query_through_mixed_population_multi_tenanted: OneOffConfigurations
     }
 
     [Fact]
-    public void query_tenanted_data_with_any_tenant_predicate()
+    public async Task query_tenanted_data_with_any_tenant_predicate()
     {
         using var session = theStore.QuerySession();
-        var users = session.Query<AdminUser>().Where(u => LinqExtensions.AnyTenant<AdminUser>(u)).ToArray();
-        users.Length.ShouldBeGreaterThan(0);
+        var users = (await session.Query<AdminUser>().Where(u => LinqExtensions.AnyTenant<AdminUser>(u)).ToListAsync());
+        users.Count.ShouldBeGreaterThan(0);
     }
 }

--- a/src/DocumentDbTests/Indexes/computed_indexes.cs
+++ b/src/DocumentDbTests/Indexes/computed_indexes.cs
@@ -18,7 +18,7 @@ namespace DocumentDbTests.Indexes;
 public class computed_indexes: OneOffConfigurationsContext
 {
     [Fact]
-    public void example()
+    public async Task example()
     {
         #region sample_using-a-simple-calculated-index
         var store = DocumentStore.For(_ =>
@@ -31,13 +31,13 @@ public class computed_indexes: OneOffConfigurationsContext
             _.Schema.For<User>().Index(x => x.UserName);
         });
 
-        using (var session = store.QuerySession())
+        await using (var session = store.QuerySession())
         {
             // Postgresql will be able to use the computed
             // index generated from above
-            var somebody = session
+            var somebody = await session
                 .Query<User>()
-                .FirstOrDefault(x => x.UserName == "somebody");
+                .FirstOrDefaultAsync(x => x.UserName == "somebody");
         }
         #endregion
 

--- a/src/DocumentDbTests/Indexes/computed_indexes.cs
+++ b/src/DocumentDbTests/Indexes/computed_indexes.cs
@@ -59,8 +59,8 @@ public class computed_indexes: OneOffConfigurationsContext
         var cmd = session.Query<Target>().Where(x => x.Number == 3)
             .ToCommand();
 
-        session.Query<Target>().Where(x => x.Number == data.First().Number)
-            .Select(x => x.Id).ToList().ShouldContain(data.First().Id);
+        (await session.Query<Target>().Where(x => x.Number == data.First().Number)
+            .Select(x => x.Id).ToListAsync()).ShouldContain(data.First().Id);
     }
 
     [Fact]

--- a/src/DocumentDbTests/Indexes/duplicated_field.cs
+++ b/src/DocumentDbTests/Indexes/duplicated_field.cs
@@ -214,7 +214,7 @@ public class duplicated_field: OneOffConfigurationsContext
 
         var thirdTarget = targets.ElementAt(2);
 
-        var results = theSession.Query<Target>().Where(x => x.Inner.Number == thirdTarget.Inner.Number).ToArray();
+        var results = (await theSession.Query<Target>().Where(x => x.Inner.Number == thirdTarget.Inner.Number).ToListAsync());
         results
             .Any(x => x.Id == thirdTarget.Id).ShouldBeTrue();
     }
@@ -233,7 +233,7 @@ public class duplicated_field: OneOffConfigurationsContext
 
         var thirdTarget = targets.ElementAt(2);
 
-        var results = theSession.Query<Target>().Where(x => x.Inner.Color == thirdTarget.Inner.Color).ToArray();
+        var results = (await theSession.Query<Target>().Where(x => x.Inner.Color == thirdTarget.Inner.Color).ToListAsync());
         results
             .Any(x => x.Id == thirdTarget.Id).ShouldBeTrue();
     }

--- a/src/DocumentDbTests/Indexes/duplicated_field.cs
+++ b/src/DocumentDbTests/Indexes/duplicated_field.cs
@@ -253,7 +253,7 @@ public class duplicated_field: OneOffConfigurationsContext
         var thirdTarget = targets.ElementAt(2);
 
         var queryable = theSession.Query<Target>().Where(x => x.Inner.Date == thirdTarget.Inner.Date);
-        var results = queryable.ToArray();
+        var results = await queryable.ToListAsync();
         results
             .Any(x => x.Id == thirdTarget.Id).ShouldBeTrue();
 

--- a/src/DocumentDbTests/Indexes/full_text_index.cs
+++ b/src/DocumentDbTests/Indexes/full_text_index.cs
@@ -248,9 +248,9 @@ public class full_text_index: OneOffConfigurationsContext
         {
             #region sample_search_in_query_sample
 
-            var posts = session.Query<BlogPost>()
+            var posts = (await session.Query<BlogPost>()
                 .Where(x => x.Search("somefilter"))
-                .ToList();
+                .ToListAsync());
 
             #endregion
 
@@ -277,9 +277,9 @@ public class full_text_index: OneOffConfigurationsContext
         {
             #region sample_plain_search_in_query_sample
 
-            var posts = session.Query<BlogPost>()
+            var posts = (await session.Query<BlogPost>()
                 .Where(x => x.PlainTextSearch("somefilter"))
-                .ToList();
+                .ToListAsync());
 
             #endregion
 
@@ -306,9 +306,9 @@ public class full_text_index: OneOffConfigurationsContext
         {
             #region sample_phrase_search_in_query_sample
 
-            var posts = session.Query<BlogPost>()
+            var posts = (await session.Query<BlogPost>()
                 .Where(x => x.PhraseSearch("somefilter"))
-                .ToList();
+                .ToListAsync());
 
             #endregion
 
@@ -335,9 +335,9 @@ public class full_text_index: OneOffConfigurationsContext
         {
             #region sample_web_search_in_query_sample
 
-            var posts = session.Query<BlogPost>()
+            var posts = (await session.Query<BlogPost>()
                 .Where(x => x.WebStyleSearch("somefilter"))
-                .ToList();
+                .ToListAsync());
 
             #endregion
 
@@ -365,10 +365,10 @@ public class full_text_index: OneOffConfigurationsContext
         {
             #region sample_text_search_combined_with_other_query_sample
 
-            var posts = session.Query<BlogPost>()
+            var posts = (await session.Query<BlogPost>()
                 .Where(x => x.Category == "LifeStyle")
                 .Where(x => x.PhraseSearch("somefilter"))
-                .ToList();
+                .ToListAsync());
 
             #endregion
 
@@ -395,9 +395,9 @@ public class full_text_index: OneOffConfigurationsContext
         {
             #region sample_text_search_with_non_default_regconfig_sample
 
-            var posts = session.Query<BlogPost>()
+            var posts = (await session.Query<BlogPost>()
                 .Where(x => x.PhraseSearch("somefilter", "italian"))
-                .ToList();
+                .ToListAsync());
 
             #endregion
 
@@ -941,16 +941,16 @@ public class full_text_index: OneOffConfigurationsContext
         using (var session = theStore.QuerySession())
         {
             // Standard Search does NOT match a partial prefix of a concatenated word
-            var noMatch = session.Query<BlogPost>()
+            var noMatch = (await session.Query<BlogPost>()
                 .Where(x => x.Search("Priced"))
-                .ToList();
+                .ToListAsync());
 
             noMatch.ShouldBeEmpty();
 
             // PrefixSearch DOES match because it uses the :* prefix operator
-            var results = session.Query<BlogPost>()
+            var results = (await session.Query<BlogPost>()
                 .Where(x => x.PrefixSearch("Priced"))
-                .ToList();
+                .ToListAsync());
 
             results.Count.ShouldBe(1);
             results[0].Id.ShouldBe(expectedId);

--- a/src/DocumentDbTests/Metadata/created_timestamp_queries.cs
+++ b/src/DocumentDbTests/Metadata/created_timestamp_queries.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Marten.Linq.CreatedAt;
 using Weasel.Postgresql.Tables;
 using Xunit;
+using Marten;
 
 namespace DocumentDbTests.Metadata;
 
@@ -52,17 +53,17 @@ public class created_timestamp_queries: OneOffConfigurationsContext
         var epoch = metadata.CreatedAt;
 
         // no where clause
-        session.Query<User>()
+        (await session.Query<User>()
             .Where(x => x.CreatedBefore(epoch))
             .OrderBy(x => x.UserName)
             .Select(x => x.UserName)
-            .ToList()
+            .ToListAsync())
             .ShouldHaveTheSameElementsAs("bar", "foo");
 
         // with a where clause
-        session.Query<User>().Where(x => x.UserName != "bar" && x.CreatedBefore(epoch))
+        (await session.Query<User>().Where(x => x.UserName != "bar" && x.CreatedBefore(epoch))
             .OrderBy(x => x.UserName)
-            .ToList()
+            .ToListAsync())
             .Select(x => x.UserName)
             .Single().ShouldBe("foo");
     }
@@ -87,17 +88,17 @@ public class created_timestamp_queries: OneOffConfigurationsContext
         await session.SaveChangesAsync();
 
         // no where clause
-        session.Query<User>()
+        (await session.Query<User>()
             .Where(x => x.CreatedSince(epoch))
             .OrderBy(x => x.UserName)
             .Select(x => x.UserName)
-            .ToList()
+            .ToListAsync())
             .ShouldHaveTheSameElementsAs("baz", "jack");
 
         // with a where clause
-        session.Query<User>().Where(x => x.UserName != "baz" && x.CreatedSince(epoch))
+        (await session.Query<User>().Where(x => x.UserName != "baz" && x.CreatedSince(epoch))
             .OrderBy(x => x.UserName)
-            .ToList()
+            .ToListAsync())
             .Select(x => x.UserName)
             .Single()
             .ShouldBe("jack");

--- a/src/DocumentDbTests/Metadata/last_modified_queries.cs
+++ b/src/DocumentDbTests/Metadata/last_modified_queries.cs
@@ -69,14 +69,14 @@ public class last_modified_queries: IntegrationContext
         await session.SaveChangesAsync();
 
         // no where clause
-        session.Query<User>().Where(x => x.ModifiedSince(epoch))
+        (await session.Query<User>().Where(x => x.ModifiedSince(epoch))
             .OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("baz", "jack");
+            .ToListAsync()).ShouldHaveTheSameElementsAs("baz", "jack");
 
         // with a where clause
-        session.Query<User>().Where(x => x.UserName != "baz" && x.ModifiedSince(epoch))
+        (await session.Query<User>().Where(x => x.UserName != "baz" && x.ModifiedSince(epoch))
             .OrderBy(x => x.UserName)
-            .ToList()
+            .ToListAsync())
             .Select(x => x.UserName)
             .Single().ShouldBe("jack");
     }
@@ -103,13 +103,13 @@ public class last_modified_queries: IntegrationContext
         var epoch = metadata.LastModified;
 
         // no where clause
-        session.Query<User>().Where(x => x.ModifiedBefore(epoch)).OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("bar", "foo");
+        (await session.Query<User>().Where(x => x.ModifiedBefore(epoch)).OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("bar", "foo");
 
         // with a where clause
-        session.Query<User>().Where(x => x.UserName != "bar" && x.ModifiedBefore(epoch))
+        (await session.Query<User>().Where(x => x.UserName != "bar" && x.ModifiedBefore(epoch))
             .OrderBy(x => x.UserName)
-            .ToList()
+            .ToListAsync())
             .Select(x => x.UserName)
             .Single().ShouldBe("foo");
     }

--- a/src/DocumentDbTests/Metadata/projecting_metadata_to_documents.cs
+++ b/src/DocumentDbTests/Metadata/projecting_metadata_to_documents.cs
@@ -128,7 +128,7 @@ namespace DocumentDbTests.Metadata
             using (var session = theStore.LightweightSession())
             {
                 IncludedDocWithMeta loadedInclude = null;
-                var loaded = session.Query<DocWithMeta>().Include<IncludedDocWithMeta>(d => d.IncludedDocId, i => loadedInclude = i).Single(d => d.Id == doc.Id);
+                var loaded = (await session.Query<DocWithMeta>().Include<IncludedDocWithMeta>(d => d.IncludedDocId, i => loadedInclude = i).SingleAsync(d => d.Id == doc.Id));
 
                 loaded.ShouldNotBeNull();
 
@@ -199,7 +199,7 @@ namespace DocumentDbTests.Metadata
 
             await using (var session = theStore.LightweightSession(tenant))
             {
-                session.Query<DocWithMeta>().Count(d => d.TenantId == tenant).ShouldBe(1);
+                (await session.Query<DocWithMeta>().CountAsync(d => d.TenantId == tenant)).ShouldBe(1);
 
                 var loaded = await session.Query<DocWithMeta>().Where(d => d.Id == doc.Id).FirstOrDefaultAsync();
                 ShouldBeStringTestExtensions.ShouldBe(loaded.TenantId, tenant);
@@ -227,7 +227,7 @@ namespace DocumentDbTests.Metadata
             await theStore.BulkInsertAsync(tenant, new[] { doc });
 
             await using var session = theStore.QuerySession(tenant);
-            session.Query<DocWithMeta>().Count(d => d.TenantId == tenant).ShouldBe(1);
+            (await session.Query<DocWithMeta>().CountAsync(d => d.TenantId == tenant)).ShouldBe(1);
 
             var loaded = await session.Query<DocWithMeta>().Where(d => d.Id == doc.Id).FirstOrDefaultAsync();
             loaded.TenantId.ShouldBe(tenant);
@@ -264,14 +264,14 @@ namespace DocumentDbTests.Metadata
 
             using (var session = theStore.IdentitySession())
             {
-                session.Query<DocWithMeta>().Count(d => d.DocType == "BASE").ShouldBe(1);
-                session.Query<DocWithMeta>().Count(d => d.DocType == "blue_doc_with_meta").ShouldBe(1);
-                session.Query<DocWithMeta>().Count(d => d.DocType == "red_doc_with_meta").ShouldBe(1);
-                session.Query<DocWithMeta>().Count(d => d.DocType == "green_doc_with_meta").ShouldBe(1);
-                session.Query<DocWithMeta>().Count(d => d.DocType == "emerald_green_doc_with_meta").ShouldBe(1);
+                (await session.Query<DocWithMeta>().CountAsync(d => d.DocType == "BASE")).ShouldBe(1);
+                (await session.Query<DocWithMeta>().CountAsync(d => d.DocType == "blue_doc_with_meta")).ShouldBe(1);
+                (await session.Query<DocWithMeta>().CountAsync(d => d.DocType == "red_doc_with_meta")).ShouldBe(1);
+                (await session.Query<DocWithMeta>().CountAsync(d => d.DocType == "green_doc_with_meta")).ShouldBe(1);
+                (await session.Query<DocWithMeta>().CountAsync(d => d.DocType == "emerald_green_doc_with_meta")).ShouldBe(1);
 
 
-                var redDocs = session.Query<RedDocWithMeta>().ToList();
+                var redDocs = (await session.Query<RedDocWithMeta>().ToListAsync());
                 redDocs.Count.ShouldBe(1);
                 ShouldBeStringTestExtensions.ShouldBe(redDocs.First().DocType, "red_doc_with_meta");
                 session.Delete(redDocs.First());
@@ -297,7 +297,7 @@ namespace DocumentDbTests.Metadata
             }
 
             using var session = theStore.QuerySession();
-            session.Query<AttVersionedDoc>().Count(d => d.Version != Guid.Empty).ShouldBe(100);
+            (await session.Query<AttVersionedDoc>().CountAsync(d => d.Version != Guid.Empty)).ShouldBe(100);
         }
 
         [Fact]
@@ -317,7 +317,7 @@ namespace DocumentDbTests.Metadata
             }
 
             using var session = theStore.QuerySession();
-            session.Query<PropVersionedDoc>().Count(d => d.Version != Guid.Empty).ShouldBe(100);
+            (await session.Query<PropVersionedDoc>().CountAsync(d => d.Version != Guid.Empty)).ShouldBe(100);
         }
     }
 

--- a/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs
+++ b/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs
@@ -278,33 +278,33 @@ public class conjoined_multi_tenancy: StoreContext<MultiTenancyFixture>, IClassF
         using (var session = store.QuerySession("Green"))
         {
             // Query tenanted document as the tenant passed in session
-            session.Query<Target>().Count().ShouldBe(10);
+            (await session.Query<Target>().CountAsync()).ShouldBe(10);
 
             // Query non-tenanted documents
-            session.Query<User>().Count().ShouldBe(2);
+            (await session.Query<User>().CountAsync()).ShouldBe(2);
 
             // Query documents in default tenant from a session using tenant Green
-            session.Query<Issue>().Count(x => x.TenantIsOneOf(StorageConstants.DefaultTenantId)).ShouldBe(2);
+            (await session.Query<Issue>().CountAsync(x => x.TenantIsOneOf(StorageConstants.DefaultTenantId))).ShouldBe(2);
 
             // Query documents from tenant Red from a session using tenant Green
-            session.Query<Target>().Count(x => x.TenantIsOneOf("Red")).ShouldBe(11);
+            (await session.Query<Target>().CountAsync(x => x.TenantIsOneOf("Red"))).ShouldBe(11);
         }
 
         // create a session without passing any tenant, session will use default tenant
         using (var session = store.QuerySession())
         {
             // Query non-tenanted documents
-            session.Query<User>().Count().ShouldBe(2);
+            (await session.Query<User>().CountAsync()).ShouldBe(2);
 
             // Query documents in default tenant
             // Note that session is using default tenant
-            session.Query<Issue>().Count().ShouldBe(2);
+            (await session.Query<Issue>().CountAsync()).ShouldBe(2);
 
             // Query documents on tenant Green
-            session.Query<Target>().Count(x => x.TenantIsOneOf("Green")).ShouldBe(10);
+            (await session.Query<Target>().CountAsync(x => x.TenantIsOneOf("Green"))).ShouldBe(10);
 
             // Query documents on tenant Red
-            session.Query<Target>().Count(x => x.TenantIsOneOf("Red")).ShouldBe(11);
+            (await session.Query<Target>().CountAsync(x => x.TenantIsOneOf("Red"))).ShouldBe(11);
         }
 
         #endregion
@@ -512,17 +512,17 @@ public class conjoined_multi_tenancy: StoreContext<MultiTenancyFixture>, IClassF
 
         await using (var red = theStore.QuerySession("Red"))
         {
-            red.Query<Target>().Count().ShouldBe(50);
+            (await red.Query<Target>().CountAsync()).ShouldBe(50);
         }
 
         await using (var green = theStore.QuerySession("Green"))
         {
-            green.Query<Target>().Count().ShouldBe(75);
+            (await green.Query<Target>().CountAsync()).ShouldBe(75);
         }
 
         await using (var blue = theStore.QuerySession("Blue"))
         {
-            blue.Query<Target>().Count().ShouldBe(25);
+            (await blue.Query<Target>().CountAsync()).ShouldBe(25);
         }
     }
 
@@ -547,17 +547,17 @@ public class conjoined_multi_tenancy: StoreContext<MultiTenancyFixture>, IClassF
 
         using (var red = theStore.QuerySession("Red"))
         {
-            red.Query<Target>().Count().ShouldBe(50);
+            (await red.Query<Target>().CountAsync()).ShouldBe(50);
         }
 
         using (var green = theStore.QuerySession("Green"))
         {
-            green.Query<Target>().Count().ShouldBe(75);
+            (await green.Query<Target>().CountAsync()).ShouldBe(75);
         }
 
         using (var blue = theStore.QuerySession("Blue"))
         {
-            blue.Query<Target>().Count().ShouldBe(25);
+            (await blue.Query<Target>().CountAsync()).ShouldBe(25);
         }
     }
 

--- a/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs
+++ b/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs
@@ -333,8 +333,8 @@ public class conjoined_multi_tenancy: StoreContext<MultiTenancyFixture>, IClassF
             #region sample_any_tenant
 
             // query data across all tenants
-            var actual = query.Query<Target>().Where(x => x.AnyTenant() && x.Flag)
-                .OrderBy(x => x.Id).Select(x => x.Id).ToArray();
+            var actual =(await  query.Query<Target>().Where(x => x.AnyTenant() && x.Flag)
+                .OrderBy(x => x.Id).Select(x => x.Id).ToListAsync());
 
             #endregion
 
@@ -360,8 +360,8 @@ public class conjoined_multi_tenancy: StoreContext<MultiTenancyFixture>, IClassF
 
         using (var query = theStore.QuerySession())
         {
-            var actual = query.Query<Target>().Where(x => x.AnyTenant() && x.Flag && x.String != null)
-                .OrderBy(x => x.Id).Select(x => x.Id).ToArray();
+            var actual =(await  query.Query<Target>().Where(x => x.AnyTenant() && x.Flag && x.String != null)
+                .OrderBy(x => x.Id).Select(x => x.Id).ToListAsync());
 
             actual.ShouldHaveTheSameElementsAs(expected);
         }

--- a/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs
+++ b/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -475,17 +476,17 @@ public class conjoined_multi_tenancy: StoreContext<MultiTenancyFixture>, IClassF
         await theStore.BulkInsertAsync("Red", reds);
         await theStore.BulkInsertAsync("Green", greens);
 
-        Guid[] actualReds = null;
-        Guid[] actualGreens = null;
+        IReadOnlyList<Guid> actualReds = null;
+        IReadOnlyList<Guid> actualGreens = null;
 
         using (var query = theStore.QuerySession("Red"))
         {
-            actualReds = query.Query<Target>().Select(x => x.Id).ToArray();
+            actualReds = await query.Query<Target>().Select(x => x.Id).ToListAsync();
         }
 
         using (var query = theStore.QuerySession("Green"))
         {
-            actualGreens = query.Query<Target>().Select(x => x.Id).ToArray();
+            actualGreens = await query.Query<Target>().Select(x => x.Id).ToListAsync();
         }
 
         actualGreens.Intersect(actualReds).Any().ShouldBeFalse();

--- a/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs
+++ b/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs
@@ -363,8 +363,8 @@ public class conjoined_multi_tenancy_with_partitioning: OneOffConfigurationsCont
             #region sample_any_tenant
 
             // query data across all tenants
-            var actual = query.Query<Target>().Where(x => x.AnyTenant() && x.Flag)
-                .OrderBy(x => x.Id).Select(x => x.Id).ToArray();
+            var actual =(await  query.Query<Target>().Where(x => x.AnyTenant() && x.Flag)
+                .OrderBy(x => x.Id).Select(x => x.Id).ToListAsync());
 
             #endregion
 
@@ -390,8 +390,8 @@ public class conjoined_multi_tenancy_with_partitioning: OneOffConfigurationsCont
 
         using (var query = theStore.QuerySession())
         {
-            var actual = query.Query<Target>().Where(x => x.AnyTenant() && x.Flag && x.String != null)
-                .OrderBy(x => x.Id).Select(x => x.Id).ToArray();
+            var actual =(await  query.Query<Target>().Where(x => x.AnyTenant() && x.Flag && x.String != null)
+                .OrderBy(x => x.Id).Select(x => x.Id).ToListAsync());
 
             actual.ShouldHaveTheSameElementsAs(expected);
         }

--- a/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs
+++ b/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs
@@ -308,33 +308,33 @@ public class conjoined_multi_tenancy_with_partitioning: OneOffConfigurationsCont
         using (var session = store.QuerySession("Green"))
         {
             // Query tenanted document as the tenant passed in session
-            session.Query<Target>().Count().ShouldBe(10);
+            (await session.Query<Target>().CountAsync()).ShouldBe(10);
 
             // Query non-tenanted documents
-            session.Query<User>().Count().ShouldBe(2);
+            (await session.Query<User>().CountAsync()).ShouldBe(2);
 
             // Query documents in default tenant from a session using tenant Green
-            session.Query<Issue>().Count(x => x.TenantIsOneOf(StorageConstants.DefaultTenantId)).ShouldBe(2);
+            (await session.Query<Issue>().CountAsync(x => x.TenantIsOneOf(StorageConstants.DefaultTenantId))).ShouldBe(2);
 
             // Query documents from tenant Red from a session using tenant Green
-            session.Query<Target>().Count(x => x.TenantIsOneOf("Red")).ShouldBe(11);
+            (await session.Query<Target>().CountAsync(x => x.TenantIsOneOf("Red"))).ShouldBe(11);
         }
 
         // create a session without passing any tenant, session will use default tenant
         using (var session = store.QuerySession())
         {
             // Query non-tenanted documents
-            session.Query<User>().Count().ShouldBe(2);
+            (await session.Query<User>().CountAsync()).ShouldBe(2);
 
             // Query documents in default tenant
             // Note that session is using default tenant
-            session.Query<Issue>().Count().ShouldBe(2);
+            (await session.Query<Issue>().CountAsync()).ShouldBe(2);
 
             // Query documents on tenant Green
-            session.Query<Target>().Count(x => x.TenantIsOneOf("Green")).ShouldBe(10);
+            (await session.Query<Target>().CountAsync(x => x.TenantIsOneOf("Green"))).ShouldBe(10);
 
             // Query documents on tenant Red
-            session.Query<Target>().Count(x => x.TenantIsOneOf("Red")).ShouldBe(11);
+            (await session.Query<Target>().CountAsync(x => x.TenantIsOneOf("Red"))).ShouldBe(11);
         }
 
         #endregion
@@ -542,17 +542,17 @@ public class conjoined_multi_tenancy_with_partitioning: OneOffConfigurationsCont
 
         await using (var red = theStore.QuerySession("Red"))
         {
-            red.Query<Target>().Count().ShouldBe(50);
+            (await red.Query<Target>().CountAsync()).ShouldBe(50);
         }
 
         await using (var green = theStore.QuerySession("Green"))
         {
-            green.Query<Target>().Count().ShouldBe(75);
+            (await green.Query<Target>().CountAsync()).ShouldBe(75);
         }
 
         await using (var blue = theStore.QuerySession("Blue"))
         {
-            blue.Query<Target>().Count().ShouldBe(25);
+            (await blue.Query<Target>().CountAsync()).ShouldBe(25);
         }
     }
 
@@ -577,17 +577,17 @@ public class conjoined_multi_tenancy_with_partitioning: OneOffConfigurationsCont
 
         using (var red = theStore.QuerySession("Red"))
         {
-            red.Query<Target>().Count().ShouldBe(50);
+            (await red.Query<Target>().CountAsync()).ShouldBe(50);
         }
 
         using (var green = theStore.QuerySession("Green"))
         {
-            green.Query<Target>().Count().ShouldBe(75);
+            (await green.Query<Target>().CountAsync()).ShouldBe(75);
         }
 
         using (var blue = theStore.QuerySession("Blue"))
         {
-            blue.Query<Target>().Count().ShouldBe(25);
+            (await blue.Query<Target>().CountAsync()).ShouldBe(25);
         }
     }
 

--- a/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs
+++ b/src/DocumentDbTests/MultiTenancy/conjoined_multi_tenancy_with_partitioning.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using JasperFx;
@@ -505,17 +506,17 @@ public class conjoined_multi_tenancy_with_partitioning: OneOffConfigurationsCont
         await theStore.BulkInsertAsync("Red", reds);
         await theStore.BulkInsertAsync("Green", greens);
 
-        Guid[] actualReds = null;
-        Guid[] actualGreens = null;
+        IReadOnlyList<Guid> actualReds = null;
+        IReadOnlyList<Guid> actualGreens = null;
 
         using (var query = theStore.QuerySession("Red"))
         {
-            actualReds = query.Query<Target>().Select(x => x.Id).ToArray();
+            actualReds = await query.Query<Target>().Select(x => x.Id).ToListAsync();
         }
 
         using (var query = theStore.QuerySession("Green"))
         {
-            actualGreens = query.Query<Target>().Select(x => x.Id).ToArray();
+            actualGreens = await query.Query<Target>().Select(x => x.Id).ToListAsync();
         }
 
         actualGreens.Intersect(actualReds).Any().ShouldBeFalse();

--- a/src/DocumentDbTests/Reading/BatchedQuerying/batched_querying_acceptance_Tests.cs
+++ b/src/DocumentDbTests/Reading/BatchedQuerying/batched_querying_acceptance_Tests.cs
@@ -65,7 +65,7 @@ public class batched_querying_acceptance_Tests: OneOffConfigurationsContext, IAs
         return Task.CompletedTask;
     }
 
-    public void sample_config()
+    public async Task sample_config()
     {
         #region sample_configure-hierarchy-of-types
 
@@ -84,10 +84,10 @@ public class batched_querying_acceptance_Tests: OneOffConfigurationsContext, IAs
         using (var session = store.QuerySession())
         {
             // query for all types of User and User itself
-            session.Query<User>().ToList();
+            await session.Query<User>().ToListAsync();
 
             // query for only SuperUser
-            session.Query<SuperUser>().ToList();
+            await session.Query<SuperUser>().ToListAsync();
         }
 
         #endregion

--- a/src/DocumentDbTests/Reading/query_by_sql.cs
+++ b/src/DocumentDbTests/Reading/query_by_sql.cs
@@ -374,7 +374,7 @@ where data ->> 'FirstName' = 'Jeremy'")).Single();
         session.Store(u);
         await session.SaveChangesAsync();
 
-        var user = session.Query<User>().Where(x => x.MatchesSql("data->> 'FirstName' = ?", "Eric")).Single();
+        var user = (await session.Query<User>().Where(x => x.MatchesSql("data->> 'FirstName' = ?", "Eric")).SingleAsync());
         user.LastName.ShouldBe("Smith");
         user.Id.ShouldBe(u.Id);
     }

--- a/src/DocumentDbTests/SessionMechanics/UnitOfWork_Operation_Ordering_Tests.cs
+++ b/src/DocumentDbTests/SessionMechanics/UnitOfWork_Operation_Ordering_Tests.cs
@@ -331,9 +331,9 @@ public class UnitOfWork_Operation_Ordering_Tests: OneOffConfigurationsContext, I
 
         using (var s = theStore.QuerySession("Bug_1229"))
         {
-            var companies = s.Query<Company>().ToList();
-            var users = s.Query<User>().ToList();
-            var issues = s.Query<Issue>().ToList();
+            var companies = (await s.Query<Company>().ToListAsync());
+            var users = (await s.Query<User>().ToListAsync());
+            var issues = (await s.Query<Issue>().ToListAsync());
 
             companies.Count.ShouldBe(expectedCompanyCount);
             users.Count.ShouldBe(expectedUserCount);

--- a/src/DocumentDbTests/SessionMechanics/Using_Global_DocumentSessionListener_Tests.cs
+++ b/src/DocumentDbTests/SessionMechanics/Using_Global_DocumentSessionListener_Tests.cs
@@ -8,6 +8,7 @@ using Npgsql;
 using Shouldly;
 using Weasel.Core;
 using Xunit;
+using Marten;
 
 namespace DocumentDbTests.SessionMechanics;
 
@@ -209,7 +210,7 @@ public class Using_Global_DocumentSessionListener_Tests : OneOffConfigurationsCo
 
             using (var session = store.LightweightSession())
             {
-                var users = session.Query<User>().ToList();
+                var users = (await session.Query<User>().ToListAsync());
 
                 stub1.LoadedDocuments.ShouldContainKeyAndValue(user1.Id, users.FirstOrDefault(where => where.Id == user1.Id));
                 stub1.LoadedDocuments.ShouldContainKeyAndValue(user2.Id, users.FirstOrDefault(where => where.Id == user2.Id));
@@ -346,7 +347,7 @@ public class Using_Global_DocumentSessionListener_Tests : OneOffConfigurationsCo
 
             using (var session = store.DirtyTrackedSession())
             {
-                var users = session.Query<User>().ToList();
+                var users = (await session.Query<User>().ToListAsync());
 
                 stub1.LoadedDocuments.ShouldContainKeyAndValue(user1.Id, users.FirstOrDefault(where => where.Id == user1.Id));
                 stub1.LoadedDocuments.ShouldContainKeyAndValue(user2.Id, users.FirstOrDefault(where => where.Id == user2.Id));

--- a/src/DocumentDbTests/SessionMechanics/Using_Local_DocumentSessionListener_Tests.cs
+++ b/src/DocumentDbTests/SessionMechanics/Using_Local_DocumentSessionListener_Tests.cs
@@ -200,7 +200,7 @@ public class Using_Local_DocumentSessionListener_Tests: OneOffConfigurationsCont
 
             using (var session = store.LightweightSession(new SessionOptions { Listeners = { stub1, stub2 } }))
             {
-                var users = session.Query<User>().ToList();
+                var users = (await session.Query<User>().ToListAsync());
 
                 stub1.LoadedDocuments.ShouldContainKeyAndValue(user1.Id,
                     users.FirstOrDefault(where => where.Id == user1.Id));
@@ -329,7 +329,7 @@ public class Using_Local_DocumentSessionListener_Tests: OneOffConfigurationsCont
 
             using (var session = store.DirtyTrackedSession(new SessionOptions { Listeners = { stub1, stub2 } }))
             {
-                var users = session.Query<User>().ToList();
+                var users = (await session.Query<User>().ToListAsync());
 
                 stub1.LoadedDocuments.ShouldContainKeyAndValue(user1.Id,
                     users.FirstOrDefault(where => where.Id == user1.Id));

--- a/src/DocumentDbTests/SessionMechanics/ejecting_documents.cs
+++ b/src/DocumentDbTests/SessionMechanics/ejecting_documents.cs
@@ -227,9 +227,9 @@ public class ejecting_documents : IntegrationContext
 
         using (var session = theStore.QuerySession())
         {
-            session.Query<Target>().ShouldBeEmpty();
-            session.LoadAsync<User>(user1.Id).ShouldNotBeNull();
-            session.LoadAsync<User>(user2.Id).ShouldNotBeNull();
+            (await session.Query<Target>().ToListAsync()).ShouldBeEmpty();
+            (await session.LoadAsync<User>(user1.Id)).ShouldNotBeNull();
+            (await session.LoadAsync<User>(user2.Id)).ShouldNotBeNull();
         }
     }
 
@@ -296,9 +296,9 @@ public class ejecting_documents : IntegrationContext
 
         using (var session = theStore.QuerySession())
         {
-            session.Query<Target>().ShouldBeEmpty();
-            session.LoadAsync<User>(user1.Id).ShouldNotBeNull();
-            session.LoadAsync<User>(user2.Id).ShouldNotBeNull();
+            (await session.Query<Target>().ToListAsync()).ShouldBeEmpty();
+            (await session.LoadAsync<User>(user1.Id)).ShouldNotBeNull();
+            (await session.LoadAsync<User>(user2.Id)).ShouldNotBeNull();
         }
     }
 
@@ -362,9 +362,9 @@ public class ejecting_documents : IntegrationContext
 
         using (var session = theStore.QuerySession())
         {
-            session.Query<Target>().ShouldBeEmpty();
-            session.LoadAsync<User>(user1.Id).ShouldNotBeNull();
-            session.LoadAsync<User>(user2.Id).ShouldNotBeNull();
+            (await session.Query<Target>().ToListAsync()).ShouldBeEmpty();
+            (await session.LoadAsync<User>(user1.Id)).ShouldNotBeNull();
+            (await session.LoadAsync<User>(user2.Id)).ShouldNotBeNull();
         }
     }
 

--- a/src/DocumentDbTests/SessionMechanics/ejecting_documents.cs
+++ b/src/DocumentDbTests/SessionMechanics/ejecting_documents.cs
@@ -4,6 +4,7 @@ using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Xunit;
 using Shouldly;
+using Marten;
 
 namespace DocumentDbTests.SessionMechanics;
 
@@ -97,7 +98,7 @@ public class ejecting_documents : IntegrationContext
 
         using (var session = theStore.QuerySession())
         {
-            session.Query<Target>().Single()
+            (await session.Query<Target>().SingleAsync())
                 .Id.ShouldBe(target1.Id);
         }
     }
@@ -119,7 +120,7 @@ public class ejecting_documents : IntegrationContext
 
         using (var session = theStore.QuerySession())
         {
-            session.Query<Target>().Single()
+            (await session.Query<Target>().SingleAsync())
                 .Id.ShouldBe(target1.Id);
         }
     }
@@ -141,7 +142,7 @@ public class ejecting_documents : IntegrationContext
 
         using (var session = theStore.QuerySession())
         {
-            session.Query<Target>().Single()
+            (await session.Query<Target>().SingleAsync())
                 .Id.ShouldBe(target1.Id);
         }
     }

--- a/src/DocumentDbTests/SessionMechanics/identity_map_mechanics.cs
+++ b/src/DocumentDbTests/SessionMechanics/identity_map_mechanics.cs
@@ -58,7 +58,7 @@ public class identity_map_mechanics: IntegrationContext
 
         using (var session2 = theStore.DirtyTrackedSession())
         {
-            var users = session2.Query<User>().Where(x => x.FirstName == "James").ToList();
+            var users = (await session2.Query<User>().Where(x => x.FirstName == "James").ToListAsync());
 
             foreach (var user in users)
             {
@@ -70,7 +70,7 @@ public class identity_map_mechanics: IntegrationContext
 
         using (var session2 = theStore.IdentitySession())
         {
-            var users = session2.Query<User>().Where(x => x.FirstName == "James").OrderBy(x => x.LastName).ToList();
+            var users = (await session2.Query<User>().Where(x => x.FirstName == "James").OrderBy(x => x.LastName).ToListAsync());
 
             users.Select(x => x.LastName)
                 .ShouldHaveTheSameElementsAs("Worthy 1 - updated", "Worthy 2 - updated", "Worthy 3 - updated");
@@ -94,7 +94,7 @@ public class identity_map_mechanics: IntegrationContext
 
         using (var session2 = theStore.DirtyTrackedSession())
         {
-            var users = session2.Query<User>().Where(x => x.FirstName == "James").ToList();
+            var users = (await session2.Query<User>().Where(x => x.FirstName == "James").ToListAsync());
 
             foreach (var user in users)
             {
@@ -106,7 +106,7 @@ public class identity_map_mechanics: IntegrationContext
 
         using (var session2 = theStore.IdentitySession())
         {
-            var users = session2.Query<User>().Where(x => x.FirstName == "James").OrderBy(x => x.LastName).ToList();
+            var users = (await session2.Query<User>().Where(x => x.FirstName == "James").OrderBy(x => x.LastName).ToListAsync());
 
             users.Select(x => x.LastName)
                 .ShouldHaveTheSameElementsAs("Worthy 1 - updated", "Worthy 2 - updated", "Worthy 3 - updated");

--- a/src/DocumentDbTests/SessionMechanics/updating_by_batch.cs
+++ b/src/DocumentDbTests/SessionMechanics/updating_by_batch.cs
@@ -21,7 +21,7 @@ public class updating_by_batch : OneOffConfigurationsContext
         session.Store(targets);
         await session.SaveChangesAsync();
 
-        session.Query<Target>().Count().ShouldBe(100);
+        (await session.Query<Target>().CountAsync()).ShouldBe(100);
     }
 
 
@@ -54,7 +54,7 @@ public class updating_by_batch : OneOffConfigurationsContext
 
         await session.SaveChangesAsync();
 
-        session.Query<Target>().Count().ShouldBe(100);
+        (await session.Query<Target>().CountAsync()).ShouldBe(100);
     }
 
     [Fact]

--- a/src/DocumentDbTests/Writing/Identity/Sequences/CombGuidIdGenerationTests.cs
+++ b/src/DocumentDbTests/Writing/Identity/Sequences/CombGuidIdGenerationTests.cs
@@ -64,7 +64,7 @@ public class CombGuidIdGenerationTests: OneOffConfigurationsContext
         Thread.Sleep(4);
         await StoreUser(theStore, "User3");
 
-        var users = GetUsers(theStore);
+        var users = await GetUsers(theStore);
 
         var id1 = FormatIdAsByteArrayString(users, "User1");
         var id2 = FormatIdAsByteArrayString(users, "User2");
@@ -102,7 +102,7 @@ public class CombGuidIdGenerationTests: OneOffConfigurationsContext
         roundtrip.ToUnixTimeMilliseconds().ShouldBe(timestamp.ToUnixTimeMilliseconds());
     }
 
-    private static string FormatIdAsByteArrayString(UserWithGuid[] users, string user1)
+    private static string FormatIdAsByteArrayString(IReadOnlyList<UserWithGuid> users, string user1)
     {
         var id = users.Single(user => user.LastName == user1).Id;
         return Format(id);
@@ -113,10 +113,10 @@ public class CombGuidIdGenerationTests: OneOffConfigurationsContext
         return id.ToString();
     }
 
-    private static UserWithGuid[] GetUsers(IDocumentStore documentStore)
+    private static async Task<IReadOnlyList<UserWithGuid>> GetUsers(IDocumentStore documentStore)
     {
-        using var session = documentStore.QuerySession();
-        return session.Query<UserWithGuid>().ToArray();
+        await using var session = documentStore.QuerySession();
+        return await session.Query<UserWithGuid>().ToListAsync();
     }
 
     private static async Task StoreUser(IDocumentStore documentStore, string lastName)

--- a/src/DocumentDbTests/Writing/Identity/Sequences/CustomKeyGenerationTests.cs
+++ b/src/DocumentDbTests/Writing/Identity/Sequences/CustomKeyGenerationTests.cs
@@ -6,6 +6,7 @@ using JasperFx.Core;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.Core.Reflection;
+using Marten;
 using Marten.Schema;
 using Marten.Schema.Identity;
 using Marten.Testing.Harness;
@@ -55,7 +56,7 @@ public class CustomKeyGenerationTests : OneOffConfigurationsContext
 
         using (var session1 = theStore.QuerySession())
         {
-            var users = session1.Query<UserWithString>().ToArray();
+            var users = (await session1.Query<UserWithString>().ToListAsync());
             users.Single(user => user.LastName == "last").Id.ShouldBe("newId");
         }
         #endregion

--- a/src/DocumentDbTests/Writing/Identity/Sequences/IdentityKeyGenerationTests.cs
+++ b/src/DocumentDbTests/Writing/Identity/Sequences/IdentityKeyGenerationTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten;
@@ -21,7 +22,7 @@ public class IdentityKeyGenerationTests : OneOffConfigurationsContext
         await StoreUser(theStore, "User2");
         await StoreUser(theStore, "User3");
 
-        var users = GetUsers(theStore);
+        var users = await GetUsers(theStore);
 
         GetId(users, "User1").ShouldBe("userwithstring/1");
         GetId(users, "User2").ShouldBe("userwithstring/2");
@@ -52,15 +53,15 @@ public class IdentityKeyGenerationTests : OneOffConfigurationsContext
         #endregion
     }
 
-    private static string GetId(UserWithString[] users, string user1)
+    private static string GetId(IReadOnlyList<UserWithString> users, string user1)
     {
         return users.Single(user => user.LastName == user1).Id;
     }
 
-    private static UserWithString[] GetUsers(IDocumentStore documentStore)
+    private static async Task<IReadOnlyList<UserWithString>> GetUsers(IDocumentStore documentStore)
     {
-        using var session = documentStore.QuerySession();
-        return session.Query<UserWithString>().ToArray();
+        await using var session = documentStore.QuerySession();
+        return await session.Query<UserWithString>().ToListAsync();
     }
 
     private static async Task StoreUser(IDocumentStore documentStore, string lastName)

--- a/src/DocumentDbTests/Writing/bulk_loading.cs
+++ b/src/DocumentDbTests/Writing/bulk_loading.cs
@@ -34,7 +34,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         await theStore.BulkInsertAsync(data2, BulkInsertMode.IgnoreDuplicates);
 
         using var session = theStore.QuerySession();
-        session.Query<Target>().Count().ShouldBe(data1.Length + data2.Length - 5);
+        (await session.Query<Target>().CountAsync()).ShouldBe(data1.Length + data2.Length - 5);
 
         for (var i = 0; i < 5; i++)
         {
@@ -49,7 +49,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
 
         await theStore.BulkInsertAsync(data, batchSize: 15);
 
-        theSession.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
 
         (await theSession.LoadAsync<Target>(data[0].Id)).ShouldNotBeNull();
     }
@@ -73,7 +73,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         await theStore.BulkInsertAsync(data2, BulkInsertMode.OverwriteExisting);
 
         using var session = theStore.QuerySession();
-        session.Query<Target>().Count().ShouldBe(data1.Length + data2.Length - 5);
+        (await session.Query<Target>().CountAsync()).ShouldBe(data1.Length + data2.Length - 5);
 
         // Values were overwritten
         for (var i = 0; i < 5; i++)
@@ -100,7 +100,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         await theStore.BulkInsertAsync(data, batchSize: 500);
 
         // And just checking that the data is actually there;)
-        theSession.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
         #endregion
 
         (await theSession.LoadAsync<Target>(data[0].Id)).ShouldNotBeNull();
@@ -118,9 +118,9 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
 
         await theStore.BulkInsertAsync(data);
 
-        theSession.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
 
-        theSession.Query<Target>().Any(x => x.Date == data[0].Date)
+        (await theSession.Query<Target>().AnyAsync(x => x.Date == data[0].Date))
             .ShouldBeTrue();
     }
 
@@ -133,9 +133,9 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
 
         await theStore.BulkInsertAsync(data);
 
-        theSession.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
 
-        theSession.Query<Target>().Any(x => x.String == data[0].String)
+        (await theSession.Query<Target>().AnyAsync(x => x.String == data[0].String))
             .ShouldBeTrue();
     }
 
@@ -148,7 +148,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         await theStore.BulkInsertAsync(data, BulkInsertMode.IgnoreDuplicates);
         #endregion
 
-        theSession.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
 
         (await theSession.LoadAsync<Target>(data[0].Id)).ShouldNotBeNull();
 
@@ -168,7 +168,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         await theStore.BulkInsertAsync(data, BulkInsertMode.OverwriteExisting);
         #endregion
 
-        theSession.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
 
         (await theSession.LoadAsync<Target>(data[0].Id)).ShouldNotBeNull();
     }
@@ -192,7 +192,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         await theStore.BulkInsertAsync(data2, BulkInsertMode.IgnoreDuplicates);
 
         await using var session = theStore.QuerySession();
-        session.Query<Target>().Count().ShouldBe(data1.Length + data2.Length - 5);
+        (await session.Query<Target>().CountAsync()).ShouldBe(data1.Length + data2.Length - 5);
 
         for (var i = 0; i < 5; i++)
         {
@@ -207,7 +207,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
 
         await theStore.BulkInsertAsync(data, batchSize: 15);
 
-        theSession.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
 
         (await theSession.LoadAsync<Target>(data[0].Id)).ShouldNotBeNull();
     }
@@ -231,7 +231,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         await theStore.BulkInsertAsync(data2, BulkInsertMode.OverwriteExisting);
 
         await using var session = theStore.QuerySession();
-        session.Query<Target>().Count().ShouldBe(data1.Length + data2.Length - 5);
+        (await session.Query<Target>().CountAsync()).ShouldBe(data1.Length + data2.Length - 5);
 
         // Values were overwritten
         for (var i = 0; i < 5; i++)
@@ -258,7 +258,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         await theStore.BulkInsertAsync(data, batchSize: 500);
 
         // And just checking that the data is actually there;)
-        theSession.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
         #endregion
 
         (await theSession.LoadAsync<Target>(data[0].Id)).ShouldNotBeNull();
@@ -283,9 +283,9 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         var tenant1Session = theStore.QuerySession(tenant1);
         var tenant2Session = theStore.QuerySession(tenant2);
 
-        theSession.Query<Target>().Where(x => x.AnyTenant()).Count().ShouldBe(data.Length * 2);
-        tenant1Session.Query<Target>().Count().ShouldBe(data.Length);
-        tenant2Session.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().Where(x => x.AnyTenant()).CountAsync()).ShouldBe(data.Length * 2);
+        (await tenant1Session.Query<Target>().CountAsync()).ShouldBe(data.Length);
+        (await tenant2Session.Query<Target>().CountAsync()).ShouldBe(data.Length);
 
         (await tenant1Session.LoadAsync<Target>(data[0].Id)).ShouldNotBeNull();
         (await tenant2Session.LoadAsync<Target>(data[0].Id)).ShouldNotBeNull();
@@ -303,11 +303,11 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
 
         await theStore.BulkInsertAsync(data);
 
-        theSession.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
 
         var cmd = theSession.Query<Target>().Where(x => x.Date == data[0].Date).ToCommand();
 
-        theSession.Query<Target>().Any(x => x.Date == data[0].Date)
+        (await theSession.Query<Target>().AnyAsync(x => x.Date == data[0].Date))
             .ShouldBeTrue();
     }
 
@@ -320,9 +320,9 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
 
         await theStore.BulkInsertAsync(data);
 
-        theSession.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
 
-        theSession.Query<Target>().Any(x => x.String == data[0].String)
+        (await theSession.Query<Target>().AnyAsync(x => x.String == data[0].String))
             .ShouldBeTrue();
     }
 
@@ -387,7 +387,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         await theStore.BulkInsertAsync(data, BulkInsertMode.IgnoreDuplicates);
         #endregion
 
-        theSession.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
 
         (await theSession.LoadAsync<Target>(data[0].Id)).ShouldNotBeNull();
 
@@ -407,7 +407,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         await theStore.BulkInsertAsync(data, BulkInsertMode.OverwriteExisting);
         #endregion
 
-        theSession.Query<Target>().Count().ShouldBe(data.Length);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
 
         (await theSession.LoadAsync<Target>(data[0].Id)).ShouldNotBeNull();
     }
@@ -427,9 +427,9 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
 
         using (var querying = theStore.QuerySession())
         {
-            querying.Query<User>().Count().ShouldBe(2);
-            querying.Query<Issue>().Count().ShouldBe(2);
-            querying.Query<Company>().Count().ShouldBe(2);
+            (await querying.Query<User>().CountAsync()).ShouldBe(2);
+            (await querying.Query<Issue>().CountAsync()).ShouldBe(2);
+            (await querying.Query<Company>().CountAsync()).ShouldBe(2);
         }
     }
 
@@ -449,9 +449,9 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
 
         using (var querying = theStore.QuerySession())
         {
-            querying.Query<User>().Count().ShouldBe(2);
-            querying.Query<Issue>().Count().ShouldBe(2);
-            querying.Query<Company>().Count().ShouldBe(2);
+            (await querying.Query<User>().CountAsync()).ShouldBe(2);
+            (await querying.Query<Issue>().CountAsync()).ShouldBe(2);
+            (await querying.Query<Company>().CountAsync()).ShouldBe(2);
         }
     }
 
@@ -471,9 +471,9 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
 
         using (var querying = theStore.QuerySession())
         {
-            querying.Query<User>().Count().ShouldBe(2);
-            querying.Query<Issue>().Count().ShouldBe(2);
-            querying.Query<Company>().Count().ShouldBe(2);
+            (await querying.Query<User>().CountAsync()).ShouldBe(2);
+            (await querying.Query<Issue>().CountAsync()).ShouldBe(2);
+            (await querying.Query<Company>().CountAsync()).ShouldBe(2);
         }
     }
 
@@ -492,9 +492,9 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         await theStore.BulkInsertDocumentsAsync(documents);
 
         await using var querying = theStore.QuerySession();
-        querying.Query<User>().Count().ShouldBe(2);
-        querying.Query<Issue>().Count().ShouldBe(2);
-        querying.Query<Company>().Count().ShouldBe(2);
+        (await querying.Query<User>().CountAsync()).ShouldBe(2);
+        (await querying.Query<Issue>().CountAsync()).ShouldBe(2);
+        (await querying.Query<Company>().CountAsync()).ShouldBe(2);
     }
 
     [Fact]
@@ -509,7 +509,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         }
 
         using var session = theStore.QuerySession();
-        session.Query<Target>().Count().ShouldBe(data.Length);
+        (await session.Query<Target>().CountAsync()).ShouldBe(data.Length);
     }
 
     [Fact]
@@ -523,7 +523,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         }
 
         using var session = theStore.QuerySession();
-        Should.Throw<MartenCommandException>(() => session.Query<Target>().Count());
+        await Should.ThrowAsync<MartenCommandException>(async () => await session.Query<Target>().CountAsync());
     }
 
     [Fact]
@@ -538,7 +538,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         }
 
         await using var session = theStore.QuerySession();
-        session.Query<Target>().Count().ShouldBe(data.Length);
+        (await session.Query<Target>().CountAsync()).ShouldBe(data.Length);
     }
 
     [Fact]
@@ -552,7 +552,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
         }
 
         await using var session = theStore.QuerySession();
-        Should.Throw<MartenCommandException>(() => session.Query<Target>().Count());
+        await Should.ThrowAsync<MartenCommandException>(async () => await session.Query<Target>().CountAsync());
     }
 
     [Fact]
@@ -575,9 +575,9 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
 
         using (var querying = theStore.QuerySession())
         {
-            querying.Query<User>().Count().ShouldBe(2);
-            querying.Query<Issue>().Count().ShouldBe(2);
-            querying.Query<Company>().Count().ShouldBe(2);
+            (await querying.Query<User>().CountAsync()).ShouldBe(2);
+            (await querying.Query<Issue>().CountAsync()).ShouldBe(2);
+            (await querying.Query<Company>().CountAsync()).ShouldBe(2);
         }
     }
 
@@ -601,9 +601,9 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
 
         await using (var querying = theStore.QuerySession())
         {
-            querying.Query<User>().Count().ShouldBe(2);
-            querying.Query<Issue>().Count().ShouldBe(2);
-            querying.Query<Company>().Count().ShouldBe(2);
+            (await querying.Query<User>().CountAsync()).ShouldBe(2);
+            (await querying.Query<Issue>().CountAsync()).ShouldBe(2);
+            (await querying.Query<Company>().CountAsync()).ShouldBe(2);
         }
     }
 
@@ -621,7 +621,7 @@ public class bulk_loading_Tests : OneOffConfigurationsContext, IAsyncLifetime
 
         await using (var querying = theStore.QuerySession())
         {
-            querying.Query<User>().Count().ShouldBe(2);
+            (await querying.Query<User>().CountAsync()).ShouldBe(2);
         }
     }
 

--- a/src/DocumentDbTests/Writing/document_inserts.cs
+++ b/src/DocumentDbTests/Writing/document_inserts.cs
@@ -6,6 +6,7 @@ using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
+using Marten;
 
 namespace DocumentDbTests.Writing;
 
@@ -23,7 +24,7 @@ public class document_inserts: IntegrationContext
 
         using (var query = theStore.QuerySession())
         {
-            query.Query<Target>().Count().ShouldBe(99);
+            (await query.Query<Target>().CountAsync()).ShouldBe(99);
         }
     }
 
@@ -44,8 +45,8 @@ public class document_inserts: IntegrationContext
 
         await using (var query = theStore.QuerySession())
         {
-            query.Query<Target>().Count().ShouldBe(3);
-            query.Query<User>().Count().ShouldBe(4);
+            (await query.Query<Target>().CountAsync()).ShouldBe(3);
+            (await query.Query<User>().CountAsync()).ShouldBe(4);
         }
     }
 
@@ -62,7 +63,7 @@ public class document_inserts: IntegrationContext
 
         using (var query = theStore.QuerySession())
         {
-            query.Query<RecordDocument>().ToList().Count.ShouldBe(1);
+            (await query.Query<RecordDocument>().ToListAsync()).Count.ShouldBe(1);
         }
     }
 

--- a/src/EventSourcingTests/Bugs/Bug_2289_tombstone_events_violate_seq_id_uniqueness.cs
+++ b/src/EventSourcingTests/Bugs/Bug_2289_tombstone_events_violate_seq_id_uniqueness.cs
@@ -1,3 +1,4 @@
+using Marten;
 using Marten.Exceptions;
 using Marten.Testing.Harness;
 using Shouldly;
@@ -39,9 +40,9 @@ public class Bug_2289_tombstone_events_violate_seq_id_uniqueness : IntegrationCo
             await theSession.SaveChangesAsync();
         });
 
-        var firstSequence = theSession.Events.QueryAllRawEvents()
+        var firstSequence = await theSession.Events.QueryAllRawEvents()
             .OrderBy(e => e.Sequence)
-            .FirstOrDefault();
+            .FirstOrDefaultAsync();
 
         firstSequence.Sequence.ShouldNotBe(0);
     }

--- a/src/EventSourcingTests/Bugs/Bug_2883_ievent_not_working_as_identity_source_in_multistream_projections.cs
+++ b/src/EventSourcingTests/Bugs/Bug_2883_ievent_not_working_as_identity_source_in_multistream_projections.cs
@@ -43,7 +43,7 @@ public class Bug_2883_ievent_not_working_as_identity_source : BugIntegrationCont
         {
             await using var session = theStore.QuerySession();
 
-            var docs = session.Query<CustomerInsightsResponse>().ToList();
+            var docs = (await session.Query<CustomerInsightsResponse>().ToListAsync());
             docs.Count.ShouldBeEquivalentTo(1);
             docs.First().NewCustomers.ShouldBe(customersToCreate);
         }
@@ -61,7 +61,7 @@ public class Bug_2883_ievent_not_working_as_identity_source : BugIntegrationCont
         {
             await using var session = theStore.QuerySession();
 
-            var docs = session.Query<CustomerInsightsResponse>().ToList();
+            var docs = (await session.Query<CustomerInsightsResponse>().ToListAsync());
             docs.Count.ShouldBeEquivalentTo(1);
             docs.First().NewCustomers.ShouldBe(customersToCreate - customersToDelete);
         }

--- a/src/EventSourcingTests/Projections/EventProjectionTests.cs
+++ b/src/EventSourcingTests/Projections/EventProjectionTests.cs
@@ -66,10 +66,10 @@ public class EventProjectionTests: OneOffConfigurationsContext, IAsyncLifetime
         theSession.Events.Append(stream, new UserDeleted { UserName = "one" });
         await theSession.SaveChangesAsync();
 
-        query.Query<User>()
+        (await query.Query<User>()
             .OrderBy(x => x.UserName)
             .Select(x => x.UserName)
-            .Single()
+            .SingleAsync())
             .ShouldBe("two");
     }
 
@@ -93,10 +93,10 @@ public class EventProjectionTests: OneOffConfigurationsContext, IAsyncLifetime
         theSession.Events.Append(stream, new UserDeleted { UserName = "one" });
         await theSession.SaveChangesAsync();
 
-        query.Query<User>()
+        (await query.Query<User>()
             .OrderBy(x => x.UserName)
             .Select(x => x.UserName)
-            .Single()
+            .SingleAsync())
             .ShouldBe("two");
     }
 
@@ -120,10 +120,10 @@ public class EventProjectionTests: OneOffConfigurationsContext, IAsyncLifetime
         theSession.Events.Append(stream, new UserDeleted { UserName = "one" });
         await theSession.SaveChangesAsync();
 
-        query.Query<User>()
+        (await query.Query<User>()
             .OrderBy(x => x.UserName)
             .Select(x => x.UserName)
-            .Single()
+            .SingleAsync())
             .ShouldBe("two");
     }
 
@@ -147,10 +147,10 @@ public class EventProjectionTests: OneOffConfigurationsContext, IAsyncLifetime
         theSession.Events.Append(stream, new UserDeleted { UserName = "one" });
         await theSession.SaveChangesAsync();
 
-        query.Query<User>()
+        (await query.Query<User>()
             .OrderBy(x => x.UserName)
             .Select(x => x.UserName)
-            .Single()
+            .SingleAsync())
             .ShouldBe("two");
     }
 
@@ -205,10 +205,10 @@ public class EventProjectionTests: OneOffConfigurationsContext, IAsyncLifetime
         theSession.Events.Append(stream, new UserDeleted { UserName = "one" });
         await theSession.SaveChangesAsync();
 
-        query.Query<User>()
+        (await query.Query<User>()
             .OrderBy(x => x.UserName)
             .Select(x => x.UserName)
-            .Single()
+            .SingleAsync())
             .ShouldBe("two");
     }
 

--- a/src/EventSourcingTests/Projections/EventProjectionTests.cs
+++ b/src/EventSourcingTests/Projections/EventProjectionTests.cs
@@ -59,8 +59,8 @@ public class EventProjectionTests: OneOffConfigurationsContext, IAsyncLifetime
 
         using var query = theStore.QuerySession();
 
-        query.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList()
+        (await query.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync())
             .ShouldHaveTheSameElementsAs("one", "two");
 
         theSession.Events.Append(stream, new UserDeleted { UserName = "one" });
@@ -86,8 +86,8 @@ public class EventProjectionTests: OneOffConfigurationsContext, IAsyncLifetime
 
         using var query = theStore.QuerySession();
 
-        query.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList()
+        (await query.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync())
             .ShouldHaveTheSameElementsAs("one", "two");
 
         theSession.Events.Append(stream, new UserDeleted { UserName = "one" });
@@ -113,8 +113,8 @@ public class EventProjectionTests: OneOffConfigurationsContext, IAsyncLifetime
 
         using var query = theStore.QuerySession();
 
-        query.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList()
+        (await query.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync())
             .ShouldHaveTheSameElementsAs("one", "two");
 
         theSession.Events.Append(stream, new UserDeleted { UserName = "one" });
@@ -140,8 +140,8 @@ public class EventProjectionTests: OneOffConfigurationsContext, IAsyncLifetime
 
         using var query = theStore.QuerySession();
 
-        query.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList()
+        (await query.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync())
             .ShouldHaveTheSameElementsAs("one", "two");
 
         theSession.Events.Append(stream, new UserDeleted { UserName = "one" });
@@ -198,8 +198,8 @@ public class EventProjectionTests: OneOffConfigurationsContext, IAsyncLifetime
 
         using var query = theStore.QuerySession();
 
-        query.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList()
+        (await query.Query<User>().OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync())
             .ShouldHaveTheSameElementsAs("one", "two");
 
         theSession.Events.Append(stream, new UserDeleted { UserName = "one" });

--- a/src/EventSourcingTests/Projections/EventProjections/EventProjectionOrderingTests.cs
+++ b/src/EventSourcingTests/Projections/EventProjections/EventProjectionOrderingTests.cs
@@ -8,6 +8,7 @@ using Marten.Events;
 using Marten.Events.Projections;
 using Marten.Testing.Harness;
 using Xunit;
+using Marten;
 
 namespace EventSourcingTests.Projections.EventProjections;
 
@@ -34,9 +35,9 @@ public class EventProjectionOrderingTests: IntegrationContext
 
         await daemon.RebuildProjectionAsync<TestOrderingEventProjection>(CancellationToken.None);
 
-        var results = theSession.Query<OrderingTracker>()
+        var results = (await theSession.Query<OrderingTracker>()
             .Where(x => x.StreamId == firstStream || x.StreamId == secondStream)
-            .ToList();
+            .ToListAsync());
 
         results.OrderBy(x => x.Sequence).ShouldHaveTheSameElementsAs(results.OrderBy(x => x.Order));
     }

--- a/src/EventSourcingTests/Projections/inline_aggregation_with_base_view_class.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_base_view_class.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using JasperFx;
+using Marten;
 using Marten.Events.Projections;
 using Marten.Testing.Harness;
 using Shouldly;
@@ -66,8 +67,8 @@ public class inline_aggregation_with_base_view_class: OneOffConfigurationsContex
         loadedView.Id.ShouldBe(streamId);
         loadedView.Monsters.ShouldHaveTheSameElementsAs("Troll", "Dragon");
 
-        var queriedView = theSession.Query<T>()
-            .Single(x => x.Id == streamId);
+        var queriedView = await theSession.Query<T>()
+            .SingleAsync(x => x.Id == streamId);
 
         queriedView.Id.ShouldBe(streamId);
         queriedView.Monsters.ShouldHaveTheSameElementsAs("Troll", "Dragon");

--- a/src/EventSourcingTests/Projections/inline_aggregation_with_non_public_setter.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_non_public_setter.cs
@@ -61,8 +61,8 @@ public class inline_aggregation_with_non_public_setter: OneOffConfigurationsCont
         loadedView.Id.ShouldBe(streamId);
         loadedView.Monsters.ShouldHaveTheSameElementsAs("Troll", "Dragon");
 
-        var queriedView = theSession.Query<T>()
-            .Single(x => x.Id == streamId);
+        var queriedView = await theSession.Query<T>()
+            .SingleAsync(x => x.Id == streamId);
 
         queriedView.Id.ShouldBe(streamId);
         queriedView.Monsters.ShouldHaveTheSameElementsAs("Troll", "Dragon");

--- a/src/EventSourcingTests/Projections/inline_aggregation_with_subclass.cs
+++ b/src/EventSourcingTests/Projections/inline_aggregation_with_subclass.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Marten;
 using Marten.Events.Projections;
 using Marten.Testing.Harness;
 using Shouldly;
@@ -28,7 +29,7 @@ public class inline_aggregation_with_subclass: OneOffConfigurationsContext
         var streamId = theSession.Events.StartStream(new FooACreated { Description = description }).Id;
         await theSession.SaveChangesAsync();
 
-        var fooInstance = theSession.Query<FooA>().Single(x => x.Id == streamId);
+        var fooInstance = await theSession.Query<FooA>().SingleAsync(x => x.Id == streamId);
 
         fooInstance.Id.ShouldBe(streamId);
         fooInstance.Description.ShouldBe(description);
@@ -42,7 +43,7 @@ public class inline_aggregation_with_subclass: OneOffConfigurationsContext
         var streamId = theSession.Events.StartStream(new FooACreated { Description = description }).Id;
         await theSession.SaveChangesAsync();
 
-        var fooInstance = theSession.Query<FooBase>().Single(x => x.Id == streamId);
+        var fooInstance = await theSession.Query<FooBase>().SingleAsync(x => x.Id == streamId);
 
         fooInstance.Id.ShouldBe(streamId);
         fooInstance.ShouldBeOfType<FooA>();

--- a/src/EventSourcingTests/QuickAppend/quick_append_event_capture_and_fetching_the_stream.cs
+++ b/src/EventSourcingTests/QuickAppend/quick_append_event_capture_and_fetching_the_stream.cs
@@ -121,36 +121,6 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
 
     [Theory]
     [MemberData(nameof(SessionParams))]
-    public async Task capture_events_to_a_new_stream_and_fetch_the_events_back_sync_with_linq(TenancyStyle tenancyStyle,
-        string[] tenants)
-    {
-        var store = ConfigureStore(tenancyStyle);
-
-        When.CalledForEachAsync(tenants, async (tenantId, _) =>
-        {
-            using var session = store.LightweightSession(tenantId);
-
-            var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-            var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-            var id = session.Events.StartStream<Quest>(joined, departed).Id;
-            await session.SaveChangesAsync();
-
-            var streamEvents = session.Events.QueryAllRawEvents()
-                .Where(x => x.StreamId == id).OrderBy(x => x.Version).ToList();
-
-            streamEvents.Count.ShouldBe(2);
-            streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
-            streamEvents.ElementAt(0).Version.ShouldBe(1);
-            streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
-            streamEvents.ElementAt(1).Version.ShouldBe(2);
-
-            streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
-        }).ShouldSucceedAsync();
-    }
-
-    [Theory]
-    [MemberData(nameof(SessionParams))]
     public async Task live_aggregate_equals_inlined_aggregate_without_hidden_contracts(TenancyStyle tenancyStyle,
         string[] tenants)
     {

--- a/src/EventSourcingTests/QuickAppend/quick_append_event_capture_and_fetching_the_stream.cs
+++ b/src/EventSourcingTests/QuickAppend/quick_append_event_capture_and_fetching_the_stream.cs
@@ -121,7 +121,7 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
 
     [Theory]
     [MemberData(nameof(SessionParams))]
-    public void capture_events_to_a_new_stream_and_fetch_the_events_back_sync_with_linq(TenancyStyle tenancyStyle,
+    public async Task capture_events_to_a_new_stream_and_fetch_the_events_back_sync_with_linq(TenancyStyle tenancyStyle,
         string[] tenants)
     {
         var store = ConfigureStore(tenancyStyle);
@@ -197,8 +197,8 @@ public class quick_append_event_capture_and_fetching_the_stream: OneOffConfigura
         {
             using (var session = store.LightweightSession(tenantId))
             {
-                var parties = session.Query<QuestParty>().ToArray();
-                parties.Length.ShouldBeLessThanOrEqualTo(index);
+                var parties = (await session.Query<QuestParty>().ToListAsync());
+                parties.Count.ShouldBeLessThanOrEqualTo(index);
             }
 
             //This SaveChanges will fail with missing method (ro collection configured?)

--- a/src/EventSourcingTests/QuickAppend/quick_append_event_capture_and_fetching_the_stream_with_string_identifiers.cs
+++ b/src/EventSourcingTests/QuickAppend/quick_append_event_capture_and_fetching_the_stream_with_string_identifiers.cs
@@ -93,32 +93,6 @@ public class
     }
 
     [Fact]
-    public async Task capture_events_to_a_new_stream_and_fetch_the_events_back_sync_with_linq()
-    {
-        #region sample_start-stream-with-aggregate-type
-
-        var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-        var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-        var id = "Fourth";
-        theSession.Events.StartStream<Quest>(id, joined, departed);
-        await theSession.SaveChangesAsync();
-
-        #endregion
-
-        var streamEvents = theSession.Events.QueryAllRawEvents()
-            .Where(x => x.StreamKey == id).OrderBy(x => x.Version).ToList();
-
-        streamEvents.Count.ShouldBe(2);
-        streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
-        streamEvents.ElementAt(0).Version.ShouldBe(1);
-        streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
-        streamEvents.ElementAt(1).Version.ShouldBe(2);
-
-        streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
-    }
-
-    [Fact]
     public async Task live_aggregate_equals_inlined_aggregate_without_hidden_contracts()
     {
         var questId = "Fifth";

--- a/src/EventSourcingTests/QuickAppend/quick_append_event_capture_and_fetching_the_stream_with_string_identifiers.cs
+++ b/src/EventSourcingTests/QuickAppend/quick_append_event_capture_and_fetching_the_stream_with_string_identifiers.cs
@@ -200,7 +200,7 @@ public class
         //GetAll
         using (var session = theStore.LightweightSession())
         {
-            var parties = session.Events.QueryRawEventDataOnly<QuestPartyWithStringIdentifier>().ToArray();
+            var parties = (await session.Events.QueryRawEventDataOnly<QuestPartyWithStringIdentifier>().ToListAsync());
             foreach (var party in parties)
             {
                 party.ShouldNotBeNull();

--- a/src/EventSourcingTests/delete_single_event_stream.cs
+++ b/src/EventSourcingTests/delete_single_event_stream.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using JasperFx.Events;
+using Marten;
 using Marten.Events;
 using Marten.Storage;
 using Marten.Testing.Harness;
@@ -38,7 +39,7 @@ public class delete_single_event_stream: OneOffConfigurationsContext
 
         using (var session = theStore.LightweightSession())
         {
-            session.Events.QueryAllRawEvents().ToList().All(x => x.StreamId == stream2)
+            (await session.Events.QueryAllRawEvents().ToListAsync()).All(x => x.StreamId == stream2)
                 .ShouldBeTrue();
         }
     }
@@ -70,7 +71,7 @@ public class delete_single_event_stream: OneOffConfigurationsContext
 
         using (var session = theStore.LightweightSession())
         {
-            session.Events.QueryAllRawEvents().ToList().All(x => x.StreamId == stream2)
+            (await session.Events.QueryAllRawEvents().ToListAsync()).All(x => x.StreamId == stream2)
                 .ShouldBeTrue();
         }
     }
@@ -102,7 +103,7 @@ public class delete_single_event_stream: OneOffConfigurationsContext
 
         using (var session = theStore.LightweightSession())
         {
-            var events = session.Events.QueryAllRawEvents().ToList();
+            var events = await session.Events.QueryAllRawEvents().ToListAsync();
             events.All(x => x.StreamId == stream2)
                 .ShouldBeTrue();
         }
@@ -134,7 +135,7 @@ public class delete_single_event_stream: OneOffConfigurationsContext
 
         await using (var session = theStore.LightweightSession())
         {
-            session.Events.QueryAllRawEvents().ToList().All(x => x.StreamId == stream2)
+            (await session.Events.QueryAllRawEvents().ToListAsync()).All(x => x.StreamId == stream2)
                 .ShouldBeTrue();
         }
     }
@@ -166,7 +167,7 @@ public class delete_single_event_stream: OneOffConfigurationsContext
 
         await using (var session = theStore.LightweightSession("one"))
         {
-            session.Events.QueryAllRawEvents().ToList().All(x => x.StreamId == stream2)
+            (await session.Events.QueryAllRawEvents().ToListAsync()).All(x => x.StreamId == stream2)
                 .ShouldBeTrue();
         }
     }
@@ -201,7 +202,7 @@ public class delete_single_event_stream: OneOffConfigurationsContext
 
         using (var session = theStore.LightweightSession())
         {
-            session.Events.QueryAllRawEvents().ToList().All(x => x.StreamKey == stream2)
+            (await session.Events.QueryAllRawEvents().ToListAsync()).All(x => x.StreamKey == stream2)
                 .ShouldBeTrue();
         }
     }
@@ -237,7 +238,7 @@ public class delete_single_event_stream: OneOffConfigurationsContext
 
         using (var session = theStore.LightweightSession())
         {
-            session.Events.QueryAllRawEvents().ToList().All(x => x.StreamKey == stream2)
+            (await session.Events.QueryAllRawEvents().ToListAsync()).All(x => x.StreamKey == stream2)
                 .ShouldBeTrue();
         }
     }

--- a/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream.cs
+++ b/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream.cs
@@ -132,40 +132,6 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
 
     [Theory]
     [MemberData(nameof(SessionParams))]
-    public async Task capture_events_to_a_new_stream_and_fetch_the_events_back_sync_with_linq(TenancyStyle tenancyStyle,
-        string[] tenants)
-    {
-        var store = InitStore(tenancyStyle);
-
-        await When.CalledForEachAsync(tenants, async (tenantId, _) =>
-        {
-            using var session = store.LightweightSession(tenantId);
-
-            #region sample_start-stream-with-aggregate-type
-
-            var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-            var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-            var id = session.Events.StartStream<Quest>(joined, departed).Id;
-            await session.SaveChangesAsync();
-
-            #endregion
-
-            var streamEvents = session.Events.QueryAllRawEvents()
-                .Where(x => x.StreamId == id).OrderBy(x => x.Version).ToList();
-
-            streamEvents.Count.ShouldBe(2);
-            streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
-            streamEvents.ElementAt(0).Version.ShouldBe(1);
-            streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
-            streamEvents.ElementAt(1).Version.ShouldBe(2);
-
-            streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
-        }).ShouldSucceedAsync();
-    }
-
-    [Theory]
-    [MemberData(nameof(SessionParams))]
     public async Task live_aggregate_equals_inlined_aggregate_without_hidden_contracts(TenancyStyle tenancyStyle,
         string[] tenants)
     {

--- a/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream.cs
+++ b/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream.cs
@@ -212,8 +212,8 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
         {
             using (var session = store.LightweightSession(tenantId))
             {
-                var parties = session.Query<QuestParty>().ToArray();
-                parties.Length.ShouldBeLessThanOrEqualTo(index);
+                var parties = (await session.Query<QuestParty>().ToListAsync());
+                parties.Count.ShouldBeLessThanOrEqualTo(index);
             }
 
             //This SaveChanges will fail with missing method (ro collection configured?)
@@ -302,7 +302,7 @@ public class end_to_end_event_capture_and_fetching_the_stream: OneOffConfigurati
 
     [Theory]
     [MemberData(nameof(SessionParams))]
-    public void capture_events_to_a_non_existing_stream_and_fetch_the_events_back(TenancyStyle tenancyStyle,
+    public async Task capture_events_to_a_non_existing_stream_and_fetch_the_events_back(TenancyStyle tenancyStyle,
         string[] tenants)
     {
         var store = InitStore(tenancyStyle);

--- a/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers.cs
+++ b/src/EventSourcingTests/end_to_end_event_capture_and_fetching_the_stream_with_string_identifiers.cs
@@ -97,32 +97,6 @@ public class
     }
 
     [Fact]
-    public async Task capture_events_to_a_new_stream_and_fetch_the_events_back_sync_with_linq()
-    {
-        #region sample_start-stream-with-aggregate-type
-
-        var joined = new MembersJoined { Members = new[] { "Rand", "Matt", "Perrin", "Thom" } };
-        var departed = new MembersDeparted { Members = new[] { "Thom" } };
-
-        var id = "Fourth";
-        theSession.Events.StartStream<Quest>(id, joined, departed);
-        await theSession.SaveChangesAsync();
-
-        #endregion
-
-        var streamEvents = theSession.Events.QueryAllRawEvents()
-            .Where(x => x.StreamKey == id).OrderBy(x => x.Version).ToList();
-
-        streamEvents.Count.ShouldBe(2);
-        streamEvents.ElementAt(0).Data.ShouldBeOfType<MembersJoined>();
-        streamEvents.ElementAt(0).Version.ShouldBe(1);
-        streamEvents.ElementAt(1).Data.ShouldBeOfType<MembersDeparted>();
-        streamEvents.ElementAt(1).Version.ShouldBe(2);
-
-        streamEvents.Each(e => e.Timestamp.ShouldNotBe(default(DateTimeOffset)));
-    }
-
-    [Fact]
     public async Task live_aggregate_equals_inlined_aggregate_without_hidden_contracts()
     {
         var questId = "Fifth";

--- a/src/EventSourcingTests/multi_tenancy_and_event_capture.cs
+++ b/src/EventSourcingTests/multi_tenancy_and_event_capture.cs
@@ -273,7 +273,7 @@ public class multi_tenancy_and_event_capture: OneOffConfigurationsContext
 
         using (var session = theStore.QuerySession("Green"))
         {
-            var memberJoins = session.Query<MembersJoined>().ToList();
+            var memberJoins = (await session.Query<MembersJoined>().ToListAsync());
             memberJoins.Count.ShouldBe(1);
         }
     }

--- a/src/EventSourcingTests/querying_event_data_with_linq.cs
+++ b/src/EventSourcingTests/querying_event_data_with_linq.cs
@@ -44,7 +44,7 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
         await theSession.SaveChangesAsync();
 
         theSession.Events.QueryRawEventDataOnly<MembersJoined>().Count().ShouldBe(2);
-        theSession.Events.QueryRawEventDataOnly<MembersJoined>().ToArray().SelectMany(x => x.Members).Distinct()
+        (await theSession.Events.QueryRawEventDataOnly<MembersJoined>().ToListAsync()).SelectMany(x => x.Members).Distinct()
             .OrderBy(x => x)
             .ShouldHaveTheSameElementsAs("Egwene", "Matt", "Nynaeve", "Perrin", "Rand", "Thom");
 
@@ -65,7 +65,7 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
         await theSession.SaveChangesAsync();
 
         theSession.Events.QueryRawEventDataOnly<MembersJoined>().Count().ShouldBe(2);
-        theSession.Events.QueryRawEventDataOnly<MembersJoined>().ToArray().SelectMany(x => x.Members).Distinct()
+        (await theSession.Events.QueryRawEventDataOnly<MembersJoined>().ToListAsync()).SelectMany(x => x.Members).Distinct()
             .OrderBy(x => x)
             .ShouldHaveTheSameElementsAs("Egwene", "Matt", "Nynaeve", "Perrin", "Rand", "Thom");
 
@@ -100,7 +100,7 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
         await theSession.SaveChangesAsync();
 
         theSession.Events.QueryRawEventDataOnly<MembersJoined>().Count().ShouldBe(2);
-        theSession.Events.QueryRawEventDataOnly<MembersJoined>().ToArray().SelectMany(x => x.Members).Distinct()
+        (await theSession.Events.QueryRawEventDataOnly<MembersJoined>().ToListAsync()).SelectMany(x => x.Members).Distinct()
             .OrderBy(x => x)
             .ShouldHaveTheSameElementsAs("Egwene", "Matt", "Nynaeve", "Perrin", "Rand", "Thom");
 
@@ -138,7 +138,7 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
         await theSession.SaveChangesAsync();
 
         theSession.Events.QueryRawEventDataOnly<MembersJoined>().Count().ShouldBe(2);
-        theSession.Events.QueryRawEventDataOnly<MembersJoined>().ToArray().SelectMany(x => x.Members).Distinct()
+        (await theSession.Events.QueryRawEventDataOnly<MembersJoined>().ToListAsync()).SelectMany(x => x.Members).Distinct()
             .OrderBy(x => x)
             .ShouldHaveTheSameElementsAs("Egwene", "Matt", "Nynaeve", "Perrin", "Rand", "Thom");
 

--- a/src/EventSourcingTests/querying_event_data_with_linq.cs
+++ b/src/EventSourcingTests/querying_event_data_with_linq.cs
@@ -43,13 +43,13 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
 
         await theSession.SaveChangesAsync();
 
-        theSession.Events.QueryRawEventDataOnly<MembersJoined>().Count().ShouldBe(2);
+        (await theSession.Events.QueryRawEventDataOnly<MembersJoined>().CountAsync()).ShouldBe(2);
         (await theSession.Events.QueryRawEventDataOnly<MembersJoined>().ToListAsync()).SelectMany(x => x.Members).Distinct()
             .OrderBy(x => x)
             .ShouldHaveTheSameElementsAs("Egwene", "Matt", "Nynaeve", "Perrin", "Rand", "Thom");
 
-        theSession.Events.QueryRawEventDataOnly<MembersDeparted>()
-            .Single(x => x.Members.Contains("Matt")).Id.ShouldBe(departed2.Id);
+        (await theSession.Events.QueryRawEventDataOnly<MembersDeparted>()
+            .SingleAsync(x => x.Members.Contains("Matt"))).Id.ShouldBe(departed2.Id);
     }
 
     #endregion
@@ -64,13 +64,13 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
 
         await theSession.SaveChangesAsync();
 
-        theSession.Events.QueryRawEventDataOnly<MembersJoined>().Count().ShouldBe(2);
+        (await theSession.Events.QueryRawEventDataOnly<MembersJoined>().CountAsync()).ShouldBe(2);
         (await theSession.Events.QueryRawEventDataOnly<MembersJoined>().ToListAsync()).SelectMany(x => x.Members).Distinct()
             .OrderBy(x => x)
             .ShouldHaveTheSameElementsAs("Egwene", "Matt", "Nynaeve", "Perrin", "Rand", "Thom");
 
-        theSession.Events.QueryRawEventDataOnly<MembersDeparted>()
-            .Single(x => x.Members.Contains("Matt")).Id.ShouldBe(departed2.Id);
+        (await theSession.Events.QueryRawEventDataOnly<MembersDeparted>()
+            .SingleAsync(x => x.Members.Contains("Matt"))).Id.ShouldBe(departed2.Id);
     }
 
     [Fact]
@@ -99,19 +99,19 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
 
         await theSession.SaveChangesAsync();
 
-        theSession.Events.QueryRawEventDataOnly<MembersJoined>().Count().ShouldBe(2);
+        (await theSession.Events.QueryRawEventDataOnly<MembersJoined>().CountAsync()).ShouldBe(2);
         (await theSession.Events.QueryRawEventDataOnly<MembersJoined>().ToListAsync()).SelectMany(x => x.Members).Distinct()
             .OrderBy(x => x)
             .ShouldHaveTheSameElementsAs("Egwene", "Matt", "Nynaeve", "Perrin", "Rand", "Thom");
 
-        theSession.Events.QueryRawEventDataOnly<MembersDeparted>().Where(x => x.Members.Contains("Matt"))
-            .Single().Id.ShouldBe(departed2.Id);
+        (await theSession.Events.QueryRawEventDataOnly<MembersDeparted>().Where(x => x.Members.Contains("Matt"))
+            .SingleAsync()).Id.ShouldBe(departed2.Id);
     }
 
     [Fact]
-    public void will_not_blow_up_if_searching_for_events_before_event_store_is_warmed_up()
+    public async Task will_not_blow_up_if_searching_for_events_before_event_store_is_warmed_up()
     {
-        theSession.Events.QueryRawEventDataOnly<MembersJoined>().Any().ShouldBeFalse();
+        (await theSession.Events.QueryRawEventDataOnly<MembersJoined>().AnyAsync()).ShouldBeFalse();
     }
 
 
@@ -137,13 +137,13 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
 
         await theSession.SaveChangesAsync();
 
-        theSession.Events.QueryRawEventDataOnly<MembersJoined>().Count().ShouldBe(2);
+        (await theSession.Events.QueryRawEventDataOnly<MembersJoined>().CountAsync()).ShouldBe(2);
         (await theSession.Events.QueryRawEventDataOnly<MembersJoined>().ToListAsync()).SelectMany(x => x.Members).Distinct()
             .OrderBy(x => x)
             .ShouldHaveTheSameElementsAs("Egwene", "Matt", "Nynaeve", "Perrin", "Rand", "Thom");
 
-        theSession.Events.QueryRawEventDataOnly<MembersDeparted>()
-            .Single(x => x.Members.Contains("Matt")).Id.ShouldBe(departed2.Id);
+        (await theSession.Events.QueryRawEventDataOnly<MembersDeparted>()
+            .SingleAsync(x => x.Members.Contains("Matt"))).Id.ShouldBe(departed2.Id);
     }
 
     [Fact]
@@ -154,18 +154,18 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
 
         await theSession.SaveChangesAsync();
 
-        var results = theSession.Events.QueryAllRawEvents().ToList();
+        var results = await theSession.Events.QueryAllRawEvents().ToListAsync();
 
         results.Count.ShouldBe(4);
     }
 
     #region sample_example_of_querying_for_event_data
-    public void example_of_querying_for_event_data(IDocumentSession session, Guid stream)
+    public async Task example_of_querying_for_event_data(IDocumentSession session, Guid stream)
     {
-        var events = session.Events.QueryAllRawEvents()
+        var events = await session.Events.QueryAllRawEvents()
             .Where(x => x.StreamId == stream)
             .OrderBy(x => x.Sequence)
-            .ToList();
+            .ToListAsync();
     }
 
     #endregion
@@ -182,7 +182,7 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
 
         var past = now.AddSeconds(-1);
 
-        var results = theSession.Events.QueryAllRawEvents().Where(x => x.Timestamp > past).ToList();
+        var results = await theSession.Events.QueryAllRawEvents().Where(x => x.Timestamp > past).ToListAsync();
 
         results.Count.ShouldBe(4);
     }
@@ -198,10 +198,10 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
         var dbNow = (DateTime)theSession.Connection.CreateCommand().Sql("select now();").ExecuteScalar();
         var now = new DateTimeOffset(dbNow).AddSeconds(5);
 
-        var all = theSession.Events.QueryAllRawEvents().ToList();
+        var all = await theSession.Events.QueryAllRawEvents().ToListAsync();
 
-        var results = theSession.Events.QueryAllRawEvents()
-            .Where(x => x.Timestamp < now).ToList();
+        var results = await theSession.Events.QueryAllRawEvents()
+            .Where(x => x.Timestamp < now).ToListAsync();
 
         results.Count.ShouldBe(4);
     }
@@ -214,8 +214,8 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
 
         await theSession.SaveChangesAsync();
 
-        theSession.Events.QueryAllRawEvents()
-            .Count(x => x.Sequence <= 2).ShouldBe(2);
+        (await theSession.Events.QueryAllRawEvents()
+            .CountAsync(x => x.Sequence <= 2)).ShouldBe(2);
     }
 
     [Fact]
@@ -226,8 +226,8 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
 
         await theSession.SaveChangesAsync();
 
-        theSession.Events.QueryAllRawEvents()
-            .Count(x => x.Version == 1).ShouldBe(2);
+        (await theSession.Events.QueryAllRawEvents()
+            .CountAsync(x => x.Version == 1)).ShouldBe(2);
     }
 
     [Fact]
@@ -238,8 +238,8 @@ public class querying_event_data_with_linq: OneOffConfigurationsContext, IAsyncL
 
         await theSession.SaveChangesAsync();
 
-        theSession.Events.QueryAllRawEvents()
-            .Count(x => x.StreamId == stream1).ShouldBe(2);
+        (await theSession.Events.QueryAllRawEvents()
+            .CountAsync(x => x.StreamId == stream1)).ShouldBe(2);
     }
 
     [Fact]

--- a/src/LinqTests/Acceptance/Support/OrderedSelectComparison.cs
+++ b/src/LinqTests/Acceptance/Support/OrderedSelectComparison.cs
@@ -24,7 +24,7 @@ public class OrderedSelectComparison<T>: LinqTestCase
     {
         var expected = _selector(documents.AsQueryable()).ToArray();
 
-        var actual = (await (_selector(session.Query<Target>()).ToListAsync())).ToArray();
+        var actual = (await _selector(session.Query<Target>()).ToListAsync()).ToArray();
 
         assertSame(expected, actual);
     }

--- a/src/LinqTests/Acceptance/Support/TargetComparison.cs
+++ b/src/LinqTests/Acceptance/Support/TargetComparison.cs
@@ -22,7 +22,7 @@ public class TargetComparison: LinqTestCase
     {
         var expected = _func(documents.AsQueryable()).Select(x => x.Id).ToArray();
 
-        var actual = (await (_func(session.Query<Target>()).Select(x => x.Id).ToListAsync())).ToArray();
+        var actual = (await _func(session.Query<Target>()).Select(x => x.Id).ToListAsync()).ToArray();
 
         assertSame(expected, actual);
 

--- a/src/LinqTests/Acceptance/chained_where_clauses.cs
+++ b/src/LinqTests/Acceptance/chained_where_clauses.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
+using Marten;
 
 namespace LinqTests.Acceptance;
 
@@ -22,7 +23,7 @@ public class chained_where_clauses : IntegrationContext
         theSession.Store(target5);
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Number == 1).Where(x => x.String == "Foo").ToArray()
+        (await theSession.Query<Target>().Where(x => x.Number == 1).Where(x => x.String == "Foo").ToListAsync())
             .Select(x => x.Id)
             .ShouldHaveTheSameElementsAs(target1.Id, target4.Id);
     }
@@ -42,7 +43,7 @@ public class chained_where_clauses : IntegrationContext
         theSession.Store(target5);
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Number == 1).Where(x => x.String == "Foo").Where(x => x.Long == 5).ToArray()
+        (await theSession.Query<Target>().Where(x => x.Number == 1).Where(x => x.String == "Foo").Where(x => x.Long == 5).ToListAsync())
             .Select(x => x.Id)
             .ShouldHaveTheSameElementsAs(target1.Id);
     }

--- a/src/LinqTests/Acceptance/custom_identity_members.cs
+++ b/src/LinqTests/Acceptance/custom_identity_members.cs
@@ -25,8 +25,8 @@ public class custom_identity_members : OneOffConfigurationsContext
 
         using (var session = theStore.QuerySession())
         {
-            session.Query<BaseClass>().Count(x => x.Id.IsOneOf(listSystemIds)).ShouldBe(0);
-            session.Query<BaseClass>().Count(x => x.SystemId.IsOneOf(listSystemIds)).ShouldBe(2);
+            (await session.Query<BaseClass>().CountAsync(x => x.Id.IsOneOf(listSystemIds))).ShouldBe(0);
+            (await session.Query<BaseClass>().CountAsync(x => x.SystemId.IsOneOf(listSystemIds))).ShouldBe(2);
         }
     }
 
@@ -46,11 +46,11 @@ public class custom_identity_members : OneOffConfigurationsContext
         {
             (await session.LoadManyAsync<BaseClass>(listSystemIds)).Count.ShouldBe(2);
 
-            session.Query<BaseClass>().Count(x => x.Id.IsOneOf(listIds)).ShouldBe(2);
-            session.Query<BaseClass>().Count(x => x.SystemId.IsOneOf(listSystemIds)).ShouldBe(2);
+            (await session.Query<BaseClass>().CountAsync(x => x.Id.IsOneOf(listIds))).ShouldBe(2);
+            (await session.Query<BaseClass>().CountAsync(x => x.SystemId.IsOneOf(listSystemIds))).ShouldBe(2);
 
-            session.Query<BaseClass>().Count(x => x.Id.IsOneOf("123", "456")).ShouldBe(0);
-            session.Query<BaseClass>().Count(x => x.SystemId.IsOneOf("qwe", "zxc")).ShouldBe(0);
+            (await session.Query<BaseClass>().CountAsync(x => x.Id.IsOneOf("123", "456"))).ShouldBe(0);
+            (await session.Query<BaseClass>().CountAsync(x => x.SystemId.IsOneOf("qwe", "zxc"))).ShouldBe(0);
         }
     }
 

--- a/src/LinqTests/Acceptance/custom_linq_extensions.cs
+++ b/src/LinqTests/Acceptance/custom_linq_extensions.cs
@@ -54,7 +54,7 @@ public class custom_linq_extensions
         await store.BulkInsertAsync(targets.ToArray());
 
         using var session = store.QuerySession();
-        session.Query<ColorTarget>().Count(x => x.Color.IsBlue())
+        (await session.Query<ColorTarget>().CountAsync(x => x.Color.IsBlue()))
             .ShouldBe(count);
     }
 

--- a/src/LinqTests/Acceptance/date_type_usage.cs
+++ b/src/LinqTests/Acceptance/date_type_usage.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
+using Marten;
 
 namespace LinqTests.Acceptance;
 
@@ -60,7 +61,7 @@ public class date_type_usage : OneOffConfigurationsContext
 
         using (var query = theStore.QuerySession())
         {
-            var dateOffset = query.Query<Target>().Where(x => x.Id == document.Id).Select(x => x.DateOffset).Single();
+            var dateOffset = (await query.Query<Target>().Where(x => x.Id == document.Id).Select(x => x.DateOffset).SingleAsync());
 
             // be aware of the Npgsql DateTime mapping https://www.npgsql.org/doc/types/datetime.html
             dateOffset.ShouldBeEqualWithDbPrecision(document.DateOffset.ToLocalTime());

--- a/src/LinqTests/Acceptance/date_type_usage.cs
+++ b/src/LinqTests/Acceptance/date_type_usage.cs
@@ -20,7 +20,7 @@ public class date_type_usage : OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.DateOffset > DateTimeOffset.UtcNow).ToArray()
+        (await theSession.Query<Target>().Where(x => x.DateOffset > DateTimeOffset.UtcNow).ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1, 2, 3);
     }
@@ -42,7 +42,7 @@ public class date_type_usage : OneOffConfigurationsContext
         await theSession.SaveChangesAsync();
 
 
-        theSession.Query<Target>().Where(x => x.DateOffset > DateTimeOffset.UtcNow).OrderBy(x => x.DateOffset).ToArray()
+        (await theSession.Query<Target>().Where(x => x.DateOffset > DateTimeOffset.UtcNow).OrderBy(x => x.DateOffset).ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1, 3, 2);
     }

--- a/src/LinqTests/Acceptance/deep_searches.cs
+++ b/src/LinqTests/Acceptance/deep_searches.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Marten.Schema;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
+using Marten;
 
 namespace LinqTests.Acceptance;
 
@@ -19,7 +20,7 @@ public class deep_searches: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Inner.Number == 2).ToArray().OrderBy(x => x.Inner.String)
+        (await theSession.Query<Target>().Where(x => x.Inner.Number == 2).ToListAsync()).OrderBy(x => x.Inner.String)
             .Select(x => x.Inner.String)
             .ShouldHaveTheSameElementsAs("Lindsey", "Max");
     }
@@ -34,7 +35,7 @@ public class deep_searches: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Inner.Inner.Long == 1).ToArray().Select(x => x.Number)
+        (await theSession.Query<Target>().Where(x => x.Inner.Inner.Long == 1).ToListAsync()).Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1, 3);
     }
 
@@ -49,7 +50,7 @@ public class deep_searches: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Inner.Number == 2).OrderBy(x => x.Inner.String).ToArray()
+        (await theSession.Query<Target>().Where(x => x.Inner.Number == 2).OrderBy(x => x.Inner.String).ToListAsync())
             .Select(x => x.Inner.String)
             .ShouldHaveTheSameElementsAs("Lindsey", "Max");
     }
@@ -71,7 +72,7 @@ public class deep_searches: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Inner.Number == 2).ToArray().OrderBy(x => x.Inner.String)
+        (await theSession.Query<Target>().Where(x => x.Inner.Number == 2).ToListAsync()).OrderBy(x => x.Inner.String)
             .Select(x => x.Inner.String)
             .ShouldHaveTheSameElementsAs("Lindsey", "Max");
     }
@@ -91,7 +92,7 @@ public class deep_searches: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Inner.Inner.Long == 1).ToArray().Select(x => x.Number)
+        (await theSession.Query<Target>().Where(x => x.Inner.Inner.Long == 1).ToListAsync()).Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1, 3);
     }
 
@@ -111,7 +112,7 @@ public class deep_searches: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Inner.Number == 2).OrderBy(x => x.Inner.String).ToArray()
+        (await theSession.Query<Target>().Where(x => x.Inner.Number == 2).OrderBy(x => x.Inner.String).ToListAsync())
             .Select(x => x.Inner.String)
             .ShouldHaveTheSameElementsAs("Lindsey", "Max");
     }

--- a/src/LinqTests/Acceptance/enum_usage.cs
+++ b/src/LinqTests/Acceptance/enum_usage.cs
@@ -27,7 +27,7 @@ public class enum_usage: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToArray()
+        (await theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1, 4, 7);
     }
@@ -47,7 +47,7 @@ public class enum_usage: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToArray()
+        (await theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1, 4, 7);
     }
@@ -67,7 +67,7 @@ public class enum_usage: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToArray()
+        (await theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1, 4, 7);
     }
@@ -91,7 +91,7 @@ public class enum_usage: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToArray()
+        (await theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1, 4, 7);
     }
@@ -115,7 +115,7 @@ public class enum_usage: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToArray()
+        (await theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1, 4, 7);
     }
@@ -139,7 +139,7 @@ public class enum_usage: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToArray()
+        (await theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1, 4, 7);
     }
@@ -163,7 +163,7 @@ public class enum_usage: OneOffConfigurationsContext
 
         await theStore.BulkInsertAsync(targets);
 
-        theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToArray()
+        (await theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1, 4, 7);
     }
@@ -187,7 +187,7 @@ public class enum_usage: OneOffConfigurationsContext
 
         await theStore.BulkInsertAsync(targets);
 
-        theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToArray()
+        (await theSession.Query<Target>().Where(x => x.Color == Colors.Blue).ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1, 4, 7);
     }

--- a/src/LinqTests/Acceptance/enum_usage.cs
+++ b/src/LinqTests/Acceptance/enum_usage.cs
@@ -202,8 +202,8 @@ public class enum_usage: OneOffConfigurationsContext
         theSession.Store(new Target { NullableEnum = null, Number = 5 });
         await theSession.SaveChangesAsync();
 
-        var results = theSession.Query<Target>().Where(x => x.NullableEnum.In(null, Colors.Green))
-            .ToList();
+        var results = (await theSession.Query<Target>().Where(x => x.NullableEnum.In(null, Colors.Green))
+            .ToListAsync());
 
         results.Count.ShouldBe(3);
     }
@@ -218,8 +218,8 @@ public class enum_usage: OneOffConfigurationsContext
         theSession.Store(new Target { NullableEnum = null, Number = 5 });
         await theSession.SaveChangesAsync();
 
-        var results = theSession.Query<Target>().Where(x => !x.NullableEnum.In(null, Colors.Green))
-            .ToList();
+        var results = (await theSession.Query<Target>().Where(x => !x.NullableEnum.In(null, Colors.Green))
+            .ToListAsync());
 
         results.Count.ShouldBe(2);
     }

--- a/src/LinqTests/Acceptance/equals_method_usage_validation.cs
+++ b/src/LinqTests/Acceptance/equals_method_usage_validation.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Marten;
 using Marten.Exceptions;
 using Marten.Linq;
 using Marten.Testing.Harness;
@@ -38,11 +39,11 @@ public class equals_method_usage_validation : IntegrationContext
 
         object notInt = "not int";
 
-        Assert.Throws<BadLinqExpressionException>(() =>
+        await Assert.ThrowsAsync<BadLinqExpressionException>(async () =>
         {
-            var value = theSession
+            var value = await theSession
                 .Query<QueryTarget>()
-                .FirstOrDefault(x => x.IntProp.Equals(notInt));
+                .FirstOrDefaultAsync(x => x.IntProp.Equals(notInt));
         });
     }
 
@@ -59,11 +60,11 @@ public class equals_method_usage_validation : IntegrationContext
 
         object notInt = "not int";
 
-        Assert.Throws<BadLinqExpressionException>(() =>
+        await Assert.ThrowsAsync<BadLinqExpressionException>(async () =>
         {
-            var firstOrDefault = theSession
+            var firstOrDefault = await theSession
                 .Query<QueryTarget>()
-                .FirstOrDefault(x => !x.IntProp.Equals(notInt));
+                .FirstOrDefaultAsync(x => !x.IntProp.Equals(notInt));
         });
     }
 

--- a/src/LinqTests/Acceptance/identity_map_mechanics.cs
+++ b/src/LinqTests/Acceptance/identity_map_mechanics.cs
@@ -48,11 +48,11 @@ public class identity_map_mechanics: IntegrationContext
     public async Task single_runs_through_the_identity_map()
     {
         await using var session = await identitySessionWithData();
-        session.Query<User>()
-            .Single(x => x.FirstName == "Jeremy").ShouldBeSameAs(user1);
+        (await session.Query<User>()
+            .SingleAsync(x => x.FirstName == "Jeremy")).ShouldBeSameAs(user1);
 
-        session.Query<User>()
-            .SingleOrDefault(x => x.FirstName == user4.FirstName).ShouldBeSameAs(user4);
+        (await session.Query<User>()
+            .SingleOrDefaultAsync(x => x.FirstName == user4.FirstName)).ShouldBeSameAs(user4);
     }
 
 
@@ -60,12 +60,12 @@ public class identity_map_mechanics: IntegrationContext
     public async Task first_runs_through_the_identity_map()
     {
         await using var session = await identitySessionWithData();
-        session.Query<User>().Where(x => x.FirstName.StartsWith("J")).OrderBy(x => x.FirstName)
-            .First().ShouldBeSameAs(user3);
+        (await session.Query<User>().Where(x => x.FirstName.StartsWith("J")).OrderBy(x => x.FirstName)
+            .FirstAsync()).ShouldBeSameAs(user3);
 
 
-        session.Query<User>().Where(x => x.FirstName.StartsWith("J")).OrderBy(x => x.FirstName)
-            .FirstOrDefault().ShouldBeSameAs(user3);
+        (await session.Query<User>().Where(x => x.FirstName.StartsWith("J")).OrderBy(x => x.FirstName)
+            .FirstOrDefaultAsync()).ShouldBeSameAs(user3);
     }
 
     [Fact]

--- a/src/LinqTests/Acceptance/identity_map_mechanics.cs
+++ b/src/LinqTests/Acceptance/identity_map_mechanics.cs
@@ -72,8 +72,8 @@ public class identity_map_mechanics: IntegrationContext
     public async Task query_runs_through_identity_map()
     {
         await using var session = await identitySessionWithData();
-        var users = session.Query<User>().Where(x => x.FirstName.StartsWith("J")).OrderBy(x => x.FirstName)
-            .ToArray();
+        var users =(await  session.Query<User>().Where(x => x.FirstName.StartsWith("J")).OrderBy(x => x.FirstName)
+            .ToListAsync());
 
         users[0].ShouldBeSameAs(user3);
         users[1].ShouldBeSameAs(user2);

--- a/src/LinqTests/Acceptance/matches_sql_queries.cs
+++ b/src/LinqTests/Acceptance/matches_sql_queries.cs
@@ -6,6 +6,7 @@ using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
 using Weasel.Postgresql.SqlGeneration;
+using Marten;
 
 namespace LinqTests.Acceptance;
 
@@ -24,13 +25,13 @@ public class matches_sql_queries: IntegrationContext
         await session.SaveChangesAsync();
 
         // no where clause
-        session.Query<User>().Where(x => x.MatchesSql("d.data ->> 'UserName' = ? or d.data ->> 'UserName' = ?", "baz", "jack")).OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("baz", "jack");
+        (await session.Query<User>().Where(x => x.MatchesSql("d.data ->> 'UserName' = ? or d.data ->> 'UserName' = ?", "baz", "jack")).OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("baz", "jack");
 
         // with a where clause
-        session.Query<User>().Where(x => x.UserName != "baz" && x.MatchesSql("d.data ->> 'UserName' != ? and d.data ->> 'UserName' != ?", "foo", "bar"))
+        (await session.Query<User>().Where(x => x.UserName != "baz" && x.MatchesSql("d.data ->> 'UserName' != ? and d.data ->> 'UserName' != ?", "foo", "bar"))
             .OrderBy(x => x.UserName)
-            .ToList()
+            .ToListAsync())
             .Select(x => x.UserName)
             .Single().ShouldBe("jack");
     }
@@ -52,13 +53,13 @@ public class matches_sql_queries: IntegrationContext
         whereFragment.Add(new WhereFragment("d.data ->> 'UserName' != ?", "jack"));
 
         // no where clause
-        session.Query<User>().Where(x => x.MatchesSql(whereFragment)).OrderBy(x => x.UserName).Select(x => x.UserName)
-            .ToList().ShouldHaveTheSameElementsAs("bar", "foo");
+        (await session.Query<User>().Where(x => x.MatchesSql(whereFragment)).OrderBy(x => x.UserName).Select(x => x.UserName)
+            .ToListAsync()).ShouldHaveTheSameElementsAs("bar", "foo");
 
         // with a where clause
-        session.Query<User>().Where(x => x.UserName != "bar" && x.MatchesSql(whereFragment))
+        (await session.Query<User>().Where(x => x.UserName != "bar" && x.MatchesSql(whereFragment))
             .OrderBy(x => x.UserName)
-            .ToList()
+            .ToListAsync())
             .Select(x => x.UserName)
             .Single().ShouldBe("foo");
     }

--- a/src/LinqTests/Acceptance/nested_boolean_logic.cs
+++ b/src/LinqTests/Acceptance/nested_boolean_logic.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 namespace LinqTests.Acceptance;
 
 public class nested_boolean_logic : IntegrationContext
@@ -23,7 +24,7 @@ public class nested_boolean_logic : IntegrationContext
         var query = theSession.Query<Target>().Where(item => (item.String != null && item.Date >= startDate && item.Date <= endDate)
                                                              || (item.String == null && item.Date >= startDate && item.Date <= endDate));
 
-        query.ToList().Count.ShouldBeGreaterThanOrEqualTo(2);
+        (await query.ToListAsync()).Count.ShouldBeGreaterThanOrEqualTo(2);
 
     }
 

--- a/src/LinqTests/Acceptance/null_or_not_null_querying.cs
+++ b/src/LinqTests/Acceptance/null_or_not_null_querying.cs
@@ -38,9 +38,9 @@ public class multi_level_is_null_querying : IntegrationContext
 
         using (var s = theStore.QuerySession())
         {
-            var notNull = s.Query<UserNested>().First(x => x.Nested.Nested.Nested != null);
-            var notNullAlso = s.Query<UserNested>().First(x => x.Nested.Nested.Nested.Nested.Nested == null);
-            var shouldBeNull = s.Query<UserNested>().FirstOrDefault(x => x.Nested.Nested.Nested == null);
+            var notNull = (await s.Query<UserNested>().FirstAsync(x => x.Nested.Nested.Nested != null));
+            var notNullAlso = (await s.Query<UserNested>().FirstAsync(x => x.Nested.Nested.Nested.Nested.Nested == null));
+            var shouldBeNull = (await s.Query<UserNested>().FirstOrDefaultAsync(x => x.Nested.Nested.Nested == null));
 
             Assert.Equal(user.Id, notNull.Id);
             Assert.Equal(user.Id, notNullAlso.Id);

--- a/src/LinqTests/Acceptance/nullable_types.cs
+++ b/src/LinqTests/Acceptance/nullable_types.cs
@@ -20,7 +20,7 @@ public class nullable_types : IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.NullableNumber > 4).Count()
+        (await theSession.Query<Target>().Where(x => x.NullableNumber > 4).CountAsync())
             .ShouldBe(3);
     }
 
@@ -35,7 +35,7 @@ public class nullable_types : IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.NullableNumber == null).Count()
+        (await theSession.Query<Target>().Where(x => x.NullableNumber == null).CountAsync())
             .ShouldBe(3);
     }
 
@@ -50,7 +50,7 @@ public class nullable_types : IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => !x.NullableNumber.HasValue).Count()
+        (await theSession.Query<Target>().Where(x => !x.NullableNumber.HasValue).CountAsync())
             .ShouldBe(3);
 
     }
@@ -63,7 +63,7 @@ public class nullable_types : IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => !x.NullableBoolean.HasValue).Count()
+        (await theSession.Query<Target>().Where(x => !x.NullableBoolean.HasValue).CountAsync())
             .ShouldBe(1);
     }
 
@@ -120,7 +120,7 @@ public class nullable_types : IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => !x.NullableDateTime.HasValue || x.NullableDateTime > new DateTime(2525,1,1)).Count()
+        (await theSession.Query<Target>().Where(x => !x.NullableDateTime.HasValue || x.NullableDateTime > new DateTime(2525,1,1)).CountAsync())
             .ShouldBe(4);
     }
 
@@ -132,7 +132,7 @@ public class nullable_types : IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Count(x => x.NullableBoolean.HasValue == false)
+        (await theSession.Query<Target>().CountAsync(x => x.NullableBoolean.HasValue == false))
             .ShouldBe(1);
     }
 
@@ -147,7 +147,7 @@ public class nullable_types : IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Count(x => x.NullableNumber.HasValue)
+        (await theSession.Query<Target>().CountAsync(x => x.NullableNumber.HasValue))
             .ShouldBe(2);
     }
 

--- a/src/LinqTests/Acceptance/query_with_inheritance.cs
+++ b/src/LinqTests/Acceptance/query_with_inheritance.cs
@@ -83,7 +83,7 @@ public class sub_class_hierarchies: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Smurf>().Count().ShouldBe(3);
+        (await theSession.Query<Smurf>().CountAsync()).ShouldBe(3);
     }
 }
 
@@ -126,7 +126,7 @@ public class query_with_inheritance: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        var list = theSession.Query<IPapaSmurf>().ToList();
+        var list = (await theSession.Query<IPapaSmurf>().ToListAsync());
         list.Count.ShouldBe(3);
         list.Count(s => s.Ability == "Invent").ShouldBe(1);
     }
@@ -159,7 +159,7 @@ public class query_with_inheritance: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Smurf>().Count().ShouldBe(3);
+        (await theSession.Query<Smurf>().CountAsync()).ShouldBe(3);
     }
 
     [Fact]
@@ -172,7 +172,7 @@ public class query_with_inheritance: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<PapaSmurf>().Count().ShouldBe(2);
+        (await theSession.Query<PapaSmurf>().CountAsync()).ShouldBe(2);
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public class query_with_inheritance: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<PapaSmurf>().Count(s => s.Ability == "Invent").ShouldBe(1);
+        (await theSession.Query<PapaSmurf>().CountAsync(s => s.Ability == "Invent")).ShouldBe(1);
     }
 
     [Fact]
@@ -219,7 +219,7 @@ public class query_with_inheritance: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<PapaSmurf>().Count(s => s.Ability == "Invent").ShouldBe(1);
+        (await theSession.Query<PapaSmurf>().CountAsync(s => s.Ability == "Invent")).ShouldBe(1);
     }
 
 
@@ -234,7 +234,7 @@ public class query_with_inheritance: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<IPapaSmurf>().Count().ShouldBe(3);
+        (await theSession.Query<IPapaSmurf>().CountAsync()).ShouldBe(3);
     }
 
     [Fact]

--- a/src/LinqTests/Acceptance/select_clause_usage.cs
+++ b/src/LinqTests/Acceptance/select_clause_usage.cs
@@ -85,10 +85,10 @@ public class select_clause_usage: IntegrationContext
         theSession.Store(new User { FirstName = "Sam" });
         theSession.Store(new User { FirstName = "Tom" });
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync();(await 
 
         theSession.Query<User>().OrderBy(x => x.FirstName).Select(x => new UserName { Name = x.FirstName })
-            .ToArray()
+            .ToListAsync())
             .Select(x => x.Name)
             .ShouldHaveTheSameElementsAs("Bill", "Hank", "Sam", "Tom");
     }
@@ -175,10 +175,10 @@ public class select_clause_usage: IntegrationContext
         theSession.Store(new User { FirstName = "Sam" });
         theSession.Store(new User { FirstName = "Tom" });
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync();(await 
 
         theSession.Query<User>().OrderBy(x => x.FirstName).Select(x => new { Name = x.FirstName })
-            .ToArray()
+            .ToListAsync())
             .Select(x => x.Name)
             .ShouldHaveTheSameElementsAs("Bill", "Hank", "Sam", "Tom");
     }

--- a/src/LinqTests/Acceptance/select_clause_usage.cs
+++ b/src/LinqTests/Acceptance/select_clause_usage.cs
@@ -24,7 +24,7 @@ public class select_clause_usage: IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<User>().OrderBy(x => x.FirstName).Select(x => x.FirstName)
+        (await theSession.Query<User>().OrderBy(x => x.FirstName).Select(x => x.FirstName).ToListAsync())
             .ShouldHaveTheSameElementsAs("Bill", "Hank", "Sam", "Tom");
     }
 
@@ -40,8 +40,8 @@ public class select_clause_usage: IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<User>().OrderBy(x => x.FirstName).Select(x => x.FirstName)
-            .First().ShouldBe("Bill");
+        (await theSession.Query<User>().OrderBy(x => x.FirstName).Select(x => x.FirstName)
+            .FirstAsync()).ShouldBe("Bill");
     }
 
     [Fact]
@@ -105,8 +105,8 @@ public class select_clause_usage: IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<User>().OrderBy(x => x.FirstName).Select(x => new UserName { Name = x.FirstName })
-            .FirstOrDefault()
+        (await theSession.Query<User>().OrderBy(x => x.FirstName).Select(x => new UserName { Name = x.FirstName })
+            .FirstOrDefaultAsync())
             ?.Name.ShouldBe("Bill");
     }
 
@@ -344,10 +344,10 @@ public class select_clause_usage: IntegrationContext
         theSession.Store(target);
         await theSession.SaveChangesAsync();
 
-        var actual = theSession.Query<Target>()
+        var actual = (await theSession.Query<Target>()
             .Where(x => x.Id == target.Id)
             .Select(x => new { x.Id, x.Number, InnerNumber = x.Inner.Number })
-            .First();
+            .FirstAsync());
 
         actual.Id.ShouldBe(target.Id);
         actual.Number.ShouldBe(target.Number);
@@ -362,10 +362,10 @@ public class select_clause_usage: IntegrationContext
         theSession.Store(target);
         await theSession.SaveChangesAsync();
 
-        var actual = theSession.Query<Target>()
+        var actual = (await theSession.Query<Target>()
             .Where(x => x.Id == target.Id)
             .Select(x => new FlatTarget(x.Id, x.Number, x.Inner.Number))
-            .First();
+            .FirstAsync());
 
         actual.Id.ShouldBe(target.Id);
         actual.Number.ShouldBe(target.Number);
@@ -380,10 +380,10 @@ public class select_clause_usage: IntegrationContext
         theSession.Store(target);
         await theSession.SaveChangesAsync();
 
-        var actual = theSession.Query<Target>()
+        var actual = (await theSession.Query<Target>()
             .Where(x => x.Id == target.Id)
             .Select(x => x.Inner)
-            .First();
+            .FirstAsync());
 
         actual.Id.ShouldBe(target.Inner.Id);
         actual.Number.ShouldBe(target.Inner.Number);

--- a/src/LinqTests/Acceptance/select_clause_usage.cs
+++ b/src/LinqTests/Acceptance/select_clause_usage.cs
@@ -195,7 +195,7 @@ public class select_clause_usage: IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        var users = theSession.Query<User>().Select(x => new { First = x.FirstName, Last = x.LastName }).ToList();
+        var users = (await theSession.Query<User>().Select(x => new { First = x.FirstName, Last = x.LastName }).ToListAsync());
 
         users.Count.ShouldBe(4);
 
@@ -217,7 +217,7 @@ public class select_clause_usage: IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        var users = theSession.Query<User>().Select(x => new User2 { First = x.FirstName, Last = x.LastName }).ToList();
+        var users = (await theSession.Query<User>().Select(x => new User2 { First = x.FirstName, Last = x.LastName }).ToListAsync());
 
         users.Count.ShouldBe(4);
 
@@ -326,7 +326,7 @@ public class select_clause_usage: IntegrationContext
 
         await theStore.BulkInsertAsync(targets);
 
-        var actual = theSession.Query<Target>().Where(x => x.Number == targets[0].Number).Select(x => x.Inner.Number).ToList().Distinct();
+        var actual = (await theSession.Query<Target>().Where(x => x.Number == targets[0].Number).Select(x => x.Inner.Number).ToListAsync()).Distinct();
 
         var expected = targets.Where(x => x.Number == targets[0].Number).Select(x => x.Inner.Number).Distinct();
 

--- a/src/LinqTests/Acceptance/select_clause_usage.cs
+++ b/src/LinqTests/Acceptance/select_clause_usage.cs
@@ -247,9 +247,9 @@ public class select_clause_usage: IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        var users = theSession.Query<User>()
+        var users = (await theSession.Query<User>()
             .Select(x => new UserDto(x.FirstName, x.LastName))
-            .ToList();
+            .ToListAsync());
 
         users.Count.ShouldBe(4);
 
@@ -270,9 +270,9 @@ public class select_clause_usage: IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        var users = theSession.Query<User>()
+        var users = (await theSession.Query<User>()
             .Select(x => new UserDto(x.FirstName, x.LastName) { YearsOld = x.Age })
-            .ToList();
+            .ToListAsync());
 
         users.Count.ShouldBe(4);
 

--- a/src/LinqTests/Acceptance/select_many.cs
+++ b/src/LinqTests/Acceptance/select_many.cs
@@ -56,11 +56,11 @@ public class select_many : IntegrationContext
         using (var query = theStore.QuerySession())
         {
 
-            query
+            (await query
                 .Query<ProductWithList>()
                 .SelectMany(x => x.Tags)
                 .Distinct()
-                .Count()
+                .CountAsync())
                 .ShouldBe(6);
         }
     }
@@ -81,11 +81,11 @@ public class select_many : IntegrationContext
         using (var query = theStore.QuerySession())
         {
 
-            query
+            (await query
                 .Query<ProductWithList>()
                 .SelectMany(x => x.Tags)
                 .Distinct()
-                .LongCount()
+                .LongCountAsync())
                 .ShouldBe(6L);
         }
     }
@@ -132,8 +132,8 @@ public class select_many : IntegrationContext
 
         using (var query = theStore.QuerySession())
         {
-            query.Query<Product>().SelectMany(x => x.Tags)
-                .Count().ShouldBe(9);
+            (await query.Query<Product>().SelectMany(x => x.Tags)
+                .CountAsync()).ShouldBe(9);
         }
     }
 
@@ -155,7 +155,7 @@ public class select_many : IntegrationContext
             var queryable = query.Query<Product>()
                 .Where(p => p.Tags.Length == 1)
                 .SelectMany(x => x.Tags);
-            var ex = Record.Exception(() => queryable.Count());
+            var ex = await Record.ExceptionAsync(async () => await queryable.CountAsync());
             ex.ShouldBeNull();
         }
     }
@@ -293,13 +293,13 @@ public class select_many : IntegrationContext
 
         using (var query = theStore.QuerySession())
         {
-            query.Query<Product>().SelectMany(x => x.Tags)
-                .Any().ShouldBeTrue();
+            (await query.Query<Product>().SelectMany(x => x.Tags)
+                .AnyAsync()).ShouldBeTrue();
 
 
 
-            query.Query<Target>().SelectMany(x => x.Children)
-                .Any().ShouldBeFalse();
+            (await query.Query<Target>().SelectMany(x => x.Children)
+                .AnyAsync()).ShouldBeFalse();
         }
     }
 

--- a/src/LinqTests/Acceptance/select_many.cs
+++ b/src/LinqTests/Acceptance/select_many.cs
@@ -29,11 +29,11 @@ public class select_many : IntegrationContext
 
         using (var query = theStore.QuerySession())
         {
-            var distinct = query.Query<Product>().SelectMany(x => x.Tags).Distinct().ToList();
+            var distinct = (await query.Query<Product>().SelectMany(x => x.Tags).Distinct().ToListAsync());
 
             distinct.OrderBy(x => x).ShouldHaveTheSameElementsAs("a", "b", "c", "d", "e", "f");
 
-            var names = query.Query<Product>().SelectMany(x => x.Tags).ToList();
+            var names = (await query.Query<Product>().SelectMany(x => x.Tags).ToListAsync());
             names
                 .Count.ShouldBe(9);
         }
@@ -107,11 +107,11 @@ public class select_many : IntegrationContext
         using (var query = theStore.QuerySession())
         {
 
-            var distinct = query.Query<ProductWithList>().SelectMany(x => x.Tags).Distinct().ToList();
+            var distinct = (await query.Query<ProductWithList>().SelectMany(x => x.Tags).Distinct().ToListAsync());
 
             distinct.OrderBy(x => x).ShouldHaveTheSameElementsAs("a", "b", "c", "d", "e", "f");
 
-            var names = query.Query<ProductWithList>().SelectMany(x => x.Tags).ToList();
+            var names = (await query.Query<ProductWithList>().SelectMany(x => x.Tags).ToListAsync());
             names
                 .Count.ShouldBe(9);
         }
@@ -219,7 +219,7 @@ public class select_many : IntegrationContext
 
         using (var query = theStore.QuerySession())
         {
-            var list = query.Query<Target>().SelectMany(x => x.Children).ToList();
+            var list = (await query.Query<Target>().SelectMany(x => x.Children).ToListAsync());
             list.Count.ShouldBe(expectedCount);
         }
     }
@@ -239,11 +239,11 @@ public class select_many : IntegrationContext
 
         using (var query = theStore.QuerySession())
         {
-            var distinct = query.Query<ProductWithNumbers>().SelectMany(x => x.Tags).Distinct().ToList();
+            var distinct = (await query.Query<ProductWithNumbers>().SelectMany(x => x.Tags).Distinct().ToListAsync());
 
             distinct.OrderBy(x => x).ShouldHaveTheSameElementsAs(1, 2, 3, 4, 5);
 
-            var names = query.Query<ProductWithNumbers>().SelectMany(x => x.Tags).ToList();
+            var names = (await query.Query<ProductWithNumbers>().SelectMany(x => x.Tags).ToListAsync());
             names
                 .Count.ShouldBe(9);
         }
@@ -268,7 +268,7 @@ public class select_many : IntegrationContext
 
             distinct.OrderBy(x => x).ShouldHaveTheSameElementsAs(1, 2, 3, 4, 5);
 
-            var names = query.Query<ProductWithNumbers>().SelectMany(x => x.Tags).ToList();
+            var names = (await query.Query<ProductWithNumbers>().SelectMany(x => x.Tags).ToListAsync());
             names
                 .Count.ShouldBe(9);
         }
@@ -343,7 +343,7 @@ public class select_many : IntegrationContext
         var expected = targets.SelectMany(x => x.Children).Where(x => x.Flag).Select(x => x.Id).OrderBy(x => x).ToList();
         expected.Any().ShouldBeTrue();
 
-        var results = query.Query<Target>().SelectMany(x => x.Children).Where(x => x.Flag).ToList();
+        var results = (await query.Query<Target>().SelectMany(x => x.Children).Where(x => x.Flag).ToListAsync());
 
         results.Select(x => x.Id).OrderBy(x => x).ShouldHaveTheSameElementsAs(expected);
     }
@@ -358,7 +358,7 @@ public class select_many : IntegrationContext
         var expected = targets.SelectMany(x => x.Children).Where(x => x.Flag).Select(x => x.Id).OrderBy(x => x).ToList();
         expected.Any().ShouldBeTrue();
 
-        var results = query.Query<Target>().SelectMany(x => x.Children).Where(x => x.Flag).OrderBy(x => x.Id).ToList();
+        var results = (await query.Query<Target>().SelectMany(x => x.Children).Where(x => x.Flag).OrderBy(x => x.Id).ToListAsync());
 
         results.Select(x => x.Id).ShouldHaveTheSameElementsAs(expected);
     }

--- a/src/LinqTests/Acceptance/select_many.cs
+++ b/src/LinqTests/Acceptance/select_many.cs
@@ -383,13 +383,13 @@ public class select_many : IntegrationContext
         expected.Any().ShouldBeTrue();
 
         #region sample_using-select-many
-        var results = query.Query<Target>()
+        var results = (await query.Query<Target>()
             .SelectMany(x => x.Children)
             .Where(x => x.Flag)
             .OrderBy(x => x.Id)
             .Skip(20)
             .Take(15)
-            .ToList();
+            .ToListAsync());
         #endregion
 
         results.Select(x => x.Id).ShouldHaveTheSameElementsAs(expected);
@@ -406,12 +406,12 @@ public class select_many : IntegrationContext
         await using var query = theStore.LightweightSession();
         QueryStatistics stats;
 
-        var actual = query.Query<Target>()
+        var actual = (await query.Query<Target>()
             .Stats(out stats)
             .SelectMany(x => x.Children)
             .Where(x => x.Flag)
             .OrderBy(x => x.Id)
-            .Take(10).ToList();
+            .Take(10).ToListAsync());
 
         var expectedCount = targets
             .SelectMany(x => x.Children)
@@ -452,10 +452,10 @@ public class select_many : IntegrationContext
 
 
 
-        var results = query.Query<Target>()
+        var results = (await query.Query<Target>()
             .SelectMany(x => x.Children)
             .Include(x => x.UserId, dict)
-            .ToList();
+            .ToListAsync());
 
         dict.Count.ShouldBe(2);
 
@@ -510,11 +510,11 @@ public class select_many : IntegrationContext
         await theStore.BulkInsertAsync(targets);
 
         using var query = theStore.QuerySession();
-        var actual = query.Query<Target>()
+        var actual = (await query.Query<Target>()
             .SelectMany(x => x.Children)
             .Where(x => x.Color == Colors.Green)
             .Select(x => new {Id = x.Id, Shade = x.Color})
-            .ToList();
+            .ToListAsync());
 
         var expected = targets
             .SelectMany(x => x.Children).Count(x => x.Color == Colors.Green);
@@ -534,9 +534,9 @@ public class select_many : IntegrationContext
     }
 
     [Fact]
-    public void try_n_deep_smoke_test()
+    public async Task try_n_deep_smoke_test()
     {
-        using var query = theStore.QuerySession();
+        await using var query = theStore.QuerySession();
 
         var command = query.Query<Target>()
             .Where(x => x.Color == Colors.Blue)
@@ -548,13 +548,13 @@ public class select_many : IntegrationContext
 
         command.ShouldNotBeNull();
 
-        query.Query<Target>()
+        (await query.Query<Target>()
             .Where(x => x.Color == Colors.Blue)
             .SelectMany(x => x.Children)
             .Where(x => x.Color == Colors.Red)
             .SelectMany(x => x.Children)
             .OrderBy(x => x.Number)
-            .ToList().ShouldNotBeNull();
+            .ToListAsync()).ShouldNotBeNull();
     }
 
     public class TargetGroup

--- a/src/LinqTests/Acceptance/select_many.cs
+++ b/src/LinqTests/Acceptance/select_many.cs
@@ -593,12 +593,12 @@ public class select_many : IntegrationContext
 
 
 
-        var loaded = query.Query<TargetGroup>()
+        var loaded = (await query.Query<TargetGroup>()
             .SelectMany(x => x.Targets)
             .Where(x => x.Color == Colors.Blue)
             .SelectMany(x => x.Children)
             .OrderBy(x => x.Number)
-            .ToArray()
+            .ToListAsync())
             .Select(x => x.Id).ToArray();
 
         /*

--- a/src/LinqTests/Acceptance/statistics_and_paged_list.cs
+++ b/src/LinqTests/Acceptance/statistics_and_paged_list.cs
@@ -28,18 +28,10 @@ public class ToPagedListData<T>: IEnumerable<object[]>
     private static readonly Func<IQueryable<T>, int, int, Task<IPagedList<T>>> ToPagedListWithCountQueryAsync
         = (query, pageNumber, pageSize) => query.ToPagedListAsync(pageNumber, pageSize, true);
 
-    private static readonly Func<IQueryable<T>, int, int, Task<IPagedList<T>>> ToPagedListSync
-        = (query, pageNumber, pageSize) => Task.FromResult(query.ToPagedList(pageNumber, pageSize));
-
-    private static readonly Func<IQueryable<T>, int, int, Task<IPagedList<T>>> ToPagedListWithCountQuerySync
-        = (query, pageNumber, pageSize) => Task.FromResult(query.ToPagedList(pageNumber, pageSize, true));
-
     public IEnumerator<object[]> GetEnumerator()
     {
         yield return [ToPagedListAsync];
         yield return [ToPagedListWithCountQueryAsync];
-        yield return [ToPagedListSync];
-        yield return [ToPagedListWithCountQuerySync];
     }
 
     IEnumerator IEnumerable.GetEnumerator()
@@ -220,13 +212,13 @@ public class statistics_and_paged_list: IntegrationContext
     }
 
     [Fact]
-    public void can_return_paged_result()
+    public async Task can_return_paged_result()
     {
         #region sample_to_paged_list
         var pageNumber = 2;
         var pageSize = 10;
 
-        var pagedList = theSession.Query<Target>().ToPagedList(pageNumber, pageSize);
+        var pagedList = await theSession.Query<Target>().ToPagedListAsync(pageNumber, pageSize);
 
         // paged list also provides a list of helper properties to deal with pagination aspects
         var totalItems = pagedList.TotalItemCount; // get total number records
@@ -257,12 +249,12 @@ public class statistics_and_paged_list: IntegrationContext
     }
 
     [Fact]
-    public void can_return_paged_result_using_separate_count_query()
+    public async Task can_return_paged_result_using_separate_count_query()
     {
         #region sample_to_paged_list_seperate_count_query
         var pageNumber = 2;
         var pageSize = 10;
-        var pagedList = theSession.Query<Target>().ToPagedList(pageNumber, pageSize, true);
+        var pagedList = await theSession.Query<Target>().ToPagedListAsync(pageNumber, pageSize, true);
 
         // paged list also provides a list of helper properties to deal with pagination aspects
         var totalItems = pagedList.TotalItemCount; // get total number records

--- a/src/LinqTests/Acceptance/statistics_and_paged_list.cs
+++ b/src/LinqTests/Acceptance/statistics_and_paged_list.cs
@@ -89,7 +89,7 @@ public class statistics_and_paged_list: IntegrationContext
     [Fact]
     public async Task can_get_the_total_from_a_compiled_query()
     {
-        var count = theSession.Query<Target>().Count(x => x.Number > 10);
+        var count = (await theSession.Query<Target>().CountAsync(x => x.Number > 10));
         count.ShouldBeGreaterThan(0);
 
         var query = new TargetPaginationQuery(2, 5);
@@ -105,7 +105,7 @@ public class statistics_and_paged_list: IntegrationContext
     public async Task can_use_json_streaming_with_statistics()
     {
 
-        var count = theSession.Query<Target>().Count(x => x.Number > 10);
+        var count = (await theSession.Query<Target>().CountAsync(x => x.Number > 10));
         count.ShouldBeGreaterThan(0);
 
         var query = new TargetPaginationQuery(2, 5);
@@ -167,7 +167,7 @@ public class statistics_and_paged_list: IntegrationContext
     [Fact]
     public async Task can_get_the_total_in_results()
     {
-        var count = theSession.Query<Target>().Count(x => x.Number > 10);
+        var count = (await theSession.Query<Target>().CountAsync(x => x.Number > 10));
         count.ShouldBeGreaterThan(0);
 
         // We're going to use stats as an output
@@ -312,7 +312,7 @@ public class statistics_and_paged_list: IntegrationContext
 
         var pageSize = 10;
 
-        var expectedPageCount = theSession.Query<Target>().Count()/pageSize;
+        var expectedPageCount = (await theSession.Query<Target>().CountAsync())/pageSize;
 
         var pagedList = await toPagedList(theSession.Query<Target>(), pageNumber, pageSize);
         pagedList.PageCount.ShouldBe(expectedPageCount);
@@ -326,7 +326,7 @@ public class statistics_and_paged_list: IntegrationContext
 
         var pageSize = 10;
 
-        var expectedTotalItemsCount = theSession.Query<Target>().Count();
+        var expectedTotalItemsCount = (await theSession.Query<Target>().CountAsync());
 
         var pagedList = await toPagedList(theSession.Query<Target>(), pageNumber, pageSize);
         pagedList.TotalItemCount.ShouldBe(expectedTotalItemsCount);

--- a/src/LinqTests/Acceptance/string_filtering.cs
+++ b/src/LinqTests/Acceptance/string_filtering.cs
@@ -5,6 +5,7 @@ using JasperFx.Core;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 namespace LinqTests.Acceptance;
 
 public class string_filtering: IntegrationContext
@@ -24,10 +25,10 @@ public class string_filtering: IntegrationContext
     [InlineData("zap", StringComparison.OrdinalIgnoreCase, 1)]
     [InlineData("Zap", StringComparison.CurrentCulture, 1)]
     [InlineData("zap", StringComparison.CurrentCulture, 0)]
-    public void CanQueryByEquals(string search, StringComparison comparison, int expectedCount)
+    public async Task CanQueryByEquals(string search, StringComparison comparison, int expectedCount)
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>().Where(x => x.FirstName.Equals(search, comparison)).ToList();
+        var fromDb = (await s.Query<User>().Where(x => x.FirstName.Equals(search, comparison)).ToListAsync());
 
         Assert.Equal(expectedCount, fromDb.Count);
         Assert.True(fromDb.All(x => x.FirstName.Equals(search, comparison)));
@@ -37,10 +38,10 @@ public class string_filtering: IntegrationContext
     [InlineData("zap", StringComparison.OrdinalIgnoreCase, 3)]
     [InlineData("Zap", StringComparison.CurrentCulture, 3)]
     [InlineData("zap", StringComparison.CurrentCulture, 4)]
-    public void CanQueryByNotEquals(string search, StringComparison comparison, int expectedCount)
+    public async Task CanQueryByNotEquals(string search, StringComparison comparison, int expectedCount)
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>().Where(x => !x.FirstName.Equals(search, comparison)).ToList();
+        var fromDb = (await s.Query<User>().Where(x => !x.FirstName.Equals(search, comparison)).ToListAsync());
 
         Assert.Equal(expectedCount, fromDb.Count);
         Assert.True(fromDb.All(x => !x.FirstName.Equals(search, comparison)));
@@ -49,10 +50,10 @@ public class string_filtering: IntegrationContext
     [Theory]
     [InlineData("zap", StringComparison.OrdinalIgnoreCase, 2)]
     [InlineData("zap", StringComparison.CurrentCulture, 0)]
-    public void CanQueryByContains(string search, StringComparison comparison, int expectedCount)
+    public async Task CanQueryByContains(string search, StringComparison comparison, int expectedCount)
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>().Where(x => x.FirstName.Contains(search, comparison)).ToList();
+        var fromDb = (await s.Query<User>().Where(x => x.FirstName.Contains(search, comparison)).ToListAsync());
 
         Assert.Equal(expectedCount, fromDb.Count);
         Assert.True(fromDb.All(x => x.FirstName.Contains(search, comparison)));
@@ -61,10 +62,10 @@ public class string_filtering: IntegrationContext
     [Theory]
     [InlineData("zap", StringComparison.OrdinalIgnoreCase, 2)]
     [InlineData("zap", StringComparison.CurrentCulture, 4)]
-    public void CanQueryByNotContains(string search, StringComparison comparison, int expectedCount)
+    public async Task CanQueryByNotContains(string search, StringComparison comparison, int expectedCount)
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>().Where(x => !x.FirstName.Contains(search, comparison)).ToList();
+        var fromDb = (await s.Query<User>().Where(x => !x.FirstName.Contains(search, comparison)).ToListAsync());
 
         Assert.Equal(expectedCount, fromDb.Count);
         Assert.True(fromDb.All(x => !x.FirstName.Contains(search, comparison)));
@@ -73,10 +74,10 @@ public class string_filtering: IntegrationContext
     [Theory]
     [InlineData("zap", StringComparison.OrdinalIgnoreCase, 2)]
     [InlineData("zap", StringComparison.CurrentCulture, 0)]
-    public void CanQueryByStartsWith(string search, StringComparison comparison, int expectedCount)
+    public async Task CanQueryByStartsWith(string search, StringComparison comparison, int expectedCount)
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>().Where(x => x.FirstName.StartsWith(search, comparison)).ToList();
+        var fromDb = (await s.Query<User>().Where(x => x.FirstName.StartsWith(search, comparison)).ToListAsync());
 
         Assert.Equal(expectedCount, fromDb.Count);
         Assert.True(fromDb.All(x => x.FirstName.StartsWith(search, comparison)));
@@ -85,10 +86,10 @@ public class string_filtering: IntegrationContext
     [Theory]
     [InlineData("zap", StringComparison.OrdinalIgnoreCase, 2)]
     [InlineData("zap", StringComparison.CurrentCulture, 4)]
-    public void CanQueryByNotStartsWith(string search, StringComparison comparison, int expectedCount)
+    public async Task CanQueryByNotStartsWith(string search, StringComparison comparison, int expectedCount)
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>().Where(x => !x.FirstName.StartsWith(search, comparison)).ToList();
+        var fromDb = (await s.Query<User>().Where(x => !x.FirstName.StartsWith(search, comparison)).ToListAsync());
 
         Assert.Equal(expectedCount, fromDb.Count);
         Assert.True(fromDb.All(x => !x.FirstName.StartsWith(search, comparison)));
@@ -98,10 +99,10 @@ public class string_filtering: IntegrationContext
     [InlineData("hod", StringComparison.OrdinalIgnoreCase, 1)]
     [InlineData("HOD", StringComparison.OrdinalIgnoreCase, 1)]
     [InlineData("Hod", StringComparison.CurrentCulture, 0)]
-    public void CanQueryByEndsWith(string search, StringComparison comparison, int expectedCount)
+    public async Task CanQueryByEndsWith(string search, StringComparison comparison, int expectedCount)
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>().Where(x => x.FirstName.EndsWith(search, comparison)).ToList();
+        var fromDb = (await s.Query<User>().Where(x => x.FirstName.EndsWith(search, comparison)).ToListAsync());
 
         Assert.Equal(expectedCount, fromDb.Count);
         Assert.True(fromDb.All(x => x.FirstName.EndsWith(search, comparison)));
@@ -111,50 +112,50 @@ public class string_filtering: IntegrationContext
     [InlineData("hod", StringComparison.OrdinalIgnoreCase, 3)]
     [InlineData("HOD", StringComparison.OrdinalIgnoreCase, 3)]
     [InlineData("Hod", StringComparison.CurrentCulture, 4)]
-    public void CanQueryByNotEndsWith(string search, StringComparison comparison, int expectedCount)
+    public async Task CanQueryByNotEndsWith(string search, StringComparison comparison, int expectedCount)
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>().Where(x => !x.FirstName.EndsWith(search, comparison)).ToList();
+        var fromDb = (await s.Query<User>().Where(x => !x.FirstName.EndsWith(search, comparison)).ToListAsync());
 
         Assert.Equal(expectedCount, fromDb.Count);
         Assert.True(fromDb.All(x => !x.FirstName.EndsWith(search, comparison)));
     }
 
     [Fact]
-    public void CanQueryByIsNullOrEmpty()
+    public async Task CanQueryByIsNullOrEmpty()
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>().Where(x => string.IsNullOrEmpty(x.Nickname)).ToList();
+        var fromDb = (await s.Query<User>().Where(x => string.IsNullOrEmpty(x.Nickname)).ToListAsync());
 
         Assert.Equal(2, fromDb.Count);
         Assert.True(fromDb.All(x => string.IsNullOrEmpty(x.Nickname)));
     }
 
     [Fact]
-    public void CanQueryByNotIsNullOrEmpty()
+    public async Task CanQueryByNotIsNullOrEmpty()
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>().Where(x => !string.IsNullOrEmpty(x.Nickname)).ToList();
+        var fromDb = (await s.Query<User>().Where(x => !string.IsNullOrEmpty(x.Nickname)).ToListAsync());
 
         Assert.Equal(2, fromDb.Count);
         Assert.True(fromDb.All(x => !string.IsNullOrEmpty(x.Nickname)));
     }
 
     [Fact]
-    public void CanQueryByIsNullOrWhiteSpace()
+    public async Task CanQueryByIsNullOrWhiteSpace()
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>().Where(x => string.IsNullOrWhiteSpace(x.Nickname)).ToList();
+        var fromDb = (await s.Query<User>().Where(x => string.IsNullOrWhiteSpace(x.Nickname)).ToListAsync());
 
         Assert.Equal(3, fromDb.Count);
         Assert.True(fromDb.All(x => string.IsNullOrWhiteSpace(x.Nickname)));
     }
 
     [Fact]
-    public void CanQueryByNotIsNullOrWhiteSpace()
+    public async Task CanQueryByNotIsNullOrWhiteSpace()
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>().Where(x => !string.IsNullOrWhiteSpace(x.Nickname)).ToList();
+        var fromDb = (await s.Query<User>().Where(x => !string.IsNullOrWhiteSpace(x.Nickname)).ToListAsync());
 
         Assert.Single(fromDb);
         Assert.True(fromDb.All(x => !string.IsNullOrWhiteSpace(x.Nickname)));
@@ -221,14 +222,14 @@ public class string_filtering: IntegrationContext
         {
             #region sample_sample-linq-equalsignorecase
 
-            query.Query<User>().Single(x => x.UserName.EqualsIgnoreCase("abc")).Id.ShouldBe(user1.Id);
-            query.Query<User>().Single(x => x.UserName.EqualsIgnoreCase("aBc")).Id.ShouldBe(user1.Id);
+            (await query.Query<User>().SingleAsync(x => x.UserName.EqualsIgnoreCase("abc"))).Id.ShouldBe(user1.Id);
+            (await query.Query<User>().SingleAsync(x => x.UserName.EqualsIgnoreCase("aBc"))).Id.ShouldBe(user1.Id);
 
             #endregion
 
-            query.Query<User>().Single(x => x.UserName.EqualsIgnoreCase("def")).Id.ShouldBe(user2.Id);
+            (await query.Query<User>().SingleAsync(x => x.UserName.EqualsIgnoreCase("def"))).Id.ShouldBe(user2.Id);
 
-            query.Query<User>().Any(x => x.UserName.EqualsIgnoreCase("abcd")).ShouldBeFalse();
+            (await query.Query<User>().AnyAsync(x => x.UserName.EqualsIgnoreCase("abcd"))).ShouldBeFalse();
         }
     }
 
@@ -245,7 +246,7 @@ public class string_filtering: IntegrationContext
 
         using (var query = theStore.QuerySession())
         {
-            query.Query<User>().Single(x => x.UserName.Equals("test_user", StringComparison.InvariantCultureIgnoreCase))
+            (await query.Query<User>().SingleAsync(x => x.UserName.Equals("test_user", StringComparison.InvariantCultureIgnoreCase)))
                 .Id.ShouldBe(user.Id);
         }
     }

--- a/src/LinqTests/Acceptance/string_filtering.cs
+++ b/src/LinqTests/Acceptance/string_filtering.cs
@@ -264,8 +264,8 @@ public class string_filtering: IntegrationContext
 
         using (var query = theStore.QuerySession())
         {
-            query.Query<User>()
-                .Single(x => x.UserName.Equals(@"domain\test_user", StringComparison.InvariantCultureIgnoreCase)).Id
+            (await query.Query<User>()
+                .SingleAsync(x => x.UserName.Equals(@"domain\test_user", StringComparison.InvariantCultureIgnoreCase))).Id
                 .ShouldBe(user.Id);
         }
     }

--- a/src/LinqTests/Acceptance/string_filtering.cs
+++ b/src/LinqTests/Acceptance/string_filtering.cs
@@ -164,12 +164,12 @@ public class string_filtering: IntegrationContext
     [Theory]
     [InlineData("zap", "hod", StringComparison.OrdinalIgnoreCase, 1)]
     [InlineData("zap", "hod", StringComparison.CurrentCulture, 0)]
-    public void CanMixContainsAndNotContains(string contains, string notContains, StringComparison comparison,
+    public async Task CanMixContainsAndNotContains(string contains, string notContains, StringComparison comparison,
         int expectedCount)
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>().Where(x =>
-            !x.FirstName.Contains(notContains, comparison) && x.FirstName.Contains(contains, comparison)).ToList();
+        var fromDb = (await s.Query<User>().Where(x =>
+            !x.FirstName.Contains(notContains, comparison) && x.FirstName.Contains(contains, comparison)).ToListAsync());
 
         Assert.Equal(expectedCount, fromDb.Count);
         Assert.True(fromDb.All(x =>
@@ -180,12 +180,12 @@ public class string_filtering: IntegrationContext
     [InlineData("hod", StringComparison.OrdinalIgnoreCase, 1)]
     [InlineData("HOD", StringComparison.OrdinalIgnoreCase, 1)]
     [InlineData("Hod", StringComparison.CurrentCulture, 2)]
-    public void CanMixNotEndsWithWithNotIsNullOrEmpty(string search, StringComparison comparison,
+    public async Task CanMixNotEndsWithWithNotIsNullOrEmpty(string search, StringComparison comparison,
         int expectedCount)
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>()
-            .Where(x => !x.FirstName.EndsWith(search, comparison) && !string.IsNullOrEmpty(x.Nickname)).ToList();
+        var fromDb = (await s.Query<User>()
+            .Where(x => !x.FirstName.EndsWith(search, comparison) && !string.IsNullOrEmpty(x.Nickname)).ToListAsync());
 
         Assert.Equal(expectedCount, fromDb.Count);
         Assert.True(
@@ -195,11 +195,11 @@ public class string_filtering: IntegrationContext
     [Theory]
     [InlineData("zap", StringComparison.OrdinalIgnoreCase, 1)]
     [InlineData("zap", StringComparison.CurrentCulture, 0)]
-    public void CanMixStartsWithAndIsNullOrWhiteSpace(string search, StringComparison comparison, int expectedCount)
+    public async Task CanMixStartsWithAndIsNullOrWhiteSpace(string search, StringComparison comparison, int expectedCount)
     {
         using var s = theStore.QuerySession();
-        var fromDb = s.Query<User>()
-            .Where(x => x.FirstName.StartsWith(search, comparison) && string.IsNullOrWhiteSpace(x.Nickname)).ToList();
+        var fromDb = (await s.Query<User>()
+            .Where(x => x.FirstName.StartsWith(search, comparison) && string.IsNullOrWhiteSpace(x.Nickname)).ToListAsync());
 
         Assert.Equal(expectedCount, fromDb.Count);
         Assert.True(

--- a/src/LinqTests/Acceptance/synchronous_apis_throw.cs
+++ b/src/LinqTests/Acceptance/synchronous_apis_throw.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten.Internal.Sessions;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+
+namespace LinqTests.Acceptance;
+
+public class synchronous_apis_throw: IntegrationContext
+{
+    public synchronous_apis_throw(DefaultStoreFixture fixture): base(fixture)
+    {
+    }
+
+    [Fact]
+    public void ToList_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<User>().ToList());
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void ToArray_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<User>().ToArray());
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void First_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<User>().First());
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void FirstOrDefault_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<User>().FirstOrDefault());
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void Single_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<User>().Single());
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void SingleOrDefault_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<User>().SingleOrDefault());
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void Count_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<User>().Count());
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void LongCount_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<User>().LongCount());
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void Any_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<User>().Any());
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void Min_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<Target>().Min(x => x.Number));
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void Max_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<Target>().Max(x => x.Number));
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void Sum_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<Target>().Sum(x => x.Number));
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void Average_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<Target>().Average(x => x.Number));
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void ToDictionary_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.Query<User>().ToDictionary(x => x.Id));
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void foreach_iteration_throws_NotSupportedException()
+    {
+        var ex = Should.Throw<NotSupportedException>(() =>
+        {
+            foreach (var _ in theSession.Query<User>())
+            {
+                // never reached
+            }
+        });
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void non_generic_enumerator_throws_NotSupportedException()
+    {
+        var queryable = theSession.Query<User>();
+        var ex = Should.Throw<NotSupportedException>(() => ((IEnumerable)queryable).GetEnumerator());
+        ex.Message.ShouldBe(QuerySession.SynchronousNotSupportedMessage);
+    }
+
+    [Fact]
+    public void exception_message_references_marten_9()
+    {
+        QuerySession.SynchronousNotSupportedMessage
+            .ShouldBe("As of Marten 9.0, only asynchronous data access is supported");
+    }
+}

--- a/src/LinqTests/Bugs/Bug_118_bad_exception_message_Tests.cs
+++ b/src/LinqTests/Bugs/Bug_118_bad_exception_message_Tests.cs
@@ -1,7 +1,9 @@
 using System.Linq;
+using System.Threading.Tasks;
 using Marten.Exceptions;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 
 namespace LinqTests.Bugs;
 
@@ -15,11 +17,11 @@ public class Bug_118_bad_exception_message_Tests: BugIntegrationContext
     internal TestClass TestNullObject { get; set; }
 
     [Fact]
-    public void When_Property_Is_Null_Exception_Should_Be_Null_Reference_Exception()
+    public async Task When_Property_Is_Null_Exception_Should_Be_Null_Reference_Exception()
     {
-        Should.Throw<BadLinqExpressionException>(() =>
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
         {
-            theSession.Query<TestClass>().Where(x => x.Id == TestNullObject.Id).ToList();
+            await theSession.Query<TestClass>().Where(x => x.Id == TestNullObject.Id).ToListAsync();
         });
     }
 

--- a/src/LinqTests/Bugs/Bug_1219_ordering_by_attributes.cs
+++ b/src/LinqTests/Bugs/Bug_1219_ordering_by_attributes.cs
@@ -35,14 +35,14 @@ public class Bug_1219_ordering_by_attributes : IntegrationContext
 
         using var query = theStore.QuerySession();
 
-        var cars = query.Query<Car>().OrderBy(x => x.Attributes["color"]).ToArray();
+        var cars = (await query.Query<Car>().OrderBy(x => x.Attributes["color"]).ToListAsync());
 
         cars[0].Id.ShouldBe(car3.Id);
         cars[1].Id.ShouldBe(car2.Id);
         cars[2].Id.ShouldBe(car4.Id);
         cars[3].Id.ShouldBe(car1.Id);
 
-        var cars2 = query.Query<Car>().OrderBy(x => x.Attributes["anumber"]).ToArray();
+        var cars2 = (await query.Query<Car>().OrderBy(x => x.Attributes["anumber"]).ToListAsync());
         cars2[0].Id.ShouldBe(car2.Id);
     }
 

--- a/src/LinqTests/Bugs/Bug_1219_ordering_by_attributes.cs
+++ b/src/LinqTests/Bugs/Bug_1219_ordering_by_attributes.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Marten.Services.Json;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 namespace LinqTests.Bugs;
 
 public class Bug_1219_ordering_by_attributes : IntegrationContext
@@ -46,10 +47,10 @@ public class Bug_1219_ordering_by_attributes : IntegrationContext
     }
 
     [Fact]
-    public void smoke_test_can_order_by_not_string_values_in_dictionary()
+    public async Task smoke_test_can_order_by_not_string_values_in_dictionary()
     {
         using var query = theStore.QuerySession();
 
-        query.Query<Car>().OrderBy(x => x.Numbers[2]).ToList();
+        await query.Query<Car>().OrderBy(x => x.Numbers[2]).ToListAsync();
     }
 }

--- a/src/LinqTests/Bugs/Bug_1245_include_plus_full_text_search.cs
+++ b/src/LinqTests/Bugs/Bug_1245_include_plus_full_text_search.cs
@@ -54,11 +54,11 @@ public class Bug_1245_include_plus_full_text_search: BugIntegrationContext
 
         await session.SaveChangesAsync();
 
-        var query = session.Query<Email>()
+        var query = await session.Query<Email>()
             .Include(x => x.UserId, userDictionary)
             //.Where(x => x.Content.PlainTextSearch(term)).ToList();
             //.Where(x => x.Content.Search(term)).ToList();
-            .Where(x => x.Content.PhraseSearch(term)).ToList();
+            .Where(x => x.Content.PhraseSearch(term)).ToListAsync();
 
         query.ShouldNotBeNull();
     }

--- a/src/LinqTests/Bugs/Bug_1256_querying_against_a_uint_type.cs
+++ b/src/LinqTests/Bugs/Bug_1256_querying_against_a_uint_type.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 
 namespace LinqTests.Bugs;
 
@@ -28,7 +29,7 @@ public class Bug_1256_querying_against_a_uint_type: IntegrationContext
             session.Store(doc1, doc2, doc3, doc4, doc5);
             await session.SaveChangesAsync();
 
-            session.Query<DocWithUint>().Count(x => x.Number > 3).ShouldBe(2);
+            (await session.Query<DocWithUint>().CountAsync(x => x.Number > 3)).ShouldBe(2);
         }
     }
 

--- a/src/LinqTests/Bugs/Bug_1325_Any_with_contains_on_IList_of_string.cs
+++ b/src/LinqTests/Bugs/Bug_1325_Any_with_contains_on_IList_of_string.cs
@@ -23,11 +23,11 @@ public class Bug_1325_Any_with_contains_on_IList_of_string: BugIntegrationContex
 
         var searchNames = new[] { "Jeremy", "Josh" };
 
-        var ids = session
+        var ids = (await session
             .Query<DocWithLists>()
             .Where(x => x.Names.Any(_ => searchNames.Contains(_)))
             .Select(x => x.Id)
-            .ToList();
+            .ToListAsync());
 
         ids.Count.ShouldBe(2);
         ids.ShouldContain(doc1.Id);
@@ -49,11 +49,11 @@ public class Bug_1325_Any_with_contains_on_IList_of_string: BugIntegrationContex
 
         var searchNames = new[] { "Jeremy", "Josh" };
 
-        var ids = session
+        var ids = (await session
             .Query<DocWithLists>()
             .Where(x => x.Names.Any(_ => searchNames.Contains(_)))
             .Select(x => x.Id)
-            .ToList();
+            .ToListAsync());
 
         ids.Count.ShouldBe(2);
         ids.ShouldContain(doc1.Id);

--- a/src/LinqTests/Bugs/Bug_1413_not_inside_of_where_against_child_collection.cs
+++ b/src/LinqTests/Bugs/Bug_1413_not_inside_of_where_against_child_collection.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 namespace LinqTests.Bugs;
 
 public class Bug_1413_not_inside_of_where_against_child_collection : IntegrationContext
@@ -15,8 +16,8 @@ public class Bug_1413_not_inside_of_where_against_child_collection : Integration
     public async Task can_do_so()
     {
         await theStore.Advanced.ResetAllData();
-        var results = theSession.Query<Target>().Where(x => x.Children.Any(c => c.String == "hello" && c.Color != Colors.Blue))
-            .ToList();
+        var results = (await theSession.Query<Target>().Where(x => x.Children.Any(c => c.String == "hello" && c.Color != Colors.Blue))
+            .ToListAsync());
 
         results.ShouldNotBeNull();
     }

--- a/src/LinqTests/Bugs/Bug_1473_warn_about_custom_value_types_in_linq.cs
+++ b/src/LinqTests/Bugs/Bug_1473_warn_about_custom_value_types_in_linq.cs
@@ -1,4 +1,6 @@
 using System.Linq;
+using System.Threading.Tasks;
+using Marten;
 using Marten.Exceptions;
 using Marten.Testing.Harness;
 using Shouldly;
@@ -12,14 +14,14 @@ public class Bug_1473_warn_about_custom_value_types_in_linq : IntegrationContext
     }
 
     [Fact]
-    public void get_a_descriptive_exception_message()
+    public async Task get_a_descriptive_exception_message()
     {
-        var ex = Should.Throw<BadLinqExpressionException>(() =>
+        var ex = await Should.ThrowAsync<BadLinqExpressionException>(async () =>
         {
-            theSession
+            await theSession
                 .Query<MyClass>()
                 .Where(x => x.CustomObject == new CustomObject())
-                .ToList();
+                .ToListAsync();
         });
 
         ex.Message.ShouldBe("Marten cannot support custom value types in Linq expression. Please query on either simple properties of the value type, or register a custom IMemberSource for this value type.");

--- a/src/LinqTests/Bugs/Bug_1703_Equality_Not_Symmetric.cs
+++ b/src/LinqTests/Bugs/Bug_1703_Equality_Not_Symmetric.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 namespace LinqTests.Bugs;
 
 public sealed class Bug_1703_Equality_Not_Symmetric: IntegrationContext
@@ -31,15 +32,15 @@ public sealed class Bug_1703_Equality_Not_Symmetric: IntegrationContext
         using (var session = theStore.QuerySession())
         {
 
-            session.Query<Target>()
+            (await session.Query<Target>()
                 .Where(x => x.String == (theString))
-                .ToList()
+                .ToListAsync())
                 .Count
                 .ShouldBe(1);
 
-            session.Query<Target>()
+            (await session.Query<Target>()
                 .Where(x => theString == x.String )
-                .ToList()
+                .ToListAsync())
                 .Count
                 .ShouldBe(1);
         }
@@ -58,15 +59,15 @@ public sealed class Bug_1703_Equality_Not_Symmetric: IntegrationContext
 
         await using (var session = theStore.QuerySession())
         {
-            session.Query<Target>()
+            (await session.Query<Target>()
                 .Where(x => x.String.Equals(theString))
-                .ToList()
+                .ToListAsync())
                 .Count
                 .ShouldBe(1);
 
-            session.Query<Target>()
+            (await session.Query<Target>()
                 .Where(x => theString.Equals(x.String))
-                .ToList()
+                .ToListAsync())
                 .Count
                 .ShouldBe(1);
         }
@@ -88,15 +89,15 @@ public sealed class Bug_1703_Equality_Not_Symmetric: IntegrationContext
         await using (var session = theStore.QuerySession())
         {
 
-            session.Query<Target>()
+            (await session.Query<Target>()
                 .Where(x => x.String.Equals(theString, StringComparison.InvariantCultureIgnoreCase))
-                .ToList()
+                .ToListAsync())
                 .Count
                 .ShouldBe(1);
 
-            session.Query<Target>()
+            (await session.Query<Target>()
                 .Where(x => theString.Equals(x.String, StringComparison.InvariantCultureIgnoreCase))
-                .ToList()
+                .ToListAsync())
                 .Count
                 .ShouldBe(1);
         }
@@ -115,15 +116,15 @@ public sealed class Bug_1703_Equality_Not_Symmetric: IntegrationContext
 
         await using (var session = theStore.QuerySession())
         {
-            session.Query<Target>()
+            (await session.Query<Target>()
                 .Where(x => x.Number.Equals(theNumber))
-                .ToList()
+                .ToListAsync())
                 .Count
                 .ShouldBe(1);
 
-            session.Query<Target>()
+            (await session.Query<Target>()
                 .Where(x => theNumber.Equals(x.Number))
-                .ToList()
+                .ToListAsync())
                 .Count
                 .ShouldBe(1);
         }
@@ -142,15 +143,15 @@ public sealed class Bug_1703_Equality_Not_Symmetric: IntegrationContext
 
         await using (var session = theStore.QuerySession())
         {
-            session.Query<Target>()
+            (await session.Query<Target>()
                 .Where(x => x.Number == theNumber )
-                .ToList()
+                .ToListAsync())
                 .Count
                 .ShouldBe(1);
 
-            session.Query<Target>()
+            (await session.Query<Target>()
                 .Where(x => theNumber == x.Number)
-                .ToList()
+                .ToListAsync())
                 .Count
                 .ShouldBe(1);
         }

--- a/src/LinqTests/Bugs/Bug_1875_duplicated_array_field_test.cs
+++ b/src/LinqTests/Bugs/Bug_1875_duplicated_array_field_test.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 
 namespace LinqTests.Bugs;
 
@@ -29,7 +30,7 @@ public class Bug_1875_duplicated_array_field_test : BugIntegrationContext
 
         using (var session = theStore.QuerySession())
         {
-            session.Query<Target>().Single(x => x.NumberArray.Contains(1))
+            (await session.Query<Target>().SingleAsync(x => x.NumberArray.Contains(1)))
                 .NumberArray[0].ShouldBe(1);
         }
     }
@@ -52,7 +53,7 @@ public class Bug_1875_duplicated_array_field_test : BugIntegrationContext
 
         using (var session = theStore.QuerySession())
         {
-            session.Query<Target>().Single(x => x.GuidArray.Contains(target.GuidArray[0]))
+            (await session.Query<Target>().SingleAsync(x => x.GuidArray.Contains(target.GuidArray[0])))
                 .GuidArray[0].ShouldBe(target.GuidArray[0]);
         }
     }

--- a/src/LinqTests/Bugs/Bug_1884_multi_tenancy_and_Any_query.cs
+++ b/src/LinqTests/Bugs/Bug_1884_multi_tenancy_and_Any_query.cs
@@ -81,7 +81,7 @@ public class Bug_1884_multi_tenancy_and_Any_query: BugIntegrationContext
 
             linq.ToCommand().CommandText.ShouldNotContain("tenant_id");
 
-            linq.ShouldHaveTheSameElementsAs("Bill", "Jill");
+            (await linq.ToListAsync()).ShouldHaveTheSameElementsAs("Bill", "Jill");
         }
     }
 
@@ -113,21 +113,23 @@ public class Bug_1884_multi_tenancy_and_Any_query: BugIntegrationContext
 
         var validRoles = new[] { "admin", "user" };
 
-        using (var query = theStore.QuerySession("tenant1"))
+        await using (var query = theStore.QuerySession("tenant1"))
         {
-            query.Query<User>()
+            (await query.Query<User>()
                 .Where(x => x.Roles.Any(_ => validRoles.Contains(_)))
                 .OrderBy(x => x.UserName)
                 .Select(x => x.UserName)
+                .ToListAsync())
                 .ShouldHaveTheSameElementsAs("Bill");
         }
 
-        using (var query = theStore.QuerySession("tenant2"))
+        await using (var query = theStore.QuerySession("tenant2"))
         {
-            query.Query<User>()
+            (await query.Query<User>()
                 .Where(x => x.Roles.Any(_ => validRoles.Contains(_)))
                 .OrderBy(x => x.UserName)
                 .Select(x => x.UserName)
+                .ToListAsync())
                 .ShouldHaveTheSameElementsAs("Jill");
         }
     }
@@ -160,12 +162,13 @@ public class Bug_1884_multi_tenancy_and_Any_query: BugIntegrationContext
 
         var validRoles = new[] { "admin", "user" };
 
-        using (var query = theStore.QuerySession("tenant1"))
+        await using (var query = theStore.QuerySession("tenant1"))
         {
-            query.Query<User>()
+            (await query.Query<User>()
                 .Where(x => x.Roles.Any(_ => validRoles.Contains(_)) && x.AnyTenant())
                 .OrderBy(x => x.UserName)
                 .Select(x => x.UserName)
+                .ToListAsync())
                 .ShouldHaveTheSameElementsAs("Bill", "Jill");
         }
     }

--- a/src/LinqTests/Bugs/Bug_2198_querying_against_UTC_DateTime_with_Npgsql.cs
+++ b/src/LinqTests/Bugs/Bug_2198_querying_against_UTC_DateTime_with_Npgsql.cs
@@ -5,6 +5,7 @@ using Marten.Exceptions;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 
 namespace LinqTests.Bugs;
 
@@ -21,11 +22,11 @@ public class Bug_2198_querying_against_UTC_DateTime_with_Npgsql : BugIntegration
 
         await theSession.SaveChangesAsync();
 
-        Should.Throw<InvalidUtcDateTimeUsageException>(() =>
+        await Should.ThrowAsync<InvalidUtcDateTimeUsageException>(async () =>
         {
-            theSession.Query<Target>()
+            (await theSession.Query<Target>()
                 .Where(x => x.Date > DateTime.UtcNow)
-                .ToArray()
+                .ToListAsync())
                 .Select(x => x.Number)
                 .ShouldHaveTheSameElementsAs(1, 2, 3);
         });
@@ -49,11 +50,10 @@ public class Bug_2198_querying_against_UTC_DateTime_with_Npgsql : BugIntegration
 
         await theSession.SaveChangesAsync();
 
-
-        theSession.Query<Target>()
+        (await theSession.Query<Target>()
             .Where(x => x.DateOffset > DateTimeOffset.UtcNow)
             .OrderBy(x => x.DateOffset)
-            .ToArray()
+            .ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(1, 3, 2);
     }

--- a/src/LinqTests/Bugs/Bug_260_Take_Skip_with_Select_Tests.cs
+++ b/src/LinqTests/Bugs/Bug_260_Take_Skip_with_Select_Tests.cs
@@ -28,7 +28,7 @@ public class Bug_260_Take_Skip_with_Select_Tests: IntegrationContext
 
         cmd.Parameters["p1"].Value.ShouldBe(10);
 
-        queryable.ToArray().Length.ShouldBe(10);
+        (await queryable.ToListAsync()).Count.ShouldBe(10);
     }
 
     public Bug_260_Take_Skip_with_Select_Tests(DefaultStoreFixture fixture) : base(fixture)

--- a/src/LinqTests/Bugs/Bug_261_double_take_or_skip.cs
+++ b/src/LinqTests/Bugs/Bug_261_double_take_or_skip.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 
 namespace LinqTests.Bugs;
 
@@ -14,7 +15,7 @@ public class Bug_261_double_take_or_skip: IntegrationContext
         var targets = Target.GenerateRandomData(100);
         await theStore.BulkInsertAsync(targets.ToArray());
 
-        theSession.Query<Target>().Take(4).Take(8).ToList()
+        (await theSession.Query<Target>().Take(4).Take(8).ToListAsync())
             .Count.ShouldBe(8);
     }
 
@@ -24,7 +25,7 @@ public class Bug_261_double_take_or_skip: IntegrationContext
         var targets = Target.GenerateRandomData(100);
         await theStore.BulkInsertAsync(targets.ToArray());
 
-        theSession.Query<Target>().Take(4).Skip(4).Skip(8).ToList()
+        (await theSession.Query<Target>().Take(4).Skip(4).Skip(8).ToListAsync())
             .Count.ShouldBe(4);
     }
 
@@ -34,7 +35,7 @@ public class Bug_261_double_take_or_skip: IntegrationContext
         var targets = Target.GenerateRandomData(100);
         await theStore.BulkInsertAsync(targets.ToArray());
 
-        var result = theSession.Query<Target>().Take(10).Take(4).ToList();
+        var result = (await theSession.Query<Target>().Take(10).Take(4).ToListAsync());
         result.Count.ShouldBe(4);
     }
 

--- a/src/LinqTests/Bugs/Bug_3031_querying_using_soft_deletes.cs
+++ b/src/LinqTests/Bugs/Bug_3031_querying_using_soft_deletes.cs
@@ -34,10 +34,10 @@ public class Bug_3031_querying_using_soft_deletes : BugIntegrationContext
             await sessionX.SaveChangesAsync();
         }
 
-        using var session = theStore.QuerySession();
+        await using var session = theStore.QuerySession();
         var q = session.Query<Entity>();
         var w = AddWhere(q);
-        var result = w.Any();
+        var result = await w.AnyAsync();
 
         result.ShouldBeTrue();
     }
@@ -54,10 +54,10 @@ public class Bug_3031_querying_using_soft_deletes : BugIntegrationContext
             await sessionX.SaveChangesAsync();
         }
 
-        using var session = theStore.QuerySession();
+        await using var session = theStore.QuerySession();
         var q = session.Query<Entity>();
         var w = AddWhereNonGeneric(q);
-        var result = w.Any();
+        var result = await w.AnyAsync();
 
         result.ShouldBeTrue();
     }
@@ -77,10 +77,10 @@ public class Bug_3031_querying_using_soft_deletes : BugIntegrationContext
 
         using var session = theStore.QuerySession();
 
-        bool result = session
+        bool result = (await session
             .Query<Entity>()
             .WithArchivedState(ArchivedState.IncludeArchived)
-            .Any();
+            .AnyAsync());
 
         result.ShouldBeTrue();
     }
@@ -120,10 +120,10 @@ public class Bug_3031_querying_using_soft_deletes : BugIntegrationContext
         }
 
         using var session = theStore.QuerySession();
-        bool result = session
+        bool result = (await session
             .Query<Entity>()
             .WithArchivedStateNonGeneric(ArchivedState.IncludeArchived)
-            .Any();
+            .AnyAsync());
 
         result.ShouldBeTrue();
     }
@@ -162,10 +162,10 @@ public class Bug_3031_querying_using_soft_deletes : BugIntegrationContext
         }
 
         using var session = theStore.QuerySession();
-        bool result = session
+        bool result = (await session
             .Query<Entity>()
             .Where(x => x.MaybeDeleted())
-            .Any();
+            .AnyAsync());
 
         result.ShouldBeTrue();
     }

--- a/src/LinqTests/Bugs/Bug_3031_querying_using_soft_deletes.cs
+++ b/src/LinqTests/Bugs/Bug_3031_querying_using_soft_deletes.cs
@@ -5,6 +5,7 @@ using Marten.Linq.SoftDeletes;
 using Marten.Metadata;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 namespace LinqTests.Bugs;
 
 public class Bug_3031_querying_using_soft_deletes : BugIntegrationContext
@@ -98,10 +99,10 @@ public class Bug_3031_querying_using_soft_deletes : BugIntegrationContext
         }
 
         using var session = theStore.QuerySession();
-        var result = session
+        var result = (await session
             .Query<Entity>()
             .WithArchivedState(ArchivedState.IncludeArchived)
-            .ToList();
+            .ToListAsync());
 
         result.Count.ShouldBe(1);
     }
@@ -140,10 +141,10 @@ public class Bug_3031_querying_using_soft_deletes : BugIntegrationContext
         }
 
         using var session = theStore.QuerySession();
-        var result = session
+        var result = (await session
             .Query<Entity>()
             .WithArchivedStateNonGeneric(ArchivedState.IncludeArchived)
-            .ToList();
+            .ToListAsync());
 
         result.Count.ShouldBe(1);
     }
@@ -190,9 +191,9 @@ public class Bug_3031_querying_using_soft_deletes : BugIntegrationContext
 
         using var query = theStore.QuerySession();
 
-        var list = query.Query<Entity>()
+        var list = (await query.Query<Entity>()
             .Where(x => x.MaybeDeleted())
-            .ToList();
+            .ToListAsync());
 
         list.Count.ShouldBe(2);
         list[0].Id.ShouldBe(entity.Id);

--- a/src/LinqTests/Bugs/Bug_3096_include_where_select.cs
+++ b/src/LinqTests/Bugs/Bug_3096_include_where_select.cs
@@ -32,14 +32,14 @@ public class Bug_3096_include_where_select : IntegrationContext
         using var query = theStore.QuerySession();
         var dict = new Dictionary<Guid, User>();
 
-        var issues = query
+        var issues =(await  query
             .Query<Issue>()
             .Where(i => i.Title.Contains("ok"))
             .Include(x => x.AssigneeId, dict)
             .Select(i => new { i.Id, i.Title, })
-            .ToArray();
+            .ToListAsync());
 
-        issues.Length.ShouldBe(1);
+        issues.Count.ShouldBe(1);
 
         dict.Count.ShouldBe(1);
         dict.ContainsKey(user1.Id).ShouldBeTrue();

--- a/src/LinqTests/Bugs/Bug_365_compiled_query_with_constant_fails.cs
+++ b/src/LinqTests/Bugs/Bug_365_compiled_query_with_constant_fails.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Marten.Linq;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 
 namespace LinqTests.Bugs;
 
@@ -74,7 +75,7 @@ public class Bug_365_compiled_query_with_constant_fails: BugIntegrationContext
             var routes = await session.QueryAsync(new RoutesPlannedAfter(from));
             var all = session.Query<Route>();
 
-            routes.Count().ShouldBe(all.Count(route => route.Status == RouteStatus.Planned && route.Date > from));
+            routes.Count().ShouldBe((await all.CountAsync(route => route.Status == RouteStatus.Planned && route.Date > from)));
         }
     }
 

--- a/src/LinqTests/Bugs/Bug_432_querying_with_UTC_times_with_offset.cs
+++ b/src/LinqTests/Bugs/Bug_432_querying_with_UTC_times_with_offset.cs
@@ -38,8 +38,8 @@ public class Bug_432_querying_with_UTC_times_with_offset: BugIntegrationContext
             await session.SaveChangesAsync();
 
 
-            session.Query<DateClass>()
-                .Count(x => now >= x.DateTimeField).ShouldBe(2);
+            (await session.Query<DateClass>()
+                .CountAsync(x => now >= x.DateTimeField)).ShouldBe(2);
         }
     }
 
@@ -73,8 +73,8 @@ public class Bug_432_querying_with_UTC_times_with_offset: BugIntegrationContext
             await session.SaveChangesAsync();
 
 
-            session.Query<DateClass>()
-                .Count(x => now >= x.DateTimeField).ShouldBe(2);
+            (await session.Query<DateClass>()
+                .CountAsync(x => now >= x.DateTimeField)).ShouldBe(2);
         }
     }
 
@@ -108,8 +108,8 @@ public class Bug_432_querying_with_UTC_times_with_offset: BugIntegrationContext
             await session.SaveChangesAsync();
 
 
-            session.Query<DateClass>()
-                .Count(x => now >= x.DateTimeField).ShouldBe(2);
+            (await session.Query<DateClass>()
+                .CountAsync(x => now >= x.DateTimeField)).ShouldBe(2);
         }
     }
 
@@ -144,8 +144,8 @@ public class Bug_432_querying_with_UTC_times_with_offset: BugIntegrationContext
 
 
 
-            session.Query<DateClass>()
-                .Count(x => now >= x.DateTimeField).ShouldBe(2);
+            (await session.Query<DateClass>()
+                .CountAsync(x => now >= x.DateTimeField)).ShouldBe(2);
         }
     }
 
@@ -178,8 +178,8 @@ public class Bug_432_querying_with_UTC_times_with_offset: BugIntegrationContext
 
 
 
-            session.Query<DateOffsetClass>()
-                .Count(x => now >= x.DateTimeOffsetField).ShouldBe(2);
+            (await session.Query<DateOffsetClass>()
+                .CountAsync(x => now >= x.DateTimeOffsetField)).ShouldBe(2);
         }
     }
 
@@ -214,8 +214,8 @@ public class Bug_432_querying_with_UTC_times_with_offset: BugIntegrationContext
 
 
 
-            session.Query<DateOffsetClass>()
-                .Count(x => now >= x.DateTimeOffsetField).ShouldBe(2);
+            (await session.Query<DateOffsetClass>()
+                .CountAsync(x => now >= x.DateTimeOffsetField)).ShouldBe(2);
         }
     }
 

--- a/src/LinqTests/Bugs/Bug_449_IsOneOf_query_with_enum_types.cs
+++ b/src/LinqTests/Bugs/Bug_449_IsOneOf_query_with_enum_types.cs
@@ -25,7 +25,7 @@ public class Bug_449_IsOneOf_query_with_enum_types: BugIntegrationContext
 
         using (var query = theStore.QuerySession())
         {
-            var list = query.Query<Target>().Where(x => x.Color.IsOneOf(Colors.Blue, Colors.Red)).ToList();
+            var list = (await query.Query<Target>().Where(x => x.Color.IsOneOf(Colors.Blue, Colors.Red)).ToListAsync());
 
             list.Count.ShouldBe(2);
             list.Select(x => x.Id).ShouldContain(blue.Id);
@@ -50,7 +50,7 @@ public class Bug_449_IsOneOf_query_with_enum_types: BugIntegrationContext
 
         using (var query = theStore.QuerySession())
         {
-            var list = query.Query<Target>().Where(x => x.Color.IsOneOf(Colors.Blue, Colors.Red)).ToList();
+            var list = (await query.Query<Target>().Where(x => x.Color.IsOneOf(Colors.Blue, Colors.Red)).ToListAsync());
 
             list.Count.ShouldBe(2);
             list.Select(x => x.Id).ShouldContain(blue.Id);

--- a/src/LinqTests/Bugs/Bug_479_select_datetime_fields.cs
+++ b/src/LinqTests/Bugs/Bug_479_select_datetime_fields.cs
@@ -6,6 +6,7 @@ using Marten.Testing.Harness;
 using Shouldly;
 using Weasel.Core;
 using Marten.Newtonsoft;
+using Marten;
 
 namespace LinqTests.Bugs;
 
@@ -28,7 +29,7 @@ public class Bug_479_select_datetime_fields: BugIntegrationContext
         session.Store(doc);
         await session.SaveChangesAsync();
 
-        var date = session.Query<DocWithDates>().Where(x => x.Id == doc.Id).Select(x => new { Date = x.DateTime }).Single();
+        var date = (await session.Query<DocWithDates>().Where(x => x.Id == doc.Id).Select(x => new { Date = x.DateTime }).SingleAsync());
 
         date.Date.ShouldBe(doc.DateTime);
     }
@@ -45,7 +46,7 @@ public class Bug_479_select_datetime_fields: BugIntegrationContext
         session.Store(doc);
         await session.SaveChangesAsync();
 
-        var date = session.Query<DocWithDates>().Where(x => x.Id == doc.Id).Select(x => new { Date = x.DateTimeOffset }).Single();
+        var date = (await session.Query<DocWithDates>().Where(x => x.Id == doc.Id).Select(x => new { Date = x.DateTimeOffset }).SingleAsync());
 
         date.Date.ShouldBe(doc.DateTimeOffset);
     }

--- a/src/LinqTests/Bugs/Bug_484_Contains_on_IList_of_string.cs
+++ b/src/LinqTests/Bugs/Bug_484_Contains_on_IList_of_string.cs
@@ -35,8 +35,8 @@ public class Bug_484_Contains_on_IList_of_string: BugIntegrationContext
         session.Store(doc1, doc2, doc3);
         await session.SaveChangesAsync();
 
-        var ids = session.Query<DocWithLists>().Where(x => x.Names.Contains("Jeremy")).Select(x => x.Id)
-            .ToList();
+        var ids = (await session.Query<DocWithLists>().Where(x => x.Names.Contains("Jeremy")).Select(x => x.Id)
+            .ToListAsync());
 
         ids.Count.ShouldBe(2);
         ids.ShouldContain(doc1.Id);
@@ -56,8 +56,8 @@ public class Bug_484_Contains_on_IList_of_string: BugIntegrationContext
         session.Store(doc1, doc2, doc3);
         await session.SaveChangesAsync();
 
-        var ids = session.Query<DocWithLists>().Where(x => x.Names.Contains("Jeremy")).Select(x => x.Id)
-            .ToList();
+        var ids = (await session.Query<DocWithLists>().Where(x => x.Names.Contains("Jeremy")).Select(x => x.Id)
+            .ToListAsync());
 
         ids.Count.ShouldBe(2);
         ids.ShouldContain(doc1.Id);

--- a/src/LinqTests/Bugs/Bug_490_hierarchy_and_include.cs
+++ b/src/LinqTests/Bugs/Bug_490_hierarchy_and_include.cs
@@ -69,9 +69,9 @@ public class Bug_490_hierarchy_and_include: BugIntegrationContext
         using (var session = theStore.QuerySession())
         {
             var accounts = new List<Account>();
-            session.Query<Activity>()
+            (await session.Query<Activity>()
                 .Include(a => a.AccountId, accounts)
-                .ToList()
+                .ToListAsync())
                 .ShouldNotBeNull()
                 .ShouldNotBeSameAs(activity);
 

--- a/src/LinqTests/Bugs/Bug_503_query_on_null_complex_object.cs
+++ b/src/LinqTests/Bugs/Bug_503_query_on_null_complex_object.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 namespace LinqTests.Bugs;
 
 public class Bug_503_query_on_null_complex_object: IntegrationContext
@@ -21,9 +22,9 @@ public class Bug_503_query_on_null_complex_object: IntegrationContext
 
         using (var querySession = theStore.QuerySession())
         {
-            var targets = querySession.Query<Target>()
+            var targets = (await querySession.Query<Target>()
                 .Where(x => x.String == "Something" && x.Inner != null)
-                .ToList();
+                .ToListAsync());
 
             targets.Count.ShouldBe(1);
             targets.First().AnotherString.ShouldBe("first");

--- a/src/LinqTests/Bugs/Bug_561_negation_of_query_on_contains.cs
+++ b/src/LinqTests/Bugs/Bug_561_negation_of_query_on_contains.cs
@@ -28,25 +28,25 @@ public class Bug_561_negation_of_query_on_contains: IntegrationContext
     }
 
     [Fact]
-    public void negated_contains()
+    public async Task negated_contains()
     {
         #region sample_negated-contains
-        theSession.Query<DocWithArrays>().Count(x => !x.Strings.Contains("c"))
+        (await theSession.Query<DocWithArrays>().CountAsync(x => !x.Strings.Contains("c")))
             .ShouldBe(2);
         #endregion
     }
 
     [Fact]
-    public void NotContainsInExpressionThrowsNotSupportedException()
+    public async Task NotContainsInExpressionThrowsNotSupportedException()
     {
-        theSession.Query<DocWithArrays>().Count(x => x.Strings.Contains("d") && !x.Strings.Contains("c"))
+        (await theSession.Query<DocWithArrays>().CountAsync(x => x.Strings.Contains("d") && !x.Strings.Contains("c")))
             .ShouldBe(1);
     }
 
     [Fact]
-    public void ExpressionWithNotContainsReturnsCorrectResults()
+    public async Task ExpressionWithNotContainsReturnsCorrectResults()
     {
-        theSession.Query<DocWithArrays>().Count(x => x.Strings.Contains("d") && !x.Strings.Contains("c"))
+        (await theSession.Query<DocWithArrays>().CountAsync(x => x.Strings.Contains("d") && !x.Strings.Contains("c")))
             .ShouldBe(1);
     }
 }
@@ -76,25 +76,25 @@ public class Bug_561_negation_of_query_on_contains_with_camel_casing: BugIntegra
     }
 
     [Fact]
-    public void negated_contains()
+    public async Task negated_contains()
     {
         #region sample_negated-contains
-        theSession.Query<DocWithArrays>().Count(x => !x.Strings.Contains("c"))
+        (await theSession.Query<DocWithArrays>().CountAsync(x => !x.Strings.Contains("c")))
             .ShouldBe(2);
         #endregion
     }
 
     [Fact]
-    public void NotContainsInExpressionThrowsNotSupportedException()
+    public async Task NotContainsInExpressionThrowsNotSupportedException()
     {
-        theSession.Query<DocWithArrays>().Count(x => x.Strings.Contains("d") && !x.Strings.Contains("c"))
+        (await theSession.Query<DocWithArrays>().CountAsync(x => x.Strings.Contains("d") && !x.Strings.Contains("c")))
             .ShouldBe(1);
     }
 
     [Fact]
-    public void ExpressionWithNotContainsReturnsCorrectResults()
+    public async Task ExpressionWithNotContainsReturnsCorrectResults()
     {
-        theSession.Query<DocWithArrays>().Count(x => x.Strings.Contains("d") && !x.Strings.Contains("c"))
+        (await theSession.Query<DocWithArrays>().CountAsync(x => x.Strings.Contains("d") && !x.Strings.Contains("c")))
             .ShouldBe(1);
     }
 }

--- a/src/LinqTests/Bugs/Bug_605_unary_expressions_in_where_clause_of_compiled_query.cs
+++ b/src/LinqTests/Bugs/Bug_605_unary_expressions_in_where_clause_of_compiled_query.cs
@@ -8,6 +8,7 @@ using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
 using Weasel.Core;
+using Marten;
 
 namespace LinqTests.Bugs;
 
@@ -26,14 +27,14 @@ public class Bug_605_unary_expressions_in_where_clause_of_compiled_query: BugInt
         await using var query = theStore.QuerySession();
         var results = (await query.QueryAsync(new FlaggedTrueTargets())).ToList();
 
-        var expected = query.Query<Target>()
+        var expected = (await query.Query<Target>()
             .SelectMany(x => x.Children)
             .Where(x => x.Color == Colors.Green)
             .Where(x => x.Flag)
             .OrderBy(x => x.Id)
             .Skip(20)
             .Take(15)
-            .ToList();
+            .ToListAsync());
 
         // Compare against the inline LINQ query rather than a hardcoded count.
         // The point of the test is "compiled query == inline LINQ for the same
@@ -57,14 +58,14 @@ public class Bug_605_unary_expressions_in_where_clause_of_compiled_query: BugInt
         await using var query = theStore.QuerySession();
         var results = (await query.QueryAsync(new FlaggedTrueTargets())).ToList();
 
-        var expected = query.Query<Target>()
+        var expected = (await query.Query<Target>()
             .SelectMany(x => x.Children)
             .Where(x => x.Color == Colors.Green)
             .Where(x => x.Flag)
             .OrderBy(x => x.Id)
             .Skip(20)
             .Take(15)
-            .ToList();
+            .ToListAsync());
 
         results.Count.ShouldBe(expected.Count);
 
@@ -82,14 +83,14 @@ public class Bug_605_unary_expressions_in_where_clause_of_compiled_query: BugInt
         await using var query = theStore.QuerySession();
         var results = (await query.QueryAsync(new FlaggedFalseTargets())).ToList();
 
-        var expected = query.Query<Target>()
+        var expected = (await query.Query<Target>()
             .SelectMany(x => x.Children)
             .Where(x => x.Color == Colors.Green)
             .Where(x => !x.Flag)
             .OrderBy(x => x.Id)
             .Skip(20)
             .Take(15)
-            .ToList();
+            .ToListAsync());
 
         results.Count.ShouldBe(expected.Count);
 

--- a/src/LinqTests/Bugs/Bug_634_include_against_soft_deleted_docs.cs
+++ b/src/LinqTests/Bugs/Bug_634_include_against_soft_deleted_docs.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 namespace LinqTests.Bugs;
 
 public class Bug_634_include_against_soft_deleted_docs: BugIntegrationContext
@@ -36,10 +37,10 @@ public class Bug_634_include_against_soft_deleted_docs: BugIntegrationContext
         {
             User expected = null;
 
-            var issues = query.Query<Issue>()
+            var issues = (await query.Query<Issue>()
                 .Include<User>(x => x.AssigneeId, i => expected = i)
                 .Where(x => x.Id == issue.Id)
-                .ToList();
+                .ToListAsync());
 
             expected.ShouldNotBeNull();
         }
@@ -74,10 +75,10 @@ public class Bug_634_include_against_soft_deleted_docs: BugIntegrationContext
         {
             User expected = null;
 
-            var issues = query.Query<Issue>()
+            var issues = (await query.Query<Issue>()
                 .Include<User>(x => x.AssigneeId, i => expected = i)
                 .Where(x => x.Id == issue.Id)
-                .ToList();
+                .ToListAsync());
 
             expected.ShouldBeNull();
         }

--- a/src/LinqTests/Bugs/Bug_717_permutation_of_Linq_queries.cs
+++ b/src/LinqTests/Bugs/Bug_717_permutation_of_Linq_queries.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Marten;
 using Marten.Linq;
 using Marten.Testing.Harness;
@@ -9,7 +10,7 @@ namespace LinqTests.Bugs;
 public class Bug_717_permutation_of_Linq_queries: IntegrationContext
 {
     [Fact]
-    public void do_not_blow_up()
+    public async Task do_not_blow_up()
     {
         var entityToStore = new MainEntity
         {
@@ -36,7 +37,7 @@ public class Bug_717_permutation_of_Linq_queries: IntegrationContext
             /*------------------------------------------------------------------*/
             //getting an Exception while trying to execute this query
 
-            var entity1 = session.Query<MainEntity>().Stats(out stats).FirstOrDefault(t => t.Entity1.StringValues.Any());
+            var entity1 = (await session.Query<MainEntity>().Stats(out stats).FirstOrDefaultAsync(t => t.Entity1.StringValues.Any()));
 
             //Marten.MartenCommandException: 'Marten Command Failure:
             //select d.data, d.id, d.mt_version, count(1) OVER() as total_rows from public.mt_doc_mainentity as d where JSONB_ARRAY_LENGTH(COALESCE(case when data->>'Entity1'->'StringValues' is not null then data->'Entity1'->'StringValues' else '[]' end)) > 0 LIMIT 1
@@ -46,7 +47,7 @@ public class Bug_717_permutation_of_Linq_queries: IntegrationContext
             /*------------------------------------------------------------------*/
             //same issue here as well
 
-            var entity2 = session.Query<MainEntity>().Stats(out stats).FirstOrDefault(t => t.Entity2.InnerEntities.Any());
+            var entity2 = (await session.Query<MainEntity>().Stats(out stats).FirstOrDefaultAsync(t => t.Entity2.InnerEntities.Any()));
             //Marten.MartenCommandException: 'Marten Command Failure:
             //select d.data, d.id, d.mt_version, count(1) OVER() as total_rows from public.mt_doc_mainentity as d where JSONB_ARRAY_LENGTH(COALESCE(case when data->>'Entity2'->'InnerEntities' is not null then data->'Entity2'->'InnerEntities' else '[]' end)) > 0 LIMIT 1
             //42883: operator does not exist: text -> unknown'
@@ -57,10 +58,10 @@ public class Bug_717_permutation_of_Linq_queries: IntegrationContext
             //and this two fail as well
 
             //var entity3 = session.Query<MainEntity>().Stats(out stats).FirstOrDefault(t => t.Entity1.StringValues.Any(n => n == "item1"));
-            var entity3 = session.Query<MainEntity>().Stats(out stats).FirstOrDefault(t => t.Entity1.StringValues.Contains("item1"));
+            var entity3 = (await session.Query<MainEntity>().Stats(out stats).FirstOrDefaultAsync(t => t.Entity1.StringValues.Contains("item1")));
             //System.NotSupportedException: 'Specified method is not supported.'
 
-            var entity4 = session.Query<MainEntity>().Stats(out stats).FirstOrDefault(t => t.Entity2.InnerEntities.Any(n => n.MyEnum == SomeEnums.TestEnum1));
+            var entity4 = (await session.Query<MainEntity>().Stats(out stats).FirstOrDefaultAsync(t => t.Entity2.InnerEntities.Any(n => n.MyEnum == SomeEnums.TestEnum1)));
             //System.NotImplementedException: 'The method or operation is not implemented.'
             /*------------------------------------------------------------------*/
         }

--- a/src/LinqTests/Bugs/Bug_834_querying_inside_of_child_collections.cs
+++ b/src/LinqTests/Bugs/Bug_834_querying_inside_of_child_collections.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 namespace LinqTests.Bugs;
 
 public class Bug_834_querying_inside_of_child_collections : IntegrationContext
@@ -26,7 +27,7 @@ public class Bug_834_querying_inside_of_child_collections : IntegrationContext
 
         await theStore.BulkInsertAsync(new Contact[]{c1, c2, c3});
 
-        theSession.Query<Contact>().Where(x => x.Tags.Any(t => t.StartsWith("A"))).Any()
+        (await theSession.Query<Contact>().Where(x => x.Tags.Any(t => t.StartsWith("A"))).AnyAsync())
             .ShouldBeTrue();
 
         theSession.Query<Contact>()

--- a/src/LinqTests/Bugs/Bug_834_querying_inside_of_child_collections.cs
+++ b/src/LinqTests/Bugs/Bug_834_querying_inside_of_child_collections.cs
@@ -30,7 +30,7 @@ public class Bug_834_querying_inside_of_child_collections : IntegrationContext
         (await theSession.Query<Contact>().Where(x => x.Tags.Any(t => t.StartsWith("A"))).AnyAsync())
             .ShouldBeTrue();
 
-        theSession.Query<Contact>()
-            .Count(x => x.Tags.Any(t => t.StartsWith("A"))).ShouldBe(2);
+        (await theSession.Query<Contact>()
+            .CountAsync(x => x.Tags.Any(t => t.StartsWith("A")))).ShouldBe(2);
     }
 }

--- a/src/LinqTests/Bugs/Bug_854_multiple_or_expressions_softdelete_tenancy_filters_appended_incorrectly.cs
+++ b/src/LinqTests/Bugs/Bug_854_multiple_or_expressions_softdelete_tenancy_filters_appended_incorrectly.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
+using Marten;
 
 namespace LinqTests.Bugs;
 
@@ -31,8 +32,8 @@ public class Bug_854_multiple_or_expressions_softdelete_tenancy_filters_appended
 
         using (var query = theStore.QuerySession("Bug_854"))
         {
-            var actual = query.Query<Target>().Where(x => x.String == "Red" || x.String == "Orange")
-                .OrderBy(x => x.Id).Select(x => x.Id).ToArray();
+            var actual =(await  query.Query<Target>().Where(x => x.String == "Red" || x.String == "Orange")
+                .OrderBy(x => x.Id).Select(x => x.Id).ToListAsync());
 
             actual.ShouldHaveTheSameElementsAs(expected);
         }

--- a/src/LinqTests/Bugs/Bug_854_multiple_or_expressions_softdelete_tenancy_filters_appended_incorrectly.cs
+++ b/src/LinqTests/Bugs/Bug_854_multiple_or_expressions_softdelete_tenancy_filters_appended_incorrectly.cs
@@ -61,7 +61,7 @@ public class Bug_854_multiple_or_expressions_softdelete_tenancy_filters_appended
             var query = session.Query<SoftDeletedItem>()
                 .Where(x => x.Number == 1 || x.Number == 2);
 
-            var actual = query.ToList().Count;
+            var actual = (await query.ToListAsync()).Count;
             Assert.Equal(expected, actual);
         }
     }

--- a/src/LinqTests/Bugs/Bug_997_or_queries_with_hierarchical_docs.cs
+++ b/src/LinqTests/Bugs/Bug_997_or_queries_with_hierarchical_docs.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Harness;
+using Marten;
 
 namespace LinqTests.Bugs;
 
@@ -35,9 +36,9 @@ public class Bug_997_or_queries_with_hierarchical_docs: BugIntegrationContext
         await theStore.BulkInsertAsync(new Bug997User[] { megaUser1, megaUser2, megaUser3 });
 
         await using var session = theStore.QuerySession();
-        session.Query<MegaUser>()
+        (await session.Query<MegaUser>()
             .Where(_ => _.DisplayName == "Yann" || _.DisplayName == "Robin").OrderBy(x => x.DisplayName).Select(x => x.DisplayName)
-            .ToList()
+            .ToListAsync())
             .ShouldHaveTheSameElementsAs("Robin", "Yann");
     }
 

--- a/src/LinqTests/Bugs/query_with_order_by.cs
+++ b/src/LinqTests/Bugs/query_with_order_by.cs
@@ -36,7 +36,7 @@ public class query_with_order_by: IntegrationContext
                 .OrderBy(x => x.String, comparer);
 
             var sql = (await query.ExplainAsync()).Command.CommandText;
-            var result = query.ToList();
+            var result = (await query.ToListAsync());
 
             if (shouldBeCaseInsensitive)
             {
@@ -71,7 +71,7 @@ public class query_with_order_by: IntegrationContext
                 .OrderByDescending(x => x.String, comparer);
 
             var sql = (await query.ExplainAsync()).Command.CommandText;
-            var result = query.ToList();
+            var result = (await query.ToListAsync());
 
             if (shouldBeCaseInsensitive)
             {
@@ -119,7 +119,7 @@ public class query_with_order_by: IntegrationContext
                 .ThenBy(x => x.String, comparer);
 
             var sql = (await query.ExplainAsync()).Command.CommandText;
-            var result = query.ToList();
+            var result = (await query.ToListAsync());
 
             if (shouldBeCaseInsensitive)
             {
@@ -159,7 +159,7 @@ public class query_with_order_by: IntegrationContext
                 .ThenByDescending(x => x.String, comparer);
 
             var sql = (await query.ExplainAsync()).Command.CommandText;
-            var result = query.ToList();
+            var result = (await query.ToListAsync());
 
             if (shouldBeCaseInsensitive)
             {

--- a/src/LinqTests/ChildCollections/count_for_child_collections.cs
+++ b/src/LinqTests/ChildCollections/count_for_child_collections.cs
@@ -21,10 +21,10 @@ public class count_for_child_collections : OneOffConfigurationsContext
 
 
 
-        var result = theSession
+        var result = (await theSession
             .Query<Root>()
             .Where(r => r.ChildsLevel1.Count(c1 => c1.Name == "child-1.1") == 1)
-            .ToList();
+            .ToListAsync());
 
         result.ShouldHaveSingleItem();
     }

--- a/src/LinqTests/ChildCollections/query_against_child_collections.cs
+++ b/src/LinqTests/ChildCollections/query_against_child_collections.cs
@@ -196,8 +196,8 @@ public class query_against_child_collections: OneOffConfigurationsContext
     {
         await buildUpTargetData();
 
-        theSession.Query<Target>()
-            .Single(x => Enumerable.Any<Target>(x.Children, _ => _.Inner.Number == -2))
+        (await theSession.Query<Target>()
+            .SingleAsync(x => Enumerable.Any<Target>(x.Children, _ => _.Inner.Number == -2)))
             .Id.ShouldBe(targets[10].Id);
     }
 
@@ -209,8 +209,8 @@ public class query_against_child_collections: OneOffConfigurationsContext
         StoreOptions(_ => _.UseSystemTextJsonForSerialization(enumStorage));
         await buildUpTargetData();
 
-        theSession.Query<Target>()
-            .Count(x => x.Children.Any<Target>(_ => _.Color == Colors.Green))
+        (await theSession.Query<Target>()
+            .CountAsync(x => x.Children.Any<Target>(_ => _.Color == Colors.Green)))
             .ShouldBeGreaterThanOrEqualTo(1);
     }
 
@@ -222,8 +222,8 @@ public class query_against_child_collections: OneOffConfigurationsContext
         StoreOptions(_ => _.UseSystemTextJsonForSerialization(enumStorage));
         await buildUpTargetData();
 
-        theSession.Query<Target>()
-            .Count(x => x.Children.Any<Target>(_ => _.Inner.Color == Colors.Blue))
+        (await theSession.Query<Target>()
+            .CountAsync(x => x.Children.Any<Target>(_ => _.Inner.Color == Colors.Blue)))
             .ShouldBeGreaterThanOrEqualTo(1);
     }
 
@@ -652,8 +652,8 @@ public class query_against_child_collections: OneOffConfigurationsContext
             .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc1.Id, doc2.Id);
 
         // Or without any predicate
-        theSession.Query<DocWithLists>()
-            .Count(x => x.Numbers.Any()).ShouldBe(3);
+        (await theSession.Query<DocWithLists>()
+            .CountAsync(x => x.Numbers.Any())).ShouldBe(3);
     }
 
     #endregion
@@ -675,8 +675,8 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
 
 
-        theSession.Query<DocWithLists>()
-            .Single(x => x.Numbers.Count() == 4).Id.ShouldBe(doc3.Id);
+        (await theSession.Query<DocWithLists>()
+            .SingleAsync(x => x.Numbers.Count() == 4)).Id.ShouldBe(doc3.Id);
     }
 
     #endregion
@@ -694,8 +694,8 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<DocWithLists>()
-            .Single(x => x.Numbers.Count == 4).Id.ShouldBe(doc3.Id);
+        (await theSession.Query<DocWithLists>()
+            .SingleAsync(x => x.Numbers.Count == 4)).Id.ShouldBe(doc3.Id);
     }
 
     [Fact]
@@ -711,8 +711,8 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<DocWithLists>()
-            .Single(x => x.Numbers.Count > 3).Id.ShouldBe(doc3.Id);
+        (await theSession.Query<DocWithLists>()
+            .SingleAsync(x => x.Numbers.Count > 3)).Id.ShouldBe(doc3.Id);
     }
 
     [Fact]

--- a/src/LinqTests/ChildCollections/query_against_child_collections.cs
+++ b/src/LinqTests/ChildCollections/query_against_child_collections.cs
@@ -379,10 +379,10 @@ public class query_against_child_collections: OneOffConfigurationsContext
         await buildAuthorData();
 
         var interests = new[] { "finance", "astrology" };
-        var res = theSession.Query<Article>()
+        var res = (await theSession.Query<Article>()
             .Where(x => x.CategoryArray.Any(s => interests.Contains(s)))
             .OrderBy(x => x.Long)
-            .ToList();
+            .ToListAsync());
 
         res.Count.ShouldBe(4);
         res[0].Long.ShouldBe(1);
@@ -428,10 +428,10 @@ public class query_against_child_collections: OneOffConfigurationsContext
         await buildAuthorData();
 
         var interests = new[] { "finance", "astrology" };
-        var res = theSession.Query<Article>()
+        var res = (await theSession.Query<Article>()
             .Where(x => x.CategoryArray.Any(s => interests.Contains(s)) && x.Published)
             .OrderBy(x => x.Long)
-            .ToList();
+            .ToListAsync());
 
         res.Count.ShouldBe(2);
         res[0].Long.ShouldBe(1);
@@ -474,10 +474,10 @@ public class query_against_child_collections: OneOffConfigurationsContext
     {
         await buildAuthorData();
 
-        var res = theSession.Query<Article>()
+        var res = (await theSession.Query<Article>()
             .Where(x => x.AuthorList.Any(s => favAuthors.Contains(s)))
             .OrderBy(x => x.Long)
-            .ToList();
+            .ToListAsync());
 
         res.Count.ShouldBe(1);
         res[0].Long.ShouldBe(5);

--- a/src/LinqTests/ChildCollections/query_against_child_collections.cs
+++ b/src/LinqTests/ChildCollections/query_against_child_collections.cs
@@ -495,7 +495,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<DocWithArrays>().Where(x => x.Numbers.Contains(3)).ToArray()
+        (await theSession.Query<DocWithArrays>().Where(x => x.Numbers.Contains(3)).ToListAsync())
             .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc1.Id, doc2.Id);
     }
 
@@ -510,7 +510,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<DocWithArrays>().Where(x => x.Numbers.Length == 4).ToArray()
+        (await theSession.Query<DocWithArrays>().Where(x => x.Numbers.Length == 4).ToListAsync())
             .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc3.Id);
     }
 
@@ -530,7 +530,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<DocWithArrays>().Where(x => x.Strings.Contains("c")).ToArray()
+        (await theSession.Query<DocWithArrays>().Where(x => x.Strings.Contains("c")).ToListAsync())
             .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc1.Id, doc2.Id);
     }
 
@@ -549,7 +549,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<DocWithArrays>().Where(x => x.Strings.Any(_ => _ == "c")).ToArray()
+        (await theSession.Query<DocWithArrays>().Where(x => x.Strings.Any(_ => _ == "c")).ToListAsync())
             .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc1.Id, doc2.Id);
     }
 
@@ -568,7 +568,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
 
 
-        theSession.Query<DocWithArrays>().Where(x => x.Strings.Length == 4).ToArray()
+        (await theSession.Query<DocWithArrays>().Where(x => x.Strings.Length == 4).ToListAsync())
             .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc3.Id);
     }
 
@@ -585,7 +585,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<DocWithArrays>().Where(x => x.Strings.Count() == 4).ToArray()
+        (await theSession.Query<DocWithArrays>().Where(x => x.Strings.Count() == 4).ToListAsync())
             .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc3.Id);
     }
 
@@ -611,7 +611,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<DocWithArrays>().Where(x => x.Dates.Contains(DateTime.Today.AddDays(2))).ToArray()
+        (await theSession.Query<DocWithArrays>().Where(x => x.Dates.Contains(DateTime.Today.AddDays(2))).ToListAsync())
             .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc1.Id, doc2.Id);
     }
 
@@ -628,7 +628,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<DocWithLists>().Where(x => x.Numbers.Contains(3)).ToArray()
+        (await theSession.Query<DocWithLists>().Where(x => x.Numbers.Contains(3)).ToListAsync())
             .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc1.Id, doc2.Id);
     }
 
@@ -648,7 +648,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
 
 
-        theSession.Query<DocWithLists>().Where(x => x.Numbers.Any(_ => _ == 3)).ToArray()
+        (await theSession.Query<DocWithLists>().Where(x => x.Numbers.Any(_ => _ == 3)).ToListAsync())
             .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc1.Id, doc2.Id);
 
         // Or without any predicate
@@ -728,7 +728,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<DocWithLists2>().Where(x => x.Numbers.Contains(3)).ToArray()
+        (await theSession.Query<DocWithLists2>().Where(x => x.Numbers.Contains(3)).ToListAsync())
             .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc1.Id, doc2.Id);
     }
 
@@ -745,7 +745,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<DocWithLists3>().Where(x => x.Numbers.Contains(3)).ToArray()
+        (await theSession.Query<DocWithLists3>().Where(x => x.Numbers.Contains(3)).ToListAsync())
             .Select(x => x.Id).ShouldHaveTheSameElementsAs(doc1.Id, doc2.Id);
     }
 

--- a/src/LinqTests/ChildCollections/query_against_child_collections.cs
+++ b/src/LinqTests/ChildCollections/query_against_child_collections.cs
@@ -247,7 +247,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
         using (var session2 = theStore.LightweightSession())
         {
             // This works
-            var o1 = session2.Query<Outer>().First(o => o.Inners.Any(i => i.Type == "T1" && i.Value == "V12"));
+            var o1 = (await session2.Query<Outer>().FirstAsync(o => o.Inners.Any(i => i.Type == "T1" && i.Value == "V12")));
             o1.ShouldNotBeNull();
 
             var o2 = await session2.QueryAsync(new FindOuterByInner("T1", "V12"));
@@ -291,20 +291,20 @@ public class query_against_child_collections: OneOffConfigurationsContext
     }
 
     [Fact]
-    public void Bug_415_can_query_when_matched_value_has_quotes()
+    public async Task Bug_415_can_query_when_matched_value_has_quotes()
     {
         using (var session = theStore.QuerySession())
         {
-            session.Query<Course>().Any(x => x.ExtIds.Contains("some'thing")).ShouldBeFalse();
+            (await session.Query<Course>().AnyAsync(x => x.ExtIds.Contains("some'thing"))).ShouldBeFalse();
         }
     }
 
     [Fact]
-    public void Bug_415_can_query_inside_of_non_primitive_collection()
+    public async Task Bug_415_can_query_inside_of_non_primitive_collection()
     {
         using (var session = theStore.QuerySession())
         {
-            session.Query<Course>().Any(x => x.Sources.Any(_ => _.Case == "some'thing"));
+            await session.Query<Course>().AnyAsync(x => x.Sources.Any(_ => _.Case == "some'thing"));
         }
     }
 
@@ -762,7 +762,7 @@ public class query_against_child_collections: OneOffConfigurationsContext
         theSession.Store(targetithchildren);
         await theSession.SaveChangesAsync();
 
-        var items = theSession.Query<Target>().Where(x => x.Children.Any()).ToList();
+        var items = (await theSession.Query<Target>().Where(x => x.Children.Any()).ToListAsync());
 
         items.Count.ShouldBe(1);
     }

--- a/src/LinqTests/ChildCollections/query_against_child_collections.cs
+++ b/src/LinqTests/ChildCollections/query_against_child_collections.cs
@@ -123,9 +123,9 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         #region sample_any-query-through-child-collections
 
-        var results = theSession.Query<Target>()
+        var results =(await  theSession.Query<Target>()
             .Where(x => x.Children.Any(_ => _.Number == 6))
-            .ToArray();
+            .ToListAsync());
 
         #endregion
 
@@ -142,9 +142,9 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
 
 
-        var results = theSession.Query<Target>()
+        var results =(await  theSession.Query<Target>()
             .Where(x => x.Children.Any(c => !string.IsNullOrEmpty(c.NullableString)))
-            .ToArray();
+            .ToListAsync());
 
         results
             .Select(x => x.Id)
@@ -159,9 +159,9 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
 
 
-        var results = theSession.Query<Target>()
+        var results =(await  theSession.Query<Target>()
             .Where(x => x.Children.Any(c => string.IsNullOrWhiteSpace(c.NullableString)))
-            .ToArray();
+            .ToListAsync());
 
         var ids = results.Select(x => x.Id).ToArray();
 
@@ -178,10 +178,10 @@ public class query_against_child_collections: OneOffConfigurationsContext
 
         #region sample_any-query-through-child-collection-with-and
 
-        var results = theSession
+        var results =(await  theSession
             .Query<Target>()
             .Where(x => x.Children.Any(_ => _.Number == 6 && _.Double == -1))
-            .ToArray();
+            .ToListAsync());
 
         #endregion
 

--- a/src/LinqTests/ChildCollections/querying_through_n_deep_sub_collections.cs
+++ b/src/LinqTests/ChildCollections/querying_through_n_deep_sub_collections.cs
@@ -100,7 +100,7 @@ public class querying_through_n_deep_sub_collections : IntegrationContext
     }
 
     [Fact]
-    public void query_inside_of_child_collections_collection()
+    public async Task query_inside_of_child_collections_collection()
     {
 
         var results = theSession.Query<Top>().Where(x =>
@@ -110,10 +110,10 @@ public class querying_through_n_deep_sub_collections : IntegrationContext
     }
 
     [Fact]
-    public void query_inside_of_child_collections_collection_2()
+    public async Task query_inside_of_child_collections_collection_2()
     {
-        var results = theSession.Query<Top>().Where(x => x.Middles.Any(m => m.Bottoms.Any(b => b.Name.StartsWith("B"))))
-            .ToList();
+        var results = (await theSession.Query<Top>().Where(x => x.Middles.Any(m => m.Bottoms.Any(b => b.Name.StartsWith("B"))))
+            .ToListAsync());
 
         results.Count.ShouldBe(2);
 

--- a/src/LinqTests/ChildCollections/querying_through_n_deep_sub_collections.cs
+++ b/src/LinqTests/ChildCollections/querying_through_n_deep_sub_collections.cs
@@ -106,7 +106,7 @@ public class querying_through_n_deep_sub_collections : IntegrationContext
         var results = theSession.Query<Top>().Where(x =>
             x.Middles.Any(m => m.Color == Colors.Green && m.Bottoms.Any(b => b.Name == "Bill")));
 
-        results.Single().ShouldBe(greenBill);
+        (await results.SingleAsync()).ShouldBe(greenBill);
     }
 
     [Fact]

--- a/src/LinqTests/Compiled/compiled_queries.cs
+++ b/src/LinqTests/Compiled/compiled_queries.cs
@@ -314,10 +314,8 @@ public class compiled_queries: IntegrationContext
         await theSession.SaveChangesAsync();
 
         // this should pass => Any works.
-        user.ShouldSatisfyAllConditions(
-            () => theSession.Query<User>().Any(x => x.Age == 6).ShouldBeFalse(),
-            () => theSession.Query<User>().Any(x => x.Age == 5).ShouldBeTrue()
-        );
+        (await theSession.Query<User>().AnyAsync(x => x.Age == 6)).ShouldBeFalse();
+        (await theSession.Query<User>().AnyAsync(x => x.Age == 5)).ShouldBeTrue();
 
         // this should pass => AnyAsync works, too
         var asyncR1 = await theSession.Query<User>().AnyAsync(x => x.Age == 6);

--- a/src/LinqTests/Includes/end_to_end_query_with_include.cs
+++ b/src/LinqTests/Includes/end_to_end_query_with_include.cs
@@ -303,10 +303,10 @@ public class end_to_end_query_with_include: IntegrationContext
 
         using var query = theStore.QuerySession();
         var users = new List<User>();
-        var issues = query.Query<Issue>()
+        var issues = (await query.Query<Issue>()
             .Include(x => x.AssigneeId, users)
             .Where(x => x.Tags.Any(t => requestedTags.Contains(t)))
-            .ToList();
+            .ToListAsync());
 
         users.Count.ShouldBe(1);
         users.ShouldContain(x => x.Id == user.Id);
@@ -797,10 +797,10 @@ public class end_to_end_query_with_include: IntegrationContext
 
             var list = new List<User>();
 
-            query.Query<Group>()
+            (await query.Query<Group>()
                 .Include(x => x.Users, list)
                 .Where(x => x.Name == "Odds")
-                .ToList()
+                .ToListAsync())
                 .Single()
                 .Name.ShouldBe("Odds");
 
@@ -925,10 +925,10 @@ public class end_to_end_query_with_include: IntegrationContext
 
             var list = new List<User>();
 
-            var groups = query.Query<Group>()
+            var groups = (await query.Query<Group>()
                 .Include(x => x.Users, list)
                 .Where(x => x.Name == "Users" || x.Name == "Empty")
-                .ToList();
+                .ToListAsync());
 
             groups.Count.ShouldBe(2);
 

--- a/src/LinqTests/Includes/end_to_end_query_with_include.cs
+++ b/src/LinqTests/Includes/end_to_end_query_with_include.cs
@@ -383,7 +383,7 @@ public class end_to_end_query_with_include: IntegrationContext
         using var query = theStore.QuerySession();
         var list = new List<User>();
 
-        var issues = query.Query<Issue>().Include<User>(x => x.AssigneeId, list).ToArray();
+        var issues = (await query.Query<Issue>().Include<User>(x => x.AssigneeId, list).ToListAsync());
 
         list.Count.ShouldBe(2);
 
@@ -442,7 +442,7 @@ public class end_to_end_query_with_include: IntegrationContext
         using var query = theStore.QuerySession();
         var list = new List<User>();
 
-        var issues = query.Query<Issue>().Include<User>(x => x.AssigneeId, list).ToArray();
+        var issues = (await query.Query<Issue>().Include<User>(x => x.AssigneeId, list).ToListAsync());
 
         list.Count.ShouldBe(2);
 
@@ -450,7 +450,7 @@ public class end_to_end_query_with_include: IntegrationContext
         list.Any(x => x.Id == user2.Id).ShouldBeTrue();
         list.Any(x => x == null).ShouldBeFalse();
 
-        issues.Length.ShouldBe(4);
+        issues.Count.ShouldBe(4);
     }
 
     [Fact]
@@ -472,7 +472,7 @@ public class end_to_end_query_with_include: IntegrationContext
         using var query = theStore.IdentitySession();
         var dict = new Dictionary<Guid, User>();
 
-        query.Query<Issue>().Include(x => x.AssigneeId, dict).ToArray();
+        await query.Query<Issue>().Include(x => x.AssigneeId, dict).ToListAsync();
 
         (await query.LoadAsync<User>(user1.Id)).ShouldBeSameAs(dict[user1.Id]);
         (await query.LoadAsync<User>(user2.Id)).ShouldBeSameAs(dict[user2.Id]);
@@ -498,7 +498,7 @@ public class end_to_end_query_with_include: IntegrationContext
         using var query = theStore.QuerySession();
         var dict = new Dictionary<Guid, User>();
 
-        query.Query<Issue>().Include(dict).On(x => x.AssigneeId).ToArray();
+        await query.Query<Issue>().Include(dict).On(x => x.AssigneeId).ToListAsync();
 
         dict.Count.ShouldBe(2);
         dict.ContainsKey(user1.Id).ShouldBeTrue();
@@ -593,13 +593,13 @@ public class end_to_end_query_with_include: IntegrationContext
         using var query = theStore.QuerySession();
         var dict = new Dictionary<Guid, User>();
 
-        var issues = query.Query<Issue>().Include(x => x.AssigneeId, dict).ToArray();
+        var issues = (await query.Query<Issue>().Include(x => x.AssigneeId, dict).ToListAsync());
 
         dict.Count.ShouldBe(2);
         dict.ContainsKey(user1.Id).ShouldBeTrue();
         dict.ContainsKey(user2.Id).ShouldBeTrue();
 
-        issues.Length.ShouldBe(4);
+        issues.Count.ShouldBe(4);
     }
 
     [Fact]

--- a/src/LinqTests/Includes/end_to_end_query_with_include.cs
+++ b/src/LinqTests/Includes/end_to_end_query_with_include.cs
@@ -96,10 +96,10 @@ public class end_to_end_query_with_include: IntegrationContext
 
 
         User included = null;
-        var issue2 = query
+        var issue2 = (await query
             .Query<Issue>()
             .Include<User>(x => included = x).On(x => x.AssigneeId)
-            .Single(x => x.Title == issue.Title);
+            .SingleAsync(x => x.Title == issue.Title));
 
         included.ShouldNotBeNull();
         included.Id.ShouldBe(user.Id);
@@ -121,10 +121,10 @@ public class end_to_end_query_with_include: IntegrationContext
 
         using var query = theStore.QuerySession();
         User included = null;
-        var issue2 = query
+        var issue2 = (await query
             .Query<Issue>()
             .Include<User>(x => x.AssigneeId, x => included = x)
-            .Single(x => x.Tags.Contains("DIY"));
+            .SingleAsync(x => x.Tags.Contains("DIY")));
 
         included.ShouldNotBeNull();
         included.Id.ShouldBe(user.Id);
@@ -148,10 +148,10 @@ public class end_to_end_query_with_include: IntegrationContext
 
         using var query = theStore.QuerySession();
         User included = null;
-        var issue2 = query.Query<Issue>()
+        var issue2 = (await query.Query<Issue>()
             .Include<User>(x => x.AssigneeId, x => included = x)
             .Where(x => x.Tags.Contains("DIY"))
-            .Single();
+            .SingleAsync());
 
         included.ShouldNotBeNull();
         included.Id.ShouldBe(user.Id);
@@ -171,10 +171,10 @@ public class end_to_end_query_with_include: IntegrationContext
 
         using var query = theStore.QuerySession();
         User included = null;
-        var issue2 = query
+        var issue2 = (await query
             .Query<Issue>()
             .Include<User>(x => x.AssigneeId, x => included = x)
-            .Single(x => x.Tags.Any<string>(t => t == "DIY"));
+            .SingleAsync(x => x.Tags.Any<string>(t => t == "DIY")));
 
         included.ShouldNotBeNull();
         included.Id.ShouldBe(user.Id);
@@ -197,10 +197,10 @@ public class end_to_end_query_with_include: IntegrationContext
 
         using var query = theStore.QuerySession();
         User included = null;
-        var issue2 = query.Query<Issue>()
+        var issue2 = (await query.Query<Issue>()
             .Include<User>(x => x.AssigneeId, x => included = x)
             .Where(x => x.Tags.Any(t => t == "DIY"))
-            .Single();
+            .SingleAsync());
 
         included.ShouldNotBeNull();
         included.Id.ShouldBe(user.Id);
@@ -223,10 +223,10 @@ public class end_to_end_query_with_include: IntegrationContext
 
         using var query = theStore.QuerySession();
         User included = null;
-        var issue2 = query.Query<Issue>()
+        var issue2 = (await query.Query<Issue>()
             .Include<User>(x => x.AssigneeId, x => included = x)
             .Where(x => x.Tags.Any(t => t == "DIY"))
-            .Single();
+            .SingleAsync());
 
         included.ShouldNotBeNull();
         included.Id.ShouldBe(user.Id);
@@ -249,10 +249,10 @@ public class end_to_end_query_with_include: IntegrationContext
 
         using var query = theStore.QuerySession();
         User included = null;
-        var issue2 = query.Query<Issue>()
+        var issue2 = (await query.Query<Issue>()
             .Include<User>(x => x.AssigneeId, x => included = x)
             .Where(x => x.Tags.Any(t => t == "DIY"))
-            .Single();
+            .SingleAsync());
 
         included.ShouldNotBeNull();
         included.Id.ShouldBe(user.Id);
@@ -275,10 +275,10 @@ public class end_to_end_query_with_include: IntegrationContext
 
         using var query = theStore.QuerySession();
         User included = null;
-        var issue2 = query.Query<Issue>()
+        var issue2 = (await query.Query<Issue>()
             .Include<User>(x => x.AssigneeId, x => included = x)
             .Where(x => x.Tags.Any(t => t == "DIY"))
-            .Single();
+            .SingleAsync());
 
         included.ShouldNotBeNull();
         included.Id.ShouldBe(user.Id);
@@ -326,17 +326,17 @@ public class end_to_end_query_with_include: IntegrationContext
         session.Store<object>(user, issue);
         await session.SaveChangesAsync();
 
-        IncludeGeneric<UserWithInterface>(user);
+        await IncludeGeneric<UserWithInterface>(user);
     }
 
-    private void IncludeGeneric<T>(UserWithInterface userToCompareAgainst) where T : class, IUserWithInterface
+    private async Task IncludeGeneric<T>(UserWithInterface userToCompareAgainst) where T : class, IUserWithInterface
     {
-        using var query = theStore.QuerySession();
+        await using var query = theStore.QuerySession();
         T included = default;
-        var issue2 = query.Query<Issue>()
+        var issue2 = (await query.Query<Issue>()
             .Include<T>(x => x.AssigneeId, x => included = x)
             .Where(x => x.Tags.Any(t => t == "DIY"))
-            .Single();
+            .SingleAsync());
 
         included.ShouldNotBeNull();
         included.Id.ShouldBe(userToCompareAgainst.Id);
@@ -355,10 +355,10 @@ public class end_to_end_query_with_include: IntegrationContext
 
         using var query = theStore.QuerySession();
         User included = null;
-        var issue2 = query.Query<Issue>()
+        var issue2 = (await query.Query<Issue>()
             .Include<User>(x => x.AssigneeId, x => included = x)
             .Where(x => x.Title == issue.Title)
-            .Single();
+            .SingleAsync());
 
         included.ShouldBeNull();
 
@@ -755,11 +755,11 @@ public class end_to_end_query_with_include: IntegrationContext
         User reporter2 = null;
 
 
-        query
+        (await query
             .Query<Issue>()
             .Include<User>(x => assignee2 = x).On(x => x.AssigneeId)
             .Include<User>(x => reporter2 = x).On(x => x.ReporterId)
-            .Single()
+            .SingleAsync())
             .ShouldNotBeNull();
 
         assignee2.Id.ShouldBe(assignee.Id);
@@ -800,8 +800,7 @@ public class end_to_end_query_with_include: IntegrationContext
             (await query.Query<Group>()
                 .Include(x => x.Users, list)
                 .Where(x => x.Name == "Odds")
-                .ToListAsync())
-                .Single()
+                .SingleAsync())
                 .Name.ShouldBe("Odds");
 
             list.Count.ShouldBe(4);
@@ -824,12 +823,12 @@ public class end_to_end_query_with_include: IntegrationContext
 
         using var query = theStore.QuerySession();
         User included = null;
-        var issue2 = query
+        var issue2 = (await query
             .Query<Issue>()
             .Include<User>(x => x.AssigneeId, x => included = x)
             .Where(x => x.Title == issue.Title)
             .Select(x => new IssueDTO { Id = x.Id, AssigneeId = x.AssigneeId })
-            .Single();
+            .SingleAsync());
 
         included.ShouldNotBeNull();
         included.Id.ShouldBe(user.Id);
@@ -892,10 +891,10 @@ public class end_to_end_query_with_include: IntegrationContext
 
         using var query = theStore.QuerySession();
         User included = null;
-        var issue2 = query
+        var issue2 = (await query
             .Query<Issue>()
             .Include<User>(x => x.AssigneeId, x => included = x)
-            .SingleOrDefault(x => x.Title == "Garage Door is not busted");
+            .SingleOrDefaultAsync(x => x.Title == "Garage Door is not busted"));
 
         included.ShouldBeNull();
         issue2.ShouldBeNull();
@@ -955,10 +954,10 @@ public class end_to_end_query_with_include: IntegrationContext
         using var query = theStore.QuerySession();
         Classroom? included = null;
 
-        var user2 = query
+        var user2 = (await query
             .Query<SchoolUser>()
             .Include<Classroom>(c => included = c).On(u => u.HomeRoom, c => c.RoomCode)
-            .Single(u => u.Name == "Student #1");
+            .SingleAsync(u => u.Name == "Student #1"));
 
         included.ShouldNotBeNull();
         included.Id.ShouldBe(classroom.Id);

--- a/src/LinqTests/Includes/end_to_end_query_with_include.cs
+++ b/src/LinqTests/Includes/end_to_end_query_with_include.cs
@@ -410,17 +410,17 @@ public class end_to_end_query_with_include: IntegrationContext
         using var query = theStore.QuerySession();
         var list = new List<User>();
 
-        var issues = query.Query<Issue>()
+        var issues =(await  query.Query<Issue>()
             .Include<User>(x => x.AssigneeId, list)
             .Where(x => x.AssigneeId.HasValue)
-            .ToArray();
+            .ToListAsync());
 
         list.Count.ShouldBe(2);
 
         list.Any(x => x.Id == user1.Id).ShouldBeTrue();
         list.Any(x => x.Id == user2.Id).ShouldBeTrue();
 
-        issues.Length.ShouldBe(3);
+        issues.Count.ShouldBe(3);
     }
 
     [Fact]
@@ -530,15 +530,15 @@ public class end_to_end_query_with_include: IntegrationContext
 
 
 
-        var ids = query.Query<Issue>().Include(dict).On(x => x.AssigneeId)
+        var ids =(await  query.Query<Issue>().Include(dict).On(x => x.AssigneeId)
             .Where(x => x.Status == "Done")
-            .Select(x => x.Number).ToArray();
+            .Select(x => x.Number).ToListAsync());
 
         dict.Count.ShouldBe(2);
         dict.ContainsKey(user1.Id).ShouldBeTrue();
         dict.ContainsKey(user2.Id).ShouldBeTrue();
 
-        ids.Length.ShouldBe(2);
+        ids.Count.ShouldBe(2);
         ids.ShouldContain(1);
         ids.ShouldContain(2);
     }
@@ -562,16 +562,16 @@ public class end_to_end_query_with_include: IntegrationContext
         using var query = theStore.QuerySession();
         var dict = new Dictionary<Guid, User>();
 
-        var issues = query
+        var issues =(await  query
             .Query<Issue>()
             .Include(x => x.AssigneeId, dict)
-            .Where(x => x.AssigneeId.HasValue).ToArray();
+            .Where(x => x.AssigneeId.HasValue).ToListAsync());
 
         dict.Count.ShouldBe(2);
         dict.ContainsKey(user1.Id).ShouldBeTrue();
         dict.ContainsKey(user2.Id).ShouldBeTrue();
 
-        issues.Length.ShouldBe(3);
+        issues.Count.ShouldBe(3);
     }
 
     [Fact]
@@ -987,12 +987,12 @@ public class end_to_end_query_with_include: IntegrationContext
         using var query = theStore.QuerySession();
         var dict = new Dictionary<string, IList<SchoolUser>>();
 
-        var classes = query
+        var classes =(await  query
             .Query<Classroom>()
             .Include(dict).On(c => c.RoomCode, u => u.HomeRoom)
-            .ToArray();
+            .ToListAsync());
 
-        classes.Length.ShouldBe(2);
+        classes.Count.ShouldBe(2);
         dict.Count.ShouldBe(2);
         dict.ContainsKey(class1.RoomCode).ShouldBeTrue();
         dict.ContainsKey(class2.RoomCode).ShouldBeTrue();

--- a/src/LinqTests/Internals/BoolNotVisitorTests.cs
+++ b/src/LinqTests/Internals/BoolNotVisitorTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Marten.Services;
 using Marten.Testing.Harness;
+using Marten;
 namespace LinqTests.Internals;
 
 public class BoolNotVisitorTests : OneOffConfigurationsContext
@@ -27,7 +28,7 @@ public class BoolNotVisitorTests : OneOffConfigurationsContext
         await theSession.SaveChangesAsync();
 
         using var s = theStore.QuerySession();
-        var items = s.Query<TestClass>().Where(x => !x.Flag).ToList();
+        var items = (await s.Query<TestClass>().Where(x => !x.Flag).ToListAsync());
 
         Assert.Single(items);
         Assert.Equal(docWithFlagFalse.Id, items[0].Id);
@@ -52,7 +53,7 @@ public class BoolNotVisitorTests : OneOffConfigurationsContext
 
         using (var s = theStore.QuerySession())
         {
-            var items = s.Query<TestClass>().Where(x => !x.Flag).ToList();
+            var items = (await s.Query<TestClass>().Where(x => !x.Flag).ToListAsync());
 
             Assert.Single(items);
             Assert.Equal(docWithFlagFalse.Id, items[0].Id);

--- a/src/LinqTests/Operators/aggregate_functions.cs
+++ b/src/LinqTests/Operators/aggregate_functions.cs
@@ -20,7 +20,7 @@ public class aggregate_functions : IntegrationContext
         theSession.Store(new Target { Color = Colors.Blue, Number = 4 });
 
         await theSession.SaveChangesAsync();
-        var maxNumber = theSession.Query<Target>().Max(t => t.Number);
+        var maxNumber = (await theSession.Query<Target>().MaxAsync(t => t.Number));
         maxNumber.ShouldBe(42);
     }
     #endregion
@@ -48,7 +48,7 @@ public class aggregate_functions : IntegrationContext
         theSession.Store(new Target { Color = Colors.Blue, Number = 42 });
 
         await theSession.SaveChangesAsync();
-        var minNumber = theSession.Query<Target>().Min(t => t.Number);
+        var minNumber = (await theSession.Query<Target>().MinAsync(t => t.Number));
         minNumber.ShouldBe(-5);
     }
     #endregion
@@ -76,7 +76,7 @@ public class aggregate_functions : IntegrationContext
         theSession.Store(new Target { Color = Colors.Blue, Number = 42 });
 
         await theSession.SaveChangesAsync();
-        var average = theSession.Query<Target>().Average(t => t.Number);
+        var average = (await theSession.Query<Target>().AverageAsync(t => t.Number));
         average.ShouldBe(10);
     }
     #endregion
@@ -103,7 +103,7 @@ public class aggregate_functions : IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        var result = theSession.Query<Target>().Sum(x => x.Number);
+        var result = (await theSession.Query<Target>().SumAsync(x => x.Number));
         result.ShouldBe(10);
     }
 
@@ -116,7 +116,7 @@ public class aggregate_functions : IntegrationContext
         theSession.Store(new Target { NullableNumber = 4 });
         await theSession.SaveChangesAsync();
 
-        var result = theSession.Query<Target>().Sum(x => x.NullableNumber);
+        var result = (await theSession.Query<Target>().SumAsync(x => x.NullableNumber));
         result.ShouldBe(10);
     }
 
@@ -157,7 +157,7 @@ public class aggregate_functions : IntegrationContext
         theSession.Store(new Target { Color = Colors.Blue, Number = 4 });
 
         await theSession.SaveChangesAsync();
-        theSession.Query<Target>().Sum(x => x.Number)
+        (await theSession.Query<Target>().SumAsync(x => x.Number))
             .ShouldBe(10);
     }
 
@@ -171,14 +171,14 @@ public class aggregate_functions : IntegrationContext
         theSession.Store(new Target { Color = Colors.Green, Decimal = 3.3m });
 
         await theSession.SaveChangesAsync();
-        theSession.Query<Target>().Sum(x => x.Decimal)
+        (await theSession.Query<Target>().SumAsync(x => x.Decimal))
             .ShouldBe(6.6m);
     }
 
     [Fact]
-    public void get_sum_of_empty_table()
+    public async Task get_sum_of_empty_table()
     {
-        theSession.Query<Target>().Sum(x => x.Number)
+        (await theSession.Query<Target>().SumAsync(x => x.Number))
             .ShouldBe(0);
     }
 
@@ -191,7 +191,7 @@ public class aggregate_functions : IntegrationContext
         theSession.Store(new Target { Color = Colors.Blue, Number = 4 });
 
         await theSession.SaveChangesAsync();
-        theSession.Query<Target>().Where(x => x.Number < 4).Sum(x => x.Number)
+        (await theSession.Query<Target>().Where(x => x.Number < 4).SumAsync(x => x.Number))
             .ShouldBe(6);
     }
 

--- a/src/LinqTests/Operators/aggregate_functions.cs
+++ b/src/LinqTests/Operators/aggregate_functions.cs
@@ -222,9 +222,9 @@ public class aggregate_functions : IntegrationContext
         theSession.Store(new Target { NullableColor = null, Number = 4 });
 
         await theSession.SaveChangesAsync();
-        theSession.Query<Target>()
+        (await theSession.Query<Target>()
             .Where(x => x.NullableColor != null)
-            .Sum(x => x.Number)
+            .SumAsync(x => x.Number))
             .ShouldBe(6);
     }
 

--- a/src/LinqTests/Operators/all_operator.cs
+++ b/src/LinqTests/Operators/all_operator.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 namespace LinqTests.Operators;
 
 public class all_operator: IntegrationContext
@@ -30,9 +31,9 @@ public class all_operator: IntegrationContext
         theSession.Store(new User { FirstName = "Joe" , Roles = [default(string), default(string)] });
         await theSession.SaveChangesAsync();
 
-        var results = theSession.Query<User>()
+        var results = (await theSession.Query<User>()
             .Where(u => u.Roles.All(r => r == "R1"))
-            .ToList();
+            .ToListAsync());
 
         results.Count.ShouldBe(2);
     }
@@ -49,9 +50,9 @@ public class all_operator: IntegrationContext
         theSession.Store(new User { FirstName = "Joe" , Roles = [default(string), default(string)] });
         await theSession.SaveChangesAsync();
 
-        var results = theSession.Query<User>()
+        var results = (await theSession.Query<User>()
             .Where(u => u.FirstName == "Joe" && u.Roles.All(r => r == "R1"))
-            .ToList();
+            .ToListAsync());
 
         results.Count.ShouldBe(1);
     }
@@ -68,9 +69,9 @@ public class all_operator: IntegrationContext
         theSession.Store(new User { FirstName = "Joe" , Roles = [default(string), default(string)] });
         await theSession.SaveChangesAsync();
 
-        var results = theSession.Query<User>()
+        var results = (await theSession.Query<User>()
             .Where(u => u.FirstName == "Jean" && u.Roles.All(r => r == "R1"))
-            .ToList();
+            .ToListAsync());
 
         results.Count.ShouldBe(0);
     }
@@ -104,9 +105,9 @@ select ctid, data from mt_temp_id_list1CTE as d where  true = ALL (select unnest
 
          */
 
-        var results = theSession.Query<User>()
+        var results = (await theSession.Query<User>()
             .Where(u => u.Roles.All(r => r == null))
-            .ToList();
+            .ToListAsync());
 
         results.Count.ShouldBe(1);
     }
@@ -136,9 +137,9 @@ select ctid, data from mt_temp_id_list1CTE as d where  true = ALL (select unnest
         });
         await theSession.SaveChangesAsync();
 
-        var results = theSession.Query<User>()
+        var results = (await theSession.Query<User>()
             .Where(u => u.Friends.All(f => f.Name == "F1"))
-            .ToList();
+            .ToListAsync());
 
         results.Count.ShouldBe(2);
     }
@@ -168,9 +169,9 @@ select ctid, data from mt_temp_id_list1CTE as d where  true = ALL (select unnest
         });
         await theSession.SaveChangesAsync();
 
-        var results = theSession.Query<User>()
+        var results = (await theSession.Query<User>()
             .Where(u => u.FirstName == "Joe" && u.Friends.All(f => f.Name == "F1"))
-            .ToList();
+            .ToListAsync());
 
         results.Count.ShouldBe(1);
     }
@@ -200,9 +201,9 @@ select ctid, data from mt_temp_id_list1CTE as d where  true = ALL (select unnest
         });
         await theSession.SaveChangesAsync();
 
-        var results = theSession.Query<User>()
+        var results = (await theSession.Query<User>()
             .Where(u => u.Friends.All(f => f.Name == null))
-            .ToList();
+            .ToListAsync());
 
         results.Count.ShouldBe(1);
     }
@@ -232,9 +233,9 @@ select ctid, data from mt_temp_id_list1CTE as d where  true = ALL (select unnest
         });
         await theSession.SaveChangesAsync();
 
-        var results = theSession.Query<User>()
+        var results = (await theSession.Query<User>()
             .Where(u => u.FirstName == "Bill" && u.Friends.All(f => f.Name == null))
-            .ToList();
+            .ToListAsync());
 
         results.Count.ShouldBe(0);
     }

--- a/src/LinqTests/Operators/any_operator.cs
+++ b/src/LinqTests/Operators/any_operator.cs
@@ -18,14 +18,14 @@ public class any_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Any(x => x.Number == 11)
+        (await theSession.Query<Target>().AnyAsync(x => x.Number == 11))
             .ShouldBeFalse();
     }
 
     [Fact]
-    public void naked_any_miss()
+    public async Task naked_any_miss()
     {
-        theSession.Query<Target>().Any()
+        (await theSession.Query<Target>().AnyAsync())
             .ShouldBeFalse();
     }
 
@@ -38,7 +38,7 @@ public class any_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Any().ShouldBeTrue();
+        (await theSession.Query<Target>().AnyAsync()).ShouldBeTrue();
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class any_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Any(x => x.Number == 3)
+        (await theSession.Query<Target>().AnyAsync(x => x.Number == 3))
             .ShouldBeTrue();
     }
 
@@ -75,7 +75,7 @@ public class any_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Number == 2).Any()
+        (await theSession.Query<Target>().Where(x => x.Number == 2).AnyAsync())
             .ShouldBeTrue();
     }
 

--- a/src/LinqTests/Operators/count_operator.cs
+++ b/src/LinqTests/Operators/count_operator.cs
@@ -18,7 +18,7 @@ public class count_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Count().ShouldBe(4);
+        (await theSession.Query<Target>().CountAsync()).ShouldBe(4);
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class count_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().LongCount().ShouldBe(4);
+        (await theSession.Query<Target>().LongCountAsync()).ShouldBe(4);
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class count_operator: IntegrationContext
         theSession.Store(new Target());
         theSession.Store(new Target());
         await theSession.SaveChangesAsync();
-        theSession.Query<Target>().Count(x => x.Id == x.OtherGuid).ShouldBe(2);
+        (await theSession.Query<Target>().CountAsync(x => x.Id == x.OtherGuid)).ShouldBe(2);
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class count_operator: IntegrationContext
         theSession.Store(new Target());
         theSession.Store(new Target());
         await theSession.SaveChangesAsync();
-        theSession.Query<Target>().Count(x => x.Id != x.OtherGuid).ShouldBe(2);
+        (await theSession.Query<Target>().CountAsync(x => x.Id != x.OtherGuid)).ShouldBe(2);
     }
 
     // Well, this is pretty much a redundant test (since we're testing the Linq translation) but covers #1067
@@ -107,7 +107,7 @@ public class count_operator: IntegrationContext
         theSession.Store(new Target { Number = 6 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().LongCount(x => x.Number > 3).ShouldBe(3);
+        (await theSession.Query<Target>().LongCountAsync(x => x.Number > 3)).ShouldBe(3);
     }
 
     [Fact]
@@ -123,7 +123,7 @@ public class count_operator: IntegrationContext
         theSession.Store(new Target { Number = 6 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Count(x => x.Number > 3).ShouldBe(3);
+        (await theSession.Query<Target>().CountAsync(x => x.Number > 3)).ShouldBe(3);
     }
 
     #endregion

--- a/src/LinqTests/Operators/distinct_operator.cs
+++ b/src/LinqTests/Operators/distinct_operator.cs
@@ -5,6 +5,7 @@ using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
 using Weasel.Core;
+using Marten;
 namespace LinqTests.Operators;
 
 public class distinct_operator : IntegrationContext
@@ -24,7 +25,7 @@ public class distinct_operator : IntegrationContext
 
         var queryable = theSession.Query<Target>().Select(x => x.Number).Distinct();
 
-        queryable.ToList().Count.ShouldBe(3);
+        (await queryable.ToListAsync()).Count.ShouldBe(3);
     }
 
     #region sample_get_distinct_numbers
@@ -46,7 +47,7 @@ public class distinct_operator : IntegrationContext
             x.Decimal
         }).Distinct();
 
-        queryable.ToList().Count.ShouldBe(4);
+        (await queryable.ToListAsync()).Count.ShouldBe(4);
     }
     #endregion
 
@@ -65,7 +66,7 @@ public class distinct_operator : IntegrationContext
 
         var queryable = theSession.Query<Target>().Select(x => x.String).Distinct();
 
-        queryable.ToList().Count.ShouldBe(3);
+        (await queryable.ToListAsync()).Count.ShouldBe(3);
     }
 
     #endregion
@@ -89,7 +90,7 @@ public class distinct_operator : IntegrationContext
             x.AnotherString
         }).Distinct();
 
-        queryable.ToList().Count.ShouldBe(4);
+        (await queryable.ToListAsync()).Count.ShouldBe(4);
     }
 
     [Fact]
@@ -107,7 +108,7 @@ public class distinct_operator : IntegrationContext
 
         var queryable = theSession.Query<Target>().Select(x => x.Color).Distinct();
 
-        queryable.ToList().Count.ShouldBe(4);
+        (await queryable.ToListAsync()).Count.ShouldBe(4);
     }
 
     [Fact]
@@ -127,7 +128,7 @@ public class distinct_operator : IntegrationContext
         var queryable = theSession.Query<Target>()
             .Select(x => x.NullableEnum).Distinct();
 
-        queryable.ToList().Count.ShouldBe(5);
+        (await queryable.ToListAsync()).Count.ShouldBe(5);
     }
 
     [Fact]
@@ -151,7 +152,7 @@ public class distinct_operator : IntegrationContext
         var queryable = theSession.Query<Target>()
             .Select(x => x.NullableEnum).Distinct();
 
-        queryable.ToList().Count.ShouldBe(5);
+        (await queryable.ToListAsync()).Count.ShouldBe(5);
     }
 
     protected override async Task fixtureSetup()

--- a/src/LinqTests/Operators/first_operator.cs
+++ b/src/LinqTests/Operators/first_operator.cs
@@ -20,7 +20,7 @@ public class first_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().First(x => x.Number == 3).ShouldNotBeNull();
+        (await theSession.Query<Target>().FirstAsync(x => x.Number == 3)).ShouldNotBeNull();
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class first_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().FirstOrDefault(x => x.Number == 3).ShouldNotBeNull();
+        (await theSession.Query<Target>().FirstOrDefaultAsync(x => x.Number == 3)).ShouldNotBeNull();
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public class first_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().FirstOrDefault(x => x.Number == 11).ShouldBeNull();
+        (await theSession.Query<Target>().FirstOrDefaultAsync(x => x.Number == 11)).ShouldBeNull();
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class first_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Number == 2).First().Flag
+        (await theSession.Query<Target>().Where(x => x.Number == 2).FirstAsync()).Flag
             .ShouldBeTrue();
     }
 
@@ -71,7 +71,7 @@ public class first_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Number == 2).First().Flag
+        (await theSession.Query<Target>().Where(x => x.Number == 2).FirstAsync()).Flag
             .ShouldBeTrue();
     }
 
@@ -84,9 +84,9 @@ public class first_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        Should.Throw<InvalidOperationException>(() =>
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
         {
-            theSession.Query<Target>().Where(x => x.Number == 11).First();
+            await theSession.Query<Target>().Where(x => x.Number == 11).FirstAsync();
         });
     }
 

--- a/src/LinqTests/Operators/is_empty_operator.cs
+++ b/src/LinqTests/Operators/is_empty_operator.cs
@@ -26,9 +26,9 @@ public class is_empty_operator : IntegrationContext
 
         using (var query = theStore.QuerySession())
         {
-            query.Query<Target>().Where(x => x.Children.IsEmpty())
+            (await query.Query<Target>().Where(x => x.Children.IsEmpty())
                 .OrderBy(x => x.Id).Select(x => x.Id)
-                .ToList()
+                .ToListAsync())
                 .ShouldHaveTheSameElementsAs(empties);
 
 

--- a/src/LinqTests/Operators/is_one_of_operator.cs
+++ b/src/LinqTests/Operators/is_one_of_operator.cs
@@ -157,9 +157,9 @@ public class is_one_of_operator: IntegrationContext
 
         var validValues = targets.Select(select).Distinct().Take(3).ToArray();
 
-        var found = theSession.Query<Target>().Where(isOneOf(validValues)).ToArray();
+        var found = (await theSession.Query<Target>().Where(isOneOf(validValues)).ToListAsync());
 
-        found.Length.ShouldBeLessThan(100);
+        found.Count.ShouldBeLessThan(100);
 
         var expected = targets
             .Where(x => validValues.Contains(select(x)))
@@ -203,7 +203,7 @@ public class is_one_of_operator: IntegrationContext
 
         var validValues = targets.Select(select).Distinct().Take(3).ToArray();
 
-        var found = theSession.Query<Target>().Where(notIsOneOf(validValues)).ToArray();
+        var found = (await theSession.Query<Target>().Where(notIsOneOf(validValues)).ToListAsync());
 
         var expected = targets
             .Where(x => !validValues.Contains(select(x)))
@@ -242,9 +242,9 @@ public class is_one_of_operator: IntegrationContext
 
         var validValues = targets.Select(select).Distinct().Take(3).ToList();
 
-        var found = theSession.Query<Target>().Where(isOneOf(validValues)).ToArray();
+        var found = (await theSession.Query<Target>().Where(isOneOf(validValues)).ToListAsync());
 
-        found.Length.ShouldBeLessThan(100);
+        found.Count.ShouldBeLessThan(100);
 
         var expected = targets
             .Where(x => validValues.Contains(select(x)))
@@ -291,7 +291,7 @@ public class is_one_of_operator: IntegrationContext
 
         var validValues = targets.Select(select).Distinct().Take(3).ToList();
 
-        var found = theSession.Query<Target>().Where(notIsOneOf(validValues)).ToArray();
+        var found = (await theSession.Query<Target>().Where(notIsOneOf(validValues)).ToListAsync());
 
         var expected = targets
             .Where(x => !validValues.Contains(select(x)))

--- a/src/LinqTests/Operators/is_subset_of_operator.cs
+++ b/src/LinqTests/Operators/is_subset_of_operator.cs
@@ -48,16 +48,16 @@ public class is_subset_of_operator : IntegrationContext
     }
 
     [Fact]
-    public void Can_query_by_array()
+    public async Task Can_query_by_array()
     {
         // given
         var tags = new[] {"c#", "mssql"};
 
         // than
-        var found = theSession
+        var found =(await  theSession
             .Query<Target>()
             .Where(x => x.TagsArray.IsSubsetOf(tags))
-            .ToArray();
+            .ToListAsync());
 
         var expected = _allTargets
             .Where(x => x.TagsArray.IsSubsetOf(tags))
@@ -66,12 +66,12 @@ public class is_subset_of_operator : IntegrationContext
             .Select(x => x.Id);
 
         // than
-        found.Length.ShouldBe(2);
+        found.Count.ShouldBe(2);
         found.OrderBy(x => x.Id).Select(x => x.Id).ShouldHaveTheSameElementsAs(expected);
     }
 
     [Fact]
-    public void Can_query_by_hashset()
+    public async Task Can_query_by_hashset()
     {
         // given
         var tags = new[] {"c#", "mssql"};
@@ -90,10 +90,10 @@ select d.id, d.data from public.mt_doc_target as d where CAST(d.data ->> 'TagsHa
          */
 
         // than
-        var found = theSession
+        var found =(await  theSession
             .Query<Target>()
             .Where(x => x.TagsHashSet.IsSubsetOf(tags))
-            .ToArray();
+            .ToListAsync());
 
         var expected = _allTargets
             .Where(x => x.TagsHashSet.IsSubsetOf(tags))
@@ -102,7 +102,7 @@ select d.id, d.data from public.mt_doc_target as d where CAST(d.data ->> 'TagsHa
             .Select(x => x.Id);
 
         // than
-        found.Length.ShouldBe(2);
+        found.Count.ShouldBe(2);
         found.OrderBy(x => x.Id).Select(x => x.Id).ShouldHaveTheSameElementsAs(expected);
     }
 }

--- a/src/LinqTests/Operators/is_super_set_of_operator.cs
+++ b/src/LinqTests/Operators/is_super_set_of_operator.cs
@@ -45,16 +45,16 @@ public class is_super_set_of_operator : IntegrationContext
     }
 
     [Fact]
-    public void Can_query_by_array()
+    public async Task Can_query_by_array()
     {
         // given
         var tags = new[] {"c#", "mssql"};
 
         // than
-        var found = theSession
+        var found =(await  theSession
             .Query<Target>()
             .Where(x => x.TagsArray.IsSupersetOf(tags))
-            .ToArray();
+            .ToListAsync());
 
         var expected = _allTargets
             .Where(x => x.TagsArray.IsSupersetOf(tags))
@@ -63,21 +63,21 @@ public class is_super_set_of_operator : IntegrationContext
             .Select(x => x.Id);
 
         // than
-        found.Length.ShouldBe(3);
+        found.Count.ShouldBe(3);
         found.OrderBy(x => x.Id).Select(x => x.Id).ShouldHaveTheSameElementsAs(expected);
     }
 
     [Fact]
-    public void Can_query_by_hashset()
+    public async Task Can_query_by_hashset()
     {
         // given
         var tags = new[] { "c#", "mssql" };
 
         // than
-        var found = theSession
+        var found =(await  theSession
             .Query<Target>()
             .Where(x => x.TagsHashSet.IsSupersetOf(tags))
-            .ToArray();
+            .ToListAsync());
 
         var expected = _allTargets
             .Where(x => x.TagsHashSet.IsSupersetOf(tags))
@@ -86,7 +86,7 @@ public class is_super_set_of_operator : IntegrationContext
             .Select(x => x.Id);
 
         // than
-        found.Length.ShouldBe(3);
+        found.Count.ShouldBe(3);
         found.OrderBy(x => x.Id).Select(x => x.Id).ShouldHaveTheSameElementsAs(expected);
     }
 

--- a/src/LinqTests/Operators/last_operator.cs
+++ b/src/LinqTests/Operators/last_operator.cs
@@ -18,7 +18,7 @@ public class last_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        Should.Throw<InvalidOperationException>(() =>
+        Should.Throw<NotSupportedException>(() =>
         {
             theSession.Query<Target>().Last(x => x.Number == 3).ShouldNotBeNull();
         });
@@ -33,7 +33,7 @@ public class last_operator: IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        Should.Throw<InvalidOperationException>(() =>
+        Should.Throw<NotSupportedException>(() =>
         {
             theSession.Query<Target>().Last(x => x.Number == 3).ShouldNotBeNull();
         });

--- a/src/LinqTests/Operators/modulo_operator.cs
+++ b/src/LinqTests/Operators/modulo_operator.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
+using Marten;
 
 namespace LinqTests.Operators;
 
@@ -20,7 +21,7 @@ public class query_with_modulo_Tests : IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Number % 2 == 0 && x.Color < Colors.Green).ToArray()
+        (await theSession.Query<Target>().Where(x => x.Number % 2 == 0 && x.Color < Colors.Green).ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(2, 4);
     }
@@ -38,7 +39,7 @@ public class query_with_modulo_Tests : IntegrationContext
 
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => 0 == x.Number % 2 && Colors.Green > x.Color).ToArray()
+        (await theSession.Query<Target>().Where(x => 0 == x.Number % 2 && Colors.Green > x.Color).ToListAsync())
             .Select(x => x.Number)
             .ShouldHaveTheSameElementsAs(2, 4);
     }

--- a/src/LinqTests/Operators/negation_operator.cs
+++ b/src/LinqTests/Operators/negation_operator.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 
 namespace LinqTests.Operators;
 
@@ -21,9 +22,9 @@ public class negation_operator : IntegrationContext
 
         using var query = theStore.QuerySession();
 
-        var players = query.Query<Player>()
+        var players =(await  query.Query<Player>()
             .Where(c => !(c.Name == "Tony" && c.Level == 10))
-            .ToArray();
+            .ToListAsync());
 
         players.Count(x => new[] { player2.Id, player3.Id, player4.Id }.Contains(x.Id)).ShouldBe(3);
     }
@@ -41,9 +42,9 @@ public class negation_operator : IntegrationContext
 
         using var query = theStore.QuerySession();
 
-        var players = query.Query<Player>()
+        var players =(await  query.Query<Player>()
             .Where(c => !(c.Name == "Tony" || c.Level == 10))
-            .ToArray();
+            .ToListAsync());
 
         players.Count(x => new[] { player2.Id, player4.Id }.Contains(x.Id)).ShouldBe(2);
     }

--- a/src/LinqTests/Operators/single_operator.cs
+++ b/src/LinqTests/Operators/single_operator.cs
@@ -19,7 +19,7 @@ public class single_operator : IntegrationContext
         theSession.Store(new Target{Number = 4});
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Single(x => x.Number == 3).ShouldNotBeNull();
+        (await theSession.Query<Target>().SingleAsync(x => x.Number == 3)).ShouldNotBeNull();
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public class single_operator : IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().SingleOrDefault(x => x.Number == 3).ShouldNotBeNull();
+        (await theSession.Query<Target>().SingleOrDefaultAsync(x => x.Number == 3)).ShouldNotBeNull();
     }
     #endregion
 
@@ -44,7 +44,7 @@ public class single_operator : IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().SingleOrDefault(x => x.Number == 11).ShouldBeNull();
+        (await theSession.Query<Target>().SingleOrDefaultAsync(x => x.Number == 11)).ShouldBeNull();
     }
 
     [Fact]
@@ -56,9 +56,9 @@ public class single_operator : IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        Should.Throw<InvalidOperationException>(() =>
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
         {
-            theSession.Query<Target>().Where(x => x.Number == 2).Single();
+            await theSession.Query<Target>().Where(x => x.Number == 2).SingleAsync();
         });
     }
 
@@ -71,7 +71,7 @@ public class single_operator : IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        theSession.Query<Target>().Where(x => x.Number == 2).Take(1).Single().ShouldNotBeNull();
+        (await theSession.Query<Target>().Where(x => x.Number == 2).Take(1).SingleAsync()).ShouldNotBeNull();
     }
 
     [Fact]
@@ -83,9 +83,9 @@ public class single_operator : IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        Should.Throw<InvalidOperationException>(() =>
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
         {
-            theSession.Query<Target>().Where(x => x.Number == 2).SingleOrDefault();
+            await theSession.Query<Target>().Where(x => x.Number == 2).SingleOrDefaultAsync();
         });
     }
 
@@ -98,9 +98,9 @@ public class single_operator : IntegrationContext
         theSession.Store(new Target { Number = 4 });
         await theSession.SaveChangesAsync();
 
-        Should.Throw<InvalidOperationException>(() =>
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
         {
-            theSession.Query<Target>().Where(x => x.Number == 11).Single();
+            await theSession.Query<Target>().Where(x => x.Number == 11).SingleAsync();
         });
     }
 

--- a/src/LinqTests/Operators/string_compare_operator.cs
+++ b/src/LinqTests/Operators/string_compare_operator.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Shouldly;
+using Marten;
 
 namespace LinqTests.Operators;
 
@@ -19,7 +20,7 @@ public class string_compare_operator: IntegrationContext
 
         var queryable = theSession.Query<Target>().Where(x => string.Compare(x.String, "Cherry") > 0);
 
-        queryable.ToList().Count.ShouldBe(1);
+        (await queryable.ToListAsync()).Count.ShouldBe(1);
     }
 
     [Fact]
@@ -33,7 +34,7 @@ public class string_compare_operator: IntegrationContext
 
         var queryable = theSession.Query<Target>().Where(x => x.String.CompareTo("Banana") > 0);
 
-        queryable.ToList().Count.ShouldBe(2);
+        (await queryable.ToListAsync()).Count.ShouldBe(2);
     }
 
     protected override async Task fixtureSetup()

--- a/src/LinqTests/using_containment_operator_in_linq_Tests.cs
+++ b/src/LinqTests/using_containment_operator_in_linq_Tests.cs
@@ -46,7 +46,7 @@ public class using_containment_operator_in_linq_Tests: OneOffConfigurationsConte
         await session.SaveChangesAsync();
 
 
-        session.Query<Target>().Where(x => x.Number == 3).Single().Number.ShouldBe(3);
+        (await session.Query<Target>().Where(x => x.Number == 3).SingleAsync()).Number.ShouldBe(3);
     }
 
     [Fact]
@@ -61,7 +61,7 @@ public class using_containment_operator_in_linq_Tests: OneOffConfigurationsConte
 
         await session.SaveChangesAsync();
 
-        session.Query<Target>().Where(x => x.String == "Python").Single().String.ShouldBe("Python");
+        (await session.Query<Target>().Where(x => x.String == "Python").SingleAsync()).String.ShouldBe("Python");
     }
 }
 
@@ -109,7 +109,7 @@ public class using_containment_operator_in_linq_with_camel_casing_Tests: OneOffC
         await session.SaveChangesAsync();
 
 
-        session.Query<Target>().Where(x => x.Number == 3).Single().Number.ShouldBe(3);
+        (await session.Query<Target>().Where(x => x.Number == 3).SingleAsync()).Number.ShouldBe(3);
     }
 
     [Fact]
@@ -124,6 +124,6 @@ public class using_containment_operator_in_linq_with_camel_casing_Tests: OneOffC
 
         await session.SaveChangesAsync();
 
-        session.Query<Target>().Where(x => x.String == "Python").Single().String.ShouldBe("Python");
+        (await session.Query<Target>().Where(x => x.String == "Python").SingleAsync()).String.ShouldBe("Python");
     }
 }

--- a/src/LinqTests/using_containment_operator_in_linq_Tests.cs
+++ b/src/LinqTests/using_containment_operator_in_linq_Tests.cs
@@ -24,10 +24,10 @@ public class using_containment_operator_in_linq_Tests: OneOffConfigurationsConte
 
         await session.SaveChangesAsync();
 
-        var actual = session.Query<Target>().Where(x => x.Date == targets.ElementAt(2).Date)
-            .ToArray();
+        var actual =(await  session.Query<Target>().Where(x => x.Date == targets.ElementAt(2).Date)
+            .ToListAsync());
 
-        actual.Length.ShouldBeGreaterThan(0);
+        actual.Count.ShouldBeGreaterThan(0);
 
         actual.ShouldContain(targets.ElementAt(2));
     }
@@ -87,10 +87,10 @@ public class using_containment_operator_in_linq_with_camel_casing_Tests: OneOffC
 
         await session.SaveChangesAsync();
 
-        var actual = session.Query<Target>().Where(x => x.Date == targets.ElementAt(2).Date)
-            .ToArray();
+        var actual =(await  session.Query<Target>().Where(x => x.Date == targets.ElementAt(2).Date)
+            .ToListAsync());
 
-        actual.Length.ShouldBeGreaterThan(0);
+        actual.Count.ShouldBeGreaterThan(0);
 
         actual.ShouldContain(targets.ElementAt(2));
     }

--- a/src/Marten.AspNetCore/Daemon/AsyncDaemonHealthCheckExtensions.cs
+++ b/src/Marten.AspNetCore/Daemon/AsyncDaemonHealthCheckExtensions.cs
@@ -167,7 +167,7 @@ public static class AsyncDaemonHealthCheckExtensions
                 return HealthCheckResult.Healthy("Healthy");
             }
 
-            var projectionMarks = allProgress.Where(x => !string.Equals("HighWaterMark", x.ShardName)).ToArray();
+            var projectionMarks = allProgress.Where(x => !string.Equals("HighWaterMark", x.ShardName));
 
             var projectionsSequences = projectionMarks.Where(x => projectionsToCheck.Contains(x.ShardName))
                 .Select(x => new { x.ShardName, x.Sequence })

--- a/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
+++ b/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
@@ -292,16 +292,16 @@ public class noda_time_acceptance: OneOffConfigurationsContext
             await session.SaveChangesAsync();
         }
 
-        using (var query = theStore.QuerySession())
+        await using (var query = theStore.QuerySession())
         {
-            var result = query
+            var result = await query
                 .Query<TargetWithDates>()
-                .Single(c => c.Id == testDoc.Id);
+                .SingleAsync(c => c.Id == testDoc.Id);
 
-            var resultWithSelect = query.Query<TargetWithDates>()
+            var resultWithSelect = await query.Query<TargetWithDates>()
                 .Where(c => c.Id == testDoc.Id)
                 .Select(c => new { c.Id, c.InstantUTC, c.NullableInstantUTC, c.NullInstantUTC })
-                .Single();
+                .SingleAsync();
 
             result.ShouldNotBeNull();
             result.Id.ShouldBe(testDoc.Id);

--- a/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
+++ b/src/Marten.NodaTime.Testing/Acceptance/noda_time_acceptance.cs
@@ -106,7 +106,7 @@ public class noda_time_acceptance: OneOffConfigurationsContext
         await session.SaveChangesAsync();
 
         await using var query = theStore.QuerySession();
-        var docFromDb = query.Query<TargetWithDates>().FirstOrDefault(d => d.Id == testDoc.Id);
+        var docFromDb = (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.Id == testDoc.Id));
 
         docFromDb.ShouldNotBeNull();
         docFromDb.Equals(testDoc).ShouldBeTrue();
@@ -144,46 +144,46 @@ public class noda_time_acceptance: OneOffConfigurationsContext
         var results = new List<TargetWithDates>
         {
             // LocalDate
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.LocalDate == localDateTime.Date),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.LocalDate < localDateTime.Date.PlusDays(1)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.LocalDate <= localDateTime.Date.PlusDays(1)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.LocalDate > localDateTime.Date.PlusDays(-1)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.LocalDate >= localDateTime.Date.PlusDays(-1)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate == localDateTime.Date)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate < localDateTime.Date.PlusDays(1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate <= localDateTime.Date.PlusDays(1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate > localDateTime.Date.PlusDays(-1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDate >= localDateTime.Date.PlusDays(-1))),
 
             //// Nullable LocalDate
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableLocalDate == localDateTime.Date),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableLocalDate < localDateTime.Date.PlusDays(1)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableLocalDate <= localDateTime.Date.PlusDays(1)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableLocalDate > localDateTime.Date.PlusDays(-1)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableLocalDate >= localDateTime.Date.PlusDays(-1)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate == localDateTime.Date)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate < localDateTime.Date.PlusDays(1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate <= localDateTime.Date.PlusDays(1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate > localDateTime.Date.PlusDays(-1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDate >= localDateTime.Date.PlusDays(-1))),
 
             //// LocalDateTime
             //query.Query<TargetWithDates>().FirstOrDefault(d => d.LocalDateTime == localDateTime),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.LocalDateTime < localDateTime.PlusSeconds(1)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.LocalDateTime <= localDateTime.PlusSeconds(1)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.LocalDateTime > localDateTime.PlusSeconds(-1)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.LocalDateTime >= localDateTime.PlusSeconds(-1)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDateTime < localDateTime.PlusSeconds(1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDateTime <= localDateTime.PlusSeconds(1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDateTime > localDateTime.PlusSeconds(-1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.LocalDateTime >= localDateTime.PlusSeconds(-1))),
 
             //// Nullable LocalDateTime
             //query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableLocalDateTime == localDateTime),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableLocalDateTime < localDateTime.PlusSeconds(1)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableLocalDateTime <= localDateTime.PlusSeconds(1)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableLocalDateTime > localDateTime.PlusSeconds(-1)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableLocalDateTime >= localDateTime.PlusSeconds(-1)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDateTime < localDateTime.PlusSeconds(1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDateTime <= localDateTime.PlusSeconds(1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDateTime > localDateTime.PlusSeconds(-1))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableLocalDateTime >= localDateTime.PlusSeconds(-1))),
 
             //// Instant UTC
             //query.Query<TargetWithDates>().FirstOrDefault(d => d.InstantUTC == instantUTC),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.InstantUTC < instantUTC.PlusTicks(1000)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.InstantUTC <= instantUTC.PlusTicks(1000)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.InstantUTC > instantUTC.PlusTicks(-1000)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.InstantUTC >= instantUTC.PlusTicks(-1000)),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.InstantUTC < instantUTC.PlusTicks(1000))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.InstantUTC <= instantUTC.PlusTicks(1000))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.InstantUTC > instantUTC.PlusTicks(-1000))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.InstantUTC >= instantUTC.PlusTicks(-1000))),
 
             // Nullable Instant UTC
             //query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableInstantUTC == instantUTC),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableInstantUTC < instantUTC.PlusTicks(1000)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableInstantUTC <= instantUTC.PlusTicks(1000)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableInstantUTC > instantUTC.PlusTicks(-1000)),
-            query.Query<TargetWithDates>().FirstOrDefault(d => d.NullableInstantUTC >= instantUTC.PlusTicks(-1000))
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableInstantUTC < instantUTC.PlusTicks(1000))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableInstantUTC <= instantUTC.PlusTicks(1000))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableInstantUTC > instantUTC.PlusTicks(-1000))),
+            (await query.Query<TargetWithDates>().FirstOrDefaultAsync(d => d.NullableInstantUTC >= instantUTC.PlusTicks(-1000)))
 
         };
 

--- a/src/Marten.Testing/Examples/DiagnosticsExamples.cs
+++ b/src/Marten.Testing/Examples/DiagnosticsExamples.cs
@@ -49,12 +49,12 @@ public class DiagnosticsExamples: IntegrationContext
         #endregion
     }
 
-    public void use_request_count()
+    public async Task use_request_count()
     {
         #region sample_using_request_count
         using (var session = theStore.QuerySession())
         {
-            var users = session.Query<User>().ToList();
+            var users = (await session.Query<User>().ToListAsync());
             var count = session.Query<User>().Count();
             var any = session.Query<User>().Any();
 

--- a/src/Marten.Testing/Examples/LinqExamples.cs
+++ b/src/Marten.Testing/Examples/LinqExamples.cs
@@ -127,10 +127,10 @@ public class LinqExamples
     #endregion
 
     #region sample_using_take_and_skip
-    public void using_take_and_skip(IDocumentSession session)
+    public async Task using_take_and_skip(IDocumentSession session)
     {
         // gets records 11-20 from the database
-        session.Query<Target>().Skip(10).Take(10).OrderBy(x => x.Number).ToArray();
+        await session.Query<Target>().Skip(10).Take(10).OrderBy(x => x.Number).ToListAsync();
     }
 
     #endregion
@@ -156,29 +156,29 @@ public class LinqExamples
     #endregion
 
     #region sample_boolean_queries
-    public void query_by_booleans(IDocumentSession session)
+    public async Task query_by_booleans(IDocumentSession session)
     {
         // Flag is a boolean property.
 
         // Where Flag is true
-        session.Query<Target>().Where(x => x.Flag).ToArray();
+        await session.Query<Target>().Where(x => x.Flag).ToListAsync();
         // or
-        session.Query<Target>().Where(x => x.Flag == true).ToArray();
+        await session.Query<Target>().Where(x => x.Flag == true).ToListAsync();
 
         // Where Flag is false
-        session.Query<Target>().Where(x => !x.Flag).ToArray();
+        await session.Query<Target>().Where(x => !x.Flag).ToListAsync();
         // or
-        session.Query<Target>().Where(x => x.Flag == false).ToArray();
+        await session.Query<Target>().Where(x => x.Flag == false).ToListAsync();
     }
 
     #endregion
 
     #region sample_query_by_nullable_types
-    public void query_by_nullable_type_nulls(IDocumentSession session)
+    public async Task query_by_nullable_type_nulls(IDocumentSession session)
     {
         // You can use Nullable<T>.HasValue in Linq queries
-        session.Query<Target>().Where(x => !x.NullableNumber.HasValue).ToArray();
-        session.Query<Target>().Where(x => x.NullableNumber.HasValue).ToArray();
+        await session.Query<Target>().Where(x => !x.NullableNumber.HasValue).ToListAsync();
+        await session.Query<Target>().Where(x => x.NullableNumber.HasValue).ToListAsync();
 
         // You can always search by field is NULL
         session.Query<Target>().Where(x => x.Inner == null);

--- a/src/Marten.Testing/Examples/MultiTenancy.cs
+++ b/src/Marten.Testing/Examples/MultiTenancy.cs
@@ -81,9 +81,9 @@ public class MultiTenancy
         // you only get data for that tenant
         using (var query = store.QuerySession("tenant1"))
         {
-            query.Query<User>()
+            (await query.Query<User>()
                 .Select(x => x.UserName)
-                .ToList()
+                .ToListAsync())
                 .ShouldHaveTheSameElementsAs("Bill", "Lindsey");
         }
 
@@ -91,9 +91,9 @@ public class MultiTenancy
 
         using (var query = store.QuerySession("tenant2"))
         {
-            query.Query<User>()
+            (await query.Query<User>()
                 .Select(x => x.UserName)
-                .ToList()
+                .ToListAsync())
                 .ShouldHaveTheSameElementsAs("Jill", "Frank");
         }
     }
@@ -174,9 +174,9 @@ public class MultiTenancy
         // you only get data for that tenant
         using (var query = store.QuerySession("tenant1"))
         {
-            query.Query<User>()
+            (await query.Query<User>()
                 .Select(x => x.UserName)
-                .ToList()
+                .ToListAsync())
                 .ShouldHaveTheSameElementsAs("Bill", "Lindsey");
         }
 
@@ -184,9 +184,9 @@ public class MultiTenancy
 
         using (var query = store.QuerySession("tenant2"))
         {
-            query.Query<User>()
+            (await query.Query<User>()
                 .Select(x => x.UserName)
-                .ToList()
+                .ToListAsync())
                 .ShouldHaveTheSameElementsAs("Jill", "Frank");
         }
     }

--- a/src/Marten/Events/Dcb/EventsExistByTagsHandler.cs
+++ b/src/Marten/Events/Dcb/EventsExistByTagsHandler.cs
@@ -140,11 +140,6 @@ internal class EventsExistByTagsHandler: IQueryHandler<bool>
         builder.Append(" limit 1)");
     }
 
-    public bool Handle(DbDataReader reader, IMartenSession session)
-    {
-        return reader.Read() && reader.GetBoolean(0);
-    }
-
     public async Task<bool> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
     {
         return await reader.ReadAsync(token).ConfigureAwait(false) &&

--- a/src/Marten/Events/Dcb/FetchForWritingByTagsHandler.cs
+++ b/src/Marten/Events/Dcb/FetchForWritingByTagsHandler.cs
@@ -139,11 +139,6 @@ internal class FetchForWritingByTagsHandler<T>: IQueryHandler<IEventBoundary<T>>
             .ToArray();
     }
 
-    public IEventBoundary<T> Handle(DbDataReader reader, IMartenSession session)
-    {
-        throw new NotSupportedException();
-    }
-
     public async Task<IEventBoundary<T>> HandleAsync(DbDataReader reader, IMartenSession session,
         CancellationToken token)
     {

--- a/src/Marten/Events/EventSequenceFetcher.cs
+++ b/src/Marten/Events/EventSequenceFetcher.cs
@@ -27,18 +27,6 @@ internal class EventSequenceFetcher: IQueryHandler<Queue<long>>
         builder.Append(_sql);
     }
 
-    public Queue<long> Handle(DbDataReader reader, IMartenSession session)
-    {
-        var queue = new Queue<long>();
-
-        while (reader.Read())
-        {
-            queue.Enqueue(reader.GetFieldValue<long>(0));
-        }
-
-        return queue;
-    }
-
     public async Task<Queue<long>> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
     {
         var queue = new Queue<long>();

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.ExpectedVersion.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.ExpectedVersion.cs
@@ -164,9 +164,5 @@ internal partial class FetchAsyncPlan<TDoc, TId>
             throw new NotSupportedException();
         }
 
-        public IEventStream<TDoc> Handle(DbDataReader reader, IMartenSession session)
-        {
-            throw new NotSupportedException();
-        }
     }
 }

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.ForReading.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.ForReading.cs
@@ -220,9 +220,5 @@ internal partial class FetchAsyncPlan<TDoc, TId>
             throw new NotSupportedException();
         }
 
-        public TDoc? Handle(DbDataReader reader, IMartenSession session)
-        {
-            throw new NotSupportedException();
-        }
     }
 }

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.ForUpdate.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.ForUpdate.cs
@@ -203,11 +203,6 @@ internal partial class FetchAsyncPlan<TDoc, TId>
             return _parent.ReadIntoStream(documentSessionBase, _id, token, reader, _loadHandler, documentSessionBase.EventStorage());
         }
 
-        public IEventStream<TDoc> Handle(DbDataReader reader, IMartenSession session)
-        {
-            throw new NotSupportedException();
-        }
-
         public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)
         {
             throw new NotSupportedException();

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.ExpectedVersion.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.ExpectedVersion.cs
@@ -119,19 +119,10 @@ internal partial class FetchInlinedPlan<TDoc, TId>
             _handler.ConfigureCommand(builder, session);
         }
 
-        #region things we don't care about
-
-        public IEventStream<TDoc> Handle(DbDataReader reader, IMartenSession session)
-        {
-            throw new NotImplementedException();
-        }
-
         public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)
         {
             throw new NotImplementedException();
         }
-
-        #endregion
 
         public Task<IEventStream<TDoc>> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
         {

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.ForUpdate.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.ForUpdate.cs
@@ -152,19 +152,9 @@ internal partial class FetchInlinedPlan<TDoc, TId>
             return _parent.ReadIntoStream((DocumentSessionBase)session, _id, token, reader, _handler);
         }
 
-        #region stuff we don't care about
-
         public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)
         {
             throw new NotImplementedException();
         }
-
-
-        public IEventStream<TDoc> Handle(DbDataReader reader, IMartenSession session)
-        {
-            throw new NotImplementedException();
-        }
-
-        #endregion
     }
 }

--- a/src/Marten/Events/Fetching/FetchLivePlan.ExpectedVersion.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.ExpectedVersion.cs
@@ -124,11 +124,6 @@ internal partial class FetchLivePlan<TDoc, TId>
             return _parent.ReadIntoStream((DocumentSessionBase)session, _id, _expectedStartingVersion, token, reader, _handler);
         }
 
-        public IEventStream<TDoc> Handle(DbDataReader reader, IMartenSession session)
-        {
-            throw new NotSupportedException();
-        }
-
         public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)
         {
             throw new NotSupportedException();

--- a/src/Marten/Events/Fetching/FetchLivePlan.ForReading.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.ForReading.cs
@@ -98,11 +98,6 @@ internal partial class FetchLivePlan<TDoc, TId>
             _handler.ConfigureCommand(builder, session);
         }
 
-        public TDoc? Handle(DbDataReader reader, IMartenSession session)
-        {
-            throw new NotSupportedException();
-        }
-
         public async Task<TDoc?> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
         {
             var events = await _handler.HandleAsync(reader, session, token).ConfigureAwait(false);

--- a/src/Marten/Events/Fetching/FetchLivePlan.ForUpdate.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.ForUpdate.cs
@@ -141,11 +141,6 @@ internal partial class FetchLivePlan<TDoc, TId>
             return _parent.ReadIntoStream((DocumentSessionBase)session, _id, token, reader, _handler);
         }
 
-        public IEventStream<TDoc> Handle(DbDataReader reader, IMartenSession session)
-        {
-            throw new NotSupportedException();
-        }
-
         public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)
         {
             throw new NotSupportedException();

--- a/src/Marten/Events/Fetching/FetchNaturalKeyPlan.cs
+++ b/src/Marten/Events/Fetching/FetchNaturalKeyPlan.cs
@@ -642,11 +642,6 @@ internal class FetchNaturalKeyPlan<TDoc, TNaturalKey>: IAggregateFetchPlan<TDoc,
             }
         }
 
-        public IEventStream<TDoc> Handle(DbDataReader reader, IMartenSession session)
-        {
-            throw new NotSupportedException();
-        }
-
         public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)
         {
             throw new NotSupportedException();
@@ -697,11 +692,6 @@ internal class FetchNaturalKeyPlan<TDoc, TNaturalKey>: IAggregateFetchPlan<TDoc,
                 return await _parent.FetchDocByString(documentSession, (string)streamIdentity, token)
                     .ConfigureAwait(false);
             }
-        }
-
-        public TDoc? Handle(DbDataReader reader, IMartenSession session)
-        {
-            throw new NotSupportedException();
         }
 
         public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)

--- a/src/Marten/Events/Fetching/PreCannedQueryHandler.cs
+++ b/src/Marten/Events/Fetching/PreCannedQueryHandler.cs
@@ -23,11 +23,6 @@ internal class PreCannedQueryHandler<T>: IQueryHandler<T>
         builder.Append("select 1");
     }
 
-    public T Handle(DbDataReader reader, IMartenSession session)
-    {
-        return _value;
-    }
-
     public Task<T> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
     {
         return Task.FromResult(_value);

--- a/src/Marten/Events/Querying/SingleEventQueryHandler.cs
+++ b/src/Marten/Events/Querying/SingleEventQueryHandler.cs
@@ -30,11 +30,6 @@ internal class SingleEventQueryHandler: IQueryHandler<IEvent>
         sql.AppendParameter(_id);
     }
 
-    public IEvent Handle(DbDataReader reader, IMartenSession session)
-    {
-        return reader.Read() ? ((ISelector<IEvent>)_selector).Resolve(reader) : null;
-    }
-
     public async Task<IEvent> HandleAsync(DbDataReader reader, IMartenSession session,
         CancellationToken token)
     {

--- a/src/Marten/Events/Querying/StreamStateSelector.cs
+++ b/src/Marten/Events/Querying/StreamStateSelector.cs
@@ -24,13 +24,6 @@ public abstract class StreamStateQueryHandler: IQueryHandler<StreamState>
 {
     public abstract void ConfigureCommand(ICommandBuilder builder, IMartenSession session);
 
-    public StreamState Handle(DbDataReader reader, IMartenSession session)
-    {
-        if (!reader.Read()) return null;
-        var selector = (ISelector<StreamState>)session.EventStorage();
-        return selector.Resolve(reader);
-    }
-
     public async Task<StreamState> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
     {
         if (!await reader.ReadAsync(token).ConfigureAwait(false)) return null;

--- a/src/Marten/Events/Schema/EventProgressionSkippingTable.cs
+++ b/src/Marten/Events/Schema/EventProgressionSkippingTable.cs
@@ -46,11 +46,6 @@ internal class EventProgressionSkipsHandler : ISingleQueryHandler<IReadOnlyList<
         builder.AppendParameter(_limit);
     }
 
-    public IReadOnlyList<HighWaterDetectionSkip> Handle(DbDataReader reader, IMartenSession session)
-    {
-        throw new NotSupportedException();
-    }
-
     public NpgsqlCommand BuildCommand()
     {
         return new NpgsqlCommand(

--- a/src/Marten/Internal/CompiledQueries/ClonedCompiledQuery.cs
+++ b/src/Marten/Internal/CompiledQueries/ClonedCompiledQuery.cs
@@ -28,12 +28,6 @@ public abstract class ClonedCompiledQuery<TOut, TQuery>: IQueryHandler<TOut>
         return _inner.StreamJson(stream, reader, token);
     }
 
-    public TOut Handle(DbDataReader reader, IMartenSession session)
-    {
-        var inner = (IQueryHandler<TOut>)_inner.CloneForSession(session, _statistics);
-        return inner.Handle(reader, session);
-    }
-
     public Task<TOut> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
     {
         var inner = (IQueryHandler<TOut>)_inner.CloneForSession(session, _statistics);

--- a/src/Marten/Internal/CompiledQueries/ComplexCompiledQuery.cs
+++ b/src/Marten/Internal/CompiledQueries/ComplexCompiledQuery.cs
@@ -25,12 +25,6 @@ public abstract class ComplexCompiledQuery<TOut, TQuery>: IQueryHandler<TOut>
         return _inner.StreamJson(stream, reader, token);
     }
 
-    public TOut Handle(DbDataReader reader, IMartenSession session)
-    {
-        var inner = BuildHandler(session);
-        return inner.Handle(reader, session);
-    }
-
     public Task<TOut> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
     {
         var inner = BuildHandler(session);

--- a/src/Marten/Internal/CompiledQueries/SourceGeneratedCompiledQuery.cs
+++ b/src/Marten/Internal/CompiledQueries/SourceGeneratedCompiledQuery.cs
@@ -4,7 +4,6 @@ using System.Data.Common;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.Internal.Sessions;
 using Marten.Linq;
 using Marten.Linq.Includes;
 using Marten.Linq.QueryHandlers;
@@ -100,9 +99,6 @@ internal abstract class SourceGeneratedCompiledQueryHandlerBase<TOut>: IQueryHan
         }
     }
 
-    [Obsolete(QuerySession.SynchronousRemoval)]
-    public abstract TOut Handle(DbDataReader reader, IMartenSession session);
-
     public abstract Task<TOut> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token);
 
     public abstract Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token);
@@ -127,10 +123,6 @@ internal sealed class SourceGeneratedStatelessHandler<TOut>: SourceGeneratedComp
     {
         _inner = inner;
     }
-
-    [Obsolete(QuerySession.SynchronousRemoval)]
-    public override TOut Handle(DbDataReader reader, IMartenSession session)
-        => _inner.Handle(reader, session);
 
     public override Task<TOut> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
         => _inner.HandleAsync(reader, session, token);
@@ -160,13 +152,6 @@ internal sealed class SourceGeneratedClonedHandler<TOut>: SourceGeneratedCompile
     {
         _statefulInner = statefulInner;
         _statistics = statistics;
-    }
-
-    [Obsolete(QuerySession.SynchronousRemoval)]
-    public override TOut Handle(DbDataReader reader, IMartenSession session)
-    {
-        var inner = (IQueryHandler<TOut>)_statefulInner.CloneForSession(session, _statistics!);
-        return inner.Handle(reader, session);
     }
 
     public override Task<TOut> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
@@ -229,10 +214,6 @@ internal sealed class SourceGeneratedComplexHandler<TOut>: SourceGeneratedCompil
         var readers = _descriptor.AttachIncludeReaders(session, _query);
         return new IncludeQueryHandler<TOut>(inner, readers);
     }
-
-    [Obsolete(QuerySession.SynchronousRemoval)]
-    public override TOut Handle(DbDataReader reader, IMartenSession session)
-        => BuildIncludingHandler(session).Handle(reader, session);
 
     public override Task<TOut> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
         => BuildIncludingHandler(session).HandleAsync(reader, session, token);

--- a/src/Marten/Internal/CompiledQueries/StatelessCompiledQuery.cs
+++ b/src/Marten/Internal/CompiledQueries/StatelessCompiledQuery.cs
@@ -25,11 +25,6 @@ public abstract class StatelessCompiledQuery<TOut, TQuery>: IQueryHandler<TOut>
         return _inner.StreamJson(stream, reader, token);
     }
 
-    public TOut Handle(DbDataReader reader, IMartenSession session)
-    {
-        return _inner.Handle(reader, session);
-    }
-
     public Task<TOut> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
     {
         return _inner.HandleAsync(reader, session, token);

--- a/src/Marten/Internal/Sessions/QuerySession.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.cs
@@ -18,7 +18,10 @@ namespace Marten.Internal.Sessions;
 public partial class QuerySession: IMartenSession, IQuerySession, ITenantedQuerySession<IQuerySession>
 {
     public const string SynchronousRemoval =
-        "All synchronous APIs that result in database calls will be removed in Marten 8.0. Please use the asynchronous equivalent";
+        "As of Marten 9.0, only asynchronous data access is supported. Please use the asynchronous equivalent.";
+
+    public const string SynchronousNotSupportedMessage =
+        "As of Marten 9.0, only asynchronous data access is supported";
 
     internal const char DefaultParameterPlaceholder = '?';
 

--- a/src/Marten/Linq/Includes/IncludeQueryHandler.cs
+++ b/src/Marten/Linq/Includes/IncludeQueryHandler.cs
@@ -41,17 +41,6 @@ public class IncludeQueryHandler<T>: IQueryHandler<T>, IIncludeQueryHandler<T>
         throw new NotSupportedException("JSON streaming is not supported in combination with Include() operations");
     }
 
-    public T Handle(DbDataReader reader, IMartenSession session)
-    {
-        foreach (var includeReader in _readers)
-        {
-            includeReader.Read(reader);
-            reader.NextResult();
-        }
-
-        return Inner.Handle(reader, session);
-    }
-
     public async Task<T> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
     {
         foreach (var includeReader in _readers)

--- a/src/Marten/Linq/MartenLinqQueryProvider.cs
+++ b/src/Marten/Linq/MartenLinqQueryProvider.cs
@@ -47,25 +47,12 @@ internal class MartenLinqQueryProvider: IQueryProvider
 
     public object Execute(Expression expression)
     {
-        throw new NotSupportedException();
+        throw new NotSupportedException(QuerySession.SynchronousNotSupportedMessage);
     }
 
     public TResult Execute<TResult>(Expression expression)
     {
-        var parser = new LinqQueryParser(this, _session, expression);
-        var handler = parser.BuildHandler<TResult>();
-
-        ensureStorageExists(parser);
-
-        return ExecuteHandler(handler)!;
-    }
-
-    private void ensureStorageExists(LinqQueryParser parser)
-    {
-        foreach (var documentType in parser.DocumentTypes())
-        {
-            _session.Database.EnsureStorageExists(documentType);
-        }
+        throw new NotSupportedException(QuerySession.SynchronousNotSupportedMessage);
     }
 
     internal async ValueTask EnsureStorageExistsAsync(LinqQueryParser parser,
@@ -144,22 +131,9 @@ internal class MartenLinqQueryProvider: IQueryProvider
         return default;
     }
 
-    [Obsolete(QuerySession.SynchronousRemoval)]
     public T? ExecuteHandler<T>(IQueryHandler<T> handler)
     {
-        try
-        {
-            var cmd = _session.BuildCommand(handler);
-
-            using var reader = _session.ExecuteReader(cmd);
-            return handler.Handle(reader, _session);
-        }
-        catch (Exception e)
-        {
-            MartenExceptionTransformer.WrapAndThrow(e);
-        }
-
-        return default;
+        throw new NotSupportedException(QuerySession.SynchronousNotSupportedMessage);
     }
 
 

--- a/src/Marten/Linq/MartenLinqQueryable.cs
+++ b/src/Marten/Linq/MartenLinqQueryable.cs
@@ -133,12 +133,12 @@ internal class MartenLinqQueryable<T> : IOrderedQueryable<T>, IMartenQueryable<T
 
     public IEnumerator<T> GetEnumerator()
     {
-        return Provider.Execute<IEnumerable<T>>(Expression).GetEnumerator();
+        throw new NotSupportedException(QuerySession.SynchronousNotSupportedMessage);
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return Provider.Execute<IEnumerable<T>>(Expression).GetEnumerator();
+        throw new NotSupportedException(QuerySession.SynchronousNotSupportedMessage);
     }
 
     public Type ElementType => typeof(T);

--- a/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/AdvancedSqlQueryHandler.cs
@@ -30,17 +30,6 @@ internal class AdvancedSqlQueryHandler<T>: AdvancedSqlQueryHandlerBase<T>, IQuer
         RegisterResultType<T>(session);
     }
 
-    public IReadOnlyList<T> Handle(DbDataReader reader, IMartenSession session)
-    {
-        var list = new List<T>();
-        while (reader.Read())
-        {
-            var item = ((ISelector<T>)Selectors[0]).Resolve(reader);
-            list.Add(item);
-        }
-        return list;
-    }
-
     public override async IAsyncEnumerable<T> EnumerateResults(DbDataReader reader,
         [EnumeratorCancellation] CancellationToken token)
     {
@@ -57,18 +46,6 @@ internal class AdvancedSqlQueryHandler<T1, T2>: AdvancedSqlQueryHandlerBase<(T1,
     {
         RegisterResultType<T1>(session);
         RegisterResultType<T2>(session);
-    }
-
-    public IReadOnlyList<(T1, T2)> Handle(DbDataReader reader, IMartenSession session)
-    {
-        var list = new List<(T1, T2)>();
-        while (reader.Read())
-        {
-            var item1 = ReadNestedRow<T1>(reader, 0);
-            var item2 = ReadNestedRow<T2>(reader, 1);
-            list.Add((item1, item2));
-        }
-        return list;
     }
 
     public override async IAsyncEnumerable<(T1, T2)> EnumerateResults(DbDataReader reader,
@@ -89,19 +66,6 @@ internal class AdvancedSqlQueryHandler<T1, T2, T3>: AdvancedSqlQueryHandlerBase<
         RegisterResultType<T1>(session);
         RegisterResultType<T2>(session);
         RegisterResultType<T3>(session);
-    }
-
-    public IReadOnlyList<(T1, T2, T3)> Handle(DbDataReader reader, IMartenSession session)
-    {
-        var list = new List<(T1, T2, T3)>();
-        while (reader.Read())
-        {
-            var item1 = ReadNestedRow<T1>(reader, 0);
-            var item2 = ReadNestedRow<T2>(reader, 1);
-            var item3 = ReadNestedRow<T3>(reader, 2);
-            list.Add((item1, item2, item3));
-        }
-        return list;
     }
 
     public override async IAsyncEnumerable<(T1, T2, T3)> EnumerateResults(DbDataReader reader,
@@ -181,21 +145,6 @@ internal abstract class AdvancedSqlQueryHandlerBase<TResult>
             if (await innerReader.ReadAsync(token).ConfigureAwait(false))
             {
                 return await ((ISelector<T>)Selectors[rowIndex]).ResolveAsync(innerReader, token).ConfigureAwait(false);
-            }
-        }
-        return default;
-    }
-
-    protected T? ReadNestedRow<T>(DbDataReader reader, int rowIndex) where T : notnull
-    {
-        var innerReader = reader.GetData(rowIndex) ??
-                          throw new ArgumentException("Invalid row index", nameof(rowIndex));
-
-        using (innerReader)
-        {
-            if (innerReader.Read())
-            {
-                return ((ISelector<T>)Selectors[rowIndex]).Resolve(innerReader);
             }
         }
         return default;

--- a/src/Marten/Linq/QueryHandlers/CheckExistsByIdHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/CheckExistsByIdHandler.cs
@@ -53,11 +53,6 @@ internal class CheckExistsByIdHandler<T, TId>: IQueryHandler<bool> where T : not
         sql.Append(")");
     }
 
-    public bool Handle(DbDataReader reader, IMartenSession session)
-    {
-        return reader.Read() && reader.GetBoolean(0);
-    }
-
     public async Task<bool> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
     {
         if (await reader.ReadAsync(token).ConfigureAwait(false))

--- a/src/Marten/Linq/QueryHandlers/IQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/IQueryHandler.cs
@@ -1,11 +1,9 @@
 #nullable enable
-using System;
 using System.Data.Common;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Internal;
-using Marten.Internal.Sessions;
 using Weasel.Postgresql;
 
 namespace Marten.Linq.QueryHandlers;
@@ -17,9 +15,6 @@ public interface IQueryHandler
 
 public interface IQueryHandler<T>: IQueryHandler
 {
-    [Obsolete(QuerySession.SynchronousRemoval)]
-    T Handle(DbDataReader reader, IMartenSession session);
-
     Task<T> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token);
 
     Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token);

--- a/src/Marten/Linq/QueryHandlers/ListQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/ListQueryHandler.cs
@@ -51,27 +51,9 @@ internal class ListQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>, IQueryHandl
         return list;
     }
 
-    IEnumerable<T> IQueryHandler<IEnumerable<T>>.Handle(DbDataReader reader, IMartenSession session)
-    {
-        return Handle(reader, session);
-    }
-
     public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
     {
         _statement?.Apply(builder);
-    }
-
-    public IReadOnlyList<T> Handle(DbDataReader reader, IMartenSession session)
-    {
-        var list = new List<T>();
-
-        while (reader.Read())
-        {
-            var item = Selector.Resolve(reader);
-            list.Add(item);
-        }
-
-        return list;
     }
 
     public Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)

--- a/src/Marten/Linq/QueryHandlers/ListWithStatsQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/ListWithStatsQueryHandler.cs
@@ -54,41 +54,9 @@ internal class ListWithStatsQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>, IQ
         return list;
     }
 
-    IEnumerable<T> IQueryHandler<IEnumerable<T>>.Handle(DbDataReader reader, IMartenSession session)
-    {
-        return Handle(reader, session);
-    }
-
     public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
     {
         _statement?.Apply(builder);
-    }
-
-    public IReadOnlyList<T> Handle(DbDataReader reader, IMartenSession session)
-    {
-        var list = new List<T>();
-
-        if (reader.Read())
-        {
-            _statistics.TotalResults = reader.GetFieldValue<int>(_countIndex);
-            var item = _selector.Resolve(reader);
-            list.Add(item);
-        }
-        else
-        {
-            // no data
-            _statistics.TotalResults = 0;
-            return list;
-        }
-
-        // Get the rest of the data
-        while (reader.Read())
-        {
-            var item = _selector.Resolve(reader);
-            list.Add(item);
-        }
-
-        return list;
     }
 
     public async Task<int> StreamJson(Stream stream, DbDataReader reader, CancellationToken token)

--- a/src/Marten/Linq/QueryHandlers/LoadByIdArrayHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/LoadByIdArrayHandler.cs
@@ -49,20 +49,6 @@ internal class LoadByIdArrayHandler<T, TKey>: IQueryHandler<IReadOnlyList<T>> wh
         storage.AddTenancyFilter(sql, session.TenantId);
     }
 
-    public IReadOnlyList<T> Handle(DbDataReader reader, IMartenSession session)
-    {
-        var list = new List<T>();
-
-        var selector = (ISelector<T>)storage.BuildSelector(session);
-
-        while (reader.Read())
-        {
-            list.Add(selector.Resolve(reader));
-        }
-
-        return list;
-    }
-
     public async Task<IReadOnlyList<T>> HandleAsync(DbDataReader reader, IMartenSession session,
         CancellationToken token)
     {

--- a/src/Marten/Linq/QueryHandlers/LoadByIdHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/LoadByIdHandler.cs
@@ -69,12 +69,6 @@ internal class LoadByIdHandler<T, TId>: IQueryHandler<T> where T : notnull where
 
 
 
-    public T Handle(DbDataReader reader, IMartenSession session)
-    {
-        var selector = (ISelector<T>)storage.BuildSelector(session);
-        return reader.Read() ? selector.Resolve(reader) : default;
-    }
-
     public async Task<T> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
     {
         var selector = (ISelector<T>)storage.BuildSelector(session);

--- a/src/Marten/Linq/QueryHandlers/OneResultHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/OneResultHandler.cs
@@ -51,29 +51,6 @@ internal class OneResultHandler<T>: IQueryHandler<T>, IMaybeStatefulHandler
         _statement?.Apply(builder);
     }
 
-    public T Handle(DbDataReader reader, IMartenSession session)
-    {
-        var hasResult = reader.Read();
-        if (!hasResult)
-        {
-            if (_canBeNull)
-            {
-                return default;
-            }
-
-            throw new InvalidOperationException(NoElementsMessage);
-        }
-
-        var result = _selector.Resolve(reader);
-
-        if (!_canBeMultiples && reader.Read())
-        {
-            throw new InvalidOperationException(MoreThanOneElementMessage);
-        }
-
-        return result;
-    }
-
     public async Task<T> HandleAsync(DbDataReader reader, IMartenSession session,
         CancellationToken token)
     {

--- a/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
+++ b/src/Marten/Linq/QueryHandlers/UserSuppliedQueryHandler.cs
@@ -91,19 +91,6 @@ internal class UserSuppliedQueryHandler<T>: IQueryHandler<IReadOnlyList<T>>
         }
     }
 
-    public IReadOnlyList<T> Handle(DbDataReader reader, IMartenSession session)
-    {
-        var list = new List<T>();
-
-        while (reader.Read())
-        {
-            var item = _selector.Resolve(reader);
-            list.Add(item);
-        }
-
-        return list;
-    }
-
     public async Task<IReadOnlyList<T>> HandleAsync(DbDataReader reader, IMartenSession session,
         CancellationToken token)
     {

--- a/src/Marten/Linq/SqlGeneration/AnySelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/AnySelectClause.cs
@@ -26,16 +26,6 @@ public class AnySelectClause: ISelectClause, IQueryHandler<bool>
         _topStatement.Apply(builder);
     }
 
-    public bool Handle(DbDataReader reader, IMartenSession session)
-    {
-        if (!reader.Read())
-        {
-            return false;
-        }
-
-        return !reader.IsDBNull(0) && reader.GetBoolean(0);
-    }
-
     public async Task<bool> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
     {
         var hasRow = await reader.ReadAsync(token).ConfigureAwait(false);

--- a/src/Marten/Linq/SqlGeneration/CountClause.cs
+++ b/src/Marten/Linq/SqlGeneration/CountClause.cs
@@ -36,14 +36,6 @@ public class CountClause<T>: IQueryHandler<T>, ICountClause
         _topStatement.Apply(builder);
     }
 
-    public T Handle(DbDataReader reader, IMartenSession session)
-    {
-        var hasNext = reader.Read();
-        return hasNext && !reader.IsDBNull(0)
-            ? reader.GetFieldValue<T>(0)
-            : default;
-    }
-
     public async Task<T> HandleAsync(DbDataReader reader, IMartenSession session, CancellationToken token)
     {
         var hasNext = await reader.ReadAsync(token).ConfigureAwait(false);

--- a/src/Marten/Pagination/PagedList.cs
+++ b/src/Marten/Pagination/PagedList.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
+using Marten.Internal.Sessions;
 using Marten.Linq;
 
 namespace Marten.Pagination;
@@ -111,9 +112,7 @@ public class PagedList<T>: IPagedList<T>
     /// <param name="pageSize"></param>
     public static PagedList<T> Create(IQueryable<T> queryable, int pageNumber, int pageSize, bool useCountQuery = false)
     {
-        var pagedList = new PagedList<T>();
-        pagedList.Init(queryable, pageNumber, pageSize, useCountQuery);
-        return pagedList;
+        throw new NotSupportedException(QuerySession.SynchronousNotSupportedMessage);
     }
 
     /// <summary>
@@ -141,15 +140,7 @@ public class PagedList<T>: IPagedList<T>
     /// <param name="useCountQuery">Use a separate count query rather than using Stats. Default is false and uses Stats</param>
     public void Init(IQueryable<T> queryable, int pageNumber, int pageSize, bool useCountQuery=false)
     {
-        var query = PrepareQuery(queryable, pageNumber, pageSize, useCountQuery, out var statistics);
-
-        if (useCountQuery)
-        {
-            statistics.TotalResults = queryable.LongCount();
-        }
-
-        var items = query.ToList();
-        ProcessResults(pageSize, items, statistics);
+        throw new NotSupportedException(QuerySession.SynchronousNotSupportedMessage);
     }
 
     /// <summary>

--- a/src/Marten/Pagination/PagedListQueryableExtensions.cs
+++ b/src/Marten/Pagination/PagedListQueryableExtensions.cs
@@ -1,7 +1,9 @@
 #nullable enable
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Marten.Internal.Sessions;
 using Marten.Linq;
 
 namespace Marten.Pagination;
@@ -24,8 +26,7 @@ public static class PagedListQueryableExtensions
         int pageNumber,
         int pageSize)
     {
-        // return paged list
-        return PagedList<T>.Create(queryable, pageNumber, pageSize, false);
+        throw new NotSupportedException(QuerySession.SynchronousNotSupportedMessage);
     }
 
     /// <summary>
@@ -42,8 +43,7 @@ public static class PagedListQueryableExtensions
         int pageNumber,
         int pageSize, bool useQueryCount)
     {
-        // return paged list
-        return PagedList<T>.Create(queryable, pageNumber, pageSize, useQueryCount);
+        throw new NotSupportedException(QuerySession.SynchronousNotSupportedMessage);
     }
 
     /// <summary>

--- a/src/Marten/Storage/Metadata/EntityMetadataQueryHandler.cs
+++ b/src/Marten/Storage/Metadata/EntityMetadataQueryHandler.cs
@@ -52,24 +52,6 @@ internal class EntityMetadataQueryHandler: IQueryHandler<DocumentMetadata>
         sql.AppendParameter(_id);
     }
 
-    public DocumentMetadata Handle(DbDataReader reader, IMartenSession session)
-    {
-        if (!reader.Read())
-        {
-            return null;
-        }
-
-        var id = reader.GetFieldValue<object>(0);
-        var metadata = new DocumentMetadata(id);
-
-        for (var i = 0; i < _columns.Length; i++)
-        {
-            _columns[i].Apply(session, metadata, i + 1, reader);
-        }
-
-        return metadata;
-    }
-
     public async Task<DocumentMetadata> HandleAsync(DbDataReader reader, IMartenSession session,
         CancellationToken token)
     {

--- a/src/PatchingTests/Patching/PatchExpressionTests.cs
+++ b/src/PatchingTests/Patching/PatchExpressionTests.cs
@@ -44,7 +44,7 @@ public class PatchExpressionTests : OneOffConfigurationsContext
             sess.Store(new Model() { Id = id, Name = "foo" });
             sess.Patch<Model>(id).Set(x => x.Name, "bar");
             await sess.SaveChangesAsync();
-            sess.Query<Model>().Where(x => x.Id == id).Select(x => x.Name).Single().ShouldBe("bar");
+            (await sess.Query<Model>().Where(x => x.Id == id).Select(x => x.Name).SingleAsync()).ShouldBe("bar");
             (await sess.LoadAsync<Model>(id)).Name.ShouldBe("bar");
         }
     }


### PR DESCRIPTION
## Summary

Closes #4420.

- Drop the synchronous `IQueryHandler<T>.Handle(DbDataReader, IMartenSession)` hook and delete the matching implementation on every shipped handler (load, list, count, exists, advanced SQL, compiled queries, fetch plans, event/stream selectors, metadata, includes, DCB).
- Make every database-bound sync LINQ entrypoint (`MartenLinqQueryProvider.Execute<T>` / `Execute`, the `MartenLinqQueryable<T>` enumerator overloads, and the now-stub `ExecuteHandler<T>` on `QuerySession` / `MartenLinqQueryProvider`) throw `NotSupportedException("As of Marten 9.0, only asynchronous data access is supported")`. Because `MartenLinqQueryProvider.Execute<T>` is what `System.Linq.Queryable` funnels every sync terminal through, this single chokepoint routes `ToList`, `ToArray`, `First`, `Single`, `Count`, `Any`, `Min`, `Max`, `Sum`, `Average`, `ToDictionary`, `Aggregate`, and `foreach` through the documented exception message.
- Update the `QuerySession.SynchronousRemoval` Obsolete-attribute text to reference Marten 9.0 and add a `SynchronousNotSupportedMessage` constant so the runtime exception and the migration guidance stay in lockstep.
- Add `synchronous_apis_throw` coverage in LinqTests exercising every removed sync LINQ entrypoint plus the bare `IEnumerable.GetEnumerator()` path; convert the two in-tree test sites that still called `ExecuteHandler` to `ExecuteHandlerAsync`.
- Sweep the test suite to convert sync `IQueryable.ToArray()` / `IQueryable.ToList()` / `IQueryable.First()` / etc. to their `await ...Async()` counterparts across DocumentDb, EventSourcing, Linq, MultiTenancy, Patching, ValueType, Daemon, and CoreTests projects.
- Document the removal, the exception message, and the async replacement table in `docs/migration-guide.md`.

## Out of scope (remaining CI failures)

The non-EventSourcing/Daemon test matrix passes after the sync sweep. The remaining red runs on this branch fall into two buckets that are **not** caused by the sync API removal and should be triaged separately:

- **Marten 9.0 default flips** — tests written against the pre-9.0 defaults (e.g. `EventAppendMode.Quick`, `EnableAdvancedAsyncTracking=true`, `UseIdentityMapForAggregates=true`, `EnableEventSkippingInProjectionsOrSubscriptions=true`) need updating against the new defaults independently of this PR.
- **Pre-existing EventSourcing failures** — FK constraint / version assertion failures in `ScenarioAggregateAndRepository` and `using_apply_metadata` reproduce on master and are unrelated to query API surface.
- **CI timeout** — the EventSourcing + Daemon jobs hit the 20-min GitHub Actions timeout on this branch even when their tests would otherwise pass; that's an infra thing, not a regression introduced here.

## Test plan

- [x] `dotnet build src/Marten.slnx` succeeds with zero errors
- [x] `dotnet test src/LinqTests/LinqTests.csproj` passes (1258 tests, including 17 new `synchronous_apis_throw` cases)
- [x] Non-EventSourcing CI matrix (Build & Test - NET10/NET9, both serializers) green
- [ ] EventSourcing / Daemon failures triaged separately — see "Out of scope" above

🤖 Generated with [Claude Code](https://claude.com/claude-code)