### PR TITLE
Populate HWM diagnostic fields (jasperfx#279, CW#150 signals 2/3)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
     <PackageVersion Include="JasperFx" Version="2.0.0-alpha.13" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.8" />
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.9" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/DaemonTests/Internals/HighWaterAgentTests.cs
+++ b/src/DaemonTests/Internals/HighWaterAgentTests.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using DaemonTests.TestingSupport;
 using JasperFx.Core;
+using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Marten.Events.Daemon;
 using Marten.Testing;
@@ -141,5 +144,48 @@ public class HighWaterAgentTests: DaemonContext
             .CreateCommand($"delete from {theStore.Events.DatabaseSchemaName}.mt_events where seq_id = ANY(:ids)")
             .With("ids", ids, NpgsqlDbType.Bigint | NpgsqlDbType.Array)
             .ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task skipped_shard_state_carries_skipped_events_count()
+    {
+        NumberOfStreams = 50;
+        await PublishSingleThreaded();
+
+        var gaps = new[] { NumberOfEvents - 20, NumberOfEvents - 8, NumberOfEvents - 3 };
+        await deleteEvents(gaps);
+
+        theStore.Options.Projections.StaleSequenceThreshold = 1.Seconds();
+
+        using var agent = await StartDaemon();
+
+        var observed = new ConcurrentBag<ShardState>();
+        using var subscription = agent.Tracker.Subscribe(new CapturingObserver(state =>
+        {
+            if (state.ShardName == ShardState.HighWaterMark && state.Action == ShardAction.Skipped)
+            {
+                observed.Add(state);
+            }
+        }));
+
+        await agent.Tracker.WaitForHighWaterMark(NumberOfEvents, 10.Seconds());
+        await agent.StopAllAsync();
+
+        observed.ShouldNotBeEmpty();
+        foreach (var state in observed)
+        {
+            state.SkippedEventsCount.HasValue.ShouldBeTrue();
+            state.SkippedEventsCount!.Value.ShouldBe(state.Sequence - state.PreviousGoodMark);
+            state.SkippedEventsCount.Value.ShouldBeGreaterThan(0);
+        }
+    }
+
+    private sealed class CapturingObserver: IObserver<ShardState>
+    {
+        private readonly Action<ShardState> _onNext;
+        public CapturingObserver(Action<ShardState> onNext) => _onNext = onNext;
+        public void OnCompleted() { }
+        public void OnError(Exception error) { }
+        public void OnNext(ShardState value) => _onNext(value);
     }
 }

--- a/src/EventSourcingTests/generating_event_store_descriptors.cs
+++ b/src/EventSourcingTests/generating_event_store_descriptors.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,6 +8,7 @@ using JasperFx.Events;
 using JasperFx.Events.Projections;
 using Marten;
 using Marten.Events.Projections;
+using Marten.Storage;
 using Marten.Testing.Harness;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -44,5 +46,38 @@ public class generating_event_store_descriptors
 
         usage.Subscriptions.Count.ShouldBe(4);
         usage.Events.Any().ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task max_event_sequence_matches_highest_persisted_seq_id()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DatabaseSchemaName = "max_seq_usage";
+                });
+            }).StartAsync();
+
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(Guid.NewGuid(), new QuestStarted { Name = "trip-1" }, new MembersJoined(1, "moria", "Frodo"));
+            session.Events.StartStream(Guid.NewGuid(), new QuestStarted { Name = "trip-2" }, new MembersJoined(1, "shire", "Sam"));
+            await session.SaveChangesAsync();
+        }
+
+        var database = (MartenDatabase)store.Storage.Database;
+        var expectedMax = await database.FetchMaxEventSequenceAsync();
+        expectedMax.HasValue.ShouldBeTrue();
+
+        var capability = host.Services.GetRequiredService<IEventStore>();
+        var usage = await capability.TryCreateUsage(CancellationToken.None);
+
+        usage.ShouldNotBeNull();
+        usage.MaxEventSequence.ShouldBe(expectedMax);
     }
 }

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -373,6 +373,21 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
             Database = await Options.Tenancy.DescribeDatabasesAsync(token).ConfigureAwait(false)
         };
 
+        // MaxEventSequence is a single-valued descriptor; in multi-database setups
+        // the per-database max isn't representable here, so leave it null.
+        if (Options.Tenancy.Cardinality == DatabaseCardinality.Single)
+        {
+            try
+            {
+                var defaultDb = (MartenDatabase)Options.Tenancy.Default.Database;
+                usage.MaxEventSequence = await defaultDb.FetchMaxEventSequenceAsync(token).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // Storage may not exist yet (no events table) — leave null.
+            }
+        }
+
         Options.Projections.Describe(usage, this);
 
         foreach (var eventMapping in Options.EventGraph.AllEvents())

--- a/src/Marten/Events/Daemon/HighWater/SkippedEventsCountObserver.cs
+++ b/src/Marten/Events/Daemon/HighWater/SkippedEventsCountObserver.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using System;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+
+namespace Marten.Events.Daemon.HighWater;
+
+/// <summary>
+///     Patches <see cref="ShardState.SkippedEventsCount"/> on the HighWaterMark
+///     state when the JasperFx.Events HighWaterAgent publishes a
+///     <see cref="ShardAction.Skipped"/> event. The shared
+///     <see cref="ShardStateTracker.MarkSkippingAsync"/> helper supplies
+///     <see cref="ShardState.Sequence"/> and <see cref="ShardState.PreviousGoodMark"/>
+///     but doesn't populate the count, so we fill it here on Marten's side using
+///     the most-recent semantic (gap size = Sequence - PreviousGoodMark).
+/// </summary>
+internal sealed class SkippedEventsCountObserver: IObserver<ShardState>
+{
+    public void OnCompleted() { }
+
+    public void OnError(Exception error) { }
+
+    public void OnNext(ShardState value)
+    {
+        if (value.Action != ShardAction.Skipped) return;
+        if (value.ShardName != ShardState.HighWaterMark) return;
+        if (value.SkippedEventsCount.HasValue) return;
+
+        var skipped = value.Sequence - value.PreviousGoodMark;
+        if (skipped > 0)
+        {
+            value.SkippedEventsCount = skipped;
+        }
+    }
+}

--- a/src/Marten/Storage/MartenDatabase.EventStorage.cs
+++ b/src/Marten/Storage/MartenDatabase.EventStorage.cs
@@ -91,6 +91,30 @@ public partial class MartenDatabase : IEventDatabase
         }
     }
 
+    /// <summary>
+    ///     Fetch the highest <c>seq_id</c> persisted in this database's <c>mt_events</c> table —
+    ///     the absolute physical maximum, distinct from the HighWaterMark (max-safe-to-read).
+    ///     Returns null when the table is empty.
+    /// </summary>
+    public async Task<long?> FetchMaxEventSequenceAsync(CancellationToken token = default)
+    {
+        await EnsureStorageExistsAsync(typeof(IEvent), token).ConfigureAwait(false);
+        await using var conn = CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+        try
+        {
+            var raw = await conn
+                .CreateCommand($"select max(seq_id) from {Options.Events.DatabaseSchemaName}.mt_events;")
+                .ExecuteScalarAsync(token).ConfigureAwait(false);
+
+            return raw is null or DBNull ? null : (long?)raw;
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
 
     /// <summary>
     ///     Fetch the current size of the event store tables, including the current value

--- a/src/Marten/Storage/MartenDatabase.cs
+++ b/src/Marten/Storage/MartenDatabase.cs
@@ -6,6 +6,7 @@ using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.Descriptors;
 using JasperFx.Events.Daemon;
+using Marten.Events.Daemon.HighWater;
 using Marten.Internal;
 using Marten.Schema;
 using Marten.Schema.Identity.Sequences;
@@ -40,6 +41,10 @@ public partial class MartenDatabase: PostgresqlDatabase, IMartenDatabase
 
         Tracker = new ShardStateTracker(options.LogFactory?.CreateLogger<MartenDatabase>() ?? options.DotNetLogger ??
             NullLogger<MartenDatabase>.Instance);
+
+        // Subscribe before any downstream observer (daemon, CritterWatch) so the
+        // Skipped state's SkippedEventsCount is populated in-place before they see it.
+        Tracker.Subscribe(new SkippedEventsCountObserver());
     }
 
     public StoreOptions Options { get; }


### PR DESCRIPTION
## Summary

Marten side of [CritterWatch#150](https://github.com/JasperFx/CritterWatch/issues/150) signals 2 + 3. Pairs with the (forthcoming) Polecat PR and the CritterWatch consumer PR.

- Bumps `JasperFx.Events` pin from `2.0.0-alpha.8` to `2.0.0-alpha.9`, which added the new `EventStoreUsage.MaxEventSequence` and `ShardState.SkippedEventsCount` wire-format fields.
- Populates `MaxEventSequence` in `IEventStore.TryCreateUsage` via a new `MartenDatabase.FetchMaxEventSequenceAsync` helper that runs `select max(seq_id) from {schema}.mt_events`. Only filled when `DatabaseCardinality == Single`; multi-database setups leave it null because a single field cannot represent per-database maxes.
- Populates `SkippedEventsCount` via a new internal `SkippedEventsCountObserver` subscribed to `MartenDatabase.Tracker` in its constructor. The shared `ShardStateTracker.MarkSkippingAsync` in JasperFx.Events publishes the `Skipped` `ShardState` but doesn't fill the count, so the observer patches it in-place (most-recent semantic: `Sequence - PreviousGoodMark`) before downstream subscribers see it.

## Test plan

- [x] `src/Marten` builds clean on net9/net10 after the pin bump.
- [x] New test `generating_event_store_descriptors.max_event_sequence_matches_highest_persisted_seq_id` (EventSourcingTests) — populates a store, queries `EventStoreUsage`, asserts `MaxEventSequence` matches `FetchMaxEventSequenceAsync`.
- [x] New test `HighWaterAgentTests.skipped_shard_state_carries_skipped_events_count` (DaemonTests) — deletes events to create sequence gaps, runs the daemon, asserts each published `Skipped` `ShardState` has `SkippedEventsCount == Sequence - PreviousGoodMark`.
- [x] Existing `HighWater | ShardState | EventStoreUsage` filter passes (15/15 DaemonTests, 2/2 descriptor tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)