### PR TITLE
[#4424] Inline multi-stream projection routes to the stream's tenant

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_3946_tenancy_with_for_tenant_and_projection_issues.cs
+++ b/src/EventSourcingTests/Bugs/Bug_3946_tenancy_with_for_tenant_and_projection_issues.cs
@@ -20,7 +20,7 @@ public class Bug_3946_tenancy_with_for_tenant_and_projection_issues : BugIntegra
 {
     [Theory]
     [InlineData(true)]
-    [InlineData(false, Skip = "Pre-existing failure on master, tracked for the 9.0 milestone in #4424")]
+    [InlineData(false)]
     public async Task when_projection_is_multi_stream_then_tenant_is_passed_to_projection_document(bool useRebuild)
     {
         StoreOptions(opts =>

--- a/src/Marten/Events/QuickEventAppender.cs
+++ b/src/Marten/Events/QuickEventAppender.cs
@@ -48,9 +48,14 @@ internal class QuickEventAppender: IEventAppender
         foreach (var stream in session.WorkTracker.Streams.Where(x => x.Events.Any()))
         {
             stream.TenantId ??= session.TenantId;
+            // #4424: see TenantPropagation. Pass a metadata context whose
+            // TenantId matches the stream so applyQuickMetadata stamps events
+            // with the stream's tenant instead of the session's.
+            var metadataContext = TenantPropagation.MetadataContextFor(session, stream);
+
             if (stream.ActionType == StreamActionType.Start)
             {
-                stream.PrepareEvents(0, eventGraph, sequences, session);
+                stream.PrepareEvents(0, eventGraph, sequences, metadataContext);
                 session.QueueOperation(storage.InsertStream(stream));
 
                 foreach (var @event in stream.Events)
@@ -66,7 +71,7 @@ internal class QuickEventAppender: IEventAppender
                 if (stream.ExpectedVersionOnServer.HasValue)
                 {
                     // We can supply the version to the events going in
-                    stream.PrepareEvents(stream.ExpectedVersionOnServer.Value, eventGraph, sequences, session);
+                    stream.PrepareEvents(stream.ExpectedVersionOnServer.Value, eventGraph, sequences, metadataContext);
                     session.QueueOperation(storage.UpdateStreamVersion(stream));
                     foreach (var @event in stream.Events)
                     {
@@ -82,7 +87,7 @@ internal class QuickEventAppender: IEventAppender
                     // array parameters. In HStore mode the function signature is trimmed
                     // (no per-tag varchar[] params), so tags are written via a follow-up
                     // UPDATE keyed on the event's id after the bulk insert completes.
-                    stream.PrepareEvents(0, eventGraph, sequences, session);
+                    stream.PrepareEvents(0, eventGraph, sequences, metadataContext);
                     var quickAppendEvents = (QuickAppendEventsOperationBase)storage.QuickAppendEvents(stream);
                     quickAppendEvents.Events = eventGraph;
                     session.QueueOperation(quickAppendEvents);

--- a/src/Marten/Events/RichEventAppender.cs
+++ b/src/Marten/Events/RichEventAppender.cs
@@ -46,7 +46,11 @@ internal class RichEventAppender: IEventAppender
 
             if (stream.ActionType == StreamActionType.Start)
             {
-                stream.PrepareEvents(0, eventGraph, sequences, session);
+                // #4424: pass a metadata context whose TenantId matches the
+                // stream so applyRichMetadata stamps events with the stream's
+                // tenant instead of the session's. See TenantPropagation.
+                stream.PrepareEvents(0, eventGraph, sequences,
+                    TenantPropagation.MetadataContextFor(session, stream));
                 session.QueueOperation(storage.InsertStream(stream));
             }
             else if (eventGraph.UseMandatoryStreamTypeDeclaration && stream.IsStarting())
@@ -108,9 +112,13 @@ internal class RichStreamAppendingStep: IEventAppendingStep
     {
         var state = await _fetcher.ConfigureAwait(false);
 
+        _stream.TenantId ??= session.TenantId;
+        // #4424: see RichEventAppender — use stream-tenant metadata context.
+        var metadataContext = TenantPropagation.MetadataContextFor(session, _stream);
+
         if (state == null)
         {
-            _stream.PrepareEvents(0, eventGraph, sequences, session);
+            _stream.PrepareEvents(0, eventGraph, sequences, metadataContext);
             session.QueueOperation(storage.InsertStream(_stream));
         }
         else
@@ -121,7 +129,7 @@ internal class RichStreamAppendingStep: IEventAppendingStep
                     $"Attempted to append event to archived stream with Id '{state.Id}'.");
             }
 
-            _stream.PrepareEvents(state.Version, eventGraph, sequences, session);
+            _stream.PrepareEvents(state.Version, eventGraph, sequences, metadataContext);
             session.QueueOperation(storage.UpdateStreamVersion(_stream));
         }
     }

--- a/src/Marten/Events/TenantPropagation.cs
+++ b/src/Marten/Events/TenantPropagation.cs
@@ -1,0 +1,128 @@
+#nullable enable
+using System.Collections.Generic;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+
+namespace Marten.Events;
+
+/// <summary>
+/// Plumbing for ensuring <see cref="IEvent.TenantId"/> reflects the owning
+/// <see cref="StreamAction.TenantId"/> by the time inline projections run.
+///
+/// <para>
+/// JasperFx.Events' <c>StreamAction.applyRichMetadata</c> /
+/// <c>applyQuickMetadata</c> assign <c>event.TenantId = session.TenantId</c>.
+/// When a caller appends via <c>session.ForTenant("X").Events.StartStream(...)</c>
+/// from a session opened on a different tenant, the stream is correctly tagged
+/// with the override tenant but the in-memory events end up with the session
+/// tenant. Storage is fine (the events row reads from
+/// <see cref="StreamAction.TenantId"/> via <c>TenantIdColumn</c>), but the
+/// inline multi-stream slicer groups events by <c>event.TenantId</c> and
+/// routes the projected document to the wrong tenant. Tracked in
+/// jasperfx/marten#4424.
+/// </para>
+///
+/// <para>
+/// The fix swaps the <see cref="IMetadataContext"/> handed to
+/// <c>StreamAction.PrepareEvents</c> for a wrapper whose <c>TenantId</c> is
+/// the stream's tenant — but only when events haven't already been explicitly
+/// tagged. That preserves <c>GlobalEventAppenderDecorator</c>'s behavior
+/// (which deliberately sets <c>stream.TenantId = default</c> while keeping
+/// <c>event.TenantId = originalTenantId</c> for global projections, jasperfx/marten#4270).
+/// </para>
+/// </summary>
+internal static class TenantPropagation
+{
+    /// <summary>
+    /// Returns the metadata context to pass to <see cref="StreamAction.PrepareEvents"/>
+    /// for <paramref name="stream"/>. When the stream's tenant differs from
+    /// the session tenant AND no other component has set
+    /// <see cref="IEvent.TenantId"/> on the stream's events, returns a wrapper
+    /// that defaults the events to <see cref="StreamAction.TenantId"/>.
+    /// Otherwise returns <paramref name="session"/> unchanged.
+    /// </summary>
+    internal static IMetadataContext MetadataContextFor(IMetadataContext session, StreamAction stream)
+    {
+        if (stream.TenantId.IsEmpty() || stream.TenantId == session.TenantId)
+        {
+            return session;
+        }
+
+        // If any event has a non-empty TenantId that differs from the stream,
+        // some caller (e.g. GlobalEventAppenderDecorator preserving the
+        // session-tenant for global single-stream projections, #4270) has
+        // explicitly tagged it. Leave it alone — using the wrapper would route
+        // applyQuickMetadata back to the stream tenant and erase that
+        // preservation. The applyRichMetadata path already respects non-empty
+        // event tenants on its own.
+        //
+        // Note: StreamAction.TenantId's setter propagates to events, so
+        // event.TenantId == stream.TenantId is the natural "no explicit
+        // override" state and DOES want the wrapper (so applyQuickMetadata
+        // doesn't clobber the propagated value).
+        foreach (var @event in stream.Events)
+        {
+            if (!@event.TenantId.IsEmpty() && @event.TenantId != stream.TenantId)
+            {
+                return session;
+            }
+        }
+
+        return new StreamTenantMetadataContext(session, stream.TenantId);
+    }
+}
+
+/// <summary>
+/// <see cref="IMetadataContext"/> wrapper that reports a caller-supplied
+/// <c>TenantId</c> while delegating every other member to the underlying
+/// session. Used by <see cref="TenantPropagation.MetadataContextFor"/> to make
+/// in-memory event metadata pick up <see cref="StreamAction.TenantId"/>
+/// instead of the session's tenant.
+/// </summary>
+internal sealed class StreamTenantMetadataContext: IMetadataContext
+{
+    private readonly IMetadataContext _inner;
+
+    public StreamTenantMetadataContext(IMetadataContext inner, string tenantId)
+    {
+        _inner = inner;
+        TenantId = tenantId;
+    }
+
+    public string TenantId { get; }
+
+    public string? CausationId
+    {
+        get => _inner.CausationId;
+        set => _inner.CausationId = value;
+    }
+
+    public string? CorrelationId
+    {
+        get => _inner.CorrelationId;
+        set => _inner.CorrelationId = value;
+    }
+
+    public string? LastModifiedBy
+    {
+        get => _inner.LastModifiedBy;
+        set => _inner.LastModifiedBy = value;
+    }
+
+    public string? CurrentUserName
+    {
+        get => _inner.CurrentUserName;
+        set => _inner.CurrentUserName = value;
+    }
+
+    public Dictionary<string, object>? Headers => _inner.Headers;
+
+    public bool CausationIdEnabled => _inner.CausationIdEnabled;
+
+    public bool CorrelationIdEnabled => _inner.CorrelationIdEnabled;
+
+    public bool HeadersEnabled => _inner.HeadersEnabled;
+
+    public bool UserNameEnabled => _inner.UserNameEnabled;
+}


### PR DESCRIPTION
## Summary

- Fix inline `MultiStreamProjection` storing the projected document under the session's tenant instead of the stream's, when a caller appends via `session.ForTenant("X").Events.StartStream(...)` from a session opened on a different tenant.
- Unskip the `useRebuild: False` case of `Bug_3946_tenancy_with_for_tenant_and_projection_issues`.

## Why it was broken

JasperFx.Events' `StreamAction.applyRichMetadata` / `applyQuickMetadata` assign `event.TenantId = session.TenantId` during `PrepareEvents`. Quick (the V9 default) overwrites unconditionally; Rich overwrites only when empty. The `StreamAction.TenantId` setter propagates to events when the user calls `ForTenant(...)`, but Quick's clobber undoes that. Storage rows are unaffected (the events table writes from `StreamAction.TenantId` via `TenantIdColumn`), but inline multi-stream projection slices by `event.TenantId` and routes the projected document to the session's tenant. Inline single-stream worked because its inline driver in JasperFx passes `stream.TenantId` directly; rebuild worked because events come from the DB row.

## How the fix works

`TenantPropagation.MetadataContextFor(session, stream)` returns an `IMetadataContext` wrapper whose `TenantId` is `stream.TenantId` — but only when:
1. The stream's tenant differs from the session's, AND
2. No event has been explicitly tagged with a different tenant (which would indicate `GlobalEventAppenderDecorator`'s [#4270](https://github.com/JasperFx/marten/issues/4270) deliberate preservation — leave that path alone).

Wired into `RichEventAppender` and `QuickEventAppender` at every `PrepareEvents` call site (Start + Append).

## Test plan

- [x] `Bug_3946_tenancy_with_for_tenant_and_projection_issues` (both `useRebuild: True` and `False`)
- [x] `Bug_4270_global_projection_preserves_event_tenant` (both tests) — global single-stream projection still routes the storage to the default tenant while preserving the original session tenant on the in-memory events
- [x] All 245 `EventSourcingTests` filtered to `Projection`
- [x] All 128 `MultiTenancyTests`
- [x] Broader sweep (`MultiStream` / `Conjoined` / `tenant` / `inline`) — 281/283 pass; the 2 failures are pre-existing flaky `live_aggregate_equals_inlined_aggregate_without_hidden_contracts` cases unrelated to this change (hard-coded `"Fifth"` stream id collides with prior test runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)