### PR TITLE
[#4428] Implement RichEventStorage.QuickAppendEventWithVersion

### DIFF
--- a/src/DaemonTests/Bugs/Bug_4428_rich_storage_side_effect_events.cs
+++ b/src/DaemonTests/Bugs/Bug_4428_rich_storage_side_effect_events.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Metadata;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.Bugs;
+
+/// <summary>
+/// Regression for jasperfx/marten#4428.
+///
+/// When <c>StoreOptions.Events.UseClosedShapeStorage = true</c> and
+/// <c>AppendMode = EventAppendMode.Rich</c>, the async-projection
+/// side-effect replay path (JasperFx.Events <c>EventSlice.BuildOperations</c>
+/// → <c>IProjectionBatch.QuickAppendEventWithVersion</c> →
+/// Marten <c>ProjectionBatch.QuickAppendEventWithVersion</c> →
+/// <c>ClosedShapeEventDocumentStorage</c> →
+/// <c>RichEventStorage&lt;TId&gt;.QuickAppendEventWithVersion</c>) used to throw
+/// <c>NotImplementedException</c>. The closed-shape Rich implementation was
+/// stubbed out and the assumption "the Rich appender only calls AppendEvent"
+/// missed the daemon's side-effect replay path. This test asserts the
+/// raised side-effect event lands in <c>mt_events</c> when running the rebuild
+/// under <c>UseClosedShapeStorage = true</c> + Rich.
+/// </summary>
+public class Bug_4428_rich_storage_side_effect_events: OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task raised_side_effect_event_persists_under_closed_shape_rich()
+    {
+        StoreOptions(opts =>
+        {
+            // Force the closed-shape Rich path explicitly so the test reproduces
+            // #4428 regardless of the suite-wide env flag (which only affects
+            // UseClosedShapeStorage, not AppendMode).
+            opts.Events.UseClosedShapeStorage = true;
+            opts.Events.AppendMode = EventAppendMode.Rich;
+            opts.Projections.Add<Bug4428CounterProjection>(ProjectionLifecycle.Async);
+        });
+
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+
+        var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+
+        var streamId = Guid.NewGuid();
+        // Five Increment events — projection raises a BonusAwarded side-effect
+        // when the counter hits a multiple of 5.
+        theSession.Events.StartStream<Bug4428Counter>(streamId,
+            new Bug4428Incremented(),
+            new Bug4428Incremented(),
+            new Bug4428Incremented(),
+            new Bug4428Incremented(),
+            new Bug4428Incremented());
+        await theSession.SaveChangesAsync();
+
+        await daemon.WaitForNonStaleData(30.Seconds());
+
+        // The raised side-effect event must have been persisted to mt_events
+        // via RichEventStorage.QuickAppendEventWithVersion (closed-shape Rich
+        // path). Before #4428 was fixed this call site threw
+        // NotImplementedException; this test is the regression guard against
+        // a future regression of that throw.
+        //
+        // We assert on the raw-events table directly rather than on the
+        // projection snapshot's Bonuses counter — applying the raised event
+        // back into the snapshot is a separate daemon re-poll pass that this
+        // test isn't trying to exercise.
+        var rawEvents = await theSession.Events.QueryAllRawEvents()
+            .Where(x => x.StreamId == streamId)
+            .ToListAsync();
+        rawEvents.OfType<IEvent<Bug4428BonusAwarded>>().Count().ShouldBe(1);
+    }
+}
+
+public record Bug4428Incremented;
+
+public record Bug4428BonusAwarded;
+
+public class Bug4428Counter: IRevisioned
+{
+    public Guid Id { get; set; }
+    public int Increments { get; set; }
+    public int Bonuses { get; set; }
+    public long Version { get; set; }
+}
+
+public class Bug4428CounterProjection: SingleStreamProjection<Bug4428Counter, Guid>
+{
+    public void Apply(Bug4428Counter counter, Bug4428Incremented _) => counter.Increments++;
+
+    public void Apply(Bug4428Counter counter, Bug4428BonusAwarded _) => counter.Bonuses++;
+
+    public override ValueTask RaiseSideEffects(IDocumentOperations operations, IEventSlice<Bug4428Counter> slice)
+    {
+        if (slice.Snapshot != null && slice.Snapshot.Increments > 0 && slice.Snapshot.Increments % 5 == 0)
+        {
+            slice.AppendEvent(new Bug4428BonusAwarded());
+        }
+
+        return new ValueTask();
+    }
+}

--- a/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
+++ b/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
@@ -56,6 +56,12 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
 
         var (orderedColumns, sqlPrefix) = BuildAppendEventFullColumnsAndPrefix(graph);
         var metadataBinders = SelectRichMetadataBinders(orderedColumns);
+        // #4428: side-effect replay through EventSlice.BuildOperations calls
+        // QuickAppendEventWithVersion on the Rich storage. That path uses the
+        // same per-event INSERT shape but with a server-side seq_id nextval()
+        // literal and no SequenceColumnBinder.
+        var metadataBindersWithoutSequence = SelectQuickModeMetadataBinders(orderedColumns);
+        var quickWithVersionSuffix = BuildAppendEventQuickWithVersionSuffix(graph);
         var isConjoined = graph.TenancyStyle == TenancyStyle.Conjoined;
         var isGuid = graph.StreamIdentity == StreamIdentity.AsGuid;
 
@@ -70,6 +76,8 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
         {
             IsTenancyConjoined = isConjoined,
             IsGuidStreamIdentity = isGuid,
+            AppendEventQuickWithVersionSqlSuffix = quickWithVersionSuffix,
+            MetadataBindersWithoutSequence = metadataBindersWithoutSequence,
             ConfigureInsertStreamCommand = BuildInsertStreamCommandConfigurer(graph, isConjoined, isGuid),
             ConfigureUpdateStreamVersionCommand = BuildUpdateStreamVersionCommandConfigurer(graph, isConjoined, isGuid),
         };

--- a/src/Marten/EventStorage/Rich/RichEventStorage.cs
+++ b/src/Marten/EventStorage/Rich/RichEventStorage.cs
@@ -2,6 +2,7 @@
 using System;
 using JasperFx.Events;
 using Marten.EventStorage.Querying;
+using Marten.EventStorage.Quick;
 using Marten.Internal;
 using Marten.Internal.Operations;
 using Marten.Linq.QueryHandlers;
@@ -29,8 +30,22 @@ internal sealed class RichEventStorage<TId>: EventStorage<TId>
     public override IStorageOperation AppendEvent(IMartenSession session, StreamAction stream, IEvent @event)
         => new RichAppendEventOperation(_descriptor, stream, @event);
 
+    // #4428: invoked by JasperFx.Events EventSlice.BuildOperations during
+    // async projection side-effect replay (raised events) — the caller
+    // pre-assigns event.Version but not event.Sequence, so the per-event
+    // INSERT uses the server-side seq_id nextval() literal in the suffix.
+    // The INSERT shape is identical to QuickAppendEventWithVersionOperation
+    // in the Quick namespace, so we reuse it: descriptor SQL strings differ,
+    // operation logic doesn't.
     public override IStorageOperation QuickAppendEventWithVersion(StreamAction stream, IEvent @event)
-        => throw new NotImplementedException("RichAppendEventQuickWithVersionOperation lands in the next iteration.");
+        => new QuickAppendEventWithVersionOperation(
+            _descriptor.AppendEventSqlPrefix,
+            _descriptor.AppendEventQuickWithVersionSqlSuffix,
+            _descriptor.MetadataBindersWithoutSequence,
+            _descriptor.IsGuidStreamIdentity,
+            _descriptor.SerializeEventData,
+            stream,
+            @event);
 
     public override IStorageOperation QuickAppendEvents(StreamAction stream)
         => throw new NotSupportedException(

--- a/src/Marten/EventStorage/Rich/RichEventStorageDescriptor.cs
+++ b/src/Marten/EventStorage/Rich/RichEventStorageDescriptor.cs
@@ -53,6 +53,31 @@ public sealed class RichEventStorageDescriptor
     public IEventMetadataBinder[] MetadataBinders { get; }
 
     /// <summary>
+    /// SQL suffix for the per-event <c>QuickWithVersion</c> path on this
+    /// Rich descriptor — same per-event INSERT shape as
+    /// <see cref="AppendEventSqlSuffix"/>, but with a server-side
+    /// <c>nextval('{schema}.mt_events_sequence')</c> literal in place of the
+    /// bound <c>seq_id</c> parameter. Used by
+    /// <see cref="RichEventStorage{TId}.QuickAppendEventWithVersion"/>, which
+    /// is invoked by <c>JasperFx.Events.EventSlice.BuildOperations</c>
+    /// during async-projection side-effect replay (raised events). The
+    /// caller pre-assigns <c>event.Version</c> but not <c>event.Sequence</c>,
+    /// so the server claims the sequence inline. Tracked in #4428.
+    /// </summary>
+    public string AppendEventQuickWithVersionSqlSuffix { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Ordered metadata-column binders for the per-event
+    /// <c>QuickWithVersion</c> path on this Rich descriptor. Identical to
+    /// <see cref="MetadataBinders"/> except <c>SequenceColumnBinder</c> is
+    /// omitted — <c>seq_id</c> is server-set via the <c>nextval(...)</c>
+    /// literal in <see cref="AppendEventQuickWithVersionSqlSuffix"/>.
+    /// Tracked in #4428.
+    /// </summary>
+    public IEventMetadataBinder[] MetadataBindersWithoutSequence { get; init; }
+        = System.Array.Empty<IEventMetadataBinder>();
+
+    /// <summary>
     /// Whether the events table is conjoined-tenant — every per-stream query
     /// (StreamState lookup, UpdateStreamVersion, etc.) needs a trailing
     /// <c>and tenant_id = $N</c> when this is true.


### PR DESCRIPTION
## Summary

Closes [#4428](https://github.com/JasperFx/marten/issues/4428) — picks **option 1 (implement)**, not "sharpen the throw."

## Why implement (not sharpen)

The issue flagged `ProjectionBatch.QuickAppendEventWithVersion` as a candidate caller that might exercise this path on a Rich descriptor, and the open question was \"does it?\" Yes — `JasperFx.Events.EventSlice.BuildOperations` calls `storage.QuickAppendEventWithVersion(action, @event)` during the daemon's side-effect replay path (`AggregationRunner.processPossibleSideEffects`) when a `SingleStreamProjection` raises events via `RaiseSideEffects → slice.AppendEvent(...)`. Under `UseClosedShapeStorage = true` + `AppendMode = Rich`, that lands on `RichEventStorage<TId>.QuickAppendEventWithVersion` and throws `NotImplementedException`.

## How

Reuses the existing `QuickAppendEventWithVersionOperation` from `Marten.EventStorage.Quick` (cross-namespace internal — same INSERT shape, different descriptor strings). The Rich descriptor now exposes two new init-only members:

* `AppendEventQuickWithVersionSqlSuffix` — `", nextval('{schema}.mt_events_sequence'))"`, mirrors Quick's same-name field. Server-side `seq_id` because the caller (`EventSlice.BuildOperations`) pre-assigns `event.Version` but not `event.Sequence`.
* `MetadataBindersWithoutSequence` — `SelectQuickModeMetadataBinders(orderedColumns)`, excludes `SequenceColumnBinder` since the suffix's `nextval(...)` literal owns that column.

## Test plan

- [x] **Regression**: `Bug_4428_rich_storage_side_effect_events.raised_side_effect_event_persists_under_closed_shape_rich` — explicit `UseClosedShapeStorage = true` + `AppendMode = EventAppendMode.Rich`, projection raises a side-effect event during async rebuild, asserts the event lands in `mt_events`. Fails on bare master with the literal `NotImplementedException` from the stub; passes with the fix.
- [x] **Adjacent**: `DaemonTests/Aggregations/side_effects_in_aggregations` (7 tests) + Bug_4428 under `MARTEN_USE_CLOSED_SHAPE_STORAGE=true` — 8/8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)