### PR TITLE
[#4427] Strict-identity CTE InsertStream for closed-shape

### DIFF
--- a/src/EventSourcingTests/strict_stream_identity_enforcement.cs
+++ b/src/EventSourcingTests/strict_stream_identity_enforcement.cs
@@ -30,19 +30,6 @@ public class strict_stream_identity_enforcement: OneOffConfigurationsContext
     [InlineData(true)]
     public async Task guid__start_archive_start_throws_when_strict_enforcement_enabled(bool usePartitioning)
     {
-        if (usePartitioning && TestsSettings.UseClosedShapeStorage)
-        {
-            // Closed-shape InsertStream doesn't yet emit the strict-identity
-            // CTE variant that detects collisions across archive-partition
-            // boundaries. The vanilla insert's unique constraint only fires
-            // when the active + archived rows share a partition, so under
-            // partitioning the collision goes undetected. Tracked on #4427;
-            // until then, skip this combination under the closed-shape flag.
-            // The codegen path (default) still runs both InlineData variants
-            // here.
-            return;
-        }
-
         StoreOptions(opts =>
         {
             opts.Events.UseArchivedStreamPartitioning = usePartitioning;
@@ -74,13 +61,6 @@ public class strict_stream_identity_enforcement: OneOffConfigurationsContext
     [InlineData(true)]
     public async Task string_key__start_archive_start_throws_when_strict_enforcement_enabled(bool usePartitioning)
     {
-        if (usePartitioning && TestsSettings.UseClosedShapeStorage)
-        {
-            // See the Guid sibling above — strict-identity CTE port for the
-            // closed-shape path is tracked on #4427.
-            return;
-        }
-
         StoreOptions(opts =>
         {
             opts.Events.StreamIdentity = StreamIdentity.AsString;
@@ -188,6 +168,41 @@ public class strict_stream_identity_enforcement: OneOffConfigurationsContext
             session.Events.StartStream(stream, new MembersJoined());
 
             await Should.NotThrowAsync(async () => await session.SaveChangesAsync());
+        }
+    }
+
+    [Fact]
+    public async Task rich_append_mode_with_strict_identity_and_partitioning()
+    {
+        // Rich + strict-identity was previously rejected at descriptor-build
+        // time on the closed-shape path (NotSupportedException). #4427 wired
+        // the CTE variant through BuildInsertStreamCommandConfigurer so all
+        // three append modes (Rich/Quick/QuickWithServerTimestamps) emit the
+        // strict-identity CTE when the flag is on.
+        StoreOptions(opts =>
+        {
+            opts.Events.AppendMode = JasperFx.Events.EventAppendMode.Rich;
+            opts.Events.UseArchivedStreamPartitioning = true;
+            opts.Events.EnableStrictStreamIdentityEnforcement = true;
+        });
+
+        var stream = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(stream, new MembersJoined());
+            await session.SaveChangesAsync();
+
+            session.Events.ArchiveStream(stream);
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(stream, new MembersJoined());
+
+            await Should.ThrowAsync<ExistingStreamIdCollisionException>(
+                async () => await session.SaveChangesAsync());
         }
     }
 }

--- a/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
+++ b/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
@@ -41,19 +41,6 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
 {
     public RichEventStorageDescriptor BuildRichDescriptor(EventGraph graph, ISerializer serializer)
     {
-        if (graph.EnableStrictStreamIdentityEnforcement)
-        {
-            // The strict-identity CTE wraps the mt_streams insert in a
-            // modifying CTE chained with a second insert into
-            // mt_streams_identity. The CTE shape is non-trivial — its
-            // closed-shape port lives behind a separate ticket so we
-            // don't ship a half-wired variant. The codegen path still
-            // covers this configuration; closed-shape just declines.
-            throw new NotSupportedException(
-                "EnableStrictStreamIdentityEnforcement isn't yet covered by the closed-shape Rich-mode " +
-                "InsertStream operation. Disable the flag or use the codegen path for now. Track on #4412.");
-        }
-
         var (orderedColumns, sqlPrefix) = BuildAppendEventFullColumnsAndPrefix(graph);
         var metadataBinders = SelectRichMetadataBinders(orderedColumns);
         var isConjoined = graph.TenancyStyle == TenancyStyle.Conjoined;
@@ -95,7 +82,19 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
     private static Action<ICommandBuilder, StreamAction> BuildInsertStreamCommandConfigurer(
         EventGraph graph, bool isConjoined, bool isGuid)
     {
-        var sqlPrefix = BuildInsertStreamSqlPrefix(graph, isConjoined);
+        // #4427: strict-identity enforcement wraps the mt_streams insert in
+        // a modifying CTE that chains an insert into the non-partitioned
+        // mt_streams_identity tracking table. Without the CTE the codegen
+        // path's collision detection across archive-partition boundaries
+        // doesn't fire under UseArchivedStreamPartitioning, because the
+        // active partition's unique index doesn't span partitions. The
+        // resulting unique-violation surfaces with
+        // TableName = mt_streams_identity, which InsertStreamBase.matches()
+        // already translates into ExistingStreamIdCollisionException —
+        // hence "implement the CTE; do not invent a new exception path."
+        var (sqlPrefix, sqlSuffix) = graph.EnableStrictStreamIdentityEnforcement
+            ? BuildStrictIdentityInsertStreamSql(graph, isConjoined)
+            : (BuildInsertStreamSqlPrefix(graph, isConjoined), ")");
 
         if (isConjoined)
         {
@@ -109,7 +108,7 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
                     pb.AppendParameter(stream.Id, NpgsqlDbType.Uuid);
                     pb.AppendParameter(stream.AggregateTypeName, NpgsqlDbType.Varchar);
                     pb.AppendParameter(stream.Version, NpgsqlDbType.Bigint);
-                    builder.Append(")");
+                    builder.Append(sqlSuffix);
                 };
             }
 
@@ -121,7 +120,7 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
                 pb.AppendParameter(stream.Key, NpgsqlDbType.Varchar);
                 pb.AppendParameter(stream.AggregateTypeName, NpgsqlDbType.Varchar);
                 pb.AppendParameter(stream.Version, NpgsqlDbType.Bigint);
-                builder.Append(")");
+                builder.Append(sqlSuffix);
             };
         }
 
@@ -135,7 +134,7 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
                 pb.AppendParameter(stream.AggregateTypeName, NpgsqlDbType.Varchar);
                 pb.AppendParameter(stream.Version, NpgsqlDbType.Bigint);
                 pb.AppendParameter(stream.TenantId, NpgsqlDbType.Varchar);
-                builder.Append(")");
+                builder.Append(sqlSuffix);
             };
         }
 
@@ -147,7 +146,7 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             pb.AppendParameter(stream.AggregateTypeName, NpgsqlDbType.Varchar);
             pb.AppendParameter(stream.Version, NpgsqlDbType.Bigint);
             pb.AppendParameter(stream.TenantId, NpgsqlDbType.Varchar);
-            builder.Append(")");
+            builder.Append(sqlSuffix);
         };
     }
 
@@ -165,6 +164,45 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             : "id, type, version, tenant_id";
 
         return $"insert into {graph.DatabaseSchemaName}.{StreamsTable.TableName} ({cols}) values (";
+    }
+
+    /// <summary>
+    /// SQL prefix + suffix pair for the strict-identity-enforcement variant
+    /// of the <c>mt_streams</c> insert (#4427). Wraps the vanilla insert in
+    /// a modifying CTE that chains an insert into
+    /// <see cref="StreamIdentityEnforcementTable"/>:
+    /// <code>
+    /// with new_stream as (insert into mt_streams (...) values (...) returning &lt;identity_cols&gt;)
+    /// insert into mt_streams_identity (&lt;identity_cols&gt;) select &lt;identity_cols&gt; from new_stream
+    /// </code>
+    /// The chained insert raises <c>UniqueViolation</c> with
+    /// <c>TableName = mt_streams_identity</c> on collision, which
+    /// <c>InsertStreamBase.matches()</c> already maps to
+    /// <c>ExistingStreamIdCollisionException</c>. No new parameters — the
+    /// CTE pipes the just-inserted identity through.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors <c>EventDocumentStorageGenerator.buildInsertStream</c>'s
+    /// strict-identity branch — column order is exactly what
+    /// <see cref="BuildInsertStreamSqlPrefix"/> produces, so the
+    /// per-variant parameter-bind code is unchanged.
+    /// </remarks>
+    private static (string Prefix, string Suffix) BuildStrictIdentityInsertStreamSql(
+        EventGraph graph, bool isConjoined)
+    {
+        var identityCols = isConjoined ? "tenant_id, id" : "id";
+        var streamsCols = isConjoined
+            ? "tenant_id, id, type, version"
+            : "id, type, version, tenant_id";
+
+        var prefix = $"with new_stream as (insert into {graph.DatabaseSchemaName}.{StreamsTable.TableName} " +
+                     $"({streamsCols}) values (";
+
+        var suffix = $") returning {identityCols}) " +
+                     $"insert into {graph.DatabaseSchemaName}.{StreamIdentityEnforcementTable.TableName} ({identityCols}) " +
+                     $"select {identityCols} from new_stream";
+
+        return (prefix, suffix);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Closes [#4427](https://github.com/JasperFx/marten/issues/4427). Ports the codegen path's strict-identity-CTE variant of `InsertStream` into the closed-shape dialect so `EnableStrictStreamIdentityEnforcement = true` + `UseArchivedStreamPartitioning = true` works under `UseClosedShapeStorage = true`.

## What was broken

Before this PR on the closed-shape path:
* **Rich** rejected loudly at descriptor-build time (`NotSupportedException`)
* **Quick / QuickWithServerTimestamps** fell through silently to the vanilla insert — under partitioning the active-partition unique index doesn't span partitions, so the collision went undetected and `ExistingStreamIdCollisionException` was never thrown.

The codegen path wraps the insert in a modifying CTE that chains an insert into the non-partitioned `mt_streams_identity` tracking table; the chained insert's `UniqueViolation` surfaces with `TableName = mt_streams_identity`, which `InsertStreamBase.matches()` already translates into `ExistingStreamIdCollisionException`.

## How

* Parameterize the existing `BuildInsertStreamCommandConfigurer` prefix + suffix. When `graph.EnableStrictStreamIdentityEnforcement` is on, the prefix becomes `with new_stream as (insert into mt_streams (...) values (` and the suffix becomes `) returning <identity_cols>) insert into mt_streams_identity (<identity_cols>) select <identity_cols> from new_stream`. All four (tenancy × stream-identity) parameter-bind branches reuse the same prefix/suffix pair.
* Drop the `NotSupportedException` at the top of `BuildRichDescriptor` so Rich also emits the CTE now.
* Remove the `if (usePartitioning && TestsSettings.UseClosedShapeStorage) return;` early-outs in the two strict-identity tests so they exercise both paths.
* Add a Rich-mode regression test (`rich_append_mode_with_strict_identity_and_partitioning`) since no existing test exercised Rich + strict-identity — Rich's previous build-time reject blocked it.

## Test plan

- [x] **The 2 tests called out in the issue** under `MARTEN_USE_CLOSED_SHAPE_STORAGE=true`:
  - `guid__start_archive_start_throws_when_strict_enforcement_enabled(usePartitioning: True)` — pass
  - `string_key__start_archive_start_throws_when_strict_enforcement_enabled(usePartitioning: True)` — pass
- [x] All 9 tests in `strict_stream_identity_enforcement` pass under **both** codegen and closed-shape paths.
- [x] Broader sweep under closed-shape: 71/71 in `archiving|Archive|strict_stream_identity|partition`-filtered `EventSourcingTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)