### PR TITLE
[#4445] Un-skip full_text_index race-flake tests; isolate shared schema

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,7 +67,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.3" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.5" />
     <PackageVersion Include="Weasel.Postgresql" Version="9.0.0-alpha.5" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
     <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.3" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0-alpha.3" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0-alpha.5" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/DocumentDbTests/Indexes/full_text_index.cs
+++ b/src/DocumentDbTests/Indexes/full_text_index.cs
@@ -195,9 +195,18 @@ public class full_text_index: OneOffConfigurationsContext
         #endregion
     }
 
-    [Fact(Skip = "Pre-existing CREATE SCHEMA race when the FTI fixture runs as a suite. Tracked at https://github.com/JasperFx/marten/issues/4445.")]
+    [Fact]
     public async Task using_full_text_query_through_query_session()
     {
+        // The "fulltext" schema is shared across runs of this test and is bypassed by the
+        // OneOffConfigurationsContext cleanAll path (which only drops the fixture's own
+        // schema). Drop it here so the Store/Search assertions don't see leftover rows.
+        await using (var preflight = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await preflight.OpenAsync();
+            await preflight.CreateCommand("drop schema if exists fulltext cascade").ExecuteNonQueryAsync();
+        }
+
         #region sample_using_full_text_query_through_query_session
 
         var store = DocumentStore.For(_ =>
@@ -230,7 +239,7 @@ public class full_text_index: OneOffConfigurationsContext
         result.Count.ShouldBe(1);
     }
 
-    [Fact(Skip = "Pre-existing CREATE SCHEMA race when the FTI fixture runs as a suite. Tracked at https://github.com/JasperFx/marten/issues/4445.")]
+    [Fact]
     public async Task search_in_query_sample()
     {
         StoreOptions(_ => _.RegisterDocumentType<BlogPost>());
@@ -259,7 +268,7 @@ public class full_text_index: OneOffConfigurationsContext
         }
     }
 
-    [Fact(Skip = "Pre-existing CREATE SCHEMA race when the FTI fixture runs as a suite. Tracked at https://github.com/JasperFx/marten/issues/4445.")]
+    [Fact]
     public async Task plain_text_search_in_query_sample()
     {
         StoreOptions(_ => _.RegisterDocumentType<BlogPost>());
@@ -346,7 +355,7 @@ public class full_text_index: OneOffConfigurationsContext
         }
     }
 
-    [Fact(Skip = "Pre-existing CREATE SCHEMA race when the FTI fixture runs as a suite. Tracked at https://github.com/JasperFx/marten/issues/4445.")]
+    [Fact]
     public async Task text_search_combined_with_other_query_sample()
     {
         StoreOptions(_ => _.RegisterDocumentType<BlogPost>());
@@ -890,7 +899,7 @@ public class full_text_index: OneOffConfigurationsContext
         Assert.Contains("drop index if exists full_text_index.mt_doc_user_idx_fts", patch.UpdateSql());
     }
 
-    [Fact(Skip = "Pre-existing CREATE SCHEMA race when the FTI fixture runs as a suite. Tracked at https://github.com/JasperFx/marten/issues/4445.")]
+    [Fact]
     public async Task migration_from_v3_to_v4_should_not_result_in_schema_difference()
     {
         // setup/simulate a full text index as in v3


### PR DESCRIPTION
## Summary

Closes #4445. Now ready for review — Weasel 9.0.0-alpha.5 published. This PR:

- **Bumps `Weasel.Postgresql` and `Weasel.EntityFrameworkCore` from `9.0.0-alpha.3` → `9.0.0-alpha.5`** to pick up the `CREATE SCHEMA` race fix from [JasperFx/weasel#282](https://github.com/JasperFx/weasel/pull/282). The Weasel migrator now wraps each schema create in a plpgsql sub-block that catches `duplicate_schema` (42P06) / `unique_violation` (23505) — the two error codes two racing sessions hit when both emit `CREATE SCHEMA <name>` after passing the existence check.
- **Un-skips the 5 `[Fact(Skip = "…#4445")]` tests in `src/DocumentDbTests/Indexes/full_text_index.cs`**.
- **Adds a pre-flight `drop schema if exists fulltext cascade`** to `using_full_text_query_through_query_session`, outside the `#region sample_*` block. That test constructs its store via `DocumentStore.For()` with a custom `DatabaseSchemaName = "fulltext"`, which bypasses `OneOffConfigurationsContext.cleanAll` (which only drops the fixture's own `full_text_index` schema). Without the pre-flight, data accumulates across runs and `result.Count.ShouldBe(1)` sees rows from prior runs.

## Verification

```bash
DISABLE_TEST_PARALLELIZATION=true dotnet test src/DocumentDbTests/DocumentDbTests.csproj \
  --filter "FullyQualifiedName~DocumentDbTests.Indexes.full_text_index" -f net9.0
```

Against the published Weasel 9.0.0-alpha.5: **31/31 passed** (was `Failed: 3+/31` intermittently before the Weasel fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)