### PR TITLE
[#4444] Port UseVersionFromMatchingStream to closed-shape SQL

### DIFF
--- a/src/EventSourcingTests/Aggregation/explicit_code_for_aggregation_logic.cs
+++ b/src/EventSourcingTests/Aggregation/explicit_code_for_aggregation_logic.cs
@@ -467,7 +467,7 @@ public class using_custom_aggregate_with_soft_deletes_and_update_only_events: On
         aggregate.Deleted.ShouldBeTrue();
     }
 
-    [Fact(Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at https://github.com/JasperFx/marten/issues/4444.")]
+    [Fact(Skip = "Pre-existing master failure (codegen + closed-shape) — soft-delete + restart flow throws ConcurrencyException. Not caused by #4444's UseVersionFromMatchingStream gap. Needs separate triage.")]
     public async Task return_correct_data_after_restarts()
     {
         var streamId = Guid.NewGuid();

--- a/src/EventSourcingTests/Aggregation/setting_version_number_on_aggregate.cs
+++ b/src/EventSourcingTests/Aggregation/setting_version_number_on_aggregate.cs
@@ -117,7 +117,7 @@ public class setting_version_number_on_aggregate : OneOffConfigurationsContext
         }
     }
 
-    [Fact(Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at https://github.com/JasperFx/marten/issues/4444.")]
+    [Fact]
     public async Task set_version_on_aggregate_with_explicit_Version_attribute()
     {
         StoreOptions(opts => opts.Projections.Snapshot<MyAggregateWithDifferentVersionProperty>(SnapshotLifecycle.Inline));

--- a/src/EventSourcingTests/Bugs/Bug_3310_inline_projections_with_quick_append.cs
+++ b/src/EventSourcingTests/Bugs/Bug_3310_inline_projections_with_quick_append.cs
@@ -40,7 +40,7 @@ public class Bug_3310_inline_projections_with_quick_append : BugIntegrationConte
         });
     }
 
-    [Fact(Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at https://github.com/JasperFx/marten/issues/4444.")]
+    [Fact]
     public async Task start_and_append_events_to_same_stream()
     {
         await using var session = theStore.LightweightSession(tenant);
@@ -80,7 +80,7 @@ public class Bug_3310_inline_projections_with_quick_append : BugIntegrationConte
         }
     }
 
-    [Theory(Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at https://github.com/JasperFx/marten/issues/4444.")]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task update_1_stream_with_many_events(bool appendWithExpectedVersion)

--- a/src/EventSourcingTests/Bugs/Bug_3946_tenancy_with_for_tenant_and_projection_issues.cs
+++ b/src/EventSourcingTests/Bugs/Bug_3946_tenancy_with_for_tenant_and_projection_issues.cs
@@ -18,7 +18,7 @@ namespace EventSourcingTests.Bugs;
 
 public class Bug_3946_tenancy_with_for_tenant_and_projection_issues : BugIntegrationContext
 {
-    [Theory(Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at https://github.com/JasperFx/marten/issues/4444.")]
+    [Theory(Skip = "Pre-existing master failure (codegen + closed-shape) — selecting Entity throws \"Reading as System.String is not supported for fields having DataTypeName 'bigint'\". MultiStreamProjection + conjoined tenancy select-path bug, unrelated to #4444's UseVersionFromMatchingStream gap. Needs separate triage.")]
     [InlineData(true)]
     [InlineData(false)]
     public async Task when_projection_is_multi_stream_then_tenant_is_passed_to_projection_document(bool useRebuild)

--- a/src/EventSourcingTests/Dcb/hstore_auto_discover_tag_types_from_projections.cs
+++ b/src/EventSourcingTests/Dcb/hstore_auto_discover_tag_types_from_projections.cs
@@ -77,7 +77,7 @@ public class hstore_auto_discover_tag_types_from_projections: OneOffConfiguratio
         registration.TableSuffix.ShouldBe("custom_hs_ticket");
     }
 
-    [Fact(Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at https://github.com/JasperFx/marten/issues/4444.")]
+    [Fact(Skip = "Pre-existing master failure (codegen + closed-shape) — inline-projection save raises ConcurrencyException for HsTicketSummary. Hstore tag-based aggregation interacts badly with revision tracking on the projection target. Unrelated to #4444's UseVersionFromMatchingStream gap; needs separate triage.")]
     public async Task auto_discovered_tag_type_works_for_querying_in_hstore_mode()
     {
         StoreOptions(opts =>
@@ -102,7 +102,7 @@ public class hstore_auto_discover_tag_types_from_projections: OneOffConfiguratio
         events[0].Data.ShouldBeOfType<HsTicketOpened>();
     }
 
-    [Fact(Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at https://github.com/JasperFx/marten/issues/4444.")]
+    [Fact(Skip = "Pre-existing master failure (codegen + closed-shape) — inline-projection save raises ConcurrencyException for HsTicketSummary. Hstore tag-based aggregation interacts badly with revision tracking on the projection target. Unrelated to #4444's UseVersionFromMatchingStream gap; needs separate triage.")]
     public async Task auto_discovered_tag_type_works_for_fetch_for_writing_in_hstore_mode()
     {
         StoreOptions(opts =>

--- a/src/EventSourcingTests/FetchForWriting/fetching_inline_aggregates_for_writing.cs
+++ b/src/EventSourcingTests/FetchForWriting/fetching_inline_aggregates_for_writing.cs
@@ -47,7 +47,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
         document.CCount.ShouldBe(2);
     }
 
-    [Fact(Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at https://github.com/JasperFx/marten/issues/4444.")]
+    [Fact]
     public async Task revision_is_updated_after_quick_appending_with_IRevisioned()
     {
         StoreOptions(opts =>
@@ -73,7 +73,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
         document.Version.ShouldBe(6);
     }
 
-    [Fact(Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at https://github.com/JasperFx/marten/issues/4444.")]
+    [Fact]
     public async Task revision_is_updated_after_quick_appending_with_IRevisioned_in_batch()
     {
         StoreOptions(opts =>
@@ -104,7 +104,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
         document.Version.ShouldBe(6);
     }
 
-    [Fact(Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at https://github.com/JasperFx/marten/issues/4444.")]
+    [Fact]
     public async Task revision_is_updated_after_quick_appending_with_custom_mapped_version()
     {
         StoreOptions(opts =>
@@ -135,7 +135,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     }
 
 
-    [Fact(Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at https://github.com/JasperFx/marten/issues/4444.")]
+    [Fact]
     public async Task revision_is_updated_after_quick_appending_with_custom_mapped_version_in_batch()
     {
         StoreOptions(opts =>
@@ -570,7 +570,7 @@ public class fetching_inline_aggregates_for_writing : OneOffConfigurationsContex
     }
 
 
-    [Fact(Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at https://github.com/JasperFx/marten/issues/4444.")]
+    [Fact]
     public async Task fetch_existing_stream_for_writing_Guid_identifier_with_expected_version_using_identity_map()
     {
         StoreOptions(

--- a/src/Marten/Internal/ClosedShape/ClosedShapeInsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeInsertOperation.cs
@@ -154,13 +154,33 @@ internal sealed class ClosedShapeInsertOperation<TDoc, TId>: IDocumentStorageOpe
         if (_descriptor.ConcurrencyMode == ConcurrencyMode.Numeric &&
             ReferenceEquals(binder, _descriptor.RevisionBinder))
         {
-            // CASE WHEN ? = 0 THEN 1 ELSE ? END — bind raw Revision to
-            // both slots.
+            // Numeric path. Two layouts depending on UseVersionFromMatchingStream:
+            //   Default:                CASE WHEN ? = 0 THEN 1 ELSE ? END (2 slots)
+            //   UseVersionFromMatchingStream (non-conjoined): CASE WHEN ? = 0
+            //       THEN COALESCE((select version from <events>.mt_streams where id = ?), 1)
+            //       ELSE ? END (3 slots: ?=0 check, subquery id, explicit revision)
+            //   UseVersionFromMatchingStream + conjoined: same with extra ? for tenant_id (4 slots)
             parameters[slot].Value = Revision;
             parameters[slot].NpgsqlDbType = NpgsqlDbType.Bigint;
-            parameters[slot + 1].Value = Revision;
-            parameters[slot + 1].NpgsqlDbType = NpgsqlDbType.Bigint;
-            return slot + 2;
+            slot++;
+
+            if (_descriptor.UseVersionFromMatchingStream)
+            {
+                parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
+                parameters[slot].NpgsqlDbType = PostgresqlProvider.Instance.ToParameterType(_descriptor.Identification.RawSqlType);
+                slot++;
+
+                if (_descriptor.IsConjoined)
+                {
+                    parameters[slot].Value = _tenantId;
+                    parameters[slot].NpgsqlDbType = NpgsqlDbType.Varchar;
+                    slot++;
+                }
+            }
+
+            parameters[slot].Value = Revision;
+            parameters[slot].NpgsqlDbType = NpgsqlDbType.Bigint;
+            return slot + 1;
         }
 
         binder.BindParameter(parameters[slot], _document, session);

--- a/src/Marten/Internal/ClosedShape/ClosedShapeOverwriteOperation.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeOverwriteOperation.cs
@@ -147,11 +147,33 @@ internal sealed class ClosedShapeOverwriteOperation<TDoc, TId>: IDocumentStorage
         if (_descriptor.ConcurrencyMode == ConcurrencyMode.Numeric &&
             ReferenceEquals(binder, _descriptor.RevisionBinder))
         {
+            // INSERT VALUES side. Two layouts depending on UseVersionFromMatchingStream:
+            //   Default:                CASE WHEN ? = 0 THEN 1 ELSE ? END (2 slots)
+            //   UseVersionFromMatchingStream (non-conjoined): CASE WHEN ? = 0
+            //       THEN COALESCE((select version from <events>.mt_streams where id = ?), 1)
+            //       ELSE ? END (3 slots)
+            //   UseVersionFromMatchingStream + conjoined: add an extra ? for tenant_id (4 slots)
             parameters[slot].Value = Revision;
             parameters[slot].NpgsqlDbType = NpgsqlDbType.Bigint;
-            parameters[slot + 1].Value = Revision;
-            parameters[slot + 1].NpgsqlDbType = NpgsqlDbType.Bigint;
-            return slot + 2;
+            slot++;
+
+            if (_descriptor.UseVersionFromMatchingStream)
+            {
+                parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
+                parameters[slot].NpgsqlDbType = PostgresqlProvider.Instance.ToParameterType(_descriptor.Identification.RawSqlType);
+                slot++;
+
+                if (_descriptor.IsConjoined)
+                {
+                    parameters[slot].Value = _tenantId;
+                    parameters[slot].NpgsqlDbType = NpgsqlDbType.Varchar;
+                    slot++;
+                }
+            }
+
+            parameters[slot].Value = Revision;
+            parameters[slot].NpgsqlDbType = NpgsqlDbType.Bigint;
+            return slot + 1;
         }
 
         binder.BindParameter(parameters[slot], _document, session);

--- a/src/Marten/Internal/ClosedShape/ClosedShapeUpsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeUpsertOperation.cs
@@ -199,12 +199,35 @@ internal sealed class ClosedShapeUpsertOperation<TDoc, TId>: IDocumentStorageOpe
         if (_descriptor.ConcurrencyMode == ConcurrencyMode.Numeric &&
             ReferenceEquals(binder, _descriptor.RevisionBinder))
         {
-            // INSERT VALUES (..., CASE WHEN ? = 0 THEN 1 ELSE ? END, ...)
+            // INSERT VALUES side; two layouts depending on UseVersionFromMatchingStream:
+            //   Default:                CASE WHEN ? = 0 THEN 1 ELSE ? END (2 slots)
+            //   UseVersionFromMatchingStream (non-conjoined): CASE WHEN ? = 0
+            //       THEN COALESCE((select version from <events>.mt_streams where id = ?), 1)
+            //       ELSE ? END (3 slots)
+            //   UseVersionFromMatchingStream + conjoined: same with extra ? for tenant_id (4 slots)
+            // The ON CONFLICT SET / WHERE branches always reference {table}.id
+            // directly so they keep their 4 revision slots downstream.
             parameters[slot].Value = Revision;
             parameters[slot].NpgsqlDbType = NpgsqlDbType.Bigint;
-            parameters[slot + 1].Value = Revision;
-            parameters[slot + 1].NpgsqlDbType = NpgsqlDbType.Bigint;
-            return slot + 2;
+            slot++;
+
+            if (_descriptor.UseVersionFromMatchingStream)
+            {
+                parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
+                parameters[slot].NpgsqlDbType = PostgresqlProvider.Instance.ToParameterType(_descriptor.Identification.RawSqlType);
+                slot++;
+
+                if (_descriptor.IsConjoined)
+                {
+                    parameters[slot].Value = _tenantId;
+                    parameters[slot].NpgsqlDbType = NpgsqlDbType.Varchar;
+                    slot++;
+                }
+            }
+
+            parameters[slot].Value = Revision;
+            parameters[slot].NpgsqlDbType = NpgsqlDbType.Bigint;
+            return slot + 1;
         }
 
         binder.BindParameter(parameters[slot], _document, session);

--- a/src/Marten/Internal/ClosedShape/DocumentStorageDescriptor.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentStorageDescriptor.cs
@@ -65,7 +65,8 @@ public sealed class DocumentStorageDescriptor<TDoc, TId>
         Marten.Schema.DocumentMapping? hierarchyMapping,
         int docTypeReadIndex,
         string tableName,
-        IDocumentMetadataBinder<TDoc>[]? partitionPkBinders = null)
+        IDocumentMetadataBinder<TDoc>[]? partitionPkBinders = null,
+        bool useVersionFromMatchingStream = false)
     {
         Identification = identification;
         ClientSideWriteBinders = clientSideWriteBinders;
@@ -84,7 +85,19 @@ public sealed class DocumentStorageDescriptor<TDoc, TId>
         HierarchyMapping = hierarchyMapping;
         DocTypeReadIndex = docTypeReadIndex;
         PartitionPkBinders = partitionPkBinders ?? System.Array.Empty<IDocumentMetadataBinder<TDoc>>();
+        UseVersionFromMatchingStream = useVersionFromMatchingStream;
     }
+
+    /// <summary>
+    /// Mirrors <see cref="Marten.Schema.DocumentMapping.UseVersionFromMatchingStream"/>.
+    /// When set, the closed-shape SQL pulls the revision from the matching
+    /// row in <c>{events_schema}.mt_streams</c> (used by inline single-stream
+    /// projections under <c>EventAppendMode.Quick</c>, where the in-memory
+    /// <c>lastEvent.Version</c> hasn't been assigned yet). The Insert /
+    /// Upsert operations consult this flag to bind extra ? slots for the
+    /// stream-lookup subquery's id (and tenant_id under conjoined tenancy).
+    /// </summary>
+    internal bool UseVersionFromMatchingStream { get; }
 
     /// <summary>
     /// Writers that bind the partition PK columns. For Update/Upsert on

--- a/src/Marten/Internal/ClosedShape/DocumentStorageDescriptorBuilder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentStorageDescriptorBuilder.cs
@@ -250,7 +250,8 @@ internal static class DocumentStorageDescriptorBuilder
             hierarchyMapping: hierarchyMapping,
             docTypeReadIndex: docTypeReadIndex,
             tableName: mapping.TableName.Name,
-            partitionPkBinders: partitionPkBinders);
+            partitionPkBinders: partitionPkBinders,
+            useVersionFromMatchingStream: mapping.UseVersionFromMatchingStream && concurrencyMode == ConcurrencyMode.Numeric);
     }
 
     /// <summary>
@@ -260,8 +261,17 @@ internal static class DocumentStorageDescriptorBuilder
     /// <c>CASE WHEN ? = 0 THEN 1 ELSE ? END</c> expression so a caller
     /// passing <c>Revision = 0</c> ends up inserting <c>1</c> (the
     /// initial revision) rather than literal zero.
+    /// When <see cref="DocumentMapping.UseVersionFromMatchingStream"/> is
+    /// set (inline single-stream projections), the auto branch is replaced
+    /// by a correlated lookup of the stream's current version from
+    /// <c>{events_schema}.mt_streams</c> — see <see cref="StreamVersionSubquery"/>.
+    /// That subquery references the row's id (and tenant_id under
+    /// conjoined tenancy), which need separate ? slots in INSERT VALUES
+    /// since one VALUES expression can't reference another at the same
+    /// statement level.
     /// </summary>
     private static (List<string> Columns, List<string> Values) BuildCoreColumns<TDoc>(
+        DocumentMapping mapping,
         IReadOnlyList<IDocumentMetadataBinder<TDoc>> binders,
         bool isConjoined,
         ConcurrencyMode mode)
@@ -286,8 +296,24 @@ internal static class DocumentStorageDescriptorBuilder
             columns.Add(b.ColumnName);
             if (mode == ConcurrencyMode.Numeric && b is DocumentRevisionBinder<TDoc>)
             {
-                // Two ? slots — the operation binds Revision to both.
-                values.Add("CASE WHEN ? = 0 THEN 1 ELSE ? END");
+                if (mapping.UseVersionFromMatchingStream)
+                {
+                    // INSERT VALUES — when Revision=0 (auto), pull the version
+                    // from mt_streams; rebind id (+ tenant_id when conjoined)
+                    // in the subquery's WHERE clause, since the row's id slot
+                    // earlier in the VALUES list isn't referenceable here.
+                    var streamLookup = StreamVersionSubquery(
+                        mapping,
+                        idExpr: "?",
+                        tenantIdExpr: isConjoined ? "?" : null,
+                        fallback: "1");
+                    values.Add($"CASE WHEN ? = 0 THEN {streamLookup} ELSE ? END");
+                }
+                else
+                {
+                    // Two ? slots — the operation binds Revision to both.
+                    values.Add("CASE WHEN ? = 0 THEN 1 ELSE ? END");
+                }
             }
             else
             {
@@ -296,6 +322,27 @@ internal static class DocumentStorageDescriptorBuilder
         }
 
         return (columns, values);
+    }
+
+    /// <summary>
+    /// Correlated lookup against <c>{events_schema}.mt_streams</c> used
+    /// by the <see cref="DocumentMapping.UseVersionFromMatchingStream"/>
+    /// path. Wrapped in <c>COALESCE(..., {fallback})</c> so a missing
+    /// stream falls back to a sensible default (initial revision <c>1</c>
+    /// on INSERT VALUES; <c>{table}.mt_version + 1</c> on ON CONFLICT DO
+    /// UPDATE so a doc with no surviving stream still increments).
+    /// </summary>
+    private static string StreamVersionSubquery(
+        DocumentMapping mapping,
+        string idExpr,
+        string? tenantIdExpr,
+        string fallback)
+    {
+        var streamsTable = $"{mapping.StoreOptions.Events.DatabaseSchemaName}.mt_streams";
+        var tenantClause = tenantIdExpr is null
+            ? string.Empty
+            : $" and {streamsTable}.{Marten.Storage.Metadata.TenantIdColumn.Name} = {tenantIdExpr}";
+        return $"COALESCE((select version from {streamsTable} where {streamsTable}.id = {idExpr}{tenantClause}), {fallback})";
     }
 
     /// <summary>
@@ -327,9 +374,18 @@ internal static class DocumentStorageDescriptorBuilder
         where TDoc : notnull
     {
         var table = mapping.TableName.QualifiedName;
-        var (columns, values) = BuildCoreColumns(binders, isConjoined, mode);
+        var (columns, values) = BuildCoreColumns(mapping, binders, isConjoined, mode);
         var versionColumn = Marten.Schema.SchemaConstants.VersionColumn;
         var conflictKey = BuildConflictKey(mapping);
+
+        // The ON CONFLICT branch reads existing-row columns directly via
+        // {table}.id / {table}.tenant_id, so when UseVersionFromMatchingStream
+        // is set we wire the stream subquery to those qualified names rather
+        // than rebinding new ? slots.
+        var streamIdExpr = $"{table}.id";
+        var streamTenantExpr = isConjoined
+            ? $"{table}.{Marten.Storage.Metadata.TenantIdColumn.Name}"
+            : null;
 
         var updateAssignments = new List<string>(1 + binders.Count) { "data = excluded.data" };
         foreach (var b in binders)
@@ -341,7 +397,10 @@ internal static class DocumentStorageDescriptorBuilder
                 // raw Revision into 2 fresh ? slots — the CASE in the
                 // INSERT VALUES already clobbered excluded.mt_version
                 // so we can't read the raw value from there anymore.
-                updateAssignments.Add($"{versionColumn} = CASE WHEN ? = 0 THEN {table}.{versionColumn} + 1 ELSE ? END");
+                var autoExpr = mapping.UseVersionFromMatchingStream
+                    ? StreamVersionSubquery(mapping, streamIdExpr, streamTenantExpr, fallback: $"{table}.{versionColumn} + 1")
+                    : $"{table}.{versionColumn} + 1";
+                updateAssignments.Add($"{versionColumn} = CASE WHEN ? = 0 THEN {autoExpr} ELSE ? END");
             }
             else
             {
@@ -353,12 +412,19 @@ internal static class DocumentStorageDescriptorBuilder
         //   Optimistic: table.mt_version (uuid) = expected (bound)
         //   Numeric:    auto-increment (? = 0) always wins; explicit
         //               revisions only when > current.
+        //   Numeric + UseVersionFromMatchingStream: explicit revisions
+        //               only when >= the current stream version (i.e.
+        //               reject when stream is strictly ahead of the
+        //               caller). Matches the codegen UpsertFunction
+        //               which used the looser ">" guard for this case.
         string conflictWhere = string.Empty;
         if (includeConcurrencyGuard)
         {
             conflictWhere = mode switch
             {
                 ConcurrencyMode.Optimistic => $" where {table}.{versionColumn} = ?",
+                ConcurrencyMode.Numeric when mapping.UseVersionFromMatchingStream
+                    => $" where ? = 0 or {StreamVersionSubquery(mapping, streamIdExpr, streamTenantExpr, fallback: "0")} <= ?",
                 ConcurrencyMode.Numeric => $" where ? = 0 or {table}.{versionColumn} < ?",
                 _ => string.Empty
             };
@@ -381,7 +447,7 @@ internal static class DocumentStorageDescriptorBuilder
         where TDoc : notnull
     {
         var table = mapping.TableName.QualifiedName;
-        var (columns, values) = BuildCoreColumns(binders, isConjoined, mode);
+        var (columns, values) = BuildCoreColumns(mapping, binders, isConjoined, mode);
         var conflictKey = BuildConflictKey(mapping);
 
         return $"insert into {table} ({columns.Join(", ")}) " +
@@ -424,13 +490,24 @@ internal static class DocumentStorageDescriptorBuilder
         var table = mapping.TableName.QualifiedName;
         var versionColumn = Marten.Schema.SchemaConstants.VersionColumn;
 
+        // UPDATE operates on the existing row; reference its id / tenant_id
+        // by qualified column name when we need them in the stream-version
+        // subquery, no extra ? slots needed.
+        var streamIdExpr = $"{table}.id";
+        var streamTenantExpr = isConjoined
+            ? $"{table}.{Marten.Storage.Metadata.TenantIdColumn.Name}"
+            : null;
+
         var setAssignments = new List<string>(1 + binders.Count) { "data = ?" };
         foreach (var b in binders)
         {
             if (mode == ConcurrencyMode.Numeric && b is DocumentRevisionBinder<TDoc>)
             {
-                // CASE WHEN ? = 0 THEN mt_version + 1 ELSE ? END
-                setAssignments.Add($"{versionColumn} = CASE WHEN ? = 0 THEN {table}.{versionColumn} + 1 ELSE ? END");
+                // CASE WHEN ? = 0 THEN <auto> ELSE ? END
+                var autoExpr = mapping.UseVersionFromMatchingStream
+                    ? StreamVersionSubquery(mapping, streamIdExpr, streamTenantExpr, fallback: $"{table}.{versionColumn} + 1")
+                    : $"{table}.{versionColumn} + 1";
+                setAssignments.Add($"{versionColumn} = CASE WHEN ? = 0 THEN {autoExpr} ELSE ? END");
             }
             else
             {
@@ -458,9 +535,19 @@ internal static class DocumentStorageDescriptorBuilder
         }
         else if (mode == ConcurrencyMode.Numeric)
         {
-            // Auto-increment (?  = 0) always wins; explicit revisions
-            // only when strictly greater than the current value.
-            whereClauses.Add($"(? = 0 or {table}.{versionColumn} < ?)");
+            if (mapping.UseVersionFromMatchingStream)
+            {
+                // Looser guard mirroring the codegen UpsertFunction for the
+                // stream-version-source case: reject only when the stream is
+                // strictly ahead of the caller's revision.
+                whereClauses.Add($"(? = 0 or {StreamVersionSubquery(mapping, streamIdExpr, streamTenantExpr, fallback: "0")} <= ?)");
+            }
+            else
+            {
+                // Auto-increment (?  = 0) always wins; explicit revisions
+                // only when strictly greater than the current value.
+                whereClauses.Add($"(? = 0 or {table}.{versionColumn} < ?)");
+            }
         }
 
         return $"update {table} " +


### PR DESCRIPTION
## Summary

Closes #4444.

Inline single-stream projections under `EventAppendMode.Quick` arrive at `StoreProjection` with `lastEvent.Version = 0`, so the closed-shape upsert receives `Revision = 0` and the existing `CASE WHEN ? = 0 THEN 1 ELSE ? END` expression in `BuildCoreColumns` made the stored revision auto-increment 1, 2, 3, … instead of tracking the stream's actual version (5, 6, …). The codegen `UpsertFunction` handled this with a plpgsql branch keyed off `mapping.UseVersionFromMatchingStream` that read `current_version` from `{events_schema}.mt_streams.version`; this PR ports that branch into the single-statement closed-shape SQL.

## Approach

- **INSERT VALUES** — auto branch becomes
  ```sql
  CASE WHEN ? = 0
       THEN COALESCE((select version from <events>.mt_streams where id = ? [and tenant_id = ?]), 1)
       ELSE ?
  END
  ```
  Subquery id (+ tenant_id under conjoined tenancy) consumes extra `?` slots because one VALUES expression can't reference another at the same statement level.
- **ON CONFLICT DO UPDATE SET mt_version** — same subquery, but id/tenant_id come from the existing row (`{table}.id` / `{table}.tenant_id`) — no extra slots on the SET side.
- **ON CONFLICT WHERE** — `? = 0 OR COALESCE(<stream-version>, 0) <= ?`, mirroring the codegen's looser `>` guard for the stream-source case (reject only when the stream is strictly ahead of the caller's revision).
- **`BuildUpdateSql`** — same SET / WHERE rewrites for the standalone UPDATE path. WHERE / SET reference the existing row, so no extra slots on UPDATE.

Plumbed via a new `DocumentStorageDescriptor.UseVersionFromMatchingStream` flag (only set when `concurrencyMode == Numeric`, since the codegen `UpsertFunction` only honored the flag under `RevisionArgument`). `ClosedShapeInsertOperation`, `ClosedShapeUpsertOperation`, and `ClosedShapeOverwriteOperation` all consume the new slot count off that flag.

## Verification

`MARTEN_USE_CLOSED_SHAPE_STORAGE=true dotnet test src/EventSourcingTests/EventSourcingTests.csproj -f net9.0 --filter "FullyQualifiedName~Bug_3310_inline_projections_with_quick_append|FullyQualifiedName~fetching_inline_aggregates_for_writing|FullyQualifiedName~setting_version_number_on_aggregate|FullyQualifiedName~Bug_3946_tenancy_with_for_tenant|FullyQualifiedName~hstore_auto_discover_tag_types_from_projections|FullyQualifiedName~using_custom_aggregate_with_soft_deletes_and_update_only_events|FullyQualifiedName~explicit_code_for_aggregation_logic"`

→ 50 passed, 0 failed (4 skipped — see below). The codegen lane is identical (50 passed, 0 failed).

## Re-tagged tests

The issue called out 14 tests tagged with `Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at #4444."` 9 of them genuinely fail on the UseVersionFromMatchingStream gap and now pass under both lanes after this PR.

The remaining 5 fail on **both** master's codegen and closed-shape lanes today — confirmed by running each against master with the closed-shape flag unset — so they aren't gated on this port:

- `using_custom_aggregate_with_soft_deletes_and_update_only_events.return_correct_data_after_restarts`
- `Bug_3946_tenancy_with_for_tenant_and_projection_issues.when_projection_is_multi_stream_then_tenant_is_passed_to_projection_document(useRebuild: True | False)`
- `hstore_auto_discover_tag_types_from_projections.auto_discovered_tag_type_works_for_querying_in_hstore_mode`
- `hstore_auto_discover_tag_types_from_projections.auto_discovered_tag_type_works_for_fetch_for_writing_in_hstore_mode`

Re-tagged each with a more accurate `[Skip = "Pre-existing master failure (codegen + closed-shape) — …"]` note so they don't carry the misleading #4444 reference into the next sweep. Worth filing separate triage tickets for these (`uuid = bigint` select-side bug for Bug_3946; soft-delete restart + hstore tag-based concurrency for the others).

## Test plan
- [x] Closed-shape lane green for the un-skipped #4444 tests
- [x] Codegen lane unchanged
- [ ] CI matrix runs both lanes

🤖 Generated with [Claude Code](https://claude.com/claude-code)