### PR TITLE
[#4443] Replace 5 object lock fields with System.Threading.Lock

### DIFF
--- a/src/Marten/Events/Daemon/Coordination/ExplicitProjectionCoordinator.cs
+++ b/src/Marten/Events/Daemon/Coordination/ExplicitProjectionCoordinator.cs
@@ -23,7 +23,7 @@ public class ExplicitProjectionCoordinator<T>: ExplicitProjectionCoordinator, IP
 
 public class ExplicitProjectionCoordinator: IProjectionCoordinator
 {
-    private readonly object _daemonLock = new();
+    private readonly System.Threading.Lock _daemonLock = new();
     private readonly ILogger _logger;
 
 

--- a/src/Marten/Events/Daemon/Coordination/ProjectionCoordinator.cs
+++ b/src/Marten/Events/Daemon/Coordination/ProjectionCoordinator.cs
@@ -23,7 +23,7 @@ public class ProjectionCoordinator<T>: ProjectionCoordinator, IProjectionCoordin
 
 public class ProjectionCoordinator: IProjectionCoordinator
 {
-    private readonly object _daemonLock = new();
+    private readonly System.Threading.Lock _daemonLock = new();
     private readonly ILogger<ProjectionCoordinator> _logger;
     private readonly StoreOptions _options;
 

--- a/src/Marten/Internal/ProviderGraph.cs
+++ b/src/Marten/Internal/ProviderGraph.cs
@@ -22,7 +22,7 @@ namespace Marten.Internal;
 public class ProviderGraph: IProviderGraph
 {
     private readonly StoreOptions _options;
-    private readonly object _storageLock = new();
+    private readonly System.Threading.Lock _storageLock = new();
     private ImHashMap<Type, object> _storage = ImHashMap<Type, object>.Empty;
 
     public ProviderGraph(StoreOptions options)

--- a/src/Marten/Schema/Identity/Sequences/HiLoSequence.cs
+++ b/src/Marten/Schema/Identity/Sequences/HiLoSequence.cs
@@ -14,7 +14,7 @@ namespace Marten.Schema.Identity.Sequences;
 public class HiloSequence: ISequence
 {
     private readonly IMartenDatabase _database;
-    private readonly object _lock = new();
+    private readonly System.Threading.Lock _lock = new();
     private readonly StoreOptions _options;
     private readonly HiloSettings _settings;
 

--- a/src/Marten/StoreOptions.GeneratesCode.cs
+++ b/src/Marten/StoreOptions.GeneratesCode.cs
@@ -73,7 +73,7 @@ public partial class StoreOptions: ICodeFileCollection
     // the mutation stays scoped to their compile and doesn't accumulate
     // on the cached base.
     private GenerationRules? _cachedBaseRules;
-    private readonly object _cachedRulesLock = new();
+    private readonly System.Threading.Lock _cachedRulesLock = new();
 
     internal GenerationRules CreateGenerationRules()
     {


### PR DESCRIPTION
## Summary

Closes #4443. Clears the five `MA0158: Use System.Threading.Lock` analyzer warnings called out in the issue. Marten targets net9.0 / net10.0 so `System.Threading.Lock` is unconditionally available — no multitargeting fork-back needed.

Files touched:
- `src/Marten/StoreOptions.GeneratesCode.cs` — `_cachedRulesLock`
- `src/Marten/Events/Daemon/Coordination/ExplicitProjectionCoordinator.cs` — `_daemonLock`
- `src/Marten/Events/Daemon/Coordination/ProjectionCoordinator.cs` — `_daemonLock`
- `src/Marten/Schema/Identity/Sequences/HiLoSequence.cs` — `_lock`
- `src/Marten/Internal/ProviderGraph.cs` — `_storageLock`

`lock(field)` call sites pick up the new type transparently — `System.Threading.Lock` is `lock`-compatible.

## Verification

`dotnet build src/Marten/Marten.csproj` — 0 errors, MA0158 no longer fires on any of the five lines.