### PR TITLE
[#4442] Document IEvent.Sequence=0 in pre-commit listeners under Quick mode

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -43,6 +43,16 @@ All of the functionality in this section was added as part of Marten v0.8
 
 Marten has a facility for listening and even intercepting document persistence events with the `IDocumentSessionListener` interface:
 
+::: warning IEvent.Sequence / IEvent.Version under "Quick" append mode
+`BeforeSaveChangesAsync` (and `IChangeListener.BeforeCommitAsync`) fires **before** the database INSERT runs. Under the Marten 9 default `Events.AppendMode = EventAppendMode.QuickWithServerTimestamps` (or `EventAppendMode.Quick`), event sequences and versions are assigned **server-side** inside that INSERT via `nextval('mt_events_sequence')`, so iterating `session.PendingChanges.GetEvents()` from a pre-commit listener returns events with `Sequence = 0` and `Version = 0`. If your listener forwards events that consumers key off `Sequence` / `Version` (for example Wolverine's `UseFastEventForwarding = true` + `SubscribeToEvent<T>().TransformedTo(e => new SomeMessage(e.Sequence, e.Version))`), opt the affected store into Rich mode so those values are assigned before the listener fires:
+
+```csharp
+opts.Events.AppendMode = EventAppendMode.Rich;
+```
+
+See [Event Appending modes](events/appending.md) for the full performance / metadata trade-off.
+:::
+
 <!-- snippet: sample_idocumentsessionlistener -->
 <a id='snippet-sample_idocumentsessionlistener'></a>
 ```cs

--- a/docs/events/appending.md
+++ b/docs/events/appending.md
@@ -60,6 +60,8 @@ numbers at the time that the inline projections are created.
 If you are using `Inline` projections with the "Quick" mode, just be aware that you will not have access to the final
 event sequence or stream version at the time the projections are built. Marten _is_ able to set the stream version into
 a single stream projection document built `Inline`, but that's done on the server side. Just be warned.
+
+The same caveat applies to pre-commit `IDocumentSessionListener.BeforeSaveChangesAsync` / `IChangeListener.BeforeCommitAsync` hooks: under `Quick` / `QuickWithServerTimestamps`, events surfaced via `session.PendingChanges.GetEvents()` from those hooks carry `Sequence = 0` and `Version = 0` because assignment happens server-side during the INSERT that runs _after_ the hook returns. Listeners that forward events to downstream consumers keyed on those values (e.g. Wolverine's `UseFastEventForwarding = true` path) need `EventAppendMode.Rich` on the relevant store. See the listener docs at [Diagnostics — Listening for Document Store Events](../diagnostics.md#listening-for-document-store-events) for the matching note.
 :::
 
 The newer `Quick` mode eschews version and sequence metadata in favor of performing the event append and stream creation


### PR DESCRIPTION
## Summary

Closes #4442 as documentation rather than code per the Marten team's position: pre-commit `IDocumentSessionListener.BeforeSaveChangesAsync` (and `IChangeListener.BeforeCommitAsync`) returning `IEvent.Sequence = 0` / `IEvent.Version = 0` is the expected, supported behavior under `EventAppendMode.Quick` / `QuickWithServerTimestamps`. In Quick mode the sequence column is assigned server-side via `nextval('mt_events_sequence')` inline in the INSERT, which runs *after* the listener hook returns. Consumers (Wolverine `UseFastEventForwarding`, custom listeners) that key downstream messages off `Sequence` / `Version` need `EventAppendMode.Rich` on the relevant store.

The caveat was already documented for *inline projections* in `docs/events/appending.md`. This PR mirrors the same note onto:

- `docs/diagnostics.md` — the Document Session Listener section, the natural landing page when users go looking for `BeforeSaveChangesAsync` behavior.
- `docs/events/appending.md` — extends the existing Inline-projection warning to also cover pre-commit listeners.

## Lint

- markdownlint: clean
- cspell: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)