### PR TITLE
Extract RevisionColumn alongside VersionColumn in DocumentTable.SelectColumns

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_3946_tenancy_with_for_tenant_and_projection_issues.cs
+++ b/src/EventSourcingTests/Bugs/Bug_3946_tenancy_with_for_tenant_and_projection_issues.cs
@@ -18,7 +18,7 @@ namespace EventSourcingTests.Bugs;
 
 public class Bug_3946_tenancy_with_for_tenant_and_projection_issues : BugIntegrationContext
 {
-    [Theory(Skip = "Closed-shape upsert needs UseVersionFromMatchingStream port. Tracked at https://github.com/JasperFx/marten/issues/4444.")]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task when_projection_is_multi_stream_then_tenant_is_passed_to_projection_document(bool useRebuild)

--- a/src/Marten/Storage/DocumentTable.cs
+++ b/src/Marten/Storage/DocumentTable.cs
@@ -184,7 +184,19 @@ internal class DocumentTable: Table
         var id = columns.OfType<IdColumn>().SingleOrDefault();
         var data = columns.OfType<DataColumn>().Single();
         var type = columns.OfType<DocumentTypeColumn>().SingleOrDefault();
-        var version = columns.OfType<VersionColumn>().SingleOrDefault();
+        // mt_version sits in either VersionColumn (Optimistic / [Version] Guid) or
+        // RevisionColumn (Numeric / [Version] long); both occupy the same physical
+        // mt_version column on the table and should land at the same canonical slot
+        // in the SELECT projection. Without pulling RevisionColumn out here it falls
+        // into the unstable trailing-rest list, which scrambles the column<->binder
+        // pairing on conjoined-tenancy aggregates whose raw column order is
+        // tenant_id, id, data, …, mt_version: the SELECT emits
+        // (id, data, tenant_id, mt_version) but the closed-shape descriptor expects
+        // (id, data, mt_version, tenant_id) and tenantIdBinder ends up reading bigint
+        // as varchar — surfaced by build_aggregate_projection.simple_scenario and
+        // Bug_3946 against MultiStreamProjection + conjoined tenancy.
+        ISelectableColumn? version = columns.OfType<VersionColumn>().SingleOrDefault();
+        version ??= columns.OfType<RevisionColumn>().SingleOrDefault();
 
         var answer = new List<ISelectableColumn>();
 


### PR DESCRIPTION
## Summary

`DocumentTable.SelectColumns` already pulls `VersionColumn` out of the trailing rest-list so the SELECT projection lands as `[id, data, doc_type?, version, …rest]`. `RevisionColumn` — the Numeric-mode counterpart that owns the same physical `mt_version` column when the mapping uses `UseNumericRevisions` / `SnapshotLifecycle` on a `long`-revisioned aggregate — was **not** being extracted the same way. So for any aggregate whose raw column order interleaves another selectable column ahead of `mt_version`, the SELECT projection scrambled and the closed-shape read binders ended up paired with the wrong column.

Concretely, a `Snapshot<T>` projection on a `TenancyStyle.Conjoined` aggregate has raw column order `[tenant_id, id, data, mt_last_modified, mt_dotnet_type, mt_version]` (tenant_id is first because the conjoined PK ordering requires it). `SelectColumns` emitted `[id, data, tenant_id, mt_version]` — `RevisionColumn` fell into the trailing rest list, **after** tenant_id. But `DocumentStorageDescriptorBuilder` lines the read binders up assuming the version slot is canonical 4th: `[revisionBinder@2, tenantIdBinder@3]`. Result: `tenantIdBinder` reads the bigint `mt_version` column as varchar and the query throws:

```
System.InvalidCastException : Reading as 'System.String' is not supported for fields having DataTypeName 'bigint'
  at DocumentTenantIdBinder.Apply
```

This surfaces as a deterministic master CI failure on `DaemonTests.Aggregations.build_aggregate_projection.simple_scenario` (the same test currently failing on the master `Daemon` workflow run and on every open PR's CI matrix) and as the underlying symptom for `Bug_3946_tenancy_with_for_tenant_and_projection_issues` (MultiStreamProjection + conjoined tenancy — previously skipped under a misattributed `#4444` tag).

## Fix

`SelectColumns` falls back to `RevisionColumn` when no `VersionColumn` is found, so the canonical version-slot ordering applies to both concurrency modes:

```csharp
ISelectableColumn? version = columns.OfType<VersionColumn>().SingleOrDefault();
version ??= columns.OfType<RevisionColumn>().SingleOrDefault();
```

Both columns target the same physical `mt_version` column on the table; the canonical SELECT slot becomes mode-agnostic.

Side effect: un-skip `Bug_3946_tenancy_with_for_tenant_and_projection_issues` — both `Theory` variants now pass under both the codegen and closed-shape lanes.

## Verification

```bash
# simple_scenario — deterministic master failure prior to this PR
dotnet test src/DaemonTests/DaemonTests.csproj --filter \
  "FullyQualifiedName=DaemonTests.Aggregations.build_aggregate_projection.simple_scenario" -f net9.0
# → 1/1 pass

# Bug_3946 — failed on both codegen + closed-shape prior, now both pass
dotnet test src/EventSourcingTests/EventSourcingTests.csproj --filter \
  "FullyQualifiedName~Bug_3946_tenancy_with_for_tenant" -f net9.0
# → 2/2 pass (codegen + MARTEN_USE_CLOSED_SHAPE_STORAGE=true)

# Regression sweep — broad slices to catch ordering side-effects
DaemonTests.Aggregations:  36/36 pass
DocumentDbTests.Reading:   126/126 pass
MultiTenancyTests:         128/128 pass
```

## Downstream

Open PRs whose CI matrix is currently failing on `simple_scenario` (#4447, #4448, #4450) will go green once they pull master with this fix in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)