### PR TITLE
[#4454 Phase 1A+B] ICompiledQueryAwareFilter.BuildSetter Action contract

### DIFF
--- a/src/Marten/DocumentStore.CompiledQueryCollection.cs
+++ b/src/Marten/DocumentStore.CompiledQueryCollection.cs
@@ -57,18 +57,12 @@ internal class CompiledQueryCollection
         // (Stateless, Cloned, Complex), so the source-gen path serves most
         // registered query types.
         //
-        // One holdout: query plans whose parameters need an
-        // ICompiledQueryAwareFilter (string Contains/StartsWith/EndsWith,
-        // JSONB containment via .Contains() on a HashSet<>, dictionary
-        // ContainsKey, child-collection JsonPath counts). Those filters
-        // customize parameter writes through codegen-time GenerateCode hooks
-        // with no runtime equivalent — for now, plans containing them fall
-        // through to the JasperFx.RuntimeCompiler path below. Lifting that
-        // restriction (filter runtime APIs) is tracked as a follow-up to
-        // #4405; once it lands, this fallthrough is deleted and a registry
-        // miss throws.
-        if (CompiledQueryHandlerRegistry.TryGet(query.GetType(), out var descriptor)
-            && !PlanRequiresCodegenFilters(plan))
+        // #4454 Phase 1A+B: ICompiledQueryAwareFilter now exposes a runtime
+        // BuildSetter() hook that the source-gen path consumes alongside the
+        // descriptor's typed BindParameter. Containment / JsonPath / Contains-
+        // style queries are therefore source-gen-eligible too — the prior
+        // PlanRequiresCodegenFilters gate is gone.
+        if (CompiledQueryHandlerRegistry.TryGet(query.GetType(), out var descriptor))
         {
             var enumAsString = _store.Options.Serializer().EnumStorage == EnumStorage.AsString;
             source = new SourceGeneratedCompiledQuerySource<TOut>(plan, descriptor, enumAsString);
@@ -97,25 +91,6 @@ internal class CompiledQueryCollection
         _querySources = _querySources.AddOrUpdate(query.GetType(), source);
 
         return source;
-    }
-
-    /// <summary>
-    /// Returns <see langword="true"/> if any parameter in the plan needs an
-    /// <see cref="Marten.Internal.CompiledQueries.ICompiledQueryAwareFilter"/>
-    /// to write its value. Those filters today only emit codegen — there's no
-    /// runtime hook for them — so the source-gen path can't fully serve such
-    /// plans. Tracked as a follow-up to #4405.
-    /// </summary>
-    private static bool PlanRequiresCodegenFilters(CompiledQueryPlan plan)
-    {
-        foreach (var command in plan.Commands)
-        {
-            foreach (var usage in command.Parameters)
-            {
-                if (usage.Filter != null) return true;
-            }
-        }
-        return false;
     }
 }
 

--- a/src/Marten/Internal/CompiledQueries/CompiledQueryMemberReader.cs
+++ b/src/Marten/Internal/CompiledQueries/CompiledQueryMemberReader.cs
@@ -1,0 +1,33 @@
+#nullable enable
+using System;
+using System.Reflection;
+
+namespace Marten.Internal.CompiledQueries;
+
+/// <summary>
+/// Tiny reflection bridge used by <see cref="ICompiledQueryAwareFilter"/>
+/// runtime setters to read the value of a captured <see cref="MemberInfo"/>
+/// from a user's compiled-query instance. Handles the two member kinds Marten
+/// matches against — <see cref="PropertyInfo"/> and <see cref="FieldInfo"/> —
+/// and surfaces a clear exception for anything else.
+/// </summary>
+/// <remarks>
+/// AOT-clean: pure reflection over the user-supplied <see cref="MemberInfo"/>,
+/// no Expression compile / no <c>MakeGenericMethod</c>. Called once per
+/// compiled-query invocation (not per row) so the reflection cost is
+/// negligible.
+/// </remarks>
+internal static class CompiledQueryMemberReader
+{
+    public static object? Read(MemberInfo member, object instance)
+    {
+        return member switch
+        {
+            PropertyInfo p => p.GetValue(instance),
+            FieldInfo f => f.GetValue(instance),
+            _ => throw new InvalidOperationException(
+                $"Unable to read compiled-query parameter from {member.DeclaringType?.FullName}.{member.Name}: " +
+                $"member kind {member.MemberType} is not supported (expected Property or Field).")
+        };
+    }
+}

--- a/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
+++ b/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
@@ -397,6 +397,15 @@ public class CompiledQueryPlan : ICommandBuilder
                         {
                             usage.Member = queryMember;
                             usage.Filter = filter;
+                            // Build the runtime setter once per (filter, query-member)
+                            // pair so the AOT/source-gen path can write the parameter
+                            // without going back through the codegen-emit hook. The
+                            // codegen path is unaffected — it still drives off
+                            // ParameterUsage.GenerateCode until Phase 1E.
+                            if (filter is not null)
+                            {
+                                usage.Setter = filter.BuildSetter();
+                            }
                             break;
                         }
                     }

--- a/src/Marten/Internal/CompiledQueries/ICompiledQueryAwareFilter.cs
+++ b/src/Marten/Internal/CompiledQueries/ICompiledQueryAwareFilter.cs
@@ -1,15 +1,55 @@
+#nullable enable
+using System;
 using System.Reflection;
 using JasperFx.CodeGeneration;
+using Npgsql;
 
 namespace Marten.Internal.CompiledQueries;
 
 /// <summary>
-/// This marker interface is used for SQL fragment filters where
-/// there needs to be some special handling within compiled queries
+/// Marker interface for SQL fragment filters whose parameter values need special
+/// runtime treatment when threaded through a compiled query — typically because the
+/// raw caller value is wrapped (LIKE escaping, <c>%</c>-prefixed) or serialized
+/// (JSON for containment / JsonPath) before it hits the <see cref="NpgsqlParameter"/>.
 /// </summary>
+/// <remarks>
+/// Two delivery mechanisms coexist during the runtime-code-generation removal
+/// (<see href="https://github.com/JasperFx/marten/issues/4454">#4454</see>):
+/// <list type="bullet">
+///   <item>
+///     <see cref="BuildSetter"/> — the AOT/source-gen path. Returns an
+///     <see cref="Action"/> that writes
+///     <see cref="NpgsqlParameter.NpgsqlDbType"/> + <see cref="NpgsqlParameter.Value"/>
+///     given the user's compiled-query instance. Implementations capture the
+///     <see cref="MemberInfo"/> cached during <see cref="TryMatchValue"/> plus any
+///     per-filter state (raw value, npgsql type, etc.). Built once per
+///     <c>(filter, query-member)</c> pair when <c>CompiledQueryPlan.MatchParameters</c>
+///     attaches a filter to a <see cref="ParameterUsage"/>; called once per
+///     <c>session.Query(...)</c>.
+///   </item>
+///   <item>
+///     <see cref="GenerateCode"/> — the Roslyn-emit codegen path that
+///     <c>CompiledQuerySourceBuilder</c> still drives until phase 1E of #4454
+///     deletes that path entirely. New filter implementations should focus on
+///     <see cref="BuildSetter"/>; the <see cref="GenerateCode"/> override can be
+///     a near-copy that emits the same value-wrapping logic into the generated
+///     handler class.
+///   </item>
+/// </list>
+/// </remarks>
 public interface ICompiledQueryAwareFilter
 {
     bool TryMatchValue(object value, MemberInfo member);
+
+    /// <summary>
+    /// Returns a delegate that writes the parameter's npgsql type + value from the
+    /// matched member on the compiled-query instance. Closes over the
+    /// <see cref="MemberInfo"/> captured by the most recent successful
+    /// <see cref="TryMatchValue"/> call plus any per-filter state. Called once per
+    /// <c>session.Query(compiledQuery)</c> invocation, never per row.
+    /// </summary>
+    Action<NpgsqlParameter, object> BuildSetter();
+
     void GenerateCode(GeneratedMethod method, int parameterIndex, string parametersVariableName);
 
     string ParameterName { get; }

--- a/src/Marten/Internal/CompiledQueries/ParameterUsage.cs
+++ b/src/Marten/Internal/CompiledQueries/ParameterUsage.cs
@@ -34,6 +34,15 @@ internal class ParameterUsage
     public IQueryMember Member { get; set; }
     public ICompiledQueryAwareFilter? Filter { get; set; }
 
+    /// <summary>
+    /// Cached runtime setter built once per (filter, query-member) pair when
+    /// <c>CompiledQueryPlan.MatchParameters</c> attaches a filter — the AOT/source-gen
+    /// path uses this delegate to write the parameter's value, bypassing the
+    /// descriptor's generic <c>BindParameter</c> for filters that need to wrap or
+    /// serialize the raw value (LIKE escaping, containment JSON, etc.).
+    /// </summary>
+    public Action<NpgsqlParameter, object>? Setter { get; set; }
+
     public void GenerateCode(GeneratedMethod method, string parametersVariableName, StoreOptions storeOptions)
     {
         if (IsTenant)

--- a/src/Marten/Internal/CompiledQueries/SourceGeneratedCompiledQuery.cs
+++ b/src/Marten/Internal/CompiledQueries/SourceGeneratedCompiledQuery.cs
@@ -84,6 +84,17 @@ internal abstract class SourceGeneratedCompiledQueryHandlerBase<TOut>: IQueryHan
                     continue;
                 }
 
+                if (usage.Setter is { } setter)
+                {
+                    // Filter-driven runtime setter — wraps / serializes the raw
+                    // value (e.g. LIKE escaping, JSONB containment). Built once
+                    // per (filter, query-member) pair when the plan was matched;
+                    // takes precedence over the descriptor's direct read because
+                    // a Contains-style query needs `%X%` rather than the raw `X`.
+                    setter(parameter, _query);
+                    continue;
+                }
+
                 if (usage.Member?.Member is { } memberInfo)
                 {
                     // Source-gen binder path — direct property/field read inside

--- a/src/Marten/Linq/Members/ChildCollectionJsonPathCountFilter.cs
+++ b/src/Marten/Linq/Members/ChildCollectionJsonPathCountFilter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -7,6 +8,7 @@ using JasperFx.CodeGeneration;
 using Marten.Internal.CompiledQueries;
 using Marten.Linq.Parsing;
 using Marten.Linq.SqlGeneration.Filters;
+using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
@@ -96,6 +98,25 @@ internal class ChildCollectionJsonPathCountFilter: ISqlFragment, ICompiledQueryA
         top.ReadDictionary(_dict, _usages);
 
         method.Frames.Add(new WriteSerializedJsonParameterFrame(parametersVariableName, parameterIndex, top));
+    }
+
+    public Action<NpgsqlParameter, object> BuildSetter()
+    {
+        // Apply() may not have been invoked yet at the time MatchParameters calls
+        // BuildSetter (Apply runs when Marten renders the SQL command, plan matching
+        // runs at session.Query time — opposite order). Snapshot what we have now;
+        // the dict + usages list are filled by Apply / TryMatchValue and shared by
+        // reference, so the captured locals see the post-Apply state at invocation.
+        var dictRef = new System.Func<Dictionary<string, object>?>(() => _dict);
+        var usagesRef = new System.Func<List<DictionaryValueUsage>?>(() => _usages);
+        var serializer = _serializer;
+        return (parameter, query) =>
+        {
+            var payload = Marten.Linq.SqlGeneration.Filters.CompiledQueryDictionaryBuilder.Build(
+                dictRef(), usagesRef(), query, default);
+            parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+            parameter.Value = payload is null ? System.DBNull.Value : (object)serializer.ToCleanJson(payload);
+        };
     }
 
     public string ParameterName { get; private set; }

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryContainsKeyFilter.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryContainsKeyFilter.cs
@@ -53,5 +53,10 @@ internal class DictionaryContainsKeyFilter: ISqlFragment, ICompiledQueryAwareFil
         throw new BadLinqExpressionException("Marten does not (yet) support Dictionary.ContainsKey() in compiled queries");
     }
 
+    public Action<Npgsql.NpgsqlParameter, object> BuildSetter()
+    {
+        throw new BadLinqExpressionException("Marten does not (yet) support Dictionary.ContainsKey() in compiled queries");
+    }
+
     public string ParameterName { get; } = "NONE";
 }

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringContains.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringContains.cs
@@ -6,6 +6,7 @@ using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
 using Marten.Internal.CompiledQueries;
 using Marten.Linq.Members;
+using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
@@ -81,6 +82,17 @@ internal class StringContainsFilter: ISqlFragment, ICompiledQueryAwareFilter
 {parametersVariableName}[{parameterIndex}].NpgsqlDbType = {{0}};
 {parametersVariableName}[{parameterIndex}].Value = {maskedValue};
 ", NpgsqlDbType.Varchar);
+    }
+
+    public Action<NpgsqlParameter, object> BuildSetter()
+    {
+        var member = _queryMember;
+        return (parameter, query) =>
+        {
+            var raw = (string?)CompiledQueryMemberReader.Read(member, query) ?? string.Empty;
+            parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
+            parameter.Value = $"%{StringComparisonParser.EscapeValue(raw)}%";
+        };
     }
 
     public string ParameterName { get; private set; }

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringEndsWith.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringEndsWith.cs
@@ -5,6 +5,7 @@ using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
 using Marten.Internal.CompiledQueries;
 using Marten.Linq.Members;
+using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
@@ -79,6 +80,17 @@ internal class StringEndsWithFilter: ISqlFragment, ICompiledQueryAwareFilter
 {parametersVariableName}[{parameterIndex}].NpgsqlDbType = {{0}};
 {parametersVariableName}[{parameterIndex}].Value = {maskedValue};
 ", NpgsqlDbType.Varchar);
+    }
+
+    public Action<NpgsqlParameter, object> BuildSetter()
+    {
+        var member = _queryMember;
+        return (parameter, query) =>
+        {
+            var raw = CompiledQueryMemberReader.Read(member, query)?.ToString() ?? string.Empty;
+            parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
+            parameter.Value = $"%{StringComparisonParser.EscapeValue(raw)}";
+        };
     }
 
     public string ParameterName { get; private set; }

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringEquals.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringEquals.cs
@@ -6,6 +6,7 @@ using JasperFx.Core.Reflection;
 using Marten.Internal.CompiledQueries;
 using Marten.Linq.Members;
 using Marten.Linq.SqlGeneration.Filters;
+using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
@@ -71,6 +72,17 @@ internal class StringEqualsIgnoreCaseFilter : ISqlFragment, ICompiledQueryAwareF
 {parametersVariableName}[{parameterIndex}].NpgsqlDbType = {{0}};
 {parametersVariableName}[{parameterIndex}].Value = {maskedValue};
 ", NpgsqlDbType.Varchar);
+    }
+
+    public Action<NpgsqlParameter, object> BuildSetter()
+    {
+        var member = _queryMember!;
+        return (parameter, query) =>
+        {
+            var raw = (string?)CompiledQueryMemberReader.Read(member, query) ?? string.Empty;
+            parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
+            parameter.Value = StringComparisonParser.EscapeValue(raw);
+        };
     }
 
     public string? ParameterName { get; private set; }

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringStartsWith.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringStartsWith.cs
@@ -5,6 +5,7 @@ using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
 using Marten.Internal.CompiledQueries;
 using Marten.Linq.Members;
+using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
@@ -70,5 +71,16 @@ internal class StringStartsWithFilter: ISqlFragment, ICompiledQueryAwareFilter
 {parametersVariableName}[{parameterIndex}].NpgsqlDbType = {{0}};
 {parametersVariableName}[{parameterIndex}].Value = {maskedValue};
 ", NpgsqlDbType.Varchar);
+    }
+
+    public Action<NpgsqlParameter, object> BuildSetter()
+    {
+        var member = _queryMember;
+        return (parameter, query) =>
+        {
+            var raw = (string?)CompiledQueryMemberReader.Read(member, query) ?? string.Empty;
+            parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
+            parameter.Value = $"{StringComparisonParser.EscapeValue(raw)}%";
+        };
     }
 }

--- a/src/Marten/Linq/SqlGeneration/Filters/CompiledQueryDictionaryBuilder.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/CompiledQueryDictionaryBuilder.cs
@@ -1,0 +1,98 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Marten.Linq.SqlGeneration.Filters;
+
+/// <summary>
+/// Runtime dictionary builder used by compiled-query <see cref="ICompiledQueryAwareFilter"/>
+/// implementations whose <see cref="ICompiledQueryAwareFilter.BuildSetter"/> writes
+/// a serialized JSON payload (containment + JsonPath count filters). Mirrors the
+/// codegen-time <see cref="DictionaryDeclaration"/> /
+/// <see cref="WriteSerializedJsonParameterFrame"/> emit: the captured
+/// <c>data</c> tree carries the constant values seen at LINQ-parse time;
+/// each <see cref="DictionaryValueUsage"/> in <paramref name="usages"/> maps a
+/// constant to the <c>MemberInfo</c> that supplied it on the compiled-query
+/// instance. At runtime we walk <paramref name="data"/> and substitute each
+/// leaf with the corresponding member read off <paramref name="query"/>.
+/// </summary>
+/// <remarks>
+/// AOT-clean: pure reflection over user-supplied <c>MemberInfo</c>, no Expression
+/// compile / no MakeGenericMethod. The reflection cost is paid once per
+/// <c>session.Query(compiledQuery)</c> invocation; the dictionary shape is small
+/// enough that the savings of a compiled-getter accessor wouldn't justify the
+/// additional FEC dependency on the hot path.
+/// </remarks>
+internal static class CompiledQueryDictionaryBuilder
+{
+    internal static Dictionary<string, object?> Build(
+        Dictionary<string, object> data,
+        List<DictionaryValueUsage> usages,
+        object query)
+    {
+        var result = new Dictionary<string, object?>(data.Count);
+        foreach (var pair in data)
+        {
+            result[pair.Key] = BuildValue(pair.Value, usages, query);
+        }
+
+        return result;
+    }
+
+    internal static Dictionary<string, object?>? Build(
+        Dictionary<string, object>? data,
+        List<DictionaryValueUsage>? usages,
+        object query,
+        bool _)
+    {
+        if (data is null) return null;
+        return Build(data, usages ?? new List<DictionaryValueUsage>(), query);
+    }
+
+    private static object? BuildValue(object value, List<DictionaryValueUsage> usages, object query)
+    {
+        switch (value)
+        {
+            case Dictionary<string, object> nested:
+                return Build(nested, usages, query);
+
+            case object[] array:
+                return BuildArray(array, usages, query);
+
+            default:
+                return ResolveLeaf(value, usages, query);
+        }
+    }
+
+    private static object?[] BuildArray(object[] array, List<DictionaryValueUsage> usages, object query)
+    {
+        var result = new object?[array.Length];
+        for (var i = 0; i < array.Length; i++)
+        {
+            result[i] = array[i] switch
+            {
+                Dictionary<string, object> nested => Build(nested, usages, query),
+                object[] innerArray => BuildArray(innerArray, usages, query),
+                var leaf => ResolveLeaf(leaf, usages, query)
+            };
+        }
+
+        return result;
+    }
+
+    private static object? ResolveLeaf(object value, List<DictionaryValueUsage> usages, object query)
+    {
+        // The captured constant value is the LINQ-parse-time snapshot. If a
+        // matching DictionaryValueUsage has a QueryMember attached, the
+        // compiled-query plumbing means we should pull the live value off the
+        // user's query instance instead — that's what the codegen path emits
+        // as `_query.<Member>`.
+        var usage = usages.FirstOrDefault(u => Equals(u.Value, value));
+        if (usage?.QueryMember is { } member)
+        {
+            return Marten.Internal.CompiledQueries.CompiledQueryMemberReader.Read(member, query);
+        }
+
+        return value;
+    }
+}

--- a/src/Marten/Linq/SqlGeneration/Filters/ContainmentWhereFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/ContainmentWhereFilter.cs
@@ -9,6 +9,7 @@ using Marten.Exceptions;
 using Marten.Internal.CompiledQueries;
 using Marten.Linq.Members;
 using Marten.Linq.Members.Dictionaries;
+using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
@@ -200,6 +201,27 @@ public class ContainmentWhereFilter: ICollectionAwareFilter, ICollectionAware, I
         var part = Usage == ContainmentUsage.Singular ? (IDictionaryPart)top : new ArrayContainer(top);
 
         method.Frames.Add(new WriteSerializedJsonParameterFrame(parametersVariableName, parameterIndex, part));
+    }
+
+    public Action<NpgsqlParameter, object> BuildSetter()
+    {
+        // Snapshot the per-filter state at plan-construction time. The captured
+        // _data tree references DictionaryValueUsage entries whose QueryMember
+        // was assigned during the matching TryMatchValue call; the setter walks
+        // the tree per session.Query(...) invocation and substitutes each leaf
+        // value with the corresponding member read off the user's query
+        // instance. AOT-clean: no reflection emit, no Expression compile.
+        var data = _data;
+        var usages = _usages;
+        var serializer = _serializer;
+        var wrapInArray = Usage == ContainmentUsage.Collection;
+        return (parameter, query) =>
+        {
+            var dict = CompiledQueryDictionaryBuilder.Build(data, usages, query);
+            var payload = wrapInArray ? (object)new object[] { dict } : dict;
+            parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+            parameter.Value = serializer.ToCleanJson(payload);
+        };
     }
 
     public string ParameterName { get; private set; }


### PR DESCRIPTION
## Summary

First phase of #4454 (removing all runtime compilation from Marten). Closes the source-gen correctness gap the issue calls out as the foundational first step — until this lands, `ICompiledQueryAwareFilter` implementations only knew how to emit Roslyn code via `GenerateCode`. The source-gen path had no runtime hook for filter-bearing parameters, and `DocumentStore.CompiledQueryCollection` had to fall back through to `JasperFx.RuntimeCompiler` for any plan whose parameters needed filter wrapping.

### Phase 1A — Action contract

`ICompiledQueryAwareFilter` now exposes:

```csharp
Action<NpgsqlParameter, object> BuildSetter();
```

Built once per `(filter, query-member)` pair when `CompiledQueryPlan.MatchParameters` attaches a filter to a `ParameterUsage`; called once per `session.Query(compiledQuery)` invocation. Implementations capture the `MemberInfo` cached by `TryMatchValue` plus per-filter state and return a closure that writes `parameter.NpgsqlDbType` + `parameter.Value`.

All 7 implementations got a `BuildSetter` override:

- `StringContainsFilter` — `%escaped(member)%`
- `StringStartsWithFilter` — `escaped(member)%`
- `StringEndsWithFilter` — `%escaped(member)`
- `StringEqualsIgnoreCaseFilter` — `escaped(member)`
- `ContainmentWhereFilter` — JSONB payload built via the new `CompiledQueryDictionaryBuilder` (mirrors the codegen `DictionaryDeclaration` → `WriteSerializedJsonParameterFrame` emit)
- `ChildCollectionJsonPathCountFilter` — same JSONB payload story
- `DictionaryContainsKeyFilter` — throws the existing `BadLinqExpressionException` (matches `TryMatchValue`)

`GenerateCode` stays on the interface for now — the codegen path still drives off it through `CompiledQuerySourceBuilder.AssembleTypes`. Both delegates emit the same value-wrapping semantics so the two paths can't diverge. Phase 1E deletes the codegen path entirely along with `GenerateCode`.

### Phase 1B — Source-gen wiring

- `ParameterUsage.Setter` caches the `BuildSetter()` result.
- `CompiledQueryPlan.MatchParameters` populates it when a filter is matched.
- `SourceGeneratedCompiledQueryHandlerBase.ConfigureCommand` prefers `usage.Setter` over the descriptor's typed `BindParameter` when present — filter-driven parameters need the wrap/serialize step, not the raw read.
- `DocumentStore.CompiledQueryCollection` drops the `PlanRequiresCodegenFilters` fallthrough. Any descriptor registered via the source-gen `[ModuleInitializer]` now serves filter-bearing plans too.

### Helpers

- `CompiledQueryMemberReader.Read(MemberInfo, object)` — handles `PropertyInfo` / `FieldInfo` without runtime emit. AOT-clean.
- `CompiledQueryDictionaryBuilder.Build(data, usages, query)` — walks the captured constant-value dictionary tree (the same shape the codegen `DictionaryDeclaration.ReadDictionary` consumes) and substitutes each `DictionaryValueUsage.QueryMember`-tagged leaf with the member read off the user's compiled-query instance. JSONB payload is identical between the two paths.

## Verification

```
dotnet test src/CompiledQueryTests/CompiledQueryTests.csproj
→ 9/9 pass

dotnet test src/LinqTests/LinqTests.csproj \
    --filter "FullyQualifiedName~Compiled|FullyQualifiedName~compiled"
→ 75/75 pass
```

## Follow-up phases (separate PRs)

- **1C + 1D**: finish the source generator (descriptor emit / module-init registration for the still-blocked shapes) + FEC fallback for un-source-gen'd queries.
- **1E**: delete the codegen path (`CompiledQuerySourceBuilder`, `StatelessCompiledQuery` / `ClonedCompiledQuery` / `ComplexCompiledQuery`, the now-unused `GenerateCode` on `ICompiledQueryAwareFilter`).
- **2**: flip event-store closed-shape to default + delete the `MARTEN_USE_CLOSED_SHAPE_STORAGE` GH Action profiles.
- **3**: port ancillary stores to the closed-shape provider.
- **4**: daemon / projection codegen audit.
- **5**: remove `JasperFx.RuntimeCompiler` `PackageReference` + retire `StoreOptions.GeneratesCode` / `dotnet marten codegen ...` CLI verbs. That's the "Boom" PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)