### PR TITLE
[#4454 Phase 3] Port ancillary stores off the codegen subclass path

### DIFF
--- a/src/Marten/Internal/SecondaryStoreConfig.cs
+++ b/src/Marten/Internal/SecondaryStoreConfig.cs
@@ -1,16 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
 using JasperFx;
-using JasperFx.CodeGeneration;
-using JasperFx.Core;
 using JasperFx.Core.Reflection;
-using JasperFx.RuntimeCompiler;
-using Marten.Schema;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Internal;
@@ -21,33 +14,11 @@ namespace Marten.Internal;
     Justification = "Class-level: generic type argument doesn't carry the DAM annotation of its target. The argument types flow in from StoreOptions / projection-registration on the caller side and are preserved by the trimmer at that boundary.")]
 [UnconditionalSuppressMessage("AOT", "IL3050",
     Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
-internal class SecondaryDocumentStores: ICodeFileCollection
+internal class SecondaryDocumentStores
 {
     private readonly List<IStoreConfig> _files = new();
 
-    public IServiceProvider Services { get; set; }
-
-    public IReadOnlyList<ICodeFile> BuildFiles()
-    {
-        return _files;
-    }
-
-    public string ChildNamespace { get; } = "Stores";
-
-
-    public GenerationRules Rules
-    {
-        get
-        {
-            var parentRules = _files.First().BuildStoreOptions(Services).CreateGenerationRules();
-            var rules = new GenerationRules();
-
-            rules.GeneratedNamespace = "Marten.Generated";
-            rules.GeneratedCodeOutputPath = parentRules.GeneratedCodeOutputPath.ParentDirectory();
-
-            return rules;
-        }
-    }
+    public IReadOnlyList<IStoreConfig> Stores => _files;
 
     public void Add(IStoreConfig config)
     {
@@ -56,7 +27,7 @@ internal class SecondaryDocumentStores: ICodeFileCollection
     }
 }
 
-internal interface IStoreConfig: ICodeFile
+internal interface IStoreConfig
 {
     SecondaryDocumentStores Parent { get; set; }
     StoreOptions BuildStoreOptions(IServiceProvider provider);
@@ -76,34 +47,11 @@ public interface IConfigureMarten<T>: IConfigureMarten where T : IDocumentStore
 internal class SecondaryStoreConfig<T>: IStoreConfig where T : IDocumentStore
 {
     private readonly Func<IServiceProvider, StoreOptions> _configuration;
-    private Type? _storeType;
 
     public SecondaryStoreConfig(Func<IServiceProvider, StoreOptions> configuration)
     {
         _configuration = configuration;
-        FileName = typeof(T).ToSuffixedTypeName("Implementation");
     }
-
-    public void AssembleTypes(GeneratedAssembly assembly)
-    {
-        var type = assembly.AddType(FileName, typeof(DocumentStore));
-        type.Implements<T>();
-    }
-
-    public Task<bool> AttachTypes(GenerationRules rules, Assembly assembly, IServiceProvider? services,
-        string containingNamespace)
-    {
-        return Task.FromResult(AttachTypesSynchronously(rules, assembly, services, containingNamespace));
-    }
-
-    public bool AttachTypesSynchronously(GenerationRules rules, Assembly assembly, IServiceProvider? services,
-        string containingNamespace)
-    {
-        _storeType = assembly.FindPreGeneratedType(containingNamespace, FileName);
-        return _storeType != null;
-    }
-
-    public string FileName { get; }
 
     public SecondaryDocumentStores Parent { get; set; }
 
@@ -133,20 +81,13 @@ internal class SecondaryStoreConfig<T>: IStoreConfig where T : IDocumentStore
     public T Build(IServiceProvider provider)
     {
         var options = BuildStoreOptions(provider);
-        var rules = options.CreateGenerationRules();
 
-        rules.GeneratedNamespace = SchemaConstants.MartenGeneratedNamespace;
-        // CreateGenerationRules() appends StoreName to the output path, but
-        // SecondaryDocumentStores.Rules (used by codegen write) strips it via
-        // ParentDirectory(). Align the paths to avoid writing duplicate files
-        // with the same namespace and class name to different directories (#4185)
-        rules.GeneratedCodeOutputPath = rules.GeneratedCodeOutputPath.ParentDirectory();
-        // 9.0 (#4309): route through the AllowRuntimeCodeGeneration gate so
-        // ancillary stores honor the AOT-friendly opt-out as well.
-        Marten.Internal.CodeGeneration.StaticOnlyCodeFileLoader.Initialize(
-            this, rules, Parent, provider, options.AllowRuntimeCodeGeneration);
-
-        var store = (T)Activator.CreateInstance(_storeType!, options)!;
+        // Phase 3 (#4454): hand-built System.Reflection.Emit subclass replaces
+        // the Roslyn-emit ICodeFile path. The user's secondary-store interface
+        // is a marker (T : IDocumentStore with no extra abstract members) so
+        // the proxy only needs a forwarding constructor.
+        var storeType = SecondaryStoreProxyFactory.GetOrCreate(typeof(T));
+        var store = (T)Activator.CreateInstance(storeType, options)!;
         store.As<DocumentStore>().Subject = new Uri("marten://" + typeof(T).Name.ToLowerInvariant());
 
         return store;

--- a/src/Marten/Internal/SecondaryStoreProxyFactory.cs
+++ b/src/Marten/Internal/SecondaryStoreProxyFactory.cs
@@ -1,0 +1,77 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Marten.Internal;
+
+/// <summary>
+/// Builds a thin runtime subclass <c>class &lt;T&gt;Implementation : DocumentStore, T</c>
+/// per user-supplied secondary-store interface — what the Roslyn-emit path
+/// in <see cref="SecondaryStoreConfig{T}"/> used to produce. Uses
+/// <see cref="System.Reflection.Emit"/> instead of JasperFx.RuntimeCompiler:
+/// <c>T</c> here is a marker interface (<c>T : IDocumentStore</c>) with no
+/// extra abstract members, so the emitted type only needs a forwarding
+/// constructor.
+/// </summary>
+[RequiresDynamicCode("Generates a runtime subclass per secondary-store interface via System.Reflection.Emit.")]
+internal static class SecondaryStoreProxyFactory
+{
+    private static readonly ConcurrentDictionary<Type, Type> _cache = new();
+
+    private static readonly Lazy<ModuleBuilder> _module = new(() =>
+    {
+        var asm = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("Marten.DynamicStores"),
+            AssemblyBuilderAccess.Run);
+        return asm.DefineDynamicModule("Marten.DynamicStores");
+    });
+
+    public static Type GetOrCreate(Type interfaceType)
+    {
+        if (!typeof(IDocumentStore).IsAssignableFrom(interfaceType))
+        {
+            throw new ArgumentException(
+                $"{interfaceType.FullName} must inherit from {nameof(IDocumentStore)} to be used as a secondary store interface.",
+                nameof(interfaceType));
+        }
+
+        return _cache.GetOrAdd(interfaceType, Build);
+    }
+
+    private static Type Build(Type interfaceType)
+    {
+        var module = _module.Value;
+        var typeName = $"Marten.DynamicStores.{interfaceType.Name}Implementation";
+
+        var tb = module.DefineType(
+            typeName,
+            TypeAttributes.Public | TypeAttributes.Class,
+            typeof(DocumentStore),
+            new[] { interfaceType });
+
+        var baseCtor = typeof(DocumentStore).GetConstructor(
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            types: new[] { typeof(StoreOptions) },
+            modifiers: null)
+            ?? throw new InvalidOperationException(
+                $"Could not find public DocumentStore(StoreOptions) constructor on {typeof(DocumentStore).FullName}.");
+
+        var ctor = tb.DefineConstructor(
+            MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
+            CallingConventions.Standard,
+            new[] { typeof(StoreOptions) });
+
+        var il = ctor.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, baseCtor);
+        il.Emit(OpCodes.Ret);
+
+        return tb.CreateType()
+            ?? throw new InvalidOperationException($"Failed to materialize the secondary-store proxy for {interfaceType.FullName}.");
+    }
+}

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -294,8 +294,6 @@ public static class MartenServiceCollectionExtensions
         services.AddJasperFx();
         services.AddSingleton<IDocumentStoreSource, DocumentStoreSource<T>>();
 
-        services.AddSingleton<IAssemblyGenerator, AssemblyGenerator>();
-
         services.AddSingleton<ISystemPart, MartenSystemPart<T>>();
 
         services.AddSingleton<IEventStore>(s => (IEventStore)s.GetRequiredService<T>());
@@ -310,13 +308,6 @@ public static class MartenServiceCollectionExtensions
         {
             stores = new SecondaryDocumentStores();
             services.AddSingleton(stores);
-            // I'm not proud of this, but you need the IServiceProvider in order to
-            // build the generation rules
-            services.AddSingleton<ICodeFileCollection>(s =>
-            {
-                stores.Services = s;
-                return stores;
-            });
         }
 
         services.AddSingleton<IDatabaseSource>(s => s.GetRequiredService<T>().As<DocumentStore>().Tenancy);
@@ -337,16 +328,6 @@ public static class MartenServiceCollectionExtensions
         });
 
         services.AddSingleton<IMasterTableMultiTenancy>(s => (IMasterTableMultiTenancy)s.GetRequiredService<T>());
-
-
-        services.AddSingleton<ICodeFileCollection>(s =>
-        {
-            var options = config.BuildStoreOptions(s);
-            return new DocumentStore(options);
-        });
-
-        services.AddSingleton<ICodeFileCollection>(s => config.BuildStoreOptions(s).EventGraph);
-        services.AddSingleton<ICodeFileCollection>(s => config.BuildStoreOptions(s));
 
         return new MartenStoreExpression<T>(services);
     }

--- a/src/StressTests/using_multiple_document_stores_in_same_host.cs
+++ b/src/StressTests/using_multiple_document_stores_in_same_host.cs
@@ -100,10 +100,13 @@ public class using_multiple_document_stores_in_same_host : IDisposable
     }
 
     [Fact]
-    public void should_have_a_single_ICodeFileCollection_registration_for_secondary_stores()
+    public void should_have_a_single_SecondaryDocumentStores_registration()
     {
-        theContainer.GetAllInstances<ICodeFileCollection>().OfType<SecondaryDocumentStores>()
-            .Count().ShouldBe(1);
+        // Phase 3 (#4454) retired SecondaryDocumentStores' ICodeFileCollection
+        // role — it's no longer part of the JasperFx codegen-write pipeline.
+        // The invariant we still need: a single shared SecondaryDocumentStores
+        // catalog per host, not one per AddMartenStore<T> call.
+        theContainer.GetAllInstances<SecondaryDocumentStores>().Count().ShouldBe(1);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Phase 3 of #4454. Retires the Roslyn-emit subclass path for `AddMartenStore<T>()` and replaces it with a thin `System.Reflection.Emit` factory.

The user's secondary-store interface is a marker (`T : IDocumentStore` with no extra abstract members), so the runtime type only needs a forwarding constructor — no method bodies, no fields. That's well within Reflection.Emit's wheelhouse and frees the path from `JasperFx.RuntimeCompiler` / `JasperFx.CodeGeneration` entirely.

### Changes

- New `SecondaryStoreProxyFactory` caches one runtime-emitted `class TImplementation : DocumentStore, T` per interface type. Uses `AssemblyBuilder` / `TypeBuilder` / `ILGenerator` directly — no Roslyn.
- `SecondaryStoreConfig<T>` drops its `ICodeFile` membership and the `StaticOnlyCodeFileLoader.Initialize` call in `Build()`. `Activator.CreateInstance` still constructs the store from `StoreOptions`.
- `SecondaryDocumentStores` drops `ICodeFileCollection` — secondary stores no longer flow into the JasperFx codegen-write pipeline. The singleton is still registered so host inspection still works.
- `AddMartenStore<T>()` drops the `IAssemblyGenerator` registration and the three `ICodeFileCollection` adaptors it used to plumb secondary stores into the CLI.
- `StressTests.using_multiple_document_stores_in_same_host.should_have_a_single_ICodeFileCollection_registration_for_secondary_stores` rewritten to assert the same invariant against the new shape (one `SecondaryDocumentStores` per host).

### Why Reflection.Emit, not source-gen

A source generator can't see user-defined interfaces in the consumer's assembly without scaffolding equivalent to the compiled-query generator. The interface is a marker with zero abstract members, so Reflection.Emit produces ~10 IL bytes per interface — much cheaper than wiring source-gen for this surface alone. AOT consumers will need the `[RequiresDynamicCode]` annotation; we already carry that flag for the FEC / closed-shape fallback paths.

## Test plan

- [x] Build clean (0 errors)
- [x] `MultiTenancyTests` — 128/128 pass
- [x] `CoreTests` — 445/445 pass, 1 pre-existing skip
- [x] `CoreTests` ancillary/secondary store filter — 35/35 pass (`jasper_fx_mechanics`, `working_with_initial_data`, `Bug_4185`, `Bug_4187`, `lazy_ancillary_store_registration`)
- [x] `ContainerScopedProjectionTests` — 15/15 pass
- [x] `StressTests.using_multiple_document_stores_in_same_host` + `reset_all_data_usage_ihost` — 10/10 pass
- [ ] Full CI matrix

Part of #4454. Phase 4 (daemon/projection codegen audit) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)