### PR TITLE
[#4454 Phase 4] Daemon/projection codegen audit + event-side dead-method cleanup

### DIFF
--- a/src/Marten/EventStorage/Metadata/CausationIdColumnBinder.cs
+++ b/src/Marten/EventStorage/Metadata/CausationIdColumnBinder.cs
@@ -9,8 +9,7 @@ namespace Marten.EventStorage.Metadata;
 /// <summary>
 /// <see cref="IEventMetadataBinder"/> for the optional <c>causation_id</c>
 /// varchar column. Binds <see cref="IEvent.CausationId"/> as a string
-/// parameter — mirrors <c>CausationIdColumn.GenerateAppendCode</c> on the
-/// codegen path. Included in the descriptor's binder array iff
+/// parameter. Included in the descriptor's binder array iff
 /// <c>StoreOptions.Events.MetadataConfig.CausationIdEnabled</c> is on.
 /// </summary>
 /// <remarks>

--- a/src/Marten/EventStorage/Metadata/UserNameColumnBinder.cs
+++ b/src/Marten/EventStorage/Metadata/UserNameColumnBinder.cs
@@ -8,14 +8,13 @@ namespace Marten.EventStorage.Metadata;
 
 /// <summary>
 /// <see cref="IEventMetadataBinder"/> for the optional <c>user_name</c>
-/// varchar column. Binds <see cref="IEvent.UserName"/> — mirrors
-/// <c>UserNameColumn.GenerateAppendCode</c> on the codegen path.
+/// varchar column. Binds <see cref="IEvent.UserName"/> as a string parameter.
 /// </summary>
 /// <remarks>
-/// The session-level "user name" lives on <see cref="IMartenSession.LastModifiedBy"/>
-/// but the codegen path binds the per-event <see cref="IEvent.UserName"/>
-/// (which the event appender plumbs in from the session before queuing
-/// the operation). We match that — bind off the event, not the session.
+/// The session-level "user name" lives on <see cref="IMartenSession.LastModifiedBy"/>,
+/// but the event appender plumbs that into the per-event
+/// <see cref="IEvent.UserName"/> before queuing the operation, and we bind
+/// off the event so the SQL stays self-contained.
 /// </remarks>
 internal sealed class UserNameColumnBinder: IEventMetadataBinder
 {

--- a/src/Marten/Events/Archiving/IsArchivedColumn.cs
+++ b/src/Marten/Events/Archiving/IsArchivedColumn.cs
@@ -2,7 +2,6 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using JasperFx.CodeGeneration;
 using JasperFx.Events;
 using Marten.Events.Schema;
 using Marten.Internal.CodeGeneration;
@@ -23,21 +22,6 @@ internal class IsArchivedColumn: TableColumn, IEventTableColumn
     public IsArchivedColumn(): base(ColumnName, "bool")
     {
         DefaultExpression = "FALSE";
-    }
-
-    public void GenerateSelectorCodeSync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.AssignMemberFromReader<IEvent>(null, index, x => x.IsArchived);
-    }
-
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.AssignMemberFromReaderAsync<IEvent>(null, index, x => x.IsArchived);
-    }
-
-    public void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full)
-    {
-        throw new NotSupportedException();
     }
 
     public string ValueSql(EventGraph graph, AppendMode mode)

--- a/src/Marten/Events/Schema/EventJsonDataColumn.cs
+++ b/src/Marten/Events/Schema/EventJsonDataColumn.cs
@@ -1,10 +1,3 @@
-using System;
-using JasperFx.CodeGeneration;
-using JasperFx.CodeGeneration.Frames;
-using JasperFx.Events;
-using Marten.Internal;
-using NpgsqlTypes;
-using Weasel.Postgresql;
 using Weasel.Postgresql.Tables;
 
 namespace Marten.Events.Schema;
@@ -14,29 +7,6 @@ internal class EventJsonDataColumn: TableColumn, IEventTableColumn
     public EventJsonDataColumn(): base("data", "jsonb")
     {
         AllowNulls = false;
-    }
-
-    public void GenerateSelectorCodeSync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        throw new NotSupportedException();
-    }
-
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        throw new NotSupportedException();
-    }
-
-    public void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full)
-    {
-        // Generated equivalent of:
-        //   var parameter{i} = parameterBuilder.AppendParameter<object>(DBNull.Value);
-        //   session.Serializer.WriteToParameter(parameter{i}, evt.Data);
-        // Skips the intermediate UTF-16 string allocation that Serializer.ToJson(evt.Data)
-        // would emit, instead serializing directly to a sized UTF-8 byte[] bound to the
-        // parameter.
-        method.Frames.Code($"var parameter{index} = parameterBuilder.{nameof(IGroupedParameterBuilder.AppendParameter)}<object>({typeof(DBNull).FullName}.Value);");
-        method.Frames.Code($"{{0}}.Serializer.{nameof(ISerializer.WriteToParameter)}(parameter{index}, {{1}}.{nameof(IEvent.Data)});",
-            Use.Type<IMartenSession>(), Use.Type<IEvent>());
     }
 
     public string ValueSql(EventGraph graph, AppendMode mode)

--- a/src/Marten/Events/Schema/EventTableColumn.cs
+++ b/src/Marten/Events/Schema/EventTableColumn.cs
@@ -2,13 +2,9 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using JasperFx.CodeGeneration;
-using JasperFx.CodeGeneration.Frames;
-using Marten.Internal.CodeGeneration;
 using Marten.Linq.Parsing;
 using JasperFx.Core.Reflection;
 using JasperFx.Events;
-using Npgsql;
 using NpgsqlTypes;
 using Weasel.Core;
 using Weasel.Postgresql;
@@ -43,31 +39,6 @@ internal class EventTableColumn: TableColumn, IEventTableColumn
     public MemberInfo Member { get; }
 
     public NpgsqlDbType NpgsqlDbType { get; set; }
-
-    public void GenerateSelectorCodeSync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.IfDbReaderValueIsNotNull(index, () =>
-        {
-            method.AssignMemberFromReader(null, index, _eventMemberExpression);
-        });
-    }
-
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.IfDbReaderValueIsNotNullAsync(index, () =>
-        {
-            method.AssignMemberFromReaderAsync(null, index, _eventMemberExpression);
-        });
-    }
-
-    public virtual void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full)
-    {
-        method.Frames.Code(
-            $"var parameter{index} = parameterBuilder.{nameof(IGroupedParameterBuilder.AppendParameter)}({{0}}.{Member.Name});", Use.Type<IEvent>());
-
-        method.Frames.Code($"parameter{index}.{nameof(NpgsqlParameter.NpgsqlDbType)} = {{0}};", NpgsqlDbType);
-
-    }
 
     public virtual string ValueSql(EventGraph graph, AppendMode mode)
     {

--- a/src/Marten/Events/Schema/EventTypeColumn.cs
+++ b/src/Marten/Events/Schema/EventTypeColumn.cs
@@ -1,7 +1,3 @@
-using System;
-using JasperFx.CodeGeneration;
-using JasperFx.Events;
-using Marten.Internal.CodeGeneration;
 using Weasel.Postgresql.Tables;
 
 namespace Marten.Events.Schema;
@@ -11,21 +7,6 @@ internal class EventTypeColumn: TableColumn, IEventTableColumn
     public EventTypeColumn(): base("type", "varchar(500)")
     {
         AllowNulls = false;
-    }
-
-    public void GenerateSelectorCodeSync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        throw new NotSupportedException();
-    }
-
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        throw new NotSupportedException();
-    }
-
-    public void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full)
-    {
-        method.SetParameterFromMember<IEvent>(index, x => x.EventTypeName);
     }
 
     public string ValueSql(EventGraph graph, AppendMode mode)

--- a/src/Marten/Events/Schema/IEventTableColumn.cs
+++ b/src/Marten/Events/Schema/IEventTableColumn.cs
@@ -1,7 +1,6 @@
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using JasperFx.CodeGeneration;
 using JasperFx.Events;
 using Marten.Services;
 
@@ -14,7 +13,9 @@ public enum AppendMode
 }
 
 /// <summary>
-///     This interface is used by the event store code generation to build the IEventStorage
+///     Describes a column on <c>mt_events</c> for the closed-shape event-storage
+///     adapter. Implementations expose the SQL fragment used to write the column
+///     plus runtime read/write delegates — no codegen.
 /// </summary>
 internal interface IEventTableColumn
 {
@@ -23,58 +24,23 @@ internal interface IEventTableColumn
     /// </summary>
     string Name { get; }
 
-    /// <summary>
-    ///     Generate the synchronous IEventSelector code for this event table column
-    /// </summary>
-    /// <param name="method"></param>
-    /// <param name="graph"></param>
-    /// <param name="index"></param>
-    public void GenerateSelectorCodeSync(GeneratedMethod method, EventGraph graph, int index);
-
-    /// <summary>
-    ///     Generate the asynchronous IEventSelector code for this event table column
-    /// </summary>
-    /// <param name="method"></param>
-    /// <param name="graph"></param>
-    /// <param name="index"></param>
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, EventGraph graph, int index);
-
-    /// <summary>
-    ///     Generate code for this column to capture the NpgsqlParameter value that should
-    ///     be persisted when appending an event to the events table
-    /// </summary>
-    /// <param name="method"></param>
-    /// <param name="graph"></param>
-    /// <param name="index"></param>
-    /// <param name="full"></param>
-    public void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full);
-
     string ValueSql(EventGraph graph, AppendMode mode);
 
     /// <summary>
-    ///     Runtime equivalent of <see cref="GenerateSelectorCodeSync"/> — reads this
-    ///     column's value from the given reader ordinal and assigns it onto the event.
-    ///     Used by the closed-shape event-storage hierarchy (#4410 W4) so the read
-    ///     path doesn't depend on runtime codegen.
+    ///     Read this column's value from the given reader ordinal and assign it
+    ///     onto the event. Used by
+    ///     <c>ClosedShapeEventDocumentStorage.ApplyReaderDataToEvent</c>.
     /// </summary>
-    /// <remarks>
-    ///     Default implementation throws — concrete column types override. The
-    ///     codegen path (today's default) doesn't call this; only the closed-shape
-    ///     <c>ClosedShapeEventDocumentStorage.ApplyReaderDataToEvent</c> does.
-    ///     Tracking issue: #4411.
-    /// </remarks>
     void ReadValueSync(DbDataReader reader, int index, IEvent @event)
         => throw new System.NotImplementedException(
-            $"Column '{Name}' ({GetType().Name}) does not implement ReadValueSync. " +
-            $"See #4411 — every concrete IEventTableColumn needs this runtime port of GenerateSelectorCodeSync.");
+            $"Column '{Name}' ({GetType().Name}) does not implement ReadValueSync.");
 
     /// <summary>
-    ///     Asynchronous twin of <see cref="ReadValueSync"/>.
+    ///     Asynchronous twin of <see cref="ReadValueSync(DbDataReader, int, IEvent)"/>.
     /// </summary>
     Task ReadValueAsync(DbDataReader reader, int index, IEvent @event, CancellationToken cancellation)
         => throw new System.NotImplementedException(
-            $"Column '{Name}' ({GetType().Name}) does not implement ReadValueAsync. " +
-            $"See #4411 — every concrete IEventTableColumn needs this runtime port of GenerateSelectorCodeAsync.");
+            $"Column '{Name}' ({GetType().Name}) does not implement ReadValueAsync.");
 
     /// <summary>
     ///     Serializer-aware read for columns that need session-level state to

--- a/src/Marten/Events/Schema/SequenceColumn.cs
+++ b/src/Marten/Events/Schema/SequenceColumn.cs
@@ -1,5 +1,3 @@
-using JasperFx.CodeGeneration;
-
 namespace Marten.Events.Schema;
 
 internal class SequenceColumn: EventTableColumn
@@ -12,14 +10,5 @@ internal class SequenceColumn: EventTableColumn
     public override string ValueSql(EventGraph graph, AppendMode mode)
     {
         return mode == AppendMode.Full ? base.ValueSql(graph, mode) : $"nextval('{graph.DatabaseSchemaName}.mt_events_sequence')";
-    }
-
-
-    public override void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode mode)
-    {
-        if (mode == AppendMode.Full)
-        {
-            base.GenerateAppendCode(method, graph, index, mode);
-        }
     }
 }

--- a/src/Marten/Events/Schema/StreamIdColumn.cs
+++ b/src/Marten/Events/Schema/StreamIdColumn.cs
@@ -2,7 +2,6 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using JasperFx.CodeGeneration;
 using JasperFx.Events;
 using Marten.Internal.CodeGeneration;
 using Weasel.Postgresql.Tables;
@@ -34,42 +33,6 @@ internal class StreamIdColumn: TableColumn, IEventTableColumn
             _streamIdentity == StreamIdentity.AsGuid
                 ? EventColumnReaders.BuildAsync(x => x.StreamId)
                 : EventColumnReaders.BuildAsync(x => x.StreamKey));
-    }
-
-    public void GenerateSelectorCodeSync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        if (graph.StreamIdentity == StreamIdentity.AsGuid)
-        {
-            method.AssignMemberFromReader<IEvent>(null, index, x => x.StreamId);
-        }
-        else
-        {
-            method.AssignMemberFromReader<IEvent>(null, index, x => x.StreamKey);
-        }
-    }
-
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        if (graph.StreamIdentity == StreamIdentity.AsGuid)
-        {
-            method.AssignMemberFromReaderAsync<IEvent>(null, index, x => x.StreamId);
-        }
-        else
-        {
-            method.AssignMemberFromReaderAsync<IEvent>(null, index, x => x.StreamKey);
-        }
-    }
-
-    public void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full)
-    {
-        if (graph.StreamIdentity == StreamIdentity.AsGuid)
-        {
-            method.SetParameterFromMember<StreamAction>(index, x => x.Id);
-        }
-        else
-        {
-            method.SetParameterFromMember<StreamAction>(index, x => x.Key);
-        }
     }
 
     public string ValueSql(EventGraph graph, AppendMode mode)

--- a/src/Marten/Events/Schema/StreamsTable.cs
+++ b/src/Marten/Events/Schema/StreamsTable.cs
@@ -2,9 +2,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using JasperFx.CodeGeneration;
 using Marten.Events.Archiving;
-using Marten.Internal.CodeGeneration;
 using Marten.Linq.Parsing;
 using Marten.Storage;
 using Marten.Storage.Metadata;
@@ -76,10 +74,6 @@ internal interface IStreamTableColumn
     bool Writes { get; }
 
     string Name { get; }
-    void GenerateAppendCode(GeneratedMethod method, int index);
-
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, int index);
-    public void GenerateSelectorCodeSync(GeneratedMethod method, int index);
 }
 
 internal class StreamTableColumn: TableColumn, IStreamTableColumn
@@ -101,19 +95,4 @@ internal class StreamTableColumn: TableColumn, IStreamTableColumn
 
     public bool Reads { get; set; } = true;
     public bool Writes { get; set; } = true;
-
-    public void GenerateAppendCode(GeneratedMethod method, int index)
-    {
-        method.SetParameterFromMember(index, _memberExpression);
-    }
-
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, int index)
-    {
-        method.AssignMemberFromReader(null, index, typeof(StreamAction), _member.Name);
-    }
-
-    public void GenerateSelectorCodeSync(GeneratedMethod method, int index)
-    {
-        method.AssignMemberFromReaderAsync(null, index, typeof(StreamAction), _member.Name);
-    }
 }

--- a/src/Marten/Internal/ProviderGraph.cs
+++ b/src/Marten/Internal/ProviderGraph.cs
@@ -1,11 +1,8 @@
 #nullable enable
 using System;
 using ImTools;
-using JasperFx.CodeGeneration;
-using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.Events;
-using JasperFx.RuntimeCompiler;
 using Marten.Events;
 using Marten.Internal.CodeGeneration;
 using Marten.Internal.Storage;
@@ -71,18 +68,16 @@ public class ProviderGraph: IProviderGraph
 
         if (documentType == typeof(IEvent))
         {
-            var rules = _options.CreateGenerationRules();
-            // 9.0 (#4309): route through the AllowRuntimeCodeGeneration gate
-            // so users can opt into AOT-friendly mode by setting the flag to
-            // false (in which case missing pre-generated types throw rather
-            // than silently triggering Roslyn).
-            StaticOnlyCodeFileLoader.Initialize(
-                _options.EventGraph, rules, _options.EventGraph, null,
-                _options.AllowRuntimeCodeGeneration);
+            // Phase 4 (#4454): closed-shape event storage is the only path —
+            // no codegen, no AllowRuntimeCodeGeneration gate to honor here.
+            // EventGraph.AttachTypesSynchronously builds
+            // ClosedShapeEventDocumentStorage directly.
+            _options.EventGraph.AttachTypesSynchronously(
+                rules: null!, assembly: null!, services: null, containingNamespace: string.Empty);
 
-            _storage = _storage.AddOrUpdate(documentType, _options.EventGraph.Provider);
+            _storage = _storage.AddOrUpdate(documentType, _options.EventGraph.Provider!);
 
-            return _options.EventGraph.Provider.As<DocumentProvider<T>>();
+            return _options.EventGraph.Provider!.As<DocumentProvider<T>>();
         }
 
         var mapping = _options.Storage.FindMapping(documentType);

--- a/src/Marten/Storage/Metadata/CausationIdColumn.cs
+++ b/src/Marten/Storage/Metadata/CausationIdColumn.cs
@@ -34,27 +34,6 @@ internal class CausationIdColumn: MetadataColumn<string>, ISelectableColumn, IEv
         ShouldUpdatePartials = true;
     }
 
-    public void GenerateSelectorCodeSync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.IfDbReaderValueIsNotNull(index, () =>
-        {
-            method.AssignMemberFromReader<IEvent>(null, index, x => x.CausationId);
-        });
-    }
-
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.IfDbReaderValueIsNotNullAsync(index, () =>
-        {
-            method.AssignMemberFromReaderAsync<IEvent>(null, index, x => x.CausationId);
-        });
-    }
-
-    public void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full)
-    {
-        method.SetParameterFromMember<IEvent>(index, x => x.CausationId);
-    }
-
     public void GenerateCode(StorageStyle storageStyle, GeneratedType generatedType, GeneratedMethod async,
         GeneratedMethod sync,
         int index, DocumentMapping mapping)

--- a/src/Marten/Storage/Metadata/CorrelationIdColumn.cs
+++ b/src/Marten/Storage/Metadata/CorrelationIdColumn.cs
@@ -34,27 +34,6 @@ internal class CorrelationIdColumn: MetadataColumn<string>, ISelectableColumn, I
         ShouldUpdatePartials = true;
     }
 
-    public void GenerateSelectorCodeSync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.IfDbReaderValueIsNotNull(index, () =>
-        {
-            method.AssignMemberFromReader<IEvent>(null, index, x => x.CorrelationId);
-        });
-    }
-
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.IfDbReaderValueIsNotNullAsync(index, () =>
-        {
-            method.AssignMemberFromReaderAsync<IEvent>(null, index, x => x.CorrelationId);
-        });
-    }
-
-    public void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full)
-    {
-        method.SetParameterFromMember<IEvent>(index, x => x.CorrelationId);
-    }
-
     public void GenerateCode(StorageStyle storageStyle, GeneratedType generatedType, GeneratedMethod async,
         GeneratedMethod sync,
         int index, DocumentMapping mapping)

--- a/src/Marten/Storage/Metadata/DotNetTypeColumn.cs
+++ b/src/Marten/Storage/Metadata/DotNetTypeColumn.cs
@@ -1,9 +1,5 @@
-using System;
-using JasperFx.CodeGeneration;
-using JasperFx.Events;
 using Marten.Events;
 using Marten.Events.Schema;
-using Marten.Internal.CodeGeneration;
 using Marten.Schema;
 
 namespace Marten.Storage.Metadata;
@@ -13,21 +9,6 @@ internal class DotNetTypeColumn: MetadataColumn<string>, IEventTableColumn
     public DotNetTypeColumn(): base(SchemaConstants.DotNetTypeColumn, x => x.DotNetType)
     {
         AllowNulls = true;
-    }
-
-    public void GenerateSelectorCodeSync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        throw new NotSupportedException();
-    }
-
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        throw new NotSupportedException();
-    }
-
-    public void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full)
-    {
-        method.SetParameterFromMember<IEvent>(index, x => x.DotNetTypeName);
     }
 
     public string ValueSql(EventGraph graph, AppendMode mode)

--- a/src/Marten/Storage/Metadata/HeadersColumn.cs
+++ b/src/Marten/Storage/Metadata/HeadersColumn.cs
@@ -30,32 +30,6 @@ internal class HeadersColumn: MetadataColumn<Dictionary<string, object>>, IEvent
         Enabled = false;
     }
 
-    public void GenerateSelectorCodeSync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.IfDbReaderValueIsNotNull(index, () =>
-        {
-            method.AssignMemberFromReader<IEvent>(null, index, x => x.Headers);
-        });
-    }
-
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.IfDbReaderValueIsNotNullAsync(index, () =>
-        {
-            method.AssignMemberFromReaderAsync<IEvent>(null, index, x => x.Headers);
-        });
-    }
-
-    public void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full)
-    {
-        // Use Serializer.WriteToParameter to skip the intermediate UTF-16 string
-        // allocation that Serializer.ToJson(evt.Headers) would emit; the resulting
-        // sized UTF-8 byte[] binds directly to the parameter.
-        method.Frames.Code($"var parameter{index} = parameterBuilder.{nameof(IGroupedParameterBuilder.AppendParameter)}<object>({typeof(DBNull).FullName}.Value);");
-        method.Frames.Code($"{{0}}.Serializer.{nameof(ISerializer.WriteToParameter)}(parameter{index}, {{1}}.{nameof(IEvent.Headers)});",
-            Use.Type<IMartenSession>(), Use.Type<IEvent>());
-    }
-
     internal override async Task ApplyAsync(IMartenSession martenSession, DocumentMetadata metadata, int index,
         DbDataReader reader, CancellationToken token)
     {

--- a/src/Marten/Storage/Metadata/TenantIdColumn.cs
+++ b/src/Marten/Storage/Metadata/TenantIdColumn.cs
@@ -28,27 +28,6 @@ internal class TenantIdColumn: MetadataColumn<string>, ISelectableColumn, IEvent
         DefaultExpression = $"'{StorageConstants.DefaultTenantId}'";
     }
 
-    public void GenerateSelectorCodeSync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.IfDbReaderValueIsNotNull(index, () =>
-        {
-            method.AssignMemberFromReader<IEvent>(null, index, x => x.TenantId);
-        });
-    }
-
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.IfDbReaderValueIsNotNullAsync(index, () =>
-        {
-            method.AssignMemberFromReaderAsync<IEvent>(null, index, x => x.TenantId);
-        });
-    }
-
-    public void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full)
-    {
-        method.SetParameterFromMember<StreamAction>(index, x => x.TenantId);
-    }
-
     public void GenerateCode(StorageStyle storageStyle, GeneratedType generatedType, GeneratedMethod async,
         GeneratedMethod sync,
         int index, DocumentMapping mapping)
@@ -72,21 +51,6 @@ internal class TenantIdColumn: MetadataColumn<string>, ISelectableColumn, IEvent
     public bool ShouldSelect(DocumentMapping mapping, StorageStyle storageStyle)
     {
         return Member != null;
-    }
-
-    void IStreamTableColumn.GenerateAppendCode(GeneratedMethod method, int index)
-    {
-        method.SetParameterFromMember<StreamAction>(index, x => x.TenantId);
-    }
-
-    void IStreamTableColumn.GenerateSelectorCodeAsync(GeneratedMethod method, int index)
-    {
-        throw new NotSupportedException();
-    }
-
-    void IStreamTableColumn.GenerateSelectorCodeSync(GeneratedMethod method, int index)
-    {
-        throw new NotSupportedException();
     }
 
     bool IStreamTableColumn.Reads => true;

--- a/src/Marten/Storage/Metadata/UserNameColumn.cs
+++ b/src/Marten/Storage/Metadata/UserNameColumn.cs
@@ -34,27 +34,6 @@ internal class UserNameColumn: MetadataColumn<string>, ISelectableColumn, IEvent
         ShouldUpdatePartials = true;
     }
 
-    public void GenerateSelectorCodeSync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.IfDbReaderValueIsNotNull(index, () =>
-        {
-            method.AssignMemberFromReader<IEvent>(null, index, x => x.UserName);
-        });
-    }
-
-    public void GenerateSelectorCodeAsync(GeneratedMethod method, EventGraph graph, int index)
-    {
-        method.IfDbReaderValueIsNotNullAsync(index, () =>
-        {
-            method.AssignMemberFromReaderAsync<IEvent>(null, index, x => x.UserName);
-        });
-    }
-
-    public void GenerateAppendCode(GeneratedMethod method, EventGraph graph, int index, AppendMode full)
-    {
-        method.SetParameterFromMember<IEvent>(index, x => x.UserName);
-    }
-
     public void GenerateCode(StorageStyle storageStyle, GeneratedType generatedType, GeneratedMethod async,
         GeneratedMethod sync,
         int index, DocumentMapping mapping)


### PR DESCRIPTION
## Summary

Phase 4 of #4454. The audit half is short: **no daemon/projection codegen lives in Marten anymore** — aggregator / event-applier / fan-out emit moved to JasperFx.Events source generators well before this branch. Nothing to port.

The cleanup half drops the orphan event-side Roslyn-emit methods left over after Phase 2 deleted `EventDocumentStorageGenerator`, and takes a ProviderGraph shortcut now that `EventGraph.AttachTypesSynchronously` is unconditional.

### Audit findings

- `src/Marten/Events/CodeGeneration/` contains only `MartenIgnoreAttribute.cs`.
- All `.GenerateXxxCode(method, ...)` callers in `src/Marten/` are doc-comments referencing methods this PR deletes — zero live call sites.
- The remaining `JasperFx.CodeGeneration` consumers are doc-storage paths (`MetadataColumn.GenerateCode` / `UpsertArgument.*` / `IIdGeneration.GenerateCode`) — left for Phase 5, entangled with `JasperFx.RuntimeCompiler` package removal.

### Changes

- `IEventTableColumn`: drop `GenerateSelectorCodeSync` / `GenerateSelectorCodeAsync` / `GenerateAppendCode` + `JasperFx.CodeGeneration` import. Runtime `ReadValueSync/Async` + `ValueSql` is the live closed-shape surface.
- `IStreamTableColumn`: drop the same three `Generate*` methods.
- Concrete column impls trimmed: `EventTableColumn`, `EventTypeColumn`, `EventJsonDataColumn`, `SequenceColumn`, `StreamIdColumn`, `StreamTableColumn`, `IsArchivedColumn`, and the `IEventTableColumn` / `IStreamTableColumn` facets of `TenantIdColumn`, `UserNameColumn`, `CausationIdColumn`, `CorrelationIdColumn`, `HeadersColumn`, `DotNetTypeColumn`.
- `ProviderGraph.CreateDocumentProvider<T>` IEvent branch calls `EventGraph.AttachTypesSynchronously` directly — no `GenerationRules` build, no `StaticOnlyCodeFileLoader` dispatch, no `AllowRuntimeCodeGeneration` gate. The closed-shape adapter constructs unconditionally so the gate is moot for events.
- Drop two stale doc-comment references on metadata binders.

Net: -373 / +25 lines.

## Test plan

- [x] Build clean (0 errors)
- [x] `EventSourcingTests` — 1333 pass, 5 pre-existing skips, 0 fail (net10.0)
- [x] `DaemonTests` — 185/185 pass (net10.0)
- [ ] Full CI matrix

Part of #4454. Phase 5 ("Boom") is next: remove the `JasperFx.RuntimeCompiler` PackageReference and retire the doc-side `GenerateCode` surface + `dotnet marten codegen` CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)