### PR TITLE
[#4462] Don't classify caller-cancelled OCE as a daemon error in ForceAllMartenDaemonActivityToCatchUpAsync

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4441_force_catch_up_with_outbox.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4441_force_catch_up_with_outbox.cs
@@ -81,7 +81,7 @@ public class Bug_4441_force_catch_up_with_outbox
         exceptions.ShouldBeEmpty();
     }
 
-    [Fact(Timeout = 30000, Skip = "Flaky in CI under timing pressure — see https://github.com/JasperFx/marten/issues/4462. Passes locally 3-for-3 but CI's Polly retry pipeline cancels the daemon catch-up socket I/O before it completes, surfacing an OperationCanceledException in the returned exceptions list.")]
+    [Fact(Timeout = 60000)]
     public async Task force_catch_up_invokes_message_batch_lifecycle_with_custom_outbox()
     {
         var outbox = new RecordingOutbox();
@@ -108,7 +108,11 @@ public class Bug_4441_force_catch_up_with_outbox
             await session.SaveChangesAsync();
         }
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        // Wider CT than `force_catch_up_returns_for_async_daemon_without_side_effects`
+        // because the custom-outbox lifecycle path adds extra hops (CreateBatch →
+        // BeforeCommit → AfterCommit per shard) on top of the catch-up loop —
+        // see #4462 for the timing context.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(45));
         var exceptions = await host.ForceAllMartenDaemonActivityToCatchUpAsync(cts.Token);
         exceptions.ShouldBeEmpty();
 

--- a/src/Marten/Events/AsyncProjectionTestingExtensions.cs
+++ b/src/Marten/Events/AsyncProjectionTestingExtensions.cs
@@ -345,6 +345,17 @@ public static class TestingExtensions
 
                 logger.LogDebug("Executed a ProjectionDaemon.CatchUp() against {Daemon} in the main Marten store", daemon);
             }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+            {
+                // Caller-initiated cancellation — propagate as a normal cancellation
+                // signal rather than reporting it as a daemon error. Without this,
+                // a test that supplies a CTS that fires while the daemon's
+                // catch-up pipeline (Polly-wrapped per-shard execution) is mid-
+                // flight would see the propagated OperationCanceledException
+                // surface as a fake "exceptions list is non-empty" assertion
+                // failure — see #4462.
+                throw;
+            }
             catch (Exception e)
             {
                 logger.LogError(e, "Error trying to execute a CatchUp on {Daemon} in the main Marten store", daemon);
@@ -404,6 +415,13 @@ public static class TestingExtensions
                 }
 
                 logger.LogDebug("Executed a ProjectionDaemon.CatchUp() against {Daemon} in Marten store {StoreType}", daemon, typeof(T).FullNameInCode());
+            }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+            {
+                // Caller-initiated cancellation — propagate, do not classify as
+                // a daemon error. See #4462 + matching guard on the main-store
+                // variant above.
+                throw;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Summary

Closes #4462. The `force_catch_up_invokes_message_batch_lifecycle_with_custom_outbox` test flaked in CI under timing pressure during the Phase 5 PR (#4461). Root cause is the `ForceAllMartenDaemonActivityToCatchUpAsync` contract treating a caller-initiated `OperationCanceledException` as if it were a daemon error.

### The flake

```
Shouldly.ShouldAssertException : exceptions
    should be empty but had
1
    item and was
[System.AggregateException: One or more errors occurred. (The operation was canceled.)
 ---> System.OperationCanceledException: The operation was canceled.
   at Polly.Utils.ExceptionUtilities.TrySetStackTrace[T](T exception)
   ...
   at Marten.Events.TestingExtensions.ForceAllMartenDaemonActivityToCatchUpAsync(...)]
```

The test passes a 15s `CancellationTokenSource` to the helper. Under CI load, the per-shard catch-up pipeline (Polly-wrapped event-loader execution → `SpinUpMessageBatchAsync` → custom outbox lifecycle: `CreateBatch` → `BeforeCommit` → `AfterCommit`) doesn't finish in time. The CTS fires, the OCE propagates up through Polly, the `catch (Exception)` in `ForceAllMartenDaemonActivityToCatchUpAsync` grabs it, and it lands in the returned list. The test asserts `exceptions.ShouldBeEmpty()` and fails — the assertion message implies a daemon bug when the real signal was "the test ran out of time."

### Fix

`AsyncProjectionTestingExtensions.cs` — both the primary-store and the `<T>` variants — get a new `catch (OperationCanceledException) when (cancellation.IsCancellationRequested)` guard that re-throws. Non-cancellation exceptions (and OCEs from sources other than the caller's CT) still flow into the returned list as before, preserving the documented "catch-and-list" contract for real daemon errors. Caller's own cancellations propagate as a normal cancellation signal (or `TaskCanceledException` on the test side), failing the test with a clear "timed out" message rather than a misleading assertion.

The Bug_4441 test:
- Skip attribute removed.
- Outer `[Fact(Timeout = ...)]` raised from 30s → 60s.
- Inner CTS raised from 15s → 45s.

Two pieces of timing headroom because the custom-outbox variant has measurable extra hops (`CreateBatch` + per-shard `BeforeCommit`/`AfterCommit`) on top of the catch-up loop the sibling `force_catch_up_returns_*` test exercises.

## Test plan

- [x] Build clean (0 errors)
- [x] Test ran locally 5 times back-to-back — all pass (~500-600ms each)
- [x] Full `EventSourcingTests` — 1333 pass, 5 pre-existing skips, 0 fail (net10.0) — Bug_4441 is back in the green count
- [ ] CI matrix (the fix is most relevant to the slower Event Sourcing lanes where the original flake fired)

Closes #4462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)