### PR TITLE
[#4183] PostgreSQL LISTEN/NOTIFY support for async daemon wakeup (supersedes #4181)

### DIFF
--- a/src/EventSourcingTests/Daemon/postgres_listen_notify_wakeup_tests.cs
+++ b/src/EventSourcingTests/Daemon/postgres_listen_notify_wakeup_tests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Aggregation;
+using Marten.Events.Daemon.HighWater;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Daemon;
+
+// Covers the IDaemonWakeup contract implementation in
+// Marten.Events.Daemon.HighWater.PostgresqlListenWakeup.
+//
+// The wakeup opens a dedicated NpgsqlConnection that LISTENs on its
+// channel, plus a Task.Run loop that drives Npgsql's connection.WaitAsync
+// to dispatch incoming NOTIFYs. WaitAsync() then awaits a SemaphoreSlim
+// the dispatcher releases.
+//
+// The tests fire a `pg_notify(...)` from a SEPARATE connection (the
+// production flow runs pg_notify inside the event-append transaction;
+// from the wakeup's point of view it's indistinguishable from any other
+// LISTEN/NOTIFY signal). We then assert the wakeup unblocks well before
+// the wait timeout — i.e. the listener wired the signal up correctly.
+public class postgres_listen_notify_wakeup_tests
+{
+    [Fact]
+    public async Task wait_async_returns_quickly_when_a_pg_notify_arrives()
+    {
+        var dataSource = NpgsqlDataSource.Create(ConnectionSource.ConnectionString);
+        try
+        {
+            using var wakeup = new PostgresqlListenWakeup(
+                dataSource,
+                NullLogger.Instance,
+                channel: "marten_test_listen_notify_wakeup");
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+            // Prime the LISTEN connection so the receiveLoop is up and dispatching
+            // before we fire the NOTIFY. Without this prime the NOTIFY can arrive
+            // before LISTEN registers and is dropped. We use the long-lived test
+            // CT (not a short timeout) so the prime doesn't tear the listener
+            // down before we get to the real wait.
+            await wakeup.WaitAsync(TimeSpan.FromMilliseconds(200), cts.Token);
+
+            var waitTask = wakeup.WaitAsync(TimeSpan.FromSeconds(10), cts.Token);
+
+            // Tiny grace period so the wait task is parked on the semaphore before
+            // pg_notify fires — WaitAsync drains accumulated signals at the top,
+            // so a notify that lands during the drain would be lost.
+            await Task.Delay(50, cts.Token);
+
+            await using (var notifier = await dataSource.OpenConnectionAsync(cts.Token))
+            await using (var cmd = notifier.CreateCommand())
+            {
+                cmd.CommandText = "select pg_notify('marten_test_listen_notify_wakeup', '')";
+                await cmd.ExecuteNonQueryAsync(cts.Token);
+            }
+
+            var sw = Stopwatch.StartNew();
+            await waitTask;
+            sw.Stop();
+
+            sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(2),
+                $"WaitAsync should unblock soon after the NOTIFY — took {sw.ElapsedMilliseconds}ms");
+        }
+        finally
+        {
+            await dataSource.DisposeAsync();
+        }
+    }
+
+    public record LnInc(int N);
+
+    public class LnCount
+    {
+        public Guid Id { get; set; }
+        public int Total { get; set; }
+    }
+
+    public class LnProjection: SingleStreamProjection<LnCount, Guid>
+    {
+        public override LnCount Evolve(LnCount? snapshot, Guid id, IEvent e)
+        {
+            snapshot ??= new LnCount { Id = id };
+            if (e.Data is LnInc inc) snapshot.Total += inc.N;
+            return snapshot;
+        }
+    }
+
+    [Fact]
+    public async Task daemon_wakes_up_through_pg_notify_when_flag_is_on()
+    {
+        // End-to-end smoke: flip the new opt-in flag, append a single event,
+        // and assert the async projection catches up promptly via the
+        // LISTEN/NOTIFY signal (rather than waiting on the slow poll cycle).
+        // The point isn't to nail down an exact wakeup latency — it's to
+        // pin the wiring: NotifyEventAppendedOperation actually fires
+        // pg_notify in the append transaction, PostgresqlListenWakeup
+        // actually gets a signal, and the daemon advances. A correctness-only
+        // assertion ("the projection processes the event before the test
+        // CT fires") sidesteps timing flakes.
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(s =>
+            {
+                s.AddMarten(m =>
+                {
+                    m.Connection(ConnectionSource.ConnectionString);
+                    m.DatabaseSchemaName = "bug4183_listen_notify";
+                    m.Events.UseListenNotifyForEventAppends = true;
+                    m.Projections.Add<LnProjection>(ProjectionLifecycle.Async);
+
+                    // Force the polling fallback to be slow so the test
+                    // only completes if LISTEN/NOTIFY actually fired —
+                    // otherwise we'd be measuring the poll cycle, not
+                    // the wakeup wiring.
+                    m.Projections.StaleSequenceThreshold = TimeSpan.FromSeconds(30);
+                }).AddAsyncDaemon(DaemonMode.Solo);
+            })
+            .StartAsync();
+
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<LnCount>(streamId, new LnInc(7));
+            await session.SaveChangesAsync();
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        LnCount? loaded = null;
+        while (!cts.IsCancellationRequested)
+        {
+            await using var query = store.QuerySession();
+            loaded = await query.LoadAsync<LnCount>(streamId, cts.Token);
+            if (loaded is { Total: 7 }) break;
+            await Task.Delay(100, cts.Token);
+        }
+
+        loaded.ShouldNotBeNull();
+        loaded!.Total.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task wait_async_returns_when_timeout_elapses_without_a_notification()
+    {
+        // Sanity check the timeout path — no notification fires, so WaitAsync
+        // returns when the per-call timeout elapses (the safety-net fallback
+        // that keeps the daemon polling at the configured pace if the
+        // listener stays silent).
+        var dataSource = NpgsqlDataSource.Create(ConnectionSource.ConnectionString);
+        try
+        {
+            using var wakeup = new PostgresqlListenWakeup(
+                dataSource,
+                NullLogger.Instance,
+                channel: "marten_test_listen_notify_wakeup_silent");
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            var sw = Stopwatch.StartNew();
+            await wakeup.WaitAsync(TimeSpan.FromMilliseconds(300), cts.Token);
+            sw.Stop();
+
+            sw.Elapsed.ShouldBeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(250));
+            sw.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            await dataSource.DisposeAsync();
+        }
+    }
+}

--- a/src/Marten/Events/Daemon/HighWater/PostgresqlListenWakeup.cs
+++ b/src/Marten/Events/Daemon/HighWater/PostgresqlListenWakeup.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Daemon.HighWater;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+namespace Marten.Events.Daemon.HighWater;
+
+/// <summary>
+/// Uses PostgreSQL LISTEN/NOTIFY to wake the <see cref="HighWaterAgent"/>
+/// immediately when new events are appended, instead of waiting for the
+/// full polling interval. Falls back to the configured timeout if no
+/// notification arrives.
+/// </summary>
+public sealed class PostgresqlListenWakeup(
+    NpgsqlDataSource dataSource,
+    ILogger logger,
+    string channel = PostgresqlListenWakeup.DefaultChannel) : IDaemonWakeup
+{
+    /// <summary>
+    /// The default PostgreSQL notification channel name used by Marten
+    /// to signal that new events have been appended to the event store.
+    /// </summary>
+    public const string DefaultChannel = "mt_events_appended";
+
+    private readonly SemaphoreSlim _connectionLock = new(1, 1);
+    private readonly SemaphoreSlim _signal = new(0);
+    private readonly CancellationTokenSource _lifetime = new();
+    private NpgsqlConnection? _connection;
+    private Task? _receiveTask;
+    private volatile bool _disposed;
+
+    public async Task WaitAsync(TimeSpan timeout, CancellationToken token)
+    {
+        await ensureListeningAsync(token).ConfigureAwait(false);
+
+        // Drain any accumulated signals so we don't spin through
+        // multiple rapid iterations after a burst of notifications.
+        while (_signal.CurrentCount > 0)
+        {
+            await _signal.WaitAsync(0, token).ConfigureAwait(false);
+        }
+
+        await _signal.WaitAsync(timeout, token).ConfigureAwait(false);
+    }
+
+    private async Task ensureListeningAsync(CancellationToken token)
+    {
+        if (_connection != null) return;
+
+        await _connectionLock.WaitAsync(token).ConfigureAwait(false);
+        try
+        {
+            if (_connection != null) return;
+
+            var conn = await dataSource.OpenConnectionAsync(token).ConfigureAwait(false);
+            conn.Notification += onNotification;
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = $"LISTEN {channel}";
+                await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            }
+
+            _connection = conn;
+
+            logger.LogInformation("Listening on PostgreSQL channel '{Channel}' for event store notifications", channel);
+
+            // Drive the notification dispatch loop on the wakeup's own lifetime
+            // CTS (not the caller's token). The caller token only governs the
+            // FIRST WaitAsync; tying the long-lived receive loop to it would
+            // tear the listener down as soon as the first call returns.
+            _receiveTask = Task.Run(() => receiveLoop(_lifetime.Token), _lifetime.Token);
+        }
+        finally
+        {
+            _connectionLock.Release();
+        }
+    }
+
+    private async Task receiveLoop(CancellationToken token)
+    {
+        try
+        {
+            while (!token.IsCancellationRequested && !_disposed)
+            {
+                var conn = _connection;
+                if (conn == null) return;
+
+                try
+                {
+                    await conn.WaitAsync(TimeSpan.FromSeconds(30), token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    if (_disposed) return;
+                    logger.LogWarning(ex, "PostgreSQL LISTEN connection error, will reconnect on next poll cycle");
+
+                    conn.Notification -= onNotification;
+                    try { await conn.DisposeAsync().ConfigureAwait(false); } catch { /* best effort */ }
+
+                    _connection = null;
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during shutdown.
+        }
+    }
+
+    private void onNotification(object sender, NpgsqlNotificationEventArgs e)
+    {
+        _signal.Release();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        // Signal the receive loop to exit before disposing the connection —
+        // Npgsql throws NpgsqlOperationInProgressException if you Dispose a
+        // connection that's still parked on conn.WaitAsync.
+        try
+        {
+            _lifetime.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // _lifetime may already be disposed if Dispose is called twice
+            // by a defensive caller; nothing else to do.
+        }
+
+        // Best-effort wait for the receive loop to unwind. If the connector's
+        // cancel is slow we'd rather risk a brief block here than throw out
+        // of Dispose into a daemon shutdown path. No CT — we already cancelled
+        // _lifetime above; this Wait is just a join barrier with a bound.
+        try
+        {
+#pragma warning disable MA0040
+            _receiveTask?.Wait(TimeSpan.FromSeconds(2));
+#pragma warning restore MA0040
+        }
+        catch
+        {
+            // Ignore — receive loop has its own swallows; this guards
+            // pathological connector states only.
+        }
+
+        if (_connection != null)
+        {
+            _connection.Notification -= onNotification;
+            try { _connection.Dispose(); } catch { /* connector may already be in a torn-down state */ }
+            _connection = null;
+        }
+
+        _signal.Dispose();
+        _connectionLock.Dispose();
+        _lifetime.Dispose();
+    }
+}

--- a/src/Marten/Events/EventGraph.Processing.cs
+++ b/src/Marten/Events/EventGraph.Processing.cs
@@ -51,6 +51,11 @@ public partial class EventGraph
         }
 
         await EventAppender.ProcessEventsAsync(this, session, _inlineProjections.Value, token).ConfigureAwait(false);
+
+        if (UseListenNotifyForEventAppends)
+        {
+            session.QueueOperation(new NotifyEventAppendedOperation());
+        }
     }
 
     internal bool TryCreateTombstoneBatch(DocumentSessionBase session, [NotNullWhen(true)]out UpdateBatch? batch)

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -231,6 +231,7 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     /// </summary>
     public bool EnableExtendedProgressionTracking { get; set; }
     public bool UseArchivedStreamPartitioning { get; set; }
+    public bool UseListenNotifyForEventAppends { get; set; }
 
     /// <summary>
     /// Opt into a global, partition-spanning unique constraint on stream identity by

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -149,6 +149,14 @@ namespace Marten.Events
         public bool EnableEventSkippingInProjectionsOrSubscriptions { get; set; }
 
         /// <summary>
+        /// When enabled, uses PostgreSQL LISTEN/NOTIFY to wake the async projection daemon
+        /// immediately when new events are appended, instead of relying solely on polling.
+        /// This provides near-instant projection updates while still falling back to polling
+        /// as a safety net. Default is false.
+        /// </summary>
+        public bool UseListenNotifyForEventAppends { get; set; }
+
+        /// <summary>
         ///     Directs the schema migration functionality to ignore the presence of the named index
         ///     on the event-store tables (<c>mt_events</c>, <c>mt_streams</c>, <c>mt_event_progression</c>).
         ///     Use this when an external mechanism (e.g. a custom <c>IFeatureSchema</c>) declares an index

--- a/src/Marten/Events/Operations/NotifyEventAppendedOperation.cs
+++ b/src/Marten/Events/Operations/NotifyEventAppendedOperation.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten.Events.Daemon.HighWater;
+using Marten.Internal;
+using Marten.Internal.Operations;
+using Marten.Services;
+using Weasel.Postgresql;
+
+namespace Marten.Events.Operations;
+
+internal class NotifyEventAppendedOperation: IStorageOperation, NoDataReturnedCall
+{
+    private static readonly string Sql = $"select pg_notify('{PostgresqlListenWakeup.DefaultChannel}', '')";
+
+    public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        builder.Append(Sql);
+    }
+
+    public Type DocumentType => typeof(IEvent);
+
+    public void Postprocess(DbDataReader reader, IList<Exception> exceptions)
+    {
+    }
+
+    public Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        return Task.CompletedTask;
+    }
+
+    public OperationRole Role()
+    {
+        return OperationRole.Events;
+    }
+}

--- a/src/Marten/Storage/MartenDatabase.EventStorage.cs
+++ b/src/Marten/Storage/MartenDatabase.EventStorage.cs
@@ -312,6 +312,12 @@ select last_value from {Options.Events.DatabaseSchemaName}.mt_events_sequence;
         logger ??= store.Options.LogFactory?.CreateLogger<ProjectionDaemon>() ??
                    store.Options.DotNetLogger ?? NullLogger.Instance;
 
+        if (Options.EventGraph.UseListenNotifyForEventAppends)
+        {
+            store.Options.Projections.Wakeup =
+                new PostgresqlListenWakeup(DataSource, logger);
+        }
+
         var detector = new HighWaterDetector(this, Options.EventGraph, logger);
 
         return new ProjectionDaemon(store, this, logger, detector);


### PR DESCRIPTION
## Summary

Closes #4183. **Supersedes #4181 by @thuijer** — rebased onto Marten 9.0 master with a few fixes the original CI didn't catch. All credit for the design and original implementation goes to @thuijer; the rebase keeps his commit shape and adds him as the primary `Co-Authored-By` on the single rebase commit.

The async daemon polls Postgres at the configured interval (250ms fast / 1s slow) to spot new appends via the high-water mark. For event sourcing workloads where projections need to catch up *now*, that polling floor is unnecessary latency. This PR adds an opt-in flag that turns the wait between polls into a PostgreSQL LISTEN — when a new event is appended (in the same transaction) we `pg_notify`, the daemon's wakeup semaphore is released, and the high-water agent loops immediately. Polling remains as the safety net for missed signals.

```csharp
services.AddMarten(opts =>
{
    opts.Events.UseListenNotifyForEventAppends = true;
});
```

## Wiring

- `Marten.Events.Daemon.HighWater.PostgresqlListenWakeup` (implements `JasperFx.Events.Daemon.HighWater.IDaemonWakeup`) — opens a dedicated connection, runs `LISTEN mt_events_appended`, and dispatches Npgsql notifications onto a `SemaphoreSlim` the high-water agent awaits.
- `Marten.Events.Operations.NotifyEventAppendedOperation` — queued by `EventGraph.ProcessEventsAsync` alongside the event-append operations when the flag is on; emits `select pg_notify('mt_events_appended', '')` in the same transaction so the signal fires only on a committed append.
- `MartenDatabase.StartProjectionDaemon` — when the flag is set, replaces `DaemonSettings.Wakeup` with the LISTEN-driven wakeup before constructing the projection daemon.
- New `IEventStoreOptions.UseListenNotifyForEventAppends` knob.

## Rebase notes vs #4181

- **Rebased on top of Marten 9.0**. The original PR was authored against pre-9.0; in 9.0 the upstream `IDaemonWakeup` abstraction has already shipped in `JasperFx.Events` (2.0.0-alpha.9), so the wakeup just plugs into it.
- **Hardened `PostgresqlListenWakeup.Dispose` against `NpgsqlOperationInProgressException`.** The original disposed the connection while the receive loop was still parked on `conn.WaitAsync`, which Npgsql 10 rejects with `'Waiting'` state. The rebase introduces an internal lifetime `CancellationTokenSource` that the receive loop observes (instead of capturing the first caller's CT — which would tear the listener down the moment the first WaitAsync returns), and Dispose cancels it + joins the loop before tearing the connection down.
- Cleaned up `_signal.Wait(0, token)` → `await _signal.WaitAsync(0, token)` in the drain loop for consistency.

## Test plan

Three new tests in `EventSourcingTests.Daemon.postgres_listen_notify_wakeup_tests`:

- `wait_async_returns_quickly_when_a_pg_notify_arrives` — pins the wiring: the wakeup signals well under the timeout when an external `pg_notify` fires (uses a separate Npgsql connection — indistinguishable from the production `NotifyEventAppendedOperation` flow from the wakeup's point of view).
- `wait_async_returns_when_timeout_elapses_without_a_notification` — sanity check on the safety-net fallback (no NOTIFY → timeout elapses → WaitAsync returns).
- `daemon_wakes_up_through_pg_notify_when_flag_is_on` — end-to-end: real Marten host, real `AddAsyncDaemon`, real append. `StaleSequenceThreshold` is bumped to 30s so the assertion (`projection.Total == 7`) only succeeds if LISTEN/NOTIFY actually fired — if the test relied on the polling fallback, the test timeout (15s) would fire first.

Broader runs:

- [x] Build clean across net9.0 + net10.0 (0 errors)
- [x] All three wakeup tests pass 3-for-3 back-to-back locally
- [x] `appending_events_workflow_specs` + `Bugs.Bug_44*` smoke — 69/69 pass
- [x] `EventSourcingTests.Daemon` + `Bug_4441` — 7/7 pass
- [ ] CI matrix

## Considerations (carried over from #4183)

- Requires the writer host and the daemon host to connect to the same PostgreSQL instance. LISTEN/NOTIFY doesn't cross read replicas.
- Burns one extra long-lived connection per daemon node for the LISTEN.
- Incompatible with PgBouncer's transaction-pooling mode (LISTEN needs session-level connection state).
- Off by default. Polling stays as both the off-mode behavior and the on-mode safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)