### PR TITLE
Fix Nullable<TWrapper> id throwing in ValueTypeIdentification (#4474)

### DIFF
--- a/src/Marten/Internal/ClosedShape/ValueTypeIdentification.cs
+++ b/src/Marten/Internal/ClosedShape/ValueTypeIdentification.cs
@@ -1,7 +1,9 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Reflection;
+using FastExpressionCompiler;
 using JasperFx.Core.Reflection;
 using Marten.Schema.Identity;
 using Marten.Storage;
@@ -28,6 +30,7 @@ public sealed class ValueTypeIdentification<TDoc, TWrapper, TInner>: IIdentifica
     where TInner : notnull
 {
     private readonly Func<TDoc, TWrapper> _getter;
+    private readonly Func<TDoc, bool>? _isNullablePropertyMissing;
     private readonly Action<TDoc, TWrapper> _setter;
     private readonly Func<TWrapper, TInner> _unwrap;
     private readonly Func<TInner, TWrapper> _wrap;
@@ -35,11 +38,60 @@ public sealed class ValueTypeIdentification<TDoc, TWrapper, TInner>: IIdentifica
 
     public ValueTypeIdentification(MemberInfo idMember, ValueTypeIdGeneration vt, Type sequenceKey)
     {
-        _getter = LambdaBuilder.Getter<TDoc, TWrapper>(idMember);
+        (_getter, _isNullablePropertyMissing) = BuildAccessors(idMember);
         _setter = LambdaBuilder.Setter<TDoc, TWrapper>(idMember)!;
         _unwrap = LambdaBuilder.Getter<TWrapper, TInner>(vt.ValueProperty);
         _wrap = vt.CreateWrapper<TWrapper, TInner>();
         _generator = PickGenerator(vt.SimpleType, sequenceKey);
+    }
+
+    /// <summary>
+    /// Build the getter and an optional "is missing" predicate for the id
+    /// member. When the document declares the id as
+    /// <c>Nullable&lt;TWrapper&gt;</c>, <see cref="LambdaBuilder.Getter{T, M}"/>
+    /// would emit <c>Expression.Convert</c> from <c>Nullable&lt;TWrapper&gt;</c>
+    /// to <c>TWrapper</c>, which throws "Nullable object must have a value"
+    /// when the property is null — the exact state for a freshly constructed
+    /// document whose id hasn't been assigned. We can't substitute
+    /// <c>default(TWrapper)</c> either: Vogen-generated wrappers throw
+    /// "Use of uninitialized Value Object" on the inner-value accessor that
+    /// <see cref="AssignIfMissing"/> calls next. So for nullable property
+    /// types we return a separate <c>_isNullablePropertyMissing</c>
+    /// predicate that lets <see cref="AssignIfMissing"/> short-circuit
+    /// straight to id generation without touching the unset wrapper.
+    /// </summary>
+    private static (Func<TDoc, TWrapper> Getter, Func<TDoc, bool>? IsMissing) BuildAccessors(MemberInfo idMember)
+    {
+        var declaredType = idMember switch
+        {
+            PropertyInfo p => p.PropertyType,
+            FieldInfo f => f.FieldType,
+            _ => throw new ArgumentException(
+                $"Strong-typed id member must be a property or field; got {idMember.MemberType}.",
+                nameof(idMember))
+        };
+
+        if (Nullable.GetUnderlyingType(declaredType) != typeof(TWrapper))
+        {
+            return (LambdaBuilder.Getter<TDoc, TWrapper>(idMember), null);
+        }
+
+        var target = Expression.Parameter(typeof(TDoc), "target");
+        Expression access = idMember is PropertyInfo prop
+            ? Expression.Property(target, prop)
+            : Expression.Field(target, (FieldInfo)idMember);
+
+        // .Value would throw for the null case, but AssignIfMissing now
+        // guards every call with the predicate below, so this getter only
+        // runs when HasValue is true.
+        var unwrapNullable = Expression.Property(access, "Value");
+        var getter = Expression.Lambda<Func<TDoc, TWrapper>>(unwrapNullable, target).CompileFast();
+
+        var hasValue = Expression.Property(access, "HasValue");
+        var isMissing = Expression.Not(hasValue);
+        var predicate = Expression.Lambda<Func<TDoc, bool>>(isMissing, target).CompileFast();
+
+        return (getter, predicate);
     }
 
     public TWrapper Identity(TDoc document) => _getter(document);
@@ -60,13 +112,20 @@ public sealed class ValueTypeIdentification<TDoc, TWrapper, TInner>: IIdentifica
 
     public TWrapper AssignIfMissing(TDoc document, IMartenDatabase database)
     {
-        var current = _getter(document);
-        if (current is not null)
+        // When the id member is Nullable<TWrapper> and the property is null,
+        // skip straight to generation — calling _getter would either throw
+        // "Nullable object must have a value" or hand out an uninitialized
+        // Vogen wrapper that _unwrap would then reject.
+        if (_isNullablePropertyMissing is null || !_isNullablePropertyMissing(document))
         {
-            var inner = _unwrap(current);
-            if (!EqualityComparer<TInner>.Default.Equals(inner, default!))
+            var current = _getter(document);
+            if (current is not null)
             {
-                return current;
+                var inner = _unwrap(current);
+                if (!EqualityComparer<TInner>.Default.Equals(inner, default!))
+                {
+                    return current;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Resolves #4474.

`ValueTypeIdentification<TDoc, TWrapper, TInner>` built its `_getter` via `LambdaBuilder.Getter<TDoc, TWrapper>(idMember)`, which emits an `Expression.Convert` from `Nullable<TWrapper>` to `TWrapper` when the document's id is declared as `InvoiceId?` / `IssueId?` / etc. — the standard Vogen + StronglyTypedId pattern. On a freshly constructed document the nullable is null, so the compiled delegate threw `Nullable object must have a value` before `AssignIfMissing` could generate the id.

Substituting `default(TWrapper)` via `GetValueOrDefault()` doesn't fix it either: Vogen wrappers throw `Use of uninitialized Value Object` the moment `_unwrap(default(IssueId))` touches the inner-value accessor.

Fix: detect `Nullable<TWrapper>` id members and emit a separate `_isNullablePropertyMissing` predicate (`!Nullable.HasValue`). `AssignIfMissing` consults the predicate first and skips straight to id generation when the property is null, never touching the unset wrapper. Non-nullable id properties stay on the unchanged stock `LambdaBuilder.Getter` path.

## Results

`./build.sh test-value-types` results:

| Branch | net9.0 | net10.0 |
| ------ | ------ | ------- |
| master | 130 failed / 209 passed | 130 failed / 209 passed |
| this PR | 32 failed / 307 passed | 32 failed / 307 passed |

The remaining 32 failures are pre-existing on master and orthogonal to #4474 (different exception types, different code paths). I'll file follow-ups:

* `*duplicated_value_type_field_operations*` (14 tests) — `InvalidCastException: Writing values of 'DuplicateValueType' is not supported for parameters having NpgsqlDbType 'Uuid'.` Strong-typed wrappers used as duplicated indexed fields skip the unwrap step at parameter binding.
* `*fsharp_discriminated_union_document_operations*` (18 tests) — `InvalidDocumentException: No closed-shape id strategy is registered for ... FSharpDiscriminatedUnionIdGeneration`. F# DU id strategy needs a registration entry in `ClosedShapeRegistration`.

## Test plan

- [x] `./build.sh test-value-types` net9.0 — 32 fail, all pre-existing on master
- [x] `./build.sh test-value-types` net10.0 — 32 fail, all pre-existing on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)