### PR TITLE
Unwrap strong-typed value types in duplicated-field binder (#4477)

### DIFF
--- a/src/Marten/Internal/ClosedShape/DocumentDuplicatedFieldBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDuplicatedFieldBinder.cs
@@ -34,6 +34,7 @@ internal sealed class DocumentDuplicatedFieldBinder<TDoc>: IDocumentMetadataBind
     private readonly bool _isEnum;
     private readonly Type? _enumType;
     private readonly EnumStorage _enumStorage;
+    private readonly PropertyInfo? _valueTypeUnwrap;
 
     public DocumentDuplicatedFieldBinder(DuplicatedField field, EnumStorage enumStorage)
     {
@@ -46,6 +47,15 @@ internal sealed class DocumentDuplicatedFieldBinder<TDoc>: IDocumentMetadataBind
             ? nullableUnderlying
             : leafType.IsEnum ? leafType : null;
         _isEnum = _enumType is not null;
+
+        // For Duplicate(x => x.SomeStrongTypedWrapper), the member walk
+        // yields the wrapper struct (e.g. a Vogen / StronglyTypedId value).
+        // _field.DbType already reflects the inner primitive (Uuid / int /
+        // long / varchar), so Npgsql will reject the wrapper as a parameter
+        // value. Stash the wrapper's inner-value property here and unwrap
+        // before binding. Mirrors what ValueTypeIdentification.ToRawSqlValue
+        // does for strong-typed ids.
+        _valueTypeUnwrap = (field as DuplicatedValueTypeField)?.ValueTypeInfo.ValueProperty;
     }
 
     public string ColumnName => _field.ColumnName.ToLowerInvariant();
@@ -77,6 +87,16 @@ internal sealed class DocumentDuplicatedFieldBinder<TDoc>: IDocumentMetadataBind
             return;
         }
 
+        if (_valueTypeUnwrap is not null)
+        {
+            current = _valueTypeUnwrap.GetValue(current);
+            if (current is null)
+            {
+                parameter.Value = DBNull.Value;
+                return;
+            }
+        }
+
         parameter.Value = current;
     }
 
@@ -106,6 +126,14 @@ internal sealed class DocumentDuplicatedFieldBinder<TDoc>: IDocumentMetadataBind
             current = _enumStorage == EnumStorage.AsString
                 ? current.ToString()!
                 : Convert.ToInt32(current);
+        }
+        else if (_valueTypeUnwrap is not null)
+        {
+            current = _valueTypeUnwrap.GetValue(current);
+            if (current is null)
+            {
+                return writer.WriteNullAsync(cancellation);
+            }
         }
 
         return writer.WriteAsync(current, _field.DbType, cancellation);


### PR DESCRIPTION
## Summary

Resolves #4477.

When a document was configured with `Schema.For<T>().Duplicate(x => x.SomeStrongTypedWrapper)`, the closed-shape binder walked the member chain straight to the wrapper struct (Vogen / StronglyTypedId) and assigned it to the Npgsql parameter. `_field.DbType` was already resolved to the inner primitive (e.g. `Uuid` for a `Guid`-backed wrapper), so Npgsql rejected the parameter with `System.InvalidCastException: Writing values of 'DuplicateValueType' is not supported for parameters having NpgsqlDbType 'Uuid'.`

Fix: cache `DuplicatedValueTypeField.ValueTypeInfo.ValueProperty` during binder construction and unwrap the walked value through it before binding — in both `BindParameter` (regular insert / upsert) and `WriteToBulkAsync` (bulk import). Mirrors what `ValueTypeIdentification.ToRawSqlValue` does on the id path.

## Results

`./build.sh test-value-types` results:

| Branch | net9.0 | net10.0 |
| ------ | ------ | ------- |
| master | 32 failed / 307 passed | 32 failed / 307 passed |
| this PR | 20 failed / 319 passed | 20 failed / 319 passed |

The remaining 20 failures are all F# discriminated-union id tests tracked separately in #4478.

## Test plan

- [x] `./build.sh test-value-types` net9.0 — 20 fail, all F# DU (#4478)
- [x] `./build.sh test-value-types` net10.0 — 20 fail, all F# DU (#4478)
- [x] All 12 `*duplicated_value_type_field_operations*` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)