### PR TITLE
Route F# discriminated-union ids through closed-shape ValueType path (#4478)

### DIFF
--- a/src/Marten/Internal/ClosedShape/ClosedShapeRegistration.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeRegistration.cs
@@ -92,7 +92,13 @@ public static class ClosedShapeRegistration
     internal static DocumentProvider<TDoc> BuildSupportedProvider<TDoc>(DocumentMapping mapping)
         where TDoc : notnull
     {
-        if (mapping.IdStrategy is ValueTypeIdGeneration vt)
+        // Both ValueTypeIdGeneration (Vogen / StronglyTypedId) and
+        // FSharpDiscriminatedUnionIdGeneration (F# single-case DU)
+        // extend ValueTypeInfo and share the same shape (OuterType /
+        // SimpleType / ValueProperty / Ctor|Builder). The closed-shape
+        // identification only needs the base shape, so dispatch them
+        // through the same provider builder.
+        if (mapping.IdStrategy is ValueTypeInfo vt)
         {
             return BuildValueTypeProvider<TDoc>(mapping, vt);
         }
@@ -138,9 +144,13 @@ public static class ClosedShapeRegistration
     /// id whose wrapper type isn't known at compile time. Constructs the
     /// per-wrapper <see cref="ValueTypeIdentification{TDoc, TWrapper, TInner}"/>
     /// via <c>CloseAndBuildAs</c> and hands the closed-shape descriptor
-    /// the wrapper type as TId.
+    /// the wrapper type as TId. Accepts the <see cref="ValueTypeInfo"/>
+    /// base so both Vogen / StronglyTypedId
+    /// (<c>ValueTypeIdGeneration</c>) and F# discriminated-union
+    /// (<c>FSharpDiscriminatedUnionIdGeneration</c>) id strategies
+    /// flow through here.
     /// </summary>
-    private static DocumentProvider<TDoc> BuildValueTypeProvider<TDoc>(DocumentMapping mapping, ValueTypeIdGeneration vt)
+    private static DocumentProvider<TDoc> BuildValueTypeProvider<TDoc>(DocumentMapping mapping, ValueTypeInfo vt)
         where TDoc : notnull
     {
         var wrapperType = vt.OuterType;

--- a/src/Marten/Internal/ClosedShape/ValueTypeIdentification.cs
+++ b/src/Marten/Internal/ClosedShape/ValueTypeIdentification.cs
@@ -5,14 +5,15 @@ using System.Linq.Expressions;
 using System.Reflection;
 using FastExpressionCompiler;
 using JasperFx.Core.Reflection;
-using Marten.Schema.Identity;
 using Marten.Storage;
 
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
 /// W3 spike (M15): <see cref="IIdentification{TDoc, TId}"/> for
-/// strong-typed ids (Marten's <see cref="ValueTypeIdGeneration"/>). The
+/// strong-typed ids — Vogen / StronglyTypedId
+/// (<c>ValueTypeIdGeneration</c>) and F# single-case discriminated
+/// unions (<c>FSharpDiscriminatedUnionIdGeneration</c>). The
 /// document's id member is a wrapper struct/class
 /// (<typeparamref name="TWrapper"/>) over a primitive
 /// (<typeparamref name="TInner"/>: Guid / int / long / string).
@@ -22,7 +23,6 @@ namespace Marten.Internal.ClosedShape;
 /// Guid -> <see cref="Guid.NewGuid"/>;
 /// int / long -> per-document HiLo sequence;
 /// string -> externally assigned (throws on missing).
-/// Matches <c>ValueTypeIdGeneration.GenerateCode</c>.
 /// </remarks>
 public sealed class ValueTypeIdentification<TDoc, TWrapper, TInner>: IIdentification<TDoc, TWrapper>
     where TDoc : notnull
@@ -36,7 +36,7 @@ public sealed class ValueTypeIdentification<TDoc, TWrapper, TInner>: IIdentifica
     private readonly Func<TInner, TWrapper> _wrap;
     private readonly Func<IMartenDatabase, TInner> _generator;
 
-    public ValueTypeIdentification(MemberInfo idMember, ValueTypeIdGeneration vt, Type sequenceKey)
+    public ValueTypeIdentification(MemberInfo idMember, ValueTypeInfo vt, Type sequenceKey)
     {
         (_getter, _isNullablePropertyMissing) = BuildAccessors(idMember);
         _setter = LambdaBuilder.Setter<TDoc, TWrapper>(idMember)!;


### PR DESCRIPTION
## Summary

Resolves #4478.

`ClosedShapeRegistration.BuildSupportedProvider` only dispatched on `ValueTypeIdGeneration`. F# single-case DU ids use `FSharpDiscriminatedUnionIdGeneration`, which shares the same shape (both extend `ValueTypeInfo`, both implement `IStrongTypedIdGeneration`, both expose `OuterType` / `SimpleType` / `ValueProperty` / `Ctor` | `Builder`) — but the dispatch fell through to the registration-error path:

```
Marten.Exceptions.InvalidDocumentException : No closed-shape id strategy is registered for FSharpTypes+Order (id type FSharpTypes+OrderId, strategy Marten.Schema.Identity.FSharpDiscriminatedUnionIdGeneration).
```

Fix: widen the pattern match to `ValueTypeInfo` so both strategies route to `BuildValueTypeProvider`. `ValueTypeIdentification`'s ctor only needed the inherited members (`ValueProperty` / `CreateWrapper` / `SimpleType`), so accept the base `ValueTypeInfo` instead of the narrower `ValueTypeIdGeneration`.

## Results

`./build.sh test-value-types` results:

| Branch | net9.0 | net10.0 |
| ------ | ------ | ------- |
| master | 32 failed / 307 passed | 32 failed / 307 passed |
| this PR | 12 failed / 327 passed | 12 failed / 327 passed |

All 20 `*fsharp_discriminated_union_document_operations*` tests pass. The remaining 12 failures are duplicated-field-binder failures tracked separately in #4477 / #4479.

## Test plan

- [x] `./build.sh test-value-types` net9.0 — 12 fail, all duplicated-field (#4477)
- [x] `./build.sh test-value-types` net10.0 — 12 fail, all duplicated-field (#4477)
- [x] All 20 `*fsharp_discriminated_union_document_operations*` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)