### PR TITLE
Marten#4466: Unskip Bug_4441_force_catch_up_with_outbox

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4441_force_catch_up_with_outbox.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4441_force_catch_up_with_outbox.cs
@@ -81,7 +81,7 @@ public class Bug_4441_force_catch_up_with_outbox
         exceptions.ShouldBeEmpty();
     }
 
-    [Fact(Timeout = 60000, Skip = "Re-skipped after the #4463 fix didn't fully stabilize this in CI — see https://github.com/JasperFx/marten/issues/4462. The remaining flake is a daemon-internal cancellation that surfaces as an AggregateException with an OCE inside well before the test's CTS would fire (failing run terminated in ~176ms with the test CTS set to 45s). The next step is the deeper-fix path in #4462 — auditing the GroupedProjectionExecution / per-shard internal CTS contract so daemon-lifecycle cancellations don't leak into ForceAllMartenDaemonActivityToCatchUpAsync's exceptions list. Passes locally 5/5.")]
+    [Fact(Timeout = 60000)]
     public async Task force_catch_up_invokes_message_batch_lifecycle_with_custom_outbox()
     {
         var outbox = new RecordingOutbox();


### PR DESCRIPTION
## Summary

Closes #4466.

JasperFx PR [#285](https://github.com/JasperFx/jasperfx/pull/285) — "Stop daemon-internal cancellations from leaking into `CatchUpAsync`" — shipped in `JasperFx.Events 2.0.0-alpha.11` and is consumed by Marten's current `alpha.13` pin (landed in #4475 Phase 2). The daemon-internal cancellation flake that motivated the re-skip in #4462 / #4463 is gone.

Removes the `Skip = "..."` from the `[Fact]` attribute. No production code change.

The companion second unskip from the chip — `rebuild_the_projection_skip_failed_events` (JasperFx#303 follow-up) — did **not** pass after unskipping despite PR #304 being in the current `alpha.13` pin. The per-event `ApplyEventException` wrapping is in `JasperFxAggregationProjectionBase.cs`'s `_buildAction` (verified in the published assembly), but raw `InvalidOperationException` instances still surface through the `AggregateException` that `AggregationRunner.BuildBatchAsync` throws — `GroupedProjectionExecution.buildBatchWithSkipping`'s `OfType<ApplyEventException>()` filter empties out, no events get skipped, and the shard times out. Per chip rules (STOP and file upstream), keeping that test skipped and tracking via a JasperFx follow-up.

## Test plan

- [x] `dotnet test src/EventSourcingTests/EventSourcingTests.csproj --filter "FullyQualifiedName~force_catch_up"` — both tests in the file pass on net9.0 and net10.0
- [x] Bug_4441 unskipped test alone passes 5/5 on both frameworks

🤖 Generated with [Claude Code](https://claude.com/claude-code)