### PR TITLE
Bump JasperFx alphas + unskip rebuild_the_projection_skip_failed_events

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,14 +13,14 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.14" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.13" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.6">
+    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.15" />
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.14" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-alpha.2" />
-    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-alpha.2" />
+    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-alpha.3" />
+    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-alpha.4" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/DaemonTests/Resiliency/rebuilds_with_serialization_or_poison_pill_events.cs
+++ b/src/DaemonTests/Resiliency/rebuilds_with_serialization_or_poison_pill_events.cs
@@ -97,7 +97,7 @@ public class rebuilds_with_serialization_or_poison_pill_events: DaemonContext
     }
 
 
-    [Theory(Skip = "9.0: JasperFx/jasperfx#303 — the SG-emitted IGeneratedSyncDetermineAction dispatches a batch of events in a single call, so a throwing Apply on event N drops the whole batch instead of routing only event N to the dead-letter queue under SkipApplyErrors=true.")]
+    [Theory]
     [InlineData(StorageConstants.DefaultTenantId)]
     [InlineData("CustomTenant")]
     public async Task rebuild_the_projection_skip_failed_events(string tenantId)


### PR DESCRIPTION
## Summary

Companion to #4482. JasperFx [PR #306](https://github.com/JasperFx/jasperfx/pull/306) — "Wrap per-event in SG DetermineActionAsync overrides (closes #305)" — shipped in the new alpha wave. This PR consumes those packages and unskips the remaining post-Phase-2 daemon test.

### Why #306 was needed

After PR #304 (alpha.13), the per-event `ApplyEventException` wrapping was in place inside `JasperFxAggregationProjectionBase._buildAction`, but the SG-emitted `DetermineActionAsync` overrides on individual projections weren't covered. So when a poison-pill event threw, the raw `InvalidOperationException` still propagated up through the `AggregateException` `AggregationRunner.BuildBatchAsync` throws, and `GroupedProjectionExecution.buildBatchWithSkipping`'s `OfType<ApplyEventException>()` filter emptied out — no events got skipped, the shard timed out. I filed [jasperfx#305](https://github.com/JasperFx/jasperfx/issues/305) with the diagnosis; PR #306 wraps each per-event call inside the SG's `DetermineActionAsync` emission and restores the seam end-to-end.

### Pin bumps

| Package | Old | New |
| --- | --- | --- |
| JasperFx | 2.0.0-alpha.14 | 2.0.0-alpha.15 |
| JasperFx.Events | 2.0.0-alpha.13 | 2.0.0-alpha.14 |
| JasperFx.Events.SourceGenerator | 2.0.0-alpha.6 | 2.0.0-alpha.7 |
| JasperFx.RuntimeCompiler | 5.0.0-alpha.2 | 5.0.0-alpha.3 |
| JasperFx.SourceGeneration | 2.0.0-alpha.2 | 2.0.0-alpha.4 |

## Test plan

- [x] `DISABLE_TEST_PARALLELIZATION=true dotnet test src/DaemonTests/DaemonTests.csproj --filter "FullyQualifiedName~rebuild_the_projection_skip_failed_events"` — both Theory inline cases (`*DEFAULT*`, `CustomTenant`) pass on net9.0 and net10.0.
- [x] `DISABLE_TEST_PARALLELIZATION=true dotnet test src/DaemonTests/DaemonTests.csproj --filter "FullyQualifiedName~rebuilds_with_serialization_or_poison_pill_events"` — all 4 tests in the class pass on both frameworks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)