### PR TITLE
Adopt JasperFx 2.0 alpha.16/.15/.8 + migrate consumer renames (#4484)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,14 +13,14 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.15" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.14" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.7">
+    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.16" />
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.15" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-alpha.3" />
-    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-alpha.4" />
+    <PackageVersion Include="JasperFx.RuntimeCompiler" Version="5.0.0-alpha.4" />
+    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-alpha.5" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -510,6 +510,21 @@ Marten 9 retires obsolete types and members deprecated in Marten 8.x:
 
 * `[Obsolete]` types and members deprecated since Marten 8.x have been retired in Marten 9. If your code compiled in Marten 8.x with `[Obsolete]` warnings against any Marten type, those members are now gone in Marten 9 — fix the warnings on 8.x first, then upgrade.
 
+### Renames coordinated with JasperFx 2.0 / JasperFx.Events 2.0
+
+The JasperFx 2.0 wave (`JasperFx` 2.0.0-alpha.16+, `JasperFx.Events` 2.0.0-alpha.15+) finishes a set of coordinated `[Obsolete]` removals. After upgrading Marten 9, audit consumer code for these renames:
+
+* **`ProjectionBase.ProjectionName` → `Name`.** If your projection subclass overrides or sets the legacy property in its constructor, switch to `Name`.
+* **`ProjectionBase.ProjectionVersion` → `Version`.** Same shape — find/replace any setter or getter usage.
+* **`JasperFxSubscriptionBase.SubscriptionName` → `Name`** and **`JasperFxSubscriptionBase.SubscriptionVersion` → `Version`.** Mirrors the projection rename for subscription subclasses.
+* **`EventSlice<T>.Aggregate` → `Snapshot`** (also on `IEventSlice<T>`). The old name was a holdover from a pre-1.0 vocabulary; semantics are unchanged.
+* **`MessageMetadata.LastModifiedBy` / `IMetadataContext.LastModifiedBy` → `CurrentUserName`.** The session-level "current user name" property was renamed for clarity. `Marten.IDocumentSession.LastModifiedBy` and `Marten.Storage.Metadata.DocumentMetadata.LastModifiedBy` are **separate document-side properties** (the "who last modified this row" stored column) and continue to use `LastModifiedBy` — only the session-level reading of the current user changed.
+* **`IEventStore.TeardownExistingProjectionProgressAsync` removed.** The full-state teardown helper `IEventStore.TeardownExistingProjectionStateAsync` (identical signature, takes `IEventDatabase`, the subscription/projection name, and a `CancellationToken`) is the replacement. The progress-only variant always also tore down the projected document state in practice, so the consolidated method matches actual behavior. Custom `IEventStore` implementations need their explicit interface implementation updated.
+* **`MultiStreamProjection.CustomGrouping(IEventSlicer<TDoc, TId, TQuerySession>)` removed.** Pass a `Func<TQuerySession, IReadOnlyList<IEvent>, IEventGrouping<TId>, Task>` lambda (the still-supported overload) or an `IAggregateGrouper<TId>` instance instead. Whole-slicer replacement is no longer a supported extension point — express the grouping logic in the lambda body.
+* **`Oakton.*` shims removed** (`OaktonEnvironment` / `ApplyOaktonExtensions` / `RunOaktonCommands`). These were `[Obsolete]` in the 1.x line. Drop the `using Oakton;` and switch to `JasperFx.JasperFxEnvironment` / `ApplyJasperFxExtensions` / `RunJasperFxCommands`.
+
+`CombGuidIdGeneration` keeps its `[Obsolete]` for one more cycle — scheduled for a future major release rather than this wave.
+
 ### Restoring V8 defaults
 
 Migrating from Marten 8? Call `StoreOptions.RestoreV8Defaults()` first, then layer your own configuration on top:

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -215,12 +215,6 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
         await session.SaveChangesAsync(token).ConfigureAwait(false);
     }
 
-    Task IEventStore<IDocumentOperations, IQuerySession>.TeardownExistingProjectionProgressAsync(
-        IEventDatabase database, string subscriptionName, CancellationToken token)
-    {
-        throw new NotSupportedException();
-    }
-
     private void teardownProjectionStorage(IProjectionSource<IDocumentOperations, IQuerySession> source, IDocumentSession session)
     {
         if (source.Options.TeardownDataOnRebuild)

--- a/src/Marten/Events/TenantPropagation.cs
+++ b/src/Marten/Events/TenantPropagation.cs
@@ -104,12 +104,6 @@ internal sealed class StreamTenantMetadataContext: IMetadataContext
         set => _inner.CorrelationId = value;
     }
 
-    public string? LastModifiedBy
-    {
-        get => _inner.LastModifiedBy;
-        set => _inner.LastModifiedBy = value;
-    }
-
     public string? CurrentUserName
     {
         get => _inner.CurrentUserName;

--- a/src/Marten/Storage/Metadata/LastModifiedByColumn.cs
+++ b/src/Marten/Storage/Metadata/LastModifiedByColumn.cs
@@ -63,7 +63,7 @@ internal class LastModifiedByArgument: UpsertArgument
     {
         if (mapping.Metadata.LastModifiedBy.Member != null)
         {
-            method.Frames.Code($"var lastModifiedBy = {{0}}.{nameof(IMartenSession.LastModifiedBy)};",
+            method.Frames.Code($"var lastModifiedBy = {{0}}.{nameof(IMartenSession.CurrentUserName)};",
                 Use.Type<IMartenSession>());
             method.Frames.SetMemberValue(mapping.Metadata.LastModifiedBy.Member, "lastModifiedBy", mapping.DocumentType,
                 type);
@@ -75,7 +75,7 @@ internal class LastModifiedByArgument: UpsertArgument
         DocumentMapping mapping, StoreOptions options)
     {
         method.Frames.Code(
-            $"setStringParameter({parameters.Usage}, {{0}}.{nameof(IMartenSession.LastModifiedBy)});",
+            $"setStringParameter({parameters.Usage}, {{0}}.{nameof(IMartenSession.CurrentUserName)});",
             Use.Type<IMartenSession>());
     }
 

--- a/src/Marten/Storage/Metadata/UserNameColumn.cs
+++ b/src/Marten/Storage/Metadata/UserNameColumn.cs
@@ -55,7 +55,7 @@ internal class UserNameColumn: MetadataColumn<string>, ISelectableColumn, IEvent
     {
         builder.Append(ColumnName);
         builder.Append(" = ");
-        builder.AppendParameter(session.LastModifiedBy);
+        builder.AppendParameter(session.CurrentUserName);
     }
 
     public string ValueSql(EventGraph graph, AppendMode mode)
@@ -92,7 +92,7 @@ internal class UserNameArgument: UpsertArgument
     {
         if (mapping.Metadata.LastModifiedBy.Member != null)
         {
-            method.Frames.Code($"var userName = {{0}}.{nameof(IMartenSession.LastModifiedBy)};",
+            method.Frames.Code($"var userName = {{0}}.{nameof(IMartenSession.CurrentUserName)};",
                 Use.Type<IMartenSession>());
             method.Frames.SetMemberValue(mapping.Metadata.LastModifiedBy.Member, "userName", mapping.DocumentType,
                 type);
@@ -103,7 +103,7 @@ internal class UserNameArgument: UpsertArgument
         Argument parameters,
         DocumentMapping mapping, StoreOptions options)
     {
-        method.Frames.Code($"setStringParameter({parameters.Usage}, {{0}}.{nameof(IMartenSession.LastModifiedBy)});",
+        method.Frames.Code($"setStringParameter({parameters.Usage}, {{0}}.{nameof(IMartenSession.CurrentUserName)});",
             Use.Type<IMartenSession>());
     }
 

--- a/src/samples/Helpdesk/Helpdesk.Api.Tests/Settings.cs
+++ b/src/samples/Helpdesk/Helpdesk.Api.Tests/Settings.cs
@@ -1,4 +1,4 @@
-using Oakton;
+using JasperFx;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -14,6 +14,6 @@ public sealed class AssemblyFixture : XunitTestFramework
     public AssemblyFixture(IMessageSink messageSink)
         :base(messageSink)
     {
-        OaktonEnvironment.AutoStartHost = true;
+        JasperFxEnvironment.AutoStartHost = true;
     }
 }

--- a/src/samples/Helpdesk/Helpdesk.Api/Program.cs
+++ b/src/samples/Helpdesk/Helpdesk.Api/Program.cs
@@ -18,7 +18,7 @@ using Marten.Schema.Identity;
 using Marten.Services.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
-using Oakton;
+using JasperFx;
 using Weasel.Core;
 using static Microsoft.AspNetCore.Http.TypedResults;
 using static Helpdesk.Api.Incidents.IncidentService;
@@ -75,7 +75,7 @@ builder.Services
         o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()))
     .AddSignalR();
 
-builder.Host.ApplyOaktonExtensions();
+builder.Host.ApplyJasperFxExtensions();
 
 var app = builder.Build();
 
@@ -244,7 +244,7 @@ if (app.Environment.IsDevelopment())
 app.UseCors("ClientPermission");
 app.MapHub<IncidentsHub>("/hubs/incidents");
 
-return await app.RunOaktonCommands(args);
+return await app.RunJasperFxCommands(args);
 
 public class IncidentsHub: Hub
 {


### PR DESCRIPTION
## Summary

Closes #4484. Adopts the new JasperFx wave that finishes the 2.0 [Obsolete] sweep removals (JasperFx PR #307 / jasperfx#273) and migrates Marten's consumer code over the few renames that surface.

## Pin bump

| Package | Old | New |
| --- | --- | --- |
| JasperFx | 2.0.0-alpha.15 | **2.0.0-alpha.16** |
| JasperFx.Events | 2.0.0-alpha.14 | **2.0.0-alpha.15** |
| JasperFx.Events.SourceGenerator | 2.0.0-alpha.7 | **2.0.0-alpha.8** |
| JasperFx.RuntimeCompiler | 5.0.0-alpha.3 | **5.0.0-alpha.4** |
| JasperFx.SourceGeneration | 2.0.0-alpha.4 | **2.0.0-alpha.5** |

## Consumer migrations applied

* **`IEventStore.TeardownExistingProjectionProgressAsync` removed.** `TeardownExistingProjectionStateAsync` (identical signature, behavior was already identical in practice) is the consolidated replacement. Marten's `DocumentStore` already implemented the State variant separately; the dead sync-throw stub of the Progress variant is removed.
* **`IMetadataContext.LastModifiedBy` → `CurrentUserName`.** Updates `StreamTenantMetadataContext` (drops the duplicate that mirrored the old name; the `CurrentUserName` property was already alongside it) and the `UserNameColumn` / `LastModifiedByColumn` session-side reads. `DocumentMetadata.LastModifiedBy` and `ITracked.LastModifiedBy` (Marten's own stored "who modified this row" columns) are **NOT** affected — only the session-level current-user property changed.
* **Oakton shims removed.** Helpdesk sample's `Helpdesk.Api/Program.cs` and `Helpdesk.Api.Tests/Settings.cs` switch:
  - `Oakton.OaktonEnvironment` → `JasperFx.JasperFxEnvironment`
  - `ApplyOaktonExtensions` → `ApplyJasperFxExtensions`
  - `RunOaktonCommands` → `RunJasperFxCommands`

## Punch-list items NOT changed (already migrated or out of scope)

* `ProjectionName` / `ProjectionVersion` / `SubscriptionName` / `SubscriptionVersion` — no consumer usages remain in the `src/Marten.slnx`-built tree (the few hits are either `DeadLetterEvent`'s own stored field or the `[ProjectionVersion(int)]` attribute, which is a different concept).
* `EventSlice.Aggregate` → `Snapshot` — every call site in `src/DaemonTests`, `src/EventSourcingTests`, `src/Marten` already uses `.Snapshot`.
* `CustomGrouping(IEventSlicer<...>)` removed — Marten's existing call sites pass `IAggregateGrouper<TId>` or lambdas, both still-supported overloads. No rewrites needed.
* `src/Marten.CommandLine.Tests/ProjectionControllerTests.cs` — pre-existing failures on master (missing `IProjectionStore` / `IProjectionHost` / `IProjectionDatabase` / `AsyncProjectionShard` types from an earlier alpha), not in `src/Marten.slnx`, separate from this wave.

## Migration guide

New subsection added under the existing **Obsolete API sweep** in `docs/migration-guide.md`: **"Renames coordinated with JasperFx 2.0 / JasperFx.Events 2.0"** — covers each rename with before/after and the `LastModifiedBy`-vs-`DocumentMetadata.LastModifiedBy` distinction so consumers don't mass-rename the wrong member.

## Test plan

- [x] `dotnet build src/Marten.slnx -c Release` — 0 errors
- [x] `dotnet test src/CoreTests/CoreTests.csproj -c Release -f net10.0` — **444 passed / 0 failed / 1 skipped** (matches the chip's expected baseline)
- [x] `dotnet test src/EventSourcingTests/EventSourcingTests.csproj -c Release -f net10.0` — **1321 passed / 0 failed / 6 skipped** (was 1320/0/7 before #4483 unskipped `rebuild_the_projection_skip_failed_events`)
- [x] `npx markdownlint-cli --disable MD009 -- docs/migration-guide.md` — clean
- [x] Helpdesk sample's pre-existing NU1605 / NU1510 package-management failures confirmed pre-existing (reproduce on master without this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)