### PR TITLE
Fix #4481: FetchForWriting without appending events shouldn't block unrelated inserts

### DIFF
--- a/src/EventSourcingTests/FetchForWriting/fetch_for_writing_and_projection_metadata_for_inline_projections.cs
+++ b/src/EventSourcingTests/FetchForWriting/fetch_for_writing_and_projection_metadata_for_inline_projections.cs
@@ -120,6 +120,48 @@ public class fetch_for_writing_and_projection_metadata_for_inline_projections : 
         ProjectionWithVersions.VersionsSeen.ShouldBe([5, 6, 7, 8]);
 
     }
+
+    // Regression for #4481: when an Evolve-based inline projection's stream is
+    // fetched via FetchForWriting and no events are appended, an unrelated
+    // document insert in the same session was failing with
+    // JasperFx.ConcurrencyException because the empty stream still flowed
+    // through the inline-projection Apply step and queued a storage operation
+    // that did an optimistic-concurrency check against the unchanged version.
+    [Fact]
+    public async Task fetch_for_writing_without_appending_does_not_block_unrelated_inserts()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.Add<ProjectionWithVersions>(ProjectionLifecycle.Inline);
+            opts.Schema.For<UnrelatedDoc>().Identity(x => x.Id);
+        });
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<VersionedGuy>(streamId, new AEvent(), new BEvent());
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            // Fetch the stream but deliberately do not append any new events.
+            await session.Events.FetchForWriting<VersionedGuy>(streamId);
+
+            // Insert an unrelated document on the same session.
+            session.Store(new UnrelatedDoc { Id = streamId, Note = "no new events" });
+
+            // Should NOT throw — the empty stream must not propagate an
+            // optimistic-concurrency check on the unchanged aggregate.
+            await session.SaveChangesAsync();
+        }
+
+        await using var verify = theStore.QuerySession();
+        var unrelated = await verify.LoadAsync<UnrelatedDoc>(streamId);
+        unrelated.ShouldNotBeNull();
+        unrelated.Note.ShouldBe("no new events");
+    }
 }
 
 public class ProjectionWithVersions : SingleStreamProjection<VersionedGuy, Guid>
@@ -165,4 +207,10 @@ public class VersionedGuy
     public int DCount { get; set; }
 
     public int Version { get; set; }
+}
+
+public class UnrelatedDoc
+{
+    public Guid Id { get; set; }
+    public string Note { get; set; } = "";
 }

--- a/src/Marten/Events/QuickEventAppender.cs
+++ b/src/Marten/Events/QuickEventAppender.cs
@@ -85,9 +85,14 @@ internal class QuickEventAppender: IEventAppender
     {
         registerOperationsForStreams(eventGraph, session);
 
+        // Issue #4481: only pass streams that actually have events. See the
+        // matching guard in RichEventAppender.ProcessEventsAsync for context.
+        var streamsWithEvents = session.WorkTracker.Streams.Where(x => x.Events.Any()).ToList();
+        if (streamsWithEvents.Count == 0) return;
+
         foreach (var projection in inlineProjections)
         {
-            await projection.ApplyAsync(session, session.WorkTracker.Streams.ToList(), token).ConfigureAwait(false);
+            await projection.ApplyAsync(session, streamsWithEvents, token).ConfigureAwait(false);
         }
     }
 }

--- a/src/Marten/Events/RichEventAppender.cs
+++ b/src/Marten/Events/RichEventAppender.cs
@@ -80,9 +80,24 @@ internal class RichEventAppender: IEventAppender
         }
 
         // TODO -- look for opportunities to batch up the requests here too!
-        foreach (var projection in inlineProjections)
+        //
+        // Issue #4481: only pass streams that actually have events. An empty
+        // stream (e.g. FetchForWriting<TAggregate> called without any
+        // subsequent AppendOne/AppendMany) used to slip through here and
+        // trigger an inline projection's snapshot-write path on the unchanged
+        // aggregate, raising a JasperFx.ConcurrencyException on the next
+        // SaveChangesAsync for any other work on the same session. The
+        // upstream JasperFx aggregation base's `AppliesTo(eventTypes)`
+        // returns `true` unconditionally when the projection has no
+        // statically-known event types (Evolve-only projections), so the
+        // empty stream was not being filtered downstream.
+        var streamsWithEvents = session.WorkTracker.Streams.Where(x => x.Events.Any()).ToList();
+        if (streamsWithEvents.Count > 0)
         {
-            await projection.ApplyAsync(session, session.WorkTracker.Streams.ToList(), token).ConfigureAwait(false);
+            foreach (var projection in inlineProjections)
+            {
+                await projection.ApplyAsync(session, streamsWithEvents, token).ConfigureAwait(false);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #4481.

When an inline aggregate's stream is fetched via `FetchForWriting<TAggregate>` and no events are subsequently appended, an unrelated document insert on the same session was failing with `JasperFx.ConcurrencyException` on `SaveChangesAsync` — the empty stream still flowed through the inline projection's apply step and queued a snapshot-update operation against the unchanged aggregate version, tripping the optimistic-concurrency check.

The symptom reproduced for projections that override `Evolve` directly but not for the conventional `Apply`/`Create` method shape.

## Root cause

Upstream in JasperFx.Events 1.x:

```csharp
// JasperFxAggregationProjectionBase.AppliesTo
public bool AppliesTo(IEnumerable<Type> eventTypes)
{
    // Have to do this because you don't know if any events catch
    if (AllEventTypes.Length == 0) return true;
    return eventTypes.Intersect(AllEventTypes).Any() || ...;
}
```

For `Apply`/`Create` projections `AllEventTypes` is populated from the discovered handler methods, so an empty stream's empty `eventTypes` collection cleanly evaluates to `false` and the stream is screened out by the early intersection check in `JasperFxSingleStreamProjectionBase.ApplyAsync`. For `Evolve`-based projections `AllEventTypes` is empty, the `Length == 0` early-out fires `return true`, and the empty stream slips through — then the projection writes a snapshot with the old expected version and a concurrency check fires when any other operation commits.

## Fix

Lives in Marten's two inline-appender entry points (`RichEventAppender`, `QuickEventAppender`): only pass streams that actually have events to the inline-projection `ApplyAsync` calls. Mirrors the same `x.Events.Any()` filter that `RichEventAppender`'s `streamActions` branch already uses on the storage side. Marten-side fix avoids needing to ship a new JasperFx.Events 1.x release.

## Test plan

- [x] New regression test `fetch_for_writing_without_appending_does_not_block_unrelated_inserts` reproduces the exact `ConcurrencyException` from the issue without the fix.
- [x] The new test passes with the fix.
- [x] All 194 `FullyQualifiedName~FetchForWriting` tests pass on net10.0.
- [x] Full `EventSourcingTests` run: 5 pre-existing failures on `8.0` baseline confirmed reproducible without this PR (verified by reverting and re-running the same test set) — no regressions introduced.

A companion PR cherry-picks the fix to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)