### PR TITLE
Fix #4481: FetchForWriting without appending events shouldn't block unrelated inserts (master)

### DIFF
--- a/src/EventSourcingTests/FetchForWriting/fetch_for_writing_and_projection_metadata_for_inline_projections.cs
+++ b/src/EventSourcingTests/FetchForWriting/fetch_for_writing_and_projection_metadata_for_inline_projections.cs
@@ -120,6 +120,48 @@ public class fetch_for_writing_and_projection_metadata_for_inline_projections : 
         ProjectionWithVersions.VersionsSeen.ShouldBe([5, 6, 7, 8]);
 
     }
+
+    // Regression for #4481: when an Evolve-based inline projection's stream is
+    // fetched via FetchForWriting and no events are appended, an unrelated
+    // document insert in the same session was failing with
+    // JasperFx.ConcurrencyException because the empty stream still flowed
+    // through the inline-projection Apply step and queued a storage operation
+    // that did an optimistic-concurrency check against the unchanged version.
+    [Fact]
+    public async Task fetch_for_writing_without_appending_does_not_block_unrelated_inserts()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.Add<ProjectionWithVersions>(ProjectionLifecycle.Inline);
+            opts.Schema.For<UnrelatedDoc>().Identity(x => x.Id);
+        });
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<VersionedGuy>(streamId, new AEvent(), new BEvent());
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            // Fetch the stream but deliberately do not append any new events.
+            await session.Events.FetchForWriting<VersionedGuy>(streamId);
+
+            // Insert an unrelated document on the same session.
+            session.Store(new UnrelatedDoc { Id = streamId, Note = "no new events" });
+
+            // Should NOT throw — the empty stream must not propagate an
+            // optimistic-concurrency check on the unchanged aggregate.
+            await session.SaveChangesAsync();
+        }
+
+        await using var verify = theStore.QuerySession();
+        var unrelated = await verify.LoadAsync<UnrelatedDoc>(streamId);
+        unrelated.ShouldNotBeNull();
+        unrelated.Note.ShouldBe("no new events");
+    }
 }
 
 public partial class ProjectionWithVersions : SingleStreamProjection<VersionedGuy, Guid>
@@ -165,4 +207,10 @@ public class VersionedGuy
     public int DCount { get; set; }
 
     public long Version { get; set; }
+}
+
+public class UnrelatedDoc
+{
+    public Guid Id { get; set; }
+    public string Note { get; set; } = "";
 }

--- a/src/Marten/Events/QuickEventAppender.cs
+++ b/src/Marten/Events/QuickEventAppender.cs
@@ -108,9 +108,11 @@ internal class QuickEventAppender: IEventAppender
 
         // 9.0 (#4306): pass the tracker collection directly now that the
         // IInlineProjection contract takes IEnumerable<StreamAction>.
+        // Issue #4481: filter to streams with events. See the matching
+        // guard in RichEventAppender.ProcessEventsAsync for context.
         foreach (var projection in inlineProjections)
         {
-            await projection.ApplyAsync(session, session.WorkTracker.Streams, token).ConfigureAwait(false);
+            await projection.ApplyAsync(session, session.WorkTracker.Streams.Where(x => x.Events.Any()), token).ConfigureAwait(false);
         }
     }
 }

--- a/src/Marten/Events/RichEventAppender.cs
+++ b/src/Marten/Events/RichEventAppender.cs
@@ -87,9 +87,23 @@ internal class RichEventAppender: IEventAppender
         // 9.0 (#4306): IInlineProjection.ApplyAsync now takes IEnumerable<StreamAction>,
         // so we can pass the session's tracker collection directly without
         // allocating a fresh List on every SaveChangesAsync.
+        //
+        // Issue #4481: only pass streams that actually have events. An empty
+        // stream (e.g. FetchForWriting<TAggregate> called without any
+        // subsequent AppendOne/AppendMany) used to slip through here and
+        // trigger an inline projection's snapshot-write path on the unchanged
+        // aggregate, raising a JasperFx.ConcurrencyException on the next
+        // SaveChangesAsync for any other work on the same session. The
+        // upstream JasperFx aggregation base's `AppliesTo(eventTypes)`
+        // returns `true` unconditionally when the projection has no
+        // statically-known event types (Evolve-only projections), so the
+        // empty stream was not being filtered downstream. The lazy `Where`
+        // preserves the no-allocation property that #4306 introduced — the
+        // filter is one tiny iterator object per projection call instead of
+        // a fresh List on every save.
         foreach (var projection in inlineProjections)
         {
-            await projection.ApplyAsync(session, session.WorkTracker.Streams, token).ConfigureAwait(false);
+            await projection.ApplyAsync(session, session.WorkTracker.Streams.Where(x => x.Events.Any()), token).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #4481. Master companion to #4489 (the 8.0 PR).

When an inline aggregate's stream was fetched via `FetchForWriting<TAggregate>` and no events were subsequently appended, an unrelated document insert on the same session was failing with `JasperFx.ConcurrencyException` on `SaveChangesAsync` — the empty stream still flowed through the inline projection's apply step and queued a snapshot-update operation against the unchanged aggregate version, tripping the optimistic-concurrency check.

Symptom reproduced only when the projection overrode `Evolve` directly; the conventional `Apply`/`Create` shape wasn't affected.

## Root cause

Upstream in `JasperFxAggregationProjectionBase.AppliesTo` (jasperfx repo, unchanged across the 1.x → 2.x rename):

```csharp
public bool AppliesTo(IEnumerable<Type> eventTypes)
{
    // Have to do this because you don't know if any events catch
    if (AllEventTypes.Length == 0) return true;
    return eventTypes.Intersect(AllEventTypes).Any() || ...;
}
```

For `Apply`/`Create` projections `AllEventTypes` is populated from the discovered handler methods, so an empty stream's empty `eventTypes` collection cleanly evaluates to `false` and the stream is screened out by the intersection check in `JasperFxSingleStreamProjectionBase.ApplyAsync`. For `Evolve`-based projections `AllEventTypes` is empty, the `Length == 0` early-out fires `return true`, and the empty stream slips through — the projection then writes a snapshot with the old expected version and a concurrency check fires when any other operation commits.

## Fix (cherry-picked from #4489, with master-side reconciliation)

Same approach as the 8.0 PR — filter empty streams at the Marten-side appender entry points. Master diverges from 8.0 on the `IInlineProjection.ApplyAsync` contract:

- 8.0 takes `IReadOnlyList<StreamAction>`. The 8.0 fix materializes a `List<>` via `.ToList()`.
- 9.0 (JasperFx.Events 2.x, after #4306) takes `IEnumerable<StreamAction>`. The cherry-pick reconciles to use a lazy `Where(x => x.Events.Any())` instead of materializing — preserves the no-allocation property that #4306 introduced.

`RichEventAppender.ProcessEventsAsync` and `QuickEventAppender.ProcessEventsAsync` both updated.

## Test plan

- [x] `fetch_for_writing_without_appending_does_not_block_unrelated_inserts` test cherry-picked from the 8.0 PR; passes on master with the fix
- [x] All 212 `FullyQualifiedName~FetchForWriting` tests pass on net10.0 with the fix
- [x] No regressions vs. master baseline

Companion PR on 8.0: #4489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)