### PR TITLE
Fix #4493: NullReferenceException combining optimistic concurrency and partitioning

### DIFF
--- a/src/CoreTests/Partitioning/Bug_4493_optimistic_partitioning.cs
+++ b/src/CoreTests/Partitioning/Bug_4493_optimistic_partitioning.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace CoreTests.Partitioning;
+
+// Regression for marten#4493. The reporter combined
+// .UseOptimisticConcurrency(true) on a document with the
+// AllDocumentsAreMultiTenantedWithPartitioning(...) policy and
+// ApplyAllConfiguredChangesToDatabaseAsync threw NullReferenceException
+// from UpsertFunction's partition-column scan. Root cause: when
+// optimistic concurrency is on a CurrentVersionArgument is added whose
+// Column is deliberately null; the partition loop called
+// arg.Column.Equals(...) on it. Started on 8.29.0. The reporter
+// confirmed setting UseOptimisticConcurrency(false) sidesteps the bug.
+//
+// Class name kept short on purpose — combined with the
+// `mt_doc_{schema}_{type}` table-name prefix and the long
+// CoreTests schema base, the 63-byte Postgres identifier limit truncates
+// partition table names and collides them. That truncation behavior is
+// separate from this issue.
+public class Bug_4493_optimistic_partitioning : OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task can_apply_schema_with_optimistic_concurrency_and_partitioning()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Part>().UseOptimisticConcurrency(true);
+
+            opts.Policies.AllDocumentsAreMultiTenantedWithPartitioning(policy =>
+            {
+                var partitions = policy.ByList();
+                partitions.AddPartition("Region1", "Region1");
+                partitions.AddPartition("Region2", "Region2");
+            });
+        });
+
+        // Should not throw — the upsert / overwrite function SQL must be
+        // valid PostgreSQL with both optimistic-concurrency and
+        // partition-pruning paths in play. Call directly so the
+        // underlying NRE is preserved when the bug is in flight.
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.All);
+
+        // Round-trip a document to confirm the function actually works
+        // against the partitioned table, not just that it created.
+        await using var session = theStore.LightweightSession("Region1");
+        var part = new Part
+        {
+            Id = Guid.NewGuid(),
+            PartNumber = "P-001",
+            Cage = "ABC",
+            Description = "Regression repro for #4493"
+        };
+        session.Store(part);
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession("Region1");
+        var loaded = await query.LoadAsync<Part>(part.Id);
+        loaded.ShouldNotBeNull();
+        loaded.PartNumber.ShouldBe("P-001");
+    }
+
+    public class Part
+    {
+        public Guid Id { get; set; }
+        public required string PartNumber { get; set; }
+        public required string Cage { get; set; }
+        public required string Description { get; set; }
+    }
+}

--- a/src/Marten/Storage/UpsertFunction.cs
+++ b/src/Marten/Storage/UpsertFunction.cs
@@ -122,9 +122,14 @@ internal class UpsertFunction: Function
             var partitionClauses = new List<string>();
             foreach (var colName in table.Partitioning.Columns)
             {
-                // Find the matching argument for this partition column
+                // Find the matching argument for this partition column. Some
+                // UpsertArguments (notably CurrentVersionArgument when
+                // optimistic concurrency is enabled) deliberately set Column
+                // to null because they don't correspond to a stored column;
+                // use string.Equals which is null-safe rather than calling
+                // .Equals on a possibly-null Column. See marten#4493.
                 var arg = Arguments.FirstOrDefault(a =>
-                    a.Column.Equals(colName, StringComparison.OrdinalIgnoreCase));
+                    string.Equals(a.Column, colName, StringComparison.OrdinalIgnoreCase));
                 if (arg != null)
                 {
                     partitionClauses.Add($"{colName} = {arg.Arg}");


### PR DESCRIPTION
## Summary

Closes #4493.

`UpsertFunction`'s partition-column scan called `arg.Column.Equals(colName, ...)` on each `UpsertArgument` when building the partition WHERE-clause fragment. `CurrentVersionArgument` deliberately sets `Column` to `null` (it's a sentinel that doesn't map to a stored column), so when optimistic concurrency was enabled on a document that also participated in `AllDocumentsAreMultiTenantedWithPartitioning(...)`, `DocumentSchema` construction blew up with `NullReferenceException` during `ApplyAllConfiguredChangesToDatabaseAsync` — exactly the symptom in the [reporter's repro](https://github.com/franktylerva/Marten-Test).

## The fix

```diff
-                var arg = Arguments.FirstOrDefault(a =>
-                    a.Column.Equals(colName, StringComparison.OrdinalIgnoreCase));
+                var arg = Arguments.FirstOrDefault(a =>
+                    string.Equals(a.Column, colName, StringComparison.OrdinalIgnoreCase));
```

`string.Equals(null, "foo", ...)` is null-safe and returns `false`, so a `CurrentVersionArgument` is naturally skipped — the only path that was crashing.

## Test plan

- [x] New regression test `CoreTests/Partitioning/Bug_4493_optimistic_partitioning.cs` reproduces the exact configuration from the reporter's repro (`.UseOptimisticConcurrency(true)` + `AllDocumentsAreMultiTenantedWithPartitioning` with two list partitions) and round-trips a document through one of the partitions.
- [x] Fails with `NullReferenceException at UpsertFunction.cs:127` without the fix (verified locally).
- [x] Passes with the fix on net8.0 / net9.0 / net10.0.
- [x] Adjacent partitioning tests (`CoreTests.Partitioning.*`) all 27 still pass.

Master companion PR will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)