### PR TITLE
Marten#4493 regression test on master (no code fix needed)

### DIFF
--- a/src/CoreTests/Partitioning/Bug_4493_optimistic_partitioning.cs
+++ b/src/CoreTests/Partitioning/Bug_4493_optimistic_partitioning.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace CoreTests.Partitioning;
+
+// Regression for marten#4493. The reporter combined
+// .UseOptimisticConcurrency(true) on a document with the
+// AllDocumentsAreMultiTenantedWithPartitioning(...) policy and
+// ApplyAllConfiguredChangesToDatabaseAsync threw NullReferenceException
+// from UpsertFunction's partition-column scan. Root cause: when
+// optimistic concurrency is on a CurrentVersionArgument is added whose
+// Column is deliberately null; the partition loop called
+// arg.Column.Equals(...) on it. Started on 8.29.0. The reporter
+// confirmed setting UseOptimisticConcurrency(false) sidesteps the bug.
+//
+// Class name kept short on purpose — combined with the
+// `mt_doc_{schema}_{type}` table-name prefix and the long
+// CoreTests schema base, the 63-byte Postgres identifier limit truncates
+// partition table names and collides them. That truncation behavior is
+// separate from this issue.
+public class Bug_4493_optimistic_partitioning : OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task can_apply_schema_with_optimistic_concurrency_and_partitioning()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Part>().UseOptimisticConcurrency(true);
+
+            opts.Policies.AllDocumentsAreMultiTenantedWithPartitioning(policy =>
+            {
+                var partitions = policy.ByList();
+                partitions.AddPartition("Region1", "Region1");
+                partitions.AddPartition("Region2", "Region2");
+            });
+        });
+
+        // Should not throw — the upsert / overwrite function SQL must be
+        // valid PostgreSQL with both optimistic-concurrency and
+        // partition-pruning paths in play. Call directly so the
+        // underlying NRE is preserved when the bug is in flight.
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync(AutoCreate.All);
+
+        // Round-trip a document to confirm the function actually works
+        // against the partitioned table, not just that it created.
+        await using var session = theStore.LightweightSession("Region1");
+        var part = new Part
+        {
+            Id = Guid.NewGuid(),
+            PartNumber = "P-001",
+            Cage = "ABC",
+            Description = "Regression repro for #4493"
+        };
+        session.Store(part);
+        await session.SaveChangesAsync();
+
+        await using var query = theStore.QuerySession("Region1");
+        var loaded = await query.LoadAsync<Part>(part.Id);
+        loaded.ShouldNotBeNull();
+        loaded.PartNumber.ShouldBe("P-001");
+    }
+
+    public class Part
+    {
+        public Guid Id { get; set; }
+        public required string PartNumber { get; set; }
+        public required string Cage { get; set; }
+        public required string Description { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #4493. Companion to the 8.0-line fix in #4496.

The bug — `NullReferenceException` when combining `.UseOptimisticConcurrency(true)` with `AllDocumentsAreMultiTenantedWithPartitioning(...)` — was in `Marten/Storage/UpsertFunction.cs`. That file was **retired entirely** on master by #4461's closed-shape storage rewrite ("Boom"), so the bug doesn't reproduce here. The cherry-pick of the 8.0 patch therefore omits the `UpsertFunction.cs` edit (file no longer exists on master) and lands **only the regression test**.

## Why land just the test

- The reporter's repro is a real configuration shape — partitioned tenant tables + optimistic concurrency is a supported combination — and worth pinning end-to-end on master.
- Any future code path that walks partition columns + UpsertArguments could re-introduce a similar null-traversal pattern. The test acts as a regression-prevention guard.
- The 8.0-line fix in #4496 carries the actual code change for users on the 8.x release.

## Test plan

- [x] `CoreTests/Partitioning/Bug_4493_optimistic_partitioning.cs` exercises the exact configuration shape from the [reporter's repro](https://github.com/franktylerva/Marten-Test): `.UseOptimisticConcurrency(true)` on a document plus `AllDocumentsAreMultiTenantedWithPartitioning` with two list partitions, then applies the schema and round-trips a document through one of the partitions.
- [x] Passes on net9.0 and net10.0 on master with no code change.
- [x] On the 8.0 line the same test fails with the reporter's exact `NullReferenceException` without the `UpsertFunction.cs` fix — confirmed in #4496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)