### PR TITLE
Fix #4425: bootstrap skip-aware high-water function so V9 default can flip

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -169,10 +169,10 @@ Marten 9 ships a handful of `StoreOptions` defaults flipped to the values recomm
 * **Restore the V8 default:** `opts.Events.AppendMode = EventAppendMode.Rich;` (or `opts.RestoreV8Defaults();`).
 * See the [Event Appending modes](events/appending.md) and [Optimizing the Event Store](events/optimizing.md) docs.
 
-#### **`Events.EnableAdvancedAsyncTracking` — flip deferred for 9.0**
+#### **`Events.EnableAdvancedAsyncTracking` now defaults to `true`**
 
-* **Stays at `false` (the V8 default) for now.** The intent is to flip this to `true` in 9.0, but turning it on caused large portions of the EventSourcing and Daemon test suites to hang. Tracked in [#4425](https://github.com/JasperFx/marten/issues/4425); the flip lands once that's root-caused.
-* **Opt in early:** `opts.Events.EnableAdvancedAsyncTracking = true;` (at your own risk until #4425 is resolved). `RestoreV8Defaults()` does not touch this setting.
+* **Was `false` in Marten 8.x.** Records high-water skips into `mt_high_water_skips` so the async daemon can reason about gaps it has already skipped past instead of re-detecting them on every poll. See [#4425](https://github.com/JasperFx/marten/issues/4425) for the bootstrap bug that previously blocked this flip.
+* **Restore the V8 default:** `opts.Events.EnableAdvancedAsyncTracking = false;` (or `opts.RestoreV8Defaults();`).
 * See the [Async Projection Daemon](events/projections/async-daemon.md) docs.
 
 #### **`Events.EnableEventSkippingInProjectionsOrSubscriptions` now defaults to `true`**
@@ -546,6 +546,7 @@ var store = DocumentStore.For(opts =>
 | Setting | V8 default it restores |
 | --- | --- |
 | `Events.AppendMode` | `EventAppendMode.Rich` — [Event Appending](events/appending.md) |
+| `Events.EnableAdvancedAsyncTracking` | `false` — [Async Projection Daemon](events/projections/async-daemon.md) |
 | `Events.EnableEventSkippingInProjectionsOrSubscriptions` | `false` — [Async Projection Daemon](events/projections/async-daemon.md) |
 | `Events.UseIdentityMapForAggregates` | `false` — [Aggregate Projections](events/projections/aggregate-projections.md) |
 | `Events.EnableBigIntEvents` | `false` — [Event Store](events/index.md) |
@@ -571,8 +572,8 @@ services.AddMarten(opts =>
         opts.Connection(configuration.GetConnectionString("Marten"));
 
         // Revert the StoreOptions defaults Marten 9 flipped (AppendMode,
-        // EnableEventSkippingInProjectionsOrSubscriptions, UseIdentityMapForAggregates,
-        // EnableBigIntEvents, DisableNpgsqlLogging).
+        // EnableAdvancedAsyncTracking, EnableEventSkippingInProjectionsOrSubscriptions,
+        // UseIdentityMapForAggregates, EnableBigIntEvents, DisableNpgsqlLogging).
         opts.RestoreV8Defaults();
 
         // Restore V8's Newtonsoft serializer default (Marten 9 ships STJ by default

--- a/src/CoreTests/V9DefaultsAndRestoreV8DefaultsTests.cs
+++ b/src/CoreTests/V9DefaultsAndRestoreV8DefaultsTests.cs
@@ -25,12 +25,9 @@ public class V9DefaultsAndRestoreV8DefaultsTests
     }
 
     [Fact]
-    public void v9_default_for_enable_advanced_async_tracking_is_still_v8_false_until_4425()
+    public void v9_default_for_enable_advanced_async_tracking_is_true()
     {
-        // The EnableAdvancedAsyncTracking flip is deferred — re-enabling it caused large
-        // portions of the EventSourcing + Daemon test suites to hang. Tracked in #4425.
-        // Update this assertion when the flip lands.
-        new StoreOptions().Events.EnableAdvancedAsyncTracking.ShouldBeFalse();
+        new StoreOptions().Events.EnableAdvancedAsyncTracking.ShouldBeTrue();
     }
 
     [Fact]
@@ -68,15 +65,11 @@ public class V9DefaultsAndRestoreV8DefaultsTests
     }
 
     [Fact]
-    public void restore_v8_defaults_keeps_enable_advanced_async_tracking_at_v8_false()
+    public void restore_v8_defaults_reverts_enable_advanced_async_tracking_to_false()
     {
-        // The flip itself is deferred (#4425) so RestoreV8Defaults() doesn't need to
-        // reset EnableAdvancedAsyncTracking — it's already at the V8 default. This test
-        // documents that and locks in the contract so it gets updated alongside #4425.
         var opts = new StoreOptions();
-        opts.Events.EnableAdvancedAsyncTracking = true;
         opts.RestoreV8Defaults();
-        opts.Events.EnableAdvancedAsyncTracking.ShouldBeTrue();
+        opts.Events.EnableAdvancedAsyncTracking.ShouldBeFalse();
     }
 
     [Fact]

--- a/src/EventSourcingTests/advanced_async_tracking.cs
+++ b/src/EventSourcingTests/advanced_async_tracking.cs
@@ -67,10 +67,18 @@ public class advanced_async_tracking : OneOffConfigurationsContext, IAsyncLifeti
     }
 
     [Fact]
-    public async Task try_mark_from_nothing_would_be_0()
+    public async Task try_mark_from_nothing_bootstraps_the_row_and_records_the_skip()
     {
+        // #4425: the null-row branch used to return 0 unconditionally, which left
+        // HighWaterAgent.CheckNowAsync polling forever waiting for the mark to advance.
+        // The function now bootstraps the high-water row at the ending sequence and
+        // records the implicit 0->ending skip so callers can observe forward progress.
         var final = await theDetector.TryMarkHighWaterSkippingAsync(1000, 100, CancellationToken.None);
-        final.ShouldBe(0);
+        final.ShouldBe(1000);
+
+        var skips = await theDetector.FetchLastProgressionSkipsAsync(100, CancellationToken.None);
+        skips[0].Ending.ShouldBe(1000);
+        skips[0].Starting.ShouldBe(100);
     }
 
     [Fact]

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -92,14 +92,11 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
         // Callers wanting V8 semantics call StoreOptions.RestoreV8Defaults() to revert
         // these. Anything not listed here kept its V8 default. See docs/migration-guide.md
         // for the per-setting rationale + the consolidated RestoreV8Defaults recipe.
-        //
-        // EnableAdvancedAsyncTracking is deferred — flipping it to true causes large
-        // portions of the EventSourcing + Daemon test suites to hang. Tracked for the
-        // 9.0 milestone in #4425; re-enable once root cause is fixed.
         AppendMode = EventAppendMode.QuickWithServerTimestamps;
         EnableEventSkippingInProjectionsOrSubscriptions = true;
         UseIdentityMapForAggregates = true;
         EnableBigIntEvents = true;
+        EnableAdvancedAsyncTracking = true;
     }
 
     /// <summary>

--- a/src/Marten/Schema/SQL/mt_mark_progression_with_skip.sql
+++ b/src/Marten/Schema/SQL/mt_mark_progression_with_skip.sql
@@ -7,7 +7,17 @@ BEGIN
     select last_seq_id into current_value from {databaseSchema}.mt_event_progression where name = shard_name;
 
     IF current_value is null then
-        return 0;
+        -- Bootstrap the high-water row on first invocation. Previously this branch
+        -- returned 0, which left HighWaterAgent.CheckNowAsync polling forever because
+        -- statistics.CurrentMark never advanced. Issue #4425.
+        INSERT INTO {databaseSchema}.mt_event_progression (name, last_seq_id, last_updated)
+        VALUES (shard_name, ending_sequence, transaction_timestamp())
+        ON CONFLICT ON CONSTRAINT pk_mt_event_progression
+            DO UPDATE SET last_seq_id = ending_sequence, last_updated = transaction_timestamp();
+        IF ending_sequence > starting_sequence THEN
+            insert into {databaseSchema}.mt_high_water_skips (ending_sequence, starting_sequence) values (ending_sequence, starting_sequence);
+        END IF;
+        return ending_sequence;
     ELSIF current_value = starting_sequence THEN
         update {databaseSchema}.mt_event_progression SET last_seq_id = ending_sequence, last_updated = transaction_timestamp() where shard_name = name;
         insert into {databaseSchema}.mt_high_water_skips (ending_sequence, starting_sequence) values (ending_sequence, starting_sequence);

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -722,8 +722,7 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
     public void RestoreV8Defaults()
     {
         Events.AppendMode = EventAppendMode.Rich;
-        // EnableAdvancedAsyncTracking is not flipped in 9.0 yet (#4425), so it
-        // already sits at its V8 default and is not touched here.
+        Events.EnableAdvancedAsyncTracking = false;
         Events.EnableEventSkippingInProjectionsOrSubscriptions = false;
         Events.UseIdentityMapForAggregates = false;
         Events.EnableBigIntEvents = false;


### PR DESCRIPTION
## Summary
- Fixes #4425 (`StoreOptions.Events.EnableAdvancedAsyncTracking` hangs in test suites).
- Bootstraps `mt_mark_progression_with_skip` on first call so the function no longer returns 0 forever — that return value pinned `HighWaterAgent.CheckNowAsync` in an infinite poll loop whenever the flag was on, hanging large slices of the EventSourcing and Daemon test suites.
- Promotes `EnableAdvancedAsyncTracking` to the V9 default flip set; `RestoreV8Defaults()` and the migration guide pick it up.

## Root cause

```sql
-- before
IF current_value is null then
    return 0;
```

`HighWaterDetector` (skip-aware branch) calls this function expecting `actual = ending_sequence` after a successful advance, falling back to the returned value as the new mark otherwise. With no progression row yet, `current_value` is null, the function returned 0, and `JasperFx.Events.Daemon.HighWaterAgent.CheckNowAsync`'s `while (statistics.CurrentMark < initialHighMark)` never exited. Net effect: any test that started the daemon with `EnableAdvancedAsyncTracking = true` and no pre-existing progression row hung indefinitely.

The standard `mt_mark_event_progression` (used when the flag is off) avoids the problem because it does an `INSERT … ON CONFLICT DO UPDATE` upsert — first-time invocation just inserts the row.

## Fix

Mirror the upsert pattern on the `IS NULL` branch of `mt_mark_progression_with_skip`: insert (or upsert) the row at `ending_sequence`, record a skip row when `ending > starting`, return `ending_sequence`. The hot `current_value = starting_sequence` path is unchanged.

With the SQL fixed, `EnableAdvancedAsyncTracking` joins the rest of the V9 defaults in `EventGraph`. `RestoreV8Defaults()` flips it back, and the migration guide adds a row for it in the V8-restoration table.

## Test plan
- [x] Standalone repro completes in ~400 ms (previously hung indefinitely).
- [x] `DaemonTests.Aggregations.multi_stream_projections.events_applied_in_sequence_across_streams` (the test xunit blame-hang originally flagged) passes.
- [x] Full `DaemonTests` on net10.0 — 185/185 in 2m33s, no hangs (180 s blame-hang detector).
- [x] `EventSourcingTests.Projections.*` on net10.0 — 167/167 in 24 s.
- [x] `markdownlint` + `cspell` clean on `docs/migration-guide.md`.
- [ ] CI matrix coverage across net8/10 and PG 15/latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)