### PR TITLE
Fix #4500: rebase Marten.IStorageOperation on Weasel.Core.IStorageOperation

### DIFF
--- a/src/Marten/Internal/Operations/IStorageOperation.cs
+++ b/src/Marten/Internal/Operations/IStorageOperation.cs
@@ -1,18 +1,13 @@
 #nullable enable
-using System;
-using System.Collections.Generic;
-using System.Data.Common;
-using System.Threading;
-using System.Threading.Tasks;
 using Marten.Linq.QueryHandlers;
 
 namespace Marten.Internal.Operations;
 
-public interface IStorageOperation: IQueryHandler
+// Subinterface over Weasel.Core.IStorageOperation. The three storage-op members
+// (DocumentType, PostprocessAsync, Role) come from Weasel.Core; ConfigureCommand
+// with the session-aware signature comes from IQueryHandler. Polecat layers its
+// own ICommandBuilder-only ConfigureCommand on the same Weasel.Core base — see
+// #4500 / Critter Stack 2026 dedupe pillar (jasperfx#214).
+public interface IStorageOperation: Weasel.Core.IStorageOperation, IQueryHandler
 {
-    Type DocumentType { get; }
-
-    Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token);
-
-    OperationRole Role();
 }


### PR DESCRIPTION
## Summary
- Closes #4500.
- Marten's `IStorageOperation` becomes an empty subinterface over `Weasel.Core.IStorageOperation`, dropping the three redundant declarations (`DocumentType`, `PostprocessAsync`, `Role()`).
- `IQueryHandler` co-inheritance is preserved — Marten's `ConfigureCommand(ICommandBuilder, IMartenSession)` is a genuine dialect divergence from Polecat's stateless variant and stays on the Marten-side subinterface.

## Why this is a 6-line diff

After #4499 (just landed in master as `38a503949`) Marten's interface had this shape:

```csharp
public interface IStorageOperation : IQueryHandler
{
    Type DocumentType { get; }
    Task PostprocessAsync(DbDataReader, IList<Exception>, CancellationToken);
    OperationRole Role();
}
```

`Weasel.Core.IStorageOperation` (already shipping in the `Weasel.Postgresql` 9.0.0-alpha.5 transitive dep Marten references) declares exactly those three members. The rebase is structural — every Marten implementer (~35 classes) already satisfies the inherited contract, so no implementer changes are needed.

`OperationRole` was already aliased to `Weasel.Core.OperationRole` via `GlobalUsings.cs:5` so there's no symbol clash.

## Why keep the Marten subinterface at all

- **`IQueryHandler` carries Marten's session-aware `ConfigureCommand(ICommandBuilder, IMartenSession)`** — implementers reach into session-scoped serializers, tenant binders, and version state. Polecat layers its own `ConfigureCommand(ICommandBuilder)` (no session) on the same Weasel.Core base, exactly the divergence the issue calls out.
- **`global using IStorageOperation = Marten.Internal.Operations.IStorageOperation;`** stays — keeps every existing usage site resolving to the Marten subinterface, which is the right hook if Marten ever needs to add Marten-specific members.

## Test plan
- [x] `dotnet build src/Marten.slnx` — 0 errors across net9/10.
- [x] `CoreTests` filter on `Internal.Sessions|retry_mechanism|Internal.Operations` — 20/20 pass on net10.0.
- [x] `DocumentDbTests` filter on `Writing` — 114/114 pass on net10.0.
- [x] `EventSourcingTests` filter on `appending_events_workflow|quick_appending_events_workflow` — 52/52 pass on net10.0.
- [ ] Full CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)