### PR TITLE
Fix #4494: AddSingleton<IAsyncConfigureMarten> now runs without ConfigureMartenWithServices<T>()

### DIFF
--- a/docs/configuration/composite-configuration.md
+++ b/docs/configuration/composite-configuration.md
@@ -25,13 +25,9 @@ The main host:
 ```csharp
 var builder = Host.CreateApplicationBuilder();
 
-// Each satellite's IConfigureMarten gets wired into DI.
-builder.Services.AddSingleton<IConfigureMarten, OrdersConfig>();         // SatelliteA
-// For IAsyncConfigureMarten, use ConfigureMartenWithServices<T>() so the
-// hosted service that drains async configs gets registered. A raw
-// AddSingleton<IAsyncConfigureMarten>() would add the type to DI but
-// never invoke its Configure method.
-builder.Services.ConfigureMartenWithServices<ReportingConfig>();         // SatelliteB
+// Each satellite's IConfigureMarten / IAsyncConfigureMarten gets wired into DI.
+builder.Services.AddSingleton<IConfigureMarten, OrdersConfig>();           // SatelliteA
+builder.Services.AddSingleton<IAsyncConfigureMarten, ReportingConfig>();   // SatelliteB
 
 // Main host carries only shared infrastructure.
 builder.Services.AddMarten(opts =>
@@ -82,14 +78,12 @@ Pin test: `src/ModularConfigTests/AddMartenTimingTests.cs`.
 
 ### 4. `IConfigureMarten` and `IAsyncConfigureMarten` compose
 
-A host can mix both. Sync contributions apply during the `StoreOptions` factory's resolution (synchronous, on first `IDocumentStore` resolution). Async contributions apply inside the `AsyncConfigureMartenApplication` hosted service, which is inserted ahead of `MartenActivator` in the `IHostedService` chain — so async configs are visible by the time anything else consumes the store.
+A host can mix both. Sync contributions apply during the `StoreOptions` factory's resolution (synchronous, on first `IDocumentStore` resolution). Async contributions apply inside the `AsyncConfigureMartenApplication` hosted service, which is inserted ahead of `MartenActivator` in the `IHostedService` chain — so async configs are visible by the time anything else consumes the store. `AddMarten` registers the hosted service unconditionally (#4494), so bare `AddSingleton<IAsyncConfigureMarten, T>()` works the same as the sync sibling.
 
-The registration APIs are asymmetric:
-
-| Contract | Sync | Async |
+| Contract | Bare `AddSingleton<...>` | Extension API |
 | --- | --- | --- |
-| Bare `AddSingleton<...>` works | ✅ | ❌ (hosted service not registered) |
-| Extension API | `services.AddSingleton<IConfigureMarten, T>()` or `services.ConfigureMarten(...)` | `services.ConfigureMartenWithServices<T>()` |
+| `IConfigureMarten` | ✅ | `services.AddSingleton<IConfigureMarten, T>()` or `services.ConfigureMarten(...)` |
+| `IAsyncConfigureMarten` | ✅ | `services.ConfigureMartenWithServices<T>()` (still available; equivalent to the bare form) |
 
 Pin test: `src/ModularConfigTests/AsyncComposeTests.cs`.
 

--- a/src/CoreTests/bootstrapping_with_service_collection_extensions.cs
+++ b/src/CoreTests/bootstrapping_with_service_collection_extensions.cs
@@ -154,12 +154,13 @@ public class bootstrapping_with_service_collection_extensions
         var store = container.GetInstance<IDocumentStore>();
         await store.Advanced.Clean.CompletelyRemoveAllAsync();
 
-        var instance = container.Model.For<IHostedService>().Instances.First();
-        instance.ImplementationType.ShouldBe(typeof(MartenActivator));
+        var instance = container.Model.For<IHostedService>().Instances
+            .Single(x => x.ImplementationType == typeof(MartenActivator));
         instance.Lifetime.ShouldBe(ServiceLifetime.Singleton);
 
         // Just a smoke test here
-        await container.GetAllInstances<IHostedService>().First().StartAsync(default);
+        var activator = container.GetAllInstances<IHostedService>().OfType<MartenActivator>().Single();
+        await activator.StartAsync(default);
 
         await store.Storage.Database.AssertDatabaseMatchesConfigurationAsync();
     }
@@ -182,12 +183,12 @@ public class bootstrapping_with_service_collection_extensions
         var store = container.GetInstance<IDocumentStore>();
         await store.Advanced.Clean.CompletelyRemoveAllAsync();
 
-        var instance = container.Model.For<IHostedService>().Instances.First();
-        instance.ImplementationType.ShouldBe(typeof(MartenActivator));
+        var instance = container.Model.For<IHostedService>().Instances
+            .Single(x => x.ImplementationType == typeof(MartenActivator));
         instance.Lifetime.ShouldBe(ServiceLifetime.Singleton);
 
-        await Assert.ThrowsAsync<DatabaseValidationException>(() =>
-            container.GetAllInstances<IHostedService>().First().StartAsync(default));
+        var activator = container.GetAllInstances<IHostedService>().OfType<MartenActivator>().Single();
+        await Assert.ThrowsAsync<DatabaseValidationException>(() => activator.StartAsync(default));
     }
 
     [Fact]

--- a/src/CoreTests/configuring_marten_with_async_extensions.cs
+++ b/src/CoreTests/configuring_marten_with_async_extensions.cs
@@ -72,6 +72,43 @@ public class configuring_marten_with_async_extensions
             .Alias.ShouldBe("module_1_event");
 
     }
+
+    [Fact]
+    public async Task bare_AddSingleton_IAsyncConfigureMarten_is_invoked()
+    {
+        // #4494 regression. Pre-fix, bare AddSingleton<IAsyncConfigureMarten, T>()
+        // registered the impl but never wired AsyncConfigureMartenApplication, so
+        // Configure() silently never ran. AddMarten now registers the hosted service
+        // unconditionally, matching how bare AddSingleton<IConfigureMarten, T>() works.
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DatabaseSchemaName = "async_config_bare";
+                });
+
+                services.AddSingleton<IAsyncConfigureMarten, RecordingAsyncConfig>();
+            }).StartAsync();
+
+        var recorded = host.Services.GetServices<IAsyncConfigureMarten>()
+            .OfType<RecordingAsyncConfig>()
+            .Single();
+
+        recorded.Invoked.ShouldBeTrue();
+    }
+}
+
+internal sealed class RecordingAsyncConfig: IAsyncConfigureMarten
+{
+    public bool Invoked { get; private set; }
+
+    public ValueTask Configure(StoreOptions options, CancellationToken cancellationToken)
+    {
+        Invoked = true;
+        return ValueTask.CompletedTask;
+    }
 }
 
 #region sample_featuremanagementusingextension

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -170,6 +170,10 @@ public static class MartenServiceCollectionExtensions
     )
     {
         services.AddJasperFx();
+        // #4494: register the hosted service that drains IAsyncConfigureMarten so
+        // bare AddSingleton<IAsyncConfigureMarten, T>() works the same way bare
+        // AddSingleton<IConfigureMarten, T>() does. The helper is idempotent.
+        services.EnsureAsyncConfigureMartenApplicationIsRegistered();
         services.AddSingleton<ISystemPart, MartenSystemPart>();
         services.AddSingleton<IEventStore>(s => (IEventStore)s.GetRequiredService<IDocumentStore>());
         services.AddSingleton<IDocumentStoreUsageSource>(s =>


### PR DESCRIPTION
## Summary
- Closes #4494.
- `AddMarten` now calls `EnsureAsyncConfigureMartenApplicationIsRegistered()` unconditionally, so the hosted service that drains `IAsyncConfigureMarten` is always present. Bare `AddSingleton<IAsyncConfigureMarten, T>()` works the same way bare `AddSingleton<IConfigureMarten, T>()` already did.
- Removes the silent-no-op foot-gun documented as a known caveat in `docs/configuration/composite-configuration.md`.

## Why the bug existed

`IConfigureMarten` is consumed *lazily inside the `StoreOptions` factory* (`MartenServiceCollectionExtensions.cs:181`), so any DI registration mechanism surfaces automatically. `IAsyncConfigureMarten` is consumed by a *separate hosted service* (`AsyncConfigureMartenApplication`) whose registration was gated behind `EnsureAsyncConfigureMartenApplicationIsRegistered()`, called only from `ConfigureMartenWithServices<T>()`. Bypass that helper and the impl was registered in DI but never resolved by anything — silent no-op.

## The fix (1 line in production)

```csharp
public static MartenConfigurationExpression AddMarten(
    this IServiceCollection services,
    Func<IServiceProvider, StoreOptions> optionSource)
{
    services.AddJasperFx();
    services.EnsureAsyncConfigureMartenApplicationIsRegistered();  // <-- new
    services.AddSingleton<ISystemPart, MartenSystemPart>();
    ...
}
```

The helper is idempotent (`if (!services.Any(...))` guard), so `ConfigureMartenWithServices<T>()` continues to work unchanged. Cost when no async configs are registered: one no-op hosted-service tick at startup.

## Secondary stores

`AddMartenStore<T>` deliberately doesn't support `IAsyncConfigureMarten` — `AsyncConfigureMartenApplication`'s constructor is hard-wired to the primary `StoreOptions` singleton. No change needed on the secondary path.

## Bootstrap-test fixups

Two pre-existing tests in `bootstrapping_with_service_collection_extensions.cs` asserted `MartenActivator` was literally `First()` in the hosted-service chain. The intended invariant — "`MartenActivator` runs after `AsyncConfigureMartenApplication`" — is already preserved by `EnsureMartenActivatorIsRegistered` (it anchors the activator *after* the async-config service when present). With the async-config service now unconditionally present, the activator drops to index 1. Tests retargeted to find `MartenActivator` by type instead of by position. Behavior unchanged.

## Test plan
- [x] New regression: `configuring_marten_with_async_extensions.bare_AddSingleton_IAsyncConfigureMarten_is_invoked` — asserts a bare `AddSingleton<IAsyncConfigureMarten, T>()` impl's `Configure()` runs after `host.StartAsync()`. 40ms.
- [x] Full `CoreTests` slice on net10.0 — 412/412 pass (1 skip), 44s.
- [x] `ModularConfigTests` pin suite — 5/5 pass.
- [x] `markdownlint` + `cspell` clean on `composite-configuration.md`.
- [ ] Full CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)