### PR TITLE
Bump JasperFx + Weasel.* nugets and Marten to 9.0.0-alpha.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.0.0-alpha.3</Version>
+        <Version>9.0.0-alpha.4</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,13 +13,13 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.16" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.15" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.8">
+    <PackageVersion Include="JasperFx" Version="2.0.0-alpha.17" />
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.16" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-alpha.5" />
+    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-alpha.6" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
@@ -66,8 +66,8 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.5" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0-alpha.5" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.6" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0-alpha.6" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary
- Routine version bump in preparation for the next Marten alpha publish.

## Bumps
| Package | From | To |
| --- | --- | --- |
| `JasperFx` | `2.0.0-alpha.16` | `2.0.0-alpha.17` |
| `JasperFx.Events` | `2.0.0-alpha.15` | `2.0.0-alpha.16` |
| `JasperFx.Events.SourceGenerator` | `2.0.0-alpha.8` | `2.0.0-alpha.9` |
| `JasperFx.SourceGeneration` | `2.0.0-alpha.5` | `2.0.0-alpha.6` |
| `Weasel.Postgresql` | `9.0.0-alpha.5` | `9.0.0-alpha.6` |
| `Weasel.EntityFrameworkCore` | `9.0.0-alpha.5` | `9.0.0-alpha.6` |
| `Marten` | `9.0.0-alpha.3` | `9.0.0-alpha.4` |

## Verification
- [x] `dotnet build src/Marten.slnx -c Release` — 0 errors across net9/net10.
- [ ] Full CI matrix.

After merge: trigger `on-manual-do-nuget-publish.yml` to publish `9.0.0-alpha.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)