### PR TITLE
Fix #4510 + #4513: FetchForWritingByTags for pure DCB boundary aggregates + docs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,8 +14,8 @@
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
     <PackageVersion Include="JasperFx" Version="2.0.0-alpha.20" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.20" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.12">
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0-alpha.21" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-alpha.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>

--- a/docs/events/dcb.md
+++ b/docs/events/dcb.md
@@ -195,6 +195,36 @@ var aggregate = await theSession.Events.AggregateByTagsAsync<StudentCourseEnroll
 
 Returns `null` if no matching events are found.
 
+### Identity-less Boundary Aggregates
+
+`StudentCourseEnrollment` above carries a single-stream `Id`, so it doubles as an ordinary aggregate. A **pure boundary aggregate** has no single-stream identity at all — it exists only as the projection of the events selected by a tag query, spanning many streams. Mark such a type with `[BoundaryAggregate]` so the source generator still emits a dispatcher for it even though it has no `Id` property and no `[AggregateIdentity]`:
+
+<!-- snippet: sample_marten_dcb_boundary_aggregate -->
+<a id='snippet-sample_marten_dcb_boundary_aggregate'></a>
+```cs
+// A *pure* DCB boundary aggregate: Apply methods, but no single-stream identity
+// (no Id property, no [AggregateIdentity]). It spans multiple streams by tag, so
+// the only thing that makes the source generator emit an evolver for it is the
+// [BoundaryAggregate] marker. See marten#4510 / jasperfx#324.
+[BoundaryAggregate]
+public class SubscriptionState
+{
+    public int EnrollmentCount { get; set; }
+    public int ProgressCount { get; set; }
+
+    public void Apply(Enrolled _) => EnrollmentCount++;
+    public void Apply(ProgressRecorded _) => ProgressCount++;
+}
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Dcb/dcb_boundary_aggregate_fetch_for_writing_tests.cs#L22-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_marten_dcb_boundary_aggregate' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Register it with `RegisterTagType<...>().ForAggregate<T>()` only — do **not** add a `LiveStreamAggregation<T>()` / `Snapshot<T>()` registration, since those require a stream identity. `AggregateByTagsAsync<T>` and `FetchForWritingByTags<T>` then work against the boundary aggregate.
+
+::: warning
+The `[BoundaryAggregate]` marker is required, and it is an explicit opt-in. Without it, an identity-less aggregate gets no source-generated dispatcher and `FetchForWritingByTags<T>` throws `InvalidProjectionException` ("No source-generated dispatcher found"). This is deliberate: a no-`Id` aggregate is far more often a forgotten identity than an intended boundary aggregate, so the marker distinguishes the two. The aggregate's assembly must reference the `JasperFx.Events.SourceGenerator` analyzer.
+:::
+
 ## Fetch for Writing (Consistency Boundary)
 
 `FetchForWritingByTags` loads the aggregate and establishes a consistency boundary. At `SaveChangesAsync` time, Marten checks whether any new events matching the query have been appended since the read, throwing `DcbConcurrencyException` if so:

--- a/src/EventSourcingTests/Dcb/dcb_boundary_aggregate_fetch_for_writing_tests.cs
+++ b/src/EventSourcingTests/Dcb/dcb_boundary_aggregate_fetch_for_writing_tests.cs
@@ -1,0 +1,93 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Tags;
+using Marten;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Dcb;
+
+// Strong-typed tag identifiers for the boundary-aggregate scenario
+public record EnrolleeId(Guid Value);
+public record ProgramId(Guid Value);
+
+public record Enrolled(string Name);
+public record ProgressRecorded(string Milestone);
+
+#region sample_marten_dcb_boundary_aggregate
+// A *pure* DCB boundary aggregate: Apply methods, but no single-stream identity
+// (no Id property, no [AggregateIdentity]). It spans multiple streams by tag, so
+// the only thing that makes the source generator emit an evolver for it is the
+// [BoundaryAggregate] marker. See marten#4510 / jasperfx#324.
+[BoundaryAggregate]
+public class SubscriptionState
+{
+    public int EnrollmentCount { get; set; }
+    public int ProgressCount { get; set; }
+
+    public void Apply(Enrolled _) => EnrollmentCount++;
+    public void Apply(ProgressRecorded _) => ProgressCount++;
+}
+#endregion
+
+[Collection("OneOffs")]
+public class dcb_boundary_aggregate_fetch_for_writing_tests: OneOffConfigurationsContext, IAsyncLifetime
+{
+    private void ConfigureStore()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+
+            opts.Events.AddEventType<Enrolled>();
+            opts.Events.AddEventType<ProgressRecorded>();
+
+            // Pure boundary aggregate: registered only via ForAggregate<T>(), with
+            // no LiveStreamAggregation / Snapshot (which would require a stream Id).
+            opts.Events.RegisterTagType<EnrolleeId>("enrollee").ForAggregate<SubscriptionState>();
+            opts.Events.RegisterTagType<ProgramId>("program").ForAggregate<SubscriptionState>();
+        });
+    }
+
+    public Task InitializeAsync()
+    {
+        ConfigureStore();
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task fetch_for_writing_by_tags_works_for_pure_boundary_aggregate()
+    {
+        var enrolleeId = new EnrolleeId(Guid.NewGuid());
+        var programId = new ProgramId(Guid.NewGuid());
+
+        // Seed two tagged events across (logically) different streams
+        var enrolled = theSession.Events.BuildEvent(new Enrolled("Alice"));
+        enrolled.WithTag(enrolleeId, programId);
+        theSession.Events.Append(Guid.NewGuid().ToString(), enrolled);
+
+        var progress = theSession.Events.BuildEvent(new ProgressRecorded("Module 1"));
+        progress.WithTag(enrolleeId);
+        theSession.Events.Append(Guid.NewGuid().ToString(), progress);
+
+        await theSession.SaveChangesAsync();
+
+        // Before jasperfx#324 this threw InvalidProjectionException
+        // "No source-generated dispatcher found for SingleStreamProjection<SubscriptionState, string>".
+        await using var session = theStore.LightweightSession();
+        var query = new EventTagQuery().Or<EnrolleeId>(enrolleeId);
+        var boundary = await session.Events.FetchForWritingByTags<SubscriptionState>(query);
+
+        boundary.Aggregate.ShouldNotBeNull();
+        boundary.Aggregate!.EnrollmentCount.ShouldBe(1);
+        boundary.Aggregate.ProgressCount.ShouldBe(1);
+        boundary.Events.Count.ShouldBe(2);
+    }
+}


### PR DESCRIPTION
Closes #4510. Consumes the source-generator fix from JasperFx/jasperfx#324 (PR #325).

## What was broken

A **pure DCB boundary aggregate** — `Apply` methods, no single-stream identity (no `Id`, no `[AggregateIdentity]`), registered only via `RegisterTagType<...>().ForAggregate<T>()` — had no way to get a source-generated evolver, so `FetchForWritingByTags<T>` threw:

```
InvalidProjectionException: No source-generated dispatcher found for
SingleStreamProjection<SubscriptionState, string>.
```

Root cause was upstream: the SG's `AnalyzeSelfAggregating` bailed when it couldn't infer an Id, so nothing was emitted for an identity-less aggregate. (Full diagnosis on #4510.)

## The fix

Bump the two packages that ship the upstream fix (they must move together — the `[BoundaryAggregate]` attribute is consumer-referenced in `JasperFx.Events`, the analyzer that acts on it is in `JasperFx.Events.SourceGenerator`):

| Package | From | To |
|---|---|---|
| `JasperFx.Events` | `2.0.0-alpha.20` | `2.0.0-alpha.21` |
| `JasperFx.Events.SourceGenerator` | `2.0.0-alpha.12` | `2.0.0-alpha.13` |

With those, marking an identity-less aggregate `[BoundaryAggregate]` makes the SG emit a string-keyed `IGeneratedSyncEvolver<TDoc, string>` into the aggregate's assembly. Marten's existing `AggregatorFor<T>` → `SingleStreamProjection<T, string>` → `tryUseAssemblyRegisteredEvolver` scan resolves it — **no Marten runtime change required**.

Adds `dcb_boundary_aggregate_fetch_for_writing_tests`: a pure boundary aggregate (no `Id`, `[BoundaryAggregate]`) registered only via `ForAggregate<T>()` (no `LiveStreamAggregation`), with `FetchForWritingByTags<T>` succeeding and aggregating across tagged streams.

## Test plan
- [x] New `fetch_for_writing_by_tags_works_for_pure_boundary_aggregate` passes (net10).
- [x] Full `EventSourcingTests.Dcb` slice — 110 passed / 0 failed / 2 skipped (net10).
- [ ] CI matrix.

## Note — unrelated pre-existing failure
`EventSourcingTests.Projections.testing_projections.test_async_aggregation` fails with `23505: duplicate key value violates unique constraint "pkey_mt_high_water_skips_ending_sequence"`. I verified this **fails identically on `master`** (alpha.20) — it's a pre-existing issue in the `mt_high_water_skips` / `EnableAdvancedAsyncTracking` area (#4425), not introduced here. Flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Also closes #4513** — adds the `[BoundaryAggregate]` documentation section to `docs/events/dcb.md` (snippet sourced from the regression test in this PR), so the feature ships with its docs. markdownlint + cspell clean.