### PR TITLE
Fix #4530: guard mt_high_water_skips inserts against PK violation on projection rebuild

### DIFF
--- a/src/EventSourcingTests/advanced_async_tracking.cs
+++ b/src/EventSourcingTests/advanced_async_tracking.cs
@@ -2,8 +2,10 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using EventSourcingTests.Aggregation;
 using EventSourcingTests.FetchForWriting;
 using JasperFx.Events;
+using Marten;
 using Marten.Events.Daemon.HighWater;
 using Marten.Events.Projections;
 using Marten.Storage;
@@ -108,5 +110,40 @@ public class advanced_async_tracking : OneOffConfigurationsContext, IAsyncLifeti
 
         var skips = await theDetector.FetchLastProgressionSkipsAsync(100, CancellationToken.None);
         skips.Any().ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task rebuilding_async_projection_twice_does_not_violate_skips_pk_4530()
+    {
+        // #4530: a rebuild rewinds mt_event_progression and re-advances the high-water
+        // mark, re-marking the same skip ending_sequence. Before the ON CONFLICT guard
+        // the second pass threw 23505 on pkey_mt_high_water_skips_ending_sequence.
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "adv_async_rebuild_4530";
+            opts.Events.EnableAdvancedAsyncTracking = true;
+            opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Async);
+        });
+
+        await store.Advanced.Clean.DeleteAllEventDataAsync();
+        await store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(SimpleAggregate));
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new BEvent(), new CEvent());
+            await session.SaveChangesAsync();
+        }
+
+        using var daemon = await store.BuildProjectionDaemonAsync();
+
+        // Two full rebuilds: the second re-marks the same high-water skip rows.
+        await daemon.RebuildProjectionAsync<SimpleAggregate>(CancellationToken.None);
+        await Should.NotThrowAsync(() => daemon.RebuildProjectionAsync<SimpleAggregate>(CancellationToken.None));
+
+        await using var query = store.QuerySession();
+        var aggregate = await query.LoadAsync<SimpleAggregate>(streamId);
+        aggregate.ShouldNotBeNull();
     }
 }

--- a/src/Marten/Schema/SQL/mt_mark_progression_with_skip.sql
+++ b/src/Marten/Schema/SQL/mt_mark_progression_with_skip.sql
@@ -15,12 +15,17 @@ BEGIN
         ON CONFLICT ON CONSTRAINT pk_mt_event_progression
             DO UPDATE SET last_seq_id = ending_sequence, last_updated = transaction_timestamp();
         IF ending_sequence > starting_sequence THEN
-            insert into {databaseSchema}.mt_high_water_skips (ending_sequence, starting_sequence) values (ending_sequence, starting_sequence);
+            -- Idempotent: a rebuild/replay re-marks the same skip (ending_sequence is the
+            -- PK). Re-recording an existing gap is a no-op. Conflict target is the PK
+            -- constraint (the bare column name collides with the function parameter). #4530.
+            insert into {databaseSchema}.mt_high_water_skips (ending_sequence, starting_sequence) values (ending_sequence, starting_sequence)
+                on conflict on constraint pkey_mt_high_water_skips_ending_sequence do nothing;
         END IF;
         return ending_sequence;
     ELSIF current_value = starting_sequence THEN
         update {databaseSchema}.mt_event_progression SET last_seq_id = ending_sequence, last_updated = transaction_timestamp() where shard_name = name;
-        insert into {databaseSchema}.mt_high_water_skips (ending_sequence, starting_sequence) values (ending_sequence, starting_sequence);
+        insert into {databaseSchema}.mt_high_water_skips (ending_sequence, starting_sequence) values (ending_sequence, starting_sequence)
+            on conflict on constraint pkey_mt_high_water_skips_ending_sequence do nothing;
         return ending_sequence;
     ELSE
         return current_value;


### PR DESCRIPTION
Closes #4530.

## Problem

Under the Marten 9 default `EnableAdvancedAsyncTracking = true`, rebuilding (or replaying) an async projection throws an unhandled

```
Npgsql.PostgresException : 23505: duplicate key value violates unique constraint "pkey_mt_high_water_skips_ending_sequence"
```

from `HighWaterDetector.calculateHighWaterMark`, failing the rebuild. (`EventSourcingTests.Projections.testing_projections.test_async_aggregation` was failing on `master` for this reason.)

## Root cause

`mt_high_water_skips` has a single-column PK on `ending_sequence`. A rebuild rewinds `mt_event_progression` to 0 and re-advances the high-water mark over the same event sequence, so `mt_mark_progression_with_skip` re-inserts a skip row with an `ending_sequence` that already exists. Both `INSERT INTO mt_high_water_skips` sites in the function (the bootstrap branch added in #4425 and the normal-advance branch) had no `ON CONFLICT` guard. Latent in V8 (flag off), active in V9.

## Fix

Add `on conflict on constraint pkey_mt_high_water_skips_ending_sequence do nothing` to both inserts. The conflict target is the PK **constraint** rather than the bare column because `ending_sequence` is also the function's parameter name (a bare `on conflict (ending_sequence)` raises `42702: ambiguous`), matching the existing `pk_mt_event_progression` pattern in the same function. Re-marking an already-recorded skip is semantically a no-op.

## Test plan
- [x] New `advanced_async_tracking.rebuilding_async_projection_twice_does_not_violate_skips_pk_4530` — two full rebuilds under `EnableAdvancedAsyncTracking`, asserts no throw.
- [x] `testing_projections.test_async_aggregation` now passes.
- [x] Full `EventSourcingTests.Projections` slice — 132 passed / 1 skipped (was 131 / 1 fail).
- [x] `advanced_async_tracking` — 7/7.
- [ ] Full CI matrix.

Refs #4425 (introduced the active path) · [Master] Marten 9.0 (#4349).

🤖 Generated with [Claude Code](https://claude.com/claude-code)