### PR TITLE
Cut 9.0.0-rc.2: fix ProjectionCoordinator construction when async daemon is Disabled

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.0.0-rc.1</Version>
+        <Version>9.0.0-rc.2</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/src/CoreTests/constructing_projection_coordinator_when_async_disabled.cs
+++ b/src/CoreTests/constructing_projection_coordinator_when_async_disabled.cs
@@ -1,0 +1,32 @@
+using Marten;
+using Marten.Events.Daemon.Coordination;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests;
+
+public class constructing_projection_coordinator_when_async_disabled
+{
+    // Regression: a ProjectionCoordinator can be *constructed* (but never started) while the
+    // async daemon is Disabled — e.g. Wolverine's ancillary-store integration directly news up
+    // IProjectionCoordinator<T> for stores whose subscription distribution it manages itself
+    // (AncillaryWolverineOptionsMartenExtensions). The #4516 dedupe lifted the coordinator loop
+    // into JasperFx.Events' ProjectionCoordinatorBase, whose ctor rejects a null distributor;
+    // BuildDistributor previously returned null in Disabled mode, so construction threw
+    // ArgumentNullException(distributor). It now returns a no-op distributor instead.
+    [Fact]
+    public void can_construct_when_async_mode_is_disabled()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            // AsyncMode is left at its default of DaemonMode.Disabled
+        });
+
+        // Previously: System.ArgumentNullException : Value cannot be null. (Parameter 'distributor')
+        var coordinator = new ProjectionCoordinator(store, NullLogger<ProjectionCoordinator>.Instance);
+        coordinator.Distributor.ShouldNotBeNull();
+    }
+}

--- a/src/Marten/Events/Daemon/Coordination/ProjectionCoordinator.cs
+++ b/src/Marten/Events/Daemon/Coordination/ProjectionCoordinator.cs
@@ -96,7 +96,17 @@ public class ProjectionCoordinator: ProjectionCoordinatorBase, IProjectionCoordi
                     baseLockId);
 
             default:
-                return null;
+                // DaemonMode.Disabled: no async daemon, so there is nothing to distribute.
+                // Return a no-op distributor rather than null. The #4516 dedupe lifted the
+                // coordinator loop into JasperFx.Events.Daemon.ProjectionCoordinatorBase,
+                // whose ctor now rejects a null distributor — and a ProjectionCoordinator can
+                // legitimately be *constructed* (but never started) in Disabled mode, e.g. when
+                // Wolverine's ancillary-store integration resolves IProjectionCoordinator<T>
+                // for a store that delegates subscription distribution to Wolverine
+                // (AncillaryWolverineOptionsMartenExtensions). Pre-dedupe this was a null
+                // assignment that constructed fine; the no-op distributor preserves that while
+                // satisfying the lifted ctor's non-null contract.
+                return new NulloProjectionDistributor();
         }
     }
 
@@ -163,4 +173,30 @@ public class ProjectionCoordinator: ProjectionCoordinatorBase, IProjectionCoordi
 
         return daemon;
     }
+}
+
+// No-op distributor for DaemonMode.Disabled. A ProjectionCoordinator can be *constructed*
+// (but never started) when the async daemon is disabled — e.g. Wolverine's ancillary-store
+// integration resolves IProjectionCoordinator<T> for stores whose subscription distribution
+// it manages itself. The #4516 dedupe lifted the coordinator loop into JasperFx.Events'
+// ProjectionCoordinatorBase, whose ctor rejects a null distributor; this preserves the
+// pre-dedupe "constructible while disabled" behavior without weakening that contract. Every
+// member is a benign no-op (empty distribution, no locks), so it is also safe if ever run.
+internal sealed class NulloProjectionDistributor : IProjectionDistributor
+{
+    public ValueTask<IReadOnlyList<IProjectionSet>> BuildDistributionAsync()
+        => new(Array.Empty<IProjectionSet>());
+
+    public Task RandomWait(System.Threading.CancellationToken token) => Task.CompletedTask;
+
+    public bool HasLock(IProjectionSet set) => false;
+
+    public Task<bool> TryAttainLockAsync(IProjectionSet set, System.Threading.CancellationToken token)
+        => Task.FromResult(false);
+
+    public Task ReleaseLockAsync(IProjectionSet set) => Task.CompletedTask;
+
+    public Task ReleaseAllLocks() => Task.CompletedTask;
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }


### PR DESCRIPTION
## Problem

The #4516 dedupe lifted the coordinator leadership/agent loop into `JasperFx.Events.Daemon.ProjectionCoordinatorBase`, whose ctor now rejects a null distributor:

```csharp
Distributor = distributor ?? throw new ArgumentNullException(nameof(distributor));
```

But Marten's `ProjectionCoordinator.BuildDistributor` returns **`null`** in the `default:` case — i.e. for `DaemonMode.Disabled`. So constructing a `ProjectionCoordinator` in Disabled mode throws:

```
System.ArgumentNullException: Value cannot be null. (Parameter 'distributor')
  at JasperFx.Events.Daemon.ProjectionCoordinatorBase..ctor(IProjectionDistributor distributor, …)
  at Marten.Events.Daemon.Coordination.ProjectionCoordinator..ctor(DocumentStore store, ILogger logger)
```

A `ProjectionCoordinator` can legitimately be **constructed (but never started)** while async projections are Disabled. Concretely, Wolverine's ancillary-store integration resolves `IProjectionCoordinator<T>` for stores whose subscription distribution Wolverine manages itself (`AncillaryWolverineOptionsMartenExtensions`), newing up Marten's `ProjectionCoordinator<T>` directly. Pre-dedupe this was a null assignment that constructed fine.

## Fix

`BuildDistributor` returns a no-op `NulloProjectionDistributor` for the `Disabled` case instead of `null`. This restores the pre-dedupe "constructible while disabled" behavior without weakening the lifted base ctor's non-null contract. Every member of the no-op distributor is benign (empty distribution, no locks held), so it is also safe if the coordinator is ever started in Disabled mode.

## Validation

- New fast unit test `constructing_projection_coordinator_when_async_disabled` — constructs the coordinator with the default (Disabled) async mode; previously threw, now passes.
- Reproduced and verified the fix end-to-end against the regressing Wolverine test `MartenTests.AncillaryStores.bootstrapping_ancillary_marten_stores_with_wolverine.projection_coordinator_from_marten` using a locally-packed Marten — fails on `9.0.0-rc.1`, passes with this change.

## Why it matters now

This is the only blocker for the **Wolverine 6.0.0-rc.1** release (the rest of the critter-stack rc bump is green). Needs a Marten 9.0.0-rc.2 with this fix before Wolverine can re-pin and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)