### PR TITLE
Keep EnableEventSkippingInProjectionsOrSubscriptions defaulting to false in 9.0

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -175,12 +175,6 @@ Marten 9 ships a handful of `StoreOptions` defaults flipped to the values recomm
 * **Restore the V8 default:** `opts.Events.EnableAdvancedAsyncTracking = false;` (or `opts.RestoreV8Defaults();`).
 * See the [Async Projection Daemon](events/projections/async-daemon.md) docs.
 
-#### **`Events.EnableEventSkippingInProjectionsOrSubscriptions` now defaults to `true`**
-
-* **Was `false` in Marten 8.x.** Enables marking individual events as "plain bad" so a stuck projection or subscription can skip them on subsequent attempts instead of jamming the shard.
-* **Restore the V8 default:** `opts.Events.EnableEventSkippingInProjectionsOrSubscriptions = false;` (or `opts.RestoreV8Defaults();`).
-* See the [Async Projection Daemon](events/projections/async-daemon.md) docs.
-
 #### **`Events.UseIdentityMapForAggregates` now defaults to `true` — read carefully**
 
 * **Was `false` in Marten 8.x.** This optimizes inline aggregate projections by keeping a session-local identity map of in-flight aggregates so multiple events in the same `SaveChangesAsync` resolve against a single aggregate instance.
@@ -544,7 +538,6 @@ var store = DocumentStore.For(opts =>
 | --- | --- |
 | `Events.AppendMode` | `EventAppendMode.Rich` — [Event Appending](events/appending.md) |
 | `Events.EnableAdvancedAsyncTracking` | `false` — [Async Projection Daemon](events/projections/async-daemon.md) |
-| `Events.EnableEventSkippingInProjectionsOrSubscriptions` | `false` — [Async Projection Daemon](events/projections/async-daemon.md) |
 | `Events.UseIdentityMapForAggregates` | `false` — [Aggregate Projections](events/projections/aggregate-projections.md) |
 | `Events.EnableBigIntEvents` | `false` — [Event Store](events/index.md) |
 | `DisableNpgsqlLogging` | `false` — [StoreOptions](configuration/storeoptions.md) |
@@ -569,8 +562,8 @@ services.AddMarten(opts =>
         opts.Connection(configuration.GetConnectionString("Marten"));
 
         // Revert the StoreOptions defaults Marten 9 flipped (AppendMode,
-        // EnableAdvancedAsyncTracking, EnableEventSkippingInProjectionsOrSubscriptions,
-        // UseIdentityMapForAggregates, EnableBigIntEvents, DisableNpgsqlLogging).
+        // EnableAdvancedAsyncTracking, UseIdentityMapForAggregates,
+        // EnableBigIntEvents, DisableNpgsqlLogging).
         opts.RestoreV8Defaults();
 
         // Restore V8's Newtonsoft serializer default (Marten 9 ships STJ by default

--- a/src/CoreTests/V9DefaultsAndRestoreV8DefaultsTests.cs
+++ b/src/CoreTests/V9DefaultsAndRestoreV8DefaultsTests.cs
@@ -31,12 +31,6 @@ public class V9DefaultsAndRestoreV8DefaultsTests
     }
 
     [Fact]
-    public void v9_default_for_enable_event_skipping_in_projections_or_subscriptions_is_true()
-    {
-        new StoreOptions().Events.EnableEventSkippingInProjectionsOrSubscriptions.ShouldBeTrue();
-    }
-
-    [Fact]
     public void v9_default_for_use_identity_map_for_aggregates_is_true()
     {
         new StoreOptions().Events.UseIdentityMapForAggregates.ShouldBeTrue();
@@ -70,14 +64,6 @@ public class V9DefaultsAndRestoreV8DefaultsTests
         var opts = new StoreOptions();
         opts.RestoreV8Defaults();
         opts.Events.EnableAdvancedAsyncTracking.ShouldBeFalse();
-    }
-
-    [Fact]
-    public void restore_v8_defaults_reverts_enable_event_skipping_in_projections_or_subscriptions_to_false()
-    {
-        var opts = new StoreOptions();
-        opts.RestoreV8Defaults();
-        opts.Events.EnableEventSkippingInProjectionsOrSubscriptions.ShouldBeFalse();
     }
 
     [Fact]

--- a/src/EventSourcingTests/EventGraphTests.cs
+++ b/src/EventSourcingTests/EventGraphTests.cs
@@ -196,9 +196,11 @@ public class EventGraphTests
     }
 
     [Fact]
-    public void enable_event_skipping_should_be_enabled_by_default()
+    public void enable_event_skipping_should_be_disabled_by_default()
     {
-        theGraph.EnableEventSkippingInProjectionsOrSubscriptions.ShouldBeTrue();
+        // Opt-in feature: defaults to false (the V8 behavior was retained for 9.0).
+        // Silently skipping poison events is too surprising to be on out of the box.
+        theGraph.EnableEventSkippingInProjectionsOrSubscriptions.ShouldBeFalse();
     }
 
     public class HouseRemodeling

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -92,7 +92,6 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
         // these. Anything not listed here kept its V8 default. See docs/migration-guide.md
         // for the per-setting rationale + the consolidated RestoreV8Defaults recipe.
         AppendMode = EventAppendMode.QuickWithServerTimestamps;
-        EnableEventSkippingInProjectionsOrSubscriptions = true;
         UseIdentityMapForAggregates = true;
         EnableBigIntEvents = true;
         EnableAdvancedAsyncTracking = true;

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -686,7 +686,6 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
     ///     and linked option documentation):
     ///     <list type="bullet">
     ///       <item><see cref="EventGraph.AppendMode"/> &rarr; <see cref="EventAppendMode.Rich"/></item>
-    ///       <item><see cref="EventGraph.EnableEventSkippingInProjectionsOrSubscriptions"/> &rarr; <c>false</c></item>
     ///       <item><see cref="EventGraph.UseIdentityMapForAggregates"/> &rarr; <c>false</c></item>
     ///       <item><see cref="EventGraph.EnableBigIntEvents"/> &rarr; <c>false</c></item>
     ///       <item><see cref="DisableNpgsqlLogging"/> &rarr; <c>false</c></item>
@@ -714,7 +713,6 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
     {
         Events.AppendMode = EventAppendMode.Rich;
         Events.EnableAdvancedAsyncTracking = false;
-        Events.EnableEventSkippingInProjectionsOrSubscriptions = false;
         Events.UseIdentityMapForAggregates = false;
         Events.EnableBigIntEvents = false;
         DisableNpgsqlLogging = false;


### PR DESCRIPTION
Reverses one of the 9.0 default flips. The default-flip work set `Events.EnableEventSkippingInProjectionsOrSubscriptions` to `true`; on review we're keeping it `false` (the Marten 8 behavior).

## Why

Silently skipping poison events in projections/subscriptions by default is too surprising for out-of-the-box behavior. A projection that throws on a bad event would advance past it rather than halting the shard — friendlier for uptime, but it can quietly mask data bugs. This stays the explicit opt-in feature it was in Marten 8; the other seven 9.0 default flips are unchanged.

## Changes

- **`EventGraph` ctor** — dropped the `EnableEventSkippingInProjectionsOrSubscriptions = true` flip; the auto-property defaults to `false` again.
- **`StoreOptions.RestoreV8Defaults()`** — removed the now-redundant reset line and its entry in the `<remarks>` default-flip list (the V9 default already equals V8).
- **`EventGraphTests`** — `enable_event_skipping_should_be_enabled_by_default` → `..._disabled_by_default`, asserting `ShouldBeFalse()`.
- **`V9DefaultsAndRestoreV8DefaultsTests`** — removed the two tests that pinned this as a flipped default (it's no longer a flip).
- **`docs/migration-guide.md`** — removed the "now defaults to `true`" section, the `RestoreV8Defaults()` table row, and the setting from the end-to-end example comment.

The opt-in feature itself is untouched — explicitly setting the flag to `true` still wires the `is_skipped` column + skip semantics. `docs/events/skipping.md` already documents it as opt-in. The ai-skills repo has no Marten V8→V9 migration guide referencing this default (reviewed — nothing to change there).

## Test plan

- [x] `V9DefaultsAndRestoreV8DefaultsTests` — 14/14.
- [x] `EventGraphTests.enable_event_skipping_should_be_disabled_by_default` — passes.
- [x] `marking_events_as_skipped_*` (opt-in feature still works when enabled) — 8/8.
- [x] markdownlint + cspell clean on the migration guide.
- [ ] Full CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)