### PR TITLE
Release Marten 9.0.0 (Critter Stack 2026)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.0.0-rc.3</Version>
+        <Version>9.0.0</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,13 +13,13 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="2.0.0-rc.3" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0-rc.3" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0-rc.3">
+    <PackageVersion Include="JasperFx" Version="2.0.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.0.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0-rc.3" />
+    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
@@ -66,8 +66,8 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0-alpha.8" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0-alpha.8" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
Foundation upgrade to final + version bump rc.3 → final.

| Package | From | To |
|---|---|---|
| JasperFx (+ Events / Events.SourceGenerator / SourceGeneration) | 2.0.0-rc.3 | **2.0.0** |
| Weasel.EntityFrameworkCore / Weasel.Postgresql | 9.0.0-alpha.8 | **9.0.0** |
| Marten.* | 9.0.0-rc.3 | **9.0.0** |

JasperFx 2.0.0 + Weasel 9.0.0 are live on nuget.org. Marten builds clean against them (0 errors). Ships in lockstep with Polecat 4.0.

After merge: tag `V9.0.0`, GitHub release, then trigger NuGet publish + docs deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)