### PR TITLE
Consume JasperFx.Events(.SourceGenerator) 2.1.0 — fixes #4542 + #4543 + regression tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,8 +14,8 @@
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
     <PackageVersion Include="JasperFx" Version="2.0.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.0.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.0.0">
+    <PackageVersion Include="JasperFx.Events" Version="2.1.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>

--- a/src/EventSourcingTests/Bug_4542_required_members_primary_ctor.cs
+++ b/src/EventSourcingTests/Bug_4542_required_members_primary_ctor.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests;
+
+// Regression for JasperFx/marten#4542: a record aggregate with a primary
+// constructor for the id PLUS required members, projected by a partial
+// SingleStreamProjection with conventional Create/Apply. With
+// JasperFx.Events.SourceGenerator 2.0.0 the generated evolver synthesized the
+// Apply-only/null-snapshot branch as `new DiagnostiekActiviteit { ... = default! }`,
+// which doesn't compile for a primary-ctor record (CS7036). Fixed in
+// jasperfx#359 / JasperFx.Events.SourceGenerator 2.1.0.
+
+public record DiagnostiekActiviteit(string Id)
+{
+    public required Guid? SubContractorId { get; set; }
+    public required string Aanlevercode { get; set; }
+    public required int Prestatiecodelijst { get; set; }
+}
+
+public record CareReceived(string ProvidedCareId, Guid? SubContractorId, string Prestatiecode, int Prestatiecodelijst);
+
+public record CareImported(string Note);
+
+public partial class DiagnostiekActiviteitProjection : SingleStreamProjection<DiagnostiekActiviteit, string>
+{
+    public static DiagnostiekActiviteit Create(CareReceived e) => new(e.ProvidedCareId)
+    {
+        SubContractorId = e.SubContractorId,
+        Aanlevercode = e.Prestatiecode,
+        Prestatiecodelijst = e.Prestatiecodelijst,
+    };
+
+    public void Apply(CareImported e, DiagnostiekActiviteit a)
+    {
+        // CareImported only mutates an already-created snapshot
+    }
+}
+
+public class Bug_4542_required_members_primary_ctor : BugIntegrationContext
+{
+    [Fact]
+    public async Task projection_with_required_member_record_builds_and_runs()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Add<DiagnostiekActiviteitProjection>(ProjectionLifecycle.Inline);
+        });
+
+        var streamId = Guid.NewGuid().ToString();
+        var subContractor = Guid.NewGuid();
+
+        theSession.Events.StartStream<DiagnostiekActiviteit>(streamId,
+            new CareReceived(streamId, subContractor, "ABC123", 42),
+            new CareImported("imported"));
+        await theSession.SaveChangesAsync();
+
+        var doc = await theSession.LoadAsync<DiagnostiekActiviteit>(streamId);
+        doc.ShouldNotBeNull();
+        doc.Id.ShouldBe(streamId);
+        doc.SubContractorId.ShouldBe(subContractor);
+        doc.Aanlevercode.ShouldBe("ABC123");
+        doc.Prestatiecodelijst.ShouldBe(42);
+    }
+}

--- a/src/EventSourcingTests/Bug_4543_nullable_read_aggregate_param.cs
+++ b/src/EventSourcingTests/Bug_4543_nullable_read_aggregate_param.cs
@@ -1,0 +1,81 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests;
+
+// Regression for JasperFx/marten#4543: an aggregate type used as a *nullable*
+// parameter decorated with an [ReadAggregate]-style attribute (anything that
+// implements IRefersToAggregate) made JasperFx.Events.SourceGenerator 2.0.0
+// feed the `?` annotation into the generated hint name, which Roslyn rejects —
+// CS8785 aborting the WHOLE generator pass, so no evolvers were emitted for the
+// assembly. Fixed in jasperfx#359 / JasperFx.Events.SourceGenerator 2.1.0 by
+// sanitizing hint names + normalizing nullable annotations.
+//
+// The real attribute lives in Wolverine.Http; a local marker attribute
+// implementing IRefersToAggregate exercises the identical source-generator path.
+
+public class ReadAggregateAttribute(string memberName) : Attribute, IRefersToAggregate
+{
+    public string MemberName { get; } = memberName;
+}
+
+public record EigenPrestatie
+{
+    public required string Id { get; init; }
+    public required string Prestatiecode { get; init; }
+
+    public static EigenPrestatie Create(EigenPrestatieAangemaakt e) => new()
+    {
+        Id = e.PrestatieId,
+        Prestatiecode = e.Prestatiecode
+    };
+}
+
+public record EigenPrestatieAangemaakt(string PrestatieId, string Prestatiecode);
+
+public record EigenTariefAanmaken(string PrestatieId);
+
+public static class EigenTariefAanmakenEndpoint
+{
+    // The nullable `EigenPrestatie?` parameter is what triggered the #4543
+    // hint-name crash during source generation.
+    public static void Validate(
+        EigenTariefAanmaken request,
+        [ReadAggregate(nameof(EigenTariefAanmaken.PrestatieId))]
+        EigenPrestatie? prestatie)
+    {
+    }
+}
+
+public class Bug_4543_nullable_read_aggregate_param : BugIntegrationContext
+{
+    [Fact]
+    public async Task generator_does_not_crash_and_snapshot_works()
+    {
+        // If the source generator had crashed (CS8785), no dispatcher would be
+        // generated for EigenPrestatie and this snapshot registration would fail
+        // at runtime with "No source-generated dispatcher found".
+        StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Projections.Snapshot<EigenPrestatie>(SnapshotLifecycle.Inline);
+        });
+
+        var id = Guid.NewGuid().ToString();
+        theSession.Events.StartStream<EigenPrestatie>(id, new EigenPrestatieAangemaakt(id, "P-100"));
+        await theSession.SaveChangesAsync();
+
+        var doc = await theSession.LoadAsync<EigenPrestatie>(id);
+        doc.ShouldNotBeNull();
+        doc.Id.ShouldBe(id);
+        doc.Prestatiecode.ShouldBe("P-100");
+    }
+}


### PR DESCRIPTION
Closes #4544. Closes #4543. Resolves #4542 for Marten consumers.

## What changed
- Bumps `JasperFx.Events` and `JasperFx.Events.SourceGenerator` to **2.1.0** in `Directory.Packages.props`. These ship the source-generator fixes from [jasperfx#359](https://github.com/JasperFx/jasperfx/pull/359): the required-member primary-ctor construction fix (#4542), the duplicate-evolver suppression, and the nullable hint-name sanitization (#4543). (`JasperFx` / `JasperFx.SourceGeneration` stay at 2.0.0 — only those two packages were republished.)
- Adds two regression tests in `EventSourcingTests`:
  - `Bug_4542_required_members_primary_ctor` — a `record DiagnostiekActiviteit(string Id)` with `required` members projected by a partial `SingleStreamProjection` with `Create`/`Apply`.
  - `Bug_4543_nullable_read_aggregate_param` — an aggregate used as a **nullable** `[ReadAggregate] EigenPrestatie?` parameter (the attribute implements `IRefersToAggregate`, the same path Wolverine.Http's `[ReadAggregate]` takes).

## Verification (real Marten build, before/after in one worktree)
**On 2.0.0 (reproduces both bugs):**
- #4542 (alone): build **FAILED** — `CS7036: There is no argument given that corresponds to the required parameter 'Id'` in the generated `DiagnostiekActiviteitProjection.Evolver.g.cs`.
- #4543: `warning CS8785: … hintName 'EventSourcingTests_EigenPrestatie?_stringEvolver.g.cs' contains an invalid character '?'`. The crash **aborts the entire generator pass** — so with both files present it even masks #4542's error and disables every dispatcher (the cascading failure #4543 describes).

**On 2.1.0 (both fixed):**
- `EventSourcingTests` builds clean — no CS7036, no CS8785.
- Both regression tests pass against Postgres.
- `Aggregation` slice (the SG-heavy codegen surface): **228 passed, 2 skipped, 0 failed** — no regressions from the source-generator upgrade.