### PR TITLE
Implement IEventDatabase dead-letter count read on MartenDatabase (#4546)

### DIFF
--- a/src/DaemonTests/Resiliency/dead_letter_count_read_tests.cs
+++ b/src/DaemonTests/Resiliency/dead_letter_count_read_tests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DaemonTests.Resiliency;
+
+// marten#4546 / jasperfx#356: MartenDatabase implements the new IEventDatabase
+// dead-letter count read. Reuses the poison-event projections from
+// when_skipping_events_in_daemon (NamedDocuments / CollateNames) whose dead-letter
+// outcome is deterministic: NamedDocuments:All -> 6 (seqs 4,5,6,7,11,14),
+// CollateNames:All -> 4 (seqs 4,5,6,7).
+public class dead_letter_count_read_tests : DaemonContext
+{
+    private readonly string[] theNames =
+    {
+        "Jane", "Jill", "Jack", "JohnBad", "JakeBad", "JillBad", "JohnBad",
+        "Derrick", "Daniel", "Donald", "DonBad", "Bob", "Beck", "BadName", "Jeremy"
+    };
+
+    public dead_letter_count_read_tests(ITestOutputHelper output) : base(output)
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.DatabaseSchemaName = "daemon";
+            opts.Projections.Add<ErrorRejectingEventProjection>(ProjectionLifecycle.Async);
+            opts.Projections.Add<CollateNames>(ProjectionLifecycle.Async);
+
+            opts.Projections.RebuildErrors.SkipApplyErrors = true;
+            opts.Projections.Errors.SkipApplyErrors = true;
+        });
+    }
+
+    [Fact]
+    public async Task fetch_and_count_dead_letter_events()
+    {
+        var daemon = await StartDaemon();
+
+        var waiter1 = daemon.Tracker.WaitForShardState("CollateNames:All", theNames.Length);
+        var waiter2 = daemon.Tracker.WaitForShardState("NamedDocuments:All", theNames.Length, 5.Minutes());
+
+        var events = theNames.Select(name => new NameEvent { Name = name }).OfType<object>().ToArray();
+        theSession.Events.StartStream(Guid.NewGuid(), events);
+        await theSession.SaveChangesAsync();
+
+        await daemon.Tracker.WaitForHighWaterMark(theNames.Length);
+        await waiter1;
+        await waiter2;
+
+        // Drain the dead letter events queued up
+        await daemon.StopAllAsync();
+
+        var database = (IEventDatabase)theStore.Tenancy.Default.Database;
+
+        // Bulk: one row per (ProjectionName, ShardKey)
+        var counts = await database.FetchDeadLetterCountsAsync();
+
+        counts.Single(x => x.ProjectionName == "NamedDocuments" && x.ShardKey == "All").Count.ShouldBe(6);
+        counts.Single(x => x.ProjectionName == "CollateNames" && x.ShardKey == "All").Count.ShouldBe(4);
+
+        // Per-shard
+        (await database.CountDeadLetterEventsAsync(new ShardName("NamedDocuments"))).ShouldBe(6);
+        (await database.CountDeadLetterEventsAsync(new ShardName("CollateNames"))).ShouldBe(4);
+
+        // A shard with no dead letters returns 0
+        (await database.CountDeadLetterEventsAsync(new ShardName("DoesNotExist"))).ShouldBe(0);
+    }
+}

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -63,6 +63,11 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
 
     private DocumentStore _store;
 
+    // The owning store, set in Initialize(store). Lets database-level operations
+    // (e.g. MartenDatabase's dead-letter count reads, #4546) open a session via
+    // SessionOptions.ForDatabase(...) to query Marten documents with LINQ.
+    internal DocumentStore Store => _store;
+
     private readonly List<ITagTypeRegistration> _tagTypes = new();
 
     internal EventGraph(StoreOptions options)

--- a/src/Marten/Storage/MartenDatabase.EventStorage.cs
+++ b/src/Marten/Storage/MartenDatabase.EventStorage.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
@@ -208,6 +209,47 @@ select last_value from {Options.Events.DatabaseSchemaName}.mt_events_sequence;
         {
             await conn.CloseAsync().ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    ///     marten#4546 / jasperfx#356: count the stored projection/subscription dead letter
+    ///     events for a single shard. With SkipApplyErrors on (the JasperFx.Events 2.0 default)
+    ///     a failed Apply is recorded as a <see cref="DeadLetterEvent" />, so the accumulation is
+    ///     the primary "this projection is unhealthy" signal. DeadLetterEvent is a single-tenanted
+    ///     document in the event store schema, so this count spans every tenant sharing this
+    ///     database (consistent with <see cref="AllProjectionProgress" />).
+    /// </summary>
+    public async Task<long> CountDeadLetterEventsAsync(ShardName shard, CancellationToken token = default)
+    {
+        await EnsureStorageExistsAsync(typeof(DeadLetterEvent), token).ConfigureAwait(false);
+
+        // DeadLetterEvent is a Marten document, so query it with LINQ — the JSONB
+        // member paths (and serializer Casing) are handled by Marten.
+        await using var session = Options.EventGraph.Store.QuerySession(SessionOptions.ForDatabase(this));
+        return await session.Query<DeadLetterEvent>()
+            .Where(x => x.ProjectionName == shard.Name && x.ShardName == shard.ShardKey)
+            .CountAsync(token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     marten#4546 / jasperfx#356: fetch the stored dead letter event counts for this database,
+    ///     one row per shard (<see cref="DeadLetterShardCount.ProjectionName" /> +
+    ///     <see cref="DeadLetterShardCount.ShardKey" />). Mirrors the "give me every row" shape of
+    ///     <see cref="AllProjectionProgress" />.
+    /// </summary>
+    public async Task<IReadOnlyList<DeadLetterShardCount>> FetchDeadLetterCountsAsync(CancellationToken token = default)
+    {
+        await EnsureStorageExistsAsync(typeof(DeadLetterEvent), token).ConfigureAwait(false);
+
+        await using var session = Options.EventGraph.Store.QuerySession(SessionOptions.ForDatabase(this));
+        var rows = await session.Query<DeadLetterEvent>()
+            .GroupBy(x => new { x.ProjectionName, x.ShardName })
+            .Select(g => new { g.Key.ProjectionName, g.Key.ShardName, Count = g.Count() })
+            .ToListAsync(token).ConfigureAwait(false);
+
+        return rows
+            .Select(x => new DeadLetterShardCount(x.ProjectionName, x.ShardName, x.Count))
+            .ToList();
     }
 
     public async Task<IReadOnlyList<ShardState>> FetchProjectionProgressFor(ShardName[] names, CancellationToken token = default)


### PR DESCRIPTION
Closes #4546.

## What changed
Overrides the JasperFx.Events 2.1.0 ([jasperfx#356](https://github.com/JasperFx/jasperfx/pull/363)) default `0`/empty stand-ins on `MartenDatabase` with real implementations:

- `CountDeadLetterEventsAsync(ShardName shard, …)` — count for a single projection/subscription shard.
- `FetchDeadLetterCountsAsync(…)` — one `DeadLetterShardCount(ProjectionName, ShardKey, Count)` per shard.

### Why
JasperFx.Events 2.0 made `SkipApplyErrors` the default — a failed projection `Apply()` is recorded as a `DeadLetterEvent` and the shard keeps advancing — so accumulating dead letters is the primary "this projection is unhealthy" signal. The abstraction previously only let you *write* them; consumers (e.g. CritterWatch) had to reflect into `Query<DeadLetterEvent>()`.

### Implementation
`DeadLetterEvent` is a Marten document, so both methods query it with **LINQ** via a `QuerySession(SessionOptions.ForDatabase(this))` — Marten handles the JSONB member paths and serializer casing, no hand-written SQL:
- `CountDeadLetterEventsAsync` → `Query<DeadLetterEvent>().Where(…).CountAsync()`.
- `FetchDeadLetterCountsAsync` → server-side `GroupBy(x => new { x.ProjectionName, x.ShardName }).Select(g => new { …, g.Count() })`.

A small internal `EventGraph.Store` accessor exposes the owning `DocumentStore` (already captured in `EventGraph.Initialize`) so the database can open a session against itself. `DeadLetterEvent` is single-tenanted in the event store schema, so counts span every tenant sharing the database (consistent with `AllProjectionProgress`).

## Test
`DaemonTests/Resiliency/dead_letter_count_read_tests` reuses the deterministic poison-event projections from `when_skipping_events_in_daemon` (`NamedDocuments:All` → 6 dead letters, `CollateNames:All` → 4) and asserts both read methods through the `IEventDatabase` interface (plus `0` for a shard with no dead letters). Green against Postgres.