### PR TITLE
Opt-in System.Text.Json source-generation context (#4540 item 2)

### DIFF
--- a/docs/configuration/json.md
+++ b/docs/configuration/json.md
@@ -137,6 +137,37 @@ When using types annotated with `[JsonDerivedType]`, you **MUST** opt into the a
 options.AllowOutOfOrderMetadataProperties = true;
 ```
 
+## Source-Generated Metadata <Badge type="tip" text="System.Text.Json" />
+
+System.Text.Json builds the serialization metadata for each type via reflection the first time that type is serialized. You can remove that first-touch cost — and move toward AOT-clean serialization — by opting into a source-generated [`JsonSerializerContext`](https://learn.microsoft.com/dotnet/standard/serialization/system-text-json/source-generation) for your document types.
+
+Declare a context for the types you want covered:
+
+```cs
+[JsonSerializable(typeof(MyDocument))]
+[JsonSerializable(typeof(AnotherDocument))]
+internal partial class MyMartenJsonContext : JsonSerializerContext;
+```
+
+Then layer it into Marten's serializer with `UseTypeInfoResolver`:
+
+```cs
+var serializer = new SystemTextJsonSerializer();
+serializer.UseTypeInfoResolver(MyMartenJsonContext.Default);
+
+var store = DocumentStore.For(opts =>
+{
+    opts.Connection(connectionString);
+    opts.Serializer(serializer);
+});
+```
+
+Types known to the context use its precompiled metadata, while everything else — Marten's internal documents, dynamic types, and any type the context does not cover — falls back to reflection. The reflection fallback is preserved on purpose, so covering only a subset of your types is safe.
+
+::: tip
+For a fully trimmed / AOT build you would supply a context that covers every serialized type and forgo the reflection fallback. See [AOT Publishing](/configuration/aot-publishing) for the broader story.
+:::
+
 ## Collection Storage <Badge type="warning" text="Newtonsoft Only" />
 
 Marten by default stores the collections as strongly typed (so with $type and $value). Because of that and current `MartenQueryable` limitations, it might result in not properly resolved nested collections queries.

--- a/src/CoreTests/stj_source_generation_context_tests.cs
+++ b/src/CoreTests/stj_source_generation_context_tests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Marten.Services;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests;
+
+// marten#4540 (Item 2): opt in to System.Text.Json source generation by layering a
+// JsonSerializerContext ahead of the reflection resolver. Types in the context use its
+// precompiled metadata (no first-serialize reflection cost / AOT-clean); everything else
+// falls back to reflection. This test proves the opt-in is wired through every internal
+// JsonSerializerOptions (serialize + deserialize) and that the reflection fallback is
+// preserved for types the context doesn't cover.
+public class stj_source_generation_context_tests : BugIntegrationContext
+{
+    [Fact]
+    public async Task round_trips_covered_and_uncovered_document_types()
+    {
+        StoreOptions(opts =>
+        {
+            var serializer = new SystemTextJsonSerializer();
+            serializer.UseTypeInfoResolver(StjOptInContext.Default);
+            opts.Serializer(serializer);
+        });
+
+        // Sanity: the context covers the one type and not the other
+        StjOptInContext.Default.GetTypeInfo(typeof(StjCoveredDoc)).ShouldNotBeNull();
+        StjOptInContext.Default.GetTypeInfo(typeof(StjUncoveredDoc)).ShouldBeNull();
+
+        var covered = new StjCoveredDoc { Id = Guid.NewGuid(), Name = "covered", Count = 7 };
+        var uncovered = new StjUncoveredDoc { Id = Guid.NewGuid(), Description = "reflection-fallback" };
+
+        theSession.Store(covered);
+        theSession.Store(uncovered);
+        await theSession.SaveChangesAsync();
+
+        // Fresh session so the values are genuinely deserialized from the database
+        await using var query = theStore.QuerySession();
+
+        var loadedCovered = await query.LoadAsync<StjCoveredDoc>(covered.Id);
+        loadedCovered.ShouldNotBeNull();
+        loadedCovered.Name.ShouldBe("covered");
+        loadedCovered.Count.ShouldBe(7);
+
+        var loadedUncovered = await query.LoadAsync<StjUncoveredDoc>(uncovered.Id);
+        loadedUncovered.ShouldNotBeNull();
+        loadedUncovered.Description.ShouldBe("reflection-fallback");
+    }
+}
+
+public class StjCoveredDoc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Count { get; set; }
+}
+
+public class StjUncoveredDoc
+{
+    public Guid Id { get; set; }
+    public string Description { get; set; } = string.Empty;
+}
+
+[JsonSerializable(typeof(StjCoveredDoc))]
+internal partial class StjOptInContext : JsonSerializerContext
+{
+}

--- a/src/Marten/Services/SystemTextJsonSerializer.cs
+++ b/src/Marten/Services/SystemTextJsonSerializer.cs
@@ -5,6 +5,7 @@ using System.Data.Common;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core;
@@ -263,6 +264,30 @@ public class SystemTextJsonSerializer: ISerializer
         configure(_withTypes);
 
         syncDocumentDeserializeOptions();
+    }
+
+    /// <summary>
+    ///     Opt in to System.Text.Json source generation by layering a
+    ///     <see cref="JsonSerializerContext"/> (or any <see cref="IJsonTypeInfoResolver"/>)
+    ///     ahead of a reflection-based resolver in every internal
+    ///     <see cref="JsonSerializerOptions"/>. Types known to the resolver use its
+    ///     precompiled metadata — removing the first-serialize reflection cost and enabling
+    ///     AOT-clean serialization for those types — while everything else (Marten's
+    ///     dynamic types, internal documents, anything the context doesn't cover) falls back
+    ///     to reflection. See marten#4540.
+    /// </summary>
+    /// <param name="resolver">
+    ///     The source-generated <see cref="JsonSerializerContext"/> (e.g. <c>MyContext.Default</c>)
+    ///     or any custom <see cref="IJsonTypeInfoResolver"/> to consult first.
+    /// </param>
+    public void UseTypeInfoResolver(IJsonTypeInfoResolver resolver)
+    {
+        if (resolver is null) throw new ArgumentNullException(nameof(resolver));
+
+        Configure(o =>
+            o.TypeInfoResolver = JsonTypeInfoResolver.Combine(
+                resolver,
+                o.TypeInfoResolver ?? new DefaultJsonTypeInfoResolver()));
     }
 
     private void syncDocumentDeserializeOptions()


### PR DESCRIPTION
Addresses item 2 of #4540 (the cold-start audit follow-ups). 9.1 candidate.

## What changed
Adds `SystemTextJsonSerializer.UseTypeInfoResolver(IJsonTypeInfoResolver)` so users can opt in to a source-generated `JsonSerializerContext`:

```cs
[JsonSerializable(typeof(MyDocument))]
internal partial class MyMartenJsonContext : JsonSerializerContext;

var serializer = new SystemTextJsonSerializer();
serializer.UseTypeInfoResolver(MyMartenJsonContext.Default);

var store = DocumentStore.For(opts =>
{
    opts.Connection(connectionString);
    opts.Serializer(serializer);
});
```

It layers the resolver ahead of a reflection-based one (via `JsonTypeInfoResolver.Combine`) across all four internal `JsonSerializerOptions` (serialize / deserialize / clean / withTypes). Types covered by the context use its precompiled metadata — removing the first-serialize reflection cost and moving toward AOT-clean serialization — while everything Marten doesn't cover (its dynamic types, internal documents, uncovered user types) falls back to reflection.

## Why
System.Text.Json builds per-type metadata via reflection on first serialize. The #4540 audit flagged this as one of the two genuine remaining cold-start improvements. `EnableDynamicTypes` only registers a converter (not a resolver), so a layered context composes cleanly.

## Test + docs
- `CoreTests/stj_source_generation_context_tests` round-trips a context-covered document **and** an uncovered document (reflection fallback) through a real store; asserts the context covers the one type and not the other. Green against Postgres.
- New "Source-Generated Metadata" section in `docs/configuration/json.md` (markdownlint + cspell clean).

## Scope note
This is item 2 of #4540. Item 1 (source-generated document accessors / `IDocumentAccessor`) is the larger AOT piece and remains open on the issue.