### PR TITLE
Stabilize flaky feature_flag_positive via distinct ApplyChangesLockId (#4552)

### DIFF
--- a/src/CoreTests/configuring_marten_with_async_extensions.cs
+++ b/src/CoreTests/configuring_marten_with_async_extensions.cs
@@ -29,6 +29,14 @@ public class configuring_marten_with_async_extensions
                 {
                     opts.Connection(ConnectionSource.ConnectionString);
                     opts.DatabaseSchemaName = "async_config";
+
+                    // #4552: ApplyAllDatabaseChangesOnStartup takes the global advisory lock
+                    // (default id 4004) to apply schema changes. That id is shared by every
+                    // store in the suite, and advisory locks are connection-scoped, so a pooled
+                    // connection from another test's startup-apply can still hold 4004 and make
+                    // this acquisition time out under CI load ("Unable to attain a global lock in
+                    // time"). Use a distinct lock id so this test can't contend with the default.
+                    opts.ApplyChangesLockId = opts.ApplyChangesLockId + 4552;
                 }).ApplyAllDatabaseChangesOnStartup();
 
                 #region sample_registering_async_config_marten


### PR DESCRIPTION
Partial fix for #4552. Tackles the first of the two flaky tests; diagnoses the second.

## `feature_flag_positive` — fixed ✅

**Root cause (from the CI log):**
```
System.InvalidOperationException : Unable to attain a global lock in time order to apply database changes
   at Marten.Services.MartenActivator.StartAsync(...) MartenActivator.cs:line 81
```
`ApplyAllDatabaseChangesOnStartup` takes the **global advisory lock** (`StoreOptions.ApplyChangesLockId`, default **4004**) before applying schema changes. That id is shared by *every* store in the suite, and PostgreSQL advisory locks are **connection-scoped** — so a pooled connection left over from another test's startup-apply can still hold 4004, and this test's bounded acquisition retries time out under CI load. (Sequential test execution doesn't help: the pooled connection persists the lock across tests.)

**Fix:** give this store a distinct lock id — `opts.ApplyChangesLockId = opts.ApplyChangesLockId + 4552;` — so it can't contend with the default. This matches the established pattern in `ContainerScopedProjectionTests` (`ApplyChangesLockId + N`). Verified the class's 3 tests still pass locally.

## conjoined `query_before_saving` — diagnosed, needs a Weasel-level fix ⤴

Different mechanism:
```
Marten.Exceptions.MartenSchemaException : DDL Execution for 'All Configured Changes' Failed!
  EXCEPTION
    WHEN duplicate_schema THEN NULL;
```
This is a **concurrent `CREATE SCHEMA` race**: the idempotent schema-creation DO block only catches `duplicate_schema` (42P06), but concurrent creation can instead raise `unique_violation` (23505 on `pg_namespace`) / "tuple concurrently updated", which escapes the handler and fails the DDL batch. That DDL is generated in **Weasel** (no `duplicate_schema` text exists in the Marten tree), so the robust fix — widening the handler to swallow concurrent-creation SQLSTATEs — belongs in Weasel, not in this test. Left out of this PR deliberately; I'll note it on #4552 as a Weasel follow-up.

## Scope
One-line, low-risk test config change. No production code touched.