### PR TITLE
Repoint JasperFx.SourceGeneration → JasperFx.SourceGenerator 2.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGeneration" Version="2.0.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.0.1" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/Marten/Marten.csproj
+++ b/src/Marten/Marten.csproj
@@ -37,7 +37,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="JasperFx.SourceGeneration">
+        <PackageReference Include="JasperFx.SourceGenerator">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
Repoints Marten off the retired `JasperFx.SourceGeneration` (noun) package onto the merged **`JasperFx.SourceGenerator`** (singular) `2.0.1`, per [JasperFx/jasperfx#365](https://github.com/JasperFx/jasperfx/issues/365).

The two JasperFx source-generator packages were combined into one: the CLI command-discovery + input-parser generators Marten consumes now ship in `JasperFx.SourceGenerator` alongside the OptionsDescription generator. `JasperFx.SourceGenerator` versions in lockstep with the `JasperFx` core package, starting at `2.0.1` (`2.0.0` of the singular package predates the merge and lacks the command generators, so `2.0.1` is required).

## Changes
- `Directory.Packages.props` — `JasperFx.SourceGeneration` `2.0.0` → `JasperFx.SourceGenerator` `2.0.1`
- `src/Marten/Marten.csproj` — `PackageReference` id renamed (analyzer wiring `PrivateAssets`/`IncludeAssets` unchanged)

## Verification
`dotnet build src/Marten/Marten.csproj` succeeds with **0 errors** — the live `2.0.1` analyzer resolves from NuGet and the generated code compiles.

Closes #4554.
