### PR TITLE
Upgrade Weasel to 9.0.1 (concurrent-DDL race fix) — closes #4552

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="2.0.0" />
+    <PackageVersion Include="JasperFx" Version="2.0.1" />
     <PackageVersion Include="JasperFx.Events" Version="2.1.0" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.1.0">
       <PrivateAssets>all</PrivateAssets>
@@ -66,8 +66,8 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.0" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.0.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.1" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.0.1" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## What

Bumps Weasel to **9.0.1**, which carries the concurrent-DDL race fix from [JasperFx/weasel#293](https://github.com/JasperFx/weasel/issues/293) (Weasel commit `60a1265`).

| Package | From | To |
|---------|------|----|
| `Weasel.Postgresql` | 9.0.0 | 9.0.1 |
| `Weasel.EntityFrameworkCore` | 9.0.0 | 9.0.1 |
| `JasperFx` | 2.0.0 | 2.0.1 |

`Weasel.EntityFrameworkCore` (consumed by `Marten.EntityFrameworkCore`) moves in lockstep. The `JasperFx` core bump to 2.0.1 is **required transitively** — `Weasel.Postgresql 9.0.1 → Weasel.Core 9.0.1 → JasperFx (>= 2.0.1)` — and without it restore fails NU1605 (package downgrade) under `TreatWarningsAsErrors`.

## Why — closes #4552

#4552 tracked two intermittent CI flakes:

1. **`feature_flag_positive`** — `InvalidOperationException: Unable to attain a global lock in time`, from advisory-lock 4004 contention during `ApplyAllDatabaseChangesOnStartup`. **Already fixed** in #4553 (distinct `ApplyChangesLockId`).
2. **conjoined-tenancy `query_before_saving`** — `Npgsql.PostgresException : XX000: tuple concurrently updated` thrown during concurrent lazy `EnsureStorageExistsAsync`. This is the piece this PR resolves.

Weasel #282 had hardened only the `CREATE SCHEMA` statement (`42P06 duplicate_schema` / `23505 unique_violation`). The broader idempotent migration DDL (`CREATE OR REPLACE FUNCTION mt_immutable_*`, etc.) still surfaced `XX000: tuple concurrently updated` when two backends updated the same `pg_proc` catalog row at once under a conjoined multi-tenant store. Weasel #293 (shipped in 9.0.1) adds a bounded retry on the transient catalog-concurrency SQLSTATEs since the DDL is idempotent.

With #4553 already merged for the first flake and this bump covering the second, **#4552 can close**.

## Verification

- `dotnet restore` clean for `src/Marten` and `src/Marten.EntityFrameworkCore` (no NU1605).
- `dotnet build src/Marten` — 0 errors.
- Real validation of the concurrency flake is CI (and is inherently statistical); the underlying fix lives upstream in Weasel 9.0.1 and is exercised by the conjoined-tenancy suite here.

Closes #4552

🤖 Generated with [Claude Code](https://claude.com/claude-code)