### PR TITLE
Migration guide: ToArray() maps to ToListAsync() (no ToArrayAsync)

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -467,7 +467,7 @@ Async-only was the recommended path for several releases — the sync methods ha
   | Before (Marten 8 — `[Obsolete]`) | After (Marten 9) |
   | --- | --- |
   | `session.Query<Foo>().ToList()` | `await session.Query<Foo>().ToListAsync()` |
-  | `session.Query<Foo>().ToArray()` | `(await session.Query<Foo>().ToListAsync()).ToArray()` |
+  | `session.Query<Foo>().ToArray()` | `await session.Query<Foo>().ToListAsync()` |
   | `session.Query<Foo>().First()` | `await session.Query<Foo>().FirstAsync()` |
   | `session.Query<Foo>().FirstOrDefault()` | `await session.Query<Foo>().FirstOrDefaultAsync()` |
   | `session.Query<Foo>().Single()` | `await session.Query<Foo>().SingleAsync()` |
@@ -480,6 +480,8 @@ Async-only was the recommended path for several releases — the sync methods ha
   | `session.Query<Foo>().Sum(x => x.N)` | `await session.Query<Foo>().SumAsync(x => x.N)` |
   | `session.Query<Foo>().Average(x => x.N)` | `await session.Query<Foo>().AverageAsync(x => x.N)` |
   | `foreach (var f in session.Query<Foo>())` | `await foreach (var f in session.Query<Foo>().ToAsyncEnumerable(ct))` |
+
+  There is **no `ToArrayAsync()`** on a Marten `IQueryable<T>` — `ToListAsync()` is the async replacement for **both** `ToList()` and `ToArray()`. Prefer working with the `IReadOnlyList<T>` it returns; if you genuinely need a `T[]`, call `.ToArray()` on the awaited result (`(await session.Query<Foo>().ToListAsync()).ToArray()`).
 
 * Replace every `Load<T>`, `LoadMany<T>`, `Query<T>(sql, ...)`, `Json.*` sync call on `IQuerySession` with the corresponding `LoadAsync`, `LoadManyAsync`, `QueryAsync`, `Json.*Async` equivalent.
 


### PR DESCRIPTION
## What

Refines the **Synchronous query APIs removed** section of the Marten 9.0 migration guide.

Marten 9 removes the synchronous data-access path entirely — every database-bound synchronous LINQ terminal operator (`ToList()`, `ToArray()`, `First()`, `Single()`, `Count()`, …) is gone and callers must use the `*Async` equivalent.

The one operator that doesn't map 1:1 is `ToArray()`: there is **no `ToArrayAsync()`** on a Marten `IQueryable<T>`. This change makes the guidance explicit — use **`ToListAsync()`** as the async replacement for both `ToList()` and `ToArray()`.

## Why

Users migrating from v8 reach for `ToArrayAsync()` by analogy with `ToListAsync()` and hit a missing-method error. Spelling out the mapping in the guide saves that round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)