### PR TITLE
docs: clarify how the event argument is identified in conventional methods (#4562)

### DIFF
--- a/docs/events/projections/conventions.md
+++ b/docs/events/projections/conventions.md
@@ -1,5 +1,19 @@
 # Aggregation with Conventional Methods
 
+## How Marten Identifies the Event Argument
+
+Every conventional method — `Create()`, `Apply()`, and `ShouldDelete()` here, as well as the `Project()` / `Transform()` methods on an [EventProjection](/events/projections/event-projections) — takes the event it handles as one of its parameters. Marten determines *which* parameter is the event using the same rules for every projection type (`SingleStreamProjection`, `MultiStreamProjection`, and `EventProjection`):
+
+1. If a parameter is typed `IEvent<T>`, that parameter is the event and `T` is the event type. Use this when you want access to the [event metadata](/events/metadata).
+2. Otherwise Marten looks for a single parameter whose type is a **concrete event type** — that is, not an interface such as `IQuerySession` / `IDocumentOperations`, not `IEvent`, not `CancellationToken`, and not the aggregate type. If exactly one parameter qualifies, it is the event. **This is the usual case, and the parameter can be named anything.**
+3. If a method has more than one parameter that could be the event (an ambiguous signature that type inference can't resolve), Marten falls back to the parameter **name**: a parameter named `@event`, `event`, `e`, or `ev` is taken as the event.
+
+In practice you almost never need to think about this. `Apply(SomeEvent e, MyAggregate aggregate)` just works, because `SomeEvent` is the only concrete, non-aggregate parameter — the name `e` is incidental, not required. The name convention only matters to disambiguate the unusual signature that has more than one candidate parameter.
+
+::: tip
+The recognized event parameter names are `@event`, `event`, `e`, and `ev`. You only ever need one of these when type inference alone cannot pick out the event parameter.
+:::
+
 ## Aggregate Creation
 
 ::: tip

--- a/docs/events/projections/event-projections.md
+++ b/docs/events/projections/event-projections.md
@@ -138,6 +138,12 @@ The `Project()` methods can accept these arguments:
 
 The return value must be either `void` or `Task` depending on whether or not the method needs to be asynchronous
 
+## Identifying the Event Parameter
+
+In both the `Create()` and `Project()` conventions above, the event parameter can be named anything — Marten identifies it **by type**, not by name. Given `Project(StopEvent1 e, IDocumentOperations ops)`, `StopEvent1` is the event because it's the only concrete event type in the signature (`IDocumentOperations` is an interface and is never treated as the event). The same applies to `IEvent<T>`, which is always recognized as the event regardless of the parameter name.
+
+You only need a conventional parameter **name** — `@event`, `event`, `e`, or `ev` — when a method's signature is ambiguous (more than one parameter could be the event) and type inference alone can't resolve it. This is the same rule used by aggregation projections; see [How Marten Identifies the Event Argument](/events/projections/conventions#how-marten-identifies-the-event-argument).
+
 ## Reusing Documents in the Same Batch
 
 ::: tip

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -370,6 +370,15 @@ Marten 9 routes aggregation through a compile-time source generator (`JasperFx.E
 
 **Migration:** flip the visibility of any private / internal / protected `Apply` / `Create` / `ShouldDelete` methods (and event-shaped constructors) to `public`.
 
+### The event argument is identified by type, not parameter name {#event-parameter-naming}
+
+A common point of confusion when moving to convention methods is *which* parameter Marten treats as the event. Both the runtime registration and the source generator use the same rule for every projection type (`SingleStreamProjection`, `MultiStreamProjection`, `EventProjection`), and it is **type-based**, not name-based:
+
+- A parameter typed `IEvent<T>` is always the event, and `T` is the event type (use this when you want the [event metadata](/events/metadata)).
+- Otherwise the single **concrete** parameter that is *not* an interface (`IQuerySession`, `IDocumentOperations`), *not* `IEvent`, *not* `CancellationToken`, and *not* the aggregate type is the event.
+
+So you do **not** need to name the event parameter anything in particular — `Apply(SomeEvent e, MyAggregate aggregate)` and `Project(SomeEvent payload, IDocumentOperations ops)` both work regardless of the parameter's name. A conventional event parameter **name** is only consulted to disambiguate an unusual signature in which more than one parameter could be the event; the recognized names are `@event`, `event`, `e`, and `ev`. Full details: [How Marten Identifies the Event Argument](/events/projections/conventions#how-marten-identifies-the-event-argument).
+
 ```csharp
 // Before — pre-9.0, worked via reflection:
 public sealed class Invoice : AggregateBase

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -374,8 +374,8 @@ Marten 9 routes aggregation through a compile-time source generator (`JasperFx.E
 
 A common point of confusion when moving to convention methods is *which* parameter Marten treats as the event. Both the runtime registration and the source generator use the same rule for every projection type (`SingleStreamProjection`, `MultiStreamProjection`, `EventProjection`), and it is **type-based**, not name-based:
 
-- A parameter typed `IEvent<T>` is always the event, and `T` is the event type (use this when you want the [event metadata](/events/metadata)).
-- Otherwise the single **concrete** parameter that is *not* an interface (`IQuerySession`, `IDocumentOperations`), *not* `IEvent`, *not* `CancellationToken`, and *not* the aggregate type is the event.
+* A parameter typed `IEvent<T>` is always the event, and `T` is the event type (use this when you want the [event metadata](/events/metadata)).
+* Otherwise the single **concrete** parameter that is *not* an interface (`IQuerySession`, `IDocumentOperations`), *not* `IEvent`, *not* `CancellationToken`, and *not* the aggregate type is the event.
 
 So you do **not** need to name the event parameter anything in particular — `Apply(SomeEvent e, MyAggregate aggregate)` and `Project(SomeEvent payload, IDocumentOperations ops)` both work regardless of the parameter's name. A conventional event parameter **name** is only consulted to disambiguate an unusual signature in which more than one parameter could be the event; the recognized names are `@event`, `event`, `e`, and `ev`. Full details: [How Marten Identifies the Event Argument](/events/projections/conventions#how-marten-identifies-the-event-argument).
 


### PR DESCRIPTION
Documentation-only. Closes the docs half of #4562.

## Why

The conventional projection method docs explain which argument *combinations* are allowed, but never state **how Marten decides which parameter is the event** — which leads people to think they must name the parameter `@event`. They don't: the event is identified by type, and a parameter name only matters to disambiguate unusual signatures.

## What

Documents the single, shared rule used by `SingleStreamProjection`, `MultiStreamProjection`, and `EventProjection`:

1. an `IEvent<T>` parameter is the event (`T` is the event type);
2. otherwise the single **concrete** parameter that isn't an interface (`IQuerySession`/`IDocumentOperations`), isn't `IEvent`, isn't `CancellationToken`, and isn't the aggregate type;
3. only if that's ambiguous, a parameter **named** `@event`, `event`, `e`, or `ev`.

Changes:
- **`events/projections/conventions.md`** — new "How Marten Identifies the Event Argument" section near the top.
- **`events/projections/event-projections.md`** — "Identifying the Event Parameter" note for `Create()`/`Project()`, linking to the shared rule.
- **`migration-guide.md`** — new subsection under the projection-conventions migration, since this trips people up when moving off inline lambdas.

## Related

- The `ev` name is being added to the accepted names in JasperFx (JasperFx/jasperfx#369); this documents the convention including `ev`.
- A matching docs clarification is going to Polecat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)