### PR TITLE
Consume JasperFx 2.1.2 across all JasperFx.* packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,13 +13,13 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="2.0.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.1.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.1.1">
+    <PackageVersion Include="JasperFx" Version="2.1.2" />
+    <PackageVersion Include="JasperFx.Events" Version="2.1.2" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.0.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.1.2" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
## What

Bumps the four JasperFx packages Marten depends on to the aligned **2.1.2** release (upstream now locks them to a single `$(JasperFxVersion)`):

| Package | From | To |
|---|---|---|
| JasperFx | 2.0.1 | 2.1.2 |
| JasperFx.Events | 2.1.1 | 2.1.2 |
| JasperFx.Events.SourceGenerator | 2.1.1 | 2.1.2 |
| JasperFx.SourceGenerator | 2.0.1 | 2.1.2 |

`JasperFx.RuntimeCompiler` is intentionally **not** touched — it versions independently upstream and isn't part of the 2.1.2 set (master no longer references it anyway).

## Why

2.1.2 carries the **#4562** event-parameter-naming generator support (the source generator now accepts `ev` as a conventional event parameter name across `SingleStreamProjection` / `MultiStreamProjection` / `EventProjection`). The documentation for that behavior already landed in #4563; this PR delivers the actual generator via the package bump.

## Validation

- Full solution builds clean against 2.1.2 — **0 errors across all 45 projects**; no API adaptation required for the `JasperFx` 2.0.1 → 2.1.2 minor bump.
- Runtime suites are exercised by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)