### PR TITLE
#4565: translate DistinctBy() to PostgreSQL DISTINCT ON

### DIFF
--- a/docs/documents/querying/linq/operators.md
+++ b/docs/documents/querying/linq/operators.md
@@ -346,6 +346,29 @@ public async Task get_distinct_numbers()
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Operators/distinct_operator.cs#L31-L52' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_get_distinct_numbers' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### DistinctBy()
+
+Marten does **not** translate the LINQ `DistinctBy(keySelector)` operator to SQL. Calling it inside a query throws a `BadLinqExpressionException` rather than silently pulling the whole table into memory. (Native support would map to PostgreSQL's `SELECT DISTINCT ON (key) ...` and is tracked by [#4565](https://github.com/JasperFx/marten/issues/4565).)
+
+Until then, materialize the results first and run `DistinctBy()` in memory with LINQ to Objects:
+
+```csharp
+// Throws BadLinqExpressionException -- DistinctBy() is not translated to SQL:
+// var institutions = await session.Query<PendingInstitutionClaimLine>()
+//     .Select(x => new { x.InstitutionId, x.InstitutionName })
+//     .DistinctBy(x => x.InstitutionId)
+//     .ToListAsync(cancellation);
+
+// Instead, fetch the projection, then DistinctBy() client-side:
+var rows = await session.Query<PendingInstitutionClaimLine>()
+    .Select(x => new { x.InstitutionId, x.InstitutionName })
+    .ToListAsync(cancellation);
+
+var institutions = rows.DistinctBy(x => x.InstitutionId).ToList();
+```
+
+For a single column, the server-side `Distinct()` operator described above is translated to SQL and does not require materializing the result set.
+
 ## Modulo Queries
 
 Marten has the ability to use the modulo operator in Linq queries:

--- a/docs/documents/querying/linq/operators.md
+++ b/docs/documents/querying/linq/operators.md
@@ -348,26 +348,27 @@ public async Task get_distinct_numbers()
 
 ### DistinctBy()
 
-Marten does **not** translate the LINQ `DistinctBy(keySelector)` operator to SQL. Calling it inside a query throws a `BadLinqExpressionException` rather than silently pulling the whole table into memory. (Native support would map to PostgreSQL's `SELECT DISTINCT ON (key) ...` and is tracked by [#4565](https://github.com/JasperFx/marten/issues/4565).)
-
-Until then, materialize the results first and run `DistinctBy()` in memory with LINQ to Objects:
+Marten translates the LINQ `DistinctBy(keySelector)` operator to PostgreSQL's [`SELECT DISTINCT ON (key) ...`](https://www.postgresql.org/docs/current/sql-select.html#SQL-DISTINCT), keeping one row per distinct key value ([#4565](https://github.com/JasperFx/marten/issues/4565)). Use it after a `Select(...)` projection:
 
 ```csharp
-// Throws BadLinqExpressionException -- DistinctBy() is not translated to SQL:
-// var institutions = await session.Query<PendingInstitutionClaimLine>()
-//     .Select(x => new { x.InstitutionId, x.InstitutionName })
-//     .DistinctBy(x => x.InstitutionId)
-//     .ToListAsync(cancellation);
-
-// Instead, fetch the projection, then DistinctBy() client-side:
-var rows = await session.Query<PendingInstitutionClaimLine>()
+var institutions = await session.Query<PendingInstitutionClaimLine>()
     .Select(x => new { x.InstitutionId, x.InstitutionName })
+    .DistinctBy(x => x.InstitutionId)
     .ToListAsync(cancellation);
-
-var institutions = rows.DistinctBy(x => x.InstitutionId).ToList();
 ```
 
-For a single column, the server-side `Distinct()` operator described above is translated to SQL and does not require materializing the result set.
+This generates roughly:
+
+```sql
+select distinct on (d.data ->> 'InstitutionId') jsonb_build_object(...) as data
+from mt_doc_pendinginstitutionclaimline as d
+order by d.data ->> 'InstitutionId'
+```
+
+Things to know:
+
+- The key expression is automatically prepended to the `ORDER BY` because Postgres requires the `DISTINCT ON` expression to be the leftmost `ORDER BY` expression. Any `OrderBy()` you add becomes a secondary sort, so _which_ row survives within each key group follows your ordering (and is otherwise arbitrary, exactly like SQL `DISTINCT ON`).
+- The `DistinctBy()` key must be a member that also exists on the queried document (the common case where the projection copies members through, e.g. `Select(x => new { x.InstitutionId, ... })`). `DistinctBy()` must be preceded by a `Select(...)` projection; calling it directly on the document (`Query<T>().DistinctBy(...)`) throws a `BadLinqExpressionException` — project first, or materialize and use `DistinctBy()` in memory.
 
 ## Modulo Queries
 

--- a/docs/documents/querying/linq/operators.md
+++ b/docs/documents/querying/linq/operators.md
@@ -380,6 +380,24 @@ Things to know:
 - The key expression is automatically prepended to the `ORDER BY` because Postgres requires the `DISTINCT ON` expression to be the leftmost `ORDER BY` expression. Any `OrderBy()` you add becomes a secondary sort, so _which_ row survives within each key group follows your ordering (and is otherwise arbitrary, exactly like SQL `DISTINCT ON`).
 - The `DistinctBy()` key must be a member that also exists on the queried document (the common case where the projection copies members through, e.g. `Select(x => new { x.InstitutionId, ... })`). `DistinctBy()` must be preceded by a `Select(...)` projection; calling it directly on the document (`Query<T>().DistinctBy(...)`) throws a `BadLinqExpressionException` — project first, or materialize and use `DistinctBy()` in memory.
 
+## CountBy(), AggregateBy(), and Index() (.NET 9)
+
+The `CountBy`, `AggregateBy`, and `Index` operators added in .NET 9 are **not translated to SQL by Marten**, because .NET only added them to `Enumerable` (there are no `IQueryable` overloads, so a query provider never sees them). Calling them on a Marten query therefore **runs client-side**: the full result set is pulled into memory first and the operator is applied there with LINQ to Objects — the same behavior you get with EF Core.
+
+::: warning
+`session.Query<Target>().CountBy(x => x.Color)` does **not** push the grouping into PostgreSQL — it materializes every matching document first. For large tables, express the grouping with `GroupBy(...).Select(...)`, which Marten does translate to a SQL `GROUP BY`:
+
+```csharp
+// Translated to SQL: select count(*), color ... group by color
+var counts = await session.Query<Target>()
+    .GroupBy(x => x.Color)
+    .Select(g => new { Color = g.Key, Count = g.Count() })
+    .ToListAsync();
+```
+
+(There is no efficient SQL equivalent for `AggregateBy`'s arbitrary accumulator function; `Index` corresponds to a window `row_number()` but is likewise only an in-memory operator today.) If/when .NET ships `Queryable` overloads for these, Marten can revisit native translation.
+:::
+
 ## Modulo Queries
 
 Marten has the ability to use the modulo operator in Linq queries:

--- a/docs/documents/querying/linq/operators.md
+++ b/docs/documents/querying/linq/operators.md
@@ -33,7 +33,7 @@ public void select_a_single_value(IDocumentSession session)
     session.Query<Target>().Single(x => x.Number == 5);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L138-L156' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_select_a_single_value' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L152-L170' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_select_a_single_value' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Filtering Documents
@@ -58,7 +58,7 @@ public async Task basic_operators(IDocumentSession session)
     await session.Query<Target>().Where(x => x.Number <= 5).ToListAsync();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L20-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_by_basic_operators' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L34-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_by_basic_operators' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Marten's Linq support will also allow you to make "deep" searches on properties of properties (or fields):
@@ -71,7 +71,7 @@ public void deep_queries(IDocumentSession session)
     session.Query<Target>().Where(x => x.Inner.Number == 3);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L50-L56' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deep_nested_properties' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L64-L70' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deep_nested_properties' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Right now, Marten supports both _and_ and _or_ queries with Linq:
@@ -88,7 +88,7 @@ public void and_or(IDocumentSession session)
     session.Query<Target>().Where(x => x.Number == 5 || x.Date == DateTime.Today);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L38-L48' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_querying_with_and_or_or' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L52-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_querying_with_and_or_or' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Ordering Results
@@ -113,7 +113,7 @@ public void order_by(IDocumentSession session)
     session.Query<Target>().OrderBySql("substring(d.data -> 'String', 1, 2)");
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L85-L101' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ordering-in-linq' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L99-L115' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ordering-in-linq' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Ordering with dynamic properties
@@ -146,7 +146,7 @@ public void order_by_dynamic_props(IDocumentSession session)
     session.Query<Target>().OrderBy("Date DESC", "Number");
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L103-L127' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ordering-in-linq-using-dynamic-props' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L117-L141' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_ordering-in-linq-using-dynamic-props' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Case-insensitive ordering for strings
@@ -193,7 +193,7 @@ public async Task sample_aggregation_operations(IQuerySession session)
     var average = await session.Query<Target>().AverageAsync(x => x.Number);
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L190-L205' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_aggregation_operations' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L204-L219' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_aggregation_operations' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Partitioning Operators
@@ -212,7 +212,7 @@ public async Task using_take_and_skip(IDocumentSession session)
     await session.Query<Target>().Skip(10).Take(10).OrderBy(x => x.Number).ToListAsync();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L129-L136' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_take_and_skip' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L143-L150' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_take_and_skip' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 TODO -- link to the paging support
@@ -350,12 +350,22 @@ public async Task get_distinct_numbers()
 
 Marten translates the LINQ `DistinctBy(keySelector)` operator to PostgreSQL's [`SELECT DISTINCT ON (key) ...`](https://www.postgresql.org/docs/current/sql-select.html#SQL-DISTINCT), keeping one row per distinct key value ([#4565](https://github.com/JasperFx/marten/issues/4565)). Use it after a `Select(...)` projection:
 
-```csharp
-var institutions = await session.Query<PendingInstitutionClaimLine>()
-    .Select(x => new { x.InstitutionId, x.InstitutionName })
-    .DistinctBy(x => x.InstitutionId)
-    .ToListAsync(cancellation);
+<!-- snippet: sample_distinct_by -->
+<a id='snippet-sample_distinct_by'></a>
+```cs
+public async Task distinct_by(IDocumentSession session)
+{
+    // Keep one row per distinct Number. DistinctBy() is translated to
+    // PostgreSQL `select distinct on (...)`, so it runs in the database
+    // rather than pulling every row into memory.
+    var results = await session.Query<Target>()
+        .Select(x => new { x.Number, x.String })
+        .DistinctBy(x => x.Number)
+        .ToListAsync();
+}
 ```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/LinqExamples.cs#L20-L32' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_distinct_by' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 This generates roughly:
 

--- a/src/LinqTests/Operators/distinct_by_operator.cs
+++ b/src/LinqTests/Operators/distinct_by_operator.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Exceptions;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace LinqTests.Operators;
+
+public class distinct_by_operator
+{
+    // https://github.com/JasperFx/marten/issues/4565
+    // DistinctBy() is not translated to SQL. Rather than the generic
+    // "operator not supported" message, callers get an actionable exception
+    // pointing at the in-memory workaround. The exception is thrown while the
+    // LINQ expression is parsed (before any database round trip).
+    [Fact]
+    public async Task distinct_by_throws_actionable_exception()
+    {
+        await using var store = DocumentStore.For(ConnectionSource.ConnectionString);
+        await using var session = store.QuerySession();
+
+        var ex = await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+        {
+            await session.Query<Target>()
+                .Select(x => new { x.Number, x.String })
+                .DistinctBy(x => x.Number)
+                .ToListAsync();
+        });
+
+        ex.Message.ShouldContain("DistinctBy");
+        ex.Message.ShouldContain("ToListAsync");
+        ex.Message.ShouldContain("4565");
+    }
+}

--- a/src/LinqTests/Operators/distinct_by_operator.cs
+++ b/src/LinqTests/Operators/distinct_by_operator.cs
@@ -9,29 +9,88 @@ using Xunit;
 
 namespace LinqTests.Operators;
 
+// https://github.com/JasperFx/marten/issues/4565
+// DistinctBy(keySelector) translates to PostgreSQL `SELECT DISTINCT ON (key) ...`.
 public class distinct_by_operator
 {
-    // https://github.com/JasperFx/marten/issues/4565
-    // DistinctBy() is not translated to SQL. Rather than the generic
-    // "operator not supported" message, callers get an actionable exception
-    // pointing at the in-memory workaround. The exception is thrown while the
-    // LINQ expression is parsed (before any database round trip).
-    [Fact]
-    public async Task distinct_by_throws_actionable_exception()
+    private static IDocumentStore BuildStore(string schema)
     {
-        await using var store = DocumentStore.For(ConnectionSource.ConnectionString);
-        await using var session = store.QuerySession();
+        return DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = schema;
+        });
+    }
+
+    [Fact]
+    public async Task distinct_by_a_projected_member()
+    {
+        await using var store = BuildStore("distinct_by_projected");
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new Target { Number = 1, String = "a" });
+            session.Store(new Target { Number = 1, String = "b" });
+            session.Store(new Target { Number = 2, String = "c" });
+            session.Store(new Target { Number = 2, String = "d" });
+            session.Store(new Target { Number = 3, String = "e" });
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+
+        var results = await query.Query<Target>()
+            .Select(x => new { x.Number, x.String })
+            .DistinctBy(x => x.Number)
+            .ToListAsync();
+
+        // One row per distinct Number; which String survives per group is arbitrary.
+        results.Count.ShouldBe(3);
+        results.Select(x => x.Number).OrderBy(x => x).ShouldHaveTheSameElementsAs(1, 2, 3);
+    }
+
+    [Fact]
+    public async Task distinct_by_combined_with_where()
+    {
+        await using var store = BuildStore("distinct_by_where");
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new Target { Number = 1, Flag = true });
+            session.Store(new Target { Number = 1, Flag = true });
+            session.Store(new Target { Number = 2, Flag = true });
+            session.Store(new Target { Number = 3, Flag = false });
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+
+        var results = await query.Query<Target>()
+            .Where(x => x.Flag)
+            .Select(x => new { x.Number, x.Flag })
+            .DistinctBy(x => x.Number)
+            .ToListAsync();
+
+        results.Count.ShouldBe(2);
+        results.Select(x => x.Number).OrderBy(x => x).ShouldHaveTheSameElementsAs(1, 2);
+    }
+
+    [Fact]
+    public async Task distinct_by_without_a_select_throws_actionable_exception()
+    {
+        await using var store = BuildStore("distinct_by_no_select");
+        await using var query = store.QuerySession();
 
         var ex = await Should.ThrowAsync<BadLinqExpressionException>(async () =>
         {
-            await session.Query<Target>()
-                .Select(x => new { x.Number, x.String })
+            await query.Query<Target>()
                 .DistinctBy(x => x.Number)
                 .ToListAsync();
         });
 
-        ex.Message.ShouldContain("DistinctBy");
-        ex.Message.ShouldContain("ToListAsync");
+        ex.Message.ShouldContain("Select");
         ex.Message.ShouldContain("4565");
     }
 }

--- a/src/Marten.Testing/Examples/LinqExamples.cs
+++ b/src/Marten.Testing/Examples/LinqExamples.cs
@@ -17,6 +17,20 @@ public class LinqExamples
 
     #endregion
 
+    #region sample_distinct_by
+    public async Task distinct_by(IDocumentSession session)
+    {
+        // Keep one row per distinct Number. DistinctBy() is translated to
+        // PostgreSQL `select distinct on (...)`, so it runs in the database
+        // rather than pulling every row into memory.
+        var results = await session.Query<Target>()
+            .Select(x => new { x.Number, x.String })
+            .DistinctBy(x => x.Number)
+            .ToListAsync();
+    }
+
+    #endregion
+
     #region sample_query_by_basic_operators
     public async Task basic_operators(IDocumentSession session)
     {

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -11,6 +11,7 @@ using Marten.Internal.Storage;
 using Marten.Linq.Includes;
 using Marten.Linq.Members;
 using Marten.Linq.Parsing;
+using Marten.Linq.Parsing.Operators;
 using Marten.Linq.SqlGeneration;
 using Marten.Linq.SqlGeneration.Filters;
 using System.Diagnostics.CodeAnalysis;
@@ -97,6 +98,7 @@ public partial class CollectionUsage
                 statement.IsDistinct = IsDistinct = Inner.IsDistinct;
                 statement.Limit ??= Inner._limit;
                 statement.Offset ??= Inner._offset;
+                DistinctByExpression ??= Inner.DistinctByExpression;
             }
         }
 
@@ -110,6 +112,8 @@ public partial class CollectionUsage
 
         statement = compileNext(session, collection, statement, statistics).SelectorStatement();
 
+        ApplyDistinctByIfAny(statement, collection);
+
         // THIS CAN BE A PROBLEM IF IT'S DONE TOO SOON
         if (IsDistinct)
         {
@@ -121,6 +125,45 @@ public partial class CollectionUsage
         }
 
         return statement.Top();
+    }
+
+    /// <summary>
+    /// Translate a <c>DistinctBy(keySelector)</c> operator to PostgreSQL
+    /// <c>SELECT DISTINCT ON (key) ...</c>. The key is resolved against the queried
+    /// document collection (the same way an OrderBy member is) and prepended to the
+    /// ORDER BY, because Postgres requires the DISTINCT ON expression to match the
+    /// leftmost ORDER BY expression. See https://github.com/JasperFx/marten/issues/4565.
+    /// </summary>
+    private void ApplyDistinctByIfAny(SelectorStatement statement, IQueryableMemberCollection collection)
+    {
+        if (DistinctByExpression == null)
+        {
+            return;
+        }
+
+        var member = collection.MemberFor(DistinctByExpression, "Invalid DistinctBy() key selector");
+
+        // Use the exact same expression for both DISTINCT ON and the leading ORDER BY.
+        // Postgres requires them to match textually, and a typed member's ordering
+        // locator (e.g. CAST(... as integer)) differs from its RawLocator. Asc never
+        // appends a direction suffix, so the result is a bare column expression.
+        var keySql = member.BuildOrderingExpression(
+            new Ordering(DistinctByExpression, OrderingDirection.Asc), CasingRule.CaseSensitive);
+
+        statement.Ordering.Expressions.Insert(0, keySql);
+
+        if (statement.SelectClause is IDistinctOnSelectClause distinctOn)
+        {
+            distinctOn.DistinctOn = keySql;
+        }
+        else
+        {
+            throw new BadLinqExpressionException(
+                "Marten can only translate DistinctBy() when it is preceded by a Select(...) projection "
+                + "(for example Select(x => new { x.Foo, x.Bar }).DistinctBy(x => x.Foo)). For other query "
+                + "shapes, materialize with ToListAsync() and call DistinctBy() in memory. "
+                + "See https://github.com/JasperFx/marten/issues/4565.");
+        }
     }
 
 

--- a/src/Marten/Linq/CollectionUsage.Parsing.cs
+++ b/src/Marten/Linq/CollectionUsage.Parsing.cs
@@ -13,6 +13,12 @@ public partial class CollectionUsage
     public List<Expression> WhereExpressions { get; } = new();
     public Expression? SelectExpression { get; set; }
 
+    /// <summary>
+    /// The key selector of a <c>DistinctBy(keySelector)</c> operator, if any.
+    /// Translated to PostgreSQL <c>SELECT DISTINCT ON (key)</c>. See #4565.
+    /// </summary>
+    public Expression? DistinctByExpression { get; set; }
+
     public void AddWhereClause(MethodCallExpression expression)
     {
         if (expression.Arguments.Count == 1)

--- a/src/Marten/Linq/Parsing/Operators/DistinctByOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/DistinctByOperator.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using System.Linq.Expressions;
+using Marten.Exceptions;
+
+namespace Marten.Linq.Parsing.Operators;
+
+internal class DistinctByOperator: LinqOperator
+{
+    public DistinctByOperator(): base("DistinctBy")
+    {
+    }
+
+    public override void Apply(ILinqQuery query, MethodCallExpression expression)
+    {
+        // Marten does not (yet) translate DistinctBy() to SQL (it would map to
+        // PostgreSQL's `SELECT DISTINCT ON (key) ...`). Rather than letting it fall
+        // through to the generic "operator not supported" message, give callers the
+        // concrete workaround. Tracked by https://github.com/JasperFx/marten/issues/4565.
+        throw new BadLinqExpressionException(
+            "Marten cannot translate the LINQ 'DistinctBy()' operator to SQL. Either use a scalar "
+            + "'Distinct()' (for example 'Select(x => x.Foo).Distinct()'), or materialize the query "
+            + "first with 'ToListAsync()' / 'ToList()' and then call 'DistinctBy()' in memory. Native "
+            + "server-side DistinctBy translation is tracked by "
+            + "https://github.com/JasperFx/marten/issues/4565.");
+    }
+}

--- a/src/Marten/Linq/Parsing/Operators/DistinctByOperator.cs
+++ b/src/Marten/Linq/Parsing/Operators/DistinctByOperator.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System.Linq.Expressions;
-using Marten.Exceptions;
 
 namespace Marten.Linq.Parsing.Operators;
 
@@ -12,15 +11,12 @@ internal class DistinctByOperator: LinqOperator
 
     public override void Apply(ILinqQuery query, MethodCallExpression expression)
     {
-        // Marten does not (yet) translate DistinctBy() to SQL (it would map to
-        // PostgreSQL's `SELECT DISTINCT ON (key) ...`). Rather than letting it fall
-        // through to the generic "operator not supported" message, give callers the
-        // concrete workaround. Tracked by https://github.com/JasperFx/marten/issues/4565.
-        throw new BadLinqExpressionException(
-            "Marten cannot translate the LINQ 'DistinctBy()' operator to SQL. Either use a scalar "
-            + "'Distinct()' (for example 'Select(x => x.Foo).Distinct()'), or materialize the query "
-            + "first with 'ToListAsync()' / 'ToList()' and then call 'DistinctBy()' in memory. Native "
-            + "server-side DistinctBy translation is tracked by "
-            + "https://github.com/JasperFx/marten/issues/4565.");
+        // DistinctBy(this IQueryable<T> source, Expression<Func<T, TKey>> keySelector)
+        // translates to PostgreSQL `SELECT DISTINCT ON (key) ...`. The key selector is
+        // resolved during compilation the same way an OrderBy member is, which also lets
+        // us satisfy Postgres's rule that the DISTINCT ON expression be the leftmost
+        // ORDER BY expression. See https://github.com/JasperFx/marten/issues/4565.
+        var usage = query.CollectionUsageFor(expression);
+        usage.DistinctByExpression = expression.Arguments[1];
     }
 }

--- a/src/Marten/Linq/Parsing/Operators/OperatorLibrary.cs
+++ b/src/Marten/Linq/Parsing/Operators/OperatorLibrary.cs
@@ -31,6 +31,7 @@ internal class OperatorLibrary
         Add<GroupByOperator>();
         Add<AnyOperator>();
         Add<DistinctOperator>();
+        Add<DistinctByOperator>();
         Add<IncludeOperator>(); // TODO -- is this necessary?
         Add<IncludePlanOperator>();
 

--- a/src/Marten/Linq/SqlGeneration/DataSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/DataSelectClause.cs
@@ -10,8 +10,10 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.SqlGeneration;
 
-internal class DataSelectClause<T>: ISelectClause, IScalarSelectClause, IModifyableFromObject where T : notnull
+internal class DataSelectClause<T>: ISelectClause, IScalarSelectClause, IModifyableFromObject, IDistinctOnSelectClause where T : notnull
 {
+    public string? DistinctOn { get; set; }
+
     public DataSelectClause(string from)
     {
         FromObject = from;
@@ -49,6 +51,13 @@ internal class DataSelectClause<T>: ISelectClause, IScalarSelectClause, IModifya
         if (MemberName.IsNotEmpty())
         {
             sql.Append("select ");
+            if (DistinctOn.IsNotEmpty())
+            {
+                sql.Append("distinct on (");
+                sql.Append(DistinctOn);
+                sql.Append(") ");
+            }
+
             sql.Append(MemberName);
             sql.Append(" as data from ");
         }

--- a/src/Marten/Linq/SqlGeneration/ISelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/ISelectClause.cs
@@ -13,6 +13,20 @@ public interface IModifyableFromObject
 }
 
 /// <summary>
+/// Implemented by select clauses that can emit a PostgreSQL
+/// <c>SELECT DISTINCT ON (expression)</c> prefix, used to translate the LINQ
+/// <c>DistinctBy(keySelector)</c> operator. See #4565.
+/// </summary>
+internal interface IDistinctOnSelectClause
+{
+    /// <summary>
+    /// Raw SQL of the DISTINCT ON key expression (for example <c>d.data ->> 'Name'</c>),
+    /// or null when no DistinctBy() is applied.
+    /// </summary>
+    string? DistinctOn { get; set; }
+}
+
+/// <summary>
 ///     Internal interface for the Linq subsystem
 /// </summary>
 public interface ISelectClause: ISqlFragment

--- a/src/Marten/Linq/SqlGeneration/SelectDataSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/SelectDataSelectClause.cs
@@ -10,8 +10,10 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.SqlGeneration;
 
-internal class SelectDataSelectClause<T>: ISelectClause, IScalarSelectClause, IModifyableFromObject where T : notnull
+internal class SelectDataSelectClause<T>: ISelectClause, IScalarSelectClause, IModifyableFromObject, IDistinctOnSelectClause where T : notnull
 {
+    public string? DistinctOn { get; set; }
+
     public SelectDataSelectClause(string from, ISqlFragment selector)
     {
         FromObject = from;
@@ -27,6 +29,13 @@ internal class SelectDataSelectClause<T>: ISelectClause, IScalarSelectClause, IM
     public void Apply(ICommandBuilder sql)
     {
         sql.Append("select ");
+
+        if (DistinctOn.IsNotEmpty())
+        {
+            sql.Append("distinct on (");
+            sql.Append(DistinctOn);
+            sql.Append(") ");
+        }
 
         if (Operator.IsNotEmpty())
         {


### PR DESCRIPTION
Resolves [#4565](https://github.com/JasperFx/marten/issues/4565).

Implements native server-side translation of the LINQ `DistinctBy(keySelector)` operator to PostgreSQL [`SELECT DISTINCT ON (key) ...`](https://www.postgresql.org/docs/current/sql-select.html#SQL-DISTINCT).

## Before

`DistinctBy()` wasn't a registered operator, so it failed with a generic "operator not supported" exception.

## After

```csharp
var institutions = await session.Query<PendingInstitutionClaimLine>()
    .Select(x => new { x.InstitutionId, x.InstitutionName })
    .DistinctBy(x => x.InstitutionId)
    .ToListAsync();
```

generates:

```sql
select distinct on (d.data ->> 'InstitutionId') jsonb_build_object(...) as data
from mt_doc_pendinginstitutionclaimline as d
order by d.data ->> 'InstitutionId'
```

## How

- `DistinctByOperator` records the key selector on the `CollectionUsage` (instead of throwing).
- At compile time the key is resolved against the document collection the same way an `OrderBy` member is, and **prepended to the `ORDER BY`** — Postgres requires the `DISTINCT ON` expression to be the leftmost `ORDER BY` expression. The **same** ordering-expression string is used for both `DISTINCT ON` and `ORDER BY`, so they match textually even for typed members (`CAST(... as integer)`).
- New internal `IDistinctOnSelectClause` lets `DataSelectClause` / `SelectDataSelectClause` emit the `distinct on (...)` prefix.

## Scope / limitations

- `DistinctBy()` must follow a `Select(...)` projection (the reported shape). Calling it directly on the document (`Query<T>().DistinctBy(...)`) throws an actionable `BadLinqExpressionException` — the document-storage select clause has no `DISTINCT ON` support yet. Follow-up candidate.
- The key must be a member that also exists on the queried document (the common copy-through projection).

## Tests

`src/LinqTests/Operators/distinct_by_operator.cs` — validated against Postgres:
- `distinct_by_a_projected_member` (the reported case)
- `distinct_by_combined_with_where`
- `distinct_by_without_a_select_throws_actionable_exception`

Existing `Distinct()`, ordering, select, and `SelectMany` tests (62) still pass — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)