### PR TITLE
[8.0 backport] Fix #4567: allow digit-leading partition suffixes; guard the 63-byte limit

### DIFF
--- a/src/Marten/AdvancedOperations.cs
+++ b/src/Marten/AdvancedOperations.cs
@@ -17,6 +17,7 @@ using Marten.Storage;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Weasel.Postgresql;
+using Weasel.Postgresql.Tables;
 using Weasel.Postgresql.Tables.Partitioning;
 
 namespace Marten;
@@ -307,7 +308,12 @@ public class AdvancedOperations
     /// <param name="tenantIds"></param>
     public Task<TablePartitionStatus[]> AddMartenManagedTenantsAsync(CancellationToken token, params Guid[] tenantIds)
     {
-        return AddMartenManagedTenantsAsync(token, tenantIds.Select(id => id.ToString()).ToArray());
+        // The tenant id stays the canonical Guid string, but the partition *suffix* uses the
+        // hyphen-free "N" format (e.g. "538f87e5...") so it is a legal PostgreSQL identifier
+        // fragment. Previously this delegated to id.ToString() (with hyphens), which always
+        // failed suffix validation. See https://github.com/JasperFx/marten/issues/4567.
+        return AddMartenManagedTenantsAsync(token,
+            tenantIds.ToDictionary(id => id.ToString(), id => id.ToString("N")));
     }
 
     /// <summary>
@@ -354,6 +360,7 @@ public class AdvancedOperations
 
         var database = (PostgresqlDatabase)_store.Tenancy.Default.Database;
 
+        AssertSuffixesWithinIdentifierLimit(tenantIdToPartitionMapping.Values, LongestPartitionedTableNameLength(database));
 
         var logger = _store.Options.LogFactory?.CreateLogger<DocumentStore>() ?? NullLogger<DocumentStore>.Instance;
         return await _store.Options.TenantPartitions.Partitions.AddPartitionToAllTables(
@@ -363,7 +370,13 @@ public class AdvancedOperations
             token).ConfigureAwait(false);
     }
 
-    internal static readonly Regex ValidPostgresqlIdentifierRegex = new(@"^[a-zA-Z_][a-zA-Z0-9_]*$", RegexOptions.Compiled);
+    // Partition suffixes are always concatenated onto an already-valid table name prefix
+    // (e.g. "mt_doc_mymessage_"), so the suffix itself does NOT need to satisfy the
+    // "identifiers start with a letter or underscore" rule — a digit-leading suffix such as
+    // a sanitized Guid ("538f87e5_...") produces a perfectly valid full identifier. We only
+    // reject characters that are illegal inside an unquoted identifier (anything other than
+    // letters, digits, and underscores). See https://github.com/JasperFx/marten/issues/4567.
+    internal static readonly Regex ValidPostgresqlIdentifierRegex = new(@"^[A-Za-z0-9_]+$", RegexOptions.Compiled);
 
     internal static void AssertValidPostgresqlIdentifiers(IEnumerable<string> suffixes)
     {
@@ -371,8 +384,51 @@ public class AdvancedOperations
         if (invalidSuffixes.Length > 0)
         {
             throw new ArgumentException(
-                $"The following partition suffix values contain illegal characters for PostgreSQL object identifiers: {string.Join(", ", invalidSuffixes.Select(s => $"'{s}'"))}. Suffixes must start with a letter or underscore and contain only letters, digits, and underscores.");
+                $"The following partition suffix values contain illegal characters for PostgreSQL object identifiers: {string.Join(", ", invalidSuffixes.Select(s => $"'{s}'"))}. Suffixes may contain only letters, digits, and underscores.");
         }
+    }
+
+    /// <summary>
+    /// The maximum length of a PostgreSQL object identifier in bytes (NAMEDATALEN - 1). Identifiers
+    /// longer than this are silently truncated by Postgres, which can collide partition tables.
+    /// </summary>
+    internal const int PostgresqlIdentifierMaxLength = 63;
+
+    /// <summary>
+    /// The real hazard for partition suffixes is not the leading character but the 63-byte identifier
+    /// limit: the full partition table name is "{baseTable}_{suffix}", and Postgres silently truncates
+    /// anything longer. Guard the full name against the longest partitioned table. See #4567.
+    /// </summary>
+    internal static void AssertSuffixesWithinIdentifierLimit(IEnumerable<string> suffixes, int longestTableNameLength)
+    {
+        if (longestTableNameLength <= 0)
+        {
+            return;
+        }
+
+        // -1 for the '_' separator between the table name and the suffix
+        var maxSuffixLength = PostgresqlIdentifierMaxLength - longestTableNameLength - 1;
+        var tooLong = suffixes.Where(s => s.Length > maxSuffixLength).Distinct().ToArray();
+        if (tooLong.Length > 0)
+        {
+            throw new ArgumentException(
+                $"The following partition suffix values would produce PostgreSQL table identifiers longer than the {PostgresqlIdentifierMaxLength}-byte limit (causing silent truncation and potential partition collisions): {string.Join(", ", tooLong.Select(s => $"'{s}'"))}. The longest partitioned table name is {longestTableNameLength} characters, so suffixes must be at most {maxSuffixLength} characters.");
+        }
+    }
+
+    private int LongestPartitionedTableNameLength(PostgresqlDatabase database)
+    {
+        var manager = _store.Options.TenantPartitions?.Partitions;
+        if (manager == null)
+        {
+            return 0;
+        }
+
+        return database.AllObjects().OfType<Table>()
+            .Where(x => x.Partitioning is ListPartitioning lp && ReferenceEquals(lp.PartitionManager, manager))
+            .Select(x => x.Identifier.Name.Length)
+            .DefaultIfEmpty(0)
+            .Max();
     }
 
     /// <summary>

--- a/src/MultiTenancyTests/validate_partition_suffixes.cs
+++ b/src/MultiTenancyTests/validate_partition_suffixes.cs
@@ -57,12 +57,13 @@ public class validate_partition_suffixes
     }
 
     [Fact]
-    public void suffix_starting_with_digit_should_throw()
+    public void suffix_starting_with_digit_should_not_throw()
     {
-        var ex = Should.Throw<ArgumentException>(() =>
-            AdvancedOperations.AssertValidPostgresqlIdentifiers(["1tenant"]));
-
-        ex.Message.ShouldContain("1tenant");
+        // #4567: digit-leading suffixes (e.g. sanitized GUIDs) are valid because the suffix is
+        // always concatenated onto an already-valid table-name prefix (e.g. "mt_doc_mymessage_").
+        Should.NotThrow(() =>
+            AdvancedOperations.AssertValidPostgresqlIdentifiers(
+                ["1tenant", "538f87e5_6872_4676_9468_54500f905f78"]));
     }
 
     [Fact]
@@ -111,6 +112,37 @@ public class validate_partition_suffixes
     }
 
     [Fact]
+    public void suffix_within_identifier_length_limit_should_not_throw()
+    {
+        // base table (50) + '_' (1) + suffix (12) = 63 -> within the 63-byte limit
+        Should.NotThrow(() =>
+            AdvancedOperations.AssertSuffixesWithinIdentifierLimit(["abcdefghijkl"], 50));
+    }
+
+    [Fact]
+    public void suffix_exceeding_identifier_length_limit_should_throw()
+    {
+        // base table (50) + '_' (1) + suffix (13) = 64 -> exceeds the 63-byte limit
+        var ex = Should.Throw<ArgumentException>(() =>
+            AdvancedOperations.AssertSuffixesWithinIdentifierLimit(["abcdefghijklm"], 50));
+
+        ex.Message.ShouldContain("abcdefghijklm");
+        ex.Message.ShouldContain("63");
+    }
+
+    [Fact]
+    public void reporter_real_world_guid_suffix_passes_both_checks()
+    {
+        // The exact suffix from #4567: it is digit-leading and, concatenated onto a normal
+        // mt_doc_* table name, stays well within the 63-byte limit.
+        var suffix = "538f87e5_6872_4676_9468_54500f905f78";
+
+        Should.NotThrow(() => AdvancedOperations.AssertValidPostgresqlIdentifiers([suffix]));
+        Should.NotThrow(() =>
+            AdvancedOperations.AssertSuffixesWithinIdentifierLimit([suffix], "mt_doc_mymessage".Length));
+    }
+
+    [Fact]
     public void add_tenants_params_overload_should_throw_for_illegal_suffixes()
     {
         using var store = DocumentStore.For(opts =>
@@ -147,7 +179,7 @@ public class validate_partition_suffixes
     }
 
     [Fact]
-    public void guid_params_overload_delegates_to_string_overload()
+    public void guid_params_overload_uses_hyphen_free_suffix()
     {
         using var store = DocumentStore.For(opts =>
         {
@@ -156,12 +188,15 @@ public class validate_partition_suffixes
             opts.Policies.PartitionMultiTenantedDocumentsUsingMartenManagement("tenants");
         });
 
-        // Guid.ToString() produces hyphens (e.g. "d3b07384-d9a0-...") which are invalid identifiers,
-        // so the validation should catch this
+        // #4567: the params Guid[] overload now derives a hyphen-free "N"-format suffix
+        // (e.g. "538f87e5..."), so it no longer fails suffix validation. It may still throw later
+        // for other reasons (database/partition state), but never an ArgumentException for the suffix.
         var id = Guid.NewGuid();
-        Should.Throw<ArgumentException>(() =>
+        var ex = Record.Exception(() =>
             store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, id)
                 .GetAwaiter().GetResult());
+
+        ex.ShouldNotBeOfType<ArgumentException>();
     }
 
     [Fact]


### PR DESCRIPTION
Backport of #4568 to the `8.0` branch (the regression was introduced in **8.21.0** via #4121, so it warrants an 8.x patch release).

Cherry-pick of commit `c88ad37b6` — applied cleanly with no conflicts.

## Summary

`AssertValidPostgresqlIdentifiers` rejected partition suffixes not matching `^[a-zA-Z_][a-zA-Z0-9_]*$`, but suffixes are always concatenated onto a valid table-name prefix, so digit-leading sanitized-GUID suffixes (e.g. `538f87e5_...`) are valid. This broke existing GUID-based Marten-managed tenancy on upgrade.

- Relax regex to `^[A-Za-z0-9_]+$` (allow digit-leading; still reject hyphens/spaces/dots/quotes/semicolons).
- Add `AssertSuffixesWithinIdentifierLimit` guarding the full `{table}_{suffix}` name against the 63-byte Postgres limit (the actual hazard).
- `params Guid[]` overload uses `id.ToString("N")` (hyphen-free) for the suffix.

## Validation

`validate_partition_suffixes.cs` — **21 tests pass on the `8.0` branch across net8.0, net9.0, and net10.0**. Marten compiles cleanly against the 8.x Weasel (the `AllObjects()` / `ListPartitioning.PartitionManager` APIs used by the length check are present).

See #4568 for the master PR and full discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)