### PR TITLE
Override IEventStore.AllDatabases() on DocumentStore; consume JasperFx 2.2.0 (#4570)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.0.2</Version>
+        <Version>9.2.0</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,13 +13,13 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="2.1.2" />
-    <PackageVersion Include="JasperFx.Events" Version="2.1.2" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.1.2">
+    <PackageVersion Include="JasperFx" Version="2.2.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.2.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.1.2" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -65,6 +65,15 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
         }
     }
 
+    async ValueTask<IReadOnlyList<IEventDatabase>> IEventStore.AllDatabases()
+    {
+        // Straight delegation to ITenancy, mirroring IMartenStorage.AllDatabases(). The IMartenDatabase
+        // interface does not itself extend IEventDatabase (only the concrete MartenDatabase does), so this
+        // projects rather than returning the list directly. See #4570.
+        var databases = await Tenancy.BuildDatabases().ConfigureAwait(false);
+        return databases.OfType<IEventDatabase>().ToList();
+    }
+
     public EventStoreIdentity Identity { get; }
 
     IEventRegistry IEventStore<IDocumentOperations, IQuerySession>.Registry => Options.EventGraph;

--- a/src/MultiTenancyTests/DocumentStore_IMartenStorage_implementation.cs
+++ b/src/MultiTenancyTests/DocumentStore_IMartenStorage_implementation.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using JasperFx.Core;
+using JasperFx.Events;
 using Marten;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
@@ -154,6 +155,23 @@ public class DocumentStore_IMartenStorage_implementation : IAsyncLifetime
     {
         var databases = await theStore.Storage.AllDatabases();
         databases.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task event_store_all_databases_returns_one_event_database_per_database()
+    {
+        // IEventStore.AllDatabases() is the store-agnostic mirror of IMartenStorage.AllDatabases() (#4570).
+        // A Marten + Wolverine host registers IEventStore (the concrete DocumentStore) in DI but not
+        // IEventDatabase, so this is how store-neutral tooling reaches every database.
+        var databases = await ((IEventStore)theStore).AllDatabases();
+        databases.Count.ShouldBe(3);
+
+        // Each IEventDatabase can serve the store-neutral read abstractions
+        foreach (var database in databases)
+        {
+            (await database.AllProjectionProgress()).ShouldNotBeNull();
+            (await database.FetchDeadLetterCountsAsync()).ShouldNotBeNull();
+        }
     }
 }
 


### PR DESCRIPTION
Closes #4570.

## What

- **Override `IEventStore.AllDatabases()` on `DocumentStore`.** Implements the store-agnostic database accessor added to `JasperFx.Events.IEventStore` in [jasperfx#387](https://github.com/JasperFx/jasperfx/issues/387) / [jasperfx#388](https://github.com/JasperFx/jasperfx/pull/388). A straight delegation to `ITenancy` (`Tenancy.BuildDatabases()`), mirroring the existing `IMartenStorage.AllDatabases()`, projecting to `IEventDatabase` via `OfType<>` since `IMartenDatabase` does not itself extend `IEventDatabase` (only the concrete `MartenDatabase` does).
- **Consume JasperFx 2.2.0** across all `JasperFx.*` packages (`JasperFx`, `JasperFx.Events`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator`).
- **Bump Marten version to 9.2.0.**

## Why

Store-agnostic monitoring/tooling (e.g. CritterWatch) needs an `IEventDatabase` to call the read abstractions — `AllProjectionProgress(...)`, `FetchDeadLetterCountsAsync(...)` / `CountDeadLetterEventsAsync(...)`. But a Marten + Wolverine host registers `IEventStore` (the concrete `DocumentStore`) in DI and does **not** register `IEventDatabase`, so `GetServices<IEventDatabase>()` is empty. `IEventStore.AllDatabases()` is the store-neutral way to reach the databases.

## Test

Added `event_store_all_databases_returns_one_event_database_per_database` to the multi-database (`MultiTenantedDatabases`) fixture in `DocumentStore_IMartenStorage_implementation`: asserts `AllDatabases()` returns one `IEventDatabase` per configured database and that each can serve `AllProjectionProgress()` / `FetchDeadLetterCountsAsync()`. Passes locally (10/10 in the fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)