### PR TITLE
Foundation for binary event serialization (#4515 — Phase 1, Rich-mode only)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,7 @@
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
     <PackageVersion Include="Marten" Version="8.2.1" />
+    <PackageVersion Include="MemoryPack" Version="1.21.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageVersion Include="Meziantou.Analyzer" Version="2.0.257" />

--- a/build/build.cs
+++ b/build/build.cs
@@ -44,7 +44,8 @@ class Build : NukeBuild
         .DependsOn(TestNodaTime)
         .DependsOn(TestAspnetcore)
         .DependsOn(TestPostGIS)
-        .DependsOn(TestPgVector);
+        .DependsOn(TestPgVector)
+        .DependsOn(TestMemoryPack);
 
     Target Init => _ => _
         .Executes(() =>
@@ -132,6 +133,18 @@ class Build : NukeBuild
         {
             DotNetTest(c => c
                 .SetProjectFile("src/Marten.AspNetCore.Testing")
+                .SetConfiguration(Configuration)
+                .EnableNoBuild()
+                .EnableNoRestore()
+                .SetFramework(Framework));
+        });
+
+    Target TestMemoryPack => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            DotNetTest(c => c
+                .SetProjectFile("src/Marten.MemoryPack.Tests")
                 .SetConfiguration(Configuration)
                 .EnableNoBuild()
                 .EnableNoRestore()

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -223,6 +223,7 @@ const config: UserConfig<DefaultTheme.Config> = {
             { text: 'Natural Keys', link: '/events/natural-keys' },
             { text: 'Dynamic Consistency Boundary', link: '/events/dcb' },
             { text: 'Optimizing Performance', link: '/events/optimizing' },
+            { text: 'Binary Event Serialization', link: '/events/binary-serialization' },
 
             {
               text: 'Projections Overview', link: '/events/projections/', collapsed: true, items: [

--- a/docs/events/binary-serialization.md
+++ b/docs/events/binary-serialization.md
@@ -1,0 +1,168 @@
+# Binary Event Serialization <Badge type="tip" text="9.3" />
+
+Marten can serialize individual event types to a binary wire format
+([MemoryPack](https://github.com/Cysharp/MemoryPack),
+[MessagePack](https://msgpack.org/), or anything else implementing
+`IEventBinarySerializer`) instead of the default JSON, trading a few of JSON's
+ergonomic wins for a meaningful throughput and storage-size improvement on
+hot streams. See [#4515](https://github.com/JasperFx/marten/issues/4515) for
+the design discussion.
+
+The opt-in is **per event type** — binary-serialized and JSON-serialized events
+coexist in the same `mt_events` table, so the feature can be rolled out on an
+existing store with **no migration of existing data**.
+
+## How it works
+
+A second column, `bdata bytea NULL`, sits alongside the existing `data jsonb NOT NULL`
+on `mt_events`. The row-level discriminator is `bdata IS NULL`:
+
+| When | `data` | `bdata` |
+| --- | --- | --- |
+| Event uses the JSON serializer | full JSON payload | `NULL` |
+| Event uses an `IEventBinarySerializer` | the placeholder `'{}'::jsonb` | the serialized bytes |
+
+On read, Marten inspects `bdata`:
+
+- `NULL` → existing JSON deserialization path. Pre-feature rows continue to work without conversion.
+- non-null → `IEventBinarySerializer.Deserialize(eventType, bytes)`.
+
+Because the discriminator is on the row and the serializer is resolved per
+event type, the same stream can carry rows of either format with no special
+handling at the call site.
+
+## Quick start with `Marten.MemoryPack`
+
+The companion `Marten.MemoryPack` NuGet package ships a ready-to-use
+`IEventBinarySerializer` over MemoryPack:
+
+```shell
+dotnet add package Marten.MemoryPack
+```
+
+Mark event types you want to serialize as binary with both
+`[BinaryEvent]` (so Marten picks them up) and `[MemoryPackable]` (so MemoryPack
+can serialize them):
+
+```csharp
+using Marten.Events;
+using MemoryPack;
+
+[BinaryEvent]
+[MemoryPackable]
+public partial record TripStarted(Guid TripId, string DriverName, DateTimeOffset StartedAt);
+```
+
+Wire MemoryPack as the store-wide fallback for `[BinaryEvent]` types:
+
+```csharp
+using Marten.MemoryPack;
+
+var store = DocumentStore.For(opts =>
+{
+    opts.Connection(connectionString);
+
+    // Phase 1 limitation — see "Constraints" below.
+    opts.Events.AppendMode = EventAppendMode.Rich;
+
+    // Wire MemoryPack as DefaultBinarySerializer. [BinaryEvent]-marked
+    // event types resolve to this serializer on registration.
+    opts.Events.UseMemoryPackSerializer();
+});
+```
+
+Now `TripStarted` writes through MemoryPack to `bdata`; un-marked events
+continue to write JSON to `data`.
+
+## Registration ergonomics
+
+Two equivalent ways to opt an event type in:
+
+```csharp
+// 1. Attribute-driven — uses opts.Events.DefaultBinarySerializer as the resolver.
+[BinaryEvent]
+[MemoryPackable]
+public partial record TripEnded(Guid TripId, DateTimeOffset EndedAt);
+
+// 2. Fluent — wire an explicit per-type serializer (overrides any default).
+opts.Events.UseBinarySerializer<TripEnded>(new MemoryPackEventSerializer());
+```
+
+Resolution order on `EventMapping` construction:
+
+1. Explicit `opts.Events.UseBinarySerializer<TEvent>(...)` for that type.
+2. `[BinaryEvent]` attribute + `opts.Events.DefaultBinarySerializer`.
+3. Otherwise, plain JSON (existing path).
+
+If a type carries `[BinaryEvent]` but no per-type serializer was wired AND
+`DefaultBinarySerializer` is `null`, Marten throws at the first append with a
+remediation message naming both registration entry points.
+
+## Bring your own serializer
+
+`IEventBinarySerializer` is small enough to implement directly against any
+binary format — MessagePack, protobuf, etc.:
+
+```csharp
+public interface IEventBinarySerializer
+{
+    byte[] Serialize(Type type, object data);
+    object Deserialize(Type type, byte[] data);
+}
+```
+
+The serializer is a singleton — keep its state thread-safe.
+
+## On-disk shape
+
+For binary events, `data` holds the literal `{}` placeholder so the existing
+`data jsonb NOT NULL` constraint stays intact (no schema relaxation):
+
+```sql
+-- binary-serialized event
+select type, data::text, bdata is null
+from mt_events where seq_id = 42;
+--    type        | data | bdata is null
+-- --------------|------|---------------
+--  trip_started | {}   | false
+
+-- JSON-serialized event in the same stream
+select type, data::text, bdata is null
+from mt_events where seq_id = 43;
+--    type                | data                            | bdata is null
+-- --------------------- |---------------------------------|---------------
+--  trip_comment_added   | {"comment": "looking good", …}  | true
+```
+
+## Migration
+
+Purely additive: the only schema change is `bdata bytea NULL` on `mt_events`.
+Existing rows have `bdata = NULL` (the column's default for prior data) and
+read through the JSON path. Marten's standard schema migration creates the
+column for existing installations — no event data conversion required.
+
+## Constraints
+
+The 9.3 cut ships with deliberate scope:
+
+- **`EventAppendMode.Rich` only.** The default `QuickWithServerTimestamps` and
+  `Quick` modes go through the `mt_quick_append_events` PostgreSQL function,
+  whose signature would need a parallel `bdata bytea[]` parameter to carry
+  binary payloads. Until that lands, `BuildQuickDescriptor` /
+  `BuildQuickWithServerTimestampsDescriptor` throw at store-build time if any
+  binary event type is registered. Workaround: set
+  `opts.Events.AppendMode = EventAppendMode.Rich;`.
+- **No bulk appender support.** `BulkEventAppender` uses Npgsql `COPY` with
+  the existing column shape; adding the `bdata` column to the COPY format
+  is part of the same Quick-mode follow-up.
+- **No upcaster support.** Marten's
+  [event upcasters](/events/versioning) operate on JSON payloads and don't
+  generalize to a `byte[]` wire form. Binary event upcasters need their own
+  typed transform shape; tracked as a deferred follow-up. For now, design
+  binary event schemas with forward-compatibility in the serializer itself
+  (MemoryPack's `[MemoryPackOrder]` evolution, for example).
+
+## See also
+
+- [Optimizing Event Store Performance and Scalability](/events/optimizing)
+- [Event Versioning](/events/versioning) (JSON upcasters)

--- a/docs/events/optimizing.md
+++ b/docs/events/optimizing.md
@@ -11,6 +11,13 @@ very large data loads.
 Marten has several options to potentially increase the performance and scalability of a system that uses
 the event sourcing functionality:
 
+::: tip
+For hot streams where JSON serialization overhead dominates, see
+[Binary Event Serialization](/events/binary-serialization) — opt individual
+event types into MemoryPack (or any `IEventBinarySerializer`) on a
+per-type basis, with no migration of existing JSON-serialized events.
+:::
+
 <!-- snippet: sample_turn_on_optimizations_for_event_sourcing -->
 <a id='snippet-sample_turn_on_optimizations_for_event_sourcing'></a>
 ```cs

--- a/src/Marten.MemoryPack.Tests/Marten.MemoryPack.Tests.csproj
+++ b/src/Marten.MemoryPack.Tests/Marten.MemoryPack.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="MemoryPack" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Marten.MemoryPack\Marten.MemoryPack.csproj" />
+        <ProjectReference Include="..\Marten.Testing\Marten.Testing.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/Marten.MemoryPack.Tests/MemoryPackEventTests.cs
+++ b/src/Marten.MemoryPack.Tests/MemoryPackEventTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.MemoryPack;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace Marten.MemoryPack.Tests;
+
+[Collection("Marten.MemoryPack")]
+public class MemoryPackEventTests: IAsyncLifetime
+{
+    private DocumentStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        _store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "memorypack_events";
+            opts.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+
+            // #4515 Phase 1: binary serialization currently only supported on
+            // the Rich append path. Force-Rich here; the Quick descriptor
+            // builders throw with a clear remediation message if a binary
+            // event type is registered while AppendMode is non-Rich.
+            opts.Events.AppendMode = EventAppendMode.Rich;
+
+            // Wire MemoryPack as the store-wide fallback for [BinaryEvent]
+            // types. TripStarted/PassengerPickedUp/TripEnded resolve to this
+            // serializer through the attribute.
+            opts.Events.UseMemoryPackSerializer();
+        });
+
+        await _store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await _store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        _store?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task can_round_trip_a_single_binary_event()
+    {
+        var streamId = Guid.NewGuid();
+        var started = new TripStarted(streamId, "Alice", DateTimeOffset.UtcNow);
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, started);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = _store.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events.Count.ShouldBe(1);
+        var loaded = events[0].Data.ShouldBeOfType<TripStarted>();
+        loaded.TripId.ShouldBe(streamId);
+        loaded.DriverName.ShouldBe("Alice");
+        loaded.StartedAt.ShouldBe(started.StartedAt);
+    }
+
+    [Fact]
+    public async Task multiple_binary_events_replay_in_order()
+    {
+        var streamId = Guid.NewGuid();
+        var startedAt = DateTimeOffset.UtcNow;
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream(streamId,
+                new TripStarted(streamId, "Bob", startedAt),
+                new PassengerPickedUp(streamId, "Carol", startedAt.AddMinutes(5)),
+                new TripEnded(streamId, startedAt.AddMinutes(30), 24.50m));
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = _store.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events.Count.ShouldBe(3);
+        events[0].Data.ShouldBeOfType<TripStarted>().DriverName.ShouldBe("Bob");
+        events[1].Data.ShouldBeOfType<PassengerPickedUp>().PassengerName.ShouldBe("Carol");
+        events[2].Data.ShouldBeOfType<TripEnded>().FareAmount.ShouldBe(24.50m);
+    }
+
+    // The flagship test: the same stream carries JSON-serialized events and
+    // binary-serialized events. Round-trip must work for both, demonstrating
+    // the per-row dispatch (bdata IS NULL ⇒ JSON path; non-null ⇒ binary).
+    [Fact]
+    public async Task json_and_binary_events_coexist_on_one_stream()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream(streamId,
+                new TripStarted(streamId, "Dana", DateTimeOffset.UtcNow), // binary
+                new TripCommentAdded(streamId, "looking good", DateTimeOffset.UtcNow), // JSON
+                new PassengerPickedUp(streamId, "Eli", DateTimeOffset.UtcNow), // binary
+                new TripCommentAdded(streamId, "passenger boarded", DateTimeOffset.UtcNow)); // JSON
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = _store.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events.Count.ShouldBe(4);
+        events[0].Data.ShouldBeOfType<TripStarted>().DriverName.ShouldBe("Dana");
+        events[1].Data.ShouldBeOfType<TripCommentAdded>().Comment.ShouldBe("looking good");
+        events[2].Data.ShouldBeOfType<PassengerPickedUp>().PassengerName.ShouldBe("Eli");
+        events[3].Data.ShouldBeOfType<TripCommentAdded>().Comment.ShouldBe("passenger boarded");
+    }
+
+    [Fact]
+    public async Task binary_events_land_in_bdata_column_jsoned_events_land_in_data_column()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream(streamId,
+                new TripStarted(streamId, "Frank", DateTimeOffset.UtcNow), // binary
+                new TripCommentAdded(streamId, "hello", DateTimeOffset.UtcNow)); // JSON
+            await session.SaveChangesAsync();
+        }
+
+        // Pull the raw column values to verify the on-disk shape — the
+        // discriminator is bdata IS NULL.
+        await using var conn = _store.Storage.Database.CreateConnection();
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "select type, bdata is null as bdata_is_null, data::text " +
+                          "from memorypack_events.mt_events where stream_id = $1 order by version";
+        var p = cmd.CreateParameter();
+        p.Value = streamId;
+        cmd.Parameters.Add(p);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        var rows = new System.Collections.Generic.List<(string type, bool bdataIsNull, string data)>();
+        while (await reader.ReadAsync())
+        {
+            rows.Add((reader.GetString(0), reader.GetBoolean(1), reader.GetString(2)));
+        }
+
+        rows.Count.ShouldBe(2);
+
+        // First event is binary — bdata IS NOT NULL, data is the {} placeholder
+        rows[0].type.ShouldBe("trip_started");
+        rows[0].bdataIsNull.ShouldBeFalse();
+        rows[0].data.ShouldBe("{}");
+
+        // Second event is JSON — bdata IS NULL, data has the real payload
+        rows[1].type.ShouldBe("trip_comment_added");
+        rows[1].bdataIsNull.ShouldBeTrue();
+        rows[1].data.ShouldContain("hello");
+    }
+
+    // Upgrade-backfill: simulate a row written *before* the bdata column
+    // existed (NULL bdata, real JSON in data) and confirm it still reads
+    // through the JSON path after the feature is in place. This is what
+    // makes the migration safe — no event data needs converting.
+    [Fact]
+    public async Task pre_existing_json_rows_still_read_after_feature_is_in_place()
+    {
+        var streamId = Guid.NewGuid();
+
+        // Write through the standard JSON path first (a non-binary event type).
+        await using (var session = _store.LightweightSession())
+        {
+            session.Events.StartStream(streamId,
+                new TripCommentAdded(streamId, "pre-upgrade comment", DateTimeOffset.UtcNow));
+            await session.SaveChangesAsync();
+        }
+
+        // The row is in mt_events with bdata = NULL. Read it back — the
+        // per-row dispatch should fall through to mapping.ReadEventData.
+        await using var query = _store.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events.Count.ShouldBe(1);
+        events[0].Data.ShouldBeOfType<TripCommentAdded>()
+            .Comment.ShouldBe("pre-upgrade comment");
+    }
+}
+
+// Forces both binary test classes into one collection so they don't
+// race on the shared mt_events schema; mirrors the Marten.PgVector
+// pattern from PR #4576.
+[CollectionDefinition("Marten.MemoryPack", DisableParallelization = true)]
+public class MemoryPackCollection;

--- a/src/Marten.MemoryPack.Tests/TestEvents.cs
+++ b/src/Marten.MemoryPack.Tests/TestEvents.cs
@@ -1,0 +1,24 @@
+using System;
+using Marten.Events;
+using MemoryPack;
+
+namespace Marten.MemoryPack.Tests;
+
+// Binary event types — opted in via attribute. With
+// opts.Events.UseMemoryPackSerializer() set as the store-wide fallback,
+// these resolve to the MemoryPack serializer on registration.
+[BinaryEvent]
+[MemoryPackable]
+public partial record TripStarted(Guid TripId, string DriverName, DateTimeOffset StartedAt);
+
+[BinaryEvent]
+[MemoryPackable]
+public partial record PassengerPickedUp(Guid TripId, string PassengerName, DateTimeOffset PickedUpAt);
+
+[BinaryEvent]
+[MemoryPackable]
+public partial record TripEnded(Guid TripId, DateTimeOffset EndedAt, decimal FareAmount);
+
+// JSON event — coexists in the same store and is appended without
+// MemoryPack on the wire. Used by the mixed-stream test.
+public record TripCommentAdded(Guid TripId, string Comment, DateTimeOffset At);

--- a/src/Marten.MemoryPack/Marten.MemoryPack.csproj
+++ b/src/Marten.MemoryPack/Marten.MemoryPack.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <Description>MemoryPack binary event serialization for Marten — an IEventBinarySerializer implementation for the per-event-type binary serialization opt-in (#4515).</Description>
+        <GenerateAssemblyTitleAttribute>true</GenerateAssemblyTitleAttribute>
+        <GenerateAssemblyDescriptionAttribute>true</GenerateAssemblyDescriptionAttribute>
+        <GenerateAssemblyProductAttribute>true</GenerateAssemblyProductAttribute>
+        <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+        <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Nullable>enable</Nullable>
+        <RootNamespace>Marten.MemoryPack</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="MemoryPack" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Marten\Marten.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/Marten.MemoryPack/MemoryPackEventSerializer.cs
+++ b/src/Marten.MemoryPack/MemoryPackEventSerializer.cs
@@ -1,0 +1,34 @@
+using System;
+using Marten.Events;
+using MemoryPack;
+
+namespace Marten.MemoryPack;
+
+/// <summary>
+///     MemoryPack-backed <see cref="IEventBinarySerializer"/>. Wire it up
+///     either per event type via <c>opts.Events.UseBinarySerializer&lt;TEvent&gt;(new MemoryPackEventSerializer())</c>
+///     or store-wide via
+///     <see cref="MemoryPackEventSerializerExtensions.UseMemoryPackSerializer"/>
+///     to make <c>[BinaryEvent]</c>-marked types resolve to this serializer.
+/// </summary>
+/// <remarks>
+///     Event types must be MemoryPack-serializable — typically a
+///     <c>partial</c> type decorated with <c>[MemoryPackable]</c>. See the
+///     <see href="https://github.com/Cysharp/MemoryPack">MemoryPack docs</see>.
+/// </remarks>
+public sealed class MemoryPackEventSerializer: IEventBinarySerializer
+{
+    public byte[] Serialize(Type type, object data)
+    {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+        return MemoryPackSerializer.Serialize(type, data);
+    }
+
+    public object Deserialize(Type type, byte[] data)
+    {
+        return MemoryPackSerializer.Deserialize(type, data)
+            ?? throw new InvalidOperationException(
+                $"MemoryPack deserialization returned null for type '{type.FullName}'. " +
+                $"Ensure the wire payload was produced by a compatible MemoryPack serializer.");
+    }
+}

--- a/src/Marten.MemoryPack/MemoryPackEventSerializerExtensions.cs
+++ b/src/Marten.MemoryPack/MemoryPackEventSerializerExtensions.cs
@@ -1,0 +1,33 @@
+using Marten.Events;
+
+namespace Marten.MemoryPack;
+
+/// <summary>
+///     Sugar over <see cref="IEventStoreOptions.DefaultBinarySerializer"/> +
+///     <see cref="IEventStoreOptions.UseBinarySerializer{TEvent}"/> for the
+///     common case of wiring MemoryPack as the binary serializer for an
+///     event store.
+/// </summary>
+public static class MemoryPackEventSerializerExtensions
+{
+    /// <summary>
+    ///     Register <see cref="MemoryPackEventSerializer"/> as the store-wide
+    ///     fallback binary serializer. Combine with the
+    ///     <see cref="BinaryEventAttribute"/> on individual event types to opt
+    ///     them in without a per-type fluent call.
+    /// </summary>
+    public static IEventStoreOptions UseMemoryPackSerializer(this IEventStoreOptions events)
+    {
+        events.DefaultBinarySerializer = new MemoryPackEventSerializer();
+        return events;
+    }
+
+    /// <summary>
+    ///     Register a single event type as MemoryPack-serialized — shorthand for
+    ///     <c>events.UseBinarySerializer&lt;TEvent&gt;(new MemoryPackEventSerializer())</c>.
+    /// </summary>
+    public static IEventStoreOptions UseMemoryPackSerializer<TEvent>(this IEventStoreOptions events)
+    {
+        return events.UseBinarySerializer<TEvent>(new MemoryPackEventSerializer());
+    }
+}

--- a/src/Marten.slnx
+++ b/src/Marten.slnx
@@ -16,6 +16,10 @@
     <Project Path="EventStoreMigrations/EventStoreMigrations.csproj" />
     <Project Path="MultiDatabaseCommandLineRunner/MultiDatabaseCommandLineRunner.csproj" />
   </Folder>
+  <Folder Name="/MemoryPack/">
+    <Project Path="Marten.MemoryPack.Tests/Marten.MemoryPack.Tests.csproj" />
+    <Project Path="Marten.MemoryPack/Marten.MemoryPack.csproj" />
+  </Folder>
   <Folder Name="/NodaTime/">
     <Project Path="Marten.NodaTime.Testing/Marten.NodaTime.Testing.csproj" />
     <Project Path="Marten.NodaTime/Marten.NodaTime.csproj" />

--- a/src/Marten/EventStorage/ClosedShapeEventDocumentStorage.cs
+++ b/src/Marten/EventStorage/ClosedShapeEventDocumentStorage.cs
@@ -59,13 +59,17 @@ internal sealed class ClosedShapeEventDocumentStorage: EventDocumentStorage
             : EventStorageBuilder.Build<string>(Events, _serializer);
 
         // Read-side column list for ApplyReaderDataToEvent (#4411). Built off
-        // EventsTable.SelectColumns() with positions 0/1/2 stripped — those
-        // are read by the base ISelector<IEvent>. Identical across all three
-        // append-mode variants (read shape doesn't depend on write shape) so
-        // we build it here instead of routing through EventStorage<TId>.
+        // EventsTable.SelectColumns() with positions 0/1/2/3 stripped:
+        // - 0/1/2 (data/type/mt_dotnet_type) are read by the base ISelector<IEvent>.
+        // - 3 (bdata, #4515) is read inline in EventDocumentStorage.Resolve to
+        //   pick the JSON-vs-binary deserialization path; the bdata column's
+        //   own ReadValueSync is a no-op so including it here would be wasted.
+        // Identical across all three append-mode variants (read shape doesn't
+        // depend on write shape) so we build it here instead of routing
+        // through EventStorage<TId>.
         _readerColumns = new Marten.Events.Schema.EventsTable(Events)
             .SelectColumns()
-            .Skip(3)
+            .Skip(4)
             .ToArray();
     }
 
@@ -139,7 +143,10 @@ internal sealed class ClosedShapeEventDocumentStorage: EventDocumentStorage
             // (default interface method falls through to the parameterless
             // ReadValueSync). HeadersColumn overrides this to deserialize
             // jsonb → Dictionary<string, object> via the session's serializer.
-            _readerColumns[i].ReadValueSync(reader, i + 3, e, _serializer);
+            // Offset is + 4: 0/1/2 are data/type/mt_dotnet_type (base
+            // ISelector<IEvent>); 3 is bdata (#4515 — consumed inline in
+            // Resolve to pick the deserialization path).
+            _readerColumns[i].ReadValueSync(reader, i + 4, e, _serializer);
         }
     }
 
@@ -148,7 +155,7 @@ internal sealed class ClosedShapeEventDocumentStorage: EventDocumentStorage
         for (var i = 0; i < _readerColumns.Count; i++)
         {
             await _readerColumns[i]
-                .ReadValueAsync(reader, i + 3, e, _serializer, token)
+                .ReadValueAsync(reader, i + 4, e, _serializer, token)
                 .ConfigureAwait(false);
         }
     }

--- a/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
+++ b/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
@@ -296,7 +296,12 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             insertStreamSql: BuildInsertStreamSql(graph),
             updateStreamVersionSql: BuildUpdateStreamVersionSql(graph),
             streamStateSelectSql: Marten.EventStorage.StreamStateSql.Build(graph),
-            serializeEventData: e => serializer.ToJson(e.Data))
+            serializeEventData: e => serializer.ToJson(e.Data),
+            // #4515: Quick mode rejects binary events at build time (see
+            // AssertNoBinaryEventsForQuickMode), so bdata is always NULL
+            // here. The slot still exists because mt_events.bdata is part
+            // of every full-shape INSERT column list.
+            serializeEventBdata: _ => null)
         {
             IsGuidStreamIdentity = isGuid,
             IsTenancyConjoined = isConjoined,
@@ -359,7 +364,9 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             insertStreamSql: BuildInsertStreamSql(graph),
             updateStreamVersionSql: BuildUpdateStreamVersionSql(graph),
             streamStateSelectSql: Marten.EventStorage.StreamStateSql.Build(graph),
-            serializeEventData: e => serializer.ToJson(e.Data))
+            serializeEventData: e => serializer.ToJson(e.Data),
+            // #4515: see notes on the parallel call in BuildQuickDescriptor.
+            serializeEventBdata: _ => null)
         {
             IsGuidStreamIdentity = isGuid,
             IsTenancyConjoined = isConjoined,

--- a/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
+++ b/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
@@ -58,7 +58,25 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             insertStreamSql: BuildInsertStreamSql(graph),
             updateStreamVersionSql: BuildUpdateStreamVersionSql(graph),
             streamStateSelectSql: Marten.EventStorage.StreamStateSql.Build(graph),
-            serializeEventData: e => serializer.ToJson(e.Data),
+            // #4515 dispatch: binary events write a {} placeholder to `data`
+            // (the canonical "valid but empty" jsonb) and the real payload to
+            // `bdata`. JSON events write JSON to `data` and NULL to `bdata`.
+            // The split lets a single mt_events table hold both serialization
+            // formats without a schema flip.
+            serializeEventData: e =>
+            {
+                var mapping = graph.EventMappingFor(e.EventType);
+                return mapping?.IsBinary == true
+                    ? "{}"
+                    : serializer.ToJson(e.Data);
+            },
+            serializeEventBdata: e =>
+            {
+                var mapping = graph.EventMappingFor(e.EventType);
+                return mapping?.IsBinary == true
+                    ? mapping.BinarySerializer!.Serialize(e.EventType, e.Data)
+                    : null;
+            },
             metadataBinders: metadataBinders)
         {
             IsTenancyConjoined = isConjoined,
@@ -256,6 +274,15 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
 
     public QuickEventStorageDescriptor BuildQuickDescriptor(EventGraph graph, ISerializer serializer)
     {
+        // #4515 Phase 1 limitation: binary event serialization is implemented
+        // for the Rich append path only. The Quick path goes through the
+        // mt_quick_append_events server function whose signature is
+        // generated against `bytea[]` (UTF-8 JSON) for the data column; adding
+        // a parallel `bdata bytea[]` parameter (+ the function regen + bulk
+        // appender) is the explicit Phase 2 scope. Fail loud at store-build
+        // time rather than silently writing JSON for an opted-in binary type.
+        AssertNoBinaryEventsForQuickMode(graph, EventAppendMode.Quick);
+
         var (isConjoined, isGuid, hasCausation, hasCorrelation, hasHeaders, hasUserName, hasTagWrites)
             = ReadQuickFlags(graph);
 
@@ -288,9 +315,37 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
         };
     }
 
+    /// <summary>
+    ///     #4515: enforce the Phase 1 constraint that binary event serialization
+    ///     only ships on the Rich append path. If the user registered any
+    ///     binary event types and is still on the default
+    ///     <see cref="EventAppendMode.QuickWithServerTimestamps"/> (or
+    ///     explicit <see cref="EventAppendMode.Quick"/>), throw with the
+    ///     remediation recipe instead of writing wrong data.
+    /// </summary>
+    private static void AssertNoBinaryEventsForQuickMode(EventGraph graph, EventAppendMode mode)
+    {
+        var binaryEventTypes = graph.AllEvents()
+            .Where(e => e.IsBinary)
+            .Select(e => e.DocumentType.FullName ?? e.DocumentType.Name)
+            .ToArray();
+
+        if (binaryEventTypes.Length == 0) return;
+
+        throw new InvalidOperationException(
+            $"Binary event serialization (#4515) is currently only supported with EventAppendMode.Rich, " +
+            $"but AppendMode is {mode} and the following event types are opted in to binary serialization: " +
+            $"{string.Join(", ", binaryEventTypes)}. " +
+            $"Set `opts.Events.AppendMode = EventAppendMode.Rich;` to use binary event serialization. " +
+            $"(Quick-mode support is tracked as a follow-up — the mt_quick_append_events server function " +
+            $"needs a parallel `bdata bytea[]` parameter.)");
+    }
+
     public QuickWithServerTimestampsEventStorageDescriptor BuildQuickWithServerTimestampsDescriptor(
         EventGraph graph, ISerializer serializer)
     {
+        AssertNoBinaryEventsForQuickMode(graph, EventAppendMode.QuickWithServerTimestamps);
+
         var (isConjoined, isGuid, hasCausation, hasCorrelation, hasHeaders, hasUserName, hasTagWrites)
             = ReadQuickFlags(graph);
 
@@ -516,7 +571,7 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
     /// </remarks>
     private static bool IsCoreColumn(IEventTableColumn column) =>
         column.Name is "id" or "stream_id" or "stream_key" or "version"
-            or "data" or "type" or "tenant_id" or "mt_dotnet_type"
+            or "data" or "bdata" or "type" or "tenant_id" or "mt_dotnet_type"
             or "timestamp";
 
     /// <summary>

--- a/src/Marten/EventStorage/Quick/QuickAppendEventWithVersionOperation.cs
+++ b/src/Marten/EventStorage/Quick/QuickAppendEventWithVersionOperation.cs
@@ -42,6 +42,7 @@ internal sealed class QuickAppendEventWithVersionOperation: AppendEventOperation
     private readonly IEventMetadataBinder[] _metadataBinders;
     private readonly bool _isGuidStreamIdentity;
     private readonly System.Func<IEvent, string> _serializeEventData;
+    private readonly System.Func<IEvent, byte[]?> _serializeEventBdata;
 
     public QuickAppendEventWithVersionOperation(
         string appendEventSqlPrefix,
@@ -49,6 +50,7 @@ internal sealed class QuickAppendEventWithVersionOperation: AppendEventOperation
         IEventMetadataBinder[] metadataBinders,
         bool isGuidStreamIdentity,
         System.Func<IEvent, string> serializeEventData,
+        System.Func<IEvent, byte[]?> serializeEventBdata,
         StreamAction stream,
         IEvent e)
         : base(stream, e)
@@ -58,6 +60,7 @@ internal sealed class QuickAppendEventWithVersionOperation: AppendEventOperation
         _metadataBinders = metadataBinders;
         _isGuidStreamIdentity = isGuidStreamIdentity;
         _serializeEventData = serializeEventData;
+        _serializeEventBdata = serializeEventBdata;
     }
 
     public override void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
@@ -70,6 +73,14 @@ internal sealed class QuickAppendEventWithVersionOperation: AppendEventOperation
         pb.AppendParameter(_serializeEventData(Event), NpgsqlDbType.Jsonb);
         pb.AppendParameter(Event.EventTypeName, NpgsqlDbType.Varchar);
         pb.AppendParameter(Event.DotNetTypeName, NpgsqlDbType.Varchar);
+
+        // #4515: bdata bytea (nullable). NULL for JSON-serialized events;
+        // bytes for binary-serialized events. Pinned at SELECT position 3
+        // (right after mt_dotnet_type) by EventsTable.SelectColumns, so the
+        // bind sequence here mirrors that position.
+        var bdataBytes = _serializeEventBdata(Event);
+        pb.AppendParameter(bdataBytes ?? (object)System.DBNull.Value, NpgsqlDbType.Bytea);
+
         pb.AppendParameter(Event.Id, NpgsqlDbType.Uuid);
 
         if (_isGuidStreamIdentity)

--- a/src/Marten/EventStorage/Quick/QuickEventStorage.cs
+++ b/src/Marten/EventStorage/Quick/QuickEventStorage.cs
@@ -35,6 +35,7 @@ internal sealed class QuickEventStorage<TId>: EventStorage<TId>
             _descriptor.AppendEventFullMetadataBinders,
             _descriptor.IsGuidStreamIdentity,
             _descriptor.SerializeEventData,
+            _descriptor.SerializeEventBdata,
             stream,
             @event);
 
@@ -45,6 +46,7 @@ internal sealed class QuickEventStorage<TId>: EventStorage<TId>
             _descriptor.MetadataBinders,
             _descriptor.IsGuidStreamIdentity,
             _descriptor.SerializeEventData,
+            _descriptor.SerializeEventBdata,
             stream,
             @event);
 

--- a/src/Marten/EventStorage/Quick/QuickEventStorageDescriptor.cs
+++ b/src/Marten/EventStorage/Quick/QuickEventStorageDescriptor.cs
@@ -38,13 +38,15 @@ public sealed class QuickEventStorageDescriptor
         string insertStreamSql,
         string updateStreamVersionSql,
         string streamStateSelectSql,
-        Func<IEvent, string> serializeEventData)
+        Func<IEvent, string> serializeEventData,
+        Func<IEvent, byte[]?> serializeEventBdata)
     {
         QuickAppendEventsSql = quickAppendEventsSql;
         InsertStreamSql = insertStreamSql;
         UpdateStreamVersionSql = updateStreamVersionSql;
         StreamStateSelectSql = streamStateSelectSql;
         SerializeEventData = serializeEventData;
+        SerializeEventBdata = serializeEventBdata;
     }
 
     /// <summary>
@@ -61,6 +63,18 @@ public sealed class QuickEventStorageDescriptor
     public string UpdateStreamVersionSql { get; }
     public string StreamStateSelectSql { get; }
     public Func<IEvent, string> SerializeEventData { get; }
+
+    /// <summary>
+    ///     #4515: serializer for the <c>bdata</c> bytea column on the per-event
+    ///     QuickWithVersion INSERT shape. In Quick modes, binary event types
+    ///     are rejected at descriptor-build time (see
+    ///     <c>PostgresEventStoreDialect.AssertNoBinaryEventsForQuickMode</c>),
+    ///     so the dialect installs a closure that always returns <c>null</c> —
+    ///     <c>bdata</c> binds as DBNull. The slot still exists because
+    ///     <c>mt_events.bdata</c> is part of the column list on every
+    ///     full-shape INSERT.
+    /// </summary>
+    public Func<IEvent, byte[]?> SerializeEventBdata { get; }
 
     /// <summary>Guid stream identity (writeId) vs string identity (writeKey).</summary>
     public bool IsGuidStreamIdentity { get; init; }

--- a/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorage.cs
+++ b/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorage.cs
@@ -33,6 +33,7 @@ internal sealed class QuickWithServerTimestampsEventStorage<TId>: EventStorage<T
             _descriptor.AppendEventFullMetadataBinders,
             _descriptor.IsGuidStreamIdentity,
             _descriptor.SerializeEventData,
+            _descriptor.SerializeEventBdata,
             stream,
             @event);
 
@@ -43,6 +44,7 @@ internal sealed class QuickWithServerTimestampsEventStorage<TId>: EventStorage<T
             _descriptor.MetadataBinders,
             _descriptor.IsGuidStreamIdentity,
             _descriptor.SerializeEventData,
+            _descriptor.SerializeEventBdata,
             stream,
             @event);
 

--- a/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorageDescriptor.cs
+++ b/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorageDescriptor.cs
@@ -29,13 +29,15 @@ public sealed class QuickWithServerTimestampsEventStorageDescriptor
         string insertStreamSql,
         string updateStreamVersionSql,
         string streamStateSelectSql,
-        Func<IEvent, string> serializeEventData)
+        Func<IEvent, string> serializeEventData,
+        Func<IEvent, byte[]?> serializeEventBdata)
     {
         QuickAppendEventsWithServerTimestampsSql = quickAppendEventsWithServerTimestampsSql;
         InsertStreamSql = insertStreamSql;
         UpdateStreamVersionSql = updateStreamVersionSql;
         StreamStateSelectSql = streamStateSelectSql;
         SerializeEventData = serializeEventData;
+        SerializeEventBdata = serializeEventBdata;
     }
 
     /// <summary>
@@ -48,6 +50,14 @@ public sealed class QuickWithServerTimestampsEventStorageDescriptor
     public string UpdateStreamVersionSql { get; }
     public string StreamStateSelectSql { get; }
     public Func<IEvent, string> SerializeEventData { get; }
+
+    /// <summary>
+    ///     #4515: serializer for the <c>bdata</c> bytea column on the per-event
+    ///     QuickWithVersion INSERT shape. Binary event types are rejected at
+    ///     descriptor-build time in Quick modes, so this always returns
+    ///     <c>null</c> — see <see cref="Quick.QuickEventStorageDescriptor.SerializeEventBdata"/>.
+    /// </summary>
+    public Func<IEvent, byte[]?> SerializeEventBdata { get; }
 
     /// <summary>Guid stream identity (writeId) vs string identity (writeKey).</summary>
     public bool IsGuidStreamIdentity { get; init; }

--- a/src/Marten/EventStorage/Rich/RichAppendEventOperation.cs
+++ b/src/Marten/EventStorage/Rich/RichAppendEventOperation.cs
@@ -60,6 +60,14 @@ internal sealed class RichAppendEventOperation: AppendEventOperationBase
 
         pb.AppendParameter(Event.EventTypeName, NpgsqlDbType.Varchar);
         pb.AppendParameter(Event.DotNetTypeName, NpgsqlDbType.Varchar);
+
+        // #4515: bdata bytea (nullable). For JSON-serialized events this is
+        // NULL; for binary-serialized events it carries the payload. Column
+        // order matches EventsTable.SelectColumns — bdata is pinned at
+        // position 3 right after mt_dotnet_type.
+        var bdataBytes = _descriptor.SerializeEventBdata(Event);
+        pb.AppendParameter(bdataBytes ?? (object)System.DBNull.Value, NpgsqlDbType.Bytea);
+
         pb.AppendParameter(Event.Id, NpgsqlDbType.Uuid);
 
         // stream_id — Guid streams use Stream.Id, string streams use Stream.Key.

--- a/src/Marten/EventStorage/Rich/RichEventStorage.cs
+++ b/src/Marten/EventStorage/Rich/RichEventStorage.cs
@@ -44,6 +44,7 @@ internal sealed class RichEventStorage<TId>: EventStorage<TId>
             _descriptor.MetadataBindersWithoutSequence,
             _descriptor.IsGuidStreamIdentity,
             _descriptor.SerializeEventData,
+            _descriptor.SerializeEventBdata,
             stream,
             @event);
 

--- a/src/Marten/EventStorage/Rich/RichEventStorageDescriptor.cs
+++ b/src/Marten/EventStorage/Rich/RichEventStorageDescriptor.cs
@@ -26,6 +26,7 @@ public sealed class RichEventStorageDescriptor
         string updateStreamVersionSql,
         string streamStateSelectSql,
         Func<IEvent, string> serializeEventData,
+        Func<IEvent, byte[]?> serializeEventBdata,
         IEventMetadataBinder[] metadataBinders)
     {
         AppendEventSqlPrefix = appendEventSqlPrefix;
@@ -34,6 +35,7 @@ public sealed class RichEventStorageDescriptor
         UpdateStreamVersionSql = updateStreamVersionSql;
         StreamStateSelectSql = streamStateSelectSql;
         SerializeEventData = serializeEventData;
+        SerializeEventBdata = serializeEventBdata;
         MetadataBinders = metadataBinders;
     }
 
@@ -42,7 +44,22 @@ public sealed class RichEventStorageDescriptor
     public string InsertStreamSql { get; }
     public string UpdateStreamVersionSql { get; }
     public string StreamStateSelectSql { get; }
+
+    /// <summary>
+    ///     Serializer for the <c>data</c> jsonb column. Returns the full JSON
+    ///     payload for JSON-serialized events and the literal <c>{}</c>
+    ///     placeholder for binary-serialized events (the real payload lives in
+    ///     <c>bdata</c> in that case — see <see cref="SerializeEventBdata"/>).
+    /// </summary>
     public Func<IEvent, string> SerializeEventData { get; }
+
+    /// <summary>
+    ///     #4515: serializer for the <c>bdata</c> bytea column. Returns the
+    ///     serialized bytes for binary-serialized events; returns <c>null</c>
+    ///     (bound as <see cref="System.DBNull.Value"/>) for JSON-serialized
+    ///     events.
+    /// </summary>
+    public Func<IEvent, byte[]?> SerializeEventBdata { get; }
 
     /// <summary>
     /// Ordered metadata-column binders. Rich-mode only — Quick-mode

--- a/src/Marten/Events/BinaryEventAttribute.cs
+++ b/src/Marten/Events/BinaryEventAttribute.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using System;
+
+namespace Marten.Events;
+
+/// <summary>
+///     Marks an event type as binary-serialized — its <c>data</c> column in
+///     <c>mt_events</c> is populated with the <c>'{}'::jsonb</c> placeholder and
+///     the actual payload lives in <c>bdata</c>, serialized by an
+///     <see cref="IEventBinarySerializer"/>. See
+///     <see href="https://github.com/JasperFx/marten/issues/4515">#4515</see>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The serializer used for an attribute-marked type is resolved at
+///         registration time: <c>opts.Events.DefaultBinarySerializer</c> is the
+///         fallback when no explicit per-type serializer was wired via
+///         <c>opts.Events.UseBinarySerializer&lt;TEvent&gt;(serializer)</c>. If
+///         the type is attribute-marked but neither a per-type nor a store-wide
+///         serializer is configured, the store will throw at the first append.
+///     </para>
+///     <para>
+///         JSON-serialized events and binary-serialized events coexist in the
+///         same table on a per-event-type basis, so applying this attribute to
+///         a single event type is a safe in-place change — existing JSON rows
+///         continue to read through the JSON path.
+///     </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+public sealed class BinaryEventAttribute: Attribute
+{
+}

--- a/src/Marten/Events/EventDocumentStorage.cs
+++ b/src/Marten/Events/EventDocumentStorage.cs
@@ -321,7 +321,31 @@ public abstract class EventDocumentStorage: IEventStorage
             }
         }
 
-        var @event = mapping.ReadEventData(_serializer, reader);
+        // #4515: per-row JSON-vs-binary dispatch. EventsTable pins bdata at
+        // column ordinal 3 right after data/type/mt_dotnet_type. bdata IS NULL
+        // means JSON-serialized event (existing path); non-null bytes mean
+        // binary-serialized — deserialize via the mapping's registered
+        // IEventBinarySerializer.
+        IEvent @event;
+        if (!reader.IsDBNull(3))
+        {
+            if (mapping.BinarySerializer is null)
+            {
+                throw new InvalidOperationException(
+                    $"Event row at mt_events.bdata is non-null but no IEventBinarySerializer is registered " +
+                    $"for type '{mapping.DocumentType.FullName}'. Configure with " +
+                    $"opts.Events.UseBinarySerializer<{mapping.DocumentType.Name}>(...) " +
+                    $"or set opts.Events.DefaultBinarySerializer.");
+            }
+
+            var bytes = reader.GetFieldValue<byte[]>(3);
+            var data = mapping.BinarySerializer.Deserialize(mapping.DocumentType, bytes);
+            @event = mapping.Wrap(data);
+        }
+        else
+        {
+            @event = mapping.ReadEventData(_serializer, reader);
+        }
 
         ApplyReaderDataToEvent(reader, @event);
 
@@ -354,11 +378,42 @@ public abstract class EventDocumentStorage: IEventStorage
         IEvent @event;
         try
         {
-            @event = await mapping.ReadEventDataAsync(_serializer, reader, token).ConfigureAwait(false);
+            // #4515: same per-row dispatch as the sync Resolve overload — bdata
+            // at ordinal 3 picks JSON-vs-binary deserialization.
+            if (!await reader.IsDBNullAsync(3, token).ConfigureAwait(false))
+            {
+                if (mapping.BinarySerializer is null)
+                {
+                    throw new InvalidOperationException(
+                        $"Event row at mt_events.bdata is non-null but no IEventBinarySerializer is registered " +
+                        $"for type '{mapping.DocumentType.FullName}'. Configure with " +
+                        $"opts.Events.UseBinarySerializer<{mapping.DocumentType.Name}>(...) " +
+                        $"or set opts.Events.DefaultBinarySerializer.");
+                }
+
+                var bytes = await reader.GetFieldValueAsync<byte[]>(3, token).ConfigureAwait(false);
+                var data = mapping.BinarySerializer.Deserialize(mapping.DocumentType, bytes);
+                @event = mapping.Wrap(data);
+            }
+            else
+            {
+                @event = await mapping.ReadEventDataAsync(_serializer, reader, token).ConfigureAwait(false);
+            }
         }
         catch (Exception e)
         {
-            var sequence = await reader.GetFieldValueAsync<long>(3, token).ConfigureAwait(false);
+            // #4515: mt_events.seq_id shifted from ordinal 3 to ordinal 4 after
+            // bdata's insertion (EventsTable.SelectColumns now pins data, type,
+            // mt_dotnet_type, bdata, seq_id at 0..4).
+            long sequence;
+            try
+            {
+                sequence = await reader.GetFieldValueAsync<long>(4, token).ConfigureAwait(false);
+            }
+            catch
+            {
+                sequence = -1;
+            }
             throw new EventDeserializationFailureException(sequence, mapping, e);
         }
 

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -333,6 +333,68 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
         _events.FillDefault(eventType);
     }
 
+    // #4515: per-event-type binary serializer registry. EventMapping<T>'s
+    // constructor calls ResolveBinarySerializerFor when the mapping is built
+    // (lazily on first use); UseBinarySerializer<T> populates this dictionary
+    // ahead of time so the resolution lands on the registered instance.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<Type, IEventBinarySerializer> _binarySerializerByType = new();
+
+    /// <inheritdoc />
+    public IEventBinarySerializer? DefaultBinarySerializer { get; set; }
+
+    /// <inheritdoc />
+    public IEventStoreOptions UseBinarySerializer<TEvent>(IEventBinarySerializer serializer)
+    {
+        if (serializer == null) throw new ArgumentNullException(nameof(serializer));
+
+        var eventType = typeof(TEvent);
+        _binarySerializerByType[eventType] = serializer;
+
+        // Make sure the mapping exists and is wired with this serializer.
+        // EventMapping<T> reads its BinarySerializer from
+        // ResolveBinarySerializerFor in its constructor, so if the mapping
+        // already exists (e.g. another store-options call referenced the type
+        // first) we need to refresh its serializer reference here too.
+        AddEventType(eventType);
+        var mapping = EventMappingFor(eventType);
+        if (mapping is not null)
+        {
+            mapping.BinarySerializer = serializer;
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    ///     #4515: resolve the binary serializer for an event type. Called from
+    ///     <see cref="EventMapping"/>'s constructor. Precedence: explicit
+    ///     per-type registration via <see cref="UseBinarySerializer{TEvent}"/>
+    ///     beats <see cref="BinaryEventAttribute"/> + <see cref="DefaultBinarySerializer"/>.
+    ///     Returns <c>null</c> for plain JSON events.
+    /// </summary>
+    internal IEventBinarySerializer? ResolveBinarySerializerFor(Type eventType)
+    {
+        if (_binarySerializerByType.TryGetValue(eventType, out var explicitSerializer))
+        {
+            return explicitSerializer;
+        }
+
+        if (eventType.IsDefined(typeof(BinaryEventAttribute), inherit: false))
+        {
+            if (DefaultBinarySerializer is null)
+            {
+                throw new InvalidOperationException(
+                    $"Event type '{eventType.FullName}' is marked with [BinaryEvent] but no IEventBinarySerializer was registered. " +
+                    $"Either call opts.Events.UseBinarySerializer<{eventType.Name}>(...) explicitly, " +
+                    $"or set opts.Events.DefaultBinarySerializer to a store-wide fallback.");
+            }
+
+            return DefaultBinarySerializer;
+        }
+
+        return null;
+    }
+
     /// <summary>
     ///     Register an event type with Marten. This isn't strictly necessary for normal usage,
     ///     but can help Marten with asynchronous projections where Marten hasn't yet encountered

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -50,6 +50,12 @@ public abstract class EventMapping: EventTypeData, IDocumentMapping, IEventType
         _parent = parent;
         DocumentType = eventType;
 
+        // #4515: pick up binary-serializer wiring at construction. Either an
+        // explicit per-type registration via UseBinarySerializer<T>(...) or
+        // the BinaryEventAttribute + store-wide DefaultBinarySerializer.
+        // Null = plain JSON-serialized event (the existing path).
+        BinarySerializer = parent.ResolveBinarySerializerFor(eventType);
+
         IdMember = DocumentType.GetProperty(nameof(IEvent.Id))!;
 
         _inner = new DocumentMapping(eventType, parent.Options);
@@ -65,6 +71,24 @@ public abstract class EventMapping: EventTypeData, IDocumentMapping, IEventType
 
         JsonTransformation(null);
     }
+
+    /// <summary>
+    ///     #4515: binary serializer for this event type, or <c>null</c> for the
+    ///     standard JSON path. When non-null, write operations route the payload
+    ///     into <c>mt_events.bdata</c> (bytea); read operations dispatch on the
+    ///     row's <c>bdata IS NULL</c> state so JSON-serialized rows for the same
+    ///     event type still read correctly.
+    /// </summary>
+    [IgnoreDescription]
+    public IEventBinarySerializer? BinarySerializer { get; internal set; }
+
+    /// <summary>
+    ///     #4515: <c>true</c> when this event type is opted in to binary
+    ///     serialization on the write path (a <see cref="BinarySerializer"/> is
+    ///     wired). Read-path dispatch remains row-by-row on <c>bdata</c>'s NULL
+    ///     state so pre-opt-in JSON rows continue to read through the JSON path.
+    /// </summary>
+    public bool IsBinary => BinarySerializer is not null;
 
     [IgnoreDescription]
     public Func<ISerializer, DbDataReader, IEvent> ReadEventData { get; private set; }

--- a/src/Marten/Events/IEventBinarySerializer.cs
+++ b/src/Marten/Events/IEventBinarySerializer.cs
@@ -1,0 +1,44 @@
+#nullable enable
+using System;
+
+namespace Marten.Events;
+
+/// <summary>
+///     Pluggable binary serializer for event data — addresses
+///     <see href="https://github.com/JasperFx/marten/issues/4515">#4515</see>.
+///     Allows individual event types to opt out of <c>jsonb</c> serialization
+///     in favor of a binary wire format (MemoryPack, MessagePack, etc.).
+/// </summary>
+/// <remarks>
+///     <para>
+///         Binary serialization is enabled <strong>per event type</strong>, not
+///         store-wide. A store can have JSON events and binary events mixed in
+///         the same <c>mt_events</c> table; the row's serialization format is
+///         determined by the <c>bdata</c> column being <c>NULL</c> (JSON) or
+///         non-null (binary). This makes the feature safe to roll out on an
+///         existing store with no migration of existing event data.
+///     </para>
+///     <para>
+///         Opt in by either marking an event type with
+///         <see cref="BinaryEventAttribute"/> or registering it through
+///         <c>opts.Events.UseBinarySerializer&lt;TEvent&gt;(serializer)</c>.
+///         Event types without a per-type serializer fall back to the
+///         store-wide <c>opts.Events.DefaultBinarySerializer</c> if one is set.
+///     </para>
+/// </remarks>
+public interface IEventBinarySerializer
+{
+    /// <summary>
+    ///     Serialize an event data instance to bytes.
+    /// </summary>
+    /// <param name="type">The runtime CLR type of the event data.</param>
+    /// <param name="data">The event data to serialize.</param>
+    byte[] Serialize(Type type, object data);
+
+    /// <summary>
+    ///     Deserialize bytes back into an event data instance.
+    /// </summary>
+    /// <param name="type">The target CLR type to deserialize into.</param>
+    /// <param name="data">The bytes previously produced by <see cref="Serialize"/>.</param>
+    object Deserialize(Type type, byte[] data);
+}

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -200,6 +200,27 @@ namespace Marten.Events
         void AddEventTypes(IEnumerable<Type> types);
 
         /// <summary>
+        ///     Store-wide fallback <see cref="IEventBinarySerializer"/> used for event types
+        ///     marked with <see cref="BinaryEventAttribute"/> when no explicit per-type
+        ///     serializer was wired via <see cref="UseBinarySerializer{TEvent}"/>. Default
+        ///     is <c>null</c>; setting this is what makes attribute-only opt-in work for
+        ///     the common case of one binary serializer per store. See #4515.
+        /// </summary>
+        public IEventBinarySerializer? DefaultBinarySerializer { get; set; }
+
+        /// <summary>
+        ///     Opt a single event type into binary serialization (#4515). The event's
+        ///     payload is written to the <c>bdata</c> bytea column instead of the
+        ///     <c>data</c> jsonb column; existing JSON rows for the same type continue
+        ///     to read through the JSON path. Calling this also adds the event type to
+        ///     the registry (no separate <see cref="AddEventType{TEvent}"/> call needed).
+        /// </summary>
+        /// <typeparam name="TEvent">CLR event type to opt in.</typeparam>
+        /// <param name="serializer">Per-type serializer to use for this event.</param>
+        /// <returns>Event store options, to allow fluent definition.</returns>
+        IEventStoreOptions UseBinarySerializer<TEvent>(IEventBinarySerializer serializer);
+
+        /// <summary>
         ///     Maps CLR event type as particular event type name. This is useful for event type migration.
         ///     See more in <a href="https://martendb.io/events/versioning.html#event-type-name-migration">documentation</a>
         /// </summary>

--- a/src/Marten/Events/Schema/EventBdataColumn.cs
+++ b/src/Marten/Events/Schema/EventBdataColumn.cs
@@ -1,0 +1,54 @@
+#nullable enable
+using System.Data.Common;
+using JasperFx.Events;
+using Marten.Services;
+using Weasel.Postgresql.Tables;
+
+namespace Marten.Events.Schema;
+
+/// <summary>
+///     Sibling to <see cref="EventJsonDataColumn"/> for binary event payloads
+///     (<see href="https://github.com/JasperFx/marten/issues/4515">#4515</see>).
+///     For event types opted in to binary serialization, the JSON <c>data</c>
+///     column holds the literal <c>'{}'::jsonb</c> placeholder and the actual
+///     payload lives here as raw bytes.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Nullable on purpose: when an event row uses JSON serialization,
+///         <c>data</c> holds the full payload and <c>bdata</c> is <c>NULL</c>.
+///         The presence of a non-null <c>bdata</c> is the on-row discriminator.
+///         This is what makes the feature additive — existing JSON rows in an
+///         upgraded store have <c>bdata = NULL</c> and continue to read through
+///         the JSON path.
+///     </para>
+///     <para>
+///         <strong>Read-path note:</strong> the bytes are consumed up in
+///         <see cref="Marten.Events.EventDocumentStorage.Resolve(System.Data.Common.DbDataReader)"/>
+///         /
+///         <see cref="Marten.Events.EventDocumentStorage.ResolveAsync(System.Data.Common.DbDataReader, System.Threading.CancellationToken)"/>
+///         (the per-row JSON-vs-binary dispatch point), so this column's
+///         <c>ReadValueSync</c> / <c>ReadValueAsync</c> are deliberately
+///         no-ops in the per-column metadata loop — they'd otherwise re-read
+///         the same bytes for nothing.
+///     </para>
+/// </remarks>
+internal sealed class EventBdataColumn: TableColumn, IEventTableColumn
+{
+    public EventBdataColumn(): base("bdata", "bytea")
+    {
+        AllowNulls = true;
+    }
+
+    public string ValueSql(EventGraph graph, AppendMode mode) => "?";
+
+    void IEventTableColumn.ReadValueSync(DbDataReader reader, int index, IEvent @event)
+    {
+        // No-op — consumed in EventDocumentStorage.Resolve to choose the
+        // JSON-vs-binary deserialization path.
+    }
+
+    System.Threading.Tasks.Task IEventTableColumn.ReadValueAsync(
+        DbDataReader reader, int index, IEvent @event, System.Threading.CancellationToken cancellation)
+        => System.Threading.Tasks.Task.CompletedTask;
+}

--- a/src/Marten/Events/Schema/EventsTable.cs
+++ b/src/Marten/Events/Schema/EventsTable.cs
@@ -23,6 +23,10 @@ internal class EventsTable: Table
 
         AddColumn(new VersionColumn());
         AddColumn<EventJsonDataColumn>();
+        // #4515: nullable sibling to `data` for binary event payloads. NULL
+        // for JSON-serialized events; bytes (e.g. MemoryPack) for events
+        // opted in via [BinaryEvent] / opts.Events.UseBinarySerializer<T>(...).
+        AddColumn<EventBdataColumn>();
         AddColumn<EventTypeColumn>();
         AddColumn(new EventTableColumn("timestamp", x => x.Timestamp))
             .NotNull().DefaultValueByString("(now())");
@@ -151,6 +155,11 @@ internal class EventsTable: Table
         var data = columns.OfType<EventJsonDataColumn>().Single();
         var typeName = columns.OfType<EventTypeColumn>().Single();
         var dotNetTypeName = columns.OfType<DotNetTypeColumn>().Single();
+        // #4515: bdata (nullable bytea) for binary event payloads. Pinned at
+        // position 3 in the SELECT projection so EventDocumentStorage.Resolve
+        // can pick JSON-vs-binary deserialization from a stable ordinal
+        // before the per-column metadata loop runs.
+        var bdata = columns.OfType<EventBdataColumn>().Single();
 
         columns.Remove(data);
         columns.Insert(0, data);
@@ -158,6 +167,8 @@ internal class EventsTable: Table
         columns.Insert(1, typeName);
         columns.Remove(dotNetTypeName);
         columns.Insert(2, dotNetTypeName);
+        columns.Remove(bdata);
+        columns.Insert(3, bdata);
 
         return columns;
     }


### PR DESCRIPTION
Closes part of [#4515](https://github.com/JasperFx/marten/issues/4515). **Phase 1** ships the foundation and a working vertical slice on the **Rich** append path; the Quick-mode write paths, BulkEventAppender, and binary upcasters are deferred as explicit, documented scope (see §Limitations).

## TL;DR

- Per-event-type binary serialization, coexisting with JSON on the same `mt_events` table.
- New optional package: `Marten.MemoryPack`.
- Additive schema change only: one new `bdata bytea NULL` column. **No migration of existing data required.**
- 5/5 new MemoryPack integration tests pass; existing EventSourcing tests unaffected.
- **Limitation:** Rich append mode only in this cut — the Quick modes throw at store-build time with a clear remediation recipe if a binary event type is registered without `AppendMode = Rich`.

## Coexistence design

Schema is purely additive:

| column | type | populated when |
| --- | --- | --- |
| `data` | `jsonb NOT NULL` | JSON event: full payload. **Binary event:** literal `'{}'::jsonb` placeholder. |
| `bdata` | `bytea NULL` (new) | Binary event: serialized bytes. JSON event: `NULL`. |

Per-row discriminator: `bdata IS NULL`. `data NOT NULL` stays intact, so existing rows in an upgraded store have `bdata = NULL` and read through the JSON path unchanged.

## Registration API — both forms, per the maintainer's recommended option

```csharp
// 1. Attribute-driven (uses opts.Events.DefaultBinarySerializer as resolver)
[BinaryEvent]
[MemoryPackable]
public partial record TripStarted(Guid TripId, string DriverName, DateTimeOffset StartedAt);

// 2. Fluent (explicit per-type serializer; wins over the default)
opts.Events.UseBinarySerializer<TripStarted>(new MemoryPackEventSerializer());
```

Resolution order on `EventMapping` construction:
1. Explicit `UseBinarySerializer<T>(...)` for that type
2. `[BinaryEvent]` + `opts.Events.DefaultBinarySerializer`
3. Otherwise, plain JSON (existing path)

If `[BinaryEvent]` is set but neither a per-type nor a default serializer is wired, the `EventMapping` constructor throws with a remediation message naming both registration entry points.

## `Marten.MemoryPack` package

```csharp
opts.Events.AppendMode = EventAppendMode.Rich;   // Phase 1 limitation
opts.Events.UseMemoryPackSerializer();           // sets DefaultBinarySerializer
```

Then `[BinaryEvent] [MemoryPackable]` types just work. The serializer itself is ~5 lines over `MemoryPackSerializer`.

## Surface area touched

| Area | What |
| --- | --- |
| `Marten/Events/{IEventBinarySerializer,BinaryEventAttribute}.cs` | New interface + attribute |
| `Marten/Events/Schema/EventBdataColumn.cs` | New nullable bytea column |
| `Marten/Events/Schema/EventsTable.cs` | Add column; pin at SELECT position 3 |
| `Marten/Events/IEventStoreOptions.cs` | `DefaultBinarySerializer` + `UseBinarySerializer<T>` |
| `Marten/Events/EventGraph.cs` | Registry + `ResolveBinarySerializerFor` |
| `Marten/Events/EventMapping.cs` | `BinarySerializer` + `IsBinary` |
| `Marten/Events/EventDocumentStorage.cs` | Per-row JSON-vs-binary dispatch in `Resolve` / `ResolveAsync` |
| `Marten/EventStorage/Rich/RichAppendEventOperation.cs` | Bind `bdata` at column slot 4 |
| `Marten/EventStorage/Rich/RichEventStorageDescriptor.cs` | `SerializeEventBdata` closure |
| `Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs` | `bdata` in `IsCoreColumn`; binary-aware closures; Quick-mode guard |
| `Marten/EventStorage/ClosedShapeEventDocumentStorage.cs` | `Skip(3)` → `Skip(4)`; +4 ordinal offset |
| `Marten.MemoryPack/` | New library — `MemoryPackEventSerializer` + sugar extensions |
| `Marten.MemoryPack.Tests/` | 5 integration tests |
| `Marten.slnx` | New `MemoryPack/` folder |
| `build/build.cs` | `TestMemoryPack` target hung off `TestExtensions` |
| `Directory.Packages.props` | `MemoryPack 1.21.4` |

## Tests

`Marten.MemoryPack.Tests` — all 5 pass against local Postgres:

| Test | What it pins |
| --- | --- |
| `can_round_trip_a_single_binary_event` | Basic MemoryPack write/read |
| `multiple_binary_events_replay_in_order` | Multi-event stream round-trip |
| `json_and_binary_events_coexist_on_one_stream` | **Mixed stream:** JSON and binary events interleaved; both read back correctly |
| `binary_events_land_in_bdata_column_jsoned_events_land_in_data_column` | On-disk shape verification — confirms binary rows have `data = '{}'` + `bdata` non-null; JSON rows have `data = real JSON` + `bdata = NULL` |
| `pre_existing_json_rows_still_read_after_feature_is_in_place` | **Upgrade-backfill:** rows written before the feature still read correctly |

Regression check: `EventSourcingTests.end_to_end_event_capture_and_fetching` 83/83 passing — JSON-only events still flow correctly through the dispatched read path.

## Phase 1 limitations (explicit, documented)

These are written up in the new `docs/events/binary-serialization.md` page; calling them out here so the review knows what's intentionally deferred:

1. **`EventAppendMode.Rich` only.** The default `QuickWithServerTimestamps` and `Quick` go through the `mt_quick_append_events` PG function, whose signature needs a parallel `bdata bytea[]` parameter to carry binary payloads. `BuildQuickDescriptor` / `BuildQuickWithServerTimestampsDescriptor` throw at store-build time if a binary event type is registered while `AppendMode` is non-Rich, with the remediation recipe in the exception message. **Quick-mode support is Phase 2.**
2. **No `BulkEventAppender` support.** Same root cause — COPY column shape needs `bdata` adding. Follow-up.
3. **No binary upcaster support.** Marten's JSON upcasters operate on JSON payloads; a separate typed transform shape for binary is needed. **Filing as a separate follow-up issue.**

## Docs

- New page: `docs/events/binary-serialization.md` (coexistence design, registration, on-disk shape, migration story, full constraints list)
- Wired into the Events sidebar in `docs/.vitepress/config.mts`
- Link from `docs/events/optimizing.md` (Performance & Scalability) pointing to the new page

Both pass `markdownlint --disable MD009` and `cspell` locally.

## Out of scope (deferred to follow-ups)

- Quick-mode write paths (the PG function `mt_quick_append_events` needs a `bdata bytea[]` parameter and matching operation binds)
- `BulkEventAppender` COPY-path binary support
- Binary event upcasters / downcasters (filed as a separate follow-up issue — see `[#4579](https://github.com/JasperFx/marten/issues/4579)`)
- Integration tests for projections / `FetchForWriting` / async daemon against binary events — the same `Resolve`/`ResolveAsync` dispatch is used everywhere, so the existing per-row tests cover the core read contract; richer integration tests can land in Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)