### PR TITLE
Add Marten.PostGIS, Marten.PgVector, Marten.MemoryPack to Nuke Pack target

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -53,6 +53,7 @@
         "TestEventSourcing",
         "TestExtensions",
         "TestLinq",
+        "TestMemoryPack",
         "TestModularConfig",
         "TestMultiTenancy",
         "TestNodaTime",

--- a/build/build.cs
+++ b/build/build.cs
@@ -390,7 +390,13 @@ class Build : NukeBuild
                 "./src/Marten.NodaTime",
                 "./src/Marten.AspNetCore",
                 "./src/Marten.EntityFrameworkCore",
-                "./src/Marten.SourceGenerator"
+                "./src/Marten.SourceGenerator",
+                // New optional companion packages — must be listed here so
+                // the existing on-manual-do-nuget-publish.yml workflow picks
+                // them up. Without this they'd silently never reach NuGet.
+                "./src/Marten.PostGIS",        // PostGIS spatial support (#4576)
+                "./src/Marten.PgVector",       // pgvector similarity search (#4576)
+                "./src/Marten.MemoryPack"      // binary event serialization (#4515 / #4578)
             };
 
             foreach (var project in projects)


### PR DESCRIPTION
Follow-up to [#4576](https://github.com/JasperFx/marten/pull/4576) and [#4578](https://github.com/JasperFx/marten/pull/4578).

## Why

The Nuke `Pack` target in `build/build.cs` lists every project that gets packed and pushed by the `on-manual-do-nuget-publish.yml` release workflow. The three new optional companion packages added in PR #4576 (PostGIS / PgVector) and PR #4578 (MemoryPack — binary event serialization) were never added to the list, so the next NuGet release would silently leave them off NuGet.

## Verification

Repacking locally now produces all 9 .nupkgs (was 6 before this PR):

```
Marten.9.2.1.nupkg
Marten.AspNetCore.9.2.1.nupkg
Marten.EntityFrameworkCore.9.2.1.nupkg
Marten.MemoryPack.9.2.1.nupkg          ← new
Marten.Newtonsoft.9.2.1.nupkg
Marten.NodaTime.9.2.1.nupkg
Marten.PgVector.9.2.1.nupkg            ← new
Marten.PostGIS.9.2.1.nupkg             ← new
Marten.SourceGenerator.9.2.1.nupkg
```

## Notes

- Gating fix before the 9.3.0 release. Without this, the release workflow would publish 9.3.0 of the 6 existing packages but consumers couldn't install Marten.PostGIS / Marten.PgVector / Marten.MemoryPack — silent failure.
- The `.nuke/build.schema.json` change is the auto-generated companion to `build.cs` (gets regenerated on every `./build.sh` invocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)