### PR TITLE
#4515 Phase 2: binary event serialization on Quick + BulkEventAppender

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -71,8 +71,8 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.1" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.0.1" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.2" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.0.2" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/docs/events/binary-serialization.md
+++ b/docs/events/binary-serialization.md
@@ -62,11 +62,10 @@ var store = DocumentStore.For(opts =>
 {
     opts.Connection(connectionString);
 
-    // Phase 1 limitation — see "Constraints" below.
-    opts.Events.AppendMode = EventAppendMode.Rich;
-
     // Wire MemoryPack as DefaultBinarySerializer. [BinaryEvent]-marked
-    // event types resolve to this serializer on registration.
+    // event types resolve to this serializer on registration. Works with
+    // every EventAppendMode (Rich / Quick / QuickWithServerTimestamps)
+    // and with BulkEventAppender — see the "Append modes" section.
     opts.Events.UseMemoryPackSerializer();
 });
 ```
@@ -141,20 +140,22 @@ Existing rows have `bdata = NULL` (the column's default for prior data) and
 read through the JSON path. Marten's standard schema migration creates the
 column for existing installations — no event data conversion required.
 
+## Append modes
+
+Binary event serialization works with **every** `EventAppendMode` Marten
+ships — `Rich`, `Quick`, and `QuickWithServerTimestamps`. The Quick modes
+route appends through the `mt_quick_append_events` PostgreSQL function,
+which carries a `bdatas bytea[]` parameter that's inserted into `mt_events.bdata`
+in parallel with the existing `bodies jsonb[]`. `BulkEventAppender` (the
+COPY-based bulk loader) also supports binary events — its COPY column list
+includes `bdata`, and each event row writes either the binary payload or
+NULL.
+
+You don't have to think about the append mode: binary opt-in is per event
+type and works identically across all of them.
+
 ## Constraints
 
-The 9.3 cut ships with deliberate scope:
-
-- **`EventAppendMode.Rich` only.** The default `QuickWithServerTimestamps` and
-  `Quick` modes go through the `mt_quick_append_events` PostgreSQL function,
-  whose signature would need a parallel `bdata bytea[]` parameter to carry
-  binary payloads. Until that lands, `BuildQuickDescriptor` /
-  `BuildQuickWithServerTimestampsDescriptor` throw at store-build time if any
-  binary event type is registered. Workaround: set
-  `opts.Events.AppendMode = EventAppendMode.Rich;`.
-- **No bulk appender support.** `BulkEventAppender` uses Npgsql `COPY` with
-  the existing column shape; adding the `bdata` column to the COPY format
-  is part of the same Quick-mode follow-up.
 - **No upcaster support.** Marten's
   [event upcasters](/events/versioning) operate on JSON payloads and don't
   generalize to a `byte[]` wire form. Binary event upcasters need their own

--- a/docs/events/binary-serialization.md
+++ b/docs/events/binary-serialization.md
@@ -154,14 +154,64 @@ NULL.
 You don't have to think about the append mode: binary opt-in is per event
 type and works identically across all of them.
 
-## Constraints
+## Schema evolution — use versioned event types
 
-- **No upcaster support.** Marten's
-  [event upcasters](/events/versioning) operate on JSON payloads and don't
-  generalize to a `byte[]` wire form. Binary event upcasters need their own
-  typed transform shape; tracked as a deferred follow-up. For now, design
-  binary event schemas with forward-compatibility in the serializer itself
-  (MemoryPack's `[MemoryPackOrder]` evolution, for example).
+Marten's existing [event upcasters](/events/versioning) operate on the JSON
+wire form and don't generalize to a `byte[]` payload, so they don't apply to
+binary events. The recommended pattern for evolving a binary event's shape
+is **introduce a new event type for each version** rather than upcasting in
+place:
+
+```csharp
+// Original
+[BinaryEvent]
+[MemoryPackable]
+public partial record TripStarted(Guid TripId, string DriverName);
+
+// Schema change — new fields. Don't edit TripStarted; add a new type.
+[BinaryEvent]
+[MemoryPackable]
+public partial record TripStartedV2(Guid TripId, string DriverName, DateTimeOffset StartedAt);
+```
+
+When the projection / aggregate handles both versions explicitly, old
+streams keep replaying through the old type and new appends use the new
+type:
+
+```csharp
+public class Trip
+{
+    public Guid Id { get; set; }
+    public string DriverName { get; set; } = "";
+    public DateTimeOffset? StartedAt { get; set; }
+
+    public void Apply(TripStarted e)   { Id = e.TripId; DriverName = e.DriverName; }
+    public void Apply(TripStartedV2 e) { Id = e.TripId; DriverName = e.DriverName; StartedAt = e.StartedAt; }
+}
+```
+
+The coexistence design lets old rows (written as `TripStarted`) and new rows
+(written as `TripStartedV2`) live on the same stream without migration.
+
+### Why not in-place backward-compatible schema changes?
+
+You *can* lean on MemoryPack's
+[backward-compatible field evolution](https://github.com/Cysharp/MemoryPack#version-tolerant-format)
+(`[MemoryPackOrder]`, nullable fields, the `VersionTolerant` mode) for
+additive-only changes to a single event type. That works as long as the
+serializer itself can deserialize old payloads into the new shape — but the
+moment a change goes beyond the serializer's tolerance rules (renaming, type
+changes, splitting a field), there's no JSON-style upcaster path to fall
+back on. Versioning the event type works for every shape of change and stays
+explicit about which version each row was written with.
+
+### Mixing binary + JSON
+
+If you have an existing JSON-serialized event and want a future version to
+go binary, the same pattern applies: define a new `[BinaryEvent]`-marked
+type for the new version, leave the old (JSON) type and its upcasters
+alone, and have the aggregate handle both. The per-row dispatch already
+copes with mixed formats on the same stream.
 
 ## See also
 

--- a/src/Marten.MemoryPack.Tests/QuickModeBinaryEventTests.cs
+++ b/src/Marten.MemoryPack.Tests/QuickModeBinaryEventTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.MemoryPack;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace Marten.MemoryPack.Tests;
+
+// #4515 Phase 2: binary event serialization works on the Quick + Quick
+// with-server-timestamps append paths too, not just Rich. The
+// mt_quick_append_events server function gained a `bdatas bytea[]`
+// parameter that's inserted into mt_events.bdata in parallel with bodies.
+// These tests pin the per-event-type dispatch on both Quick variants.
+[Collection("Marten.MemoryPack")]
+public class QuickModeBinaryEventTests
+{
+    [Fact]
+    public async Task quick_with_server_timestamps_round_trips_binary_events()
+    {
+        await using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "memorypack_quick_sts";
+            opts.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+            // Default append mode — no Rich override.
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseMemoryPackSerializer();
+        });
+
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId,
+                new TripStarted(streamId, "Alice", DateTimeOffset.UtcNow),     // binary
+                new TripCommentAdded(streamId, "leaving", DateTimeOffset.UtcNow), // JSON
+                new TripEnded(streamId, DateTimeOffset.UtcNow, 33.00m));       // binary
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events.Count.ShouldBe(3);
+        events[0].Data.ShouldBeOfType<TripStarted>().DriverName.ShouldBe("Alice");
+        events[1].Data.ShouldBeOfType<TripCommentAdded>().Comment.ShouldBe("leaving");
+        events[2].Data.ShouldBeOfType<TripEnded>().FareAmount.ShouldBe(33.00m);
+    }
+
+    [Fact]
+    public async Task quick_mode_round_trips_binary_events()
+    {
+        await using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "memorypack_quick_plain";
+            opts.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+            opts.Events.AppendMode = EventAppendMode.Quick;
+            opts.Events.UseMemoryPackSerializer();
+        });
+
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId,
+                new TripStarted(streamId, "Bob", DateTimeOffset.UtcNow),
+                new PassengerPickedUp(streamId, "Carol", DateTimeOffset.UtcNow),
+                new TripEnded(streamId, DateTimeOffset.UtcNow, 15.50m));
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+
+        events.Count.ShouldBe(3);
+        events[0].Data.ShouldBeOfType<TripStarted>().DriverName.ShouldBe("Bob");
+        events[1].Data.ShouldBeOfType<PassengerPickedUp>().PassengerName.ShouldBe("Carol");
+        events[2].Data.ShouldBeOfType<TripEnded>().FareAmount.ShouldBe(15.50m);
+    }
+
+    // On-disk shape verification — binary events under Quick mode produce
+    // the same row shape as under Rich mode: data is the {} placeholder,
+    // bdata holds the bytes.
+    [Fact]
+    public async Task quick_mode_binary_events_land_in_bdata_column()
+    {
+        const string schema = "memorypack_quick_shape";
+
+        await using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = schema;
+            opts.AutoCreateSchemaObjects = JasperFx.AutoCreate.All;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseMemoryPackSerializer();
+        });
+
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId,
+                new TripStarted(streamId, "Dana", DateTimeOffset.UtcNow),         // binary
+                new TripCommentAdded(streamId, "hello", DateTimeOffset.UtcNow));  // JSON
+            await session.SaveChangesAsync();
+        }
+
+        await using var conn = store.Storage.Database.CreateConnection();
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"select type, bdata is null as bdata_is_null, data::text " +
+                          $"from {schema}.mt_events where stream_id = $1 order by version";
+        var p = cmd.CreateParameter();
+        p.Value = streamId;
+        cmd.Parameters.Add(p);
+
+        var rows = new System.Collections.Generic.List<(string type, bool bdataIsNull, string data)>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            rows.Add((reader.GetString(0), reader.GetBoolean(1), reader.GetString(2)));
+        }
+
+        rows.Count.ShouldBe(2);
+        rows[0].type.ShouldBe("trip_started");
+        rows[0].bdataIsNull.ShouldBeFalse();
+        rows[0].data.ShouldBe("{}");
+        rows[1].type.ShouldBe("trip_comment_added");
+        rows[1].bdataIsNull.ShouldBeTrue();
+        rows[1].data.ShouldContain("hello");
+    }
+}

--- a/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
+++ b/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
@@ -274,14 +274,11 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
 
     public QuickEventStorageDescriptor BuildQuickDescriptor(EventGraph graph, ISerializer serializer)
     {
-        // #4515 Phase 1 limitation: binary event serialization is implemented
-        // for the Rich append path only. The Quick path goes through the
-        // mt_quick_append_events server function whose signature is
-        // generated against `bytea[]` (UTF-8 JSON) for the data column; adding
-        // a parallel `bdata bytea[]` parameter (+ the function regen + bulk
-        // appender) is the explicit Phase 2 scope. Fail loud at store-build
-        // time rather than silently writing JSON for an opted-in binary type.
-        AssertNoBinaryEventsForQuickMode(graph, EventAppendMode.Quick);
+        // #4515 Phase 2: Quick mode now supports binary events too. The
+        // mt_quick_append_events PG function gained a `bdatas bytea[]`
+        // parameter that's inserted into mt_events.bdata in parallel with
+        // bodies[]. SerializeEventBdata below dispatches per event type
+        // (real bytes for binary events, null for JSON).
 
         var (isConjoined, isGuid, hasCausation, hasCorrelation, hasHeaders, hasUserName, hasTagWrites)
             = ReadQuickFlags(graph);
@@ -296,12 +293,23 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             insertStreamSql: BuildInsertStreamSql(graph),
             updateStreamVersionSql: BuildUpdateStreamVersionSql(graph),
             streamStateSelectSql: Marten.EventStorage.StreamStateSql.Build(graph),
-            serializeEventData: e => serializer.ToJson(e.Data),
-            // #4515: Quick mode rejects binary events at build time (see
-            // AssertNoBinaryEventsForQuickMode), so bdata is always NULL
-            // here. The slot still exists because mt_events.bdata is part
-            // of every full-shape INSERT column list.
-            serializeEventBdata: _ => null)
+            // #4515 Phase 2: binary events write {} to data + real bytes to
+            // bdata; JSON events write JSON to data + NULL to bdata. Same
+            // dispatch shape as the Rich descriptor.
+            serializeEventData: e =>
+            {
+                var mapping = graph.EventMappingFor(e.EventType);
+                return mapping?.IsBinary == true
+                    ? "{}"
+                    : serializer.ToJson(e.Data);
+            },
+            serializeEventBdata: e =>
+            {
+                var mapping = graph.EventMappingFor(e.EventType);
+                return mapping?.IsBinary == true
+                    ? mapping.BinarySerializer!.Serialize(e.EventType, e.Data)
+                    : null;
+            })
         {
             IsGuidStreamIdentity = isGuid,
             IsTenancyConjoined = isConjoined,
@@ -320,36 +328,11 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
         };
     }
 
-    /// <summary>
-    ///     #4515: enforce the Phase 1 constraint that binary event serialization
-    ///     only ships on the Rich append path. If the user registered any
-    ///     binary event types and is still on the default
-    ///     <see cref="EventAppendMode.QuickWithServerTimestamps"/> (or
-    ///     explicit <see cref="EventAppendMode.Quick"/>), throw with the
-    ///     remediation recipe instead of writing wrong data.
-    /// </summary>
-    private static void AssertNoBinaryEventsForQuickMode(EventGraph graph, EventAppendMode mode)
-    {
-        var binaryEventTypes = graph.AllEvents()
-            .Where(e => e.IsBinary)
-            .Select(e => e.DocumentType.FullName ?? e.DocumentType.Name)
-            .ToArray();
-
-        if (binaryEventTypes.Length == 0) return;
-
-        throw new InvalidOperationException(
-            $"Binary event serialization (#4515) is currently only supported with EventAppendMode.Rich, " +
-            $"but AppendMode is {mode} and the following event types are opted in to binary serialization: " +
-            $"{string.Join(", ", binaryEventTypes)}. " +
-            $"Set `opts.Events.AppendMode = EventAppendMode.Rich;` to use binary event serialization. " +
-            $"(Quick-mode support is tracked as a follow-up — the mt_quick_append_events server function " +
-            $"needs a parallel `bdata bytea[]` parameter.)");
-    }
-
     public QuickWithServerTimestampsEventStorageDescriptor BuildQuickWithServerTimestampsDescriptor(
         EventGraph graph, ISerializer serializer)
     {
-        AssertNoBinaryEventsForQuickMode(graph, EventAppendMode.QuickWithServerTimestamps);
+        // #4515 Phase 2: Quick-with-server-timestamps supports binary events
+        // too — see BuildQuickDescriptor for the dispatch shape.
 
         var (isConjoined, isGuid, hasCausation, hasCorrelation, hasHeaders, hasUserName, hasTagWrites)
             = ReadQuickFlags(graph);
@@ -364,9 +347,21 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             insertStreamSql: BuildInsertStreamSql(graph),
             updateStreamVersionSql: BuildUpdateStreamVersionSql(graph),
             streamStateSelectSql: Marten.EventStorage.StreamStateSql.Build(graph),
-            serializeEventData: e => serializer.ToJson(e.Data),
-            // #4515: see notes on the parallel call in BuildQuickDescriptor.
-            serializeEventBdata: _ => null)
+            // #4515 Phase 2: same dispatch as BuildQuickDescriptor.
+            serializeEventData: e =>
+            {
+                var mapping = graph.EventMappingFor(e.EventType);
+                return mapping?.IsBinary == true
+                    ? "{}"
+                    : serializer.ToJson(e.Data);
+            },
+            serializeEventBdata: e =>
+            {
+                var mapping = graph.EventMappingFor(e.EventType);
+                return mapping?.IsBinary == true
+                    ? mapping.BinarySerializer!.Serialize(e.EventType, e.Data)
+                    : null;
+            })
         {
             IsGuidStreamIdentity = isGuid,
             IsTenancyConjoined = isConjoined,

--- a/src/Marten/EventStorage/Quick/QuickAppendEventsOperation.cs
+++ b/src/Marten/EventStorage/Quick/QuickAppendEventsOperation.cs
@@ -53,9 +53,11 @@ internal sealed class QuickAppendEventsOperation: QuickAppendEventsOperationBase
             writeKey(pb);
 
         // Always-on: aggregate type, tenant id, event_ids[], event_types[],
-        // dotnet_types[], bodies[]. Bodies are serialized via the session
-        // serializer to a sized UTF-8 byte[] (no intermediate string alloc).
-        writeBasicParameters(pb, session);
+        // dotnet_types[], bodies[], bdatas[]. Bodies are serialized via the
+        // session serializer to a sized UTF-8 byte[] (no intermediate string
+        // alloc) for JSON events; binary events (#4515) get a {} JSON
+        // placeholder in bodies and their bytes in the parallel bdatas[].
+        writeBasicParameters(pb, session, _descriptor.SerializeEventBdata);
 
         // Configuration-gated metadata column arrays. Order MUST match the
         // dialect's QuickAppendEventFunction.WriteCreateStatement column

--- a/src/Marten/EventStorage/QuickWithServerTimestamps/QuickAppendEventsWithServerTimestampsOperation.cs
+++ b/src/Marten/EventStorage/QuickWithServerTimestamps/QuickAppendEventsWithServerTimestampsOperation.cs
@@ -44,7 +44,10 @@ internal sealed class QuickAppendEventsWithServerTimestampsOperation: QuickAppen
         else
             writeKey(pb);
 
-        writeBasicParameters(pb, session);
+        // #4515 Phase 2: SerializeEventBdata gives the binary bytes per event
+        // (null for JSON events). Appends a bdatas bytea[] parameter right
+        // after bodies in the function call.
+        writeBasicParameters(pb, session, _descriptor.SerializeEventBdata);
 
         // Order MUST match the dialect's function-signature ordering:
         // metadata columns first, then timestamps, then tag arrays.

--- a/src/Marten/Events/BulkEventAppender.cs
+++ b/src/Marten/Events/BulkEventAppender.cs
@@ -256,6 +256,11 @@ internal class BulkEventAppender
             "stream_id",
             "version",
             "data",
+            // #4515 Phase 2: bdata bytea (nullable) — bytes for binary events,
+            // NULL for JSON events. Always present in the COPY column list
+            // because mt_events.bdata is universal; writeEventRow writes
+            // either the binary payload or NULL per event.
+            "bdata",
             "type",
             "timestamp",
             "tenant_id",
@@ -308,9 +313,29 @@ internal class BulkEventAppender
         // version
         await writer.WriteAsync(e.Version, NpgsqlDbType.Bigint, cancellation).ConfigureAwait(false);
 
-        // data (jsonb) — direct UTF-8 serialization, no intermediate string allocation.
-        var dataBytes = SerializeToUtf8(_serializer, e.Data);
+        // data (jsonb) — direct UTF-8 serialization, no intermediate string
+        // allocation. For binary events (#4515), emits the {} placeholder so
+        // the `data NOT NULL` constraint stays intact; the real payload
+        // travels in the bdata bytea slot below.
+        var mapping = _events.EventMappingFor(e.EventType);
+        var isBinary = mapping?.IsBinary == true;
+
+        var dataBytes = isBinary
+            ? "{}"u8.ToArray()
+            : SerializeToUtf8(_serializer, e.Data);
         await writer.WriteAsync(dataBytes, NpgsqlDbType.Jsonb, cancellation).ConfigureAwait(false);
+
+        // bdata (bytea, nullable) — binary payload for [BinaryEvent] types;
+        // NULL for JSON-serialized events.
+        if (isBinary)
+        {
+            var bdataBytes = mapping!.BinarySerializer!.Serialize(e.EventType, e.Data);
+            await writer.WriteAsync(bdataBytes, NpgsqlDbType.Bytea, cancellation).ConfigureAwait(false);
+        }
+        else
+        {
+            await writer.WriteNullAsync(cancellation).ConfigureAwait(false);
+        }
 
         // type
         await writer.WriteAsync(e.EventTypeName, NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);

--- a/src/Marten/Events/Operations/QuickAppendEventsOperationBase.cs
+++ b/src/Marten/Events/Operations/QuickAppendEventsOperationBase.cs
@@ -96,7 +96,16 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation, IExcep
         param.NpgsqlDbType = NpgsqlDbType.Varchar;
     }
 
-    protected void writeBasicParameters(IGroupedParameterBuilder builder, IMartenSession session)
+    // #4515 / #4578 Phase 2: placeholder for the data jsonb column when an
+    // event is binary-serialized. The real payload travels in the parallel
+    // bdata bytea[] array; this keeps the `data NOT NULL` constraint intact
+    // without holding the real payload twice.
+    private static readonly byte[] s_emptyJsonObjectUtf8 = "{}"u8.ToArray();
+
+    protected void writeBasicParameters(
+        IGroupedParameterBuilder builder,
+        IMartenSession session,
+        Func<IEvent, byte[]?>? serializeEventBdata = null)
     {
         var param1 = Stream.AggregateTypeName.IsEmpty() ? builder.AppendParameter<object>(DBNull.Value) :  builder.AppendParameter(Stream.AggregateTypeName);
         param1.NpgsqlDbType = NpgsqlDbType.Varchar;
@@ -116,6 +125,11 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation, IExcep
         var typeNames = rentColumn<string>(count);
         var dotNetTypeNames = rentColumn<string>(count);
         var jsonBodies = rentColumn<byte[]>(count);
+        // #4515 Phase 2: parallel bdata column — bytes for binary events,
+        // null for JSON. Always rented even when no binary events are
+        // registered, because the mt_quick_append_events function signature
+        // unconditionally carries the bdatas bytea[] parameter.
+        var bdataArray = rentColumn<byte[]>(count);
 
         for (int i = 0; i < count; i++)
         {
@@ -123,7 +137,20 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation, IExcep
             ids[i] = e.Id;
             typeNames[i] = e.EventTypeName;
             dotNetTypeNames[i] = e.DotNetTypeName;
-            jsonBodies[i] = SerializeToUtf8(session.Serializer, e.Data);
+
+            var bdataBytes = serializeEventBdata?.Invoke(e);
+            if (bdataBytes is not null)
+            {
+                // Binary event — placeholder in data, real payload in bdata.
+                jsonBodies[i] = s_emptyJsonObjectUtf8;
+                bdataArray[i] = bdataBytes;
+            }
+            else
+            {
+                // JSON event — payload in data, NULL in bdata.
+                jsonBodies[i] = SerializeToUtf8(session.Serializer, e.Data);
+                bdataArray[i] = null!;
+            }
         }
 
         var param3 = builder.AppendParameter<IList<Guid>>(ids);
@@ -137,6 +164,13 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation, IExcep
 
         var param6 = builder.AppendParameter<IList<byte[]>>(jsonBodies);
         param6.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Jsonb;
+
+        // #4515 Phase 2: bdata bytea[] — must appear in the call-site parameter
+        // sequence in the same position as the function signature declares
+        // (right after bodies). The PG function inserts bdatas[index] into
+        // mt_events.bdata.
+        var param7 = builder.AppendParameter<IList<byte[]>>(bdataArray);
+        param7.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Bytea;
     }
 
     /// <summary>

--- a/src/Marten/Events/Schema/QuickAppendEventFunction.cs
+++ b/src/Marten/Events/Schema/QuickAppendEventFunction.cs
@@ -111,7 +111,7 @@ namespace Marten.Events.Schema;
             var returnType = _events.EnableBigIntEvents ? "bigint[]" : "int[]";
 
             writer.WriteLine($@"
-CREATE OR REPLACE FUNCTION {Identifier}(stream {streamIdType}, stream_type varchar, tenantid varchar, event_ids uuid[], event_types varchar[], dotnet_types varchar[], bodies jsonb[]{metadataParameters}{tagParameters}) RETURNS {returnType} AS $$
+CREATE OR REPLACE FUNCTION {Identifier}(stream {streamIdType}, stream_type varchar, tenantid varchar, event_ids uuid[], event_types varchar[], dotnet_types varchar[], bodies jsonb[], bdatas bytea[]{metadataParameters}{tagParameters}) RETURNS {returnType} AS $$
 DECLARE
 	event_version {intType};
 	stream_is_archived boolean;
@@ -151,10 +151,14 @@ BEGIN
 		event_type = event_types[index];
 		body = bodies[index];
 
+		-- #4515 / #4578 / Phase 2: bdatas[index] carries the binary payload
+		-- for events opted in to binary serialization (NULL otherwise).
+		-- bodies[index] is the {{}} JSON placeholder for those events so the
+		-- existing data jsonb NOT NULL constraint stays intact.
 		insert into {databaseSchema}.mt_events
-			(seq_id, id, stream_id, version, data, type, tenant_id, timestamp, {SchemaConstants.DotNetTypeColumn}, is_archived{metadataColumns})
+			(seq_id, id, stream_id, version, data, bdata, type, tenant_id, timestamp, {SchemaConstants.DotNetTypeColumn}, is_archived{metadataColumns})
 		values
-			(seq, event_id, stream, event_version, body, event_type, tenantid, {timestampValue}, dotnet_types[index], FALSE{metadataValues});
+			(seq, event_id, stream, event_version, body, bdatas[index], event_type, tenantid, {timestampValue}, dotnet_types[index], FALSE{metadataValues});
 {tagInserts}
 		index := index + 1;
 	end loop;


### PR DESCRIPTION
Phase 2 follow-up to [#4578](https://github.com/JasperFx/marten/pull/4578). Lifts the Rich-only constraint — binary event serialization now works on **every** `EventAppendMode` and through the `BulkEventAppender`.

## TL;DR

| Path | #4578 | This PR |
|---|---|---|
| Rich | ✅ | ✅ |
| QuickWithServerTimestamps (default) | ❌ (guarded) | ✅ |
| Quick | ❌ (guarded) | ✅ |
| BulkEventAppender (COPY) | ❌ (no bdata) | ✅ |

The `AssertNoBinaryEventsForQuickMode` guard from #4578 is gone — no longer needed.

## Wire-format change: `mt_quick_append_events` grows a `bdatas bytea[]` parameter

The PG function used by both Quick variants now accepts a parallel `bdatas bytea[]` parameter right after `bodies jsonb[]`. The INSERT writes `bdatas[index]` into `mt_events.bdata`. JSON events get NULL in that slot; binary events get the bytes + a `{}` placeholder in `bodies`. **Same on-disk row shape as the Rich path** — `bdata IS NULL` remains the discriminator the read path keys off.

Weasel's standard function-diff migration handles the signature change as DROP + CREATE on existing installations. Existing JSON rows are untouched.

## Call-site dispatch — symmetric with Rich

`PostgresEventStoreDialect.BuildQuickDescriptor` and `BuildQuickWithServerTimestampsDescriptor` now install the same `serializeEventData` / `serializeEventBdata` closures the Rich descriptor uses (look up `EventMapping`, branch on `IsBinary`). `QuickAppendEventsOperationBase.writeBasicParameters` accepts a `Func<IEvent, byte[]?> serializeEventBdata` and binds the parallel `bdatas bytea[]` array right after `bodies`.

## BulkEventAppender — `bdata` in the COPY column list

`buildEventColumns()` adds `bdata` right after `data`; `writeEventRow` looks up the EventMapping per event and writes either the binary payload (for `[BinaryEvent]` types) or NULL (for JSON). COPY natively supports NULL per column — no schema relaxation.

## Tests

Three new tests in `QuickModeBinaryEventTests` (one fixture per AppendMode):

| Test | Pins |
| --- | --- |
| `quick_with_server_timestamps_round_trips_binary_events` | Mixed binary + JSON stream on the default mode |
| `quick_mode_round_trips_binary_events` | Explicit `Quick` mode |
| `quick_mode_binary_events_land_in_bdata_column` | On-disk shape: binary rows have `data = '{}'` + `bdata != NULL`; JSON rows have `data = real JSON` + `bdata = NULL` |

Regression checks:
- **`Marten.MemoryPack.Tests`**: 8/8 ✅
- **`EventSourcingTests.end_to_end_event_capture_and_fetching`**: 83/83 ✅
- **`DaemonTests.Bug_3059_double_application`**: 1/1 ✅ (re-running the test that surfaced the column-count bug in #4578's first CI run)

## Docs

`docs/events/binary-serialization.md` updated:
- Removed the "EventAppendMode.Rich only" + "No bulk appender support" constraints from the Constraints section.
- Added a new "Append modes" section explaining the feature works across all three modes + BulkEventAppender.
- Quick-start example no longer forces `AppendMode = Rich`.

## What's still deferred

Just **binary event upcasters/downcasters** — tracked at [#4579](https://github.com/JasperFx/marten/issues/4579). 4 open design questions in the issue body; waiting for a real consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)