### PR TITLE
Bump JasperFx.* to 2.2.1 — Marten 9.3.1 fix release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.3.0</Version>
+        <Version>9.3.1</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,13 +13,13 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.100" />
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
-    <PackageVersion Include="JasperFx" Version="2.2.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.2.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.2.0">
+    <PackageVersion Include="JasperFx" Version="2.2.1" />
+    <PackageVersion Include="JasperFx.Events" Version="2.2.1" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.2.1" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Consumes the latest 2.2.1 patch across all four `JasperFx.*` NuGets:

| Package | From | To |
| --- | --- | --- |
| `JasperFx` | 2.2.0 | 2.2.1 |
| `JasperFx.Events` | 2.2.0 | 2.2.1 |
| `JasperFx.Events.SourceGenerator` | 2.2.0 | 2.2.1 |
| `JasperFx.SourceGenerator` | 2.2.0 | 2.2.1 |

Also bumps `Directory.Build.props` 9.3.0 → 9.3.1 to mark this as the fix release.

No Marten-side code changes — straight dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)