### PR TITLE
Fix BoundaryAggregate default stream identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,6 +230,7 @@ stresults.htm
 
 docs/.vitepress/dist
 docs/.vitepress/cache
+docs/public/freight-shipping-tutorial.zip
 
 src/CommandLineRunner/Internal/*
 

--- a/src/EventSourcingTests/Dcb/dcb_boundary_aggregate_fetch_for_writing_tests.cs
+++ b/src/EventSourcingTests/Dcb/dcb_boundary_aggregate_fetch_for_writing_tests.cs
@@ -91,3 +91,48 @@ public class dcb_boundary_aggregate_fetch_for_writing_tests: OneOffConfiguration
         boundary.Events.Count.ShouldBe(2);
     }
 }
+
+// Same setup as the sibling fixture but without overriding StreamIdentity,
+// covering the default AsGuid path.
+[Collection("OneOffs")]
+public class dcb_boundary_aggregate_default_stream_identity_tests: OneOffConfigurationsContext, IAsyncLifetime
+{
+    private void ConfigureStore()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.AddEventType<Enrolled>();
+            opts.Events.AddEventType<ProgressRecorded>();
+
+            opts.Events.RegisterTagType<EnrolleeId>("enrollee").ForAggregate<SubscriptionState>();
+            opts.Events.RegisterTagType<ProgramId>("program").ForAggregate<SubscriptionState>();
+        });
+    }
+
+    public Task InitializeAsync()
+    {
+        ConfigureStore();
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task fetch_for_writing_by_tags_works_with_default_guid_stream_identity()
+    {
+        var enrolleeId = new EnrolleeId(Guid.NewGuid());
+
+        var enrolled = theSession.Events.BuildEvent(new Enrolled("Bob"));
+        enrolled.WithTag(enrolleeId);
+        theSession.Events.Append(Guid.NewGuid(), enrolled);
+
+        await theSession.SaveChangesAsync();
+
+        await using var session = theStore.LightweightSession();
+        var query = new EventTagQuery().Or<EnrolleeId>(enrolleeId);
+        var boundary = await session.Events.FetchForWritingByTags<SubscriptionState>(query);
+
+        boundary.Aggregate.ShouldNotBeNull();
+        boundary.Aggregate!.EnrollmentCount.ShouldBe(1);
+    }
+}

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -123,7 +123,13 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
         // there is no Id member
         if (idType == null)
         {
-            if (StreamIdentity == StreamIdentity.AsGuid)
+            // [BoundaryAggregate] SG emits TId=string (see jasperfx#324); match
+            // it here so the dispatcher lookup hits regardless of StreamIdentity.
+            if (typeof(TDoc).IsDefined(typeof(BoundaryAggregateAttribute), inherit: false))
+            {
+                idType = typeof(string);
+            }
+            else if (StreamIdentity == StreamIdentity.AsGuid)
             {
                 idType = typeof(Guid);
             }


### PR DESCRIPTION
Match SG `TId=string` for `[BoundaryAggregate]` in `EventGraph.Build<TDoc>`
    
The JasperFx SG emits `IGeneratedSyncEvolver<TDoc, string>` for boundary aggregates (jasperfx#324). `EventGraph.Build<TDoc>()` was picking `TId` from `StreamIdentity`, so under the default `AsGuid` the runtime built `SingleStreamProjection<TDoc, Guid>` and `FetchForWritingByTags<TDoc>(...)` threw `No source-generated dispatcher found ...`. Force `TId=string` when `[BoundaryAggregate]` is present, regardless of `StreamIdentity`.

Existing dcb_boundary_aggregate_fetch_for_writing_tests only covered `StreamIdentity.AsString;` added a sibling fixture for the default-Guid path.

Also a little unrelated .gitgnore entry (was sitting in my local commit)