### PR TITLE
Fix #4598: provision per-tenant event partition + sequence under sharded tenancy

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,14 +15,18 @@
     <PackageVersion Include="FSharp.SystemTextJson" Version="1.3.13" />
     <!-- JasperFx 2.5.0: per-tenant event partitioning + tenant-aware async daemon
          surface (jasperfx#407 / CritterWatch#209). Released to nuget.org; this
-         consumes the published packages rather than the local-feed pt209 prereleases. -->
-    <PackageVersion Include="JasperFx" Version="2.5.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.5.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.5.0">
+         consumes the published packages rather than the local-feed pt209 prereleases.
+         JasperFx 2.8.0: dynamic-tenancy surface (jasperfx#413) — IDynamicTenantSource<T>
+         gains an `AddTenantAsync(tenantId, ct) → string` auto-assign provisioning
+         overload. ShardedTenancy implements it so store-agnostic provisioning works
+         under the sharded multi-tenancy model. -->
+    <PackageVersion Include="JasperFx" Version="2.8.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.8.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.5.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.8.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/Marten/AdvancedOperations.cs
+++ b/src/Marten/AdvancedOperations.cs
@@ -352,8 +352,42 @@ public class AdvancedOperations
 
         if (_store.Tenancy is not DefaultTenancy)
         {
+            // #4598: route the sharded case to the dynamic-tenant provisioning path
+            // (which covers both the document LIST partitions AND the per-tenant event
+            // sequence under UseTenantPartitionedEvents). The Marten-managed partition
+            // model assumes one DocumentStore-wide partition registry — under sharded
+            // tenancy that registry lives per shard, so we delegate per tenant rather
+            // than building a registry-wide dictionary across all shards.
+            if (_store.Tenancy is ShardedTenancy sharded)
+            {
+                foreach (var pair in tenantIdToPartitionMapping)
+                {
+                    // Sharded provisioning has a 1:1 tenant↔partition-suffix shape
+                    // (see ShardedTenancy.createPartitionsForTenant), so we reject any
+                    // override where the caller wants a partition suffix that differs
+                    // from the tenant id rather than silently dropping it.
+                    if (!string.Equals(pair.Key, pair.Value, StringComparison.Ordinal))
+                    {
+                        throw new InvalidOperationException(
+                            $"Under sharded multi-tenancy, tenant id and partition suffix must match. " +
+                            $"Got tenantId='{pair.Key}' suffix='{pair.Value}'. " +
+                            $"Use AddTenantToShardAsync(tenantId) (auto-assign) or AddTenantToShardAsync(tenantId, databaseId) instead.");
+                    }
+
+                    await sharded.AddTenantAsync(pair.Key, token).ConfigureAwait(false);
+                }
+
+                // Sharded provisioning's per-shard table statuses come from each
+                // shard's own AddPartitionToAllTables call (richer shape than the
+                // single-DB TablePartitionStatus[] this method returns). Return empty
+                // — callers wanting per-shard status should use the per-shard admin path.
+                return Array.Empty<TablePartitionStatus>();
+            }
+
             throw new InvalidOperationException(
-                "This option is not (yet) supported in combination with database per tenant multi-tenancy");
+                "AddMartenManagedTenantsAsync supports DefaultTenancy and ShardedTenancy. " +
+                "MasterTableTenancy uses caller-supplied connection strings — call " +
+                "IServiceProvider.AddTenantAsync(tenantId, connectionValue) instead.");
         }
 
         AssertValidPostgresqlIdentifiers(tenantIdToPartitionMapping.Values);
@@ -371,24 +405,19 @@ public class AdvancedOperations
 
         // #4596 Phase 1 Session 2: when UseTenantPartitionedEvents is on, also
         // create the per-tenant event sequence `mt_events_sequence_{suffix}` for
-        // every freshly-registered partition. CREATE SEQUENCE IF NOT EXISTS keeps
-        // it idempotent so re-running with overlapping or already-present
-        // partitions is safe. Without this, the QuickAppendEventFunction's
-        // `nextval(mt_events_sequence_<suffix>)` would fail for tenants that
-        // joined post-schema-apply.
+        // every freshly-registered partition. Without this, the
+        // QuickAppendEventFunction's `nextval(mt_events_sequence_<suffix>)` would
+        // fail for tenants that joined post-schema-apply.
+        // #4598: extracted into PerTenantEventSequences.EnsureSequencesAsync so the
+        // sharded runtime-assignment path (ShardedTenancy.createPartitionsForTenant)
+        // can call the same implementation against the assigned shard database.
         if (_store.Options.Events.UseTenantPartitionedEvents)
         {
-            await using var conn = database.CreateConnection();
-            await conn.OpenAsync(token).ConfigureAwait(false);
-            var schema = _store.Options.Events.DatabaseSchemaName;
-            foreach (var pair in tenantIdToPartitionMapping)
-            {
-                var sequenceName = $"\"{schema}\".\"mt_events_sequence_{pair.Value}\"";
-                await conn
-                    .CreateCommand($"create sequence if not exists {sequenceName} as bigint;")
-                    .ExecuteNonQueryAsync(token).ConfigureAwait(false);
-            }
-            await conn.CloseAsync().ConfigureAwait(false);
+            await Events.Schema.PerTenantEventSequences.EnsureSequencesAsync(
+                database,
+                _store.Options.Events.DatabaseSchemaName,
+                tenantIdToPartitionMapping.Values,
+                token).ConfigureAwait(false);
         }
 
         return statuses;
@@ -500,18 +529,22 @@ public class AdvancedOperations
 
     /// <summary>
     ///     Auto-assign a tenant to a database using the configured assignment strategy,
-    ///     then create list partitions in the target database. Only available with sharded tenancy.
+    ///     then create list partitions (and, under <c>UseTenantPartitionedEvents</c>, the
+    ///     per-tenant event sequence) in the target database. Only available with sharded
+    ///     tenancy.
     /// </summary>
     /// <returns>The database_id the tenant was assigned to</returns>
-    public async Task<string> AddTenantToShardAsync(string tenantId, CancellationToken ct)
+    public Task<string> AddTenantToShardAsync(string tenantId, CancellationToken ct)
     {
         var sharded = _store.Options.Tenancy as ShardedTenancy
             ?? throw new InvalidOperationException(
                 "AddTenantToShardAsync is only available when using MultiTenantedWithShardedDatabases()");
 
-        await sharded.GetTenantAsync(tenantId).ConfigureAwait(false);
-        return await sharded.FindDatabaseForTenantAsync(tenantId, ct).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"Tenant '{tenantId}' was not assigned to any database");
+        // #4598: delegate to ShardedTenancy.AddTenantAsync — the jasperfx#413
+        // IDynamicTenantSource<string> auto-assign override — so the documented Advanced
+        // entry point and the store-agnostic JasperFx admin extension drive ONE code path
+        // (auto-assign → createPartitionsForTenant → per-tenant event sequence).
+        return sharded.AddTenantAsync(tenantId, ct);
     }
 
     /// <summary>

--- a/src/Marten/Events/Schema/PerTenantEventSequences.cs
+++ b/src/Marten/Events/Schema/PerTenantEventSequences.cs
@@ -122,4 +122,46 @@ internal class PerTenantEventSequences: ISchemaObject
             yield return seq.Identifier;
         }
     }
+
+    /// <summary>
+    /// Imperative sibling of the schema-apply path: ensures the per-tenant
+    /// <c>mt_events_sequence_{suffix}</c> sequence exists for each supplied
+    /// partition suffix, in the given database. <c>CREATE SEQUENCE IF NOT EXISTS</c>
+    /// keeps it idempotent.
+    ///
+    /// <para>
+    /// Originally inlined inside <c>AdvancedOperations.AddMartenManagedTenantsAsync</c>
+    /// for the <c>DefaultTenancy</c> + Marten-managed-partitioning case (#4596
+    /// Phase 1 Session 2). Extracted so the sharded runtime-assignment path
+    /// (<c>ShardedTenancy.createPartitionsForTenant</c>) can call the same
+    /// implementation against the assigned shard database — without this, the
+    /// shard's first event append for a newly-provisioned tenant fails with
+    /// <c>42P01: relation "{schema}.mt_events_sequence_{suffix}" does not exist</c>
+    /// because quick-append calls <c>nextval(...)</c> on the per-tenant sequence.
+    /// See #4598.
+    /// </para>
+    /// </summary>
+    /// <param name="database">The database to provision the sequence(s) in. For
+    /// sharded tenancy this must be the tenant's assigned shard, NOT the default.</param>
+    /// <param name="eventSchema">Schema that hosts <c>mt_events</c> — usually
+    /// <c>EventGraph.DatabaseSchemaName</c>.</param>
+    /// <param name="partitionSuffixes">Partition suffixes to provision. For the
+    /// Marten-managed model the suffix is the tenant id itself.</param>
+    public static async Task EnsureSequencesAsync(
+        Weasel.Postgresql.PostgresqlDatabase database,
+        string eventSchema,
+        IEnumerable<string> partitionSuffixes,
+        CancellationToken token = default)
+    {
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+        foreach (var suffix in partitionSuffixes)
+        {
+            var sequenceName = $"\"{eventSchema}\".\"mt_events_sequence_{suffix}\"";
+            await conn
+                .CreateCommand($"create sequence if not exists {sequenceName} as bigint;")
+                .ExecuteNonQueryAsync(token).ConfigureAwait(false);
+        }
+        await conn.CloseAsync().ConfigureAwait(false);
+    }
 }

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -164,13 +164,35 @@ public static class MartenServiceCollectionExtensions
         // concrete Marten tenancy types. Conditional so non-dynamic stores
         // (DefaultTenancy / StaticMultiTenant) keep GetServices empty — the
         // graceful-no-op behavior the consumer relies on.
-        if (options.Tenancy is IDynamicTenantSource<string>)
+        //
+        // Probed safely: `options.Tenancy` throws if no tenancy is configured yet
+        // (e.g. when the caller uses the AddMarten() + later UseNpgsqlDataSource()
+        // pattern). Dynamic tenancies are always set inside the StoreOptions
+        // configure callback before AddMarten returns, so a not-yet-configured
+        // store is by construction not dynamic and the registration is correctly
+        // skipped.
+        if (TryGetDynamicTenantSource(options) is not null)
         {
             services.AddSingleton<IDynamicTenantSource<string>>(s =>
                 (IDynamicTenantSource<string>)s.GetRequiredService<IDocumentStore>().As<DocumentStore>().Tenancy);
         }
 
         return new MartenConfigurationExpression(services, options);
+    }
+
+    private static IDynamicTenantSource<string>? TryGetDynamicTenantSource(StoreOptions options)
+    {
+        try
+        {
+            return options.Tenancy as IDynamicTenantSource<string>;
+        }
+        catch (InvalidOperationException)
+        {
+            // No tenancy configured yet — the caller is on the AddMarten() +
+            // UseNpgsqlDataSource() flow, which only ever lands on DefaultTenancy
+            // (not dynamic). Safe to treat as "not a dynamic source".
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx;
+using JasperFx.MultiTenancy;
 using JasperFx.CommandLine;
 using JasperFx.CommandLine.Descriptions;
 using JasperFx.Core.Reflection;
@@ -155,6 +156,20 @@ public static class MartenServiceCollectionExtensions
     )
     {
         services.AddMarten(s => options);
+
+        // #4598 / jasperfx#413: when the configured tenancy is a dynamic source
+        // (MasterTableTenancy or ShardedTenancy as of #4598), register it as
+        // IDynamicTenantSource<string> so a store-agnostic admin tool (e.g.
+        // CritterWatch) can resolve it via GetServices without referencing
+        // concrete Marten tenancy types. Conditional so non-dynamic stores
+        // (DefaultTenancy / StaticMultiTenant) keep GetServices empty — the
+        // graceful-no-op behavior the consumer relies on.
+        if (options.Tenancy is IDynamicTenantSource<string>)
+        {
+            services.AddSingleton<IDynamicTenantSource<string>>(s =>
+                (IDynamicTenantSource<string>)s.GetRequiredService<IDocumentStore>().As<DocumentStore>().Tenancy);
+        }
+
         return new MartenConfigurationExpression(services, options);
     }
 

--- a/src/Marten/Storage/ShardedTenancy.cs
+++ b/src/Marten/Storage/ShardedTenancy.cs
@@ -27,7 +27,8 @@ namespace Marten.Storage;
 /// Multi-tenancy implementation that distributes tenants across a pool of databases
 /// with conjoined tenancy and native PG list partitioning per tenant within each database.
 /// </summary>
-public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatabasePool
+public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatabasePool,
+    IDynamicTenantSource<string>
 {
     private readonly StoreOptions _options;
     private readonly ShardedTenancyOptions _configuration;
@@ -360,6 +361,93 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
 
     #endregion
 
+    #region IDynamicTenantSource<string>
+
+    // jasperfx#413 / #4598: ShardedTenancy is an auto-assign source — the connection-value
+    // surface (AddTenantAsync(tenantId, databaseId)) maps to AssignTenantAsync, and the
+    // auto-assign override (AddTenantAsync(tenantId, ct) → string) maps to the same path
+    // that Advanced.AddTenantToShardAsync(tenantId, ct) drives. The DisableTenantAsync /
+    // EnableTenantAsync / AllDisabledAsync surface is intentionally NOT yet implemented —
+    // the sharded tenant assignment table has no `disabled` column and no consumer needs
+    // those yet. Add column + lifecycle if/when a consumer surfaces.
+
+    /// <summary>
+    /// jasperfx#413 / #4598: store-agnostic FindAsync. For ShardedTenancy the "value" is
+    /// the database id the tenant is assigned to (NOT the connection string — the pool
+    /// owns connection strings via the master database).
+    /// </summary>
+    async ValueTask<string> ITenantedSource<string>.FindAsync(string tenantId)
+    {
+        var databaseId = await FindDatabaseForTenantAsync(tenantId, CancellationToken.None).ConfigureAwait(false);
+        if (databaseId == null)
+        {
+            throw new UnknownTenantIdException(tenantId);
+        }
+
+        return databaseId;
+    }
+
+    Task ITenantedSource<string>.RefreshAsync()
+    {
+        // Reset the cached tenant→database map so next lookup re-reads from the pool tables.
+        _tenantToDatabase = ImHashMap<string, MartenDatabase>.Empty;
+        return Task.CompletedTask;
+    }
+
+    IReadOnlyList<string> ITenantedSource<string>.AllActive()
+        => _databasesById.Enumerate().Select(x => x.Key).ToList();
+
+    IReadOnlyList<Assignment<string>> ITenantedSource<string>.AllActiveByTenant()
+        => _tenantToDatabase.Enumerate()
+            .Select(pair => new Assignment<string>(pair.Key, pair.Value.Identifier))
+            .ToList();
+
+    /// <summary>
+    /// jasperfx#413 / #4598: caller-supplied connection value. For ShardedTenancy the
+    /// "value" is the target database id, so this maps to <see cref="AssignTenantAsync" />.
+    /// </summary>
+    Task IDynamicTenantSource<string>.AddTenantAsync(string tenantId, string databaseId)
+        => AssignTenantAsync(tenantId, databaseId, CancellationToken.None).AsTask();
+
+    /// <summary>
+    /// jasperfx#413 / #4598: auto-assign override. Runs the same auto-assign +
+    /// partition/sequence provisioning path that
+    /// <c>Advanced.AddTenantToShardAsync(tenantId, ct)</c> drives, and returns the
+    /// resolved database id. This is the entrypoint CritterWatch (and any other
+    /// store-agnostic admin tool) uses to provision a sharded tenant without sniffing
+    /// the concrete tenancy type — see jasperfx#413.
+    /// </summary>
+    public async Task<string> AddTenantAsync(string tenantId, CancellationToken token = default)
+    {
+        // findOrAssignTenantDatabaseAsync (the existing internal) runs the full
+        // auto-assign + createPartitionsForTenant flow (now including the per-tenant
+        // event sequence — #4598). It already caches the resolved database in
+        // _tenantToDatabase, so FindDatabaseForTenantAsync hits the pool table only
+        // when this method races a concurrent provisioning.
+        await findOrAssignTenantDatabaseAsync(tenantId).ConfigureAwait(false);
+        return await FindDatabaseForTenantAsync(tenantId, token).ConfigureAwait(false)
+            ?? throw new InvalidOperationException(
+                $"Tenant '{tenantId}' was not assigned to any database after auto-assignment");
+    }
+
+    Task IDynamicTenantSource<string>.DisableTenantAsync(string tenantId)
+        => throw new NotSupportedException(
+            "Disable/enable tenant lifecycle is not yet supported on sharded tenancy. " +
+            "Use RemoveTenantAsync to drop a tenant assignment, or open an issue to request the soft-delete surface.");
+
+    Task IDynamicTenantSource<string>.RemoveTenantAsync(string tenantId)
+        => RemoveTenantAsync(tenantId, CancellationToken.None).AsTask();
+
+    Task<IReadOnlyList<string>> IDynamicTenantSource<string>.AllDisabledAsync()
+        => throw new NotSupportedException(
+            "Disable/enable tenant lifecycle is not yet supported on sharded tenancy.");
+
+    Task IDynamicTenantSource<string>.EnableTenantAsync(string tenantId)
+        => throw new NotSupportedException(
+            "Disable/enable tenant lifecycle is not yet supported on sharded tenancy.");
+
+    #endregion
+
 #pragma warning disable MA0032
     #region Internals
 
@@ -475,6 +563,22 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
 
         await partitions.AddPartitionToAllTables(
             NullLogger.Instance, database, dict, ct).ConfigureAwait(false);
+
+        // #4598: when per-tenant event partitioning is on, the new tenant also
+        // needs its `mt_events_sequence_<suffix>` sequence in the SAME shard
+        // database (the QuickAppendEventFunction calls
+        // nextval(mt_events_sequence_<suffix>) when it inserts events for that
+        // tenant). Without this, the tenant's first event append fails with
+        // 42P01: relation "{schema}.mt_events_sequence_<tenant>" does not exist.
+        // Suffix == tenantId per the dict above; idempotent CREATE IF NOT EXISTS.
+        if (_options.Events.UseTenantPartitionedEvents)
+        {
+            await Events.Schema.PerTenantEventSequences.EnsureSequencesAsync(
+                database,
+                _options.Events.DatabaseSchemaName,
+                dict.Values,
+                ct).ConfigureAwait(false);
+        }
     }
 
     private async Task maybeApplyChanges()

--- a/src/MultiTenancyTests/sharded_tenancy_per_tenant_events_tests.cs
+++ b/src/MultiTenancyTests/sharded_tenancy_per_tenant_events_tests.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Events;
+using Marten.Storage;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace MultiTenancyTests;
+
+/// <summary>
+/// #4598 — per-tenant event partitioning under sharded multi-tenancy. The headline bug
+/// was that runtime-provisioned sharded tenants got the document LIST partitions but NOT
+/// the per-tenant <c>mt_events_sequence_{suffix}</c> sequence, so the first event append
+/// for such a tenant failed with <c>42P01: relation "{schema}.mt_events_sequence_{tenant}"
+/// does not exist</c>. Fix: wire <c>PerTenantEventSequences.EnsureSequencesAsync</c> into
+/// <c>ShardedTenancy.createPartitionsForTenant</c>; expose it via the jasperfx#413
+/// <see cref="IDynamicTenantSource{T}.AddTenantAsync(string,CancellationToken)" />
+/// auto-assign override so CritterWatch can provision store-agnostically.
+/// </summary>
+[Collection("sharded-tenancy")]
+public class sharded_tenancy_per_tenant_events_tests : IAsyncLifetime
+{
+    private readonly ShardedTenancyFixture _fixture;
+    private IDocumentStore _store = null!;
+
+    public sharded_tenancy_per_tenant_events_tests(ShardedTenancyFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Clean schemas before each test — both the master pool DB and each shard.
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedTenancyFixture.cleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        _store?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private IDocumentStore CreateStore(Action<ShardedTenancyOptions>? customConfig = null)
+    {
+        _store = DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded";
+                x.PartitionSchemaName = "tenants";
+
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+
+                customConfig?.Invoke(x);
+            });
+
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+
+            // The config CritterWatch hits: conjoined events, quick-append,
+            // per-tenant event partitioning. The docs at
+            // martendb.io/events/multitenancy.html#per-tenant-event-partitioning
+            // claim this composes with the sharded model.
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+
+            opts.Events.AddEventType<ShardedTestEvent>();
+        });
+
+        return _store;
+    }
+
+    // ---- Headline regression: append works after runtime provisioning ----
+
+    [Fact]
+    public async Task append_event_for_runtime_provisioned_tenant_does_not_throw_42P01()
+    {
+        CreateStore(x => x.UseSmallestDatabaseAssignment());
+
+        // The documented provisioning entry point — succeeds today (creates document partitions)
+        // but on master fails when the tenant later tries to append events.
+        var dbId = await _store.Advanced.AddTenantToShardAsync("alpha", CancellationToken.None);
+        dbId.ShouldNotBeNull();
+
+        // The actual bug surface: append. On master this throws 42P01 because
+        // quick-append calls nextval(mt_events_sequence_alpha) and the sequence was
+        // never created. With the fix, it succeeds.
+        await using var session = _store.LightweightSession("alpha");
+        session.Events.StartStream(Guid.NewGuid(), new ShardedTestEvent { Value = "first" });
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task per_tenant_event_sequence_lives_in_the_assigned_shard()
+    {
+        CreateStore(x => x.UseSmallestDatabaseAssignment());
+
+        var dbId = await _store.Advanced.AddTenantToShardAsync("bravo", CancellationToken.None);
+        dbId.ShouldNotBeNull();
+
+        // mt_events_sequence_bravo must exist in the ASSIGNED shard (not the default DB,
+        // not other shards). That placement is what the fix has to get right — calling
+        // EnsureSequencesAsync against `Tenancy.Default.Database` would create the
+        // sequence in the wrong place and the assigned shard would still fail on append.
+        await assertSequenceExists(_fixture.ConnectionStrings[dbId], expected: "mt_events_sequence_bravo");
+
+        foreach (var (otherDbName, otherConnStr) in _fixture.ConnectionStrings)
+        {
+            if (otherDbName == dbId) continue;
+            await assertSequenceDoesNotExist(otherConnStr, "mt_events_sequence_bravo",
+                $"the sequence must live ONLY in the assigned shard '{dbId}', not in '{otherDbName}'");
+        }
+    }
+
+    [Fact]
+    public async Task per_tenant_event_partition_also_created_in_assigned_shard()
+    {
+        CreateStore(x => x.UseSmallestDatabaseAssignment());
+
+        var dbId = await _store.Advanced.AddTenantToShardAsync("charlie", CancellationToken.None);
+
+        // Trigger the lazy schema apply on the assigned shard via a real append —
+        // this is the same flow a production caller hits and what the regression
+        // exercised. Sharded provisioning leaves the parent schema creation to the
+        // first storage interaction with the shard, so without an actual write we
+        // would only see the partition-management tables.
+        await using (var session = _store.LightweightSession("charlie"))
+        {
+            session.Events.StartStream(Guid.NewGuid(), new ShardedTestEvent { Value = "for-partition-check" });
+            await session.SaveChangesAsync();
+        }
+
+        // The original report observed that AddTenantToShardAsync created the document
+        // LIST partitions but not the event partition. This pins both ends — event
+        // partition + sequence — for the runtime-provisioning path.
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await conn.OpenAsync();
+
+        var tables = await conn.ExistingTablesAsync();
+        tables.Any(t => t.Name == "mt_events_charlie").ShouldBeTrue(
+            $"mt_events_charlie partition must exist in shard '{dbId}'. Tables: {string.Join(", ", tables.Select(t => t.QualifiedName))}");
+    }
+
+    // ---- Sibling entry points hit the same one code path ----
+
+    [Fact]
+    public async Task explicit_AddTenantToShardAsync_provisions_the_event_sequence_too()
+    {
+        CreateStore();
+
+        // Explicit-target overload — different ShardedTenancy entry (AssignTenantAsync)
+        // but must converge on the same createPartitionsForTenant path so the fix covers
+        // it too.
+        await _store.Advanced.AddTenantToShardAsync("delta", _fixture.DbNames[1], CancellationToken.None);
+
+        await assertSequenceExists(_fixture.ConnectionStrings[_fixture.DbNames[1]],
+            expected: "mt_events_sequence_delta");
+    }
+
+    [Fact]
+    public async Task IDynamicTenantSource_AddTenantAsync_returns_assigned_database_id_and_provisions()
+    {
+        // jasperfx#413: the store-agnostic auto-assign override. CritterWatch will call
+        // this via IServiceProvider.AddTenantAsync(tenantId) without referencing the
+        // concrete ShardedTenancy type.
+        CreateStore(x => x.UseSmallestDatabaseAssignment());
+
+        var source = (IDynamicTenantSource<string>)_store.Options.Tenancy;
+        var dbId = await source.AddTenantAsync("echo", CancellationToken.None);
+
+        dbId.ShouldBeOneOf(_fixture.DbNames);
+        await assertSequenceExists(_fixture.ConnectionStrings[dbId], expected: "mt_events_sequence_echo");
+
+        // And the append actually works — the full surface this enables.
+        await using var session = _store.LightweightSession("echo");
+        session.Events.StartStream(Guid.NewGuid(), new ShardedTestEvent { Value = "via-dynamic-source" });
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task IDynamicTenantSource_caller_supplied_overload_assigns_to_named_shard()
+    {
+        CreateStore();
+
+        var source = (IDynamicTenantSource<string>)_store.Options.Tenancy;
+        await source.AddTenantAsync("foxtrot", _fixture.DbNames[2]);
+
+        var sharded = (ShardedTenancy)_store.Options.Tenancy;
+        (await sharded.FindDatabaseForTenantAsync("foxtrot", CancellationToken.None))
+            .ShouldBe(_fixture.DbNames[2]);
+        await assertSequenceExists(_fixture.ConnectionStrings[_fixture.DbNames[2]],
+            expected: "mt_events_sequence_foxtrot");
+    }
+
+    // ---- DI registration (jasperfx#413 addendum) ----
+
+    [Fact]
+    public void IDynamicTenantSource_is_registered_in_the_container_when_tenancy_is_sharded()
+    {
+        // jasperfx#413: store-agnostic admin tools (CritterWatch) resolve via GetServices.
+        // Mirror the existing IMasterTableMultiTenancy registration pattern, conditional
+        // on the configured tenancy actually implementing the interface.
+        var services = new ServiceCollection();
+        services.AddMarten(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded";
+                x.PartitionSchemaName = "tenants";
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+            });
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var source = provider.GetService<IDynamicTenantSource<string>>();
+        source.ShouldNotBeNull("ShardedTenancy implements IDynamicTenantSource<string>; the DI registration must surface it");
+        source.ShouldBeOfType<ShardedTenancy>();
+    }
+
+    [Fact]
+    public void IDynamicTenantSource_is_NOT_registered_when_tenancy_is_default()
+    {
+        // Conditional registration: a non-dynamic tenancy must keep
+        // GetServices<IDynamicTenantSource<string>>() empty so the JasperFx admin
+        // extensions' graceful-no-op behavior holds.
+        var services = new ServiceCollection();
+        services.AddMarten(opts => opts.Connection(ConnectionSource.ConnectionString));
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetService<IDynamicTenantSource<string>>().ShouldBeNull();
+    }
+
+    // ---- helpers ----
+
+    private static async Task assertSequenceExists(string connectionString, string expected)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        var exists = (long)(await conn.CreateCommand(
+            "select count(*) from pg_sequences where schemaname = 'public' and sequencename = :n")
+            .With("n", expected)
+            .ExecuteScalarAsync())!;
+        exists.ShouldBe(1L, $"sequence '{expected}' should exist in {connectionString}");
+    }
+
+    private static async Task assertSequenceDoesNotExist(string connectionString, string name, string because)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        var exists = (long)(await conn.CreateCommand(
+            "select count(*) from pg_sequences where schemaname = 'public' and sequencename = :n")
+            .With("n", name)
+            .ExecuteScalarAsync())!;
+        exists.ShouldBe(0L, because);
+    }
+}


### PR DESCRIPTION
Fixes #4598.

The docs at [martendb.io/events/multitenancy.html#per-tenant-event-partitioning](https://martendb.io/events/multitenancy.html#per-tenant-event-partitioning) claim per-tenant event partitioning composes with the Sharded Multi-Tenancy with Database Pooling model. In 9.4.0 it didn't: runtime-provisioned sharded tenants got the document LIST partitions but **not** the per-tenant `mt_events_sequence_{suffix}` sequence. The first event append for such a tenant failed with:

```
42P01: relation "{schema}.mt_events_sequence_<tenant>" does not exist
```

because quick-append calls `nextval(mt_events_sequence_<suffix>)` and the sequence creation lived only inside `AdvancedOperations.AddMartenManagedTenantsAsync` — `DefaultTenancy`-guarded and unreachable on a sharded store.

## Three coordinated changes

### 1. Bump JasperFx 2.5.0 → 2.8.0

Picks up [jasperfx#413](https://github.com/JasperFx/jasperfx/issues/413)'s `IDynamicTenantSource<T>.AddTenantAsync(tenantId, ct) → string` auto-assign provisioning overload that `ShardedTenancy` now implements (part 3).

### 2. Wire the sequence provisioning into the sharded path

- Extract `AdvancedOperations.AddMartenManagedTenantsAsync`'s inline sequence-creation loop into `PerTenantEventSequences.EnsureSequencesAsync` so both call sites share one idempotent `CREATE SEQUENCE IF NOT EXISTS …` implementation.
- `ShardedTenancy.createPartitionsForTenant` calls the helper against the **assigned shard database** (not the default) right after `AddPartitionToAllTables`. Tenant id == partition suffix per the existing 1:1 assumption.
- `AdvancedOperations.AddMartenManagedTenantsAsync`'s `DefaultTenancy` guard now routes sharded calls through `ShardedTenancy.AddTenantAsync` per tenant (rejecting suffix-overrides since the sharded model assumes `tenant id == suffix`). Master-table tenancy keeps throwing, with a clearer message pointing at the caller-supplied connection-string path.

### 3. Implement `IDynamicTenantSource<string>` on `ShardedTenancy`

So the [JasperFx 2.8.0 store-agnostic admin extensions](https://github.com/JasperFx/jasperfx/blob/main/src/JasperFx/MultiTenancy/DynamicTenancyAdminExtensions.cs) work end-to-end without sniffing the concrete tenancy type:

- `AddTenantAsync(tenantId, databaseId)` wraps `AssignTenantAsync`.
- `AddTenantAsync(tenantId, ct) → string` (the auto-assign override) runs the same `findOrAssignTenantDatabaseAsync` + `createPartitionsForTenant` path that `Advanced.AddTenantToShardAsync` drives and returns the resolved database id.
- `AddTenantToShardAsync` delegates to it — **one code path**.
- Disable/enable lifecycle is not implemented on sharded tenancy yet (no `disabled` column in the assignment table); those methods throw `NotSupportedException` with a clear message until a consumer needs them.

### 4. Conditional DI registration in `AddMarten(services, StoreOptions)`

Per the [issue addendum](https://github.com/JasperFx/marten/issues/4598#issuecomment-4607361472). So `IServiceProvider.GetServices<IDynamicTenantSource<string>>()` surfaces the configured tenancy when (and only when) it's dynamic. Mirrors the existing `IMasterTableMultiTenancy` registration pattern; `DefaultTenancy` / `StaticMultiTenant` keep returning an empty enumerable — the graceful-no-op shape the JasperFx admin extensions rely on. Without this, store-agnostic consumers (CritterWatch) would either stay Marten-coupled or no-op.

## Tests

`src/MultiTenancyTests/sharded_tenancy_per_tenant_events_tests.cs` (new, 8 tests):

| Test | What it pins |
|------|--------------|
| `append_event_for_runtime_provisioned_tenant_does_not_throw_42P01` | Headline regression — would throw on 9.4.0. |
| `per_tenant_event_sequence_lives_in_the_assigned_shard` | Sequence lands in the assigned shard only (not in default DB, not in sibling shards). |
| `per_tenant_event_partition_also_created_in_assigned_shard` | `mt_events_<tenant>` partition materialises on the assigned shard. |
| `explicit_AddTenantToShardAsync_provisions_the_event_sequence_too` | Sibling code path (explicit target) hits the same provisioning. |
| `IDynamicTenantSource_AddTenantAsync_returns_assigned_database_id_and_provisions` | jasperfx#413 auto-assign override — returns the resolved id; append works. |
| `IDynamicTenantSource_caller_supplied_overload_assigns_to_named_shard` | jasperfx#413 caller-supplied overload routes to the named shard. |
| `IDynamicTenantSource_is_registered_in_the_container_when_tenancy_is_sharded` | DI: present on a sharded store. |
| `IDynamicTenantSource_is_NOT_registered_when_tenancy_is_default` | DI: absent on default tenancy (graceful no-op). |

### Regression sweep (net9.0)

- `sharded_tenancy_tests`: **12/12 PASS**
- `use_tenant_partitioned_events_*`: **32/33 PASS** — the single fail (`use_tenant_partitioned_events_admin_overrides.delete_projection_progress_with_tenant_id_drops_only_that_tenants_rows`) is a pre-existing partition-setup race independent of this work.

## Note on a related-but-separate bug

While writing the tests I hit a second issue: the runtime partition-attach on `mt_events` (Weasel's `additivelyMigrateTablesForNewPartitions`) fails with `42P16: cannot drop inherited constraint mt_events_tenant_id_stream_id_fkey` when the parent schema was applied via `ApplyAllConfiguredChangesToDatabaseAsync` **before** runtime tenant provisioning. The tests therefore exercise the lazy-apply flow (parent schema is created on first append after `AddTenantToShardAsync`) which matches typical production usage anyway. The eager-apply path will need its own fix (Marten or Weasel side); I treated it as out-of-scope for #4598 since it's distinct from the reported `42P01` sequence-missing failure.

Related: [jasperfx#413](https://github.com/JasperFx/jasperfx/issues/413) (dynamic tenancy auto-assign abstraction, shipped in 2.8.0), CritterWatch#267, CritterWatch#269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)