### PR TITLE
Closes #4606: fix 42P16 inherited-FK on eager-apply + sharded per-tenant events

### DIFF
--- a/src/Marten/Events/Schema/EventsTable.cs
+++ b/src/Marten/Events/Schema/EventsTable.cs
@@ -69,14 +69,40 @@ internal class EventsTable: Table
 
         if (events.TenancyStyle == TenancyStyle.Conjoined)
         {
+            // #4606: under UseTenantPartitionedEvents, mt_events is itself a partitioned
+            // table (by tenant_id) and so is mt_streams. Declaring a parent-level FK from
+            // mt_events → mt_streams makes Postgres auto-propagate a partition-targeting
+            // FK (mt_events → mt_streams_<tenant>) into mt_events as an INHERITED constraint
+            // the moment the first mt_streams_<tenant> partition is attached. The next
+            // mt_events_<tenant> partition-attach then trips
+            // `42P16: cannot drop inherited constraint` because Weasel's
+            // additivelyMigrateTablesForNewPartitions treats the auto-propagated FK as an
+            // "extra" (not in Marten's declared FK set) and tries to drop it, which
+            // Postgres refuses on an inherited constraint. The downstream symptom is
+            // 23514 on the first event append because the partition attach was silently
+            // swallowed by the migration's catch block.
+            //
+            // Skipping the explicit FK trades database-level referential integrity from
+            // mt_events to mt_streams for the per-tenant-partitioning combination
+            // working at all. Marten's append path always inserts/updates the stream row
+            // before persisting events, so application-level integrity is preserved;
+            // external tooling that writes mt_events directly without ensuring the
+            // stream exists in mt_streams is the only at-risk path, and that's already
+            // outside Marten's contract. The non-partitioned and archived-partitioning
+            // shapes keep their FK because they don't trigger the auto-propagation.
+            var skipMtEventsFkForTenantPartitioning = events.UseTenantPartitionedEvents;
+
             if (events.UseArchivedStreamPartitioning)
             {
-                ForeignKeys.Add(new ForeignKey("fkey_mt_events_stream_id_tenant_id_is_archived")
+                if (!skipMtEventsFkForTenantPartitioning)
                 {
-                    ColumnNames = new[] { TenantIdColumn.Name, "stream_id", "is_archived" },
-                    LinkedNames = new[] { TenantIdColumn.Name, "id", "is_archived" },
-                    LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, "mt_streams")
-                });
+                    ForeignKeys.Add(new ForeignKey("fkey_mt_events_stream_id_tenant_id_is_archived")
+                    {
+                        ColumnNames = new[] { TenantIdColumn.Name, "stream_id", "is_archived" },
+                        LinkedNames = new[] { TenantIdColumn.Name, "id", "is_archived" },
+                        LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, "mt_streams")
+                    });
+                }
 
                 Indexes.Add(new IndexDefinition("pk_mt_events_stream_and_version")
                 {
@@ -85,12 +111,15 @@ internal class EventsTable: Table
             }
             else
             {
-                ForeignKeys.Add(new ForeignKey("fkey_mt_events_stream_id_tenant_id")
+                if (!skipMtEventsFkForTenantPartitioning)
                 {
-                    ColumnNames = new[] { TenantIdColumn.Name, "stream_id" },
-                    LinkedNames = new[] { TenantIdColumn.Name, "id" },
-                    LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, "mt_streams")
-                });
+                    ForeignKeys.Add(new ForeignKey("fkey_mt_events_stream_id_tenant_id")
+                    {
+                        ColumnNames = new[] { TenantIdColumn.Name, "stream_id" },
+                        LinkedNames = new[] { TenantIdColumn.Name, "id" },
+                        LinkedTable = new PostgresqlObjectName(events.DatabaseSchemaName, "mt_streams")
+                    });
+                }
 
                 Indexes.Add(new IndexDefinition("pk_mt_events_stream_and_version")
                 {

--- a/src/MultiTenancyTests/sharded_eager_apply_per_tenant_events_tests.cs
+++ b/src/MultiTenancyTests/sharded_eager_apply_per_tenant_events_tests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Events;
+using Marten.Storage;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace MultiTenancyTests;
+
+/// <summary>
+/// #4606 regression — eager schema apply on a sharded + per-tenant-events store,
+/// followed by runtime tenant provisioning, must succeed (no 42P16 on the partition
+/// attach's FK drop).
+///
+/// <para>
+/// The shape this exercises is the production startup pattern:
+///   <c>ApplyAllConfiguredChangesToDatabaseAsync()</c> at boot → tenant arrives later
+///   → <c>AddTenantToShardAsync(tenantId)</c> → first append.
+/// In 9.4.x the FK on the parent <c>mt_events</c> table is inherited the moment
+/// the first partition is attached, and Weasel's partition-attach drop-and-recreate
+/// of that FK trips Postgres' 42P16 (cannot drop inherited constraint). #4598's
+/// tests deliberately exercised the lazy-apply flow to dodge this; #4606 is the
+/// eager-apply variant.
+/// </para>
+/// </summary>
+[Collection("sharded-tenancy")]
+public class sharded_eager_apply_per_tenant_events_tests : IAsyncLifetime
+{
+    private readonly ShardedTenancyFixture _fixture;
+    private IDocumentStore _store = null!;
+
+    public sharded_eager_apply_per_tenant_events_tests(ShardedTenancyFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedTenancyFixture.cleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        _store?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private IDocumentStore CreateStore()
+    {
+        _store = DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded";
+                x.PartitionSchemaName = "tenants";
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+                x.UseSmallestDatabaseAssignment();
+            });
+
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AddEventType<ShardedTestEvent>();
+        });
+
+        return _store;
+    }
+
+    [Fact]
+    public async Task eager_apply_then_AddTenantToShardAsync_then_append_succeeds()
+    {
+        CreateStore();
+
+        // The eager-apply pattern: create the parent partitioned schema on every
+        // shard at startup time, BEFORE any tenant is provisioned. This is the
+        // startup-migrate deployment shape that #4606 needs to support.
+        var databases = await _store.Options.Tenancy.BuildDatabases();
+        foreach (var db in databases.OfType<IMartenDatabase>())
+        {
+            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+        }
+
+        // Runtime tenant provisioning hits the partition-attach path against an
+        // already-created parent mt_events. Master fails here with
+        // 42P16 cannot drop inherited constraint "mt_events_tenant_id_stream_id_fkey".
+        var dbId = await _store.Advanced.AddTenantToShardAsync("alpha", CancellationToken.None);
+        dbId.ShouldNotBeNull();
+
+        // The actual user-facing failure surface: first append for the new tenant.
+        // On master this throws either the same 42P16 (the attach was silently
+        // swallowed and the partition is missing) or a downstream 23514 (no
+        // partition of relation mt_events found for row).
+        await using var session = _store.LightweightSession("alpha");
+        session.Events.StartStream(Guid.NewGuid(), new ShardedTestEvent { Value = "eager-apply-then-tenant" });
+        await session.SaveChangesAsync();
+
+        // Sanity: the partition lives in the assigned shard.
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await conn.OpenAsync();
+        var tables = await conn.ExistingTablesAsync();
+        tables.Any(t => t.Name == "mt_events_alpha").ShouldBeTrue(
+            $"mt_events_alpha partition must exist after eager-apply + runtime tenant. Tables: {string.Join(", ", tables.Select(t => t.QualifiedName))}");
+    }
+}


### PR DESCRIPTION
Closes #4606. Follow-up to #4598 / #4605 (explicitly out of scope there).

The eager `ApplyAllConfiguredChangesToDatabaseAsync()` startup pattern, combined with `MultiTenantedWithShardedDatabases` and `UseTenantPartitionedEvents`, makes runtime-provisioned sharded tenants fail their first event append. User-facing symptom: `23514: no partition of relation "mt_events" found for row`. Actual root cause hidden behind Weasel's silently-logged `42P16: cannot drop inherited constraint "mt_events_tenant_id_stream_id_fkey"` in the partition-attach path.

## Root cause

When `UseTenantPartitionedEvents` is on, BOTH `mt_streams` and `mt_events` are list-partitioned by `tenant_id`. Marten declares an explicit FK on the parent `mt_events` referencing `mt_streams(tenant_id, id)`. Eager schema apply + the first per-tenant partition (`mt_streams_alpha`) triggers Postgres to auto-propagate a partition-targeting FK onto `mt_events`:

```
fkey_mt_events_stream_id_tenant_id  → mt_streams           (Marten-declared, conislocal=t, coninhcount=0)
mt_events_tenant_id_stream_id_fkey  → mt_streams_alpha     (PG-propagated, conislocal=f, coninhcount=1)
```

The next partition attach for `mt_events_alpha` runs Weasel's `additivelyMigrateTablesForNewPartitions`, which treats the auto-propagated FK as "extra" (not in Marten's declared set) and emits `ALTER TABLE mt_events DROP CONSTRAINT IF EXISTS mt_events_tenant_id_stream_id_fkey`. Postgres refuses with 42P16 because the constraint is inherited. The error is logged via `NullLogger` and the partition attach is dropped on the floor; the next append fails with 23514 because the partition that was supposed to exist isn't there.

## Fix

Skip the explicit `mt_events → mt_streams` FK declaration in `EventsTable.cs` when `UseTenantPartitionedEvents` is on. Without the parent FK, Postgres never auto-propagates the inherited variant, so Weasel's partition-attach has nothing to incorrectly drop and the attach succeeds. The non-partitioned and `UseArchivedStreamPartitioning` shapes keep their FK unchanged — only the per-tenant-partitioning combination hits this.

## Trade-off

Database-level referential integrity between `mt_events` and `mt_streams` is lost in the `UseTenantPartitionedEvents` configuration. Marten's append path always inserts/updates the stream row before persisting events (application-level integrity preserved), so the only at-risk surface is external tooling that writes to `mt_events` directly without ensuring the stream exists in `mt_streams` — already outside Marten's contract.

The alternative would be a Weasel-side fix to skip inherited FKs in the table-delta introspection. That's the architecturally cleaner fix but requires a coordinated Weasel release; this change unblocks the eager-apply pattern on the current Marten release line without that dependency.

## Tests

**`sharded_eager_apply_per_tenant_events_tests.eager_apply_then_AddTenantToShardAsync_then_append_succeeds`** — the headline regression. Reproduces the exact eager-apply + runtime-provision + first-append shape from the #4606 report; would throw `23514` on master and now succeeds.

### Regression sweep (net9.0)

| Suite | Result |
|-------|--------|
| All sharded test suites (`sharded_tenancy_tests` + `sharded_tenancy_per_tenant_events_tests` + new eager-apply test) | **21/21 PASS** |
| DefaultTenancy `use_tenant_partitioned_events_*` | 32/33 PASS (single fail is pre-existing, unrelated) |
| Conjoined + ForeignKey event-sourcing tests | **75/75 PASS** |

The single use_tenant_partitioned_events fail (`delete_projection_progress_with_tenant_id_drops_only_that_tenants_rows`) is a pre-existing partition-setup race that also fails on master and is unrelated to this work.

Related: #4598, #4605 (the "Note on a related-but-separate bug" section), CritterWatch#267 (form D test) and CritterWatch#271 (eager-apply harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)