### PR TITLE
Fix #4610 net10.0 follow-up: enum-aware Contains path for MemoryExtensions

### DIFF
--- a/src/Marten/Linq/Parsing/Methods/MemoryExtensionsContains.cs
+++ b/src/Marten/Linq/Parsing/Methods/MemoryExtensionsContains.cs
@@ -1,9 +1,12 @@
 #nullable enable
 using System;
+using System.Collections;
+using System.Linq;
 using System.Linq.Expressions;
 using Marten.Exceptions;
 using Marten.Linq.Members;
 using Marten.Linq.QueryHandlers;
+using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Parsing.Methods;
@@ -30,6 +33,31 @@ internal class MemoryExtensionsContains: IMethodCallParser
         {
             // This is the constant.Contains(value) pattern
             var collectionMember = memberCollection.MemberFor(expression.Arguments[1]);
+
+            // #4610 mirror: on net10.0 the C# compiler resolves `array.Contains(x)` to
+            // MemoryExtensions.Contains (via the implicit array → ReadOnlySpan conversion),
+            // routing the same shape that EnumerableContains handles on net9 through this
+            // parser instead. The enum case has the same Npgsql parameter-mapping problem
+            // (`Writing values of 'EnumType[]' is not supported for parameters having
+            // NpgsqlDbType '-2147483639'`) and the same fix: project the constant
+            // collection through EnumIsOneOfWhereFragment so it becomes a string[]/int[]
+            // with the right NpgsqlDbType for the active EnumStorage.
+            if (collectionMember.MemberType.IsEnum && constant.Value is not null)
+            {
+                // EnumIsOneOfWhereFragment requires a System.Array; for net10's
+                // ReadOnlySpan path the captured value is still the original array, but
+                // a hand-written List<EnumType>.Contains-via-MemoryExtensions shape
+                // could land here too, so guard the conversion the same way.
+                var arrayValue = constant.Value is Array
+                    ? constant.Value
+                    : ((IEnumerable)constant.Value).Cast<object>().ToArray();
+
+                return new EnumIsOneOfWhereFragment(
+                    arrayValue,
+                    options.Serializer().EnumStorage,
+                    collectionMember.TypedLocator);
+            }
+
             return new IsOneOfFilter(collectionMember, new CommandParameter(constant.Value));
         }
 


### PR DESCRIPTION
## Context

#4610 fixed `values.Contains(p.EnumMember)` against an `EnumStorage.AsString` document member by routing the case through `EnumIsOneOfWhereFragment` in `EnumerableContains.Parse`. That worked on **net9.0** locally and in CI, but the regression test file is now failing on **net10.0** in CI for both open PRs (#4613, #4615) with the same `Writing values of 'YourEnum[]' is not supported for parameters having NpgsqlDbType '-2147483639'` shape from the original bug.

## Root cause

On **net10.0** the C# compiler resolves `array.Contains(x)` to `MemoryExtensions.Contains` via the implicit `T[]` → `ReadOnlySpan<T>` conversion — not `Enumerable.Contains`. Marten's parser registry has a dedicated `MemoryExtensionsContains` parser at `LinqParsing.cs:52` (ahead of `EnumerableContains` at line 53) precisely to handle that case, and its `Parse` had the **same** raw-`CommandParameter`-from-enum-array bug:

```csharp
// MemoryExtensionsContains.cs:33 (pre-fix)
return new IsOneOfFilter(collectionMember, new CommandParameter(constant.Value));
```

#4610's fix only patched `EnumerableContains` — `MemoryExtensionsContains` was missed because the local test runs were on net9.0 only.

## Fix

Mirror the same enum-aware branch into `MemoryExtensionsContains.Parse`:

```csharp
if (collectionMember.MemberType.IsEnum && constant.Value is not null)
{
    var arrayValue = constant.Value is Array
        ? constant.Value
        : ((IEnumerable)constant.Value).Cast<object>().ToArray();

    return new EnumIsOneOfWhereFragment(
        arrayValue,
        options.Serializer().EnumStorage,
        collectionMember.TypedLocator);
}
```

The existing `Bug_enum_asstring_array_contains` regression tests already cover both parsers — they target the user-facing shape (`values.Contains(p.Status)`), and each .NET version routes that shape to a different parser.

## Verified

- `Bug_enum_asstring_array_contains`: **6/6 pass on net9.0**
- `Bug_enum_asstring_array_contains`: **6/6 pass on net10.0** ← the regression
- Full **LinqTests on net10.0**: **1269 passed, 0 failed**

Once this lands, the CI failures on #4613 and #4615 should clear with a rerun (they're not touching either parser, just running into the same flaky net10 fallout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)