### PR TITLE
Fix #4618: make SecondaryStoreProxyFactory thread-safe on first build

### DIFF
--- a/src/CoreTests/Bugs/Bug_4618_secondary_store_proxy_race.cs
+++ b/src/CoreTests/Bugs/Bug_4618_secondary_store_proxy_race.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using Marten;
+using Marten.Internal;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests.Bugs;
+
+/// <summary>
+/// Regression test for #4618: building the runtime proxy for the same ancillary-store
+/// interface from multiple threads at once threw
+/// "ArgumentException: Duplicate type name within an assembly".
+/// <para>
+/// <see cref="SecondaryStoreProxyFactory"/> cached the raw <see cref="Type"/> via
+/// <c>ConcurrentDictionary.GetOrAdd</c>, whose value-factory is not guaranteed to run
+/// only once under contention, so several threads could call
+/// <c>ModuleBuilder.DefineType</c> with the same type name on the shared module and
+/// collide. The race only fires on the FIRST build of a given interface, so this test
+/// uses a fresh marker interface that no other test touches.
+/// </para>
+/// <para>
+/// This exercises the factory directly rather than through <c>AddMartenStore</c>: it is
+/// the exact code path that raced, reproduces reliably in milliseconds, and avoids
+/// bootstrapping dozens of <c>DocumentStore</c>s. The public-API wiring
+/// (<c>AddMartenStore</c> -&gt; <c>SecondaryStoreConfig.Build</c> -&gt; the factory) is
+/// already covered by the existing single-threaded ancillary-store tests.
+/// </para>
+/// </summary>
+public class Bug_4618_secondary_store_proxy_race
+{
+    // Fresh marker interface — must not be touched by any other test, or the factory
+    // cache is already warm for that type and the first-build race cannot fire.
+    public interface IRaceStore : IDocumentStore;
+
+    [Fact]
+    public void proxy_factory_is_thread_safe_on_first_build()
+    {
+        const int threads = 64;
+        var exceptions = new ConcurrentBag<Exception>();
+        using var ready = new Barrier(threads);
+
+        var workers = Enumerable.Range(0, threads).Select(_ => new Thread(() =>
+        {
+            // Release all threads simultaneously to maximise the contention window.
+            ready.SignalAndWait();
+            try
+            {
+                SecondaryStoreProxyFactory.GetOrCreate(typeof(IRaceStore));
+            }
+            catch (Exception e)
+            {
+                exceptions.Add(e);
+            }
+        })).ToArray();
+
+        foreach (var t in workers) t.Start();
+        foreach (var t in workers) t.Join();
+
+        exceptions.ShouldBeEmpty();
+    }
+}

--- a/src/Marten/Internal/SecondaryStoreProxyFactory.cs
+++ b/src/Marten/Internal/SecondaryStoreProxyFactory.cs
@@ -17,7 +17,23 @@ namespace Marten.Internal;
 [RequiresDynamicCode("Generates a runtime subclass per secondary-store interface via System.Reflection.Emit.")]
 internal static class SecondaryStoreProxyFactory
 {
-    private static readonly ConcurrentDictionary<Type, Type> _cache = new();
+    // Lazy<Type> (not Type) is the value: ConcurrentDictionary.GetOrAdd does NOT
+    // guarantee the value-factory runs only once under contention, so caching the
+    // raw Type would let multiple threads run Build for the same key — each calling
+    // DefineType with the same name on the shared module and throwing
+    // "Duplicate type name within an assembly". Caching a Lazy makes Build run
+    // exactly once per key.
+    //
+    // Note: Lazy (ExecutionAndPublication) caches a thrown exception permanently,
+    // so a failed Build is no longer retried on the next call as it was with the
+    // bare GetOrAdd(Build). Build only fails deterministically here (a non-marker
+    // interface that can't be implemented), so caching the failure is acceptable.
+    private static readonly ConcurrentDictionary<Type, Lazy<Type>> _cache = new();
+
+    // The ModuleBuilder is process-shared across every secondary-store interface,
+    // and ModuleBuilder.DefineType/CreateType are not thread-safe even for distinct
+    // type names. Serialise all emission through this gate.
+    private static readonly object _emitLock = new();
 
     private static readonly Lazy<ModuleBuilder> _module = new(() =>
     {
@@ -36,10 +52,18 @@ internal static class SecondaryStoreProxyFactory
                 nameof(interfaceType));
         }
 
-        return _cache.GetOrAdd(interfaceType, Build);
+        return _cache.GetOrAdd(interfaceType, t => new Lazy<Type>(() => Build(t))).Value;
     }
 
     private static Type Build(Type interfaceType)
+    {
+        lock (_emitLock)
+        {
+            return BuildCore(interfaceType);
+        }
+    }
+
+    private static Type BuildCore(Type interfaceType)
     {
         var module = _module.Value;
         var typeName = $"Marten.DynamicStores.{interfaceType.Name}Implementation";


### PR DESCRIPTION
Fixes #4618.

## Problem

Building the runtime proxy for the same ancillary-store interface from multiple threads at once could throw `ArgumentException: Duplicate type name within an assembly`. `SecondaryStoreProxyFactory` cached the raw `Type` via `ConcurrentDictionary.GetOrAdd`, whose value-factory is **not** guaranteed to run only once under contention. Several threads could therefore call `ModuleBuilder.DefineType` with the same type name on the process-shared module and collide.

## Fix

- Cache `Lazy<Type>` (instead of the raw `Type`) so `Build` runs **exactly once per interface**.
- Serialise all emission through a static `_emitLock`, because `ModuleBuilder.DefineType`/`CreateType` are not thread-safe even for distinct type names.

The two mechanisms are complementary: the `Lazy` collapses concurrent requests for the *same* interface into one build; the lock protects the shared `ModuleBuilder` across *distinct* interfaces. The steady-state path is unaffected — after warm-up `GetOrCreate` is just a dictionary lookup plus a materialized-`Lazy` read, with no lock taken.

### Behavior note

Switching to `Lazy` (default `ExecutionAndPublication` mode) means a thrown exception from `Build` is now **cached permanently** rather than retried on the next call as it was with the bare `GetOrAdd(Build)`. `Build` only fails deterministically here (a non-marker interface that can't be implemented), so caching the failure is an acceptable trade.

## Test

Adds `Bug_4618_secondary_store_proxy_race`, which hammers the factory from 64 threads released by a `Barrier`. It targets the factory directly — the exact code path that raced — reproduces reliably in milliseconds, and fails without this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)