### PR TITLE
Fix #4614 + start #4617: optimistic-concurrency appends under UseTenantPartitionedEvents

### DIFF
--- a/build/build.cs
+++ b/build/build.cs
@@ -37,6 +37,7 @@ class Build : NukeBuild
         .DependsOn(TestCli)
         .DependsOn(TestLinq)
         .DependsOn(TestMultiTenancy)
+        .DependsOn(TestTenantPartitionedEvents)
         .DependsOn(TestPatching)
         .DependsOn(TestValueTypes);
 
@@ -265,6 +266,23 @@ class Build : NukeBuild
         {
             DotNetTest(c => c
                 .SetProjectFile("src/MultiTenancyTests")
+                .SetConfiguration(Configuration)
+                .EnableNoBuild()
+                .EnableNoRestore()
+                .SetFramework(Framework));
+        });
+
+    // #4617: dedicated project for the UseTenantPartitionedEvents feature
+    // surface. Single-store shared fixtures (string + guid) + per-test unique
+    // tenant ids — the schema-creation race lives in the partition-CREATE
+    // path, so isolation is on tenant not schema. See AssemblyInfo.cs for the
+    // DisableTestParallelization rationale.
+    Target TestTenantPartitionedEvents => _ => _
+        .ProceedAfterFailure()
+        .Executes(() =>
+        {
+            DotNetTest(c => c
+                .SetProjectFile("src/TenantPartitionedEventsTests")
                 .SetConfiguration(Configuration)
                 .EnableNoBuild()
                 .EnableNoRestore()

--- a/src/Marten.slnx
+++ b/src/Marten.slnx
@@ -90,4 +90,5 @@
   <Project Path="Marten.SourceGenerator.Tests/Marten.SourceGenerator.Tests.csproj" />
   <Project Path="Marten/Marten.csproj" />
   <Project Path="MemoryUsageChecker/MemoryUsageChecker.csproj" />
+  <Project Path="TenantPartitionedEventsTests/TenantPartitionedEventsTests.csproj" />
 </Solution>

--- a/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
+++ b/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
@@ -318,6 +318,11 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             HasHeaders = hasHeaders,
             HasUserName = hasUserName,
             HasTagWrites = hasTagWrites,
+            // #4614: pass-through the partitioning + bigint flags so the operation
+            // knows whether to bind the trailing optimistic-concurrency parameter
+            // and what NpgsqlDbType it should be.
+            UseTenantPartitionedEvents = graph.UseTenantPartitionedEvents,
+            UseBigIntEvents = graph.EnableBigIntEvents,
             ConfigureInsertStreamCommand = BuildInsertStreamCommandConfigurer(graph, isConjoined, isGuid),
             ConfigureUpdateStreamVersionCommand = BuildUpdateStreamVersionCommandConfigurer(graph, isConjoined, isGuid),
             AppendEventSqlPrefix = appendEventSqlPrefix,
@@ -370,6 +375,11 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             HasHeaders = hasHeaders,
             HasUserName = hasUserName,
             HasTagWrites = hasTagWrites,
+            // #4614: pass-through the partitioning + bigint flags so the operation
+            // knows whether to bind the trailing optimistic-concurrency parameter
+            // and what NpgsqlDbType it should be.
+            UseTenantPartitionedEvents = graph.UseTenantPartitionedEvents,
+            UseBigIntEvents = graph.EnableBigIntEvents,
             ConfigureInsertStreamCommand = BuildInsertStreamCommandConfigurer(graph, isConjoined, isGuid),
             ConfigureUpdateStreamVersionCommand = BuildUpdateStreamVersionCommandConfigurer(graph, isConjoined, isGuid),
             AppendEventSqlPrefix = appendEventSqlPrefix,

--- a/src/Marten/EventStorage/Quick/QuickAppendEventsOperation.cs
+++ b/src/Marten/EventStorage/Quick/QuickAppendEventsOperation.cs
@@ -75,6 +75,15 @@ internal sealed class QuickAppendEventsOperation: QuickAppendEventsOperationBase
         // dialect flagged this configuration as needing tag writes.
         if (_descriptor.HasTagWrites) writeAllTagValues(pb);
 
+        // #4614: the trailing optimistic-concurrency parameter only exists
+        // on the function signature when partitioning is on (the non-partitioned
+        // bulk path never gets here with ExpectedVersionOnServer set — those
+        // streams route through the per-event InsertStream + UpdateStreamVersion
+        // path in QuickEventAppender). Always bind when present so the bulk
+        // function's NULL-check short-circuits when not optimistic.
+        if (_descriptor.UseTenantPartitionedEvents)
+            writeExpectedVersion(pb, _descriptor.UseBigIntEvents);
+
         builder.Append(")");
     }
 }

--- a/src/Marten/EventStorage/Quick/QuickEventStorageDescriptor.cs
+++ b/src/Marten/EventStorage/Quick/QuickEventStorageDescriptor.cs
@@ -102,6 +102,24 @@ public sealed class QuickEventStorageDescriptor
     public bool HasTagWrites { get; init; }
 
     /// <summary>
+    /// #4614: <c>UseTenantPartitionedEvents</c> is on, which means the bulk
+    /// function carries the trailing <c>expected_version</c> parameter (default
+    /// NULL) for the optimistic-concurrency append shapes (<c>FetchForWriting</c>,
+    /// <c>AppendOptimistic</c>, <c>AppendExclusive</c>, expected-version
+    /// StartStream/Append). The Quick operation binds the parameter via
+    /// <c>writeExpectedVersion</c> when this flag is on.
+    /// </summary>
+    public bool UseTenantPartitionedEvents { get; init; }
+
+    /// <summary>
+    /// <c>EnableBigIntEvents</c> picks <c>bigint</c> over <c>int</c> for sequence
+    /// + version columns, which propagates to the optimistic-concurrency
+    /// parameter type — has to match the function-signature width so Postgres
+    /// doesn't refuse the bind on the strict typed path.
+    /// </summary>
+    public bool UseBigIntEvents { get; init; }
+
+    /// <summary>
     /// SQL prefix <c>insert into mt_events (cols) values (</c> for the
     /// per-event QuickWithVersion path. The Quick appender uses this shape
     /// (one INSERT per event) for new streams and for existing streams

--- a/src/Marten/EventStorage/QuickWithServerTimestamps/QuickAppendEventsWithServerTimestampsOperation.cs
+++ b/src/Marten/EventStorage/QuickWithServerTimestamps/QuickAppendEventsWithServerTimestampsOperation.cs
@@ -63,6 +63,12 @@ internal sealed class QuickAppendEventsWithServerTimestampsOperation: QuickAppen
 
         if (_descriptor.HasTagWrites) writeAllTagValues(pb);
 
+        // #4614: trailing optimistic-concurrency parameter; only present on the
+        // function signature under partitioning. See QuickAppendEventsOperation
+        // for the rationale on why this is gated.
+        if (_descriptor.UseTenantPartitionedEvents)
+            writeExpectedVersion(pb, _descriptor.UseBigIntEvents);
+
         builder.Append(")");
     }
 }

--- a/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorageDescriptor.cs
+++ b/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorageDescriptor.cs
@@ -84,6 +84,16 @@ public sealed class QuickWithServerTimestampsEventStorageDescriptor
     public bool HasTagWrites { get; init; }
 
     /// <summary>
+    /// #4614: see <see cref="Quick.QuickEventStorageDescriptor.UseTenantPartitionedEvents"/>.
+    /// </summary>
+    public bool UseTenantPartitionedEvents { get; init; }
+
+    /// <summary>
+    /// See <see cref="Quick.QuickEventStorageDescriptor.UseBigIntEvents"/>.
+    /// </summary>
+    public bool UseBigIntEvents { get; init; }
+
+    /// <summary>
     /// SQL prefix <c>insert into mt_events (cols) values (</c> for the
     /// per-event QuickWithVersion path used by the Quick appender.
     /// </summary>

--- a/src/Marten/Events/Operations/QuickAppendEventsOperationBase.cs
+++ b/src/Marten/Events/Operations/QuickAppendEventsOperationBase.cs
@@ -24,6 +24,14 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation, IExcep
     // Keep in sync with QuickAppendEventFunction.WriteCreateStatement.
     private const string ArchivedStreamSqlState = "MT001";
 
+    // #4614: SQLSTATE raised by mt_quick_append_events when the caller's
+    // ExpectedVersionOnServer doesn't match the stream's actual version under
+    // UseTenantPartitionedEvents (the bulk path is the only one available there,
+    // so it has to enforce optimistic concurrency itself). Translated to
+    // EventStreamUnexpectedMaxEventIdException so the user-visible exception
+    // matches the rich path's UpdateStreamVersion contract.
+    private const string OptimisticVersionMismatchSqlState = "MT003";
+
     public bool TryTransform(Exception original, out Exception transformed)
     {
         var pg = original as PostgresException ?? original.InnerException as PostgresException;
@@ -31,6 +39,16 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation, IExcep
         {
             transformed = new InvalidStreamOperationException(
                 $"Attempted to append event to archived stream with Id '{Stream.Id}'.");
+            return true;
+        }
+
+        if (pg is { SqlState: OptimisticVersionMismatchSqlState })
+        {
+            transformed = new EventStreamUnexpectedMaxEventIdException(
+                Stream.Key ?? (object)Stream.Id,
+                Stream.AggregateType,
+                expected: Stream.ExpectedVersionOnServer ?? -1,
+                actual: -1);
             return true;
         }
 
@@ -227,6 +245,34 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation, IExcep
 
         var param = builder.AppendParameter<IList<string>>(userNames);
         param.NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Varchar;
+    }
+
+    /// <summary>
+    /// #4614: bind the caller's <see cref="StreamAction.ExpectedVersionOnServer"/>
+    /// to the <c>expected_version</c> parameter of <c>mt_quick_append_events</c>.
+    /// Pass null when this stream isn't an optimistic append — the function then
+    /// short-circuits the version check entirely.
+    /// </summary>
+    /// <remarks>
+    /// Only called by the partitioned bulk path. The non-partitioned bulk path
+    /// is never reached with <c>ExpectedVersionOnServer</c> set — those streams
+    /// route through the rich per-event InsertStream + UpdateStreamVersion in
+    /// <c>QuickEventAppender.registerOperationsForStreams</c>.
+    /// </remarks>
+    protected void writeExpectedVersion(IGroupedParameterBuilder builder, bool useBigInt)
+    {
+        var dbType = useBigInt ? NpgsqlDbType.Bigint : NpgsqlDbType.Integer;
+        if (Stream.ExpectedVersionOnServer is { } expected)
+        {
+            object value = useBigInt ? expected : (object)checked((int)expected);
+            var param = builder.AppendParameter(value);
+            param.NpgsqlDbType = dbType;
+        }
+        else
+        {
+            var param = builder.AppendParameter<object>(DBNull.Value);
+            param.NpgsqlDbType = dbType;
+        }
     }
 
     protected void writeTimestamps(IGroupedParameterBuilder builder)

--- a/src/Marten/Events/QuickEventAppender.cs
+++ b/src/Marten/Events/QuickEventAppender.cs
@@ -54,28 +54,22 @@ internal class QuickEventAppender: IEventAppender
             // with the stream's tenant instead of the session's.
             var metadataContext = TenantPropagation.MetadataContextFor(session, stream);
 
-            // #4596 Phase 1 Session 2: when per-tenant partitioning is on, the
-            // per-event `QuickAppendEventWithVersion` INSERT (used by the Start
-            // and ExpectedVersionOnServer paths) would inline
-            // `nextval('mt_events_sequence')` — the *global* sequence — via
-            // SequenceColumn.ValueSql. Only the bulk `mt_quick_append_events`
-            // function honors the per-tenant sequence pick (#4596 Session 2
-            // rewrite). Route every per-tenant append through the bulk function
-            // so the seq_id always comes from the tenant's
+            // #4596 Phase 1 Session 2 / #4614 Session 4: when per-tenant
+            // partitioning is on, the per-event `QuickAppendEventWithVersion`
+            // INSERT (used by the Start and ExpectedVersionOnServer paths) would
+            // inline `nextval('mt_events_sequence')` — the *global* sequence —
+            // via SequenceColumn.ValueSql. Only the bulk
+            // `mt_quick_append_events` function honors the per-tenant sequence
+            // pick. Route every per-tenant append through the bulk function so
+            // the seq_id always comes from the tenant's
             // `mt_events_sequence_{suffix}`. The function handles new-stream
-            // creation internally and rejects unregistered tenants with
-            // SQLSTATE MT002. Optimistic-concurrency (ExpectedVersionOnServer)
-            // appends with per-tenant partitioning are not supported yet —
-            // Session 3's progression rework lays the groundwork, Session 4
-            // wires the function signature for it.
+            // creation internally, rejects unregistered tenants with SQLSTATE
+            // MT002, and (#4614) now enforces the optimistic version check via
+            // the trailing `expected_version` parameter, raising MT003 on
+            // mismatch — translated back to EventStreamUnexpectedMaxEventIdException
+            // by QuickAppendEventsOperationBase.TryTransform so the user-facing
+            // exception type matches the rich path's UpdateStreamVersion.
             var forceBulkFunction = eventGraph.UseTenantPartitionedEvents;
-            if (forceBulkFunction && stream.ExpectedVersionOnServer.HasValue)
-            {
-                throw new NotSupportedException(
-                    $"Optimistic-concurrency event appends with explicit ExpectedVersionOnServer are not yet " +
-                    $"supported when Events.UseTenantPartitionedEvents is on (stream id '{stream.Id}'). " +
-                    $"This combination lands in #4596 Phase 1 Session 4. Use unconditional append for now.");
-            }
 
             if (!forceBulkFunction && stream.ActionType == StreamActionType.Start)
             {
@@ -111,7 +105,17 @@ internal class QuickEventAppender: IEventAppender
                     // array parameters. In HStore mode the function signature is trimmed
                     // (no per-tag varchar[] params), so tags are written via a follow-up
                     // UPDATE keyed on the event's id after the bulk insert completes.
-                    stream.PrepareEvents(0, eventGraph, sequences, metadataContext);
+                    // #4614: when ExpectedVersionOnServer is set (FetchForWriting,
+                    // AppendOptimistic, AppendExclusive, expected-version StartStream/
+                    // Append), pass it as the currentVersion to PrepareEvents so the
+                    // client-side optimistic-concurrency guard (StreamAction.PrepareEvents
+                    // lines 319-341 in jasperfx) doesn't false-positive on "expected N
+                    // but was 0" — events get their server-bound versions assigned from
+                    // ExpectedVersionOnServer + 1. The actual version check still happens
+                    // server-side in mt_quick_append_events via the trailing
+                    // expected_version parameter (MT003 on mismatch).
+                    var preparedFrom = stream.ExpectedVersionOnServer ?? 0L;
+                    stream.PrepareEvents(preparedFrom, eventGraph, sequences, metadataContext);
                     var quickAppendEvents = (QuickAppendEventsOperationBase)storage.QuickAppendEvents(stream);
                     quickAppendEvents.Events = eventGraph;
                     session.QueueOperation(quickAppendEvents);

--- a/src/Marten/Events/Schema/QuickAppendEventFunction.cs
+++ b/src/Marten/Events/Schema/QuickAppendEventFunction.cs
@@ -147,8 +147,39 @@ namespace Marten.Events.Schema;
                 sequencePickPerEvent = $"        seq := nextval('{databaseSchema}.mt_events_sequence');";
             }
 
+            // #4614 (#4596 Phase 1 Session 4): when partitioning is on, the bulk
+            // function is the only path for *every* event append — including the
+            // FetchForWriting / AppendOptimistic / AppendExclusive shapes that
+            // pass a caller-supplied ExpectedVersionOnServer. Take it as an
+            // optional trailing parameter, default NULL (no check) so previously
+            // generated call sites still match the signature, and raise MT003
+            // on mismatch so QuickAppendEventsOperationBase.TryTransform can
+            // surface it as EventStreamUnexpectedMaxEventIdException — the same
+            // exception type the rich path's UpdateStreamVersion already throws.
+            // Only emitted under partitioning because the non-partitioned bulk
+            // path is never reached with ExpectedVersionOnServer set (the
+            // QuickEventAppender takes the per-event InsertStream + atomic
+            // UpdateStreamVersion route instead).
+            var expectedVersionParameter = string.Empty;
+            var expectedVersionCheck = string.Empty;
+            if (_events.UseTenantPartitionedEvents)
+            {
+                expectedVersionParameter = $", expected_version {intType} DEFAULT NULL";
+                expectedVersionCheck = $@"
+    if expected_version IS NOT NULL then
+        -- COALESCE turns the NULL we get for a brand-new stream into 0, so a
+        -- FetchForWriting against a non-existent stream (which sets
+        -- ExpectedVersionOnServer = 0) and a StartStream(id, version: 0) both
+        -- land on the new-stream branch instead of mis-firing the guard.
+        if COALESCE(event_version, 0) != expected_version then
+            RAISE EXCEPTION 'Stream version mismatch on ''%'': expected %, actual %', stream, expected_version, COALESCE(event_version, 0) USING ERRCODE = 'MT003';
+        end if;
+    end if;
+";
+            }
+
             writer.WriteLine($@"
-CREATE OR REPLACE FUNCTION {Identifier}(stream {streamIdType}, stream_type varchar, tenantid varchar, event_ids uuid[], event_types varchar[], dotnet_types varchar[], bodies jsonb[], bdatas bytea[]{metadataParameters}{tagParameters}) RETURNS {returnType} AS $$
+CREATE OR REPLACE FUNCTION {Identifier}(stream {streamIdType}, stream_type varchar, tenantid varchar, event_ids uuid[], event_types varchar[], dotnet_types varchar[], bodies jsonb[], bdatas bytea[]{metadataParameters}{tagParameters}{expectedVersionParameter}) RETURNS {returnType} AS $$
 DECLARE
 	event_version {intType};
 	stream_is_archived boolean;
@@ -160,7 +191,7 @@ DECLARE
     actual_tenant varchar;
 	return_value {returnType};{sequenceDecl}
 BEGIN{sequenceResolveUpFront}
-	select version, is_archived into event_version, stream_is_archived from {databaseSchema}.mt_streams where {streamsWhere};
+	select version, is_archived into event_version, stream_is_archived from {databaseSchema}.mt_streams where {streamsWhere};{expectedVersionCheck}
 	if event_version IS NULL then
 		event_version = 0;
 		insert into {databaseSchema}.mt_streams (id, type, version, timestamp, tenant_id) values (stream, stream_type, 0, now(), tenantid);

--- a/src/TenantPartitionedEventsTests/AssemblyInfo.cs
+++ b/src/TenantPartitionedEventsTests/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+using Xunit;
+
+// #4617: structurally serialize this assembly's test runs. The
+// `UseTenantPartitionedEvents` schema-creation path is currently exposed to a
+// 42P07 / 23505 race when two cross-TFM test runs (net9 + net10) or two
+// in-assembly classes race to CREATE the per-tenant partition with the same
+// name. Three layers of defense are required for stability: (1) this attribute
+// (in-assembly), (2) Environment.ProcessId in the fixture schema names
+// (cross-TFM), (3) unique-per-test tenant ids (same-assembly siblings) — see
+// the issue text for the full rationale.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/TenantPartitionedEventsTests/Fixtures/GuidPartitionedFixture.cs
+++ b/src/TenantPartitionedEventsTests/Fixtures/GuidPartitionedFixture.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using System;
+using JasperFx.Events;
+using Marten;
+
+namespace TenantPartitionedEventsTests.Fixtures;
+
+/// <summary>
+/// Shared <see cref="DocumentStore"/> for guid-keyed (default) streams. Schema
+/// name carries <see cref="Environment.ProcessId"/> so net9 + net10 in the same
+/// database never race on partition / sequence names. DaemonLockId is a
+/// fixed-but-unique-per-fixture value (distinct from the string fixture's) so
+/// the two fixtures' daemons don't fight over the same advisory lock when both
+/// collections happen to schedule a daemon test in parallel between assemblies.
+/// </summary>
+public sealed class GuidPartitionedFixture: PartitionedFixtureBase
+{
+    public const int DaemonLockId = 19981022;
+    public string SchemaName { get; } = $"tp_events_guid_p{Environment.ProcessId}";
+
+    protected override void ConfigureStore(StoreOptions opts)
+    {
+        opts.Connection(Marten.Testing.Harness.ConnectionSource.ConnectionString);
+        opts.DatabaseSchemaName = SchemaName;
+        opts.Events.StreamIdentity = StreamIdentity.AsGuid;
+        opts.Projections.DaemonLockId = DaemonLockId;
+    }
+}
+
+[Xunit.CollectionDefinition("guid-partitioned")]
+public sealed class GuidPartitionedCollection: Xunit.ICollectionFixture<GuidPartitionedFixture>;

--- a/src/TenantPartitionedEventsTests/Fixtures/PartitionedFixtureBase.cs
+++ b/src/TenantPartitionedEventsTests/Fixtures/PartitionedFixtureBase.cs
@@ -1,0 +1,174 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Fixtures;
+
+/// <summary>
+/// Shared base for the two stream-identity-flavored fixtures. Each fixture
+/// builds ONE <see cref="DocumentStore"/> shared by every test in its collection
+/// — per-test isolation lives on the <see cref="NewTenant"/> tenant-id, not on
+/// the schema. The store is built once in <see cref="InitializeAsync"/> and the
+/// same projection set is registered up front (projection registration is
+/// immutable after the store is built).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Why share a store at all: every existing per-tenant-partitioning test today
+/// builds a fresh <see cref="DocumentStore"/> and drops the schema in-between —
+/// schema creation under <c>UseTenantPartitionedEvents</c> is the hot path that
+/// trips 42P07/23505 partition-name races when two TFMs race to CREATE the same
+/// partition. One store + per-test unique tenants neutralizes the race
+/// structurally and keeps the suite fast.
+/// </para>
+/// <para>
+/// Schema name carries <see cref="Environment.ProcessId"/> so net9 + net10 runs
+/// in the same DB never collide.
+/// </para>
+/// </remarks>
+public abstract class PartitionedFixtureBase: IAsyncLifetime
+{
+    /// <summary>
+    /// Lowercase, hyphen-free, leading-digit-safe (#4567), under the 63-byte
+    /// suffix limit. Format <c>t_{12 hex chars}</c> — fits comfortably inside
+    /// <c>mt_events_sequence_t_xxxxxxxxxxxx</c> at 32 chars total, well under 63.
+    /// </summary>
+    public static string NewTenant() => "t_" + Guid.NewGuid().ToString("N")[..12];
+
+    public DocumentStore Store { get; private set; } = null!;
+
+    /// <summary>
+    /// Subclass picks the schema name (suffixed by ProcessId in the call) +
+    /// stream-identity flavor + a unique <see cref="EventGraphProjections.DaemonLockId"/>.
+    /// </summary>
+    protected abstract void ConfigureStore(StoreOptions opts);
+
+    public virtual async Task InitializeAsync()
+    {
+        Store = DocumentStore.For(opts =>
+        {
+            ConfigureStore(opts);
+
+            // Common config required by UseTenantPartitionedEvents:
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Policies.AllDocumentsAreMultiTenanted();
+
+            // Representative projections registered up front. Short DocumentAlias
+            // matters: nested type names + tenant suffix overflow PG's 64-byte
+            // identifier limit.
+            opts.Projections.Add<TripDistanceProjection>(ProjectionLifecycle.Async);
+            opts.Projections.Add<TripCountInlineProjection>(ProjectionLifecycle.Inline);
+            opts.Projections.LiveStreamAggregation<TripSnapshot>();
+
+            opts.Schema.For<TripDistance>().Identity(x => x.Id).DocumentAlias("p2c_trip_dist");
+            opts.Schema.For<TripCount>().Identity(x => x.Id).DocumentAlias("p2c_trip_count");
+        });
+
+        // Sanity: the schema applies cleanly on its own. Caller tests register
+        // tenants on-demand via Store.Advanced.AddMartenManagedTenantsAsync.
+        await Store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+    }
+
+    public virtual Task DisposeAsync()
+    {
+        Store?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Read the `mt_events_sequence_{suffix}` last-value for a tenant — handy
+    /// for per-tenant monotonicity assertions.
+    /// </summary>
+    public async Task<long> ReadSequenceLastValueAsync(string tenantId, string schemaName)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        // pg_sequences.last_value: NULL until the first nextval.
+        var raw = await conn.CreateCommand(
+            $"select last_value from {schemaName}.mt_events_sequence_{tenantId}")
+            .ExecuteScalarAsync();
+        return raw is long v ? v : 0L;
+    }
+
+    /// <summary>
+    /// Counted via <c>mt_events</c> directly, scoped to one tenant. Useful when a
+    /// test wants to assert isolation without going through a query-builder.
+    /// </summary>
+    public async Task<long> CountEventsForTenantAsync(string tenantId, string schemaName)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        return (long)(await conn.CreateCommand(
+            $"select count(*) from {schemaName}.mt_events where tenant_id = :t")
+            .With("t", tenantId)
+            .ExecuteScalarAsync())!;
+    }
+}
+
+// ---- Representative projection / aggregate types ----
+// Kept here (not in test files) so the projection registration is wired to
+// stable types the fixture controls. Short DocumentAliases bake the 64-byte
+// identifier limit constraint into the type design.
+
+public class TripDistance
+{
+    public Guid Id { get; set; }
+    public double Distance { get; set; }
+    public int Version { get; set; }
+}
+
+public partial class TripDistanceProjection: SingleStreamProjection<TripDistance, Guid>
+{
+    public void Apply(TripDistance agg, TripLeg @event) => agg.Distance += @event.Distance;
+}
+
+public class TripCount
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+    public int Version { get; set; }
+}
+
+public partial class TripCountInlineProjection: SingleStreamProjection<TripCount, Guid>
+{
+    public void Apply(TripCount agg, TripLeg @event) => agg.Count++;
+}
+
+public class TripSnapshot
+{
+    public Guid Id { get; set; }
+    public double Distance { get; set; }
+    public int LegCount { get; set; }
+    public int Version { get; set; }
+
+    public void Apply(TripLeg @event)
+    {
+        Distance += @event.Distance;
+        LegCount++;
+    }
+
+    public static TripSnapshot Create(TripStarted @event) => new() { Id = @event.Id };
+}
+
+public record TripStarted(Guid Id);
+public record TripLeg(double Distance);

--- a/src/TenantPartitionedEventsTests/Fixtures/StringPartitionedFixture.cs
+++ b/src/TenantPartitionedEventsTests/Fixtures/StringPartitionedFixture.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using System;
+using JasperFx.Events;
+using Marten;
+
+namespace TenantPartitionedEventsTests.Fixtures;
+
+/// <summary>
+/// Shared <see cref="DocumentStore"/> for string-keyed streams. Mirrors
+/// <see cref="GuidPartitionedFixture"/> with the only divergences that matter
+/// at the schema level: <c>StreamIdentity.AsString</c> drives a <c>varchar</c>
+/// `id` on `mt_streams` and the corresponding `streamid` argument type on the
+/// generated quick-append function. A distinct DaemonLockId keeps advisory-lock
+/// claims from the two fixtures non-overlapping.
+/// </summary>
+public sealed class StringPartitionedFixture: PartitionedFixtureBase
+{
+    public const int DaemonLockId = 19981023;
+    public string SchemaName { get; } = $"tp_events_string_p{Environment.ProcessId}";
+
+    protected override void ConfigureStore(StoreOptions opts)
+    {
+        opts.Connection(Marten.Testing.Harness.ConnectionSource.ConnectionString);
+        opts.DatabaseSchemaName = SchemaName;
+        opts.Events.StreamIdentity = StreamIdentity.AsString;
+        opts.Projections.DaemonLockId = DaemonLockId;
+    }
+}
+
+[Xunit.CollectionDefinition("string-partitioned")]
+public sealed class StringPartitionedCollection: Xunit.ICollectionFixture<StringPartitionedFixture>;

--- a/src/TenantPartitionedEventsTests/OptimisticConcurrency/Optimistic_concurrency_under_partitioned_events.cs
+++ b/src/TenantPartitionedEventsTests/OptimisticConcurrency/Optimistic_concurrency_under_partitioned_events.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Exceptions;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using TenantPartitionedEventsTests.Fixtures;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.OptimisticConcurrency;
+
+/// <summary>
+/// #4614 — optimistic-concurrency event appends now work under
+/// <c>UseTenantPartitionedEvents</c>. Before this fix, every
+/// <c>FetchForWriting</c> / <c>AppendOptimistic</c> / <c>AppendExclusive</c> /
+/// expected-version <c>StartStream</c>+<c>Append</c> shape threw
+/// <c>NotSupportedException</c> at <c>SaveChangesAsync</c> from
+/// <c>QuickEventAppender.registerOperationsForStreams</c>, blocking the
+/// canonical CQRS aggregate-handler write pattern (Wolverine
+/// <c>[AggregateHandler]</c>) on every partitioned store.
+///
+/// <para>
+/// The implementation routes through the bulk <c>mt_quick_append_events</c>
+/// function (the only path under partitioning), which now accepts a trailing
+/// <c>expected_version</c> parameter, checks it against the stream's actual
+/// version, and raises SQLSTATE MT003 on mismatch.
+/// <c>QuickAppendEventsOperationBase.TryTransform</c> translates MT003 back to
+/// <see cref="EventStreamUnexpectedMaxEventIdException"/> so the user-facing
+/// exception matches the rich path's <c>UpdateStreamVersion</c> contract.
+/// </para>
+/// </summary>
+[Collection("guid-partitioned")]
+public class Optimistic_concurrency_under_partitioned_events_guid
+{
+    private readonly GuidPartitionedFixture _fixture;
+
+    public Optimistic_concurrency_under_partitioned_events_guid(GuidPartitionedFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task FetchForWriting_then_append_succeeds_on_existing_stream()
+    {
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        // Seed the stream — Quick path, no version on this call.
+        var streamId = Guid.NewGuid();
+        await using (var seed = _fixture.Store.LightweightSession(tenant))
+        {
+            seed.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId), new TripLeg(1));
+            await seed.SaveChangesAsync();
+        }
+
+        // The canonical aggregate-handler shape: load, decide, append.
+        // Pre-#4614, the SaveChangesAsync below threw NotSupportedException —
+        // this assertion is the headline regression-guard.
+        await using var session = _fixture.Store.LightweightSession(tenant);
+        var stream = await session.Events.FetchForWriting<TripSnapshot>(streamId);
+        stream.AppendOne(new TripLeg(2));
+        stream.AppendOne(new TripLeg(3));
+        await session.SaveChangesAsync();
+
+        await using var query = _fixture.Store.QuerySession(tenant);
+        var events = await query.Events.FetchStreamAsync(streamId);
+        events.Count.ShouldBe(4); // TripStarted + 3 TripLegs
+    }
+
+    [Fact]
+    public async Task FetchForWriting_on_brand_new_stream_then_append_succeeds()
+    {
+        // FetchForWriting against a never-started stream sets ExpectedVersionOnServer = 0
+        // (the surprising-but-correct behavior #4614's repro called out). Under
+        // partitioning that previously tripped the throw because 0.HasValue is true.
+        // It now routes through the bulk function with expected_version = 0, which
+        // COALESCEs the NULL stream-version to 0 and matches.
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var streamId = Guid.NewGuid();
+        await using var session = _fixture.Store.LightweightSession(tenant);
+        var stream = await session.Events.FetchForWriting<TripSnapshot>(streamId);
+        stream.AppendOne(new TripStarted(streamId));
+        stream.AppendOne(new TripLeg(5));
+        await session.SaveChangesAsync();
+
+        await using var query = _fixture.Store.QuerySession(tenant);
+        var events = await query.Events.FetchStreamAsync(streamId);
+        events.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task FetchForWriting_with_stale_expected_version_throws_concurrency_exception()
+    {
+        // The version-check teeth: two sessions race the same stream. The second
+        // SaveChangesAsync must see the first's append and throw the rich path's
+        // standard exception type (EventStreamUnexpectedMaxEventIdException, which
+        // inherits ConcurrencyException) — pin the EXACT exception type so the
+        // bulk path's MT003 translation stays equivalent to the rich path's
+        // UpdateStreamVersion behavior.
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var streamId = Guid.NewGuid();
+        await using (var seed = _fixture.Store.LightweightSession(tenant))
+        {
+            seed.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId));
+            await seed.SaveChangesAsync();
+        }
+
+        // Session A loads — sees version 1.
+        await using var sessionA = _fixture.Store.LightweightSession(tenant);
+        var streamA = await sessionA.Events.FetchForWriting<TripSnapshot>(streamId);
+
+        // Session B writes a competing event behind A's back — bumps the stream
+        // to version 2.
+        await using (var sessionB = _fixture.Store.LightweightSession(tenant))
+        {
+            var streamB = await sessionB.Events.FetchForWriting<TripSnapshot>(streamId);
+            streamB.AppendOne(new TripLeg(10));
+            await sessionB.SaveChangesAsync();
+        }
+
+        // Now A tries to commit — its ExpectedVersionOnServer is 1, but the
+        // stream is at 2. MT003 from the SQL function, translated to
+        // EventStreamUnexpectedMaxEventIdException by TryTransform.
+        streamA.AppendOne(new TripLeg(99));
+        await Should.ThrowAsync<EventStreamUnexpectedMaxEventIdException>(async () =>
+            await sessionA.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task AppendOptimistic_with_correct_expected_version_succeeds()
+    {
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var streamId = Guid.NewGuid();
+        await using (var seed = _fixture.Store.LightweightSession(tenant))
+        {
+            seed.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId), new TripLeg(1));
+            await seed.SaveChangesAsync();
+        }
+
+        await using var session = _fixture.Store.LightweightSession(tenant);
+        await session.Events.AppendOptimistic(streamId, new TripLeg(2));
+        await session.SaveChangesAsync();
+
+        await using var query = _fixture.Store.QuerySession(tenant);
+        (await query.Events.FetchStreamAsync(streamId)).Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task AppendOptimistic_on_non_existent_stream_throws_NonExistentStreamException()
+    {
+        // AppendOptimistic eagerly reads the stream's current state to compute
+        // ExpectedVersionOnServer. A non-existent stream returns null, so this
+        // throws NonExistentStreamException DURING THE APPEND CALL — same as the
+        // non-partitioned path, never reaches SaveChangesAsync.
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var streamId = Guid.NewGuid();
+        await using var session = _fixture.Store.LightweightSession(tenant);
+        await Should.ThrowAsync<NonExistentStreamException>(async () =>
+            await session.Events.AppendOptimistic(streamId, new TripLeg(1)));
+    }
+
+    [Fact]
+    public async Task AppendExclusive_then_append_succeeds_and_releases_lock()
+    {
+        // AppendExclusive acquires an advisory lock on the stream id then routes
+        // through the same optimistic path under partitioning. Most importantly,
+        // verify the session disposes cleanly so the connection isn't poisoned —
+        // pre-#4614 the throw at SaveChangesAsync left a leaked aborted tx in
+        // some shapes.
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var streamId = Guid.NewGuid();
+        await using (var seed = _fixture.Store.LightweightSession(tenant))
+        {
+            seed.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId));
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var session = _fixture.Store.LightweightSession(tenant))
+        {
+            await session.Events.AppendExclusive(streamId, new TripLeg(7));
+            await session.SaveChangesAsync();
+        }
+
+        // A follow-up plain append on the same tenant proves the prior session
+        // released its lock + disposed cleanly.
+        await using (var session = _fixture.Store.LightweightSession(tenant))
+        {
+            session.Events.Append(streamId, new TripLeg(8));
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = _fixture.Store.QuerySession(tenant);
+        (await query.Events.FetchStreamAsync(streamId)).Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task expected_version_check_is_tenant_isolated()
+    {
+        // Two tenants race the same stream id. Each tenant's stream is a separate
+        // row in mt_streams (different partitions), so an append in tenant A
+        // must NOT trip a version-mismatch in tenant B's session — the version
+        // check is scoped to (tenant_id, stream_id), not stream_id alone.
+        var tenantA = PartitionedFixtureBase.NewTenant();
+        var tenantB = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(
+            CancellationToken.None, tenantA, tenantB);
+
+        var streamId = Guid.NewGuid();
+        await using (var seedA = _fixture.Store.LightweightSession(tenantA))
+        {
+            seedA.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId));
+            await seedA.SaveChangesAsync();
+        }
+        await using (var seedB = _fixture.Store.LightweightSession(tenantB))
+        {
+            seedB.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId));
+            await seedB.SaveChangesAsync();
+        }
+
+        // Each tenant's FetchForWriting reads its own stream — both at version 1.
+        // Both append concurrently — both succeed.
+        await using var sessionA = _fixture.Store.LightweightSession(tenantA);
+        var streamA = await sessionA.Events.FetchForWriting<TripSnapshot>(streamId);
+        await using var sessionB = _fixture.Store.LightweightSession(tenantB);
+        var streamB = await sessionB.Events.FetchForWriting<TripSnapshot>(streamId);
+
+        streamA.AppendOne(new TripLeg(1));
+        streamB.AppendOne(new TripLeg(2));
+
+        await sessionA.SaveChangesAsync();
+        await sessionB.SaveChangesAsync(); // would throw if version check leaked across tenants
+    }
+}

--- a/src/TenantPartitionedEventsTests/TenantPartitionedEventsTests.csproj
+++ b/src/TenantPartitionedEventsTests/TenantPartitionedEventsTests.csproj
@@ -1,0 +1,81 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+        <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Marten\Marten.csproj" />
+        <ProjectReference Include="..\Marten.Newtonsoft\Marten.Newtonsoft.csproj" />
+        <!-- Marten.csproj sets PrivateAssets="all" on the SG; this project
+             defines its own SingleStreamProjection subclasses so it needs
+             the analyzer locally. -->
+        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FSharp.Core" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Npgsql.DependencyInjection" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Shouldly" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- Harness files linked from Marten.Testing rather than ProjectReference
+             so this project picks up only the bits it needs (no Document samples). -->
+        <Compile Include="..\Marten.Testing\Harness\BugIntegrationContext.cs">
+            <Link>Harness\BugIntegrationContext.cs</Link>
+        </Compile>
+        <Compile Include="..\Marten.Testing\Harness\ConnectionSource.cs">
+            <Link>Harness\ConnectionSource.cs</Link>
+        </Compile>
+        <Compile Include="..\Marten.Testing\Harness\DefaultStoreFixture.cs">
+            <Link>Harness\DefaultStoreFixture.cs</Link>
+        </Compile>
+        <Compile Include="..\Marten.Testing\Harness\DestructiveIntegrationContext.cs">
+            <Link>Harness\DestructiveIntegrationContext.cs</Link>
+        </Compile>
+        <Compile Include="..\Marten.Testing\Harness\IntegrationContext.cs">
+            <Link>Harness\IntegrationContext.cs</Link>
+        </Compile>
+        <Compile Include="..\Marten.Testing\Harness\OneOffConfigurationsContext.cs">
+            <Link>Harness\OneOffConfigurationsContext.cs</Link>
+        </Compile>
+        <Compile Include="..\Marten.Testing\Harness\SpecificationExtensions.cs">
+            <Link>Harness\SpecificationExtensions.cs</Link>
+        </Compile>
+        <Compile Include="..\Marten.Testing\Harness\StoreContext.cs">
+            <Link>Harness\StoreContext.cs</Link>
+        </Compile>
+        <Compile Include="..\Marten.Testing\Harness\StoreFixture.cs">
+            <Link>Harness\StoreFixture.cs</Link>
+        </Compile>
+        <Compile Include="..\Marten.Testing\Harness\TestOutputMartenLogger.cs">
+            <Link>Harness\TestOutputMartenLogger.cs</Link>
+        </Compile>
+        <Compile Include="..\Marten.Testing\Harness\TestsSettings.cs">
+            <Link>Harness\TestsSettings.cs</Link>
+        </Compile>
+        <Compile Include="..\Marten.Testing\SchemaMigrationExtensions.cs">
+            <Link>SchemaMigrationExtensions.cs</Link>
+        </Compile>
+    </ItemGroup>
+
+    <PropertyGroup>
+        <NoWarn>xUnit1013</NoWarn>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
First slice of the combined #4614 (feature) + #4617 (expansive test battery) work. Scope was deliberately narrowed per the design discussion: ship the optimistic-concurrency feature fully + lay the new project's foundation with a focused regression suite for the new behavior. Existing partitioned-test file migrations and the rest of #4617's new test categories are explicitly deferred to subsequent PRs.

## Fixes #4614 — the feature

`Events.UseTenantPartitionedEvents = true` no longer blocks `FetchForWriting<T>`, `AppendOptimistic`, `AppendExclusive`, or expected-version `StartStream`/`Append`. Before this fix, every optimistic-append shape threw `NotSupportedException` at `SaveChangesAsync` from `QuickEventAppender.registerOperationsForStreams`, which made per-tenant event partitioning unusable for any application built on aggregate command handlers (Wolverine `[AggregateHandler]`, the standard "load → decide → append" CQRS pattern).

### Implementation walk-through

| Layer | Change |
|---|---|
| **SQL function** (`QuickAppendEventFunction.cs`) | Trailing `expected_version` parameter (default NULL) added to `mt_quick_append_events` **only when `UseTenantPartitionedEvents` is on** — non-partitioned signature is unchanged so we don't drag every consumer through a function migration. When non-null, fetches the stream's actual version (`COALESCE` to 0 for brand-new streams so `FetchForWriting`-against-non-existent and `StartStream(version: 0)` both work) and raises `SQLSTATE MT003` on mismatch. |
| **SQLSTATE translation** (`QuickAppendEventsOperationBase.TryTransform`) | New catch for MT003 → `EventStreamUnexpectedMaxEventIdException` so the user-facing exception type matches the rich path's `UpdateStreamVersion.PostprocessAsync` contract. Same exception, regardless of partitioning. |
| **Parameter binding** (`QuickAppendEventsOperationBase.writeExpectedVersion`) | New protected helper; binds `Stream.ExpectedVersionOnServer` (or `DBNull` when no check) with `NpgsqlDbType.Integer` or `Bigint` per the descriptor's `UseBigIntEvents` flag. |
| **Descriptors** | `UseTenantPartitionedEvents` and `UseBigIntEvents` added to both `QuickEventStorageDescriptor` and `QuickWithServerTimestampsEventStorageDescriptor` — wired from `PostgresEventStoreDialect`. Operations gate the trailing parameter on `UseTenantPartitionedEvents` (the non-partitioned bulk path is never reached with `ExpectedVersionOnServer` set; those streams route through the per-event `InsertStream + UpdateStreamVersion` path). |
| **Throw removal** (`QuickEventAppender.registerOperationsForStreams`) | Dropped the up-front "not yet supported" `NotSupportedException` throw. |
| **PrepareEvents fix** (`QuickEventAppender`) | The bulk-optimistic path now passes `ExpectedVersionOnServer` as `currentVersion` to `PrepareEvents` so the client-side `StreamAction.PrepareEvents` guard (jasperfx `StreamAction.cs:319-341`) doesn't false-positive with "expected N but was 0" before the bulk function runs the real server-side check. |

### Why the SQL signature change is OK

The new parameter is **only added when `UseTenantPartitionedEvents` is on**, and has `DEFAULT NULL`, so:
- Non-partitioned stores: function signature unchanged → no schema migration.
- Partitioned stores: function signature changes by one parameter; Weasel's existing function-replace machinery picks up the diff on `ApplyAllConfiguredChangesToDatabaseAsync` (the same path that already replaces this function across other config changes).

## Starts #4617 — the test platform (Phase A0)

New `TenantPartitionedEventsTests` project laying down the **shared-fixture architecture** the issue spec'd:

- **`GuidPartitionedFixture` + `StringPartitionedFixture`**: each holds ONE `DocumentStore` per stream-identity flavor, schema name carrying `Environment.ProcessId` for cross-TFM safety (net9 + net10 can't race on partition names), unique `DaemonLockId`s, representative projection set registered up front (Async + Inline + LiveStreamAggregation). Short `DocumentAlias`es bake the 64-byte identifier limit constraint into the type design.
- **Per-test isolation on tenant, not schema** — `PartitionedFixtureBase.NewTenant()` returns `t_{12 hex chars}`, lowercase, hyphen-free, leading-digit-safe (#4567), comfortably under the 63-byte sequence-suffix limit. Tests register on-demand via `AddMartenManagedTenantsAsync` and assert only on their own tenant's rows.
- **`[assembly: CollectionBehavior(DisableTestParallelization = true)]`** — the third defense layer (alongside `ProcessId` schema names + unique per-test tenants) against the 42P07/23505 partition-CREATE race that bit the existing partitioned tests.
- **Nuke target** `TestTenantPartitionedEvents` wired into the `test` aggregate.

### Tests in this PR

`Optimistic_concurrency_under_partitioned_events_guid` — 7 tests pinning the new feature end-to-end:

- `FetchForWriting_then_append_succeeds_on_existing_stream` (the headline regression — Wolverine's bread-and-butter shape).
- `FetchForWriting_on_brand_new_stream_then_append_succeeds` (covers `ExpectedVersionOnServer = 0` against `NULL` stream, the `COALESCE`-to-0 path).
- `FetchForWriting_with_stale_expected_version_throws_concurrency_exception` (proves MT003 → `EventStreamUnexpectedMaxEventIdException` translation — same exception type as the rich path).
- `AppendOptimistic_with_correct_expected_version_succeeds`.
- `AppendOptimistic_on_non_existent_stream_throws_NonExistentStreamException` (caller-side fetch path — throws during the call, not at save).
- `AppendExclusive_then_append_succeeds_and_releases_lock` (proves the lock + tx dispose cleanly post-fix).
- `expected_version_check_is_tenant_isolated` (two tenants, same stream id → independent version checks; no cross-tenant leak).

## What's deliberately NOT in this PR

Per the design discussion (option A), this PR is the **smallest reviewable slice**. Subsequent PRs will iterate on:

1. Migrate the 9 existing `use_tenant_partitioned_events_*.cs` + `sharded_*_per_tenant_events_*.cs` files from `MultiTenancyTests` into the new project (the issue's explicit checklist).
2. The 100+ new test categories from #4617 sections 3-5 (DCB partitioned coverage, EventProjection, FlatTableProjection, MultiStream `RollUpByTenant` / `AcrossTenants`, MasterTableTenancy + SingleServerMultiTenancy gap pins, daemon-in-depth, regression families).
3. String-identity coverage of the optimistic-concurrency feature this PR adds (the guid suite proves the pattern; string just needs the parallel class against `StringPartitionedFixture`).

## Verification

| Suite | Result |
|---|---|
| New `Optimistic_concurrency_under_partitioned_events_guid` (7 tests) | **net9.0**: 7/7 pass — **net10.0**: 7/7 pass |
| Existing partitioned suite in `MultiTenancyTests` (`use_tenant_partitioned_*` + `sharded_*_per_tenant_events_*`) | 43/44 pass — the 1 failure (`delete_projection_progress_with_tenant_id_drops_only_that_tenants_rows`) is a **pre-existing master flake**: PostgresqlIdentifierTooLongException on the test's 66-char doc-table name. Verified by checking out master and re-running the same test. **Not** introduced by this change. |
| Full `EventSourcingTests` (non-partitioned event paths) | 1358 passed, 0 failed (14m26s) — proves the function signature change is correctly gated by `UseTenantPartitionedEvents` and doesn't affect non-partitioned consumers. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)