### PR TITLE
#4617 PR 3: migrate sharded partitioned tests + per_tenant_events_flag guard subset

### DIFF
--- a/src/CoreTests/StoreOptionsTests.cs
+++ b/src/CoreTests/StoreOptionsTests.cs
@@ -442,51 +442,10 @@ public class StoreOptionsTests
         var description = new OptionsDescription(new StoreOptions());
     }
 
-    // #4596 — Phase 0 surface: UseTenantPartitionedEvents flag + AppendMode guard.
-    // Per the issue spec, only Quick / QuickWithServerTimestamps append modes are
-    // compatible with per-tenant partitioning; Rich is explicitly out of scope
-    // (the per-tenant sequence pick lives in QuickAppendEventFunction only).
-    public class per_tenant_events_flag
-    {
-        [Fact]
-        public void defaults_to_false()
-        {
-            new StoreOptions().Events.UseTenantPartitionedEvents.ShouldBeFalse();
-        }
-
-        [Fact]
-        public void validate_throws_when_combined_with_rich_append_mode()
-        {
-            var options = new StoreOptions();
-            options.Connection(ConnectionSource.ConnectionString);
-            // #4596 Session 1: per-tenant partitioning also requires Conjoined event
-            // tenancy. Set it so the tenancy guard passes and we reach the AppendMode
-            // guard we're actually testing.
-            options.Events.TenancyStyle = JasperFx.MultiTenancy.TenancyStyle.Conjoined;
-            options.Events.UseTenantPartitionedEvents = true;
-            options.Events.AppendMode = JasperFx.Events.EventAppendMode.Rich;
-
-            var ex = Should.Throw<InvalidOperationException>(() => options.Validate());
-
-            ex.Message.ShouldContain(nameof(IEventStoreOptions.UseTenantPartitionedEvents));
-            ex.Message.ShouldContain("EventAppendMode.Rich");
-        }
-
-        [Theory]
-        [InlineData(JasperFx.Events.EventAppendMode.Quick)]
-        [InlineData(JasperFx.Events.EventAppendMode.QuickWithServerTimestamps)]
-        public void validate_succeeds_with_quick_modes(JasperFx.Events.EventAppendMode mode)
-        {
-            var options = new StoreOptions();
-            options.Connection(ConnectionSource.ConnectionString);
-            // #4596 Session 1: per-tenant partitioning requires Conjoined event tenancy.
-            options.Events.TenancyStyle = JasperFx.MultiTenancy.TenancyStyle.Conjoined;
-            options.Events.UseTenantPartitionedEvents = true;
-            options.Events.AppendMode = mode;
-
-            Should.NotThrow(() => options.Validate());
-        }
-    }
+    // #4617 PR 3: the per_tenant_events_flag nested class moved to
+    // src/TenantPartitionedEventsTests/Config/per_tenant_events_flag_guards.cs
+    // so every per-tenant-partitioning guard lives alongside its companions
+    // (schema_groundwork_for_partitioned_events, etc).
 
 
     private class DummyNpgsqlDataSourceFactory: INpgsqlDataSourceFactory

--- a/src/TenantPartitionedEventsTests/Config/per_tenant_events_flag_guards.cs
+++ b/src/TenantPartitionedEventsTests/Config/per_tenant_events_flag_guards.cs
@@ -1,0 +1,63 @@
+using System;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Config;
+
+/// <summary>
+/// #4596 Phase 0 — surface-level guards on
+/// <c>Events.UseTenantPartitionedEvents</c>: the flag defaults to false, and
+/// <c>StoreOptions.Validate()</c> rejects the combination with
+/// <c>EventAppendMode.Rich</c> (the per-tenant sequence pick lives only in
+/// <c>QuickAppendEventFunction</c>). Migrated here from the
+/// <c>per_tenant_events_flag</c> nested class in
+/// <c>CoreTests/StoreOptionsTests.cs</c> so every per-tenant-partitioning
+/// guard lives in one project alongside its companion schema/config tests
+/// in <see cref="schema_groundwork_for_partitioned_events"/>.
+/// </summary>
+public class per_tenant_events_flag_guards
+{
+    [Fact]
+    public void defaults_to_false()
+    {
+        new StoreOptions().Events.UseTenantPartitionedEvents.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void validate_throws_when_combined_with_rich_append_mode()
+    {
+        var options = new StoreOptions();
+        options.Connection(ConnectionSource.ConnectionString);
+        // #4596 Session 1: per-tenant partitioning also requires Conjoined event
+        // tenancy. Set it so the tenancy guard passes and we reach the AppendMode
+        // guard we're actually testing.
+        options.Events.TenancyStyle = TenancyStyle.Conjoined;
+        options.Events.UseTenantPartitionedEvents = true;
+        options.Events.AppendMode = EventAppendMode.Rich;
+
+        var ex = Should.Throw<InvalidOperationException>(() => options.Validate());
+
+        ex.Message.ShouldContain(nameof(IEventStoreOptions.UseTenantPartitionedEvents));
+        ex.Message.ShouldContain("EventAppendMode.Rich");
+    }
+
+    [Theory]
+    [InlineData(EventAppendMode.Quick)]
+    [InlineData(EventAppendMode.QuickWithServerTimestamps)]
+    public void validate_succeeds_with_quick_modes(EventAppendMode mode)
+    {
+        var options = new StoreOptions();
+        options.Connection(ConnectionSource.ConnectionString);
+        // #4596 Session 1: per-tenant partitioning requires Conjoined event tenancy.
+        options.Events.TenancyStyle = TenancyStyle.Conjoined;
+        options.Events.UseTenantPartitionedEvents = true;
+        options.Events.AppendMode = mode;
+
+        Should.NotThrow(() => options.Validate());
+    }
+}

--- a/src/TenantPartitionedEventsTests/Sharded/ShardedPartitionedFixture.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/ShardedPartitionedFixture.cs
@@ -1,0 +1,116 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten.Testing.Harness;
+using Npgsql;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+/// <summary>
+/// xUnit collection for sharded-tenancy partitioned tests in this project. The
+/// collection id is intentionally NOT the same as MultiTenancyTests' own
+/// "sharded-tenancy" — xUnit collections are per-assembly, but using a
+/// distinct name removes any ambiguity for readers cross-referencing the two
+/// projects. <see cref="DisableParallelization"/> stays true (the 3 physical
+/// shard databases are single-master resources; concurrent tests would race
+/// over per-database schema state).
+/// </summary>
+[CollectionDefinition("sharded-tenant-partitioned", DisableParallelization = true)]
+public sealed class ShardedPartitionedCollection : ICollectionFixture<ShardedPartitionedFixture>;
+
+/// <summary>
+/// Clone of MultiTenancyTests/sharded_tenancy_tests.cs's <c>ShardedTenancyFixture</c>
+/// — provisions the 3 physical shard databases (<c>marten_shard_a/b/c</c>) on
+/// the master connection, drops the well-known per-test schemas + every
+/// <c>mt_*</c> object from their public schemas, and exposes the per-shard
+/// connection strings for tests to use. Kept as a copy in this project so
+/// MultiTenancyTests doesn't have to grow a public extraction; the cloned
+/// fixture is internal to the per-tenant-partitioning test surface.
+/// </summary>
+public sealed class ShardedPartitionedFixture : IAsyncLifetime
+{
+    public string[] DbNames { get; private set; } = null!;
+    public Dictionary<string, string> ConnectionStrings { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        DbNames = new[] { "marten_shard_a", "marten_shard_b", "marten_shard_c" };
+        ConnectionStrings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var name in DbNames)
+        {
+            var exists = await conn.DatabaseExists(name);
+            if (!exists)
+            {
+                await new DatabaseSpecification().BuildDatabase(conn, name);
+            }
+
+            var builder = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+            {
+                Database = name
+            };
+            ConnectionStrings[name] = builder.ConnectionString;
+        }
+
+        // Clean up master database schemas
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+
+        // Clean up tenant database schemas
+        foreach (var connStr in ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await CleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    /// <summary>
+    /// Wipe every <c>mt_*</c> table / function / sequence from the public schema
+    /// of the given (shard) connection. Used by the fixture init and reused by
+    /// individual tests that need to scrub a specific shard mid-suite.
+    /// </summary>
+    public static async Task CleanMartenObjectsInPublicSchema(NpgsqlConnection conn)
+    {
+        try
+        {
+            // Ensure public schema exists (may have been dropped by a previous test)
+            await conn.CreateCommand("CREATE SCHEMA IF NOT EXISTS public").ExecuteNonQueryAsync();
+
+            // Drop all mt_ tables
+            var tables = await conn.ExistingTablesAsync();
+            foreach (var table in tables.Where(t => t.Schema == "public" && t.Name.StartsWith("mt_")))
+            {
+                await conn.CreateCommand($"DROP TABLE IF EXISTS {table.QualifiedName} CASCADE").ExecuteNonQueryAsync();
+            }
+
+            // Drop all mt_ functions
+            var funcs = await conn.CreateCommand(
+                "SELECT proname FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid WHERE n.nspname = 'public' AND p.proname LIKE 'mt_%'")
+                .ExecuteReaderAsync();
+            var funcNames = new List<string>();
+            while (await funcs.ReadAsync()) funcNames.Add(await funcs.GetFieldValueAsync<string>(0));
+            await funcs.CloseAsync();
+            foreach (var f in funcNames)
+            {
+                await conn.CreateCommand($"DROP FUNCTION IF EXISTS public.{f} CASCADE").ExecuteNonQueryAsync();
+            }
+
+            // Drop all mt_ sequences
+            await conn.CreateCommand(
+                "DO $$ DECLARE r RECORD; BEGIN FOR r IN (SELECT sequencename FROM pg_sequences WHERE schemaname = 'public' AND sequencename LIKE 'mt_%') LOOP EXECUTE 'DROP SEQUENCE IF EXISTS public.' || r.sequencename || ' CASCADE'; END LOOP; END $$")
+                .ExecuteNonQueryAsync();
+        }
+        catch { }
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}

--- a/src/TenantPartitionedEventsTests/Sharded/sharded_eager_apply_per_tenant_events.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/sharded_eager_apply_per_tenant_events.cs
@@ -5,11 +5,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx;
 using JasperFx.Events;
-using JasperFx.MultiTenancy;
 using Marten;
 using Marten.Events;
 using Marten.Storage;
-using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Npgsql;
 using Shouldly;
@@ -17,9 +15,10 @@ using Weasel.Core;
 using Weasel.Postgresql;
 using Xunit;
 
-namespace MultiTenancyTests;
+namespace TenantPartitionedEventsTests.Sharded;
 
 /// <summary>
+/// Migrated from MultiTenancyTests/sharded_eager_apply_per_tenant_events_tests.cs.
 /// #4606 regression — eager schema apply on a sharded + per-tenant-events store,
 /// followed by runtime tenant provisioning, must succeed (no 42P16 on the partition
 /// attach's FK drop).
@@ -35,13 +34,13 @@ namespace MultiTenancyTests;
 /// eager-apply variant.
 /// </para>
 /// </summary>
-[Collection("sharded-tenancy")]
-public class sharded_eager_apply_per_tenant_events_tests : IAsyncLifetime
+[Collection("sharded-tenant-partitioned")]
+public class sharded_eager_apply_per_tenant_events : IAsyncLifetime
 {
-    private readonly ShardedTenancyFixture _fixture;
+    private readonly ShardedPartitionedFixture _fixture;
     private IDocumentStore _store = null!;
 
-    public sharded_eager_apply_per_tenant_events_tests(ShardedTenancyFixture fixture)
+    public sharded_eager_apply_per_tenant_events(ShardedPartitionedFixture fixture)
     {
         _fixture = fixture;
     }
@@ -57,7 +56,7 @@ public class sharded_eager_apply_per_tenant_events_tests : IAsyncLifetime
             await using var tenantConn = new NpgsqlConnection(connStr);
             await tenantConn.OpenAsync();
             try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedTenancyFixture.cleanMartenObjectsInPublicSchema(tenantConn);
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
         }
     }
 

--- a/src/TenantPartitionedEventsTests/Sharded/sharded_tenancy_per_tenant_events.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/sharded_tenancy_per_tenant_events.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +12,6 @@ using Marten;
 using Marten.Events;
 using Marten.Exceptions;
 using Marten.Storage;
-using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
@@ -20,9 +20,10 @@ using Weasel.Core;
 using Weasel.Postgresql;
 using Xunit;
 
-namespace MultiTenancyTests;
+namespace TenantPartitionedEventsTests.Sharded;
 
 /// <summary>
+/// Migrated from MultiTenancyTests/sharded_tenancy_per_tenant_events_tests.cs.
 /// #4598 — per-tenant event partitioning under sharded multi-tenancy. The headline bug
 /// was that runtime-provisioned sharded tenants got the document LIST partitions but NOT
 /// the per-tenant <c>mt_events_sequence_{suffix}</c> sequence, so the first event append
@@ -32,13 +33,13 @@ namespace MultiTenancyTests;
 /// <see cref="IDynamicTenantSource{T}.AddTenantAsync(string,CancellationToken)" />
 /// auto-assign override so CritterWatch can provision store-agnostically.
 /// </summary>
-[Collection("sharded-tenancy")]
-public class sharded_tenancy_per_tenant_events_tests : IAsyncLifetime
+[Collection("sharded-tenant-partitioned")]
+public class sharded_tenancy_per_tenant_events : IAsyncLifetime
 {
-    private readonly ShardedTenancyFixture _fixture;
+    private readonly ShardedPartitionedFixture _fixture;
     private IDocumentStore _store = null!;
 
-    public sharded_tenancy_per_tenant_events_tests(ShardedTenancyFixture fixture)
+    public sharded_tenancy_per_tenant_events(ShardedPartitionedFixture fixture)
     {
         _fixture = fixture;
     }
@@ -55,7 +56,7 @@ public class sharded_tenancy_per_tenant_events_tests : IAsyncLifetime
             await using var tenantConn = new NpgsqlConnection(connStr);
             await tenantConn.OpenAsync();
             try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
-            await ShardedTenancyFixture.cleanMartenObjectsInPublicSchema(tenantConn);
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
         }
     }
 
@@ -393,6 +394,11 @@ public class sharded_tenancy_per_tenant_events_tests : IAsyncLifetime
             .ExecuteScalarAsync())!;
         exists.ShouldBe(0L, because);
     }
+}
+
+public class ShardedTestEvent
+{
+    public string Value { get; set; } = "";
 }
 
 public class ShardedAggregate


### PR DESCRIPTION
Completes the existing-test-file migration leg of #4617 by moving the last 3 files into `TenantPartitionedEventsTests`. With this PR, every existing partitioned test file from `MultiTenancyTests` + the `CoreTests` config-guard subset is now consolidated in the new project.

## Sharded migrations (15 tests across 2 files)

New `Sharded/ShardedPartitionedFixture.cs` — a clone of `MultiTenancyTests`'s `ShardedTenancyFixture` with a distinct xUnit collection id (`\"sharded-tenant-partitioned\"` vs the original `\"sharded-tenancy\"`) so the two projects' collection definitions never get mistaken for each other in a shared run. The fixture provisions the 3 physical shard databases (`marten_shard_a/b/c`), drops the well-known per-test schemas, and exposes the per-shard connection strings — identical setup to the original. Helper `CleanMartenObjectsInPublicSchema` is public (vs the original's internal visibility) so tests can call it directly when they need to scrub a shard.

| File | Tests | Coverage |
|---|---|---|
| `Sharded/sharded_tenancy_per_tenant_events.cs` | 10 | Headline sharded per-tenant-partitioning surface + #4598 sequence-provisioning regressions + #4605 `IDynamicTenantSource<string>` lifecycle |
| `Sharded/sharded_eager_apply_per_tenant_events.cs` | 1 | #4606 eager-apply + per-tenant partition-attach regression |

Per-test isolation is preserved (each test still builds its own `DocumentStore` and wipes shard schemas in `InitializeAsync` — sharded tests have always been per-test-store; the fixture only provides the shard DBs). Hardcoded tenant names (`\"alpha\"`, `\"bravo\"`, `\"india\"`, `\"echo\"`) stay — they're safe under the fixture's `DisableParallelization` + per-test wipe pattern.

## Config-guard migration (4 tests in 1 file)

`Config/per_tenant_events_flag_guards.cs` extracts the `per_tenant_events_flag` nested class from `CoreTests/StoreOptionsTests.cs` into the new project so every per-tenant-partitioning guard lives in one place alongside its companions (`schema_groundwork_for_partitioned_events`, etc.):

- `defaults_to_false`
- `validate_throws_when_combined_with_rich_append_mode`
- `validate_succeeds_with_quick_modes` `[Theory]` over `Quick` + `QuickWithServerTimestamps`

The `CoreTests` slot keeps a one-line breadcrumb pointing to the new location.

## Verification

| Suite | Result |
|---|---|
| `TenantPartitionedEventsTests` (full project) | **net9.0**: 55/55 pass (was 40 in PR #4622) — **net10.0**: 55/55 pass |
| `CoreTests.StoreOptionsTests` filtered sweep | 27 passed / 1 skipped (clean after the 4 moved out) |
| `MultiTenancyTests` build | clean — no dangling refs to the 2 deleted sharded files |

## Migration leg complete

With this PR, all 9 existing partitioned test files from `MultiTenancyTests` + the `CoreTests` config-guard subset are now consolidated in `TenantPartitionedEventsTests`. Subsequent PRs per the #4617 checklist will add the new test categories from sections 3-5 (DCB partitioned coverage, EventProjection, FlatTableProjection, MultiStream `RollUpByTenant` / `AcrossTenants`, MasterTableTenancy + SingleServerMultiTenancy gap pins, daemon-in-depth, regression families) plus the string-identity coverage of the optimistic-append feature shipped in #4621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)