### PR TITLE
#4617 PR 7: section 3d tenancy gap pins + 3e admin/stats/archive coverage

### DIFF
--- a/src/TenantPartitionedEventsTests/Admin/event_store_statistics_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Admin/event_store_statistics_under_partitioning.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Storage;
+using Shouldly;
+using TenantPartitionedEventsTests.Fixtures;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Admin;
+
+/// <summary>
+/// #4617 section 3e — statistics + high-water APIs under
+/// <c>UseTenantPartitionedEvents</c>. Pins what's correct (EventCount,
+/// StreamCount, FetchMaxEventSequenceAsync) vs what's KNOWN-STALE
+/// (FetchEventStoreStatistics.EventSequenceNumber, FetchHighestEventSequenceNumber
+/// — both read the store-global mt_events_sequence, which is never advanced
+/// under partitioning since per-tenant sequences are used instead).
+///
+/// <para>
+/// Monitoring tools (CritterWatch, dashboards) that depend on EventSequenceNumber
+/// as the event-store high-water mark have to switch to FetchMaxEventSequenceAsync
+/// under partitioning. These tests pin BOTH sides so the contract is explicit.
+/// </para>
+/// </summary>
+[Collection("guid-partitioned")]
+public class event_store_statistics_under_partitioning
+{
+    private readonly GuidPartitionedFixture _fixture;
+
+    public event_store_statistics_under_partitioning(GuidPartitionedFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task FetchEventStoreStatistics_EventCount_and_StreamCount_reflect_appends_across_all_partitions()
+    {
+        // EventCount + StreamCount run `count(*)` against mt_events / mt_streams.
+        // Under partitioning, `count(*)` scans every partition transparently, so
+        // both should grow by the expected amount after we append events.
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var db = (MartenDatabase)_fixture.Store.Storage.Database;
+        var statsBefore = await db.FetchEventStoreStatistics(token: CancellationToken.None);
+
+        // Append 1 stream, 4 events.
+        var streamId = Guid.NewGuid();
+        await using (var session = _fixture.Store.LightweightSession(tenant))
+        {
+            session.Events.StartStream<TripSnapshot>(streamId,
+                new TripStarted(streamId), new TripLeg(1), new TripLeg(2), new TripLeg(3));
+            await session.SaveChangesAsync();
+        }
+
+        var statsAfter = await db.FetchEventStoreStatistics(token: CancellationToken.None);
+
+        // Delta-based assertions — exact totals depend on sibling tests on the
+        // shared store, but the relative growth must match what we just wrote.
+        (statsAfter.EventCount - statsBefore.EventCount).ShouldBe(4L,
+            "EventCount must reflect the 4 events this test appended (count(*) scans all partitions)");
+        (statsAfter.StreamCount - statsBefore.StreamCount).ShouldBe(1L,
+            "StreamCount must reflect the 1 stream this test started");
+    }
+
+    [Fact]
+    public async Task FetchEventStoreStatistics_EventSequenceNumber_is_STALE_under_partitioning()
+    {
+        // The pin: the global mt_events_sequence is NEVER nextval'd under
+        // partitioning (per-tenant sequences are used instead). The
+        // EventSequenceNumber field of statistics reads `last_value` from that
+        // dead global sequence, so it stays at its starting value regardless
+        // of how many events have been appended store-wide.
+        //
+        // This is by-design — but monitoring tools that historically used
+        // EventSequenceNumber as the event-store high-water need to switch to
+        // FetchMaxEventSequenceAsync under partitioning. Pin the broken-by-design
+        // value so the divergence is part of the documented contract.
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        // Snapshot the global "high-water" BEFORE we append.
+        var db = (MartenDatabase)_fixture.Store.Storage.Database;
+        var globalBefore = await db.FetchHighestEventSequenceNumber(CancellationToken.None);
+        var statsBefore = await db.FetchEventStoreStatistics(token: CancellationToken.None);
+
+        // Now append 10 events to a fresh tenant.
+        await _fixture.AppendNEventsAsync(tenant, 10);
+
+        var globalAfter = await db.FetchHighestEventSequenceNumber(CancellationToken.None);
+        var statsAfter = await db.FetchEventStoreStatistics(token: CancellationToken.None);
+
+        // The global sequence is unchanged — pin the staleness.
+        globalAfter.ShouldBe(globalBefore,
+            "FetchHighestEventSequenceNumber reads the store-global sequence which is " +
+            "NEVER advanced under per-tenant partitioning — stale by design");
+        statsAfter.EventSequenceNumber.ShouldBe(statsBefore.EventSequenceNumber,
+            "FetchEventStoreStatistics.EventSequenceNumber is the same dead value " +
+            "as FetchHighestEventSequenceNumber");
+    }
+
+    [Fact]
+    public async Task FetchMaxEventSequenceAsync_returns_the_correct_high_water_under_partitioning()
+    {
+        // FetchMaxEventSequenceAsync runs `select max(seq_id) from mt_events`,
+        // which Postgres pushes down across every partition. That's the
+        // monitoring-grade high-water mark to use under per-tenant partitioning,
+        // and the spec calls it out as the replacement for the stale
+        // FetchHighestEventSequenceNumber.
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var db = (MartenDatabase)_fixture.Store.Storage.Database;
+        var maxBefore = (await db.FetchMaxEventSequenceAsync(CancellationToken.None)) ?? 0L;
+
+        // Append 3 events for the fresh tenant — its per-tenant sequence
+        // starts at 1, so its max(seq_id) jumps to 3.
+        await _fixture.AppendNEventsAsync(tenant, 3);
+
+        var maxAfter = (await db.FetchMaxEventSequenceAsync(CancellationToken.None)) ?? 0L;
+
+        // The store-global max(seq_id) must reflect at least the largest
+        // per-tenant seq_id assigned in any partition. For this fresh tenant's
+        // 3 events with seq_ids 1, 2, 3, the global max either stays at its
+        // prior value (if some other tenant has higher seq_ids) or moves to 3 —
+        // but in BOTH cases it must be > 0 once any event has been written.
+        maxAfter.ShouldBeGreaterThan(0L,
+            "FetchMaxEventSequenceAsync must return the global max(seq_id) across partitions");
+
+        // After this tenant's 3 appends, the store-global max is at least
+        // 3 — either from this tenant if no sibling has more, or higher if
+        // a sibling tenant has already written more events.
+        maxAfter.ShouldBeGreaterThanOrEqualTo(3L);
+
+        // And critically: this MUST diverge from FetchHighestEventSequenceNumber
+        // under partitioning — that's the whole point.
+        var globalSeq = await db.FetchHighestEventSequenceNumber(CancellationToken.None);
+        maxAfter.ShouldBeGreaterThan(globalSeq,
+            "FetchMaxEventSequenceAsync must diverge from the stale FetchHighestEventSequenceNumber " +
+            "under partitioning — this divergence IS the monitoring-grade pin");
+    }
+}

--- a/src/TenantPartitionedEventsTests/AppendWrite/archive_stream_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/AppendWrite/archive_stream_under_partitioning.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Exceptions;
+using Shouldly;
+using TenantPartitionedEventsTests.Fixtures;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.AppendWrite;
+
+/// <summary>
+/// #4617 section 3e — <c>ArchiveStream</c> under <c>UseTenantPartitionedEvents</c>.
+/// The <c>mt_archive_stream</c> SQL function scopes its UPDATE / INSERT / DELETE
+/// by <c>tenant_id</c> when <see cref="JasperFx.MultiTenancy.TenancyStyle.Conjoined"/>
+/// is on, so archiving one tenant's stream must not touch another tenant's
+/// stream — even when both tenants share the exact same stream id (the
+/// silent-split shape established by the AppendWrite tests).
+///
+/// <para>
+/// After archive: the owning tenant's <c>FetchStreamStateAsync.IsArchived</c>
+/// reads <c>true</c>; the other tenant's same-id stream stays
+/// <c>IsArchived = false</c>; and any re-append to the archived stream throws
+/// <see cref="InvalidStreamOperationException"/> (MT001).
+/// </para>
+/// </summary>
+[Collection("guid-partitioned")]
+public class archive_stream_under_partitioning
+{
+    private readonly GuidPartitionedFixture _fixture;
+
+    public archive_stream_under_partitioning(GuidPartitionedFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task archive_in_one_tenant_does_not_archive_same_id_stream_in_other_tenant()
+    {
+        var alpha = PartitionedFixtureBase.NewTenant();
+        var beta = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, alpha, beta);
+
+        // Both tenants start a stream with THE SAME id (independent streams in
+        // independent partitions per the silent-split pin).
+        var sharedId = Guid.NewGuid();
+        await using (var s = _fixture.Store.LightweightSession(alpha))
+        {
+            s.Events.StartStream<TripSnapshot>(sharedId, new TripStarted(sharedId), new TripLeg(1));
+            await s.SaveChangesAsync();
+        }
+        await using (var s = _fixture.Store.LightweightSession(beta))
+        {
+            s.Events.StartStream<TripSnapshot>(sharedId, new TripStarted(sharedId), new TripLeg(2));
+            await s.SaveChangesAsync();
+        }
+
+        // Archive only alpha's stream.
+        await using (var s = _fixture.Store.LightweightSession(alpha))
+        {
+            s.Events.ArchiveStream(sharedId);
+            await s.SaveChangesAsync();
+        }
+
+        // Alpha's stream state shows archived; beta's same-id stream stays live.
+        await using (var qa = _fixture.Store.QuerySession(alpha))
+        {
+            var alphaState = await qa.Events.FetchStreamStateAsync(sharedId);
+            alphaState.ShouldNotBeNull();
+            alphaState!.IsArchived.ShouldBeTrue(
+                "alpha's stream was archived — its mt_streams row must have is_archived = true");
+        }
+
+        await using (var qb = _fixture.Store.QuerySession(beta))
+        {
+            var betaState = await qb.Events.FetchStreamStateAsync(sharedId);
+            betaState.ShouldNotBeNull(
+                "beta's same-id stream must survive — archive is scoped by (tenant_id, stream_id)");
+            betaState!.IsArchived.ShouldBeFalse(
+                "beta's stream was NOT archived — its is_archived stays false despite the shared stream id");
+        }
+    }
+
+    [Fact]
+    public async Task re_append_to_archived_stream_throws_InvalidStreamOperationException()
+    {
+        // The archive function flips is_archived on mt_streams; subsequent
+        // appends hit the MT001 guard in mt_quick_append_events and surface as
+        // InvalidStreamOperationException via TryTransform.
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var streamId = Guid.NewGuid();
+        await using (var s = _fixture.Store.LightweightSession(tenant))
+        {
+            s.Events.StartStream<TripSnapshot>(streamId, new TripStarted(streamId));
+            await s.SaveChangesAsync();
+        }
+
+        await using (var s = _fixture.Store.LightweightSession(tenant))
+        {
+            s.Events.ArchiveStream(streamId);
+            await s.SaveChangesAsync();
+        }
+
+        await using (var s = _fixture.Store.LightweightSession(tenant))
+        {
+            s.Events.Append(streamId, new TripLeg(99));
+            await Should.ThrowAsync<InvalidStreamOperationException>(async () =>
+                await s.SaveChangesAsync());
+        }
+    }
+}

--- a/src/TenantPartitionedEventsTests/Config/master_table_tenancy_partitioning_gap.cs
+++ b/src/TenantPartitionedEventsTests/Config/master_table_tenancy_partitioning_gap.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Config;
+
+/// <summary>
+/// #4617 section 3d — THE GAP: combining <c>UseTenantPartitionedEvents</c>
+/// with <c>MultiTenantedDatabasesWithMasterDatabaseTable</c>
+/// (<see cref="MasterTableTenancy"/>) is unsupported, but
+/// <c>StoreOptions.Validate()</c> does NOT reject the combo at configuration
+/// time. The user-visible failure shows up later when they call
+/// <c>AddMartenManagedTenantsAsync</c> — and then again at first event append
+/// because nothing provisions the per-tenant partition / sequence in each
+/// per-tenant database. These tests pin the actual current behavior so a
+/// future fail-fast guard in <c>Validate()</c> gets intentional review rather
+/// than accidental drift.
+/// </summary>
+public class master_table_tenancy_partitioning_gap
+{
+    [Fact]
+    public void validate_does_NOT_reject_MasterTableTenancy_combined_with_partitioning()
+    {
+        // The gap: Validate's per-tenant-partitioning guards cover Rich append,
+        // non-Conjoined tenancy, and ArchivedStreamPartitioning — but NOT
+        // MasterTableTenancy. Build a fully-configured options object and call
+        // Validate(); assert it doesn't throw. If this assertion ever starts
+        // failing, the guard was finally added — update the test to assert the
+        // new throw shape instead.
+        var opts = new StoreOptions();
+        opts.MultiTenantedDatabasesWithMasterDatabaseTable(x =>
+        {
+            x.ConnectionString = ConnectionSource.ConnectionString;
+            x.SchemaName = "tp_gap_master_" + Guid.NewGuid().ToString("N")[..8];
+        });
+        opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+        opts.Events.UseTenantPartitionedEvents = true;
+        opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+
+        Should.NotThrow(() => opts.Validate(),
+            "Validate() currently does NOT reject MasterTableTenancy + UseTenantPartitionedEvents — " +
+            "the user-visible failure surfaces later. If this starts throwing, a fail-fast guard has " +
+            "been added; update the test to pin the new shape.");
+    }
+
+    [Fact]
+    public async Task AddMartenManagedTenantsAsync_throws_for_MasterTableTenancy()
+    {
+        // Once the user gets past Validate(), the next step they typically take
+        // is AddMartenManagedTenantsAsync — and that's where the actual rejection
+        // happens. Pin the exception shape (InvalidOperationException + message
+        // mentioning the supported tenancy modes) so users get a clear signal.
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedDatabasesWithMasterDatabaseTable(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "tp_gap_master_" + Guid.NewGuid().ToString("N")[..8];
+            });
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+        });
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "tenant1"));
+
+        ex.Message.ShouldContain("DefaultTenancy");
+        ex.Message.ShouldContain("ShardedTenancy");
+    }
+}

--- a/src/TenantPartitionedEventsTests/Config/single_server_multi_tenancy_partitioning_gap.cs
+++ b/src/TenantPartitionedEventsTests/Config/single_server_multi_tenancy_partitioning_gap.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Config;
+
+/// <summary>
+/// #4617 section 3d — same gap as <see cref="master_table_tenancy_partitioning_gap"/>
+/// but for <c>MultiTenantedWithSingleServer</c>
+/// (<see cref="SingleServerMultiTenancy"/>). <c>Validate()</c> doesn't reject
+/// the combo and <c>AddMartenManagedTenantsAsync</c> rejects later. Pinning
+/// both shapes so future hardening (a config-time guard) is a deliberate
+/// change rather than accidental drift.
+/// </summary>
+public class single_server_multi_tenancy_partitioning_gap
+{
+    [Fact]
+    public void validate_does_NOT_reject_SingleServerMultiTenancy_combined_with_partitioning()
+    {
+        var opts = new StoreOptions();
+        opts.MultiTenantedWithSingleServer(ConnectionSource.ConnectionString, tenancy =>
+        {
+            tenancy.WithTenants("t1", "t2").InDatabaseNamed("tp_gap_ss_" + Guid.NewGuid().ToString("N")[..8]);
+        });
+        opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+        opts.Events.UseTenantPartitionedEvents = true;
+        opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+
+        Should.NotThrow(() => opts.Validate(),
+            "Validate() currently does NOT reject SingleServerMultiTenancy + UseTenantPartitionedEvents — " +
+            "the user-visible failure surfaces later. If this starts throwing, a fail-fast guard has been " +
+            "added; update the test to pin the new shape.");
+    }
+
+    [Fact]
+    public async Task AddMartenManagedTenantsAsync_throws_for_SingleServerMultiTenancy()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithSingleServer(ConnectionSource.ConnectionString, tenancy =>
+            {
+                tenancy.WithTenants("t1", "t2").InDatabaseNamed("tp_gap_ss_" + Guid.NewGuid().ToString("N")[..8]);
+            });
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+        });
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "t1"));
+
+        ex.Message.ShouldContain("DefaultTenancy");
+        ex.Message.ShouldContain("ShardedTenancy");
+    }
+}


### PR DESCRIPTION
Seventh #4617 slice — 9 new tests across four files covering known-unsupported tenancy combinations (3d gap pins) + statistics-correctness pins + archive isolation (3e).

## 3d — Tenancy database model GAP PINS (4 tests, 2 files)

Two combinations the spec calls out as known-unsupported but missing a fail-fast guard at `Validate()` time. These pin the actual current behavior so a future hardening becomes intentional rather than a silent contract change:

### `Config/master_table_tenancy_partitioning_gap.cs` (2 tests)

- `validate_does_NOT_reject_MasterTableTenancy_combined_with_partitioning` — pins that `StoreOptions.Validate()` returns without throwing.
- `AddMartenManagedTenantsAsync_throws_for_MasterTableTenancy` — pins where the rejection actually happens (`InvalidOperationException` with a message pointing users at `DefaultTenancy` / `ShardedTenancy`).

### `Config/single_server_multi_tenancy_partitioning_gap.cs` (2 tests)

Same shape for `MultiTenantedWithSingleServer`.

## 3e — Admin / statistics / archive (5 tests, 2 files)

### `Admin/event_store_statistics_under_partitioning.cs` (3 tests)

Pins what's CORRECT vs what's KNOWN-STALE so monitoring tools (CritterWatch, dashboards) know which API to use:

| Test | Pins |
|---|---|
| `FetchEventStoreStatistics_EventCount_and_StreamCount_reflect_appends_across_all_partitions` | `count(*)` queries scan every partition transparently — accurate. Delta-based assertion. |
| `FetchEventStoreStatistics_EventSequenceNumber_is_STALE_under_partitioning` | `EventSequenceNumber` AND `FetchHighestEventSequenceNumber` both read the store-global `mt_events_sequence` which is **never advanced** under partitioning. Monitoring tools that historically used these as the high-water need to switch. |
| `FetchMaxEventSequenceAsync_returns_the_correct_high_water_under_partitioning` | `select max(seq_id) from mt_events` is the right API; assert it **diverges** from the stale `FetchHighestEventSequenceNumber` once any events have been written. The divergence IS the monitoring-grade pin. |

### `AppendWrite/archive_stream_under_partitioning.cs` (2 tests)

- `archive_in_one_tenant_does_not_archive_same_id_stream_in_other_tenant` — silent-split at the archive layer (the `mt_archive_stream` function's `AND tenant_id = ?` predicate scopes correctly).
- `re_append_to_archived_stream_throws_InvalidStreamOperationException` — MT001 from the archive guard, surfaced via `TryTransform`.

## Verified

| Suite | Before | After |
|---|---|---|
| `TenantPartitionedEventsTests` net9.0 | 102/102 | **111/111** |
| `TenantPartitionedEventsTests` net10.0 | 102/102 | **111/111** |

## Subsequent PRs per the #4617 checklist

- 3c remaining: EventProjection, FlatTableProjection, MultiStream `RollUpByTenant` + `AcrossTenants`, custom `IAggregateGrouper`, raw `IProjection`, lifecycle equivalence
- 3d remaining: `AddMartenManagedTenantsAsync(Guid[])` N-format pin, sharded one-MartenDatabase-per-shard, IDynamicTenantSource lifecycle
- 3e remaining: `DeleteAllTenantDataAsync` orphan-sequence leak pin (needs own-store), `RemoveMartenManagedTenantsAsync`, `AssertDatabaseMatchesConfigurationAsync` drift, DDL generation, `PerTenantEventSequences` schema-object correctness, AutoCreate matrix
- 3f DCB partitioned coverage
- Section 4 daemon in-depth
- Section 5 regression families
- 3a remaining (return-shapes, metadata propagation, seq_id gap, timestamp source)
- 3b deferred items

🤖 Generated with [Claude Code](https://claude.com/claude-code)