### PR TITLE
#4617 PR 9: 4 next-checklist items — DeleteAllTenantData/Remove orphan-sequence, Quick vs QuickWithServerTimestamps, seq_id gap

### DIFF
--- a/src/TenantPartitionedEventsTests/Admin/delete_all_tenant_data_orphan_sequence_pin.cs
+++ b/src/TenantPartitionedEventsTests/Admin/delete_all_tenant_data_orphan_sequence_pin.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Events;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Admin;
+
+/// <summary>
+/// #4617 section 3e — pin the orphan-sequence behavior on
+/// <c>DeleteAllTenantDataAsync(tenantId)</c>. The cleaner drops the tenant's
+/// partition tables (mt_events_&lt;tenant&gt; / mt_streams_&lt;tenant&gt;)
+/// AND deletes rows from the parent mt_events / mt_streams tables, but it
+/// does NOT drop the per-tenant <c>mt_events_sequence_&lt;tenant&gt;</c>
+/// sequence (no equivalent cleanup hook on
+/// <see cref="Marten.Internal.TenantDataCleaner"/>).
+///
+/// <para>
+/// Consequence: re-registering the same tenant id after a
+/// <c>DeleteAllTenantDataAsync</c> picks up the OLD sequence and the new
+/// events' seq_ids continue from the last value, not from 1. Pinned so a
+/// future fix that DOES drop the sequence flips the assertion intentionally.
+/// </para>
+///
+/// <para>
+/// Own-store because this test scrubs partition + sequence state in ways
+/// the shared GuidPartitionedFixture's other tests can't tolerate.
+/// </para>
+/// </summary>
+public class delete_all_tenant_data_orphan_sequence_pin : IAsyncLifetime
+{
+    private string _schema = null!;
+    private DocumentStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        _schema = $"tp_del_{Environment.ProcessId}_{Guid.NewGuid():N}".Substring(0, 32);
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync(_schema); } catch { }
+
+        _store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = _schema;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Policies.AllDocumentsAreMultiTenanted();
+
+            opts.Events.AddEventType<DelEvent>();
+        });
+
+        await _store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+    }
+
+    public Task DisposeAsync()
+    {
+        _store?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task DeleteAllTenantDataAsync_drops_partitions_but_LEAVES_the_per_tenant_sequence()
+    {
+        var tenant = "delpin";
+        await _store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        // Seed some events so the per-tenant sequence advances.
+        var streamId = Guid.NewGuid();
+        await using (var session = _store.LightweightSession(tenant))
+        {
+            session.Events.StartStream(streamId,
+                new DelEvent("a"), new DelEvent("b"), new DelEvent("c"));
+            await session.SaveChangesAsync();
+        }
+
+        var seqValueBefore = await ReadSequenceLastValueAsync(_schema, $"mt_events_sequence_{tenant}");
+        seqValueBefore.ShouldBeGreaterThanOrEqualTo(3L, "the sequence advanced past the 3 appended events");
+
+        // Act: delete all data for this tenant.
+        await _store.Advanced.DeleteAllTenantDataAsync(tenant, CancellationToken.None);
+
+        // The partition tables are gone — pinning the cleaner's positive effect.
+        var partitionExists = await TableExistsAsync(_schema, $"mt_events_{tenant}");
+        partitionExists.ShouldBeFalse(
+            "DeleteAllTenantDataAsync drops the tenant's mt_events partition table");
+
+        // The orphan-sequence pin: the per-tenant sequence is STILL THERE.
+        var seqStillExists = await SequenceExistsAsync(_schema, $"mt_events_sequence_{tenant}");
+        seqStillExists.ShouldBeTrue(
+            "DeleteAllTenantDataAsync does NOT drop the per-tenant mt_events_sequence_<tenant> " +
+            "— pinned as the documented leak. A future fix to TenantDataCleaner that DOES drop the " +
+            "sequence will flip this assertion to ShouldBeFalse and force a contract review.");
+    }
+
+    [Fact]
+    public async Task RemoveMartenManagedTenantsAsync_drops_partitions_but_LEAVES_the_per_tenant_sequence()
+    {
+        // Companion pin for RemoveMartenManagedTenantsAsync (the explicit
+        // "I no longer need this tenant" path, vs DeleteAllTenantDataAsync's
+        // "wipe this tenant's data but keep registration"). Same partition-drop
+        // but no sequence drop — same orphan leak.
+        var tenant = "rempin";
+        await _store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var streamId = Guid.NewGuid();
+        await using (var session = _store.LightweightSession(tenant))
+        {
+            session.Events.StartStream(streamId,
+                new DelEvent("x"), new DelEvent("y"));
+            await session.SaveChangesAsync();
+        }
+
+        var seqValueBefore = await ReadSequenceLastValueAsync(_schema, $"mt_events_sequence_{tenant}");
+        seqValueBefore.ShouldBeGreaterThanOrEqualTo(2L);
+
+        await _store.Advanced.RemoveMartenManagedTenantsAsync(new[] { tenant }, CancellationToken.None);
+
+        // Partition table dropped.
+        (await TableExistsAsync(_schema, $"mt_events_{tenant}")).ShouldBeFalse();
+
+        // Sequence still present — the orphan-leak pin.
+        (await SequenceExistsAsync(_schema, $"mt_events_sequence_{tenant}")).ShouldBeTrue(
+            "RemoveMartenManagedTenantsAsync drops partitions but does NOT drop the per-tenant " +
+            "mt_events_sequence_<tenant> — pinned as the documented leak");
+    }
+
+    // ----- helpers -----
+
+    private static async Task<long> ReadSequenceLastValueAsync(string schema, string sequenceName)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand(
+            "select last_value from pg_sequences where schemaname = @s and sequencename = @n");
+        cmd.Parameters.AddWithValue("s", schema);
+        cmd.Parameters.AddWithValue("n", sequenceName);
+        var raw = await cmd.ExecuteScalarAsync();
+        return raw is long v ? v : (raw is null || raw == DBNull.Value ? 0L : Convert.ToInt64(raw));
+    }
+
+    private static async Task<bool> SequenceExistsAsync(string schema, string sequenceName)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand(
+            "select count(*) from pg_sequences where schemaname = @s and sequencename = @n");
+        cmd.Parameters.AddWithValue("s", schema);
+        cmd.Parameters.AddWithValue("n", sequenceName);
+        return (long)(await cmd.ExecuteScalarAsync())! == 1L;
+    }
+
+    private static async Task<bool> TableExistsAsync(string schema, string tableName)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand(
+            "select count(*) from information_schema.tables where table_schema = @s and table_name = @t");
+        cmd.Parameters.AddWithValue("s", schema);
+        cmd.Parameters.AddWithValue("t", tableName);
+        return (long)(await cmd.ExecuteScalarAsync())! == 1L;
+    }
+}
+
+public record DelEvent(string Label);

--- a/src/TenantPartitionedEventsTests/AppendWrite/seq_id_gap_after_failed_batch.cs
+++ b/src/TenantPartitionedEventsTests/AppendWrite/seq_id_gap_after_failed_batch.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Exceptions;
+using Marten.Linq;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using TenantPartitionedEventsTests.Fixtures;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.AppendWrite;
+
+/// <summary>
+/// #4617 section 3a — pin the gap-tolerance shape on the per-tenant sequence.
+/// PostgreSQL sequences are non-transactional: <c>nextval</c> advances the
+/// sequence even if the surrounding transaction rolls back. So a failed
+/// append (e.g. MT001 archived-stream rejection) consumes seq_id values that
+/// never reach <c>mt_events</c> — the next successful append's seq_id is
+/// strictly greater than the last successful one, but there's a HOLE in
+/// between.
+///
+/// <para>
+/// Consumers reading from <c>mt_events</c> ordered by <c>seq_id</c> must be
+/// gap-tolerant. The daemon's HighWaterMark / GapDetector already handles
+/// this. Pinned here so the gap shape is part of the documented contract.
+/// </para>
+/// </summary>
+[Collection("guid-partitioned")]
+public class seq_id_gap_after_failed_batch
+{
+    private readonly GuidPartitionedFixture _fixture;
+
+    public seq_id_gap_after_failed_batch(GuidPartitionedFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task per_tenant_seq_id_is_monotonic_with_gaps_pin()
+    {
+        // PostgreSQL sequences are non-transactional — `nextval` advances the
+        // sequence even if the surrounding transaction rolls back. This test
+        // pins the consumer-facing invariant: the per-tenant sequence is
+        // strictly increasing but NOT contiguous; consumers reading mt_events
+        // ordered by seq_id must tolerate gaps.
+        //
+        // Cause-agnostic simulation: explicitly burn one nextval() to model the
+        // shape a partial-function-execution or pooled-batch-failure would
+        // leave behind. (The archived-stream MT001 path doesn't actually
+        // produce a gap — the function raises BEFORE the per-event nextval loop
+        // — so a synthetic burn is the most direct way to pin the invariant
+        // without coupling to a specific failure mode.)
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        // 1) Append one event to make the tenant's sequence active + reachable.
+        var firstStream = Guid.NewGuid();
+        long lastSeqBeforeBurn;
+        await using (var s = _fixture.Store.LightweightSession(tenant))
+        {
+            s.Events.StartStream<TripSnapshot>(firstStream, new TripStarted(firstStream));
+            await s.SaveChangesAsync();
+            var seeded = await s.Events.QueryAllRawEvents()
+                .Where(e => e.StreamId == firstStream)
+                .ToListAsync();
+            lastSeqBeforeBurn = seeded.Max(e => e.Sequence);
+        }
+
+        // 2) Burn ONE nextval directly on the per-tenant sequence — this
+        //    models the gap a partial / failed batch would produce.
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand(
+                $"select nextval('{_fixture.SchemaName}.mt_events_sequence_{tenant}')");
+            await cmd.ExecuteScalarAsync();
+        }
+
+        // 3) Successful append — its first seq_id must SKIP the burned value.
+        var nextStream = Guid.NewGuid();
+        long nextStreamFirstSeq;
+        await using (var s = _fixture.Store.LightweightSession(tenant))
+        {
+            s.Events.StartStream<TripSnapshot>(nextStream, new TripStarted(nextStream));
+            await s.SaveChangesAsync();
+            var events = await s.Events.QueryAllRawEvents()
+                .Where(e => e.StreamId == nextStream)
+                .ToListAsync();
+            nextStreamFirstSeq = events.Single().Sequence;
+        }
+
+        // The pin: the next successful seq_id is GREATER than
+        // lastSeqBeforeBurn + 1 — there's a hole that consumers must tolerate.
+        nextStreamFirstSeq.ShouldBeGreaterThan(lastSeqBeforeBurn + 1,
+            "the burned nextval consumed at least one seq_id value that never landed in " +
+            "mt_events — pin the resulting gap so consumers are reminded the per-tenant " +
+            "sequence is monotonic-with-gaps, not strictly contiguous");
+    }
+}

--- a/src/TenantPartitionedEventsTests/AppendWrite/timestamp_source_per_append_mode.cs
+++ b/src/TenantPartitionedEventsTests/AppendWrite/timestamp_source_per_append_mode.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Events;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.AppendWrite;
+
+/// <summary>
+/// #4617 section 3a — pin the timestamp source for each Quick append mode:
+///
+/// <list type="bullet">
+///   <item><c>EventAppendMode.Quick</c> — the function uses server
+///     <c>now() at time zone 'utc'</c> for every event's timestamp; caller's
+///     <c>IEvent.Timestamp</c> is ignored.</item>
+///   <item><c>EventAppendMode.QuickWithServerTimestamps</c> — despite the
+///     name, the function honors the caller's <c>IEvent.Timestamp</c> via
+///     the <c>timestamps[index]</c> array parameter.</item>
+/// </list>
+///
+/// <para>
+/// Each test builds its own store because <c>AppendMode</c> is a store-level
+/// config switch. The Quick mode pin couldn't run on the shared
+/// QuickWithServerTimestamps fixture without subverting it.
+/// </para>
+/// </summary>
+public class timestamp_source_per_append_mode
+{
+    private static async Task<DocumentStore> BuildStoreAsync(EventAppendMode mode, string schema)
+    {
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            try { await conn.DropSchemaAsync(schema); } catch { }
+        }
+
+        var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = schema;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = mode;
+            opts.Policies.AllDocumentsAreMultiTenanted();
+            opts.Events.AddEventType<TickEvent>();
+        });
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+        return store;
+    }
+
+    [Fact]
+    public async Task Quick_mode_uses_server_now_and_ignores_caller_timestamp()
+    {
+        var schema = $"tp_ts_q_{Environment.ProcessId}_{Guid.NewGuid():N}".Substring(0, 32);
+        await using var store = await BuildStoreAsync(EventAppendMode.Quick, schema);
+        await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "tq");
+
+        // A caller-supplied timestamp deliberately set in 1900 — the Quick
+        // function should IGNORE this and use server now() instead.
+        var bogus = new DateTimeOffset(1900, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var streamId = Guid.NewGuid();
+        var sentAtUtc = DateTimeOffset.UtcNow;
+        await using (var session = store.LightweightSession("tq"))
+        {
+            // Use the IEvent envelope to set Timestamp explicitly.
+            var envelope = new Event<TickEvent>(new TickEvent("alpha")) { Timestamp = bogus };
+            session.Events.StartStream(streamId, envelope);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession("tq");
+        var fetched = await query.Events.FetchStreamAsync(streamId);
+        var serverTs = fetched.Single().Timestamp;
+
+        serverTs.Year.ShouldBeGreaterThan(2000,
+            "Quick mode must IGNORE caller Timestamp and use server now() — observed year proves we got server time, not the 1900 sentinel");
+        Math.Abs((serverTs - sentAtUtc).TotalMinutes).ShouldBeLessThan(5,
+            "Quick mode's server now() must be close (within a few minutes) to when the test sent the append");
+    }
+
+    [Fact]
+    public async Task QuickWithServerTimestamps_mode_honors_caller_supplied_timestamp()
+    {
+        var schema = $"tp_ts_qst_{Environment.ProcessId}_{Guid.NewGuid():N}".Substring(0, 32);
+        await using var store = await BuildStoreAsync(EventAppendMode.QuickWithServerTimestamps, schema);
+        await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "tqst");
+
+        // Despite the mode's name, this branch HONORS the caller's Timestamp.
+        var caller = new DateTimeOffset(2010, 6, 15, 12, 30, 0, TimeSpan.Zero);
+
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession("tqst"))
+        {
+            var envelope = new Event<TickEvent>(new TickEvent("beta")) { Timestamp = caller };
+            session.Events.StartStream(streamId, envelope);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession("tqst");
+        var fetched = await query.Events.FetchStreamAsync(streamId);
+        var roundTripped = fetched.Single().Timestamp;
+
+        // Postgres timestamp-with-time-zone has microsecond precision; the
+        // round-trip should preserve the year/month/day exactly.
+        roundTripped.Year.ShouldBe(2010);
+        roundTripped.Month.ShouldBe(6);
+        roundTripped.Day.ShouldBe(15);
+    }
+}
+
+public record TickEvent(string Label);


### PR DESCRIPTION
Ninth #4617 slice — 5 tests across three files, covering 4 distinct checklist items.

## Item 1+2 — 3e DeleteAllTenantDataAsync + RemoveMartenManagedTenantsAsync orphan-sequence leak pin

### `Admin/delete_all_tenant_data_orphan_sequence_pin.cs` (2 tests, own-store)

Both admin paths drop the tenant's partition tables (`mt_events_<tenant>` / `mt_streams_<tenant>`) AND delete rows from the parent tables, but **neither drops the per-tenant `mt_events_sequence_<tenant>` sequence** — no equivalent cleanup hook on `TenantDataCleaner` / `RemoveMartenManagedTenantsAsync`.

Consequence: re-registering the same tenant id after a cleanup picks up the **OLD** sequence and the new events' seq_ids continue from the last value, not from 1. Pinned so a future fix that DOES drop the sequence flips the assertion intentionally rather than silently changing the contract.

- `DeleteAllTenantDataAsync_drops_partitions_but_LEAVES_the_per_tenant_sequence`
- `RemoveMartenManagedTenantsAsync_drops_partitions_but_LEAVES_the_per_tenant_sequence`

## Item 3 — 3a Quick vs QuickWithServerTimestamps timestamp source

### `AppendWrite/timestamp_source_per_append_mode.cs` (2 tests, own-stores per mode)

Pins the documented contract for each Quick append mode's timestamp source:

- `Quick_mode_uses_server_now_and_ignores_caller_timestamp` — caller-supplied `Timestamp` (deliberately set to 1900-01-01) is IGNORED; the function uses server `now() at time zone 'utc'` so the persisted timestamp lands in the current decade, within minutes of when the test fired.
- `QuickWithServerTimestamps_mode_honors_caller_supplied_timestamp` — despite the mode's name, this branch HONORS the caller's `Timestamp`; round-trip preserves the year/month/day exactly.

## Item 4 — 3a per-tenant seq_id is monotonic-with-gaps

### `AppendWrite/seq_id_gap_after_failed_batch.cs` (1 test, shared fixture)

PostgreSQL sequences are non-transactional — `nextval` advances the sequence even if the surrounding transaction rolls back. Pins the consumer-facing invariant: **the per-tenant sequence is strictly increasing but NOT contiguous**; consumers reading `mt_events` ordered by `seq_id` must tolerate gaps.

Cause-agnostic: the archived-stream MT001 path doesn't actually produce a gap (the function raises BEFORE the per-event `nextval` loop), so the test **synthetically burns one `nextval`** to model the shape a partial-function-execution or pooled-batch-failure would leave behind. The pin is about the **consumer-side contract** — gap-tolerance — not the specific failure mode.

## Verified

| Suite | Before | After |
|---|---|---|
| `TenantPartitionedEventsTests` net9.0 | 118/118 | **123/123** |
| `TenantPartitionedEventsTests` net10.0 | 118/118 | **123/123** |

## Subsequent PRs per the #4617 checklist

- 3c remaining: EventProjection, FlatTableProjection, MultiStream `RollUpByTenant` + `AcrossTenants`, custom `IAggregateGrouper`, raw `IProjection`, lifecycle equivalence
- 3d remaining: `AddMartenManagedTenantsAsync(Guid[])` N-format, sharded one-DB-per-shard, `IDynamicTenantSource` lifecycle
- 3e remaining: `AssertDatabaseMatchesConfigurationAsync` drift, DDL generation, `PerTenantEventSequences` schema-object correctness, AutoCreate matrix
- 3f DCB partitioned coverage
- Section 4 daemon in-depth
- Section 5 remaining: 42P01 / 42P16 / 42P07 / MT002-rebuild regression families
- 3b deferred items

🤖 Generated with [Claude Code](https://claude.com/claude-code)