### PR TITLE
Fix #4619 — mt_archive_stream uses explicit column list to survive ALTER TABLE ADD COLUMN

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4619_archive_stream_explicit_column_list_after_column_add.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4619_archive_stream_explicit_column_list_after_column_add.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+/// <summary>
+/// #4619 — mt_archive_stream emits INSERT INTO mt_events / mt_streams without
+/// an explicit column list, relying on positional alignment between the in-memory
+/// EventsTable / StreamsTable model and the physical table. ALTER TABLE ADD
+/// COLUMN appends physically at the END (Postgres can't reposition columns),
+/// so after any column-add migration the model order diverges from the physical
+/// order — and the positional INSERT misaligns. The user-visible failure
+/// (introduced by the #4515 bdata column addition on upgrade) is:
+///
+/// <code>
+/// 42804: column "timestamp" is of type timestamp with time zone but expression
+///   is of type character varying
+///   Where: PL/pgSQL function mt_archive_stream(character varying) line 4 at
+///     SQL statement
+/// </code>
+///
+/// <para>
+/// Repro: simulate the upgrade by manually appending a no-op column to
+/// mt_events after schema creation, then archive a stream. With the fix
+/// (explicit column list on both INSERT target and SELECT source), the archive
+/// is robust to physical-order drift.
+/// </para>
+/// </summary>
+public class Bug_4619_archive_stream_explicit_column_list_after_column_add
+{
+    [Fact]
+    public async Task archive_stream_succeeds_after_a_post_creation_column_add()
+    {
+        var schema = $"bug4619_{Environment.ProcessId}_{Guid.NewGuid():N}".Substring(0, 32);
+
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            try { await conn.DropSchemaAsync(schema); } catch { }
+        }
+
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = schema;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            // UseArchivedStreamPartitioning routes archives through the bulk
+            // function variant (writeWithPartitioning) — the broken positional
+            // INSERT path. Without this flag the simple UPDATE path is used
+            // and the bug doesn't trigger.
+            opts.Events.UseArchivedStreamPartitioning = true;
+
+            opts.Events.AddEventType<ArchiveProbeEvent>();
+        });
+
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+
+        // Seed a stream.
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new ArchiveProbeEvent("first"));
+            await session.SaveChangesAsync();
+        }
+
+        // Simulate the reporter's upgrade scenario directly: drop bdata from the
+        // physical mt_events table and re-add it. Postgres ALTER TABLE ADD COLUMN
+        // always appends physically at the end (it can't reposition columns), so
+        // after this round-trip the model still has bdata at position 4 (after
+        // `data`) but the physical layout has bdata at the END — exactly the
+        // shape an upgrade to Marten 9.5.1 produces on a pre-9.5.1 mt_events
+        // table. From position 5 (`type` in model) onward, model and physical
+        // column orders diverge by one, and the positional INSERT in
+        // mt_archive_stream misaligns column-by-column.
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.CreateCommand($"alter table {schema}.mt_events drop column bdata").ExecuteNonQueryAsync();
+            await conn.CreateCommand($"alter table {schema}.mt_events add column bdata bytea null").ExecuteNonQueryAsync();
+        }
+
+        // Archive — the positional INSERT inside mt_archive_stream would
+        // misalign by one column and trip 42804. With the fix (explicit
+        // column list), the SELECT and INSERT both name the columns
+        // explicitly so the appended column is harmlessly excluded.
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.ArchiveStream(streamId);
+            await session.SaveChangesAsync();
+        }
+
+        // Sanity: the stream is archived.
+        await using (var query = store.QuerySession())
+        {
+            var state = await query.Events.FetchStreamStateAsync(streamId);
+            state.ShouldNotBeNull();
+            state!.IsArchived.ShouldBeTrue();
+        }
+    }
+
+    public record ArchiveProbeEvent(string Label);
+}

--- a/src/Marten/Events/Archiving/ArchiveStreamFunction.cs
+++ b/src/Marten/Events/Archiving/ArchiveStreamFunction.cs
@@ -46,18 +46,44 @@ internal class ArchiveStreamFunction: Function
 
     private void writeWithPartitioning(TextWriter writer, string argList, string tenantWhere)
     {
-        var eventColumns = new EventsTable(_events).Columns.Where(x => x.Name != IsArchivedColumn.ColumnName)
-            .Select(x => x.Name).Join(", ");
+        // #4619: emit an EXPLICIT column list on both the INSERT target AND the
+        // SELECT source. The previous implementation relied on positional
+        // ordering — the SELECT enumerated columns from the in-memory
+        // EventsTable/StreamsTable model and the INSERT had no target column
+        // list. That works on a freshly-created table where the model order
+        // matches the physical order, but breaks the moment ALTER TABLE ADD
+        // COLUMN appends a new column at the end of an existing table (PG
+        // can't reposition columns), shifting the positional alignment by one.
+        // The #4515 bdata column added at model position 3 reproduces this on
+        // any upgrade: physical layout is `... data, type, timestamp, ...,
+        // bdata` while the model + SELECT walks `... data, bdata, type,
+        // timestamp, ...`, so the timestamptz `timestamp` column receives the
+        // varchar `type` value → 42804. Naming the columns on both sides
+        // makes the function robust to physical-order drift forever.
+        var eventColumnNames = new EventsTable(_events).Columns
+            .Where(x => x.Name != IsArchivedColumn.ColumnName)
+            .Select(x => x.Name)
+            .ToList();
+        var eventColumnList = eventColumnNames.Join(", ");
+        var eventInsertColumns = eventColumnNames
+            .Append(IsArchivedColumn.ColumnName)
+            .Join(", ");
 
-        var streamColumns = new StreamsTable(_events).Columns.Where(x => x.Name != IsArchivedColumn.ColumnName)
-            .Select(x => x.Name).Join(", ");
+        var streamColumnNames = new StreamsTable(_events).Columns
+            .Where(x => x.Name != IsArchivedColumn.ColumnName)
+            .Select(x => x.Name)
+            .ToList();
+        var streamColumnList = streamColumnNames.Join(", ");
+        var streamInsertColumns = streamColumnNames
+            .Append(IsArchivedColumn.ColumnName)
+            .Join(", ");
 
         writer.WriteLine($@"
 CREATE OR REPLACE FUNCTION {_events.DatabaseSchemaName}.{Name}({argList}) RETURNS VOID LANGUAGE plpgsql AS
 $function$
 BEGIN
-  insert into {_events.DatabaseSchemaName}.mt_streams select {streamColumns}, TRUE from {_events.DatabaseSchemaName}.mt_streams where id = streamid {tenantWhere};
-  insert into {_events.DatabaseSchemaName}.mt_events select {eventColumns}, TRUE from {_events.DatabaseSchemaName}.mt_events where stream_id = streamid {tenantWhere};
+  insert into {_events.DatabaseSchemaName}.mt_streams ({streamInsertColumns}) select {streamColumnList}, TRUE from {_events.DatabaseSchemaName}.mt_streams where id = streamid {tenantWhere};
+  insert into {_events.DatabaseSchemaName}.mt_events ({eventInsertColumns}) select {eventColumnList}, TRUE from {_events.DatabaseSchemaName}.mt_events where stream_id = streamid {tenantWhere};
   delete from {_events.DatabaseSchemaName}.mt_events where stream_id = streamid and {IsArchivedColumn.ColumnName} = FALSE {tenantWhere};
   delete from {_events.DatabaseSchemaName}.mt_streams where id = streamid and {IsArchivedColumn.ColumnName} = FALSE {tenantWhere};
 END;


### PR DESCRIPTION
Fixes #4619. The user-visible symptom is archiving a stream on an existing event store after upgrading to Marten 9.5.1 (which added the `bdata` column via #4515) failing with:

```
42804: column \"timestamp\" is of type timestamp with time zone but expression is of type character varying
  Where: PL/pgSQL function <schema>.mt_archive_stream(character varying) line 4 at SQL statement
```

## Root cause

`ArchiveStreamFunction.writeWithPartitioning` generated:

```sql
insert into <schema>.mt_streams select {streamColumns}, TRUE from <schema>.mt_streams where id = streamid;
insert into <schema>.mt_events  select {eventColumns},  TRUE from <schema>.mt_events  where stream_id = streamid;
```

with NO explicit target column list. The SELECT enumerated columns from the in-memory `EventsTable` / `StreamsTable` model. The INSERT (without a column list) is **positional** — values are assigned to physical-table columns by ordinal.

`ALTER TABLE ADD COLUMN` appends physically at the END (Postgres can't reposition a column), so after any column-add migration the model order diverges from the physical order, and the positional INSERT misaligns column-by-column. The `bdata` column added at model position 4 by #4515 reproduces this on every existing mt_events table that gets upgraded: SELECT walks `… data, bdata, type, timestamp, …` while the INSERT writes positionally into `… data, type, timestamp, …, bdata`. The timestamptz `timestamp` column receives the varchar `type` value → 42804.

## Fix

Emit **explicit column lists** on both the INSERT target AND the SELECT source. Naming the columns makes the function robust to physical-order drift permanently — a future column-add (or anything that reorders the physical layout) won't shift the alignment.

```sql
insert into mt_streams ({streamInsertColumns}) select {streamColumnList}, TRUE from mt_streams where id = streamid;
insert into mt_events  ({eventInsertColumns})  select {eventColumnList},  TRUE from mt_events  where stream_id = streamid;
```

## Regression test

`src/EventSourcingTests/Bugs/Bug_4619_archive_stream_explicit_column_list_after_column_add.cs` reproduces the user's scenario directly: build a partitioned-archive store, seed a stream, then drop-and-re-add `bdata` (which physically moves it to the end of `mt_events` while the model keeps it at position 4 — exactly the shape an upgrade from pre-9.5.1 to 9.5.1 produces), then `ArchiveStream`.

- **Verified pre-fix**: the test FAILS with the EXACT `42804: column \"timestamp\" is of type timestamp with time zone but expression is of type character varying` from the issue.
- **Verified post-fix**: the test PASSES; the `IsArchived` flag round-trips correctly.
- **Regression sweep**: archive-related tests in `EventSourcingTests` — 29 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)