### PR TITLE
Fix #4625 — BulkInsertEventsAsync writes mt_streams.type from AggregateType

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4625_bulk_insert_events_derives_aggregate_type_name.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4625_bulk_insert_events_derives_aggregate_type_name.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+/// <summary>
+/// #4625 — <c>BulkInsertEventsAsync</c> (via <c>BulkEventAppender</c>) writes
+/// <c>mt_streams.type</c> from <c>StreamAction.AggregateTypeName</c>, but never
+/// derives that string from the public <c>StreamAction.AggregateType</c>. The
+/// only path that populates <c>AggregateTypeName</c> is
+/// <c>StreamAction.PrepareEvents</c> — and that's NOT called on the bulk path
+/// (it would also dequeue sequence values + assign Sequence/Version/Timestamp,
+/// work the bulk importer does itself). Result: bulk-inserting a stream with
+/// <c>action.AggregateType = typeof(T)</c> set produces <c>mt_streams.type = NULL</c>.
+///
+/// <para>
+/// Under <c>UseMandatoryStreamTypeDeclaration</c>, the migrated stream then
+/// has no type, so subsequent appends are rejected and the stream can't
+/// participate in single-stream aggregation by type. Fix: derive
+/// <c>AggregateTypeName</c> from <c>AggregateType</c> in <c>BulkEventAppender</c>
+/// before writing the row, so the public API surface is honored without
+/// callers needing to reach for the <c>internal set</c>.
+/// </para>
+/// </summary>
+public class Bug_4625_bulk_insert_events_derives_aggregate_type_name
+{
+    [Fact]
+    public async Task BulkInsertEventsAsync_writes_mt_streams_type_from_AggregateType()
+    {
+        var schema = $"bug4625_{Environment.ProcessId}_{Guid.NewGuid():N}".Substring(0, 32);
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            try { await conn.DropSchemaAsync(schema); } catch { }
+        }
+
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = schema;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.AddEventType<SomethingHappened>();
+        });
+
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+
+        // The repro shape from the issue: build a StreamAction explicitly, set
+        // AggregateType via the PUBLIC setter (not the internal AggregateTypeName
+        // setter), and bulk-insert. Pre-fix, mt_streams.type ends up NULL.
+        var streamKey = "stream-" + Guid.NewGuid().ToString("N")[..10];
+        var action = StreamAction.Start(store.Events, streamKey, new SomethingHappened("first"));
+        action.AggregateType = typeof(MyAggregate);
+        action.TenantId = "alpha";
+
+        await store.BulkInsertEventsAsync("alpha", new[] { action });
+
+        // Read mt_streams.type back directly — assert it carries the alias.
+        await using var conn2 = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn2.OpenAsync();
+        await using var cmd = conn2.CreateCommand(
+            $"select type from {schema}.mt_streams where id = @id and tenant_id = @tid");
+        cmd.Parameters.AddWithValue("id", streamKey);
+        cmd.Parameters.AddWithValue("tid", "alpha");
+        var typeName = (string?)await cmd.ExecuteScalarAsync();
+
+        typeName.ShouldNotBeNull(
+            "BulkInsertEventsAsync must derive mt_streams.type from StreamAction.AggregateType — " +
+            "pre-fix this was NULL because BulkEventAppender only ever read AggregateTypeName " +
+            "(which is populated only inside StreamAction.PrepareEvents, NOT called on the bulk path)");
+        typeName.ShouldBe(store.Events.AggregateAliasFor(typeof(MyAggregate)));
+    }
+
+    [Fact]
+    public async Task bulk_inserted_stream_with_AggregateType_supports_subsequent_Append_under_mandatory_stream_type_declaration()
+    {
+        // The downstream consequence the issue calls out: with
+        // UseMandatoryStreamTypeDeclaration on, a bulk-inserted stream whose
+        // type was lost (NULL) can't take any further appends — the mandatory
+        // guard fires on every subsequent operation. Post-fix, the bulk-inserted
+        // stream's type IS set, so appends work.
+        var schema = $"bug4625b_{Environment.ProcessId}_{Guid.NewGuid():N}".Substring(0, 32);
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            try { await conn.DropSchemaAsync(schema); } catch { }
+        }
+
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = schema;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseMandatoryStreamTypeDeclaration = true;
+            opts.Events.AddEventType<SomethingHappened>();
+        });
+
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+
+        var streamKey = "stream-" + Guid.NewGuid().ToString("N")[..10];
+        var action = StreamAction.Start(store.Events, streamKey, new SomethingHappened("first"));
+        action.AggregateType = typeof(MyAggregate);
+        action.TenantId = "alpha";
+
+        await store.BulkInsertEventsAsync("alpha", new[] { action });
+
+        // Now append more events to the bulk-inserted stream — must succeed
+        // because mt_streams.type was correctly set to the MyAggregate alias.
+        await using var session = store.LightweightSession("alpha");
+        session.Events.Append(streamKey, new SomethingHappened("second"));
+        await session.SaveChangesAsync();
+
+        await using var query = store.QuerySession("alpha");
+        var events = await query.Events.FetchStreamAsync(streamKey);
+        events.Count.ShouldBe(2);
+    }
+
+    public record SomethingHappened(string Label);
+
+    public class MyAggregate
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Label { get; set; } = string.Empty;
+    }
+}

--- a/src/Marten/Events/BulkEventAppender.cs
+++ b/src/Marten/Events/BulkEventAppender.cs
@@ -183,9 +183,32 @@ internal class BulkEventAppender
             await writer.WriteAsync(stream.Key!, NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
         }
 
-        if (stream.AggregateTypeName != null)
+        // #4625: BulkInsertEventsAsync writes mt_streams.type from
+        // AggregateTypeName, but that string is only ever populated inside
+        // StreamAction.PrepareEvents (which is NOT called on the bulk path —
+        // PrepareEvents also dequeues sequence values and assigns
+        // Sequence/Version/Timestamp, work the bulk importer does itself).
+        // So a caller that does the documented thing —
+        //   var action = StreamAction.Start(events, key, …);
+        //   action.AggregateType = typeof(MyAggregate);
+        //   await store.BulkInsertEventsAsync(tenant, new[] { action });
+        // — would end up with mt_streams.type = NULL, breaking later appends
+        // under UseMandatoryStreamTypeDeclaration. Derive the alias here so
+        // the public API surface (AggregateType) is honored without making
+        // callers reach for the internal AggregateTypeName setter.
+        // AggregateTypeName has an internal set scoped to JasperFx.Events so
+        // we can't assign it from Marten — compute a local fallback string
+        // and write THAT instead. Future-proofing: if AggregateTypeName is
+        // ever already set (e.g. caller round-tripped a fully-prepared action),
+        // honor that value first.
+        var aggregateTypeName = stream.AggregateTypeName
+                                ?? (stream.AggregateType != null
+                                    ? _events.AggregateAliasFor(stream.AggregateType)
+                                    : null);
+
+        if (aggregateTypeName != null)
         {
-            await writer.WriteAsync(stream.AggregateTypeName, NpgsqlDbType.Varchar, cancellation)
+            await writer.WriteAsync(aggregateTypeName, NpgsqlDbType.Varchar, cancellation)
                 .ConfigureAwait(false);
         }
         else


### PR DESCRIPTION
Fixes #4625.

## Problem

`BulkEventAppender.writeStreamRow` reads `mt_streams.type` from `StreamAction.AggregateTypeName` — but that string is **only** ever populated inside `StreamAction.PrepareEvents`, which is NOT called on the bulk path (PrepareEvents also dequeues sequence values and assigns Sequence / Version / Timestamp, work the bulk importer does itself).

So a caller following the documented pattern —

```csharp
var action = StreamAction.Start(events, key, …);
action.AggregateType = typeof(MyAggregate);
await store.BulkInsertEventsAsync(tenant, new[] { action });
```

— lands `mt_streams.type = NULL` despite explicitly setting `AggregateType` via the public setter.

The downstream consequence: subsequent appends to that stream are rejected under `UseMandatoryStreamTypeDeclaration` (no type ⇒ no aggregate identity), and the stream can't participate in single-stream aggregation by type.

## Fix

In `BulkEventAppender.writeStreamRow`, compute a local fallback that honors the public `AggregateType` setter via `EventGraph.AggregateAliasFor`:

```csharp
var aggregateTypeName = stream.AggregateTypeName
                        ?? (stream.AggregateType != null
                            ? _events.AggregateAliasFor(stream.AggregateType)
                            : null);
```

Done as a local rather than mutating `StreamAction.AggregateTypeName` because that property's setter is `internal` to `JasperFx.Events` — Marten can't set it from outside the assembly. The local-fallback approach:

1. Honors `AggregateTypeName` if already set (future-proofing for callers that round-trip a fully-prepared action).
2. Derives the alias from `AggregateType` via `_events.AggregateAliasFor` when only `AggregateType` is set (the issue's repro shape).
3. Writes NULL when neither is set (the pre-fix behavior for genuinely untyped streams).

## Regression tests

`src/EventSourcingTests/Bugs/Bug_4625_bulk_insert_events_derives_aggregate_type_name.cs`:

- `BulkInsertEventsAsync_writes_mt_streams_type_from_AggregateType` — exact repro from the issue (string identity, conjoined, Quick). Reads `mt_streams.type` directly via raw SQL, asserts it equals `AggregateAliasFor(typeof(MyAggregate))`.
- `bulk_inserted_stream_with_AggregateType_supports_subsequent_Append_under_mandatory_stream_type_declaration` — pins the downstream consequence: post-fix, the bulk-inserted stream takes a subsequent `Append` under `UseMandatoryStreamTypeDeclaration`.

**Verified pre-fix**: both tests fail with the documented shape (`mt_streams.type` NULL + later append throws).
**Verified post-fix**: both pass.
**Bulk-insert regression sweep**: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)