### PR TITLE
Fix #4645 — tighten DCB tag-query JOIN with tenant_id under partitioning

### DIFF
--- a/src/Marten/Events/EventStore.Dcb.cs
+++ b/src/Marten/Events/EventStore.Dcb.cs
@@ -159,6 +159,27 @@ internal partial class EventStore
                 sb.Append(" on e.seq_id = t");
                 sb.Append(i);
                 sb.Append(".seq_id");
+
+                // #4645: under UseTenantPartitionedEvents the per-tenant
+                // mt_events_sequence_{suffix} sequences make seq_id alone
+                // non-unique across tenants — seq_id=1 exists in EVERY tenant's
+                // mt_events partition. Without the tenant_id JOIN predicate
+                // alpha's event row matches BOTH alpha's tag row AND beta's
+                // tag row sharing the same seq_id, duplicating alpha's event
+                // in the result. The trailing `e.tenant_id = @p` filter only
+                // constrains the events side and doesn't deduplicate.
+                //
+                // Only emit the predicate under conjoined tenancy — that's the
+                // only mode where EventTagTable carries a tenant_id column
+                // (see EventTagTable.cs). For non-conjoined tenancy seq_id IS
+                // unique store-wide (single global mt_events_sequence) so the
+                // predicate isn't needed anyway.
+                if (_store.Events.TenancyStyle == TenancyStyle.Conjoined)
+                {
+                    sb.Append(" and e.tenant_id = t");
+                    sb.Append(i);
+                    sb.Append(".tenant_id");
+                }
             }
         }
 

--- a/src/TenantPartitionedEventsTests/Dcb/dcb_cross_tenant_query_isolation_pin.cs
+++ b/src/TenantPartitionedEventsTests/Dcb/dcb_cross_tenant_query_isolation_pin.cs
@@ -18,37 +18,34 @@ using Xunit;
 namespace TenantPartitionedEventsTests.Dcb;
 
 /// <summary>
-/// #4617 section 3f deferred — pin the currently-BROKEN cross-tenant query
-/// isolation for DCB <see cref="DcbStorageMode.TagTables"/> mode under
-/// <c>UseTenantPartitionedEvents</c>.
+/// #4617 section 3f — pin cross-tenant query isolation for DCB
+/// <see cref="DcbStorageMode.TagTables"/> mode under
+/// <c>UseTenantPartitionedEvents</c>. Verifies the #4645 fix.
 ///
 /// <para>
-/// Root cause (Marten/Events/EventStore.Dcb.cs:159–161): the non-HStore tag
-/// query path joins
+/// Pre-fix bug (Marten/Events/EventStore.Dcb.cs:159–161): the non-HStore tag
+/// query path joined
 /// <code>from mt_events e left join mt_event_tag_xxx t on e.seq_id = t.seq_id</code>
-/// Under <c>UseTenantPartitionedEvents</c> the per-tenant
-/// <c>mt_events_sequence_{suffix}</c> sequences mean <c>seq_id = 1</c> exists
-/// in EVERY tenant's mt_events partition. The trailing <c>e.tenant_id = @p</c>
-/// filter only constrains the events side, so alpha's event row gets joined
-/// to BOTH alpha's tag row AND beta's tag row (both have seq_id 1) — the
-/// result set duplicates alpha's event N-ways where N = the number of
-/// tenants that happen to share that tag value with the same per-tenant
-/// seq_id. The leak shape is DUPLICATED-OWN-EVENTS, not cross-tenant DATA
-/// bleed (the WHERE filter still scrubs other tenants' event rows), but
-/// it's still incorrect.
+/// Under per-tenant <c>mt_events_sequence_{suffix}</c> sequences <c>seq_id=1</c>
+/// existed in EVERY tenant's mt_events partition, so alpha's event row got
+/// joined to BOTH alpha's tag row AND beta's tag row, duplicating alpha's
+/// event N-ways in the result set. The leak shape was DUPLICATED-OWN-EVENTS
+/// rather than cross-tenant DATA bleed (the trailing <c>e.tenant_id = @p</c>
+/// WHERE filter scrubbed other tenants' event rows) — still incorrect.
 /// </para>
 ///
 /// <para>
-/// SUT fix needed: tighten the JOIN to <c>on e.seq_id = t.seq_id AND
-/// e.tenant_id = t.tenant_id</c> (the tag table's PK already includes
-/// tenant_id under conjoined tenancy, so the predicate is well-defined).
+/// Fix: tightened the JOIN to also require <c>e.tenant_id = t.tenant_id</c>
+/// under conjoined tenancy (the tag table's PK includes tenant_id, so the
+/// predicate is well-defined). For non-conjoined tenancy the tag table
+/// doesn't have a tenant_id column AND seq_id is unique store-wide via the
+/// single global mt_events_sequence — predicate is skipped there.
 /// </para>
 ///
 /// <para>
-/// Pin captures the CURRENT broken behavior so the SUT fix flips this
-/// assertion intentionally. <see cref="DcbStorageMode.HStore"/> is unaffected
-/// because the tag predicate is on the event row itself, not a JOIN. The
-/// theory only covers <c>TagTables</c> to keep the broken-state pin focused.
+/// <see cref="DcbStorageMode.HStore"/> is unaffected because the tag predicate
+/// is on the event row itself, not a JOIN. The theory only covers
+/// <c>TagTables</c> to keep the pin focused on the path that was broken.
 /// </para>
 /// </summary>
 public class dcb_cross_tenant_query_isolation_pin : IAsyncLifetime
@@ -94,17 +91,18 @@ public class dcb_cross_tenant_query_isolation_pin : IAsyncLifetime
     }
 
     [Fact]
-    public async Task tag_query_under_partitioning_currently_BLEEDS_across_tenants_pin()
+    public async Task tag_query_under_partitioning_returns_only_own_tenant_event()
     {
         // BOTH tenants tag an event with the SAME customer id string. Because
         // each tenant's per-tenant mt_events_sequence_{suffix} starts at 1,
         // both events end up with seq_id = 1 in their respective partitions.
         //
-        // Tenant A's tag query for that customer SHOULD see only tenant A's
-        // event. Today it sees BOTH because the JOIN matches on seq_id alone.
+        // Tenant A's tag query for that customer must see ONLY tenant A's
+        // event — the #4645 fix tightened the JOIN to also match on tenant_id
+        // so the per-tenant-seq-id collision no longer produces a duplicate
+        // (or — if the WHERE clause hadn't held — a cross-tenant leak).
         await _store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "alpha", "beta");
 
-        // Pick a tag value both tenants will register.
         var sharedCustomer = new DcbXtCustomerId(Guid.NewGuid());
 
         await using (var session = _store.LightweightSession("alpha"))
@@ -123,36 +121,20 @@ public class dcb_cross_tenant_query_isolation_pin : IAsyncLifetime
             await session.SaveChangesAsync();
         }
 
-        // Query from alpha — under correct behavior we should see only the
-        // ALPHA-PAYMENT event. Today the broken JOIN bleeds beta's event in.
         var query = new EventTagQuery().Or<DcbXtCustomerId>(sharedCustomer);
 
         await using var alphaQuery = _store.LightweightSession("alpha");
         var events = await alphaQuery.Events.QueryByTagsAsync(query);
 
-        // PIN — broken state. EventStore.Dcb.cs:159 JOIN is on `e.seq_id =
-        // t.seq_id` only; under per-tenant sequences alpha's event row joins
-        // BOTH alpha's tag row AND beta's tag row, duplicating alpha's event
-        // in the result. The WHERE filter `e.tenant_id = @p` scrubs beta's
-        // EVENTS but doesn't deduplicate the join product.
-        //
-        // Future SUT fix tightens the JOIN:
-        //     on e.seq_id = t.seq_id AND e.tenant_id = t.tenant_id
-        // Once applied, this assertion flips to `events.Count.ShouldBe(1)`.
-        events.Count.ShouldBeGreaterThan(1,
-            "EXPECTED-FAILURE PIN: under the broken JOIN, alpha's event row gets duplicated by " +
-            "the cross-tenant tag-row match (per-tenant seq_id 1 exists in both partitions). " +
-            "Fix: tighten EventStore.Dcb.cs:159 JOIN to also require e.tenant_id = t.tenant_id. " +
-            "When fixed, flip this to events.Count.ShouldBe(1) and drop the deduplication sub-pin below.");
+        // Exactly one row — alpha's own event. The fix to EventStore.Dcb.cs:
+        // adding `AND e.tenant_id = t.tenant_id` to the JOIN means alpha's
+        // event row no longer multiplies through beta's tag row.
+        events.Count.ShouldBe(1,
+            "alpha's tag query must return ONLY alpha's own matching event under partitioning — " +
+            "duplication via cross-tenant seq_id collision was fixed in #4645 by tightening the JOIN");
 
-        // Sub-pin: every row returned IS alpha's data (the WHERE filter still
-        // scrubs beta's event rows from the result — leak is duplication, not
-        // cross-tenant data bleed). All rows have Reference == "ALPHA-PAYMENT".
-        foreach (var e in events)
-        {
-            e.TenantId.ShouldBe("alpha");
-            e.Data.ShouldBeOfType<DcbXtPayment>().Reference.ShouldBe("ALPHA-PAYMENT");
-        }
+        events[0].TenantId.ShouldBe("alpha");
+        events[0].Data.ShouldBeOfType<DcbXtPayment>().Reference.ShouldBe("ALPHA-PAYMENT");
     }
 }
 


### PR DESCRIPTION
**Base branch: `feature/4617-deferred-12-dcb-cross-tenant` (PR #4645)** — once that PR merges, this auto-rebases onto master.

## Bug

The non-HStore DCB tag query path in `EventStore.Dcb.cs:159` joined:

```sql
from mt_events e left join mt_event_tag_xxx t on e.seq_id = t.seq_id
```

Under `UseTenantPartitionedEvents` the per-tenant `mt_events_sequence_{suffix}` sequences make `seq_id` non-unique across tenants — `seq_id=1` exists in EVERY tenant's `mt_events` partition. Alpha's event row joined to BOTH alpha's tag row AND beta's tag row sharing the same `seq_id`, duplicating alpha's event in the result set. The trailing `e.tenant_id = @p` WHERE filter scrubbed beta's EVENT rows but didn't deduplicate the join product.

## Fix

Add `AND e.tenant_id = t{i}.tenant_id` to the JOIN predicate under conjoined tenancy:

```csharp
sb.Append(" on e.seq_id = t");
sb.Append(i);
sb.Append(".seq_id");

if (_store.Events.TenancyStyle == TenancyStyle.Conjoined)
{
    sb.Append(" and e.tenant_id = t");
    sb.Append(i);
    sb.Append(".tenant_id");
}
```

`EventTagTable` already includes `tenant_id` in its PK when `TenancyStyle.Conjoined` is set, so the predicate is well-defined.

## Scoping

Only emitted under conjoined tenancy. For non-conjoined tenancy:
1. The tag table doesn't have a `tenant_id` column (would error: column does not exist).
2. `seq_id` is unique store-wide via the single global `mt_events_sequence`, so the JOIN couldn't double-match anyway.

## Test verification

PR #4645's `dcb_cross_tenant_query_isolation_pin` is flipped from a "duplicate-events" broken pin to a single-row "fixed" assertion. Cross-checks:

```
Passed!  - Failed:     0, Passed:   156, Skipped:     0, Total:   156  (full TenantPartitionedEventsTests suite)
Passed!  - Failed:     0, Passed:   116, Skipped:     2, Total:   118  (full EventSourcingTests DCB folder — non-conjoined and conjoined paths both intact)
```

## Tracking

- Bug: #4645 (the JOIN-duplication pin from the deferred-12 series)
- Base PR: #4645 (depends on it; will auto-rebase once #4645 merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)