### PR TITLE
Fix #4657: bypass session VersionTracker from projection StoreProjection (async daemon race)

### DIFF
--- a/src/Marten/Events/EventDocumentStorage.cs
+++ b/src/Marten/Events/EventDocumentStorage.cs
@@ -223,6 +223,11 @@ public abstract class EventDocumentStorage: IEventStorage
         throw new NotSupportedException();
     }
 
+    public IStorageOperation OverwriteProjected(IEvent document, string tenant)
+    {
+        throw new NotSupportedException();
+    }
+
     public abstract IStorageOperation AppendEvent(EventGraph events, IMartenSession session, StreamAction stream,
         IEvent e);
 

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -329,6 +329,11 @@ public class EventMapping<T>: EventMapping, IDocumentStorage<T> where T : class
         throw new NotSupportedException();
     }
 
+    IStorageOperation IDocumentStorage<T>.OverwriteProjected(T document, string tenant)
+    {
+        throw new NotSupportedException();
+    }
+
     public IDeletion DeleteForDocument(T document, string tenant)
     {
         throw new NotSupportedException();

--- a/src/Marten/Internal/ClosedShape/ClosedShapeOverwriteOperation.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeOverwriteOperation.cs
@@ -175,11 +175,21 @@ internal sealed class ClosedShapeOverwriteOperation<TDoc, TId>: IDocumentStorage
         switch (_descriptor.ConcurrencyMode)
         {
             case ConcurrencyMode.Optimistic:
-                _versions![_id] = _newVersion;
+                // Trackers are null when built via DocumentStorage.OverwriteProjected
+                // (async-daemon projection path) — see issue #4657.
+                if (_versions is not null)
+                {
+                    _versions[_id] = _newVersion;
+                }
                 break;
             case ConcurrencyMode.Numeric:
+                // Must still consume the RETURNING row so the OperationPage cursor
+                // stays aligned; only the tracker write is conditional.
                 var newRevision = reader.GetFieldValue<long>(0);
-                _revisions![_id] = newRevision;
+                if (_revisions is not null)
+                {
+                    _revisions[_id] = newRevision;
+                }
                 _descriptor.RevisionBinder?.ApplyRevisionTo(_document, newRevision);
                 break;
         }

--- a/src/Marten/Internal/ClosedShape/DirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/DirtyCheckedClosedShapeStorage.cs
@@ -50,6 +50,9 @@ public sealed class DirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyCheckedDocum
     public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
         => new ClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, VersionsFor(session), RevisionsFor(session));
 
+    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
+        => new ClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null, null);
+
     public override ISelector BuildSelector(IMartenSession session)
         => new ClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
 

--- a/src/Marten/Internal/ClosedShape/IdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/IdentityMapClosedShapeStorage.cs
@@ -50,6 +50,9 @@ public sealed class IdentityMapClosedShapeStorage<TDoc, TId>: IdentityMapDocumen
     public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
         => new ClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, VersionsFor(session), RevisionsFor(session));
 
+    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
+        => new ClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null, null);
+
     public override ISelector BuildSelector(IMartenSession session)
         => new ClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
 

--- a/src/Marten/Internal/ClosedShape/LightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/LightweightClosedShapeStorage.cs
@@ -70,6 +70,9 @@ public sealed class LightweightClosedShapeStorage<TDoc, TId>: LightweightDocumen
     public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
         => new ClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, VersionsFor(session), RevisionsFor(session));
 
+    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
+        => new ClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null, null);
+
     public override ISelector BuildSelector(IMartenSession session)
         => new ClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
 

--- a/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
@@ -58,6 +58,9 @@ public sealed class QueryOnlyClosedShapeStorage<TDoc, TId>: QueryOnlyDocumentSto
     public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
         => throw new NotSupportedException("QueryOnly storage doesn't support Overwrite.");
 
+    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
+        => throw new NotSupportedException("QueryOnly storage doesn't support OverwriteProjected.");
+
     public override ISelector BuildSelector(IMartenSession session)
         => new ClosedShapeQueryOnlySelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs
@@ -153,7 +153,13 @@ internal class ProjectionStorage<TDoc, TId>: IProjectionStorage<TDoc, TId> where
 
     public void StoreProjection(TDoc aggregate, IEvent lastEvent, AggregationScope scope)
     {
-        var op = _storage.Overwrite(aggregate, _session, TenantId);
+        // OverwriteProjected (not Overwrite) so we never touch _session.Versions. The async
+        // daemon shares a single session across parallel slice handlers (Block(10, ...) inside
+        // AggregationRunner.BuildBatchAsync), and IMartenSession is documented as not
+        // thread-safe. The projection path doesn't need session-level tracking anyway --
+        // the revision is set explicitly from the event below and IgnoreConcurrencyViolation
+        // = true makes any tracker bookkeeping moot.
+        var op = _storage.OverwriteProjected(aggregate, TenantId);
         if (op is IRevisionedOperation r)
         {
             r.Revision = scope == AggregationScope.SingleStream ? (int)lastEvent.Version : (int)lastEvent.Sequence;

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -292,6 +292,9 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
 
     public abstract IStorageOperation Overwrite(T document, IMartenSession session, string tenant);
 
+    /// <inheritdoc />
+    public abstract IStorageOperation OverwriteProjected(T document, string tenant);
+
     public IDeletion DeleteForDocument(T document, string tenant)
     {
         var id = Identity(document);

--- a/src/Marten/Internal/Storage/IDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IDocumentStorage.cs
@@ -109,6 +109,17 @@ public interface IDocumentStorage<T>: IDocumentStorage where T : notnull
 
     IStorageOperation Overwrite(T document, IMartenSession session, string tenantId);
 
+    /// <summary>
+    /// Lighter-weight overwrite for projection storage. Builds the same Overwrite operation
+    /// but does NOT consult session-level version / revision tracking, so it is safe to call
+    /// from parallel async-daemon slice handlers that share an <see cref="IMartenSession"/>
+    /// (see https://github.com/JasperFx/marten/issues/4657). The session is, by contract,
+    /// not thread-safe; projections set the revision explicitly from the event and never
+    /// read the session's <c>Versions</c> back, so there is no reason for the projection
+    /// path to touch it.
+    /// </summary>
+    IStorageOperation OverwriteProjected(T document, string tenantId);
+
     IDeletion DeleteForDocument(T document, string tenantId);
 
 

--- a/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
@@ -167,6 +167,11 @@ internal class SubClassDocumentStorage<T, TRoot, TId>: IDocumentStorage<T, TId>,
         return _parent.Overwrite(document, session, tenant);
     }
 
+    public IStorageOperation OverwriteProjected(T document, string tenant)
+    {
+        return _parent.OverwriteProjected(document, tenant);
+    }
+
     public IDeletion DeleteForDocument(T document, string tenant)
     {
         return _parent.DeleteForDocument(document, tenant);

--- a/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
+++ b/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
@@ -138,6 +138,9 @@ internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: ID
     public IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenantId)
         => Inner.Overwrite(document, session, tenantId);
 
+    public IStorageOperation OverwriteProjected(TDoc document, string tenantId)
+        => Inner.OverwriteProjected(document, tenantId);
+
     public IDeletion DeleteForDocument(TDoc document, string tenantId)
         => Inner.DeleteForDocument(document, tenantId);
 


### PR DESCRIPTION
Fixes [#4657](https://github.com/JasperFx/marten/issues/4657).

## Problem

A user running an async-daemon `MultiStreamProjection` (same race exists for `SingleStreamProjection`) hit:

\`\`\`
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. ...
   at System.Collections.Generic.Dictionary\`2.TryInsert(...)
   at Marten.Internal.VersionTracker.RevisionsFor[TDoc,TId]()  ← Dictionary<Type, object> _byType, no sync
   at Marten.Internal.ClosedShape.LightweightClosedShapeStorage\`2.Overwrite(...)
   at Marten.Internal.Sessions.ProjectionStorage\`2.StoreProjection(...)
   at JasperFx.Events.Daemon.AggregationRunner\`4.ApplyChangesAsync(...)
\`\`\`

`AggregationRunner.BuildBatchAsync` (in JasperFx.Events) spins up `new Block<EventSliceExecution>(10, ...)` — **ten parallel workers** all calling `ApplyChangesAsync` against the same `IProjectionBatch` / `IMartenSession`. Each call goes through `StoreProjection` → `_storage.Overwrite(aggregate, _session, TenantId)` → `RevisionsFor(session)` → mutating insert on `VersionTracker._byType`. The first parallel calls race on that insert, and `Dictionary` detects the concurrent modification.

`DocumentSessionBase` / `IMartenSession` are **by-contract not thread-safe**, so synchronizing `VersionTracker` would just be papering over the wrong layer — the same race would surface next on `UnitOfWork._eventOperations`, the identity map, etc.

## Fix — give projections a session-free overwrite

`StoreProjection()` doesn't actually need session-level version tracking on this path: the revision is set explicitly from the event right after the op is built, and `IgnoreConcurrencyViolation = true` makes any tracker bookkeeping moot. So the right move is to **not call `IDocumentStorage.Overwrite(...)` from projections**.

- Add `IStorageOperation OverwriteProjected(T document, string tenantId)` to `IDocumentStorage<T, TId>` and as an abstract method on `DocumentStorage<T, TId>`.
- Each closed-shape variant overrides it to construct `ClosedShapeOverwriteOperation` directly with `null` for both tracker dicts (the op already tolerates this — that's how `ConcurrencyMode.Off` works today via the existing `VersionsFor` / `RevisionsFor` helpers).
- `QueryOnlyClosedShapeStorage` throws `NotSupported`, matching its `Overwrite`.
- `SubClassDocumentStorage` + `ValueTypeIdentifiedDocumentStorage` delegate to the inner storage.
- `EventDocumentStorage` + `EventMapping<T>` throw `NotSupported` (events aren't overwritten via the projection storage path).
- Switch `ProjectionStorage<TDoc, TId>.StoreProjection` to call `OverwriteProjected(aggregate, TenantId)` — no session arg.

After this, the projection write path **never touches `_session.Versions`**, so 10-way parallel `ApplyChangesAsync` is safe on the projection path by construction (no shared mutable session state read or written along the way).

## Scope note

This resolves the reported crash. The broader \"`DocumentSessionBase` isn't thread-safe but the daemon shares one across 10 parallel workers\" question stays open — `_session.QueueOperation(op)` still mutates `UnitOfWork._eventOperations` (a plain `List<T>`) concurrently. That doesn't fire a `Dictionary`-style modification check, so it corrupts silently rather than throwing. The proper architectural fix lives daemon-side (serialize the storage-mutation phase, or use per-task sessions); intentionally left for a follow-up.

## Validation

- Full solution builds clean (0 errors, all 45 projects, both `net9.0` and `net10.0`).
- Integration tests will be run by CI — my local Marten test Postgres (5432) isn't currently up. The change is structural (delete a side-effect on `_session`), so a clean local build + CI cover it adequately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)