### PR TITLE
#4659 Phase 1 — eliminate ConcurrencyMode runtime branches via type splits in closed-shape

### DIFF
--- a/src/Marten/Internal/ClosedShape/ClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeDirtyTrackingSelector.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
@@ -12,29 +11,27 @@ using Marten.Internal.CodeGeneration;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// W3 spike (M2): <see cref="ISelector{T}"/> for the
-/// <see cref="DirtyCheckedSequentialGuidStorage{TDoc}"/> path.
-/// Identity-map writes (like <see cref="ClosedShapeIdentityMapSelector{T, TId}"/>)
-/// plus a <see cref="ChangeTracker{T}"/> registered on the session for
-/// every loaded document — gives <c>SaveChangesAsync</c> a baseline to
-/// compare against when dirty-checking which loaded docs were modified.
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
+/// DirtyTracking <see cref="ISelector{T}"/>. Identity-map writes (like
+/// <see cref="ClosedShapeIdentityMapSelector{T, TId}"/>) plus a
+/// <see cref="ChangeTracker{T}"/> registered on the session per loaded
+/// document. Sealed concurrency-specific subclasses override
+/// <c>CaptureVersion</c> (#4659).
 /// </summary>
-internal sealed class ClosedShapeDirtyTrackingSelector<T, TId>: ISelector<T>, IDocumentSelector
+internal abstract class ClosedShapeDirtyTrackingSelector<T, TId>: ISelector<T>, IDocumentSelector
     where T : notnull
     where TId : notnull
 {
-    private const int IdColumn = 0;
-    private const int DataColumn = 1;
-    private const int FirstMetadataColumn = 2;
+    protected const int IdColumn = 0;
+    protected const int DataColumn = 1;
+    protected const int FirstMetadataColumn = 2;
 
-    private readonly IMartenSession _session;
-    private readonly ISerializer _serializer;
-    private readonly DocumentStorageDescriptor<T, TId> _descriptor;
-    private readonly Dictionary<TId, T> _identityMap;
-    private readonly Dictionary<TId, Guid>? _versions;
-    private readonly Dictionary<TId, long>? _revisions;
+    protected readonly IMartenSession _session;
+    protected readonly ISerializer _serializer;
+    protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
+    protected readonly Dictionary<TId, T> _identityMap;
 
-    public ClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected ClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
     {
         _session = session;
         _serializer = session.Serializer;
@@ -49,13 +46,6 @@ internal sealed class ClosedShapeDirtyTrackingSelector<T, TId>: ISelector<T>, ID
             _identityMap = new Dictionary<TId, T>();
             session.ItemMap[typeof(T)] = _identityMap;
         }
-
-        _versions = descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic
-            ? session.Versions.ForType<T, TId>()
-            : null;
-        _revisions = descriptor.ConcurrencyMode == ConcurrencyMode.Numeric
-            ? session.Versions.RevisionsFor<T, TId>()
-            : null;
     }
 
     public T Resolve(DbDataReader reader)
@@ -96,7 +86,12 @@ internal sealed class ClosedShapeDirtyTrackingSelector<T, TId>: ISelector<T>, ID
         return doc;
     }
 
-    private T ReadDocument(DbDataReader reader)
+    /// <summary>
+    /// Concurrency-specific per-row version capture.
+    /// </summary>
+    protected abstract void CaptureVersion(DbDataReader reader, TId id);
+
+    protected T ReadDocument(DbDataReader reader)
     {
         if (_descriptor.HierarchyMapping is { } hierarchy)
         {
@@ -106,7 +101,7 @@ internal sealed class ClosedShapeDirtyTrackingSelector<T, TId>: ISelector<T>, ID
         return _serializer.FromJson<T>(reader, DataColumn);
     }
 
-    private async System.Threading.Tasks.ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    protected async System.Threading.Tasks.ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
     {
         if (_descriptor.HierarchyMapping is { } hierarchy)
         {
@@ -116,30 +111,13 @@ internal sealed class ClosedShapeDirtyTrackingSelector<T, TId>: ISelector<T>, ID
         return await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
     }
 
-    private void ApplyMetadata(DbDataReader reader, T document)
+    protected void ApplyMetadata(DbDataReader reader, T document)
     {
         var ordinal = FirstMetadataColumn;
         foreach (var binder in _descriptor.ReadBinders)
         {
             binder.Apply(reader, ordinal, document, _session);
             ordinal++;
-        }
-    }
-
-    private void CaptureVersion(DbDataReader reader, TId id)
-    {
-        var versionIndex = _descriptor.VersionReadIndex;
-        if (versionIndex < 0) return;
-        var versionOrdinal = FirstMetadataColumn + versionIndex;
-        if (reader.IsDBNull(versionOrdinal)) return;
-
-        if (_versions is not null)
-        {
-            _versions[id] = reader.GetFieldValue<Guid>(versionOrdinal);
-        }
-        else if (_revisions is not null)
-        {
-            _revisions[id] = reader.GetFieldValue<long>(versionOrdinal);
         }
     }
 }

--- a/src/Marten/Internal/ClosedShape/ClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeIdentityMapSelector.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
@@ -11,37 +10,27 @@ using Marten.Internal.CodeGeneration;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// W3 spike (M2): <see cref="ISelector{T}"/> for the
-/// <see cref="IdentityMapSequentialGuidStorage{TDoc}"/> path. Reads
-/// id+data+metadata and writes <c>(id, doc)</c> into the session's
-/// identity-map dictionary so subsequent <c>LoadAsync</c> calls
-/// short-circuit to the in-memory instance.
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
+/// IdentityMap <see cref="ISelector{T}"/>. Owns the identity-map cache
+/// init + lookup; sealed subclasses provide a monomorphic
+/// <c>CaptureVersion</c> override so the per-row hot path doesn't read
+/// <c>ConcurrencyMode</c> (#4659).
 /// </summary>
-/// <remarks>
-/// The identity map lives on <see cref="IMartenSession.ItemMap"/> keyed by
-/// document type. The selector acquires it (or creates a fresh one) at
-/// construction so per-row writes don't re-walk the dictionary lookup.
-/// Mirrors what the codegen-emitted <c>DocumentSelectorWithIdentityMap</c>
-/// subclass does today.
-/// </remarks>
-internal sealed class ClosedShapeIdentityMapSelector<T, TId>: ISelector<T>, IDocumentSelector
+internal abstract class ClosedShapeIdentityMapSelector<T, TId>: ISelector<T>, IDocumentSelector
     where T : notnull
     where TId : notnull
 {
     // Same column layout as Lightweight: id at 0, data at 1, metadata at 2+.
-    // IdColumn.ShouldSelect is true for all non-QueryOnly styles.
-    private const int IdColumn = 0;
-    private const int DataColumn = 1;
-    private const int FirstMetadataColumn = 2;
+    protected const int IdColumn = 0;
+    protected const int DataColumn = 1;
+    protected const int FirstMetadataColumn = 2;
 
-    private readonly IMartenSession _session;
-    private readonly ISerializer _serializer;
-    private readonly DocumentStorageDescriptor<T, TId> _descriptor;
-    private readonly Dictionary<TId, T> _identityMap;
-    private readonly Dictionary<TId, Guid>? _versions;
-    private readonly Dictionary<TId, long>? _revisions;
+    protected readonly IMartenSession _session;
+    protected readonly ISerializer _serializer;
+    protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
+    protected readonly Dictionary<TId, T> _identityMap;
 
-    public ClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected ClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
     {
         _session = session;
         _serializer = session.Serializer;
@@ -56,13 +45,6 @@ internal sealed class ClosedShapeIdentityMapSelector<T, TId>: ISelector<T>, IDoc
             _identityMap = new Dictionary<TId, T>();
             session.ItemMap[typeof(T)] = _identityMap;
         }
-
-        _versions = descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic
-            ? session.Versions.ForType<T, TId>()
-            : null;
-        _revisions = descriptor.ConcurrencyMode == ConcurrencyMode.Numeric
-            ? session.Versions.RevisionsFor<T, TId>()
-            : null;
     }
 
     public T Resolve(DbDataReader reader)
@@ -106,7 +88,13 @@ internal sealed class ClosedShapeIdentityMapSelector<T, TId>: ISelector<T>, IDoc
         return doc;
     }
 
-    private T ReadDocument(DbDataReader reader)
+    /// <summary>
+    /// Concurrency-specific per-row version capture. Off-mode subclasses
+    /// no-op; Optimistic / Numeric capture into their typed tracker.
+    /// </summary>
+    protected abstract void CaptureVersion(DbDataReader reader, TId id);
+
+    protected T ReadDocument(DbDataReader reader)
     {
         if (_descriptor.HierarchyMapping is { } hierarchy)
         {
@@ -116,7 +104,7 @@ internal sealed class ClosedShapeIdentityMapSelector<T, TId>: ISelector<T>, IDoc
         return _serializer.FromJson<T>(reader, DataColumn);
     }
 
-    private async System.Threading.Tasks.ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    protected async System.Threading.Tasks.ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
     {
         if (_descriptor.HierarchyMapping is { } hierarchy)
         {
@@ -126,30 +114,13 @@ internal sealed class ClosedShapeIdentityMapSelector<T, TId>: ISelector<T>, IDoc
         return await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
     }
 
-    private void ApplyMetadata(DbDataReader reader, T document)
+    protected void ApplyMetadata(DbDataReader reader, T document)
     {
         var ordinal = FirstMetadataColumn;
         foreach (var binder in _descriptor.ReadBinders)
         {
             binder.Apply(reader, ordinal, document, _session);
             ordinal++;
-        }
-    }
-
-    private void CaptureVersion(DbDataReader reader, TId id)
-    {
-        var versionIndex = _descriptor.VersionReadIndex;
-        if (versionIndex < 0) return;
-        var versionOrdinal = FirstMetadataColumn + versionIndex;
-        if (reader.IsDBNull(versionOrdinal)) return;
-
-        if (_versions is not null)
-        {
-            _versions[id] = reader.GetFieldValue<Guid>(versionOrdinal);
-        }
-        else if (_revisions is not null)
-        {
-            _revisions[id] = reader.GetFieldValue<long>(versionOrdinal);
         }
     }
 }

--- a/src/Marten/Internal/ClosedShape/ClosedShapeInsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeInsertOperation.cs
@@ -4,10 +4,6 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using JasperFx;
-using JasperFx.Core;
-using Marten.Exceptions;
-using Marten.Internal;
 using Marten.Internal.Operations;
 using Npgsql;
 using NpgsqlTypes;
@@ -17,55 +13,50 @@ using Weasel.Postgresql;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// W3 spike (M3+M7+M8): hand-written Insert operation. Emits
-/// <c>INSERT … ON CONFLICT (id) DO NOTHING RETURNING {id|mt_version}</c>.
-/// Parameter ordering matches <see cref="ClosedShapeUpsertOperation{TDoc, TId}"/>:
-/// id, data, then each client-side metadata binder. RETURNING lets
-/// <see cref="Postprocess"/> distinguish "row inserted" from "row already
-/// existed" and raise <see cref="DocumentAlreadyExistsException"/> in the
-/// latter case.
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
+/// Insert operation. Holds the shared infrastructure (document, identity,
+/// tenant, descriptor, interface boilerplate) but pushes the parameter-
+/// binding and postprocess decisions onto sealed concurrency-specific
+/// subclasses so the hot path doesn't read <c>ConcurrencyMode</c> at
+/// runtime (#4659).
 /// </summary>
 /// <remarks>
-/// Under <see cref="ConcurrencyMode.Optimistic"/> the operation generates
-/// the new Guid version client-side at construction time; under
-/// <see cref="ConcurrencyMode.Numeric"/> it binds the caller-supplied
-/// (or default <c>0</c> = auto-increment to <c>1</c>) <c>Revision</c>.
-/// Either way the new value is written back onto the document +
-/// session.Versions in postprocess.
+/// <para>
+/// Subclasses:
+/// <list type="bullet">
+/// <item><see cref="UnversionedClosedShapeInsertOperation{TDoc, TId}"/> —
+///       <c>ConcurrencyMode.Off</c>; no version/revision binders to special-case.</item>
+/// <item><see cref="OptimisticClosedShapeInsertOperation{TDoc, TId}"/> —
+///       <c>ConcurrencyMode.Optimistic</c>; binds + tracks a Guid version
+///       per row.</item>
+/// <item><see cref="NumericClosedShapeInsertOperation{TDoc, TId}"/> —
+///       <c>ConcurrencyMode.Numeric</c>; binds a (2–4) revision-CASE block
+///       and tracks the returned revision.</item>
+/// </list>
+/// </para>
 /// </remarks>
-internal sealed class ClosedShapeInsertOperation<TDoc, TId>: IDocumentStorageOperation, IRevisionedOperation, IIdentifiedOperation<TDoc, TId>, JasperFx.Core.Exceptions.IExceptionTransform
+internal abstract class ClosedShapeInsertOperation<TDoc, TId>: IDocumentStorageOperation, IRevisionedOperation, IIdentifiedOperation<TDoc, TId>, JasperFx.Core.Exceptions.IExceptionTransform
     where TDoc : notnull
     where TId : notnull
 {
-    public TId Id => _id;
+    protected readonly TDoc _document;
+    protected readonly TId _id;
+    protected readonly string _tenantId;
+    protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
 
-    private readonly TDoc _document;
-    private readonly TId _id;
-    private readonly string _tenantId;
-    private readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
-    private readonly Dictionary<TId, Guid>? _versions;
-    private readonly Dictionary<TId, long>? _revisions;
-    private readonly Guid _newVersion;
-
-    public ClosedShapeInsertOperation(
+    protected ClosedShapeInsertOperation(
         TDoc document,
         TId id,
         string tenantId,
-        DocumentStorageDescriptor<TDoc, TId> descriptor,
-        Dictionary<TId, Guid>? versions,
-        Dictionary<TId, long>? revisions)
+        DocumentStorageDescriptor<TDoc, TId> descriptor)
     {
         _document = document;
         _id = id;
         _tenantId = tenantId;
         _descriptor = descriptor;
-        _versions = versions;
-        _revisions = revisions;
-        if (descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic)
-        {
-            _newVersion = CombGuidIdGeneration.NewGuid();
-        }
     }
+
+    public TId Id => _id;
 
     public long Revision { get; set; }
 
@@ -80,15 +71,22 @@ internal sealed class ClosedShapeInsertOperation<TDoc, TId>: IDocumentStorageOpe
 
     public OperationRole Role() => OperationRole.Insert;
 
-    public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
-    {
-        // Parameter ordering matches the descriptor's SQL:
-        //   non-conjoined: id (0), data (1), client-side binders (2+)
-        //   conjoined:     tenant_id (0), id (1), data (2), binders (3+)
-        // Under Numeric mode, the revision binder consumes TWO ? slots
-        // (the CASE WHEN ? = 0 THEN 1 ELSE ? END expression).
-        var parameters = builder.AppendWithParameters(_descriptor.InsertSql, '?');
+    public abstract void ConfigureCommand(ICommandBuilder builder, IMartenSession session);
 
+    public abstract Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token);
+
+    /// <summary>
+    /// Bind the leading <c>[tenant_id, ] id, data</c> parameter triple and
+    /// project session-derived metadata onto the document before
+    /// serialization. Returns the next free parameter slot.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors the codegen path's GenerateCodeToModifyDocument frames:
+    /// Correlation / Causation / Headers / LastModifiedBy etc. land on
+    /// the document so they flow into the JSON data column too.
+    /// </remarks>
+    protected int BindLeadingParameters(NpgsqlParameter[] parameters, IMartenSession session)
+    {
         var slot = 0;
         if (_descriptor.IsConjoined)
         {
@@ -101,10 +99,6 @@ internal sealed class ClosedShapeInsertOperation<TDoc, TId>: IDocumentStorageOpe
         parameters[slot].NpgsqlDbType = PostgresqlProvider.Instance.ToParameterType(_descriptor.Identification.RawSqlType);
         slot++;
 
-        // Project session-derived metadata (Correlation/Causation/
-        // Headers/LastModifiedBy) onto the document BEFORE serialization
-        // so the values flow into the JSON data column too. Mirrors the
-        // codegen path's GenerateCodeToModifyDocument frames.
         foreach (var binder in _descriptor.WriteBinders)
         {
             binder.ApplyToDocument(_document, session);
@@ -113,90 +107,31 @@ internal sealed class ClosedShapeInsertOperation<TDoc, TId>: IDocumentStorageOpe
         session.Serializer.WriteToParameter(parameters[slot], _document);
         slot++;
 
-        foreach (var binder in _descriptor.ClientSideWriteBinders)
-        {
-            slot = BindBinder(parameters, slot, binder, session);
-        }
+        return slot;
     }
 
-    public async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    /// <summary>
+    /// Bind the optional <c>id [, tenant_id]</c> subquery slots that
+    /// <c>UseVersionFromMatchingStream</c> emits inside the revision
+    /// CASE expression. Returns the next free slot. Common to the
+    /// Numeric variants of Insert / Upsert / Overwrite.
+    /// </summary>
+    protected int BindUseVersionFromMatchingStreamSubquery(NpgsqlParameter[] parameters, int slot)
     {
-        if (!await reader.ReadAsync(token).ConfigureAwait(false))
-        {
-            exceptions.Add(new DocumentAlreadyExistsException(null, typeof(TDoc), _id));
-            return;
-        }
+        parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
+        parameters[slot].NpgsqlDbType = PostgresqlProvider.Instance.ToParameterType(_descriptor.Identification.RawSqlType);
+        slot++;
 
-        ApplyConcurrencyResult(reader);
-    }
-
-    private int BindBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)
-    {
-        if (_descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic &&
-            ReferenceEquals(binder, _descriptor.VersionBinder))
+        if (_descriptor.IsConjoined)
         {
-            parameters[slot].Value = _newVersion;
-            parameters[slot].NpgsqlDbType = NpgsqlDbType.Uuid;
-            _descriptor.VersionBinder.ApplyVersionTo(_document, _newVersion);
-            return slot + 1;
-        }
-
-        if (_descriptor.ConcurrencyMode == ConcurrencyMode.Numeric &&
-            ReferenceEquals(binder, _descriptor.RevisionBinder))
-        {
-            // Numeric path. Two layouts depending on UseVersionFromMatchingStream:
-            //   Default:                CASE WHEN ? = 0 THEN 1 ELSE ? END (2 slots)
-            //   UseVersionFromMatchingStream (non-conjoined): CASE WHEN ? = 0
-            //       THEN COALESCE((select version from <events>.mt_streams where id = ?), 1)
-            //       ELSE ? END (3 slots: ?=0 check, subquery id, explicit revision)
-            //   UseVersionFromMatchingStream + conjoined: same with extra ? for tenant_id (4 slots)
-            // #4614: parameter type follows the column width (integer vs bigint).
-            var revisionDbType = _descriptor.RevisionBinder.ColumnDbType;
-            var revisionValue = revisionDbType == NpgsqlDbType.Integer
-                ? (object)checked((int)Revision)
-                : Revision;
-            parameters[slot].Value = revisionValue;
-            parameters[slot].NpgsqlDbType = revisionDbType;
+            parameters[slot].Value = _tenantId;
+            parameters[slot].NpgsqlDbType = NpgsqlDbType.Varchar;
             slot++;
-
-            if (_descriptor.UseVersionFromMatchingStream)
-            {
-                parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
-                parameters[slot].NpgsqlDbType = PostgresqlProvider.Instance.ToParameterType(_descriptor.Identification.RawSqlType);
-                slot++;
-
-                if (_descriptor.IsConjoined)
-                {
-                    parameters[slot].Value = _tenantId;
-                    parameters[slot].NpgsqlDbType = NpgsqlDbType.Varchar;
-                    slot++;
-                }
-            }
-
-            parameters[slot].Value = revisionValue;
-            parameters[slot].NpgsqlDbType = revisionDbType;
-            return slot + 1;
         }
 
-        binder.BindParameter(parameters[slot], _document, session);
-        return slot + 1;
+        return slot;
     }
 
-    private void ApplyConcurrencyResult(DbDataReader reader)
-    {
-        switch (_descriptor.ConcurrencyMode)
-        {
-            case ConcurrencyMode.Optimistic:
-                _versions![_id] = _newVersion;
-                break;
-            case ConcurrencyMode.Numeric:
-                var newRevision = reader.GetFieldValue<long>(0);
-                _revisions![_id] = newRevision;
-                _descriptor.RevisionBinder?.ApplyRevisionTo(_document, newRevision);
-                break;
-        }
-    }
     public bool TryTransform(System.Exception original, out System.Exception? transformed)
         => ClosedShapeOperationExceptionTransform.TryTransform(original, _descriptor.TableName, typeof(TDoc), _id!, out transformed);
-
 }

--- a/src/Marten/Internal/ClosedShape/ClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeLightweightSelector.cs
@@ -1,6 +1,4 @@
 #nullable enable
-using System;
-using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,50 +9,42 @@ using Marten.Internal.CodeGeneration;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// W3 spike (M1+M2+M7): <see cref="ISelector{T}"/> for the lightweight
-/// closed-shape storage path. Reads the data column at index 1 and
-/// dispatches each <see cref="IDocumentMetadataBinder{TDoc}"/>.Apply at
-/// the binder's column position (2, 3, …). Lightweight skips
-/// identity-map writes — every <c>LoadAsync</c> hits the database.
-/// Under <see cref="ConcurrencyMode.Optimistic"/> the selector also
-/// captures each row's <c>mt_version</c> into <c>session.Versions</c>
-/// so subsequent updates can supply it as the expected version.
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
+/// Lightweight <see cref="ISelector{T}"/>. Owns the shared row-shape
+/// (id at col 0, data at col 1, metadata at 2+) plus document
+/// deserialization and metadata-apply. The per-row
+/// <c>CaptureVersion</c> step is virtual; sealed subclasses provide a
+/// monomorphic implementation so the JIT can devirtualize the hot
+/// path (#4659).
 /// </summary>
-internal sealed class ClosedShapeLightweightSelector<T, TId>: ISelector<T>, IDocumentSelector
+internal abstract class ClosedShapeLightweightSelector<T, TId>: ISelector<T>, IDocumentSelector
     where T : notnull
     where TId : notnull
 {
     // Lightweight column order from DocumentTable.SelectColumns:
     //   id (col 0), data (col 1), then ShouldSelect metadata columns.
-    private const int IdColumn = 0;
-    private const int DataColumn = 1;
-    private const int FirstMetadataColumn = 2;
+    protected const int IdColumn = 0;
+    protected const int DataColumn = 1;
+    protected const int FirstMetadataColumn = 2;
 
-    private readonly IMartenSession _session;
-    private readonly ISerializer _serializer;
-    private readonly DocumentStorageDescriptor<T, TId> _descriptor;
-    private readonly Dictionary<TId, Guid>? _versions;
-    private readonly Dictionary<TId, long>? _revisions;
+    protected readonly IMartenSession _session;
+    protected readonly ISerializer _serializer;
+    protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
 
-    public ClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected ClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
     {
         _session = session;
         _serializer = session.Serializer;
         _descriptor = descriptor;
-        _versions = descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic
-            ? session.Versions.ForType<T, TId>()
-            : null;
-        _revisions = descriptor.ConcurrencyMode == ConcurrencyMode.Numeric
-            ? session.Versions.RevisionsFor<T, TId>()
-            : null;
     }
 
     public T Resolve(DbDataReader reader)
     {
         var doc = ReadDocument(reader);
         ApplyMetadata(reader, doc);
-        CaptureVersion(reader);
-        _session.MarkAsDocumentLoaded(_descriptor.Identification.ReadIdFromReader(reader, IdColumn), doc);
+        var id = _descriptor.Identification.ReadIdFromReader(reader, IdColumn);
+        CaptureVersion(reader, id);
+        _session.MarkAsDocumentLoaded(id, doc);
         return doc;
     }
 
@@ -62,12 +52,20 @@ internal sealed class ClosedShapeLightweightSelector<T, TId>: ISelector<T>, IDoc
     {
         var doc = await ReadDocumentAsync(reader, token).ConfigureAwait(false);
         ApplyMetadata(reader, doc);
-        CaptureVersion(reader);
-        _session.MarkAsDocumentLoaded(_descriptor.Identification.ReadIdFromReader(reader, IdColumn), doc);
+        var id = _descriptor.Identification.ReadIdFromReader(reader, IdColumn);
+        CaptureVersion(reader, id);
+        _session.MarkAsDocumentLoaded(id, doc);
         return doc;
     }
 
-    private T ReadDocument(DbDataReader reader)
+    /// <summary>
+    /// Concurrency-specific per-row version capture. Off-mode subclasses
+    /// no-op; Optimistic captures the Guid into the per-type version
+    /// dict; Numeric captures the long into the per-type revision dict.
+    /// </summary>
+    protected abstract void CaptureVersion(DbDataReader reader, TId id);
+
+    protected T ReadDocument(DbDataReader reader)
     {
         if (_descriptor.HierarchyMapping is { } hierarchy)
         {
@@ -77,7 +75,7 @@ internal sealed class ClosedShapeLightweightSelector<T, TId>: ISelector<T>, IDoc
         return _serializer.FromJson<T>(reader, DataColumn);
     }
 
-    private async System.Threading.Tasks.ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    protected async System.Threading.Tasks.ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
     {
         if (_descriptor.HierarchyMapping is { } hierarchy)
         {
@@ -87,32 +85,13 @@ internal sealed class ClosedShapeLightweightSelector<T, TId>: ISelector<T>, IDoc
         return await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
     }
 
-    private void ApplyMetadata(DbDataReader reader, T document)
+    protected void ApplyMetadata(DbDataReader reader, T document)
     {
         var ordinal = FirstMetadataColumn;
         foreach (var binder in _descriptor.ReadBinders)
         {
             binder.Apply(reader, ordinal, document, _session);
             ordinal++;
-        }
-    }
-
-    private void CaptureVersion(DbDataReader reader)
-    {
-        var versionIndex = _descriptor.VersionReadIndex;
-        if (versionIndex < 0) return;
-        var versionOrdinal = FirstMetadataColumn + versionIndex;
-        if (reader.IsDBNull(versionOrdinal)) return;
-
-        if (_versions is not null)
-        {
-            var id = _descriptor.Identification.ReadIdFromReader(reader, IdColumn);
-            _versions[id] = reader.GetFieldValue<Guid>(versionOrdinal);
-        }
-        else if (_revisions is not null)
-        {
-            var id = _descriptor.Identification.ReadIdFromReader(reader, IdColumn);
-            _revisions[id] = reader.GetFieldValue<long>(versionOrdinal);
         }
     }
 }

--- a/src/Marten/Internal/ClosedShape/ClosedShapeOverwriteOperation.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeOverwriteOperation.cs
@@ -4,8 +4,6 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using JasperFx.Core;
-using Marten.Internal;
 using Marten.Internal.Operations;
 using Npgsql;
 using NpgsqlTypes;
@@ -15,48 +13,38 @@ using Weasel.Postgresql;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// W3 spike (M7+M8): hand-written Overwrite operation. Same shape as
-/// <see cref="ClosedShapeUpsertOperation{TDoc, TId}"/> except the
-/// trailing concurrency guard is dropped — the caller has explicitly
-/// asked to bypass the optimistic / numeric check
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
+/// Overwrite operation. Same shape as Upsert but the trailing
+/// concurrency guard is dropped — the caller has explicitly opted to
+/// bypass the optimistic / numeric check
 /// (<c>session.Store(doc, ignoreConcurrencyCheck: true)</c> or
-/// <see cref="Marten.Services.ConcurrencyChecks.Disabled"/> session
-/// option). Under <see cref="ConcurrencyMode.Off"/> overwrite is
-/// functionally identical to upsert.
+/// <see cref="Marten.Services.ConcurrencyChecks.Disabled"/>). Sealed
+/// subclasses provide the concrete <see cref="ConfigureCommand"/> +
+/// <see cref="PostprocessAsync"/> bodies so the hot path doesn't branch
+/// on <c>ConcurrencyMode</c> (#4659).
 /// </summary>
-internal sealed class ClosedShapeOverwriteOperation<TDoc, TId>: IDocumentStorageOperation, IRevisionedOperation, IIdentifiedOperation<TDoc, TId>, JasperFx.Core.Exceptions.IExceptionTransform
+internal abstract class ClosedShapeOverwriteOperation<TDoc, TId>: IDocumentStorageOperation, IRevisionedOperation, IIdentifiedOperation<TDoc, TId>, JasperFx.Core.Exceptions.IExceptionTransform
     where TDoc : notnull
     where TId : notnull
 {
-    public TId Id => _id;
+    protected readonly TDoc _document;
+    protected readonly TId _id;
+    protected readonly string _tenantId;
+    protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
 
-    private readonly TDoc _document;
-    private readonly TId _id;
-    private readonly string _tenantId;
-    private readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
-    private readonly Dictionary<TId, Guid>? _versions;
-    private readonly Dictionary<TId, long>? _revisions;
-    private readonly Guid _newVersion;
-
-    public ClosedShapeOverwriteOperation(
+    protected ClosedShapeOverwriteOperation(
         TDoc document,
         TId id,
         string tenantId,
-        DocumentStorageDescriptor<TDoc, TId> descriptor,
-        Dictionary<TId, Guid>? versions,
-        Dictionary<TId, long>? revisions)
+        DocumentStorageDescriptor<TDoc, TId> descriptor)
     {
         _document = document;
         _id = id;
         _tenantId = tenantId;
         _descriptor = descriptor;
-        _versions = versions;
-        _revisions = revisions;
-        if (descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic)
-        {
-            _newVersion = CombGuidIdGeneration.NewGuid();
-        }
     }
+
+    public TId Id => _id;
 
     public long Revision { get; set; }
 
@@ -71,10 +59,17 @@ internal sealed class ClosedShapeOverwriteOperation<TDoc, TId>: IDocumentStorage
 
     public OperationRole Role() => OperationRole.Update;
 
-    public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
-    {
-        var parameters = builder.AppendWithParameters(_descriptor.OverwriteSql, '?');
+    public abstract void ConfigureCommand(ICommandBuilder builder, IMartenSession session);
 
+    public abstract Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token);
+
+    /// <summary>
+    /// Bind <c>[tenant_id,] id, data</c> + the client-side write binders
+    /// up to (not including) the trailing ON CONFLICT SET concurrency
+    /// slots. Returns the next free parameter slot.
+    /// </summary>
+    protected int BindPreOnConflictParameters(NpgsqlParameter[] parameters, IMartenSession session)
+    {
         var slot = 0;
         if (_descriptor.IsConjoined)
         {
@@ -87,8 +82,6 @@ internal sealed class ClosedShapeOverwriteOperation<TDoc, TId>: IDocumentStorage
         parameters[slot].NpgsqlDbType = PostgresqlProvider.Instance.ToParameterType(_descriptor.Identification.RawSqlType);
         slot++;
 
-        // Project session-derived metadata onto the document BEFORE
-        // serialization so the values flow into the JSON data column.
         foreach (var binder in _descriptor.WriteBinders)
         {
             binder.ApplyToDocument(_document, session);
@@ -99,102 +92,39 @@ internal sealed class ClosedShapeOverwriteOperation<TDoc, TId>: IDocumentStorage
 
         foreach (var binder in _descriptor.ClientSideWriteBinders)
         {
-            slot = BindBinder(parameters, slot, binder, session);
+            slot = BindClientSideBinder(parameters, slot, binder, session);
         }
 
-        if (_descriptor.ConcurrencyMode == ConcurrencyMode.Numeric)
-        {
-            // DO UPDATE SET mt_version = CASE WHEN ? = 0 THEN current+1 ELSE ? END
-            // No WHERE guard — Overwrite always wins.
-            parameters[slot].Value = Revision;
-            parameters[slot].NpgsqlDbType = NpgsqlDbType.Bigint;
-            parameters[slot + 1].Value = Revision;
-            parameters[slot + 1].NpgsqlDbType = NpgsqlDbType.Bigint;
-        }
+        return slot;
     }
 
-    public async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    /// <summary>
+    /// Bind the optional <c>id [, tenant_id]</c> subquery slots that
+    /// <c>UseVersionFromMatchingStream</c> emits inside the revision CASE
+    /// expression.
+    /// </summary>
+    protected int BindUseVersionFromMatchingStreamSubquery(NpgsqlParameter[] parameters, int slot)
     {
-        if (_descriptor.ConcurrencyMode == ConcurrencyMode.Off) return;
+        parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
+        parameters[slot].NpgsqlDbType = PostgresqlProvider.Instance.ToParameterType(_descriptor.Identification.RawSqlType);
+        slot++;
 
-        if (await reader.ReadAsync(token).ConfigureAwait(false))
+        if (_descriptor.IsConjoined)
         {
-            ApplyConcurrencyResult(reader);
-        }
-    }
-
-    private int BindBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)
-    {
-        if (_descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic &&
-            ReferenceEquals(binder, _descriptor.VersionBinder))
-        {
-            parameters[slot].Value = _newVersion;
-            parameters[slot].NpgsqlDbType = NpgsqlDbType.Uuid;
-            _descriptor.VersionBinder.ApplyVersionTo(_document, _newVersion);
-            return slot + 1;
-        }
-
-        if (_descriptor.ConcurrencyMode == ConcurrencyMode.Numeric &&
-            ReferenceEquals(binder, _descriptor.RevisionBinder))
-        {
-            // INSERT VALUES side. Two layouts depending on UseVersionFromMatchingStream:
-            //   Default:                CASE WHEN ? = 0 THEN 1 ELSE ? END (2 slots)
-            //   UseVersionFromMatchingStream (non-conjoined): CASE WHEN ? = 0
-            //       THEN COALESCE((select version from <events>.mt_streams where id = ?), 1)
-            //       ELSE ? END (3 slots)
-            //   UseVersionFromMatchingStream + conjoined: add an extra ? for tenant_id (4 slots)
-            parameters[slot].Value = Revision;
-            parameters[slot].NpgsqlDbType = NpgsqlDbType.Bigint;
+            parameters[slot].Value = _tenantId;
+            parameters[slot].NpgsqlDbType = NpgsqlDbType.Varchar;
             slot++;
-
-            if (_descriptor.UseVersionFromMatchingStream)
-            {
-                parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
-                parameters[slot].NpgsqlDbType = PostgresqlProvider.Instance.ToParameterType(_descriptor.Identification.RawSqlType);
-                slot++;
-
-                if (_descriptor.IsConjoined)
-                {
-                    parameters[slot].Value = _tenantId;
-                    parameters[slot].NpgsqlDbType = NpgsqlDbType.Varchar;
-                    slot++;
-                }
-            }
-
-            parameters[slot].Value = Revision;
-            parameters[slot].NpgsqlDbType = NpgsqlDbType.Bigint;
-            return slot + 1;
         }
 
-        binder.BindParameter(parameters[slot], _document, session);
-        return slot + 1;
+        return slot;
     }
 
-    private void ApplyConcurrencyResult(DbDataReader reader)
-    {
-        switch (_descriptor.ConcurrencyMode)
-        {
-            case ConcurrencyMode.Optimistic:
-                // Trackers are null when built via DocumentStorage.OverwriteProjected
-                // (async-daemon projection path) — see issue #4657.
-                if (_versions is not null)
-                {
-                    _versions[_id] = _newVersion;
-                }
-                break;
-            case ConcurrencyMode.Numeric:
-                // Must still consume the RETURNING row so the OperationPage cursor
-                // stays aligned; only the tracker write is conditional.
-                var newRevision = reader.GetFieldValue<long>(0);
-                if (_revisions is not null)
-                {
-                    _revisions[_id] = newRevision;
-                }
-                _descriptor.RevisionBinder?.ApplyRevisionTo(_document, newRevision);
-                break;
-        }
-    }
+    /// <summary>
+    /// Concurrency-aware subclasses override to special-case the
+    /// VersionBinder / RevisionBinder.
+    /// </summary>
+    protected abstract int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session);
+
     public bool TryTransform(System.Exception original, out System.Exception? transformed)
         => ClosedShapeOperationExceptionTransform.TryTransform(original, _descriptor.TableName, typeof(TDoc), _id!, out transformed);
-
 }

--- a/src/Marten/Internal/ClosedShape/ClosedShapeRegistration.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeRegistration.cs
@@ -177,9 +177,14 @@ public static class ClosedShapeRegistration
         var descriptor = DocumentStorageDescriptorBuilder.Build<TDoc, TId>(mapping, identification);
 
         var queryOnly = new QueryOnlyClosedShapeStorage<TDoc, TId>(mapping, descriptor);
-        var lightweight = new LightweightClosedShapeStorage<TDoc, TId>(mapping, descriptor);
-        var identityMap = new IdentityMapClosedShapeStorage<TDoc, TId>(mapping, descriptor);
-        var dirtyTracking = new DirtyCheckedClosedShapeStorage<TDoc, TId>(mapping, descriptor);
+
+        // #4659: dispatch on ConcurrencyMode ONCE at registration time so the
+        // three writeable storage styles are monomorphic-by-construction
+        // (each leaf knows its concurrency mode at type identity, no per-
+        // operation / per-row reads of _descriptor.ConcurrencyMode left).
+        var lightweight = BuildLightweightStorage(mapping, descriptor);
+        var identityMap = BuildIdentityMapStorage(mapping, descriptor);
+        var dirtyTracking = BuildDirtyCheckedStorage(mapping, descriptor);
 
         // M16: real bulk loader, COPY-based, built from the descriptor's
         // column list. Lightweight is fine to use as the storage backing
@@ -193,4 +198,37 @@ public static class ClosedShapeRegistration
             identityMap: identityMap,
             dirtyTracking: dirtyTracking);
     }
+
+    private static LightweightClosedShapeStorage<TDoc, TId> BuildLightweightStorage<TDoc, TId>(
+        DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        where TDoc : notnull
+        where TId : notnull
+        => descriptor.ConcurrencyMode switch
+        {
+            ConcurrencyMode.Optimistic => new OptimisticLightweightClosedShapeStorage<TDoc, TId>(mapping, descriptor),
+            ConcurrencyMode.Numeric => new NumericLightweightClosedShapeStorage<TDoc, TId>(mapping, descriptor),
+            _ => new UnversionedLightweightClosedShapeStorage<TDoc, TId>(mapping, descriptor),
+        };
+
+    private static IdentityMapClosedShapeStorage<TDoc, TId> BuildIdentityMapStorage<TDoc, TId>(
+        DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        where TDoc : notnull
+        where TId : notnull
+        => descriptor.ConcurrencyMode switch
+        {
+            ConcurrencyMode.Optimistic => new OptimisticIdentityMapClosedShapeStorage<TDoc, TId>(mapping, descriptor),
+            ConcurrencyMode.Numeric => new NumericIdentityMapClosedShapeStorage<TDoc, TId>(mapping, descriptor),
+            _ => new UnversionedIdentityMapClosedShapeStorage<TDoc, TId>(mapping, descriptor),
+        };
+
+    private static DirtyCheckedClosedShapeStorage<TDoc, TId> BuildDirtyCheckedStorage<TDoc, TId>(
+        DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        where TDoc : notnull
+        where TId : notnull
+        => descriptor.ConcurrencyMode switch
+        {
+            ConcurrencyMode.Optimistic => new OptimisticDirtyCheckedClosedShapeStorage<TDoc, TId>(mapping, descriptor),
+            ConcurrencyMode.Numeric => new NumericDirtyCheckedClosedShapeStorage<TDoc, TId>(mapping, descriptor),
+            _ => new UnversionedDirtyCheckedClosedShapeStorage<TDoc, TId>(mapping, descriptor),
+        };
 }

--- a/src/Marten/Internal/ClosedShape/ClosedShapeUpdateOperation.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeUpdateOperation.cs
@@ -4,10 +4,6 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using JasperFx;
-using JasperFx.Core;
-using Marten.Exceptions;
-using Marten.Internal;
 using Marten.Internal.Operations;
 using Npgsql;
 using NpgsqlTypes;
@@ -17,51 +13,45 @@ using Weasel.Postgresql;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// W3 spike (M3+M7+M8): hand-written Update operation. Emits
-/// <c>UPDATE … SET data = ?, … WHERE id = ? [and tenant_id = ?] [and concurrency-guard] RETURNING {id|mt_version}</c>.
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
+/// Update operation. Sealed subclasses provide the concrete
+/// <see cref="ConfigureCommand"/> + <see cref="PostprocessAsync"/> bodies
+/// so the hot path doesn't branch on <c>ConcurrencyMode</c> (#4659).
 /// </summary>
 /// <remarks>
-/// Postprocess branches on <see cref="ConcurrencyMode"/>:
+/// Subclasses:
 /// <list type="bullet">
-/// <item><c>Off</c>: a missing row raises <see cref="NonExistentDocumentException"/>.</item>
-/// <item><c>Optimistic</c>: a missing row raises <see cref="ConcurrencyException"/>.</item>
-/// <item><c>Numeric</c>: a missing row raises <see cref="ConcurrencyException"/> unless
-/// <see cref="IRevisionedOperation.IgnoreConcurrencyViolation"/> is set.</item>
+/// <item><see cref="UnversionedClosedShapeUpdateOperation{TDoc, TId}"/> —
+///       missing row → <see cref="Marten.Exceptions.NonExistentDocumentException"/>.</item>
+/// <item><see cref="OptimisticClosedShapeUpdateOperation{TDoc, TId}"/> —
+///       missing row → <see cref="Marten.Exceptions.ConcurrencyException"/>
+///       (unless <see cref="IRevisionedOperation.IgnoreConcurrencyViolation"/>).</item>
+/// <item><see cref="NumericClosedShapeUpdateOperation{TDoc, TId}"/> —
+///       same as Optimistic but with a revision CASE/WHERE block.</item>
 /// </list>
 /// </remarks>
-internal sealed class ClosedShapeUpdateOperation<TDoc, TId>: IDocumentStorageOperation, IRevisionedOperation, IIdentifiedOperation<TDoc, TId>, JasperFx.Core.Exceptions.IExceptionTransform
+internal abstract class ClosedShapeUpdateOperation<TDoc, TId>: IDocumentStorageOperation, IRevisionedOperation, IIdentifiedOperation<TDoc, TId>, JasperFx.Core.Exceptions.IExceptionTransform
     where TDoc : notnull
     where TId : notnull
 {
-    public TId Id => _id;
+    protected readonly TDoc _document;
+    protected readonly TId _id;
+    protected readonly string _tenantId;
+    protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
 
-    private readonly TDoc _document;
-    private readonly TId _id;
-    private readonly string _tenantId;
-    private readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
-    private readonly Dictionary<TId, Guid>? _versions;
-    private readonly Dictionary<TId, long>? _revisions;
-    private readonly Guid _newVersion;
-
-    public ClosedShapeUpdateOperation(
+    protected ClosedShapeUpdateOperation(
         TDoc document,
         TId id,
         string tenantId,
-        DocumentStorageDescriptor<TDoc, TId> descriptor,
-        Dictionary<TId, Guid>? versions,
-        Dictionary<TId, long>? revisions)
+        DocumentStorageDescriptor<TDoc, TId> descriptor)
     {
         _document = document;
         _id = id;
         _tenantId = tenantId;
         _descriptor = descriptor;
-        _versions = versions;
-        _revisions = revisions;
-        if (descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic)
-        {
-            _newVersion = CombGuidIdGeneration.NewGuid();
-        }
     }
+
+    public TId Id => _id;
 
     public long Revision { get; set; }
 
@@ -76,16 +66,24 @@ internal sealed class ClosedShapeUpdateOperation<TDoc, TId>: IDocumentStorageOpe
 
     public OperationRole Role() => OperationRole.Update;
 
-    public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
-    {
-        // Update SQL ordering:
-        //   data (0), binders (1+), id (n), [tenant_id], [guard params]
-        // Numeric: revision binder consumes 2 slots in SET; WHERE adds 2
-        // more slots for the same Revision value.
-        var parameters = builder.AppendWithParameters(_descriptor.UpdateSql, '?');
+    public abstract void ConfigureCommand(ICommandBuilder builder, IMartenSession session);
 
-        // Project session-derived metadata onto the document BEFORE
-        // serialization so the values flow into the JSON data column.
+    public abstract Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token);
+
+    /// <summary>
+    /// Bind data + client-side binders + id [+ tenant_id] [+ partition PK
+    /// binders], stopping at the trailing concurrency WHERE slot. Returns
+    /// the slot index for the concurrency-guard parameters that each
+    /// concurrency-specific leaf appends.
+    /// </summary>
+    /// <remarks>
+    /// Bug #4223: partitioned tables include the partition column(s) in
+    /// the PK, so the WHERE clause adds a <c>{col} = ?</c> slot per
+    /// partition column. Without this we'd update every row matching
+    /// <c>id = ?</c> across partitions.
+    /// </remarks>
+    protected int BindPreConcurrencyParameters(NpgsqlParameter[] parameters, IMartenSession session)
+    {
         foreach (var binder in _descriptor.WriteBinders)
         {
             binder.ApplyToDocument(_document, session);
@@ -96,7 +94,7 @@ internal sealed class ClosedShapeUpdateOperation<TDoc, TId>: IDocumentStorageOpe
         var slot = 1;
         foreach (var binder in _descriptor.ClientSideWriteBinders)
         {
-            slot = BindBinder(parameters, slot, binder, session);
+            slot = BindClientSideBinder(parameters, slot, binder, session);
         }
 
         parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
@@ -110,108 +108,22 @@ internal sealed class ClosedShapeUpdateOperation<TDoc, TId>: IDocumentStorageOpe
             slot++;
         }
 
-        // Bug #4223: partitioned tables include the partition column in
-        // the PK; the Update WHERE clause adds a `<col> = ?` slot per
-        // partition column so we update exactly the right row, not
-        // every row matching `id = ?`.
         foreach (var pk in _descriptor.PartitionPkBinders)
         {
             pk.BindParameter(parameters[slot], _document, session);
             slot++;
         }
 
-        if (_descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic)
-        {
-            if (_versions!.TryGetValue(_id, out var expected))
-            {
-                parameters[slot].Value = expected;
-            }
-            else
-            {
-                parameters[slot].Value = DBNull.Value;
-            }
-            parameters[slot].NpgsqlDbType = NpgsqlDbType.Uuid;
-        }
-        else if (_descriptor.ConcurrencyMode == ConcurrencyMode.Numeric)
-        {
-            // WHERE (? = 0 or {table}.mt_version < ?) — bind raw Revision to both slots.
-            // #4614: parameter type tracks the column width (integer/bigint).
-            var revisionDbType = _descriptor.RevisionBinder!.ColumnDbType;
-            var revisionValue = revisionDbType == NpgsqlDbType.Integer
-                ? (object)checked((int)Revision)
-                : Revision;
-            parameters[slot].Value = revisionValue;
-            parameters[slot].NpgsqlDbType = revisionDbType;
-            parameters[slot + 1].Value = revisionValue;
-            parameters[slot + 1].NpgsqlDbType = revisionDbType;
-        }
+        return slot;
     }
 
-    public async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
-    {
-        if (!await reader.ReadAsync(token).ConfigureAwait(false))
-        {
-            if (!IgnoreConcurrencyViolation)
-            {
-                exceptions.Add(MissingRowException());
-            }
-            return;
-        }
+    /// <summary>
+    /// Bind a single client-side write binder; concurrency-aware
+    /// subclasses override this to special-case the VersionBinder /
+    /// RevisionBinder.
+    /// </summary>
+    protected abstract int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session);
 
-        ApplyConcurrencyResult(reader);
-    }
-
-    private Exception MissingRowException()
-        => _descriptor.ConcurrencyMode == ConcurrencyMode.Off
-            ? new NonExistentDocumentException(typeof(TDoc), _id)
-            : new ConcurrencyException(typeof(TDoc), _id);
-
-    private int BindBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)
-    {
-        if (_descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic &&
-            ReferenceEquals(binder, _descriptor.VersionBinder))
-        {
-            parameters[slot].Value = _newVersion;
-            parameters[slot].NpgsqlDbType = NpgsqlDbType.Uuid;
-            _descriptor.VersionBinder.ApplyVersionTo(_document, _newVersion);
-            return slot + 1;
-        }
-
-        if (_descriptor.ConcurrencyMode == ConcurrencyMode.Numeric &&
-            ReferenceEquals(binder, _descriptor.RevisionBinder))
-        {
-            // SET mt_version = CASE WHEN ? = 0 THEN current+1 ELSE ? END
-            // #4614: parameter type tracks the column width (integer/bigint).
-            var revisionDbType = _descriptor.RevisionBinder.ColumnDbType;
-            var revisionValue = revisionDbType == NpgsqlDbType.Integer
-                ? (object)checked((int)Revision)
-                : Revision;
-            parameters[slot].Value = revisionValue;
-            parameters[slot].NpgsqlDbType = revisionDbType;
-            parameters[slot + 1].Value = revisionValue;
-            parameters[slot + 1].NpgsqlDbType = revisionDbType;
-            return slot + 2;
-        }
-
-        binder.BindParameter(parameters[slot], _document, session);
-        return slot + 1;
-    }
-
-    private void ApplyConcurrencyResult(DbDataReader reader)
-    {
-        switch (_descriptor.ConcurrencyMode)
-        {
-            case ConcurrencyMode.Optimistic:
-                _versions![_id] = _newVersion;
-                break;
-            case ConcurrencyMode.Numeric:
-                var newRevision = reader.GetFieldValue<long>(0);
-                _revisions![_id] = newRevision;
-                _descriptor.RevisionBinder?.ApplyRevisionTo(_document, newRevision);
-                break;
-        }
-    }
     public bool TryTransform(System.Exception original, out System.Exception? transformed)
         => ClosedShapeOperationExceptionTransform.TryTransform(original, _descriptor.TableName, typeof(TDoc), _id!, out transformed);
-
 }

--- a/src/Marten/Internal/ClosedShape/ClosedShapeUpsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeUpsertOperation.cs
@@ -4,10 +4,6 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using JasperFx;
-using JasperFx.Core;
-using Marten.Exceptions;
-using Marten.Internal;
 using Marten.Internal.Operations;
 using Npgsql;
 using NpgsqlTypes;
@@ -17,59 +13,42 @@ using Weasel.Postgresql;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// W3 spike (M1+M7+M8): hand-written upsert operation that consumes the
-/// descriptor's pre-built SQL + client-side binder array.
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
+/// Upsert operation. Sealed subclasses provide the concrete
+/// <see cref="ConfigureCommand"/> + <see cref="PostprocessAsync"/> bodies
+/// so the hot path doesn't branch on <c>ConcurrencyMode</c> (#4659).
 /// </summary>
 /// <remarks>
-/// Concurrency variants:
-/// <list type="bullet">
-/// <item><c>Optimistic</c>: ON CONFLICT DO UPDATE adds <c>where mt_version = ?</c>
-/// (caller-supplied expected version). A mismatch produces no
-/// RETURNING row → <see cref="ConcurrencyException"/>.</item>
-/// <item><c>Numeric</c>: revision binder writes
-/// <c>CASE WHEN ? = 0 THEN current+1 ELSE ? END</c>; ON CONFLICT
-/// guard is <c>? = 0 OR current &lt; supplied</c>. A failed guard
-/// surfaces as <see cref="ConcurrencyException"/> unless
-/// <see cref="IRevisionedOperation.IgnoreConcurrencyViolation"/> is
-/// set.</item>
-/// </list>
+/// The Upsert <see cref="OperationRole"/> is supplied by the caller
+/// (Upsert or Insert) so the dirty-tracking change tracker can register
+/// the right kind of op against the session. Subclasses inherit the same
+/// role choice.
 /// </remarks>
-internal sealed class ClosedShapeUpsertOperation<TDoc, TId>: IDocumentStorageOperation, IRevisionedOperation, IIdentifiedOperation<TDoc, TId>, JasperFx.Core.Exceptions.IExceptionTransform
+internal abstract class ClosedShapeUpsertOperation<TDoc, TId>: IDocumentStorageOperation, IRevisionedOperation, IIdentifiedOperation<TDoc, TId>, JasperFx.Core.Exceptions.IExceptionTransform
     where TDoc : notnull
     where TId : notnull
 {
-    public TId Id => _id;
+    protected readonly TDoc _document;
+    protected readonly TId _id;
+    protected readonly string _tenantId;
+    protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
+    protected readonly OperationRole _role;
 
-    private readonly TDoc _document;
-    private readonly TId _id;
-    private readonly string _tenantId;
-    private readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
-    private readonly OperationRole _role;
-    private readonly Dictionary<TId, Guid>? _versions;
-    private readonly Dictionary<TId, long>? _revisions;
-    private readonly Guid _newVersion;
-
-    public ClosedShapeUpsertOperation(
+    protected ClosedShapeUpsertOperation(
         TDoc document,
         TId id,
         string tenantId,
         DocumentStorageDescriptor<TDoc, TId> descriptor,
-        OperationRole role,
-        Dictionary<TId, Guid>? versions,
-        Dictionary<TId, long>? revisions)
+        OperationRole role)
     {
         _document = document;
         _id = id;
         _tenantId = tenantId;
         _descriptor = descriptor;
         _role = role;
-        _versions = versions;
-        _revisions = revisions;
-        if (descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic)
-        {
-            _newVersion = CombGuidIdGeneration.NewGuid();
-        }
     }
+
+    public TId Id => _id;
 
     public long Revision { get; set; }
 
@@ -84,13 +63,17 @@ internal sealed class ClosedShapeUpsertOperation<TDoc, TId>: IDocumentStorageOpe
 
     public OperationRole Role() => _role;
 
-    public void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
-    {
-        // Upsert SQL ordering (non-conjoined, Numeric):
-        //   id, data, rev (INSERT CASE × 2), [other binders],
-        //   rev (SET CASE × 2), rev (WHERE × 2)
-        var parameters = builder.AppendWithParameters(_descriptor.UpsertSql, '?');
+    public abstract void ConfigureCommand(ICommandBuilder builder, IMartenSession session);
 
+    public abstract Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token);
+
+    /// <summary>
+    /// Bind <c>[tenant_id,] id, data</c> + the client-side write binders
+    /// up to (not including) the trailing ON CONFLICT concurrency-extras
+    /// slots. Returns the next free parameter slot.
+    /// </summary>
+    protected int BindPreOnConflictParameters(NpgsqlParameter[] parameters, IMartenSession session)
+    {
         var slot = 0;
         if (_descriptor.IsConjoined)
         {
@@ -103,8 +86,6 @@ internal sealed class ClosedShapeUpsertOperation<TDoc, TId>: IDocumentStorageOpe
         parameters[slot].NpgsqlDbType = PostgresqlProvider.Instance.ToParameterType(_descriptor.Identification.RawSqlType);
         slot++;
 
-        // Project session-derived metadata onto the document BEFORE
-        // serialization so the values flow into the JSON data column.
         foreach (var binder in _descriptor.WriteBinders)
         {
             binder.ApplyToDocument(_document, session);
@@ -115,127 +96,39 @@ internal sealed class ClosedShapeUpsertOperation<TDoc, TId>: IDocumentStorageOpe
 
         foreach (var binder in _descriptor.ClientSideWriteBinders)
         {
-            slot = BindBinder(parameters, slot, binder, session);
+            slot = BindClientSideBinder(parameters, slot, binder, session);
         }
 
-        // ON CONFLICT side concurrency-related extras.
-        if (_descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic)
-        {
-            // ON CONFLICT DO UPDATE ... WHERE table.mt_version = ?
-            if (_versions!.TryGetValue(_id, out var expected))
-            {
-                parameters[slot].Value = expected;
-            }
-            else
-            {
-                parameters[slot].Value = DBNull.Value;
-            }
-            parameters[slot].NpgsqlDbType = NpgsqlDbType.Uuid;
-        }
-        else if (_descriptor.ConcurrencyMode == ConcurrencyMode.Numeric)
-        {
-            // DO UPDATE SET mt_version = CASE WHEN ? = 0 THEN current+1 ELSE ? END
-            // WHERE ? = 0 OR table.mt_version < ?
-            for (var i = 0; i < 4; i++)
-            {
-                parameters[slot + i].Value = Revision;
-                parameters[slot + i].NpgsqlDbType = NpgsqlDbType.Bigint;
-            }
-        }
+        return slot;
     }
 
-    public async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    /// <summary>
+    /// Bind the optional <c>id [, tenant_id]</c> subquery slots that
+    /// <c>UseVersionFromMatchingStream</c> emits inside the revision CASE
+    /// expression. Common to Numeric Upsert / Overwrite.
+    /// </summary>
+    protected int BindUseVersionFromMatchingStreamSubquery(NpgsqlParameter[] parameters, int slot)
     {
-        if (_descriptor.ConcurrencyMode == ConcurrencyMode.Off)
-        {
-            // Mode Off Upsert is fire-and-forget today — RETURNING id is
-            // there for symmetry with Insert/Update but the result isn't
-            // inspected.
-            return;
-        }
+        parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
+        parameters[slot].NpgsqlDbType = PostgresqlProvider.Instance.ToParameterType(_descriptor.Identification.RawSqlType);
+        slot++;
 
-        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        if (_descriptor.IsConjoined)
         {
-            if (!IgnoreConcurrencyViolation)
-            {
-                exceptions.Add(new ConcurrencyException(typeof(TDoc), _id));
-            }
-            return;
-        }
-
-        ApplyConcurrencyResult(reader);
-    }
-
-    private int BindBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)
-    {
-        if (_descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic &&
-            ReferenceEquals(binder, _descriptor.VersionBinder))
-        {
-            parameters[slot].Value = _newVersion;
-            parameters[slot].NpgsqlDbType = NpgsqlDbType.Uuid;
-            _descriptor.VersionBinder.ApplyVersionTo(_document, _newVersion);
-            return slot + 1;
-        }
-
-        if (_descriptor.ConcurrencyMode == ConcurrencyMode.Numeric &&
-            ReferenceEquals(binder, _descriptor.RevisionBinder))
-        {
-            // INSERT VALUES side; two layouts depending on UseVersionFromMatchingStream:
-            //   Default:                CASE WHEN ? = 0 THEN 1 ELSE ? END (2 slots)
-            //   UseVersionFromMatchingStream (non-conjoined): CASE WHEN ? = 0
-            //       THEN COALESCE((select version from <events>.mt_streams where id = ?), 1)
-            //       ELSE ? END (3 slots)
-            //   UseVersionFromMatchingStream + conjoined: same with extra ? for tenant_id (4 slots)
-            // The ON CONFLICT SET / WHERE branches always reference {table}.id
-            // directly so they keep their 4 revision slots downstream.
-            // #4614: the parameter type follows the column width (integer for IRevisioned,
-            // bigint for ILongVersioned) so the CASE expression's branch types align.
-            var revisionDbType = _descriptor.RevisionBinder.ColumnDbType;
-            var revisionValue = revisionDbType == NpgsqlDbType.Integer
-                ? (object)checked((int)Revision)
-                : Revision;
-            parameters[slot].Value = revisionValue;
-            parameters[slot].NpgsqlDbType = revisionDbType;
+            parameters[slot].Value = _tenantId;
+            parameters[slot].NpgsqlDbType = NpgsqlDbType.Varchar;
             slot++;
-
-            if (_descriptor.UseVersionFromMatchingStream)
-            {
-                parameters[slot].Value = _descriptor.Identification.ToRawSqlValue(_id);
-                parameters[slot].NpgsqlDbType = PostgresqlProvider.Instance.ToParameterType(_descriptor.Identification.RawSqlType);
-                slot++;
-
-                if (_descriptor.IsConjoined)
-                {
-                    parameters[slot].Value = _tenantId;
-                    parameters[slot].NpgsqlDbType = NpgsqlDbType.Varchar;
-                    slot++;
-                }
-            }
-
-            parameters[slot].Value = revisionValue;
-            parameters[slot].NpgsqlDbType = revisionDbType;
-            return slot + 1;
         }
 
-        binder.BindParameter(parameters[slot], _document, session);
-        return slot + 1;
+        return slot;
     }
 
-    private void ApplyConcurrencyResult(DbDataReader reader)
-    {
-        switch (_descriptor.ConcurrencyMode)
-        {
-            case ConcurrencyMode.Optimistic:
-                _versions![_id] = _newVersion;
-                break;
-            case ConcurrencyMode.Numeric:
-                var newRevision = reader.GetFieldValue<long>(0);
-                _revisions![_id] = newRevision;
-                _descriptor.RevisionBinder?.ApplyRevisionTo(_document, newRevision);
-                break;
-        }
-    }
+    /// <summary>
+    /// Concurrency-aware subclasses override to special-case the
+    /// VersionBinder / RevisionBinder.
+    /// </summary>
+    protected abstract int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session);
+
     public bool TryTransform(System.Exception original, out System.Exception? transformed)
         => ClosedShapeOperationExceptionTransform.TryTransform(original, _descriptor.TableName, typeof(TDoc), _id!, out transformed);
-
 }

--- a/src/Marten/Internal/ClosedShape/DirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/DirtyCheckedClosedShapeStorage.cs
@@ -9,18 +9,18 @@ using Marten.Storage;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// W3 spike (M2+M4+M7): hand-written, closed-shape
-/// <see cref="DirtyCheckedDocumentStorage{T, TId}"/> for any
-/// <typeparamref name="TId"/>. Selected when a session opens with
-/// <c>DocumentTracking.DirtyTracking</c>.
+/// Closed-shape <see cref="DirtyCheckedDocumentStorage{T, TId}"/> base.
+/// Sealed concurrency-mode leaves provide the write factories +
+/// <c>BuildSelector</c>. See <see cref="LightweightClosedShapeStorage{TDoc,TId}"/>
+/// for the rationale (#4659).
 /// </summary>
-public sealed class DirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyCheckedDocumentStorage<TDoc, TId>
+public abstract class DirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyCheckedDocumentStorage<TDoc, TId>
     where TDoc : notnull
     where TId : notnull
 {
-    private readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
+    protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
 
-    public DirtyCheckedClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+    protected DirtyCheckedClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
         : base(mapping)
     {
         _descriptor = descriptor;
@@ -37,32 +37,4 @@ public sealed class DirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyCheckedDocum
 
     public override Npgsql.NpgsqlParameter BuildManyIdParameter(TId[] ids)
         => ClosedShapeIdHelpers.BuildManyIdParameter(ids, _descriptor.Identification);
-
-    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
-        => new ClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, VersionsFor(session), RevisionsFor(session));
-
-    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
-        => new ClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, VersionsFor(session), RevisionsFor(session));
-
-    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
-        => new ClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, VersionsFor(session), RevisionsFor(session));
-
-    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
-        => new ClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, VersionsFor(session), RevisionsFor(session));
-
-    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
-        => new ClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null, null);
-
-    public override ISelector BuildSelector(IMartenSession session)
-        => new ClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
-
-    private System.Collections.Generic.Dictionary<TId, System.Guid>? VersionsFor(IMartenSession session)
-        => _descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic
-            ? session.Versions.ForType<TDoc, TId>()
-            : null;
-
-    private System.Collections.Generic.Dictionary<TId, long>? RevisionsFor(IMartenSession session)
-        => _descriptor.ConcurrencyMode == ConcurrencyMode.Numeric
-            ? session.Versions.RevisionsFor<TDoc, TId>()
-            : null;
 }

--- a/src/Marten/Internal/ClosedShape/IdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/IdentityMapClosedShapeStorage.cs
@@ -9,18 +9,18 @@ using Marten.Storage;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// W3 spike (M2+M4+M7): hand-written, closed-shape
-/// <see cref="IdentityMapDocumentStorage{T, TId}"/> for any
-/// <typeparamref name="TId"/>. Selected when a session opens with
-/// <c>DocumentTracking.IdentityOnly</c>.
+/// Closed-shape <see cref="IdentityMapDocumentStorage{T, TId}"/> base.
+/// Sealed concurrency-mode leaves provide the write factories +
+/// <c>BuildSelector</c>. See <see cref="LightweightClosedShapeStorage{TDoc,TId}"/>
+/// for the rationale (#4659).
 /// </summary>
-public sealed class IdentityMapClosedShapeStorage<TDoc, TId>: IdentityMapDocumentStorage<TDoc, TId>
+public abstract class IdentityMapClosedShapeStorage<TDoc, TId>: IdentityMapDocumentStorage<TDoc, TId>
     where TDoc : notnull
     where TId : notnull
 {
-    private readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
+    protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
 
-    public IdentityMapClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+    protected IdentityMapClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
         : base(mapping)
     {
         _descriptor = descriptor;
@@ -37,32 +37,4 @@ public sealed class IdentityMapClosedShapeStorage<TDoc, TId>: IdentityMapDocumen
 
     public override Npgsql.NpgsqlParameter BuildManyIdParameter(TId[] ids)
         => ClosedShapeIdHelpers.BuildManyIdParameter(ids, _descriptor.Identification);
-
-    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
-        => new ClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, VersionsFor(session), RevisionsFor(session));
-
-    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
-        => new ClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, VersionsFor(session), RevisionsFor(session));
-
-    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
-        => new ClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, VersionsFor(session), RevisionsFor(session));
-
-    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
-        => new ClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, VersionsFor(session), RevisionsFor(session));
-
-    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
-        => new ClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null, null);
-
-    public override ISelector BuildSelector(IMartenSession session)
-        => new ClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
-
-    private System.Collections.Generic.Dictionary<TId, System.Guid>? VersionsFor(IMartenSession session)
-        => _descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic
-            ? session.Versions.ForType<TDoc, TId>()
-            : null;
-
-    private System.Collections.Generic.Dictionary<TId, long>? RevisionsFor(IMartenSession session)
-        => _descriptor.ConcurrencyMode == ConcurrencyMode.Numeric
-            ? session.Versions.RevisionsFor<TDoc, TId>()
-            : null;
 }

--- a/src/Marten/Internal/ClosedShape/LightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/LightweightClosedShapeStorage.cs
@@ -9,36 +9,31 @@ using Marten.Storage;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// W3 spike (M2+M4+M7): hand-written, closed-shape
-/// <see cref="LightweightDocumentStorage{T, TId}"/> for any
-/// <typeparamref name="TId"/>. Composes
-/// <see cref="DocumentStorageDescriptor{TDoc, TId}"/> (SQL + metadata
-/// binders) and <see cref="IIdentification{TDoc, TId}"/> (identity
-/// strategy). The closed-shape JIT specialization happens at
-/// construction time per <c>(TDoc, TId)</c> closure — no runtime
-/// branching after that.
+/// Closed-shape <see cref="LightweightDocumentStorage{T, TId}"/> base.
+/// Holds the shared infrastructure (Identity / AssignIdentity /
+/// RawIdentityValue / BuildManyIdParameter) common to every concurrency
+/// flavor; concrete subclasses provide the Insert / Update / Upsert /
+/// Overwrite factories + BuildSelector so the storage class is
+/// monomorphic-by-construction per <c>(TDoc, TId, ConcurrencyMode)</c>
+/// closure (#4659).
 /// </summary>
 /// <remarks>
 /// <para>
-/// One cell of the planned W3 matrix: Lightweight + any id type + any
-/// concurrency mode + no revisions + no tenancy + no hierarchical.
-/// </para>
-/// <para>
-/// Inheriting <see cref="LightweightDocumentStorage{T, TId}"/> picks up
-/// Store / Eject / LoadAsync / LoadManyAsync. What we hand-write here:
-/// Identity / AssignIdentity (via the descriptor's
-/// <see cref="IIdentification{TDoc, TId}"/>), Insert / Update / Upsert /
-/// Overwrite (return the corresponding closed-shape operation), and
-/// BuildSelector (returns <see cref="ClosedShapeLightweightSelector{TDoc, TId}"/>).
+/// Public sealed → public abstract. The class still exists as a public
+/// type but cannot be instantiated directly; consumers go through
+/// <see cref="ClosedShapeRegistration"/> which builds the right
+/// concurrency-mode leaf. The W3 spike's <c>Use…ClosedShape</c>
+/// extension helpers still work — the registration internals just
+/// dispatch on <see cref="DocumentStorageDescriptor{TDoc,TId}.ConcurrencyMode"/>.
 /// </para>
 /// </remarks>
-public sealed class LightweightClosedShapeStorage<TDoc, TId>: LightweightDocumentStorage<TDoc, TId>
+public abstract class LightweightClosedShapeStorage<TDoc, TId>: LightweightDocumentStorage<TDoc, TId>
     where TDoc : notnull
     where TId : notnull
 {
-    private readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
+    protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
 
-    public LightweightClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+    protected LightweightClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
         : base(mapping)
     {
         _descriptor = descriptor;
@@ -57,32 +52,4 @@ public sealed class LightweightClosedShapeStorage<TDoc, TId>: LightweightDocumen
 
     public override Npgsql.NpgsqlParameter BuildManyIdParameter(TId[] ids)
         => ClosedShapeIdHelpers.BuildManyIdParameter(ids, _descriptor.Identification);
-
-    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
-        => new ClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, VersionsFor(session), RevisionsFor(session));
-
-    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
-        => new ClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, VersionsFor(session), RevisionsFor(session));
-
-    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
-        => new ClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, VersionsFor(session), RevisionsFor(session));
-
-    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
-        => new ClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, VersionsFor(session), RevisionsFor(session));
-
-    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
-        => new ClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null, null);
-
-    public override ISelector BuildSelector(IMartenSession session)
-        => new ClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
-
-    private System.Collections.Generic.Dictionary<TId, System.Guid>? VersionsFor(IMartenSession session)
-        => _descriptor.ConcurrencyMode == ConcurrencyMode.Optimistic
-            ? session.Versions.ForType<TDoc, TId>()
-            : null;
-
-    private System.Collections.Generic.Dictionary<TId, long>? RevisionsFor(IMartenSession session)
-        => _descriptor.ConcurrencyMode == ConcurrencyMode.Numeric
-            ? session.Versions.RevisionsFor<TDoc, TId>()
-            : null;
 }

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,33 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> DirtyTracking selector. CaptureVersion
+/// writes the row's mt_version (long) into the session's per-type
+/// revision dict. #4659 leaf.
+/// </summary>
+internal sealed class NumericClosedShapeDirtyTrackingSelector<T, TId>: ClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long> _revisions;
+
+    public NumericClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _revisions = session.Versions.RevisionsFor<T, TId>();
+    }
+
+    protected override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        var versionIndex = _descriptor.VersionReadIndex;
+        if (versionIndex < 0) return;
+        var versionOrdinal = FirstMetadataColumn + versionIndex;
+        if (reader.IsDBNull(versionOrdinal)) return;
+
+        _revisions[id] = reader.GetFieldValue<long>(versionOrdinal);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,33 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> IdentityMap selector. CaptureVersion
+/// writes the row's mt_version (long) into the session's per-type
+/// revision dict. #4659 leaf.
+/// </summary>
+internal sealed class NumericClosedShapeIdentityMapSelector<T, TId>: ClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long> _revisions;
+
+    public NumericClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _revisions = session.Versions.RevisionsFor<T, TId>();
+    }
+
+    protected override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        var versionIndex = _descriptor.VersionReadIndex;
+        if (versionIndex < 0) return;
+        var versionOrdinal = FirstMetadataColumn + versionIndex;
+        if (reader.IsDBNull(versionOrdinal)) return;
+
+        _revisions[id] = reader.GetFieldValue<long>(versionOrdinal);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeInsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeInsertOperation.cs
@@ -1,0 +1,108 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten.Exceptions;
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> closed-shape Insert. Binds the revision
+/// <c>CASE WHEN ? = 0 THEN … ELSE ? END</c> block (2–4 parameter slots
+/// depending on <see cref="DocumentStorageDescriptor{TDoc,TId}.UseVersionFromMatchingStream"/>
+/// + <see cref="DocumentStorageDescriptor{TDoc,TId}.IsConjoined"/>),
+/// reads the resolved revision out of the RETURNING row, and writes it
+/// back through <see cref="DocumentRevisionBinder{TDoc}.ApplyRevisionTo"/>
+/// + the session's per-type revision tracker. #4659 leaf.
+/// </summary>
+internal sealed class NumericClosedShapeInsertOperation<TDoc, TId>: ClosedShapeInsertOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long> _revisions;
+
+    public NumericClosedShapeInsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        Dictionary<TId, long> revisions)
+        : base(document, id, tenantId, descriptor)
+    {
+        _revisions = revisions;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var parameters = builder.AppendWithParameters(_descriptor.InsertSql, '?');
+        var slot = BindLeadingParameters(parameters, session);
+
+        foreach (var binder in _descriptor.ClientSideWriteBinders)
+        {
+            if (ReferenceEquals(binder, _descriptor.RevisionBinder))
+            {
+                slot = BindRevisionBlock(parameters, slot);
+            }
+            else
+            {
+                binder.BindParameter(parameters[slot], _document, session);
+                slot++;
+            }
+        }
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            exceptions.Add(new DocumentAlreadyExistsException(null, typeof(TDoc), _id));
+            return;
+        }
+
+        var newRevision = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
+        _revisions[_id] = newRevision;
+        _descriptor.RevisionBinder!.ApplyRevisionTo(_document, newRevision);
+    }
+
+    /// <summary>
+    /// Numeric Insert binds the revision CASE expression in two/three/four
+    /// slots:
+    /// <list type="bullet">
+    /// <item>Default: <c>CASE WHEN ? = 0 THEN 1 ELSE ? END</c> (2 slots).</item>
+    /// <item><c>UseVersionFromMatchingStream</c> (non-conjoined):
+    ///   <c>CASE WHEN ? = 0 THEN COALESCE((select version from mt_streams where id = ?), 1) ELSE ? END</c>
+    ///   (3 slots — the <c>? = 0</c> check, the id subquery, the explicit revision).</item>
+    /// <item><c>UseVersionFromMatchingStream + IsConjoined</c>: extra <c>?</c> for
+    ///   <c>tenant_id</c> inside the subquery (4 slots).</item>
+    /// </list>
+    /// #4614: the parameter type tracks the column width (integer vs bigint)
+    /// so the CASE branch types align.
+    /// </summary>
+    private int BindRevisionBlock(NpgsqlParameter[] parameters, int slot)
+    {
+        var revisionDbType = _descriptor.RevisionBinder!.ColumnDbType;
+        var revisionValue = revisionDbType == NpgsqlDbType.Integer
+            ? (object)checked((int)Revision)
+            : Revision;
+
+        parameters[slot].Value = revisionValue;
+        parameters[slot].NpgsqlDbType = revisionDbType;
+        slot++;
+
+        if (_descriptor.UseVersionFromMatchingStream)
+        {
+            slot = BindUseVersionFromMatchingStreamSubquery(parameters, slot);
+        }
+
+        parameters[slot].Value = revisionValue;
+        parameters[slot].NpgsqlDbType = revisionDbType;
+        return slot + 1;
+    }
+}

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeLightweightSelector.cs
@@ -1,0 +1,33 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> Lightweight selector. Captures the
+/// row's mt_version (long) into the session's per-type revision dict so
+/// subsequent updates can supply it as the expected revision. #4659 leaf.
+/// </summary>
+internal sealed class NumericClosedShapeLightweightSelector<T, TId>: ClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long> _revisions;
+
+    public NumericClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _revisions = session.Versions.RevisionsFor<T, TId>();
+    }
+
+    protected override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        var versionIndex = _descriptor.VersionReadIndex;
+        if (versionIndex < 0) return;
+        var versionOrdinal = FirstMetadataColumn + versionIndex;
+        if (reader.IsDBNull(versionOrdinal)) return;
+
+        _revisions[id] = reader.GetFieldValue<long>(versionOrdinal);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeOverwriteOperation.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeOverwriteOperation.cs
@@ -1,0 +1,94 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> closed-shape Overwrite. Same INSERT
+/// VALUES revision CASE block as the Numeric Upsert path, but the SET
+/// CASE is 2 slots (no WHERE guard). #4658 — the
+/// <see cref="DocumentStorage{TDoc,TId}.OverwriteProjected"/> path passes
+/// a null revisions tracker so the projection doesn't poison the
+/// session's revision dictionary. #4659 leaf.
+/// </summary>
+internal sealed class NumericClosedShapeOverwriteOperation<TDoc, TId>: ClosedShapeOverwriteOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long>? _revisions;
+
+    public NumericClosedShapeOverwriteOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        Dictionary<TId, long>? revisions)
+        : base(document, id, tenantId, descriptor)
+    {
+        _revisions = revisions;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var parameters = builder.AppendWithParameters(_descriptor.OverwriteSql, '?');
+        var slot = BindPreOnConflictParameters(parameters, session);
+
+        // DO UPDATE SET mt_version = CASE WHEN ? = 0 THEN current+1 ELSE ? END
+        // No WHERE guard — Overwrite always wins.
+        parameters[slot].Value = Revision;
+        parameters[slot].NpgsqlDbType = NpgsqlDbType.Bigint;
+        parameters[slot + 1].Value = Revision;
+        parameters[slot + 1].NpgsqlDbType = NpgsqlDbType.Bigint;
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            var newRevision = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
+            // #4658 — null tracker (OverwriteProjected) just skips the
+            // tracker write. RevisionBinder write still happens so the
+            // document's revision field is fresh.
+            if (_revisions is not null)
+            {
+                _revisions[_id] = newRevision;
+            }
+            _descriptor.RevisionBinder!.ApplyRevisionTo(_document, newRevision);
+        }
+    }
+
+    protected override int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)
+    {
+        if (ReferenceEquals(binder, _descriptor.RevisionBinder))
+        {
+            // INSERT VALUES CASE block — same shape as NumericClosedShapeUpsertOperation.
+            var revisionDbType = _descriptor.RevisionBinder!.ColumnDbType;
+            var revisionValue = revisionDbType == NpgsqlDbType.Integer
+                ? (object)checked((int)Revision)
+                : Revision;
+            parameters[slot].Value = revisionValue;
+            parameters[slot].NpgsqlDbType = revisionDbType;
+            slot++;
+
+            if (_descriptor.UseVersionFromMatchingStream)
+            {
+                slot = BindUseVersionFromMatchingStreamSubquery(parameters, slot);
+            }
+
+            parameters[slot].Value = revisionValue;
+            parameters[slot].NpgsqlDbType = revisionDbType;
+            return slot + 1;
+        }
+
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeUpdateOperation.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeUpdateOperation.cs
@@ -1,0 +1,93 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten.Exceptions;
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> closed-shape Update. Two revision
+/// slots in the SET CASE expression (<c>CASE WHEN ? = 0 THEN
+/// current+1 ELSE ? END</c>) plus two in the trailing WHERE clause
+/// (<c>? = 0 OR table.mt_version &lt; ?</c>). Missing RETURNING row →
+/// revision-guard failure → <see cref="ConcurrencyException"/>. #4659 leaf.
+/// </summary>
+internal sealed class NumericClosedShapeUpdateOperation<TDoc, TId>: ClosedShapeUpdateOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long> _revisions;
+
+    public NumericClosedShapeUpdateOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        Dictionary<TId, long> revisions)
+        : base(document, id, tenantId, descriptor)
+    {
+        _revisions = revisions;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var parameters = builder.AppendWithParameters(_descriptor.UpdateSql, '?');
+        var slot = BindPreConcurrencyParameters(parameters, session);
+
+        // Trailing WHERE (? = 0 or {table}.mt_version < ?) — bind the raw
+        // Revision to both slots. #4614: parameter type tracks column width.
+        var revisionDbType = _descriptor.RevisionBinder!.ColumnDbType;
+        var revisionValue = revisionDbType == NpgsqlDbType.Integer
+            ? (object)checked((int)Revision)
+            : Revision;
+        parameters[slot].Value = revisionValue;
+        parameters[slot].NpgsqlDbType = revisionDbType;
+        parameters[slot + 1].Value = revisionValue;
+        parameters[slot + 1].NpgsqlDbType = revisionDbType;
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            if (!IgnoreConcurrencyViolation)
+            {
+                exceptions.Add(new ConcurrencyException(typeof(TDoc), _id));
+            }
+            return;
+        }
+
+        var newRevision = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
+        _revisions[_id] = newRevision;
+        _descriptor.RevisionBinder!.ApplyRevisionTo(_document, newRevision);
+    }
+
+    protected override int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)
+    {
+        if (ReferenceEquals(binder, _descriptor.RevisionBinder))
+        {
+            // SET mt_version = CASE WHEN ? = 0 THEN current+1 ELSE ? END
+            // (2 slots — Update side never uses UseVersionFromMatchingStream)
+            var revisionDbType = _descriptor.RevisionBinder!.ColumnDbType;
+            var revisionValue = revisionDbType == NpgsqlDbType.Integer
+                ? (object)checked((int)Revision)
+                : Revision;
+            parameters[slot].Value = revisionValue;
+            parameters[slot].NpgsqlDbType = revisionDbType;
+            parameters[slot + 1].Value = revisionValue;
+            parameters[slot + 1].NpgsqlDbType = revisionDbType;
+            return slot + 2;
+        }
+
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeUpsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeUpsertOperation.cs
@@ -1,0 +1,102 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten.Exceptions;
+using Marten.Internal.Operations;
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> closed-shape Upsert. Two/three/four
+/// revision slots in the INSERT VALUES CASE block (depending on
+/// <see cref="DocumentStorageDescriptor{TDoc,TId}.UseVersionFromMatchingStream"/>
+/// + <see cref="DocumentStorageDescriptor{TDoc,TId}.IsConjoined"/>) plus
+/// four more in the ON CONFLICT DO UPDATE SET/WHERE block. Missing
+/// RETURNING row → revision-guard failure →
+/// <see cref="ConcurrencyException"/>. #4659 leaf.
+/// </summary>
+internal sealed class NumericClosedShapeUpsertOperation<TDoc, TId>: ClosedShapeUpsertOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, long> _revisions;
+
+    public NumericClosedShapeUpsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        OperationRole role,
+        Dictionary<TId, long> revisions)
+        : base(document, id, tenantId, descriptor, role)
+    {
+        _revisions = revisions;
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var parameters = builder.AppendWithParameters(_descriptor.UpsertSql, '?');
+        var slot = BindPreOnConflictParameters(parameters, session);
+
+        // ON CONFLICT trailing:
+        //   DO UPDATE SET mt_version = CASE WHEN ? = 0 THEN current+1 ELSE ? END
+        //   WHERE ? = 0 OR table.mt_version < ?
+        for (var i = 0; i < 4; i++)
+        {
+            parameters[slot + i].Value = Revision;
+            parameters[slot + i].NpgsqlDbType = NpgsqlDbType.Bigint;
+        }
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            if (!IgnoreConcurrencyViolation)
+            {
+                exceptions.Add(new ConcurrencyException(typeof(TDoc), _id));
+            }
+            return;
+        }
+
+        var newRevision = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
+        _revisions[_id] = newRevision;
+        _descriptor.RevisionBinder!.ApplyRevisionTo(_document, newRevision);
+    }
+
+    protected override int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)
+    {
+        if (ReferenceEquals(binder, _descriptor.RevisionBinder))
+        {
+            // INSERT VALUES CASE block — see NumericClosedShapeInsertOperation
+            // for the slot-count rationale.
+            var revisionDbType = _descriptor.RevisionBinder!.ColumnDbType;
+            var revisionValue = revisionDbType == NpgsqlDbType.Integer
+                ? (object)checked((int)Revision)
+                : Revision;
+            parameters[slot].Value = revisionValue;
+            parameters[slot].NpgsqlDbType = revisionDbType;
+            slot++;
+
+            if (_descriptor.UseVersionFromMatchingStream)
+            {
+                slot = BindUseVersionFromMatchingStreamSubquery(parameters, slot);
+            }
+
+            parameters[slot].Value = revisionValue;
+            parameters[slot].NpgsqlDbType = revisionDbType;
+            return slot + 1;
+        }
+
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Marten/Internal/ClosedShape/NumericDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericDirtyCheckedClosedShapeStorage.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using Marten.Internal;
+using Marten.Internal.Operations;
+using Marten.Linq.Selectors;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> closed-shape DirtyChecked storage. #4659 leaf.
+/// </summary>
+internal sealed class NumericDirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyCheckedClosedShapeStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public NumericDirtyCheckedClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(mapping, descriptor)
+    {
+    }
+
+    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+        => new NumericClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
+
+    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+        => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
+
+    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+        => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, session.Versions.RevisionsFor<TDoc, TId>());
+
+    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+        => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
+
+    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
+        => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
+    public override ISelector BuildSelector(IMartenSession session)
+        => new NumericClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
+}

--- a/src/Marten/Internal/ClosedShape/NumericIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericIdentityMapClosedShapeStorage.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using Marten.Internal;
+using Marten.Internal.Operations;
+using Marten.Linq.Selectors;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> closed-shape IdentityMap storage. #4659 leaf.
+/// </summary>
+internal sealed class NumericIdentityMapClosedShapeStorage<TDoc, TId>: IdentityMapClosedShapeStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public NumericIdentityMapClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(mapping, descriptor)
+    {
+    }
+
+    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+        => new NumericClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
+
+    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+        => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
+
+    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+        => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, session.Versions.RevisionsFor<TDoc, TId>());
+
+    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+        => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
+
+    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
+        => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
+    public override ISelector BuildSelector(IMartenSession session)
+        => new NumericClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
+}

--- a/src/Marten/Internal/ClosedShape/NumericLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericLightweightClosedShapeStorage.cs
@@ -1,0 +1,43 @@
+#nullable enable
+using Marten.Internal;
+using Marten.Internal.Operations;
+using Marten.Linq.Selectors;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Numeric</c> closed-shape Lightweight storage.
+/// Factories construct <c>Numeric…</c> operation leaves and pass the
+/// session's typed long revision tracker; BuildSelector returns the
+/// numeric read selector. #4659 leaf.
+/// </summary>
+internal sealed class NumericLightweightClosedShapeStorage<TDoc, TId>: LightweightClosedShapeStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public NumericLightweightClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(mapping, descriptor)
+    {
+    }
+
+    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+        => new NumericClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
+
+    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+        => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
+
+    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+        => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, session.Versions.RevisionsFor<TDoc, TId>());
+
+    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+        => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
+
+    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
+        // #4658: projection path passes null tracker so it doesn't poison
+        // the session's numeric-revision map for the projected doc.
+        => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
+    public override ISelector BuildSelector(IMartenSession session)
+        => new NumericClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
+}

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> DirtyTracking selector.
+/// CaptureVersion writes the row's mt_version (Guid) into the session's
+/// per-type version dict. #4659 leaf.
+/// </summary>
+internal sealed class OptimisticClosedShapeDirtyTrackingSelector<T, TId>: ClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid> _versions;
+
+    public OptimisticClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _versions = session.Versions.ForType<T, TId>();
+    }
+
+    protected override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        var versionIndex = _descriptor.VersionReadIndex;
+        if (versionIndex < 0) return;
+        var versionOrdinal = FirstMetadataColumn + versionIndex;
+        if (reader.IsDBNull(versionOrdinal)) return;
+
+        _versions[id] = reader.GetFieldValue<Guid>(versionOrdinal);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> IdentityMap selector. CaptureVersion
+/// writes the row's mt_version (Guid) into the session's per-type version
+/// dict. #4659 leaf.
+/// </summary>
+internal sealed class OptimisticClosedShapeIdentityMapSelector<T, TId>: ClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid> _versions;
+
+    public OptimisticClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _versions = session.Versions.ForType<T, TId>();
+    }
+
+    protected override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        var versionIndex = _descriptor.VersionReadIndex;
+        if (versionIndex < 0) return;
+        var versionOrdinal = FirstMetadataColumn + versionIndex;
+        if (reader.IsDBNull(versionOrdinal)) return;
+
+        _versions[id] = reader.GetFieldValue<Guid>(versionOrdinal);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeInsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeInsertOperation.cs
@@ -1,0 +1,74 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using Marten.Exceptions;
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> closed-shape Insert. Generates a
+/// fresh Guid version at construction time, binds it in place of the
+/// VersionBinder's parameter slot, then writes it back through
+/// <see cref="DocumentVersionBinder{TDoc}.ApplyVersionTo"/> + the
+/// session's per-type version tracker on RETURNING success. #4659 leaf.
+/// </summary>
+internal sealed class OptimisticClosedShapeInsertOperation<TDoc, TId>: ClosedShapeInsertOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid> _versions;
+    private readonly Guid _newVersion;
+
+    public OptimisticClosedShapeInsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        Dictionary<TId, Guid> versions)
+        : base(document, id, tenantId, descriptor)
+    {
+        _versions = versions;
+        _newVersion = CombGuidIdGeneration.NewGuid();
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var parameters = builder.AppendWithParameters(_descriptor.InsertSql, '?');
+        var slot = BindLeadingParameters(parameters, session);
+
+        foreach (var binder in _descriptor.ClientSideWriteBinders)
+        {
+            if (ReferenceEquals(binder, _descriptor.VersionBinder))
+            {
+                parameters[slot].Value = _newVersion;
+                parameters[slot].NpgsqlDbType = NpgsqlDbType.Uuid;
+                _descriptor.VersionBinder!.ApplyVersionTo(_document, _newVersion);
+            }
+            else
+            {
+                binder.BindParameter(parameters[slot], _document, session);
+            }
+            slot++;
+        }
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            exceptions.Add(new DocumentAlreadyExistsException(null, typeof(TDoc), _id));
+            return;
+        }
+
+        _versions[_id] = _newVersion;
+    }
+}

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeLightweightSelector.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> Lightweight selector. Captures the
+/// row's mt_version (Guid) into the session's per-type version dict so
+/// subsequent updates can supply it as the expected version. #4659 leaf.
+/// </summary>
+internal sealed class OptimisticClosedShapeLightweightSelector<T, TId>: ClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid> _versions;
+
+    public OptimisticClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _versions = session.Versions.ForType<T, TId>();
+    }
+
+    protected override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        var versionIndex = _descriptor.VersionReadIndex;
+        if (versionIndex < 0) return;
+        var versionOrdinal = FirstMetadataColumn + versionIndex;
+        if (reader.IsDBNull(versionOrdinal)) return;
+
+        _versions[id] = reader.GetFieldValue<Guid>(versionOrdinal);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeOverwriteOperation.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeOverwriteOperation.cs
@@ -1,0 +1,79 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> closed-shape Overwrite. Generates a
+/// fresh Guid version, binds it for the SET VersionBinder slot, no
+/// trailing WHERE guard (Overwrite explicitly skips the version check).
+/// PostprocessAsync writes the new version to the session tracker on
+/// RETURNING success; a missing row only happens when the tracker dict
+/// was supplied null (the projection / fire-and-forget path) — silent
+/// no-op. #4659 leaf.
+/// </summary>
+internal sealed class OptimisticClosedShapeOverwriteOperation<TDoc, TId>: ClosedShapeOverwriteOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid>? _versions;
+    private readonly Guid _newVersion;
+
+    public OptimisticClosedShapeOverwriteOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        Dictionary<TId, Guid>? versions)
+        : base(document, id, tenantId, descriptor)
+    {
+        _versions = versions;
+        _newVersion = CombGuidIdGeneration.NewGuid();
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var parameters = builder.AppendWithParameters(_descriptor.OverwriteSql, '?');
+        BindPreOnConflictParameters(parameters, session);
+        // Overwrite drops the trailing concurrency-guard slot vs Upsert.
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            // #4658 — null tracker (the OverwriteProjected path) just
+            // skips the tracker write. The fresh version is still
+            // applied to the document via VersionBinder during command
+            // configuration.
+            if (_versions is not null)
+            {
+                _versions[_id] = _newVersion;
+            }
+        }
+    }
+
+    protected override int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)
+    {
+        if (ReferenceEquals(binder, _descriptor.VersionBinder))
+        {
+            parameters[slot].Value = _newVersion;
+            parameters[slot].NpgsqlDbType = NpgsqlDbType.Uuid;
+            _descriptor.VersionBinder!.ApplyVersionTo(_document, _newVersion);
+            return slot + 1;
+        }
+
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeUpdateOperation.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeUpdateOperation.cs
@@ -1,0 +1,88 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using Marten.Exceptions;
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> closed-shape Update. Generates a
+/// fresh Guid version at construction time, binds it for the SET
+/// VersionBinder slot, and binds the caller's expected Guid version
+/// (from the session tracker, or DBNull if unknown) at the trailing
+/// WHERE concurrency slot. Missing RETURNING row → version mismatch →
+/// <see cref="ConcurrencyException"/>. #4659 leaf.
+/// </summary>
+internal sealed class OptimisticClosedShapeUpdateOperation<TDoc, TId>: ClosedShapeUpdateOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid> _versions;
+    private readonly Guid _newVersion;
+
+    public OptimisticClosedShapeUpdateOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        Dictionary<TId, Guid> versions)
+        : base(document, id, tenantId, descriptor)
+    {
+        _versions = versions;
+        _newVersion = CombGuidIdGeneration.NewGuid();
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var parameters = builder.AppendWithParameters(_descriptor.UpdateSql, '?');
+        var slot = BindPreConcurrencyParameters(parameters, session);
+
+        // Trailing WHERE mt_version = ? guard.
+        if (_versions.TryGetValue(_id, out var expected))
+        {
+            parameters[slot].Value = expected;
+        }
+        else
+        {
+            parameters[slot].Value = DBNull.Value;
+        }
+        parameters[slot].NpgsqlDbType = NpgsqlDbType.Uuid;
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            if (!IgnoreConcurrencyViolation)
+            {
+                exceptions.Add(new ConcurrencyException(typeof(TDoc), _id));
+            }
+            return;
+        }
+
+        _versions[_id] = _newVersion;
+    }
+
+    protected override int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)
+    {
+        if (ReferenceEquals(binder, _descriptor.VersionBinder))
+        {
+            parameters[slot].Value = _newVersion;
+            parameters[slot].NpgsqlDbType = NpgsqlDbType.Uuid;
+            _descriptor.VersionBinder!.ApplyVersionTo(_document, _newVersion);
+            return slot + 1;
+        }
+
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeUpsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeUpsertOperation.cs
@@ -1,0 +1,90 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using Marten.Exceptions;
+using Marten.Internal.Operations;
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> closed-shape Upsert. Generates a
+/// fresh Guid version, binds it for the SET VersionBinder slot, and
+/// binds the caller's expected Guid version at the trailing
+/// <c>ON CONFLICT DO UPDATE … WHERE table.mt_version = ?</c> slot.
+/// Missing RETURNING row → version mismatch →
+/// <see cref="ConcurrencyException"/>. #4659 leaf.
+/// </summary>
+internal sealed class OptimisticClosedShapeUpsertOperation<TDoc, TId>: ClosedShapeUpsertOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    private readonly Dictionary<TId, Guid> _versions;
+    private readonly Guid _newVersion;
+
+    public OptimisticClosedShapeUpsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        OperationRole role,
+        Dictionary<TId, Guid> versions)
+        : base(document, id, tenantId, descriptor, role)
+    {
+        _versions = versions;
+        _newVersion = CombGuidIdGeneration.NewGuid();
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var parameters = builder.AppendWithParameters(_descriptor.UpsertSql, '?');
+        var slot = BindPreOnConflictParameters(parameters, session);
+
+        // Trailing WHERE table.mt_version = ? guard.
+        if (_versions.TryGetValue(_id, out var expected))
+        {
+            parameters[slot].Value = expected;
+        }
+        else
+        {
+            parameters[slot].Value = DBNull.Value;
+        }
+        parameters[slot].NpgsqlDbType = NpgsqlDbType.Uuid;
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            if (!IgnoreConcurrencyViolation)
+            {
+                exceptions.Add(new ConcurrencyException(typeof(TDoc), _id));
+            }
+            return;
+        }
+
+        _versions[_id] = _newVersion;
+    }
+
+    protected override int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)
+    {
+        if (ReferenceEquals(binder, _descriptor.VersionBinder))
+        {
+            parameters[slot].Value = _newVersion;
+            parameters[slot].NpgsqlDbType = NpgsqlDbType.Uuid;
+            _descriptor.VersionBinder!.ApplyVersionTo(_document, _newVersion);
+            return slot + 1;
+        }
+
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Marten/Internal/ClosedShape/OptimisticDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticDirtyCheckedClosedShapeStorage.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using Marten.Internal;
+using Marten.Internal.Operations;
+using Marten.Linq.Selectors;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> closed-shape DirtyChecked storage. #4659 leaf.
+/// </summary>
+internal sealed class OptimisticDirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyCheckedClosedShapeStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public OptimisticDirtyCheckedClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(mapping, descriptor)
+    {
+    }
+
+    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+        => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
+
+    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+        => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
+
+    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+        => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, session.Versions.ForType<TDoc, TId>());
+
+    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+        => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
+
+    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
+        => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
+    public override ISelector BuildSelector(IMartenSession session)
+        => new OptimisticClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
+}

--- a/src/Marten/Internal/ClosedShape/OptimisticIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticIdentityMapClosedShapeStorage.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using Marten.Internal;
+using Marten.Internal.Operations;
+using Marten.Linq.Selectors;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> closed-shape IdentityMap storage. #4659 leaf.
+/// </summary>
+internal sealed class OptimisticIdentityMapClosedShapeStorage<TDoc, TId>: IdentityMapClosedShapeStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public OptimisticIdentityMapClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(mapping, descriptor)
+    {
+    }
+
+    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+        => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
+
+    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+        => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
+
+    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+        => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, session.Versions.ForType<TDoc, TId>());
+
+    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+        => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
+
+    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
+        => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
+    public override ISelector BuildSelector(IMartenSession session)
+        => new OptimisticClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
+}

--- a/src/Marten/Internal/ClosedShape/OptimisticLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticLightweightClosedShapeStorage.cs
@@ -1,0 +1,43 @@
+#nullable enable
+using Marten.Internal;
+using Marten.Internal.Operations;
+using Marten.Linq.Selectors;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Optimistic</c> closed-shape Lightweight storage.
+/// Factories construct <c>Optimistic…</c> operation leaves and pass the
+/// session's typed Guid version tracker; BuildSelector returns the
+/// optimistic read selector. #4659 leaf.
+/// </summary>
+internal sealed class OptimisticLightweightClosedShapeStorage<TDoc, TId>: LightweightClosedShapeStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public OptimisticLightweightClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(mapping, descriptor)
+    {
+    }
+
+    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+        => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
+
+    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+        => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
+
+    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+        => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, session.Versions.ForType<TDoc, TId>());
+
+    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+        => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
+
+    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
+        // #4658: projection path passes null tracker so it doesn't poison
+        // the session's optimistic-version map for the projected doc.
+        => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
+    public override ISelector BuildSelector(IMartenSession session)
+        => new OptimisticClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
+}

--- a/src/Marten/Internal/ClosedShape/UnversionedClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,20 @@
+#nullable enable
+using System.Data.Common;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> DirtyTracking selector. CaptureVersion is
+/// a no-op. #4659 leaf.
+/// </summary>
+internal sealed class UnversionedClosedShapeDirtyTrackingSelector<T, TId>: ClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public UnversionedClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override void CaptureVersion(DbDataReader reader, TId id) { /* no-op */ }
+}

--- a/src/Marten/Internal/ClosedShape/UnversionedClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,20 @@
+#nullable enable
+using System.Data.Common;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> IdentityMap selector. CaptureVersion is a
+/// no-op. #4659 leaf.
+/// </summary>
+internal sealed class UnversionedClosedShapeIdentityMapSelector<T, TId>: ClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public UnversionedClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override void CaptureVersion(DbDataReader reader, TId id) { /* no-op */ }
+}

--- a/src/Marten/Internal/ClosedShape/UnversionedClosedShapeInsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedClosedShapeInsertOperation.cs
@@ -1,0 +1,56 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten.Exceptions;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> closed-shape Insert. Hand-written for the
+/// no-version-no-revision shape: bind <c>[tenant_id,] id, data</c> + the
+/// client-side metadata binders, then on RETURNING expect a row (otherwise
+/// raise <see cref="DocumentAlreadyExistsException"/>). No tracker writes,
+/// no version/revision binder special-casing. #4659 leaf.
+/// </summary>
+internal sealed class UnversionedClosedShapeInsertOperation<TDoc, TId>: ClosedShapeInsertOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public UnversionedClosedShapeInsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(document, id, tenantId, descriptor)
+    {
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var parameters = builder.AppendWithParameters(_descriptor.InsertSql, '?');
+        var slot = BindLeadingParameters(parameters, session);
+
+        // Off mode: every client-side write binder binds its single slot.
+        // No version or revision binder is in this array under Off mode.
+        foreach (var binder in _descriptor.ClientSideWriteBinders)
+        {
+            binder.BindParameter(parameters[slot], _document, session);
+            slot++;
+        }
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            exceptions.Add(new DocumentAlreadyExistsException(null, typeof(TDoc), _id));
+        }
+    }
+}

--- a/src/Marten/Internal/ClosedShape/UnversionedClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedClosedShapeLightweightSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> Lightweight selector. No version/revision
+/// tracker — CaptureVersion is a no-op. #4659 leaf.
+/// </summary>
+internal sealed class UnversionedClosedShapeLightweightSelector<T, TId>: ClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public UnversionedClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override void CaptureVersion(DbDataReader reader, TId id)
+    {
+        // Off-mode: nothing to capture. The mt_version column may or may
+        // not be present in ReadBinders (depends on the user's mapping)
+        // but the session has no tracker to push it into.
+    }
+}

--- a/src/Marten/Internal/ClosedShape/UnversionedClosedShapeOverwriteOperation.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedClosedShapeOverwriteOperation.cs
@@ -1,0 +1,47 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> closed-shape Overwrite. Functionally
+/// identical to <see cref="UnversionedClosedShapeUpsertOperation{TDoc, TId}"/>
+/// — no concurrency guard either way under Off. PostprocessAsync is
+/// fire-and-forget. #4659 leaf.
+/// </summary>
+internal sealed class UnversionedClosedShapeOverwriteOperation<TDoc, TId>: ClosedShapeOverwriteOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public UnversionedClosedShapeOverwriteOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(document, id, tenantId, descriptor)
+    {
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var parameters = builder.AppendWithParameters(_descriptor.OverwriteSql, '?');
+        BindPreOnConflictParameters(parameters, session);
+        // Off-mode OverwriteSql has no trailing concurrency-extras slot.
+    }
+
+    public override Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+        => Task.CompletedTask;
+
+    protected override int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)
+    {
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Marten/Internal/ClosedShape/UnversionedClosedShapeUpdateOperation.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedClosedShapeUpdateOperation.cs
@@ -1,0 +1,57 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Exceptions;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> closed-shape Update. Plain
+/// <c>WHERE id = ? [AND tenant_id = ?] [AND partition_col = ?…]</c> —
+/// no concurrency guard. A missing row signals the document didn't
+/// exist; raises <see cref="NonExistentDocumentException"/>. #4659 leaf.
+/// </summary>
+internal sealed class UnversionedClosedShapeUpdateOperation<TDoc, TId>: ClosedShapeUpdateOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public UnversionedClosedShapeUpdateOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(document, id, tenantId, descriptor)
+    {
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var parameters = builder.AppendWithParameters(_descriptor.UpdateSql, '?');
+        // Off mode has no trailing concurrency-guard slot — we just consume
+        // data + binders + id + tenant + partition PK.
+        BindPreConcurrencyParameters(parameters, session);
+    }
+
+    public override async Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            if (!IgnoreConcurrencyViolation)
+            {
+                exceptions.Add(new NonExistentDocumentException(typeof(TDoc), _id));
+            }
+        }
+    }
+
+    protected override int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)
+    {
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Marten/Internal/ClosedShape/UnversionedClosedShapeUpsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedClosedShapeUpsertOperation.cs
@@ -1,0 +1,51 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Internal.Operations;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> closed-shape Upsert. Plain
+/// <c>INSERT … ON CONFLICT (id) DO UPDATE SET … RETURNING id</c> — no
+/// version/revision guard. PostprocessAsync is fire-and-forget: the
+/// RETURNING row is there for symmetry with Insert/Update but the result
+/// isn't inspected (Off-mode Upsert always wins, no concurrency-failure
+/// outcome to detect). #4659 leaf.
+/// </summary>
+internal sealed class UnversionedClosedShapeUpsertOperation<TDoc, TId>: ClosedShapeUpsertOperation<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public UnversionedClosedShapeUpsertOperation(
+        TDoc document,
+        TId id,
+        string tenantId,
+        DocumentStorageDescriptor<TDoc, TId> descriptor,
+        OperationRole role)
+        : base(document, id, tenantId, descriptor, role)
+    {
+    }
+
+    public override void ConfigureCommand(ICommandBuilder builder, IMartenSession session)
+    {
+        var parameters = builder.AppendWithParameters(_descriptor.UpsertSql, '?');
+        BindPreOnConflictParameters(parameters, session);
+        // Off-mode UpsertSql has no trailing concurrency-extras slot.
+    }
+
+    public override Task PostprocessAsync(DbDataReader reader, IList<Exception> exceptions, CancellationToken token)
+        => Task.CompletedTask;
+
+    protected override int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)
+    {
+        binder.BindParameter(parameters[slot], _document, session);
+        return slot + 1;
+    }
+}

--- a/src/Marten/Internal/ClosedShape/UnversionedDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedDirtyCheckedClosedShapeStorage.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using Marten.Internal;
+using Marten.Internal.Operations;
+using Marten.Linq.Selectors;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> closed-shape DirtyChecked storage. #4659 leaf.
+/// </summary>
+internal sealed class UnversionedDirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyCheckedClosedShapeStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public UnversionedDirtyCheckedClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(mapping, descriptor)
+    {
+    }
+
+    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+        => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+        => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+        => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert);
+
+    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+        => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
+        => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override ISelector BuildSelector(IMartenSession session)
+        => new UnversionedClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
+}

--- a/src/Marten/Internal/ClosedShape/UnversionedIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedIdentityMapClosedShapeStorage.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using Marten.Internal;
+using Marten.Internal.Operations;
+using Marten.Linq.Selectors;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> closed-shape IdentityMap storage. #4659 leaf.
+/// </summary>
+internal sealed class UnversionedIdentityMapClosedShapeStorage<TDoc, TId>: IdentityMapClosedShapeStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public UnversionedIdentityMapClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(mapping, descriptor)
+    {
+    }
+
+    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+        => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+        => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+        => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert);
+
+    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+        => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
+        => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override ISelector BuildSelector(IMartenSession session)
+        => new UnversionedClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
+}

--- a/src/Marten/Internal/ClosedShape/UnversionedLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedLightweightClosedShapeStorage.cs
@@ -1,0 +1,41 @@
+#nullable enable
+using Marten.Internal;
+using Marten.Internal.Operations;
+using Marten.Linq.Selectors;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// <c>ConcurrencyMode.Off</c> closed-shape Lightweight storage. No
+/// version / revision tracker plumbed — each write factory constructs
+/// its <c>Unversioned…</c> operation leaf and BuildSelector returns the
+/// unversioned read selector. #4659 leaf.
+/// </summary>
+internal sealed class UnversionedLightweightClosedShapeStorage<TDoc, TId>: LightweightClosedShapeStorage<TDoc, TId>
+    where TDoc : notnull
+    where TId : notnull
+{
+    public UnversionedLightweightClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
+        : base(mapping, descriptor)
+    {
+    }
+
+    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+        => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+        => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+        => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert);
+
+    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+        => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
+        => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override ISelector BuildSelector(IMartenSession session)
+        => new UnversionedClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
+}


### PR DESCRIPTION
First of the two PRs the #4659 phased plan calls for.

## What this changes

Each writeable closed-shape class in `src/Marten/Internal/ClosedShape/` is split into a small abstract base + three `internal sealed` leaves keyed on the document's `ConcurrencyMode` (`Off` → `Unversioned…` / `Optimistic` / `Numeric`). After the split, **zero per-operation or per-row reads of `_descriptor.ConcurrencyMode`** remain — the storage class is monomorphic by construction.

### Operations (12 sealed leaves + 4 abstract bases)

| | Off | Optimistic | Numeric |
|---|---|---|---|
| Insert | `UnversionedClosedShapeInsertOperation` | `Optimistic…` | `Numeric…` |
| Update | `UnversionedClosedShapeUpdateOperation` | `Optimistic…` | `Numeric…` |
| Upsert | `UnversionedClosedShapeUpsertOperation` | `Optimistic…` | `Numeric…` |
| Overwrite | `UnversionedClosedShapeOverwriteOperation` | `Optimistic…` | `Numeric…` |

Each leaf binds exactly the slots its mode needs. Optimistic leaves carry `Dictionary<TId, Guid>` trackers; Numeric leaves carry `Dictionary<TId, long>` trackers; Unversioned leaves carry none. The Numeric leaves own the `UseVersionFromMatchingStream` subquery shape. The Optimistic / Numeric Overwrite leaves keep the tracker nullable to preserve the #4658 `OverwriteProjected` contract.

### Storages (9 sealed leaves + 3 abstract bases)

| | Off | Optimistic | Numeric |
|---|---|---|---|
| Lightweight | `UnversionedLightweightClosedShapeStorage` | `Optimistic…` | `Numeric…` |
| IdentityMap | `UnversionedIdentityMapClosedShapeStorage` | `Optimistic…` | `Numeric…` |
| DirtyChecked | `UnversionedDirtyCheckedClosedShapeStorage` | `Optimistic…` | `Numeric…` |

`QueryOnlyClosedShapeStorage` is unchanged — no write path, no concurrency interaction.

The shared `VersionsFor` / `RevisionsFor` helpers are gone; each leaf knows its mode.

### Selectors (9 sealed leaves + 3 abstract bases)

`ClosedShape{Lightweight, IdentityMap, DirtyTracking}Selector` each becomes an abstract base + 3 `Unversioned…` / `Optimistic…` / `Numeric…` sealed leaves. The hot path is the per-row `CaptureVersion` virtual override:

- Unversioned: no-op.
- Optimistic: read Guid, store in per-type version dict.
- Numeric: read long, store in per-type revision dict.

`ClosedShapeQueryOnlySelector` is unchanged (no concurrency capture path).

### Registration

`ClosedShapeRegistration.BuildProvider` gains three small helpers (`BuildLightweightStorage` / `BuildIdentityMapStorage` / `BuildDirtyCheckedStorage`) that switch on `descriptor.ConcurrencyMode` ONCE at registration time and construct the right leaf. The closed-shape `DocumentProvider` keeps its 4-tuple shape; only the writeable members change leaf identity.

## Public API impact

`IDocumentStorage<T, TId>` and `DocumentStorage<T, TId>` are unchanged.

The three writeable storage classes flip from `public sealed` → `public abstract`. They still exist as public types but are no longer directly instantiable — the registration internals build the concurrency-specific leaves. The W3 spike's `UseLightweightSequentialGuidClosedShape` / `UseExternallyAssignedStringClosedShape` extensions continue to work because they route through `ClosedShapeRegistration.RegisterClosedShape`.

All 30 new variants are `internal sealed`.

## Why this also helps AOT

Before: the storage class was monomorphic *post-construction* but the JIT couldn't prove it because every method still read `_descriptor` to decide what to do. After: monomorphic *by construction* — the JIT (and a future Marten source generator) can specialize and inline aggressively. This is the necessary precondition for source-gen specialization of `IDocumentAccessor<TDoc, TId>` per the W5 spike notes.

## Acceptance criteria

```
$ grep -rn "_descriptor\.ConcurrencyMode" src/Marten/Internal/ClosedShape/
# 0 hits (modulo ClosedShapeRegistration's 3 dispatch sites + 1 comment)
```

All new variants are `internal sealed`. No new public API surface. `OverwriteProjected` (#4658) still routes through the Optimistic / Numeric variant appropriately and passes `null` trackers in the versioned variants.

## Local test results

```
DocumentDbTests:  999 passed,  0 failed (1 unrelated pre-existing skip)
PatchingTests:    122 passed,  0 failed (1 unrelated pre-existing skip)
```

(One unrelated `Bug_4187_ancillary_store_isolation` CoreTests flake — "Unable to attain a global lock in time" — is a pre-existing timing issue unrelated to this refactor.)

## What this PR does NOT do

- `IsConjoined` (4 param-binding sites) and `UseVersionFromMatchingStream` (rolled into Numeric leaves) — Phase 1 scope explicitly leaves the former alone per the issue's non-goals; the latter is now Numeric-only.
- `HierarchyMapping is { }` per-row branch in the 4 read selectors — that's the Phase 2 follow-up PR per the issue's phased plan.
- `DocumentStorageDescriptor` and `DocumentStorageDescriptorBuilder` are untouched (per the issue: "DescriptorBuilder is unchanged — it already computes everything; we just slice the registration further").

## Tracking

- Implements #4659 Phase 1
- Phase 2 (hierarchy split) coming as a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)