### PR TITLE
#4659 Phase 2 — hierarchy selector split eliminates last per-row branch

### DIFF
--- a/src/Marten/Internal/ClosedShape/ClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeDirtyTrackingSelector.cs
@@ -11,12 +11,14 @@ using Marten.Internal.CodeGeneration;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
-/// DirtyTracking <see cref="ISelector{T}"/>. Identity-map writes (like
-/// <see cref="ClosedShapeIdentityMapSelector{T, TId}"/>) plus a
-/// <see cref="ChangeTracker{T}"/> registered on the session per loaded
-/// document. Sealed concurrency-specific subclasses override
-/// <c>CaptureVersion</c> (#4659).
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> ×
+/// <see cref="DocumentStorageDescriptor{T,TId}.HierarchyMapping"/>
+/// closed-shape DirtyTracking <see cref="ISelector{T}"/>. Identity-map
+/// writes (like <see cref="ClosedShapeIdentityMapSelector{T, TId}"/>)
+/// plus a <see cref="ChangeTracker{T}"/> registered on the session per
+/// loaded document. Sealed concurrency × hierarchy leaves provide
+/// monomorphic <c>CaptureVersion</c> + <c>ReadDocument</c> bodies
+/// (#4659).
 /// </summary>
 internal abstract class ClosedShapeDirtyTrackingSelector<T, TId>: ISelector<T>, IDocumentSelector
     where T : notnull
@@ -86,30 +88,11 @@ internal abstract class ClosedShapeDirtyTrackingSelector<T, TId>: ISelector<T>, 
         return doc;
     }
 
-    /// <summary>
-    /// Concurrency-specific per-row version capture.
-    /// </summary>
     protected abstract void CaptureVersion(DbDataReader reader, TId id);
 
-    protected T ReadDocument(DbDataReader reader)
-    {
-        if (_descriptor.HierarchyMapping is { } hierarchy)
-        {
-            var alias = reader.GetFieldValue<string>(FirstMetadataColumn + _descriptor.DocTypeReadIndex);
-            return (T)_serializer.FromJson(hierarchy.TypeFor(alias), reader, DataColumn);
-        }
-        return _serializer.FromJson<T>(reader, DataColumn);
-    }
+    protected abstract T ReadDocument(DbDataReader reader);
 
-    protected async System.Threading.Tasks.ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
-    {
-        if (_descriptor.HierarchyMapping is { } hierarchy)
-        {
-            var alias = await reader.GetFieldValueAsync<string>(FirstMetadataColumn + _descriptor.DocTypeReadIndex, token).ConfigureAwait(false);
-            return (T)await _serializer.FromJsonAsync(hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
-        }
-        return await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
-    }
+    protected abstract ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token);
 
     protected void ApplyMetadata(DbDataReader reader, T document)
     {

--- a/src/Marten/Internal/ClosedShape/ClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeIdentityMapSelector.cs
@@ -10,11 +10,12 @@ using Marten.Internal.CodeGeneration;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
-/// IdentityMap <see cref="ISelector{T}"/>. Owns the identity-map cache
-/// init + lookup; sealed subclasses provide a monomorphic
-/// <c>CaptureVersion</c> override so the per-row hot path doesn't read
-/// <c>ConcurrencyMode</c> (#4659).
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> ×
+/// <see cref="DocumentStorageDescriptor{T,TId}.HierarchyMapping"/>
+/// closed-shape IdentityMap <see cref="ISelector{T}"/>. Owns the
+/// identity-map cache init + lookup; sealed concurrency × hierarchy
+/// leaves override <c>CaptureVersion</c> + <c>ReadDocument</c> so the
+/// per-row hot path doesn't branch on either descriptor field (#4659).
 /// </summary>
 internal abstract class ClosedShapeIdentityMapSelector<T, TId>: ISelector<T>, IDocumentSelector
     where T : notnull
@@ -88,31 +89,11 @@ internal abstract class ClosedShapeIdentityMapSelector<T, TId>: ISelector<T>, ID
         return doc;
     }
 
-    /// <summary>
-    /// Concurrency-specific per-row version capture. Off-mode subclasses
-    /// no-op; Optimistic / Numeric capture into their typed tracker.
-    /// </summary>
     protected abstract void CaptureVersion(DbDataReader reader, TId id);
 
-    protected T ReadDocument(DbDataReader reader)
-    {
-        if (_descriptor.HierarchyMapping is { } hierarchy)
-        {
-            var alias = reader.GetFieldValue<string>(FirstMetadataColumn + _descriptor.DocTypeReadIndex);
-            return (T)_serializer.FromJson(hierarchy.TypeFor(alias), reader, DataColumn);
-        }
-        return _serializer.FromJson<T>(reader, DataColumn);
-    }
+    protected abstract T ReadDocument(DbDataReader reader);
 
-    protected async System.Threading.Tasks.ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
-    {
-        if (_descriptor.HierarchyMapping is { } hierarchy)
-        {
-            var alias = await reader.GetFieldValueAsync<string>(FirstMetadataColumn + _descriptor.DocTypeReadIndex, token).ConfigureAwait(false);
-            return (T)await _serializer.FromJsonAsync(hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
-        }
-        return await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
-    }
+    protected abstract ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token);
 
     protected void ApplyMetadata(DbDataReader reader, T document)
     {

--- a/src/Marten/Internal/ClosedShape/ClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeLightweightSelector.cs
@@ -9,13 +9,14 @@ using Marten.Internal.CodeGeneration;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// Abstract base for the per-<see cref="ConcurrencyMode"/> closed-shape
-/// Lightweight <see cref="ISelector{T}"/>. Owns the shared row-shape
-/// (id at col 0, data at col 1, metadata at 2+) plus document
-/// deserialization and metadata-apply. The per-row
-/// <c>CaptureVersion</c> step is virtual; sealed subclasses provide a
-/// monomorphic implementation so the JIT can devirtualize the hot
-/// path (#4659).
+/// Abstract base for the per-<see cref="ConcurrencyMode"/> ×
+/// <see cref="DocumentStorageDescriptor{T,TId}.HierarchyMapping"/>
+/// closed-shape Lightweight <see cref="ISelector{T}"/>. Owns the shared
+/// row-shape (id at col 0, data at col 1, metadata at 2+) plus
+/// metadata-apply. Sealed concurrency × hierarchy leaves provide
+/// monomorphic <c>CaptureVersion</c> + <c>ReadDocument</c> /
+/// <c>ReadDocumentAsync</c> bodies so the per-row hot path doesn't
+/// branch on either descriptor field (#4659).
 /// </summary>
 internal abstract class ClosedShapeLightweightSelector<T, TId>: ISelector<T>, IDocumentSelector
     where T : notnull
@@ -60,30 +61,19 @@ internal abstract class ClosedShapeLightweightSelector<T, TId>: ISelector<T>, ID
 
     /// <summary>
     /// Concurrency-specific per-row version capture. Off-mode subclasses
-    /// no-op; Optimistic captures the Guid into the per-type version
-    /// dict; Numeric captures the long into the per-type revision dict.
+    /// no-op; Optimistic / Numeric capture into their typed tracker.
     /// </summary>
     protected abstract void CaptureVersion(DbDataReader reader, TId id);
 
-    protected T ReadDocument(DbDataReader reader)
-    {
-        if (_descriptor.HierarchyMapping is { } hierarchy)
-        {
-            var alias = reader.GetFieldValue<string>(FirstMetadataColumn + _descriptor.DocTypeReadIndex);
-            return (T)_serializer.FromJson(hierarchy.TypeFor(alias), reader, DataColumn);
-        }
-        return _serializer.FromJson<T>(reader, DataColumn);
-    }
+    /// <summary>
+    /// Hierarchy-specific per-row deserialization. Flat subclasses
+    /// deserialize straight to <typeparamref name="T"/>; Hierarchical
+    /// subclasses read <c>mt_doc_type</c> and dispatch through the
+    /// hierarchy mapping. (#4659 Phase 2.)
+    /// </summary>
+    protected abstract T ReadDocument(DbDataReader reader);
 
-    protected async System.Threading.Tasks.ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
-    {
-        if (_descriptor.HierarchyMapping is { } hierarchy)
-        {
-            var alias = await reader.GetFieldValueAsync<string>(FirstMetadataColumn + _descriptor.DocTypeReadIndex, token).ConfigureAwait(false);
-            return (T)await _serializer.FromJsonAsync(hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
-        }
-        return await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
-    }
+    protected abstract ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token);
 
     protected void ApplyMetadata(DbDataReader reader, T document)
     {

--- a/src/Marten/Internal/ClosedShape/ClosedShapeQueryOnlySelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeQueryOnlySelector.cs
@@ -7,25 +7,27 @@ using Marten.Linq.Selectors;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// W3 spike (M2): <see cref="ISelector{T}"/> for the
-/// <see cref="QueryOnlySequentialGuidStorage{TDoc}"/> path. QueryOnly
-/// storage excludes the id column from its SELECT projection (see
-/// <c>IdColumn.ShouldSelect</c> — false for QueryOnly), so the data
+/// Abstract base for the QueryOnly closed-shape <see cref="ISelector{T}"/>.
+/// QueryOnly storage excludes the id column from its SELECT projection
+/// (see <c>IdColumn.ShouldSelect</c> — false for QueryOnly), so the data
 /// column sits at index 0 and metadata starts at 1. No identity-map
 /// writes — QueryOnly sessions don't track loaded docs.
+/// Sealed subclasses provide a monomorphic <c>ReadDocument</c> /
+/// <c>ReadDocumentAsync</c> so the per-row hot path doesn't branch on
+/// <c>HierarchyMapping</c> (#4659 Phase 2).
 /// </summary>
-internal sealed class ClosedShapeQueryOnlySelector<T, TId>: ISelector<T>
+internal abstract class ClosedShapeQueryOnlySelector<T, TId>: ISelector<T>
     where T : notnull
     where TId : notnull
 {
-    private const int DataColumn = 0;
-    private const int FirstMetadataColumn = 1;
+    protected const int DataColumn = 0;
+    protected const int FirstMetadataColumn = 1;
 
-    private readonly IMartenSession _session;
-    private readonly ISerializer _serializer;
-    private readonly DocumentStorageDescriptor<T, TId> _descriptor;
+    protected readonly IMartenSession _session;
+    protected readonly ISerializer _serializer;
+    protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
 
-    public ClosedShapeQueryOnlySelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected ClosedShapeQueryOnlySelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
     {
         _session = session;
         _serializer = session.Serializer;
@@ -46,25 +48,9 @@ internal sealed class ClosedShapeQueryOnlySelector<T, TId>: ISelector<T>
         return doc;
     }
 
-    private T ReadDocument(DbDataReader reader)
-    {
-        if (_descriptor.HierarchyMapping is { } hierarchy)
-        {
-            var alias = reader.GetFieldValue<string>(FirstMetadataColumn + _descriptor.DocTypeReadIndex);
-            return (T)_serializer.FromJson(hierarchy.TypeFor(alias), reader, DataColumn);
-        }
-        return _serializer.FromJson<T>(reader, DataColumn);
-    }
+    protected abstract T ReadDocument(DbDataReader reader);
 
-    private async System.Threading.Tasks.ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
-    {
-        if (_descriptor.HierarchyMapping is { } hierarchy)
-        {
-            var alias = await reader.GetFieldValueAsync<string>(FirstMetadataColumn + _descriptor.DocTypeReadIndex, token).ConfigureAwait(false);
-            return (T)await _serializer.FromJsonAsync(hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
-        }
-        return await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
-    }
+    protected abstract ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token);
 
     private void ApplyMetadata(DbDataReader reader, T document)
     {

--- a/src/Marten/Internal/ClosedShape/FlatClosedShapeQueryOnlySelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatClosedShapeQueryOnlySelector.cs
@@ -1,0 +1,27 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Non-hierarchical QueryOnly selector. <c>ReadDocument</c> deserializes
+/// straight to <typeparamref name="T"/> — no per-row mt_doc_type
+/// inspection. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class FlatClosedShapeQueryOnlySelector<T, TId>: ClosedShapeQueryOnlySelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatClosedShapeQueryOnlySelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Marten/Internal/ClosedShape/FlatNumericClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatNumericClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Non-hierarchical, Numeric DirtyTracking selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class FlatNumericClosedShapeDirtyTrackingSelector<T, TId>: NumericClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatNumericClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Marten/Internal/ClosedShape/FlatNumericClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatNumericClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Non-hierarchical, Numeric IdentityMap selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class FlatNumericClosedShapeIdentityMapSelector<T, TId>: NumericClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatNumericClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Marten/Internal/ClosedShape/FlatNumericClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatNumericClosedShapeLightweightSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Non-hierarchical, Numeric Lightweight selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class FlatNumericClosedShapeLightweightSelector<T, TId>: NumericClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatNumericClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Marten/Internal/ClosedShape/FlatOptimisticClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatOptimisticClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Non-hierarchical, Optimistic DirtyTracking selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class FlatOptimisticClosedShapeDirtyTrackingSelector<T, TId>: OptimisticClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatOptimisticClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Marten/Internal/ClosedShape/FlatOptimisticClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatOptimisticClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Non-hierarchical, Optimistic IdentityMap selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class FlatOptimisticClosedShapeIdentityMapSelector<T, TId>: OptimisticClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatOptimisticClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Marten/Internal/ClosedShape/FlatOptimisticClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatOptimisticClosedShapeLightweightSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Non-hierarchical, Optimistic Lightweight selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class FlatOptimisticClosedShapeLightweightSelector<T, TId>: OptimisticClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatOptimisticClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Marten/Internal/ClosedShape/FlatUnversionedClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatUnversionedClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Non-hierarchical, Off-mode DirtyTracking selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class FlatUnversionedClosedShapeDirtyTrackingSelector<T, TId>: UnversionedClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatUnversionedClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Marten/Internal/ClosedShape/FlatUnversionedClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatUnversionedClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Non-hierarchical, Off-mode IdentityMap selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class FlatUnversionedClosedShapeIdentityMapSelector<T, TId>: UnversionedClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatUnversionedClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Marten/Internal/ClosedShape/FlatUnversionedClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatUnversionedClosedShapeLightweightSelector.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Non-hierarchical, Off-mode Lightweight selector. ReadDocument
+/// deserializes straight to <typeparamref name="T"/>. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class FlatUnversionedClosedShapeLightweightSelector<T, TId>: UnversionedClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    public FlatUnversionedClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+        => _serializer.FromJson<T>(reader, DataColumn);
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+        => await _serializer.FromJsonAsync<T>(reader, DataColumn, token).ConfigureAwait(false);
+}

--- a/src/Marten/Internal/ClosedShape/HierarchicalClosedShapeQueryOnlySelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalClosedShapeQueryOnlySelector.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Hierarchical QueryOnly selector. Reads the <c>mt_doc_type</c> alias
+/// from the descriptor's <see cref="DocumentStorageDescriptor{T,TId}.DocTypeReadIndex"/>
+/// and dispatches deserialization through the
+/// <see cref="DocumentStorageDescriptor{T,TId}.HierarchyMapping"/> root —
+/// the alias-to-.NET-type lookup the polymorphic JSON path needs.
+/// #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class HierarchicalClosedShapeQueryOnlySelector<T, TId>: ClosedShapeQueryOnlySelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly DocumentMapping _hierarchy;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalClosedShapeQueryOnlySelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        // The factory only constructs this leaf when HierarchyMapping is
+        // non-null; capture it once to avoid the per-row pattern-match.
+        _hierarchy = descriptor.HierarchyMapping
+            ?? throw new InvalidOperationException(
+                "HierarchicalClosedShapeQueryOnlySelector requires a non-null descriptor.HierarchyMapping; " +
+                "the storage factory must dispatch to FlatClosedShapeQueryOnlySelector otherwise.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Hierarchical, Numeric DirtyTracking selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class HierarchicalNumericClosedShapeDirtyTrackingSelector<T, TId>: NumericClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly DocumentMapping _hierarchy;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalNumericClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _hierarchy = descriptor.HierarchyMapping
+            ?? throw new InvalidOperationException(
+                "HierarchicalNumericClosedShapeDirtyTrackingSelector requires a non-null descriptor.HierarchyMapping.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Hierarchical, Numeric IdentityMap selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class HierarchicalNumericClosedShapeIdentityMapSelector<T, TId>: NumericClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly DocumentMapping _hierarchy;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalNumericClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _hierarchy = descriptor.HierarchyMapping
+            ?? throw new InvalidOperationException(
+                "HierarchicalNumericClosedShapeIdentityMapSelector requires a non-null descriptor.HierarchyMapping.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeLightweightSelector.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Hierarchical, Numeric Lightweight selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class HierarchicalNumericClosedShapeLightweightSelector<T, TId>: NumericClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly DocumentMapping _hierarchy;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalNumericClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _hierarchy = descriptor.HierarchyMapping
+            ?? throw new InvalidOperationException(
+                "HierarchicalNumericClosedShapeLightweightSelector requires a non-null descriptor.HierarchyMapping.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Hierarchical, Optimistic DirtyTracking selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class HierarchicalOptimisticClosedShapeDirtyTrackingSelector<T, TId>: OptimisticClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly DocumentMapping _hierarchy;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalOptimisticClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _hierarchy = descriptor.HierarchyMapping
+            ?? throw new InvalidOperationException(
+                "HierarchicalOptimisticClosedShapeDirtyTrackingSelector requires a non-null descriptor.HierarchyMapping.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Hierarchical, Optimistic IdentityMap selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class HierarchicalOptimisticClosedShapeIdentityMapSelector<T, TId>: OptimisticClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly DocumentMapping _hierarchy;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalOptimisticClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _hierarchy = descriptor.HierarchyMapping
+            ?? throw new InvalidOperationException(
+                "HierarchicalOptimisticClosedShapeIdentityMapSelector requires a non-null descriptor.HierarchyMapping.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeLightweightSelector.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Hierarchical, Optimistic Lightweight selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class HierarchicalOptimisticClosedShapeLightweightSelector<T, TId>: OptimisticClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly DocumentMapping _hierarchy;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalOptimisticClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _hierarchy = descriptor.HierarchyMapping
+            ?? throw new InvalidOperationException(
+                "HierarchicalOptimisticClosedShapeLightweightSelector requires a non-null descriptor.HierarchyMapping.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeDirtyTrackingSelector.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Hierarchical, Off-mode DirtyTracking selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class HierarchicalUnversionedClosedShapeDirtyTrackingSelector<T, TId>: UnversionedClosedShapeDirtyTrackingSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly DocumentMapping _hierarchy;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalUnversionedClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _hierarchy = descriptor.HierarchyMapping
+            ?? throw new InvalidOperationException(
+                "HierarchicalUnversionedClosedShapeDirtyTrackingSelector requires a non-null descriptor.HierarchyMapping.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeIdentityMapSelector.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Hierarchical, Off-mode IdentityMap selector. #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class HierarchicalUnversionedClosedShapeIdentityMapSelector<T, TId>: UnversionedClosedShapeIdentityMapSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly DocumentMapping _hierarchy;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalUnversionedClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _hierarchy = descriptor.HierarchyMapping
+            ?? throw new InvalidOperationException(
+                "HierarchicalUnversionedClosedShapeIdentityMapSelector requires a non-null descriptor.HierarchyMapping.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeLightweightSelector.cs
@@ -1,0 +1,44 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Schema;
+
+namespace Marten.Internal.ClosedShape;
+
+/// <summary>
+/// Hierarchical, Off-mode Lightweight selector. Reads <c>mt_doc_type</c>
+/// from the descriptor's <see cref="DocumentStorageDescriptor{T,TId}.DocTypeReadIndex"/>
+/// and dispatches deserialization through the
+/// <see cref="DocumentStorageDescriptor{T,TId}.HierarchyMapping"/> root.
+/// #4659 Phase 2 leaf.
+/// </summary>
+internal sealed class HierarchicalUnversionedClosedShapeLightweightSelector<T, TId>: UnversionedClosedShapeLightweightSelector<T, TId>
+    where T : notnull
+    where TId : notnull
+{
+    private readonly DocumentMapping _hierarchy;
+    private readonly int _docTypeOrdinal;
+
+    public HierarchicalUnversionedClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+        : base(session, descriptor)
+    {
+        _hierarchy = descriptor.HierarchyMapping
+            ?? throw new InvalidOperationException(
+                "HierarchicalUnversionedClosedShapeLightweightSelector requires a non-null descriptor.HierarchyMapping.");
+        _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
+    }
+
+    protected override T ReadDocument(DbDataReader reader)
+    {
+        var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
+        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+    }
+
+    protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
+    {
+        var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+    }
+}

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeDirtyTrackingSelector.cs
@@ -5,23 +5,24 @@ using System.Data.Common;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// <c>ConcurrencyMode.Numeric</c> DirtyTracking selector. CaptureVersion
-/// writes the row's mt_version (long) into the session's per-type
-/// revision dict. #4659 leaf.
+/// <c>ConcurrencyMode.Numeric</c> DirtyTracking selector — concurrency-
+/// mode intermediate. CaptureVersion writes long into the session's
+/// per-type revision dict. Sealed Flat / Hierarchical subclasses
+/// provide ReadDocument. #4659 Phase 2.
 /// </summary>
-internal sealed class NumericClosedShapeDirtyTrackingSelector<T, TId>: ClosedShapeDirtyTrackingSelector<T, TId>
+internal abstract class NumericClosedShapeDirtyTrackingSelector<T, TId>: ClosedShapeDirtyTrackingSelector<T, TId>
     where T : notnull
     where TId : notnull
 {
     private readonly Dictionary<TId, long> _revisions;
 
-    public NumericClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected NumericClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _revisions = session.Versions.RevisionsFor<T, TId>();
     }
 
-    protected override void CaptureVersion(DbDataReader reader, TId id)
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
     {
         var versionIndex = _descriptor.VersionReadIndex;
         if (versionIndex < 0) return;

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeIdentityMapSelector.cs
@@ -5,23 +5,24 @@ using System.Data.Common;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// <c>ConcurrencyMode.Numeric</c> IdentityMap selector. CaptureVersion
-/// writes the row's mt_version (long) into the session's per-type
-/// revision dict. #4659 leaf.
+/// <c>ConcurrencyMode.Numeric</c> IdentityMap selector — concurrency-
+/// mode intermediate. CaptureVersion writes long into the session's
+/// per-type revision dict. Sealed Flat / Hierarchical subclasses
+/// provide ReadDocument. #4659 Phase 2.
 /// </summary>
-internal sealed class NumericClosedShapeIdentityMapSelector<T, TId>: ClosedShapeIdentityMapSelector<T, TId>
+internal abstract class NumericClosedShapeIdentityMapSelector<T, TId>: ClosedShapeIdentityMapSelector<T, TId>
     where T : notnull
     where TId : notnull
 {
     private readonly Dictionary<TId, long> _revisions;
 
-    public NumericClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected NumericClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _revisions = session.Versions.RevisionsFor<T, TId>();
     }
 
-    protected override void CaptureVersion(DbDataReader reader, TId id)
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
     {
         var versionIndex = _descriptor.VersionReadIndex;
         if (versionIndex < 0) return;

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeLightweightSelector.cs
@@ -5,23 +5,25 @@ using System.Data.Common;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// <c>ConcurrencyMode.Numeric</c> Lightweight selector. Captures the
-/// row's mt_version (long) into the session's per-type revision dict so
-/// subsequent updates can supply it as the expected revision. #4659 leaf.
+/// <c>ConcurrencyMode.Numeric</c> Lightweight selector — concurrency-
+/// mode intermediate. CaptureVersion writes the row's mt_version (long)
+/// into the session's per-type revision dict; sealed Flat / Hierarchical
+/// subclasses provide <c>ReadDocument</c> / <c>ReadDocumentAsync</c>
+/// (#4659 Phase 2).
 /// </summary>
-internal sealed class NumericClosedShapeLightweightSelector<T, TId>: ClosedShapeLightweightSelector<T, TId>
+internal abstract class NumericClosedShapeLightweightSelector<T, TId>: ClosedShapeLightweightSelector<T, TId>
     where T : notnull
     where TId : notnull
 {
     private readonly Dictionary<TId, long> _revisions;
 
-    public NumericClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected NumericClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _revisions = session.Versions.RevisionsFor<T, TId>();
     }
 
-    protected override void CaptureVersion(DbDataReader reader, TId id)
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
     {
         var versionIndex = _descriptor.VersionReadIndex;
         if (versionIndex < 0) return;

--- a/src/Marten/Internal/ClosedShape/NumericDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericDirtyCheckedClosedShapeStorage.cs
@@ -34,5 +34,7 @@ internal sealed class NumericDirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyChe
         => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
     public override ISelector BuildSelector(IMartenSession session)
-        => new NumericClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
+        => _descriptor.HierarchyMapping is not null
+            ? new HierarchicalNumericClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor)
+            : new FlatNumericClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/NumericIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericIdentityMapClosedShapeStorage.cs
@@ -34,5 +34,7 @@ internal sealed class NumericIdentityMapClosedShapeStorage<TDoc, TId>: IdentityM
         => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
     public override ISelector BuildSelector(IMartenSession session)
-        => new NumericClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
+        => _descriptor.HierarchyMapping is not null
+            ? new HierarchicalNumericClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor)
+            : new FlatNumericClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/NumericLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericLightweightClosedShapeStorage.cs
@@ -39,5 +39,7 @@ internal sealed class NumericLightweightClosedShapeStorage<TDoc, TId>: Lightweig
         => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
     public override ISelector BuildSelector(IMartenSession session)
-        => new NumericClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
+        => _descriptor.HierarchyMapping is not null
+            ? new HierarchicalNumericClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor)
+            : new FlatNumericClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeDirtyTrackingSelector.cs
@@ -6,23 +6,24 @@ using System.Data.Common;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// <c>ConcurrencyMode.Optimistic</c> DirtyTracking selector.
-/// CaptureVersion writes the row's mt_version (Guid) into the session's
-/// per-type version dict. #4659 leaf.
+/// <c>ConcurrencyMode.Optimistic</c> DirtyTracking selector —
+/// concurrency-mode intermediate. CaptureVersion writes Guid into the
+/// session's per-type version dict. Sealed Flat / Hierarchical
+/// subclasses provide ReadDocument. #4659 Phase 2.
 /// </summary>
-internal sealed class OptimisticClosedShapeDirtyTrackingSelector<T, TId>: ClosedShapeDirtyTrackingSelector<T, TId>
+internal abstract class OptimisticClosedShapeDirtyTrackingSelector<T, TId>: ClosedShapeDirtyTrackingSelector<T, TId>
     where T : notnull
     where TId : notnull
 {
     private readonly Dictionary<TId, Guid> _versions;
 
-    public OptimisticClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected OptimisticClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _versions = session.Versions.ForType<T, TId>();
     }
 
-    protected override void CaptureVersion(DbDataReader reader, TId id)
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
     {
         var versionIndex = _descriptor.VersionReadIndex;
         if (versionIndex < 0) return;

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeIdentityMapSelector.cs
@@ -6,23 +6,24 @@ using System.Data.Common;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// <c>ConcurrencyMode.Optimistic</c> IdentityMap selector. CaptureVersion
-/// writes the row's mt_version (Guid) into the session's per-type version
-/// dict. #4659 leaf.
+/// <c>ConcurrencyMode.Optimistic</c> IdentityMap selector — concurrency-
+/// mode intermediate. CaptureVersion writes Guid into the session's
+/// per-type version dict. Sealed Flat / Hierarchical subclasses provide
+/// ReadDocument. #4659 Phase 2.
 /// </summary>
-internal sealed class OptimisticClosedShapeIdentityMapSelector<T, TId>: ClosedShapeIdentityMapSelector<T, TId>
+internal abstract class OptimisticClosedShapeIdentityMapSelector<T, TId>: ClosedShapeIdentityMapSelector<T, TId>
     where T : notnull
     where TId : notnull
 {
     private readonly Dictionary<TId, Guid> _versions;
 
-    public OptimisticClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected OptimisticClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _versions = session.Versions.ForType<T, TId>();
     }
 
-    protected override void CaptureVersion(DbDataReader reader, TId id)
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
     {
         var versionIndex = _descriptor.VersionReadIndex;
         if (versionIndex < 0) return;

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeLightweightSelector.cs
@@ -6,23 +6,25 @@ using System.Data.Common;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// <c>ConcurrencyMode.Optimistic</c> Lightweight selector. Captures the
-/// row's mt_version (Guid) into the session's per-type version dict so
-/// subsequent updates can supply it as the expected version. #4659 leaf.
+/// <c>ConcurrencyMode.Optimistic</c> Lightweight selector — concurrency-
+/// mode intermediate. CaptureVersion writes the row's mt_version (Guid)
+/// into the session's per-type version dict; sealed Flat / Hierarchical
+/// subclasses provide <c>ReadDocument</c> / <c>ReadDocumentAsync</c>
+/// (#4659 Phase 2).
 /// </summary>
-internal sealed class OptimisticClosedShapeLightweightSelector<T, TId>: ClosedShapeLightweightSelector<T, TId>
+internal abstract class OptimisticClosedShapeLightweightSelector<T, TId>: ClosedShapeLightweightSelector<T, TId>
     where T : notnull
     where TId : notnull
 {
     private readonly Dictionary<TId, Guid> _versions;
 
-    public OptimisticClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected OptimisticClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _versions = session.Versions.ForType<T, TId>();
     }
 
-    protected override void CaptureVersion(DbDataReader reader, TId id)
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
     {
         var versionIndex = _descriptor.VersionReadIndex;
         if (versionIndex < 0) return;

--- a/src/Marten/Internal/ClosedShape/OptimisticDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticDirtyCheckedClosedShapeStorage.cs
@@ -34,5 +34,7 @@ internal sealed class OptimisticDirtyCheckedClosedShapeStorage<TDoc, TId>: Dirty
         => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
     public override ISelector BuildSelector(IMartenSession session)
-        => new OptimisticClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
+        => _descriptor.HierarchyMapping is not null
+            ? new HierarchicalOptimisticClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor)
+            : new FlatOptimisticClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/OptimisticIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticIdentityMapClosedShapeStorage.cs
@@ -34,5 +34,7 @@ internal sealed class OptimisticIdentityMapClosedShapeStorage<TDoc, TId>: Identi
         => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
     public override ISelector BuildSelector(IMartenSession session)
-        => new OptimisticClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
+        => _descriptor.HierarchyMapping is not null
+            ? new HierarchicalOptimisticClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor)
+            : new FlatOptimisticClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/OptimisticLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticLightweightClosedShapeStorage.cs
@@ -39,5 +39,7 @@ internal sealed class OptimisticLightweightClosedShapeStorage<TDoc, TId>: Lightw
         => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
     public override ISelector BuildSelector(IMartenSession session)
-        => new OptimisticClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
+        => _descriptor.HierarchyMapping is not null
+            ? new HierarchicalOptimisticClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor)
+            : new FlatOptimisticClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
@@ -62,5 +62,10 @@ public sealed class QueryOnlyClosedShapeStorage<TDoc, TId>: QueryOnlyDocumentSto
         => throw new NotSupportedException("QueryOnly storage doesn't support OverwriteProjected.");
 
     public override ISelector BuildSelector(IMartenSession session)
-        => new ClosedShapeQueryOnlySelector<TDoc, TId>(session, _descriptor);
+        // #4659 Phase 2: pick the Flat / Hierarchical selector ONCE per
+        // query — neither selector class branches on HierarchyMapping per
+        // row.
+        => _descriptor.HierarchyMapping is not null
+            ? new HierarchicalClosedShapeQueryOnlySelector<TDoc, TId>(session, _descriptor)
+            : new FlatClosedShapeQueryOnlySelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/UnversionedClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedClosedShapeDirtyTrackingSelector.cs
@@ -4,17 +4,18 @@ using System.Data.Common;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// <c>ConcurrencyMode.Off</c> DirtyTracking selector. CaptureVersion is
-/// a no-op. #4659 leaf.
+/// <c>ConcurrencyMode.Off</c> DirtyTracking selector — concurrency-mode
+/// intermediate. CaptureVersion is a no-op. Sealed Flat / Hierarchical
+/// subclasses provide ReadDocument. #4659 Phase 2.
 /// </summary>
-internal sealed class UnversionedClosedShapeDirtyTrackingSelector<T, TId>: ClosedShapeDirtyTrackingSelector<T, TId>
+internal abstract class UnversionedClosedShapeDirtyTrackingSelector<T, TId>: ClosedShapeDirtyTrackingSelector<T, TId>
     where T : notnull
     where TId : notnull
 {
-    public UnversionedClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected UnversionedClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }
 
-    protected override void CaptureVersion(DbDataReader reader, TId id) { /* no-op */ }
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id) { /* no-op */ }
 }

--- a/src/Marten/Internal/ClosedShape/UnversionedClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedClosedShapeIdentityMapSelector.cs
@@ -4,17 +4,18 @@ using System.Data.Common;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// <c>ConcurrencyMode.Off</c> IdentityMap selector. CaptureVersion is a
-/// no-op. #4659 leaf.
+/// <c>ConcurrencyMode.Off</c> IdentityMap selector — concurrency-mode
+/// intermediate. CaptureVersion is a no-op. Sealed Flat / Hierarchical
+/// subclasses provide ReadDocument. #4659 Phase 2.
 /// </summary>
-internal sealed class UnversionedClosedShapeIdentityMapSelector<T, TId>: ClosedShapeIdentityMapSelector<T, TId>
+internal abstract class UnversionedClosedShapeIdentityMapSelector<T, TId>: ClosedShapeIdentityMapSelector<T, TId>
     where T : notnull
     where TId : notnull
 {
-    public UnversionedClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected UnversionedClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }
 
-    protected override void CaptureVersion(DbDataReader reader, TId id) { /* no-op */ }
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id) { /* no-op */ }
 }

--- a/src/Marten/Internal/ClosedShape/UnversionedClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedClosedShapeLightweightSelector.cs
@@ -4,22 +4,22 @@ using System.Data.Common;
 namespace Marten.Internal.ClosedShape;
 
 /// <summary>
-/// <c>ConcurrencyMode.Off</c> Lightweight selector. No version/revision
-/// tracker — CaptureVersion is a no-op. #4659 leaf.
+/// <c>ConcurrencyMode.Off</c> Lightweight selector — concurrency-mode
+/// intermediate. CaptureVersion is a no-op; sealed Flat / Hierarchical
+/// subclasses provide <c>ReadDocument</c> /
+/// <c>ReadDocumentAsync</c> (#4659 Phase 2).
 /// </summary>
-internal sealed class UnversionedClosedShapeLightweightSelector<T, TId>: ClosedShapeLightweightSelector<T, TId>
+internal abstract class UnversionedClosedShapeLightweightSelector<T, TId>: ClosedShapeLightweightSelector<T, TId>
     where T : notnull
     where TId : notnull
 {
-    public UnversionedClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected UnversionedClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }
 
-    protected override void CaptureVersion(DbDataReader reader, TId id)
+    protected sealed override void CaptureVersion(DbDataReader reader, TId id)
     {
-        // Off-mode: nothing to capture. The mt_version column may or may
-        // not be present in ReadBinders (depends on the user's mapping)
-        // but the session has no tracker to push it into.
+        // Off-mode: nothing to capture.
     }
 }

--- a/src/Marten/Internal/ClosedShape/UnversionedDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedDirtyCheckedClosedShapeStorage.cs
@@ -34,5 +34,7 @@ internal sealed class UnversionedDirtyCheckedClosedShapeStorage<TDoc, TId>: Dirt
         => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
     public override ISelector BuildSelector(IMartenSession session)
-        => new UnversionedClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
+        => _descriptor.HierarchyMapping is not null
+            ? new HierarchicalUnversionedClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor)
+            : new FlatUnversionedClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/UnversionedIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedIdentityMapClosedShapeStorage.cs
@@ -34,5 +34,7 @@ internal sealed class UnversionedIdentityMapClosedShapeStorage<TDoc, TId>: Ident
         => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
     public override ISelector BuildSelector(IMartenSession session)
-        => new UnversionedClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
+        => _descriptor.HierarchyMapping is not null
+            ? new HierarchicalUnversionedClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor)
+            : new FlatUnversionedClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/UnversionedLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedLightweightClosedShapeStorage.cs
@@ -37,5 +37,7 @@ internal sealed class UnversionedLightweightClosedShapeStorage<TDoc, TId>: Light
         => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
     public override ISelector BuildSelector(IMartenSession session)
-        => new UnversionedClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
+        => _descriptor.HierarchyMapping is not null
+            ? new HierarchicalUnversionedClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor)
+            : new FlatUnversionedClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
 }


### PR DESCRIPTION
Second (and final) PR for #4659. Builds on Phase 1 (#4660, merged).

Closes #4659.

## What this changes

Each closed-shape selector now further splits on `DocumentStorageDescriptor.HierarchyMapping`. Each Phase-1 concurrency-mode leaf gains 2 sealed `Flat…` / `Hierarchical…` sub-leaves that provide a monomorphic `ReadDocument` / `ReadDocumentAsync`. The per-row hot path no longer branches on `HierarchyMapping`.

### Shape

**QueryOnly** (no concurrency split):
- `ClosedShapeQueryOnlySelector` (now abstract)
  - `FlatClosedShapeQueryOnlySelector` (sealed)
  - `HierarchicalClosedShapeQueryOnlySelector` (sealed)

**Each tracking style** (Lightweight, IdentityMap, DirtyTracking):
- `ClosedShape{X}Selector` (abstract — `Resolve` / `ResolveAsync` / `ApplyMetadata`)
  - 3 concurrency-mode intermediates (abstract — provide `CaptureVersion`)
    - `Unversioned…` (no-op), `Optimistic…` (Guid capture), `Numeric…` (long capture)
  - 6 sealed leaves per intermediate: `Flat…` / `Hierarchical…` × Unv/Opt/Num
- **18 sealed tracking leaves per tracking style** × 3 styles = 18 sealed leaves total + 9 intermediate abstracts

The Phase-1 concrete sealed concurrency leaves (`UnversionedClosedShape{X}Selector`, etc.) are promoted to abstract intermediates that hold the concurrency-specific `CaptureVersion` impl. Same class names, same identity — just no longer instantiable directly.

### BuildSelector factories

Each writeable storage leaf's `BuildSelector` + the `QueryOnlyClosedShapeStorage` `BuildSelector` now dispatch on `_descriptor.HierarchyMapping is not null` ONCE per query and construct the matching `Flat…` / `Hierarchical…` selector. Per-row branches are gone.

## Hierarchical leaves capture descriptor state at construction

Each `Hierarchical…` leaf captures `descriptor.HierarchyMapping` and `FirstMetadataColumn + descriptor.DocTypeReadIndex` in its constructor with a null-guard `InvalidOperationException`. A future misrouted factory call would fail fast rather than NRE on the first row read. The captured fields avoid the per-row pattern-match the abstract base had.

## Acceptance criteria

```
$ grep -rn "HierarchyMapping is " src/Marten/Internal/ClosedShape/
```

Returns exactly 10 hits — all in storage `BuildSelector` factory dispatches (9 tracking storage leaves + 1 QueryOnly storage). Per-row `ReadDocument` / `ReadDocumentAsync` no longer reads `HierarchyMapping` at all; each leaf is one strategy.

## Local test results

```
DocumentDbTests.Hierarchical.*:   31 passed,   0 failed
DocumentDbTests (full):          999 passed,   0 failed (1 unrelated pre-existing skip)
```

## What this closes

Closes #4659 entirely — combined with Phase 1, the closed-shape storage class is now monomorphic by construction across all four runtime branching axes the issue cataloged (`ConcurrencyMode` per-op + per-row; `HierarchyMapping` per-row). `IsConjoined` and `UseVersionFromMatchingStream` were explicit non-goals (cheap per-write branches) — Phase 1 already pulled `UseVersionFromMatchingStream` into the Numeric variants.

## Why this also helps AOT

Combined with Phase 1: the storage class is now monomorphic by construction across ALL four runtime branching axes the issue cataloged. The JIT (and a future source generator) can specialize and inline aggressively without having to look at `_descriptor` at all in the hot path.

## Tracking

- Closes #4659 (Phase 2 of 2)
- Builds on #4660 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)