### PR TITLE
Bump Weasel.Postgresql + Weasel.EntityFrameworkCore 9.0.2 → 9.0.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,8 +78,8 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.2" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.0.2" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.3" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.0.3" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
Patch bump of the Weasel pins to pick up the single change in 9.0.3.

## What's in Weasel 9.0.3

- **JasperFx/weasel#300** — fix non-idempotent migration for a managed list partition whose suffix is literally `"default"`. The repeated apply path stopped detecting the partition as already-attached because the suffix matched a Postgres reserved-name pathway. Now re-running migrations for a `"default"` suffix is a no-op like every other suffix.

No Marten code changes required.

## Verification

- Build: clean (`dotnet build src/Marten/Marten.csproj -f net9.0` → 0 errors).
- **CoreTests**: 421/422 (1 pre-existing unrelated skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)