### PR TITLE
#4667 Phase 1 — write-path *Projected variants bypass session-shared trackers

### DIFF
--- a/src/Marten/Events/EventDocumentStorage.cs
+++ b/src/Marten/Events/EventDocumentStorage.cs
@@ -228,6 +228,22 @@ public abstract class EventDocumentStorage: IEventStorage
         throw new NotSupportedException();
     }
 
+    // #4667 — events aren't projected through the document write path.
+    public IStorageOperation UpsertProjected(IEvent document, string tenant)
+    {
+        throw new NotSupportedException();
+    }
+
+    public IStorageOperation InsertProjected(IEvent document, string tenant)
+    {
+        throw new NotSupportedException();
+    }
+
+    public IStorageOperation UpdateProjected(IEvent document, string tenant)
+    {
+        throw new NotSupportedException();
+    }
+
     public abstract IStorageOperation AppendEvent(EventGraph events, IMartenSession session, StreamAction stream,
         IEvent e);
 

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -334,6 +334,22 @@ public class EventMapping<T>: EventMapping, IDocumentStorage<T> where T : class
         throw new NotSupportedException();
     }
 
+    // #4667 — events aren't projected through the document write path.
+    IStorageOperation IDocumentStorage<T>.UpsertProjected(T document, string tenant)
+    {
+        throw new NotSupportedException();
+    }
+
+    IStorageOperation IDocumentStorage<T>.InsertProjected(T document, string tenant)
+    {
+        throw new NotSupportedException();
+    }
+
+    IStorageOperation IDocumentStorage<T>.UpdateProjected(T document, string tenant)
+    {
+        throw new NotSupportedException();
+    }
+
     public IDeletion DeleteForDocument(T document, string tenant)
     {
         throw new NotSupportedException();

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeInsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeInsertOperation.cs
@@ -26,14 +26,14 @@ internal sealed class NumericClosedShapeInsertOperation<TDoc, TId>: ClosedShapeI
     where TDoc : notnull
     where TId : notnull
 {
-    private readonly Dictionary<TId, long> _revisions;
+    private readonly Dictionary<TId, long>? _revisions;
 
     public NumericClosedShapeInsertOperation(
         TDoc document,
         TId id,
         string tenantId,
         DocumentStorageDescriptor<TDoc, TId> descriptor,
-        Dictionary<TId, long> revisions)
+        Dictionary<TId, long>? revisions)
         : base(document, id, tenantId, descriptor)
     {
         _revisions = revisions;
@@ -67,7 +67,13 @@ internal sealed class NumericClosedShapeInsertOperation<TDoc, TId>: ClosedShapeI
         }
 
         var newRevision = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
-        _revisions[_id] = newRevision;
+        // #4667 — null tracker (the InsertProjected path) skips the tracker
+        // write. RevisionBinder still applies so the document's revision
+        // field is fresh.
+        if (_revisions is not null)
+        {
+            _revisions[_id] = newRevision;
+        }
         _descriptor.RevisionBinder!.ApplyRevisionTo(_document, newRevision);
     }
 

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeUpdateOperation.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeUpdateOperation.cs
@@ -24,14 +24,14 @@ internal sealed class NumericClosedShapeUpdateOperation<TDoc, TId>: ClosedShapeU
     where TDoc : notnull
     where TId : notnull
 {
-    private readonly Dictionary<TId, long> _revisions;
+    private readonly Dictionary<TId, long>? _revisions;
 
     public NumericClosedShapeUpdateOperation(
         TDoc document,
         TId id,
         string tenantId,
         DocumentStorageDescriptor<TDoc, TId> descriptor,
-        Dictionary<TId, long> revisions)
+        Dictionary<TId, long>? revisions)
         : base(document, id, tenantId, descriptor)
     {
         _revisions = revisions;
@@ -66,7 +66,13 @@ internal sealed class NumericClosedShapeUpdateOperation<TDoc, TId>: ClosedShapeU
         }
 
         var newRevision = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
-        _revisions[_id] = newRevision;
+        // #4667 — null tracker (the UpdateProjected path) skips the tracker
+        // write. RevisionBinder still applies so the document's revision
+        // field is fresh.
+        if (_revisions is not null)
+        {
+            _revisions[_id] = newRevision;
+        }
         _descriptor.RevisionBinder!.ApplyRevisionTo(_document, newRevision);
     }
 

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeUpsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeUpsertOperation.cs
@@ -27,7 +27,7 @@ internal sealed class NumericClosedShapeUpsertOperation<TDoc, TId>: ClosedShapeU
     where TDoc : notnull
     where TId : notnull
 {
-    private readonly Dictionary<TId, long> _revisions;
+    private readonly Dictionary<TId, long>? _revisions;
 
     public NumericClosedShapeUpsertOperation(
         TDoc document,
@@ -35,7 +35,7 @@ internal sealed class NumericClosedShapeUpsertOperation<TDoc, TId>: ClosedShapeU
         string tenantId,
         DocumentStorageDescriptor<TDoc, TId> descriptor,
         OperationRole role,
-        Dictionary<TId, long> revisions)
+        Dictionary<TId, long>? revisions)
         : base(document, id, tenantId, descriptor, role)
     {
         _revisions = revisions;
@@ -68,7 +68,13 @@ internal sealed class NumericClosedShapeUpsertOperation<TDoc, TId>: ClosedShapeU
         }
 
         var newRevision = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
-        _revisions[_id] = newRevision;
+        // #4667 — null tracker (the UpsertProjected path) skips the tracker
+        // write. RevisionBinder still applies so the document's revision
+        // field is fresh.
+        if (_revisions is not null)
+        {
+            _revisions[_id] = newRevision;
+        }
         _descriptor.RevisionBinder!.ApplyRevisionTo(_document, newRevision);
     }
 

--- a/src/Marten/Internal/ClosedShape/NumericDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericDirtyCheckedClosedShapeStorage.cs
@@ -33,6 +33,16 @@ internal sealed class NumericDirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyChe
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
         => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
+    // #4667 — null revision tracker; see Lightweight peer for semantics.
+    public override IStorageOperation UpsertProjected(TDoc document, string tenant)
+        => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, null);
+
+    public override IStorageOperation InsertProjected(TDoc document, string tenant)
+        => new NumericClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
+    public override IStorageOperation UpdateProjected(TDoc document, string tenant)
+        => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
     public override ISelector BuildSelector(IMartenSession session)
         => _descriptor.HierarchyMapping is not null
             ? new HierarchicalNumericClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor)

--- a/src/Marten/Internal/ClosedShape/NumericIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericIdentityMapClosedShapeStorage.cs
@@ -33,6 +33,16 @@ internal sealed class NumericIdentityMapClosedShapeStorage<TDoc, TId>: IdentityM
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
         => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
+    // #4667 — null revision tracker; see Lightweight peer for semantics.
+    public override IStorageOperation UpsertProjected(TDoc document, string tenant)
+        => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, null);
+
+    public override IStorageOperation InsertProjected(TDoc document, string tenant)
+        => new NumericClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
+    public override IStorageOperation UpdateProjected(TDoc document, string tenant)
+        => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
     public override ISelector BuildSelector(IMartenSession session)
         => _descriptor.HierarchyMapping is not null
             ? new HierarchicalNumericClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor)

--- a/src/Marten/Internal/ClosedShape/NumericLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericLightweightClosedShapeStorage.cs
@@ -38,6 +38,19 @@ internal sealed class NumericLightweightClosedShapeStorage<TDoc, TId>: Lightweig
         // the session's numeric-revision map for the projected doc.
         => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
+    // #4667 — null revision tracker. Numeric ops bind the IRevisionedOperation
+    // `Revision` property (default 0) in ConfigureCommand, so the WHERE guard
+    // `? = 0 OR table.mt_version < ?` always passes when the caller leaves
+    // Revision at the default.
+    public override IStorageOperation UpsertProjected(TDoc document, string tenant)
+        => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, null);
+
+    public override IStorageOperation InsertProjected(TDoc document, string tenant)
+        => new NumericClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
+    public override IStorageOperation UpdateProjected(TDoc document, string tenant)
+        => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
     public override ISelector BuildSelector(IMartenSession session)
         => _descriptor.HierarchyMapping is not null
             ? new HierarchicalNumericClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor)

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeInsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeInsertOperation.cs
@@ -25,7 +25,7 @@ internal sealed class OptimisticClosedShapeInsertOperation<TDoc, TId>: ClosedSha
     where TDoc : notnull
     where TId : notnull
 {
-    private readonly Dictionary<TId, Guid> _versions;
+    private readonly Dictionary<TId, Guid>? _versions;
     private readonly Guid _newVersion;
 
     public OptimisticClosedShapeInsertOperation(
@@ -33,7 +33,7 @@ internal sealed class OptimisticClosedShapeInsertOperation<TDoc, TId>: ClosedSha
         TId id,
         string tenantId,
         DocumentStorageDescriptor<TDoc, TId> descriptor,
-        Dictionary<TId, Guid> versions)
+        Dictionary<TId, Guid>? versions)
         : base(document, id, tenantId, descriptor)
     {
         _versions = versions;
@@ -69,6 +69,12 @@ internal sealed class OptimisticClosedShapeInsertOperation<TDoc, TId>: ClosedSha
             return;
         }
 
-        _versions[_id] = _newVersion;
+        // #4667 — null tracker (the InsertProjected path) just skips the
+        // tracker write. The fresh version is still applied to the document
+        // via VersionBinder during command configuration.
+        if (_versions is not null)
+        {
+            _versions[_id] = _newVersion;
+        }
     }
 }

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeUpdateOperation.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeUpdateOperation.cs
@@ -26,7 +26,7 @@ internal sealed class OptimisticClosedShapeUpdateOperation<TDoc, TId>: ClosedSha
     where TDoc : notnull
     where TId : notnull
 {
-    private readonly Dictionary<TId, Guid> _versions;
+    private readonly Dictionary<TId, Guid>? _versions;
     private readonly Guid _newVersion;
 
     public OptimisticClosedShapeUpdateOperation(
@@ -34,7 +34,7 @@ internal sealed class OptimisticClosedShapeUpdateOperation<TDoc, TId>: ClosedSha
         TId id,
         string tenantId,
         DocumentStorageDescriptor<TDoc, TId> descriptor,
-        Dictionary<TId, Guid> versions)
+        Dictionary<TId, Guid>? versions)
         : base(document, id, tenantId, descriptor)
     {
         _versions = versions;
@@ -46,8 +46,12 @@ internal sealed class OptimisticClosedShapeUpdateOperation<TDoc, TId>: ClosedSha
         var parameters = builder.AppendWithParameters(_descriptor.UpdateSql, '?');
         var slot = BindPreConcurrencyParameters(parameters, session);
 
-        // Trailing WHERE mt_version = ? guard.
-        if (_versions.TryGetValue(_id, out var expected))
+        // Trailing WHERE mt_version = ? guard. #4667 — null tracker (the
+        // UpdateProjected path) treats expected version as DBNull, which the
+        // SQL WHERE never matches. Callers that go through UpdateProjected
+        // should also set IgnoreConcurrencyViolation = true to suppress the
+        // resulting "no row" exception.
+        if (_versions is not null && _versions.TryGetValue(_id, out var expected))
         {
             parameters[slot].Value = expected;
         }
@@ -69,7 +73,13 @@ internal sealed class OptimisticClosedShapeUpdateOperation<TDoc, TId>: ClosedSha
             return;
         }
 
-        _versions[_id] = _newVersion;
+        // #4667 — null tracker (the UpdateProjected path) just skips the
+        // tracker write. The fresh version is still applied to the document
+        // via VersionBinder during command configuration.
+        if (_versions is not null)
+        {
+            _versions[_id] = _newVersion;
+        }
     }
 
     protected override int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeUpsertOperation.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeUpsertOperation.cs
@@ -27,7 +27,7 @@ internal sealed class OptimisticClosedShapeUpsertOperation<TDoc, TId>: ClosedSha
     where TDoc : notnull
     where TId : notnull
 {
-    private readonly Dictionary<TId, Guid> _versions;
+    private readonly Dictionary<TId, Guid>? _versions;
     private readonly Guid _newVersion;
 
     public OptimisticClosedShapeUpsertOperation(
@@ -36,7 +36,7 @@ internal sealed class OptimisticClosedShapeUpsertOperation<TDoc, TId>: ClosedSha
         string tenantId,
         DocumentStorageDescriptor<TDoc, TId> descriptor,
         OperationRole role,
-        Dictionary<TId, Guid> versions)
+        Dictionary<TId, Guid>? versions)
         : base(document, id, tenantId, descriptor, role)
     {
         _versions = versions;
@@ -48,8 +48,12 @@ internal sealed class OptimisticClosedShapeUpsertOperation<TDoc, TId>: ClosedSha
         var parameters = builder.AppendWithParameters(_descriptor.UpsertSql, '?');
         var slot = BindPreOnConflictParameters(parameters, session);
 
-        // Trailing WHERE table.mt_version = ? guard.
-        if (_versions.TryGetValue(_id, out var expected))
+        // Trailing WHERE table.mt_version = ? guard. #4667 — null tracker
+        // (the UpsertProjected path) treats expected version as DBNull. On
+        // the ON CONFLICT branch the WHERE will never match, so existing
+        // rows in Optimistic mode are left untouched. The INSERT branch
+        // still fires for new rows.
+        if (_versions is not null && _versions.TryGetValue(_id, out var expected))
         {
             parameters[slot].Value = expected;
         }
@@ -71,7 +75,13 @@ internal sealed class OptimisticClosedShapeUpsertOperation<TDoc, TId>: ClosedSha
             return;
         }
 
-        _versions[_id] = _newVersion;
+        // #4667 — null tracker (the UpsertProjected path) just skips the
+        // tracker write. The fresh version is still applied to the document
+        // via VersionBinder during command configuration.
+        if (_versions is not null)
+        {
+            _versions[_id] = _newVersion;
+        }
     }
 
     protected override int BindClientSideBinder(NpgsqlParameter[] parameters, int slot, IDocumentMetadataBinder<TDoc> binder, IMartenSession session)

--- a/src/Marten/Internal/ClosedShape/OptimisticDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticDirtyCheckedClosedShapeStorage.cs
@@ -33,6 +33,16 @@ internal sealed class OptimisticDirtyCheckedClosedShapeStorage<TDoc, TId>: Dirty
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
         => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
+    // #4667 — null version tracker; see Lightweight peer for semantics.
+    public override IStorageOperation UpsertProjected(TDoc document, string tenant)
+        => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, null);
+
+    public override IStorageOperation InsertProjected(TDoc document, string tenant)
+        => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
+    public override IStorageOperation UpdateProjected(TDoc document, string tenant)
+        => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
     public override ISelector BuildSelector(IMartenSession session)
         => _descriptor.HierarchyMapping is not null
             ? new HierarchicalOptimisticClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor)

--- a/src/Marten/Internal/ClosedShape/OptimisticIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticIdentityMapClosedShapeStorage.cs
@@ -33,6 +33,16 @@ internal sealed class OptimisticIdentityMapClosedShapeStorage<TDoc, TId>: Identi
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
         => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
+    // #4667 — null version tracker; see Lightweight peer for semantics.
+    public override IStorageOperation UpsertProjected(TDoc document, string tenant)
+        => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, null);
+
+    public override IStorageOperation InsertProjected(TDoc document, string tenant)
+        => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
+    public override IStorageOperation UpdateProjected(TDoc document, string tenant)
+        => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
     public override ISelector BuildSelector(IMartenSession session)
         => _descriptor.HierarchyMapping is not null
             ? new HierarchicalOptimisticClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor)

--- a/src/Marten/Internal/ClosedShape/OptimisticLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticLightweightClosedShapeStorage.cs
@@ -38,6 +38,21 @@ internal sealed class OptimisticLightweightClosedShapeStorage<TDoc, TId>: Lightw
         // the session's optimistic-version map for the projected doc.
         => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
+    // #4667 — projection write paths pass null tracker (no session-shared
+    // dict access). Optimistic Upsert/Update with null tracker bind DBNull
+    // for the WHERE-guard; existing rows are left untouched on the ON CONFLICT
+    // branch. Callers in the projection runtime set IgnoreConcurrencyViolation
+    // = true (see ProjectionStorage.StoreProjection / Store flows) to suppress
+    // the resulting "no row" exception.
+    public override IStorageOperation UpsertProjected(TDoc document, string tenant)
+        => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, null);
+
+    public override IStorageOperation InsertProjected(TDoc document, string tenant)
+        => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
+    public override IStorageOperation UpdateProjected(TDoc document, string tenant)
+        => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
+
     public override ISelector BuildSelector(IMartenSession session)
         => _descriptor.HierarchyMapping is not null
             ? new HierarchicalOptimisticClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor)

--- a/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
@@ -61,6 +61,16 @@ public sealed class QueryOnlyClosedShapeStorage<TDoc, TId>: QueryOnlyDocumentSto
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
         => throw new NotSupportedException("QueryOnly storage doesn't support OverwriteProjected.");
 
+    // #4667 — projection write paths aren't reachable from query sessions.
+    public override IStorageOperation UpsertProjected(TDoc document, string tenant)
+        => throw new NotSupportedException("QueryOnly storage doesn't support UpsertProjected.");
+
+    public override IStorageOperation InsertProjected(TDoc document, string tenant)
+        => throw new NotSupportedException("QueryOnly storage doesn't support InsertProjected.");
+
+    public override IStorageOperation UpdateProjected(TDoc document, string tenant)
+        => throw new NotSupportedException("QueryOnly storage doesn't support UpdateProjected.");
+
     public override ISelector BuildSelector(IMartenSession session)
         // #4659 Phase 2: pick the Flat / Hierarchical selector ONCE per
         // query — neither selector class branches on HierarchyMapping per

--- a/src/Marten/Internal/ClosedShape/UnversionedDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedDirtyCheckedClosedShapeStorage.cs
@@ -33,6 +33,16 @@ internal sealed class UnversionedDirtyCheckedClosedShapeStorage<TDoc, TId>: Dirt
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
         => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
+    // #4667 — Unversioned ops have no tracker plumbing; see Lightweight peer.
+    public override IStorageOperation UpsertProjected(TDoc document, string tenant)
+        => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert);
+
+    public override IStorageOperation InsertProjected(TDoc document, string tenant)
+        => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override IStorageOperation UpdateProjected(TDoc document, string tenant)
+        => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
     public override ISelector BuildSelector(IMartenSession session)
         => _descriptor.HierarchyMapping is not null
             ? new HierarchicalUnversionedClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor)

--- a/src/Marten/Internal/ClosedShape/UnversionedIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedIdentityMapClosedShapeStorage.cs
@@ -33,6 +33,16 @@ internal sealed class UnversionedIdentityMapClosedShapeStorage<TDoc, TId>: Ident
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
         => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
+    // #4667 — Unversioned ops have no tracker plumbing; see Lightweight peer.
+    public override IStorageOperation UpsertProjected(TDoc document, string tenant)
+        => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert);
+
+    public override IStorageOperation InsertProjected(TDoc document, string tenant)
+        => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override IStorageOperation UpdateProjected(TDoc document, string tenant)
+        => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
     public override ISelector BuildSelector(IMartenSession session)
         => _descriptor.HierarchyMapping is not null
             ? new HierarchicalUnversionedClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor)

--- a/src/Marten/Internal/ClosedShape/UnversionedLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedLightweightClosedShapeStorage.cs
@@ -36,6 +36,18 @@ internal sealed class UnversionedLightweightClosedShapeStorage<TDoc, TId>: Light
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)
         => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
+    // #4667 — Unversioned ops have no tracker plumbing to begin with, so
+    // the *Projected factories return the same op as their session-aware
+    // counterparts. They exist for API uniformity across concurrency modes.
+    public override IStorageOperation UpsertProjected(TDoc document, string tenant)
+        => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert);
+
+    public override IStorageOperation InsertProjected(TDoc document, string tenant)
+        => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
+    public override IStorageOperation UpdateProjected(TDoc document, string tenant)
+        => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
+
     public override ISelector BuildSelector(IMartenSession session)
         => _descriptor.HierarchyMapping is not null
             ? new HierarchicalUnversionedClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor)

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs
@@ -83,7 +83,10 @@ internal class ProjectionStorage<TDoc, TId>: IProjectionStorage<TDoc, TId> where
 
     public void Store(TDoc snapshot)
     {
-        var upsert = _storage.Upsert(snapshot, _session, TenantId);
+        // #4667 — UpsertProjected (not Upsert) so we never read or mutate
+        // _session.Versions / _session.Revisions from a daemon worker. The
+        // projection runtime is by-contract not session-state-aware.
+        var upsert = _storage.UpsertProjected(snapshot, TenantId);
         _session.QueueOperation(upsert);
     }
 
@@ -118,19 +121,35 @@ internal class ProjectionStorage<TDoc, TId>: IProjectionStorage<TDoc, TId> where
     {
         _storage.SetIdentity(snapshot, id);
 
-        // The aggregate may already be in the identity map from a prior SaveChangesAsync
-        // on the same session — for example, a FetchForWriting → save → StartStream
-        // sequence. In that case the projection has built a NEW snapshot instance for
-        // this save, and the duplicate-instance guard in IdentityMapDocumentStorage.store
-        // would throw before the underlying event store can surface the real conflict
-        // (ExistingStreamIdCollisionException). Evict the stale entry so the new snapshot
-        // can take its place.
-        _session.EjectAggregateFromIdentityMap<TDoc, TId>(id);
+        // #4667 — The ItemMap eject + IdentityMap-storage Store call below is
+        // the GH-3850 fix: inline-projection-rewriting-an-immutable-aggregate
+        // on an IdentitySession needs the freshly-built snapshot instance to
+        // replace the stale identity-map entry so a subsequent FetchLatest on
+        // the same session sees the new state. That ItemMap mutation is a race
+        // source under the async daemon's parallel Block(10, ...) workers
+        // (#4657), but the daemon never opts into UseIdentityMapForAggregates,
+        // so we gate the identity-map maintenance on the same flag. The
+        // default (false) case takes the session-state-free UpsertProjected
+        // path; the opt-in (true) case preserves the GH-3850 semantics and
+        // accepts the documented race risk per the #4667 Phase 3 design note
+        // ("opt-in is not safe for parallel projection workers").
+        if (_session.Options.EventGraph.UseIdentityMapForAggregates)
+        {
+            // The aggregate may already be in the identity map from a prior
+            // SaveChangesAsync on the same session — for example, a
+            // FetchForWriting → save → StartStream sequence. In that case
+            // the projection has built a NEW snapshot instance for this save
+            // and the duplicate-instance guard in IdentityMapDocumentStorage.store
+            // would throw before the underlying event store can surface the
+            // real conflict (ExistingStreamIdCollisionException). Evict the
+            // stale entry so the new snapshot can take its place.
+            _session.EjectAggregateFromIdentityMap<TDoc, TId>(id);
 
-        // Put it in the identity map -- if necessary
-        _storage.Store(_session, snapshot);
+            // Put it in the identity map -- if necessary
+            _storage.Store(_session, snapshot);
+        }
 
-        var upsert = _storage.Upsert(snapshot, _session, tenantId);
+        var upsert = _storage.UpsertProjected(snapshot, tenantId);
         _session.QueueOperation(upsert);
     }
 

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -295,6 +295,15 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
     /// <inheritdoc />
     public abstract IStorageOperation OverwriteProjected(T document, string tenant);
 
+    /// <inheritdoc />
+    public abstract IStorageOperation UpsertProjected(T document, string tenant);
+
+    /// <inheritdoc />
+    public abstract IStorageOperation InsertProjected(T document, string tenant);
+
+    /// <inheritdoc />
+    public abstract IStorageOperation UpdateProjected(T document, string tenant);
+
     public IDeletion DeleteForDocument(T document, string tenant)
     {
         var id = Identity(document);

--- a/src/Marten/Internal/Storage/IDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IDocumentStorage.cs
@@ -120,6 +120,26 @@ public interface IDocumentStorage<T>: IDocumentStorage where T : notnull
     /// </summary>
     IStorageOperation OverwriteProjected(T document, string tenantId);
 
+    /// <summary>
+    /// Session-free Upsert for projection storage (#4667 Phase 1). Builds the same Upsert
+    /// operation as <see cref="Upsert"/> but passes a null version/revision tracker so the
+    /// projection path never touches <see cref="IMartenSession.Versions"/>. Safe to call
+    /// from parallel async-daemon slice handlers that share an <see cref="IMartenSession"/>.
+    /// </summary>
+    IStorageOperation UpsertProjected(T document, string tenantId);
+
+    /// <summary>
+    /// Session-free Insert for projection storage (#4667 Phase 1). See
+    /// <see cref="UpsertProjected"/>.
+    /// </summary>
+    IStorageOperation InsertProjected(T document, string tenantId);
+
+    /// <summary>
+    /// Session-free Update for projection storage (#4667 Phase 1). See
+    /// <see cref="UpsertProjected"/>.
+    /// </summary>
+    IStorageOperation UpdateProjected(T document, string tenantId);
+
     IDeletion DeleteForDocument(T document, string tenantId);
 
 

--- a/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
@@ -172,6 +172,23 @@ internal class SubClassDocumentStorage<T, TRoot, TId>: IDocumentStorage<T, TId>,
         return _parent.OverwriteProjected(document, tenant);
     }
 
+    // #4667 — delegate the new projection write entry points to the parent
+    // hierarchy storage just like Overwrite/OverwriteProjected do.
+    public IStorageOperation UpsertProjected(T document, string tenant)
+    {
+        return _parent.UpsertProjected(document, tenant);
+    }
+
+    public IStorageOperation InsertProjected(T document, string tenant)
+    {
+        return _parent.InsertProjected(document, tenant);
+    }
+
+    public IStorageOperation UpdateProjected(T document, string tenant)
+    {
+        return _parent.UpdateProjected(document, tenant);
+    }
+
     public IDeletion DeleteForDocument(T document, string tenant)
     {
         return _parent.DeleteForDocument(document, tenant);

--- a/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
+++ b/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
@@ -141,6 +141,16 @@ internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: ID
     public IStorageOperation OverwriteProjected(TDoc document, string tenantId)
         => Inner.OverwriteProjected(document, tenantId);
 
+    // #4667 — delegate the projection write entry points.
+    public IStorageOperation UpsertProjected(TDoc document, string tenantId)
+        => Inner.UpsertProjected(document, tenantId);
+
+    public IStorageOperation InsertProjected(TDoc document, string tenantId)
+        => Inner.InsertProjected(document, tenantId);
+
+    public IStorageOperation UpdateProjected(TDoc document, string tenantId)
+        => Inner.UpdateProjected(document, tenantId);
+
     public IDeletion DeleteForDocument(TDoc document, string tenantId)
         => Inner.DeleteForDocument(document, tenantId);
 


### PR DESCRIPTION
Phase 1 of [#4667](https://github.com/JasperFx/marten/issues/4667) — eliminate
session-shared dictionary access from the projection write path.

## Background

Async-daemon parallel slice workers share a single `DocumentSessionBase` (10-wide
`Block<EventSliceExecution>` per `(range, tenant)` in `AggregationRunner`). The
projection write path was still reaching into `_session.Versions` / `_session.Revisions`
/ `_session.ItemMap` from inside that parallel block. `IMartenSession` is documented
as not thread-safe; #4658 closed `StoreProjection`; this phase closes the remaining
write sites that `ProjectionStorage`'s `Store(snapshot)` and
`Store(snapshot, id, tenantId)` routed through.

## What changes

**New `IDocumentStorage<T>` surface** (mirrors the existing `OverwriteProjected` pattern):

```csharp
IStorageOperation UpsertProjected(T document, string tenantId);
IStorageOperation InsertProjected(T document, string tenantId);
IStorageOperation UpdateProjected(T document, string tenantId);
```

**Closed-shape storage leaves** — the 9 writeable variants (Unversioned / Optimistic /
Numeric × Lightweight / IdentityMap / DirtyChecked) build their corresponding
closed-shape op with null trackers. `QueryOnlyClosedShapeStorage` throws
`NotSupportedException`; `SubClassDocumentStorage` / `ValueTypeIdentifiedDocumentStorage`
delegate; `EventDocumentStorage` / `EventMapping` throw — all consistent with the
established `OverwriteProjected` shape.

**Null-tolerance audit** on all four `ConcurrencyMode` op classes that hold a
tracker dictionary (Optimistic Insert/Update/Upsert + Numeric Insert/Update/Upsert):
`_versions` / `_revisions` are now nullable and the dict writes in `PostprocessAsync`
are guarded. Optimistic Update/Upsert's `ConfigureCommand` treats a null tracker as
"expected version unknown" and binds `DBNull` for the WHERE-guard slot — callers that
go through `*Projected` should also set `IgnoreConcurrencyViolation = true` if they
want silent no-op semantics on the conflict branch (the projection runtime already
does this via `IRevisionedOperation` in `StoreProjection`).

**`ProjectionStorage` rewrites:**

| Site | Before | After |
|---|---|---|
| `Store(snapshot)` line 86 | `_storage.Upsert(snapshot, _session, TenantId)` | `_storage.UpsertProjected(snapshot, TenantId)` |
| `Store(snapshot, id, tenantId)` line 117–135 | eject + `_storage.Store(_session, ...)` + `_storage.Upsert(snapshot, _session, tenantId)` | gated eject + `_storage.UpsertProjected(snapshot, tenantId)` |

The GH-3850 identity-map maintenance (`EjectAggregateFromIdentityMap` +
`_storage.Store(_session, snapshot)`) is **preserved** but gated on
`Options.EventGraph.UseIdentityMapForAggregates`. The default (false) path now takes
the session-state-free write; the opt-in (true) path still gets correct
inline-projection-rewriting-an-immutable-aggregate semantics. Per the #4667 Phase 3
design note, opt-in is documented as not safe for parallel projection workers — that
race is accepted with the flag on.

## Acceptance criteria

* Every `ProjectionStorage` write method now routes through a `*Projected` variant. ✅
* `grep -nE '_storage\.(Upsert|Insert|Update)\b' src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs` returns zero hits. ✅
* All four closed-shape op `Postprocess` methods tolerate null trackers. ✅
* Daemon tests in `src/DaemonTests/` pass. ✅

## Verification

Local on net9.0:

| Suite | Result |
|---|---|
| DaemonTests | 187 / 187 ✅ |
| EventSourcingTests | 1361 passed / 7 pre-existing skips ✅ |
| CoreTests | 421 passed / 1 pre-existing skip ✅ |

The GH-3850 regression test (`fetch_latest_immutable_aggregate_running_inline_and_identity_map`)
specifically covers the identity-map-maintenance path and is green.

## Follow-ups

* Phase 2 ([#4667](https://github.com/JasperFx/marten/issues/4667)) — read-path
  `LoadProjectedAsync` / `LoadManyProjectedAsync` + a fifth projection-safe selector
  flavor per closed-shape storage.
* Phase 3 — `ProjectionDocumentSession` overrides for user-code reads from inside
  `EvolveAsync`, gated by `UseIdentityMapForAggregates`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)