### PR TITLE
#4666 Phase B — TelehealthComposite 4+2+2 + rebuild subcommand

### DIFF
--- a/src/Marten.ScaleTesting/Commands/RebuildCommand.cs
+++ b/src/Marten.ScaleTesting/Commands/RebuildCommand.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics;
+using JasperFx;
+using JasperFx.CommandLine;
+using Spectre.Console;
+
+namespace Marten.ScaleTesting.Commands;
+
+[Description("Rebuild a registered projection (default: TelehealthComposite) via the single-pass CompositeReplayExecutor. " +
+             "Drives the daemon's RebuildProjectionAsync across every shard. Expects events to be already seeded — see the `seed` subcommand.")]
+public sealed class RebuildCommand: JasperFxAsyncCommand<RebuildInput>
+{
+    public override async Task<bool> Execute(RebuildInput input)
+    {
+        using var host = input.BuildHost();
+        var store = host.DocumentStore();
+
+        // Ensure the schema is in place so a brand-new database can still
+        // rebuild even if the user skipped the `seed` step (no events =
+        // immediate no-op).
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync().ConfigureAwait(false);
+
+        var stats = await store.Advanced.FetchEventStoreStatistics().ConfigureAwait(false);
+        AnsiConsole.MarkupLine(
+            $"[blue]Rebuilding projection [yellow]{input.ProjectionFlag}[/] against {stats.EventCount:N0} events / {stats.StreamCount:N0} streams.[/]");
+
+        using var daemon = await store.BuildProjectionDaemonAsync().ConfigureAwait(false);
+
+        var shardTimeout = TimeSpan.FromSeconds(input.ShardTimeoutSecondsFlag);
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            await daemon.RebuildProjectionAsync(input.ProjectionFlag, shardTimeout, CancellationToken.None)
+                .ConfigureAwait(false);
+            stopwatch.Stop();
+        }
+        catch (Exception e)
+        {
+            stopwatch.Stop();
+            AnsiConsole.MarkupLine($"[red]Rebuild FAILED after {stopwatch.Elapsed.TotalSeconds:N1}s.[/]");
+            AnsiConsole.WriteException(e);
+            return false;
+        }
+
+        var rate = stats.EventCount > 0
+            ? stats.EventCount / Math.Max(0.001, stopwatch.Elapsed.TotalSeconds)
+            : 0;
+
+        AnsiConsole.MarkupLine($"[green]Rebuild complete.[/]");
+        var table = new Table().AddColumn("Metric").AddColumn(new TableColumn("Value").RightAligned());
+        table.AddRow("Projection", input.ProjectionFlag);
+        table.AddRow("Events processed", stats.EventCount.ToString("N0"));
+        table.AddRow("Streams", stats.StreamCount.ToString("N0"));
+        table.AddRow("Elapsed", $"{stopwatch.Elapsed.TotalSeconds:N1}s");
+        table.AddRow("Throughput (events/sec)", rate.ToString("N0"));
+        AnsiConsole.Write(table);
+
+        return true;
+    }
+}

--- a/src/Marten.ScaleTesting/Commands/RebuildInput.cs
+++ b/src/Marten.ScaleTesting/Commands/RebuildInput.cs
@@ -1,0 +1,13 @@
+using JasperFx;
+using JasperFx.CommandLine;
+
+namespace Marten.ScaleTesting.Commands;
+
+public sealed class RebuildInput: NetCoreInput
+{
+    [Description("Projection name to rebuild. Defaults to the TelehealthComposite. Pass any registered projection name to scope a narrower rebuild.")]
+    public string ProjectionFlag { get; set; } = "TelehealthComposite";
+
+    [Description("Per-shard rebuild timeout, in seconds. Default: 600s (10 min). Bump for very large event counts.")]
+    public int ShardTimeoutSecondsFlag { get; set; } = 600;
+}

--- a/src/Marten.ScaleTesting/Domain/Stage2Projections.cs
+++ b/src/Marten.ScaleTesting/Domain/Stage2Projections.cs
@@ -1,0 +1,303 @@
+// Lifted from src/DaemonTests/TeleHealth/{AppointmentDetailsProjection,BoardSummary}.cs
+// (#4666 Phase B). Stage-2 multi-stream + enrichment projections — these read
+// the stage-1 single-stream snapshots (Updated<Appointment> / Updated<Board> /
+// Updated<ProviderShift>) plus reference docs (Patient, Provider, Specialty,
+// RoutingReason, Board) and roll up richer enriched views.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Grouping;
+using Marten;
+using Marten.Events.Projections;
+using Marten.Schema;
+
+namespace Marten.ScaleTesting.Domain;
+
+// ---- AppointmentDetails -------------------------------------------------
+
+public class AppointmentDetails
+{
+    public Guid Id { get; set; }
+
+    public AppointmentDetails() { }
+
+    public AppointmentDetails(Guid id)
+    {
+        Id = id;
+    }
+
+    public string PatientFirstName { get; set; } = string.Empty;
+    public string PatientLastName { get; set; } = string.Empty;
+    public Guid PatientId { get; set; }
+    public Guid ProviderId { get; set; }
+
+    public string SpecialtyCode { get; set; } = string.Empty;
+    public string SpecialtyDescription { get; set; } = string.Empty;
+
+    public string BoardName { get; set; } = string.Empty;
+    public Guid? BoardId { get; set; }
+    public string ProviderFirstName { get; set; } = string.Empty;
+    public string ProviderLastName { get; set; } = string.Empty;
+    public ProviderRole ProviderRole { get; set; }
+
+    public DateTimeOffset Requested { get; set; }
+    public DateTimeOffset? EstimatedTime { get; set; }
+    public DateTimeOffset? CompletedTime { get; set; }
+    public AppointmentStatus Status { get; set; }
+    public string RoutingReasonCode { get; set; } = string.Empty;
+    public string RoutingReasonDescription { get; set; } = string.Empty;
+    public int RoutingReasonSeverity { get; set; }
+}
+
+public partial class AppointmentDetailsProjection: MultiStreamProjection<AppointmentDetails, Guid>
+{
+    public AppointmentDetailsProjection()
+    {
+        Options.CacheLimitPerTenant = 1000;
+
+        Identity<Updated<Appointment>>(x => x.Entity.Id);
+        Identity<IEvent<ProviderAssigned>>(x => x.StreamId);
+        Identity<IEvent<AppointmentRouted>>(x => x.StreamId);
+
+        // Synthetic event published from upstream projections so we can mirror
+        // the simpler Appointment projection's delete decisions here.
+        Identity<ProjectionDeleted<Appointment, Guid>>(x => x.Identity);
+    }
+
+    public override async Task EnrichEventsAsync(SliceGroup<AppointmentDetails, Guid> group, IQuerySession querySession,
+        CancellationToken cancellation)
+    {
+        await group
+            .EnrichWith<Specialty>()
+            .ForEvent<Updated<Appointment>>()
+            .ForEntityId(x => x.Entity.Requirement!.SpecialtyCode)
+            .AddReferences();
+
+        await group
+            .EnrichWith<Patient>()
+            .ForEvent<Updated<Appointment>>()
+            .ForEntityId(x => x.Entity.PatientId)
+            .AddReferences();
+
+        await group
+            .EnrichWith<Provider>()
+            .ForEvent<ProviderAssigned>()
+            .ForEntityId(x => x.ProviderId)
+            .AddReferences();
+
+        await group
+            .EnrichWith<Board>()
+            .ForEvent<AppointmentRouted>()
+            .ForEntityId(x => x.BoardId)
+            .AddReferences();
+
+        // RoutingReason is looked up by business key (ReasonCode), not document id,
+        // so we use the EnrichUsingEntityQuery escape hatch + the slice cache.
+        await group
+            .EnrichWith<RoutingReason>()
+            .ForEvent<AppointmentRouted>()
+            .EnrichUsingEntityQuery<string>(async (slices, events, cache, ct) =>
+            {
+                var reasonCodes = events
+                    .Select(e => e.Data.ReasonCode)
+                    .Where(x => x.IsNotEmpty())
+                    .Distinct()
+                    .ToArray();
+                if (reasonCodes.Length == 0) return;
+
+                var missingCodes = cache != null
+                    ? reasonCodes.Where(code => !cache.TryFind(code, out _)).ToList()
+                    : reasonCodes.ToList();
+
+                var localLookup = new Dictionary<string, RoutingReason>();
+                if (missingCodes.Count > 0)
+                {
+                    var reasonsFromDb = await querySession
+                        .Query<RoutingReason>()
+                        .Where(r => r.Code.IsOneOf(missingCodes))
+                        .Where(r => r.IsActive)
+                        .ToListAsync(ct);
+
+                    foreach (var reason in reasonsFromDb)
+                    {
+                        cache?.Store(reason.Code, reason);
+                        localLookup[reason.Code] = reason;
+                    }
+                }
+
+                foreach (var slice in slices)
+                {
+                    var codesInSlice = slice.Events()
+                        .OfType<IEvent<AppointmentRouted>>()
+                        .Select(x => x.Data.ReasonCode)
+                        .Where(x => x.IsNotEmpty())
+                        .Distinct()
+                        .ToArray();
+
+                    foreach (var code in codesInSlice)
+                    {
+                        if ((cache != null && cache.TryFind(code, out var reason)) ||
+                            localLookup.TryGetValue(code, out reason))
+                        {
+                            slice.Reference(reason);
+                        }
+                    }
+                }
+            }, cancellation);
+    }
+
+    public override AppointmentDetails? Evolve(AppointmentDetails? snapshot, Guid id, IEvent e)
+    {
+        // Enrichment-added References<T> synthetic events sometimes arrive
+        // before the snapshot-creating Updated<Appointment>. Default-init up
+        // front so every case can safely write fields without an NRE.
+        snapshot ??= new AppointmentDetails(id);
+
+        switch (e.Data)
+        {
+            case AppointmentRequested requested:
+                snapshot.SpecialtyCode = requested.SpecialtyCode;
+                snapshot.PatientId = requested.PatientId;
+                break;
+
+            case Updated<Appointment> updated:
+                snapshot.Status = updated.Entity.Status;
+                snapshot.EstimatedTime = updated.Entity.EstimatedTime;
+                snapshot.SpecialtyCode = updated.Entity.SpecialtyCode;
+                break;
+
+            case References<Patient> patient:
+                snapshot.PatientFirstName = patient.Entity.FirstName;
+                snapshot.PatientLastName = patient.Entity.LastName;
+                break;
+
+            case References<Specialty> specialty:
+                snapshot.SpecialtyCode = specialty.Entity.Code;
+                snapshot.SpecialtyDescription = specialty.Entity.Description;
+                break;
+
+            case References<Provider> provider:
+                snapshot.ProviderId = provider.Entity.Id;
+                snapshot.ProviderFirstName = provider.Entity.FirstName;
+                snapshot.ProviderLastName = provider.Entity.LastName;
+                break;
+
+            case References<Board> board:
+                snapshot.BoardName = board.Entity.Name;
+                snapshot.BoardId = board.Entity.Id;
+                break;
+
+            case References<RoutingReason> reason:
+                snapshot.RoutingReasonCode = reason.Entity.Code;
+                snapshot.RoutingReasonDescription = reason.Entity.Description;
+                snapshot.RoutingReasonSeverity = reason.Entity.Severity;
+                break;
+
+            case ProjectionDeleted<Appointment>:
+                return null;
+        }
+
+        return snapshot;
+    }
+}
+
+// ---- BoardSummary -------------------------------------------------------
+
+public class BoardSummary
+{
+    public Guid Id { get; set; }
+    public Board? Board { get; set; }
+
+    public Dictionary<Guid, ProviderShift> ActiveProviders { get; set; } = new();
+    public Dictionary<Guid, AssignedAppointment> Assigned { get; set; } = new();
+    public Dictionary<Guid, Appointment> Unassigned { get; set; } = new();
+}
+
+public record AssignedAppointment(Appointment Appointment, Provider? Provider);
+
+public partial class BoardSummaryProjection: MultiStreamProjection<BoardSummary, Guid>
+{
+    public BoardSummaryProjection()
+    {
+        Options.CacheLimitPerTenant = 100;
+
+        Identity<Updated<Appointment>>(x => x.Entity.BoardId ?? Guid.Empty);
+        Identity<Updated<Board>>(x => x.Entity.Id);
+        Identity<Updated<ProviderShift>>(x => x.Entity.BoardId);
+    }
+
+    public override Task EnrichEventsAsync(SliceGroup<BoardSummary, Guid> group, IQuerySession querySession, CancellationToken cancellation)
+    {
+        return group.ReferencePeerView<Board>();
+    }
+
+    public override (BoardSummary, ActionType) DetermineAction(BoardSummary snapshot, Guid identity, IReadOnlyList<IEvent> events)
+    {
+        snapshot ??= new BoardSummary { Id = identity };
+        if (events.TryFindReference<Board>(out var board))
+        {
+            snapshot.Board = board;
+        }
+
+        var shifts = events.AllReferenced<ProviderShift>().ToArray();
+        foreach (var providerShift in shifts)
+        {
+            snapshot.ActiveProviders[providerShift.ProviderId] = providerShift;
+            if (providerShift.AppointmentId.HasValue)
+            {
+                snapshot.Unassigned.Remove(providerShift.ProviderId);
+            }
+        }
+
+        foreach (var appointment in events.AllReferenced<Appointment>())
+        {
+            if (appointment.ProviderId == null)
+            {
+                snapshot.Unassigned[appointment.Id] = appointment;
+                snapshot.Assigned.Remove(appointment.Id);
+            }
+            else
+            {
+                snapshot.Unassigned.Remove(appointment.Id);
+                var shift = shifts.FirstOrDefault(x => x.Id == appointment.ProviderId.Value);
+                snapshot.Assigned[appointment.Id] = new AssignedAppointment(appointment, shift?.Provider);
+            }
+        }
+
+        return (snapshot, ActionType.Store);
+    }
+}
+
+// ---- AppointmentMetrics (custom IProjection) ---------------------------
+
+public class AppointmentMetrics
+{
+    [Identity]
+    public string SpecialtyCode { get; set; } = string.Empty;
+    public int Count { get; set; }
+}
+
+public class AppointmentMetricsProjection: IProjection
+{
+    public async Task ApplyAsync(IDocumentOperations operations, IReadOnlyList<IEvent> events,
+        CancellationToken cancellation)
+    {
+        var groups = events
+            .Where(e => e.Data is AppointmentRequested)
+            .Select(e => (AppointmentRequested)e.Data)
+            .GroupBy(r => r.SpecialtyCode);
+
+        foreach (var group in groups)
+        {
+            var metrics = await operations.LoadAsync<AppointmentMetrics>(group.Key, cancellation)
+                          ?? new AppointmentMetrics { SpecialtyCode = group.Key };
+            metrics.Count += group.Count();
+            operations.Store(metrics);
+        }
+    }
+}

--- a/src/Marten.ScaleTesting/Domain/Stage3Projections.cs
+++ b/src/Marten.ScaleTesting/Domain/Stage3Projections.cs
@@ -1,0 +1,172 @@
+// #4666 Phase B — stage-3 projections that read stage-2 AppointmentDetails +
+// BoardSummary output. Two new multi-stream projections specifically built for
+// the scaletesting harness; not lifted from DaemonTests (they don't exist there).
+// Purpose: stress the (a) cross-stage Updated<TUpstream> chaining, (b) enrichment
+// + reference-data joins under load, (c) per-tenant aggregation under conjoined
+// tenancy.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Grouping;
+using Marten;
+using Marten.Events.Projections;
+using Marten.Schema;
+
+namespace Marten.ScaleTesting.Domain;
+
+// ---- ProviderUtilization ------------------------------------------------
+//
+// Per-provider rollup: how many appointments has each provider been assigned,
+// how many have they completed, what's the average appointment-to-completion
+// wall-time. Keyed by ProviderId; triggered by stage-2
+// Updated<AppointmentDetails> emissions whose ProviderId is non-empty.
+// Optionally enriched with the Provider reference document so the doc can
+// carry the provider's display name without a second lookup at read time.
+
+public class ProviderUtilization
+{
+    public Guid Id { get; set; } // = ProviderId
+    public string ProviderFirstName { get; set; } = string.Empty;
+    public string ProviderLastName { get; set; } = string.Empty;
+    public ProviderRole ProviderRole { get; set; }
+    public int AssignedCount { get; set; }
+    public int CompletedCount { get; set; }
+    public int CancelledCount { get; set; }
+}
+
+public partial class ProviderUtilizationProjection: MultiStreamProjection<ProviderUtilization, Guid>
+{
+    public ProviderUtilizationProjection()
+    {
+        Options.CacheLimitPerTenant = 500;
+
+        // Slice key: ProviderId. Skip stage-2 updates that don't have a provider
+        // assigned yet (the appointment may have been routed but not staffed).
+        Identity<Updated<AppointmentDetails>>(x =>
+            x.Entity.ProviderId == Guid.Empty ? Guid.Empty : x.Entity.ProviderId);
+
+        // When the upstream Appointment is deleted (cancelled), surface that
+        // so we can decrement appropriately.
+        Identity<ProjectionDeleted<AppointmentDetails, Guid>>(x => x.Identity);
+    }
+
+    public override async Task EnrichEventsAsync(SliceGroup<ProviderUtilization, Guid> group,
+        IQuerySession querySession, CancellationToken cancellation)
+    {
+        // One-shot lookup of the Provider doc per slice so the rollup picks up
+        // the provider's name/role even if the upstream AppointmentDetails was
+        // written before the Provider reference was materialised.
+        await group
+            .EnrichWith<Provider>()
+            .ForEvent<Updated<AppointmentDetails>>()
+            .ForEntityId(x => x.Entity.ProviderId)
+            .AddReferences();
+    }
+
+    public override ProviderUtilization? Evolve(ProviderUtilization? snapshot, Guid id, IEvent e)
+    {
+        // Skip the synthetic "no provider yet" slice entirely.
+        if (id == Guid.Empty) return snapshot;
+
+        switch (e.Data)
+        {
+            case Updated<AppointmentDetails> updated:
+                snapshot ??= new ProviderUtilization { Id = id };
+                snapshot.AssignedCount++;
+                if (updated.Entity.Status == AppointmentStatus.Completed)
+                {
+                    snapshot.CompletedCount++;
+                }
+                break;
+
+            case References<Provider> provider:
+                snapshot ??= new ProviderUtilization { Id = id };
+                snapshot.ProviderFirstName = provider.Entity.FirstName;
+                snapshot.ProviderLastName = provider.Entity.LastName;
+                snapshot.ProviderRole = provider.Entity.Role;
+                break;
+
+            case ProjectionDeleted<AppointmentDetails>:
+                // The upstream AppointmentDetails was deleted (cancelled
+                // appointment). We can't tell from a delete event which
+                // provider this referred to, so we let CancelledCount climb
+                // at the slice we're already in.
+                snapshot ??= new ProviderUtilization { Id = id };
+                snapshot.CancelledCount++;
+                break;
+        }
+
+        return snapshot;
+    }
+}
+
+// ---- TenantDailyRollup --------------------------------------------------
+//
+// Per-day rollup of appointment activity for the current tenant. Conjoined
+// tenancy means each tenant sees its own slice of the projection table —
+// keying on date alone is fine because the tenant column filters reads.
+// Demonstrates per-tenant aggregation under load: every tenant has its own
+// (Date) → TenantDailyRollup row set, and the daemon must keep them isolated.
+
+public class TenantDailyRollup
+{
+    [Identity]
+    public string Date { get; set; } = string.Empty; // ISO "yyyy-MM-dd"
+    public int RequestedCount { get; set; }
+    public int CompletedCount { get; set; }
+    public int CancelledCount { get; set; }
+    public Dictionary<string, int> ByRoutingReason { get; set; } = new();
+}
+
+public partial class TenantDailyRollupProjection: MultiStreamProjection<TenantDailyRollup, string>
+{
+    public TenantDailyRollupProjection()
+    {
+        Options.CacheLimitPerTenant = 100;
+
+        // Bucket by the appointment's Requested date if known, else by the
+        // event timestamp date. Both lookups are cheap because Updated<T>
+        // carries the snapshot in-line.
+        Identity<Updated<AppointmentDetails>>(x =>
+            DateOnlyOf(x.Entity.Requested == default
+                ? DateTimeOffset.UtcNow
+                : x.Entity.Requested));
+
+        Identity<ProjectionDeleted<AppointmentDetails, Guid>>(_ =>
+            DateOnlyOf(DateTimeOffset.UtcNow));
+    }
+
+    public override TenantDailyRollup? Evolve(TenantDailyRollup? snapshot, string id, IEvent e)
+    {
+        switch (e.Data)
+        {
+            case Updated<AppointmentDetails> updated:
+                snapshot ??= new TenantDailyRollup { Date = id };
+                snapshot.RequestedCount++;
+                if (updated.Entity.Status == AppointmentStatus.Completed)
+                {
+                    snapshot.CompletedCount++;
+                }
+                if (!string.IsNullOrEmpty(updated.Entity.RoutingReasonCode))
+                {
+                    snapshot.ByRoutingReason.TryGetValue(updated.Entity.RoutingReasonCode, out var current);
+                    snapshot.ByRoutingReason[updated.Entity.RoutingReasonCode] = current + 1;
+                }
+                break;
+
+            case ProjectionDeleted<AppointmentDetails>:
+                snapshot ??= new TenantDailyRollup { Date = id };
+                snapshot.CancelledCount++;
+                break;
+        }
+
+        return snapshot;
+    }
+
+    private static string DateOnlyOf(DateTimeOffset moment)
+        => moment.UtcDateTime.ToString("yyyy-MM-dd");
+}

--- a/src/Marten.ScaleTesting/Marten.ScaleTesting.csproj
+++ b/src/Marten.ScaleTesting/Marten.ScaleTesting.csproj
@@ -22,6 +22,12 @@
          reference it directly to avoid a CPM downgrade pin (JasperFx 2.8.0
          already requires Spectre 0.55+). -->
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <!-- #4666 Phase B: source-gen dispatcher for the conventional Apply /
+         Create / ShouldDelete methods on Board / Appointment / ProviderShift
+         + the multi-stream Evolve methods on the stage-2/3 projections.
+         OutputItemType=Analyzer + ReferenceOutputAssembly=false matches the
+         shape every Marten test project uses. -->
+    <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Marten.ScaleTesting/Program.cs
+++ b/src/Marten.ScaleTesting/Program.cs
@@ -1,8 +1,10 @@
 using JasperFx;
 using JasperFx.Events;
+using JasperFx.Events.Projections;
 using Marten;
 using Marten.Events;
 using Marten.ScaleTesting;
+using Marten.ScaleTesting.Domain;
 using Marten.Storage;
 using Microsoft.Extensions.Hosting;
 
@@ -36,15 +38,37 @@ builder.ConfigureServices(services =>
         });
         opts.Advanced.DefaultTenantUsageEnabled = false;
 
-        // Phase A intentionally does NOT register the snapshot projections —
-        // the seeder only writes raw events. Registering Snapshot<T> would
-        // require the JasperFx.Events.SourceGenerator to emit the dispatcher
-        // for each aggregate's partial class, which is fine when we wire up
-        // the composite projection in Phase B but is dead weight for a
-        // pure-seeding run. Without registration, StartStream<T> on the
-        // seeder just tags the stream with the aggregate type name; that
-        // doesn't trigger any projection machinery and Phase B's rebuild
-        // builds the snapshots from the seeded events.
+        // Phase B — register the 4+2+2 composite projection per the #4666
+        // issue's topology. Async lifecycle so the seed itself doesn't trigger
+        // any projection work; rebuild is driven explicitly via the daemon
+        // (the `rebuild` subcommand).
+        //
+        // Stage 1 — single-stream snapshots + the custom AppointmentMetrics
+        //   IProjection (independent per-stream rollups).
+        // Stage 2 — multi-stream + enrichment projections that read the
+        //   stage-1 Updated<TUpstream> emissions (AppointmentDetails fans
+        //   out from Updated<Appointment>+ProviderAssigned+AppointmentRouted;
+        //   BoardSummary aggregates Updated<Board>+Updated<Appointment>+
+        //   Updated<ProviderShift>).
+        // Stage 3 — NEW projections that read stage-2 Updated<TDownstream>
+        //   emissions, exercising the cross-stage chaining + per-tenant
+        //   aggregation under the conjoined boundary.
+        opts.Projections.CompositeProjectionFor("TelehealthComposite", projection =>
+        {
+            // Stage 1
+            projection.Add<AppointmentProjection>(stageNumber: 1);
+            projection.Add<ProviderShiftProjection>(stageNumber: 1);
+            projection.Snapshot<Board>(stageNumber: 1);
+            projection.Add(new AppointmentMetricsProjection(), stageNumber: 1);
+
+            // Stage 2
+            projection.Add<AppointmentDetailsProjection>(stageNumber: 2);
+            projection.Add<BoardSummaryProjection>(stageNumber: 2);
+
+            // Stage 3
+            projection.Add<ProviderUtilizationProjection>(stageNumber: 3);
+            projection.Add<TenantDailyRollupProjection>(stageNumber: 3);
+        });
     });
 });
 


### PR DESCRIPTION
Phase B of [#4666](https://github.com/JasperFx/marten/issues/4666). Wires the
composite projection topology and the `rebuild` subcommand so the harness can
actually exercise the daemon's projection paths under load — the regression
bed for the #4667 race fixes.

## What ships

| Bit | Notes |
|---|---|
| **Stage-2 projections** (`Domain/Stage2Projections.cs`) | Lifted from `src/DaemonTests/TeleHealth/`: `AppointmentDetailsProjection` (multi-stream + enrichment), `BoardSummaryProjection` (multi-stream + `ReferencePeerView<Board>`), `AppointmentMetricsProjection` (custom `IProjection`). |
| **Stage-3 projections** (`Domain/Stage3Projections.cs`) — **NEW** | `ProviderUtilizationProjection` (per-provider rollup keyed by `ProviderId`, reads stage-2 `Updated<AppointmentDetails>`, enriches with `Provider`) + `TenantDailyRollupProjection` (per-day rollup keyed by ISO date string; under conjoined tenancy the date-only key naturally scopes per-tenant, exercising cross-stage chaining + per-tenant aggregation). |
| **CompositeProjection wiring** (`Program.cs`) | `opts.Projections.CompositeProjectionFor("TelehealthComposite", ...)` with the issue's 4+2+2 stage layout. |
| **SourceGen analyzer dependency** (`csproj`) | Adds `JasperFx.Events.SourceGenerator` as `Analyzer` (matches every Marten test project shape). Without it the rebuild fails with `No source-generated dispatcher found for SingleStreamProjection<Board, Guid>`. |
| **`rebuild` CLI subcommand** | `marten-scaletest rebuild [--projection TelehealthComposite] [--shard-timeout-seconds 600]`. Builds the daemon, calls `RebuildProjectionAsync`, prints a Spectre summary. Returns false on any exception so a stress chain can stop early. |

## Snapshot init guard

`AppointmentDetailsProjection.Evolve` got a `snapshot ??= new ...(id)` at the
top: enrichment-added `References<T>` synthetic events can arrive before the
snapshot-creating `Updated<Appointment>`, which made the lifted
`snapshot!.X = ...` pattern NRE on rebuild (smoke caught this immediately —
~16GB memory blow-up before I killed the process, root cause was the
unguarded NRE adding to the daemon's exception/retry queue).

## Smoke (local Postgres on docker-compose's localhost:5432)

| Step | Result |
|---|---|
| Build | clean |
| `seed --tenants 2 --events-per-tenant 500` | 1,136 events / 150 streams, 0.4s |
| `rebuild --projection TelehealthComposite` | clean, 0.5s (~2,247 events/sec) |

Projection row counts after rebuild (direct psql):

| Table | Rows |
|---|---|
| `mt_doc_appointment` | 100 |
| `mt_doc_board` | 6 |
| `mt_doc_providershift` | 36 |
| `mt_doc_appointmentmetrics` | 16 |
| `mt_doc_appointmentdetails` | 108 |
| `mt_doc_boardsummary` | 6 |
| `mt_doc_providerutilization` | 93 |
| `mt_doc_tenantdailyrollup` | 2 |

All 8 projections populated end-to-end through the composite's 3 stages.

## Phase C / D follow-ups

* **Phase C** (separate PR): `validate` subcommand (single-shard baseline diff) + JSON metrics sink + `stress` chain.
* **Phase D**: actually run `stress` at scale against the dev box; if crash-free, close [#4667](https://github.com/JasperFx/marten/issues/4667).

🤖 Generated with [Claude Code](https://claude.com/claude-code)