### PR TITLE
Fix several LINQ gaps: DateOnly/TimeOnly projection, SelectMany Distinct().Count(), and GroupJoin Distinct/scalar/aggregates

### DIFF
--- a/src/LinqTests/Bugs/Bug_dateonly_timeonly_scalar_projection.cs
+++ b/src/LinqTests/Bugs/Bug_dateonly_timeonly_scalar_projection.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+// Projecting a DateOnly/TimeOnly member directly -- Query<T>().Select(x => x.SomeDateOnly)
+// -- threw System.Text.Json "'-' is an invalid end of a number": the bare scalar projection
+// fell through to DataSelectClause, which JSON-deserializes the quote-stripped `data ->> 'x'`
+// text. Fixed by routing DateOnly/TimeOnly through NewScalarSelectClause (native date/time read).
+public class Bug_dateonly_timeonly_scalar_projection: BugIntegrationContext
+{
+    public sealed class DocWithDateOnly
+    {
+        public Guid Id { get; set; }
+        public DateOnly Date { get; set; }
+        public TimeOnly Time { get; set; }
+        public DateOnly? NullableDate { get; set; }
+        public TimeOnly? NullableTime { get; set; }
+    }
+
+    private void ConfigureStore()
+    {
+        StoreOptions(opts =>
+        {
+            opts.UseSystemTextJsonForSerialization();
+            opts.Schema.For<DocWithDateOnly>();
+        });
+    }
+
+    private async Task seedAsync()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(
+            new DocWithDateOnly
+            {
+                Id = Guid.NewGuid(),
+                Date = new DateOnly(2026, 4, 29),
+                Time = new TimeOnly(9, 30, 0),
+                NullableDate = new DateOnly(2026, 4, 29),
+                NullableTime = new TimeOnly(9, 30, 0)
+            },
+            new DocWithDateOnly
+            {
+                Id = Guid.NewGuid(),
+                Date = new DateOnly(2026, 5, 1),
+                Time = new TimeOnly(14, 0, 0),
+                NullableDate = null,
+                NullableTime = null
+            });
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task select_dateonly_scalar_directly()
+    {
+        ConfigureStore();
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        var dates = await query.Query<DocWithDateOnly>()
+            .OrderByDescending(x => x.Date)
+            .Select(x => x.Date)
+            .ToListAsync();
+
+        dates.ShouldBe(new[] { new DateOnly(2026, 5, 1), new DateOnly(2026, 4, 29) });
+    }
+
+    [Fact]
+    public async Task select_timeonly_scalar_directly()
+    {
+        ConfigureStore();
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        var times = await query.Query<DocWithDateOnly>()
+            .OrderBy(x => x.Date)
+            .Select(x => x.Time)
+            .ToListAsync();
+
+        times.ShouldBe(new[] { new TimeOnly(9, 30, 0), new TimeOnly(14, 0, 0) });
+    }
+
+    [Fact]
+    public async Task select_nullable_dateonly_scalar_directly()
+    {
+        ConfigureStore();
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        var dates = await query.Query<DocWithDateOnly>()
+            .OrderBy(x => x.Date)
+            .Select(x => x.NullableDate)
+            .ToListAsync();
+
+        dates.Count.ShouldBe(2);
+        dates[0].ShouldBe(new DateOnly(2026, 4, 29));
+        dates[1].ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task select_nullable_timeonly_scalar_directly()
+    {
+        ConfigureStore();
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        var times = await query.Query<DocWithDateOnly>()
+            .OrderBy(x => x.Date)
+            .Select(x => x.NullableTime)
+            .ToListAsync();
+
+        times.Count.ShouldBe(2);
+        times[0].ShouldBe(new TimeOnly(9, 30, 0));
+        times[1].ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task select_dateonly_with_where()
+    {
+        ConfigureStore();
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        var dates = await query.Query<DocWithDateOnly>()
+            .Where(x => x.Date >= new DateOnly(2026, 5, 1))
+            .Select(x => x.Date)
+            .ToListAsync();
+
+        dates.ShouldBe(new[] { new DateOnly(2026, 5, 1) });
+    }
+}

--- a/src/LinqTests/Bugs/Bug_dateonly_timeonly_scalar_projection.cs
+++ b/src/LinqTests/Bugs/Bug_dateonly_timeonly_scalar_projection.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten;
+using Marten.Newtonsoft;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
@@ -132,5 +133,41 @@ public class Bug_dateonly_timeonly_scalar_projection: BugIntegrationContext
             .ToListAsync();
 
         dates.ShouldBe(new[] { new DateOnly(2026, 5, 1) });
+    }
+
+    [Fact]
+    public async Task select_dateonly_scalar_directly_with_newtonsoft()
+    {
+        // The fix reads the native date/time locator, so it is serializer-agnostic -- pin Newtonsoft too.
+        StoreOptions(opts =>
+        {
+            opts.UseNewtonsoftForSerialization();
+            opts.Schema.For<DocWithDateOnly>();
+        });
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        var dates = await query.Query<DocWithDateOnly>()
+            .OrderByDescending(x => x.Date)
+            .Select(x => x.Date)
+            .ToListAsync();
+
+        dates.ShouldBe(new[] { new DateOnly(2026, 5, 1), new DateOnly(2026, 4, 29) });
+    }
+
+    [Fact]
+    public async Task select_distinct_dateonly_scalar()
+    {
+        ConfigureStore();
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        // both rows have distinct dates already; add no duplicates -> 2 distinct
+        var dates = await query.Query<DocWithDateOnly>()
+            .Select(x => x.Date)
+            .Distinct()
+            .ToListAsync();
+
+        dates.OrderBy(d => d).ShouldBe(new[] { new DateOnly(2026, 4, 29), new DateOnly(2026, 5, 1) });
     }
 }

--- a/src/LinqTests/Bugs/Bug_distinct_count_over_selectmany.cs
+++ b/src/LinqTests/Bugs/Bug_distinct_count_over_selectmany.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+// A Count()/LongCount() over a Distinct() projection of a SelectMany(child-collection) threw
+// NotSupportedException "The database operator 'DISTINCT' cannot be used with non-simple types",
+// even though the equivalent Distinct().ToList() worked: BuildSelectManyStatement re-applied
+// DISTINCT to the count clause that ProcessSingleValueModeIfAny had already produced (and the
+// Inner-merged IsDistinct flag never reached the count path, so a plain count of all rows was
+// produced instead of count of distinct values).
+public class Bug_distinct_count_over_selectmany: BugIntegrationContext
+{
+    public record Tag(string Value);
+    public class Doc { public Guid Id { get; set; } public List<Tag> Tags { get; set; } = new(); }
+
+    private async Task seedAsync()
+    {
+        StoreOptions(opts => opts.Schema.For<Doc>());
+        await using var session = theStore.LightweightSession();
+        // flattened values x,x,y,y,z -> 3 distinct, 5 total
+        session.Store(
+            new Doc { Id = Guid.NewGuid(), Tags = [new("x"), new("x"), new("y")] },
+            new Doc { Id = Guid.NewGuid(), Tags = [new("y"), new("z")] });
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task select_many_select_distinct_count()
+    {
+        await seedAsync();
+        await using var query = theStore.QuerySession();
+        var count = await query.Query<Doc>().SelectMany(d => d.Tags).Select(t => t.Value).Distinct().CountAsync();
+        count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task select_many_select_distinct_long_count()
+    {
+        await seedAsync();
+        await using var query = theStore.QuerySession();
+        var count = await query.Query<Doc>().SelectMany(d => d.Tags).Select(t => t.Value).Distinct().LongCountAsync();
+        count.ShouldBe(3L);
+    }
+
+    [Fact]
+    public async Task select_many_select_count_without_distinct_is_unaffected()
+    {
+        await seedAsync();
+        await using var query = theStore.QuerySession();
+        var count = await query.Query<Doc>().SelectMany(d => d.Tags).Select(t => t.Value).CountAsync();
+        count.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task select_many_select_distinct_to_list_still_works()
+    {
+        await seedAsync();
+        await using var query = theStore.QuerySession();
+        var values = await query.Query<Doc>().SelectMany(d => d.Tags).Select(t => t.Value).Distinct().ToListAsync();
+        values.OrderBy(v => v).ShouldBe(new[] { "x", "y", "z" });
+    }
+}

--- a/src/LinqTests/Bugs/Bug_groupjoin_distinct_and_scalar_projection.cs
+++ b/src/LinqTests/Bugs/Bug_groupjoin_distinct_and_scalar_projection.cs
@@ -257,4 +257,76 @@ public class Bug_groupjoin_distinct_and_scalar_projection: BugIntegrationContext
                 .SelectMany(x => x.children, (x, c) => c.Amount + 1)
                 .ToListAsync());
     }
+
+    // ---- aggregates over a bare scalar projection (Sum / Min / Max / Average) ----
+    // Inner-join rows from seedAsync: P1->10, P1->10, P2->20.
+
+    private static IQueryable<int> InnerJoinAmount(IQuerySession q) =>
+        q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => c.Amount);
+
+    [Fact]
+    public async Task scalar_sum_over_inner_join()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinAmount(q).SumAsync(z => z)).ShouldBe(40);
+    }
+
+    [Fact]
+    public async Task scalar_min_and_max_over_inner_join()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinAmount(q).MinAsync(z => z)).ShouldBe(10);
+        (await InnerJoinAmount(q).MaxAsync(z => z)).ShouldBe(20);
+    }
+
+    [Fact]
+    public async Task scalar_average_over_inner_join_returns_double()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinAmount(q).AverageAsync(z => z)).ShouldBe(40d / 3d, 0.0001);
+    }
+
+    [Fact]
+    public async Task scalar_decimal_sum_over_inner_join()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        // p.Score over the joined rows: 1.5 (P1) + 1.5 (P1) + 2.5 (P2) = 5.5
+        var sum = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => x.p.Score)
+            .SumAsync(z => z);
+        sum.ShouldBe(5.5m);
+    }
+
+    [Fact]
+    public async Task scalar_sum_over_left_join_ignores_null_inner()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        // left join adds P3 (null inner); SUM ignores the null data row => still 40
+        var sum = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children.DefaultIfEmpty(), (x, c) => c.Amount)
+            .SumAsync(z => z);
+        sum.ShouldBe(40);
+    }
+
+    [Fact]
+    public async Task nullable_scalar_sum_over_inner_join()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        // (int?)c.Amount over inner-join rows 10, 10, 20 -> 40
+        var sum = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => (int?)c.Amount)
+            .SumAsync(z => z);
+        sum.ShouldBe(40);
+    }
 }

--- a/src/LinqTests/Bugs/Bug_groupjoin_distinct_and_scalar_projection.cs
+++ b/src/LinqTests/Bugs/Bug_groupjoin_distinct_and_scalar_projection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten;
+using Marten.Exceptions;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
@@ -20,7 +21,15 @@ namespace LinqTests.Bugs;
 // rendered as to_jsonb(<scalar>) so the existing SerializationSelector + distinct machinery apply.
 public class Bug_groupjoin_distinct_and_scalar_projection: BugIntegrationContext
 {
-    public class Parent { public Guid Id { get; set; } public string Name { get; set; } = ""; }
+    public enum Color { Red, Green, Blue }
+    public class Parent
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = "";
+        public decimal Score { get; set; }
+        public Color Tone { get; set; }
+        public DateOnly Day { get; set; }
+    }
     public class Child { public Guid Id { get; set; } public Guid ParentId { get; set; } public int Amount { get; set; } }
     public class AmountRow { public int Amount { get; set; } }
 
@@ -38,9 +47,9 @@ public class Bug_groupjoin_distinct_and_scalar_projection: BugIntegrationContext
 
         await using var session = theStore.LightweightSession();
         session.Store(
-            new Parent { Id = P1, Name = "a" },
-            new Parent { Id = P2, Name = "b" },
-            new Parent { Id = P3, Name = "c" });
+            new Parent { Id = P1, Name = "a", Score = 1.5m, Tone = Color.Red, Day = new DateOnly(2026, 1, 1) },
+            new Parent { Id = P2, Name = "b", Score = 2.5m, Tone = Color.Blue, Day = new DateOnly(2026, 2, 2) },
+            new Parent { Id = P3, Name = "c", Score = 3.5m, Tone = Color.Green, Day = new DateOnly(2026, 3, 3) });
         // P1 has two children (amount 10, 10), P2 has one (amount 20). Joined rows for inner join = 3,
         // distinct parents = 2, distinct amounts = {10, 20} = 2.
         session.Store(
@@ -155,5 +164,97 @@ public class Bug_groupjoin_distinct_and_scalar_projection: BugIntegrationContext
 
         // P1 children amount 10, 10; P2 amount 20; P3 -> null. Distinct = { 10, 20, null }.
         amounts.OrderBy(a => a.HasValue).ThenBy(a => a).ShouldBe(new int?[] { null, 10, 20 });
+    }
+
+    // ---- dedup correctness: DISTINCT must dedupe by the FULL projected value, not over-merge ----
+
+    [Fact]
+    public async Task object_projection_distinct_keeps_rows_differing_in_one_field()
+    {
+        StoreOptions(opts => { opts.Schema.For<Parent>(); opts.Schema.For<Child>(); });
+        var p = Guid.NewGuid();
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Parent { Id = p, Name = "a" });
+            // same parent (Name "a") but DIFFERENT amounts -> {a,10} and {a,20} must NOT merge
+            session.Store(
+                new Child { Id = Guid.NewGuid(), ParentId = p, Amount = 10 },
+                new Child { Id = Guid.NewGuid(), ParentId = p, Amount = 20 });
+            await session.SaveChangesAsync();
+        }
+
+        await using var q = theStore.QuerySession();
+        var rows = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), x => x.Id, c => c.ParentId, (x, children) => new { x, children })
+            .SelectMany(z => z.children, (z, c) => new { z.x.Name, c.Amount })
+            .Distinct()
+            .ToListAsync();
+
+        rows.Count.ShouldBe(2);
+        rows.Select(r => r.Amount).OrderBy(a => a).ShouldBe(new[] { 10, 20 });
+    }
+
+    // ---- scalar projection across types (round-trip via to_jsonb), distinct over an inner join ----
+
+    [Fact]
+    public async Task scalar_projection_string_distinct_values()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var names = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => x.p.Name)
+            .Distinct().ToListAsync();
+        names.OrderBy(n => n).ShouldBe(new[] { "a", "b" });
+    }
+
+    [Fact]
+    public async Task scalar_projection_decimal_distinct_values()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var scores = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => x.p.Score)
+            .Distinct().ToListAsync();
+        scores.OrderBy(s => s).ShouldBe(new[] { 1.5m, 2.5m });
+    }
+
+    [Fact]
+    public async Task scalar_projection_enum_distinct_values()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var tones = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => x.p.Tone)
+            .Distinct().ToListAsync();
+        tones.OrderBy(t => t).ShouldBe(new[] { Color.Red, Color.Blue }.OrderBy(t => t));
+    }
+
+    [Fact]
+    public async Task scalar_projection_dateonly_distinct_values()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var days = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => x.p.Day)
+            .Distinct().ToListAsync();
+        days.OrderBy(d => d).ShouldBe(new[] { new DateOnly(2026, 1, 1), new DateOnly(2026, 2, 2) });
+    }
+
+    // ---- a non-member-access scalar body is not translatable: fail with a clear error ----
+
+    [Fact]
+    public async Task scalar_projection_of_computed_expression_throws_clear_error()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await q.Query<Parent>()
+                .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+                .SelectMany(x => x.children, (x, c) => c.Amount + 1)
+                .ToListAsync());
     }
 }

--- a/src/LinqTests/Bugs/Bug_groupjoin_distinct_and_scalar_projection.cs
+++ b/src/LinqTests/Bugs/Bug_groupjoin_distinct_and_scalar_projection.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+// GroupJoin + SelectMany had two distinct/projection gaps:
+//   1. Distinct() was silently dropped over the join projection (JoinSelectClause was neither
+//      IScalarSelectClause nor ICountClause, so neither distinct branch matched). Distinct().Count()
+//      returned the full joined row count, and Distinct().ToList() returned non-distinct rows.
+//   2. A bare scalar result selector ((x, t) => x.l.Id) built an empty NewObject and threw
+//      "Sequence contains no elements" at materialization.
+// Fix: JoinSelectClause implements IScalarSelectClause (renders DISTINCT(<projection>)); IsDistinct
+// is transferred from the SelectMany usage in CompileGroupJoin; and a scalar result selector is
+// rendered as to_jsonb(<scalar>) so the existing SerializationSelector + distinct machinery apply.
+public class Bug_groupjoin_distinct_and_scalar_projection: BugIntegrationContext
+{
+    public class Parent { public Guid Id { get; set; } public string Name { get; set; } = ""; }
+    public class Child { public Guid Id { get; set; } public Guid ParentId { get; set; } public int Amount { get; set; } }
+    public class AmountRow { public int Amount { get; set; } }
+
+    private readonly Guid P1 = Guid.NewGuid();
+    private readonly Guid P2 = Guid.NewGuid();
+    private readonly Guid P3 = Guid.NewGuid(); // no children — only seen via left join
+
+    private async Task seedAsync()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Parent>();
+            opts.Schema.For<Child>();
+        });
+
+        await using var session = theStore.LightweightSession();
+        session.Store(
+            new Parent { Id = P1, Name = "a" },
+            new Parent { Id = P2, Name = "b" },
+            new Parent { Id = P3, Name = "c" });
+        // P1 has two children (amount 10, 10), P2 has one (amount 20). Joined rows for inner join = 3,
+        // distinct parents = 2, distinct amounts = {10, 20} = 2.
+        session.Store(
+            new Child { Id = Guid.NewGuid(), ParentId = P1, Amount = 10 },
+            new Child { Id = Guid.NewGuid(), ParentId = P1, Amount = 10 },
+            new Child { Id = Guid.NewGuid(), ParentId = P2, Amount = 20 });
+        await session.SaveChangesAsync();
+    }
+
+    private static IQueryable<AmountRow> InnerJoinObject(IQuerySession q) =>
+        q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => new AmountRow { Amount = c.Amount });
+
+    private static IQueryable<Guid> InnerJoinScalar(IQuerySession q) =>
+        q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => x.p.Id);
+
+    // ---- object projection ----
+
+    [Fact]
+    public async Task object_projection_count_without_distinct_is_unaffected()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinObject(q).CountAsync()).ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task object_projection_distinct_tolist_dedupes()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var rows = await InnerJoinObject(q).Distinct().ToListAsync();
+        rows.Select(r => r.Amount).OrderBy(a => a).ShouldBe(new[] { 10, 20 });
+    }
+
+    [Fact]
+    public async Task object_projection_distinct_count()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinObject(q).Distinct().CountAsync()).ShouldBe(2);
+    }
+
+    // ---- scalar projection ----
+
+    [Fact]
+    public async Task scalar_projection_tolist_without_distinct()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var rows = await InnerJoinScalar(q).ToListAsync();
+        rows.Count.ShouldBe(3);
+        rows.ShouldAllBe(id => id == P1 || id == P2);
+    }
+
+    [Fact]
+    public async Task scalar_projection_distinct_tolist_values()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var rows = await InnerJoinScalar(q).Distinct().ToListAsync();
+        rows.OrderBy(x => x).ShouldBe(new[] { P1, P2 }.OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task scalar_projection_distinct_count()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinScalar(q).Distinct().CountAsync()).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task scalar_projection_distinct_long_count()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinScalar(q).Distinct().LongCountAsync()).ShouldBe(2L);
+    }
+
+    // ---- left join (DefaultIfEmpty) + scalar distinct: P3 has no children but still appears ----
+
+    [Fact]
+    public async Task left_join_scalar_distinct_count_includes_childless_outer()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var distinctParents = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children.DefaultIfEmpty(), (x, c) => x.p.Id)
+            .Distinct()
+            .CountAsync();
+
+        distinctParents.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task left_join_nullable_inner_scalar_yields_null_for_childless_outer()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        // P3 has no children, so the left join yields a null inner row; projecting an inner
+        // member must materialize as null (the "data" column is null), not throw.
+        var amounts = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children.DefaultIfEmpty(), (x, c) => (int?)c.Amount)
+            .Distinct()
+            .ToListAsync();
+
+        // P1 children amount 10, 10; P2 amount 20; P3 -> null. Distinct = { 10, 20, null }.
+        amounts.OrderBy(a => a.HasValue).ThenBy(a => a).ShouldBe(new int?[] { null, 10, 20 });
+    }
+}

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -179,7 +179,11 @@ public partial class CollectionUsage
 
         statement = ConfigureSelectManyStatement(session, collection, statement, statistics).SelectorStatement();
 
-        if (IsDistinct)
+        // Count()/LongCount() over a Distinct() is already wrapped in a CTE and counted by
+        // ProcessSingleValueModeIfAny; re-applying DISTINCT here would hit the count clause
+        // and throw "DISTINCT cannot be used with non-simple types".
+        if (IsDistinct && SingleValueMode is not (Marten.Linq.Parsing.SingleValueMode.Count
+                or Marten.Linq.Parsing.SingleValueMode.LongCount))
         {
             statement.ApplySqlOperator("DISTINCT");
         }
@@ -238,6 +242,17 @@ public partial class CollectionUsage
                 statement.Limit ??= Inner._limit;
                 statement.Offset ??= Inner._offset;
             }
+        }
+
+        // A SelectMany(...).Distinct().Count() carries IsDistinct on the Inner usage merged
+        // in just above; re-sync it onto the statement so the Count branch of
+        // ProcessSingleValueModeIfAny wraps the DISTINCT projection in a CTE and counts that.
+        // Only for the count modes -- the non-aggregate Distinct() is applied via the
+        // ApplySqlOperator("DISTINCT") below, so leaving its flag set would double the DISTINCT.
+        if (SingleValueMode is Marten.Linq.Parsing.SingleValueMode.Count
+            or Marten.Linq.Parsing.SingleValueMode.LongCount)
+        {
+            statement.IsDistinct = IsDistinct;
         }
 
         ProcessSingleValueModeIfAny(statement, session, collection, statistics);

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -397,7 +397,7 @@ public partial class CollectionUsage
             resultType,
             new object[]
             {
-                joinParser.NewObject,
+                joinParser.Projection,
                 outerCteAlias,
                 innerCteAlias,
                 groupJoin.IsLeftJoin,
@@ -450,6 +450,15 @@ public partial class CollectionUsage
                 joinStatement.Limit ??= deepInner._limit;
                 joinStatement.Offset ??= deepInner._offset;
             }
+        }
+
+        // Transfer Distinct() from the SelectMany usage chain. JoinSelectClause implements
+        // IScalarSelectClause, so ProcessSingleValueModeIfAny renders DISTINCT(<projection>) for
+        // a materialized Distinct() and wraps it in a count(*) CTE for Distinct().Count().
+        // Without this the join would silently return non-distinct rows / the joined row count.
+        if ((Inner?.IsDistinct ?? false) || (Inner?.Inner?.IsDistinct ?? false))
+        {
+            joinStatement.IsDistinct = true;
         }
 
         // Apply single value mode to the join statement

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -392,12 +392,22 @@ public partial class CollectionUsage
         // 6-arg ctor doesn't fit the fixed-arity overloads, so we pay an
         // array allocation per call in exchange for skipping MakeGenericType.
         var resultType = groupJoin.FlattenedResultSelector.ReturnType;
+
+        // Sum()/Min()/Max()/Average() over a bare scalar projection cannot aggregate the
+        // to_jsonb(...) form (Postgres has no sum/min/max/avg for jsonb). For those, render the
+        // raw scalar into the join CTE and put a standard scalar select clause over it below.
+        var pendingMode = Inner?.SingleValueMode ?? Inner?.Inner?.SingleValueMode;
+        var scalarAggregate = joinParser.ScalarRawProjection != null
+            && pendingMode is Marten.Linq.Parsing.SingleValueMode.Sum or Marten.Linq.Parsing.SingleValueMode.Min
+                or Marten.Linq.Parsing.SingleValueMode.Max or Marten.Linq.Parsing.SingleValueMode.Average
+            && (resultType == typeof(string) || resultType.IsValueType);
+
         var joinSelectClause = (ISelectClause)GenericFactoryCache.BuildAs<object>(
             typeof(JoinSelectClause<>),
             resultType,
             new object[]
             {
-                joinParser.Projection,
+                scalarAggregate ? joinParser.ScalarRawProjection : joinParser.Projection,
                 outerCteAlias,
                 innerCteAlias,
                 groupJoin.IsLeftJoin,
@@ -459,6 +469,30 @@ public partial class CollectionUsage
         if ((Inner?.IsDistinct ?? false) || (Inner?.Inner?.IsDistinct ?? false))
         {
             joinStatement.IsDistinct = true;
+        }
+
+        if (scalarAggregate)
+        {
+            // Wrap the raw-scalar join in a CTE and aggregate over its single 'data' column with a
+            // standard scalar select clause, which already handles the aggregate result types
+            // (SUM(int)->bigint, AVG->double via CloneToDouble, etc.).
+            joinStatement.ConvertToCommonTableExpression(session);
+
+            // For a nullable scalar (e.g. (int?)c.Amount) build the clause over the underlying type
+            // -- NewScalarSelectClause<T> is `where T : struct` and also implements ISelector<T?>,
+            // so the single-value handler reads the nullable result (null when all rows are null).
+            var clauseType = Nullable.GetUnderlyingType(resultType) ?? resultType;
+            var scalarClause = clauseType == typeof(string)
+                ? new NewScalarStringSelectClause("d.data", joinStatement.ExportName)
+                : typeof(NewScalarSelectClause<>).CloseAndBuildAs<ISelectClause>(
+                    "d.data", joinStatement.ExportName, clauseType);
+
+            var scalarStatement = new SelectorStatement { SelectClause = scalarClause };
+            joinStatement.AddToEnd(scalarStatement);
+
+            ProcessSingleValueModeIfAny(scalarStatement, session, null, statistics);
+
+            return joinStatement;
         }
 
         // Apply single value mode to the join statement

--- a/src/Marten/Linq/Parsing/JoinSelectParser.cs
+++ b/src/Marten/Linq/Parsing/JoinSelectParser.cs
@@ -45,6 +45,10 @@ internal class JoinSelectParser: ExpressionVisitor
     // SerializationSelector<T> deserializes it and the DISTINCT machinery applies unchanged.
     public ISqlFragment ScalarProjection { get; private set; }
 
+    // The same scalar without the to_jsonb wrapper -- the native column. Used for aggregates
+    // (Sum/Min/Max/Average), which cannot operate on a jsonb value.
+    public ISqlFragment ScalarRawProjection { get; private set; }
+
     // The fragment to render after SELECT: the scalar wrap if present, else the jsonb_build_object.
     public ISqlFragment Projection => ScalarProjection ?? NewObject;
 
@@ -85,11 +89,11 @@ internal class JoinSelectParser: ExpressionVisitor
         // Resolve it as a single scalar fragment wrapped in to_jsonb(...).
         if (NewObject.Members.Count == 0)
         {
-            ScalarProjection = ResolveScalarProjection(selectManyResultSelector.Body);
+            ResolveScalarProjection(selectManyResultSelector.Body);
         }
     }
 
-    private ISqlFragment ResolveScalarProjection(Expression body)
+    private void ResolveScalarProjection(Expression body)
     {
         // Strip compiler-inserted Convert/TypeAs (e.g. (decimal?)o.Amount).
         while (body is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.TypeAs } unary)
@@ -106,11 +110,11 @@ internal class JoinSelectParser: ExpressionVisitor
                 + "other than a single outer/inner member access.");
         }
 
-        var fragment = ResolveMember(body, classification.Value.isOuter);
+        ScalarRawProjection = ResolveMember(body, classification.Value.isOuter);
 
         // Wrap in to_jsonb so the rendered 'data' column is a JSON value the SerializationSelector
         // can deserialize back to the scalar T (a raw text/uuid locator would not be valid JSON).
-        return new ToJsonbScalarFragment(fragment);
+        ScalarProjection = new ToJsonbScalarFragment(ScalarRawProjection);
     }
 
     private void ParseGroupJoinResultSelector(LambdaExpression resultSelector)

--- a/src/Marten/Linq/Parsing/JoinSelectParser.cs
+++ b/src/Marten/Linq/Parsing/JoinSelectParser.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using Marten.Exceptions;
 using Marten.Linq.Members;
 using Marten.Linq.SqlGeneration;
 using Weasel.Postgresql;
@@ -39,6 +40,14 @@ internal class JoinSelectParser: ExpressionVisitor
 
     public NewObject NewObject { get; private set; }
 
+    // Non-null when the SelectMany result selector is a bare scalar (e.g. (temp, o) => o.Amount)
+    // rather than an object projection. Rendered as to_jsonb(<scalar>) so the existing
+    // SerializationSelector<T> deserializes it and the DISTINCT machinery applies unchanged.
+    public ISqlFragment ScalarProjection { get; private set; }
+
+    // The fragment to render after SELECT: the scalar wrap if present, else the jsonb_build_object.
+    public ISqlFragment Projection => ScalarProjection ?? NewObject;
+
     public JoinSelectParser(
         ISerializer serializer,
         IQueryableMemberCollection outerMembers,
@@ -70,6 +79,38 @@ internal class JoinSelectParser: ExpressionVisitor
         _selectManyElementParam = selectManyResultSelector.Parameters[1]; // the inner element
 
         Visit(selectManyResultSelector.Body);
+
+        // A bare scalar result selector — (temp, o) => o.Amount — adds nothing to NewObject
+        // (VisitMember early-returns because _currentField is never set by a New/MemberInit).
+        // Resolve it as a single scalar fragment wrapped in to_jsonb(...).
+        if (NewObject.Members.Count == 0)
+        {
+            ScalarProjection = ResolveScalarProjection(selectManyResultSelector.Body);
+        }
+    }
+
+    private ISqlFragment ResolveScalarProjection(Expression body)
+    {
+        // Strip compiler-inserted Convert/TypeAs (e.g. (decimal?)o.Amount).
+        while (body is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.TypeAs } unary)
+        {
+            body = unary.Operand;
+        }
+
+        var classification = ClassifyMemberAccess(body);
+        if (classification == null)
+        {
+            throw new BadLinqExpressionException(
+                "Marten cannot translate this GroupJoin/SelectMany result selector. Project into an "
+                + "anonymous type or record (for example (x, o) => new { x.c.Id, o.Amount }) for shapes "
+                + "other than a single outer/inner member access.");
+        }
+
+        var fragment = ResolveMember(body, classification.Value.isOuter);
+
+        // Wrap in to_jsonb so the rendered 'data' column is a JSON value the SerializationSelector
+        // can deserialize back to the scalar T (a raw text/uuid locator would not be valid JSON).
+        return new ToJsonbScalarFragment(fragment);
     }
 
     private void ParseGroupJoinResultSelector(LambdaExpression resultSelector)
@@ -359,5 +400,27 @@ internal class CteAliasedFragment: ISqlFragment
     public void Apply(ICommandBuilder builder)
     {
         builder.Append(_sql);
+    }
+}
+
+/// <summary>
+/// Wraps a scalar SQL fragment in <c>to_jsonb(...)</c> so a bare scalar GroupJoin/SelectMany
+/// projection renders a JSON value in the "data" column that <see cref="Marten.Linq.Selectors.SerializationSelector{T}"/>
+/// can deserialize back to the scalar type.
+/// </summary>
+internal class ToJsonbScalarFragment: ISqlFragment
+{
+    private readonly ISqlFragment _inner;
+
+    public ToJsonbScalarFragment(ISqlFragment inner)
+    {
+        _inner = inner;
+    }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        builder.Append("to_jsonb(");
+        _inner.Apply(builder);
+        builder.Append(")");
     }
 }

--- a/src/Marten/Linq/Parsing/SelectorVisitor.cs
+++ b/src/Marten/Linq/Parsing/SelectorVisitor.cs
@@ -101,8 +101,11 @@ public class SelectorVisitor: ExpressionVisitor
         }
         else if (member.MemberType.IsSimple() || member.MemberType == typeof(Guid) ||
                  member.MemberType == typeof(decimal) ||
-                 member.MemberType == typeof(DateTimeOffset) || member.MemberType == typeof(DateTime))
+                 member.MemberType == typeof(DateTimeOffset) || member.MemberType == typeof(DateTime) ||
+                 member.MemberType == typeof(DateOnly) || member.MemberType == typeof(TimeOnly))
         {
+            // DateOnly/TimeOnly read their native date/time TypedLocator here; the
+            // DataSelectClause fallback would JSON-deserialize the raw ->> text and fail.
             _statement.SelectClause =
                 typeof(NewScalarSelectClause<>).CloseAndBuildAs<ISelectClause>(member,
                     _statement.SelectClause.FromObject,

--- a/src/Marten/Linq/SqlGeneration/JoinSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/JoinSelectClause.cs
@@ -130,8 +130,10 @@ internal class JoinSelectClause<T>: ISelectClause, IScalarSelectClause where T :
     }
 
     // IScalarSelectClause — implemented so GroupJoin(...).SelectMany(...).Distinct()[.Count()]
-    // reuses the standard distinct machinery. Only DISTINCT is meaningful over a join projection;
-    // the scalar aggregate operators (MIN/MAX/SUM/AVG) and table cloning are not applicable here.
+    // reuses the standard distinct machinery (renders DISTINCT(<projection>)). Aggregates over a
+    // bare SCALAR projection are handled separately: CompileGroupJoin renders the raw scalar and
+    // routes Sum/Min/Max/Average through a CTE + standard scalar clause. This throw only guards the
+    // object-projection (or nullable-scalar) case, where there is no single column to aggregate.
     public string MemberName => "data";
 
     public void ApplyOperator(string op)
@@ -139,18 +141,24 @@ internal class JoinSelectClause<T>: ISelectClause, IScalarSelectClause where T :
         if (op != "DISTINCT")
         {
             throw new NotSupportedException(
-                $"Marten does not support the '{op}' operator over a GroupJoin/SelectMany projection. Only Distinct() is supported.");
+                $"Marten does not support the '{op}' aggregate over this GroupJoin/SelectMany projection. "
+                + "Aggregates are supported over a bare non-nullable scalar projection, e.g. "
+                + ".SelectMany(..., (x, c) => c.Amount).Sum(z => z).");
         }
 
         _operator = op;
     }
 
+    // Reached only for an object/nullable-scalar Average(); scalar aggregates use a real scalar clause.
     public ISelectClause CloneToDouble()
     {
         throw new NotSupportedException(
-            "Average aggregation is not supported over a GroupJoin/SelectMany projection.");
+            "Marten does not support Average() over this GroupJoin/SelectMany projection. "
+            + "Average a bare non-nullable scalar projection, e.g. .SelectMany(..., (x, c) => c.Amount).Average(z => z).");
     }
 
+    // Not reachable for a join statement (only the dictionary / value-collection scalar paths clone
+    // a select clause to another table); present only to satisfy IScalarSelectClause.
     public ISelectClause CloneToOtherTable(string tableName)
     {
         throw new NotSupportedException(

--- a/src/Marten/Linq/SqlGeneration/JoinSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/JoinSelectClause.cs
@@ -1,5 +1,8 @@
 #nullable enable
 using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 using JasperFx.Core;
 using Marten.Internal;
 using Marten.Linq.Parsing;
@@ -14,7 +17,7 @@ namespace Marten.Linq.SqlGeneration;
 /// ISelectClause that renders a JOIN between two CTEs with a jsonb_build_object projection.
 /// Produces: SELECT projection as data FROM outer_cte [INNER|LEFT] JOIN inner_cte ON condition
 /// </summary>
-internal class JoinSelectClause<T>: ISelectClause where T : notnull
+internal class JoinSelectClause<T>: ISelectClause, IScalarSelectClause where T : notnull
 {
     private readonly ISqlFragment _projection;
     private readonly string _outerCteAlias;
@@ -22,6 +25,10 @@ internal class JoinSelectClause<T>: ISelectClause where T : notnull
     private readonly bool _isLeftJoin;
     private readonly string _outerKeyLocator;
     private readonly string _innerKeyLocator;
+
+    // Set to "DISTINCT" when GroupJoin(...).SelectMany(...).Distinct() is used so the join
+    // projection is rendered as DISTINCT(<projection>) — Postgres reads DISTINCT(x) as DISTINCT x.
+    private string? _operator;
 
     public JoinSelectClause(
         ISqlFragment projection,
@@ -46,7 +53,19 @@ internal class JoinSelectClause<T>: ISelectClause where T : notnull
     public void Apply(ICommandBuilder sql)
     {
         sql.Append("select ");
+        if (_operator != null)
+        {
+            sql.Append(_operator);
+            sql.Append("(");
+        }
+
         _projection.Apply(sql);
+
+        if (_operator != null)
+        {
+            sql.Append(")");
+        }
+
         sql.Append(" as data from ");
         sql.Append(_outerCteAlias);
         sql.Append(_isLeftJoin ? " LEFT" : " INNER");
@@ -65,18 +84,76 @@ internal class JoinSelectClause<T>: ISelectClause where T : notnull
 
     public ISelector BuildSelector(IMartenSession session)
     {
-        return new SerializationSelector<T>(session.Serializer);
+        return new JoinDataSelector(session.Serializer);
     }
 
     public IQueryHandler<TResult> BuildHandler<TResult>(IMartenSession session, ISqlFragment topStatement,
         ISqlFragment currentStatement) where TResult : notnull
     {
-        var selector = new SerializationSelector<T>(session.Serializer);
+        var selector = new JoinDataSelector(session.Serializer);
         return LinqQueryParser.BuildHandler<T, TResult>(selector, topStatement);
+    }
+
+    // The "data" column is null only for a bare scalar projection whose value is null
+    // (e.g. a left join projecting an inner member of an unmatched outer row). Object
+    // projections always render a non-null jsonb object. Return default for a null column
+    // -- matching Marten's scalar-select convention -- instead of letting the serializer
+    // throw "Column 'data' is null".
+    private sealed class JoinDataSelector: ISelector<T>
+    {
+        private readonly ISerializer _serializer;
+
+        public JoinDataSelector(ISerializer serializer)
+        {
+            _serializer = serializer;
+        }
+
+        public T Resolve(DbDataReader reader)
+        {
+            return reader.IsDBNull(0) ? default! : _serializer.FromJson<T>(reader, 0);
+        }
+
+        public async Task<T> ResolveAsync(DbDataReader reader, CancellationToken token)
+        {
+            if (await reader.IsDBNullAsync(0, token).ConfigureAwait(false))
+            {
+                return default!;
+            }
+
+            return await _serializer.FromJsonAsync<T>(reader, 0, token).ConfigureAwait(false);
+        }
     }
 
     public ISelectClause UseStatistics(QueryStatistics statistics)
     {
         return new StatsSelectClause<T>(this, statistics);
+    }
+
+    // IScalarSelectClause — implemented so GroupJoin(...).SelectMany(...).Distinct()[.Count()]
+    // reuses the standard distinct machinery. Only DISTINCT is meaningful over a join projection;
+    // the scalar aggregate operators (MIN/MAX/SUM/AVG) and table cloning are not applicable here.
+    public string MemberName => "data";
+
+    public void ApplyOperator(string op)
+    {
+        if (op != "DISTINCT")
+        {
+            throw new NotSupportedException(
+                $"Marten does not support the '{op}' operator over a GroupJoin/SelectMany projection. Only Distinct() is supported.");
+        }
+
+        _operator = op;
+    }
+
+    public ISelectClause CloneToDouble()
+    {
+        throw new NotSupportedException(
+            "Average aggregation is not supported over a GroupJoin/SelectMany projection.");
+    }
+
+    public ISelectClause CloneToOtherTable(string tableName)
+    {
+        throw new NotSupportedException(
+            "A GroupJoin/SelectMany projection cannot be cloned to another table.");
     }
 }


### PR DESCRIPTION
## Summary

This fixes a few related LINQ-translation gaps I ran into while using Marten, each with a focused regression test. They're independent, so **I'm very happy to split this into separate PRs, rework it in whatever direction you'd prefer, or drop it entirely if any of it is the wrong approach** — no attachment to the implementation, I just wanted to surface the bugs with repros.

The changes are ~220 lines across 4 source files in `src/Marten/Linq`, plus 32 tests in three `Bug_*` files.

## What's fixed

### 1. `DateOnly` / `TimeOnly` scalar projection
```csharp
session.Query<Doc>().Select(x => x.SomeDateOnly).ToListAsync();
```
threw `System.Text.Json.JsonException: '-' is an invalid end of a number` on non-empty results. `SelectorVisitor.ToScalar` didn't list `DateOnly`/`TimeOnly` among the scalar types, so the projection fell through to `DataSelectClause`, which selects the quote-stripped `data ->> 'x'` text and JSON-deserializes it. Fix: add them to the scalar branch (mirroring `DateTime`) so the value is read from the member's native `mt_immutable_date()`/`mt_immutable_time()` locator. Nullable variants covered.

### 2. `Count()`/`LongCount()` over a `Distinct()` of a `SelectMany()` projection
```csharp
session.Query<Doc>().SelectMany(d => d.Children).Select(c => c.Value).Distinct().CountAsync();
```
threw `The database operator 'DISTINCT' cannot be used with non-simple types` even though `.Distinct().ToList()` returned the correct distinct set. `BuildSelectManyStatement` re-applied `DISTINCT` to the count clause `ProcessSingleValueModeIfAny` had already produced, and the `Inner`-merged `IsDistinct` never reached the count path. Fix: skip the tail `DISTINCT` for `Count`/`LongCount` and re-sync `IsDistinct` for those modes.

### 3. `GroupJoin(...).SelectMany(...)` — `Distinct`, scalar projections, and aggregates

All of the following used to throw or return wrong results, and now work:

```csharp
var join = session.Query<Customer>()
    .GroupJoin(session.Query<Order>(), c => c.Id, o => o.CustomerId, (c, orders) => new { c, orders });

// --- Distinct over an object projection ---
// previously: Distinct() was silently dropped (non-distinct rows / full joined row count)
await join.SelectMany(x => x.orders, (x, o) => new { x.c.Name, o.Amount }).Distinct().ToListAsync();
await join.SelectMany(x => x.orders, (x, o) => new { x.c.Name, o.Amount }).Distinct().CountAsync();

// --- Bare scalar result selector ---
// previously: threw "Sequence contains no elements" at materialization
await join.SelectMany(x => x.orders, (x, o) => o.Amount).ToListAsync();
await join.SelectMany(x => x.orders, (x, o) => o.Amount).Distinct().CountAsync();

// --- Aggregates over a scalar projection ---
// previously: threw NotSupportedException
await join.SelectMany(x => x.orders, (x, o) => o.Amount).SumAsync(z => z);
await join.SelectMany(x => x.orders, (x, o) => o.Amount).MinAsync(z => z);
await join.SelectMany(x => x.orders, (x, o) => o.Amount).MaxAsync(z => z);
await join.SelectMany(x => x.orders, (x, o) => o.Amount).AverageAsync(z => z); // -> double

// --- Left join (DefaultIfEmpty): childless outer rows included, null inner handled ---
await join.SelectMany(x => x.orders.DefaultIfEmpty(), (x, o) => x.c.Id).Distinct().CountAsync();
await join.SelectMany(x => x.orders.DefaultIfEmpty(), (x, o) => (int?)o.Amount).SumAsync(z => z);
```

The three underlying issues:

- **`Distinct()` was silently dropped.** `JoinSelectClause` was neither `IScalarSelectClause` nor `ICountClause`, so neither distinct branch in `ProcessSingleValueModeIfAny` matched: `Distinct().Count()` returned the full joined row count, and `Distinct().ToList()` returned non-distinct rows. Fix: `JoinSelectClause` implements `IScalarSelectClause` (renders `DISTINCT(<projection>)`), and `CompileGroupJoin` transfers `IsDistinct` from the SelectMany usage. Reuses the existing distinct / count-over-CTE machinery.
- **A bare scalar result selector threw.** `(x, o) => o.Amount` built an empty `NewObject` → `Sequence contains no elements` at materialization (`JoinSelectParser` only handled `new {...}` projections). Fix: render a bare scalar as `to_jsonb(<scalar>)` so the existing `SerializationSelector<T>` deserializes it; the join selector also returns `default` for a null `data` column (a left-join unmatched inner row) instead of throwing.
- **`Sum`/`Min`/`Max`/`Average` over a scalar projection threw.** The scalar is rendered as `to_jsonb(...)` and Postgres has no `sum`/`min`/`max`/`avg` for `jsonb`. Fix: for an aggregate, render the *raw* scalar into the join CTE and put a standard `NewScalarSelectClause` over it, so the existing aggregate machinery handles result types (`SUM(int)->bigint`, `AVG->double`), enums, nullable scalars, and left-join nulls.

## Known limitations (left in place, fail with a clear error — not silently)

- **Aggregates over an *object* projection** (`.SelectMany(... => new {...}).Sum(z => z.Amount)`) — there's no single column to aggregate. Workaround: project the scalar directly in the result selector.
- **`.Select()` / `.Where()` *after* the join's `SelectMany`** — `CompileGroupJoin` ignores a post-`SelectMany` `SelectExpression`. Supporting it would need a synthesized member collection mapping the anonymous result type's members onto the join's jsonb `data` column; I judged that a separate, larger feature and left it as a documented limitation (workaround: put the projection in the `SelectMany` result selector). Happy to take a run at it if you think it's worthwhile.

## Testing

- 32 regression tests across `Bug_dateonly_timeonly_scalar_projection`, `Bug_distinct_count_over_selectmany`, and `Bug_groupjoin_distinct_and_scalar_projection`. Each headline bug was verified red→green (fails without the fix, passes with it).
- Full `LinqTests` suite passes on **both net9.0 and net10.0** (1301 passing), including all existing `group_join_operator` tests — no regressions.
- I also did an adversarial pass over the GroupJoin `Distinct` for silent-wrong-result shapes (multi-field dedup correctness, type round-trips under both System.Text.Json and Newtonsoft, left-join nulls) — none found.

## Notes for reviewers

These are independent fixes; I bundled them only because I found them together. **Please tell me if you'd rather I split them into separate PRs** (the DateOnly/TimeOnly and SelectMany-`Distinct().Count()` ones are small and standalone; the GroupJoin change is the larger one), **rework any of them, or drop them.** I'll happily adapt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
