### PR TITLE
#4677 follow-up — object-projection aggregates + post-SelectMany Select/Where

### DIFF
--- a/src/LinqTests/Bugs/Bug_4677_groupjoin_post_selectmany.cs
+++ b/src/LinqTests/Bugs/Bug_4677_groupjoin_post_selectmany.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+// Follow-up to #4677. Two LINQ-translation gaps were called out as known limitations
+// in that PR; this file holds the regressions that pin the new behavior:
+//
+//   1. Aggregates over an *object* projection -- .SelectMany(... => new {...}).Sum(z => z.Member).
+//      QueryableExtensions.SumAsync(z => z.Member) is implemented as .Select(z => z.Member).SumAsync(),
+//      so the chain that arrives at re-linq looks like .Select(z => z.Member).Sum(). The Select
+//      lands as a SelectExpression on the post-SelectMany usage; the FlattenedResultSelector's
+//      object body needs to be reduced to just the aggregated source expression before the join
+//      is rendered, so the scalar-aggregate path lights up.
+//
+//   2. .Select(...) / .Where(...) *after* the join's .SelectMany(...). CompileGroupJoin used to
+//      ignore both: a post-SelectMany Select() returned the original anon-typed rows and a
+//      post-SelectMany Where() was silently dropped. Both need to be expanded through the
+//      FlattenedResultSelector's bindings -- z.Member -> the (x, c) source expression -- and
+//      either folded into the join projection (Select) or routed to the appropriate CTE's
+//      Where pipeline (Where).
+//
+// Shared seed: Parent { Score } with three children of varying Amount, plus an unmatched Parent
+// for left-join coverage. Same shape as the upstream Bug_groupjoin_distinct_and_scalar_projection
+// fixture so the cross-cutting math (sums, distinct counts) lines up.
+public class Bug_4677_groupjoin_post_selectmany: BugIntegrationContext
+{
+    public class Parent
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = "";
+        public decimal Score { get; set; }
+    }
+
+    public class Child
+    {
+        public Guid Id { get; set; }
+        public Guid ParentId { get; set; }
+        public int Amount { get; set; }
+    }
+
+    private readonly Guid P1 = Guid.NewGuid();
+    private readonly Guid P2 = Guid.NewGuid();
+    private readonly Guid P3 = Guid.NewGuid(); // no children -- only present on left joins
+
+    private async Task seedAsync()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Parent>();
+            opts.Schema.For<Child>();
+        });
+
+        await using var session = theStore.LightweightSession();
+        session.Store(
+            new Parent { Id = P1, Name = "a", Score = 1.5m },
+            new Parent { Id = P2, Name = "b", Score = 2.5m },
+            new Parent { Id = P3, Name = "c", Score = 3.5m });
+        session.Store(
+            new Child { Id = Guid.NewGuid(), ParentId = P1, Amount = 10 },
+            new Child { Id = Guid.NewGuid(), ParentId = P1, Amount = 10 },
+            new Child { Id = Guid.NewGuid(), ParentId = P2, Amount = 20 });
+        await session.SaveChangesAsync();
+    }
+
+    // ---- 1. Aggregates over an object projection -----------------------------------
+
+    [Fact]
+    public async Task object_projection_sum_of_inner_member()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+
+        // 3 joined rows (P1->10, P1->10, P2->20). SumAsync(z => z.Amount) lowers to
+        // .Select(z => z.Amount).SumAsync() via QueryableExtensions, which is the chain
+        // the parser sees.
+        var sum = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => new { c.Amount, x.p.Name })
+            .SumAsync(z => z.Amount);
+        sum.ShouldBe(40);
+    }
+
+    [Fact]
+    public async Task object_projection_sum_of_outer_member()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+
+        // x.p.Score over the 3 joined rows: 1.5 + 1.5 + 2.5 = 5.5.
+        var sum = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => new { c.Amount, x.p.Score })
+            .SumAsync(z => z.Score);
+        sum.ShouldBe(5.5m);
+    }
+
+    [Fact]
+    public async Task object_projection_min_and_max()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+
+        var min = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => new { c.Amount, x.p.Name })
+            .MinAsync(z => z.Amount);
+        var max = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => new { c.Amount, x.p.Name })
+            .MaxAsync(z => z.Amount);
+        min.ShouldBe(10);
+        max.ShouldBe(20);
+    }
+
+    [Fact]
+    public async Task object_projection_average_returns_double()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+
+        var avg = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => new { c.Amount, x.p.Name })
+            .AverageAsync(z => z.Amount);
+        avg.ShouldBe(40d / 3d, 0.0001);
+    }
+
+    [Fact]
+    public async Task object_projection_sum_over_left_join_ignores_unmatched()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+
+        // Left join adds P3 with a null inner row; the rendered scalar c.Amount returns NULL on
+        // that row at the SQL level and Postgres SUM ignores nulls -- so the result is still 40.
+        // (We rely on SQL null semantics rather than a C# ternary because the projection-parser
+        // only accepts direct member accesses; computed expressions are pinned as a separate
+        // known limitation in the upstream PR's `scalar_projection_of_computed_expression`.)
+        var sum = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children.DefaultIfEmpty(), (x, c) => new { c.Amount, x.p.Name })
+            .SumAsync(z => z.Amount);
+        sum.ShouldBe(40);
+    }
+
+    // ---- 2a. Select() after the join's SelectMany --------------------------------
+
+    [Fact]
+    public async Task post_select_many_select_reduces_to_scalar_member()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+
+        // .Select(z => z.Amount) reduces the object projection to a single inner column,
+        // matching the bare-scalar SelectMany result selector path.
+        var amounts = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => new { c.Amount, x.p.Name })
+            .Select(z => z.Amount)
+            .ToListAsync();
+        amounts.OrderBy(a => a).ShouldBe(new[] { 10, 10, 20 });
+    }
+
+    [Fact]
+    public async Task post_select_many_select_reshuffles_to_new_anonymous_type()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+
+        // The Select reshuffles the projection -- swaps positions and renames -- without any
+        // computed expression. (Compute on the projected members like z.Amount * 2 falls under
+        // the existing "computed scalar projection" limitation pinned in the upstream PR.)
+        var rows = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => new { c.Amount, x.p.Name })
+            .Select(z => new { ParentName = z.Name, ChildAmount = z.Amount })
+            .ToListAsync();
+        rows.Count.ShouldBe(3);
+        rows.Select(r => r.ChildAmount).OrderBy(a => a).ShouldBe(new[] { 10, 10, 20 });
+        rows.Select(r => r.ParentName).OrderBy(n => n).ShouldBe(new[] { "a", "a", "b" });
+    }
+
+    // ---- pinned limitations ------------------------------------------------------
+
+    [Fact]
+    public async Task post_select_many_where_touching_both_sides_throws_clear_error()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+
+        // A filter referencing both x.p.* and c.* on the projected anon type can't be folded
+        // onto either CTE -- pinned as a clear-error limitation rather than silently dropped
+        // or mis-rendered.
+        await Should.ThrowAsync<Marten.Exceptions.BadLinqExpressionException>(async () =>
+            await q.Query<Parent>()
+                .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+                .SelectMany(x => x.children, (x, c) => new { c.Amount, x.p.Name, x.p.Score })
+                .Where(z => z.Amount > 5 && z.Name == "a")
+                .ToListAsync());
+    }
+
+    // ---- 2b. Where() after the join's SelectMany ---------------------------------
+
+    [Fact]
+    public async Task post_select_many_where_filters_on_inner_member()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+
+        var rows = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => new { c.Amount, x.p.Name })
+            .Where(z => z.Amount >= 15)
+            .ToListAsync();
+        rows.Count.ShouldBe(1);
+        rows[0].Amount.ShouldBe(20);
+        rows[0].Name.ShouldBe("b");
+    }
+
+    [Fact]
+    public async Task post_select_many_where_filters_on_outer_member()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+
+        var rows = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => new { c.Amount, x.p.Name })
+            .Where(z => z.Name == "a")
+            .ToListAsync();
+        rows.Count.ShouldBe(2);
+        rows.Select(r => r.Amount).OrderBy(a => a).ShouldBe(new[] { 10, 10 });
+    }
+
+    [Fact]
+    public async Task post_select_many_where_then_sum_chains()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+
+        // Where filters the joined rows to just P1's children, then Sum(z => z.Amount)
+        // aggregates the object projection. Exercises both fixes in one chain.
+        var sum = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => new { c.Amount, x.p.Name })
+            .Where(z => z.Name == "a")
+            .SumAsync(z => z.Amount);
+        sum.ShouldBe(20);
+    }
+}

--- a/src/LinqTests/Bugs/Bug_dateonly_timeonly_scalar_projection.cs
+++ b/src/LinqTests/Bugs/Bug_dateonly_timeonly_scalar_projection.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+// Projecting a DateOnly/TimeOnly member directly -- Query<T>().Select(x => x.SomeDateOnly)
+// -- threw System.Text.Json "'-' is an invalid end of a number": the bare scalar projection
+// fell through to DataSelectClause, which JSON-deserializes the quote-stripped `data ->> 'x'`
+// text. Fixed by routing DateOnly/TimeOnly through NewScalarSelectClause (native date/time read).
+public class Bug_dateonly_timeonly_scalar_projection: BugIntegrationContext
+{
+    public sealed class DocWithDateOnly
+    {
+        public Guid Id { get; set; }
+        public DateOnly Date { get; set; }
+        public TimeOnly Time { get; set; }
+        public DateOnly? NullableDate { get; set; }
+        public TimeOnly? NullableTime { get; set; }
+    }
+
+    private void ConfigureStore()
+    {
+        StoreOptions(opts =>
+        {
+            opts.UseSystemTextJsonForSerialization();
+            opts.Schema.For<DocWithDateOnly>();
+        });
+    }
+
+    private async Task seedAsync()
+    {
+        await using var session = theStore.LightweightSession();
+        session.Store(
+            new DocWithDateOnly
+            {
+                Id = Guid.NewGuid(),
+                Date = new DateOnly(2026, 4, 29),
+                Time = new TimeOnly(9, 30, 0),
+                NullableDate = new DateOnly(2026, 4, 29),
+                NullableTime = new TimeOnly(9, 30, 0)
+            },
+            new DocWithDateOnly
+            {
+                Id = Guid.NewGuid(),
+                Date = new DateOnly(2026, 5, 1),
+                Time = new TimeOnly(14, 0, 0),
+                NullableDate = null,
+                NullableTime = null
+            });
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task select_dateonly_scalar_directly()
+    {
+        ConfigureStore();
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        var dates = await query.Query<DocWithDateOnly>()
+            .OrderByDescending(x => x.Date)
+            .Select(x => x.Date)
+            .ToListAsync();
+
+        dates.ShouldBe(new[] { new DateOnly(2026, 5, 1), new DateOnly(2026, 4, 29) });
+    }
+
+    [Fact]
+    public async Task select_timeonly_scalar_directly()
+    {
+        ConfigureStore();
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        var times = await query.Query<DocWithDateOnly>()
+            .OrderBy(x => x.Date)
+            .Select(x => x.Time)
+            .ToListAsync();
+
+        times.ShouldBe(new[] { new TimeOnly(9, 30, 0), new TimeOnly(14, 0, 0) });
+    }
+
+    [Fact]
+    public async Task select_nullable_dateonly_scalar_directly()
+    {
+        ConfigureStore();
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        var dates = await query.Query<DocWithDateOnly>()
+            .OrderBy(x => x.Date)
+            .Select(x => x.NullableDate)
+            .ToListAsync();
+
+        dates.Count.ShouldBe(2);
+        dates[0].ShouldBe(new DateOnly(2026, 4, 29));
+        dates[1].ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task select_nullable_timeonly_scalar_directly()
+    {
+        ConfigureStore();
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        var times = await query.Query<DocWithDateOnly>()
+            .OrderBy(x => x.Date)
+            .Select(x => x.NullableTime)
+            .ToListAsync();
+
+        times.Count.ShouldBe(2);
+        times[0].ShouldBe(new TimeOnly(9, 30, 0));
+        times[1].ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task select_dateonly_with_where()
+    {
+        ConfigureStore();
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        var dates = await query.Query<DocWithDateOnly>()
+            .Where(x => x.Date >= new DateOnly(2026, 5, 1))
+            .Select(x => x.Date)
+            .ToListAsync();
+
+        dates.ShouldBe(new[] { new DateOnly(2026, 5, 1) });
+    }
+}

--- a/src/LinqTests/Bugs/Bug_dateonly_timeonly_scalar_projection.cs
+++ b/src/LinqTests/Bugs/Bug_dateonly_timeonly_scalar_projection.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten;
+using Marten.Newtonsoft;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
@@ -132,5 +133,41 @@ public class Bug_dateonly_timeonly_scalar_projection: BugIntegrationContext
             .ToListAsync();
 
         dates.ShouldBe(new[] { new DateOnly(2026, 5, 1) });
+    }
+
+    [Fact]
+    public async Task select_dateonly_scalar_directly_with_newtonsoft()
+    {
+        // The fix reads the native date/time locator, so it is serializer-agnostic -- pin Newtonsoft too.
+        StoreOptions(opts =>
+        {
+            opts.UseNewtonsoftForSerialization();
+            opts.Schema.For<DocWithDateOnly>();
+        });
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        var dates = await query.Query<DocWithDateOnly>()
+            .OrderByDescending(x => x.Date)
+            .Select(x => x.Date)
+            .ToListAsync();
+
+        dates.ShouldBe(new[] { new DateOnly(2026, 5, 1), new DateOnly(2026, 4, 29) });
+    }
+
+    [Fact]
+    public async Task select_distinct_dateonly_scalar()
+    {
+        ConfigureStore();
+        await seedAsync();
+
+        await using var query = theStore.QuerySession();
+        // both rows have distinct dates already; add no duplicates -> 2 distinct
+        var dates = await query.Query<DocWithDateOnly>()
+            .Select(x => x.Date)
+            .Distinct()
+            .ToListAsync();
+
+        dates.OrderBy(d => d).ShouldBe(new[] { new DateOnly(2026, 4, 29), new DateOnly(2026, 5, 1) });
     }
 }

--- a/src/LinqTests/Bugs/Bug_distinct_count_over_selectmany.cs
+++ b/src/LinqTests/Bugs/Bug_distinct_count_over_selectmany.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+// A Count()/LongCount() over a Distinct() projection of a SelectMany(child-collection) threw
+// NotSupportedException "The database operator 'DISTINCT' cannot be used with non-simple types",
+// even though the equivalent Distinct().ToList() worked: BuildSelectManyStatement re-applied
+// DISTINCT to the count clause that ProcessSingleValueModeIfAny had already produced (and the
+// Inner-merged IsDistinct flag never reached the count path, so a plain count of all rows was
+// produced instead of count of distinct values).
+public class Bug_distinct_count_over_selectmany: BugIntegrationContext
+{
+    public record Tag(string Value);
+    public class Doc { public Guid Id { get; set; } public List<Tag> Tags { get; set; } = new(); }
+
+    private async Task seedAsync()
+    {
+        StoreOptions(opts => opts.Schema.For<Doc>());
+        await using var session = theStore.LightweightSession();
+        // flattened values x,x,y,y,z -> 3 distinct, 5 total
+        session.Store(
+            new Doc { Id = Guid.NewGuid(), Tags = [new("x"), new("x"), new("y")] },
+            new Doc { Id = Guid.NewGuid(), Tags = [new("y"), new("z")] });
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task select_many_select_distinct_count()
+    {
+        await seedAsync();
+        await using var query = theStore.QuerySession();
+        var count = await query.Query<Doc>().SelectMany(d => d.Tags).Select(t => t.Value).Distinct().CountAsync();
+        count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task select_many_select_distinct_long_count()
+    {
+        await seedAsync();
+        await using var query = theStore.QuerySession();
+        var count = await query.Query<Doc>().SelectMany(d => d.Tags).Select(t => t.Value).Distinct().LongCountAsync();
+        count.ShouldBe(3L);
+    }
+
+    [Fact]
+    public async Task select_many_select_count_without_distinct_is_unaffected()
+    {
+        await seedAsync();
+        await using var query = theStore.QuerySession();
+        var count = await query.Query<Doc>().SelectMany(d => d.Tags).Select(t => t.Value).CountAsync();
+        count.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task select_many_select_distinct_to_list_still_works()
+    {
+        await seedAsync();
+        await using var query = theStore.QuerySession();
+        var values = await query.Query<Doc>().SelectMany(d => d.Tags).Select(t => t.Value).Distinct().ToListAsync();
+        values.OrderBy(v => v).ShouldBe(new[] { "x", "y", "z" });
+    }
+}

--- a/src/LinqTests/Bugs/Bug_groupjoin_distinct_and_scalar_projection.cs
+++ b/src/LinqTests/Bugs/Bug_groupjoin_distinct_and_scalar_projection.cs
@@ -257,4 +257,76 @@ public class Bug_groupjoin_distinct_and_scalar_projection: BugIntegrationContext
                 .SelectMany(x => x.children, (x, c) => c.Amount + 1)
                 .ToListAsync());
     }
+
+    // ---- aggregates over a bare scalar projection (Sum / Min / Max / Average) ----
+    // Inner-join rows from seedAsync: P1->10, P1->10, P2->20.
+
+    private static IQueryable<int> InnerJoinAmount(IQuerySession q) =>
+        q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => c.Amount);
+
+    [Fact]
+    public async Task scalar_sum_over_inner_join()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinAmount(q).SumAsync(z => z)).ShouldBe(40);
+    }
+
+    [Fact]
+    public async Task scalar_min_and_max_over_inner_join()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinAmount(q).MinAsync(z => z)).ShouldBe(10);
+        (await InnerJoinAmount(q).MaxAsync(z => z)).ShouldBe(20);
+    }
+
+    [Fact]
+    public async Task scalar_average_over_inner_join_returns_double()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinAmount(q).AverageAsync(z => z)).ShouldBe(40d / 3d, 0.0001);
+    }
+
+    [Fact]
+    public async Task scalar_decimal_sum_over_inner_join()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        // p.Score over the joined rows: 1.5 (P1) + 1.5 (P1) + 2.5 (P2) = 5.5
+        var sum = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => x.p.Score)
+            .SumAsync(z => z);
+        sum.ShouldBe(5.5m);
+    }
+
+    [Fact]
+    public async Task scalar_sum_over_left_join_ignores_null_inner()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        // left join adds P3 (null inner); SUM ignores the null data row => still 40
+        var sum = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children.DefaultIfEmpty(), (x, c) => c.Amount)
+            .SumAsync(z => z);
+        sum.ShouldBe(40);
+    }
+
+    [Fact]
+    public async Task nullable_scalar_sum_over_inner_join()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        // (int?)c.Amount over inner-join rows 10, 10, 20 -> 40
+        var sum = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => (int?)c.Amount)
+            .SumAsync(z => z);
+        sum.ShouldBe(40);
+    }
 }

--- a/src/LinqTests/Bugs/Bug_groupjoin_distinct_and_scalar_projection.cs
+++ b/src/LinqTests/Bugs/Bug_groupjoin_distinct_and_scalar_projection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten;
+using Marten.Exceptions;
 using Marten.Testing.Harness;
 using Shouldly;
 using Xunit;
@@ -20,7 +21,15 @@ namespace LinqTests.Bugs;
 // rendered as to_jsonb(<scalar>) so the existing SerializationSelector + distinct machinery apply.
 public class Bug_groupjoin_distinct_and_scalar_projection: BugIntegrationContext
 {
-    public class Parent { public Guid Id { get; set; } public string Name { get; set; } = ""; }
+    public enum Color { Red, Green, Blue }
+    public class Parent
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = "";
+        public decimal Score { get; set; }
+        public Color Tone { get; set; }
+        public DateOnly Day { get; set; }
+    }
     public class Child { public Guid Id { get; set; } public Guid ParentId { get; set; } public int Amount { get; set; } }
     public class AmountRow { public int Amount { get; set; } }
 
@@ -38,9 +47,9 @@ public class Bug_groupjoin_distinct_and_scalar_projection: BugIntegrationContext
 
         await using var session = theStore.LightweightSession();
         session.Store(
-            new Parent { Id = P1, Name = "a" },
-            new Parent { Id = P2, Name = "b" },
-            new Parent { Id = P3, Name = "c" });
+            new Parent { Id = P1, Name = "a", Score = 1.5m, Tone = Color.Red, Day = new DateOnly(2026, 1, 1) },
+            new Parent { Id = P2, Name = "b", Score = 2.5m, Tone = Color.Blue, Day = new DateOnly(2026, 2, 2) },
+            new Parent { Id = P3, Name = "c", Score = 3.5m, Tone = Color.Green, Day = new DateOnly(2026, 3, 3) });
         // P1 has two children (amount 10, 10), P2 has one (amount 20). Joined rows for inner join = 3,
         // distinct parents = 2, distinct amounts = {10, 20} = 2.
         session.Store(
@@ -155,5 +164,97 @@ public class Bug_groupjoin_distinct_and_scalar_projection: BugIntegrationContext
 
         // P1 children amount 10, 10; P2 amount 20; P3 -> null. Distinct = { 10, 20, null }.
         amounts.OrderBy(a => a.HasValue).ThenBy(a => a).ShouldBe(new int?[] { null, 10, 20 });
+    }
+
+    // ---- dedup correctness: DISTINCT must dedupe by the FULL projected value, not over-merge ----
+
+    [Fact]
+    public async Task object_projection_distinct_keeps_rows_differing_in_one_field()
+    {
+        StoreOptions(opts => { opts.Schema.For<Parent>(); opts.Schema.For<Child>(); });
+        var p = Guid.NewGuid();
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(new Parent { Id = p, Name = "a" });
+            // same parent (Name "a") but DIFFERENT amounts -> {a,10} and {a,20} must NOT merge
+            session.Store(
+                new Child { Id = Guid.NewGuid(), ParentId = p, Amount = 10 },
+                new Child { Id = Guid.NewGuid(), ParentId = p, Amount = 20 });
+            await session.SaveChangesAsync();
+        }
+
+        await using var q = theStore.QuerySession();
+        var rows = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), x => x.Id, c => c.ParentId, (x, children) => new { x, children })
+            .SelectMany(z => z.children, (z, c) => new { z.x.Name, c.Amount })
+            .Distinct()
+            .ToListAsync();
+
+        rows.Count.ShouldBe(2);
+        rows.Select(r => r.Amount).OrderBy(a => a).ShouldBe(new[] { 10, 20 });
+    }
+
+    // ---- scalar projection across types (round-trip via to_jsonb), distinct over an inner join ----
+
+    [Fact]
+    public async Task scalar_projection_string_distinct_values()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var names = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => x.p.Name)
+            .Distinct().ToListAsync();
+        names.OrderBy(n => n).ShouldBe(new[] { "a", "b" });
+    }
+
+    [Fact]
+    public async Task scalar_projection_decimal_distinct_values()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var scores = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => x.p.Score)
+            .Distinct().ToListAsync();
+        scores.OrderBy(s => s).ShouldBe(new[] { 1.5m, 2.5m });
+    }
+
+    [Fact]
+    public async Task scalar_projection_enum_distinct_values()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var tones = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => x.p.Tone)
+            .Distinct().ToListAsync();
+        tones.OrderBy(t => t).ShouldBe(new[] { Color.Red, Color.Blue }.OrderBy(t => t));
+    }
+
+    [Fact]
+    public async Task scalar_projection_dateonly_distinct_values()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var days = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => x.p.Day)
+            .Distinct().ToListAsync();
+        days.OrderBy(d => d).ShouldBe(new[] { new DateOnly(2026, 1, 1), new DateOnly(2026, 2, 2) });
+    }
+
+    // ---- a non-member-access scalar body is not translatable: fail with a clear error ----
+
+    [Fact]
+    public async Task scalar_projection_of_computed_expression_throws_clear_error()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await q.Query<Parent>()
+                .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+                .SelectMany(x => x.children, (x, c) => c.Amount + 1)
+                .ToListAsync());
     }
 }

--- a/src/LinqTests/Bugs/Bug_groupjoin_distinct_and_scalar_projection.cs
+++ b/src/LinqTests/Bugs/Bug_groupjoin_distinct_and_scalar_projection.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+// GroupJoin + SelectMany had two distinct/projection gaps:
+//   1. Distinct() was silently dropped over the join projection (JoinSelectClause was neither
+//      IScalarSelectClause nor ICountClause, so neither distinct branch matched). Distinct().Count()
+//      returned the full joined row count, and Distinct().ToList() returned non-distinct rows.
+//   2. A bare scalar result selector ((x, t) => x.l.Id) built an empty NewObject and threw
+//      "Sequence contains no elements" at materialization.
+// Fix: JoinSelectClause implements IScalarSelectClause (renders DISTINCT(<projection>)); IsDistinct
+// is transferred from the SelectMany usage in CompileGroupJoin; and a scalar result selector is
+// rendered as to_jsonb(<scalar>) so the existing SerializationSelector + distinct machinery apply.
+public class Bug_groupjoin_distinct_and_scalar_projection: BugIntegrationContext
+{
+    public class Parent { public Guid Id { get; set; } public string Name { get; set; } = ""; }
+    public class Child { public Guid Id { get; set; } public Guid ParentId { get; set; } public int Amount { get; set; } }
+    public class AmountRow { public int Amount { get; set; } }
+
+    private readonly Guid P1 = Guid.NewGuid();
+    private readonly Guid P2 = Guid.NewGuid();
+    private readonly Guid P3 = Guid.NewGuid(); // no children — only seen via left join
+
+    private async Task seedAsync()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<Parent>();
+            opts.Schema.For<Child>();
+        });
+
+        await using var session = theStore.LightweightSession();
+        session.Store(
+            new Parent { Id = P1, Name = "a" },
+            new Parent { Id = P2, Name = "b" },
+            new Parent { Id = P3, Name = "c" });
+        // P1 has two children (amount 10, 10), P2 has one (amount 20). Joined rows for inner join = 3,
+        // distinct parents = 2, distinct amounts = {10, 20} = 2.
+        session.Store(
+            new Child { Id = Guid.NewGuid(), ParentId = P1, Amount = 10 },
+            new Child { Id = Guid.NewGuid(), ParentId = P1, Amount = 10 },
+            new Child { Id = Guid.NewGuid(), ParentId = P2, Amount = 20 });
+        await session.SaveChangesAsync();
+    }
+
+    private static IQueryable<AmountRow> InnerJoinObject(IQuerySession q) =>
+        q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => new AmountRow { Amount = c.Amount });
+
+    private static IQueryable<Guid> InnerJoinScalar(IQuerySession q) =>
+        q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children, (x, c) => x.p.Id);
+
+    // ---- object projection ----
+
+    [Fact]
+    public async Task object_projection_count_without_distinct_is_unaffected()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinObject(q).CountAsync()).ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task object_projection_distinct_tolist_dedupes()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var rows = await InnerJoinObject(q).Distinct().ToListAsync();
+        rows.Select(r => r.Amount).OrderBy(a => a).ShouldBe(new[] { 10, 20 });
+    }
+
+    [Fact]
+    public async Task object_projection_distinct_count()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinObject(q).Distinct().CountAsync()).ShouldBe(2);
+    }
+
+    // ---- scalar projection ----
+
+    [Fact]
+    public async Task scalar_projection_tolist_without_distinct()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var rows = await InnerJoinScalar(q).ToListAsync();
+        rows.Count.ShouldBe(3);
+        rows.ShouldAllBe(id => id == P1 || id == P2);
+    }
+
+    [Fact]
+    public async Task scalar_projection_distinct_tolist_values()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var rows = await InnerJoinScalar(q).Distinct().ToListAsync();
+        rows.OrderBy(x => x).ShouldBe(new[] { P1, P2 }.OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task scalar_projection_distinct_count()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinScalar(q).Distinct().CountAsync()).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task scalar_projection_distinct_long_count()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        (await InnerJoinScalar(q).Distinct().LongCountAsync()).ShouldBe(2L);
+    }
+
+    // ---- left join (DefaultIfEmpty) + scalar distinct: P3 has no children but still appears ----
+
+    [Fact]
+    public async Task left_join_scalar_distinct_count_includes_childless_outer()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        var distinctParents = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children.DefaultIfEmpty(), (x, c) => x.p.Id)
+            .Distinct()
+            .CountAsync();
+
+        distinctParents.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task left_join_nullable_inner_scalar_yields_null_for_childless_outer()
+    {
+        await seedAsync();
+        await using var q = theStore.QuerySession();
+        // P3 has no children, so the left join yields a null inner row; projecting an inner
+        // member must materialize as null (the "data" column is null), not throw.
+        var amounts = await q.Query<Parent>()
+            .GroupJoin(q.Query<Child>(), p => p.Id, c => c.ParentId, (p, children) => new { p, children })
+            .SelectMany(x => x.children.DefaultIfEmpty(), (x, c) => (int?)c.Amount)
+            .Distinct()
+            .ToListAsync();
+
+        // P1 children amount 10, 10; P2 amount 20; P3 -> null. Distinct = { 10, 20, null }.
+        amounts.OrderBy(a => a.HasValue).ThenBy(a => a).ShouldBe(new int?[] { null, 10, 20 });
+    }
+}

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -179,7 +179,11 @@ public partial class CollectionUsage
 
         statement = ConfigureSelectManyStatement(session, collection, statement, statistics).SelectorStatement();
 
-        if (IsDistinct)
+        // Count()/LongCount() over a Distinct() is already wrapped in a CTE and counted by
+        // ProcessSingleValueModeIfAny; re-applying DISTINCT here would hit the count clause
+        // and throw "DISTINCT cannot be used with non-simple types".
+        if (IsDistinct && SingleValueMode is not (Marten.Linq.Parsing.SingleValueMode.Count
+                or Marten.Linq.Parsing.SingleValueMode.LongCount))
         {
             statement.ApplySqlOperator("DISTINCT");
         }
@@ -238,6 +242,17 @@ public partial class CollectionUsage
                 statement.Limit ??= Inner._limit;
                 statement.Offset ??= Inner._offset;
             }
+        }
+
+        // A SelectMany(...).Distinct().Count() carries IsDistinct on the Inner usage merged
+        // in just above; re-sync it onto the statement so the Count branch of
+        // ProcessSingleValueModeIfAny wraps the DISTINCT projection in a CTE and counts that.
+        // Only for the count modes -- the non-aggregate Distinct() is applied via the
+        // ApplySqlOperator("DISTINCT") below, so leaving its flag set would double the DISTINCT.
+        if (SingleValueMode is Marten.Linq.Parsing.SingleValueMode.Count
+            or Marten.Linq.Parsing.SingleValueMode.LongCount)
+        {
+            statement.IsDistinct = IsDistinct;
         }
 
         ProcessSingleValueModeIfAny(statement, session, collection, statistics);

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -397,7 +397,7 @@ public partial class CollectionUsage
             resultType,
             new object[]
             {
-                joinParser.NewObject,
+                joinParser.Projection,
                 outerCteAlias,
                 innerCteAlias,
                 groupJoin.IsLeftJoin,
@@ -450,6 +450,15 @@ public partial class CollectionUsage
                 joinStatement.Limit ??= deepInner._limit;
                 joinStatement.Offset ??= deepInner._offset;
             }
+        }
+
+        // Transfer Distinct() from the SelectMany usage chain. JoinSelectClause implements
+        // IScalarSelectClause, so ProcessSingleValueModeIfAny renders DISTINCT(<projection>) for
+        // a materialized Distinct() and wraps it in a count(*) CTE for Distinct().Count().
+        // Without this the join would silently return non-distinct rows / the joined row count.
+        if ((Inner?.IsDistinct ?? false) || (Inner?.Inner?.IsDistinct ?? false))
+        {
+            joinStatement.IsDistinct = true;
         }
 
         // Apply single value mode to the join statement

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -392,12 +392,22 @@ public partial class CollectionUsage
         // 6-arg ctor doesn't fit the fixed-arity overloads, so we pay an
         // array allocation per call in exchange for skipping MakeGenericType.
         var resultType = groupJoin.FlattenedResultSelector.ReturnType;
+
+        // Sum()/Min()/Max()/Average() over a bare scalar projection cannot aggregate the
+        // to_jsonb(...) form (Postgres has no sum/min/max/avg for jsonb). For those, render the
+        // raw scalar into the join CTE and put a standard scalar select clause over it below.
+        var pendingMode = Inner?.SingleValueMode ?? Inner?.Inner?.SingleValueMode;
+        var scalarAggregate = joinParser.ScalarRawProjection != null
+            && pendingMode is Marten.Linq.Parsing.SingleValueMode.Sum or Marten.Linq.Parsing.SingleValueMode.Min
+                or Marten.Linq.Parsing.SingleValueMode.Max or Marten.Linq.Parsing.SingleValueMode.Average
+            && (resultType == typeof(string) || resultType.IsValueType);
+
         var joinSelectClause = (ISelectClause)GenericFactoryCache.BuildAs<object>(
             typeof(JoinSelectClause<>),
             resultType,
             new object[]
             {
-                joinParser.Projection,
+                scalarAggregate ? joinParser.ScalarRawProjection : joinParser.Projection,
                 outerCteAlias,
                 innerCteAlias,
                 groupJoin.IsLeftJoin,
@@ -459,6 +469,30 @@ public partial class CollectionUsage
         if ((Inner?.IsDistinct ?? false) || (Inner?.Inner?.IsDistinct ?? false))
         {
             joinStatement.IsDistinct = true;
+        }
+
+        if (scalarAggregate)
+        {
+            // Wrap the raw-scalar join in a CTE and aggregate over its single 'data' column with a
+            // standard scalar select clause, which already handles the aggregate result types
+            // (SUM(int)->bigint, AVG->double via CloneToDouble, etc.).
+            joinStatement.ConvertToCommonTableExpression(session);
+
+            // For a nullable scalar (e.g. (int?)c.Amount) build the clause over the underlying type
+            // -- NewScalarSelectClause<T> is `where T : struct` and also implements ISelector<T?>,
+            // so the single-value handler reads the nullable result (null when all rows are null).
+            var clauseType = Nullable.GetUnderlyingType(resultType) ?? resultType;
+            var scalarClause = clauseType == typeof(string)
+                ? new NewScalarStringSelectClause("d.data", joinStatement.ExportName)
+                : typeof(NewScalarSelectClause<>).CloseAndBuildAs<ISelectClause>(
+                    "d.data", joinStatement.ExportName, clauseType);
+
+            var scalarStatement = new SelectorStatement { SelectClause = scalarClause };
+            joinStatement.AddToEnd(scalarStatement);
+
+            ProcessSingleValueModeIfAny(scalarStatement, session, null, statistics);
+
+            return joinStatement;
         }
 
         // Apply single value mode to the join statement

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -357,6 +357,116 @@ public partial class CollectionUsage
         };
         var innerCteAlias = innerStatement.ExportName;
 
+        // 3b. #4677 follow-up — reduce a post-SelectMany Select(z => ...) / Where(z => ...) chain
+        // back into the join's (x, c) projection space, so the join SQL collapses to the actually
+        // used shape. Without this:
+        //   * .SelectMany(.., (x,c) => new {..}).Sum(z=>z.X) (which lowers to .Select(z=>z.X).SumAsync())
+        //     hits JoinSelectClause.ApplyOperator("SUM") on an object projection and throws.
+        //   * .SelectMany(.., (x,c) => new {..}).Select(z=>z.X) silently returns the original anon rows.
+        //   * .SelectMany(.., (x,c) => new {..}).Where(z=>...) is dropped entirely.
+        //
+        // Both Select() and inner-side Where() can be folded by walking the FlattenedResultSelector's
+        // bindings -- z.MemberName -> the source expression in (x, c) terms. The Select rewrites the
+        // effective result selector that JoinSelectParser then renders; the Where(s) get re-homed onto
+        // the inner CTE's WhereExpressions just before ParseWhereClause runs below.
+        //
+        // The Select / Where can land on Inner (the SelectMany usage) OR on Inner.Inner (when the
+        // post-SelectMany .Select(...) changed the element type and re-linq cut a new usage), so we
+        // walk the chain and gather them — mirroring how SingleValueMode / IsDistinct already cope
+        // with both levels just below.
+        var effectiveResultSelector = groupJoin.FlattenedResultSelector;
+        var expander = new AnonProjectionExpander(groupJoin.FlattenedResultSelector);
+
+        Expression? postSmSelect = null;
+        CollectionUsage? postSmSelectCarrier = null;
+        var postSmWheres = new List<(CollectionUsage Carrier, Expression Where)>();
+
+        for (var sweep = Inner; sweep != null; sweep = sweep.Inner)
+        {
+            if (postSmSelect == null && sweep.SelectExpression != null)
+            {
+                postSmSelect = sweep.SelectExpression;
+                postSmSelectCarrier = sweep;
+            }
+
+            foreach (var w in sweep.WhereExpressions)
+            {
+                postSmWheres.Add((sweep, w));
+            }
+        }
+
+        if (expander.CanExpand && postSmSelect != null)
+        {
+            // Reduce: (x, c) => <expanded SelectExpression>. Null the carrier's SelectExpression so
+            // the post-join compileNext / SVM processing doesn't try to re-apply it.
+            var expanded = expander.Expand(postSmSelect);
+            effectiveResultSelector = Expression.Lambda(expanded, groupJoin.FlattenedResultSelector.Parameters);
+            postSmSelectCarrier!.SelectExpression = null;
+        }
+
+        // Route post-SelectMany Where filters that resolve cleanly to one side onto that CTE's
+        // existing Where pipeline. Inner-side filters get pushed onto the InnerCollectionUsage's
+        // WhereExpressions before ParseWhereClause runs below; outer-side filters get parsed
+        // straight into the already-compiled outer CTE's Wheres list (the second ParseWhereClause
+        // call uses storage=null so we don't double-apply tenant / soft-delete defaults). Filters
+        // that reference both sides are pinned as a known limitation -- they'd need a join-level
+        // WHERE clause in JoinSelectClause; left for a follow-up if anyone hits it.
+        if (expander.CanExpand && postSmWheres.Count > 0)
+        {
+            var carriersTouched = new HashSet<CollectionUsage>();
+            var outerSideFilters = new List<Expression>();
+            foreach (var (carrier, where) in postSmWheres)
+            {
+                var expanded = expander.Expand(where);
+                var sides = PostSelectManyFilterSideAnalyzer.Analyze(
+                    expanded, groupJoin.FlattenedResultSelector.Parameters);
+                if (sides == PostSelectManyFilterSideAnalyzer.Side.InnerOnly)
+                {
+                    // Replace the SelectMany inner parameter c with a fresh parameter so MemberFor's
+                    // standard pipeline binds against the inner document type cleanly.
+                    var innerParam = Expression.Parameter(groupJoin.InnerElementType, "child");
+                    var rewritten = new ParameterReplacingVisitor(
+                            groupJoin.FlattenedResultSelector.Parameters[1], innerParam)
+                        .Visit(expanded);
+                    groupJoin.InnerCollectionUsage.WhereExpressions.Add(rewritten);
+                    carriersTouched.Add(carrier);
+                }
+                else if (sides == PostSelectManyFilterSideAnalyzer.Side.OuterOnly)
+                {
+                    // The expanded filter still references the GroupJoin result selector's
+                    // anon-type navigation (e.g. x.p.Name where x = new { p, children }). Strip
+                    // that navigation so MemberFor binds against the outer document type directly.
+                    var outerParam = Expression.Parameter(ElementType, "outer");
+                    var rewritten = new GroupJoinOuterNavigationStripper(
+                            groupJoin.FlattenedResultSelector.Parameters[0],
+                            groupJoin.ResultSelector, outerParam)
+                        .Visit(expanded);
+                    outerSideFilters.Add(rewritten);
+                    carriersTouched.Add(carrier);
+                }
+                else
+                {
+                    throw new BadLinqExpressionException(
+                        "Marten cannot translate this post-SelectMany Where() filter -- it touches both "
+                        + "the outer and inner sides of the GroupJoin (or neither). Single-sided filters "
+                        + "are supported. Combine the predicate into either the outer Query<T>().Where(...) "
+                        + "or the inner GroupJoin argument's Where(...).");
+                }
+            }
+
+            if (outerSideFilters.Count > 0)
+            {
+                // Append to the already-compiled outer CTE. storage=null so we don't re-apply the
+                // default tenant / soft-delete filter that the first ParseWhereClause call wrapped.
+                outerStatement.ParseWhereClause(outerSideFilters, session, outerCollection);
+            }
+
+            foreach (var carrier in carriersTouched)
+            {
+                carrier.WhereExpressions.Clear();
+            }
+        }
+
         // Apply extracted Where clauses and default filters (soft delete, tenancy) to inner CTE.
         innerStatement.ParseWhereClause(
             groupJoin.InnerCollectionUsage.WhereExpressions,
@@ -385,13 +495,13 @@ public partial class CollectionUsage
             outerCteAlias,
             innerCteAlias,
             groupJoin.ResultSelector,
-            groupJoin.FlattenedResultSelector);
+            effectiveResultSelector);
 
         // 5. Create the JoinSelectClause and final SelectorStatement
         // 9.0 (#4308): use GenericFactoryCache's object[] overload — the
         // 6-arg ctor doesn't fit the fixed-arity overloads, so we pay an
         // array allocation per call in exchange for skipping MakeGenericType.
-        var resultType = groupJoin.FlattenedResultSelector.ReturnType;
+        var resultType = effectiveResultSelector.ReturnType;
 
         // Sum()/Min()/Max()/Average() over a bare scalar projection cannot aggregate the
         // to_jsonb(...) form (Postgres has no sum/min/max/avg for jsonb). For those, render the

--- a/src/Marten/Linq/Parsing/JoinSelectParser.cs
+++ b/src/Marten/Linq/Parsing/JoinSelectParser.cs
@@ -45,6 +45,10 @@ internal class JoinSelectParser: ExpressionVisitor
     // SerializationSelector<T> deserializes it and the DISTINCT machinery applies unchanged.
     public ISqlFragment ScalarProjection { get; private set; }
 
+    // The same scalar without the to_jsonb wrapper -- the native column. Used for aggregates
+    // (Sum/Min/Max/Average), which cannot operate on a jsonb value.
+    public ISqlFragment ScalarRawProjection { get; private set; }
+
     // The fragment to render after SELECT: the scalar wrap if present, else the jsonb_build_object.
     public ISqlFragment Projection => ScalarProjection ?? NewObject;
 
@@ -85,11 +89,11 @@ internal class JoinSelectParser: ExpressionVisitor
         // Resolve it as a single scalar fragment wrapped in to_jsonb(...).
         if (NewObject.Members.Count == 0)
         {
-            ScalarProjection = ResolveScalarProjection(selectManyResultSelector.Body);
+            ResolveScalarProjection(selectManyResultSelector.Body);
         }
     }
 
-    private ISqlFragment ResolveScalarProjection(Expression body)
+    private void ResolveScalarProjection(Expression body)
     {
         // Strip compiler-inserted Convert/TypeAs (e.g. (decimal?)o.Amount).
         while (body is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.TypeAs } unary)
@@ -106,11 +110,11 @@ internal class JoinSelectParser: ExpressionVisitor
                 + "other than a single outer/inner member access.");
         }
 
-        var fragment = ResolveMember(body, classification.Value.isOuter);
+        ScalarRawProjection = ResolveMember(body, classification.Value.isOuter);
 
         // Wrap in to_jsonb so the rendered 'data' column is a JSON value the SerializationSelector
         // can deserialize back to the scalar T (a raw text/uuid locator would not be valid JSON).
-        return new ToJsonbScalarFragment(fragment);
+        ScalarProjection = new ToJsonbScalarFragment(ScalarRawProjection);
     }
 
     private void ParseGroupJoinResultSelector(LambdaExpression resultSelector)

--- a/src/Marten/Linq/Parsing/JoinSelectParser.cs
+++ b/src/Marten/Linq/Parsing/JoinSelectParser.cs
@@ -428,3 +428,224 @@ internal class ToJsonbScalarFragment: ISqlFragment
         builder.Append(")");
     }
 }
+
+/// <summary>
+/// Reduces a member access on a GroupJoin/SelectMany result-selector's projected anon type
+/// back into the (outer, inner) parameter space the projection was built from. The SelectMany
+/// result selector body builds an anon type (or a MemberInit) whose members map to source
+/// expressions in terms of the SelectMany (x, c) parameters; this visitor walks an arbitrary
+/// expression and replaces any <c>z.MemberName</c> access on a parameter of the projection
+/// type with the corresponding source expression. Used so a post-SelectMany .Select(z =&gt; z.X)
+/// or .Sum(z =&gt; z.X) collapses cleanly back into the join's projection space.
+///
+/// Recognises both anon-type binding shapes:
+/// * <c>new { c.Amount, x.p.Name }</c> — NewExpression carries the member names on its Members property
+/// * <c>new Row { Amount = c.Amount }</c> — MemberInitExpression carries them as MemberAssignment bindings
+/// </summary>
+internal sealed class AnonProjectionExpander: ExpressionVisitor
+{
+    private readonly Dictionary<string, Expression> _memberToSource = new(StringComparer.Ordinal);
+    private readonly Type _projectionType;
+
+    public AnonProjectionExpander(LambdaExpression flattenedResultSelector)
+    {
+        _projectionType = flattenedResultSelector.ReturnType;
+        ExtractBindings(flattenedResultSelector.Body);
+    }
+
+    /// <summary>True if the result selector body was a NewExpression / MemberInit we could index.</summary>
+    public bool CanExpand => _memberToSource.Count > 0;
+
+    /// <summary>Rewrites <paramref name="body"/>, replacing every <c>z.X</c> (where z is the projection type) with the bound source expression.</summary>
+    public Expression Expand(Expression body) => Visit(body);
+
+    private void ExtractBindings(Expression body)
+    {
+        if (body is NewExpression newExpr)
+        {
+            // Anon types: prefer the Members property (anonymous-type member infos), fall back to
+            // constructor parameter names. Records / explicit ctors only expose parameter names.
+            if (newExpr.Members != null)
+            {
+                for (var i = 0; i < newExpr.Members.Count; i++)
+                {
+                    _memberToSource[newExpr.Members[i].Name] = newExpr.Arguments[i];
+                }
+            }
+            else
+            {
+                var parameters = newExpr.Constructor!.GetParameters();
+                for (var i = 0; i < parameters.Length; i++)
+                {
+                    if (parameters[i].Name is { } name)
+                    {
+                        _memberToSource[name] = newExpr.Arguments[i];
+                    }
+                }
+            }
+        }
+        else if (body is MemberInitExpression memberInit)
+        {
+            ExtractBindings(memberInit.NewExpression);
+            foreach (var binding in memberInit.Bindings.OfType<MemberAssignment>())
+            {
+                _memberToSource[binding.Member.Name] = binding.Expression;
+            }
+        }
+    }
+
+    protected override Expression VisitMember(MemberExpression node)
+    {
+        // z.MemberName where z is *any* parameter of the projection's anon type.
+        // We match by Type rather than reference because the SelectExpression body
+        // stored on the CollectionUsage has lost the original lambda parameter.
+        if (node.Expression is ParameterExpression p && p.Type == _projectionType
+            && _memberToSource.TryGetValue(node.Member.Name, out var source))
+        {
+            return source;
+        }
+
+        return base.VisitMember(node);
+    }
+}
+
+/// <summary>
+/// Classifies an expanded post-SelectMany Where filter by which side of the join its
+/// parameter references touch (outer, inner, both, or neither). Used to decide whether
+/// the filter can be routed onto the inner CTE's existing WhereExpressions pipeline
+/// or needs the (not-yet-implemented) outer / cross-CTE handling.
+/// </summary>
+internal static class PostSelectManyFilterSideAnalyzer
+{
+    [Flags]
+    public enum Side
+    {
+        None = 0,
+        Outer = 1,
+        Inner = 2,
+        Both = Outer | Inner,
+        InnerOnly = Inner,
+        OuterOnly = Outer,
+    }
+
+    public static Side Analyze(Expression expression, IReadOnlyList<ParameterExpression> selectManyParameters)
+    {
+        var visitor = new SideVisitor(selectManyParameters[0], selectManyParameters[1]);
+        visitor.Visit(expression);
+        return visitor.Touched;
+    }
+
+    private sealed class SideVisitor: ExpressionVisitor
+    {
+        private readonly ParameterExpression _outer;
+        private readonly ParameterExpression _inner;
+        public Side Touched { get; private set; }
+
+        public SideVisitor(ParameterExpression outer, ParameterExpression inner)
+        {
+            _outer = outer;
+            _inner = inner;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            if (node == _outer) Touched |= Side.Outer;
+            else if (node == _inner) Touched |= Side.Inner;
+            return node;
+        }
+    }
+}
+
+/// <summary>
+/// Substitutes one ParameterExpression for another in an expression tree. Used to retarget
+/// a hoisted post-SelectMany inner-side Where filter from the SelectMany lambda's <c>c</c>
+/// parameter onto a fresh parameter of the inner document type, so MemberFor's standard
+/// pipeline binds it cleanly without needing to know about the original SelectMany lambda.
+/// </summary>
+internal sealed class ParameterReplacingVisitor: ExpressionVisitor
+{
+    private readonly ParameterExpression _from;
+    private readonly ParameterExpression _to;
+
+    public ParameterReplacingVisitor(ParameterExpression from, ParameterExpression to)
+    {
+        _from = from;
+        _to = to;
+    }
+
+    protected override Expression VisitParameter(ParameterExpression node)
+        => node == _from ? _to : base.VisitParameter(node);
+}
+
+/// <summary>
+/// Strips the GroupJoin result selector's anon-type navigation off a hoisted post-SelectMany
+/// outer-side Where filter, so the resulting expression binds against the outer document type
+/// directly via <see cref="Marten.Linq.Members.IQueryableMemberCollection.MemberFor"/>.
+///
+/// The GroupJoin result selector typically looks like <c>(p, children) =&gt; new { p, children }</c>,
+/// so the SelectMany's outer parameter <c>x</c> has the anon type. A user filter
+/// <c>z.OuterMember == "a"</c> expands through the FlattenedResultSelector to <c>x.p.OuterMember</c>;
+/// this visitor rewrites <c>x.p</c> (the anon member access of the outer-side binding) to a
+/// fresh <c>outerParam</c> of the outer document type, leaving the trailing member access intact.
+/// </summary>
+internal sealed class GroupJoinOuterNavigationStripper: ExpressionVisitor
+{
+    private readonly ParameterExpression _selectManyOuterParam;
+    private readonly ParameterExpression _outerDocParam;
+    // The anonymous-type member name on x whose value is the outer document, eg. "p".
+    private readonly string? _outerMemberName;
+
+    public GroupJoinOuterNavigationStripper(
+        ParameterExpression selectManyOuterParam,
+        LambdaExpression groupJoinResultSelector,
+        ParameterExpression outerDocParam)
+    {
+        _selectManyOuterParam = selectManyOuterParam;
+        _outerDocParam = outerDocParam;
+        _outerMemberName = FindOuterMember(groupJoinResultSelector);
+    }
+
+    private static string? FindOuterMember(LambdaExpression resultSelector)
+    {
+        // (outer, inner) => new { p = outer, children = inner }: walk the anon-type bindings and
+        // return the member name whose value is the GroupJoin outer parameter.
+        var outerParam = resultSelector.Parameters[0];
+        if (resultSelector.Body is NewExpression newExpr)
+        {
+            for (var i = 0; i < newExpr.Arguments.Count; i++)
+            {
+                if (newExpr.Arguments[i] == outerParam)
+                {
+                    return newExpr.Members != null
+                        ? newExpr.Members[i].Name
+                        : newExpr.Constructor!.GetParameters()[i].Name;
+                }
+            }
+        }
+        else if (resultSelector.Body is MemberInitExpression memberInit)
+        {
+            foreach (var binding in memberInit.Bindings.OfType<MemberAssignment>())
+            {
+                if (binding.Expression == outerParam)
+                {
+                    return binding.Member.Name;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    protected override Expression VisitMember(MemberExpression node)
+    {
+        // x.p  ->  outerDocParam
+        if (node.Expression == _selectManyOuterParam
+            && _outerMemberName != null
+            && node.Member.Name == _outerMemberName)
+        {
+            return _outerDocParam;
+        }
+
+        return base.VisitMember(node);
+    }
+}

--- a/src/Marten/Linq/Parsing/JoinSelectParser.cs
+++ b/src/Marten/Linq/Parsing/JoinSelectParser.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using Marten.Exceptions;
 using Marten.Linq.Members;
 using Marten.Linq.SqlGeneration;
 using Weasel.Postgresql;
@@ -39,6 +40,14 @@ internal class JoinSelectParser: ExpressionVisitor
 
     public NewObject NewObject { get; private set; }
 
+    // Non-null when the SelectMany result selector is a bare scalar (e.g. (temp, o) => o.Amount)
+    // rather than an object projection. Rendered as to_jsonb(<scalar>) so the existing
+    // SerializationSelector<T> deserializes it and the DISTINCT machinery applies unchanged.
+    public ISqlFragment ScalarProjection { get; private set; }
+
+    // The fragment to render after SELECT: the scalar wrap if present, else the jsonb_build_object.
+    public ISqlFragment Projection => ScalarProjection ?? NewObject;
+
     public JoinSelectParser(
         ISerializer serializer,
         IQueryableMemberCollection outerMembers,
@@ -70,6 +79,38 @@ internal class JoinSelectParser: ExpressionVisitor
         _selectManyElementParam = selectManyResultSelector.Parameters[1]; // the inner element
 
         Visit(selectManyResultSelector.Body);
+
+        // A bare scalar result selector — (temp, o) => o.Amount — adds nothing to NewObject
+        // (VisitMember early-returns because _currentField is never set by a New/MemberInit).
+        // Resolve it as a single scalar fragment wrapped in to_jsonb(...).
+        if (NewObject.Members.Count == 0)
+        {
+            ScalarProjection = ResolveScalarProjection(selectManyResultSelector.Body);
+        }
+    }
+
+    private ISqlFragment ResolveScalarProjection(Expression body)
+    {
+        // Strip compiler-inserted Convert/TypeAs (e.g. (decimal?)o.Amount).
+        while (body is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.TypeAs } unary)
+        {
+            body = unary.Operand;
+        }
+
+        var classification = ClassifyMemberAccess(body);
+        if (classification == null)
+        {
+            throw new BadLinqExpressionException(
+                "Marten cannot translate this GroupJoin/SelectMany result selector. Project into an "
+                + "anonymous type or record (for example (x, o) => new { x.c.Id, o.Amount }) for shapes "
+                + "other than a single outer/inner member access.");
+        }
+
+        var fragment = ResolveMember(body, classification.Value.isOuter);
+
+        // Wrap in to_jsonb so the rendered 'data' column is a JSON value the SerializationSelector
+        // can deserialize back to the scalar T (a raw text/uuid locator would not be valid JSON).
+        return new ToJsonbScalarFragment(fragment);
     }
 
     private void ParseGroupJoinResultSelector(LambdaExpression resultSelector)
@@ -359,5 +400,27 @@ internal class CteAliasedFragment: ISqlFragment
     public void Apply(ICommandBuilder builder)
     {
         builder.Append(_sql);
+    }
+}
+
+/// <summary>
+/// Wraps a scalar SQL fragment in <c>to_jsonb(...)</c> so a bare scalar GroupJoin/SelectMany
+/// projection renders a JSON value in the "data" column that <see cref="Marten.Linq.Selectors.SerializationSelector{T}"/>
+/// can deserialize back to the scalar type.
+/// </summary>
+internal class ToJsonbScalarFragment: ISqlFragment
+{
+    private readonly ISqlFragment _inner;
+
+    public ToJsonbScalarFragment(ISqlFragment inner)
+    {
+        _inner = inner;
+    }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        builder.Append("to_jsonb(");
+        _inner.Apply(builder);
+        builder.Append(")");
     }
 }

--- a/src/Marten/Linq/Parsing/SelectorVisitor.cs
+++ b/src/Marten/Linq/Parsing/SelectorVisitor.cs
@@ -101,8 +101,11 @@ public class SelectorVisitor: ExpressionVisitor
         }
         else if (member.MemberType.IsSimple() || member.MemberType == typeof(Guid) ||
                  member.MemberType == typeof(decimal) ||
-                 member.MemberType == typeof(DateTimeOffset) || member.MemberType == typeof(DateTime))
+                 member.MemberType == typeof(DateTimeOffset) || member.MemberType == typeof(DateTime) ||
+                 member.MemberType == typeof(DateOnly) || member.MemberType == typeof(TimeOnly))
         {
+            // DateOnly/TimeOnly read their native date/time TypedLocator here; the
+            // DataSelectClause fallback would JSON-deserialize the raw ->> text and fail.
             _statement.SelectClause =
                 typeof(NewScalarSelectClause<>).CloseAndBuildAs<ISelectClause>(member,
                     _statement.SelectClause.FromObject,

--- a/src/Marten/Linq/SqlGeneration/JoinSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/JoinSelectClause.cs
@@ -130,8 +130,10 @@ internal class JoinSelectClause<T>: ISelectClause, IScalarSelectClause where T :
     }
 
     // IScalarSelectClause — implemented so GroupJoin(...).SelectMany(...).Distinct()[.Count()]
-    // reuses the standard distinct machinery. Only DISTINCT is meaningful over a join projection;
-    // the scalar aggregate operators (MIN/MAX/SUM/AVG) and table cloning are not applicable here.
+    // reuses the standard distinct machinery (renders DISTINCT(<projection>)). Aggregates over a
+    // bare SCALAR projection are handled separately: CompileGroupJoin renders the raw scalar and
+    // routes Sum/Min/Max/Average through a CTE + standard scalar clause. This throw only guards the
+    // object-projection (or nullable-scalar) case, where there is no single column to aggregate.
     public string MemberName => "data";
 
     public void ApplyOperator(string op)
@@ -139,18 +141,24 @@ internal class JoinSelectClause<T>: ISelectClause, IScalarSelectClause where T :
         if (op != "DISTINCT")
         {
             throw new NotSupportedException(
-                $"Marten does not support the '{op}' operator over a GroupJoin/SelectMany projection. Only Distinct() is supported.");
+                $"Marten does not support the '{op}' aggregate over this GroupJoin/SelectMany projection. "
+                + "Aggregates are supported over a bare non-nullable scalar projection, e.g. "
+                + ".SelectMany(..., (x, c) => c.Amount).Sum(z => z).");
         }
 
         _operator = op;
     }
 
+    // Reached only for an object/nullable-scalar Average(); scalar aggregates use a real scalar clause.
     public ISelectClause CloneToDouble()
     {
         throw new NotSupportedException(
-            "Average aggregation is not supported over a GroupJoin/SelectMany projection.");
+            "Marten does not support Average() over this GroupJoin/SelectMany projection. "
+            + "Average a bare non-nullable scalar projection, e.g. .SelectMany(..., (x, c) => c.Amount).Average(z => z).");
     }
 
+    // Not reachable for a join statement (only the dictionary / value-collection scalar paths clone
+    // a select clause to another table); present only to satisfy IScalarSelectClause.
     public ISelectClause CloneToOtherTable(string tableName)
     {
         throw new NotSupportedException(

--- a/src/Marten/Linq/SqlGeneration/JoinSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/JoinSelectClause.cs
@@ -1,5 +1,8 @@
 #nullable enable
 using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 using JasperFx.Core;
 using Marten.Internal;
 using Marten.Linq.Parsing;
@@ -14,7 +17,7 @@ namespace Marten.Linq.SqlGeneration;
 /// ISelectClause that renders a JOIN between two CTEs with a jsonb_build_object projection.
 /// Produces: SELECT projection as data FROM outer_cte [INNER|LEFT] JOIN inner_cte ON condition
 /// </summary>
-internal class JoinSelectClause<T>: ISelectClause where T : notnull
+internal class JoinSelectClause<T>: ISelectClause, IScalarSelectClause where T : notnull
 {
     private readonly ISqlFragment _projection;
     private readonly string _outerCteAlias;
@@ -22,6 +25,10 @@ internal class JoinSelectClause<T>: ISelectClause where T : notnull
     private readonly bool _isLeftJoin;
     private readonly string _outerKeyLocator;
     private readonly string _innerKeyLocator;
+
+    // Set to "DISTINCT" when GroupJoin(...).SelectMany(...).Distinct() is used so the join
+    // projection is rendered as DISTINCT(<projection>) — Postgres reads DISTINCT(x) as DISTINCT x.
+    private string? _operator;
 
     public JoinSelectClause(
         ISqlFragment projection,
@@ -46,7 +53,19 @@ internal class JoinSelectClause<T>: ISelectClause where T : notnull
     public void Apply(ICommandBuilder sql)
     {
         sql.Append("select ");
+        if (_operator != null)
+        {
+            sql.Append(_operator);
+            sql.Append("(");
+        }
+
         _projection.Apply(sql);
+
+        if (_operator != null)
+        {
+            sql.Append(")");
+        }
+
         sql.Append(" as data from ");
         sql.Append(_outerCteAlias);
         sql.Append(_isLeftJoin ? " LEFT" : " INNER");
@@ -65,18 +84,76 @@ internal class JoinSelectClause<T>: ISelectClause where T : notnull
 
     public ISelector BuildSelector(IMartenSession session)
     {
-        return new SerializationSelector<T>(session.Serializer);
+        return new JoinDataSelector(session.Serializer);
     }
 
     public IQueryHandler<TResult> BuildHandler<TResult>(IMartenSession session, ISqlFragment topStatement,
         ISqlFragment currentStatement) where TResult : notnull
     {
-        var selector = new SerializationSelector<T>(session.Serializer);
+        var selector = new JoinDataSelector(session.Serializer);
         return LinqQueryParser.BuildHandler<T, TResult>(selector, topStatement);
+    }
+
+    // The "data" column is null only for a bare scalar projection whose value is null
+    // (e.g. a left join projecting an inner member of an unmatched outer row). Object
+    // projections always render a non-null jsonb object. Return default for a null column
+    // -- matching Marten's scalar-select convention -- instead of letting the serializer
+    // throw "Column 'data' is null".
+    private sealed class JoinDataSelector: ISelector<T>
+    {
+        private readonly ISerializer _serializer;
+
+        public JoinDataSelector(ISerializer serializer)
+        {
+            _serializer = serializer;
+        }
+
+        public T Resolve(DbDataReader reader)
+        {
+            return reader.IsDBNull(0) ? default! : _serializer.FromJson<T>(reader, 0);
+        }
+
+        public async Task<T> ResolveAsync(DbDataReader reader, CancellationToken token)
+        {
+            if (await reader.IsDBNullAsync(0, token).ConfigureAwait(false))
+            {
+                return default!;
+            }
+
+            return await _serializer.FromJsonAsync<T>(reader, 0, token).ConfigureAwait(false);
+        }
     }
 
     public ISelectClause UseStatistics(QueryStatistics statistics)
     {
         return new StatsSelectClause<T>(this, statistics);
+    }
+
+    // IScalarSelectClause — implemented so GroupJoin(...).SelectMany(...).Distinct()[.Count()]
+    // reuses the standard distinct machinery. Only DISTINCT is meaningful over a join projection;
+    // the scalar aggregate operators (MIN/MAX/SUM/AVG) and table cloning are not applicable here.
+    public string MemberName => "data";
+
+    public void ApplyOperator(string op)
+    {
+        if (op != "DISTINCT")
+        {
+            throw new NotSupportedException(
+                $"Marten does not support the '{op}' operator over a GroupJoin/SelectMany projection. Only Distinct() is supported.");
+        }
+
+        _operator = op;
+    }
+
+    public ISelectClause CloneToDouble()
+    {
+        throw new NotSupportedException(
+            "Average aggregation is not supported over a GroupJoin/SelectMany projection.");
+    }
+
+    public ISelectClause CloneToOtherTable(string tableName)
+    {
+        throw new NotSupportedException(
+            "A GroupJoin/SelectMany projection cannot be cloned to another table.");
     }
 }


### PR DESCRIPTION
**Stacked on top of [#4677](https://github.com/JasperFx/marten/pull/4677)** — must merge after #4677 (the diff includes that PR's commits because the base branch lives on the contributor's fork and isn't reachable from this remote). Addresses the two **Known limitations** that #4677 explicitly left open:

1. **Aggregates over an *object* projection.**
   `.SelectMany(.., (x, c) => new {..}).Sum(z => z.X)` (which `QueryableExtensions`
   lowers to `.Select(z => z.X).SumAsync()`) used to hit
   `JoinSelectClause.ApplyOperator(\"SUM\")` on the object projection and throw the
   clear-error pin shipped in #4677.

2. **`.Select(...)` / `.Where(...)` *after* the join's `.SelectMany(...)`.**
   `CompileGroupJoin` ignored both: a post-SelectMany `Select` returned the original
   anon-typed rows and a post-SelectMany `Where` was silently dropped.

## Approach

The fix is a single seam in `CompileGroupJoin` — a new `AnonProjectionExpander`
visitor walks the `FlattenedResultSelector`'s `(x, c) => new { Member = source }`
bindings and rewrites a `z.Member` access (on a parameter of the projection's
anon type) back to its source expression in `(x, c)` terms.

With the expander in hand:

* **Post-SelectMany `Select(z => ...)`** reduces to a synthesized effective
  result selector that `JoinSelectParser` then renders normally — including
  lighting up the bare-scalar aggregate path that already handles
  `Sum`/`Min`/`Max`/`Average` over a scalar projection.
* **Post-SelectMany `Where(z => ...)`** filters get expanded the same way and
  routed onto the appropriate CTE's existing Where pipeline — inner-side onto
  `InnerCollectionUsage.WhereExpressions` before its `ParseWhereClause` runs;
  outer-side onto `outerStatement.ParseWhereClause` after the fact with
  `storage=null` so we don't double-apply tenant / soft-delete defaults.

Both `Select` and `Where` walk the `Inner` chain (`Inner` and `Inner.Inner`)
the same way `SingleValueMode` / `IsDistinct` already do — re-linq sometimes
pushes a post-SelectMany `Select` onto a new usage because the element type
changed, so the operators don't always sit on `Inner` directly.

## Pinned limitations (clear-error, not silent)

* **Cross-side `Where` filters** that touch both `x.*` and `c.*` on the
  projected anon type throw `BadLinqExpressionException`. Would need a
  join-level `WHERE` clause in `JoinSelectClause`; left for a follow-up.
* **Computed expressions on projected members** (`z.Amount * 2`) inherit the
  existing \"computed scalar projection\" pin from #4677 — no change.

## Tests

11 new tests in `Bug_4677_groupjoin_post_selectmany.cs`:

* `object_projection_sum_of_inner_member` / `_of_outer_member` / `_min_and_max`
  / `_average_returns_double` / `_sum_over_left_join_ignores_unmatched`
* `post_select_many_select_reduces_to_scalar_member`
* `post_select_many_select_reshuffles_to_new_anonymous_type`
* `post_select_many_where_filters_on_inner_member` / `_on_outer_member`
* `post_select_many_where_then_sum_chains` (both fixes in one chain)
* `post_select_many_where_touching_both_sides_throws_clear_error` (limitation pin)

The 53 existing tests across `Bug_groupjoin_distinct_and_scalar_projection`,
`Bug_distinct_count_over_selectmany`, `Bug_dateonly_timeonly_scalar_projection`,
and the `group_join_operator` family stay green. Full `LinqTests` suite passes
on both **net9.0** and **net10.0** (1312 / 1313 — 1 unrelated pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)