### PR TITLE
Bump JasperFx.* 2.8.2 → 2.9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,14 +31,20 @@
          path was used, but the global mt_events_sequence is never advanced under
          partitioning, so catch-up stayed pinned at zero). Per-tenant fan-out mirrors
          rebuildProjectionForTenant's ceiling-lookup pattern. Single-tenant / non-
-         partitioned stores keep the byte-for-byte global path. -->
-    <PackageVersion Include="JasperFx" Version="2.8.2" />
-    <PackageVersion Include="JasperFx.Events" Version="2.8.2" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.8.2">
+         partitioned stores keep the byte-for-byte global path.
+         JasperFx 2.9.0: jasperfx#419 (ShardName.Compose is now the only path used
+         for shard name construction), #420 (cap concurrent projection rebuilds per
+         database, default 4), #422 (MultiStreamProjection.Options.CacheLimitPerTenant
+         now defaults to 1000 instead of 0 — projections that relied on the unbounded
+         default still work but per-tenant slice caches now bound by default), and
+         #424 (new storage-agnostic IEventStoreInstrumentation hook for telemetry). -->
+    <PackageVersion Include="JasperFx" Version="2.9.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.9.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.8.2" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Picks up the JasperFx 2.9.0 release. Four upstream fixes, all additive:

| jasperfx# | Change |
|---|---|
| **#419** | Routes every `ShardName` construction through `ShardName.Compose` so shard-name semantics stay aligned across the daemon, instrumentation, and rebuild paths. |
| **#420** | Caps concurrent projection rebuilds per database (default 4) so a multi-projection rebuild storm no longer floods a single database's slot. |
| **#422** | `MultiStreamProjection.Options.CacheLimitPerTenant` default 0 → **1000**. Projections that relied on unbounded slice caches still function, but the default is now bounded. |
| **#424** | New storage-agnostic `IEventStoreInstrumentation` hook for telemetry. Marten's existing instrumentation surface unchanged. |

Bump is just the `Directory.Packages.props` version pins (2.8.2 → 2.9.0 on `JasperFx`, `JasperFx.Events`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator`). No source changes.

## Verification

Local smoke against 2.9.0:

| Project | Result | TFM |
|---|---|---|
| `CoreTests` | **421 / 421** (1 unrelated skip) | net9.0 |
| `EventSourcingTests` | **1361 / 1368** (7 unrelated skips) | net9.0 |

Full solution compiles clean on both net9.0 and net10.0 (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)