### PR TITLE
#4684 Phase E.1 — per-period throughput sampling + Npgsql round-trip counting

### DIFF
--- a/src/Marten.ScaleTesting/Commands/RebuildCommand.cs
+++ b/src/Marten.ScaleTesting/Commands/RebuildCommand.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
+using System.Text.Json;
 using JasperFx;
 using JasperFx.CommandLine;
+using Marten.ScaleTesting.Instrumentation;
 using Spectre.Console;
 
 namespace Marten.ScaleTesting.Commands;
@@ -13,6 +15,7 @@ public sealed class RebuildCommand: JasperFxAsyncCommand<RebuildInput>
     {
         using var host = input.BuildHost();
         var store = host.DocumentStore();
+        var schemaName = store.Options.DatabaseSchemaName ?? "public";
 
         // Ensure the schema is in place so a brand-new database can still
         // rebuild even if the user skipped the `seed` step (no events =
@@ -26,6 +29,16 @@ public sealed class RebuildCommand: JasperFxAsyncCommand<RebuildInput>
         using var daemon = await store.BuildProjectionDaemonAsync().ConfigureAwait(false);
 
         var shardTimeout = TimeSpan.FromSeconds(input.ShardTimeoutSecondsFlag);
+
+        // #4684 Phase E.1: arm the optional harness instrumentation. When --instrument is off
+        // (or implied off because no trace path was set), the returned object is a no-op so
+        // production-style runs aren't paying for measurement.
+        var instrumentationOptions = BuildInstrumentationOptions(input);
+        var progressionRow = input.ProjectionFlag + ":All";
+        await using var instrumentation = RebuildInstrumentation.Start(
+            instrumentationOptions, ConnectionSource.ConnectionString,
+            schemaName, progressionRow, CancellationToken.None);
+
         var stopwatch = Stopwatch.StartNew();
 
         try
@@ -42,6 +55,7 @@ public sealed class RebuildCommand: JasperFxAsyncCommand<RebuildInput>
             return false;
         }
 
+        var snapshot = await instrumentation.CaptureAsync().ConfigureAwait(false);
         var rate = stats.EventCount > 0
             ? stats.EventCount / Math.Max(0.001, stopwatch.Elapsed.TotalSeconds)
             : 0;
@@ -53,8 +67,63 @@ public sealed class RebuildCommand: JasperFxAsyncCommand<RebuildInput>
         table.AddRow("Streams", stats.StreamCount.ToString("N0"));
         table.AddRow("Elapsed", $"{stopwatch.Elapsed.TotalSeconds:N1}s");
         table.AddRow("Throughput (events/sec)", rate.ToString("N0"));
+        if (snapshot.Enabled)
+        {
+            table.AddRow("Throughput p50 (events/sec)", snapshot.Throughput.P50.ToString("N0"));
+            table.AddRow("Throughput p95 (events/sec)", snapshot.Throughput.P95.ToString("N0"));
+            table.AddRow("Throughput max (events/sec)", snapshot.Throughput.Max.ToString("N0"));
+            table.AddRow("Npgsql commands total", snapshot.NpgsqlCommandCount.ToString("N0"));
+            table.AddRow("Progress samples", snapshot.Samples.Count.ToString("N0"));
+        }
         AnsiConsole.Write(table);
 
+        await WriteMetricsAsync(input.MetricsFlag, stats, stopwatch.Elapsed, rate, snapshot).ConfigureAwait(false);
+
         return true;
+    }
+
+    private static InstrumentationOptions BuildInstrumentationOptions(RebuildInput input)
+    {
+        // --instrument-trace implies --instrument so users don't have to remember both flags.
+        var enabled = input.InstrumentFlag || !string.IsNullOrWhiteSpace(input.InstrumentTraceFlag);
+        return new InstrumentationOptions
+        {
+            Enabled = enabled,
+            ProgressSampleInterval = TimeSpan.FromSeconds(Math.Max(0.1, input.InstrumentSampleSecondsFlag)),
+            TracePath = string.IsNullOrWhiteSpace(input.InstrumentTraceFlag) ? null : input.InstrumentTraceFlag
+        };
+    }
+
+    private static async Task WriteMetricsAsync(string? path, Marten.Events.EventStoreStatistics stats,
+        TimeSpan elapsed, double rate, RebuildInstrumentation.Snapshot snapshot)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        // Slim the instrumentation block for JSON -- a multi-hour run's per-sample list would
+        // bloat metrics.json into the MB range; the rolled-up percentiles + total are what the
+        // dashboard / regression-comparison tooling actually consumes. Per-sample detail lives in
+        // the CSV trace when --instrument-trace is set.
+        var doc = new
+        {
+            projection = "rebuild",
+            events = stats.EventCount,
+            streams = stats.StreamCount,
+            elapsedSeconds = elapsed.TotalSeconds,
+            throughputEventsPerSecond = rate,
+            instrumentation = new
+            {
+                enabled = snapshot.Enabled,
+                sampleCount = snapshot.Samples.Count,
+                npgsqlCommandCount = snapshot.NpgsqlCommandCount,
+                throughput = snapshot.Throughput
+            }
+        };
+        await File.WriteAllTextAsync(path,
+            JsonSerializer.Serialize(doc, new JsonSerializerOptions { WriteIndented = true }))
+            .ConfigureAwait(false);
+        AnsiConsole.MarkupLine($"[grey]Wrote metrics to {path}[/]");
     }
 }

--- a/src/Marten.ScaleTesting/Commands/RebuildInput.cs
+++ b/src/Marten.ScaleTesting/Commands/RebuildInput.cs
@@ -10,4 +10,16 @@ public sealed class RebuildInput: NetCoreInput
 
     [Description("Per-shard rebuild timeout, in seconds. Default: 600s (10 min). Bump for very large event counts.")]
     public int ShardTimeoutSecondsFlag { get; set; } = 600;
+
+    [Description("#4684 Phase E.1: enable per-period throughput sampling against mt_event_progression + Npgsql command counting. Adds an Activity span around the rebuild and writes the rolled-up percentiles into the metrics file. Off by default so production-style runs don't pay for the measurement.")]
+    public bool InstrumentFlag { get; set; }
+
+    [Description("Optional CSV trace path. Implies --instrument. One row per progress sample: timestamp, sequence_id, delta, events_per_second, npgsql_commands_in_interval.")]
+    public string? InstrumentTraceFlag { get; set; }
+
+    [Description("Sample interval for the progression poller when --instrument is on. Default 1s. Lower for finer-grained percentiles; raise to keep harness overhead negligible on multi-hour runs.")]
+    public double InstrumentSampleSecondsFlag { get; set; } = 1.0;
+
+    [Description("Metrics JSON output path. When set (and --instrument is on), the instrumentation snapshot is written here as JSON. Default unset = no JSON file emitted; instrumentation is still reported on the console.")]
+    public string? MetricsFlag { get; set; }
 }

--- a/src/Marten.ScaleTesting/Commands/StressCommand.cs
+++ b/src/Marten.ScaleTesting/Commands/StressCommand.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
+using System.Text.Json;
 using JasperFx;
 using JasperFx.CommandLine;
+using Marten.ScaleTesting.Instrumentation;
 using Marten.ScaleTesting.Seeding;
 using Marten.ScaleTesting.Validation;
 using Spectre.Console;
@@ -60,8 +62,19 @@ public sealed class StressCommand: JasperFxAsyncCommand<StressInput>
         // ---- Phase 2: rebuild --------------------------------------------
 
         AnsiConsole.MarkupLine($"[blue]Phase 2: rebuild [yellow]{input.ProjectionFlag}[/][/]");
+
+        // #4684 Phase E.1: arm harness instrumentation around the rebuild only. Seed phase isn't
+        // measured by the same machinery -- it's a bulk-writer path that exercises a different
+        // bottleneck and gets its own per-batch console reporting already.
+        var instrumentationOptions = BuildInstrumentationOptions(input);
+        var progressionRow = input.ProjectionFlag + ":All";
+        await using var instrumentation = RebuildInstrumentation.Start(
+            instrumentationOptions, ConnectionSource.ConnectionString,
+            schemaName, progressionRow, CancellationToken.None);
+
         var rebuildSw = Stopwatch.StartNew();
         var rebuildEventCount = 0L;
+        RebuildInstrumentation.Snapshot rebuildSnapshot = RebuildInstrumentation.Snapshot.Disabled;
         try
         {
             var stats = await store.Advanced.FetchEventStoreStatistics().ConfigureAwait(false);
@@ -73,10 +86,13 @@ public sealed class StressCommand: JasperFxAsyncCommand<StressInput>
                 TimeSpan.FromSeconds(input.ShardTimeoutSecondsFlag),
                 CancellationToken.None).ConfigureAwait(false);
             rebuildSw.Stop();
+            rebuildSnapshot = await instrumentation.CaptureAsync().ConfigureAwait(false);
         }
         catch (Exception e)
         {
             rebuildSw.Stop();
+            // Capture whatever the sampler observed before the crash; useful for post-mortem.
+            try { rebuildSnapshot = await instrumentation.CaptureAsync().ConfigureAwait(false); } catch { /* shutdown */ }
             summary.Add(("rebuild", "FAILED", rebuildSw.Elapsed, e.GetType().Name + ": " + e.Message));
             AnsiConsole.MarkupLine($"[red]Rebuild FAILED after {rebuildSw.Elapsed.TotalSeconds:N1}s — skipping validate.[/]");
             AnsiConsole.WriteException(e);
@@ -85,11 +101,12 @@ public sealed class StressCommand: JasperFxAsyncCommand<StressInput>
         }
 
         var rate = rebuildEventCount > 0 ? rebuildEventCount / Math.Max(0.001, rebuildSw.Elapsed.TotalSeconds) : 0;
-        summary.Add((
-            "rebuild",
-            "OK",
-            rebuildSw.Elapsed,
-            $"{rebuildEventCount:N0} events @ {rate:N0}/sec"));
+        var rebuildNote = $"{rebuildEventCount:N0} events @ {rate:N0}/sec";
+        if (rebuildSnapshot.Enabled)
+        {
+            rebuildNote += $" (p50 {rebuildSnapshot.Throughput.P50:N0}, p95 {rebuildSnapshot.Throughput.P95:N0}, {rebuildSnapshot.NpgsqlCommandCount:N0} pg cmds)";
+        }
+        summary.Add(("rebuild", "OK", rebuildSw.Elapsed, rebuildNote));
 
         // ---- Phase 3: validate -------------------------------------------
 
@@ -156,6 +173,17 @@ public sealed class StressCommand: JasperFxAsyncCommand<StressInput>
             PrintSummary(summary, totalStopwatch);
             return false;
         }
+    }
+
+    private static InstrumentationOptions BuildInstrumentationOptions(StressInput input)
+    {
+        var enabled = input.InstrumentFlag || !string.IsNullOrWhiteSpace(input.InstrumentTraceFlag);
+        return new InstrumentationOptions
+        {
+            Enabled = enabled,
+            ProgressSampleInterval = TimeSpan.FromSeconds(Math.Max(0.1, input.InstrumentSampleSecondsFlag)),
+            TracePath = string.IsNullOrWhiteSpace(input.InstrumentTraceFlag) ? null : input.InstrumentTraceFlag
+        };
     }
 
     private static void PrintSummary(List<(string Phase, string Status, TimeSpan Elapsed, string Note)> rows, Stopwatch total)

--- a/src/Marten.ScaleTesting/Commands/StressInput.cs
+++ b/src/Marten.ScaleTesting/Commands/StressInput.cs
@@ -47,6 +47,20 @@ public sealed class StressInput: NetCoreInput
     [Description("Skip the validate phase entirely (just seed + rebuild). Useful for the very first stress run before a baseline exists.")]
     public bool SkipValidateFlag { get; set; }
 
+    // ---- instrumentation flags (#4684 Phase E.1) ----------------------------
+
+    [Description("Enable per-period throughput sampling against mt_event_progression + Npgsql command counting during the rebuild phase. Off by default.")]
+    public bool InstrumentFlag { get; set; }
+
+    [Description("Optional CSV trace path. Implies --instrument. One row per progress sample: timestamp, sequence_id, delta, events_per_second, npgsql_commands_in_interval.")]
+    public string? InstrumentTraceFlag { get; set; }
+
+    [Description("Sample interval for the progression poller when --instrument is on. Default 1s.")]
+    public double InstrumentSampleSecondsFlag { get; set; } = 1.0;
+
+    [Description("Metrics JSON output path. When set (and --instrument is on), the instrumentation snapshot is written here as JSON.")]
+    public string? MetricsFlag { get; set; }
+
     public SeedOptions ToSeedOptions() => new(
         TenantCount: TenantsFlag,
         EventsPerTenant: EventsPerTenantFlag,

--- a/src/Marten.ScaleTesting/Instrumentation/InstrumentationOptions.cs
+++ b/src/Marten.ScaleTesting/Instrumentation/InstrumentationOptions.cs
@@ -1,0 +1,24 @@
+namespace Marten.ScaleTesting.Instrumentation;
+
+/// <summary>
+/// Toggles for the harness-side instrumentation surface (#4684 Phase E.1). Built behind a
+/// `--instrument` flag so production-style runs don't pay for the measurement; the no-op
+/// implementations on <see cref="RebuildInstrumentation"/> return zero-allocation null
+/// shapes when <see cref="Enabled"/> is false.
+/// </summary>
+public sealed class InstrumentationOptions
+{
+    /// <summary>Master toggle. False ⇒ all sampling / counting is a no-op.</summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>Periodic poll of <c>mt_event_progression</c> to compute rebuild throughput
+    /// samples between intervals. Default 1s; reduce for finer-grained percentiles, raise
+    /// to keep overhead negligible on very long runs.</summary>
+    public TimeSpan ProgressSampleInterval { get; init; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>Optional CSV trace path. One row per progress sample: timestamp, sequence,
+    /// delta-sequence, instantaneous-events-per-second, npgsql-commands-since-last-sample.
+    /// Set via <c>--instrument-trace &lt;path&gt;</c>. When null, only the rolled-up JSON
+    /// metrics are written.</summary>
+    public string? TracePath { get; init; }
+}

--- a/src/Marten.ScaleTesting/Instrumentation/NpgsqlCommandCounter.cs
+++ b/src/Marten.ScaleTesting/Instrumentation/NpgsqlCommandCounter.cs
@@ -1,0 +1,59 @@
+using System.Diagnostics;
+
+namespace Marten.ScaleTesting.Instrumentation;
+
+/// <summary>
+/// Counts the total Npgsql command executions during a rebuild scope by subscribing to the
+/// <c>Npgsql</c> ActivitySource (Npgsql ≥ 8 emits one Activity per command, aligning with
+/// OpenTelemetry's <c>db.*</c> semantic conventions). Subscribing via <see cref="ActivityListener"/>
+/// avoids poking at Npgsql internals; the histogram-style Meter instruments would record durations
+/// rather than counts, which is the wrong primitive for "how many round-trips."
+/// </summary>
+internal sealed class NpgsqlCommandCounter : IDisposable
+{
+    private readonly ActivityListener _listener;
+    private long _count;
+    private bool _disposed;
+
+    private NpgsqlCommandCounter()
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == "Npgsql",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.PropagationData,
+            ActivityStopped = OnStopped
+        };
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    public static NpgsqlCommandCounter Start() => new();
+
+    private void OnStopped(Activity activity)
+    {
+        // One Activity per command (Execute / ExecuteReader / ExecuteScalar / etc). Filter by
+        // OperationName so connection-open / connection-close spans don't inflate the count.
+        // Npgsql tags command spans with kind=Client and emits them under operation names like
+        // "Npgsql.OpenConnection" vs the actual SQL operation; the SQL operations are the ones
+        // we care about and they carry a DisplayName matching the command text.
+        if (activity.Source.Name != "Npgsql") return;
+        if (activity.OperationName == "Npgsql.OpenConnection"
+            || activity.OperationName == "Npgsql.CloseConnection") return;
+        Interlocked.Increment(ref _count);
+    }
+
+    public long SnapshotCount() => Interlocked.Read(ref _count);
+
+    public long Stop()
+    {
+        var final = SnapshotCount();
+        Dispose();
+        return final;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _listener.Dispose();
+    }
+}

--- a/src/Marten.ScaleTesting/Instrumentation/ProgressSampler.cs
+++ b/src/Marten.ScaleTesting/Instrumentation/ProgressSampler.cs
@@ -1,0 +1,153 @@
+using System.Globalization;
+using Npgsql;
+
+namespace Marten.ScaleTesting.Instrumentation;
+
+/// <summary>
+/// Background poll loop against <c>mt_event_progression</c>. Every
+/// <see cref="InstrumentationOptions.ProgressSampleInterval"/> ticks we read the watched row's
+/// <c>last_seq_id</c>, compute the delta since the last sample, and emit a <see cref="ProgressSample"/>.
+/// CompositeReplayExecutor batches progression writes ahead of actual scan position, so the
+/// per-sample rate is a useful aggregate signal (mean/p50/p95) even though it isn't true
+/// per-batch wall-clock -- that needs JasperFx-side hooks (#4684 follow-ups).
+/// </summary>
+internal sealed class ProgressSampler : IAsyncDisposable
+{
+    private readonly string _connectionString;
+    private readonly string _sqlText;
+    private readonly TimeSpan _interval;
+    private readonly NpgsqlCommandCounter _commandCounter;
+    private readonly string? _tracePath;
+    private readonly CancellationTokenSource _cts;
+    private readonly Task _loop;
+    private readonly List<ProgressSample> _samples = new();
+    private readonly StreamWriter? _traceWriter;
+    private long _previousSequence;
+    private long _previousCommandCount;
+    private DateTimeOffset _previousAt;
+
+    private ProgressSampler(string connectionString, string schema, string progressionRowName,
+        TimeSpan interval, NpgsqlCommandCounter commandCounter, string? tracePath,
+        CancellationToken outerCancellation)
+    {
+        _connectionString = connectionString;
+        _sqlText = $"select coalesce(last_seq_id, 0) from {schema}.mt_event_progression where name = '{progressionRowName.Replace("'", "''")}'";
+        _interval = interval;
+        _commandCounter = commandCounter;
+        _tracePath = tracePath;
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(outerCancellation);
+        if (tracePath != null)
+        {
+            _traceWriter = new StreamWriter(tracePath, append: false);
+            _traceWriter.WriteLine("timestamp,sequence_id,delta_sequence_id,events_per_second,npgsql_commands_in_interval");
+        }
+        _previousAt = DateTimeOffset.UtcNow;
+        _loop = Task.Run(LoopAsync, CancellationToken.None);
+    }
+
+    public static ProgressSampler Start(
+        string connectionString, string schema, string progressionRowName,
+        TimeSpan interval, NpgsqlCommandCounter commandCounter, string? tracePath,
+        CancellationToken cancellation)
+        => new(connectionString, schema, progressionRowName, interval, commandCounter, tracePath, cancellation);
+
+    private async Task LoopAsync()
+    {
+        try
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                try
+                {
+                    await SampleOnceAsync().ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception)
+                {
+                    // Sampling is best-effort -- a transient connection blip should not crash the
+                    // rebuild. Drop the sample and try again next tick.
+                }
+
+                try
+                {
+                    await Task.Delay(_interval, _cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            // Final tick at shutdown so the last partial interval is captured before we stop.
+            try { await SampleOnceAsync().ConfigureAwait(false); } catch { /* best effort */ }
+        }
+    }
+
+    private async Task SampleOnceAsync()
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync(_cts.Token).ConfigureAwait(false);
+        await using var cmd = new NpgsqlCommand(_sqlText, conn);
+        var current = (long?)await cmd.ExecuteScalarAsync(_cts.Token).ConfigureAwait(false) ?? 0;
+        var now = DateTimeOffset.UtcNow;
+
+        var deltaSeq = current - _previousSequence;
+        var elapsed = (now - _previousAt).TotalSeconds;
+        var rate = elapsed > 0 ? deltaSeq / elapsed : 0;
+
+        var commandSnapshot = _commandCounter.SnapshotCount();
+        var commandsInInterval = commandSnapshot - _previousCommandCount;
+
+        var sample = new ProgressSample(
+            Timestamp: now,
+            SequenceId: current,
+            DeltaSequenceId: deltaSeq,
+            EventsPerSecondSinceLastSample: rate,
+            NpgsqlCommandsSinceLastSample: commandsInInterval);
+        lock (_samples)
+        {
+            _samples.Add(sample);
+        }
+
+        if (_traceWriter != null)
+        {
+            // Flush per-line so a kill -9 still leaves a usable partial trace.
+            lock (_traceWriter)
+            {
+                _traceWriter.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                    "{0:O},{1},{2},{3:F1},{4}",
+                    now.UtcDateTime, current, deltaSeq, rate, commandsInInterval));
+                _traceWriter.Flush();
+            }
+        }
+
+        _previousSequence = current;
+        _previousCommandCount = commandSnapshot;
+        _previousAt = now;
+    }
+
+    public async Task<ProgressSample[]> StopAsync()
+    {
+        _cts.Cancel();
+        try { await _loop.ConfigureAwait(false); } catch { /* shutdown */ }
+        _traceWriter?.Dispose();
+        lock (_samples)
+        {
+            return _samples.ToArray();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!_cts.IsCancellationRequested)
+        {
+            await StopAsync().ConfigureAwait(false);
+        }
+        _cts.Dispose();
+    }
+}

--- a/src/Marten.ScaleTesting/Instrumentation/RebuildInstrumentation.cs
+++ b/src/Marten.ScaleTesting/Instrumentation/RebuildInstrumentation.cs
@@ -1,0 +1,167 @@
+using System.Diagnostics;
+
+namespace Marten.ScaleTesting.Instrumentation;
+
+/// <summary>
+/// Orchestrates the harness-side instrumentation for a single rebuild (#4684 Phase E.1).
+/// Owns the <see cref="ProgressSampler"/> background poller against
+/// <c>mt_event_progression</c>, the <see cref="NpgsqlCommandCounter"/> DiagnosticSource
+/// subscription, and the percentile aggregation that lands in <c>metrics.json</c>.
+///
+/// All methods are safe to call when <see cref="InstrumentationOptions.Enabled"/> is false --
+/// they are no-ops that allocate nothing and return the disabled-shape <see cref="Snapshot"/>.
+/// </summary>
+public sealed class RebuildInstrumentation : IAsyncDisposable
+{
+    private readonly InstrumentationOptions _options;
+    private readonly ProgressSampler? _sampler;
+    private readonly NpgsqlCommandCounter? _commands;
+    private readonly Activity? _activity;
+    private static readonly ActivitySource s_activitySource = new("Marten.ScaleTesting", "1.0");
+
+    private RebuildInstrumentation(InstrumentationOptions options, ProgressSampler? sampler,
+        NpgsqlCommandCounter? commands, Activity? activity)
+    {
+        _options = options;
+        _sampler = sampler;
+        _commands = commands;
+        _activity = activity;
+    }
+
+    /// <summary>
+    /// Spin up an instrumented rebuild scope. When <paramref name="options"/>.Enabled is false
+    /// the returned object is a no-op (no background sampler, no DiagnosticSource subscription,
+    /// no Activity).
+    /// </summary>
+    public static RebuildInstrumentation Start(
+        InstrumentationOptions options,
+        string connectionString,
+        string schemaName,
+        string progressionRowName,
+        CancellationToken cancellation)
+    {
+        if (!options.Enabled)
+        {
+            return new RebuildInstrumentation(options, null, null, null);
+        }
+
+        var activity = s_activitySource.StartActivity("scaletest.rebuild", ActivityKind.Internal);
+        activity?.SetTag("progression.name", progressionRowName);
+        activity?.SetTag("schema", schemaName);
+
+        var commands = NpgsqlCommandCounter.Start();
+        var sampler = ProgressSampler.Start(
+            connectionString, schemaName, progressionRowName, options.ProgressSampleInterval,
+            commands, options.TracePath, cancellation);
+
+        return new RebuildInstrumentation(options, sampler, commands, activity);
+    }
+
+    /// <summary>
+    /// Capture the final snapshot. Stops the sampler / counter / activity. Idempotent.
+    /// </summary>
+    public async Task<Snapshot> CaptureAsync()
+    {
+        if (!_options.Enabled)
+        {
+            return Snapshot.Disabled;
+        }
+
+        var samples = _sampler != null ? await _sampler.StopAsync().ConfigureAwait(false) : Array.Empty<ProgressSample>();
+        var commandCount = _commands?.Stop() ?? 0;
+        _activity?.SetTag("samples", samples.Length);
+        _activity?.SetTag("npgsql.commands", commandCount);
+        _activity?.Stop();
+
+        return new Snapshot(
+            Enabled: true,
+            Samples: samples,
+            NpgsqlCommandCount: commandCount,
+            Throughput: ThroughputPercentiles.From(samples));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Idempotent disposal so the using/await-using pattern works even when CaptureAsync was
+        // already called explicitly by the command.
+        if (_sampler != null)
+        {
+            await _sampler.DisposeAsync().ConfigureAwait(false);
+        }
+        _commands?.Dispose();
+        _activity?.Dispose();
+    }
+
+    /// <summary>Result shape emitted into <c>metrics.json</c> under <c>"instrumentation"</c>.</summary>
+    public sealed record Snapshot(
+        bool Enabled,
+        IReadOnlyList<ProgressSample> Samples,
+        long NpgsqlCommandCount,
+        ThroughputPercentiles Throughput)
+    {
+        public static Snapshot Disabled { get; } =
+            new(false, Array.Empty<ProgressSample>(), 0, ThroughputPercentiles.Empty);
+    }
+}
+
+/// <summary>
+/// One progress sample: where progression sat at a wall-clock moment, plus the delta-events-per-second
+/// since the previous sample. <see cref="NpgsqlCommandsSinceLastSample"/> reads the
+/// <see cref="NpgsqlCommandCounter"/> at sample time, so a per-sample throughput row also carries the
+/// matching round-trip count.
+/// </summary>
+public sealed record ProgressSample(
+    DateTimeOffset Timestamp,
+    long SequenceId,
+    long DeltaSequenceId,
+    double EventsPerSecondSinceLastSample,
+    long NpgsqlCommandsSinceLastSample);
+
+/// <summary>
+/// Throughput percentiles computed from a finished rebuild's <see cref="ProgressSample"/> series.
+/// Excludes the cold-start sample (delta is total processed at first poll) so the p50/p95/p99
+/// reflect steady-state rather than the first-tick artifact.
+/// </summary>
+public sealed record ThroughputPercentiles(double P50, double P95, double P99, double Mean, double Max)
+{
+    public static ThroughputPercentiles Empty { get; } = new(0, 0, 0, 0, 0);
+
+    public static ThroughputPercentiles From(IReadOnlyList<ProgressSample> samples)
+    {
+        if (samples.Count < 2)
+        {
+            return Empty;
+        }
+
+        // Drop the first sample -- its delta is the whole "from zero to first poll" total, not a
+        // representative steady-state tick.
+        var rates = samples
+            .Skip(1)
+            .Where(s => s.EventsPerSecondSinceLastSample > 0)
+            .Select(s => s.EventsPerSecondSinceLastSample)
+            .OrderBy(r => r)
+            .ToArray();
+
+        if (rates.Length == 0)
+        {
+            return Empty;
+        }
+
+        return new ThroughputPercentiles(
+            P50: Percentile(rates, 0.50),
+            P95: Percentile(rates, 0.95),
+            P99: Percentile(rates, 0.99),
+            Mean: rates.Average(),
+            Max: rates[^1]);
+    }
+
+    private static double Percentile(IReadOnlyList<double> sorted, double q)
+    {
+        // Nearest-rank percentile -- a small-N-friendly definition that doesn't interpolate. For
+        // the harness rate-sample volumes (a few thousand at most) interpolation noise isn't worth
+        // the algorithmic complexity.
+        var rank = (int)Math.Ceiling(q * sorted.Count);
+        var idx = Math.Clamp(rank - 1, 0, sorted.Count - 1);
+        return sorted[idx];
+    }
+}

--- a/src/Marten.ScaleTesting/README.md
+++ b/src/Marten.ScaleTesting/README.md
@@ -33,13 +33,54 @@ Override with the `marten_testing_database` env var.
 | `Domain/` | TeleHealth events / aggregates / reference data **lifted** (copied) from `src/DaemonTests/TeleHealth/`. Self-contained so we can extend without touching test fixtures. |
 | `Seeding/` | Producer-consumer event seeder: per-stream `IEnumerable<EventBatch>` generators, weighted-random k-way merge, `Channel<EventBatch>` pipeline. |
 | `Commands/` | JasperFx.CommandLine subcommands. Modelled on `src/EventAppenderPerfTester/`. |
+| `Instrumentation/` | `--instrument`-gated rebuild observability (#4684 Phase E.1) — `RebuildInstrumentation`, `ProgressSampler`, `NpgsqlCommandCounter`. No-op when off, zero overhead. |
 
 ## Phases
 
-* **Phase A (this PR):** project scaffold + lifted Telehealth domain + event seeder + `seed` subcommand. Idempotent via `mt_events` row count check.
+* **Phase A:** project scaffold + lifted Telehealth domain + event seeder + `seed` subcommand. Idempotent via `mt_events` row count check.
 * **Phase B:** 4+2+2 composite topology (stage 1: single-stream snapshots + `AppointmentMetricsProjection`; stage 2: `AppointmentDetailsProjection` + `BoardSummaryProjection`; stage 3: NEW `ProviderUtilizationProjection` + `TenantDailyRollupProjection`) + `rebuild` subcommand on the single-pass `CompositeReplayExecutor` path.
 * **Phase C:** `validate` (single-shard baseline diff) + `stress` (chain `seed` + `rebuild` + `validate`) + JSON metrics sink.
 * **Phase D:** use it. Drive the daemon-thread-safety fixes against the harness — each fix should hold the crash gate AND not regress rebuild time.
+* **Phase E.1 (this PR):** per-period throughput sampling + Npgsql round-trip counting via `--instrument`. Surfaces p50/p95/p99/max throughput + total command count in the console summary and `--metrics` JSON; per-sample CSV trace under `--instrument-trace`. Out of scope and pinned as follow-ups (need JasperFx-side or core-Marten hooks that don't exist yet): per-batch wall-clock breakdown, per-stage composite timing, RecentlyUsedCache hit/miss, lookup-count per `EvolveAsync`, progression-lock wait time.
+
+## Measuring a rebuild
+
+Add `--instrument` to either subcommand to enable per-period sampling against `mt_event_progression` and Npgsql round-trip counting. Default 1s sample interval; tune with `--instrument-sample-seconds`. The console summary picks up four extra rows (p50 / p95 / max throughput, total Npgsql commands, sample count). `--metrics <path>` writes a JSON file with the rolled-up percentiles; `--instrument-trace <path>` adds per-sample CSV.
+
+```bash
+# Instrumented rebuild against existing seeded data, JSON + CSV output
+dotnet run --project src/Marten.ScaleTesting -- rebuild \
+    --instrument \
+    --instrument-sample-seconds 1.0 \
+    --instrument-trace rebuild-trace.csv \
+    --metrics rebuild-metrics.json
+
+# Chained stress run with instrumentation on the rebuild phase only
+dotnet run --project src/Marten.ScaleTesting -- stress \
+    --wipe --tenants 50 --events-per-tenant 400000 --writers 8 \
+    --shard-timeout-seconds 3600 --baseline scaletest-baseline.json \
+    --instrument --instrument-trace stress-trace.csv
+```
+
+`metrics.json` shape:
+
+```json
+{
+  "projection": "rebuild",
+  "events": 22610,
+  "streams": 2980,
+  "elapsedSeconds": 2.6,
+  "throughputEventsPerSecond": 8685,
+  "instrumentation": {
+    "enabled": true,
+    "sampleCount": 6,
+    "npgsqlCommandCount": 3876,
+    "throughput": { "P50": 9986, "P95": 10965, "P99": 10965, "Mean": 8972, "Max": 10965 }
+  }
+}
+```
+
+Without `--instrument` the sampler / counter / activity are not constructed at all -- a measured rebuild has no perceptible overhead and the JSON section reads `"enabled": false` with zeroed totals.
 
 ## Non-goals
 


### PR DESCRIPTION
First slice of the Phase E instrumentation tracked in [#4684](https://github.com/JasperFx/marten/issues/4684). The parent issue lists six items; this PR ships the ones that can be done from the harness side without core observability hooks. Items needing JasperFx-side or Marten-core hooks (per-batch wall-clock, per-stage composite timing, RecentlyUsedCache hit/miss, lookup-count per `EvolveAsync`, progression-lock wait) are scoped as Phase E.2–E.4 follow-ups so each PR stays focused.

## What ships

| File | Role |
|---|---|
| `Instrumentation/RebuildInstrumentation.cs` | Orchestrator. Owns the Activity span, progress sampler, and command counter for one rebuild. Null-object when `--instrument` is off. |
| `Instrumentation/ProgressSampler.cs` | Background poll loop against `mt_event_progression` every `--instrument-sample-seconds` (default 1s). Computes events/sec since the last sample + matching Npgsql command delta. Best-effort. |
| `Instrumentation/NpgsqlCommandCounter.cs` | ActivityListener on the `Npgsql` source. One Activity per command, skips OpenConnection / CloseConnection spans. (A Meter-based histogram listener sums durations, not counts -- wrong primitive.) |
| `Instrumentation/InstrumentationOptions.cs` | Toggles. |
| `Commands/{Rebuild,Stress}Input.cs` | New flags: `--instrument`, `--instrument-trace`, `--instrument-sample-seconds`, `--metrics`. `--instrument-trace` implies `--instrument`. |
| `Commands/RebuildCommand.cs` | Writes slim JSON metrics file; adds 4 console rows (p50 / p95 / max throughput, Npgsql command total, sample count) when on. |
| `Commands/StressCommand.cs` | Instruments the rebuild phase only (seed has its own per-batch reporting). Crashes still capture whatever the sampler observed for post-mortem. |
| `src/Marten.ScaleTesting/README.md` | New \"Measuring a rebuild\" section + `metrics.json` shape. |

## Verification

Smoke at 22.6k events (4 tenants × 5k events × 4 writers):

| Aspect | Result |
|---|---|
| `--instrument` on, rebuild console | 4 extra rows below the standard summary (p50 9,947, p95 11,965, max 11,965, 3,876 pg cmds, 6 samples) |
| `--metrics out.json` | slim JSON with throughput percentiles + command total + sample count (no per-sample bloat) |
| `--instrument-trace out.csv` | 6 rows per ~3s rebuild at 0.5s interval, sensible deltas |
| `--instrument` off (default) | no extra console rows, no JSON written, no Activity / counter / sampler constructed -- true no-op |

End-to-end metrics from the smoke: 9,720 events/sec end-to-end, p50 9,947, p95 11,965, **3,876 Npgsql commands total**. Trace CSV deltas line up with the progression-row advance.

> **Caveat:** `CompositeReplayExecutor` flushes progression writes in batches that lag the actual scan position, so the per-sample rate reads ~half of true steady-state -- documented in the README, same artifact Phase D's external monitor saw. Surfacing true per-batch wall-clock is part of the E.2-E.4 follow-ups that need JasperFx-side hooks.

## Phase E.2-E.4 follow-ups (separate PRs)

* **E.2** -- `pg_stat_activity`-based wait-time sampler for `mt_event_progression` contention. Marten-side, no core changes.
* **E.3** -- `RecentlyUsedCache` hit/miss counters. Requires a JasperFx-side instrumentation hook on `RecentlyUsedCache<TId, TDoc>`; will need a jasperfx PR + Marten consumption.
* **E.4** -- Per-`EvolveAsync` lookup count. Requires wrapping `IDocumentOperations` query/load calls inside projection user-code; needs core Marten hook or a JasperFx-side hook on `SliceGroup`.

Parent #4684 stays open until E.2-E.4 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)