### PR TITLE
#4684 Phase E.2 — progression lock-wait sampler

### DIFF
--- a/src/Marten.ScaleTesting/Commands/RebuildCommand.cs
+++ b/src/Marten.ScaleTesting/Commands/RebuildCommand.cs
@@ -74,6 +74,10 @@ public sealed class RebuildCommand: JasperFxAsyncCommand<RebuildInput>
             table.AddRow("Throughput max (events/sec)", snapshot.Throughput.Max.ToString("N0"));
             table.AddRow("Npgsql commands total", snapshot.NpgsqlCommandCount.ToString("N0"));
             table.AddRow("Progress samples", snapshot.Samples.Count.ToString("N0"));
+            var lw = snapshot.ProgressionLockWaits;
+            table.AddRow("Progression max waiters", lw.MaxConcurrentWaiters.ToString("N0"));
+            table.AddRow("Progression max single-wait (ms)", lw.MaxSingleWaitMs.ToString("N0"));
+            table.AddRow("Progression observed waiter-seconds", lw.ObservedWaiterSeconds.ToString("N1"));
         }
         AnsiConsole.Write(table);
 
@@ -84,13 +88,17 @@ public sealed class RebuildCommand: JasperFxAsyncCommand<RebuildInput>
 
     private static InstrumentationOptions BuildInstrumentationOptions(RebuildInput input)
     {
-        // --instrument-trace implies --instrument so users don't have to remember both flags.
-        var enabled = input.InstrumentFlag || !string.IsNullOrWhiteSpace(input.InstrumentTraceFlag);
+        // --instrument-trace and --instrument-lock-trace both imply --instrument so users don't
+        // have to remember the master toggle separately.
+        var enabled = input.InstrumentFlag
+            || !string.IsNullOrWhiteSpace(input.InstrumentTraceFlag)
+            || !string.IsNullOrWhiteSpace(input.InstrumentLockTraceFlag);
         return new InstrumentationOptions
         {
             Enabled = enabled,
             ProgressSampleInterval = TimeSpan.FromSeconds(Math.Max(0.1, input.InstrumentSampleSecondsFlag)),
-            TracePath = string.IsNullOrWhiteSpace(input.InstrumentTraceFlag) ? null : input.InstrumentTraceFlag
+            TracePath = string.IsNullOrWhiteSpace(input.InstrumentTraceFlag) ? null : input.InstrumentTraceFlag,
+            LockTracePath = string.IsNullOrWhiteSpace(input.InstrumentLockTraceFlag) ? null : input.InstrumentLockTraceFlag
         };
     }
 
@@ -118,7 +126,8 @@ public sealed class RebuildCommand: JasperFxAsyncCommand<RebuildInput>
                 enabled = snapshot.Enabled,
                 sampleCount = snapshot.Samples.Count,
                 npgsqlCommandCount = snapshot.NpgsqlCommandCount,
-                throughput = snapshot.Throughput
+                throughput = snapshot.Throughput,
+                progressionLockWaits = snapshot.ProgressionLockWaits
             }
         };
         await File.WriteAllTextAsync(path,

--- a/src/Marten.ScaleTesting/Commands/RebuildInput.cs
+++ b/src/Marten.ScaleTesting/Commands/RebuildInput.cs
@@ -17,6 +17,9 @@ public sealed class RebuildInput: NetCoreInput
     [Description("Optional CSV trace path. Implies --instrument. One row per progress sample: timestamp, sequence_id, delta, events_per_second, npgsql_commands_in_interval.")]
     public string? InstrumentTraceFlag { get; set; }
 
+    [Description("Optional CSV trace path for the progression lock-wait sampler (#4684 Phase E.2). One row per sample: timestamp, current waiter count on mt_event_progression, max single-waiter wait in ms. Implies --instrument.")]
+    public string? InstrumentLockTraceFlag { get; set; }
+
     [Description("Sample interval for the progression poller when --instrument is on. Default 1s. Lower for finer-grained percentiles; raise to keep harness overhead negligible on multi-hour runs.")]
     public double InstrumentSampleSecondsFlag { get; set; } = 1.0;
 

--- a/src/Marten.ScaleTesting/Commands/StressCommand.cs
+++ b/src/Marten.ScaleTesting/Commands/StressCommand.cs
@@ -104,7 +104,10 @@ public sealed class StressCommand: JasperFxAsyncCommand<StressInput>
         var rebuildNote = $"{rebuildEventCount:N0} events @ {rate:N0}/sec";
         if (rebuildSnapshot.Enabled)
         {
-            rebuildNote += $" (p50 {rebuildSnapshot.Throughput.P50:N0}, p95 {rebuildSnapshot.Throughput.P95:N0}, {rebuildSnapshot.NpgsqlCommandCount:N0} pg cmds)";
+            var lw = rebuildSnapshot.ProgressionLockWaits;
+            rebuildNote += $" (p50 {rebuildSnapshot.Throughput.P50:N0}, p95 {rebuildSnapshot.Throughput.P95:N0}, "
+                + $"{rebuildSnapshot.NpgsqlCommandCount:N0} pg cmds, "
+                + $"lock max-waiters {lw.MaxConcurrentWaiters}, waiter-sec {lw.ObservedWaiterSeconds:N1})";
         }
         summary.Add(("rebuild", "OK", rebuildSw.Elapsed, rebuildNote));
 
@@ -177,12 +180,15 @@ public sealed class StressCommand: JasperFxAsyncCommand<StressInput>
 
     private static InstrumentationOptions BuildInstrumentationOptions(StressInput input)
     {
-        var enabled = input.InstrumentFlag || !string.IsNullOrWhiteSpace(input.InstrumentTraceFlag);
+        var enabled = input.InstrumentFlag
+            || !string.IsNullOrWhiteSpace(input.InstrumentTraceFlag)
+            || !string.IsNullOrWhiteSpace(input.InstrumentLockTraceFlag);
         return new InstrumentationOptions
         {
             Enabled = enabled,
             ProgressSampleInterval = TimeSpan.FromSeconds(Math.Max(0.1, input.InstrumentSampleSecondsFlag)),
-            TracePath = string.IsNullOrWhiteSpace(input.InstrumentTraceFlag) ? null : input.InstrumentTraceFlag
+            TracePath = string.IsNullOrWhiteSpace(input.InstrumentTraceFlag) ? null : input.InstrumentTraceFlag,
+            LockTracePath = string.IsNullOrWhiteSpace(input.InstrumentLockTraceFlag) ? null : input.InstrumentLockTraceFlag
         };
     }
 

--- a/src/Marten.ScaleTesting/Commands/StressInput.cs
+++ b/src/Marten.ScaleTesting/Commands/StressInput.cs
@@ -55,6 +55,9 @@ public sealed class StressInput: NetCoreInput
     [Description("Optional CSV trace path. Implies --instrument. One row per progress sample: timestamp, sequence_id, delta, events_per_second, npgsql_commands_in_interval.")]
     public string? InstrumentTraceFlag { get; set; }
 
+    [Description("Optional CSV trace path for the progression lock-wait sampler (#4684 Phase E.2). One row per sample: timestamp, current waiter count, max single-waiter wait in ms. Implies --instrument.")]
+    public string? InstrumentLockTraceFlag { get; set; }
+
     [Description("Sample interval for the progression poller when --instrument is on. Default 1s.")]
     public double InstrumentSampleSecondsFlag { get; set; } = 1.0;
 

--- a/src/Marten.ScaleTesting/Instrumentation/InstrumentationOptions.cs
+++ b/src/Marten.ScaleTesting/Instrumentation/InstrumentationOptions.cs
@@ -21,4 +21,11 @@ public sealed class InstrumentationOptions
     /// Set via <c>--instrument-trace &lt;path&gt;</c>. When null, only the rolled-up JSON
     /// metrics are written.</summary>
     public string? TracePath { get; init; }
+
+    /// <summary>Optional CSV trace path for the per-sample progression-lock-wait series
+    /// (#4684 Phase E.2). One row per sample: timestamp, current waiter count on
+    /// <c>mt_event_progression</c>, max single-waiter wait in ms. Set via
+    /// <c>--instrument-lock-trace &lt;path&gt;</c>; when null, only the rolled-up stats
+    /// land in <c>metrics.json</c>.</summary>
+    public string? LockTracePath { get; init; }
 }

--- a/src/Marten.ScaleTesting/Instrumentation/ProgressionLockSampler.cs
+++ b/src/Marten.ScaleTesting/Instrumentation/ProgressionLockSampler.cs
@@ -1,0 +1,193 @@
+using System.Globalization;
+using Npgsql;
+
+namespace Marten.ScaleTesting.Instrumentation;
+
+/// <summary>
+/// Background poll loop that snapshots <c>pg_stat_activity</c> + <c>pg_locks</c> to estimate
+/// row-level lock contention on <c>mt_event_progression</c> during a rebuild (#4684 Phase E.2,
+/// item 5 of the issue). PostgreSQL doesn't expose cumulative per-row lock-wait history --
+/// <c>pg_stat_activity</c> shows the *current* wait of each session -- so we approximate by
+/// sampling at <see cref="InstrumentationOptions.ProgressSampleInterval"/> and treating each
+/// observed waiter as having waited for roughly the interval. Sum across samples gives an
+/// observed-waiter-seconds estimate; max across samples gives peak contention.
+///
+/// Filters out the sampler's own session via <c>pid != pg_backend_pid()</c> so we don't see
+/// ourselves; only sessions in <c>state = 'active'</c> with a non-null
+/// <c>wait_event_type</c> are counted, and only when they hold an *ungranted* lock on the
+/// <c>mt_event_progression</c> relation (joined through <c>pg_locks</c>).
+/// </summary>
+internal sealed class ProgressionLockSampler : IAsyncDisposable
+{
+    private const string SqlText = @"
+SELECT
+    count(*) AS waiter_count,
+    coalesce(max(extract(epoch from (now() - a.state_change)) * 1000), 0)::bigint AS max_wait_ms
+FROM pg_stat_activity a
+WHERE a.state = 'active'
+  AND a.wait_event_type IS NOT NULL
+  AND a.pid != pg_backend_pid()
+  AND EXISTS (
+      SELECT 1 FROM pg_locks l
+      JOIN pg_class c ON c.oid = l.relation
+      WHERE l.pid = a.pid
+        AND c.relname = 'mt_event_progression'
+        AND l.granted = false
+  );";
+
+    private readonly string _connectionString;
+    private readonly TimeSpan _interval;
+    private readonly string? _tracePath;
+    private readonly CancellationTokenSource _cts;
+    private readonly Task _loop;
+    private readonly List<LockSample> _samples = new();
+    private readonly StreamWriter? _traceWriter;
+
+    private ProgressionLockSampler(string connectionString, TimeSpan interval,
+        string? tracePath, CancellationToken outerCancellation)
+    {
+        _connectionString = connectionString;
+        _interval = interval;
+        _tracePath = tracePath;
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(outerCancellation);
+        if (tracePath != null)
+        {
+            _traceWriter = new StreamWriter(tracePath, append: false);
+            _traceWriter.WriteLine("timestamp,waiter_count,max_wait_ms");
+        }
+        _loop = Task.Run(LoopAsync, CancellationToken.None);
+    }
+
+    public static ProgressionLockSampler Start(string connectionString, TimeSpan interval,
+        string? tracePath, CancellationToken cancellation)
+        => new(connectionString, interval, tracePath, cancellation);
+
+    private async Task LoopAsync()
+    {
+        try
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                try
+                {
+                    await SampleOnceAsync().ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception)
+                {
+                    // Best effort -- a transient blip should not crash the rebuild. Sampling missed
+                    // ticks would slightly under-report; safer than crashing.
+                }
+
+                try
+                {
+                    await Task.Delay(_interval, _cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            try { await SampleOnceAsync().ConfigureAwait(false); } catch { /* best effort */ }
+        }
+    }
+
+    private async Task SampleOnceAsync()
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync(_cts.Token).ConfigureAwait(false);
+        await using var cmd = new NpgsqlCommand(SqlText, conn);
+        await using var reader = await cmd.ExecuteReaderAsync(_cts.Token).ConfigureAwait(false);
+
+        var waiterCount = 0L;
+        var maxWaitMs = 0L;
+        if (await reader.ReadAsync(_cts.Token).ConfigureAwait(false))
+        {
+            waiterCount = await reader.GetFieldValueAsync<long>(0, _cts.Token).ConfigureAwait(false);
+            maxWaitMs = await reader.GetFieldValueAsync<long>(1, _cts.Token).ConfigureAwait(false);
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var sample = new LockSample(now, waiterCount, maxWaitMs);
+        lock (_samples)
+        {
+            _samples.Add(sample);
+        }
+
+        if (_traceWriter != null)
+        {
+            lock (_traceWriter)
+            {
+                _traceWriter.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                    "{0:O},{1},{2}", now.UtcDateTime, waiterCount, maxWaitMs));
+                _traceWriter.Flush();
+            }
+        }
+    }
+
+    public async Task<LockWaitStats> StopAsync()
+    {
+        _cts.Cancel();
+        try { await _loop.ConfigureAwait(false); } catch { /* shutdown */ }
+        _traceWriter?.Dispose();
+        LockSample[] samples;
+        lock (_samples)
+        {
+            samples = _samples.ToArray();
+        }
+        return LockWaitStats.From(samples, _interval);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!_cts.IsCancellationRequested)
+        {
+            await StopAsync().ConfigureAwait(false);
+        }
+        _cts.Dispose();
+    }
+}
+
+/// <summary>One snapshot of progression lock contention.</summary>
+internal sealed record LockSample(DateTimeOffset Timestamp, long WaiterCount, long MaxWaitMs);
+
+/// <summary>
+/// Rolled-up lock contention stats across a rebuild. <see cref="ObservedWaiterSeconds"/> is the
+/// approximation: <c>sum(waiter_count_at_sample) * sample_interval_seconds</c>. A large value
+/// signals frequent or long contention; zero means no UPDATE on the progression row ever waited
+/// on a lock during the run (the common case once concurrent-rebuild caps are tuned).
+/// </summary>
+public sealed record LockWaitStats(
+    int SampleCount,
+    long MaxConcurrentWaiters,
+    long MaxSingleWaitMs,
+    double ObservedWaiterSeconds)
+{
+    public static LockWaitStats Empty { get; } = new(0, 0, 0, 0);
+
+    internal static LockWaitStats From(IReadOnlyList<LockSample> samples, TimeSpan interval)
+    {
+        if (samples.Count == 0)
+        {
+            return Empty;
+        }
+
+        long maxWaiters = 0;
+        long maxWaitMs = 0;
+        long totalWaiterTicks = 0; // sum of waiter_count, weighted later by interval seconds
+        foreach (var s in samples)
+        {
+            if (s.WaiterCount > maxWaiters) maxWaiters = s.WaiterCount;
+            if (s.MaxWaitMs > maxWaitMs) maxWaitMs = s.MaxWaitMs;
+            totalWaiterTicks += s.WaiterCount;
+        }
+        var observedWaiterSeconds = totalWaiterTicks * interval.TotalSeconds;
+        return new LockWaitStats(samples.Count, maxWaiters, maxWaitMs, observedWaiterSeconds);
+    }
+}

--- a/src/Marten.ScaleTesting/Instrumentation/RebuildInstrumentation.cs
+++ b/src/Marten.ScaleTesting/Instrumentation/RebuildInstrumentation.cs
@@ -16,15 +16,17 @@ public sealed class RebuildInstrumentation : IAsyncDisposable
     private readonly InstrumentationOptions _options;
     private readonly ProgressSampler? _sampler;
     private readonly NpgsqlCommandCounter? _commands;
+    private readonly ProgressionLockSampler? _lockSampler;
     private readonly Activity? _activity;
     private static readonly ActivitySource s_activitySource = new("Marten.ScaleTesting", "1.0");
 
     private RebuildInstrumentation(InstrumentationOptions options, ProgressSampler? sampler,
-        NpgsqlCommandCounter? commands, Activity? activity)
+        NpgsqlCommandCounter? commands, ProgressionLockSampler? lockSampler, Activity? activity)
     {
         _options = options;
         _sampler = sampler;
         _commands = commands;
+        _lockSampler = lockSampler;
         _activity = activity;
     }
 
@@ -42,7 +44,7 @@ public sealed class RebuildInstrumentation : IAsyncDisposable
     {
         if (!options.Enabled)
         {
-            return new RebuildInstrumentation(options, null, null, null);
+            return new RebuildInstrumentation(options, null, null, null, null);
         }
 
         var activity = s_activitySource.StartActivity("scaletest.rebuild", ActivityKind.Internal);
@@ -53,8 +55,10 @@ public sealed class RebuildInstrumentation : IAsyncDisposable
         var sampler = ProgressSampler.Start(
             connectionString, schemaName, progressionRowName, options.ProgressSampleInterval,
             commands, options.TracePath, cancellation);
+        var lockSampler = ProgressionLockSampler.Start(
+            connectionString, options.ProgressSampleInterval, options.LockTracePath, cancellation);
 
-        return new RebuildInstrumentation(options, sampler, commands, activity);
+        return new RebuildInstrumentation(options, sampler, commands, lockSampler, activity);
     }
 
     /// <summary>
@@ -69,15 +73,19 @@ public sealed class RebuildInstrumentation : IAsyncDisposable
 
         var samples = _sampler != null ? await _sampler.StopAsync().ConfigureAwait(false) : Array.Empty<ProgressSample>();
         var commandCount = _commands?.Stop() ?? 0;
+        var lockWait = _lockSampler != null ? await _lockSampler.StopAsync().ConfigureAwait(false) : LockWaitStats.Empty;
         _activity?.SetTag("samples", samples.Length);
         _activity?.SetTag("npgsql.commands", commandCount);
+        _activity?.SetTag("progression.max_waiters", lockWait.MaxConcurrentWaiters);
+        _activity?.SetTag("progression.observed_waiter_seconds", lockWait.ObservedWaiterSeconds);
         _activity?.Stop();
 
         return new Snapshot(
             Enabled: true,
             Samples: samples,
             NpgsqlCommandCount: commandCount,
-            Throughput: ThroughputPercentiles.From(samples));
+            Throughput: ThroughputPercentiles.From(samples),
+            ProgressionLockWaits: lockWait);
     }
 
     public async ValueTask DisposeAsync()
@@ -88,6 +96,10 @@ public sealed class RebuildInstrumentation : IAsyncDisposable
         {
             await _sampler.DisposeAsync().ConfigureAwait(false);
         }
+        if (_lockSampler != null)
+        {
+            await _lockSampler.DisposeAsync().ConfigureAwait(false);
+        }
         _commands?.Dispose();
         _activity?.Dispose();
     }
@@ -97,10 +109,11 @@ public sealed class RebuildInstrumentation : IAsyncDisposable
         bool Enabled,
         IReadOnlyList<ProgressSample> Samples,
         long NpgsqlCommandCount,
-        ThroughputPercentiles Throughput)
+        ThroughputPercentiles Throughput,
+        LockWaitStats ProgressionLockWaits)
     {
         public static Snapshot Disabled { get; } =
-            new(false, Array.Empty<ProgressSample>(), 0, ThroughputPercentiles.Empty);
+            new(false, Array.Empty<ProgressSample>(), 0, ThroughputPercentiles.Empty, LockWaitStats.Empty);
     }
 }
 

--- a/src/Marten.ScaleTesting/README.md
+++ b/src/Marten.ScaleTesting/README.md
@@ -33,7 +33,7 @@ Override with the `marten_testing_database` env var.
 | `Domain/` | TeleHealth events / aggregates / reference data **lifted** (copied) from `src/DaemonTests/TeleHealth/`. Self-contained so we can extend without touching test fixtures. |
 | `Seeding/` | Producer-consumer event seeder: per-stream `IEnumerable<EventBatch>` generators, weighted-random k-way merge, `Channel<EventBatch>` pipeline. |
 | `Commands/` | JasperFx.CommandLine subcommands. Modelled on `src/EventAppenderPerfTester/`. |
-| `Instrumentation/` | `--instrument`-gated rebuild observability (#4684 Phase E.1) — `RebuildInstrumentation`, `ProgressSampler`, `NpgsqlCommandCounter`. No-op when off, zero overhead. |
+| `Instrumentation/` | `--instrument`-gated rebuild observability (#4684 Phase E.1+E.2) — `RebuildInstrumentation`, `ProgressSampler`, `NpgsqlCommandCounter`, `ProgressionLockSampler`. No-op when off, zero overhead. |
 
 ## Phases
 
@@ -41,11 +41,12 @@ Override with the `marten_testing_database` env var.
 * **Phase B:** 4+2+2 composite topology (stage 1: single-stream snapshots + `AppointmentMetricsProjection`; stage 2: `AppointmentDetailsProjection` + `BoardSummaryProjection`; stage 3: NEW `ProviderUtilizationProjection` + `TenantDailyRollupProjection`) + `rebuild` subcommand on the single-pass `CompositeReplayExecutor` path.
 * **Phase C:** `validate` (single-shard baseline diff) + `stress` (chain `seed` + `rebuild` + `validate`) + JSON metrics sink.
 * **Phase D:** use it. Drive the daemon-thread-safety fixes against the harness — each fix should hold the crash gate AND not regress rebuild time.
-* **Phase E.1 (this PR):** per-period throughput sampling + Npgsql round-trip counting via `--instrument`. Surfaces p50/p95/p99/max throughput + total command count in the console summary and `--metrics` JSON; per-sample CSV trace under `--instrument-trace`. Out of scope and pinned as follow-ups (need JasperFx-side or core-Marten hooks that don't exist yet): per-batch wall-clock breakdown, per-stage composite timing, RecentlyUsedCache hit/miss, lookup-count per `EvolveAsync`, progression-lock wait time.
+* **Phase E.1:** per-period throughput sampling + Npgsql round-trip counting via `--instrument`. Surfaces p50/p95/p99/max throughput + total command count in the console summary and `--metrics` JSON; per-sample CSV trace under `--instrument-trace`.
+* **Phase E.2 (this PR):** progression-row lock-wait sampler. `pg_stat_activity` joined to `pg_locks` at each interval, counting ungranted lock holders on `mt_event_progression` that aren't our own session. Surfaces `MaxConcurrentWaiters`, `MaxSingleWaitMs`, and the approximation `ObservedWaiterSeconds = sum(waiter_count_per_sample) * sample_interval`. Per-sample CSV trace under `--instrument-lock-trace`. Out of scope and pinned as Phase E.3-E.4 follow-ups (need JasperFx-side hooks that don't exist yet): per-batch wall-clock breakdown, per-stage composite timing, `RecentlyUsedCache` hit/miss, lookup-count per `EvolveAsync`.
 
 ## Measuring a rebuild
 
-Add `--instrument` to either subcommand to enable per-period sampling against `mt_event_progression` and Npgsql round-trip counting. Default 1s sample interval; tune with `--instrument-sample-seconds`. The console summary picks up four extra rows (p50 / p95 / max throughput, total Npgsql commands, sample count). `--metrics <path>` writes a JSON file with the rolled-up percentiles; `--instrument-trace <path>` adds per-sample CSV.
+Add `--instrument` to either subcommand to enable per-period sampling against `mt_event_progression`, Npgsql round-trip counting, and (E.2) `pg_stat_activity`-based progression lock-wait sampling. Default 1s sample interval; tune with `--instrument-sample-seconds`. The console summary picks up seven extra rows (throughput percentiles + total Npgsql commands + sample count + three lock-wait counters). `--metrics <path>` writes a JSON file with the rolled-up percentiles + lock-wait stats; `--instrument-trace <path>` adds per-sample progress CSV; `--instrument-lock-trace <path>` adds per-sample lock-wait CSV.
 
 ```bash
 # Instrumented rebuild against existing seeded data, JSON + CSV output
@@ -53,13 +54,15 @@ dotnet run --project src/Marten.ScaleTesting -- rebuild \
     --instrument \
     --instrument-sample-seconds 1.0 \
     --instrument-trace rebuild-trace.csv \
+    --instrument-lock-trace rebuild-lock-trace.csv \
     --metrics rebuild-metrics.json
 
 # Chained stress run with instrumentation on the rebuild phase only
 dotnet run --project src/Marten.ScaleTesting -- stress \
     --wipe --tenants 50 --events-per-tenant 400000 --writers 8 \
     --shard-timeout-seconds 3600 --baseline scaletest-baseline.json \
-    --instrument --instrument-trace stress-trace.csv
+    --instrument --instrument-trace stress-trace.csv \
+    --instrument-lock-trace stress-lock-trace.csv
 ```
 
 `metrics.json` shape:
@@ -75,12 +78,20 @@ dotnet run --project src/Marten.ScaleTesting -- stress \
     "enabled": true,
     "sampleCount": 6,
     "npgsqlCommandCount": 3876,
-    "throughput": { "P50": 9986, "P95": 10965, "P99": 10965, "Mean": 8972, "Max": 10965 }
+    "throughput": { "P50": 9986, "P95": 10965, "P99": 10965, "Mean": 8972, "Max": 10965 },
+    "progressionLockWaits": {
+      "SampleCount": 6,
+      "MaxConcurrentWaiters": 0,
+      "MaxSingleWaitMs": 0,
+      "ObservedWaiterSeconds": 0.0
+    }
   }
 }
 ```
 
-Without `--instrument` the sampler / counter / activity are not constructed at all -- a measured rebuild has no perceptible overhead and the JSON section reads `"enabled": false` with zeroed totals.
+`progressionLockWaits.ObservedWaiterSeconds` is the approximation `sum(waiter_count_per_sample) * sample_interval_seconds` — zero means no rebuild ever found a contended waiter on the progression row at sample time; a non-zero number signals the new concurrent-rebuild cap (jasperfx#420 in 2.9.0) is being exercised or that something outside the daemon is racing the same row.
+
+Without `--instrument` the samplers / counter / activity are not constructed at all -- a measured rebuild has no perceptible overhead and the JSON section reads `"enabled": false` with zeroed totals.
 
 ## Non-goals
 


### PR DESCRIPTION
Second slice of [#4684](https://github.com/JasperFx/marten/issues/4684) (item 5 of the parent spec). Marten-side only, no core hooks needed.

## Why

PostgreSQL doesn't expose cumulative per-row lock-wait history -- `pg_stat_activity` shows the *current* wait of each session. The sampler approximates by polling at the existing `--instrument-sample-seconds` cadence and counting ungranted lock holders on `mt_event_progression` that aren't our own session:

```sql
WHERE a.state = 'active'
  AND a.wait_event_type IS NOT NULL
  AND a.pid != pg_backend_pid()
  AND EXISTS (
      SELECT 1 FROM pg_locks l
      JOIN pg_class c ON c.oid = l.relation
      WHERE l.pid = a.pid
        AND c.relname = 'mt_event_progression'
        AND l.granted = false)
```

Per-sample `(timestamp, waiter_count, max_wait_ms)` rolls up at end-of-run to three numbers:

| Metric | Meaning |
|---|---|
| `MaxConcurrentWaiters` | Peak count of ungranted lock holders observed in any single sample |
| `MaxSingleWaitMs` | Longest wait observed in any single sample |
| `ObservedWaiterSeconds` | `sum(waiter_count_per_sample) * sample_interval` -- approximation of cumulative time spent waiting |

Zero across all three signals no contention; non-zero signals the new concurrent-rebuild cap ([jasperfx#420](https://github.com/JasperFx/jasperfx/pull/420) in 2.9.0) is being exercised, or that something outside the daemon is racing the row.

## What ships

| File | Role |
|---|---|
| `Instrumentation/ProgressionLockSampler.cs` | Background poll loop. Separate connection per tick (cheap, dev-tool only). Filters our own pid out so the sampler never observes itself. Best-effort: a transient blip drops a sample. |
| `Instrumentation/LockWaitStats` (record in same file) | Rolled-up summary that lands in `RebuildInstrumentation.Snapshot`. |
| `InstrumentationOptions.LockTracePath` + `--instrument-lock-trace <path>` | Per-sample CSV trace, implies `--instrument` like its sibling flag. |
| `RebuildInstrumentation` | Owns the new sampler alongside `ProgressSampler` / `NpgsqlCommandCounter`; one Activity span tags the rolled-up contention numbers. |
| `RebuildCommand` / `StressCommand` | Console output picks up three new rows; `metrics.json` grows a `\"progressionLockWaits\"` section. |
| `src/Marten.ScaleTesting/README.md` | Documents the metric, the new flag, and the interpretation. |

## Verification

Smoke at 22.5k events (4 tenants × 5k × 4 writers):

| Aspect | Result |
|---|---|
| Lock trace CSV | 6 rows at 0.5s interval, all `(0, 0)` -- no contention on a single rebuild against a fresh DB (expected). |
| Console row | `lock max-waiters 0, waiter-sec 0.0` alongside the existing E.1 throughput / pg-cmd rows. |
| `--instrument` off | True no-op -- sampler / counter / activity never constructed. |

Real non-zero readings need parallel concurrent rebuilds racing the same row; the harness is wired to report them when the situation arises rather than manufacture contention in a smoke test.

## Remaining Phase E follow-ups

* **E.3** -- `RecentlyUsedCache` hit/miss counters. Requires a JasperFx-side instrumentation hook on `RecentlyUsedCache<TId, TDoc>`.
* **E.4** -- Per-`EvolveAsync` lookup count. Requires wrapping `IDocumentOperations` query/load calls inside projection user-code; likely a JasperFx-side hook on `SliceGroup`.

Parent #4684 stays open until E.3-E.4 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)