### PR TITLE
Fix #4687 — default ExtendedProgressionEnabled to true (Critter Stack 1.0 timing)

### DIFF
--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -501,25 +501,34 @@ that just emits and update every time that Marten has to "skip" stale events.
 
 ## Extended Progression Tracking
 
-When you opt into extended progression tracking, Marten adds six monitoring
-columns (`heartbeat`, `agent_status`, `pause_reason`, `running_on_node`,
-`warning_behind_threshold`, `critical_behind_threshold`) to `mt_event_progression`
-and the async daemon writes them from runtime state. The shard-state selector
-reads them back into `ShardState` so monitoring tooling such as CritterWatch can
-display per-shard health.
+Extended progression tracking adds six monitoring columns (`heartbeat`,
+`agent_status`, `pause_reason`, `running_on_node`, `warning_behind_threshold`,
+`critical_behind_threshold`) to `mt_event_progression`. The async daemon writes
+them from existing runtime state and the shard-state selector reads them back
+into `ShardState` so monitoring tooling such as CritterWatch can display
+per-shard health.
+
+**Default: on** (#4687, Critter Stack 1.0 timing). The columns are useful for
+any stuck-shard diagnosis -- not just CritterWatch -- and the write-side cost is
+negligible because they're already-computed daemon-internal values. The next
+`ApplyAllConfiguredChangesToDatabaseAsync()` adds the columns to an existing
+database; they're nullable so no backfill is required.
+
+Opt out (e.g. you have your own monitoring story and don't want the columns)
+by setting the toggle to false explicitly:
 
 ```cs
-opts.Events.EnableExtendedProgressionTracking = true;
+opts.Events.EnableExtendedProgressionTracking = false;
 ```
 
-Marten 9.7 also implements the storage-agnostic
+Marten implements the storage-agnostic
 [`IEventStoreInstrumentation`](https://github.com/JasperFx/jasperfx/blob/main/src/JasperFx.Events/IEventStoreInstrumentation.cs)
-abstraction from JasperFx.Events 2.9.0 — `Wolverine.CritterWatch.Marten` and
-similar satellite packages flip the same toggle via the interface without
+abstraction from JasperFx.Events 2.9.0 -- `Wolverine.CritterWatch.Marten` and
+similar satellite packages can flip the same toggle via the interface without
 referencing Marten's concrete `EventGraph`:
 
 ```cs
-((IEventStoreInstrumentation)opts.Events).ExtendedProgressionEnabled = true;
+((IEventStoreInstrumentation)opts.Events).ExtendedProgressionEnabled = false;
 ```
 
 Both names refer to the same underlying field. New code is encouraged to prefer

--- a/src/CoreTests/Events/EventGraph_IEventStoreInstrumentation.cs
+++ b/src/CoreTests/Events/EventGraph_IEventStoreInstrumentation.cs
@@ -26,14 +26,42 @@ public class EventGraph_IEventStoreInstrumentation
         BuildEventGraph().ShouldBeAssignableTo<IEventStoreInstrumentation>();
     }
 
+    // #4687: default flipped from false → true (Critter Stack 1.0 timing). The six
+    // monitoring columns are written from existing daemon runtime state so the cost is
+    // negligible, and they're useful for any stuck-shard diagnosis -- not just CritterWatch.
+    // Opt-out remains via either name.
     [Fact]
-    public void default_is_disabled()
+    public void default_is_enabled()
     {
         var events = BuildEventGraph();
 
+        events.EnableExtendedProgressionTracking.ShouldBeTrue();
+        events.ExtendedProgressionEnabled.ShouldBeTrue();
+        ((IEventStoreInstrumentation)events).ExtendedProgressionEnabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void opt_out_via_legacy_name_disables_both_surfaces()
+    {
+        var events = BuildEventGraph();
+        var instrumentation = (IEventStoreInstrumentation)events;
+
+        events.EnableExtendedProgressionTracking = false;
+
+        events.ExtendedProgressionEnabled.ShouldBeFalse();
+        instrumentation.ExtendedProgressionEnabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void opt_out_via_interface_disables_both_surfaces()
+    {
+        var events = BuildEventGraph();
+        var instrumentation = (IEventStoreInstrumentation)events;
+
+        instrumentation.ExtendedProgressionEnabled = false;
+
         events.EnableExtendedProgressionTracking.ShouldBeFalse();
         events.ExtendedProgressionEnabled.ShouldBeFalse();
-        ((IEventStoreInstrumentation)events).ExtendedProgressionEnabled.ShouldBeFalse();
     }
 
     [Fact]

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -255,8 +255,15 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     /// <see cref="IEventStoreInstrumentation.ExtendedProgressionEnabled"/> -- the primary
     /// (storage-agnostic) toggle that controls extended progression tracking. Aliased by the
     /// legacy <see cref="EnableExtendedProgressionTracking"/> property.
+    /// <para>
+    /// **Default: true** (#4687, Critter Stack 1.0 timing). The six monitoring columns are
+    /// written from existing daemon runtime state, so the cost is negligible (no extra queries,
+    /// 6 nullable columns on a low-volume progression table) and they're useful for any
+    /// stuck-shard diagnosis -- not just CritterWatch. Opt out by setting this to false (or
+    /// the legacy <c>EnableExtendedProgressionTracking</c>) explicitly.
+    /// </para>
     /// </summary>
-    public bool ExtendedProgressionEnabled { get; set; }
+    public bool ExtendedProgressionEnabled { get; set; } = true;
     public bool UseArchivedStreamPartitioning { get; set; }
     public bool UseListenNotifyForEventAppends { get; set; }
 


### PR DESCRIPTION
Closes #4687. Flips the default of `EventGraph.ExtendedProgressionEnabled` (and its alias `EnableExtendedProgressionTracking`) from `false` → **`true`**.

## Why

The six monitoring columns (`heartbeat`, `agent_status`, `pause_reason`, `running_on_node`, `warning_behind_threshold`, `critical_behind_threshold`) are written from existing daemon runtime state -- no extra queries, just a few nullable columns on a low-volume progression table. They're useful for any stuck-shard diagnosis, not just CritterWatch, so flipping the default:

1. Drops the \"did you remember to set the flag?\" footgun out of the CritterWatch onboarding story.
2. Gives anyone debugging a paused projection the diagnostic info they usually need.
3. Costs essentially nothing on the hot path.

Opt-out still works via either name:

```cs
opts.Events.EnableExtendedProgressionTracking = false;
// or
((IEventStoreInstrumentation)opts.Events).ExtendedProgressionEnabled = false;
```

## Migration story

Existing databases pick up the columns on the next `ApplyAllConfiguredChangesToDatabaseAsync()`. All six are nullable, so the `ALTER TABLE` is a no-op for storage on existing rows -- no backfill needed. Verified locally against a database that had the older shape.

## Tests

The existing `EventGraph_IEventStoreInstrumentation` suite is updated:

* `default_is_disabled` → `default_is_enabled` (asserts the new `true` default)
* Two new tests pin that opt-out via either name disables both surfaces

| Project | Result |
|---|---|
| CoreTests | **434/434** (1 unrelated skip) |
| DaemonTests | **188/188** -- progression-heavy |

## Docs

`docs/events/projections/async-daemon.md` calls out the new default and rewrites the example to show **opt-out** (rather than opt-in) usage, since opting in is now the silent default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)