### PR TITLE
Fix #4680 — upcaster shadowed when source type is typed-appended in same DocumentStore

### DIFF
--- a/src/EventSourcingTests/SchemaChange/Bug_4680_upcaster_shadowed_by_typed_append.cs
+++ b/src/EventSourcingTests/SchemaChange/Bug_4680_upcaster_shadowed_by_typed_append.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.SchemaChange;
+
+// #4680 — when Upcast<TOld, TNew> is registered AND a TOld instance is appended (typed)
+// into the same DocumentStore, the read path bypasses the upcaster and returns TOld.
+//
+// Mechanism (pre-fix):
+//   * Upcast(typeof(TNew), oldEventName, transformation) builds an EventMapping<TNew>
+//     keyed under oldEventName in _byEventName. ReadEventData uses the JsonTransformation
+//     to produce TNew from the JSON.
+//   * Typed Append(TOld) goes through EventMappingFor(typeof(TOld)), which lazily creates
+//     an EventMapping<TOld> (Storage.AddMapping). The new TOld mapping also lives in the
+//     mapping registry.
+//   * On Resolve, the by-name lookup returns the upcaster mapping (good), but then the
+//     dotnet_type column read fires the alt-mapping swap: TryGetRegisteredMappingForDotNetTypeName
+//     finds the EventMapping<TOld> the typed Append created and replaces the upcaster.
+//     The deserializer then materialises TOld and the upcaster is bypassed.
+//
+// Fix pins:
+//   * Reading back from the SAME store after a typed append returns TNew, not TOld.
+//   * The original existing-mapping-swap behavior (same eventTypeName, different
+//     DotNetTypeName) still works for the non-upcaster case — covered by the
+//     `alt_mapping_swap_still_works_when_no_upcaster_registered` test below.
+public class Bug_4680_upcaster_shadowed_by_typed_append: BugIntegrationContext
+{
+    public record UpcastReproOld(string Value);
+
+    public record UpcastReproNew
+    {
+        public required string Value { get; init; }
+    }
+
+    [Fact]
+    public async Task same_store_typed_append_is_upcast_on_read()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.Upcast<UpcastReproOld, UpcastReproNew>(x => new UpcastReproNew { Value = x.Value });
+        });
+
+        var streamId = Guid.NewGuid();
+        await using (var write = theStore.LightweightSession())
+        {
+            write.Events.StartStream(streamId, new UpcastReproOld("hello"));
+            await write.SaveChangesAsync();
+        }
+
+        // Fresh session, reads straight from the database — the cache should not save us.
+        await using var read = theStore.LightweightSession();
+        var events = await read.Events.FetchStreamAsync(streamId);
+
+        events.Count.ShouldBe(1);
+        var data = events[0].Data;
+        data.ShouldBeOfType<UpcastReproNew>();
+        ((UpcastReproNew)data).Value.ShouldBe("hello");
+    }
+
+    // Regression pin for the original purpose of the dotnet_type alt-mapping swap: when
+    // two CLR types intentionally share the same EventTypeName (e.g. moved namespaces),
+    // the dotnet_type column should still steer the resolver to the right mapping when
+    // there is NO upcaster registered for that name. This keeps the fix from over-rotating
+    // and breaking the unrelated mapping-versioning use case.
+    public record SharedNameVariantA
+    {
+        public string Label { get; init; } = "";
+    }
+
+    public record SharedNameVariantB
+    {
+        public string Label { get; init; } = "";
+    }
+
+    [Fact]
+    public async Task alt_mapping_swap_still_works_when_no_upcaster_registered()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.MapEventType<SharedNameVariantA>("shared_event_name");
+            opts.Events.MapEventType<SharedNameVariantB>("shared_event_name");
+        });
+
+        var streamId = Guid.NewGuid();
+        await using (var write = theStore.LightweightSession())
+        {
+            write.Events.StartStream(streamId, new SharedNameVariantB { Label = "b-shape" });
+            await write.SaveChangesAsync();
+        }
+
+        await using var read = theStore.LightweightSession();
+        var events = await read.Events.FetchStreamAsync(streamId);
+
+        events.Count.ShouldBe(1);
+        // The dotnet_type column resolves to VariantB even though SharedNameVariantA also
+        // claims the same EventTypeName. (Marten falls back to whichever mapping was
+        // registered first when the dotnet_type column is null; with the column set on
+        // append, the resolver should honour it.)
+        events[0].Data.ShouldBeOfType<SharedNameVariantB>();
+        ((SharedNameVariantB)events[0].Data).Label.ShouldBe("b-shape");
+    }
+}

--- a/src/Marten/Events/EventDocumentStorage.cs
+++ b/src/Marten/Events/EventDocumentStorage.cs
@@ -329,7 +329,12 @@ public abstract class EventDocumentStorage: IEventStorage
 
             mapping = eventMappingForDotNetTypeName(dotnetTypeName, eventTypeName);
         }
-        else if (!reader.IsDBNull(2))
+        // #4680: an upcaster mapping is the authoritative interpretation of the stored
+        // event-type name (it was registered with that name as its SOURCE). Skip the
+        // dotnet_type alt-mapping swap or a typed Append of TOld in the same store would
+        // shadow the upcaster on read. The swap remains for the original case it was added
+        // for: same EventTypeName, multiple CLR types, NO upcaster registered.
+        else if (!mapping.IsUpcastTarget && !reader.IsDBNull(2))
         {
             var dotnetTypeName = reader.GetFieldValue<string>(2);
             if (!string.IsNullOrEmpty(dotnetTypeName) && dotnetTypeName != mapping.DotNetTypeName)
@@ -383,7 +388,10 @@ public abstract class EventDocumentStorage: IEventStorage
 
             mapping = eventMappingForDotNetTypeName(dotnetTypeName, eventTypeName);
         }
-        else if (!await reader.IsDBNullAsync(2, token).ConfigureAwait(false))
+        // #4680: see the sync Resolve overload above -- upcaster mappings are authoritative
+        // for their source event-type name and the dotnet_type alt-mapping swap would shadow
+        // them when the source type is appended (typed) into the same store.
+        else if (!mapping.IsUpcastTarget && !await reader.IsDBNullAsync(2, token).ConfigureAwait(false))
         {
             var dotnetTypeName = await reader.GetFieldValueAsync<string>(2, token).ConfigureAwait(false);
             if (!string.IsNullOrEmpty(dotnetTypeName) && dotnetTypeName != mapping.DotNetTypeName)

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -572,6 +572,12 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
         var eventMapping = typeof(EventMapping<>).CloseAndBuildAs<EventMapping>(this, eventType);
         eventMapping.EventTypeName = eventTypeName;
         eventMapping.JsonTransformation(jsonTransformation);
+        // #4680: pin the mapping as an upcast target so EventDocumentStorage.Resolve skips
+        // its dotnet_type alt-mapping swap on read. Without this, a typed Append of the
+        // SOURCE type into the same store registers a concrete EventMapping<TOld> whose
+        // DotNetTypeName matches the stored dotnet_type, and the swap shadows the upcaster
+        // -- events read back as TOld instead of TNew. See the Bug_4680 regression test.
+        eventMapping.IsUpcastTarget = true;
 
         _byEventName.Fill(eventTypeName, eventMapping);
 

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -83,6 +83,20 @@ public abstract class EventMapping: EventTypeData, IDocumentMapping, IEventType
     public IEventBinarySerializer? BinarySerializer { get; internal set; }
 
     /// <summary>
+    /// #4680: true when this <see cref="EventMapping"/> was created by
+    /// <c>EventGraph.Upcast(...)</c>. The mapping's <see cref="DocumentType"/> is the
+    /// upcast TARGET type (TNew); the <see cref="EventTypeName"/> still belongs to the
+    /// SOURCE event-type-name (so on-disk events written under that name continue to
+    /// resolve here). The resolver in <c>EventDocumentStorage.Resolve/ResolveAsync</c>
+    /// uses this flag to skip the <c>dotnet_type</c>-driven alt-mapping swap; otherwise
+    /// a typed Append of TOld into the same store would register a separate
+    /// EventMapping&lt;TOld&gt; and the alt-mapping swap would shadow the upcaster on
+    /// read.
+    /// </summary>
+    [IgnoreDescription]
+    internal bool IsUpcastTarget { get; set; }
+
+    /// <summary>
     ///     #4515: <c>true</c> when this event type is opted in to binary
     ///     serialization on the write path (a <see cref="BinarySerializer"/> is
     ///     wired). Read-path dispatch remains row-by-row on <c>bdata</c>'s NULL


### PR DESCRIPTION
Closes #4680.

When `Upcast<TOld, TNew>(...)` is registered AND a `TOld` instance is appended (typed) into the same `DocumentStore`, reading back returned `TOld` instead of `TNew`. Reading from a different store instance worked, which the issue reporter narrowed to \"appending the typed source event registers a concrete EventMapping for TOld that shadows the upcaster on read.\"

## Mechanism

| Step | What happens |
|---|---|
| 1 | `Upcast(typeof(TNew), oldEventName, transformation)` builds an `EventMapping<TNew>` keyed under `oldEventName` in `_byEventName`. Its `ReadEventData` runs the JsonTransformation to produce TNew. |
| 2 | Typed `Append(TOld)` flows through `EventMappingFor(typeof(TOld))`, whose OnMissing factory lazily creates an `EventMapping<TOld>`. The new mapping lives in the registry alongside the upcaster mapping. |
| 3 | On `EventDocumentStorage.Resolve` / `ResolveAsync`, the by-name lookup returns the upcaster (good), but then the dotnet_type column fires the existing alt-mapping swap: `TryGetRegisteredMappingForDotNetTypeName(dotnetTypeName)` finds the `EventMapping<TOld>` the typed Append created, replaces the upcaster, and the deserializer materialises `TOld` -- bypassing the upcaster entirely. |

The alt-mapping swap is **correct for its original purpose**: same `EventTypeName`, multiple CLR types, NO upcaster registered (e.g. moved-namespace renames). The bug is that the swap fires unconditionally even when the by-name mapping is an authoritative upcaster.

## Fix

New `EventMapping.IsUpcastTarget` flag, set in `EventGraph.Upcast(...)`. `EventDocumentStorage.Resolve` / `ResolveAsync` skip the dotnet_type alt-mapping swap when the by-name mapping is an upcast target. The swap remains for the non-upcaster case it was originally added for.

## Tests

`src/EventSourcingTests/SchemaChange/Bug_4680_upcaster_shadowed_by_typed_append.cs`:

* `same_store_typed_append_is_upcast_on_read` -- the headline repro. **Failing before this commit, passing after.**
* `alt_mapping_swap_still_works_when_no_upcaster_registered` -- regression pin for the alt-mapping swap's legitimate use case. Two CLR types share `\"shared_event_name\"` with no upcaster; the dotnet_type column should still steer the resolver to the appended type's mapping. Pinning this protects against the fix over-rotating.

| Project | Result |
|---|---|
| EventSourcingTests | **1363 / 1370** (7 unrelated skips) on net9.0 |

Including the 2 new bug tests; no other regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)