### PR TITLE
Fix #4683 (fixes 1+2) — drop per-tenant sequence + progression rows on tenant removal

### DIFF
--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -205,3 +205,28 @@ Per-tenant event partitioning composes with the
 model: sharding distributes tenants across a pool of databases, and per-tenant partitioning physically isolates each
 tenant's events _within_ whichever database hosts that tenant.
 :::
+
+### Dropping Tenants
+
+Both routes that remove a tenant under `UseTenantPartitionedEvents` clean up the full
+per-tenant footprint -- partition tables, the freestanding `mt_events_sequence_{tenantId}`
+sequence, and the per-tenant `mt_event_progression` rows (one per projection's per-tenant
+catch-up plus the `HighWaterMark:{tenantId}` row):
+
+```cs
+// Wipe all data for a tenant, keep the partition registered (re-seeding works after this)
+await store.Advanced.DeleteAllTenantDataAsync("tenant-a", cancellationToken);
+
+// Remove the tenants entirely (drops their partitions + cleanup)
+await store.Advanced.RemoveMartenManagedTenantsAsync(
+    new[] { "tenant-b", "tenant-c" }, cancellationToken);
+```
+
+Store-global progression rows (the `HighWaterMark` constant, `MyProjection:All` without a
+tenant suffix) are intentionally preserved by the per-tenant cleanup -- they belong to
+the store as a whole. Other tenants' partitions, sequences, and progression rows are
+untouched.
+
+The cleanup identifies per-tenant `mt_event_progression` rows by parsing the
+`ShardName` grammar rather than pattern-matching the name, so a projection whose name
+happens to end with a tenant id is never mistakenly deleted (#4683).

--- a/src/Marten/AdvancedOperations.cs
+++ b/src/Marten/AdvancedOperations.cs
@@ -604,8 +604,22 @@ public class AdvancedOperations
 
 
         var logger = _store.Options.LogFactory?.CreateLogger<DocumentStore>() ?? NullLogger<DocumentStore>.Instance;
+
+        // #4683: capture sequence-suffix mapping BEFORE the partition drop. Weasel's drop may
+        // clear the tenant from the partition registry, and we still need the suffix to drop
+        // the freestanding mt_events_sequence_{suffix} afterwards.
+        var capturedSuffixes = Marten.Internal.PerTenantPartitionedCleanup.CaptureSequenceSuffixes(
+            _store.Options, suffixes);
+
         await _store.Options.TenantPartitions.Partitions.DropPartitionFromAllTables(database, logger, suffixes,
             token).ConfigureAwait(false);
+
+        // #4683: drop the per-tenant sequence and per-tenant mt_event_progression rows for the
+        // removed tenants. The partition drop above leaves the freestanding sequence orphaned
+        // and the progression rows untouched; both leak across drop-tenant cycles otherwise.
+        await Marten.Internal.PerTenantPartitionedCleanup.RunAsync(
+            _store.Options, _store.Tenancy.Default.Database, suffixes, capturedSuffixes, token)
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Marten/Internal/PerTenantPartitionedCleanup.cs
+++ b/src/Marten/Internal/PerTenantPartitionedCleanup.cs
@@ -1,0 +1,172 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Marten.Events.Daemon.HighWater;
+using Marten.Storage;
+using Weasel.Postgresql;
+
+namespace Marten.Internal;
+
+/// <summary>
+/// Shared per-tenant cleanup for the two paths that drop a tenant under
+/// <c>UseTenantPartitionedEvents</c>: <c>AdvancedOperations.DeleteAllTenantDataAsync</c>
+/// (via <see cref="TenantDataCleaner"/>) and <c>AdvancedOperations.RemoveMartenManagedTenantsAsync</c>.
+/// Both routes drop the tenant's partition tables but neither, until #4683, dropped:
+///   * the freestanding <c>mt_events_sequence_{suffix}</c> sequence (no <c>OWNED BY</c> link
+///     to the partition, so the partition drop leaves it orphaned)
+///   * the per-tenant <c>mt_event_progression</c> rows -- one per projection per tenant
+///     plus the per-tenant high-water row
+/// Both leak slowly but unboundedly across drop-tenant cycles (trial-account churn, etc).
+/// </summary>
+internal static class PerTenantPartitionedCleanup
+{
+    /// <summary>
+    /// Capture the per-tenant sequence suffix for <paramref name="tenantIds"/> BEFORE the
+    /// partition drop runs -- the Weasel managed-list registry may forget the tenant once
+    /// <c>DropPartitionFromAllTablesForValue</c> succeeds, so we read the mapping first and
+    /// hold it for the post-drop cleanup. Returned dictionary maps tenant id → suffix; missing
+    /// keys mean "no suffix recorded in the registry for that tenant, skip the sequence drop"
+    /// (defensive -- the partition drop is the source of truth for tenants whose partitions
+    /// existed).
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> CaptureSequenceSuffixes(
+        StoreOptions options, IEnumerable<string> tenantIds)
+    {
+        var suffixes = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (!options.Events.UseTenantPartitionedEvents) return suffixes;
+        if (options.TenantPartitions?.Partitions.Partitions is not { } registry) return suffixes;
+
+        foreach (var tenantId in tenantIds)
+        {
+            if (registry.TryGetValue(tenantId, out var suffix))
+            {
+                suffixes[tenantId] = suffix;
+            }
+        }
+        return suffixes;
+    }
+
+    /// <summary>
+    /// Run the post-partition-drop cleanup for the supplied tenant ids on
+    /// <paramref name="database"/>. <paramref name="capturedSequenceSuffixes"/> should come
+    /// from <see cref="CaptureSequenceSuffixes"/> called BEFORE the partition drop. Issues:
+    /// <list type="bullet">
+    ///   <item><c>DROP SEQUENCE IF EXISTS mt_events_sequence_{suffix}</c> for each captured suffix</item>
+    ///   <item><c>DELETE FROM mt_event_progression WHERE name = ANY(...)</c> for the union of
+    ///     row names matched by <see cref="MatchesAnyTenant"/></item>
+    /// </list>
+    /// Both statements run as a single batch on a fresh connection; the partition drop has
+    /// already been committed by the caller. <c>IF EXISTS</c> + idempotent SELECT-then-DELETE
+    /// keep re-runs safe.
+    /// </summary>
+    public static async Task RunAsync(
+        StoreOptions options,
+        IMartenDatabase database,
+        IReadOnlyCollection<string> tenantIds,
+        IReadOnlyDictionary<string, string> capturedSequenceSuffixes,
+        CancellationToken token)
+    {
+        if (!options.Events.UseTenantPartitionedEvents) return;
+        if (tenantIds.Count == 0) return;
+
+        var eventsSchema = options.Events.DatabaseSchemaName;
+        var progressionRows = await CollectMatchingProgressionRowsAsync(
+            eventsSchema, database, tenantIds, token).ConfigureAwait(false);
+
+        if (capturedSequenceSuffixes.Count == 0 && progressionRows.Count == 0) return;
+
+        var builder = new BatchBuilder();
+        foreach (var suffix in capturedSequenceSuffixes.Values)
+        {
+            builder.StartNewCommand();
+            builder.Append($"DROP SEQUENCE IF EXISTS \"{eventsSchema}\".\"mt_events_sequence_{suffix}\"");
+        }
+
+        if (progressionRows.Count > 0)
+        {
+            builder.StartNewCommand();
+            builder.Append($"DELETE FROM \"{eventsSchema}\".\"mt_event_progression\" WHERE name = ANY(");
+            builder.AppendParameter(progressionRows.ToArray());
+            builder.Append(")");
+        }
+
+        var batch = builder.Compile();
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+        try
+        {
+            batch.Connection = conn;
+            await batch.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Collect <c>mt_event_progression.name</c> rows that belong to any of
+    /// <paramref name="tenantIds"/>. We resolve membership via two paths so we never use a
+    /// LIKE pattern that could false-positive-match a projection name happening to end with a
+    /// tenant id:
+    /// <list type="bullet">
+    ///   <item>Per-tenant <c>HighWaterMark:{tenantId}</c> rows: matched exactly via
+    ///     <see cref="HighWaterShardIdentity.PerTenantPrefix"/> -- ShardName intentionally
+    ///     collapses HighWaterMark identities to the constant, so they don't round-trip
+    ///     through <see cref="ShardName.TryParse"/>.</item>
+    ///   <item>Per-projection per-tenant rows: <see cref="ShardName.TryParse"/> recognises
+    ///     <c>Name:ShardKey:Tenant</c> / <c>Name:V{n}:ShardKey:Tenant</c>; tenant slot match
+    ///     against the input set.</item>
+    /// </list>
+    /// Store-global rows ("HighWaterMark", "MyProjection:All", etc) never match -- they have
+    /// no tenant slot or use the literal HighWaterMark constant.
+    /// </summary>
+    private static async Task<List<string>> CollectMatchingProgressionRowsAsync(
+        string eventsSchema,
+        IMartenDatabase database,
+        IReadOnlyCollection<string> tenantIds,
+        CancellationToken token)
+    {
+        var matched = new List<string>();
+        var tenantSet = new HashSet<string>(tenantIds, StringComparer.Ordinal);
+
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+        try
+        {
+            await using var cmd = conn.CreateCommand(
+                $"SELECT name FROM \"{eventsSchema}\".\"mt_event_progression\"");
+            await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            while (await reader.ReadAsync(token).ConfigureAwait(false))
+            {
+                var name = await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false);
+                if (MatchesAnyTenant(name, tenantSet))
+                {
+                    matched.Add(name);
+                }
+            }
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+        return matched;
+    }
+
+    internal static bool MatchesAnyTenant(string progressionName, ICollection<string> tenantIds)
+    {
+        if (progressionName.StartsWith(HighWaterShardIdentity.PerTenantPrefix, StringComparison.Ordinal))
+        {
+            var nameTenantId = progressionName.Substring(HighWaterShardIdentity.PerTenantPrefix.Length);
+            return tenantIds.Contains(nameTenantId);
+        }
+
+        return ShardName.TryParse(progressionName, out var shard)
+            && shard?.TenantId is { } shardTenant
+            && tenantIds.Contains(shardTenant);
+    }
+}

--- a/src/Marten/Internal/TenantDataCleaner.cs
+++ b/src/Marten/Internal/TenantDataCleaner.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core;
-using Marten.Events.Schema;
 using Marten.Schema;
 using Marten.Services;
 using Marten.Storage;
@@ -11,7 +10,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Weasel.Core;
 using Weasel.Postgresql;
-using Weasel.Postgresql.Tables.Partitioning;
 
 namespace Marten.Internal;
 
@@ -31,6 +29,13 @@ internal class TenantDataCleaner
         var logger = _store.Options.LogFactory?.CreateLogger<DocumentStore>() ?? NullLogger<DocumentStore>.Instance;
 
         var database = await _store.Storage.FindOrCreateDatabase(_tenantId).ConfigureAwait(false);
+
+        // #4683: capture the per-tenant sequence suffix *before* the partition drop, so we can
+        // drop the freestanding mt_events_sequence_{suffix} afterwards. The Weasel managed-list
+        // partition registry may forget the tenant once DropPartitionFromAllTablesForValue runs.
+        var capturedSuffixes = PerTenantPartitionedCleanup.CaptureSequenceSuffixes(
+            _store.Options, new[] { _tenantId });
+
         if (_store.Options is { TenantPartitions: not null})
         {
             await _store.Options.TenantPartitions.Partitions.DropPartitionFromAllTablesForValue(
@@ -89,14 +94,22 @@ internal class TenantDataCleaner
             deleteDataForTenantDatabase(deleteTenantedDataIfExists, deleteDataIfExists);
         }
 
-        if (!foundTables) return;
+        if (foundTables)
+        {
+            var batch = builder.Compile();
+            await using var conn = database.CreateConnection();
+            await conn.OpenAsync(token).ConfigureAwait(false);
+            batch.Connection = conn;
+            await batch.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
 
-        var batch = builder.Compile();
-        await using var conn = database.CreateConnection();
-        await conn.OpenAsync(token).ConfigureAwait(false);
-        batch.Connection = conn;
-        await batch.ExecuteNonQueryAsync(token).ConfigureAwait(false);
-        await conn.CloseAsync().ConfigureAwait(false);
+        // #4683: drop the freestanding per-tenant sequence and per-tenant progression rows
+        // that aren't covered by the partition drop. Lives in the shared helper so
+        // RemoveMartenManagedTenantsAsync (which doesn't go through this cleaner) can call
+        // the same code path.
+        await PerTenantPartitionedCleanup.RunAsync(
+            _store.Options, database, new[] { _tenantId }, capturedSuffixes, token).ConfigureAwait(false);
     }
 
     private void deleteDataForTenantDatabase(Action<DbObjectName> deleteTenantedDataIfExists, Action<DbObjectName> deleteDataIfExists)

--- a/src/TenantPartitionedEventsTests/Admin/delete_all_tenant_data_orphan_sequence_pin.cs
+++ b/src/TenantPartitionedEventsTests/Admin/delete_all_tenant_data_orphan_sequence_pin.cs
@@ -1,10 +1,15 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Events;
+using JasperFx.Events.Projections;
 using JasperFx.MultiTenancy;
 using Marten;
 using Marten.Events;
+using Marten.Events.Daemon.HighWater;
+using Marten.Events.Projections;
 using Marten.Storage;
 using Marten.Testing.Harness;
 using Npgsql;
@@ -15,25 +20,14 @@ using Xunit;
 namespace TenantPartitionedEventsTests.Admin;
 
 /// <summary>
-/// #4617 section 3e — pin the orphan-sequence behavior on
-/// <c>DeleteAllTenantDataAsync(tenantId)</c>. The cleaner drops the tenant's
-/// partition tables (mt_events_&lt;tenant&gt; / mt_streams_&lt;tenant&gt;)
-/// AND deletes rows from the parent mt_events / mt_streams tables, but it
-/// does NOT drop the per-tenant <c>mt_events_sequence_&lt;tenant&gt;</c>
-/// sequence (no equivalent cleanup hook on
-/// <see cref="Marten.Internal.TenantDataCleaner"/>).
-///
-/// <para>
-/// Consequence: re-registering the same tenant id after a
-/// <c>DeleteAllTenantDataAsync</c> picks up the OLD sequence and the new
-/// events' seq_ids continue from the last value, not from 1. Pinned so a
-/// future fix that DOES drop the sequence flips the assertion intentionally.
-/// </para>
-///
-/// <para>
-/// Own-store because this test scrubs partition + sequence state in ways
-/// the shared GuidPartitionedFixture's other tests can't tolerate.
-/// </para>
+/// #4683 — was the orphan-sequence + orphan-progression pin from #4617 section 3e.
+/// <c>DeleteAllTenantDataAsync</c> and <c>RemoveMartenManagedTenantsAsync</c> now route
+/// the per-tenant cleanup through <see cref="Marten.Internal.PerTenantPartitionedCleanup"/>:
+/// after the partition drop they also <c>DROP SEQUENCE IF EXISTS mt_events_sequence_{suffix}</c>
+/// and <c>DELETE</c> any <c>mt_event_progression</c> rows whose
+/// <see cref="ShardName.TryParse"/> tenant slot (or
+/// <see cref="HighWaterShardIdentity.PerTenantPrefix"/> match) is the dropped tenant.
+/// Store-global progression rows are intentionally left alone.
 /// </summary>
 public class delete_all_tenant_data_orphan_sequence_pin : IAsyncLifetime
 {
@@ -58,6 +52,9 @@ public class delete_all_tenant_data_orphan_sequence_pin : IAsyncLifetime
             opts.Policies.AllDocumentsAreMultiTenanted();
 
             opts.Events.AddEventType<DelEvent>();
+            // #4683 progression test wants an async projection so the rebuild populates
+            // per-tenant mt_event_progression rows we can then assert on.
+            opts.Projections.Add<DelCountProjection>(ProjectionLifecycle.Async);
         });
 
         await _store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
@@ -70,7 +67,7 @@ public class delete_all_tenant_data_orphan_sequence_pin : IAsyncLifetime
     }
 
     [Fact]
-    public async Task DeleteAllTenantDataAsync_drops_partitions_but_LEAVES_the_per_tenant_sequence()
+    public async Task DeleteAllTenantDataAsync_drops_partitions_and_the_per_tenant_sequence()
     {
         var tenant = "delpin";
         await _store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
@@ -95,21 +92,20 @@ public class delete_all_tenant_data_orphan_sequence_pin : IAsyncLifetime
         partitionExists.ShouldBeFalse(
             "DeleteAllTenantDataAsync drops the tenant's mt_events partition table");
 
-        // The orphan-sequence pin: the per-tenant sequence is STILL THERE.
+        // #4683: per-tenant sequence is now dropped (was the orphan-leak pin).
         var seqStillExists = await SequenceExistsAsync(_schema, $"mt_events_sequence_{tenant}");
-        seqStillExists.ShouldBeTrue(
-            "DeleteAllTenantDataAsync does NOT drop the per-tenant mt_events_sequence_<tenant> " +
-            "— pinned as the documented leak. A future fix to TenantDataCleaner that DOES drop the " +
-            "sequence will flip this assertion to ShouldBeFalse and force a contract review.");
+        seqStillExists.ShouldBeFalse(
+            "DeleteAllTenantDataAsync now drops the per-tenant mt_events_sequence_<tenant> via " +
+            "PerTenantPartitionedCleanup (#4683). Was previously pinned as the orphan leak.");
     }
 
     [Fact]
-    public async Task RemoveMartenManagedTenantsAsync_drops_partitions_but_LEAVES_the_per_tenant_sequence()
+    public async Task RemoveMartenManagedTenantsAsync_drops_partitions_and_the_per_tenant_sequence()
     {
-        // Companion pin for RemoveMartenManagedTenantsAsync (the explicit
-        // "I no longer need this tenant" path, vs DeleteAllTenantDataAsync's
-        // "wipe this tenant's data but keep registration"). Same partition-drop
-        // but no sequence drop — same orphan leak.
+        // Companion to the DeleteAll test for the alternate "drop everything for this tenant"
+        // path. RemoveMartenManagedTenantsAsync skips TenantDataCleaner entirely (it's the
+        // explicit "I no longer need this tenant" route), so this confirms PerTenantPartitionedCleanup
+        // is wired in on *both* paths -- not just the cleaner's.
         var tenant = "rempin";
         await _store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
 
@@ -129,13 +125,108 @@ public class delete_all_tenant_data_orphan_sequence_pin : IAsyncLifetime
         // Partition table dropped.
         (await TableExistsAsync(_schema, $"mt_events_{tenant}")).ShouldBeFalse();
 
-        // Sequence still present — the orphan-leak pin.
-        (await SequenceExistsAsync(_schema, $"mt_events_sequence_{tenant}")).ShouldBeTrue(
-            "RemoveMartenManagedTenantsAsync drops partitions but does NOT drop the per-tenant " +
-            "mt_events_sequence_<tenant> — pinned as the documented leak");
+        // #4683: sequence is dropped too (was the second orphan-leak pin).
+        (await SequenceExistsAsync(_schema, $"mt_events_sequence_{tenant}")).ShouldBeFalse(
+            "RemoveMartenManagedTenantsAsync now drops the per-tenant mt_events_sequence_<tenant> " +
+            "via PerTenantPartitionedCleanup (#4683). Was previously pinned as the orphan leak.");
+    }
+
+    [Fact]
+    public async Task DeleteAllTenantDataAsync_removes_per_tenant_progression_rows_and_preserves_store_global()
+    {
+        // Two tenants. We seed the progression rows directly via SQL rather than driving the
+        // daemon -- the daemon's per-tenant fan-out depends on a registered async projection +
+        // ForceAllMartenDaemonActivity catch-up, and we want to test PerTenantPartitionedCleanup
+        // in isolation: given a set of progression rows in the table, the cleanup deletes
+        // exactly the dropped tenant's per-tenant rows (across both the ShardName grammar and
+        // the HighWaterShardIdentity grammar) and leaves store-global rows alone.
+        var keep = "keepme";
+        var drop = "dropme";
+        await _store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, keep, drop);
+
+        // Touch the events table so the cleaner's batched DELETEs find data to delete (the
+        // partition drop itself is the load-bearing part of this test; the actual event count
+        // is incidental).
+        await using (var session = _store.LightweightSession(drop))
+        {
+            session.Events.StartStream(Guid.NewGuid(), new DelEvent("x"));
+            await session.SaveChangesAsync();
+        }
+
+        // Seed the progression rows we want the cleanup to target. Names span the two grammars:
+        //  * HighWaterMark:<tenant>   — Marten's per-tenant high-water (HighWaterShardIdentity)
+        //  * {Name}:All:<tenant>      — ShardName.Compose for per-tenant projection catch-up
+        //  * {Name}:V2:All:<tenant>   — versioned variant
+        // Plus a store-global "HighWaterMark" row + a "SomeProjection:All" row that must
+        // survive the drop.
+        await SeedProgressionRowsAsync(_schema, new[]
+        {
+            // store-global -- must survive
+            "HighWaterMark",
+            "SomeProjection:All",
+            // per-tenant for the keep tenant -- must survive
+            $"HighWaterMark:{keep}",
+            $"DelCountProjection:All:{keep}",
+            $"VersionedProjection:V2:All:{keep}",
+            // per-tenant for the drop tenant -- must be removed
+            $"HighWaterMark:{drop}",
+            $"DelCountProjection:All:{drop}",
+            $"VersionedProjection:V2:All:{drop}",
+        });
+
+        var beforeNames = await ReadProgressionRowNamesAsync(_schema);
+        beforeNames.ShouldContain($"HighWaterMark:{drop}");
+        beforeNames.ShouldContain($"DelCountProjection:All:{drop}");
+        beforeNames.ShouldContain($"VersionedProjection:V2:All:{drop}");
+
+        // Act.
+        await _store.Advanced.DeleteAllTenantDataAsync(drop, CancellationToken.None);
+
+        var afterNames = await ReadProgressionRowNamesAsync(_schema);
+
+        // The dropped tenant's per-tenant rows are gone, across both grammars + the versioned form.
+        afterNames.Any(n => MentionsTenant(n, drop)).ShouldBeFalse(
+            $"Expected no progression rows mentioning '{drop}' after the drop, found: " +
+            string.Join(", ", afterNames.Where(n => MentionsTenant(n, drop))));
+
+        // The other tenant's per-tenant rows are untouched (also across both grammars).
+        afterNames.ShouldContain($"HighWaterMark:{keep}");
+        afterNames.ShouldContain($"DelCountProjection:All:{keep}");
+        afterNames.ShouldContain($"VersionedProjection:V2:All:{keep}");
+
+        // The store-global rows (no tenant suffix) are intentionally preserved.
+        afterNames.ShouldContain(HighWaterShardIdentity.StoreGlobal,
+            "the store-global HighWaterMark progression row must not be deleted by per-tenant cleanup");
+        afterNames.ShouldContain("SomeProjection:All",
+            "store-global projection catch-up rows must not be deleted by per-tenant cleanup");
+    }
+
+    private static async Task SeedProgressionRowsAsync(string schema, string[] names)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        foreach (var name in names)
+        {
+            await using var cmd = conn.CreateCommand(
+                $"insert into \"{schema}\".\"mt_event_progression\" (name, last_seq_id) values (@n, 0) on conflict (name) do nothing");
+            cmd.Parameters.AddWithValue("n", name);
+            await cmd.ExecuteNonQueryAsync();
+        }
     }
 
     // ----- helpers -----
+
+    /// <summary>Recognises both the per-tenant HighWaterMark grammar ("HighWaterMark:&lt;tenant&gt;")
+    /// and the canonical ShardName grammar ({Name}:{ShardKey}:{tenant} / {Name}:V{n}:{ShardKey}:{tenant}).</summary>
+    private static bool MentionsTenant(string progressionName, string tenantId)
+    {
+        if (progressionName.StartsWith(HighWaterShardIdentity.PerTenantPrefix, StringComparison.Ordinal))
+        {
+            return progressionName.Substring(HighWaterShardIdentity.PerTenantPrefix.Length) == tenantId;
+        }
+        return ShardName.TryParse(progressionName, out var shard)
+            && shard?.TenantId == tenantId;
+    }
 
     private static async Task<long> ReadSequenceLastValueAsync(string schema, string sequenceName)
     {
@@ -170,6 +261,32 @@ public class delete_all_tenant_data_orphan_sequence_pin : IAsyncLifetime
         cmd.Parameters.AddWithValue("t", tableName);
         return (long)(await cmd.ExecuteScalarAsync())! == 1L;
     }
+
+    private static async Task<List<string>> ReadProgressionRowNamesAsync(string schema)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand($"select name from \"{schema}\".\"mt_event_progression\"");
+        var names = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            names.Add(reader.GetString(0));
+        }
+        return names;
+    }
 }
 
 public record DelEvent(string Label);
+
+public class DelCount
+{
+    public Guid Id { get; set; }
+    public int Total { get; set; }
+}
+
+public partial class DelCountProjection: Marten.Events.Aggregation.SingleStreamProjection<DelCount, Guid>
+{
+    public DelCount Create(DelEvent e) => new() { Total = 1 };
+    public void Apply(DelEvent e, DelCount agg) => agg.Total++;
+}


### PR DESCRIPTION
Closes the first two fixes from #4683 (fix 3 — drop → re-add scale test in `Marten.ScaleTesting` — split as a follow-up per the \"one focused PR at a time\" preference).

Under `UseTenantPartitionedEvents`, dropping a tenant via either `DeleteAllTenantDataAsync` or `RemoveMartenManagedTenantsAsync` removed the partition tables but left two side-tables orphaned:

| Leak | Where |
|---|---|
| Freestanding `mt_events_sequence_{suffix}` sequence | Created without `OWNED BY`, so the partition drop skips it. Every drop-add cycle accumulated another sequence. |
| Per-tenant `mt_event_progression` rows | One per projection's `{Projection}:All:{tenantId}` catch-up plus the `HighWaterMark:{tenantId}` row. Silent leak. |

Both were originally pinned in `delete_all_tenant_data_orphan_sequence_pin.cs` (#4617 section 3e deferred items) as documented bugs awaiting a fix.

## What ships

| File | Role |
|---|---|
| `Marten.Internal.PerTenantPartitionedCleanup` | New helper. `CaptureSequenceSuffixes(...)` runs BEFORE the partition drop (Weasel may clear the tenant entry); `RunAsync(...)` runs the batched DROP SEQUENCE + DELETE FROM mt_event_progression afterwards. |
| `TenantDataCleaner.ExecuteAsync` | Routes through the helper after the partition drop + table DELETEs. |
| `AdvancedOperations.RemoveMartenManagedTenantsAsync` | Now also routes through the helper (this path skipped `TenantDataCleaner` entirely before, so it had to be wired separately). |

Per-tenant `mt_event_progression` rows are identified by parsing the **ShardName grammar** rather than LIKE-matching the row name -- so a projection whose name happens to end with a tenant id is never mistakenly deleted. Two grammars handled:

* `HighWaterShardIdentity.PerTenantPrefix` exact match (Marten's per-tenant HighWater grammar -- `ShardName` collapses `HighWaterMark` identities to the constant, so they don't round-trip through `ShardName.TryParse`).
* `ShardName.TryParse` for everything else, across `Name:ShardKey:Tenant` and the versioned `Name:V{n}:ShardKey:Tenant` form.

**Store-global rows** (`HighWaterMark`, `MyProjection:All`, etc) never match -- no tenant slot. Verified explicitly via direct progression-row seeding in the test.

## Tests

The pre-existing pin in `delete_all_tenant_data_orphan_sequence_pin.cs` is flipped from `ShouldBeTrue(\"...the orphan leak\")` to `ShouldBeFalse(\"...now drops...\")`. The two original cases (DeleteAll path + RemoveMartenManagedTenants path) now verify the fix instead of pinning the bug.

A third case, `DeleteAllTenantDataAsync_removes_per_tenant_progression_rows_and_preserves_store_global`, seeds 8 progression rows directly via SQL spanning all three grammars + store-global + versioned variants and asserts:

* Dropped tenant's rows removed across all three grammars (HighWaterMark + `:All:` + versioned `:V2:All:`).
* Keep tenant's rows untouched.
* Store-global `HighWaterMark` and `SomeProjection:All` rows preserved.

| Suite | Result |
|---|---|
| TenantPartitionedEventsTests | **178/178** on net9.0 |
| MultiTenancyTests (touches RemoveMartenManagedTenantsAsync) | **146/146** on net9.0 |
| CoreTests | 432/435 — 2 of those failures are a pre-existing flake confirmed on master (`partitioning_and_foreign_keys.*` shared-schema state); the test passes alone on both branches |

## Docs

`docs/events/multitenancy.md` gets a new \"Dropping Tenants\" subsection under \"Per-Tenant Event Partitioning\" that documents both routes, preservation of store-global rows, and the `ShardName`-grammar-based row identification.

## Followups

* **#4683 fix 3** — drop → re-add scale test in `Marten.ScaleTesting` (20M events, full cycle). Separate PR.
* **Structural cleanup** — declare each `mt_events_sequence_{suffix}` as `OWNED BY` its partition table at creation time so the partition drop drops the sequence automatically. Needs a schema migration for existing deployments; deferred as a structural follow-up. This PR handles both new and existing deployments today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)