### PR TITLE
#4685 PR 1 — ProjectionUpdateBatch insert-only flush-mode plumbing

### DIFF
--- a/src/CoreTests/Events/Daemon/BatchFlushModeClassifier_pin.cs
+++ b/src/CoreTests/Events/Daemon/BatchFlushModeClassifier_pin.cs
@@ -1,0 +1,74 @@
+using Marten.Events.Daemon.Internals;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace CoreTests.Events.Daemon;
+
+// #4685 PR 1 -- pin the BatchFlushMode classifier's transition rule. Subsequent PRs in the
+// series dispatch the BulkWriter (binary COPY) flush path on this signal; if the classifier
+// ever over-classifies a Mixed batch as InsertOnly, a rebuild that should have used the
+// per-row UPSERT path silently uses COPY instead and loses update / patch / delete semantics.
+//
+// Rule:
+//   * Initial state -- InsertOnly (an empty batch is trivially insert-only; the BulkWriter
+//     path is a no-op on zero rows).
+//   * On Insert -- stay InsertOnly.
+//   * On any other role -- transition to Mixed and stay there.
+//   * Transition is monotonic -- once Mixed, never back to InsertOnly within the same batch.
+public class BatchFlushModeClassifier_pin
+{
+    [Fact]
+    public void initial_state_is_insert_only()
+    {
+        BatchFlushModeClassifier.Initial.ShouldBe(BatchFlushMode.InsertOnly);
+    }
+
+    [Fact]
+    public void insert_keeps_insert_only()
+    {
+        var mode = BatchFlushModeClassifier.Initial;
+        mode = BatchFlushModeClassifier.WithOperation(mode, OperationRole.Insert);
+        mode.ShouldBe(BatchFlushMode.InsertOnly);
+        mode = BatchFlushModeClassifier.WithOperation(mode, OperationRole.Insert);
+        mode.ShouldBe(BatchFlushMode.InsertOnly);
+    }
+
+    [Theory]
+    [InlineData(OperationRole.Update)]
+    [InlineData(OperationRole.Upsert)]
+    [InlineData(OperationRole.Patch)]
+    [InlineData(OperationRole.Deletion)]
+    [InlineData(OperationRole.Events)]
+    [InlineData(OperationRole.Other)]
+    public void any_non_insert_role_demotes_to_mixed(OperationRole role)
+    {
+        var mode = BatchFlushModeClassifier.Initial;
+        mode = BatchFlushModeClassifier.WithOperation(mode, role);
+        mode.ShouldBe(BatchFlushMode.Mixed);
+    }
+
+    [Fact]
+    public void transition_to_mixed_is_monotonic()
+    {
+        // Once Mixed, even a string of inserts can't bring the batch back.
+        var mode = BatchFlushMode.Mixed;
+        mode = BatchFlushModeClassifier.WithOperation(mode, OperationRole.Insert);
+        mode = BatchFlushModeClassifier.WithOperation(mode, OperationRole.Insert);
+        mode = BatchFlushModeClassifier.WithOperation(mode, OperationRole.Insert);
+        mode.ShouldBe(BatchFlushMode.Mixed);
+    }
+
+    [Fact]
+    public void interleaved_insert_then_update_demotes()
+    {
+        var mode = BatchFlushModeClassifier.Initial;
+        mode = BatchFlushModeClassifier.WithOperation(mode, OperationRole.Insert);
+        mode = BatchFlushModeClassifier.WithOperation(mode, OperationRole.Insert);
+        mode.ShouldBe(BatchFlushMode.InsertOnly);
+        mode = BatchFlushModeClassifier.WithOperation(mode, OperationRole.Update);
+        mode.ShouldBe(BatchFlushMode.Mixed);
+        mode = BatchFlushModeClassifier.WithOperation(mode, OperationRole.Insert);
+        mode.ShouldBe(BatchFlushMode.Mixed); // stays Mixed even after subsequent inserts
+    }
+}

--- a/src/Marten/Events/Daemon/Internals/BatchFlushMode.cs
+++ b/src/Marten/Events/Daemon/Internals/BatchFlushMode.cs
@@ -1,0 +1,58 @@
+#nullable enable
+using Weasel.Core;
+
+namespace Marten.Events.Daemon.Internals;
+
+/// <summary>
+/// Classifies a <see cref="ProjectionUpdateBatch"/> by what kind of write traffic it has
+/// accumulated. The classifier is the seam where the BulkWriter (binary <c>COPY</c>) rebuild
+/// flush path being added in #4685 plugs in: rebuild post-<c>TRUNCATE</c> is INSERT-only and
+/// safe to dispatch through <c>BeginBinaryImport</c>; continuous catch-up mixes updates / upserts
+/// / patches / deletes and must keep the per-row UPSERT path.
+/// </summary>
+public enum BatchFlushMode
+{
+    /// <summary>
+    /// Default. The batch holds (or could hold) operations beyond plain inserts -- updates,
+    /// upserts, patches, deletes, ad-hoc SQL. The existing per-row UPSERT flush is the only
+    /// safe choice; the BulkWriter path is skipped.
+    /// </summary>
+    Mixed,
+
+    /// <summary>
+    /// Every operation accumulated so far carries <c>OperationRole.Insert</c>. Eligible for
+    /// the BulkWriter (binary <c>COPY</c>) flush path being added in subsequent PRs of #4685.
+    /// A rebuild that <c>TRUNCATE</c>d its target table before replaying events is the
+    /// canonical producer of this mode.
+    /// </summary>
+    InsertOnly
+}
+
+/// <summary>
+/// Pure classifier for <see cref="BatchFlushMode"/>. Extracted so the incremental update done
+/// inside <see cref="ProjectionUpdateBatch"/> is unit-testable without standing up a full
+/// session / database, and so the transition rule lives in one place that subsequent PRs in
+/// the #4685 series can dispatch against.
+/// </summary>
+internal static class BatchFlushModeClassifier
+{
+    /// <summary>
+    /// Initial mode for an empty batch. <see cref="BatchFlushMode.InsertOnly"/> -- a batch
+    /// that never sees any operation is trivially insert-only (the BulkWriter path is a
+    /// no-op on zero rows), and demoting only on a non-Insert arrival keeps the transition
+    /// monotonic.
+    /// </summary>
+    public const BatchFlushMode Initial = BatchFlushMode.InsertOnly;
+
+    /// <summary>
+    /// Update <paramref name="current"/> with the arrival of a new operation whose role is
+    /// <paramref name="role"/>. Once a batch demotes to <see cref="BatchFlushMode.Mixed"/> it
+    /// stays there for the rest of its lifetime; the transition is monotonic so the caller
+    /// can short-circuit further classification work once it's seen a non-Insert.
+    /// </summary>
+    public static BatchFlushMode WithOperation(BatchFlushMode current, OperationRole role)
+    {
+        if (current == BatchFlushMode.Mixed) return BatchFlushMode.Mixed;
+        return role == OperationRole.Insert ? BatchFlushMode.InsertOnly : BatchFlushMode.Mixed;
+    }
+}

--- a/src/Marten/Events/Daemon/Internals/ProjectionUpdateBatch.cs
+++ b/src/Marten/Events/Daemon/Internals/ProjectionUpdateBatch.cs
@@ -15,6 +15,7 @@ using Marten.Internal.Operations;
 using Marten.Internal.Sessions;
 using Marten.Patching;
 using Marten.Services;
+using Weasel.Core;
 
 namespace Marten.Events.Daemon.Internals;
 
@@ -56,6 +57,17 @@ public class ProjectionUpdateBatch: IUpdateBatch, IAsyncDisposable, IDisposable,
     public ShardExecutionMode Mode { get; }
 
     public bool ShouldApplyListeners { get; set; }
+
+    /// <summary>
+    /// #4685 PR 1 plumbing: classifies the batch as <see cref="BatchFlushMode.InsertOnly"/> when
+    /// every queued operation carries <see cref="OperationRole.Insert"/>, or
+    /// <see cref="BatchFlushMode.Mixed"/> otherwise. Maintained incrementally as operations
+    /// arrive; once demoted to <c>Mixed</c> it stays there for the lifetime of the batch (the
+    /// transition is monotonic). Subsequent PRs in the #4685 series dispatch the BulkWriter
+    /// (binary <c>COPY</c>) flush path on this signal; <b>this PR is plumbing only and does
+    /// not change the flush behavior</b>.
+    /// </summary>
+    public BatchFlushMode FlushMode { get; private set; } = BatchFlushModeClassifier.Initial;
 
     // TODO -- make this private
     public Block<IStorageOperation> Queue { get; }
@@ -356,6 +368,10 @@ public class ProjectionUpdateBatch: IUpdateBatch, IAsyncDisposable, IDisposable,
         _current.Append(operation);
 
         _documentTypes.Fill(operation.DocumentType);
+
+        // #4685 PR 1 plumbing: keep FlushMode in sync with the operations queued so far.
+        // Subsequent PRs dispatch the BulkWriter (binary COPY) path on this signal.
+        FlushMode = BatchFlushModeClassifier.WithOperation(FlushMode, operation.Role());
 
         if (_session != null && !_token.IsCancellationRequested && _current.Count >= Session.Options.UpdateBatchSize)
         {


### PR DESCRIPTION
First PR in the BulkWriter (binary `COPY`) rebuild optimization series tracked in #4685. **Foundation only — no behavior change.** Adds the seam where subsequent PRs plug in.

## Series sketch

| PR | Scope |
|---|---|
| **PR 1 (this)** | Classifier + `BatchFlushMode` property on `ProjectionUpdateBatch`. No behavior change. |
| PR 2 | `TRUNCATE` step at the start of a per-(tenant, projection) rebuild. Partition-aware under `UseTenantPartitionedEvents`. |
| PR 3 | BulkWriter (binary `COPY`) flush path that activates when `FlushMode == InsertOnly`. Reuses `BulkInsertAsync`'s column binders. |
| PR 4 | Composite-stage propagation review — verify the `Upstream` cache propagation handles stage 2 reading stage 1's un-flushed COPY data. |
| PR 5 | ScaleTesting harness validation. Phase E (#4684) measurement confirms the ≥30% wall-clock reduction target on the write-side of a 20M-event Telehealth composite rebuild. |

## What ships in this PR

| File | Role |
|---|---|
| `Marten.Events.Daemon.Internals.BatchFlushMode` | New enum -- `Mixed` (default; current flush path applies) and `InsertOnly` (eligible for the BulkWriter path in PR 3). |
| `BatchFlushModeClassifier` | Pure, unit-testable transition rule. `Initial = InsertOnly` (empty batch is trivially insert-only -- BulkWriter is a no-op on zero rows); `WithOperation(current, role)` demotes to `Mixed` on any non-Insert role and is **monotonic** -- once `Mixed`, stays `Mixed` for the lifetime of the batch. |
| `ProjectionUpdateBatch.FlushMode` | New public read-only property maintained incrementally in `applyOperation`. PR 3 dispatches on this signal. |

## Tests

10 cases in `CoreTests/Events/Daemon/BatchFlushModeClassifier_pin.cs`:

* Initial state is `InsertOnly`
* `Insert` keeps `InsertOnly` across multiple arrivals
* Each of the non-Insert roles (`Update`, `Upsert`, `Patch`, `Deletion`, `Events`, `Other`) **independently** demotes to `Mixed`
* Monotonic: once `Mixed`, subsequent `Insert`s can't bring it back
* Interleaved sequence: `Insert` → `Insert` (still `InsertOnly`) → `Update` (`Mixed`) → `Insert` (still `Mixed`)

| Suite | Result |
|---|---|
| New classifier tests | **10/10** on net9.0 |
| `DaemonTests` (rebuild + continuous catch-up exercise `applyOperation` on every role) | **188/188** on net9.0 |

The new property maintenance is one increment per operation arrival -- the perf footprint on the hot path is unmeasurable. The plumbing for PR 3 has somewhere to plug in without any of this PR changing observable Marten behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)