### PR TITLE
#4679 — Skipped reproduction fixture for catchUpPerTenantAsync 23505 regression

### DIFF
--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4679_catch_up_per_tenant_23505.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4679_catch_up_per_tenant_23505.cs
@@ -1,0 +1,242 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Daemon;
+using Marten.Events.Projections;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TenantPartitionedEventsTests.Regressions;
+
+/// <summary>
+/// Regression reproduction for
+/// <see href="https://github.com/JasperFx/marten/issues/4679">#4679</see> —
+/// follow-up to the #4665 fix. The new per-tenant catch-up path
+/// (<c>JasperFxAsyncDaemon.catchUpPerTenantAsync</c>, introduced in
+/// JasperFx.Events 2.8.2) throws
+/// <c>23505: duplicate key value violates unique constraint "pk_mt_event_progression"</c>
+/// for store-global (<c>:All</c>) projection shards when
+/// <c>Events.UseTenantPartitionedEvents</c> is on and more than one tenant
+/// participates in the catch-up. The conflicting key is the store-global
+/// identity (no tenant suffix), so something in the per-tenant iteration loop
+/// writes the store-global progression-row name once per tenant instead of
+/// per-tenant scoped names.
+///
+/// <para>
+/// Stack from the original report:
+/// <code>
+/// 23505: duplicate key value violates unique constraint "pk_mt_event_progression"
+/// DETAIL: Key (name)=(PreGoLiveMidwiferyProvidedCare:V9:All) already exists.
+///   at JasperFxAsyncDaemon`3.catchUpPerTenantAsync ... JasperFxAsyncDaemon.cs:989
+///   at JasperFxAsyncDaemon`3.CatchUpAsync ... JasperFxAsyncDaemon.cs:921
+///   at TestingExtensions.ForceAllMartenDaemonActivityToCatchUpAsync ...
+/// </code>
+/// </para>
+///
+/// <para>
+/// <b>Repro shape</b>: same partitioning + Conjoined config as Bug_4665, add
+/// 2+ tenants, append events to each, call <c>BuildProjectionDaemonAsync().CatchUpAsync</c>
+/// (same entry point ForceAllMartenDaemonActivityToCatchUpAsync drives). With
+/// store-global async projections registered, the second tenant's per-tenant
+/// catchup hits 23505 trying to insert the store-global progression row that
+/// the first tenant's catchup already created.
+/// </para>
+///
+/// <para>
+/// <b>Repro status</b>: this Marten-side single-DB Conjoined repro does NOT
+/// trigger the 23505 in isolation -- multiple attempts (host-based via
+/// <c>ForceAllMartenDaemonActivityToCatchUpAsync</c> with the live daemon
+/// started, store-direct via <c>BuildProjectionDaemonAsync().CatchUpAsync</c>)
+/// all pass with three tenants × one event each. The user's reported config
+/// includes <c>MultiTenantedWithShardedDatabases</c> + a much wider set of
+/// async projections (<c>ClientClaimLine:V6:All</c>, <c>Invoice:V7:All</c>,
+/// etc -- ~11 enumerated in the report) and per-tenant sequence positions
+/// likely well above zero from accumulated production traffic. One of those
+/// dimensions appears load-bearing for the bug.
+/// </para>
+///
+/// <para>
+/// <b>Fix is JasperFx-side</b>: <c>JasperFxAsyncDaemon.catchUpPerTenantAsync</c>
+/// at <c>src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs:945-991</c>.
+/// The Marten reproduction <see cref="Skip"/>'s itself; bumping
+/// <c>JasperFx.Events</c> past the fix version + replacing the <c>Skip</c>
+/// with an <c>[Fact]</c> attribute is the consume step (in addition to,
+/// ideally, a tighter Marten-side repro than this fixture once the bug's
+/// actual trigger is pinned).
+/// </para>
+/// </summary>
+public partial class Bug_4679_catch_up_per_tenant_23505
+{
+    private readonly ITestOutputHelper _output;
+
+    public Bug_4679_catch_up_per_tenant_23505(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private static readonly string SchemaName = $"bug4679_p{Environment.ProcessId}";
+
+    public class TripDistance
+    {
+        public Guid Id { get; set; }
+        public double Distance { get; set; }
+        public int Version { get; set; }
+    }
+
+    public record TripStarted(Guid Id);
+    public record TripLeg(double Distance);
+
+    public partial class TripDistanceProjection: SingleStreamProjection<TripDistance, Guid>
+    {
+        public TripDistanceProjection()
+        {
+            // Store-global :All shard -- the exact shape the bug fires on (the
+            // user's report enumerates ClientClaimLine:V6:All, Invoice:V7:All,
+            // etc -- every async projection registered without explicit
+            // tenancy sharding gets a :All shard).
+            Name = "Bug4679TripDistance";
+        }
+
+        public void Apply(TripDistance agg, TripLeg @event) => agg.Distance += @event.Distance;
+    }
+
+    [Fact(Skip = "#4679: JasperFx-side regression in catchUpPerTenantAsync. " +
+                 "This minimal single-DB Conjoined + UseTenantPartitionedEvents " +
+                 "reproduction does NOT trigger the 23505 in isolation -- the user's " +
+                 "MultiTenantedWithShardedDatabases setup appears load-bearing. " +
+                 "Pinned here as a permanent regression fixture; once the upstream fix lands + " +
+                 "a tighter repro emerges, replace this Skip with an [Fact] and update the body.")]
+    public async Task force_catch_up_across_multiple_tenants_does_not_throw_23505()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = SchemaName;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Policies.AllDocumentsAreMultiTenanted();
+
+            opts.Projections.Add<TripDistanceProjection>(ProjectionLifecycle.Async);
+        });
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+
+        // Two tenants minimum — the bug needs ≥2 to fire (first tenant's loop
+        // iteration inserts the store-global progression row; second tenant's
+        // iteration collides).
+        var tenants = Enumerable.Range(0, 3)
+            .Select(_ => $"t_{Guid.NewGuid():N}".Substring(0, 12))
+            .ToArray();
+        await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenants);
+
+        // Seed each tenant with one stream + one TripLeg so the per-tenant
+        // catch-up has something to advance through (an empty tenant's
+        // `ceiling == 0` short-circuit at JasperFxAsyncDaemon.cs:977 would
+        // skip the iteration and mask the bug).
+        var lastTripPerTenant = new Dictionary<string, Guid>();
+        foreach (var tenant in tenants)
+        {
+            var streamId = Guid.NewGuid();
+            lastTripPerTenant[tenant] = streamId;
+            await using var session = store.LightweightSession(tenant);
+            session.Events.StartStream<TripDistance>(streamId,
+                new TripStarted(streamId),
+                new TripLeg(1.0));
+            await session.SaveChangesAsync();
+        }
+
+        // Drive the buggy path via ForceAllMartenDaemonActivityToCatchUpAsync — matches
+        // the user's stack trace exactly. The internal flow is identical to
+        // daemon.CatchUpAsync() but goes through IProjectionCoordinator + the live
+        // daemon AddAsyncDaemon(Solo) started, which is the configuration the user reported.
+        Exception? thrown = null;
+        var hostBuilder = Host.CreateApplicationBuilder();
+        hostBuilder.Services.AddMarten(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = SchemaName;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Policies.AllDocumentsAreMultiTenanted();
+            opts.Projections.Add<TripDistanceProjection>(ProjectionLifecycle.Async);
+        }).AddAsyncDaemon(DaemonMode.Solo);
+
+        using var host = hostBuilder.Build();
+        await host.StartAsync();
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            // Exact entry point in the user's stack trace.
+            var exceptions = await host.ForceAllMartenDaemonActivityToCatchUpAsync(cts.Token);
+            if (exceptions.Count > 0)
+            {
+                thrown = new AggregateException(exceptions);
+            }
+        }
+        catch (Exception e)
+        {
+            thrown = e;
+        }
+        await host.StopAsync();
+
+        // Headline: no 23505 anywhere in the exception chain. Drill into
+        // AggregateException so the per-shard exceptions surface.
+        if (thrown != null)
+        {
+            var allMessages = string.Join("\n", Flatten(thrown).Select(x => $"  {x.GetType().Name}: {x.Message}"));
+            _output.WriteLine("CatchUpAsync threw:\n" + allMessages);
+        }
+
+        Flatten(thrown).ShouldNotContain(
+            x => x.Message.Contains("23505", StringComparison.Ordinal)
+                 || x.Message.Contains("pk_mt_event_progression", StringComparison.Ordinal),
+            "CatchUpAsync under per-tenant partitioning must not throw 23505 on the global :All " +
+            "shard's progression row -- the per-tenant catch-up loop should write tenant-scoped " +
+            "progression rows, not the store-global identity.");
+
+        // Sanity: each tenant's projection actually advanced (the fix mustn't
+        // regress the original #4665 advance-correctness pin).
+        foreach (var (tenant, streamId) in lastTripPerTenant)
+        {
+            await using var query = store.QuerySession(tenant);
+            var doc = await query.LoadAsync<TripDistance>(streamId);
+            doc.ShouldNotBeNull($"tenant {tenant} stream {streamId} should have a projected doc after catch-up");
+            doc.Distance.ShouldBe(1.0);
+        }
+    }
+
+    private static IEnumerable<Exception> Flatten(Exception? root)
+    {
+        if (root is null) yield break;
+        if (root is AggregateException agg)
+        {
+            foreach (var inner in agg.Flatten().InnerExceptions)
+            {
+                yield return inner;
+                if (inner.InnerException != null) foreach (var x in Flatten(inner.InnerException)) yield return x;
+            }
+        }
+        else
+        {
+            yield return root;
+            if (root.InnerException != null) foreach (var x in Flatten(root.InnerException)) yield return x;
+        }
+    }
+}


### PR DESCRIPTION
Permanent regression fixture for [#4679](https://github.com/JasperFx/marten/issues/4679) -- the 23505 follow-up to my own #4665 fix in `JasperFxAsyncDaemon.catchUpPerTenantAsync` (shipped in JasperFx.Events 2.8.2 / Marten 9.6.0).

## Repro status -- honest

Multiple attempts in a single-DB Conjoined + `UseTenantPartitionedEvents` config (three tenants × one stream each, both host-based via `ForceAllMartenDaemonActivityToCatchUpAsync` and store-direct via `BuildProjectionDaemonAsync().CatchUpAsync`) **all pass with no 23505**. The bug report's config includes `MultiTenantedWithShardedDatabases` + ~11 enumerated async `:All` projections + accumulated production traffic; one of those dimensions appears load-bearing for the bug to fire.

## Why land it as Skipped anyway

Mirrors the #4665 fixture pattern: a Skipped pin holds the bug's identity (name, schema, headline assertion shape) so when the upstream fix lands + a tighter Marten-side repro emerges, the `Skip` becomes `[Fact]` in one diff and we have a permanent regression fixture.

The class XML doc captures:

* The full stack from the user report
* The Marten-side reproduction status (what was tried, why nothing fires)
* The fix location -- `JasperFx.Events` `JasperFxAsyncDaemon.cs:945-991`
* The consume step (JasperFx bump + `Skip` → `[Fact]`)

## Why not a JasperFx-side fix in this session

Without a confirmed local repro I won't ship a speculative fix to JasperFx based on guesses about which call site captures the wrong identity. The honest path is:

1. Land this Skipped pin (this PR)
2. Get the user's `MultiTenantedWithShardedDatabases` reproduction PR (the issue offers one: \"Happy to provide a minimal standalone repro / PR\")
3. Diagnose with the actual reproduction
4. Fix at JasperFx + bump + consume (unskip)

## Build / test

| Aspect | Result |
|---|---|
| Marten compile | clean on net9.0 |
| New test runs | **Skipped** (1) — the test is intentionally inert pending the upstream fix |

🤖 Generated with [Claude Code](https://claude.com/claude-code)