### PR TITLE
#4685 PR 2 — rebuild Insert-only routing seam + proof of the Phase-4 prerequisite

### DIFF
--- a/src/DaemonTests/Bug_4685_rebuild_insert_only_multipage.cs
+++ b/src/DaemonTests/Bug_4685_rebuild_insert_only_multipage.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Aggregation;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DaemonTests;
+
+public record Bug4685Incremented();
+
+public class Bug4685Counter
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+}
+
+public partial class Bug4685CounterProjection: SingleStreamProjection<Bug4685Counter, Guid>
+{
+    public Bug4685CounterProjection()
+    {
+        Name = "Bug4685Counter";
+        Options.TeardownDataOnRebuild = true;
+
+        // Force a single stream's events to span multiple rebuild pages: 30 events / BatchSize 10
+        // => 3 pages => 3 ProjectionUpdateBatch flushes that each re-store this stream's aggregate.
+        Options.BatchSize = 10;
+    }
+
+    public void Apply(Bug4685Incremented _, Bug4685Counter counter) => counter.Count++;
+}
+
+/// <summary>
+/// #4685 PR 2 — proving the blocker. Marten's rebuild flushes page-by-page (one
+/// <c>ProjectionUpdateBatch</c> per <c>EventPage</c>, see
+/// <c>GroupedProjectionExecution.processRangeAsync</c>), and the aggregate cache spans pages,
+/// so a stream whose events span more than one page has its aggregate written once per page.
+/// <para>
+/// With the default UPSERT/OVERWRITE routing that is correct (later pages overwrite). The
+/// EXPERIMENTAL <c>ProjectionOptions.RebuildWithInsertOnly</c> routing (the INSERT-only seam the
+/// BulkWriter binary <c>COPY</c> flush in PR 3 needs) instead INSERTs each write — so the second
+/// page that touches the stream's aggregate throws <c>23505 / DocumentAlreadyExistsException</c>.
+/// The INSERT-only premise only holds once CritterWatch#208 Phase 4 (deferred flush via
+/// identity-map accumulation) guarantees each aggregate is written exactly once. These two tests
+/// pin that boundary; when Phase 4 lands, the second test's assertion flips to expect success.
+/// </para>
+/// </summary>
+public class Bug_4685_rebuild_insert_only_multipage: DaemonContext
+{
+    public Bug_4685_rebuild_insert_only_multipage(ITestOutputHelper output): base(output)
+    {
+    }
+
+    private async Task<Guid> seedSingleStreamSpanningPagesAsync()
+    {
+        var streamId = Guid.NewGuid();
+        await using var session = theStore.LightweightSession();
+        for (var i = 0; i < 30; i++)
+        {
+            session.Events.Append(streamId, new Bug4685Incremented());
+        }
+
+        await session.SaveChangesAsync();
+        return streamId;
+    }
+
+    [Fact]
+    public async Task default_upsert_routing_rebuilds_a_multipage_stream_correctly()
+    {
+        // Default behavior — RebuildWithInsertOnly is off. No behavior change from PR 2.
+        StoreOptions(x => x.Projections.Add(new Bug4685CounterProjection(), ProjectionLifecycle.Async));
+
+        var streamId = await seedSingleStreamSpanningPagesAsync();
+
+        var daemon = await StartDaemon();
+        await daemon.RebuildProjectionAsync("Bug4685Counter", CancellationToken.None);
+
+        await using var query = theStore.QuerySession();
+        var counter = await query.LoadAsync<Bug4685Counter>(streamId);
+        counter.ShouldNotBeNull();
+        counter.Count.ShouldBe(30);
+    }
+
+    [Fact]
+    public async Task insert_only_routing_collides_on_a_multipage_stream_until_phase_4()
+    {
+        // Turn on the experimental INSERT-only rebuild routing. This is the blocker proof:
+        // the page-batched rebuild re-stores the stream's aggregate on the second page,
+        // and INSERT of an already-present id fails with 23505.
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new Bug4685CounterProjection(), ProjectionLifecycle.Async);
+            x.Projections.RebuildWithInsertOnly = true;
+        });
+
+        var streamId = await seedSingleStreamSpanningPagesAsync();
+
+        var daemon = await StartDaemon();
+
+        // The daemon records the 23505 / DocumentAlreadyExistsException internally and stops the
+        // shard rather than always rethrowing to the caller, so the failure manifests as either a
+        // thrown exception OR a silently incomplete rebuild. Capture both.
+        var thrown = await Record.ExceptionAsync(() =>
+            daemon.RebuildProjectionAsync("Bug4685Counter", CancellationToken.None));
+
+        await using var query = theStore.QuerySession();
+        var counter = await query.LoadAsync<Bug4685Counter>(streamId);
+
+        // The correct, post-Phase-4 outcome is Count == 30. The INSERT-only routing cannot reach
+        // it on a multipage stream: the rebuild either faults or leaves the aggregate incomplete.
+        var rebuiltCorrectly = thrown is null && counter is { Count: 30 };
+        rebuiltCorrectly.ShouldBeFalse(
+            "INSERT-only rebuild routing must NOT correctly rebuild a multipage stream until " +
+            "CritterWatch#208 Phase 4 (single-flush) lands; this pins the duplicate-key blocker. " +
+            $"thrown={thrown?.GetType().Name ?? "none"}, count={counter?.Count.ToString() ?? "null"}");
+    }
+}

--- a/src/Marten/Events/Daemon/Internals/ProjectionDocumentSession.cs
+++ b/src/Marten/Events/Daemon/Internals/ProjectionDocumentSession.cs
@@ -20,6 +20,10 @@ internal class ProjectionDocumentSession: DocumentSessionBase, ITransactionParti
 {
     public ShardExecutionMode Mode { get; }
 
+    // #4685 PR 2 — surface the per-shard execution mode to ProjectionStorage so a rebuild
+    // replay can route to INSERT-only operations.
+    internal override ShardExecutionMode ExecutionMode => Mode;
+
     public ProjectionDocumentSession(DocumentStore store,
         ISessionWorkTracker workTracker,
         SessionOptions sessionOptions, ShardExecutionMode mode): base(store, sessionOptions, sessionOptions.BuildAutoClosingLifetime(store), workTracker)

--- a/src/Marten/Events/Projections/ProjectionOptions.cs
+++ b/src/Marten/Events/Projections/ProjectionOptions.cs
@@ -73,6 +73,23 @@ public class ProjectionOptions: ProjectionGraph<IProjection, IDocumentOperations
     /// </summary>
     public bool DiscoverGeneratedEvolversOnStartup { get; set; } = true;
 
+    /// <summary>
+    /// #4685 PR 2 — EXPERIMENTAL, default <see langword="false"/>. When enabled, a projection
+    /// rebuild replay routes its aggregate writes through INSERT-only operations (the seam the
+    /// BulkWriter binary <c>COPY</c> flush in PR 3 dispatches on) instead of UPSERT/OVERWRITE.
+    /// <para>
+    /// This is correct ONLY once each aggregate id is written exactly once across the whole
+    /// rebuild. Marten's rebuild flushes page-by-page (one <c>ProjectionUpdateBatch</c> per
+    /// <c>EventPage</c>), so any stream whose events span more than one page has its aggregate
+    /// re-stored once per page — and a second INSERT of the same id throws
+    /// <c>23505 / DocumentAlreadyExistsException</c>. The single-flush guarantee that makes this
+    /// safe is CritterWatch#208 Phase 4 (deferred flush via identity-map accumulation), which
+    /// must land first. Until then this flag is for the proving test only.
+    /// See <c>Bug_4685_rebuild_insert_only_multipage</c>.
+    /// </para>
+    /// </summary>
+    internal bool RebuildWithInsertOnly { get; set; }
+
     // Snapshot of AppDomain.CurrentDomain.GetAssemblies() taken on first construction
     // of any DocumentStore in the process. The audit row #4294/Lens-1/#1 calls this out
     // as a top-fix candidate — multiple DocumentStore instances (multi-database tenancy)

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs
@@ -61,6 +61,20 @@ internal class ProjectionStorage<TDoc, TId>: IProjectionStorage<TDoc, TId> where
 
     public Type IdType => typeof(TId);
 
+    // #4685 PR 2 (proving the blocker) — when the backing session is a rebuild replay, the
+    // projection table was TRUNCATEd / per-tenant-DELETEd before replay started, so every
+    // write is (in principle) an INSERT. Routing through InsertProjected instead of
+    // UpsertProjected/OverwriteProjected makes the batch classify as BatchFlushMode.InsertOnly
+    // so the BulkWriter (binary COPY) path can pick it up. CAUTION: this is only correct when
+    // each aggregate id is written exactly once across the whole rebuild, which Marten's
+    // page-batched rebuild does NOT guarantee today — see the EXPERIMENTAL
+    // ProjectionOptions.RebuildWithInsertOnly flag (default off, no behavior change) and the
+    // Bug_4685_rebuild_insert_only_multipage proving test for why this is gated off until
+    // CritterWatch#208 Phase 4 (single-flush) lands.
+    private bool IsRebuild =>
+        _session.ExecutionMode == JasperFx.Events.Daemon.ShardExecutionMode.Rebuild
+        && _session.Options.Projections.RebuildWithInsertOnly;
+
     public TId Identity(TDoc document)
     {
         return _storage.Identity(document);
@@ -86,8 +100,9 @@ internal class ProjectionStorage<TDoc, TId>: IProjectionStorage<TDoc, TId> where
         // #4667 — UpsertProjected (not Upsert) so we never read or mutate
         // _session.Versions / _session.Revisions from a daemon worker. The
         // projection runtime is by-contract not session-state-aware.
-        var upsert = _storage.UpsertProjected(snapshot, TenantId);
-        _session.QueueOperation(upsert);
+        // #4685 PR 2 — rebuild replay routes to InsertProjected.
+        var op = IsRebuild ? _storage.InsertProjected(snapshot, TenantId) : _storage.UpsertProjected(snapshot, TenantId);
+        _session.QueueOperation(op);
     }
 
     public void Delete(TId identity)
@@ -149,8 +164,9 @@ internal class ProjectionStorage<TDoc, TId>: IProjectionStorage<TDoc, TId> where
             _storage.Store(_session, snapshot);
         }
 
-        var upsert = _storage.UpsertProjected(snapshot, tenantId);
-        _session.QueueOperation(upsert);
+        // #4685 PR 2 — rebuild replay routes to InsertProjected.
+        var op = IsRebuild ? _storage.InsertProjected(snapshot, tenantId) : _storage.UpsertProjected(snapshot, tenantId);
+        _session.QueueOperation(op);
     }
 
     public void Delete(TId identity, string tenantId)
@@ -188,7 +204,9 @@ internal class ProjectionStorage<TDoc, TId>: IProjectionStorage<TDoc, TId> where
         // thread-safe. The projection path doesn't need session-level tracking anyway --
         // the revision is set explicitly from the event below and IgnoreConcurrencyViolation
         // = true makes any tracker bookkeeping moot.
-        var op = _storage.OverwriteProjected(aggregate, TenantId);
+        // #4685 PR 2 — rebuild replay routes to InsertProjected (still INSERT-only post-teardown);
+        // the revision is set explicitly from the event below either way.
+        var op = IsRebuild ? _storage.InsertProjected(aggregate, TenantId) : _storage.OverwriteProjected(aggregate, TenantId);
         if (op is IRevisionedOperation r)
         {
             r.Revision = scope == AggregationScope.SingleStream ? (int)lastEvent.Version : (int)lastEvent.Sequence;

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.Events;
+using JasperFx.Events.Daemon;
 using Marten.Events;
 using Marten.Exceptions;
 using Marten.Internal.Operations;
@@ -64,6 +65,17 @@ public abstract partial class DocumentSessionBase: QuerySession, IDocumentSessio
         _workTracker.EjectAll();
         ChangeTrackers.Clear();
     }
+
+    /// <summary>
+    /// #4685 PR 2 (proving the blocker): the shard execution mode this session is operating
+    /// under when it backs an async projection / subscription apply. Defaults to
+    /// <see cref="ShardExecutionMode.Continuous"/> for ordinary sessions;
+    /// <see cref="Marten.Events.Daemon.Internals.ProjectionDocumentSession"/> overrides it with the
+    /// daemon's per-shard mode, and <see cref="NestedTenantSession"/> delegates to its parent.
+    /// <see cref="ProjectionStorage{TDoc,TId}"/> reads it to decide whether a post-teardown rebuild
+    /// replay can be routed through INSERT-only operations (the BulkWriter COPY win) instead of UPSERT.
+    /// </summary>
+    internal virtual ShardExecutionMode ExecutionMode => ShardExecutionMode.Continuous;
 
     public void Store<T>(IEnumerable<T> entities) where T : notnull
     {

--- a/src/Marten/Internal/Sessions/NestedTenantSession.cs
+++ b/src/Marten/Internal/Sessions/NestedTenantSession.cs
@@ -24,6 +24,10 @@ internal class NestedTenantSession: DocumentSessionBase, ITenantOperations
 
     public IDocumentSession Parent => _parent;
 
+    // #4685 PR 2 — a nested tenant session shares the parent's work tracker / batch, so it
+    // inherits the parent's rebuild-vs-continuous execution mode.
+    internal override JasperFx.Events.Daemon.ShardExecutionMode ExecutionMode => _parent.ExecutionMode;
+
     protected internal override void ejectById<T>(long id)
     {
         _parent.ejectById<T>(id);


### PR DESCRIPTION
Part of #4685 (Phase 4-bis: BulkWriter binary `COPY` for INSERT-only rebuild batches). Follows #4685 PR 1 (the `BatchFlushMode` classifier seam).

## What this does

1. **Adds the `ExecutionMode` seam.** `DocumentSessionBase.ExecutionMode` (virtual, default `Continuous`), overridden by `ProjectionDocumentSession` to return its per-shard `Mode`, and delegated by `NestedTenantSession` to its parent (cross-tenant projection writes share the parent's batch). This is the rebuild-vs-continuous signal PR 3's BulkWriter dispatch needs.

2. **Routes projection-storage writes to `InsertProjected` when rebuilding.** The real aggregate-persistence seam is `ProjectionStorage<TDoc,TId>` (`Store` / `Store(id,tenant)` / `StoreProjection`), **not** `DocumentSessionBase.store<T>` — the daemon uses the session-free `*Projected` operations (the #4667 path). When rebuilding, those route to `InsertProjected` instead of `UpsertProjected`/`OverwriteProjected`, so a rebuild batch classifies as `BatchFlushMode.InsertOnly`.

3. **Gates the routing behind an EXPERIMENTAL, default-off flag** (`ProjectionOptions.RebuildWithInsertOnly`, internal). **Zero behavior change to any existing rebuild.**

## Why it's gated off — the Phase-4 prerequisite (proven, not asserted)

The issue's "rebuild is INSERT-only post-TRUNCATE" premise only holds if **each aggregate id is written exactly once** across the whole rebuild. Marten's rebuild does **not** guarantee that today: it flushes **page-by-page** (one `ProjectionUpdateBatch` per `EventPage`, `GroupedProjectionExecution.processRangeAsync`), and the aggregate cache spans pages — so a stream whose events span multiple pages has its aggregate re-stored once per page. With UPSERT that's fine (later pages overwrite). With INSERT, the second page throws `23505 / DocumentAlreadyExistsException`.

`Bug_4685_rebuild_insert_only_multipage` pins this empirically with a 30-event single stream at `BatchSize=10` (3 pages):

- `default_upsert_routing_rebuilds_a_multipage_stream_correctly` → **passes** (Count == 30; default routing unchanged).
- `insert_only_routing_collides_on_a_multipage_stream_until_phase_4` → with the flag on, the rebuild cannot reach Count == 30 (duplicate-key).

The single-flush guarantee that makes INSERT-only safe is **CritterWatch#208 Phase 4** (deferred flush via identity-map accumulation), which must land first. When it does, the second test flips to expect success and the flag can be promoted to default-on (and PR 3 dispatches the binary `COPY` path on the resulting `InsertOnly` batches).

## Tests

- `DaemonTests.Bug_4685_rebuild_insert_only_multipage` (2 tests, both green)
- Regression sweep green: `DaemonTests.Aggregations` (36), `DaemonTests.MultiTenancy` (8), `rebuilding_an_inline_projection`.

Draft until Phase 4 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)