### PR TITLE
#4682 PR 1 — conjoined→tenant-partitioning migration: Phase 1 (Prepare/dry-run)

### DIFF
--- a/src/Marten/Events/TenantPartitioning/TenantPartitioningMigrationPlan.cs
+++ b/src/Marten/Events/TenantPartitioning/TenantPartitioningMigrationPlan.cs
@@ -1,0 +1,95 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Marten.Events.TenantPartitioning;
+
+/// <summary>
+/// #4682 — classification of an existing <c>mt_event_progression</c> row, produced by the
+/// migration's audit pass. The conjoined → tenant-partitioned migration must be able to account
+/// for every progression row before the table swap: known store-global and per-tenant identities
+/// are carried across untouched, while anything that doesn't match the shard grammar is a
+/// hand-rolled straggler that needs operator attention.
+/// </summary>
+public enum ProgressionRowKind
+{
+    /// <summary>The single store-global high-water row, <c>HighWaterMark</c>.</summary>
+    StoreGlobalHighWater,
+
+    /// <summary>A per-tenant high-water row, <c>HighWaterMark:{tenantId}</c>.</summary>
+    PerTenantHighWater,
+
+    /// <summary>A store-global projection shard, e.g. <c>Invoice:All</c> or <c>Invoice:V7:All</c>.</summary>
+    StoreGlobalShard,
+
+    /// <summary>A per-tenant projection shard, e.g. <c>Invoice:All:acme</c> or <c>Invoice:V7:All:acme</c>.</summary>
+    PerTenantShard,
+
+    /// <summary>Does not match any known identity grammar — a hand-rolled row needing review.</summary>
+    Unrecognized
+}
+
+/// <summary>
+/// #4682 — one audited <c>mt_event_progression</c> row.
+/// </summary>
+public sealed record ProgressionRowAudit(string Name, long LastSeqId, ProgressionRowKind Kind, string? TenantId);
+
+/// <summary>
+/// #4682 — per-tenant event inventory taken during the migration's Prepare phase. The seed value
+/// for each tenant's new <c>mt_events_sequence_{suffix}</c> is <see cref="MaxSeqId"/> + 1.
+/// </summary>
+public sealed record TenantEventInventory(
+    string TenantId,
+    long EventCount,
+    long MaxSeqId,
+    bool PartitionRegistered,
+    string? PartitionSuffix);
+
+/// <summary>
+/// #4682 — the output of the conjoined → <c>UseTenantPartitionedEvents</c> migration's Prepare
+/// phase (the <c>--dry-run</c> result). It is read-only: building a plan touches no data, only
+/// inventories the source store and validates the prerequisites so an operator can review the
+/// scope before any data movement begins. Phases 2 (per-tenant copy + attach) and 3 (swap +
+/// cleanup) consume this plan.
+/// </summary>
+public sealed class TenantPartitioningMigrationPlan
+{
+    /// <summary>
+    /// Hard prerequisite failures. When non-empty the migration must not proceed; these are
+    /// configuration / data problems an operator has to fix first.
+    /// </summary>
+    public List<string> Errors { get; } = new();
+
+    /// <summary>
+    /// Non-blocking findings (e.g. tenants with events but no registered partition yet, or
+    /// hand-rolled progression rows) that an operator should review but that do not by themselves
+    /// stop the migration.
+    /// </summary>
+    public List<string> Warnings { get; } = new();
+
+    /// <summary>Per-tenant event inventory, ordered by tenant id.</summary>
+    public List<TenantEventInventory> Tenants { get; } = new();
+
+    /// <summary>Audit of every <c>mt_event_progression</c> row in the source store.</summary>
+    public List<ProgressionRowAudit> ProgressionRows { get; } = new();
+
+    /// <summary>
+    /// Count of <c>mt_events</c> rows with a null <c>tenant_id</c>. Must be zero to migrate: a row
+    /// with no tenant cannot be routed to a tenant partition.
+    /// </summary>
+    public long EventsWithoutTenant { get; set; }
+
+    /// <summary>True when there are no hard prerequisite failures.</summary>
+    public bool CanProceed => Errors.Count == 0;
+
+    /// <summary>Total event rows across all tenants.</summary>
+    public long TotalEvents => Tenants.Sum(x => x.EventCount);
+
+    /// <summary>Tenants that have events but no registered partition in <c>mt_tenant_partitions</c>.</summary>
+    public IEnumerable<TenantEventInventory> TenantsMissingPartitions =>
+        Tenants.Where(x => !x.PartitionRegistered);
+
+    /// <summary>Progression rows the audit could not classify (hand-rolled stragglers).</summary>
+    public IEnumerable<ProgressionRowAudit> UnrecognizedProgressionRows =>
+        ProgressionRows.Where(x => x.Kind == ProgressionRowKind.Unrecognized);
+}

--- a/src/Marten/Storage/MartenDatabase.TenantPartitioningMigration.cs
+++ b/src/Marten/Storage/MartenDatabase.TenantPartitioningMigration.cs
@@ -1,0 +1,202 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Marten.Events.Daemon.HighWater;
+using Marten.Events.Schema;
+using Marten.Events.TenantPartitioning;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Postgresql;
+
+namespace Marten.Storage;
+
+/// <summary>
+/// #4682 — conjoined → <c>UseTenantPartitionedEvents</c> migration, Phase 1 (Prepare).
+/// Builds a read-only <see cref="TenantPartitioningMigrationPlan"/>: validates the prerequisites,
+/// inventories per-tenant event counts and high-water sequence values, and audits the existing
+/// <c>mt_event_progression</c> rows. This is the <c>--dry-run</c> path — it touches no data.
+/// Phases 2 (per-tenant copy + attach) and 3 (swap + cleanup) build on the plan this produces.
+/// </summary>
+public partial class MartenDatabase
+{
+    /// <summary>
+    /// Inventory and validate this (conjoined) event store for migration to
+    /// <c>Events.UseTenantPartitionedEvents</c>. Read-only: no schema or data changes are made.
+    /// Inspect <see cref="TenantPartitioningMigrationPlan.CanProceed"/> and
+    /// <see cref="TenantPartitioningMigrationPlan.Errors"/> before running the data-movement phases.
+    /// </summary>
+    public async Task<TenantPartitioningMigrationPlan> CreateTenantPartitioningMigrationPlanAsync(
+        CancellationToken token = default)
+    {
+        var plan = new TenantPartitioningMigrationPlan();
+        var events = Options.Events;
+        var schema = events.DatabaseSchemaName;
+
+        // --- Static prerequisite validation (no DB access needed) ---
+        if (events.TenancyStyle != TenancyStyle.Conjoined)
+        {
+            plan.Errors.Add(
+                $"The source event store must use TenancyStyle.Conjoined to migrate to tenant partitioning; found {events.TenancyStyle}.");
+        }
+
+        if (!events.UseTenantPartitionedEvents)
+        {
+            plan.Errors.Add(
+                "The target configuration must set Events.UseTenantPartitionedEvents = true. Configure the store for partitioning, then build the migration plan against it.");
+        }
+
+        await using var conn = CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+        try
+        {
+            var eventsTable = $"{schema}.mt_events";
+            if (await regclassAsync(conn, eventsTable, token).ConfigureAwait(false) == null)
+            {
+                plan.Errors.Add($"No {eventsTable} table found — there is no conjoined event store to migrate.");
+                return plan;
+            }
+
+            // Every event must carry a tenant_id; a null tenant cannot be routed to a partition.
+            plan.EventsWithoutTenant = await countAsync(conn,
+                $"select count(*) from {eventsTable} where tenant_id is null", token).ConfigureAwait(false);
+            if (plan.EventsWithoutTenant > 0)
+            {
+                plan.Errors.Add(
+                    $"{plan.EventsWithoutTenant} event row(s) have a null tenant_id and cannot be assigned to a tenant partition. Backfill tenant_id before migrating.");
+            }
+
+            // Registered partitions (tenant_id -> partition_suffix), if the lookup table exists yet.
+            var registeredSuffixes = await loadRegisteredPartitionsAsync(conn, token).ConfigureAwait(false);
+
+            await loadTenantInventoryAsync(conn, eventsTable, registeredSuffixes, plan, token).ConfigureAwait(false);
+            await auditProgressionRowsAsync(conn, schema, plan, token).ConfigureAwait(false);
+
+            foreach (var tenant in plan.TenantsMissingPartitions)
+            {
+                plan.Warnings.Add(
+                    $"Tenant '{tenant.TenantId}' has {tenant.EventCount} event(s) but no registered partition. Register it via AddMartenManagedTenantsAsync before Phase 2 (or the tool can auto-populate from distinct tenant ids).");
+            }
+
+            foreach (var straggler in plan.UnrecognizedProgressionRows)
+            {
+                plan.Warnings.Add(
+                    $"mt_event_progression row '{straggler.Name}' does not match any known shard or high-water identity. Review it before the table swap.");
+            }
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+
+        return plan;
+    }
+
+    private async Task<Dictionary<string, string>> loadRegisteredPartitionsAsync(
+        NpgsqlConnection conn, CancellationToken token)
+    {
+        var result = new Dictionary<string, string>();
+        var tenantPartitions = Options.TenantPartitions;
+        if (tenantPartitions == null)
+        {
+            return result;
+        }
+
+        var tenantsTable = tenantPartitions.TenantsTableName.QualifiedName;
+        if (await regclassAsync(conn, tenantsTable, token).ConfigureAwait(false) == null)
+        {
+            return result;
+        }
+
+        await using var cmd = conn.CreateCommand(
+            $"select partition_value, partition_suffix from {tenantsTable}");
+        await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            result[reader.GetString(0)] = reader.GetString(1);
+        }
+
+        return result;
+    }
+
+    private static async Task loadTenantInventoryAsync(NpgsqlConnection conn, string eventsTable,
+        IReadOnlyDictionary<string, string> registeredSuffixes,
+        TenantPartitioningMigrationPlan plan, CancellationToken token)
+    {
+        await using var cmd = conn.CreateCommand(
+            $"select tenant_id, count(*), max(seq_id) from {eventsTable} where tenant_id is not null group by tenant_id order by tenant_id");
+        await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            var tenantId = reader.GetString(0);
+            var count = reader.GetInt64(1);
+            var maxSeq = reader.GetInt64(2);
+            var registered = registeredSuffixes.TryGetValue(tenantId, out var suffix);
+            plan.Tenants.Add(new TenantEventInventory(tenantId, count, maxSeq, registered, registered ? suffix : null));
+        }
+    }
+
+    private static async Task auditProgressionRowsAsync(NpgsqlConnection conn, string schema,
+        TenantPartitioningMigrationPlan plan, CancellationToken token)
+    {
+        var progressionTable = $"{schema}.{EventProgressionTable.Name}";
+        if (await regclassAsync(conn, progressionTable, token).ConfigureAwait(false) == null)
+        {
+            return;
+        }
+
+        await using var cmd = conn.CreateCommand($"select name, last_seq_id from {progressionTable} order by name");
+        await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            var name = reader.GetString(0);
+            var lastSeqId = reader.GetInt64(1);
+            plan.ProgressionRows.Add(classifyProgressionRow(name, lastSeqId));
+        }
+    }
+
+    /// <summary>
+    /// Classify an <c>mt_event_progression.name</c> against the shard / high-water identity grammar.
+    /// High-water rows are checked first because <see cref="ShardName.TryParse"/> would otherwise
+    /// (mis)read <c>HighWaterMark:{tenant}</c> as a store-global shard named "HighWaterMark".
+    /// </summary>
+    internal static ProgressionRowAudit classifyProgressionRow(string name, long lastSeqId)
+    {
+        if (name == HighWaterShardIdentity.StoreGlobal)
+        {
+            return new ProgressionRowAudit(name, lastSeqId, ProgressionRowKind.StoreGlobalHighWater, null);
+        }
+
+        if (name.StartsWith(HighWaterShardIdentity.PerTenantPrefix, StringComparison.Ordinal))
+        {
+            var tenantId = name.Substring(HighWaterShardIdentity.PerTenantPrefix.Length);
+            return new ProgressionRowAudit(name, lastSeqId, ProgressionRowKind.PerTenantHighWater, tenantId);
+        }
+
+        if (ShardName.TryParse(name, out var shardName) && shardName != null)
+        {
+            return shardName.TenantId == null
+                ? new ProgressionRowAudit(name, lastSeqId, ProgressionRowKind.StoreGlobalShard, null)
+                : new ProgressionRowAudit(name, lastSeqId, ProgressionRowKind.PerTenantShard, shardName.TenantId);
+        }
+
+        return new ProgressionRowAudit(name, lastSeqId, ProgressionRowKind.Unrecognized, null);
+    }
+
+    private static async Task<string?> regclassAsync(NpgsqlConnection conn, string qualifiedName,
+        CancellationToken token)
+    {
+        await using var cmd = conn.CreateCommand("select to_regclass(:name)::text").With("name", qualifiedName);
+        var result = await cmd.ExecuteScalarAsync(token).ConfigureAwait(false);
+        return result == null || result is DBNull ? null : (string)result;
+    }
+
+    private static async Task<long> countAsync(NpgsqlConnection conn, string sql, CancellationToken token)
+    {
+        await using var cmd = conn.CreateCommand(sql);
+        var result = await cmd.ExecuteScalarAsync(token).ConfigureAwait(false);
+        return result is long l ? l : Convert.ToInt64(result);
+    }
+}

--- a/src/TenantPartitionedEventsTests/Migration/conjoined_to_partitioned_migration_plan.cs
+++ b/src/TenantPartitionedEventsTests/Migration/conjoined_to_partitioned_migration_plan.cs
@@ -1,0 +1,148 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using Marten;
+using Marten.Events.TenantPartitioning;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Migration;
+
+public record MigrationStreamStarted(string Name);
+
+public record MigrationThingHappened(int Number);
+
+/// <summary>
+/// #4682 Phase 1 — the read-only Prepare / dry-run path of the conjoined →
+/// UseTenantPartitionedEvents migration. Verifies prerequisite validation, per-tenant inventory
+/// (counts + high-water seq ids), and the mt_event_progression audit classifier.
+/// </summary>
+public class conjoined_to_partitioned_migration_plan: IAsyncLifetime
+{
+    private readonly string _schema = "tp_migrate_p" + Environment.ProcessId;
+
+    public async Task InitializeAsync()
+    {
+        // Start from a clean schema so the conjoined seed and the dry-run read are deterministic.
+        await using var store = sourceStore(AutoCreate.All);
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private DocumentStore sourceStore(AutoCreate autoCreate) =>
+        DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = _schema;
+            opts.AutoCreateSchemaObjects = autoCreate;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+        });
+
+    // The store the operator would configure for the *target* state: same database / schema,
+    // conjoined + partitioning turned on, but AutoCreate.None so building it never disturbs the
+    // existing conjoined schema. The dry-run only reads.
+    private DocumentStore targetStore() =>
+        DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = _schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.None;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.Events.UseTenantPartitionedEvents = true;
+        });
+
+    private async Task seedConjoinedEventsAsync()
+    {
+        await using var store = sourceStore(AutoCreate.All);
+
+        // Single-threaded, sequential appends so the global sequence is deterministic:
+        // acme => seq 1..5 (max 5), globex => 6..8 (max 8), initech => 9..10 (max 10).
+        await appendAsync(store, "acme", 5);
+        await appendAsync(store, "globex", 3);
+        await appendAsync(store, "initech", 2);
+    }
+
+    private static async Task appendAsync(IDocumentStore store, string tenantId, int count)
+    {
+        await using var session = store.LightweightSession(tenantId);
+        var streamId = $"{tenantId}-stream";
+        session.Events.StartStream(streamId, new MigrationStreamStarted(tenantId));
+        for (var i = 1; i < count; i++)
+        {
+            session.Events.Append(streamId, new MigrationThingHappened(i));
+        }
+
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task dry_run_inventories_tenants_and_validates_prerequisites()
+    {
+        await seedConjoinedEventsAsync();
+
+        await using var target = targetStore();
+        var database = (MartenDatabase)target.Tenancy.Default.Database;
+
+        var plan = await database.CreateTenantPartitioningMigrationPlanAsync();
+
+        plan.CanProceed.ShouldBeTrue();
+        plan.Errors.ShouldBeEmpty();
+        plan.EventsWithoutTenant.ShouldBe(0);
+        plan.TotalEvents.ShouldBe(10);
+
+        plan.Tenants.Select(x => x.TenantId).ShouldBe(new[] { "acme", "globex", "initech" });
+
+        var acme = plan.Tenants.Single(x => x.TenantId == "acme");
+        acme.EventCount.ShouldBe(5);
+        acme.MaxSeqId.ShouldBe(5); // per-tenant sequence will START WITH max+1 = 6
+
+        plan.Tenants.Single(x => x.TenantId == "globex").MaxSeqId.ShouldBe(8);
+        plan.Tenants.Single(x => x.TenantId == "initech").MaxSeqId.ShouldBe(10);
+
+        // No partitions registered yet => every tenant flagged, but it's only a warning.
+        plan.TenantsMissingPartitions.Select(x => x.TenantId)
+            .ShouldBe(new[] { "acme", "globex", "initech" });
+        plan.Warnings.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task validation_blocks_when_partitioning_is_not_configured()
+    {
+        await seedConjoinedEventsAsync();
+
+        // Build the plan against a store that is still plain conjoined (UseTenantPartitionedEvents off).
+        await using var store = sourceStore(AutoCreate.None);
+        var database = (MartenDatabase)store.Tenancy.Default.Database;
+
+        var plan = await database.CreateTenantPartitioningMigrationPlanAsync();
+
+        plan.CanProceed.ShouldBeFalse();
+        plan.Errors.ShouldContain(e => e.Contains("UseTenantPartitionedEvents"));
+    }
+
+    [Theory]
+    [InlineData("HighWaterMark", ProgressionRowKind.StoreGlobalHighWater, null)]
+    [InlineData("HighWaterMark:acme", ProgressionRowKind.PerTenantHighWater, "acme")]
+    [InlineData("Invoice:All", ProgressionRowKind.StoreGlobalShard, null)]
+    [InlineData("Invoice:V7:All", ProgressionRowKind.StoreGlobalShard, null)]
+    [InlineData("Invoice:All:acme", ProgressionRowKind.PerTenantShard, "acme")]
+    [InlineData("Invoice:V7:All:acme", ProgressionRowKind.PerTenantShard, "acme")]
+    [InlineData("totally-hand-rolled", ProgressionRowKind.Unrecognized, null)]
+    public void classifies_progression_rows(string name, ProgressionRowKind expectedKind, string? expectedTenant)
+    {
+        var audit = MartenDatabase.classifyProgressionRow(name, 42);
+
+        audit.Kind.ShouldBe(expectedKind);
+        audit.TenantId.ShouldBe(expectedTenant);
+        audit.LastSeqId.ShouldBe(42);
+    }
+}


### PR DESCRIPTION
First slice of #4682 (Conjoined → `UseTenantPartitionedEvents` migration tool). Lands the read-only **Prepare** phase; the data-movement phases sequence after.

## Design decision

The marten CLI commands live in the external `Marten.CommandLine` package (`RunJasperFxCommands`), not this repo. So the migration **engine** lives in Marten core as a first-class, directly-testable API, and the `marten migrate-to-tenant-partitioning` CLI subcommand becomes a thin wrapper added to that package later. This also means the partitioned-schema DDL is **driven by Marten's own machinery** (`AddPartitionToAllTables` + `PerTenantEventSequences.EnsureSequencesAsync`) in Phase 2 rather than hand-rolled.

## What this PR does

`MartenDatabase.CreateTenantPartitioningMigrationPlanAsync(...)` (mirrors the existing `FindRebuildTenantsAsync` pattern) builds a read-only `TenantPartitioningMigrationPlan` — the `--dry-run` result:

- **Validates prerequisites:** source is `TenancyStyle.Conjoined`, target config sets `Events.UseTenantPartitionedEvents = true`, and every `mt_events` row carries a `tenant_id` (a null tenant can't be routed to a partition).
- **Inventories per tenant:** event count + `MAX(seq_id)` (the per-tenant sequence will `START WITH max+1`, per the issue's no-renumbering data policy) + whether a partition is already registered in `mt_tenant_partitions`.
- **Audits `mt_event_progression`:** classifies each row against the shard / high-water identity grammar — store-global vs per-tenant high water, store-global vs per-tenant shard, or an unrecognized hand-rolled straggler. High-water rows are matched via `HighWaterShardIdentity` **before** `ShardName.TryParse`, which would otherwise misread `HighWaterMark:{tenant}` as a shard named "HighWaterMark".

Building a plan touches **no schema or data**.

## Tests (`TenantPartitionedEventsTests/Migration`, 9 green on net9)

- `dry_run_inventories_tenants_and_validates_prerequisites` — a deterministic conjoined seed (3 tenants; per-tenant `MAX(seq_id)` = 5 / 8 / 10) drives the inventory; asserts counts, totals, and missing-partition warnings.
- `validation_blocks_when_partitioning_is_not_configured` — a non-partitioned target config trips the prerequisite error.
- `classifies_progression_rows` — 7-case theory pinning the progression-row classifier.

Both TFMs (net9/net10) build clean.

## Sequenced next (this issue)

- **Phase 2** — per-tenant copy + `ATTACH PARTITION` + per-tenant sequence (`START WITH max+1`) + seed `mt_event_progression` high-water rows via `HighWaterShardIdentity.PerTenant(tenantId)`; migration-state table for `--resume`.
- **Phase 3** — short-transaction parent-table swap + grace-period cleanup.
- **CLI** — `marten migrate-to-tenant-partitioning` wrapper in `Marten.CommandLine` (separate repo).
- **Docs** — `docs/events/multitenancy.md` operational runbook, landed with the runnable end-to-end flow.
- **Scale validation** — 20M-event / 50-tenant run via the `Marten.ScaleTesting` harness (#4666).

Draft until at least Phase 2 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)