### PR TITLE
Bump JasperFx packages to 2.9.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,14 +37,16 @@
          database, default 4), #422 (MultiStreamProjection.Options.CacheLimitPerTenant
          now defaults to 1000 instead of 0 — projections that relied on the unbounded
          default still work but per-tenant slice caches now bound by default), and
-         #424 (new storage-agnostic IEventStoreInstrumentation hook for telemetry). -->
-    <PackageVersion Include="JasperFx" Version="2.9.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.9.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.0">
+         #424 (new storage-agnostic IEventStoreInstrumentation hook for telemetry).
+         JasperFx 2.9.1: jasperfx#429 — source generator dedupes overridden required
+         members in evolver construction (codegen-only fix; no runtime/daemon change). -->
+    <PackageVersion Include="JasperFx" Version="2.9.1" />
+    <PackageVersion Include="JasperFx.Events" Version="2.9.1" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.1" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Upgrades the JasperFx package set from 2.9.0 to **2.9.1**.

All four JasperFx packages share `JasperFxVersion` and publish together, so they move in lockstep:
- `JasperFx`
- `JasperFx.Events`
- `JasperFx.Events.SourceGenerator`
- `JasperFx.SourceGenerator`

## What's in 2.9.1

[jasperfx#429](https://github.com/JasperFx/jasperfx/pull/429) — the source generator now dedupes overridden `required` members during evolver construction. **Codegen-only fix**; there is no runtime or daemon change (`JasperFxAsyncDaemon` / `catchUpPerTenantAsync` are byte-identical to 2.9.0), so this does not touch #4679.

## Verification

- `dotnet restore` resolves `JasperFx 2.9.1` / `JasperFx.Events 2.9.1`.
- `Marten` builds clean (net9.0).
- The source-generator-consuming `TenantPartitionedEventsTests` project builds clean — the relevant surface for a codegen change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)