### PR TITLE
feat(events): populate ProjectionErrors / ProjectionRebuildErrors on TryCreateUsage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,14 +39,17 @@
          default still work but per-tenant slice caches now bound by default), and
          #424 (new storage-agnostic IEventStoreInstrumentation hook for telemetry).
          JasperFx 2.9.1: jasperfx#429 — source generator dedupes overridden required
-         members in evolver construction (codegen-only fix; no runtime/daemon change). -->
-    <PackageVersion Include="JasperFx" Version="2.9.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.9.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.1">
+         members in evolver construction (codegen-only fix; no runtime/daemon change).
+         JasperFx 2.9.2: jasperfx#431 — ProjectionErrorHandlingDescriptor on EventStoreUsage
+         so monitoring tools (CritterWatch) can read the daemon error-handling policy off
+         the wire instead of presuming skip-and-DLQ behaviour. See JasperFx/ProductSupport#3. -->
+    <PackageVersion Include="JasperFx" Version="2.9.2" />
+    <PackageVersion Include="JasperFx.Events" Version="2.9.2" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.2" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/CoreTests/jasper_fx_mechanics.cs
+++ b/src/CoreTests/jasper_fx_mechanics.cs
@@ -69,6 +69,40 @@ public class jasper_fx_mechanics
     }
 
     [Fact]
+    public async Task try_create_usage_populates_projection_error_handling_descriptors()
+    {
+        // JasperFx/ProductSupport#3 — the projection error policy needs to ride
+        // along on EventStoreUsage so monitoring tools can render the right
+        // affordance (DLQ button vs "shard halts on error" indicator) without
+        // sniffing into Marten internals.
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(m =>
+                {
+                    m.Connection(ConnectionSource.ConnectionString);
+                    m.DatabaseSchemaName = "ps3_error_policy";
+
+                    // Stop-on-error normal-run policy — the reporter's actual
+                    // config in PS#3. Without this opt-out, the JasperFx.Events 2.0
+                    // default is SkipApplyErrors=true.
+                    m.Projections.Errors.SkipApplyErrors = false;
+                    m.Projections.Errors.SkipSerializationErrors = false;
+                });
+            }).StartAsync();
+
+        var usage = await host.Services.GetRequiredService<IEventStore>().TryCreateUsage(CancellationToken.None);
+
+        usage.ProjectionErrors.ShouldNotBeNull();
+        usage.ProjectionErrors.SkipApplyErrors.ShouldBeFalse();
+        usage.ProjectionErrors.SkipSerializationErrors.ShouldBeFalse();
+
+        // RebuildErrors stays at JasperFx.Events 2.0 defaults (all three false).
+        usage.ProjectionRebuildErrors.ShouldNotBeNull();
+        usage.ProjectionRebuildErrors.SkipApplyErrors.ShouldBeFalse();
+    }
+
+    [Fact]
     public async Task run_describe_with_single_document_store_and_single_tenancy()
     {
         var result = await Host.CreateDefaultBuilder()

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -499,6 +499,24 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
 
         Options.Projections.Describe(usage, this);
 
+        // JasperFx/ProductSupport#3 — surface the async-daemon error-handling
+        // policy on the wire so monitoring tools (CritterWatch) can render the
+        // right "shard halts on error" vs "view related dead letters" affordance.
+        // Normal-run + rebuild-mode are mirrored as separate descriptors because
+        // they carry independent ErrorHandlingOptions on the store.
+        usage.ProjectionErrors = new ProjectionErrorHandlingDescriptor
+        {
+            SkipApplyErrors = Options.Projections.Errors.SkipApplyErrors,
+            SkipUnknownEvents = Options.Projections.Errors.SkipUnknownEvents,
+            SkipSerializationErrors = Options.Projections.Errors.SkipSerializationErrors
+        };
+        usage.ProjectionRebuildErrors = new ProjectionErrorHandlingDescriptor
+        {
+            SkipApplyErrors = Options.Projections.RebuildErrors.SkipApplyErrors,
+            SkipUnknownEvents = Options.Projections.RebuildErrors.SkipUnknownEvents,
+            SkipSerializationErrors = Options.Projections.RebuildErrors.SkipSerializationErrors
+        };
+
         foreach (var eventMapping in Options.EventGraph.AllEvents())
         {
             var descriptor =


### PR DESCRIPTION
## What

Companion to JasperFx/jasperfx#431 — populates the new descriptor fields on `EventStoreUsage` from `StoreOptions.Projections.Errors` and `.RebuildErrors` inside `DocumentStore.EventStore.TryCreateUsage`. With these on the wire, downstream monitoring tools (CritterWatch) can render the projection-error policy operators have actually configured and pick the right operator affordance.

| Wire field | Sourced from |
|---|---|
| `usage.ProjectionErrors` | `Options.Projections.Errors` (normal-run config) |
| `usage.ProjectionRebuildErrors` | `Options.Projections.RebuildErrors` (rebuild-mode config) |

Each descriptor mirrors `ErrorHandlingOptions`'s three flags: `SkipApplyErrors`, `SkipUnknownEvents`, `SkipSerializationErrors`.

## Why

JasperFx/ProductSupport#3 — a Marten consumer running with `Projections.Errors.SkipApplyErrors = false` (stop-on-error policy) was shown a *"View Related Dead Letters"* button on CritterWatch's projection detail page because CritterWatch had no way to read the policy off the wire and assumed skip-and-DLQ behavior. With this PR (after jasperfx#431 ships) CritterWatch will be able to render the right affordance per store.

## Coordination

- **Depends on:** JasperFx/jasperfx#431 (adds `ProjectionErrors` / `ProjectionRebuildErrors` to `EventStoreUsage`)
- **Companion:** JasperFx/polecat PR (Polecat-side equivalent)
- **Consumer:** JasperFx/CritterWatch follow-up that bumps pins + adjusts the UI

## Verification

- New `CoreTests/jasper_fx_mechanics.cs` test exercises a stop-on-error config end-to-end and asserts both descriptors carry the right values. Passes locally against a local-feed prerelease of JasperFx.Events with the descriptor types in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)