### PR TITLE
Fix #4706 — managed partitioned tables destructively rebuilt on sharded redeploy

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -99,8 +99,14 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.0.3" />
-    <PackageVersion Include="Weasel.Postgresql" Version="9.0.3" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.1.2" />
+    <!-- Weasel.Postgresql 9.1.2: fix for marten#4706 — managed LIST partitions are no longer
+         destructively rebuilt under multi-database (sharded) apply. The explicit, out-of-band
+         AddPartitionToAllTables path bypasses IgnorePartitionsInMigration so partition creation
+         still works while the generic schema diff leaves managed-partition tables alone (Marten
+         sets IgnorePartitionsInMigration on those tables; see DocumentTable). 9.1.2 supersedes
+         9.1.1, whose per-database reload regressed lazy sharded event-partition creation. -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.1.2" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/CoreTests/Partitioning/Bug_4706_partitioned_table_idempotent_migration.cs
+++ b/src/CoreTests/Partitioning/Bug_4706_partitioned_table_idempotent_migration.cs
@@ -1,0 +1,97 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreTests.Partitioning;
+
+public class Bug4706Doc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// #4706 — re-applying schema to a Marten-managed ByList tenant-partitioned document table over
+/// existing data must be idempotent. The report: on every startup the partitioned doc table is
+/// diffed as "needs rebuild" (CREATE _temp -> INSERT ... SELECT -> drop/rename) even when nothing
+/// changed, and the copy fails with 23514 (no partition for row) because the rebuilt table's
+/// per-tenant LIST partitions aren't recreated before the copy. Suspected trigger: StartIndexesByTenantId.
+/// </summary>
+public class Bug_4706_partitioned_table_idempotent_migration: IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _schema = "bug4706_p" + Environment.ProcessId;
+    private readonly string _partitionSchema = "bug4706_tenants_p" + Environment.ProcessId;
+
+    public Bug_4706_partitioned_table_idempotent_migration(ITestOutputHelper output) => _output = output;
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync(_partitionSchema); } catch { }
+        try { await conn.DropSchemaAsync(_schema); } catch { }
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private DocumentStore BuildStore() => (DocumentStore)DocumentStore.For(opts =>
+    {
+        opts.Connection(ConnectionSource.ConnectionString);
+        opts.DatabaseSchemaName = _schema;
+        opts.Policies.AllDocumentsAreMultiTenanted();
+        opts.Policies.PartitionMultiTenantedDocumentsUsingMartenManagement(_partitionSchema);
+
+        opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+        opts.Events.UseTenantPartitionedEvents = true;
+
+        // Match the reporter's per-document form exactly: explicit MultiTenantedWithPartitioning(ByList)
+        // + StartIndexesByTenantId + a computed index.
+        opts.Schema.For<Bug4706Doc>()
+            .MultiTenantedWithPartitioning(x => x.ByList())
+            .Index(x => x.Name)
+            .StartIndexesByTenantId();
+    });
+
+    [Fact]
+    public async Task reapply_over_existing_tenant_data_is_idempotent()
+    {
+        // 1. First deploy: create schema, register tenants (=> per-tenant LIST partitions), store data.
+        await using (var store = BuildStore())
+        {
+            await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+            await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "acme", "globex");
+
+            foreach (var tenant in new[] { "acme", "globex" })
+            {
+                await using var session = store.LightweightSession(tenant);
+                session.Store(new Bug4706Doc { Id = Guid.NewGuid(), Name = "n-" + tenant });
+                await session.SaveChangesAsync();
+            }
+        }
+
+        // 2. Second deploy (nothing changed): the diff must be None — no destructive rebuild.
+        await using (var store = BuildStore())
+        {
+            var migration = await store.Storage.CreateMigrationAsync();
+            _output.WriteLine($"Difference = {migration.Difference}");
+
+            migration.Difference.ShouldBe(SchemaPatchDifference.None,
+                "Re-applying an unchanged ByList tenant-partitioned doc table must not diff as a change");
+
+            // And a real re-apply must not throw 23514 / rebuild-copy failure.
+            await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+        }
+    }
+}

--- a/src/Marten/Storage/DocumentTable.cs
+++ b/src/Marten/Storage/DocumentTable.cs
@@ -106,6 +106,19 @@ internal class DocumentTable: Table
         if (Partitioning != null)
         {
             IgnorePartitionsInMigration = mapping.IgnorePartitions;
+
+            // #4706: a Marten-managed LIST partitioning keeps its PARTITION BY clause but is exempt from
+            // child-partition reconciliation in the generic schema diff. The per-tenant partitions are
+            // created/dropped out-of-band by AddMartenManagedTenantsAsync / DeleteAllTenantDataAsync (the
+            // additive path). Without this, re-applying the schema over existing data — especially under
+            // sharded tenancy, where databases migrate in parallel against one shared partition manager —
+            // sees the live per-tenant partitions as "unexpected" and destructively rebuilds the table
+            // (CREATE _temp / copy), failing with 23514 because the rebuilt parent has no partitions.
+            if (Partitioning is Weasel.Postgresql.Tables.Partitioning.ListPartitioning { PartitionManager: not null })
+            {
+                IgnorePartitionsInMigration = true;
+            }
+
             foreach (var columnName in Partitioning.Columns)
             {
                 var column = ModifyColumn(columnName);

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4706_sharded_partitioned_doc_rebuild.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4706_sharded_partitioned_doc_rebuild.cs
@@ -1,0 +1,136 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+public class Bug4706Doc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// #4706 — re-applying schema to a sharded, Marten-managed ByList tenant-partitioned document table
+/// over existing data must be idempotent. Report: every redeploy destructively rebuilds the
+/// partitioned doc tables (CREATE _temp -> INSERT ... SELECT -> drop/rename) without recreating the
+/// per-tenant LIST partitions first, so the copy fails with 23514 (no partition for row). A fresh DB
+/// is fine. A single-DB managed-ByList store is idempotent; this exercises the sharded path.
+/// </summary>
+[Collection("sharded-tenant-partitioned")]
+public class Bug_4706_sharded_partitioned_doc_rebuild: IAsyncLifetime
+{
+    private readonly ShardedPartitionedFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public Bug_4706_sharded_partitioned_doc_rebuild(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private DocumentStore BuildStore() => (DocumentStore)DocumentStore.For(opts =>
+    {
+        opts.MultiTenantedWithShardedDatabases(x =>
+        {
+            x.ConnectionString = ConnectionSource.ConnectionString;
+            x.SchemaName = "sharded";
+            x.PartitionSchemaName = "tenants";
+            foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+            {
+                x.AddDatabase(dbName, connStr);
+            }
+        });
+
+        opts.AutoCreateSchemaObjects = AutoCreate.All;
+        opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+        opts.Events.UseTenantPartitionedEvents = true;
+
+        opts.Schema.For<Bug4706Doc>()
+            .MultiTenantedWithPartitioning(x => x.ByList())
+            .Index(x => x.Name)
+            .StartIndexesByTenantId();
+    });
+
+    [Fact]
+    public async Task reapply_over_existing_tenant_data_is_idempotent()
+    {
+        var assignment = new Dictionary<string, string>
+        {
+            ["tA"] = _fixture.DbNames[0],
+            ["tB"] = _fixture.DbNames[1],
+            ["tC"] = _fixture.DbNames[2],
+        };
+
+        // First deploy: production eager-apply shape — create the parent partitioned
+        // schema on every shard up front (per database, sequentially), THEN provision
+        // tenants (which adds each tenant's partition to its shard via the additive
+        // path), THEN write data.
+        await using (var store = BuildStore())
+        {
+            var databases = await store.Options.Tenancy.BuildDatabases();
+            foreach (var db in databases.OfType<IMartenDatabase>())
+            {
+                await db.ApplyAllConfiguredChangesToDatabaseAsync();
+            }
+
+            foreach (var (tenant, shard) in assignment)
+            {
+                await store.Advanced.AddTenantToShardAsync(tenant, shard, CancellationToken.None);
+            }
+
+            foreach (var tenant in assignment.Keys)
+            {
+                await using var session = store.LightweightSession(tenant);
+                session.Store(new Bug4706Doc { Id = Guid.NewGuid(), Name = "n-" + tenant });
+                await session.SaveChangesAsync();
+            }
+        }
+
+        // Second deploy (nothing changed): re-apply across all shards via the store-wide
+        // path (Parallel.ForEachAsync over databases — the #4706 trigger). Must be
+        // idempotent: no destructive rebuild of the per-tenant partitioned tables, no 23514.
+        await using (var store = BuildStore())
+        {
+            var ex = await Record.ExceptionAsync(() =>
+                store.Storage.ApplyAllConfiguredChangesToDatabaseAsync());
+
+            if (ex != null)
+            {
+                _output.WriteLine(ex.ToString());
+            }
+
+            ex.ShouldBeNull("Re-applying an unchanged sharded ByList tenant-partitioned doc table " +
+                            "must not rebuild it / must not fail with 23514");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4706.

## Problem
Re-applying the schema over existing data to a Marten-managed `ByList` tenant-partitioned **document** table destructively rebuilds it (`create <t>_temp as select *` → drop → recreate → `insert … select`) and fails with `23514: no partition of relation found for row` — the rebuilt parent has no child partitions. A fresh database is fine; a single-database managed-`ByList` store is idempotent. The failure is specific to **sharded** multi-tenancy on redeploy.

## Root cause
On redeploy a fresh `DocumentStore` builds a fresh store-wide `ManagedListPartitions` that loads only the **first** shard's `mt_tenant_partitions` set. `IMartenStorage.ApplyAllConfiguredChangesToDatabaseAsync` then diffs **every** shard against that single set (`Parallel.ForEachAsync` over databases). For any shard whose real partitions differ from that first set, `ListPartitioning.CreateDelta` sees the live per-tenant partitions as "unexpected" and returns `PartitionDelta.Rebuild` → destructive rebuild → 23514.

## Fix
`DocumentTable` sets `IgnorePartitionsInMigration = true` on Marten-managed LIST-partitioned tables (`Partitioning is ListPartitioning { PartitionManager: not null }`). The generic schema diff then short-circuits to `PartitionDelta.None` for those tables, so it never rebuilds them. The per-tenant partitions are reconciled **out-of-band** by `AddMartenManagedTenantsAsync` / `AddTenantToShardAsync` (the additive path), which still creates them because **Weasel 9.1.2**'s `additivelyMigrateTablesForNewPartitions` clears the flag locally for that explicit path. This is concurrency-immune: the diff no longer depends on the shared partition manager's state.

Bumps `Weasel.Postgresql` / `Weasel.EntityFrameworkCore` to **9.1.2** ([JasperFx/weasel#303](https://github.com/JasperFx/weasel/pull/303)).

## Tests
- `Bug_4706_sharded_partitioned_doc_rebuild` (sharded) — eager per-DB apply + per-tenant data, then a store-wide parallel re-apply must be idempotent. **RED (23514) before the fix, green after.**
- `Bug_4706_partitioned_table_idempotent_migration` (single-DB control) — managed `ByList` re-apply is idempotent (passes regardless; proves sharding/concurrency is load-bearing for the bug).

Full `TenantPartitionedEventsTests` 182/182 and `CoreTests` partitioning 33/33 green against the published Weasel 9.1.2.

## Out of scope
Event tables (`mt_events`/`mt_streams`) are intentionally **not** flagged here — the flag breaks their *lazy* sharded partition creation, and their redeploy hardening (the #4682 conjoined→partitioned migration) needs a deeper per-database partition-state design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)