### PR TITLE
Bump JasperFx 2.9.5 → 2.9.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,13 +43,13 @@
          JasperFx 2.9.2: jasperfx#431 — ProjectionErrorHandlingDescriptor on EventStoreUsage
          so monitoring tools (CritterWatch) can read the daemon error-handling policy off
          the wire instead of presuming skip-and-DLQ behaviour. See JasperFx/ProductSupport#3. -->
-    <PackageVersion Include="JasperFx" Version="2.9.5" />
-    <PackageVersion Include="JasperFx.Events" Version="2.9.5" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.5">
+    <PackageVersion Include="JasperFx" Version="2.9.6" />
+    <PackageVersion Include="JasperFx.Events" Version="2.9.6" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.5" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.6" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Tracks the current mainline JasperFx release. **2.9.6** was cut from jasperfx `main` after the self-aggregating source-gen regression fix (JasperFx/jasperfx#439) was merged; its content matches the 2.9.5 that #4714 already adopted, so this just keeps Marten on the latest released line.

Sanity-checked: `EventSourcingTests` self-aggregating projection tests green against published 2.9.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)