### PR TITLE
Fix #4720 — adaptive EventLoader timeout fallback was unreachable

### DIFF
--- a/src/DaemonTests/Internals/Bug_4720_adaptive_eventloader_timeout.cs
+++ b/src/DaemonTests/Internals/Bug_4720_adaptive_eventloader_timeout.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading.Tasks;
+using Marten.Events.Daemon.Internals;
+using Marten.Exceptions;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.Internals;
+
+public class Bug_4720_adaptive_eventloader_timeout
+{
+    // #4720: the adaptive EventLoader's timeout classifier only inspected the OUTERMOST exception,
+    // but AutoClosingLifetime re-throws every command failure through MartenExceptionTransformer,
+    // which wraps the original NpgsqlException/PostgresException into a MartenCommandException
+    // (NOT an NpgsqlException). The classifier therefore returned false for every real timeout and
+    // the skip-ahead / window-step fallback never engaged. It must now walk the inner-exception chain.
+
+    private static PostgresException StatementTimeout()
+        => new("canceling statement due to statement timeout", "ERROR", "ERROR",
+            PostgresErrorCodes.QueryCanceled); // 57014
+
+    [Fact]
+    public void wrapped_statement_timeout_is_recognized()
+    {
+        // This is the exact shape #4720 reported: the 57014 PostgresException buried inside a
+        // MartenCommandException. The pre-fix code returned false here.
+        var wrapped = new MartenCommandException((NpgsqlCommand)null, StatementTimeout());
+
+        EventLoader.isTimeoutException(wrapped).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void wrapped_client_timeout_is_recognized()
+    {
+        var clientTimeout = new NpgsqlException("Exception while reading from stream", new TimeoutException());
+        var wrapped = new MartenCommandException((NpgsqlCommand)null, clientTimeout);
+
+        EventLoader.isTimeoutException(wrapped).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void deeply_nested_timeout_is_recognized()
+    {
+        var nested = new InvalidOperationException("outer",
+            new AggregateException(new MartenCommandException((NpgsqlCommand)null, StatementTimeout())));
+
+        EventLoader.isTimeoutException(nested).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void bare_statement_timeout_is_still_recognized()
+    {
+        EventLoader.isTimeoutException(StatementTimeout()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void unrelated_exception_is_not_a_timeout()
+    {
+        EventLoader.isTimeoutException(new InvalidOperationException("boom")).ShouldBeFalse();
+        EventLoader.isTimeoutException(
+            new MartenCommandException((NpgsqlCommand)null, new InvalidOperationException("boom")))
+            .ShouldBeFalse();
+    }
+}

--- a/src/Marten/Events/Daemon/Internals/EventLoader.cs
+++ b/src/Marten/Events/Daemon/Internals/EventLoader.cs
@@ -143,10 +143,16 @@ internal sealed class EventLoader: IEventLoader
                 _ => await loadNormalAsync(request, token).ConfigureAwait(false)
             };
         }
-        catch (Exception ex) when (isTimeoutException(ex))
+        // #4720: a deliberate daemon shutdown cancels this token and surfaces as an
+        // OperationCanceledException — do not treat that as a query timeout and escalate;
+        // let it propagate so the shard stops cleanly.
+        catch (Exception ex) when (!token.IsCancellationRequested && isTimeoutException(ex))
         {
-            // Only escalate strategy if we have a type filter (otherwise the timeout is from something else)
-            if (_hasTypeFilter && !_hasEventTypeIndex)
+            // Only escalate strategy if we have a type filter (otherwise the timeout is from something else).
+            // #4720: escalate regardless of whether the (type, seq_id) event-type index is enabled. That
+            // composite index cannot serve a multi-type, globally seq_id-ordered LIMIT query, so the normal
+            // query can still time out with the index present — the flag now only governs the advisory text.
+            if (_hasTypeFilter)
             {
                 var nextStrategy = _currentStrategy switch
                 {
@@ -155,10 +161,20 @@ internal sealed class EventLoader: IEventLoader
                     _ => LoadStrategy.WindowStep
                 };
 
-                request.Runtime?.Logger.LogWarning(
-                    "Event loading timed out with {Strategy} strategy for range [{Floor}, {Ceiling}]. " +
-                    "Falling back to {NextStrategy}. Consider enabling opts.Events.EnableEventTypeIndex for better performance.",
-                    _currentStrategy, request.Floor, request.HighWater, nextStrategy);
+                if (_hasEventTypeIndex)
+                {
+                    request.Runtime?.Logger.LogWarning(
+                        "Event loading timed out with {Strategy} strategy for range [{Floor}, {Ceiling}]. " +
+                        "Falling back to {NextStrategy}.",
+                        _currentStrategy, request.Floor, request.HighWater, nextStrategy);
+                }
+                else
+                {
+                    request.Runtime?.Logger.LogWarning(
+                        "Event loading timed out with {Strategy} strategy for range [{Floor}, {Ceiling}]. " +
+                        "Falling back to {NextStrategy}. Consider enabling opts.Events.EnableEventTypeIndex for better performance.",
+                        _currentStrategy, request.Floor, request.HighWater, nextStrategy);
+                }
 
                 _currentStrategy = nextStrategy;
 
@@ -395,12 +411,31 @@ internal sealed class EventLoader: IEventLoader
         return emptyPage;
     }
 
-    private static bool isTimeoutException(Exception ex)
+    // internal (not private) so the #4720 regression test can assert the chain-walking directly.
+    internal static bool isTimeoutException(Exception? ex)
     {
-        return ex is NpgsqlException { InnerException: TimeoutException }
-            or NpgsqlException { SqlState: "57014" } // query_canceled (statement timeout)
-            or TimeoutException
-            or OperationCanceledException;
+        // #4720: a query timeout does not always arrive as a bare NpgsqlException. Marten's
+        // AutoClosingLifetime catches the original exception and re-throws it through
+        // MartenExceptionTransformer, which wraps any NpgsqlException into a MartenCommandException
+        // (which is NOT an NpgsqlException) before it reaches this catch filter. Inspecting only the
+        // outermost exception therefore missed every wrapped timeout and the adaptive fallback never
+        // engaged. Walk the whole inner-exception chain instead.
+        //
+        // Note: the bare TimeoutException arm subsumes the old "NpgsqlException { InnerException:
+        // TimeoutException }" case once we walk inner exceptions.
+        while (ex is not null)
+        {
+            if (ex is NpgsqlException { SqlState: "57014" } // query_canceled (statement timeout)
+                or TimeoutException
+                or OperationCanceledException)
+            {
+                return true;
+            }
+
+            ex = ex.InnerException;
+        }
+
+        return false;
     }
 }
 


### PR DESCRIPTION
Fixes #4720.

The adaptive `EventLoader` fallback (skip-ahead / window-step) added in #4233 never engaged in practice. Two independent bugs, both confirmed in code:

### Bug 1 — the timeout never matched the catch filter
`loadNormalAsync` calls `session.ExecuteReaderAsync` → `AutoClosingLifetime.ExecuteReaderAsync` catches every exception and re-throws through `MartenExceptionTransformer`, whose catch-all wraps any `NpgsqlException` (a statement timeout is a `PostgresException` with `SqlState "57014"`) into a **`MartenCommandException`** — which is `: MartenException : Exception`, **not** an `NpgsqlException`.

`isTimeoutException` only pattern-matched the **outermost** exception, so it saw `MartenCommandException` and returned `false`. The fallback never ran. Fixed by walking the inner-exception chain.

### Bug 2 — `EnableEventTypeIndex=true` disabled the fallback
The escalation gate was `_hasTypeFilter && !_hasEventTypeIndex`. But a `(type, seq_id)` composite index cannot serve a multi-type, globally `seq_id`-ordered `LIMIT` query, so the normal query still times out with the index on — and nothing rescued it. The gate is now just `_hasTypeFilter`; the index flag only governs the advisory warning text.

### Plus: clean shutdown
Guarded the catch filter with `!token.IsCancellationRequested` so a deliberate daemon-shutdown `OperationCanceledException` propagates cleanly instead of triggering pointless strategy escalation.

### Tests
`Bug_4720_adaptive_eventloader_timeout` asserts the chain-walking deterministically (wrapped 57014, wrapped client `TimeoutException`, deeply nested, bare 57014, and non-timeout negatives). All 5 green.

Also being backported to `8.0` (identical defect there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)