### PR TITLE
Fix #4720 (8.0 backport) — adaptive EventLoader timeout fallback was unreachable

### DIFF
--- a/src/DaemonTests/Internals/Bug_4720_adaptive_eventloader_timeout.cs
+++ b/src/DaemonTests/Internals/Bug_4720_adaptive_eventloader_timeout.cs
@@ -1,0 +1,64 @@
+using System;
+using Marten.Events.Daemon.Internals;
+using Marten.Exceptions;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.Internals;
+
+public class Bug_4720_adaptive_eventloader_timeout
+{
+    // #4720: the adaptive EventLoader's timeout classifier only inspected the OUTERMOST exception,
+    // but AutoClosingLifetime re-throws every command failure through MartenExceptionTransformer,
+    // which wraps the original NpgsqlException/PostgresException into a MartenCommandException
+    // (NOT an NpgsqlException). The classifier therefore returned false for every real timeout and
+    // the skip-ahead / window-step fallback never engaged. It must now walk the inner-exception chain.
+
+    private static PostgresException StatementTimeout()
+        => new("canceling statement due to statement timeout", "ERROR", "ERROR",
+            PostgresErrorCodes.QueryCanceled); // 57014
+
+    [Fact]
+    public void wrapped_statement_timeout_is_recognized()
+    {
+        // This is the exact shape #4720 reported: the 57014 PostgresException buried inside a
+        // MartenCommandException. The pre-fix code returned false here.
+        var wrapped = new MartenCommandException((NpgsqlCommand)null, StatementTimeout());
+
+        EventLoader.isTimeoutException(wrapped).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void wrapped_client_timeout_is_recognized()
+    {
+        var clientTimeout = new NpgsqlException("Exception while reading from stream", new TimeoutException());
+        var wrapped = new MartenCommandException((NpgsqlCommand)null, clientTimeout);
+
+        EventLoader.isTimeoutException(wrapped).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void deeply_nested_timeout_is_recognized()
+    {
+        var nested = new InvalidOperationException("outer",
+            new AggregateException(new MartenCommandException((NpgsqlCommand)null, StatementTimeout())));
+
+        EventLoader.isTimeoutException(nested).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void bare_statement_timeout_is_still_recognized()
+    {
+        EventLoader.isTimeoutException(StatementTimeout()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void unrelated_exception_is_not_a_timeout()
+    {
+        EventLoader.isTimeoutException(new InvalidOperationException("boom")).ShouldBeFalse();
+        EventLoader.isTimeoutException(
+            new MartenCommandException((NpgsqlCommand)null, new InvalidOperationException("boom")))
+            .ShouldBeFalse();
+    }
+}

--- a/src/Marten/Events/Daemon/Internals/EventLoader.cs
+++ b/src/Marten/Events/Daemon/Internals/EventLoader.cs
@@ -106,10 +106,16 @@ internal sealed class EventLoader: IEventLoader
                 _ => await loadNormalAsync(request, token).ConfigureAwait(false)
             };
         }
-        catch (Exception ex) when (isTimeoutException(ex))
+        // #4720: a deliberate daemon shutdown cancels this token and surfaces as an
+        // OperationCanceledException — do not treat that as a query timeout and escalate;
+        // let it propagate so the shard stops cleanly.
+        catch (Exception ex) when (!token.IsCancellationRequested && isTimeoutException(ex))
         {
-            // Only escalate strategy if we have a type filter (otherwise the timeout is from something else)
-            if (_hasTypeFilter && !_hasEventTypeIndex)
+            // Only escalate strategy if we have a type filter (otherwise the timeout is from something else).
+            // #4720: escalate regardless of whether the (type, seq_id) event-type index is enabled. That
+            // composite index cannot serve a multi-type, globally seq_id-ordered LIMIT query, so the normal
+            // query can still time out with the index present — the flag now only governs the advisory text.
+            if (_hasTypeFilter)
             {
                 var nextStrategy = _currentStrategy switch
                 {
@@ -118,10 +124,20 @@ internal sealed class EventLoader: IEventLoader
                     _ => LoadStrategy.WindowStep
                 };
 
-                request.Runtime?.Logger.LogWarning(
-                    "Event loading timed out with {Strategy} strategy for range [{Floor}, {Ceiling}]. " +
-                    "Falling back to {NextStrategy}. Consider enabling opts.Events.EnableEventTypeIndex for better performance.",
-                    _currentStrategy, request.Floor, request.HighWater, nextStrategy);
+                if (_hasEventTypeIndex)
+                {
+                    request.Runtime?.Logger.LogWarning(
+                        "Event loading timed out with {Strategy} strategy for range [{Floor}, {Ceiling}]. " +
+                        "Falling back to {NextStrategy}.",
+                        _currentStrategy, request.Floor, request.HighWater, nextStrategy);
+                }
+                else
+                {
+                    request.Runtime?.Logger.LogWarning(
+                        "Event loading timed out with {Strategy} strategy for range [{Floor}, {Ceiling}]. " +
+                        "Falling back to {NextStrategy}. Consider enabling opts.Events.EnableEventTypeIndex for better performance.",
+                        _currentStrategy, request.Floor, request.HighWater, nextStrategy);
+                }
 
                 _currentStrategy = nextStrategy;
 
@@ -348,12 +364,31 @@ internal sealed class EventLoader: IEventLoader
         return emptyPage;
     }
 
-    private static bool isTimeoutException(Exception ex)
+    // internal (not private) so the #4720 regression test can assert the chain-walking directly.
+    internal static bool isTimeoutException(Exception? ex)
     {
-        return ex is NpgsqlException { InnerException: TimeoutException }
-            or NpgsqlException { SqlState: "57014" } // query_canceled (statement timeout)
-            or TimeoutException
-            or OperationCanceledException;
+        // #4720: a query timeout does not always arrive as a bare NpgsqlException. Marten's
+        // AutoClosingLifetime catches the original exception and re-throws it through
+        // MartenExceptionTransformer, which wraps any NpgsqlException into a MartenCommandException
+        // (which is NOT an NpgsqlException) before it reaches this catch filter. Inspecting only the
+        // outermost exception therefore missed every wrapped timeout and the adaptive fallback never
+        // engaged. Walk the whole inner-exception chain instead.
+        //
+        // Note: the bare TimeoutException arm subsumes the old "NpgsqlException { InnerException:
+        // TimeoutException }" case once we walk inner exceptions.
+        while (ex is not null)
+        {
+            if (ex is NpgsqlException { SqlState: "57014" } // query_canceled (statement timeout)
+                or TimeoutException
+                or OperationCanceledException)
+            {
+                return true;
+            }
+
+            ex = ex.InnerException;
+        }
+
+        return false;
     }
 }
 


### PR DESCRIPTION
Fixes #4720 on the `8.0` maintenance branch. Backport of #4722 (master).

The adaptive `EventLoader` fallback (skip-ahead / window-step, #4233) never engaged:

1. **Wrapped timeout.** `AutoClosingLifetime` re-throws command failures through `MartenExceptionTransformer`, which wraps the timeout `NpgsqlException`/`PostgresException` (SqlState `57014`) into a `MartenCommandException` (not an `NpgsqlException`). `isTimeoutException` only inspected the outermost exception → every real timeout classified as non-timeout → fallback skipped. Now walks the inner-exception chain.
2. **Index gate.** Escalation also required `!EnableEventTypeIndex`, but the `(type, seq_id)` composite index can't serve a multi-type, globally `seq_id`-ordered `LIMIT` query, so the normal query still times out with the index on. Gate is now just `_hasTypeFilter`; the flag only controls the advisory text.
3. **Clean shutdown.** Catch filter guarded with `!token.IsCancellationRequested` so a deliberate daemon-shutdown OCE propagates instead of escalating.

Includes the `Bug_4720_adaptive_eventloader_timeout` regression suite (5 tests, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)