### PR TITLE
Bump JasperFx.* to 2.9.9 — composite rebuild deadlock fix (#4721)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,14 +42,20 @@
          members in evolver construction (codegen-only fix; no runtime/daemon change).
          JasperFx 2.9.2: jasperfx#431 — ProjectionErrorHandlingDescriptor on EventStoreUsage
          so monitoring tools (CritterWatch) can read the daemon error-handling policy off
-         the wire instead of presuming skip-and-DLQ behaviour. See JasperFx/ProductSupport#3. -->
-    <PackageVersion Include="JasperFx" Version="2.9.8" />
-    <PackageVersion Include="JasperFx.Events" Version="2.9.8" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.8">
+         the wire instead of presuming skip-and-DLQ behaviour. See JasperFx/ProductSupport#3.
+         JasperFx 2.9.9: jasperfx#443 (marten#4721) — the continuous-startup composite
+         "optimized rebuild" now runs on a task separate from the SubscriptionAgent's
+         single-consumer command loop. It previously ran inline inside that loop while the
+         replay posted RangeCompleted commands back into the same bounded (10k) command
+         channel, so the only reader was blocked awaiting its own posts — the shard silently
+         wedged at a batch boundary under UseTenantPartitionedEvents once the channel filled. -->
+    <PackageVersion Include="JasperFx" Version="2.9.9" />
+    <PackageVersion Include="JasperFx.Events" Version="2.9.9" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.8" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.9" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Closes #4721.

Bumps all four JasperFx packages 2.9.8 → 2.9.9 in `Directory.Packages.props`. 2.9.9 carries [jasperfx#443](https://github.com/JasperFx/jasperfx/pull/443), the fix for #4721.

### What #4721 was

Composite projection rebuilds **silently froze at a batch boundary** under `UseTenantPartitionedEvents` on a sharded conjoined store during continuous-startup — idle process, no exception, no pause, no active query, no lock; the stall seq varied per run and did not reproduce on a fast local Postgres.

Root cause: `SubscriptionAgent._commandBlock` is a bounded channel (capacity 10 000, single reader). On continuous startup, `Apply(CommandType.Start)` ran the *entire* composite optimized rebuild **inline on that single consumer thread**, while `CompositeReplayExecutor` posts a `RangeCompleted` command per page back into the same channel via `MarkSuccessAsync`. The only reader was blocked awaiting the replay, so those posts piled up undrained — once the channel filled, `PostAsync` blocked and the reader was wedged awaiting its own post. Self-deadlock.

### The fix (jasperfx#443)

The rebuild now runs on a task separate from the command-loop consumer, so the consumer is free to drain the posts; a `_replaying` flag suppresses continuous loading during the rebuild (no race over the same events) and a new `Command.ReplayCompleted` resumes continuous operation when it finishes. Covered by a JasperFx unit test that deadlocks on the old code and passes with the fix.

### Verification here

Version-bump only — no Marten source changes. Marten core builds clean against 2.9.9. Local regression slices green:
- `DaemonTests` composite suite — 10/10
- `TenantPartitionedEventsTests` Bug_4705 / composite — 4/4

(The deadlock itself is latency/scheduling-sensitive and does not reproduce on a fast local Postgres — the deterministic regression guard lives in JasperFx, exercised through the real command channel.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)