### PR TITLE
Fix #4727: release the message-batch semaphore on the double-checked-lock fast path (composite rebuild deadlock)

### DIFF
--- a/src/DaemonTests/Bugs/Bug_4727_message_batch_semaphore_leak.cs
+++ b/src/DaemonTests/Bugs/Bug_4727_message_batch_semaphore_leak.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DaemonTests.Aggregations;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using Marten.Events.Aggregation;
+using Marten.Events.Daemon.Internals;
+using Marten.Internal.Sessions;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DaemonTests.Bugs;
+
+/// <summary>
+/// marten#4727 — composite projection rebuilds self-deadlock when a stage emits side-effect
+/// messages. Several event slices run in parallel and each calls
+/// <see cref="ProjectionUpdateBatch.CurrentMessageBatch"/> (via ProjectionBatch.PublishMessageAsync).
+/// The double-checked lock there returned the freshly-created batch from INSIDE the critical
+/// section but OUTSIDE the try/finally, so the second caller to win the semaphore returned
+/// without releasing it — leaking the semaphore and deadlocking every remaining caller
+/// (observed in production as an optimized composite rebuild frozen forever, all slices parked
+/// on SemaphoreSlim.WaitAsync, idle CPU, no error).
+///
+/// This test forces that exact interleaving deterministically with a gated outbox: the first
+/// caller holds the semaphore while it is blocked creating the batch; the others pile up on the
+/// semaphore; then the gate is released. With the bug, the callers that already queued never
+/// complete.
+/// </summary>
+public class Bug_4727_message_batch_semaphore_leak : OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task concurrent_CurrentMessageBatch_callers_must_not_deadlock()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var outbox = new GatedMessageOutbox(gate);
+
+        StoreOptions(opts => opts.Events.MessageOutbox = outbox);
+
+        using var cts = new CancellationTokenSource(30.Seconds());
+        var session = (DocumentSessionBase)theStore.LightweightSession();
+        await using var batch = new ProjectionUpdateBatch(
+            theStore.Options.Projections, session, ShardExecutionMode.Continuous, cts.Token);
+
+        // Several concurrent callers, mirroring the parallel event slices of one composite stage.
+        var callers = Enumerable.Range(0, 5)
+            .Select(_ => Task.Run(() => batch.CurrentMessageBatch(session).AsTask(), cts.Token))
+            .ToArray();
+
+        // Let every caller pass the first null-check and pile up on the semaphore (the first one
+        // is blocked inside CreateBatch on the gate, holding the semaphore)...
+        await Task.Delay(1.Seconds(), cts.Token);
+        // ...then release the first CreateBatch so it sets the batch and exits the critical section.
+        gate.SetResult();
+
+        var all = Task.WhenAll(callers);
+        var winner = await Task.WhenAny(all, Task.Delay(15.Seconds(), CancellationToken.None));
+
+        winner.ShouldBe(all,
+            "every concurrent CurrentMessageBatch caller must complete — a leaked semaphore deadlocks the queued callers");
+
+        await all; // surface any exceptions
+        callers.Select(t => t.Result).Distinct().Count()
+            .ShouldBe(1, "all callers must observe the single shared message batch");
+    }
+}
+
+/// <summary>
+/// First <see cref="CreateBatch"/> call blocks on the gate (holding the ProjectionUpdateBatch
+/// semaphore) so the other concurrent callers are guaranteed to queue on that semaphore before
+/// the batch is published — the precise window that triggers the #4727 leak.
+/// </summary>
+internal class GatedMessageOutbox : IMessageOutbox
+{
+    private readonly TaskCompletionSource _gate;
+    private int _count;
+
+    public GatedMessageOutbox(TaskCompletionSource gate) => _gate = gate;
+
+    public async ValueTask<IMessageBatch> CreateBatch(DocumentSessionBase session)
+    {
+        if (Interlocked.Increment(ref _count) == 1)
+        {
+            await _gate.Task.ConfigureAwait(false);
+        }
+
+        return new RecordingMessageBatch();
+    }
+}

--- a/src/Marten/Events/Daemon/Internals/ProjectionUpdateBatch.cs
+++ b/src/Marten/Events/Daemon/Internals/ProjectionUpdateBatch.cs
@@ -408,17 +408,19 @@ public class ProjectionUpdateBatch: IUpdateBatch, IAsyncDisposable, IDisposable,
             return _batch;
         }
 
-        // The semaphore is being sensitive to race conditions, so let's try to alleviate that
-        await Task.Delay(Random.Shared.Next(25, 200).Milliseconds(), _token).ConfigureAwait(false);
         await _semaphore.WaitAsync(_token).ConfigureAwait(false);
-
-        if (_batch != null)
-        {
-            return _batch;
-        }
 
         try
         {
+            // Double-checked locking: another caller may have created the batch while we waited.
+            // This check MUST live inside the try so the finally always releases the semaphore —
+            // returning here without releasing leaks the semaphore and deadlocks every later caller
+            // (the parallel event slices in a composite rebuild all park on WaitAsync forever).
+            if (_batch != null)
+            {
+                return _batch;
+            }
+
             _batch = await _session.Options.Events.MessageOutbox.CreateBatch(session).ConfigureAwait(false);
             Listeners.Add(_batch);
 

--- a/src/TenantPartitionedEventsTests/Sharded/composite_side_effects_rebuild_under_sharded_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/composite_side_effects_rebuild_under_sharded_partitioning.cs
@@ -1,0 +1,216 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Internal.Sessions;
+using Marten.Services;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+/// <summary>
+/// Coverage for the full VIPLive zorgdeclaraties production configuration that surfaced the
+/// composite-rebuild deadlock (marten#4727): <c>MultiTenantedWithShardedDatabases</c> +
+/// <c>TenancyStyle.Conjoined</c> + <c>UseTenantPartitionedEvents</c> + a multi-stage
+/// <c>CompositeProjectionFor</c> whose stage-2 member PUBLISHES side-effect messages
+/// (<c>RaiseSideEffects</c> -&gt; <c>slice.PublishMessage(...)</c>), driven through an optimized
+/// composite rebuild.
+///
+/// The optimized composite rebuild runs in <c>ShardExecutionMode.Continuous</c>, so stage-2 side
+/// effects fire and the parallel event slices all call
+/// <c>ProjectionUpdateBatch.CurrentMessageBatch</c> concurrently. Before the #4727 fix that leaked
+/// the batch semaphore and the rebuild deadlocked forever; this test pins that the rebuild
+/// completes and every tenant's documents on the multi-tenant shard materialize.
+/// </summary>
+[Collection("sharded-tenant-partitioned")]
+public partial class composite_side_effects_rebuild_under_sharded_partitioning: IAsyncLifetime
+{
+    private readonly ShardedPartitionedFixture _fixture;
+    private readonly ITestOutputHelper _output;
+    private readonly RecordingOutbox _outbox = new();
+
+    public composite_side_effects_rebuild_under_sharded_partitioning(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    public record TripStarted(Guid Id);
+    public record TripLeg(double Distance);
+
+    public class CsTrip
+    {
+        public Guid Id { get; set; }
+        public double Distance { get; set; }
+        public int Version { get; set; }
+    }
+
+    public partial class CsTripProjection: SingleStreamProjection<CsTrip, Guid>
+    {
+        public CsTripProjection() => Name = "CsTrip";
+        public void Apply(CsTrip agg, TripLeg e) => agg.Distance += e.Distance;
+    }
+
+    public class CsTripNotice
+    {
+        public Guid Id { get; set; }
+        public int Legs { get; set; }
+        public int Version { get; set; }
+    }
+
+    public record TripNoticed(Guid Id);
+
+    /// <summary>Stage-2 member that publishes a side-effect message for every slice — the
+    /// concurrency that contends on the shared ProjectionUpdateBatch message-batch semaphore.</summary>
+    public partial class CsTripNoticeProjection: SingleStreamProjection<CsTripNotice, Guid>
+    {
+        public CsTripNoticeProjection() => Name = "CsTripNotice";
+        public void Apply(CsTripNotice agg, TripLeg e) => agg.Legs++;
+
+        public override ValueTask RaiseSideEffects(IDocumentOperations operations, IEventSlice<CsTripNotice> slice)
+        {
+            slice.PublishMessage(new TripNoticed(slice.Events().First().StreamId));
+            return new ValueTask();
+        }
+    }
+
+    private void configure(StoreOptions opts)
+    {
+        opts.MultiTenantedWithShardedDatabases(x =>
+        {
+            x.ConnectionString = ConnectionSource.ConnectionString;
+            x.SchemaName = "sharded";
+            x.PartitionSchemaName = "tenants";
+
+            foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+            {
+                x.AddDatabase(dbName, connStr);
+            }
+        });
+
+        opts.AutoCreateSchemaObjects = AutoCreate.All;
+        opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+        opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+        opts.Events.UseTenantPartitionedEvents = true;
+        opts.Events.AddEventType<TripLeg>();
+
+        // The side-effect path goes through this outbox; a no-op recorder keeps the test focused
+        // on the rebuild completing (not on message delivery).
+        opts.Events.MessageOutbox = _outbox;
+
+        opts.Projections.CompositeProjectionFor("CsComposite", c =>
+        {
+            c.Add<CsTripProjection>(stageNumber: 1);
+            c.Add<CsTripNoticeProjection>(stageNumber: 2);
+        });
+
+        opts.Schema.For<CsTrip>().DocumentAlias("cs_trip");
+        opts.Schema.For<CsTripNotice>().DocumentAlias("cs_notice");
+    }
+
+    [Fact]
+    public async Task optimized_composite_rebuild_with_side_effect_publishing_completes()
+    {
+        var tenants = new[] { "tA", "tB", "tC", "tD", "tE" };
+        var shardAssignment = new Dictionary<string, string>
+        {
+            ["tA"] = _fixture.DbNames[0],
+            ["tB"] = _fixture.DbNames[0],
+            ["tC"] = _fixture.DbNames[0],
+            ["tD"] = _fixture.DbNames[1],
+            ["tE"] = _fixture.DbNames[2],
+        };
+
+        await using var store = (DocumentStore)DocumentStore.For(configure);
+        foreach (var tenant in tenants)
+        {
+            await store.Advanced.AddTenantToShardAsync(tenant, shardAssignment[tenant], CancellationToken.None);
+        }
+
+        // Many streams per tenant so a rebuild page carries many parallel slices that all publish a
+        // side-effect message -> concurrent CurrentMessageBatch calls (the #4727 deadlock window).
+        const int streamsPerTenant = 25;
+        foreach (var tenant in tenants)
+        {
+            await using var session = store.LightweightSession(tenant);
+            for (var i = 0; i < streamsPerTenant; i++)
+            {
+                var id = Guid.NewGuid();
+                session.Events.StartStream<CsTrip>(id, new TripStarted(id), new TripLeg(1.0), new TripLeg(2.5));
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        using var daemon = await store.BuildProjectionDaemonAsync("tA");
+
+        Exception? thrown = null;
+        try
+        {
+            await daemon.RebuildProjectionAsync("CsComposite", 45.Seconds(), CancellationToken.None);
+        }
+        catch (Exception e)
+        {
+            thrown = e;
+            _output.WriteLine(e.ToString());
+        }
+
+        thrown.ShouldBeNull(
+            "the optimized composite rebuild with side-effect-publishing stage members must complete, " +
+            "not deadlock on the ProjectionUpdateBatch message-batch semaphore (#4727)");
+
+        // Documents for the 3 tenants on the multi-tenant shard materialized for both stages.
+        foreach (var tenant in new[] { "tA", "tB", "tC" })
+        {
+            await using var session = store.QuerySession(tenant);
+            (await session.Query<CsTrip>().CountAsync()).ShouldBe(streamsPerTenant);
+            (await session.Query<CsTripNotice>().CountAsync()).ShouldBe(streamsPerTenant);
+        }
+    }
+
+    private sealed class RecordingOutbox: IMessageOutbox
+    {
+        public ValueTask<IMessageBatch> CreateBatch(DocumentSessionBase session)
+            => new(new RecordingBatch());
+    }
+
+    private sealed class RecordingBatch: IMessageBatch
+    {
+        public Task BeforeCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token) => Task.CompletedTask;
+        public Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token) => Task.CompletedTask;
+        public ValueTask PublishAsync<T>(T message, string tenantId) => new();
+    }
+}


### PR DESCRIPTION
Fixes #4727 (and the residual deadlock behind the closed #4721).

### Problem

`ProjectionUpdateBatch.CurrentMessageBatch` leaks its `SemaphoreSlim`. After `await _semaphore.WaitAsync(...)`, the inner double-checked `if (_batch != null) return _batch;` sits **outside** the `try/finally`, so the second concurrent caller to acquire the semaphore returns without ever calling `_semaphore.Release()`.

During an optimized **composite** rebuild whose stage emits side-effect messages, the parallel event slices all call `CurrentMessageBatch` via `ProjectionBatch.PublishMessageAsync`. They queue on the semaphore; the first creates the batch and releases; the second hits the inner early-return and leaks the semaphore — so every remaining queued slice is parked on `WaitAsync` forever and the rebuild freezes (idle, no error, no DB query). Captured via a managed dump in #4727.

### Fix

Move the inner null-check **inside** the `try` so `finally` always releases the semaphore, and drop the `Task.Delay(Random.Shared.Next(25, 200))` band-aid that was only masking the race.

### Test

`DaemonTests/Bugs/Bug_4727_message_batch_semaphore_leak.cs` — a gated `IMessageOutbox` holds the semaphore while the first batch is created so N concurrent `CurrentMessageBatch` callers reliably pile up on it. The test **deadlocks (15s timeout) on the previous code** and **passes in ~1s with this fix**; all callers observe the single shared batch.

Found in production on a sharded + tenant-partitioned store (Marten 9.7.3 / JasperFx 2.9.9 / Wolverine 6.8.0): an `invoices` composite rebuild whose stage-2 members publish side-effect messages froze at a batch boundary on every deploy.
