### PR TITLE
Fix #4730 — bump JasperFx to 2.9.10 (aggregate-cache double-apply) + regression test

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,14 +48,20 @@
          single-consumer command loop. It previously ran inline inside that loop while the
          replay posted RangeCompleted commands back into the same bounded (10k) command
          channel, so the only reader was blocked awaiting its own posts — the shard silently
-         wedged at a batch boundary under UseTenantPartitionedEvents once the channel filled. -->
-    <PackageVersion Include="JasperFx" Version="2.9.9" />
-    <PackageVersion Include="JasperFx.Events" Version="2.9.9" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.9">
+         wedged at a batch boundary under UseTenantPartitionedEvents once the channel filled.
+         JasperFx 2.9.10: jasperfx#444 (marten#4730) — the in-memory aggregate cache is OFF by
+         default again (CacheLimitPerTenant 1000 → 0) and, when enabled, only populates after the
+         owning batch commits. Previously the cache was written during batch build before commit,
+         so a failed/retried batch (e.g. an out-of-order Update-before-Create stream throwing)
+         re-applied events on top of the already-mutated cached aggregate, double-applying to
+         unrelated, correctly-ordered streams in the same page. -->
+    <PackageVersion Include="JasperFx" Version="2.9.10" />
+    <PackageVersion Include="JasperFx.Events" Version="2.9.10" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.9" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.10" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/DaemonTests/Bugs/Bug_4730_double_apply_with_out_of_order_stream.cs
+++ b/src/DaemonTests/Bugs/Bug_4730_double_apply_with_out_of_order_stream.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Aggregation;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DaemonTests.Bugs;
+
+// Regression for marten#4730 (fixed upstream in JasperFx 2.9.10, jasperfx#444).
+//
+// A stream with an out-of-order (Update-before-Create) sequence throws inside the projection's
+// Apply. That exception used to cause an UNRELATED, correctly-ordered "control" stream in the same
+// page to have its Update applied TWICE. Root cause: the in-memory aggregate cache was written
+// during batch build (before commit); when the poison event triggered a skip-and-rebuild, the
+// rebuild read the already-mutated control aggregate back from the cache and re-applied its events.
+//
+// The fix turned the cache off by default AND made it populate only after a successful commit.
+// This test guards BOTH: it runs with the cache disabled (the default) and explicitly enabled, and
+// asserts the control stream's Update is applied exactly once either way.
+public class Bug_4730_double_apply_with_out_of_order_stream: OneOffConfigurationsContext
+{
+    private readonly ITestOutputHelper _output;
+
+    public Bug_4730_double_apply_with_out_of_order_stream(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Theory]
+    [InlineData(0)]    // cache disabled (the post-#4730 default)
+    [InlineData(1000)] // cache enabled — guards the "populate only on commit" half of the fix
+    public async Task control_stream_update_applied_exactly_once_despite_out_of_order_sibling(int cacheLimitPerTenant)
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.Add(new AccountProjection4730 { Options = { CacheLimitPerTenant = cacheLimitPerTenant } },
+                ProjectionLifecycle.Async);
+        });
+
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+
+        var streamOutOfOrder = Guid.NewGuid();
+        var streamControl = Guid.NewGuid();
+        var delta = 123.45m;
+        var t0 = DateTimeOffset.UtcNow.AddMinutes(-2);
+        var t1 = DateTimeOffset.UtcNow.AddMinutes(-1);
+
+        // Out-of-order stream: Update appended before Create -> the projection's Apply throws.
+        theSession.Events.StartStream(streamOutOfOrder,
+            new Updated4730(streamOutOfOrder, delta, t1),
+            new Created4730(streamOutOfOrder, t0));
+
+        // Control stream: correct order. Its Update must be applied exactly once.
+        theSession.Events.StartStream(streamControl,
+            new Created4730(streamControl, t0),
+            new Updated4730(streamControl, delta, t1));
+
+        await theSession.SaveChangesAsync();
+
+        using var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+
+        try
+        {
+            await daemon.WaitForNonStaleData(15.Seconds());
+        }
+        catch (Exception e)
+        {
+            // The out-of-order stream's poison event is skipped+dead-lettered; non-stale wait can still
+            // time out in some runs. The assertion below is what matters.
+            _output.WriteLine($"WaitForNonStaleData threw: {e.GetType().Name}: {e.Message}");
+        }
+
+        await using var query = theStore.QuerySession();
+        var control = await query.LoadAsync<AccountReadModel4730>(streamControl);
+
+        _output.WriteLine($"cacheLimit={cacheLimitPerTenant} control TotalDelta actual={control?.TotalDelta} expected={delta}");
+
+        control.ShouldNotBeNull();
+        control.TotalDelta.ShouldBe(delta);
+    }
+}
+
+public record Created4730(Guid Id, DateTimeOffset CreatedAt);
+
+public record Updated4730(Guid Id, decimal Delta, DateTimeOffset UpdatedAt);
+
+public class AccountReadModel4730
+{
+    public Guid Id { get; set; }
+    public decimal TotalDelta { get; set; }
+}
+
+public partial class AccountProjection4730: SingleStreamProjection<AccountReadModel4730, Guid>
+{
+    public AccountReadModel4730 Create(Created4730 e) => new() { Id = e.Id, TotalDelta = 0m };
+
+    public void Apply(Updated4730 e, AccountReadModel4730 model)
+    {
+        if (model == null || model.Id == Guid.Empty)
+            throw new InvalidOperationException("Update received before creation event.");
+
+        model.TotalDelta += e.Delta;
+    }
+}


### PR DESCRIPTION
Closes #4730. Consumes the upstream fix ([jasperfx#444](https://github.com/JasperFx/jasperfx/pull/444), shipped in JasperFx 2.9.10).

### The bug

An async aggregate projection double-applied a correctly-ordered "control" stream's event when an **unrelated** stream in the same page threw during apply (an out-of-order Update-before-Create). Reproduced cleanly: the control stream's value came out **2×** expected. Worked in 9.6, broke in 9.7.

### Root cause (fixed upstream)

The in-memory aggregate cache was turned on by default in JasperFx 2.9.0 and isn't transactional — `AggregationRunner` wrote the mutated aggregate to the cache **during batch build, before commit**. When the poison event triggered `buildBatchWithSkipping` to skip-and-rebuild, the rebuild read the already-mutated control aggregate back from the cache and applied its events again.

### What 2.9.10 changes

- `CacheLimitPerTenant` defaults back to **0** (cache off / opt-in), restoring pre-2.9.0 behavior.
- When the cache **is** enabled, it now populates **only after the batch commits**, so a failed/retried build rebuilds from committed state instead of double-applying. (Composite member batches keep in-build population for cross-stage in-flight reads, #4329.)

### This PR

- Bumps the four `JasperFx.*` packages 2.9.9 → **2.9.10** in `Directory.Packages.props`.
- Adds `Bug_4730_double_apply_with_out_of_order_stream`, a **theory over `CacheLimitPerTenant` 0 and 1000** so it permanently guards *both* halves of the fix (default-off **and** populate-on-commit): the control stream's Update must be applied exactly once even though a sibling stream throws.

### Verification

- `Bug_4730` — 2/2 green against the published 2.9.10 (cache off **and** cache on). The same test fails on 2.9.9.
- Composite + rebuild daemon slice (42 tests incl. `Bug_4730`, `Bug_4428`) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)