### PR TITLE
Fix #4729: composite rebuild must not re-fire member side effects (JasperFx 2.9.13)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,14 +54,25 @@
          owning batch commits. Previously the cache was written during batch build before commit,
          so a failed/retried batch (e.g. an out-of-order Update-before-Create stream throwing)
          re-applied events on top of the already-mutated cached aggregate, double-applying to
-         unrelated, correctly-ordered streams in the same page. -->
-    <PackageVersion Include="JasperFx" Version="2.9.10" />
-    <PackageVersion Include="JasperFx.Events" Version="2.9.10" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.10">
+         unrelated, correctly-ordered streams in the same page.
+         JasperFx 2.9.13: marten#4729 (two parts) — the optimized composite rebuild now propagates
+         the composite's ShardExecutionMode down to its member executions (jasperfx#447). Member
+         executions defaulted to ShardExecutionMode.Continuous (CompositeReplayExecutor only set the
+         parent's Mode), so during a composite rebuild the stage members fired their RaiseSideEffects
+         (PublishMessage/AppendEvent) — unlike the classic single-stream rebuild, which is pinned by
+         side_effects_do_not_happen_in_rebuilds. Members now inherit CatchUp/Rebuild and suppress
+         side effects during a rebuild. The follow-up (jasperfx#448) decouples slice.Snapshot
+         assignment from side-effect publishing in AggregationRunner so multi-stage composites still
+         fan the upstream Updated<TDoc> events to downstream stages during a rebuild (previously the
+         snapshot was only set on the Continuous path, so post-#447 a rebuild produced no upstream
+         snapshot and downstream stages threw NREs). 2.9.12 shipped only #447 and is incomplete. -->
+    <PackageVersion Include="JasperFx" Version="2.9.13" />
+    <PackageVersion Include="JasperFx.Events" Version="2.9.13" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.10" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.13" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/DaemonTests/Composites/composite_rebuild_suppresses_side_effects.cs
+++ b/src/DaemonTests/Composites/composite_rebuild_suppresses_side_effects.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Aggregation;
+using Marten.Internal.Sessions;
+using Marten.Services;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DaemonTests.Composites;
+
+// marten#4729 regression: a composite projection whose stage member raises side effects
+// (RaiseSideEffects -> slice.PublishMessage / slice.AppendEvent) must fire those side effects
+// during continuous/live operation but NOT during a rebuild — matching the classic single-stream
+// rebuild semantics pinned by side_effects_in_aggregations.side_effects_do_not_happen_in_rebuilds.
+//
+// The bug: CompositeReplayExecutor set ShardExecutionMode only on the parent composite execution,
+// while the member executions defaulted to ShardExecutionMode.Continuous and were never updated,
+// so the optimized composite rebuild re-published the member's side-effect messages every time.
+// Fixed in JasperFx 2.9.12 (jasperfx#447): CompositeExecution propagates its Mode to every member.
+public class composite_rebuild_suppresses_side_effects: DaemonContext
+{
+    public composite_rebuild_suppresses_side_effects(ITestOutputHelper output): base(output)
+    {
+    }
+
+    [Fact]
+    public async Task side_effects_fire_continuously_but_not_during_a_composite_rebuild()
+    {
+        var outbox = new RecordingMessageOutbox();
+
+        StoreOptions(opts =>
+        {
+            opts.Events.MessageOutbox = outbox;
+
+            opts.Projections.CompositeProjectionFor("SideEffectComposite", c =>
+            {
+                c.Add<CsCounterProjection>(stageNumber: 1);
+                c.Add<CsNoticeProjection>(stageNumber: 2);
+            });
+        }, true);
+
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+
+        using var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+
+        var streamIds = new List<Guid>();
+        for (var i = 0; i < 10; i++)
+        {
+            var id = Guid.NewGuid();
+            streamIds.Add(id);
+            theSession.Events.StartStream<CsCounter>(id, new CsLeg(), new CsLeg(), new CsLeg());
+        }
+
+        await theSession.SaveChangesAsync();
+
+        await daemon.WaitForNonStaleData(30.Seconds());
+
+        // Both stages materialized
+        (await theSession.Query<CsCounter>().CountAsync()).ShouldBe(10);
+        (await theSession.Query<CsNotice>().CountAsync()).ShouldBe(10);
+
+        // The stage-2 member published a CsNoticed message per stream during continuous operation
+        var publishedDuringContinuous = outbox.PublishedMessages.OfType<CsNoticed>().Count();
+        publishedDuringContinuous.ShouldBe(10);
+
+        await daemon.StopAllAsync();
+
+        // Capture the baseline, then rebuild the composite by its registered name
+        var messageCountBeforeRebuild = outbox.PublishedMessages.Count;
+
+        await daemon.RebuildProjectionAsync("SideEffectComposite", 60.Seconds(), CancellationToken.None);
+
+        // The rebuild re-derived the read models...
+        (await theSession.Query<CsCounter>().CountAsync()).ShouldBe(10);
+        (await theSession.Query<CsNotice>().CountAsync()).ShouldBe(10);
+
+        // ...but published NO additional side-effect messages. Before the #4729 fix the composite
+        // members ran in Continuous mode during the rebuild and re-published all 10 CsNoticed messages.
+        outbox.PublishedMessages.Count.ShouldBe(messageCountBeforeRebuild);
+        outbox.PublishedMessages.OfType<CsNoticed>().Count().ShouldBe(publishedDuringContinuous);
+    }
+}
+
+public record CsLeg;
+
+public record CsNoticed(Guid Id);
+
+public class CsCounter
+{
+    public Guid Id { get; set; }
+    public int Legs { get; set; }
+    public int Version { get; set; }
+}
+
+public partial class CsCounterProjection: SingleStreamProjection<CsCounter, Guid>
+{
+    public CsCounterProjection() => Name = "CsCounter";
+
+    public void Apply(CsCounter agg, CsLeg _) => agg.Legs++;
+}
+
+public class CsNotice
+{
+    public Guid Id { get; set; }
+    public int Legs { get; set; }
+    public int Version { get; set; }
+}
+
+public partial class CsNoticeProjection: SingleStreamProjection<CsNotice, Guid>
+{
+    public CsNoticeProjection() => Name = "CsNotice";
+
+    public void Apply(CsNotice agg, CsLeg _) => agg.Legs++;
+
+    public override ValueTask RaiseSideEffects(IDocumentOperations operations, IEventSlice<CsNotice> slice)
+    {
+        slice.PublishMessage(new CsNoticed(slice.Events().First().StreamId));
+        return new ValueTask();
+    }
+}
+
+public class RecordingMessageOutbox: IMessageOutbox
+{
+    private readonly List<RecordingMessageBatch> _batches = new();
+
+    public IReadOnlyList<object> PublishedMessages =>
+        _batches.SelectMany(x => x.Messages).Select(x => x.message).ToList();
+
+    public ValueTask<IMessageBatch> CreateBatch(DocumentSessionBase session)
+    {
+        var batch = new RecordingMessageBatch();
+        lock (_batches)
+        {
+            _batches.Add(batch);
+        }
+
+        return new ValueTask<IMessageBatch>(batch);
+    }
+}
+
+public record OutboxMessage(string tenantId, object message);
+
+public class RecordingMessageBatch: IMessageBatch
+{
+    private readonly List<OutboxMessage> _messages = new();
+
+    public IReadOnlyList<OutboxMessage> Messages
+    {
+        get
+        {
+            lock (_messages)
+            {
+                return _messages.ToList();
+            }
+        }
+    }
+
+    public Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token) =>
+        Task.CompletedTask;
+
+    public Task BeforeCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token) =>
+        Task.CompletedTask;
+
+    public ValueTask PublishAsync<T>(T message, string tenantId)
+    {
+        lock (_messages)
+        {
+            _messages.Add(new OutboxMessage(tenantId, message));
+        }
+
+        return new ValueTask();
+    }
+}

--- a/src/TenantPartitionedEventsTests/Sharded/composite_side_effects_rebuild_under_sharded_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/composite_side_effects_rebuild_under_sharded_partitioning.cs
@@ -32,11 +32,13 @@ namespace TenantPartitionedEventsTests.Sharded;
 /// (<c>RaiseSideEffects</c> -&gt; <c>slice.PublishMessage(...)</c>), driven through an optimized
 /// composite rebuild.
 ///
-/// The optimized composite rebuild runs in <c>ShardExecutionMode.Continuous</c>, so stage-2 side
-/// effects fire and the parallel event slices all call
-/// <c>ProjectionUpdateBatch.CurrentMessageBatch</c> concurrently. Before the #4727 fix that leaked
-/// the batch semaphore and the rebuild deadlocked forever; this test pins that the rebuild
-/// completes and every tenant's documents on the multi-tenant shard materialize.
+/// When this test was written the optimized composite rebuild ran its members in
+/// <c>ShardExecutionMode.Continuous</c>, so stage-2 side effects fired and the parallel event slices
+/// all called <c>ProjectionUpdateBatch.CurrentMessageBatch</c> concurrently — that leaked the batch
+/// semaphore and the rebuild deadlocked forever (#4727). As of marten#4729 (JasperFx 2.9.12) the
+/// composite propagates its Mode to the members, so side effects are now SUPPRESSED during a rebuild
+/// and that concurrency window is closed; this test remains a guard that the optimized composite
+/// rebuild completes (no deadlock) and every tenant's documents on the multi-tenant shard materialize.
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
 public partial class composite_side_effects_rebuild_under_sharded_partitioning: IAsyncLifetime


### PR DESCRIPTION
Closes #4729.

## Problem

A `CompositeProjectionFor` whose stage member raises side effects (`RaiseSideEffects` → `slice.PublishMessage` / `slice.AppendEvent`) re-fired those side effects on **every rebuild**, whereas an equivalent standalone `SingleStreamProjection` rebuild does not (pinned by `side_effects_in_aggregations.side_effects_do_not_happen_in_rebuilds`). For a member that publishes an external message (invoice/notification), a composite rebuild re-published it every time.

## Fix (JasperFx 2.9.13)

This bumps the JasperFx packages 2.9.10 → **2.9.13**, which carries the two-part fix:

- **jasperfx#447** — `CompositeReplayExecutor` only set the `ShardExecutionMode` on the *parent* composite execution; the member executions defaulted to `Continuous` and were never updated, so the optimized rebuild ran members in `Continuous` and fired their side effects. `CompositeExecution` now propagates its `Mode` to every member, so members run in `CatchUp`/`Rebuild` during a rebuild and suppress side effects — matching the classic single-stream path.
- **jasperfx#448** — a follow-up that decouples `slice.Snapshot` assignment from side-effect publishing in `AggregationRunner`. After #447, multi-stage composites lost the upstream `Updated<TDoc>` fan-out during a rebuild (the snapshot was only set on the `Continuous` path, and downstream stages threw NREs). The snapshot is now set in every mode; only the side effects stay `Continuous`-only. (2.9.12 shipped #447 alone and regressed `multi_stage_projections` — this PR targets 2.9.13.)

## Tests

- New regression test `src/DaemonTests/Composites/composite_rebuild_suppresses_side_effects.cs`: a composite whose stage-2 member publishes a message must publish during continuous operation but **not** during `RebuildProjectionAsync`. Verified RED on 2.9.10 (re-published all messages during rebuild) and GREEN on 2.9.13.
- Corrects the now-inaccurate class comment on `composite_side_effects_rebuild_under_sharded_partitioning` (the #4727 sharded test): side effects are suppressed during a rebuild as of #4729, so it stays a "rebuild completes / no deadlock" guard.
- Full `DaemonTests.Composites` (incl. `multi_stage_projections`) + `side_effects_in_aggregations` green against published 2.9.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)