### PR TITLE
Upgrade JasperFx family 2.9.13 → 2.10.0 (release 9.7.6)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.7.5</Version>
+        <Version>9.7.6</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,13 +66,13 @@
          fan the upstream Updated<TDoc> events to downstream stages during a rebuild (previously the
          snapshot was only set on the Continuous path, so post-#447 a rebuild produced no upstream
          snapshot and downstream stages threw NREs). 2.9.12 shipped only #447 and is incomplete. -->
-    <PackageVersion Include="JasperFx" Version="2.9.13" />
-    <PackageVersion Include="JasperFx.Events" Version="2.9.13" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.9.13">
+    <PackageVersion Include="JasperFx" Version="2.10.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.10.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.10.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.9.13" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.10.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Bumps `JasperFx`, `JasperFx.Events`, `JasperFx.Events.SourceGenerator`, `JasperFx.SourceGenerator` → **2.10.0** and the package version to **9.7.6**.

**Why:** JasperFx.Events 2.10.0 (jasperfx #449 + #450) made the positional record `DeadLetterShardCount` 4-arg (`+ string? TenantId`), which is binary-breaking. Marten 9.7.5 (compiled against the 3-arg ctor) throws `MissingMethodException` at runtime in `MartenDatabase.FetchDeadLetterCountsAsync` against 2.10.0. Rebuilding against 2.10.0 fixes the call site so downstream consumers (CritterWatch) can adopt 2.10.0.

Core build verified locally (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)