### PR TITLE
docs: fix snippet-source inaccuracies and regenerate

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -365,7 +365,7 @@ var store = DocumentStore.For(_ =>
     _.Logger(new ConsoleMartenLogger());
 });
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/StoreOptionsTests.cs#L185-L192' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_plugging-in-marten-logger' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/StoreOptionsTests.cs#L186-L193' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_plugging-in-marten-logger' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 You can also directly apply a session logger to any `IQuerySession` or `IDocumentSession` like this:
@@ -377,7 +377,7 @@ using var session = store.LightweightSession();
 // Replace the logger for only this one session
 session.Logger = new RecordingLogger();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/StoreOptionsTests.cs#L194-L200' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_plugging-in-session-logger' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/StoreOptionsTests.cs#L195-L201' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_plugging-in-session-logger' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The session logging is a different abstraction specifically so that you _could_ track database commands issued per session. In effect, my own shop is going to use this capability to understand what HTTP endpoints or service bus message handlers are being unnecessarily chatty in their database interactions. We also hope that the contextual logging of commands per document session makes it easier to understand how our systems behave.
@@ -585,8 +585,8 @@ just understand what kinds of operations are being chatty in the first place. To
 using (var session = theStore.QuerySession())
 {
     var users = (await session.Query<User>().ToListAsync());
-    var count = session.Query<User>().Count();
-    var any = session.Query<User>().Any();
+    var count = await session.Query<User>().CountAsync();
+    var any = await session.Query<User>().AnyAsync();
 
     session.RequestCount.ShouldBe(3);
 }

--- a/docs/documents/indexing/computed-indexes.md
+++ b/docs/documents/indexing/computed-indexes.md
@@ -161,7 +161,7 @@ var store = DocumentStore.For(_ =>
     // the sort order from the default of "ascending"
     _.Schema.For<User>().Index(x => x.LastName, x =>
     {
-        // Change the index method to "brin"
+        // Change the sort order to descending
         x.SortOrder = SortOrder.Desc;
     });
 });

--- a/docs/documents/indexing/unique.md
+++ b/docs/documents/indexing/unique.md
@@ -220,7 +220,7 @@ var store = DocumentStore.For(_ =>
     // the sort order from the default of "ascending"
     _.Schema.For<User>().Index(x => x.LastName, x =>
     {
-        // Change the index method to "brin"
+        // Change the sort order to descending
         x.SortOrder = SortOrder.Desc;
     });
 });

--- a/docs/documents/querying/linq/operators.md
+++ b/docs/documents/querying/linq/operators.md
@@ -26,10 +26,10 @@ public void select_a_single_value(IDocumentSession session)
     session.Query<Target>().Where(x => x.Number == 5).OrderBy(x => x.Date).First();
     session.Query<Target>().Where(x => x.Number == 5).OrderBy(x => x.Date).FirstOrDefault();
 
-    session.Query<Target>().Where(x => x.Number == 5).OrderBy(x => x.Date).Last();
-    session.Query<Target>().Where(x => x.Number == 5).OrderBy(x => x.Date).LastOrDefault();
+    // Marten does not support Last()/LastOrDefault(). Reverse the ordering
+    // and use First()/FirstOrDefault() instead.
 
-    // Using the query inside of Single/Last/First is supported as well
+    // Using the query predicate inside of Single/First is supported as well
     session.Query<Target>().Single(x => x.Number == 5);
 }
 ```

--- a/docs/events/appending.md
+++ b/docs/events/appending.md
@@ -39,7 +39,8 @@ modes of event appending you can use with Marten:
 var builder = Host.CreateApplicationBuilder();
 builder.Services.AddMarten(opts =>
     {
-        // This is the default Marten behavior from 4.0 on
+        // "Rich" was the default behavior through Marten 8. As of Marten 9
+        // the default is EventAppendMode.QuickWithServerTimestamps.
         opts.Events.AppendMode = EventAppendMode.Rich;
 
         // Lighter weight mode that should result in better
@@ -49,7 +50,7 @@ builder.Services.AddMarten(opts =>
     })
     .UseNpgsqlDataSource();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/QuickAppend/Examples.cs#L13-L28' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_event_append_mode' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/QuickAppend/Examples.cs#L13-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_event_append_mode' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The classic `Rich` mode will append events in a two step process where the local session will first determine all possible

--- a/docs/events/optimizing.md
+++ b/docs/events/optimizing.md
@@ -94,7 +94,7 @@ public partial class DayProjection: MultiStreamProjection<Day, int>
 
         Name = "Day";
 
-        // Opt into 2nd level caching of up to 100
+        // Opt into 2nd level caching of up to 1000
         // most recently encountered aggregates as a
         // performance optimization
         Options.CacheLimitPerTenant = 1000;

--- a/docs/events/projections/multi-stream-projections.md
+++ b/docs/events/projections/multi-stream-projections.md
@@ -947,7 +947,7 @@ public partial class DayProjection: MultiStreamProjection<Day, int>
 
         Name = "Day";
 
-        // Opt into 2nd level caching of up to 100
+        // Opt into 2nd level caching of up to 1000
         // most recently encountered aggregates as a
         // performance optimization
         Options.CacheLimitPerTenant = 1000;

--- a/docs/events/subscriptions.md
+++ b/docs/events/subscriptions.md
@@ -583,13 +583,13 @@ public class ErrorHandlingSubscription: SubscriptionBase
     {
         public Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
         {
-            Console.WriteLine("Marten is about to make a commit for any changes");
+            Console.WriteLine("Marten just made a commit for any changes");
             return Task.CompletedTask;
         }
 
         public Task BeforeCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
         {
-            Console.WriteLine("Marten just made a commit for any changes");
+            Console.WriteLine("Marten is about to make a commit for any changes");
             return Task.CompletedTask;
         }
     }

--- a/docs/schema/authorization.md
+++ b/docs/schema/authorization.md
@@ -16,10 +16,10 @@ to do this generation by doing a single `CREATE TABLE IF NOT EXISTS` statement. 
 ```cs
 var store = DocumentStore.For(_ =>
 {
+    // This is the default
     _.Advanced.Migrator.TableCreation = CreationStyle.CreateIfNotExists;
 
-    // or the default
-
+    // or, to drop and recreate the table on each schema migration
     _.Advanced.Migrator.TableCreation = CreationStyle.DropThenCreate;
 });
 ```

--- a/src/DaemonTests/Aggregations/multi_stream_projections.cs
+++ b/src/DaemonTests/Aggregations/multi_stream_projections.cs
@@ -274,7 +274,7 @@ public partial class DayProjection: MultiStreamProjection<Day, int>
 
         Name = "Day";
 
-        // Opt into 2nd level caching of up to 100
+        // Opt into 2nd level caching of up to 1000
         // most recently encountered aggregates as a
         // performance optimization
         Options.CacheLimitPerTenant = 1000;

--- a/src/DaemonTests/Subscriptions/SubscriptionSamples.cs
+++ b/src/DaemonTests/Subscriptions/SubscriptionSamples.cs
@@ -108,13 +108,13 @@ public class ErrorHandlingSubscription: SubscriptionBase
     {
         public Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
         {
-            Console.WriteLine("Marten is about to make a commit for any changes");
+            Console.WriteLine("Marten just made a commit for any changes");
             return Task.CompletedTask;
         }
 
         public Task BeforeCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
         {
-            Console.WriteLine("Marten just made a commit for any changes");
+            Console.WriteLine("Marten is about to make a commit for any changes");
             return Task.CompletedTask;
         }
     }

--- a/src/DocumentDbTests/Indexes/computed_indexes.cs
+++ b/src/DocumentDbTests/Indexes/computed_indexes.cs
@@ -118,7 +118,7 @@ public class computed_indexes: OneOffConfigurationsContext
             // the sort order from the default of "ascending"
             _.Schema.For<User>().Index(x => x.LastName, x =>
             {
-                // Change the index method to "brin"
+                // Change the sort order to descending
                 x.SortOrder = SortOrder.Desc;
             });
         });

--- a/src/EventSourcingTests/QuickAppend/Examples.cs
+++ b/src/EventSourcingTests/QuickAppend/Examples.cs
@@ -15,7 +15,8 @@ public class Examples
         var builder = Host.CreateApplicationBuilder();
         builder.Services.AddMarten(opts =>
             {
-                // This is the default Marten behavior from 4.0 on
+                // "Rich" was the default behavior through Marten 8. As of Marten 9
+                // the default is EventAppendMode.QuickWithServerTimestamps.
                 opts.Events.AppendMode = EventAppendMode.Rich;
 
                 // Lighter weight mode that should result in better

--- a/src/Marten.Testing/Examples/DDLCustomization.cs
+++ b/src/Marten.Testing/Examples/DDLCustomization.cs
@@ -11,10 +11,10 @@ public class DDLCustomization
         #region sample_customizing_table_creation
         var store = DocumentStore.For(_ =>
         {
+            // This is the default
             _.Advanced.Migrator.TableCreation = CreationStyle.CreateIfNotExists;
 
-            // or the default
-
+            // or, to drop and recreate the table on each schema migration
             _.Advanced.Migrator.TableCreation = CreationStyle.DropThenCreate;
         });
         #endregion

--- a/src/Marten.Testing/Examples/DiagnosticsExamples.cs
+++ b/src/Marten.Testing/Examples/DiagnosticsExamples.cs
@@ -55,8 +55,8 @@ public class DiagnosticsExamples: IntegrationContext
         using (var session = theStore.QuerySession())
         {
             var users = (await session.Query<User>().ToListAsync());
-            var count = session.Query<User>().Count();
-            var any = session.Query<User>().Any();
+            var count = await session.Query<User>().CountAsync();
+            var any = await session.Query<User>().AnyAsync();
 
             session.RequestCount.ShouldBe(3);
         }

--- a/src/Marten.Testing/Examples/LinqExamples.cs
+++ b/src/Marten.Testing/Examples/LinqExamples.cs
@@ -160,10 +160,10 @@ public class LinqExamples
         session.Query<Target>().Where(x => x.Number == 5).OrderBy(x => x.Date).First();
         session.Query<Target>().Where(x => x.Number == 5).OrderBy(x => x.Date).FirstOrDefault();
 
-        session.Query<Target>().Where(x => x.Number == 5).OrderBy(x => x.Date).Last();
-        session.Query<Target>().Where(x => x.Number == 5).OrderBy(x => x.Date).LastOrDefault();
+        // Marten does not support Last()/LastOrDefault(). Reverse the ordering
+        // and use First()/FirstOrDefault() instead.
 
-        // Using the query inside of Single/Last/First is supported as well
+        // Using the query predicate inside of Single/First is supported as well
         session.Query<Target>().Single(x => x.Number == 5);
     }
 


### PR DESCRIPTION
## What

Second follow-up from the docs audit. These defects live **inside generated snippet blocks**, so the fix is in the source `#region` markers; the markdown is then regenerated with `mdsnippets`. Source changes are comment-only except where noted.

## Fixes

- **`diagnostics` / `sample_using_request_count`** — sync `Count()`/`Any()` → `CountAsync()`/`AnyAsync()`. Synchronous query execution was removed in Marten 9 (these would throw `NotSupportedException`). Request count is unchanged (3).
- **`linq/operators` / `sample_select_a_single_value`** — removed `Last()`/`LastOrDefault()` from the element-operations sample. Marten throws `InvalidOperationException` on them; the guidance is to reverse the ordering and use `First()`/`FirstOrDefault()`. Comment updated accordingly.
- **`events/appending` / `sample_configuring_event_append_mode`** — comment claimed `Rich` is the default "from 4.0 on"; the default is `QuickWithServerTimestamps` as of Marten 9.
- **`events/subscriptions` / `sample_errorhandlingsubscription`** — `AfterCommitAsync` and `BeforeCommitAsync` log messages were swapped.
- **`multi-stream` + `optimizing` / `sample_showing_fanout_rules`** — cache comment said "up to 100" but the value is `1000`.
- **`computed-indexes` + `unique` / `sample_customizing-calculated-index`** — copy-paste "Change the index method to brin" comment sat over a `SortOrder.Desc` assignment.
- **`schema/authorization` / `sample_customizing_table_creation`** — comment implied `DropThenCreate` is the default; `CreateIfNotExists` is the default.

## Verification

`mdsnippets` regenerated the affected markdown (incidental snippet source-link line-number refreshes ride along). `Marten.Testing` builds clean (the only non-comment source edits — `CountAsync`/`AnyAsync` and the removed `Last()` lines — are there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)