### PR TITLE
docs: fix mismatched and missing code samples

### DIFF
--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -86,7 +86,7 @@ public Task OpenIssues([FromServices] IQuerySession session, [FromQuery] string?
             .WriteArray(HttpContext, onFoundStatus: int.Parse(sc));
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L84-L99' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_writing_multiple_documents_to_httpcontext' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L82-L97' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_writing_multiple_documents_to_httpcontext' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Compiled Query Support
@@ -107,7 +107,7 @@ public class OpenIssues: ICompiledListQuery<Issue>
     }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L114-L124' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_openissues' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L112-L122' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_openissues' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And use that in an MVC Controller method like this:
@@ -123,7 +123,7 @@ public Task OpenIssues2([FromServices] IQuerySession session, [FromQuery] string
         : session.WriteArray(new OpenIssues(), HttpContext, onFoundStatus: int.Parse(sc));
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L101-L111' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_compiled_query_with_json_streaming' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L99-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_compiled_query_with_json_streaming' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Likewise, you _could_ use a compiled query to write a single document. As a contrived
@@ -143,7 +143,7 @@ public class IssueById: ICompiledQuery<Issue, Issue>
     public Guid Id { get; set; }
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L126-L138' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_issuebyid' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L124-L136' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_issuebyid' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 And the usage of that to write JSON directly to the `HttpContext` in a controller method:
@@ -155,13 +155,11 @@ And the usage of that to write JSON directly to the `HttpContext` in a controlle
 public Task Get3(Guid issueId, [FromServices] IQuerySession session, [FromQuery] string? sc = null)
 {
     return sc is null
-        ? session.Query<Issue>().Where(x => x.Id == issueId)
-            .WriteSingle(HttpContext)
-        : session.Query<Issue>().Where(x => x.Id == issueId)
-            .WriteSingle(HttpContext, onFoundStatus: int.Parse(sc));
+        ? session.WriteOne(new IssueById { Id = issueId }, HttpContext)
+        : session.WriteOne(new IssueById { Id = issueId }, HttpContext, onFoundStatus: int.Parse(sc));
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L69-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_write_single_document_to_httpcontext_with_compiled_query' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/Controllers/IssueController.cs#L69-L79' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_write_single_document_to_httpcontext_with_compiled_query' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Writing Event Sourcing Aggregates

--- a/docs/documents/deletes.md
+++ b/docs/documents/deletes.md
@@ -482,22 +482,10 @@ public async Task query_is_soft_deleted_since_docs()
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Deleting/soft_deletes.cs#L1074-L1098' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_query_soft_deleted_since-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-_Neither `DeletedSince` nor `DeletedBefore` are inclusive searches as shown_below:
-
-<!-- snippet: sample_alldocumenttypesshouldbesoftdeleted -->
-<a id='snippet-sample_alldocumenttypesshouldbesoftdeleted'></a>
-```cs
-internal void AllDocumentTypesShouldBeSoftDeleted()
-{
-    using var store = DocumentStore.For(opts =>
-    {
-        opts.Connection("some connection string");
-        opts.Policies.AllDocumentsSoftDeleted();
-    });
-}
-```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/Deletes.cs#L36-L47' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_alldocumenttypesshouldbesoftdeleted' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
+::: tip
+Neither `DeletedSince` nor `DeletedBefore` are inclusive searches — the supplied boundary
+timestamp itself is excluded from the results.
+:::
 
 ### Undoing Soft-Deleted Documents
 

--- a/docs/documents/querying/advanced-sql.md
+++ b/docs/documents/querying/advanced-sql.md
@@ -141,15 +141,24 @@ results[1].detail.Detail.ShouldBe("Likes to cook");
 
 All `AdvancedSql` methods also support parameters:
 
-<!-- snippet: sample_document_schema_resolver_resolve_schemas -->
-<a id='snippet-sample_document_schema_resolver_resolve_schemas'></a>
+<!-- snippet: sample_advanced_sql_query_parameters -->
+<a id='snippet-sample_advanced_sql_query_parameters'></a>
 ```cs
-var schema = theSession.DocumentStore.Options.Schema;
+var schema = session.DocumentStore.Options.Schema;
 
-schema.DatabaseSchemaName.ShouldBe("public");
-schema.EventsSchemaName.ShouldBe("public");
+var name = (await session.AdvancedSql.QueryAsync<string>(
+    $"select data ->> ? from {schema.For<DocWithMeta>()} limit 1",
+    CancellationToken.None,
+    "Name")).First();
+
+// Use ^ as the parameter placeholder
+var name2 = (await session.AdvancedSql.QueryAsync<string>(
+    '^',
+    $"select data ->> ^ from {schema.For<DocWithMeta>()} limit 1",
+    CancellationToken.None,
+    "Name")).First();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/DocumentSchemaResolverTests.cs#L25-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_document_schema_resolver_resolve_schemas' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Reading/advanced_sql_query.cs#L151-L166' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_advanced_sql_query_parameters' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 For sync queries you can use the `AdvancedSql.Query<T>(...)` overloads.

--- a/docs/documents/storing.md
+++ b/docs/documents/storing.md
@@ -81,7 +81,7 @@ using (var session = theStore.LightweightSession())
     await session.SaveChangesAsync();
 }
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/document_inserts.cs#L78-L86' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sample-document-insertonly' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/document_inserts.cs#L79-L87' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_sample-document-insertonly' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Bulk Loading
@@ -106,28 +106,10 @@ await theStore.BulkInsertAsync(data, batchSize: 500);
 
 The bulk insert is done with a single transaction. For really large document collections, you may need to page the calls to `IDocumentStore.BulkInsert()`.
 
-And new with Marten v4.0 is an asynchronous version:
-
 ::: tip
-If you are concerned with server resource utilization, you probably want to be using
-the asynchronous versions of Marten APIs.
+All bulk insert APIs are asynchronous. If you are concerned with server resource utilization,
+prefer the batched overloads shown above.
 :::
-
-<!-- snippet: sample_using_bulk_insert_async -->
-<a id='snippet-sample_using_bulk_insert_async'></a>
-```cs
-// This is just creating some randomized
-// document data
-var data = Target.GenerateRandomData(100).ToArray();
-
-// Load all of these into a Marten-ized database
-await theStore.BulkInsertAsync(data, batchSize: 500);
-
-// And just checking that the data is actually there;)
-(await theSession.Query<Target>().CountAsync()).ShouldBe(data.Length);
-```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DocumentDbTests/Writing/bulk_loading.cs#L252-L262' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_bulk_insert_async' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
 
 By default, bulk insert will fail if there are any duplicate id's between the documents being inserted and the existing database data. You can alter this behavior through the `BulkInsertMode` enumeration as shown below:
 

--- a/docs/events/querying.md
+++ b/docs/events/querying.md
@@ -140,6 +140,33 @@ public interface IEvent
     /// <param name="key"></param>
     /// <returns></returns>
     object? GetHeader(string key);
+
+    /// <summary>
+    ///     Optional user name captured for this event
+    /// </summary>
+    string? UserName { get; set; }
+
+    /// <summary>
+    ///     Has this event been marked as skipped and filtered out of
+    ///     projection and subscription processing
+    /// </summary>
+    bool IsSkipped { get; set; }
+
+    /// <summary>
+    ///     Strong-typed identifier values used for cross-stream querying
+    ///     and consistency (dynamic consistency boundaries). May be null.
+    /// </summary>
+    IReadOnlyList<EventTag>? Tags { get; }
+
+    /// <summary>
+    ///     Add a strong-typed tag value to this event
+    /// </summary>
+    void AddTag<TTag>(TTag tag) where TTag : notnull;
+
+    /// <summary>
+    ///     Add a tag value to this event
+    /// </summary>
+    void AddTag(EventTag tag);
 }
 ```
 

--- a/docs/events/skipping.md
+++ b/docs/events/skipping.md
@@ -45,3 +45,17 @@ flag alters Marten behavior by:
 
 To mark events as skipped, you can either use raw SQL against your `mt_events` table, or
 this helper API:
+
+<!-- snippet: sample_mark_events_as_skipped -->
+<a id='snippet-sample_mark_events_as_skipped'></a>
+```cs
+public static async Task mark_events_as_skipped(
+    IDocumentStore store,
+    long[] sequences,
+    CancellationToken cancellation)
+{
+    await store.Storage.Database.MarkEventsAsSkipped(sequences, cancellation);
+}
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/Examples/EventSkipping.cs#L30-L38' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_mark_events_as_skipped' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->

--- a/src/EventSourcingTests/Examples/EventSkipping.cs
+++ b/src/EventSourcingTests/Examples/EventSkipping.cs
@@ -27,6 +27,7 @@ public class EventSkipping
         #endregion
     }
 
+    #region sample_mark_events_as_skipped
     public static async Task mark_events_as_skipped(
         IDocumentStore store,
         long[] sequences,
@@ -34,6 +35,7 @@ public class EventSkipping
     {
         await store.Storage.Database.MarkEventsAsSkipped(sequences, cancellation);
     }
+    #endregion
 
     // If you're using multi-tenancy through separate databases,
     // you'll need to use the correct database

--- a/src/IssueService/Controllers/IssueController.cs
+++ b/src/IssueService/Controllers/IssueController.cs
@@ -72,10 +72,8 @@ namespace IssueService.Controllers
         public Task Get3(Guid issueId, [FromServices] IQuerySession session, [FromQuery] string? sc = null)
         {
             return sc is null
-                ? session.Query<Issue>().Where(x => x.Id == issueId)
-                    .WriteSingle(HttpContext)
-                : session.Query<Issue>().Where(x => x.Id == issueId)
-                    .WriteSingle(HttpContext, onFoundStatus: int.Parse(sc));
+                ? session.WriteOne(new IssueById { Id = issueId }, HttpContext)
+                : session.WriteOne(new IssueById { Id = issueId }, HttpContext, onFoundStatus: int.Parse(sc));
         }
 
         #endregion


### PR DESCRIPTION
## What

Third follow-up from the docs audit: pages whose embedded sample pointed at the wrong `#region`, was missing, or was duplicated. Where the right sample didn't exist, the source was given a proper region (and `mdsnippets` regenerated the markdown).

## Fixes

- **`querying/advanced-sql`** — the "All `AdvancedSql` methods also support parameters" section embedded `sample_document_schema_resolver_resolve_schemas` (schema-name resolution). Pointed it at `sample_advanced_sql_query_parameters`, which actually demonstrates parameter usage.
- **`documents/aspnetcore`** — the "compiled query" sample (`Get3`) was a plain LINQ query byte-identical to the non-compiled `Get2`. Rewrote it to use the existing `IssueById` compiled query via `session.WriteOne(new IssueById { Id = issueId }, HttpContext)` (the `ICompiledQuery` overload). `IssueService` builds clean.
- **`events/skipping`** — the page ended mid-sentence ("…or this helper API:") with no example. Added a `sample_mark_events_as_skipped` region around the existing `MarkEventsAsSkipped` helper and referenced it.
- **`documents/storing`** — removed a second "asynchronous version" bulk-insert snippet that was byte-identical to the one above it; all bulk-insert APIs are already async.
- **`documents/deletes`** — under "Neither `DeletedSince` nor `DeletedBefore` are inclusive…" the embedded snippet was an unrelated global-soft-delete config. Replaced with the actual statement of the exclusivity behavior.
- **`events/querying`** — added the `Tags`, `UserName`, `IsSkipped`, and `AddTag(...)` members to the inline `IEvent` interface listing to match the current interface.

## Source changes

Only `IssueController.Get3` (compiled-query usage) and a new `#region` marker in `EventSkipping.cs`; the rest is regenerated markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)