### PR TITLE
docs: fix EventProjection enrichment sample to use method conventions

### DIFF
--- a/docs/events/projections/event-projections.md
+++ b/docs/events/projections/event-projections.md
@@ -253,18 +253,15 @@ now extended to `EventProjection`.
 Override `EnrichEventsAsync` in your `EventProjection` subclass:
 
 ```cs
-public class TaskSummaryProjection : EventProjection
+public partial class TaskSummaryProjection : EventProjection
 {
-    public TaskSummaryProjection()
+    // The Project handler reads UserName that was set by EnrichEventsAsync
+    public void Project(TaskAssigned e, IDocumentOperations ops)
     {
-        // The Project handler reads UserName that was set by EnrichEventsAsync
-        Project<TaskAssigned>((e, ops) =>
+        ops.Store(new TaskSummary
         {
-            ops.Store(new TaskSummary
-            {
-                Id = e.TaskId,
-                AssignedUserName = e.UserName
-            });
+            Id = e.TaskId,
+            AssignedUserName = e.UserName
         });
     }
 


### PR DESCRIPTION
## What

The "Basic Usage" sample under [event projections / EnrichEventsAsync] used the inline-lambda `Project<TaskAssigned>((e, ops) => {...})` constructor form — which **the same page's own warning** (top of the Method Conventions section) states was removed in Marten 9.0.

## Fix

Rewrote the hand-written sample as a `partial class` with a `public void Project(TaskAssigned e, IDocumentOperations ops)` method convention, matching the `Project(...)` convention shown elsewhere on the same page (and the migration guidance in the warning).

## Note

A few related items from the same audit need a design decision and are intentionally **not** included here: the `TrackedEventProjection` source sample is a `NotImplementedException("Redo")` stub that needs a real `EnableDocumentTrackingByIdentity` rewrite; the compiled-query `AsJson()` prose vs. sample needs an API-behavior confirmation; and the `command_handler_workflow` "Async lifecycle" bullet needs the revision-tracking nuance spelled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)