### PR TITLE
Upgrade JasperFx family → 2.12.0 + dead-letter row drill-in / per-tenant counts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,13 +66,16 @@
          fan the upstream Updated<TDoc> events to downstream stages during a rebuild (previously the
          snapshot was only set on the Continuous path, so post-#447 a rebuild produced no upstream
          snapshot and downstream stages threw NREs). 2.9.12 shipped only #447 and is incomplete. -->
-    <PackageVersion Include="JasperFx" Version="2.10.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.10.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.10.0">
+    <!-- JasperFx 2.12.0: dead-letter row drill-in (IEventDatabase.QueryDeadLetterEventsAsync) +
+         DeadLetterEvent.TenantId + tenant-aware daemon PauseShardAsync/rebuild fan-out (jasperfx#453).
+         Marten implements QueryDeadLetterEventsAsync + per-tenant FetchDeadLetterCountsAsync below. -->
+    <PackageVersion Include="JasperFx" Version="2.12.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.12.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.10.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.12.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/Marten/Storage/MartenDatabase.EventStorage.cs
+++ b/src/Marten/Storage/MartenDatabase.EventStorage.cs
@@ -320,6 +320,35 @@ select count(*) from {Options.Events.DatabaseSchemaName}.mt_streams;
             .ToList();
     }
 
+    /// <summary>
+    ///     Per-tenant dead-letter counts (CritterWatch#381 / jasperfx#450). Under
+    ///     <c>UseTenantPartitionedEvents</c> the dead-letter table stays store-global, but each row
+    ///     records the failing event's <see cref="DeadLetterEvent.TenantId" />, so the counts that
+    ///     would otherwise collide on <c>{ProjectionName}:{ShardName}</c> are separated per tenant.
+    ///     A null <paramref name="tenantId" /> falls back to the store-global (tenant-collapsed) shape.
+    /// </summary>
+    public async Task<IReadOnlyList<DeadLetterShardCount>> FetchDeadLetterCountsAsync(string? tenantId,
+        CancellationToken token = default)
+    {
+        if (tenantId == null)
+        {
+            return await FetchDeadLetterCountsAsync(token).ConfigureAwait(false);
+        }
+
+        await EnsureStorageExistsAsync(typeof(DeadLetterEvent), token).ConfigureAwait(false);
+
+        await using var session = Options.EventGraph.Store.QuerySession(SessionOptions.ForDatabase(this));
+        var rows = await session.Query<DeadLetterEvent>()
+            .Where(x => x.TenantId == tenantId)
+            .GroupBy(x => new { x.ProjectionName, x.ShardName })
+            .Select(g => new { g.Key.ProjectionName, g.Key.ShardName, Count = g.Count() })
+            .ToListAsync(token).ConfigureAwait(false);
+
+        return rows
+            .Select(x => new DeadLetterShardCount(x.ProjectionName, x.ShardName, x.Count, tenantId))
+            .ToList();
+    }
+
     public async Task<IReadOnlyList<ShardState>> FetchProjectionProgressFor(ShardName[] names, CancellationToken token = default)
     {
         await EnsureStorageExistsAsync(typeof(IEvent), token).ConfigureAwait(false);

--- a/src/Marten/Storage/MartenDatabase.EventStorage.cs
+++ b/src/Marten/Storage/MartenDatabase.EventStorage.cs
@@ -349,6 +349,33 @@ select count(*) from {Options.Events.DatabaseSchemaName}.mt_streams;
             .ToList();
     }
 
+    /// <summary>
+    ///     CritterWatch#369: fetch the stored dead-letter event rows for a single shard — the drill-in
+    ///     companion to <see cref="CountDeadLetterEventsAsync" />. Most recent failures first (by event
+    ///     sequence), paged. A null <paramref name="tenantId" /> spans every tenant sharing this database;
+    ///     under <c>UseTenantPartitionedEvents</c> pass a tenant to scope to one partition.
+    /// </summary>
+    public async Task<IReadOnlyList<DeadLetterEvent>> QueryDeadLetterEventsAsync(ShardName shard,
+        string? tenantId, int offset, int limit, CancellationToken token = default)
+    {
+        await EnsureStorageExistsAsync(typeof(DeadLetterEvent), token).ConfigureAwait(false);
+
+        await using var session = Options.EventGraph.Store.QuerySession(SessionOptions.ForDatabase(this));
+        var query = session.Query<DeadLetterEvent>()
+            .Where(x => x.ProjectionName == shard.Name && x.ShardName == shard.ShardKey);
+
+        if (tenantId != null)
+        {
+            query = query.Where(x => x.TenantId == tenantId);
+        }
+
+        return await query
+            .OrderByDescending(x => x.EventSequence)
+            .Skip(offset)
+            .Take(limit)
+            .ToListAsync(token).ConfigureAwait(false);
+    }
+
     public async Task<IReadOnlyList<ShardState>> FetchProjectionProgressFor(ShardName[] names, CancellationToken token = default)
     {
         await EnsureStorageExistsAsync(typeof(IEvent), token).ConfigureAwait(false);


### PR DESCRIPTION
Bumps the JasperFx family `2.10.0 → 2.12.0` and implements the two `IEventDatabase` dead-letter surfaces that 2.12.0 (jasperfx#453) adds.

### Changes
- **`Directory.Packages.props`** — JasperFx / JasperFx.Events / JasperFx.Events.SourceGenerator / JasperFx.SourceGenerator → `2.12.0`.
- **`QueryDeadLetterEventsAsync` (#369)** — `MartenDatabase` implements the new `IEventDatabase.QueryDeadLetterEventsAsync`: fetch the actual dead-letter event rows for a shard (id, sequence, exception type/message, timestamp, tenant), most-recent-first, paged, optionally scoped to one tenant. Companion to the existing `CountDeadLetterEventsAsync`.
- **Per-tenant `FetchDeadLetterCountsAsync` (#381)** — tenant-scoped override of the dead-letter count fetch, reading `DeadLetterEvent.TenantId` (new in 2.12.0).

### Verification
`dotnet build src/Marten/Marten.csproj` is green against the published JasperFx.Events 2.12.0 — the implementations override 2.12.0's new interface method and read the new `DeadLetterEvent.TenantId`, so a green compile confirms the published surface matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)