### PR TITLE
Propagate JasperFxOptions.EnableAdvancedTracking to Events.EnableExtendedProgressionTracking

### DIFF
--- a/src/CoreTests/jasper_fx_mechanics.cs
+++ b/src/CoreTests/jasper_fx_mechanics.cs
@@ -345,7 +345,93 @@ public class jasper_fx_mechanics
         result2.ShouldBe(0);
     }
 
+    [Fact]
+    public async Task enable_advanced_tracking_propagates_to_main_document_store()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddJasperFx(o => o.EnableAdvancedTracking = true);
 
+                services.AddMarten(m =>
+                {
+                    m.Connection(ConnectionSource.ConnectionString);
+                    m.DatabaseSchemaName = "advanced_tracking_main";
+                });
+            }).StartAsync();
+
+        var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
+        store.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task enable_advanced_tracking_propagates_to_ancillary_document_stores()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddJasperFx(o => o.EnableAdvancedTracking = true);
+
+                services.AddMarten(m =>
+                {
+                    m.Connection(ConnectionSource.ConnectionString);
+                    m.DatabaseSchemaName = "advanced_tracking_main";
+                });
+
+                services.AddMartenStore<IFirstStore>(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DatabaseSchemaName = "advanced_tracking_first";
+                });
+
+                services.AddMartenStore<ISecondStore>(services =>
+                {
+                    var opts = new StoreOptions();
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DatabaseSchemaName = "advanced_tracking_second";
+                    return opts;
+                });
+            }).StartAsync();
+
+        var main = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
+        main.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+
+        var first = host.Services.GetRequiredService<IFirstStore>().As<DocumentStore>();
+        first.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+
+        var second = host.Services.GetRequiredService<ISecondStore>().As<DocumentStore>();
+        second.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task advanced_tracking_off_leaves_extended_progression_tracking_at_default()
+    {
+        // Sanity: when EnableAdvancedTracking is not set (default false), we do NOT
+        // flip EnableExtendedProgressionTracking on. Per-store opt-in is preserved.
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddJasperFx();
+
+                services.AddMarten(m =>
+                {
+                    m.Connection(ConnectionSource.ConnectionString);
+                    m.DatabaseSchemaName = "advanced_tracking_off_main";
+                });
+
+                services.AddMartenStore<IFirstStore>(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DatabaseSchemaName = "advanced_tracking_off_first";
+                });
+            }).StartAsync();
+
+        var main = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
+        main.Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
+
+        var first = host.Services.GetRequiredService<IFirstStore>().As<DocumentStore>();
+        first.Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
+    }
 }
 
 public interface IFirstStore : IDocumentStore{}

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -320,6 +320,15 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
 
         ApplicationAssembly ??= options.ApplicationAssembly;
         _autoCreate ??= options.ActiveProfile.ResourceAutoCreate;
+
+        // CritterWatch / advanced-tooling opt-in: when the JasperFx host turns on
+        // EnableAdvancedTracking, every Marten DocumentStore in the container
+        // (main + ancillary) opts into extended progression tracking so downstream
+        // tools (CritterWatch in particular) see the richer per-shard state.
+        if (options.EnableAdvancedTracking)
+        {
+            Events.EnableExtendedProgressionTracking = true;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

When `JasperFxOptions.EnableAdvancedTracking == true` is set on the container (typically via CritterWatch configuration), every Marten `DocumentStore` — the main one registered via `AddMarten` and any ancillary stores registered via `AddMartenStore<T>` — opts into `Events.EnableExtendedProgressionTracking`. Downstream tools (CritterWatch in particular) then see the richer per-shard progression state.

## Implementation

The single integration point is `StoreOptions.ReadJasperFxOptions` ([`src/Marten/StoreOptions.cs:312`](https://github.com/JasperFx/marten/blob/master/src/Marten/StoreOptions.cs#L312)). Both call sites already wire through it:

- **Main store:** `MartenServiceCollectionExtensions.cs:230` calls `options.ReadJasperFxOptions(...)` inside the `StoreOptions` singleton factory, before the `IDocumentStore` factory at line 239.
- **Ancillary stores:** `SecondaryStoreConfig.cs:72` calls it inside `BuildStoreOptions`, before `Build` constructs the proxied store.

Adding the propagation in `ReadJasperFxOptions` covers both paths with a single change and satisfies the "before `StoreOptions` is passed into `DocumentStore`" sequencing requirement.

```csharp
if (options.EnableAdvancedTracking)
{
    Events.EnableExtendedProgressionTracking = true;
}
```

The flip is one-directional: when `EnableAdvancedTracking` is `true`, we force `EnableExtendedProgressionTracking` on. When it's `false` (default), the per-store value is untouched and per-store opt-in semantics are preserved.

## Test plan

Three tests added to `CoreTests/jasper_fx_mechanics.cs`:

- [x] `enable_advanced_tracking_propagates_to_main_document_store` — main `DocumentStore` registered via `AddMarten` gets `EnableExtendedProgressionTracking = true`
- [x] `enable_advanced_tracking_propagates_to_ancillary_document_stores` — main + two ancillary stores (`IFirstStore`, `ISecondStore`) all get `EnableExtendedProgressionTracking = true`
- [x] `advanced_tracking_off_leaves_extended_progression_tracking_at_default` — sanity: without `EnableAdvancedTracking`, neither main nor ancillary stores flip the flag (per-store opt-in preserved)
- [x] All 16 existing tests in `jasper_fx_mechanics.cs` still pass (13 prior + 3 new)
- [x] `dotnet build` clean on both `src/Marten` and `src/CoreTests` (net9.0 + net10.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)