### PR TITLE
Fix #4742: bigint mt_version tolerated by db-assert, not just apply

### DIFF
--- a/src/CoreTests/Bugs/Bug_4614_revision_column_int_for_IRevisioned.cs
+++ b/src/CoreTests/Bugs/Bug_4614_revision_column_int_for_IRevisioned.cs
@@ -134,7 +134,7 @@ public class Bug_4614_revision_column_int_for_IRevisioned: OneOffConfigurationsC
     }
 
     [Fact]
-    public async Task existing_9x_bigint_column_for_IRevisioned_is_tolerated_not_narrowed_migration_check()
+    public async Task existing_9x_bigint_column_for_IRevisioned_is_tolerated_not_narrowed_assert_check()
     {
         // The reverse-direction safety: a deployment that already migrated to V9-with-bigint
         // (before this fix) MUST NOT get force-narrowed to integer on the next apply — a
@@ -151,8 +151,7 @@ public class Bug_4614_revision_column_int_for_IRevisioned: OneOffConfigurationsC
                 .ExecuteNonQueryAsync();
         }
 
-        var migration = await theStore.Storage.CreateMigrationAsync();
-        migration.Difference.ShouldBe(SchemaPatchDifference.None);
+        await theStore.Storage.Database.AssertDatabaseMatchesConfigurationAsync().ShouldNotThrowAsync();
     }
 
     // ---- CRUD round-trip on both shapes ----

--- a/src/CoreTests/Bugs/Bug_4614_revision_column_int_for_IRevisioned.cs
+++ b/src/CoreTests/Bugs/Bug_4614_revision_column_int_for_IRevisioned.cs
@@ -133,6 +133,28 @@ public class Bug_4614_revision_column_int_for_IRevisioned: OneOffConfigurationsC
         (await readVersionColumnType(typeof(RevisionedDoc))).ShouldBe("bigint");
     }
 
+    [Fact]
+    public async Task existing_9x_bigint_column_for_IRevisioned_is_tolerated_not_narrowed_migration_check()
+    {
+        // The reverse-direction safety: a deployment that already migrated to V9-with-bigint
+        // (before this fix) MUST NOT get force-narrowed to integer on the next apply — a
+        // `USING mt_version::integer` cast would silently truncate any out-of-range value.
+        // The diff treats bigint-actual + integer-desired as compatible (no SQL emitted).
+        StoreOptions(opts => opts.Schema.For<RevisionedDoc>());
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.CreateCommand(
+                    $"alter table {SchemaName}.mt_doc_revisioneddoc alter column mt_version type bigint")
+                .ExecuteNonQueryAsync();
+        }
+
+        var migration = await theStore.Storage.CreateMigrationAsync();
+        migration.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+
     // ---- CRUD round-trip on both shapes ----
 
     [Fact]

--- a/src/Marten/Storage/Metadata/RevisionColumn.cs
+++ b/src/Marten/Storage/Metadata/RevisionColumn.cs
@@ -88,6 +88,10 @@ internal class RevisionColumn: MetadataColumn<long>, ISelectableColumn
 /// <see cref="Metadata.IRevisioned"/>. Tolerates a pre-existing <c>bigint</c>
 /// column on disk (already-on-9.x deployments are not force-narrowed); the
 /// schema diff treats either width as acceptable to avoid lossy migrations.
+/// The tolerance lives on two surfaces that must agree: the SQL side
+/// (<see cref="AlterColumnTypeSql"/> no-ops a bigint actual) and the diff
+/// classification side (<see cref="Equals(object)"/> reports a bigint actual as
+/// a match so the column never lands in the delta) — see #4742.
 /// </summary>
 internal class RevisionColumnInt32: MetadataColumn<int>, ISelectableColumn
 {
@@ -145,6 +149,30 @@ internal class RevisionColumnInt32: MetadataColumn<int>, ISelectableColumn
         // column with potential constraint loss.
         return actual.Type.EqualsIgnoreCase("uuid") || actual.Type.EqualsIgnoreCase("bigint");
     }
+
+    // #4742: tolerating the wider bigint column means the schema *diff* must see it as a
+    // match, not merely suppress the ALTER. Weasel's ItemDelta compares columns via
+    // expected.Equals(actual) (expected being this Marten-owned column). Without this an
+    // on-disk bigint lands in TableDelta.Columns.Different, which keeps the empty
+    // AlterColumnTypeSql no-op for ApplyAllConfiguredChanges (fine) but classifies the
+    // table as SchemaPatchDifference.Update — so AssertDatabaseMatchesConfiguration
+    // (the db-assert CLI gate) throws with an empty change set. Treating a bigint actual
+    // as equal routes the column to ItemDelta.Matched and the two paths agree again.
+    // Deliberately asymmetric (integer tolerates bigint, not the reverse); safe because
+    // ItemDelta only ever evaluates expected.Equals(actual), never the other direction.
+    public override bool Equals(object? obj)
+    {
+        if (obj is TableColumn actual
+            && string.Equals(Name, actual.Name, StringComparison.OrdinalIgnoreCase)
+            && actual.RawType().EqualsIgnoreCase("bigint"))
+        {
+            return true;
+        }
+
+        return base.Equals(obj);
+    }
+
+    public override int GetHashCode() => base.GetHashCode();
 
     public override void WriteMetadataInUpdateStatement(ICommandBuilder builder, DocumentSessionBase session)
     {

--- a/src/Marten/Storage/Metadata/RevisionColumn.cs
+++ b/src/Marten/Storage/Metadata/RevisionColumn.cs
@@ -133,6 +133,12 @@ internal class RevisionColumnInt32: MetadataColumn<int>, ISelectableColumn
         // legitimate IRevisioned data is comfortably in Int32 range, but Postgres
         // refuses to verify that without scanning the table and a forced narrow risks
         // silent data loss if anything slipped through. Tolerate => no-op.
+        //
+        // #4742: as of the Equals override below, a bigint actual now compares equal and
+        // is sorted into ItemDelta.Matched, so this branch is no longer hit on the normal
+        // path. Kept as intentional defense-in-depth — do NOT strip it as dead code: it
+        // guards the SQL surface should any other call site reach AlterColumnTypeSql with
+        // a bigint actual (or should the diff-side equality ever regress).
         if (changeActual.Type.EqualsIgnoreCase("bigint"))
         {
             return string.Empty;
@@ -144,9 +150,11 @@ internal class RevisionColumnInt32: MetadataColumn<int>, ISelectableColumn
 
     public override bool CanAlter(TableColumn actual)
     {
-        // bigint is reported as acceptable so the diff machinery routes it through
-        // AlterColumnTypeSql above (which then no-ops) rather than re-creating the
-        // column with potential constraint loss.
+        // uuid (Guid concurrency mode) routes through AlterColumnTypeSql's drop-and-recreate.
+        // bigint is also reported acceptable as defense-in-depth: the Equals override below
+        // normally matches a bigint actual before the diff ever asks CanAlter, but if it
+        // does reach here we want the no-op ALTER path, not a column re-create with
+        // potential constraint loss. See #4742.
         return actual.Type.EqualsIgnoreCase("uuid") || actual.Type.EqualsIgnoreCase("bigint");
     }
 


### PR DESCRIPTION
Builds on #4742 (test by @Romanx) and adds the fix.

## Problem

#4615 tolerated a pre-existing `bigint` `mt_version` column for `IRevisioned` documents (early-9.x deployments that migrated to bigint before that fix shouldn't be force-narrowed). But the tolerance only covered the **SQL-emission** surface:

- `RevisionColumnInt32.AlterColumnTypeSql` no-ops a `bigint` actual, and `CanAlter(bigint)` returns `true`.

It did **not** cover the **diff-classification** surface. Weasel's `ItemDelta` compares columns via `expected.Equals(actual)`, and `TableColumn.Equals` compares `RawType()` — so `integer` (desired) ≠ `bigint` (actual), and the column lands in `TableDelta.Columns.Different`. That classifies the table as `SchemaPatchDifference.Update`.

The two consumers of that delta then disagree:

- `ApplyAllConfiguredChangesToDatabaseAsync` → writes the empty `AlterColumnTypeSql` → effective no-op ✅
- `AssertDatabaseMatchesConfigurationAsync` (the `db-assert` CLI gate) → only checks `Difference != None` → **throws**, with an empty change set ❌

So the same physical schema is reported "in sync" by `apply` and "out of sync" by `db-assert`, breaking deploy pipelines that gate on `db-assert`. @Romanx's test reproduces exactly this.

## Fix

Extend the tolerance to the diff-classification surface: `RevisionColumnInt32` now reports a `bigint` actual as an `Equals` match, routing the column to `ItemDelta.Matched` so it never enters the delta. Both `apply` and `db-assert` agree again.

The override is deliberately **asymmetric** (`integer` tolerates `bigint`, not the reverse) — safe because `ItemDelta` only ever evaluates `expected.Equals(actual)`, never the other direction. `GetHashCode` is overridden to keep the pair consistent.

The pre-existing `bigint` branches in `AlterColumnTypeSql`/`CanAlter` (from #4615) are now off the normal path — the `Equals` match sorts a `bigint` actual into `ItemDelta.Matched` before the diff asks `CanAlter`. They're kept and explicitly commented as **intentional defense-in-depth** (guarding the SQL surface for any other call site or a diff-side equality regression), so they aren't later mistaken for dead code.

> Note: the arguably cleaner long-term home for this is a Weasel-side hook (a virtual column-match used by `ItemDelta`, mirroring how ignored indexes already work). That's a separate Weasel change; this Marten-only override fully closes the user-visible bug today.

## Tests

`Bug_4614_revision_column_int_for_IRevisioned` — 9/9 green (incl. @Romanx's `..._assert_check`). Broader Revision/Versioned/Numeric suite in CoreTests — 22/22 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
