### PR TITLE
Fix #4745: async daemon fetch excludes archived streams under partitioning

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4745_async_daemon_fetch_filters_archived_streams.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4745_async_daemon_fetch_filters_archived_streams.cs
@@ -1,5 +1,6 @@
 using System;
 using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
 using Marten;
 using Marten.Events.Daemon.Internals;
 using Marten.Storage;

--- a/src/EventSourcingTests/Bugs/Bug_4745_async_daemon_fetch_filters_archived_streams.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4745_async_daemon_fetch_filters_archived_streams.cs
@@ -1,0 +1,65 @@
+using System;
+using JasperFx.Events.Daemon;
+using Marten;
+using Marten.Events.Daemon.Internals;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Postgresql.SqlGeneration;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+/// <summary>
+/// #4745 — the async daemon event fetch joined <c>mt_events</c> to
+/// <c>mt_streams</c> but only filtered the event row's <c>is_archived</c>, never
+/// the stream's. With <c>UseArchivedStreamPartitioning = true</c> the planner
+/// therefore could not partition-prune the archived <c>mt_streams</c> partition,
+/// and an archived stream's events could still surface if an event row's flag
+/// drifted out of sync with its stream. The loader now appends
+/// <c>and s.is_archived = FALSE</c> to the stream join whenever partitioning is on.
+///
+/// <para>
+/// These are pure SQL-shape assertions — <see cref="EventLoader"/> builds its
+/// command from <see cref="StoreOptions"/> with no database round-trip, so the
+/// store is never applied.
+/// </para>
+/// </summary>
+public class Bug_4745_async_daemon_fetch_filters_archived_streams
+{
+    private static string UniqueSchema() =>
+        $"bug4745_{Guid.NewGuid().ToString("N")[..16]}_{Environment.ProcessId}";
+
+    private static EventLoader BuildLoader(bool usePartitioning)
+    {
+        var store = DocumentStore.For(o =>
+        {
+            o.Connection(ConnectionSource.ConnectionString);
+            o.DatabaseSchemaName = UniqueSchema();
+            o.Events.UseArchivedStreamPartitioning = usePartitioning;
+        });
+
+        var db = (MartenDatabase)store.Storage.Database;
+        return new EventLoader(store, db, new AsyncOptions(), Array.Empty<ISqlFragment>());
+    }
+
+    [Fact]
+    public void fetch_sql_constrains_stream_is_archived_when_partitioning_is_on()
+    {
+        var loader = BuildLoader(usePartitioning: true);
+
+        loader.CommandText.ShouldContain("s.is_archived = FALSE",
+            Case.Insensitive,
+            "the join to mt_streams must exclude archived streams so the archived partition can be pruned");
+    }
+
+    [Fact]
+    public void fetch_sql_does_not_constrain_stream_is_archived_when_partitioning_is_off()
+    {
+        var loader = BuildLoader(usePartitioning: false);
+
+        // Without partitioning, mt_streams is not partitioned by is_archived, so the
+        // stream-level predicate adds no value and could miss an index.
+        loader.CommandText.ShouldNotContain("s.is_archived");
+    }
+}

--- a/src/Marten/Events/Daemon/Internals/EventLoader.cs
+++ b/src/Marten/Events/Daemon/Internals/EventLoader.cs
@@ -6,6 +6,7 @@ using JasperFx.Core;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
+using Marten.Events.Archiving;
 using Marten.Exceptions;
 using Marten.Internal.Sessions;
 using Marten.Linq.Selectors;
@@ -100,6 +101,18 @@ internal sealed class EventLoader: IEventLoader
             builder.Append(" and d.tenant_id = s.tenant_id");
         }
 
+        if (_store.Options.Events.UseArchivedStreamPartitioning)
+        {
+            // #4745: when archived streams live in their own partition of mt_streams,
+            // constrain the join so the planner can partition-prune the archived
+            // mt_streams partition (the active partition is all the daemon needs),
+            // and so an archived stream's events are never surfaced to projections
+            // even if an event row's own is_archived flag is somehow out of sync
+            // with its stream. The event-row predicate (d.is_archived = false) only
+            // prunes the mt_events archived partition; it does nothing for mt_streams.
+            builder.Append($" and s.{IsArchivedColumn.ColumnName} = FALSE");
+        }
+
         var parameters = builder.AppendWithParameters(" where d.seq_id > ? and d.seq_id <= ?");
         _floor = parameters[0];
         _ceiling = parameters[1];
@@ -131,6 +144,10 @@ internal sealed class EventLoader: IEventLoader
     }
 
     public IMartenDatabase Database { get; }
+
+    // Exposed for regression tests that assert the generated fetch SQL (e.g. the
+    // #4745 archived-stream-partition pruning predicate). Not used at runtime.
+    internal string CommandText => _command.CommandText;
 
     public async Task<EventPage> LoadAsync(EventRequest request, CancellationToken token)
     {

--- a/src/Marten/Events/Daemon/Internals/EventLoader.cs
+++ b/src/Marten/Events/Daemon/Internals/EventLoader.cs
@@ -105,11 +105,14 @@ internal sealed class EventLoader: IEventLoader
         {
             // #4745: when archived streams live in their own partition of mt_streams,
             // constrain the join so the planner can partition-prune the archived
-            // mt_streams partition (the active partition is all the daemon needs),
-            // and so an archived stream's events are never surfaced to projections
-            // even if an event row's own is_archived flag is somehow out of sync
-            // with its stream. The event-row predicate (d.is_archived = false) only
-            // prunes the mt_events archived partition; it does nothing for mt_streams.
+            // mt_streams partition (the active partition is all the daemon needs).
+            // The event-row predicate (d.is_archived = false) only prunes the
+            // mt_events archived partition; without this the planner must scan both
+            // mt_streams partitions to resolve the join. Gated to the partitioned
+            // case only: unpartitioned, this predicate buys no pruning (the join
+            // already resolves each event to one stream row by primary key), so we
+            // keep the SQL minimal — mirroring the TenantFilterValue convention
+            // above of only injecting a literal predicate that earns its pruning.
             builder.Append($" and s.{IsArchivedColumn.ColumnName} = FALSE");
         }
 


### PR DESCRIPTION
Fixes #4745

## Problem

The async daemon's event-fetch query joins `mt_events` to `mt_streams` but only filtered the **event** row's `is_archived` (`d.is_archived = false`), never the **stream**'s. With `UseArchivedStreamPartitioning = true`:

1. The planner could not partition-prune the archived `mt_streams` partition — the join had to consider both partitions.
2. An archived stream's events could still surface to projections if an event row's `is_archived` flag ever drifted out of sync with its stream.

## Fix

`EventLoader` now appends `and s.is_archived = FALSE` to the `mt_streams` join, **only when `UseArchivedStreamPartitioning` is enabled**:

```csharp
if (_store.Options.Events.UseArchivedStreamPartitioning)
{
    builder.Append($" and s.{IsArchivedColumn.ColumnName} = FALSE");
}
```

The flag gate is deliberate: without partitioning, `mt_streams.is_archived` is an ordinary column with no supporting index, so the predicate would add cost without benefit (the existing `d.is_archived = false` already excludes archived events). With partitioning on, the predicate lets Postgres prune the archived stream partition.

The `loadWithSkipAheadAsync` MIN fallback only touches `mt_events` (no stream join), so it needs no change.

## Test

Added `Bug_4745_async_daemon_fetch_filters_archived_streams` — two SQL-shape assertions (no DB round-trip, since `EventLoader` builds its command from `StoreOptions`) verifying the predicate is present when partitioning is on and absent when off. A small internal `CommandText` property was added to `EventLoader` for this, mirroring the existing `TenantFilterValue` test seam.

> Note: I was unable to compile/run the tests locally — `dotnet restore` fails with `403 Forbidden` fetching `JasperFx.Events.SourceGenerator` from the private feed in my environment. CI should validate the build.
