### PR TITLE
Fix #4744: skip-ahead MIN probe must join mt_streams

### DIFF
--- a/src/DaemonTests/Internals/Bug_4744_skip_ahead_min_query_joins_streams.cs
+++ b/src/DaemonTests/Internals/Bug_4744_skip_ahead_min_query_joins_streams.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DaemonTests.MultiTenancy;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten.Events.Daemon.Internals;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Postgresql.SqlGeneration;
+using Xunit;
+
+namespace DaemonTests.Internals;
+
+public class Bug_4744_skip_ahead_min_query_joins_streams: OneOffConfigurationsContext
+{
+    // #4744: a projection that filters incoming events on stream type contributes an
+    // AggregateTypeFilter, which emits "s.type = ?". When the normal fetch times out on a
+    // high-volume store the loader escalates to the skip-ahead MIN(seq_id) probe — but that
+    // probe built its SQL from mt_events ALONE, with no join to mt_streams, so the s.type
+    // predicate referenced a missing FROM-clause entry and Postgres threw 42P01
+    // ("missing FROM-clause entry for table s"). Drive the probe directly (no need to provoke a
+    // real timeout) and prove it both runs and returns the matching events.
+    [Fact]
+    public async Task skip_ahead_probe_joins_streams_when_filtering_on_aggregate_type()
+    {
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream<Letters>(streamId, new MTAEvent(), new MTBEvent(), new MTCEvent());
+        await theSession.SaveChangesAsync();
+
+        var filters = new ISqlFragment[]
+        {
+            // Mirrors the reported SQL shape: d.type = ANY(...) AND s.type = ?
+            new EventTypeFilter(theStore.Events, new[] { typeof(MTAEvent), typeof(MTBEvent), typeof(MTCEvent) }),
+            new AggregateTypeFilter(typeof(Letters), theStore.Events)
+        };
+
+        var loader = new EventLoader(theStore, (MartenDatabase)theStore.Tenancy.Default.Database,
+            new AsyncOptions(), filters);
+
+        var request = new EventRequest
+        {
+            Floor = 0,
+            HighWater = 1000,
+            BatchSize = 1000,
+            ErrorOptions = new ErrorHandlingOptions(),
+            Runtime = new NulloDaemonRuntime(),
+            Name = new ShardName("Letters", "All", 1)
+        };
+
+        // Pre-fix this throws PostgresException 42P01 from the malformed MIN(seq_id) probe.
+        var page = await loader.LoadWithSkipAheadAsync(request, CancellationToken.None);
+
+        page.Count.ShouldBe(3);
+    }
+}

--- a/src/Marten/Events/Daemon/Internals/EventLoader.cs
+++ b/src/Marten/Events/Daemon/Internals/EventLoader.cs
@@ -266,6 +266,13 @@ internal sealed class EventLoader: IEventLoader
         return page;
     }
 
+    // #4744 test seam: drive the skip-ahead MIN probe directly so a regression test can prove
+    // its SQL is valid (the probe must join mt_streams whenever a filter references the s alias,
+    // e.g. AggregateTypeFilter's "s.type = ?") without having to provoke a real statement
+    // timeout. Not used at runtime.
+    internal Task<EventPage> LoadWithSkipAheadAsync(EventRequest request, CancellationToken token)
+        => loadWithSkipAheadAsync(request, token);
+
     /// <summary>
     /// Skip-ahead strategy: find the MIN(seq_id) matching the type filter after the floor,
     /// then run the normal query starting from there. Avoids scanning non-matching events.
@@ -274,9 +281,21 @@ internal sealed class EventLoader: IEventLoader
     {
         await using var session = (QuerySession)_store.QuerySession(SessionOptions.ForDatabase(Database));
 
-        // Build a MIN query to find the next matching event
+        // Build a MIN query to find the next matching event. #4744: this MUST mirror the normal
+        // query's FROM clause — including the join to mt_streams — because the same _filters are
+        // replayed below, and an AggregateTypeFilter (from a projection that filters on stream
+        // type) emits "s.type = ?". Without the join that predicate references a missing FROM-clause
+        // entry and Postgres throws 42P01. seq_id lives only on mt_events, so qualify it as d.seq_id.
         var minBuilder = new CommandBuilder();
-        minBuilder.Append($"select min(seq_id) from {_schemaName}.mt_events as d where d.seq_id > ");
+        minBuilder.Append(
+            $"select min(d.seq_id) from {_schemaName}.mt_events as d inner join {_schemaName}.mt_streams as s on d.stream_id = s.id");
+
+        if (_store.Options.Events.TenancyStyle == TenancyStyle.Conjoined)
+        {
+            minBuilder.Append(" and d.tenant_id = s.tenant_id");
+        }
+
+        minBuilder.Append(" where d.seq_id > ");
         minBuilder.AppendParameter(request.Floor, NpgsqlDbType.Bigint);
 
         if (TenantFilterValue != null)


### PR DESCRIPTION
## Problem

Closes #4744.

In Marten 9.8.0 the async daemon throws on high-volume stores:

```
42P01: missing FROM-clause entry for table "s"
```

from a malformed `min(seq_id)` query such as:

```sql
select min(seq_id) from public.mt_events as d
where d.seq_id > :p0 and d.type = ANY(:p1)
and s.type = :p2 and d.is_archived = FALSE
```

## Root cause

The adaptive `EventLoader` (added in #4720) escalates to a **skip-ahead** strategy when the normal fetch times out: it runs a separate `min(seq_id)` probe to find the next matching event after the floor, then resumes the normal load from there.

That probe built its SQL from `mt_events` **alone**, with no join to `mt_streams` — but it replayed the *same* filter list as the normal query. For a projection that calls `FilterIncomingEventsOnStreamType()`, that list contains an `AggregateTypeFilter`, which emits `s.type = ?`. With no `s` in the FROM clause, Postgres rejects the query (`42P01`).

This only triggers when **both** conditions hold:
- the normal fetch times out and escalates to `SkipAhead` (needs high event volume), **and**
- the projection filters on stream type (so `s.type` is injected).

That's why it isn't reproducible locally and only appeared post-upgrade on a large production store. The window-step strategy was unaffected because it reuses the already-correct main command.

## Fix

The MIN probe now mirrors the normal query's FROM clause: it joins `mt_streams as s on d.stream_id = s.id` (plus the conjoined `d.tenant_id = s.tenant_id` condition) and qualifies the aggregate as `min(d.seq_id)`.

## Test

`Bug_4744_skip_ahead_min_query_joins_streams` (DaemonTests, ~0.8s) drives the skip-ahead probe directly through a small internal seam, so it reproduces deterministically without provoking a real statement timeout. It was **RED** before the fix with the exact `42P01`, **GREEN** after. Full DaemonTests suite passes (198/198).

🤖 Generated with [Claude Code](https://claude.com/claude-code)