### PR TITLE
Run TenantPartitionedEventsTests in CI + fix #4753/#4754 (event-table partition rebuild)

### DIFF
--- a/.github/workflows/on-push-do-ci-build-tenant-partitioned-events.yml
+++ b/.github/workflows/on-push-do-ci-build-tenant-partitioned-events.yml
@@ -1,0 +1,79 @@
+name: Build & Test - NET9 - PG15 - Newtonsoft - TenantPartitionedEvents
+
+on:
+  push:
+    branches:
+      - master
+      - "7.0"
+    paths-ignore:
+      - 'documentation/**'
+      - 'docs/**'
+      - 'azure-pipelines.yml'
+  pull_request:
+    branches:
+      - master
+      - "7.0"
+    paths-ignore:
+      - 'documentation/**'
+      - 'docs/**'
+      - 'azure-pipelines.yml'
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  pg_db: marten_testing
+  pg_user: postgres
+  CONFIGURATION: Release
+  FRAMEWORK: net9.0
+  DISABLE_TEST_PARALLELIZATION: true
+  DEFAULT_SERIALIZER: "Newtonsoft"
+  NUKE_TELEMETRY_OPTOUT: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_DB: ${{ env.pg_db }}
+          NAMEDATALEN: 150
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --user postgres
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Optimize database for running tests faster
+        run: |
+          PG_CONTAINER_NAME=$(docker ps --filter expose=5432/tcp --format {{.Names}})
+          docker exec $PG_CONTAINER_NAME bash -c "echo -e '\nfsync = off' >> /var/lib/postgresql/data/postgresql.conf"
+          docker exec $PG_CONTAINER_NAME bash -c "echo -e '\nfull_page_writes = off' >> /var/lib/postgresql/data/postgresql.conf"
+          docker exec $PG_CONTAINER_NAME bash -c "echo -e '\nsynchronous_commit = off' >> /var/lib/postgresql/data/postgresql.conf"
+          docker container restart $PG_CONTAINER_NAME
+        shell: bash
+
+      - name: compile
+        run: ./build.sh compile-project --project src/TenantPartitionedEventsTests/TenantPartitionedEventsTests.csproj
+        shell: bash
+
+      - name: test-tenant-partitioned-events
+        if: ${{ success() || failure() }}
+        run: ./build.sh test-tenant-partitioned-events
+        shell: bash


### PR DESCRIPTION
This PR does two related things for the per-tenant event-store partitioning surface.

## 1. Run `TenantPartitionedEventsTests` in CI (was never executed)

The `TenantPartitionedEventsTests` project (the `UseTenantPartitionedEvents` feature, #4617) has had a Nuke target (`TestTenantPartitionedEvents`, wired into the aggregate `Test` target) since it was created, but **no CI workflow ever invoked it** — the workflows run individual `./build.sh test-*` steps and a `test-tenant-partitioned-events` step was never added (its neighbor `test-multi-tenancy` is also commented out). So these tests have not been running in CI at all.

Adds a dedicated workflow modeled on the PG15/Newtonsoft event-sourcing job: service-container Postgres, `compile-project`, then `./build.sh test-tenant-partitioned-events`. Aspire workload step omitted (no Aspire dependency); `DISABLE_TEST_PARALLELIZATION` set (the suite also disables it at the assembly level).

## 2. Fix #4753 / #4754 — destructive rebuild of tenant-partitioned event tables

Closes #4753. Closes #4754.

With `Events.UseTenantPartitionedEvents = true` on a sharded store, re-applying an unchanged schema (every app restart) destructively rebuilt the managed ByList partitioned `mt_streams` / `mt_events` (`CREATE _temp` → `DROP … CASCADE` → recreate parent → `INSERT … SELECT`) **without recreating the per-tenant LIST partitions first**, so the copy of existing events failed with `23514: no partition of relation "mt_streams" found for row`.

#4706 fixed exactly this for document tables by setting `IgnorePartitionsInMigration = true` on the managed-partition `DocumentTable`; the same flag was never applied to the event tables. This mirrors it on `StreamsTable` and `EventsTable` in the `UseTenantPartitionedEvents` block. The per-tenant partitions are created out-of-band by `AddMartenManagedTenantsAsync` / `AddTenantToShardAsync` (the additive path), so the generic schema diff must not reconcile them. With the flag set, Weasel's `ListPartitioning.CreateDelta` short-circuits to `PartitionDelta.None`, making the destructive Rebuild branch (#4754) **unreachable for Marten's managed tables** — no Weasel change is required to resolve the reported symptom.

### Test
`Bug_4753_sharded_partitioned_event_rebuild` (sharded, mirrors `Bug_4706_sharded_partitioned_doc_rebuild` but appends **events** so the rebuild's `INSERT … SELECT` actually has rows to fail on): **RED before the fix** with the exact 23514, **GREEN after**. Full `TenantPartitionedEventsTests` suite green (189/189).

## Note on #4751

#4751 (async composite projection not catching up on sharded tenant-partitioned stores) was investigated but **not reproducible in a pure-Marten harness** against the pinned JasperFx.Events 2.10.0 — a sharded composite's stage-1 and stage-2 read models both materialize correctly through the per-tenant catch-up path. The report hinges on WolverineFx subscription distribution (a separate integration) and the catch-up control flow lives in JasperFx.Events, so it is **out of scope for this PR** and tracked separately pending a faithful reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)