### PR TITLE
Fix #4749: QueryForNonStaleData truly times out + opt-in return-stale-data overload

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4749_query_for_non_stale_data_sequence_gap.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4749_query_for_non_stale_data_sequence_gap.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventSourcingTests.Aggregation;
+using EventSourcingTests.FetchForWriting;
+using JasperFx.Core;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EventSourcingTests.Bugs;
+
+/// <summary>
+/// #4749 — after a failed append (duplicate key from concurrent identical PUTs under AppendMode.Quick)
+/// the global mt_events_sequence advances past the last committed event, leaving a permanent gap
+/// (sequence = N+1 while max committed seq_id = N). QueryForNonStaleData then computes a high-water
+/// ceiling of N+1 that the async projection can never reach, so every call waits the full timeout.
+/// This pins (1) that the wait surfaces a clean TimeoutException, and (2) the opt-in overload that
+/// returns the latest available data instead of throwing.
+/// </summary>
+public class Bug_4749_query_for_non_stale_data_sequence_gap: OneOffConfigurationsContext
+{
+    private readonly ITestOutputHelper _output;
+
+    public Bug_4749_query_for_non_stale_data_sequence_gap(ITestOutputHelper output)
+    {
+        _output = output;
+        StoreOptions(opts => opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Async));
+    }
+
+    private async Task SeedCatchUpAndCreateSequenceGap()
+    {
+        for (var i = 0; i < 4; i++)
+        {
+            theSession.Events.StartStream(new AEvent(), new BEvent(), new CEvent());
+            theSession.Events.StartStream(new DEvent(), new AEvent());
+        }
+        await theSession.SaveChangesAsync();
+
+        using (var daemon = await theStore.BuildProjectionDaemonAsync())
+        {
+            await daemon.StartAllAsync();
+            await daemon.WaitForNonStaleData(10.Seconds());
+        }
+
+        // Simulate the #4749 gap: a failed append advanced the sequence without committing an event,
+        // so mt_events_sequence is now ahead of the highest committed seq_id. The async projection has
+        // already caught up to the real high-water, but FetchHighestEventSequenceNumber reads the
+        // (now unreachable) sequence value.
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        var schema = theStore.Options.Events.DatabaseSchemaName;
+        await conn.CreateCommand($"select setval('{schema}.mt_events_sequence', (select last_value from {schema}.mt_events_sequence) + 5)")
+            .ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task default_overload_throws_a_clean_timeout_exception()
+    {
+        await SeedCatchUpAndCreateSequenceGap();
+
+        var ex = await Record.ExceptionAsync(() =>
+            theSession.QueryForNonStaleData<SimpleAggregate>(2.Seconds()).ToListAsync());
+
+        _output.WriteLine(ex?.GetType().FullName ?? "<no exception>");
+        ex.ShouldBeOfType<TimeoutException>();
+    }
+
+    [Fact]
+    public async Task return_stale_data_overload_returns_latest_available_instead_of_throwing()
+    {
+        await SeedCatchUpAndCreateSequenceGap();
+
+        // The projection caught up to the real high-water before the gap, so the materialized data is
+        // present — the only problem is the unreachable sequence ceiling. With ReturnStaleData the query
+        // must return that data rather than throw.
+        var items = await theSession
+            .QueryForNonStaleData<SimpleAggregate>(2.Seconds(), NonStaleDataTimeoutMode.ReturnStaleData)
+            .ToListAsync();
+
+        items.Count.ShouldBe(8);
+    }
+}

--- a/src/Marten/Events/AsyncProjectionTestingExtensions.cs
+++ b/src/Marten/Events/AsyncProjectionTestingExtensions.cs
@@ -280,23 +280,31 @@ public static class TestingExtensions
         using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(token);
         cancellationSource.CancelAfter(timeout);
 
-        while (!cancellationSource.Token.IsCancellationRequested)
+        try
         {
-            var current = await database.FetchProjectionProgressFor(shards, cancellationSource.Token).ConfigureAwait(false);
-            foreach (var state in current)
+            while (true)
             {
-                tracking[state.ShardName] = state.Sequence;
+                var current = await database.FetchProjectionProgressFor(shards, cancellationSource.Token).ConfigureAwait(false);
+                foreach (var state in current)
+                {
+                    tracking[state.ShardName] = state.Sequence;
+                }
+
+                if (tracking.isComplete(highWaterMark)) return;
+
+                await Task.Delay(100.Milliseconds(), cancellationSource.Token).ConfigureAwait(false);
             }
-
-            if (tracking.isComplete(highWaterMark)) return;
-
-            await Task.Delay(100.Milliseconds(), cancellationSource.Token).ConfigureAwait(false);
         }
-
-        if (cancellationSource.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
+            // #4749: distinguish the internal timeout from caller-initiated cancellation. The awaited
+            // operations above throw a TaskCanceledException/OperationCanceledException when EITHER token
+            // fires; previously that leaked out of this method, so a caller's `catch (TimeoutException)`
+            // never triggered and QueryForNonStaleData never "truly" timed out. Propagate genuine caller
+            // cancellation as-is; convert our own timeout into a clean TimeoutException.
+            token.ThrowIfCancellationRequested();
             throw new TimeoutException(
-                $"The projections timed out before reaching the initial sequence of {highWaterMark}");
+                $"The query for {aggregationType.FullNameInCode()} timed out after {timeout} while waiting for the projection to reach the event store high-water mark of {highWaterMark}");
         }
     }
 

--- a/src/Marten/IQuerySession.cs
+++ b/src/Marten/IQuerySession.cs
@@ -192,6 +192,20 @@ public interface IQuerySession: IDisposable, IAsyncDisposable
     IMartenQueryable<T> QueryForNonStaleData<T>(TimeSpan timeout) where T : notnull;
 
     /// <summary>
+    /// A variation of <see cref="QueryForNonStaleData{T}(TimeSpan)"/> that lets you control what happens
+    /// when the asynchronous projection cannot catch up to the current event store high-water mark within
+    /// the timeout. With <see cref="NonStaleDataTimeoutMode.ReturnStaleData"/> the query returns the latest
+    /// available data instead of throwing a <see cref="TimeoutException"/> — useful when an unreachable
+    /// high-water mark (e.g. a gap left in mt_events_sequence by a failed append) would otherwise make
+    /// every call throw.
+    /// </summary>
+    /// <param name="timeout"></param>
+    /// <param name="timeoutMode">What to do if the projection has not caught up within <paramref name="timeout"/></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    IMartenQueryable<T> QueryForNonStaleData<T>(TimeSpan timeout, NonStaleDataTimeoutMode timeoutMode) where T : notnull;
+
+    /// <summary>
     ///     Stream the results of a user-supplied query directly to a stream as a JSON array
     /// </summary>
     /// <param name="destination"></param>

--- a/src/Marten/Internal/Sessions/QuerySession.Querying.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Querying.cs
@@ -25,8 +25,14 @@ public partial class QuerySession
 
     public IMartenQueryable<T> QueryForNonStaleData<T>(TimeSpan timeout) where T : notnull
     {
+        return QueryForNonStaleData<T>(timeout, NonStaleDataTimeoutMode.ThrowException);
+    }
+
+    public IMartenQueryable<T> QueryForNonStaleData<T>(TimeSpan timeout, NonStaleDataTimeoutMode timeoutMode)
+        where T : notnull
+    {
         var queryable = new MartenLinqQueryable<T>(this);
-        queryable.MartenProvider.Waiter = new WaitForAggregate(timeout);
+        queryable.MartenProvider.Waiter = new WaitForAggregate(timeout, timeoutMode);
 
         return queryable;
     }

--- a/src/Marten/Linq/MartenLinqQueryProvider.cs
+++ b/src/Marten/Linq/MartenLinqQueryProvider.cs
@@ -17,7 +17,7 @@ using Marten.Util;
 
 namespace Marten.Linq;
 
-internal record WaitForAggregate(TimeSpan Timeout);
+internal record WaitForAggregate(TimeSpan Timeout, NonStaleDataTimeoutMode TimeoutMode = NonStaleDataTimeoutMode.ThrowException);
 
 internal class MartenLinqQueryProvider: IQueryProvider
 {
@@ -65,7 +65,17 @@ internal class MartenLinqQueryProvider: IQueryProvider
 
         if (Waiter != null)
         {
-            await _session.Database.WaitForNonStaleProjectionDataAsync(SourceType, Waiter.Timeout, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await _session.Database.WaitForNonStaleProjectionDataAsync(SourceType, Waiter.Timeout, cancellationToken).ConfigureAwait(false);
+            }
+            catch (TimeoutException) when (Waiter.TimeoutMode == NonStaleDataTimeoutMode.ReturnStaleData)
+            {
+                // #4749: the caller opted to receive the latest available (possibly stale) data rather
+                // than fail when the projection cannot catch up within the timeout — e.g. when a gap in
+                // mt_events_sequence left by a failed append makes the high-water mark unreachable. Fall
+                // through to execute the query against whatever the projection has materialized so far.
+            }
         }
     }
 

--- a/src/Marten/NonStaleDataTimeoutMode.cs
+++ b/src/Marten/NonStaleDataTimeoutMode.cs
@@ -1,0 +1,24 @@
+namespace Marten;
+
+/// <summary>
+/// Governs what <see cref="IQuerySession.QueryForNonStaleData{T}(System.TimeSpan, NonStaleDataTimeoutMode)"/>
+/// does when the asynchronous projection it is querying cannot catch up to the event store high-water
+/// mark within the supplied timeout.
+/// </summary>
+public enum NonStaleDataTimeoutMode
+{
+    /// <summary>
+    /// Throw a <see cref="System.TimeoutException"/> when the projection does not reach the high-water
+    /// mark within the timeout. This is the behavior of the single-argument
+    /// <see cref="IQuerySession.QueryForNonStaleData{T}(System.TimeSpan)"/> overload.
+    /// </summary>
+    ThrowException,
+
+    /// <summary>
+    /// Return the latest available data even if it may be stale rather than throwing when the projection
+    /// cannot catch up within the timeout. Useful when an unreachable high-water mark (e.g. a gap in
+    /// mt_events_sequence left by a failed append) would otherwise make every query throw indefinitely,
+    /// and serving slightly stale data is preferable to failing the request.
+    /// </summary>
+    ReturnStaleData
+}


### PR DESCRIPTION
Addresses the two concerns raised in #4749. Scope is deliberately the **wait/timeout behavior**, not the root-cause sequence gap.

## Background

When a failed append (e.g. a duplicate-key violation from concurrent identical PUTs under `AppendMode.Quick`) advances `mt_events_sequence` without committing an event, the global sequence is left permanently ahead of the highest committed `seq_id` (the reporter saw `mt_events_sequence = 231` with only 230 committed events). `QueryForNonStaleData` derives its high-water ceiling from that sequence (`FetchHighestEventSequenceNumber` → `last_value`), and the async projection can never reach it — so every call waits the full timeout forever.

Two problems followed from that, both fixed here:

## 1. It didn't *truly* time out

The query-path wait (`WaitForNonStaleProjectionDataAsync(Type, timeout, token)`) cancelled an internal linked `CancellationTokenSource` via `CancelAfter(timeout)`, but the awaited `Task.Delay` / progress-fetch threw a `TaskCanceledException` that **leaked out** of the method — the intended `throw new TimeoutException(...)` was effectively unreachable. A caller's `catch (TimeoutException)` therefore never triggered.

Fixed by catching the cancellation, propagating **genuine caller cancellation** as-is (`token.ThrowIfCancellationRequested()`), and converting the method's **own** timeout into a clean `TimeoutException` with a useful message. Verified by a regression test that previously caught a `TaskCanceledException`.

## 2. No way to get data back instead of an exception

Added an overload:

```csharp
IMartenQueryable<T> QueryForNonStaleData<T>(TimeSpan timeout, NonStaleDataTimeoutMode timeoutMode);
```

with `NonStaleDataTimeoutMode.ReturnStaleData`, which returns the latest available (possibly stale) data instead of throwing when the projection can't catch up within the timeout. The default single-argument overload is unchanged (`ThrowException`). So an unreachable high-water mark no longer makes every read fail — callers can choose to serve slightly stale data.

## Notes

- The fix lives in the shared query-path wait method and is **tenancy-agnostic** — it covers the reporter's `MultiTenantedDatabasesWithMasterDatabaseTable` configuration.
- Regression tests (`Bug_4749_query_for_non_stale_data_sequence_gap`) simulate the sequence gap with `setval` and cover **both** the clean `TimeoutException` and the `ReturnStaleData` path. Existing `querying_with_non_stale_data`, `Bug_3769`, and composite `multi_stage_projections` tests stay green.
- This does **not** fix the root cause (a failed `AppendMode.Quick` append advancing the sequence without a committed event / leaving projections unable to advance). That's a separate concern worth its own issue/fix; switching to `AppendMode.Rich` (tombstone events) avoids the gap today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)