### PR TITLE
Fix #4750: opt-in ResourceMigrationFailureMode for startup migrations (Phase 3)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,13 +69,13 @@
     <!-- JasperFx 2.12.0: dead-letter row drill-in (IEventDatabase.QueryDeadLetterEventsAsync) +
          DeadLetterEvent.TenantId + tenant-aware daemon PauseShardAsync/rebuild fan-out (jasperfx#453).
          Marten implements QueryDeadLetterEventsAsync + per-tenant FetchDeadLetterCountsAsync below. -->
-    <PackageVersion Include="JasperFx" Version="2.12.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.12.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.12.0">
+    <PackageVersion Include="JasperFx" Version="2.13.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.13.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.12.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.13.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
@@ -128,7 +128,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.1.5" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.2.0" />
     <!-- Weasel.Postgresql 9.1.x: managed LIST partitions under multi-database (sharded) apply.
          9.1.2 (marten#4706): managed-partition tables are no longer destructively rebuilt — the
          out-of-band AddPartitionToAllTables path creates partitions while the generic schema diff
@@ -136,7 +136,7 @@
          9.1.5 (marten#4713): the additive reconcile now SAVES/RESTORES IgnorePartitionsInMigration
          instead of permanently clearing it on the shared DocumentTable singleton, so a re-apply after
          tenant provisioning stays idempotent (no 42P07 / no rebuild). -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.1.5" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.2.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/CoreTests/bootstrapping_with_service_collection_extensions.cs
+++ b/src/CoreTests/bootstrapping_with_service_collection_extensions.cs
@@ -69,6 +69,27 @@ public class bootstrapping_with_service_collection_extensions
     }
 
     [Fact]
+    public async Task use_jasper_fx_active_profile_for_resource_migration_failure_mode()
+    {
+        // #4750: the store inherits ResourceMigrationFailureMode from the active JasperFx profile so a
+        // failed startup migration (e.g. lock loss during a rolling deploy) can be made non-fatal.
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(ConnectionSource.ConnectionString);
+
+                services.AddJasperFx(opts =>
+                {
+                    opts.Development.ResourceMigrationFailureMode = ResourceMigrationFailureMode.ContinueOnFailures;
+                });
+            })
+            .UseEnvironment("Development").StartAsync();
+
+        var store = (DocumentStore)host.DocumentStore();
+        store.Options.ResourceMigrationFailureMode.ShouldBe(ResourceMigrationFailureMode.ContinueOnFailures);
+    }
+
+    [Fact]
     public void add_marten_by_store_options()
     {
         using var container = Container.For(x =>

--- a/src/Marten/Services/MartenActivator.cs
+++ b/src/Marten/Services/MartenActivator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx;
@@ -76,11 +77,28 @@ internal class MartenActivator: IHostedService, IGlobalLock<NpgsqlConnection>
 
         if (Store.Options.ShouldApplyChangesOnStartup)
         {
+            var failureMode = Store.Options.ResourceMigrationFailureMode;
             foreach (PostgresqlDatabase database in databases)
             {
-                await database
-                    .ApplyAllConfiguredChangesToDatabaseAsync(this, AutoCreate.CreateOrUpdate, ct: cancellationToken)
-                    .ConfigureAwait(false);
+                // #4750: propagate the failure mode so Weasel's apply returns rather than throwing when it
+                // can't attain the global migration lock (e.g. a replica that loses the lock race during a
+                // multi-replica rolling deploy).
+                database.ResourceMigrationFailureMode = failureMode;
+
+                try
+                {
+                    await database
+                        .ApplyAllConfiguredChangesToDatabaseAsync(this, AutoCreate.CreateOrUpdate, ct: cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception e) when (failureMode == ResourceMigrationFailureMode.ContinueOnFailures)
+                {
+                    // Belt-and-suspenders for migration failures of any kind (not just the lock timeout):
+                    // log and keep starting up rather than crash-looping. FailFast (default) rethrows.
+                    _logger.LogError(e,
+                        "Failed to apply configured database changes to {Database} at startup. Continuing startup anyway because ResourceMigrationFailureMode is ContinueOnFailures.",
+                        database.Identifier);
+                }
             }
         }
 

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -133,6 +133,8 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
 
     private AutoCreate? _autoCreate;
 
+    private ResourceMigrationFailureMode? _resourceMigrationFailureMode;
+
     /// <summary>
     ///     Whether or Marten should attempt to create any missing database schema objects at runtime. This
     ///     property is "CreateOrUpdate" by default for more efficient development, but can be set to lower values for production usage.
@@ -150,6 +152,22 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
         {
             _autoCreate = value;
         }
+    }
+
+    /// <summary>
+    /// #4750: controls whether a failure to apply schema/migration changes at application startup
+    /// (e.g. losing the global migration advisory lock during a multi-replica rolling deploy) aborts
+    /// startup. Defaults to <see cref="JasperFx.ResourceMigrationFailureMode.FailFast"/> (throw). Set to
+    /// <see cref="JasperFx.ResourceMigrationFailureMode.ContinueOnFailures"/> to log and continue starting up.
+    /// If left unset it is inherited from the active JasperFx profile
+    /// (<c>JasperFxOptions.ActiveProfile.ResourceMigrationFailureMode</c>); set it explicitly to override
+    /// the profile for this store. You can also configure it globally for all Critter Stack tools via
+    /// <c>IServiceCollection.AddJasperFx()</c>.
+    /// </summary>
+    public ResourceMigrationFailureMode ResourceMigrationFailureMode
+    {
+        get => _resourceMigrationFailureMode ?? ResourceMigrationFailureMode.FailFast;
+        set => _resourceMigrationFailureMode = value;
     }
 
     public StoreOptions()
@@ -320,6 +338,7 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
 
         ApplicationAssembly ??= options.ApplicationAssembly;
         _autoCreate ??= options.ActiveProfile.ResourceAutoCreate;
+        _resourceMigrationFailureMode ??= options.ActiveProfile.ResourceMigrationFailureMode;
 
         // CritterWatch / advanced-tooling opt-in: when the JasperFx host turns on
         // EnableAdvancedTracking, every Marten DocumentStore in the container


### PR DESCRIPTION
Closes #4750. Final phase of the multi-repo "wait-instead-of-crash" startup work.

- **JasperFx** ✅ — `ResourceMigrationFailureMode { FailFast, ContinueOnFailures }` on `Profile` ([jasperfx#456](https://github.com/JasperFx/jasperfx/pull/456), shipped in 2.13.0).
- **Weasel** ✅ — `DatabaseBase` honors the mode on a lock-timeout ([weasel#310](https://github.com/JasperFx/weasel/pull/310), shipped in 9.2.0).
- **Marten** — this PR.

## What

- Bumps the JasperFx family **2.12.0 → 2.13.0** and **Weasel.Postgresql / Weasel.EntityFrameworkCore 9.1.5 → 9.2.0**.
- `StoreOptions.ResourceMigrationFailureMode` (default `FailFast`), inherited from `JasperFxOptions.ActiveProfile.ResourceMigrationFailureMode` when not set explicitly — same precedence as `AutoCreateSchemaObjects`.
- `MartenActivator` propagates the mode to each `PostgresqlDatabase` before applying changes (so Weasel returns instead of throwing when it can't attain the global migration lock), **and** wraps the apply in a `try/catch` honoring the mode so a startup migration failure of *any* kind is logged and startup continues under `ContinueOnFailures`. `FailFast` (default) rethrows exactly as today.

## Usage

```csharp
services.AddJasperFx(opts =>
{
    // crash-loop-proof rolling deploys in prod; fail fast locally
    opts.Production.ResourceMigrationFailureMode = ResourceMigrationFailureMode.ContinueOnFailures;
});
```

## Behavior / safety

Default is unchanged — fail fast. `ContinueOnFailures` is purely opt-in. A replica that loses the migration advisory lock during a multi-replica rolling deploy now logs and starts up against the (soon-to-be) current schema instead of crash-looping.

## Tests

`use_jasper_fx_active_profile_for_resource_migration_failure_mode` verifies the store inherits the mode from the active profile. Marten + EventSourcingTests build against JasperFx 2.13.0 / Weasel 9.2.0; the existing AutoCreate-from-profile test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)