### PR TITLE
Failing repros: sharded tenant-partitioned daemon catch-up + tenant-count divergence (#4751, #4761, #4763)

### DIFF
--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4751_composite_catchup_under_sharded.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4751_composite_catchup_under_sharded.cs
@@ -1,0 +1,157 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+public record CmpLeg(double Distance);
+
+public class CmpTrip
+{
+    public Guid Id { get; set; }
+    public double Distance { get; set; }
+}
+
+public class CmpTripCount
+{
+    public Guid Id { get; set; }
+    public int Legs { get; set; }
+}
+
+public partial class CmpTripProjection: SingleStreamProjection<CmpTrip, Guid>
+{
+    public CmpTripProjection() => Name = "CmpTrip";
+    public void Apply(CmpTrip agg, CmpLeg e) => agg.Distance += e.Distance;
+}
+
+public partial class CmpTripCountProjection: SingleStreamProjection<CmpTripCount, Guid>
+{
+    public CmpTripCountProjection() => Name = "CmpTripCount";
+    public void Apply(CmpTripCount agg, CmpLeg _) => agg.Legs++;
+}
+
+/// <summary>
+/// #4751 — under <c>MultiTenantedWithShardedDatabases</c> + <c>UseTenantPartitionedEvents</c>, an async
+/// <c>CompositeProjection</c> is not driven to a non-stale state by the normal daemon catch-up path
+/// (<c>StartAllAsync</c> + <c>WaitForNonStaleData</c> / <c>IDocumentStore.WaitForNonStaleProjectionDataAsync</c>).
+/// The composite's member read models stay empty after catch-up returns.
+///
+/// <para>
+/// Contrast: <see cref="composite_side_effects_rebuild_under_sharded_partitioning"/> exercises the SAME
+/// shape of composite but via <c>RebuildProjectionAsync</c>, which DOES complete and materialize the
+/// documents. So the composite/projection logic is fine — the gap is specifically the continuous
+/// async catch-up path for a composite on a sharded, tenant-partitioned store (the per-tenant composite
+/// agent churns / its caught-up check counts store-global shards, not per-tenant ones — see the note in
+/// <see cref="sharded_daemon_per_shard_progression"/>).
+/// </para>
+/// </summary>
+[Collection("sharded-tenant-partitioned")]
+public class Bug_4751_composite_catchup_under_sharded: IAsyncLifetime
+{
+    private readonly ShardedPartitionedFixture _fixture;
+    private readonly ITestOutputHelper _output;
+    private DocumentStore _store = null!;
+
+    public Bug_4751_composite_catchup_under_sharded(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_store != null!) await _store.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task composite_reaches_non_stale_via_normal_daemon_catchup()
+    {
+        _store = (DocumentStore)DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded";
+                x.PartitionSchemaName = "tenants";
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+            });
+
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AddEventType<CmpLeg>();
+
+            opts.Projections.CompositeProjectionFor("Cmp", c =>
+            {
+                c.Add<CmpTripProjection>(stageNumber: 1);
+                c.Add<CmpTripCountProjection>(stageNumber: 2);
+            });
+
+            opts.Schema.For<CmpTrip>().DocumentAlias("cmp_trip");
+            opts.Schema.For<CmpTripCount>().DocumentAlias("cmp_trip_count");
+        });
+
+        var shard = _fixture.DbNames[0];
+        await _store.Advanced.AddTenantToShardAsync("tenant_a", shard, CancellationToken.None);
+
+        const int streams = 10;
+        await using (var session = _store.LightweightSession("tenant_a"))
+        {
+            for (var i = 0; i < streams; i++)
+            {
+                session.Events.StartStream<CmpTrip>(Guid.NewGuid(), new CmpLeg(1.0), new CmpLeg(2.5));
+            }
+            await session.SaveChangesAsync();
+        }
+
+        // Normal async catch-up (NOT RebuildProjectionAsync): start the daemon and wait for non-stale.
+        using var daemon = await _store.BuildProjectionDaemonAsync("tenant_a");
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(20.Seconds());
+
+        // After the catch-up helper returns, BOTH composite stages must be materialized for the tenant.
+        await using var query = _store.QuerySession("tenant_a");
+        var stage1 = await query.Query<CmpTrip>().CountAsync();
+        var stage2 = await query.Query<CmpTripCount>().CountAsync();
+        _output.WriteLine($"stage1 (CmpTrip) = {stage1}, stage2 (CmpTripCount) = {stage2}, expected {streams}");
+
+        stage1.ShouldBe(streams, "stage-1 of the composite must be caught up by the async daemon");
+        stage2.ShouldBe(streams, "stage-2 of the composite must be caught up by the async daemon");
+    }
+}

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4761_per_tenant_progression_same_shard.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4761_per_tenant_progression_same_shard.cs
@@ -1,0 +1,148 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+/// <summary>
+/// #4761 — under <c>MultiTenantedWithShardedDatabases</c> + <c>UseTenantPartitionedEvents</c>, when
+/// MULTIPLE tenants are assigned to the SAME shard database, the async daemon does not create
+/// per-tenant progression rows (<c>HighWaterMark:&lt;tenant&gt;</c> / <c>&lt;projection&gt;:All:&lt;tenant&gt;</c>).
+/// Only the store-global <c>HighWaterMark</c> / <c>&lt;projection&gt;:All</c> rows exist.
+///
+/// <para>
+/// Each tenant has its own independent <c>mt_events_sequence_&lt;suffix&gt;</c>, so their seq_id values
+/// overlap. A single store-global high-water over two overlapping sequences cannot track a lagging
+/// tenant independently: once the shard high-water advances past tenant Y's range (because tenant X
+/// has more events), tenant Y's later appends land below the high-water and the daemon skips them.
+/// #4717 added per-tenant progression to fix exactly this; this test pins that the per-tenant rows
+/// are actually created when two tenants share a shard.
+/// </para>
+///
+/// <para>
+/// Distinct from <see cref="sharded_daemon_per_shard_progression"/>, which deliberately puts each
+/// tenant on a DIFFERENT shard (one tenant per shard DB → a store-global row per shard is enough).
+/// </para>
+/// </summary>
+[Collection("sharded-tenant-partitioned")]
+public class Bug_4761_per_tenant_progression_same_shard: IAsyncLifetime
+{
+    private readonly ShardedPartitionedFixture _fixture;
+    private readonly ITestOutputHelper _output;
+    private DocumentStore _store = null!;
+
+    public Bug_4761_per_tenant_progression_same_shard(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_store != null!) await _store.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task per_tenant_progression_rows_exist_when_two_tenants_share_a_shard()
+    {
+        _store = (DocumentStore)DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded";
+                x.PartitionSchemaName = "tenants";
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+            });
+
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AddEventType<ShardedDaemonEvent>();
+
+            opts.Projections.Add<ShardedDaemonProjection>(ProjectionLifecycle.Async);
+            opts.Schema.For<ShardedDaemonCounter>().DocumentAlias("p4761_sdc");
+        });
+
+        // Both tenants on the SAME shard, with DIFFERENT event counts so their per-tenant
+        // sequences diverge (x: 3, y: 2) and their seq_id ranges overlap.
+        var shard = _fixture.DbNames[0];
+        await _store.Advanced.AddTenantToShardAsync("tenant_x", shard, CancellationToken.None);
+        await _store.Advanced.AddTenantToShardAsync("tenant_y", shard, CancellationToken.None);
+
+        var xStream = Guid.NewGuid();
+        await using (var session = _store.LightweightSession("tenant_x"))
+        {
+            session.Events.StartStream<ShardedDaemonCounter>(xStream,
+                new ShardedDaemonEvent("x-1"), new ShardedDaemonEvent("x-2"), new ShardedDaemonEvent("x-3"));
+            await session.SaveChangesAsync();
+        }
+
+        var yStream = Guid.NewGuid();
+        await using (var session = _store.LightweightSession("tenant_y"))
+        {
+            session.Events.StartStream<ShardedDaemonCounter>(yStream,
+                new ShardedDaemonEvent("y-1"), new ShardedDaemonEvent("y-2"));
+            await session.SaveChangesAsync();
+        }
+
+        using var daemon = await _store.BuildProjectionDaemonAsync("tenant_x");
+        await daemon.StartAllAsync();
+
+        // Prove the projection docs DO materialize for both tenants — the per-tenant events ARE
+        // processed (so this is NOT a "data not projected" problem).
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        ShardedDaemonCounter? dx = null, dy = null;
+        while (sw.Elapsed < 20.Seconds())
+        {
+            await using (var q = _store.QuerySession("tenant_x")) dx = await q.LoadAsync<ShardedDaemonCounter>(xStream);
+            await using (var q = _store.QuerySession("tenant_y")) dy = await q.LoadAsync<ShardedDaemonCounter>(yStream);
+            if (dx is { EventCount: 3 } && dy is { EventCount: 2 }) break;
+            await Task.Delay(250);
+        }
+        dx.ShouldNotBeNull(); dx!.EventCount.ShouldBe(3);
+        dy.ShouldNotBeNull(); dy!.EventCount.ShouldBe(2);
+
+        // The bug: a normal daemon catch-up must complete for a multi-tenant shard whose data is
+        // fully projected (proven above — both tenants' docs are materialized). It instead TIMES OUT.
+        // Per-tenant progression rows (HighWaterMark:<tenant>, <projection>:All:<tenant>) advance
+        // correctly, but the store-global <projection>:All mark stays at 0, and WaitForNonStaleData's
+        // caught-up check reads the store-global mark — so it never sees the shard as non-stale.
+        await daemon.WaitForNonStaleData(20.Seconds());
+    }
+}

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4763_reassign_count_divergence.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4763_reassign_count_divergence.cs
@@ -1,0 +1,135 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using Marten;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+/// <summary>
+/// #4763 — `ShardedTenancy` tenant-assignment bookkeeping drifts: re-assigning a tenant from shard A
+/// to shard B recomputes only the TARGET shard's `tenant_count` (`AssignTenantAsync`, ShardedTenancy.cs
+/// :337-340), never decrements the SOURCE shard. So shard A's count stays inflated forever, which makes
+/// `UseSmallestDatabaseAssignment` mis-rank shards (it favours A, which only *looks* fuller).
+///
+/// <para>This test moves one tenant A→B and asserts the pool's `tenant_count` for A reflects reality
+/// (0 active tenants). It fails because A's count remains 1.</para>
+/// </summary>
+[Collection("sharded-tenant-partitioned")]
+public class Bug_4763_reassign_count_divergence: IAsyncLifetime
+{
+    private readonly ShardedPartitionedFixture _fixture;
+    private readonly ITestOutputHelper _output;
+    private DocumentStore _store = null!;
+
+    public Bug_4763_reassign_count_divergence(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_store != null!) await _store.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task reassigning_a_tenant_decrements_the_source_shard_count()
+    {
+        _store = (DocumentStore)DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded";
+                x.PartitionSchemaName = "tenants";
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+            });
+
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AddEventType<ShardedDaemonEvent>();
+            opts.Schema.For<ShardedDaemonCounter>().DocumentAlias("p4763_sdc");
+        });
+
+        var shardA = _fixture.DbNames[0];
+        var shardB = _fixture.DbNames[1];
+
+        // Assign the tenant to A, then move it to B.
+        await _store.Advanced.AddTenantToShardAsync("mover", shardA, CancellationToken.None);
+        await _store.Advanced.AddTenantToShardAsync("mover", shardB, CancellationToken.None);
+
+        var counts = await ReadPoolCountsAsync();
+        _output.WriteLine("pool tenant_count per database_id: " +
+                          string.Join(", ", counts.Count == 0 ? new[] { "(none)" } : Array.Empty<string>()));
+        foreach (var (db, count) in counts) _output.WriteLine($"  {db} = {count}");
+
+        // The tenant now lives on B, so A has 0 active tenants and B has 1.
+        counts.ShouldContainKey(shardB);
+        counts[shardB].ShouldBe(1, "target shard B has the moved tenant");
+        counts.ShouldContainKey(shardA);
+        counts[shardA].ShouldBe(0,
+            "source shard A should be decremented when the tenant moves away — it is not (stays 1), " +
+            "so UseSmallestDatabaseAssignment keeps treating A as fuller than it is");
+    }
+
+    /// <summary>Read the sharded pool's per-database tenant_count from the master/pool DB, discovering
+    /// the pool table via information_schema so the test does not depend on the internal table name.</summary>
+    private static async Task<Dictionary<string, int>> ReadPoolCountsAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        string? poolTable = null;
+        await using (var find = await conn
+                         .CreateCommand(
+                             "select table_name from information_schema.columns " +
+                             "where table_schema = 'sharded' and column_name = 'tenant_count' limit 1")
+                         .ExecuteReaderAsync())
+        {
+            if (await find.ReadAsync()) poolTable = find.GetString(0);
+        }
+
+        var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        if (poolTable == null) return result;
+
+        await using var reader = await conn
+            .CreateCommand($"select database_id, tenant_count from sharded.{poolTable}")
+            .ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            result[reader.GetString(0)] = Convert.ToInt32(reader.GetValue(1));
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Adds **failing** integration tests under `src/TenantPartitionedEventsTests/Sharded/` that reproduce three problems under `MultiTenantedWithShardedDatabases` + `Events.UseTenantPartitionedEvents = true`. The daemon repros use Marten's own daemon (`BuildProjectionDaemonAsync` + `StartAllAsync` + `WaitForNonStaleData`) — no Wolverine involved — and reuse the existing `ShardedPartitionedFixture`.

### `Bug_4751_composite_catchup_under_sharded` — reproduces #4751
An async `CompositeProjectionFor` is not driven to a non-stale state by the normal async catch-up path. After `StartAllAsync` + `WaitForNonStaleData`, **both** composite stages are empty (`stage1 = 0, stage2 = 0`, expected 10). The same composite shape *does* materialize via `RebuildProjectionAsync` (see the existing `composite_side_effects_rebuild_under_sharded_partitioning` test), so the projection logic is fine — the gap is the continuous async catch-up of a composite on a sharded, tenant-partitioned store.

### `Bug_4761_per_tenant_progression_same_shard` — reproduces #4761
Two tenants assigned to the **same** shard DB, with divergent event counts (3 and 2). The per-tenant projection docs **do** materialize and the **per-tenant** progression rows **do** advance (`HighWaterMark:<tenant>`, `<projection>:All:<tenant>` reach 3/2) — so this corrects the original #4761 premise — but the **store-global** `<projection>:All` mark stays at `0`. `WaitForNonStaleData` reads the store-global mark, so it never sees the shard as non-stale and times out, even though every tenant is fully caught up.

### `Bug_4763_reassign_count_divergence` — reproduces #4763
Assigns a tenant to shard A, then re-assigns it to shard B via `AddTenantToShardAsync`, and reads the pool table back: shard A still reports `tenant_count = 1` after the tenant has left (expected 0). `AssignTenantAsync` recomputes only the target shard count and never decrements the source, so `UseSmallestDatabaseAssignment` mis-ranks shards. (The non-atomic provisioning sub-bug of #4763 — assignment committed before `createPartitionsForTenant` — needs fault injection and is **not** covered here.)

### Shared root of the two daemon repros
Both #4751 and #4761 look like the same underlying issue: on a shard that hosts more than one tenant, the **store-global** `<projection>:All` / `HighWaterMark` progression mark is never advanced (only the per-tenant marks are), and the catch-up helpers (`WaitForNonStaleData`, and by extension `ForceAllMartenDaemonActivityToCatchUpAsync`) key off the store-global mark.

### Notes
- Tests are written to **fail** on `master` (9.9.0) to demonstrate the bugs; they are not skipped.
- Verified failing locally against PostgreSQL 17.

Relates to: #4751, #4761, #4763