### PR TITLE
Fix #4761 + #4763: per-tenant non-stale wait + sharded reassignment tenant_count

### DIFF
--- a/src/Marten/Events/AsyncProjectionTestingExtensions.cs
+++ b/src/Marten/Events/AsyncProjectionTestingExtensions.cs
@@ -188,15 +188,56 @@ public static class TestingExtensions
     public static async Task WaitForNonStaleDataAsync(this IMartenDatabase database, CancellationTokenSource cancellationSource,
         int projectionsCount, EventStoreStatistics initial)
     {
+        var options = database.As<MartenDatabase>().Options;
+        var perTenant = options.Events.UseTenantPartitionedEvents;
+        var shardIdentities = options.Projections.AllShards().Select(s => s.Name.Identity).ToArray();
+
+        bool isCaughtUp(IReadOnlyList<ShardState> rows)
+        {
+            if (!perTenant)
+            {
+                return rows.Count >= projectionsCount && rows.All(x => x.Sequence >= initial.EventSequenceNumber);
+            }
+
+            // #4761: under per-tenant event partitioning each tenant has its own mt_events_sequence, so a
+            // single store-global "initial" cannot be the bar for every progression row — a tenant with
+            // fewer events legitimately tops out below the global max, and comparing its rows against the
+            // global max makes the wait time out forever. Instead require each registered projection shard
+            // to have caught its OWN tenant up to that tenant's high-water mark.
+            const string hw = ShardState.HighWaterMark;
+            var tenantHighWater = rows
+                .Where(x => x.ShardName.StartsWith(hw + ":", StringComparison.Ordinal))
+                .ToDictionary(x => x.ShardName.Substring(hw.Length + 1), x => x.Sequence);
+
+            // Nothing established yet, or the leading tenant has not reached the store-wide high-water —
+            // keep waiting so we never report "caught up" before the daemon has actually done the work.
+            if (tenantHighWater.Count == 0 || tenantHighWater.Values.Max() < initial.EventSequenceNumber)
+            {
+                return false;
+            }
+
+            var byName = rows.ToDictionary(x => x.ShardName, x => x.Sequence);
+            foreach (var (tenant, highWater) in tenantHighWater)
+            {
+                foreach (var shard in shardIdentities)
+                {
+                    if (!byName.TryGetValue($"{shard}:{tenant}", out var seq) || seq < highWater)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
         IReadOnlyList<ShardState> projections = [];
         try
         {
             do
             {
                 projections = await database.AllProjectionProgress(cancellationSource.Token).ConfigureAwait(false);
-                if ((projections.Count >= projectionsCount &&
-                     projections.All(x => x.Sequence >= initial.EventSequenceNumber))
-                    || cancellationSource.IsCancellationRequested)
+                if (isCaughtUp(projections) || cancellationSource.IsCancellationRequested)
                 {
                     break;
                 }

--- a/src/Marten/Storage/ShardedTenancy.cs
+++ b/src/Marten/Storage/ShardedTenancy.cs
@@ -324,6 +324,15 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
 
         try
         {
+            // #4763: capture the tenant's current shard (if any) BEFORE the upsert so we can recompute the
+            // SOURCE shard's tenant_count when this is a re-assignment. Without this only the target shard
+            // is recomputed below, leaving the source shard's count permanently inflated and making
+            // UseSmallestDatabaseAssignment mis-rank it as fuller than it really is.
+            var previousDatabaseId = (await conn.CreateCommand(
+                    $"select database_id from {_schemaName}.{TenantAssignmentTable.TableName} where tenant_id = :tid")
+                .With("tid", tenantId)
+                .ExecuteScalarAsync(ct).ConfigureAwait(false)) as string;
+
             // #4607: explicit assignment also clears the disabled flag so re-assigning
             // a soft-deleted tenant via this API reactivates it. Pairs with the
             // tolerant DisableTenantAsync / EnableTenantAsync semantics — explicit
@@ -338,6 +347,16 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
                     $"update {_schemaName}.{DatabasePoolTable.TableName} set tenant_count = (select count(*) from {_schemaName}.{TenantAssignmentTable.TableName} where database_id = :did and {MartenTenantAssignmentTable.DisabledColumn} = false) where database_id = :did")
                 .With("did", databaseId)
                 .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+            // #4763: re-assignment moved the tenant off its previous shard — recompute that shard's
+            // tenant_count too so it reflects the tenant having left.
+            if (previousDatabaseId != null && !previousDatabaseId.EqualsIgnoreCase(databaseId))
+            {
+                await conn.CreateCommand(
+                        $"update {_schemaName}.{DatabasePoolTable.TableName} set tenant_count = (select count(*) from {_schemaName}.{TenantAssignmentTable.TableName} where database_id = :prev and {MartenTenantAssignmentTable.DisabledColumn} = false) where database_id = :prev")
+                    .With("prev", previousDatabaseId)
+                    .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+            }
 
             // Create partition in the target database
             if (_databasesById.TryFind(databaseId, out var database))

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4761_per_tenant_progression_same_shard.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4761_per_tenant_progression_same_shard.cs
@@ -1,0 +1,148 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+/// <summary>
+/// #4761 — under <c>MultiTenantedWithShardedDatabases</c> + <c>UseTenantPartitionedEvents</c>, when
+/// MULTIPLE tenants are assigned to the SAME shard database, the async daemon does not create
+/// per-tenant progression rows (<c>HighWaterMark:&lt;tenant&gt;</c> / <c>&lt;projection&gt;:All:&lt;tenant&gt;</c>).
+/// Only the store-global <c>HighWaterMark</c> / <c>&lt;projection&gt;:All</c> rows exist.
+///
+/// <para>
+/// Each tenant has its own independent <c>mt_events_sequence_&lt;suffix&gt;</c>, so their seq_id values
+/// overlap. A single store-global high-water over two overlapping sequences cannot track a lagging
+/// tenant independently: once the shard high-water advances past tenant Y's range (because tenant X
+/// has more events), tenant Y's later appends land below the high-water and the daemon skips them.
+/// #4717 added per-tenant progression to fix exactly this; this test pins that the per-tenant rows
+/// are actually created when two tenants share a shard.
+/// </para>
+///
+/// <para>
+/// Distinct from <see cref="sharded_daemon_per_shard_progression"/>, which deliberately puts each
+/// tenant on a DIFFERENT shard (one tenant per shard DB → a store-global row per shard is enough).
+/// </para>
+/// </summary>
+[Collection("sharded-tenant-partitioned")]
+public class Bug_4761_per_tenant_progression_same_shard: IAsyncLifetime
+{
+    private readonly ShardedPartitionedFixture _fixture;
+    private readonly ITestOutputHelper _output;
+    private DocumentStore _store = null!;
+
+    public Bug_4761_per_tenant_progression_same_shard(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_store != null!) await _store.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task per_tenant_progression_rows_exist_when_two_tenants_share_a_shard()
+    {
+        _store = (DocumentStore)DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded";
+                x.PartitionSchemaName = "tenants";
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+            });
+
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AddEventType<ShardedDaemonEvent>();
+
+            opts.Projections.Add<ShardedDaemonProjection>(ProjectionLifecycle.Async);
+            opts.Schema.For<ShardedDaemonCounter>().DocumentAlias("p4761_sdc");
+        });
+
+        // Both tenants on the SAME shard, with DIFFERENT event counts so their per-tenant
+        // sequences diverge (x: 3, y: 2) and their seq_id ranges overlap.
+        var shard = _fixture.DbNames[0];
+        await _store.Advanced.AddTenantToShardAsync("tenant_x", shard, CancellationToken.None);
+        await _store.Advanced.AddTenantToShardAsync("tenant_y", shard, CancellationToken.None);
+
+        var xStream = Guid.NewGuid();
+        await using (var session = _store.LightweightSession("tenant_x"))
+        {
+            session.Events.StartStream<ShardedDaemonCounter>(xStream,
+                new ShardedDaemonEvent("x-1"), new ShardedDaemonEvent("x-2"), new ShardedDaemonEvent("x-3"));
+            await session.SaveChangesAsync();
+        }
+
+        var yStream = Guid.NewGuid();
+        await using (var session = _store.LightweightSession("tenant_y"))
+        {
+            session.Events.StartStream<ShardedDaemonCounter>(yStream,
+                new ShardedDaemonEvent("y-1"), new ShardedDaemonEvent("y-2"));
+            await session.SaveChangesAsync();
+        }
+
+        using var daemon = await _store.BuildProjectionDaemonAsync("tenant_x");
+        await daemon.StartAllAsync();
+
+        // Prove the projection docs DO materialize for both tenants — the per-tenant events ARE
+        // processed (so this is NOT a "data not projected" problem).
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        ShardedDaemonCounter? dx = null, dy = null;
+        while (sw.Elapsed < 20.Seconds())
+        {
+            await using (var q = _store.QuerySession("tenant_x")) dx = await q.LoadAsync<ShardedDaemonCounter>(xStream);
+            await using (var q = _store.QuerySession("tenant_y")) dy = await q.LoadAsync<ShardedDaemonCounter>(yStream);
+            if (dx is { EventCount: 3 } && dy is { EventCount: 2 }) break;
+            await Task.Delay(250);
+        }
+        dx.ShouldNotBeNull(); dx!.EventCount.ShouldBe(3);
+        dy.ShouldNotBeNull(); dy!.EventCount.ShouldBe(2);
+
+        // The bug: a normal daemon catch-up must complete for a multi-tenant shard whose data is
+        // fully projected (proven above — both tenants' docs are materialized). It instead TIMES OUT.
+        // Per-tenant progression rows (HighWaterMark:<tenant>, <projection>:All:<tenant>) advance
+        // correctly, but the store-global <projection>:All mark stays at 0, and WaitForNonStaleData's
+        // caught-up check reads the store-global mark — so it never sees the shard as non-stale.
+        await daemon.WaitForNonStaleData(20.Seconds());
+    }
+}

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4763_reassign_count_divergence.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4763_reassign_count_divergence.cs
@@ -1,0 +1,135 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using Marten;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+/// <summary>
+/// #4763 — `ShardedTenancy` tenant-assignment bookkeeping drifts: re-assigning a tenant from shard A
+/// to shard B recomputes only the TARGET shard's `tenant_count` (`AssignTenantAsync`, ShardedTenancy.cs
+/// :337-340), never decrements the SOURCE shard. So shard A's count stays inflated forever, which makes
+/// `UseSmallestDatabaseAssignment` mis-rank shards (it favours A, which only *looks* fuller).
+///
+/// <para>This test moves one tenant A→B and asserts the pool's `tenant_count` for A reflects reality
+/// (0 active tenants). It fails because A's count remains 1.</para>
+/// </summary>
+[Collection("sharded-tenant-partitioned")]
+public class Bug_4763_reassign_count_divergence: IAsyncLifetime
+{
+    private readonly ShardedPartitionedFixture _fixture;
+    private readonly ITestOutputHelper _output;
+    private DocumentStore _store = null!;
+
+    public Bug_4763_reassign_count_divergence(ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_store != null!) await _store.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task reassigning_a_tenant_decrements_the_source_shard_count()
+    {
+        _store = (DocumentStore)DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded";
+                x.PartitionSchemaName = "tenants";
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+            });
+
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AddEventType<ShardedDaemonEvent>();
+            opts.Schema.For<ShardedDaemonCounter>().DocumentAlias("p4763_sdc");
+        });
+
+        var shardA = _fixture.DbNames[0];
+        var shardB = _fixture.DbNames[1];
+
+        // Assign the tenant to A, then move it to B.
+        await _store.Advanced.AddTenantToShardAsync("mover", shardA, CancellationToken.None);
+        await _store.Advanced.AddTenantToShardAsync("mover", shardB, CancellationToken.None);
+
+        var counts = await ReadPoolCountsAsync();
+        _output.WriteLine("pool tenant_count per database_id: " +
+                          string.Join(", ", counts.Count == 0 ? new[] { "(none)" } : Array.Empty<string>()));
+        foreach (var (db, count) in counts) _output.WriteLine($"  {db} = {count}");
+
+        // The tenant now lives on B, so A has 0 active tenants and B has 1.
+        counts.ShouldContainKey(shardB);
+        counts[shardB].ShouldBe(1, "target shard B has the moved tenant");
+        counts.ShouldContainKey(shardA);
+        counts[shardA].ShouldBe(0,
+            "source shard A should be decremented when the tenant moves away — it is not (stays 1), " +
+            "so UseSmallestDatabaseAssignment keeps treating A as fuller than it is");
+    }
+
+    /// <summary>Read the sharded pool's per-database tenant_count from the master/pool DB, discovering
+    /// the pool table via information_schema so the test does not depend on the internal table name.</summary>
+    private static async Task<Dictionary<string, int>> ReadPoolCountsAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        string? poolTable = null;
+        await using (var find = await conn
+                         .CreateCommand(
+                             "select table_name from information_schema.columns " +
+                             "where table_schema = 'sharded' and column_name = 'tenant_count' limit 1")
+                         .ExecuteReaderAsync())
+        {
+            if (await find.ReadAsync()) poolTable = find.GetString(0);
+        }
+
+        var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        if (poolTable == null) return result;
+
+        await using var reader = await conn
+            .CreateCommand($"select database_id, tenant_count from sharded.{poolTable}")
+            .ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            result[reader.GetString(0)] = Convert.ToInt32(reader.GetValue(1));
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Closes #4761. Closes #4763. Reproductions courtesy of #4762 (@erdtsieck) — those two repro tests are included here and now pass. (#4751 from that same repro PR needs a JasperFx-side change and is being handled separately.)

## #4761 — `WaitForNonStaleData` never completes for a multi-tenant shard

Under `MultiTenantedWithShardedDatabases` + `UseTenantPartitionedEvents`, when two tenants share a shard, each has its own `mt_events_sequence_<suffix>` (overlapping seq_ids). `WaitForNonStaleDataAsync` checked `projections.All(x => x.Sequence >= initial.EventSequenceNumber)` where `initial` is the **global** max seq_id. A tenant with fewer events legitimately tops out below that max (e.g. `HighWaterMark:tenant_y = 2` while global = 3), so the check could never pass — the wait timed out (`"...reaching the initial sequence of 3"`) even though both tenants' data was fully projected.

**Fix:** `WaitForNonStaleDataAsync` is now per-tenant aware under partitioning — it requires each registered projection shard to have caught its **own** tenant up to that tenant's `HighWaterMark:<tenant>` mark (and guards against a premature pass before the daemon has done any work). The non-partitioned path is byte-for-byte unchanged.

## #4763 — sharded reassignment leaves the source shard's `tenant_count` inflated

`ShardedTenancy.AssignTenantAsync` recomputed `tenant_count` only for the **target** shard. Re-assigning a tenant A→B never decremented A, so A stayed inflated forever and `UseSmallestDatabaseAssignment` kept mis-ranking it as fuller.

**Fix:** capture the tenant's prior shard before the upsert and recompute **both** the source and target shard counts.

## Tests
- `Bug_4761_per_tenant_progression_same_shard` and `Bug_4763_reassign_count_divergence` (from #4762) now pass.
- Full `TenantPartitionedEventsTests` suite green (191); non-partitioned `WaitForNonStaleData` consumers (e.g. `querying_with_non_stale_data`) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)