### PR TITLE
Fix #4765: close mt_events_sequence gap on Quick + ExpectedVersion OCC failure

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4765_quick_occ_no_sequence_gap.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4765_quick_occ_no_sequence_gap.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Threading.Tasks;
+using EventSourcingTests.Aggregation;
+using EventSourcingTests.FetchForWriting;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Testing.Harness;
+using Npgsql;
+using NpgsqlTypes;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EventSourcingTests.Bugs;
+
+/// <summary>
+/// #4765 (root cause of #4749) — under <see cref="EventAppendMode.Quick"/> /
+/// <see cref="EventAppendMode.QuickWithServerTimestamps"/> on the
+/// non-partitioned event store, an optimistic-concurrency loser
+/// (FetchForWriting / AppendOptimistic / AppendExclusive / expected-version
+/// StartStream) used to leave a permanent gap in <c>mt_events_sequence</c>:
+/// the per-event INSERT fired <c>nextval()</c> (non-transactional) before the
+/// 23505 raised and rolled the txn back, so the sequence stayed advanced past
+/// the highest committed seq_id. The async daemon's high-water detector then
+/// stalled on the unreachable value forever.
+///
+/// The fix routes every Quick append through <c>mt_quick_append_events</c>,
+/// which checks the version (MT003) BEFORE any nextval — so an OCC loss
+/// advances no sequence. These tests pin the no-gap invariant, the unchanged
+/// concurrency-exception contract, and the (now consistent) timestamp behavior.
+/// </summary>
+public class Bug_4765_quick_occ_no_sequence_gap: OneOffConfigurationsContext
+{
+    private readonly ITestOutputHelper _output;
+
+    public Bug_4765_quick_occ_no_sequence_gap(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private async Task<DocumentStore> BuildStoreAsync(
+        string label, EventAppendMode mode, bool asyncSnapshot, TimeProvider timeProvider = null)
+    {
+        // Keep schema names well under PostgreSQL's 63-char identifier limit —
+        // a too-long name gets silently truncated by PG, which then trips schema
+        // validation (config name != truncated actual name).
+        var modeCode = mode == EventAppendMode.Quick ? "q" : "qst";
+        var schema = $"b4765_{label}_{modeCode}";
+
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await conn.CreateCommand($"drop schema if exists {schema} cascade").ExecuteNonQueryAsync();
+        }
+
+        var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = schema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Events.AppendMode = mode;
+            if (timeProvider != null)
+            {
+                opts.Events.TimeProvider = timeProvider;
+            }
+
+            if (asyncSnapshot)
+            {
+                opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Async);
+            }
+        });
+
+        _disposables.Add(store);
+        return store;
+    }
+
+    private static async Task<(long lastValue, long maxSeq, long rowCount)> ReadSequenceStateAsync(DocumentStore store)
+    {
+        var schema = store.Options.Events.DatabaseSchemaName;
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        var lastValue = Convert.ToInt64(
+            await conn.CreateCommand($"select last_value from {schema}.mt_events_sequence").ExecuteScalarAsync());
+
+        var maxObj = await conn.CreateCommand($"select max(seq_id) from {schema}.mt_events").ExecuteScalarAsync();
+        var maxSeq = maxObj is null or DBNull ? 0L : Convert.ToInt64(maxObj);
+
+        var rowCount = Convert.ToInt64(
+            await conn.CreateCommand($"select count(*) from {schema}.mt_events").ExecuteScalarAsync());
+
+        return (lastValue, maxSeq, rowCount);
+    }
+
+    [Theory]
+    [InlineData(EventAppendMode.Quick)]
+    [InlineData(EventAppendMode.QuickWithServerTimestamps)]
+    public async Task occ_loser_leaves_no_sequence_gap(EventAppendMode mode)
+    {
+        using var store = await BuildStoreAsync("gap", mode, asyncSnapshot: false);
+
+        var streamId = Guid.NewGuid();
+        await using (var seed = store.LightweightSession())
+        {
+            seed.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new BEvent());
+            await seed.SaveChangesAsync();
+        }
+
+        // Two sessions fetch the same stream at the same version, then race to append.
+        await using var s1 = store.LightweightSession();
+        await using var s2 = store.LightweightSession();
+
+        var w1 = await s1.Events.FetchForWriting<SimpleAggregate>(streamId);
+        var w2 = await s2.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        w1.AppendOne(new CEvent());
+        w2.AppendMany(new DEvent(), new EEvent());
+
+        // Winner commits.
+        await s1.SaveChangesAsync();
+
+        // Loser must throw a concurrency exception...
+        var ex = await Record.ExceptionAsync(() => s2.SaveChangesAsync());
+        _output.WriteLine(ex?.GetType().FullName ?? "<no exception>");
+        ex.ShouldNotBeNull();
+        ex.ShouldBeAssignableTo<ConcurrencyException>();
+
+        // ...and must NOT have advanced the sequence (no nextval before the version
+        // check). This assertion FAILS on master for the non-partitioned Quick path.
+        var (lastValue, maxSeq, rowCount) = await ReadSequenceStateAsync(store);
+        lastValue.ShouldBe(maxSeq);
+
+        // 2 seed + 1 winner; the loser's events rolled back entirely.
+        rowCount.ShouldBe(3);
+
+        // No tombstones leaked from the failure.
+        var schema = store.Options.Events.DatabaseSchemaName;
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        var tombstones = Convert.ToInt64(await conn
+            .CreateCommand($"select count(*) from {schema}.mt_events where type = 'tombstone'")
+            .ExecuteScalarAsync());
+        tombstones.ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData(EventAppendMode.Quick)]
+    [InlineData(EventAppendMode.QuickWithServerTimestamps)]
+    public async Task async_daemon_recovers_after_occ_loss(EventAppendMode mode)
+    {
+        using var store = await BuildStoreAsync("daemon", mode, asyncSnapshot: true);
+
+        var streamId = Guid.NewGuid();
+        await using (var seed = store.LightweightSession())
+        {
+            seed.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new BEvent());
+            await seed.SaveChangesAsync();
+        }
+
+        // Force a concurrency failure to exercise the (previously gap-leaving) path.
+        await using (var s1 = store.LightweightSession())
+        await using (var s2 = store.LightweightSession())
+        {
+            var w1 = await s1.Events.FetchForWriting<SimpleAggregate>(streamId);
+            var w2 = await s2.Events.FetchForWriting<SimpleAggregate>(streamId);
+            w1.AppendOne(new CEvent());
+            w2.AppendOne(new DEvent());
+            await s1.SaveChangesAsync();
+            await Record.ExceptionAsync(() => s2.SaveChangesAsync());
+        }
+
+        // With no sequence gap, the async daemon catches up to the real high-water
+        // promptly instead of stalling forever on an unreachable ceiling (#4749).
+        using var daemon = await store.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(15.Seconds());
+
+        await using var query = store.QuerySession();
+        var aggregate = await query.LoadAsync<SimpleAggregate>(streamId);
+        aggregate.ShouldNotBeNull();
+        aggregate.ACount.ShouldBe(1);
+        aggregate.BCount.ShouldBe(1);
+        aggregate.CCount.ShouldBe(1); // winner's event
+        aggregate.DCount.ShouldBe(0); // loser rolled back
+    }
+
+    [Theory]
+    [InlineData(EventAppendMode.Quick)]
+    [InlineData(EventAppendMode.QuickWithServerTimestamps)]
+    public async Task quick_append_function_is_idempotent_with_expected_version(EventAppendMode mode)
+    {
+        // The mt_quick_append_events function now always carries the trailing
+        // `expected_version` parameter. PostgreSQL canonicalizes a declared `int`
+        // parameter to `integer` and a bare `DEFAULT NULL` to `DEFAULT NULL::<type>`
+        // in pg_get_functiondef, which Weasel's function-diff reads back. If the
+        // generated SQL doesn't already match that rendering, schema validation
+        // reports a perpetual delta. This pins idempotency on the common
+        // non-bigint (integer) Quick path.
+        using var store = await BuildStoreAsync("idem", mode, asyncSnapshot: false);
+
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(JasperFx.Events.IEvent), default);
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Must not detect any further changes (would throw DatabaseValidationException).
+        await Should.NotThrowAsync(() => store.Storage.Database.AssertDatabaseMatchesConfigurationAsync());
+    }
+
+    private sealed class FixedTimeProvider: TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FixedTimeProvider(DateTimeOffset now) => _now = now;
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    [Fact]
+    public async Task quick_mode_uses_server_timestamp_on_optimistic_path()
+    {
+        // EventAppendMode.Quick contracts "timestamps from the database server".
+        // The old per-event OCC path bound the client IEvent.Timestamp regardless —
+        // a latent inconsistency the consolidation onto mt_quick_append_events fixes.
+        var staleClientTime = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        using var store = await BuildStoreAsync(
+            "tssrv", EventAppendMode.Quick, asyncSnapshot: false, timeProvider: new FixedTimeProvider(staleClientTime));
+
+        var streamId = Guid.NewGuid();
+        await using (var seed = store.LightweightSession())
+        {
+            seed.Events.StartStream<SimpleAggregate>(streamId, new AEvent());
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var session = store.LightweightSession())
+        {
+            var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.AppendOne(new BEvent());
+            await session.SaveChangesAsync();
+        }
+
+        var persisted = await ReadLatestTimestampAsync(store, streamId);
+        // Server time, not the stale 2000 client time.
+        persisted.Year.ShouldBe(DateTimeOffset.UtcNow.Year);
+    }
+
+    [Fact]
+    public async Task quick_with_server_timestamps_uses_client_timestamp_on_optimistic_path()
+    {
+        // EventAppendMode.QuickWithServerTimestamps contracts "timestamps from the
+        // .NET TimeProvider" — the bulk function binds the client-supplied array.
+        var clientTime = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        using var store = await BuildStoreAsync(
+            "tscli", EventAppendMode.QuickWithServerTimestamps, asyncSnapshot: false,
+            timeProvider: new FixedTimeProvider(clientTime));
+
+        var streamId = Guid.NewGuid();
+        await using (var seed = store.LightweightSession())
+        {
+            seed.Events.StartStream<SimpleAggregate>(streamId, new AEvent());
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var session = store.LightweightSession())
+        {
+            var stream = await session.Events.FetchForWriting<SimpleAggregate>(streamId);
+            stream.AppendOne(new BEvent());
+            await session.SaveChangesAsync();
+        }
+
+        var persisted = await ReadLatestTimestampAsync(store, streamId);
+        persisted.Year.ShouldBe(2000);
+    }
+
+    private static async Task<DateTimeOffset> ReadLatestTimestampAsync(DocumentStore store, Guid streamId)
+    {
+        var schema = store.Options.Events.DatabaseSchemaName;
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        var value = await conn
+            .CreateCommand($"select timestamp from {schema}.mt_events where stream_id = :id order by version desc limit 1")
+            .With("id", streamId, NpgsqlDbType.Uuid)
+            .ExecuteScalarAsync();
+
+        return value switch
+        {
+            DateTimeOffset dto => dto,
+            DateTime dt => new DateTimeOffset(DateTime.SpecifyKind(dt, DateTimeKind.Utc)),
+            _ => throw new InvalidOperationException($"Unexpected timestamp value: {value}")
+        };
+    }
+}

--- a/src/Marten/EventStorage/Quick/QuickAppendEventsOperation.cs
+++ b/src/Marten/EventStorage/Quick/QuickAppendEventsOperation.cs
@@ -75,14 +75,15 @@ internal sealed class QuickAppendEventsOperation: QuickAppendEventsOperationBase
         // dialect flagged this configuration as needing tag writes.
         if (_descriptor.HasTagWrites) writeAllTagValues(pb);
 
-        // #4614: the trailing optimistic-concurrency parameter only exists
-        // on the function signature when partitioning is on (the non-partitioned
-        // bulk path never gets here with ExpectedVersionOnServer set — those
-        // streams route through the per-event InsertStream + UpdateStreamVersion
-        // path in QuickEventAppender). Always bind when present so the bulk
-        // function's NULL-check short-circuits when not optimistic.
-        if (_descriptor.UseTenantPartitionedEvents)
-            writeExpectedVersion(pb, _descriptor.UseBigIntEvents);
+        // #4614 / #4765: the trailing optimistic-concurrency parameter is now
+        // always on the function signature (default NULL). Every Quick append —
+        // partitioned or not, optimistic or not — routes through this bulk
+        // operation, so always bind it. The bulk function's NULL-check
+        // short-circuits when the stream isn't an optimistic append, and binds
+        // the caller's ExpectedVersionOnServer otherwise so the version check
+        // (MT003) happens server-side BEFORE any nextval — closing the
+        // sequence-gap-on-OCC-loss hazard from #4749.
+        writeExpectedVersion(pb, _descriptor.UseBigIntEvents);
 
         builder.Append(")");
     }

--- a/src/Marten/EventStorage/QuickWithServerTimestamps/QuickAppendEventsWithServerTimestampsOperation.cs
+++ b/src/Marten/EventStorage/QuickWithServerTimestamps/QuickAppendEventsWithServerTimestampsOperation.cs
@@ -63,11 +63,10 @@ internal sealed class QuickAppendEventsWithServerTimestampsOperation: QuickAppen
 
         if (_descriptor.HasTagWrites) writeAllTagValues(pb);
 
-        // #4614: trailing optimistic-concurrency parameter; only present on the
-        // function signature under partitioning. See QuickAppendEventsOperation
-        // for the rationale on why this is gated.
-        if (_descriptor.UseTenantPartitionedEvents)
-            writeExpectedVersion(pb, _descriptor.UseBigIntEvents);
+        // #4614 / #4765: trailing optimistic-concurrency parameter, now always
+        // on the function signature (default NULL) and always bound. See
+        // QuickAppendEventsOperation for the full rationale.
+        writeExpectedVersion(pb, _descriptor.UseBigIntEvents);
 
         builder.Append(")");
     }

--- a/src/Marten/Events/QuickEventAppender.cs
+++ b/src/Marten/Events/QuickEventAppender.cs
@@ -56,23 +56,27 @@ internal class QuickEventAppender: IEventAppender
 
             // #4596 Phase 1 Session 2 / #4614 Session 4: when per-tenant
             // partitioning is on, the per-event `QuickAppendEventWithVersion`
-            // INSERT (used by the Start and ExpectedVersionOnServer paths) would
-            // inline `nextval('mt_events_sequence')` — the *global* sequence —
-            // via SequenceColumn.ValueSql. Only the bulk
+            // INSERT would inline `nextval('mt_events_sequence')` — the *global*
+            // sequence — via SequenceColumn.ValueSql. Only the bulk
             // `mt_quick_append_events` function honors the per-tenant sequence
-            // pick. Route every per-tenant append through the bulk function so
-            // the seq_id always comes from the tenant's
-            // `mt_events_sequence_{suffix}`. The function handles new-stream
-            // creation internally, rejects unregistered tenants with SQLSTATE
-            // MT002, and (#4614) now enforces the optimistic version check via
-            // the trailing `expected_version` parameter, raising MT003 on
-            // mismatch — translated back to EventStreamUnexpectedMaxEventIdException
-            // by QuickAppendEventsOperationBase.TryTransform so the user-facing
-            // exception type matches the rich path's UpdateStreamVersion.
+            // pick, so partitioning forces the bulk function for every shape.
             var forceBulkFunction = eventGraph.UseTenantPartitionedEvents;
 
             if (!forceBulkFunction && stream.ActionType == StreamActionType.Start)
             {
+                // New-stream StartStream stays on the per-event InsertStream +
+                // QuickAppendEventWithVersion route. This is deliberate and NOT
+                // affected by #4765:
+                //   * The InsertStream's mt_streams PK violation is what surfaces
+                //     ExistingStreamIdCollisionException when an id is reused
+                //     (including reuse of a previously-archived stream id) — the
+                //     bulk function can't distinguish that case. It also routes
+                //     the insert to mt_streams_default so UseArchivedStreamPartitioning
+                //     reuse semantics are preserved.
+                //   * There is no deterministic sequence-gap hazard here: a
+                //     colliding StartStream fails on the InsertStream (queued
+                //     first in the batch) before any per-event nextval runs, so
+                //     the loser advances no sequence.
                 stream.PrepareEvents(0, eventGraph, sequences, metadataContext);
                 session.QueueOperation(storage.InsertStream(stream));
 
@@ -86,44 +90,51 @@ internal class QuickEventAppender: IEventAppender
             }
             else
             {
-                if (!forceBulkFunction && stream.ExpectedVersionOnServer.HasValue)
-                {
-                    // We can supply the version to the events going in
-                    stream.PrepareEvents(stream.ExpectedVersionOnServer.Value, eventGraph, sequences, metadataContext);
-                    session.QueueOperation(storage.UpdateStreamVersion(stream));
-                    foreach (var @event in stream.Events)
-                    {
-                        session.QueueOperation(storage.QuickAppendEventWithVersion(stream, @event));
-                    }
+                // #4765: everything else — plain appends AND the optimistic
+                // shapes (FetchForWriting / AppendOptimistic / AppendExclusive /
+                // expected-version Append) — routes through the bulk
+                // `mt_quick_append_events` function. This is the fix: the
+                // ExpectedVersionOnServer shape used to take a per-event
+                // UpdateStreamVersion + N × QuickAppendEventWithVersion route
+                // whose OCC check was C#-side (RecordsAffected). On a concurrent
+                // OCC loser, the per-event INSERT still fired
+                // nextval('mt_events_sequence') before raising 23505 on the
+                // events PK — and nextval is non-transactional, so the sequence
+                // stayed advanced past the highest committed seq_id, leaving a
+                // permanent gap that stalls the async daemon's high-water
+                // detector forever (#4749). The bulk function checks the version
+                // via the trailing `expected_version` parameter (MT003 on
+                // mismatch, translated to EventStreamUnexpectedMaxEventIdException
+                // by QuickAppendEventsOperationBase.TryTransform — the same
+                // exception type the rich path's UpdateStreamVersion throws)
+                // *before* the foreach that calls nextval, so an OCC loss
+                // advances no sequence.
+                //
+                // The per-event QuickAppendEventWithVersion op is NOT dead — the
+                // daemon's projection side-effect emission (JasperFx EventSlice ->
+                // IProjectionBatch.QuickAppendEventWithVersion, #4428) and the
+                // StartStream branch above both still use it.
+                //
+                // Tags in TagTables mode are written inside the PostgreSQL
+                // function via array parameters. In HStore mode the function
+                // signature is trimmed (no per-tag varchar[] params), so tags are
+                // written via a follow-up UPDATE keyed on the event's id.
+                //
+                // PrepareEvents gets ExpectedVersionOnServer (or 0) as the current
+                // version so the client-side optimistic-concurrency guard
+                // (StreamAction.PrepareEvents in jasperfx) doesn't false-positive
+                // on "expected N but was 0" — events get their server-bound
+                // versions from ExpectedVersionOnServer + 1. The authoritative
+                // version check still happens server-side.
+                var preparedFrom = stream.ExpectedVersionOnServer ?? 0L;
+                stream.PrepareEvents(preparedFrom, eventGraph, sequences, metadataContext);
+                var quickAppendEvents = (QuickAppendEventsOperationBase)storage.QuickAppendEvents(stream);
+                quickAppendEvents.Events = eventGraph;
+                session.QueueOperation(quickAppendEvents);
 
-                    // Individual inserts don't use the function, so queue separate tag operations
+                if (eventGraph.DcbStorageMode == DcbStorageMode.HStore)
+                {
                     EventTagOperations.QueueTagOperationsByEventId(eventGraph, session, stream);
-                }
-                else
-                {
-                    // Tags in TagTables mode are handled inside the PostgreSQL function via
-                    // array parameters. In HStore mode the function signature is trimmed
-                    // (no per-tag varchar[] params), so tags are written via a follow-up
-                    // UPDATE keyed on the event's id after the bulk insert completes.
-                    // #4614: when ExpectedVersionOnServer is set (FetchForWriting,
-                    // AppendOptimistic, AppendExclusive, expected-version StartStream/
-                    // Append), pass it as the currentVersion to PrepareEvents so the
-                    // client-side optimistic-concurrency guard (StreamAction.PrepareEvents
-                    // lines 319-341 in jasperfx) doesn't false-positive on "expected N
-                    // but was 0" — events get their server-bound versions assigned from
-                    // ExpectedVersionOnServer + 1. The actual version check still happens
-                    // server-side in mt_quick_append_events via the trailing
-                    // expected_version parameter (MT003 on mismatch).
-                    var preparedFrom = stream.ExpectedVersionOnServer ?? 0L;
-                    stream.PrepareEvents(preparedFrom, eventGraph, sequences, metadataContext);
-                    var quickAppendEvents = (QuickAppendEventsOperationBase)storage.QuickAppendEvents(stream);
-                    quickAppendEvents.Events = eventGraph;
-                    session.QueueOperation(quickAppendEvents);
-
-                    if (eventGraph.DcbStorageMode == DcbStorageMode.HStore)
-                    {
-                        EventTagOperations.QueueTagOperationsByEventId(eventGraph, session, stream);
-                    }
                 }
             }
 

--- a/src/Marten/Events/Schema/QuickAppendEventFunction.cs
+++ b/src/Marten/Events/Schema/QuickAppendEventFunction.cs
@@ -147,25 +147,42 @@ namespace Marten.Events.Schema;
                 sequencePickPerEvent = $"        seq := nextval('{databaseSchema}.mt_events_sequence');";
             }
 
-            // #4614 (#4596 Phase 1 Session 4): when partitioning is on, the bulk
-            // function is the only path for *every* event append — including the
-            // FetchForWriting / AppendOptimistic / AppendExclusive shapes that
-            // pass a caller-supplied ExpectedVersionOnServer. Take it as an
-            // optional trailing parameter, default NULL (no check) so previously
-            // generated call sites still match the signature, and raise MT003
-            // on mismatch so QuickAppendEventsOperationBase.TryTransform can
-            // surface it as EventStreamUnexpectedMaxEventIdException — the same
-            // exception type the rich path's UpdateStreamVersion already throws.
-            // Only emitted under partitioning because the non-partitioned bulk
-            // path is never reached with ExpectedVersionOnServer set (the
-            // QuickEventAppender takes the per-event InsertStream + atomic
-            // UpdateStreamVersion route instead).
-            var expectedVersionParameter = string.Empty;
-            var expectedVersionCheck = string.Empty;
-            if (_events.UseTenantPartitionedEvents)
-            {
-                expectedVersionParameter = $", expected_version {intType} DEFAULT NULL";
-                expectedVersionCheck = $@"
+            // #4614 (#4596 Phase 1 Session 4): the bulk function is the path for
+            // *every* event append — including the FetchForWriting /
+            // AppendOptimistic / AppendExclusive shapes that pass a
+            // caller-supplied ExpectedVersionOnServer. Take it as an optional
+            // trailing parameter, default NULL (no check) so previously generated
+            // call sites still match the signature, and raise MT003 on mismatch
+            // so QuickAppendEventsOperationBase.TryTransform can surface it as
+            // EventStreamUnexpectedMaxEventIdException — the same exception type
+            // the rich path's UpdateStreamVersion already throws.
+            //
+            // #4765: emitted unconditionally now (was gated on
+            // UseTenantPartitionedEvents). The non-partitioned Quick +
+            // ExpectedVersion path used to take a per-event UpdateStreamVersion +
+            // QuickAppendEventWithVersion route where the OCC check was C#-side
+            // (RecordsAffected). On a concurrent loser the per-event INSERT still
+            // fired nextval('mt_events_sequence') before the 23505 raised, and
+            // nextval is non-transactional — leaving a permanent gap that stalls
+            // the async daemon's high-water detector forever (#4749). Routing
+            // every Quick append through this function, which checks the version
+            // BEFORE any nextval, closes that gap for the non-partitioned store
+            // exactly as it already does for the partitioned one.
+            //
+            // Emit the parameter type + DEFAULT in PostgreSQL's already-canonical
+            // form. pg_get_functiondef (what Weasel's function-diff reads back)
+            // rewrites a declared `int` parameter to `integer` and renders a bare
+            // `DEFAULT NULL` as `DEFAULT NULL::<type>`. Weasel's CanonicizeSql does
+            // NOT normalize either, so emitting `int DEFAULT NULL` here would
+            // produce a perpetual "Update" delta (non-idempotent schema). Matching
+            // pg's rendering up front keeps the function idempotent. This also
+            // fixes the same latent non-idempotency the #4614 partitioned function
+            // carried (it emitted `{intType} DEFAULT NULL`); existing partitioned
+            // DBs converge cleanly because pg had already stored the canonical form.
+            var expectedVersionParamType = _events.EnableBigIntEvents ? "bigint" : "integer";
+            var expectedVersionParameter =
+                $", expected_version {expectedVersionParamType} DEFAULT NULL::{expectedVersionParamType}";
+            var expectedVersionCheck = $@"
     if expected_version IS NOT NULL then
         -- COALESCE turns the NULL we get for a brand-new stream into 0, so a
         -- FetchForWriting against a non-existent stream (which sets
@@ -176,7 +193,6 @@ namespace Marten.Events.Schema;
         end if;
     end if;
 ";
-            }
 
             writer.WriteLine($@"
 CREATE OR REPLACE FUNCTION {Identifier}(stream {streamIdType}, stream_type varchar, tenantid varchar, event_ids uuid[], event_types varchar[], dotnet_types varchar[], bodies jsonb[], bdatas bytea[]{metadataParameters}{tagParameters}{expectedVersionParameter}) RETURNS {returnType} AS $$


### PR DESCRIPTION
Closes #4765 (root cause of #4749).

## Problem

Under `EventAppendMode.Quick` / `QuickWithServerTimestamps` on the **non-partitioned** event store, an optimistic-concurrency loser (`FetchForWriting` / `AppendOptimistic` / `AppendExclusive` / expected-version `Append`) left a **permanent gap** in `mt_events_sequence`.

The per-event route (`UpdateStreamVersion` + N × `QuickAppendEventWithVersion`) checked OCC **C#-side** (`RecordsAffected`), so a concurrent loser's `INSERT` still fired `nextval('mt_events_sequence')` before raising `23505` on the events PK. `nextval()` is non-transactional, so the sequence stayed advanced past the highest committed `seq_id` — and the async daemon's high-water detector then stalled on the unreachable value forever (the #4749 symptom).

The **partitioned** path was already safe via #4614, which routes every append through `mt_quick_append_events` and checks the version **before** any `nextval()`. This PR extends the same hardening to the non-partitioned path.

## Fix

Route the OCC append shapes through `mt_quick_append_events` (MT003 → `EventStreamUnexpectedMaxEventIdException`, same exception the rich path throws), which validates the expected version **before** the `foreach` that calls `nextval`.

- **`QuickAppendEventFunction`** — emit the trailing `expected_version` parameter unconditionally (was gated on `UseTenantPartitionedEvents`), in PostgreSQL's already-canonical form `expected_version {bigint|integer} DEFAULT NULL::{type}` so Weasel's function-diff stays **idempotent**. `pg_get_functiondef` rewrites a declared `int` param to `integer` and a bare `DEFAULT NULL` to `DEFAULT NULL::<type>`, and `CanonicizeSql` normalizes neither — so this also fixes a **latent non-idempotency the #4614 partitioned function carried** (never caught because no partitioned idempotency test exercised it).
- **`QuickAppendEventsOperation`** + **`QuickAppendEventsWithServerTimestampsOperation`** — always bind `expected_version` (the function's NULL-check short-circuits when unset).
- **`QuickEventAppender`** — route the `ExpectedVersionOnServer` shape through the bulk function. **The `StartStream` branch is intentionally kept** on the per-event `InsertStream` path: its `mt_streams` PK violation is what surfaces `ExistingStreamIdCollisionException` on id reuse (including reuse of a previously-archived stream id) and routes the insert to `mt_streams_default` so `UseArchivedStreamPartitioning` reuse semantics hold. There is no gap hazard there — a colliding `StartStream` fails on `InsertStream` (queued first) before any per-event `nextval`.

Note: `QuickAppendEventWithVersionOperation` is **not** removed — it's a live JasperFx `IProjectionBatch.QuickAppendEventWithVersion` contract used by `EventSlice` for projection side-effect event emission (#4428), and the kept `StartStream` branch still uses it.

Consolidating the OCC path onto the bulk function also fixes a **latent timestamp inconsistency**: the old per-event path bound the client `IEvent.Timestamp` even under `EventAppendMode.Quick` (which contracts server `now()`).

## Tests

New `Bug_4765_quick_occ_no_sequence_gap` (Theory across `Quick` + `QuickWithServerTimestamps`):

- **No sequence gap on OCC loss** — `mt_events_sequence.last_value == max(seq_id)` after a concurrent loser throws. *(Verified to fail on master.)*
- **Async daemon recovers** — `WaitForNonStaleData` returns promptly instead of stalling.
- **Timestamp-mode parity** — `Quick` → server `now()`, `QuickWithServerTimestamps` → client `TimeProvider`.
- **Function idempotency** — `AssertDatabaseMatchesConfigurationAsync` detects no drift.

Full `EventSourcingTests` suite green on **net10.0** (1375 passed, 7 skipped, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)