### PR TITLE
Register JasperFx.Events IProjectionCoordinator base interface (jasperfx#430) + JasperFx 2.13.1 / Weasel 9.2.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,13 +69,13 @@
     <!-- JasperFx 2.12.0: dead-letter row drill-in (IEventDatabase.QueryDeadLetterEventsAsync) +
          DeadLetterEvent.TenantId + tenant-aware daemon PauseShardAsync/rebuild fan-out (jasperfx#453).
          Marten implements QueryDeadLetterEventsAsync + per-tenant FetchDeadLetterCountsAsync below. -->
-    <PackageVersion Include="JasperFx" Version="2.13.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.13.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.0">
+    <PackageVersion Include="JasperFx" Version="2.13.1" />
+    <PackageVersion Include="JasperFx.Events" Version="2.13.1" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.13.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.13.1" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
@@ -128,7 +128,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
-    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.2.0" />
+    <PackageVersion Include="Weasel.EntityFrameworkCore" Version="9.2.1" />
     <!-- Weasel.Postgresql 9.1.x: managed LIST partitions under multi-database (sharded) apply.
          9.1.2 (marten#4706): managed-partition tables are no longer destructively rebuilt — the
          out-of-band AddPartitionToAllTables path creates partitions while the generic schema diff
@@ -136,7 +136,7 @@
          9.1.5 (marten#4713): the additive reconcile now SAVES/RESTORES IgnorePartitionsInMigration
          instead of permanently clearing it on the shared DocumentTable singleton, so a re-apply after
          tenant provisioning stays idempotent (no 42P07 / no rebuild). -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.2.0" />
+    <PackageVersion Include="Weasel.Postgresql" Version="9.2.1" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/Marten/HostExtensions.cs
+++ b/src/Marten/HostExtensions.cs
@@ -124,6 +124,8 @@ public static class HostExtensions
     {
         services.AddSingleton<IConfigureMarten, OverrideDaemonModeToSolo>();
         services.AddSingleton<IProjectionCoordinator, ExplicitProjectionCoordinator>();
+        // jasperfx#430 — resolve the JasperFx.Events base interface from the Solo coordinator too.
+        services.AddSingleton<JasperFx.Events.Daemon.IProjectionCoordinator>(s => s.GetRequiredService<IProjectionCoordinator>());
 
         foreach (var descriptor in services.ToArray())
         {

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -754,6 +754,10 @@ public static class MartenServiceCollectionExtensions
             {
                 Services.AddSingleton<Marten.Events.Daemon.Coordination.IProjectionCoordinator, ProjectionCoordinator>();
                 Services.AddSingleton<IHostedService>(s => s.GetRequiredService<Marten.Events.Daemon.Coordination.IProjectionCoordinator>());
+                // jasperfx#430 — also resolve the JasperFx.Events base interface, so a stock host can
+                // GetService<JasperFx.Events.Daemon.IProjectionCoordinator>() directly instead of walking
+                // the registered IHostedServices for one.
+                Services.AddSingleton<JasperFx.Events.Daemon.IProjectionCoordinator>(s => s.GetRequiredService<Marten.Events.Daemon.Coordination.IProjectionCoordinator>());
             }
 
             return this;


### PR DESCRIPTION
## What

1. **jasperfx#430** — register the `JasperFx.Events.Daemon.IProjectionCoordinator` base interface alongside Marten's store-specific `Marten.Events.Daemon.Coordination.IProjectionCoordinator` subtype, in both the async-daemon and Solo registration paths. A stock host's `GetService<JasperFx.Events.Daemon.IProjectionCoordinator>()` returned `null` even though the subtype implements that base, forcing consumers (CritterWatch) to walk `GetServices<IHostedService>().OfType<…>()`. Now the base resolves directly.

2. **Dependency upgrade** — `JasperFx` / `JasperFx.Events` / source generators `2.13.0 → 2.13.1`; `Weasel.Postgresql` / `Weasel.EntityFrameworkCore` `9.2.0 → 9.2.1` (the latter picks up the list-partition suffix sanitization fix, JasperFx/weasel#311).

## Verification
`dotnet build src/Marten/Marten.csproj` is clean against the upgraded dependencies. Full suite via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)