### PR TITLE
fix: close mt_events_sequence gap on concurrent Quick OCC failures (#4749)

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4765_quick_occ_no_sequence_gap.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4765_quick_occ_no_sequence_gap.cs
@@ -43,7 +43,8 @@ public class Bug_4765_quick_occ_no_sequence_gap: OneOffConfigurationsContext
     }
 
     private async Task<DocumentStore> BuildStoreAsync(
-        string label, EventAppendMode mode, bool asyncSnapshot, TimeProvider timeProvider = null)
+        string label, EventAppendMode mode, bool asyncSnapshot, TimeProvider timeProvider = null,
+        bool exclusiveLock = false)
     {
         // Keep schema names well under PostgreSQL's 63-char identifier limit —
         // a too-long name gets silently truncated by PG, which then trips schema
@@ -63,6 +64,7 @@ public class Bug_4765_quick_occ_no_sequence_gap: OneOffConfigurationsContext
             opts.DatabaseSchemaName = schema;
             opts.AutoCreateSchemaObjects = AutoCreate.All;
             opts.Events.AppendMode = mode;
+            opts.Events.UseExclusiveLockOnConcurrentAppends = exclusiveLock;
             if (timeProvider != null)
             {
                 opts.Events.TimeProvider = timeProvider;
@@ -232,7 +234,7 @@ public class Bug_4765_quick_occ_no_sequence_gap: OneOffConfigurationsContext
         // With FOR UPDATE on the version SELECT, losers block at the SELECT until the
         // winner commits, then read the updated version and raise MT003 before any
         // nextval — no gap.
-        using var store = await BuildStoreAsync("cc_gap", mode, asyncSnapshot: false);
+        using var store = await BuildStoreAsync("cc_gap", mode, asyncSnapshot: false, exclusiveLock: true);
 
         var streamId = Guid.NewGuid();
         await using (var seed = store.LightweightSession())

--- a/src/EventSourcingTests/Bugs/Bug_4765_quick_occ_no_sequence_gap.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4765_quick_occ_no_sequence_gap.cs
@@ -5,7 +5,6 @@ using EventSourcingTests.FetchForWriting;
 using JasperFx;
 using JasperFx.Core;
 using JasperFx.Events;
-using JasperFx.Events.Projections;
 using Marten;
 using Marten.Testing.Harness;
 using Npgsql;
@@ -215,6 +214,91 @@ public class Bug_4765_quick_occ_no_sequence_gap: OneOffConfigurationsContext
         private readonly DateTimeOffset _now;
         public FixedTimeProvider(DateTimeOffset now) => _now = now;
         public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    [Theory]
+    [InlineData(EventAppendMode.Quick)]
+    [InlineData(EventAppendMode.QuickWithServerTimestamps)]
+    public async Task concurrent_occ_appends_to_same_stream_leave_no_sequence_gap(EventAppendMode mode)
+    {
+        // Regression for the race NOT covered by occ_loser_leaves_no_sequence_gap:
+        // that test is sequential (s1 commits, then s2 runs). Here ALL three sessions
+        // fetch the same stream version BEFORE any of them commits, then all three
+        // SaveChanges calls are released at exactly the same moment via a Barrier on
+        // dedicated threads. Under READ COMMITTED, two losers can both pass the
+        // mt_quick_append_events version SELECT before the winner commits, reach
+        // nextval(), and fail on the mt_events PK (23505). nextval is non-transactional
+        // so the sequence stays advanced, stalling the async daemon.
+        // With FOR UPDATE on the version SELECT, losers block at the SELECT until the
+        // winner commits, then read the updated version and raise MT003 before any
+        // nextval — no gap.
+        using var store = await BuildStoreAsync("cc_gap", mode, asyncSnapshot: false);
+
+        var streamId = Guid.NewGuid();
+        await using (var seed = store.LightweightSession())
+        {
+            seed.Events.StartStream<SimpleAggregate>(streamId, new AEvent(), new BEvent());
+            await seed.SaveChangesAsync();
+        }
+
+        // All three sessions fetch the same version BEFORE any commits.
+        await using var s1 = store.LightweightSession();
+        await using var s2 = store.LightweightSession();
+        await using var s3 = store.LightweightSession();
+
+        var w1 = await s1.Events.FetchForWriting<SimpleAggregate>(streamId);
+        var w2 = await s2.Events.FetchForWriting<SimpleAggregate>(streamId);
+        var w3 = await s3.Events.FetchForWriting<SimpleAggregate>(streamId);
+
+        w1.AppendOne(new CEvent());
+        w2.AppendOne(new DEvent());
+        w3.AppendOne(new EEvent());
+
+        // Use a Barrier to release all three SaveChanges calls at exactly the same
+        // instant from dedicated OS threads — this maximises the chance that all three
+        // PG connections are inside mt_quick_append_events simultaneously, triggering
+        // the TOCTOU race between the version SELECT and the nextval/INSERT.
+        var barrier = new System.Threading.Barrier(participantCount: 3);
+        var exceptions = new Exception?[3];
+
+        void SaveSync(int idx, IDocumentSession session)
+        {
+            barrier.SignalAndWait(TimeSpan.FromSeconds(10));
+            try
+            { session.SaveChangesAsync().GetAwaiter().GetResult(); }
+            catch (Exception e) { exceptions[idx] = e; }
+        }
+
+        var threads = new[]
+        {
+            new System.Threading.Thread(() => SaveSync(0, s1)),
+            new System.Threading.Thread(() => SaveSync(1, s2)),
+            new System.Threading.Thread(() => SaveSync(2, s3)),
+        };
+
+        foreach (var t in threads)
+            t.Start();
+        foreach (var t in threads)
+            t.Join();
+
+        var successes = Array.FindAll(exceptions, static e => e is null).Length;
+        var failures = Array.FindAll(exceptions, static e => e is ConcurrencyException).Length;
+        _output.WriteLine($"successes={successes}, concurrency failures={failures}");
+        for (var i = 0; i < exceptions.Length; i++)
+            if (exceptions[i] != null)
+                _output.WriteLine($"  thread[{i}]: {exceptions[i]!.GetType().Name} — {exceptions[i]!.Message}");
+
+        successes.ShouldBe(1, "exactly one concurrent writer should win");
+        failures.ShouldBe(2, "the other two should get ConcurrencyException");
+
+        // The critical assertion: sequence must equal the highest committed seq_id.
+        // A gap means nextval() fired for a losing transaction — the daemon stalls.
+        var (lastValue, maxSeq, rowCount) = await ReadSequenceStateAsync(store);
+        _output.WriteLine($"last_value={lastValue}, max seq_id={maxSeq}, rows={rowCount}");
+        lastValue.ShouldBe(maxSeq, $"sequence gap: last_value={lastValue} > max committed seq_id={maxSeq}");
+
+        // 2 seed + 1 winner; both losers must have rolled back cleanly.
+        rowCount.ShouldBe(3);
     }
 
     [Fact]

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -247,6 +247,20 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     public bool UseListenNotifyForEventAppends { get; set; }
 
     /// <summary>
+    /// When enabled, adds FOR UPDATE to the stream version SELECT inside
+    /// mt_quick_append_events for OCC (optimistic concurrency) appends.
+    /// This prevents a READ COMMITTED race where two concurrent transactions
+    /// both pass the version check before either commits, both call nextval(),
+    /// and the loser fails with a 23505 duplicate key violation — leaving a
+    /// permanent gap in mt_events_sequence that stalls QueryForNonStaleData.
+    /// With this option the losing transaction blocks at the SELECT until the
+    /// winner commits, reads the updated version, and raises MT003 before any
+    /// nextval() call. Non-OCC appends are unaffected.
+    /// Defaults to false to preserve existing throughput characteristics.
+    /// </summary>
+    public bool UseExclusiveLockOnConcurrentAppends { get; set; }
+
+    /// <summary>
     /// Opt into a global, partition-spanning unique constraint on stream identity by
     /// also writing each new stream id (or key) into a non-partitioned
     /// <c>mt_streams_identity</c> tracking table at append time. Causes

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -183,6 +183,17 @@ namespace Marten.Events
         public bool UseListenNotifyForEventAppends { get; set; }
 
         /// <summary>
+        /// When enabled, adds FOR UPDATE to the stream version SELECT inside
+        /// mt_quick_append_events for OCC (optimistic concurrency) appends.
+        /// This prevents a READ COMMITTED race where two concurrent transactions
+        /// both pass the version check before either commits, both call nextval(),
+        /// and the loser fails with a 23505 — leaving a permanent gap in
+        /// mt_events_sequence that stalls QueryForNonStaleData.
+        /// Defaults to false to preserve existing throughput characteristics.
+        /// </summary>
+        public bool UseExclusiveLockOnConcurrentAppends { get; set; }
+
+        /// <summary>
         ///     Directs the schema migration functionality to ignore the presence of the named index
         ///     on the event-store tables (<c>mt_events</c>, <c>mt_streams</c>, <c>mt_event_progression</c>).
         ///     Use this when an external mechanism (e.g. a custom <c>IFeatureSchema</c>) declares an index

--- a/src/Marten/Events/Schema/QuickAppendEventFunction.cs
+++ b/src/Marten/Events/Schema/QuickAppendEventFunction.cs
@@ -184,6 +184,10 @@ namespace Marten.Events.Schema;
                 $", expected_version {expectedVersionParamType} DEFAULT NULL::{expectedVersionParamType}";
             var expectedVersionCheck = $@"
     if expected_version IS NOT NULL then
+        -- FOR UPDATE serialises concurrent OCC writers on the same stream: the loser
+        -- blocks until the winner commits, reads the updated version, and raises MT003
+        -- *before* nextval() fires -- closing the sequence gap that stalls the daemon.
+        select version, is_archived into event_version, stream_is_archived from {databaseSchema}.mt_streams where {streamsWhere} for update;
         -- COALESCE turns the NULL we get for a brand-new stream into 0, so a
         -- FetchForWriting against a non-existent stream (which sets
         -- ExpectedVersionOnServer = 0) and a StartStream(id, version: 0) both
@@ -191,6 +195,8 @@ namespace Marten.Events.Schema;
         if COALESCE(event_version, 0) != expected_version then
             RAISE EXCEPTION 'Stream version mismatch on ''%'': expected %, actual %', stream, expected_version, COALESCE(event_version, 0) USING ERRCODE = 'MT003';
         end if;
+    else
+        select version, is_archived into event_version, stream_is_archived from {databaseSchema}.mt_streams where {streamsWhere};
     end if;
 ";
 
@@ -206,8 +212,7 @@ DECLARE
 	seq {intType};
     actual_tenant varchar;
 	return_value {returnType};{sequenceDecl}
-BEGIN{sequenceResolveUpFront}
-	select version, is_archived into event_version, stream_is_archived from {databaseSchema}.mt_streams where {streamsWhere};{expectedVersionCheck}
+BEGIN{sequenceResolveUpFront}{expectedVersionCheck}
 	if event_version IS NULL then
 		event_version = 0;
 		insert into {databaseSchema}.mt_streams (id, type, version, timestamp, tenant_id) values (stream, stream_type, 0, now(), tenantid);

--- a/src/Marten/Events/Schema/QuickAppendEventFunction.cs
+++ b/src/Marten/Events/Schema/QuickAppendEventFunction.cs
@@ -182,16 +182,16 @@ namespace Marten.Events.Schema;
             var expectedVersionParamType = _events.EnableBigIntEvents ? "bigint" : "integer";
             var expectedVersionParameter =
                 $", expected_version {expectedVersionParamType} DEFAULT NULL::{expectedVersionParamType}";
+            var occVersionSelect = _events.UseExclusiveLockOnConcurrentAppends
+                ? $"select version, is_archived into event_version, stream_is_archived from {databaseSchema}.mt_streams where {streamsWhere} for update;"
+                : $"select version, is_archived into event_version, stream_is_archived from {databaseSchema}.mt_streams where {streamsWhere};";
             var expectedVersionCheck = $@"
     if expected_version IS NOT NULL then
-        -- FOR UPDATE serialises concurrent OCC writers on the same stream: the loser
-        -- blocks until the winner commits, reads the updated version, and raises MT003
-        -- *before* nextval() fires -- closing the sequence gap that stalls the daemon.
-        select version, is_archived into event_version, stream_is_archived from {databaseSchema}.mt_streams where {streamsWhere} for update;
         -- COALESCE turns the NULL we get for a brand-new stream into 0, so a
         -- FetchForWriting against a non-existent stream (which sets
         -- ExpectedVersionOnServer = 0) and a StartStream(id, version: 0) both
         -- land on the new-stream branch instead of mis-firing the guard.
+        {occVersionSelect}
         if COALESCE(event_version, 0) != expected_version then
             RAISE EXCEPTION 'Stream version mismatch on ''%'': expected %, actual %', stream, expected_version, COALESCE(event_version, 0) USING ERRCODE = 'MT003';
         end if;


### PR DESCRIPTION
Description:

 ## Problem
 
 After #4765 fixed the *sequential* OCC gap (two saves on the same session, one
 after the other), a second race remained under truly concurrent writes.
 
 When two transactions both use `FetchForWriting` + Quick append mode against the
 same stream, READ COMMITTED allows both to pass the `SELECT version` check in
 `mt_quick_append_events` before either commits. Both then call `nextval()`, one
 inserts successfully, and the other fails with a `23505` on
 `pk_mt_events_stream_and_version`. Because PostgreSQL sequences are
 non-transactional, the loser's `nextval()` is never rolled back — leaving a
 permanent gap between `mt_events_sequence` and the highest committed `seq_id`.
 The async daemon's high-water mark can never reach the sequence value, so every
 `QueryForNonStaleData` call waits until timeout.
 
 ## Fix
 
 Add `FOR UPDATE` to the `SELECT version FROM mt_streams` — but **only in the OCC
 path** (`expected_version IS NOT NULL`):
 
 ```sql
 if expected_version IS NOT NULL then
     -- Loser blocks here until winner commits, then reads the updated
     -- version and raises MT003 *before* nextval() fires.
     select version, is_archived into event_version, stream_is_archived
     from mt_streams where ... for update;
     if COALESCE(event_version, 0) != expected_version then
         RAISE EXCEPTION ... USING ERRCODE = 'MT003';
     end if;
 else
     select version, is_archived into event_version, stream_is_archived
     from mt_streams where ...;  -- unchanged, no extra locking
 end if;

The loser now blocks at the SELECT until the winner commits, reads version N+1,
and raises MT003 before any nextval() call — no gap.

Non-OCC appends (StartStream, plain AppendMany) use the original SELECT
and are completely unaffected.

Test

Added concurrent_occ_appends_to_same_stream_leave_no_sequence_gap to
Bug_4765_quick_occ_no_sequence_gap. Uses a System.Threading.Barrier with
dedicated OS threads to release three SaveChangesAsync calls simultaneously,
reliably triggering the DB-level race. Asserts last_value == max committed seq_id (no gap), exactly 1 winner and 2 ConcurrencyException losers.