### PR TITLE
#4772: verify SubscriptionDescriptor carries ImplementationType/AggregateType

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,13 +69,17 @@
     <!-- JasperFx 2.12.0: dead-letter row drill-in (IEventDatabase.QueryDeadLetterEventsAsync) +
          DeadLetterEvent.TenantId + tenant-aware daemon PauseShardAsync/rebuild fan-out (jasperfx#453).
          Marten implements QueryDeadLetterEventsAsync + per-tenant FetchDeadLetterCountsAsync below. -->
-    <PackageVersion Include="JasperFx" Version="2.13.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.13.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.1">
+    <!-- JasperFx 2.13.2: jasperfx#464 — SubscriptionDescriptor carries ImplementationType +
+         AggregateType (TypeDescriptor), populated in the shared
+         SubscriptionDescriptor(ISubscriptionSource, IEventStore) ctor that Marten's projections
+         funnel through via ProjectionGraph.Describe. See marten#4772. -->
+    <PackageVersion Include="JasperFx" Version="2.13.2" />
+    <PackageVersion Include="JasperFx.Events" Version="2.13.2" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.13.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.13.2" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/generating_event_store_descriptors.cs
+++ b/src/EventSourcingTests/generating_event_store_descriptors.cs
@@ -2,11 +2,14 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using EventSourcingTests.Aggregation;
 using EventSourcingTests.FetchForWriting;
 using EventSourcingTests.Projections;
+using JasperFx.Descriptors;
 using JasperFx.Events;
 using JasperFx.Events.Projections;
 using Marten;
+using Marten.Events.Aggregation;
 using Marten.Events.Projections;
 using Marten.Storage;
 using Marten.Testing.Harness;
@@ -46,6 +49,48 @@ public class generating_event_store_descriptors
 
         usage.Subscriptions.Count.ShouldBe(4);
         usage.Events.Any().ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task subscription_descriptors_carry_implementation_and_aggregate_types()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DatabaseSchemaName = "descriptor_enrichment";
+
+                    opts.Projections.Snapshot<SimpleAggregate>(SnapshotLifecycle.Async);
+                    opts.Projections.Add<LapMultiStreamProjection>(ProjectionLifecycle.Inline);
+                    opts.Projections.Add<MyAggregateProjection>(ProjectionLifecycle.Inline);
+                });
+            }).StartAsync();
+
+        var capability = host.Services.GetRequiredService<IEventStore>();
+        var usage = await capability.TryCreateUsage(CancellationToken.None);
+
+        usage.ShouldNotBeNull();
+
+        // A registered multi-stream projection carries the concrete projection type as
+        // ImplementationType, plus the aggregate/document type it projects into.
+        var multiStream = usage.Subscriptions.Single(x =>
+            x.ImplementationType == TypeDescriptor.For(typeof(LapMultiStreamProjection)));
+        multiStream.AggregateType.ShouldBe(TypeDescriptor.For(typeof(Lap)));
+
+        // A user-defined SingleStreamProjection<T> subclass carries its own type as the
+        // ImplementationType and the aggregate type T as AggregateType.
+        var singleStream = usage.Subscriptions.Single(x =>
+            x.ImplementationType == TypeDescriptor.For(typeof(MyAggregateProjection)));
+        singleStream.AggregateType.ShouldBe(TypeDescriptor.For(typeof(MyAggregate)));
+
+        // A Snapshot<T> is implemented by Marten's SingleStreamProjection<T, TId> and carries
+        // the aggregate type T as AggregateType.
+        var snapshot = usage.Subscriptions.Single(x =>
+            x.AggregateType == TypeDescriptor.For(typeof(SimpleAggregate)));
+        snapshot.ImplementationType.ShouldBe(
+            TypeDescriptor.For(typeof(SingleStreamProjection<SimpleAggregate, Guid>)));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #4772

## What

JasperFx.Events 2.13.2 enriches the shared `SubscriptionDescriptor(ISubscriptionSource, IEventStore)` ctor with `ImplementationType` + `AggregateType` (`TypeDescriptor`). Marten's projections funnel through that ctor via `ProjectionGraph.Describe`, so **no Marten production code change is required**. This PR adds the verification/regression guard the issue asks for, so the descriptor enrichment can't silently regress for the descriptors Marten produces.

## Changes

- Bump all four JasperFx pins `2.13.0` → `2.13.2` to consume the enrichment (additive between those versions: `EventStoreUsage.DisplayName` + the descriptor `ImplementationType`/`AggregateType` fields).
- Add `subscription_descriptors_carry_implementation_and_aggregate_types` to `src/EventSourcingTests/generating_event_store_descriptors.cs`:
  - A registered **multi-stream projection** → `ImplementationType == TypeDescriptor.For(typeof(LapMultiStreamProjection))`, `AggregateType == TypeDescriptor.For(typeof(Lap))`.
  - A user-defined **`SingleStreamProjection<T>` subclass** → `ImplementationType == TypeDescriptor.For(typeof(MyAggregateProjection))`, `AggregateType == TypeDescriptor.For(typeof(MyAggregate))`.
  - A **`Snapshot<T>`** → `ImplementationType == TypeDescriptor.For(typeof(SingleStreamProjection<SimpleAggregate, Guid>))`, `AggregateType == TypeDescriptor.For(typeof(SimpleAggregate))`.

## Verification

`EventSourcingTests` `generating_event_store_descriptors` (3 tests) green locally on net10.0 against published JasperFx.Events 2.13.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)