### PR TITLE
Implement IDocumentStoreDiagnostics + enrich mapping descriptor (9.11.0-alpha.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.10.0</Version>
+        <Version>9.11.0-alpha.1</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,8 +73,8 @@
          AggregateType (TypeDescriptor), populated in the shared
          SubscriptionDescriptor(ISubscriptionSource, IEventStore) ctor that Marten's projections
          funnel through via ProjectionGraph.Describe. See marten#4772. -->
-    <PackageVersion Include="JasperFx" Version="2.13.2" />
-    <PackageVersion Include="JasperFx.Events" Version="2.13.2" />
+    <PackageVersion Include="JasperFx" Version="2.13.4-cwdocs" />
+    <PackageVersion Include="JasperFx.Events" Version="2.13.4-cwdocs" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,13 +73,13 @@
          AggregateType (TypeDescriptor), populated in the shared
          SubscriptionDescriptor(ISubscriptionSource, IEventStore) ctor that Marten's projections
          funnel through via ProjectionGraph.Describe. See marten#4772. -->
-    <PackageVersion Include="JasperFx" Version="2.13.4-cwdocs" />
-    <PackageVersion Include="JasperFx.Events" Version="2.13.4-cwdocs" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.13.2">
+    <PackageVersion Include="JasperFx" Version="2.14.2" />
+    <PackageVersion Include="JasperFx.Events" Version="2.14.2" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.14.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.13.2" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.14.2" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/Marten/DocumentStore.DocumentDiagnostics.cs
+++ b/src/Marten/DocumentStore.DocumentDiagnostics.cs
@@ -1,0 +1,120 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+using JasperFx.Documents;
+using Marten.Schema;
+
+namespace Marten;
+
+public partial class DocumentStore : IDocumentStoreDiagnostics
+{
+    /// <summary>
+    /// Store-agnostic, read-only document-query surface for monitoring consoles
+    /// (CritterWatch #545). Mirrors the role <see cref="JasperFx.Events.IEventStore"/>
+    /// plays for event streams: list the mapped document types, page their stored
+    /// rows as raw JSON, and fetch one by id — all without the console referencing
+    /// Marten directly. Reads the canonical <c>data</c> jsonb column straight off
+    /// the document table so the JSON matches exactly what Marten persisted.
+    /// </summary>
+    async Task<IReadOnlyList<DocumentTypeRef>> IDocumentStoreDiagnostics.DocumentTypesAsync(
+        CancellationToken token)
+    {
+        // Match TryCreateUsage: force lazy mappings to materialize before enumerating.
+        Options.Storage.BuildAllMappings();
+
+        var refs = Options.Storage.DocumentMappingsWithSchema
+            .OrderBy(x => x.Alias)
+            .Select(m => new DocumentTypeRef(m.DocumentType.FullNameInCode(), m.Alias, m.DatabaseSchemaName))
+            .ToList();
+
+        return await Task.FromResult<IReadOnlyList<DocumentTypeRef>>(refs).ConfigureAwait(false);
+    }
+
+    async Task<DocumentQueryResult> IDocumentStoreDiagnostics.QueryDocumentsAsync(
+        string documentTypeName, DocumentQueryOptions options, CancellationToken token)
+    {
+        var mapping = ResolveMappingForDiagnostics(documentTypeName);
+        if (mapping == null)
+        {
+            return new DocumentQueryResult(Array.Empty<string>(), 0, options.PageNumber, options.PageSize);
+        }
+
+        var table = mapping.TableName.QualifiedName;
+        var where = options.IdEquals != null ? " where id::text = @id" : "";
+
+        var pageNumber = Math.Max(1, options.PageNumber);
+        var pageSize = Math.Max(1, options.PageSize);
+        var offset = (pageNumber - 1) * pageSize;
+
+        await using var conn = Tenancy.Default.Database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        long total;
+        await using (var countCmd = conn.CreateCommand())
+        {
+            countCmd.CommandText = $"select count(*) from {table}{where}";
+            if (options.IdEquals != null)
+            {
+                countCmd.Parameters.AddWithValue("id", options.IdEquals);
+            }
+
+            total = Convert.ToInt64(await countCmd.ExecuteScalarAsync(token).ConfigureAwait(false));
+        }
+
+        var rows = new List<string>();
+        await using (var cmd = conn.CreateCommand())
+        {
+            // data::text guarantees the jsonb column comes back as JSON text.
+            cmd.CommandText = $"select data::text from {table}{where} order by id limit {pageSize} offset {offset}";
+            if (options.IdEquals != null)
+            {
+                cmd.Parameters.AddWithValue("id", options.IdEquals);
+            }
+
+            await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+            while (await reader.ReadAsync(token).ConfigureAwait(false))
+            {
+                rows.Add(reader.GetString(0));
+            }
+        }
+
+        return new DocumentQueryResult(rows, total, pageNumber, pageSize);
+    }
+
+    async Task<string?> IDocumentStoreDiagnostics.LoadDocumentJsonAsync(
+        string documentTypeName, string id, CancellationToken token)
+    {
+        var mapping = ResolveMappingForDiagnostics(documentTypeName);
+        if (mapping == null)
+        {
+            return null;
+        }
+
+        var table = mapping.TableName.QualifiedName;
+
+        await using var conn = Tenancy.Default.Database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"select data::text from {table} where id::text = @id limit 1";
+        cmd.Parameters.AddWithValue("id", id);
+
+        var result = await cmd.ExecuteScalarAsync(token).ConfigureAwait(false);
+        return result == null || result is DBNull ? null : (string)result;
+    }
+
+    private DocumentMapping? ResolveMappingForDiagnostics(string documentTypeName)
+    {
+        Options.Storage.BuildAllMappings();
+
+        return Options.Storage.DocumentMappingsWithSchema.FirstOrDefault(m =>
+            string.Equals(m.DocumentType.FullNameInCode(), documentTypeName, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(m.DocumentType.FullName, documentTypeName, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(m.DocumentType.Name, documentTypeName, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(m.Alias, documentTypeName, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Marten/DocumentStore.DocumentStoreUsage.cs
+++ b/src/Marten/DocumentStore.DocumentStoreUsage.cs
@@ -8,6 +8,7 @@ using JasperFx.Descriptors;
 using JasperFx.Events;
 using Marten.Schema;
 using Weasel.Core.Migrations;
+using Weasel.Postgresql.Tables.Partitioning;
 
 namespace Marten;
 
@@ -74,9 +75,32 @@ public partial class DocumentStore : IDocumentStoreUsageSource
             UseOptimisticConcurrency = mapping.UseOptimisticConcurrency,
             UseNumericRevisions = mapping.UseNumericRevisions,
             SubClassCount = mapping.SubClasses.Count(),
+            SubClasses = mapping.SubClasses.Select(x => TypeDescriptor.For(x.DocumentType)).ToArray(),
             PartitioningStrategy = mapping.Partitioning?.GetType().Name,
+            Partitioning = BuildPartitioning(mapping.Partitioning),
             Ddl = ddl,
         };
+    }
+
+    private static PartitioningDescriptor? BuildPartitioning(IPartitionStrategy? partitioning)
+    {
+        if (partitioning == null)
+        {
+            return null;
+        }
+
+        // "ListPartitioning" -> "List", "HashPartitioning" -> "Hash", etc.
+        var strategy = partitioning.GetType().Name.Replace("Partitioning", "");
+
+        var names = partitioning switch
+        {
+            ListPartitioning list => list.Partitions.Select(x => x.Suffix).ToArray(),
+            RangePartitioning range => range.Ranges.Select(x => x.Suffix).ToArray(),
+            HashPartitioning hash => hash.Suffixes,
+            _ => Array.Empty<string>()
+        };
+
+        return new PartitioningDescriptor { Strategy = strategy, PartitionNames = names };
     }
 
     private string WriteSchemaCreationDdl(DocumentMapping mapping)

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx;
+using JasperFx.Documents;
 using JasperFx.MultiTenancy;
 using JasperFx.CommandLine;
 using JasperFx.CommandLine.Descriptions;
@@ -215,6 +216,8 @@ public static class MartenServiceCollectionExtensions
         services.AddSingleton<IEventStore>(s => (IEventStore)s.GetRequiredService<IDocumentStore>());
         services.AddSingleton<IDocumentStoreUsageSource>(s =>
             (IDocumentStoreUsageSource)s.GetRequiredService<IDocumentStore>());
+        services.AddSingleton<IDocumentStoreDiagnostics>(s =>
+            (IDocumentStoreDiagnostics)s.GetRequiredService<IDocumentStore>());
 
         var instrument = new SetEventStoreInstrumentation();
         services.AddSingleton<IConfigureMarten>(instrument);
@@ -332,6 +335,7 @@ public static class MartenServiceCollectionExtensions
 
         services.AddSingleton<IEventStore>(s => (IEventStore)s.GetRequiredService<T>());
         services.AddSingleton<IDocumentStoreUsageSource>(s => (IDocumentStoreUsageSource)s.GetRequiredService<T>());
+        services.AddSingleton<IDocumentStoreDiagnostics>(s => (IDocumentStoreDiagnostics)s.GetRequiredService<T>());
 
         var instrument = new SetEventStoreInstrumentation<T>();
         services.AddSingleton<IConfigureMarten<T>>(instrument);


### PR DESCRIPTION
Adopts the document-diagnostics surface from **JasperFx 2.14.0** (JasperFx/jasperfx#469). Companion: JasperFx/polecat#209. Consumer: JasperFx/CritterWatch#545.

## Changes
- `DocumentStore` implements `JasperFx.Documents.IDocumentStoreDiagnostics` — list mapped document types, page their stored rows as raw JSON (read straight off the canonical `data` jsonb column), and fetch one by id. Registered in DI for the main store and ancillary stores, mirroring `IDocumentStoreUsageSource`.
- `BuildMappingDescriptor` populates `DocumentMappingDescriptor.SubClasses` (subclass document types) and the structured `PartitioningDescriptor` (strategy + partition suffixes from the Weasel List/Hash/Range strategies).
- JasperFx family pinned to 2.14.0; version → 9.11.0-alpha.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)