### PR TITLE
Fix #4761 follow-up: WaitForNonStaleData global-shard fallback under tenant partitioning (9.11.0-alpha.2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.11.0-alpha.1</Version>
+        <Version>9.11.0-alpha.2</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/src/Marten/Events/AsyncProjectionTestingExtensions.cs
+++ b/src/Marten/Events/AsyncProjectionTestingExtensions.cs
@@ -194,11 +194,6 @@ public static class TestingExtensions
 
         bool isCaughtUp(IReadOnlyList<ShardState> rows)
         {
-            if (!perTenant)
-            {
-                return rows.Count >= projectionsCount && rows.All(x => x.Sequence >= initial.EventSequenceNumber);
-            }
-
             // #4761: under per-tenant event partitioning each tenant has its own mt_events_sequence, so a
             // single store-global "initial" cannot be the bar for every progression row — a tenant with
             // fewer events legitimately tops out below the global max, and comparing its rows against the
@@ -209,9 +204,21 @@ public static class TestingExtensions
                 .Where(x => x.ShardName.StartsWith(hw + ":", StringComparison.Ordinal))
                 .ToDictionary(x => x.ShardName.Substring(hw.Length + 1), x => x.Sequence);
 
-            // Nothing established yet, or the leading tenant has not reached the store-wide high-water —
-            // keep waiting so we never report "caught up" before the daemon has actually done the work.
-            if (tenantHighWater.Count == 0 || tenantHighWater.Values.Max() < initial.EventSequenceNumber)
+            // The per-tenant bar only applies when the daemon actually distributes a shard PER TENANT and
+            // therefore records per-tenant high-water rows (HighWaterMark:<tenant>). A single agent that
+            // spans every tenant partition — the common "<shard>:All" case, including Wolverine-managed
+            // event-subscription distribution — records ONE global HighWaterMark plus one global
+            // shard-progress row and no per-tenant rows. #4761's bar then has no high-water rows to check
+            // and waits forever (#4761 follow-up). Fall back to the store-global check, which is exactly
+            // the pre-#4761 behaviour for that shape.
+            if (!perTenant || tenantHighWater.Count == 0)
+            {
+                return rows.Count >= projectionsCount && rows.All(x => x.Sequence >= initial.EventSequenceNumber);
+            }
+
+            // The leading tenant has not reached the store-wide high-water yet — keep waiting so we never
+            // report "caught up" before the daemon has actually done the work.
+            if (tenantHighWater.Values.Max() < initial.EventSequenceNumber)
             {
                 return false;
             }


### PR DESCRIPTION
## Problem
#4761 made `WaitForNonStaleDataAsync` per-tenant aware under `UseTenantPartitionedEvents` — it requires each registered projection shard to catch its own tenant up to that tenant's `HighWaterMark:<tenant>` mark. That's correct only when the daemon distributes a shard **per tenant** and records per-tenant high-water rows.

A single async projection over one database yields exactly **one** agent (`<shard>:All`) spanning every tenant partition — the per-(shard×database) granularity case, including **Wolverine-managed event-subscription distribution**. That records one **global** `HighWaterMark` + one global shard-progress row and **no** per-tenant rows, so #4761's bar had no high-water rows to check and returned `false` forever (`projections timed out before reaching the initial sequence of 1`).

Regressed in **9.9.1**; 9.9.0 and earlier passed. Surfaced by Wolverine adopting Marten 9.10+ (its `tenant_partitioned_distribution_granularity.the_single_shard_projects_every_tenant_partition`).

## Fix
When there are no per-tenant `HighWaterMark:<tenant>` rows, fall back to the store-global check (`rows.Count >= projectionsCount && all sequences >= initial`) — exactly the pre-#4761 behaviour for that shape. The per-tenant path is unchanged when per-tenant rows exist.

## Validation
- Marten **TenantPartitionedEventsTests 192/192** (per-tenant path unchanged).
- Wolverine `tenant_partitioned_distribution_granularity` now **passes** (was timing out 70s).
- Bisect: 9.8.0/9.8.2/9.9.0 pass, 9.9.1/9.10.0 fail → #4761.

Version → 9.11.0-alpha.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)