### PR TITLE
Range-partition a document table by a non-tenant date column (#4779)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -140,7 +140,9 @@
          9.1.5 (marten#4713): the additive reconcile now SAVES/RESTORES IgnorePartitionsInMigration
          instead of permanently clearing it on the shared DocumentTable singleton, so a re-apply after
          tenant provisioning stays idempotent (no 42P07 / no rebuild). -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.2.1" />
+    <!-- 9.3.0 (marten#4779 / weasel#318): RANGE partition bound round-trip fix so date-keyed (and
+         quoted/integer) partitions no longer drift into a destructive rebuild on every migration. -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.3.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/docs/cSpell.json
+++ b/docs/cSpell.json
@@ -105,6 +105,7 @@
     "ngram",
     "ngrams",
     "pgcrypto",
+    "partman",
     "pgvector",
     "Ollama",
     "Jeremie",

--- a/docs/documents/storage.md
+++ b/docs/documents/storage.md
@@ -169,3 +169,53 @@ var store = DocumentStore.For(opts =>
 ```
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Partitioning/partitioning_documents_on_duplicate_fields.cs#L35-L86' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_configuring_partitioning_by_document_member' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+### Time-based Retention with Date Range Partitioning
+
+A common use case is a high volume, append-only document table — think metrics, telemetry, or audit
+samples — where retention is time based. By range-partitioning the table on a duplicated `DateTime` or
+`DateTimeOffset` member, you turn "delete everything older than N months" into an instant
+`DROP TABLE partition` instead of a large `DELETE` that bloats the table and forces vacuum churn.
+
+Declare the monthly (or daily, weekly, etc.) partitions up front and let Marten manage them:
+
+<!-- snippet: sample_partitioning_document_by_date_range -->
+<a id='snippet-sample_partitioning_document_by_date_range'></a>
+```cs
+opts.Schema.For<MetricsSample>()
+    .Duplicate(x => x.BucketEnd)
+    .PartitionOn(x => x.BucketEnd, x =>
+    {
+        x.ByRange()
+            .AddRange("2026_01",
+                new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero))
+            .AddRange("2026_02",
+                new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero));
+    });
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Partitioning/Bug_4779_partition_document_by_date.cs#L53-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_partitioning_document_by_date_range' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: tip
+Because PostgreSQL renders `timestamptz` partition bounds in the session time zone, always express your
+range boundaries as explicit instants (use `DateTimeOffset` values, or UTC `DateTime` values). Marten and
+Weasel compare the declared bounds against the database by instant, so the partitions stay stable across
+deployments and across servers configured with different time zones.
+:::
+
+More commonly for time-series data, teams roll partitions forward with a scheduler or
+[pg_partman](https://github.com/pgpartman/pg_partman) rather than declaring every partition up front. Use
+the externally managed variant so Marten creates the partitioned parent table but leaves the individual
+partitions alone:
+
+<!-- snippet: sample_partitioning_document_by_date_externally_managed -->
+<a id='snippet-sample_partitioning_document_by_date_externally_managed'></a>
+```cs
+opts.Schema.For<MetricsSample>()
+    .Duplicate(x => x.BucketEnd)
+    .PartitionOn(x => x.BucketEnd, x => x.ByExternallyManagedRangePartitions());
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/CoreTests/Partitioning/Bug_4779_partition_document_by_date.cs#L76-L82' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_partitioning_document_by_date_externally_managed' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->

--- a/src/CoreTests/Partitioning/Bug_4779_partition_document_by_date.cs
+++ b/src/CoreTests/Partitioning/Bug_4779_partition_document_by_date.cs
@@ -1,0 +1,146 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tables.Partitioning;
+using Xunit;
+
+namespace CoreTests.Partitioning;
+
+public class MetricsSample
+{
+    public Guid Id { get; set; }
+
+    // A duplicated, indexed timestamp used as the range partition key for time-based retention.
+    public DateTimeOffset BucketEnd { get; set; }
+
+    public double Value { get; set; }
+}
+
+/// <summary>
+/// #4779 — range-partition a single-tenant document table by an arbitrary (non-tenant) DateTimeOffset
+/// column, the classic time-series retention pattern. The public entry point already exists
+/// (<see cref="Marten.MartenRegistry.DocumentMappingExpression{T}.PartitionOn"/>); these tests pin the
+/// date-keyed scenario and, critically, that a Marten-managed monthly range does not drift on re-apply
+/// (which depended on the Weasel partition-bound round-trip fix).
+/// </summary>
+public class Bug_4779_partition_document_by_date: IAsyncLifetime
+{
+    private readonly string _schema = "bug4779_p" + Environment.ProcessId;
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync(_schema); } catch { }
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private DocumentStore BuildManagedStore() => (DocumentStore)DocumentStore.For(opts =>
+    {
+        opts.Connection(ConnectionSource.ConnectionString);
+        opts.DatabaseSchemaName = _schema;
+
+        #region sample_partitioning_document_by_date_range
+
+        opts.Schema.For<MetricsSample>()
+            .Duplicate(x => x.BucketEnd)
+            .PartitionOn(x => x.BucketEnd, x =>
+            {
+                x.ByRange()
+                    .AddRange("2026_01",
+                        new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                        new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero))
+                    .AddRange("2026_02",
+                        new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero),
+                        new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero));
+            });
+
+        #endregion
+    });
+
+    private DocumentStore BuildExternallyManagedStore() => (DocumentStore)DocumentStore.For(opts =>
+    {
+        opts.Connection(ConnectionSource.ConnectionString);
+        opts.DatabaseSchemaName = _schema;
+
+        #region sample_partitioning_document_by_date_externally_managed
+
+        opts.Schema.For<MetricsSample>()
+            .Duplicate(x => x.BucketEnd)
+            .PartitionOn(x => x.BucketEnd, x => x.ByExternallyManagedRangePartitions());
+
+        #endregion
+    });
+
+    [Fact]
+    public async Task marten_managed_monthly_range_partitioning_is_idempotent()
+    {
+        // 1. First deploy: create the partitioned table and store data into the monthly partitions.
+        await using (var store = BuildManagedStore())
+        {
+            await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+            var table = new DocumentTable(store.Options.Storage.MappingFor(typeof(MetricsSample)));
+            var partitioning = table.Partitioning.ShouldBeOfType<RangePartitioning>();
+            partitioning.Columns.Single().ShouldBe("bucket_end");
+
+            await using var session = store.LightweightSession();
+            session.Store(new MetricsSample
+            {
+                Id = Guid.NewGuid(), BucketEnd = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero), Value = 1
+            });
+            session.Store(new MetricsSample
+            {
+                Id = Guid.NewGuid(), BucketEnd = new DateTimeOffset(2026, 2, 10, 6, 0, 0, TimeSpan.Zero), Value = 2
+            });
+            await session.SaveChangesAsync();
+        }
+
+        // 2. Second deploy (nothing changed): the diff must be None. Before the Weasel round-trip fix
+        // the declared DateTimeOffset bounds never matched PostgreSQL's echoed-back literals, so every
+        // startup reported a destructive partition rebuild.
+        await using (var store = BuildManagedStore())
+        {
+            var migration = await store.Storage.CreateMigrationAsync();
+            migration.Difference.ShouldBe(SchemaPatchDifference.None,
+                "Re-applying an unchanged date-range-partitioned document table must not diff as a change");
+
+            await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+        }
+
+        // 3. Data survived and is queryable.
+        await using (var store = BuildManagedStore())
+        {
+            await using var session = store.QuerySession();
+            (await session.Query<MetricsSample>().CountAsync()).ShouldBe(2);
+        }
+    }
+
+    [Fact]
+    public async Task externally_managed_range_partitioning_by_date()
+    {
+        await using var store = BuildExternallyManagedStore();
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        var table = new DocumentTable(store.Options.Storage.MappingFor(typeof(MetricsSample)));
+        var partitioning = table.Partitioning.ShouldBeOfType<RangePartitioning>();
+        partitioning.Columns.Single().ShouldBe("bucket_end");
+
+        // pg_partman / a scheduler owns the child partitions, so Marten leaves them alone.
+        table.IgnorePartitionsInMigration.ShouldBeTrue();
+
+        // Re-apply is a no-op: Marten never touches the externally-managed partitions.
+        var migration = await store.Storage.CreateMigrationAsync();
+        migration.Difference.ShouldBe(SchemaPatchDifference.None);
+    }
+}


### PR DESCRIPTION
Closes #4779.

## Summary

The public API the issue asks for **already exists**: `DocumentMappingExpression<T>.PartitionOn(member, cfg)` range-partitions a document table on a duplicated, caller-chosen member (not just `tenant_id`). What was missing was a working **date-keyed** path — the classic time-series retention pattern — because the underlying Weasel partition-bound comparison drifted for `timestamptz`/quoted literals and reported a **spurious, destructive partition rebuild on every migration**.

That root cause was fixed in Weasel ([JasperFx/weasel#318](https://github.com/JasperFx/weasel/pull/318), shipped in **9.3.0**): partition bounds are now compared by normalized instant rather than raw SQL literal, so date (and integer) ranges stay stable across deployments and time zones.

## Changes

- **Consume Weasel.Postgresql 9.3.0** (`Directory.Packages.props`).
- **Regression test** `src/CoreTests/Partitioning/Bug_4779_partition_document_by_date.cs`:
  - `marten_managed_monthly_range_partitioning_is_idempotent` — a `MetricsSample` table range-partitioned monthly on a duplicated `DateTimeOffset`, asserting a re-applied managed range diffs as `SchemaPatchDifference.None` (the case that depended on the Weasel fix) and that data survives.
  - `externally_managed_range_partitioning_by_date` — the `ByExternallyManagedRangePartitions()` (pg_partman / scheduler) variant the issue calls "the most useful first cut".
- **Docs**: a "Time-based Retention with Date Range Partitioning" section in `docs/documents/storage.md` (with snippets), plus `partman` added to the cSpell dictionary.

## Verification

Against the published Weasel 9.3.0: `Bug_4779` (2/2) green, and the full `CoreTests` partitioning sweep (35/35) green. The managed-idempotency test was confirmed to fail against pre-fix Weasel.

## Notes

- No new Marten API surface — this is the dependency bump + tests + docs that make the existing `PartitionOn` usable for non-tenant date partitioning.
- `ListPartition` has the same latent integer-quote drift in Weasel; left for a separate follow-up (range was the reported need).
- Polecat (SQL Server) parity is a separate follow-up per the issue.