### PR TITLE
Emit runtime event-append observations via IEventStoreInstrumentation (#4782)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,10 @@
 - **Test framework:** xUnit + Shouldly
 - **Docs:** VitePress (`docs/`)
 
+## Coding Conventions
+
+- **Naming:** Use PascalCasing for all `public` or `internal` members (types, methods, properties, fields, events). Use camelCasing for all `protected` and `private` members. (Private fields keep the conventional leading underscore, e.g. `_workTracker`.)
+
 ## Project Structure
 
 ```

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,13 +73,13 @@
          AggregateType (TypeDescriptor), populated in the shared
          SubscriptionDescriptor(ISubscriptionSource, IEventStore) ctor that Marten's projections
          funnel through via ProjectionGraph.Describe. See marten#4772. -->
-    <PackageVersion Include="JasperFx" Version="2.14.2" />
-    <PackageVersion Include="JasperFx.Events" Version="2.14.2" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.14.2">
+    <PackageVersion Include="JasperFx" Version="2.15.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.15.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.14.2" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.15.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/EventSourcingTests/event_append_observation.cs
+++ b/src/EventSourcingTests/event_append_observation.cs
@@ -2,12 +2,17 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core.Reflection;
 using JasperFx.Events;
 using Marten;
 using Marten.Events;
 using Marten.Testing.Harness;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
 using Shouldly;
+using Weasel.Postgresql;
 using Xunit;
 
 namespace EventSourcingTests;
@@ -16,19 +21,30 @@ public record DiagObservedA(string Note);
 
 public record DiagObservedB(int Amount);
 
+public class DiagDocForObservation
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = "";
+}
+
+public interface IObservationStore: IDocumentStore;
+
 /// <summary>
-/// #4782: Marten emits a runtime event-append observation through the storage-agnostic
-/// JasperFx.Events <see cref="IEventStoreInstrumentation.AppendObserver"/> after each successful
-/// SaveChanges, so lifecycle tooling (CritterWatch) can record runtime-observed "appends" edges.
+/// #4782: when <c>JasperFxOptions.EnableAdvancedTracking</c> is on, Marten auto-applies an
+/// <see cref="Marten.IDocumentSessionListener"/> that forwards each committed unit of work's appended
+/// events to the storage-agnostic <see cref="IEventStoreInstrumentation.AppendObserver"/>, so lifecycle
+/// tooling (CritterWatch) can record runtime-observed "appends" edges. Covers main and ancillary stores.
 /// </summary>
-public class event_append_observation: OneOffConfigurationsContext
+public class event_append_observation
 {
     [Fact]
     public async Task observer_receives_the_appended_events_with_metadata()
     {
-        var observed = new List<IReadOnlyList<IEvent>>();
+        using var host = await startHost("eao_basic", advancedTracking: true);
+        var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
 
-        var store = StoreOptions(opts => opts.EventGraph.AppendObserver = list => observed.Add(list));
+        var observed = new List<IReadOnlyList<IEvent>>();
+        store.Options.EventGraph.AppendObserver = list => observed.Add(list);
 
         var streamId = Guid.NewGuid();
         await using var session = store.LightweightSession();
@@ -38,7 +54,6 @@ public class event_append_observation: OneOffConfigurationsContext
         observed.Count.ShouldBe(1);
         var batch = observed.Single();
         batch.Count.ShouldBe(2);
-
         batch.ShouldAllBe(e => e.StreamId == streamId);
         batch.ShouldContain(e => e.Data is DiagObservedA);
         batch.ShouldContain(e => e.Data is DiagObservedB);
@@ -47,49 +62,65 @@ public class event_append_observation: OneOffConfigurationsContext
     }
 
     [Fact]
+    public async Task no_listener_and_no_observation_when_advanced_tracking_is_off()
+    {
+        using var host = await startHost("eao_off", advancedTracking: false);
+        var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
+
+        store.Options.Listeners.OfType<AppendEventObservationListener>().ShouldBeEmpty();
+
+        var observed = new List<IReadOnlyList<IEvent>>();
+        store.Options.EventGraph.AppendObserver = list => observed.Add(list);
+
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(Guid.NewGuid(), new DiagObservedA("ignored"));
+        await session.SaveChangesAsync();
+
+        observed.ShouldBeEmpty();
+    }
+
+    [Fact]
     public async Task observer_carries_the_stream_key_for_string_identified_streams()
     {
-        var observed = new List<IReadOnlyList<IEvent>>();
+        using var host = await startHost("eao_string", advancedTracking: true,
+            opts => opts.Events.StreamIdentity = StreamIdentity.AsString);
+        var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
 
-        var store = StoreOptions(opts =>
-        {
-            opts.Events.StreamIdentity = StreamIdentity.AsString;
-            opts.EventGraph.AppendObserver = list => observed.Add(list);
-        });
+        var observed = new List<IReadOnlyList<IEvent>>();
+        store.Options.EventGraph.AppendObserver = list => observed.Add(list);
 
         await using var session = store.LightweightSession();
         session.Events.StartStream("metrics/widget-7", new DiagObservedA("k"));
         await session.SaveChangesAsync();
 
-        var batch = observed.Single();
-        batch.ShouldAllBe(e => e.StreamKey == "metrics/widget-7");
+        observed.Single().ShouldAllBe(e => e.StreamKey == "metrics/widget-7");
     }
 
     [Fact]
     public async Task observer_carries_the_tenant_id_when_multi_tenanted()
     {
-        var observed = new List<IReadOnlyList<IEvent>>();
+        using var host = await startHost("eao_tenant", advancedTracking: true,
+            opts => opts.Events.TenancyStyle = TenancyStyle.Conjoined);
+        var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
 
-        var store = StoreOptions(opts =>
-        {
-            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
-            opts.EventGraph.AppendObserver = list => observed.Add(list);
-        });
+        var observed = new List<IReadOnlyList<IEvent>>();
+        store.Options.EventGraph.AppendObserver = list => observed.Add(list);
 
         await using var session = store.LightweightSession("acme");
         session.Events.StartStream(Guid.NewGuid(), new DiagObservedA("t"));
         await session.SaveChangesAsync();
 
-        var batch = observed.Single();
-        batch.ShouldAllBe(e => e.TenantId == "acme");
+        observed.Single().ShouldAllBe(e => e.TenantId == "acme");
     }
 
     [Fact]
     public async Task observer_does_not_fire_when_no_events_are_appended()
     {
-        var fired = false;
+        using var host = await startHost("eao_doconly", advancedTracking: true);
+        var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
 
-        var store = StoreOptions(opts => opts.EventGraph.AppendObserver = _ => fired = true);
+        var fired = false;
+        store.Options.EventGraph.AppendObserver = _ => fired = true;
 
         await using var session = store.LightweightSession();
         session.Store(new DiagDocForObservation { Id = Guid.NewGuid(), Name = "doc-only" });
@@ -101,8 +132,10 @@ public class event_append_observation: OneOffConfigurationsContext
     [Fact]
     public async Task a_throwing_observer_does_not_break_save_changes()
     {
-        var store = StoreOptions(opts =>
-            opts.EventGraph.AppendObserver = _ => throw new InvalidOperationException("boom"));
+        using var host = await startHost("eao_throw", advancedTracking: true);
+        var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
+
+        store.Options.EventGraph.AppendObserver = _ => throw new InvalidOperationException("boom");
 
         var streamId = Guid.NewGuid();
         await using var session = store.LightweightSession();
@@ -118,32 +151,23 @@ public class event_append_observation: OneOffConfigurationsContext
     }
 
     [Fact]
-    public async Task no_observer_is_a_safe_no_op()
+    public async Task observer_set_through_the_di_instrumentation_bridge_fires()
     {
-        var store = StoreOptions(_ => { });
-
-        await using var session = store.LightweightSession();
-        session.Events.StartStream(Guid.NewGuid(), new DiagObservedA("no observer"));
-
-        await Should.NotThrowAsync(async () => await session.SaveChangesAsync());
-    }
-
-    [Fact]
-    public async Task observer_set_through_the_di_instrumentation_bridge_is_wired_to_the_store()
-    {
-        var observed = new List<IReadOnlyList<IEvent>>();
+        await dropSchema("eao_bridge");
 
         var services = new ServiceCollection();
+        services.AddJasperFx(o => o.EnableAdvancedTracking = true);
         services.AddMarten(opts =>
         {
             opts.Connection(ConnectionSource.ConnectionString);
-            opts.DatabaseSchemaName = "event_append_obs_di";
+            opts.DatabaseSchemaName = "eao_bridge";
         });
 
         await using var provider = services.BuildServiceProvider();
 
-        // The consumer (e.g. a CritterWatch satellite) sets the observer on the storage-agnostic
+        // A consumer (e.g. a CritterWatch satellite) sets the observer on the storage-agnostic
         // instrumentation surface before the store is built.
+        var observed = new List<IReadOnlyList<IEvent>>();
         var instrumentation = provider.GetRequiredService<IEventStoreInstrumentation>();
         instrumentation.AppendObserver += list => observed.Add(list);
 
@@ -157,10 +181,72 @@ public class event_append_observation: OneOffConfigurationsContext
         observed.Count.ShouldBe(1);
         observed.Single().ShouldAllBe(e => e.StreamId == streamId);
     }
-}
 
-public class DiagDocForObservation
-{
-    public Guid Id { get; set; }
-    public string Name { get; set; } = "";
+    [Fact]
+    public async Task listener_is_applied_to_ancillary_stores()
+    {
+        await dropSchema("eao_anc_main");
+        await dropSchema("eao_anc_first");
+
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddJasperFx(o => o.EnableAdvancedTracking = true);
+
+                services.AddMarten(m =>
+                {
+                    m.Connection(ConnectionSource.ConnectionString);
+                    m.DatabaseSchemaName = "eao_anc_main";
+                });
+
+                services.AddMartenStore<IObservationStore>(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DatabaseSchemaName = "eao_anc_first";
+                });
+            }).StartAsync();
+
+        var ancillary = host.Services.GetRequiredService<IObservationStore>().As<DocumentStore>();
+        ancillary.Options.Listeners.OfType<AppendEventObservationListener>().ShouldNotBeEmpty();
+
+        var observed = new List<IReadOnlyList<IEvent>>();
+        ancillary.Options.EventGraph.AppendObserver = list => observed.Add(list);
+
+        var streamId = Guid.NewGuid();
+        await using var session = ancillary.LightweightSession();
+        session.Events.StartStream(streamId, new DiagObservedA("ancillary"));
+        await session.SaveChangesAsync();
+
+        observed.Count.ShouldBe(1);
+        observed.Single().ShouldAllBe(e => e.StreamId == streamId);
+    }
+
+    private static async Task<IHost> startHost(string schema, bool advancedTracking,
+        Action<StoreOptions>? configure = null)
+    {
+        await dropSchema(schema);
+
+        return await Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                if (advancedTracking)
+                {
+                    services.AddJasperFx(o => o.EnableAdvancedTracking = true);
+                }
+
+                services.AddMarten(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DatabaseSchemaName = schema;
+                    configure?.Invoke(opts);
+                });
+            }).StartAsync();
+    }
+
+    private static async Task dropSchema(string schema)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync(schema);
+    }
 }

--- a/src/EventSourcingTests/event_append_observation.cs
+++ b/src/EventSourcingTests/event_append_observation.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests;
+
+public record DiagObservedA(string Note);
+
+public record DiagObservedB(int Amount);
+
+/// <summary>
+/// #4782: Marten emits a runtime event-append observation through the storage-agnostic
+/// JasperFx.Events <see cref="IEventStoreInstrumentation.AppendObserver"/> after each successful
+/// SaveChanges, so lifecycle tooling (CritterWatch) can record runtime-observed "appends" edges.
+/// </summary>
+public class event_append_observation: OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task observer_receives_the_appended_events_with_metadata()
+    {
+        var observed = new List<IReadOnlyList<IEvent>>();
+
+        var store = StoreOptions(opts => opts.EventGraph.AppendObserver = list => observed.Add(list));
+
+        var streamId = Guid.NewGuid();
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(streamId, new DiagObservedA("hello"), new DiagObservedB(3));
+        await session.SaveChangesAsync();
+
+        observed.Count.ShouldBe(1);
+        var batch = observed.Single();
+        batch.Count.ShouldBe(2);
+
+        batch.ShouldAllBe(e => e.StreamId == streamId);
+        batch.ShouldContain(e => e.Data is DiagObservedA);
+        batch.ShouldContain(e => e.Data is DiagObservedB);
+        batch.ShouldAllBe(e => !string.IsNullOrEmpty(e.EventTypeName));
+        batch.ShouldAllBe(e => e.Timestamp != default);
+    }
+
+    [Fact]
+    public async Task observer_carries_the_stream_key_for_string_identified_streams()
+    {
+        var observed = new List<IReadOnlyList<IEvent>>();
+
+        var store = StoreOptions(opts =>
+        {
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+            opts.EventGraph.AppendObserver = list => observed.Add(list);
+        });
+
+        await using var session = store.LightweightSession();
+        session.Events.StartStream("metrics/widget-7", new DiagObservedA("k"));
+        await session.SaveChangesAsync();
+
+        var batch = observed.Single();
+        batch.ShouldAllBe(e => e.StreamKey == "metrics/widget-7");
+    }
+
+    [Fact]
+    public async Task observer_carries_the_tenant_id_when_multi_tenanted()
+    {
+        var observed = new List<IReadOnlyList<IEvent>>();
+
+        var store = StoreOptions(opts =>
+        {
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.EventGraph.AppendObserver = list => observed.Add(list);
+        });
+
+        await using var session = store.LightweightSession("acme");
+        session.Events.StartStream(Guid.NewGuid(), new DiagObservedA("t"));
+        await session.SaveChangesAsync();
+
+        var batch = observed.Single();
+        batch.ShouldAllBe(e => e.TenantId == "acme");
+    }
+
+    [Fact]
+    public async Task observer_does_not_fire_when_no_events_are_appended()
+    {
+        var fired = false;
+
+        var store = StoreOptions(opts => opts.EventGraph.AppendObserver = _ => fired = true);
+
+        await using var session = store.LightweightSession();
+        session.Store(new DiagDocForObservation { Id = Guid.NewGuid(), Name = "doc-only" });
+        await session.SaveChangesAsync();
+
+        fired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_throwing_observer_does_not_break_save_changes()
+    {
+        var store = StoreOptions(opts =>
+            opts.EventGraph.AppendObserver = _ => throw new InvalidOperationException("boom"));
+
+        var streamId = Guid.NewGuid();
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(streamId, new DiagObservedA("still committed"));
+
+        // The observer is best-effort: its failure must not surface from SaveChanges.
+        await Should.NotThrowAsync(async () => await session.SaveChangesAsync());
+
+        // ...and the events were genuinely committed.
+        await using var query = store.QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamId);
+        events.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task no_observer_is_a_safe_no_op()
+    {
+        var store = StoreOptions(_ => { });
+
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(Guid.NewGuid(), new DiagObservedA("no observer"));
+
+        await Should.NotThrowAsync(async () => await session.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task observer_set_through_the_di_instrumentation_bridge_is_wired_to_the_store()
+    {
+        var observed = new List<IReadOnlyList<IEvent>>();
+
+        var services = new ServiceCollection();
+        services.AddMarten(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "event_append_obs_di";
+        });
+
+        await using var provider = services.BuildServiceProvider();
+
+        // The consumer (e.g. a CritterWatch satellite) sets the observer on the storage-agnostic
+        // instrumentation surface before the store is built.
+        var instrumentation = provider.GetRequiredService<IEventStoreInstrumentation>();
+        instrumentation.AppendObserver += list => observed.Add(list);
+
+        var store = provider.GetRequiredService<IDocumentStore>();
+
+        var streamId = Guid.NewGuid();
+        await using var session = store.LightweightSession();
+        session.Events.StartStream(streamId, new DiagObservedA("via di"));
+        await session.SaveChangesAsync();
+
+        observed.Count.ShouldBe(1);
+        observed.Single().ShouldAllBe(e => e.StreamId == streamId);
+    }
+}
+
+public class DiagDocForObservation
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = "";
+}

--- a/src/Marten/Events/AppendEventObservationListener.cs
+++ b/src/Marten/Events/AppendEventObservationListener.cs
@@ -1,0 +1,53 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Services;
+using Npgsql;
+
+namespace Marten.Events;
+
+/// <summary>
+/// Auto-registered on a <see cref="DocumentStore"/> when <c>JasperFxOptions.EnableAdvancedTracking</c>
+/// is true (see <see cref="StoreOptions.ReadJasperFxOptions"/>). After each successful commit it
+/// forwards the events appended in that unit of work to the storage-agnostic
+/// <see cref="JasperFx.Events.IEventStoreInstrumentation.AppendObserver"/>, so lifecycle tooling such
+/// as CritterWatch can record runtime-observed "appends" edges (#4782). Best-effort: a null observer or
+/// a throwing observer never disrupts the unit of work.
+/// </summary>
+internal class AppendEventObservationListener: DocumentSessionListenerBase
+{
+    private readonly EventGraph _events;
+
+    public AppendEventObservationListener(EventGraph events)
+    {
+        _events = events;
+    }
+
+    public override Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+    {
+        var observer = _events.AppendObserver;
+        if (observer is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        var events = commit.GetEvents().ToList();
+        if (events.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        try
+        {
+            observer(events);
+        }
+        catch (Exception e)
+        {
+            session.Logger.LogFailure(new NpgsqlCommand(), e);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -242,6 +242,16 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
         set;
     }
 
+    /// <summary>
+    /// Optional best-effort observer invoked after each successful <c>SaveChangesAsync</c> with the
+    /// events that were appended in that unit of work. Backs
+    /// <see cref="JasperFx.Events.IEventStoreInstrumentation.AppendObserver"/> so storage-agnostic
+    /// lifecycle tooling (CritterWatch) can record runtime-observed "appends" edges. Each
+    /// <see cref="IEvent"/> carries its event type, stream id/key, aggregate type, tenant id, and
+    /// timestamp. See #4782.
+    /// </summary>
+    public Action<IReadOnlyList<IEvent>>? AppendObserver { get; set; }
+
 
     public bool UseArchivedStreamPartitioning { get; set; }
     public bool UseListenNotifyForEventAppends { get; set; }

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
@@ -76,39 +76,8 @@ public abstract partial class DocumentSessionBase
             await listener.AfterCommitAsync(this, _workTracker, token).ConfigureAwait(false);
         }
 
-        notifyAppendObserver();
-
         // Need to clear the unit of work here
         _workTracker.Reset();
-    }
-
-    // Best-effort notification of the storage-agnostic append observer (JasperFx.Events
-    // IEventStoreInstrumentation.AppendObserver) with the events committed in this unit of work,
-    // so lifecycle tooling such as CritterWatch can record runtime-observed "appends" edges (#4782).
-    // Runs after a successful commit and must never disrupt the unit of work, so any observer
-    // failure is logged and swallowed. _workTracker still holds the events; Reset() follows.
-    private void notifyAppendObserver()
-    {
-        var observer = Options.EventGraph.AppendObserver;
-        if (observer is null)
-        {
-            return;
-        }
-
-        var events = _workTracker.GetEvents().ToList();
-        if (events.Count == 0)
-        {
-            return;
-        }
-
-        try
-        {
-            observer(events);
-        }
-        catch (Exception e)
-        {
-            Logger.LogFailure(new NpgsqlCommand(), e);
-        }
     }
 
     private IMessageBatch? _messageBatch;

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.SaveChanges.cs
@@ -76,8 +76,39 @@ public abstract partial class DocumentSessionBase
             await listener.AfterCommitAsync(this, _workTracker, token).ConfigureAwait(false);
         }
 
+        notifyAppendObserver();
+
         // Need to clear the unit of work here
         _workTracker.Reset();
+    }
+
+    // Best-effort notification of the storage-agnostic append observer (JasperFx.Events
+    // IEventStoreInstrumentation.AppendObserver) with the events committed in this unit of work,
+    // so lifecycle tooling such as CritterWatch can record runtime-observed "appends" edges (#4782).
+    // Runs after a successful commit and must never disrupt the unit of work, so any observer
+    // failure is logged and swallowed. _workTracker still holds the events; Reset() follows.
+    private void notifyAppendObserver()
+    {
+        var observer = Options.EventGraph.AppendObserver;
+        if (observer is null)
+        {
+            return;
+        }
+
+        var events = _workTracker.GetEvents().ToList();
+        if (events.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            observer(events);
+        }
+        catch (Exception e)
+        {
+            Logger.LogFailure(new NpgsqlCommand(), e);
+        }
     }
 
     private IMessageBatch? _messageBatch;

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -1105,9 +1105,11 @@ internal class SetEventStoreInstrumentation: IConfigureMarten, IEventStoreInstru
     public void Configure(IServiceProvider services, StoreOptions options)
     {
         options.EventGraph.EnableExtendedProgressionTracking = ExtendedProgressionEnabled;
+        options.EventGraph.AppendObserver = AppendObserver;
     }
 
     public bool ExtendedProgressionEnabled { get; set; }
+    public Action<IReadOnlyList<IEvent>>? AppendObserver { get; set; }
 }
 
 internal class SetEventStoreInstrumentation<T>: IConfigureMarten<T>, IEventStoreInstrumentation where T : IDocumentStore
@@ -1115,7 +1117,9 @@ internal class SetEventStoreInstrumentation<T>: IConfigureMarten<T>, IEventStore
     public void Configure(IServiceProvider services, StoreOptions options)
     {
         options.EventGraph.EnableExtendedProgressionTracking = ExtendedProgressionEnabled;
+        options.EventGraph.AppendObserver = AppendObserver;
     }
 
     public bool ExtendedProgressionEnabled { get; set; }
+    public Action<IReadOnlyList<IEvent>>? AppendObserver { get; set; }
 }

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -347,6 +347,15 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
         if (options.EnableAdvancedTracking)
         {
             Events.EnableExtendedProgressionTracking = true;
+
+            // Forward each committed unit of work's appended events to the storage-agnostic
+            // IEventStoreInstrumentation.AppendObserver so CritterWatch can record runtime-observed
+            // "appends" edges (#4782). Applied to every store in the container (main + ancillary),
+            // since ReadJasperFxOptions runs for both.
+            if (!Listeners.OfType<AppendEventObservationListener>().Any())
+            {
+                Listeners.Add(new AppendEventObservationListener(EventGraph));
+            }
         }
     }
 


### PR DESCRIPTION
Closes #4782.

Implements the Marten side of the storage-agnostic append-observation hook added upstream in **JasperFx.Events 2.15.0** (`IEventStoreInstrumentation.AppendObserver`, jasperfx#472), so lifecycle tooling such as CritterWatch (#500) can record runtime-observed command→event→stream `appends` edges without referencing Marten directly.

## How it works

- **`EventGraph.AppendObserver`** — an `Action<IReadOnlyList<IEvent>>?` that backs the JasperFx.Events interface member; `SetEventStoreInstrumentation` (the DI bridge) copies the consumer's observer onto it at store build.
- **`AppendEventObservationListener`** — a dedicated `IDocumentSessionListener` whose `AfterCommitAsync` forwards the events committed in that unit of work (`IChangeSet.GetEvents()`) to the observer. Each `IEvent` already carries event type, stream id/key, aggregate type, tenant id, and timestamp.
- **Auto-applied when `JasperFxOptions.EnableAdvancedTracking` is `true`** — registered in the existing `StoreOptions.ReadJasperFxOptions` seam, which runs for the **main store and every ancillary store** (`AddMartenStore<T>`). When advanced tracking is off, no listener is added and nothing is observed.
- Best-effort: a null or throwing observer never disrupts the unit of work.

Bumps the four JasperFx packages 2.14.2 → 2.15.0 to consume the new abstraction.

## Consumer usage

```csharp
builder.Services.AddJasperFx(o => o.EnableAdvancedTracking = true);

// store-agnostic — references only JasperFx.Events
var instrumentation = services.GetRequiredService<IEventStoreInstrumentation>();
instrumentation.AppendObserver += events =>
{
    foreach (var e in events)
    {
        // e.EventTypeName, e.StreamId / e.StreamKey, e.TenantId, e.Timestamp, ...
    }
};
```

## Tests (`src/EventSourcingTests/event_append_observation.cs`)

Driven through the realistic `AddJasperFx(EnableAdvancedTracking) → AddMarten` DI path:

- observer receives the appended events with correct metadata;
- **no listener / no observation when advanced tracking is off**;
- carries the stream **key** for string-identified streams;
- carries the **tenant id** under conjoined multi-tenancy;
- does not fire for document-only saves;
- a throwing observer does not break `SaveChanges` (events still committed);
- observer set through the `IEventStoreInstrumentation` DI bridge fires;
- **the listener is applied to ancillary stores** (`AddMartenStore<T>`).

8/8 green on both net9.0 and net10.0.

## Also in this PR

- Documents the member-naming convention in `CLAUDE.md` (PascalCase for public/internal, camelCase for protected/private).

## Notes

- Polecat ships the symmetric implementation separately (polecat#213).
- No user-facing docs added (niche, CritterWatch-facing hook; API carries full XML docs). Happy to add a docs section if you'd like.