### PR TITLE
Fix false ConcurrencyException from non-RETURNING event ops in batched SaveChanges (#4778)

### DIFF
--- a/src/EventSourcingTests/Bug_4778_overwrite_event_with_returning_upsert.cs
+++ b/src/EventSourcingTests/Bug_4778_overwrite_event_with_returning_upsert.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests;
+
+public record Bug4778Event(string Name);
+
+public class Bug4778Projection
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = "";
+}
+
+/// <summary>
+/// #4778: mixing OverwriteEventOperation (a plain UPDATE with no RETURNING) with a RETURNING
+/// upsert (an optimistic-concurrency document) in a single SaveChanges batch throws a false
+/// ConcurrencyException. OverwriteEventOperation is not marked NoDataReturnedCall, so the
+/// OperationPage walk fires a spurious NextResultAsync() that consumes the upsert's result-set,
+/// leaving the upsert's reader exhausted.
+/// </summary>
+public class Bug_4778_overwrite_event_with_returning_upsert: OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task overwrite_events_then_occ_upsert_in_one_batch_does_not_throw()
+    {
+        StoreOptions(opts => opts.Schema.For<Bug4778Projection>().UseOptimisticConcurrency(true));
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream(streamId, new Bug4778Event("a"), new Bug4778Event("b"));
+            await session.SaveChangesAsync();
+        }
+
+        IReadOnlyList<IEvent> events;
+        await using (var query = theStore.QuerySession())
+        {
+            events = await query.Events.FetchStreamAsync(streamId);
+        }
+
+        await using (var session = theStore.LightweightSession())
+        {
+            // Mixed batch: non-RETURNING OverwriteEvent UPDATEs queued first, then a RETURNING OCC upsert.
+            foreach (var e in events)
+            {
+                session.Events.OverwriteEvent(e);
+            }
+
+            session.Store(new Bug4778Projection { Id = streamId, Name = "projected" });
+
+            // Today this throws a false ConcurrencyException.
+            await Should.NotThrowAsync(async () => await session.SaveChangesAsync());
+        }
+
+        await using (var query = theStore.QuerySession())
+        {
+            (await query.LoadAsync<Bug4778Projection>(streamId)).ShouldNotBeNull();
+        }
+    }
+}

--- a/src/Marten/Events/Daemon/Progress/DeleteProjectionProgress.cs
+++ b/src/Marten/Events/Daemon/Progress/DeleteProjectionProgress.cs
@@ -9,9 +9,11 @@ using Marten.Internal.Operations;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 
+using Marten.Services;
+
 namespace Marten.Events.Daemon.Progress;
 
-internal class DeleteProjectionProgress: IStorageOperation
+internal class DeleteProjectionProgress: IStorageOperation, NoDataReturnedCall
 {
     private readonly EventGraph _events;
     private readonly string _shardName;

--- a/src/Marten/Events/EventStore.StreamCompacting.cs
+++ b/src/Marten/Events/EventStore.StreamCompacting.cs
@@ -18,6 +18,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Weasel.Postgresql;
 
+using Marten.Services;
+
 namespace Marten.Events;
 
 internal partial class EventStore
@@ -183,7 +185,7 @@ public sealed class SampleArchiverDocumentation : IEventsArchiver<IDocumentOpera
 
 #endregion
 
-internal class DeleteEventsOperation: IStorageOperation
+internal class DeleteEventsOperation: IStorageOperation, NoDataReturnedCall
 {
     private readonly long[] _sequences;
 

--- a/src/Marten/Events/Operations/AssignTagWhereHstoreOperation.cs
+++ b/src/Marten/Events/Operations/AssignTagWhereHstoreOperation.cs
@@ -10,6 +10,8 @@ using NpgsqlTypes;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
 
+using Marten.Services;
+
 namespace Marten.Events.Operations;
 
 /// <summary>
@@ -18,7 +20,7 @@ namespace Marten.Events.Operations;
 /// a user-supplied WHERE clause. Uses the <c>hstore || hstore</c> concatenation
 /// operator so existing tags on the row are preserved.
 /// </summary>
-internal class AssignTagWhereHstoreOperation: IStorageOperation
+internal class AssignTagWhereHstoreOperation: IStorageOperation, NoDataReturnedCall
 {
     private readonly string _schemaName;
     private readonly Dictionary<string, string> _tags;

--- a/src/Marten/Events/Operations/AssignTagWhereOperation.cs
+++ b/src/Marten/Events/Operations/AssignTagWhereOperation.cs
@@ -10,6 +10,8 @@ using Marten.Internal.Operations;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
 
+using Marten.Services;
+
 namespace Marten.Events.Operations;
 
 /// <summary>
@@ -18,7 +20,7 @@ namespace Marten.Events.Operations;
 ///            SELECT @value, d.seq_id FROM schema.mt_events as d WHERE {where}
 ///            ON CONFLICT DO NOTHING
 /// </summary>
-internal class AssignTagWhereOperation: IStorageOperation
+internal class AssignTagWhereOperation: IStorageOperation, NoDataReturnedCall
 {
     private readonly string _schemaName;
     private readonly ITagTypeRegistration _registration;

--- a/src/Marten/Events/Operations/IncrementStreamVersionById.cs
+++ b/src/Marten/Events/Operations/IncrementStreamVersionById.cs
@@ -8,9 +8,11 @@ using Marten.Internal;
 using Marten.Internal.Operations;
 using Weasel.Postgresql;
 
+using Marten.Services;
+
 namespace Marten.Events.Operations;
 
-internal class IncrementStreamVersionById: IStorageOperation
+internal class IncrementStreamVersionById: IStorageOperation, NoDataReturnedCall
 {
     private readonly EventGraph _events;
 

--- a/src/Marten/Events/Operations/IncrementStreamVersionByKey.cs
+++ b/src/Marten/Events/Operations/IncrementStreamVersionByKey.cs
@@ -8,9 +8,11 @@ using Marten.Internal;
 using Marten.Internal.Operations;
 using Weasel.Postgresql;
 
+using Marten.Services;
+
 namespace Marten.Events.Operations;
 
-internal class IncrementStreamVersionByKey: IStorageOperation
+internal class IncrementStreamVersionByKey: IStorageOperation, NoDataReturnedCall
 {
     private readonly EventGraph _events;
 

--- a/src/Marten/Events/Operations/InsertEventTagByEventIdOperation.cs
+++ b/src/Marten/Events/Operations/InsertEventTagByEventIdOperation.cs
@@ -9,13 +9,15 @@ using Marten.Internal;
 using Marten.Internal.Operations;
 using Weasel.Postgresql;
 
+using Marten.Services;
+
 namespace Marten.Events.Operations;
 
 /// <summary>
 /// Inserts a tag row by looking up seq_id from the event's id.
 /// Used in Quick append mode where sequences aren't pre-assigned.
 /// </summary>
-internal class InsertEventTagByEventIdOperation: IStorageOperation
+internal class InsertEventTagByEventIdOperation: IStorageOperation, NoDataReturnedCall
 {
     private readonly string _schemaName;
     private readonly ITagTypeRegistration _registration;

--- a/src/Marten/Events/Operations/InsertEventTagOperation.cs
+++ b/src/Marten/Events/Operations/InsertEventTagOperation.cs
@@ -9,9 +9,11 @@ using Marten.Internal;
 using Marten.Internal.Operations;
 using Weasel.Postgresql;
 
+using Marten.Services;
+
 namespace Marten.Events.Operations;
 
-internal class InsertEventTagOperation: IStorageOperation
+internal class InsertEventTagOperation: IStorageOperation, NoDataReturnedCall
 {
     private readonly string _schemaName;
     private readonly ITagTypeRegistration _registration;

--- a/src/Marten/Events/Operations/SetEventTagsHstoreByEventIdOperation.cs
+++ b/src/Marten/Events/Operations/SetEventTagsHstoreByEventIdOperation.cs
@@ -9,6 +9,8 @@ using Marten.Internal.Operations;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 
+using Marten.Services;
+
 namespace Marten.Events.Operations;
 
 /// <summary>
@@ -17,7 +19,7 @@ namespace Marten.Events.Operations;
 /// Mirrors <see cref="InsertEventTagByEventIdOperation"/> but writes the tags as a
 /// single hstore concatenation against the existing row.
 /// </summary>
-internal class SetEventTagsHstoreByEventIdOperation: IStorageOperation
+internal class SetEventTagsHstoreByEventIdOperation: IStorageOperation, NoDataReturnedCall
 {
     private readonly string _schemaName;
     private readonly Guid _eventId;

--- a/src/Marten/Events/Operations/SetEventTagsHstoreOperation.cs
+++ b/src/Marten/Events/Operations/SetEventTagsHstoreOperation.cs
@@ -9,6 +9,8 @@ using Marten.Internal.Operations;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 
+using Marten.Services;
+
 namespace Marten.Events.Operations;
 
 /// <summary>
@@ -17,7 +19,7 @@ namespace Marten.Events.Operations;
 /// <c>hstore || hstore</c> concatenation operator so multiple tag writes on the same
 /// event compose correctly.
 /// </summary>
-internal class SetEventTagsHstoreOperation: IStorageOperation
+internal class SetEventTagsHstoreOperation: IStorageOperation, NoDataReturnedCall
 {
     private readonly string _schemaName;
     private readonly long _seqId;

--- a/src/Marten/Events/Protected/OverwriteEventOperation.cs
+++ b/src/Marten/Events/Protected/OverwriteEventOperation.cs
@@ -10,9 +10,11 @@ using Marten.Internal.Operations;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 
+using Marten.Services;
+
 namespace Marten.Events.Protected;
 
-internal class OverwriteEventOperation : IStorageOperation
+internal class OverwriteEventOperation : IStorageOperation, NoDataReturnedCall
 {
     private readonly EventGraph _graph;
     private readonly IEvent _e;

--- a/src/Marten/Events/Protected/ReplaceEventOperation.cs
+++ b/src/Marten/Events/Protected/ReplaceEventOperation.cs
@@ -10,9 +10,11 @@ using Marten.Internal.Operations;
 using NpgsqlTypes;
 using Weasel.Postgresql;
 
+using Marten.Services;
+
 namespace Marten.Events.Protected;
 
-internal class ReplaceEventOperation<T> : IStorageOperation where T : class
+internal class ReplaceEventOperation<T> : IStorageOperation, NoDataReturnedCall where T : class
 {
     private readonly EventGraph _graph;
     private readonly T _eventBody;


### PR DESCRIPTION
Closes #4778.

## Problem

Mixing an `OverwriteEvent` (a plain `UPDATE … mt_events`, no `RETURNING`) with a `RETURNING` upsert (e.g. an optimistic-concurrency projection document) in a single `SaveChangesAsync` throws a **false `ConcurrencyException`**, even though nothing actually conflicted. Regressed on 9.x when the closed-shape upsert (#4659) switched to inline `INSERT … ON CONFLICT … RETURNING`.

## Root cause

`OperationPage.ApplyCallbacksAsync` walks **one result-set per operation that is not `NoDataReturnedCall`** (`Postprocess` → `NextResultAsync`). Under `NpgsqlBatch`, only row-producing statements (`… RETURNING`, `SELECT`) yield result-sets — plain `UPDATE`/`DELETE`/`INSERT` produce none. `OverwriteEventOperation` issues such a non-`RETURNING` `UPDATE`, has a no-op `PostprocessAsync`, and was **not** marked `NoDataReturnedCall`, so its spurious `NextResultAsync()` consumed the *next* operation's result-set. By the time the `RETURNING` upsert ran, the reader was exhausted → `ReadAsync()` returned `false` → false `ConcurrencyException`. (`Deletion` was already marked and correctly skipped — the fix already existed for a sibling.)

Order matters: the overwrites must land before the `RETURNING` op. They do — `OverwriteEvent` queues its op immediately while `Store` builds its upsert during `SaveChanges`, and with no doc-type FK relationship the batch stays in insertion order.

## Fix

Marked every event-family operation that produces **no result-set** and has a **no-op `PostprocessAsync`** as `NoDataReturnedCall`, so the walk skips them (audited the whole family, not just the reported op):

- `OverwriteEventOperation`, `ReplaceEventOperation` (masking)
- `AssignTagWhereOperation`, `AssignTagWhereHstoreOperation`, `SetEventTagsHstoreOperation`, `SetEventTagsHstoreByEventIdOperation`, `InsertEventTagOperation`, `InsertEventTagByEventIdOperation` (tagging — all `INSERT … [SELECT] … ON CONFLICT`, no `RETURNING`)
- `IncrementStreamVersionById`, `IncrementStreamVersionByKey`
- `DeleteProjectionProgress`, `DeleteEventsOperation` (stream compaction)

Deliberately **not** marked: `DcbTagVersionAssertion` (it reads the reader), and the `RETURNING` upserts/asserts (correctly walked).

## Tests

- `Bug_4778_overwrite_event_with_returning_upsert` — the regression test (committed first as a failing repro; throws `JasperFx.ConcurrencyException` before the fix, passes after).
- Full suites green after the fix: **EventSourcingTests 1387 passed / 7 skipped**, **DocumentDbTests 999 passed / 1 skipped** (net10.0).

## Note

The deeper alternative is to make `ApplyCallbacksAsync` result-set-driven rather than operation-driven (advance only for ops that actually return data), which would immunize *all* operation families permanently. This PR takes the targeted marker fix for the event family per the issue; happy to follow up with the reader-driven walk if preferred.