### PR TITLE
feat: populate event/document metadata capabilities + tenant-scoped document diagnostics (9.12.0-alpha.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.11.0</Version>
+        <Version>9.12.0-alpha.1</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,13 +73,13 @@
          AggregateType (TypeDescriptor), populated in the shared
          SubscriptionDescriptor(ISubscriptionSource, IEventStore) ctor that Marten's projections
          funnel through via ProjectionGraph.Describe. See marten#4772. -->
-    <PackageVersion Include="JasperFx" Version="2.16.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.16.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.16.0">
+    <PackageVersion Include="JasperFx" Version="2.17.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.17.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.16.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.17.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/Marten/DocumentStore.DocumentDiagnostics.cs
+++ b/src/Marten/DocumentStore.DocumentDiagnostics.cs
@@ -5,7 +5,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
+using JasperFx.Descriptors;
 using JasperFx.Documents;
+using JasperFx.MultiTenancy;
 using Marten.Schema;
 
 namespace Marten;
@@ -44,13 +46,27 @@ public partial class DocumentStore : IDocumentStoreDiagnostics
         }
 
         var table = mapping.TableName.QualifiedName;
-        var where = options.IdEquals != null ? " where id::text = @id" : "";
 
         var pageNumber = Math.Max(1, options.PageNumber);
         var pageSize = Math.Max(1, options.PageSize);
         var offset = (pageNumber - 1) * pageSize;
 
-        await using var conn = Tenancy.Default.Database.CreateConnection();
+        // Tenant scoping (#475 / EVENT_STORE_EXPLORER_PLAN §3.1): a database-per-tenant
+        // store selects the tenant's physical database; conjoined tenancy keeps every
+        // tenant in one database with a tenant_id column we filter on.
+        var database = options.TenantId != null && Tenancy.Cardinality != DatabaseCardinality.Single
+            ? await Tenancy.FindOrCreateDatabase(options.TenantId).ConfigureAwait(false)
+            : Tenancy.Default.Database;
+        var filterByTenant = options.TenantId != null
+            && Tenancy.Cardinality == DatabaseCardinality.Single
+            && mapping.TenancyStyle == TenancyStyle.Conjoined;
+
+        var conditions = new List<string>();
+        if (options.IdEquals != null) conditions.Add("id::text = @id");
+        if (filterByTenant) conditions.Add("tenant_id = @tenant");
+        var where = conditions.Count > 0 ? " where " + string.Join(" and ", conditions) : "";
+
+        await using var conn = database.CreateConnection();
         await conn.OpenAsync(token).ConfigureAwait(false);
 
         long total;
@@ -60,6 +76,10 @@ public partial class DocumentStore : IDocumentStoreDiagnostics
             if (options.IdEquals != null)
             {
                 countCmd.Parameters.AddWithValue("id", options.IdEquals);
+            }
+            if (filterByTenant)
+            {
+                countCmd.Parameters.AddWithValue("tenant", options.TenantId!);
             }
 
             total = Convert.ToInt64(await countCmd.ExecuteScalarAsync(token).ConfigureAwait(false));
@@ -73,6 +93,10 @@ public partial class DocumentStore : IDocumentStoreDiagnostics
             if (options.IdEquals != null)
             {
                 cmd.Parameters.AddWithValue("id", options.IdEquals);
+            }
+            if (filterByTenant)
+            {
+                cmd.Parameters.AddWithValue("tenant", options.TenantId!);
             }
 
             await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);

--- a/src/Marten/DocumentStore.DocumentStoreUsage.cs
+++ b/src/Marten/DocumentStore.DocumentStoreUsage.cs
@@ -57,6 +57,21 @@ public partial class DocumentStore : IDocumentStoreUsageSource
         // Configured/Default masking, etc.).
         ApplyFlatOptionValues(usage);
 
+        // jasperfx#475 — advertise which document metadata Marten captures so
+        // store-aware consumers (CritterWatch) gate document-query facets by what is
+        // actually persisted. Version / last-modified / tenant / soft-delete are
+        // universal facets in Marten and keep the descriptor's default of true; the
+        // opt-in columns (correlation/causation/last-modified-by) are only queryable
+        // where some document mapping has enabled them.
+        var mappings = Options.Storage.DocumentMappingsWithSchema.ToList();
+        usage.DocumentMetadata = new DocumentMetadataCapabilities
+        {
+            StoreType = "Marten",
+            CorrelationId = mappings.Any(m => m.Metadata.CorrelationId.Enabled),
+            CausationId = mappings.Any(m => m.Metadata.CausationId.Enabled),
+            LastModifiedBy = mappings.Any(m => m.Metadata.LastModifiedBy.Enabled)
+        };
+
         return usage;
     }
 

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -565,6 +565,23 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
             usage.GlobalAggregates.Add(TypeDescriptor.For(aggregateType));
         }
 
+        // jasperfx#475 — advertise WHICH event/stream metadata this store captures
+        // so store-aware consumers (CritterWatch) can gate query facets by what is
+        // actually persisted, rather than sniffing Marten's MetadataConfig directly.
+        // The event flags are opt-in columns and map straight off MetadataConfig.
+        // The stream flags are universal in Marten (mt_streams always exposes the
+        // aggregate-type / version / created+updated / tenant / archived columns),
+        // so they keep the EventMetadataCapabilities defaults of true.
+        var metadata = Options.EventGraph.MetadataConfig;
+        usage.EventMetadata = new EventMetadataCapabilities
+        {
+            StoreType = "Marten",
+            CorrelationId = metadata.CorrelationIdEnabled,
+            CausationId = metadata.CausationIdEnabled,
+            Headers = metadata.HeadersEnabled,
+            UserName = metadata.UserNameEnabled
+        };
+
         return usage;
     }
 


### PR DESCRIPTION
Implements the JasperFx 2.17.0 monitoring-descriptor surfaces for store-aware consoles (CritterWatch). Part of the Event Store / Document Store Explorer work.

## Changes
- Populate `EventStoreUsage.EventMetadata` (from the event `MetadataConfig`) and `DocumentStoreUsage.DocumentMetadata` (from per-document metadata) in the store usage descriptors (jasperfx#475) — so a console can gate query facets by what the store actually captures.
- Tenant-scope `IDocumentStoreDiagnostics.QueryDocumentsAsync` via `DocumentQueryOptions.TenantId`: database-per-tenant resolves the tenant database (`Tenancy.FindOrCreateDatabase`); conjoined tenancy filters the `tenant_id` column; null keeps the prior default-tenant behaviour.
- Bump to **9.12.0-alpha.1**; `JasperFx.*` pins → **2.17.0**.

## Depends on
**JasperFx 2.17.0** (JasperFx/jasperfx#477) — the abstraction + `DocumentQueryOptions.TenantId`. Publish that first; CI here stays red until 2.17.0 is on NuGet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
