### PR TITLE
Per-tenant agent distribution, database-affine assignment + order-preserving streaming bulk import (wolverine#3280, #4806)

### DIFF
--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -467,14 +467,9 @@ opts.Events.UseTenantPartitionedEvents = true;
 
 // Group a shard database's per-tenant agents onto a single node (opt-in, default off).
 opts.Events.UseDatabaseAffineAgentAssignment = true;
-
-// Bounded fan-out ("the mix"): let one shard database's agents spread across up to N nodes for
-// more parallelism (default 1 = strict affinity). Choose N so databases × N × pool stays under
-// the server's max_connections. Surfaced as IEventStore.MaxNodesPerDatabaseForAgents (clamped to >= 1).
-opts.Events.DatabaseAffineAgentFanout = 2;
 ```
 
-These options only take effect for a sharded, per-tenant-partitioned store driven by a distribution-aware host; on any
+This option only takes effect for a sharded, per-tenant-partitioned store driven by a distribution-aware host; on any
 other store `IEventStore.GroupAgentAssignmentsByDatabase` stays `false` and distribution is unchanged.
 
 ## Dynamically applying changes to tenants databases

--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -449,6 +449,34 @@ runs asynchronous projections across all of them. When new databases or tenants 
 the daemon's periodic health check picks them up and starts projection processing without any
 downtime or reconfiguration.
 
+#### Node-Distributed Daemons and Connection Fan-out
+
+When the sharded model is combined with [per-tenant event partitioning](/events/multitenancy#per-tenant-event-partitioning)
+and a node-distributed async daemon (e.g. [Wolverine-managed event subscription distribution](https://wolverinefx.net/guide/durability/marten/distribution.html)),
+the daemon fans agents out one-per-`(shard, tenant)` — a single store-global high-water mark cannot track tenants whose
+independent sequences overlap. Marten reports this to the host through `IEventStore.DistributesAgentsPerTenant`.
+
+With many tenants spread across many shard databases, distributing those per-tenant agents *evenly* by count makes every
+node open a connection pool to nearly every shard database, so the pool count grows as `nodes × databases` and can exhaust
+a shared server's `max_connections`. Opt into **database-affine assignment** so a host keeps a shard database's agents
+together on one node — each node then only connects to the databases it owns, and pools scale with the number of shard
+databases rather than `nodes × databases`:
+
+```cs
+opts.Events.UseTenantPartitionedEvents = true;
+
+// Group a shard database's per-tenant agents onto a single node (opt-in, default off).
+opts.Events.UseDatabaseAffineAgentAssignment = true;
+
+// Bounded fan-out ("the mix"): let one shard database's agents spread across up to N nodes for
+// more parallelism (default 1 = strict affinity). Choose N so databases × N × pool stays under
+// the server's max_connections. Surfaced as IEventStore.MaxNodesPerDatabaseForAgents (clamped to >= 1).
+opts.Events.DatabaseAffineAgentFanout = 2;
+```
+
+These options only take effect for a sharded, per-tenant-partitioned store driven by a distribution-aware host; on any
+other store `IEventStore.GroupAgentAssignmentsByDatabase` stays `false` and distribution is unchanged.
+
 ## Dynamically applying changes to tenants databases
 
 If you didn't call the `ApplyAllDatabaseChangesOnStartup` method, Marten would still try to create a database [upon the session creation](/documents/sessions). This action is invasive and can cause issues like timeouts, cold starts, or deadlocks. It also won't apply all defined changes upfront (so, e.g. [indexes](/documents/indexing/), [custom schema extensions](/schema/extensions)).

--- a/docs/events/bulk-appending.md
+++ b/docs/events/bulk-appending.md
@@ -20,7 +20,10 @@ The bulk append API:
 1. Pre-allocates event sequence numbers from the `mt_events_sequence`
 2. Uses `NpgsqlBinaryImporter` to COPY stream records into `mt_streams`
 3. Uses `NpgsqlBinaryImporter` to COPY event records into `mt_events`
-4. Updates the high water mark in `mt_event_progression` so the async daemon knows where to start
+4. Updates the high water mark in `mt_event_progression` so the async daemon knows where to start. On a
+   [per-tenant-partitioned store](/events/multitenancy#per-tenant-event-partitioning) it advances each affected
+   tenant's own `HighWaterMark:{tenant}` row (to that tenant's `max(seq_id)`) — the row the per-tenant daemon actually
+   reads — instead of the store-global `HighWaterMark`
 
 This approach is significantly faster than the normal append path because it avoids per-row function
 calls, version checking, and individual INSERT statements.

--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -170,6 +170,12 @@ When `UseTenantPartitionedEvents` is enabled, Marten:
 * **Runs the async daemon with a vectorized per-tenant high-water mark** — one query per database reports the high-water
   position for every active tenant in a single round trip — plus **per-tenant rebuild isolation**, so a projection can
   be rebuilt for a single tenant without tearing down or replaying every other tenant's progress.
+* **Fans daemon agents out per tenant under a node-distributed host.** Because each tenant draws its own event sequence,
+  a store-global agent cannot track them; Marten reports `IEventStore.DistributesAgentsPerTenant` so a distribution-aware
+  host (e.g. Wolverine-managed distribution) runs one agent per `(shard, tenant)`. For sharded stores with many tenants,
+  see [database-affine agent assignment](/configuration/multitenancy#node-distributed-daemons-and-connection-fan-out)
+  (`Events.UseDatabaseAffineAgentAssignment` / `Events.DatabaseAffineAgentFanout`) to keep the resulting connection
+  fan-out bounded.
 
 ### Constraints
 

--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -174,8 +174,7 @@ When `UseTenantPartitionedEvents` is enabled, Marten:
   a store-global agent cannot track them; Marten reports `IEventStore.DistributesAgentsPerTenant` so a distribution-aware
   host (e.g. Wolverine-managed distribution) runs one agent per `(shard, tenant)`. For sharded stores with many tenants,
   see [database-affine agent assignment](/configuration/multitenancy#node-distributed-daemons-and-connection-fan-out)
-  (`Events.UseDatabaseAffineAgentAssignment` / `Events.DatabaseAffineAgentFanout`) to keep the resulting connection
-  fan-out bounded.
+  (`Events.UseDatabaseAffineAgentAssignment`) to keep the resulting connection fan-out bounded.
 
 ### Constraints
 

--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -105,6 +105,10 @@ If your Marten store is only using a single database, Marten will distribute pro
 [separate databases for multi-tenancy](/configuration/multitenancy), the async daemon will group all projections for a single
 database on the same executing node as a purposeful strategy to reduce the total number of connections to the databases.
 
+For a [sharded store with per-tenant event partitioning](/configuration/multitenancy#sharded-multi-tenancy-with-database-pooling),
+a node-distributed host runs one agent per `(shard, tenant)`, and you can keep the resulting connection fan-out bounded with
+[database-affine agent assignment](/configuration/multitenancy#node-distributed-daemons-and-connection-fan-out).
+
 ::: tip
 The built in capability of Marten to distribute projections is somewhat limited, and it's still likely that all projections
 will end up running on the first process to start up. If your system requires better load distribution for increased scalability,

--- a/src/EventSourcingTests/BulkEventStreamAppendTests.cs
+++ b/src/EventSourcingTests/BulkEventStreamAppendTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests;
+
+/// <summary>
+/// JasperFx/marten#4806: bulk event append must preserve the ORIGINAL cross-stream order when migrating an
+/// existing event log. The seq_id assigned to each event decides the global order the async daemon replays
+/// in, so a multi-stream projection that compares Sequence across streams (e.g. "decisions appended before
+/// this invoice was created") only works if migration keeps the interleaving. These tests cover both the
+/// streaming import (<see cref="IDocumentStore.BulkInsertEventStreamAsync"/>) and the batch path, asserting
+/// directly on the stored <c>mt_events</c> order — the thing that actually governs replay.
+/// </summary>
+public class BulkEventStreamAppendTests : OneOffConfigurationsContext
+{
+    public record Started(string Label);
+    public record Progressed(int Step);
+    public record Ended(string Label);
+
+    // Register the event types up front (as the real migration does via its event registrations) so
+    // ApplyAllConfiguredChangesToDatabaseAsync provisions the event tables — the streaming import builds
+    // raw IEvents directly rather than going through StreamAction.Start, which would auto-register them.
+    private DocumentStore StringIdentityStore() => StoreOptions(opts =>
+    {
+        opts.Events.StreamIdentity = StreamIdentity.AsString;
+        opts.Events.AddEventType<Started>();
+        opts.Events.AddEventType<Progressed>();
+        opts.Events.AddEventType<Ended>();
+    });
+
+    // Build a raw IEvent carrying its stream key + per-stream version, as a migration read would produce.
+    private static IEvent EventFor(string streamKey, long version, object data)
+    {
+        var e = (IEvent)Activator.CreateInstance(typeof(Event<>).MakeGenericType(data.GetType()), data)!;
+        e.StreamKey = streamKey;
+        e.Version = version;
+        e.Id = Guid.NewGuid();
+        e.Sequence = version; // source seq is irrelevant to the streaming path (it uses arrival order)
+        return e;
+    }
+
+    private static async IAsyncEnumerable<IEvent> Stream(IEnumerable<IEvent> events)
+    {
+        foreach (var e in events)
+        {
+            yield return e;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    // Stored stream ids in seq_id order — the global order the async daemon will replay in.
+    private static async Task<List<string>> StreamIdsBySeqAsync(DocumentStore store)
+    {
+        var ids = new List<string>();
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            $"select stream_id from {store.Options.Events.DatabaseSchemaName}.mt_events order by seq_id", conn);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            ids.Add(reader.GetString(0));
+        }
+
+        return ids;
+    }
+
+    private static async Task<List<long>> VersionsForStreamAsync(DocumentStore store, string streamKey)
+    {
+        var versions = new List<long>();
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            $"select version from {store.Options.Events.DatabaseSchemaName}.mt_events where stream_id = @s order by seq_id",
+            conn);
+        cmd.Parameters.AddWithValue("s", streamKey);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            versions.Add(reader.GetInt64(0));
+        }
+
+        return versions;
+    }
+
+    [Fact]
+    public async Task streaming_import_preserves_cross_stream_order()
+    {
+        var store = StringIdentityStore();
+
+        // Two streams, interleaved in the exact global order they occurred: A1, B1, A2, B2, A3.
+        var ordered = new[]
+        {
+            EventFor("A", 1, new Started("A1")),
+            EventFor("B", 1, new Started("B1")),
+            EventFor("A", 2, new Progressed(1)),
+            EventFor("B", 2, new Ended("B2")),
+            EventFor("A", 3, new Ended("A3"))
+        };
+
+        var headers = new List<BulkEventStreamHeader>
+        {
+            new() { Key = "A", Version = 3 },
+            new() { Key = "B", Version = 2 }
+        };
+
+        // batchSize 2 forces multiple COPY batches + a sequence-block refill mid-stream.
+        await store.BulkInsertEventStreamAsync(StorageConstants.DefaultTenantId, headers, Stream(ordered),
+            batchSize: 2, cancellation: CancellationToken.None);
+
+        // The seq_id order (what the daemon replays in) must be the ORIGINAL interleaving, not per-stream
+        // blocks (which would be A, A, A, B, B).
+        (await StreamIdsBySeqAsync(store)).ShouldBe(new[] { "A", "B", "A", "B", "A" });
+
+        // Per-stream versions preserved and contiguous.
+        (await VersionsForStreamAsync(store, "A")).ShouldBe(new long[] { 1, 2, 3 });
+        (await VersionsForStreamAsync(store, "B")).ShouldBe(new long[] { 1, 2 });
+    }
+
+    [Fact]
+    public async Task batch_import_assigns_seq_ids_in_source_order_across_streams()
+    {
+        var store = StringIdentityStore();
+
+        // Two stream actions; simulate a migration by stamping each event's SOURCE sequence so the global
+        // order is interleaved A1, B1, A2, B2, A3 even though the events are grouped per stream.
+        var actionA = StreamAction.Start(store.Events, "A",
+            new object[] { new Started("A1"), new Progressed(1), new Ended("A3") });
+        var actionB = StreamAction.Start(store.Events, "B",
+            new object[] { new Started("B1"), new Ended("B2") });
+
+        actionA.Events[0].Sequence = 1;
+        actionB.Events[0].Sequence = 2;
+        actionA.Events[1].Sequence = 3;
+        actionB.Events[1].Sequence = 4;
+        actionA.Events[2].Sequence = 5;
+
+        await store.BulkInsertEventsAsync(new[] { actionA, actionB });
+
+        // Target seq_id order must honor the source interleaving, not each stream's contiguous block.
+        (await StreamIdsBySeqAsync(store)).ShouldBe(new[] { "A", "B", "A", "B", "A" });
+    }
+
+    [Fact]
+    public async Task batch_import_of_freshly_created_streams_is_unchanged()
+    {
+        // Fresh seeding (no meaningful source Sequence, all 0): the stable sort must keep the per-stream
+        // order the caller passed, i.e. behavior identical to before the ordering fix.
+        var store = StringIdentityStore();
+
+        var actionA = StreamAction.Start(store.Events, "A",
+            new object[] { new Started("A1"), new Ended("A2") });
+        var actionB = StreamAction.Start(store.Events, "B",
+            new object[] { new Started("B1"), new Ended("B2") });
+
+        await store.BulkInsertEventsAsync(new[] { actionA, actionB });
+
+        (await StreamIdsBySeqAsync(store)).ShouldBe(new[] { "A", "A", "B", "B" });
+        (await VersionsForStreamAsync(store, "A")).ShouldBe(new long[] { 1, 2 });
+        (await VersionsForStreamAsync(store, "B")).ShouldBe(new long[] { 1, 2 });
+    }
+}

--- a/src/EventSourcingTests/BulkEventStreamAppendTests.cs
+++ b/src/EventSourcingTests/BulkEventStreamAppendTests.cs
@@ -131,6 +131,41 @@ public class BulkEventStreamAppendTests : OneOffConfigurationsContext
     }
 
     [Fact]
+    public async Task streaming_import_refills_sequences_across_multiple_blocks()
+    {
+        // Regression for JasperFx/marten#4806: sequences are fetched one block (batchSize) at a time, so a
+        // tenant with more events than batchSize empties the queue mid-stream and must refill. The refill runs
+        // a nextval SELECT, which must NOT happen while the mt_events COPY is open on the same connection —
+        // Npgsql rejects that with "connection is already in state 'Copy'". batchSize 2 with 7 events forces
+        // several block boundaries + refills; the import must still complete with cross-stream order intact.
+        var store = StringIdentityStore();
+
+        var ordered = new[]
+        {
+            EventFor("A", 1, new Started("A1")),
+            EventFor("B", 1, new Started("B1")),
+            EventFor("A", 2, new Progressed(2)),
+            EventFor("B", 2, new Progressed(2)),
+            EventFor("A", 3, new Progressed(3)),
+            EventFor("B", 3, new Ended("B3")),
+            EventFor("A", 4, new Ended("A4"))
+        };
+
+        var headers = new List<BulkEventStreamHeader>
+        {
+            new() { Key = "A", Version = 4 },
+            new() { Key = "B", Version = 3 }
+        };
+
+        await store.BulkInsertEventStreamAsync(StorageConstants.DefaultTenantId, headers, Stream(ordered),
+            batchSize: 2, cancellation: CancellationToken.None);
+
+        (await StreamIdsBySeqAsync(store)).ShouldBe(new[] { "A", "B", "A", "B", "A", "B", "A" });
+        (await VersionsForStreamAsync(store, "A")).ShouldBe(new long[] { 1, 2, 3, 4 });
+        (await VersionsForStreamAsync(store, "B")).ShouldBe(new long[] { 1, 2, 3 });
+    }
+
+    [Fact]
     public async Task batch_import_assigns_seq_ids_in_source_order_across_streams()
     {
         var store = StringIdentityStore();

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -73,6 +73,15 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
     bool IEventStore.DistributesAgentsPerTenant
         => Options.Events.UseTenantPartitionedEvents && Options.Tenancy is Storage.ShardedTenancy;
 
+    // JasperFx/marten#4806 (opt-in, default off): with per-tenant agents scattered across many shard
+    // databases, group each database's agents onto one node so a node opens pools only to the databases it
+    // owns (pools scale with databases, not nodes×databases). Only meaningful for the sharded per-tenant
+    // store this fans agents out on.
+    bool IEventStore.GroupAgentAssignmentsByDatabase
+        => Options.Events.UseDatabaseAffineAgentAssignment
+           && Options.Events.UseTenantPartitionedEvents
+           && Options.Tenancy is Storage.ShardedTenancy;
+
     async ValueTask<IReadOnlyList<IEventDatabase>> IEventStore.AllDatabases()
     {
         // Straight delegation to ITenancy, mirroring IMartenStorage.AllDatabases(). The IMartenDatabase

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -82,11 +82,6 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
            && Options.Events.UseTenantPartitionedEvents
            && Options.Tenancy is Storage.ShardedTenancy;
 
-    // JasperFx/marten#4806: bounded fan-out ("mix") — how many nodes a shard database's agents may spread
-    // across when database-affine assignment is on. 1 = strict affinity. Clamped to >= 1.
-    int IEventStore.MaxNodesPerDatabaseForAgents
-        => Math.Max(1, Options.Events.DatabaseAffineAgentFanout);
-
     async ValueTask<IReadOnlyList<IEventDatabase>> IEventStore.AllDatabases()
     {
         // Straight delegation to ITenancy, mirroring IMartenStorage.AllDatabases(). The IMartenDatabase

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -65,6 +65,14 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
         }
     }
 
+    // wolverine#3280: under sharded databases + per-tenant event partitioning, multiple tenants are
+    // co-located in one shard database and each draws its own mt_events_sequence_<tenant> (independent,
+    // overlapping). A single store-global high-water cannot track them, so node-distributed daemons must
+    // fan out one agent per (shard, tenant). Single-database partitioning and database-per-tenant do NOT
+    // need this (one agent per database already covers a single tenant or the single partitioned table).
+    bool IEventStore.DistributesAgentsPerTenant
+        => Options.Events.UseTenantPartitionedEvents && Options.Tenancy is Storage.ShardedTenancy;
+
     async ValueTask<IReadOnlyList<IEventDatabase>> IEventStore.AllDatabases()
     {
         // Straight delegation to ITenancy, mirroring IMartenStorage.AllDatabases(). The IMartenDatabase

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -82,6 +82,11 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
            && Options.Events.UseTenantPartitionedEvents
            && Options.Tenancy is Storage.ShardedTenancy;
 
+    // JasperFx/marten#4806: bounded fan-out ("mix") — how many nodes a shard database's agents may spread
+    // across when database-affine assignment is on. 1 = strict affinity. Clamped to >= 1.
+    int IEventStore.MaxNodesPerDatabaseForAgents
+        => Math.Max(1, Options.Events.DatabaseAffineAgentFanout);
+
     async ValueTask<IReadOnlyList<IEventDatabase>> IEventStore.AllDatabases()
     {
         // Straight delegation to ITenancy, mirroring IMartenStorage.AllDatabases(). The IMartenDatabase

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -248,6 +248,44 @@ public partial class DocumentStore: IDocumentStore, IDescribeMyself
         }
     }
 
+    /// <summary>
+    /// Streaming, order-preserving bulk import of an existing event log for a single tenant. Unlike
+    /// <see cref="BulkInsertEventsAsync(string,IReadOnlyList{StreamAction},int,CancellationToken)"/> — which
+    /// materializes every event of the tenant in memory — this consumes <paramref name="orderedEvents"/>
+    /// lazily in batches, so a tenant with millions of events imports in bounded memory. The events MUST be
+    /// supplied in the exact order their <c>seq_id</c>s should be assigned (typically the source log's global
+    /// order): each is given the next ascending sequence in arrival order, so cross-stream ordering is
+    /// preserved. Per-stream versions are taken from the events. <paramref name="streamHeaders"/> seed
+    /// <c>mt_streams</c> (written first, for the foreign key). Runs as one transaction per tenant.
+    /// </summary>
+    public async Task BulkInsertEventStreamAsync(string tenantId,
+        IReadOnlyList<BulkEventStreamHeader> streamHeaders, IAsyncEnumerable<IEvent> orderedEvents,
+        int batchSize = 1000, CancellationToken cancellation = default)
+    {
+        await Storage.ApplyAllConfiguredChangesToDatabaseAsync().ConfigureAwait(false);
+
+        var tenant = await Tenancy.GetTenantAsync(Options.TenantIdStyle.MaybeCorrectTenantId(tenantId))
+            .ConfigureAwait(false);
+        var appender = new BulkEventAppender(Events, Options.Serializer());
+
+        await using var conn = tenant.Database.CreateConnection();
+        await conn.OpenAsync(cancellation).ConfigureAwait(false);
+        var tx = await conn.BeginTransactionAsync(cancellation).ConfigureAwait(false);
+
+        try
+        {
+            await appender
+                .BulkInsertEventStreamAsync(conn, tenantId, streamHeaders, orderedEvents, batchSize, cancellation)
+                .ConfigureAwait(false);
+            await tx.CommitAsync(cancellation).ConfigureAwait(false);
+        }
+        catch
+        {
+            await tx.RollbackAsync(cancellation).ConfigureAwait(false);
+            throw;
+        }
+    }
+
     public IDiagnostics Diagnostics { get; }
 
     public IDocumentSession OpenSession(SessionOptions options)

--- a/src/Marten/Events/BulkEventAppender.cs
+++ b/src/Marten/Events/BulkEventAppender.cs
@@ -58,9 +58,206 @@ internal class BulkEventAppender
         await updateHighWaterMark(conn, schema, streams, cancellation).ConfigureAwait(false);
     }
 
-    private async Task<Queue<long>> fetchSequences(
+    /// <summary>
+    /// Streaming, order-preserving bulk import for a single tenant — see
+    /// <see cref="Marten.DocumentStore.BulkInsertEventStreamAsync" />. Consumes <paramref name="orderedEvents" />
+    /// lazily in batches (bounded memory), assigning each event the next ascending sequence in arrival order
+    /// (so cross-stream ordering is preserved) and taking per-stream versions from the events themselves.
+    /// <paramref name="streamHeaders" /> seed mt_streams first so the mt_events foreign key holds.
+    /// </summary>
+    public async Task BulkInsertEventStreamAsync(
+        NpgsqlConnection conn,
+        string tenantId,
+        IReadOnlyList<BulkEventStreamHeader> streamHeaders,
+        IAsyncEnumerable<IEvent> orderedEvents,
+        int batchSize,
+        CancellationToken cancellation)
+    {
+        var schema = _events.DatabaseSchemaName;
+
+        // mt_streams first — it is the foreign-key target for mt_events. Bounded: one row per stream.
+        await copyStreamHeaders(conn, schema, tenantId, streamHeaders, batchSize, cancellation)
+            .ConfigureAwait(false);
+
+        var columns = buildEventColumns();
+        var copySql = $"COPY {schema}.mt_events({string.Join(", ", columns.Select(c => $"\"{c}\""))}) FROM STDIN BINARY";
+
+        // Sequences are pulled a block at a time (not the whole tenant up front) so memory stays bounded even
+        // when the total event count is unknown. Blocks of max(batchSize, 1000) keep the round-trips low.
+        var sequenceBlock = Math.Max(batchSize, 1000);
+        var sequences = new Queue<long>(sequenceBlock);
+        long maxSequence = 0;
+        var count = 0;
+        NpgsqlBinaryImporter? writer = null;
+
+        try
+        {
+            await foreach (var e in orderedEvents.WithCancellation(cancellation).ConfigureAwait(false))
+            {
+                if (sequences.Count == 0)
+                {
+                    await refillSequences(conn, schema, sequences, sequenceBlock, cancellation)
+                        .ConfigureAwait(false);
+                }
+
+                var seq = sequences.Dequeue();
+                e.Sequence = seq;
+                if (seq > maxSequence)
+                {
+                    maxSequence = seq;
+                }
+
+                // Ensure event type metadata is populated (a migration may clear it so the current alias is
+                // re-derived from the upcasted CLR type).
+                if (string.IsNullOrEmpty(e.EventTypeName))
+                {
+                    var mapping = _events.EventMappingFor(e.EventType);
+                    e.EventTypeName = mapping.EventTypeName;
+                    e.DotNetTypeName = mapping.DotNetTypeName;
+                }
+
+                if (count % batchSize == 0)
+                {
+                    if (writer != null)
+                    {
+                        await writer.CompleteAsync(cancellation).ConfigureAwait(false);
+                        await writer.DisposeAsync().ConfigureAwait(false);
+                    }
+
+                    writer = await conn.BeginBinaryImportAsync(copySql, cancellation).ConfigureAwait(false);
+                }
+
+                await writer!.StartRowAsync(cancellation).ConfigureAwait(false);
+                await writeEventRow(writer, e, e.StreamId, e.StreamKey, e.TenantId ?? tenantId, cancellation)
+                    .ConfigureAwait(false);
+                count++;
+            }
+
+            if (writer != null)
+            {
+                await writer.CompleteAsync(cancellation).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            if (writer != null)
+            {
+                await writer.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        if (count == 0)
+        {
+            return;
+        }
+
+        var name = _events.UseTenantPartitionedEvents
+            ? HighWaterShardIdentity.PerTenant(tenantId)
+            : HighWaterShardIdentity.StoreGlobal;
+        await upsertHighWaterMark(conn, schema, name, maxSequence, cancellation).ConfigureAwait(false);
+    }
+
+    private async Task copyStreamHeaders(
         NpgsqlConnection conn,
         string schema,
+        string tenantId,
+        IReadOnlyList<BulkEventStreamHeader> headers,
+        int batchSize,
+        CancellationToken cancellation)
+    {
+        if (headers.Count == 0)
+        {
+            return;
+        }
+
+        var columns = buildStreamColumns();
+        var copySql = $"COPY {schema}.mt_streams({string.Join(", ", columns.Select(c => $"\"{c}\""))}) FROM STDIN BINARY";
+
+        var batch = 0;
+        NpgsqlBinaryImporter? writer = null;
+
+        try
+        {
+            foreach (var header in headers)
+            {
+                if (batch % batchSize == 0)
+                {
+                    if (writer != null)
+                    {
+                        await writer.CompleteAsync(cancellation).ConfigureAwait(false);
+                        await writer.DisposeAsync().ConfigureAwait(false);
+                    }
+
+                    writer = await conn.BeginBinaryImportAsync(copySql, cancellation).ConfigureAwait(false);
+                }
+
+                await writer!.StartRowAsync(cancellation).ConfigureAwait(false);
+
+                if (_events.TenancyStyle == TenancyStyle.Conjoined)
+                {
+                    await writer.WriteAsync(tenantId, NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
+                }
+
+                if (_events.StreamIdentity == StreamIdentity.AsGuid)
+                {
+                    await writer.WriteAsync(header.Id, NpgsqlDbType.Uuid, cancellation).ConfigureAwait(false);
+                }
+                else
+                {
+                    await writer.WriteAsync(header.Key!, NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
+                }
+
+                var aggregateTypeName = header.AggregateTypeName
+                                        ?? (header.AggregateType != null
+                                            ? _events.AggregateAliasFor(header.AggregateType)
+                                            : null);
+                if (aggregateTypeName != null)
+                {
+                    await writer.WriteAsync(aggregateTypeName, NpgsqlDbType.Varchar, cancellation)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await writer.WriteNullAsync(cancellation).ConfigureAwait(false);
+                }
+
+                await writer.WriteAsync(header.Version, NpgsqlDbType.Bigint, cancellation).ConfigureAwait(false);
+                await writer.WriteAsync(false, NpgsqlDbType.Boolean, cancellation).ConfigureAwait(false);
+
+                batch++;
+            }
+
+            if (writer != null)
+            {
+                await writer.CompleteAsync(cancellation).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            if (writer != null)
+            {
+                await writer.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async Task<Queue<long>> fetchSequences(
+        NpgsqlConnection conn,
+        string schema,
+        int count,
+        CancellationToken cancellation)
+    {
+        var queue = new Queue<long>(count);
+        await refillSequences(conn, schema, queue, count, cancellation).ConfigureAwait(false);
+        return queue;
+    }
+
+    // Pull a block of freshly allocated sequence numbers into the queue. Used by the streaming import to
+    // top up lazily (block by block) instead of pre-allocating the whole tenant's range up front.
+    private static async Task refillSequences(
+        NpgsqlConnection conn,
+        string schema,
+        Queue<long> queue,
         int count,
         CancellationToken cancellation)
     {
@@ -69,17 +266,15 @@ internal class BulkEventAppender
         cmd.CommandText = sql;
         await using var reader = await cmd.ExecuteReaderAsync(cancellation).ConfigureAwait(false);
 
-        var queue = new Queue<long>(count);
         while (await reader.ReadAsync(cancellation).ConfigureAwait(false))
         {
             queue.Enqueue(reader.GetInt64(0));
         }
-
-        return queue;
     }
 
     private void assignVersionsAndSequences(IReadOnlyList<StreamAction> streams, Queue<long> sequences)
     {
+        // Version is per-stream (1..N in the stream's own event order).
         foreach (var stream in streams)
         {
             long version = 0;
@@ -87,7 +282,6 @@ internal class BulkEventAppender
             {
                 version++;
                 e.Version = version;
-                e.Sequence = sequences.Dequeue();
 
                 // Ensure event type metadata is populated
                 if (string.IsNullOrEmpty(e.EventTypeName))
@@ -99,6 +293,18 @@ internal class BulkEventAppender
             }
 
             stream.Version = version;
+        }
+
+        // seq_id is assigned GLOBALLY across all streams, honoring the order the events already carry in
+        // their Sequence — so a caller that supplies events in their original global order (e.g. a migration
+        // reading source events by seq_id) keeps cross-stream ordering in the target, instead of each stream
+        // getting a contiguous seq_id block that flattens the interleaving. That matters for multi-stream
+        // projections / subscriptions that compare Sequence across streams. LINQ OrderBy is stable, so events
+        // with no meaningful pre-set Sequence (fresh seeding, all 0) keep the per-stream order the caller
+        // passed — identical to the previous behavior. See JasperFx/marten#4806.
+        foreach (var e in streams.SelectMany(s => s.Events).OrderBy(e => e.Sequence))
+        {
+            e.Sequence = sequences.Dequeue();
         }
     }
 
@@ -252,7 +458,9 @@ internal class BulkEventAppender
                     }
 
                     await writer!.StartRowAsync(cancellation).ConfigureAwait(false);
-                    await writeEventRow(writer, stream, e, cancellation).ConfigureAwait(false);
+                    await writeEventRow(writer, e, stream.Id, stream.Key,
+                        e.TenantId ?? stream.TenantId ?? StorageConstants.DefaultTenantId, cancellation)
+                        .ConfigureAwait(false);
                     batch++;
                 }
             }
@@ -315,8 +523,8 @@ internal class BulkEventAppender
         return columns;
     }
 
-    private async Task writeEventRow(NpgsqlBinaryImporter writer, StreamAction stream, IEvent e,
-        CancellationToken cancellation)
+    private async Task writeEventRow(NpgsqlBinaryImporter writer, IEvent e, Guid streamId, string? streamKey,
+        string tenantId, CancellationToken cancellation)
     {
         // seq_id
         await writer.WriteAsync(e.Sequence, NpgsqlDbType.Bigint, cancellation).ConfigureAwait(false);
@@ -327,11 +535,11 @@ internal class BulkEventAppender
         // stream_id
         if (_events.StreamIdentity == StreamIdentity.AsGuid)
         {
-            await writer.WriteAsync(stream.Id, NpgsqlDbType.Uuid, cancellation).ConfigureAwait(false);
+            await writer.WriteAsync(streamId, NpgsqlDbType.Uuid, cancellation).ConfigureAwait(false);
         }
         else
         {
-            await writer.WriteAsync(stream.Key!, NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
+            await writer.WriteAsync(streamKey!, NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
         }
 
         // version
@@ -369,8 +577,7 @@ internal class BulkEventAppender
             NpgsqlDbType.TimestampTz, cancellation).ConfigureAwait(false);
 
         // tenant_id
-        await writer.WriteAsync(e.TenantId ?? stream.TenantId ?? StorageConstants.DefaultTenantId,
-            NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
+        await writer.WriteAsync(tenantId, NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
 
         // mt_dotnet_type
         if (!string.IsNullOrEmpty(e.DotNetTypeName))
@@ -442,14 +649,6 @@ internal class BulkEventAppender
         IReadOnlyList<StreamAction> streams,
         CancellationToken cancellation)
     {
-        // #4681: the 'HighWaterMark' name(s) are produced by HighWaterShardIdentity so any future change
-        // to the grammar lands in one place rather than in scattered SQL. The name is parameterized so the
-        // same upsert serves both the store-global row and the per-tenant rows below.
-        var sql = $@"
-INSERT INTO {schema}.mt_event_progression (name, last_seq_id)
-VALUES (@name, @seq)
-ON CONFLICT (name) DO UPDATE SET last_seq_id = GREATEST({schema}.mt_event_progression.last_seq_id, @seq)";
-
         if (_events.UseTenantPartitionedEvents)
         {
             // With per-tenant partitioning the high-water is tracked per tenant ("HighWaterMark:<tenant>"):
@@ -468,11 +667,8 @@ ON CONFLICT (name) DO UPDATE SET last_seq_id = GREATEST({schema}.mt_event_progre
 
             foreach (var (tenant, max) in maxByTenant)
             {
-                await using var tenantCmd = conn.CreateCommand();
-                tenantCmd.CommandText = sql;
-                tenantCmd.Parameters.AddWithValue("name", HighWaterShardIdentity.PerTenant(tenant));
-                tenantCmd.Parameters.AddWithValue("seq", max);
-                await tenantCmd.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
+                await upsertHighWaterMark(conn, schema, HighWaterShardIdentity.PerTenant(tenant), max, cancellation)
+                    .ConfigureAwait(false);
             }
 
             return;
@@ -482,10 +678,29 @@ ON CONFLICT (name) DO UPDATE SET last_seq_id = GREATEST({schema}.mt_event_progre
             .SelectMany(s => s.Events)
             .Max(e => e.Sequence);
 
+        await upsertHighWaterMark(conn, schema, HighWaterShardIdentity.StoreGlobal, maxSequence, cancellation)
+            .ConfigureAwait(false);
+    }
+
+    // #4681: the 'HighWaterMark' name(s) are produced by HighWaterShardIdentity so any future change to the
+    // grammar lands in one place rather than in scattered SQL. The name is parameterized so the same upsert
+    // serves both the store-global row and the per-tenant rows.
+    private static async Task upsertHighWaterMark(
+        NpgsqlConnection conn,
+        string schema,
+        string name,
+        long seq,
+        CancellationToken cancellation)
+    {
+        var sql = $@"
+INSERT INTO {schema}.mt_event_progression (name, last_seq_id)
+VALUES (@name, @seq)
+ON CONFLICT (name) DO UPDATE SET last_seq_id = GREATEST({schema}.mt_event_progression.last_seq_id, @seq)";
+
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
-        cmd.Parameters.AddWithValue("name", HighWaterShardIdentity.StoreGlobal);
-        cmd.Parameters.AddWithValue("seq", maxSequence);
+        cmd.Parameters.AddWithValue("name", name);
+        cmd.Parameters.AddWithValue("seq", seq);
         await cmd.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
     }
 

--- a/src/Marten/Events/BulkEventAppender.cs
+++ b/src/Marten/Events/BulkEventAppender.cs
@@ -442,19 +442,49 @@ internal class BulkEventAppender
         IReadOnlyList<StreamAction> streams,
         CancellationToken cancellation)
     {
+        // #4681: the 'HighWaterMark' name(s) are produced by HighWaterShardIdentity so any future change
+        // to the grammar lands in one place rather than in scattered SQL. The name is parameterized so the
+        // same upsert serves both the store-global row and the per-tenant rows below.
+        var sql = $@"
+INSERT INTO {schema}.mt_event_progression (name, last_seq_id)
+VALUES (@name, @seq)
+ON CONFLICT (name) DO UPDATE SET last_seq_id = GREATEST({schema}.mt_event_progression.last_seq_id, @seq)";
+
+        if (_events.UseTenantPartitionedEvents)
+        {
+            // With per-tenant partitioning the high-water is tracked per tenant ("HighWaterMark:<tenant>"):
+            // the async daemon's per-tenant coordinators only ever read those rows, never the store-global
+            // one. A bulk insert may span multiple tenants (each StreamAction carries its own TenantId), so
+            // advance each tenant's own high-water row to that tenant's max sequence. Writing the store-global
+            // row here would be useless (no per-tenant coordinator reads it) and misleading (it would hold the
+            // max sequence across every tenant on the shard). Pre-setting the per-tenant mark also lets the
+            // daemon start that tenant's projection catch-up immediately, rather than waiting for the next
+            // high-water detection poll to discover the bulk-loaded events.
+            var maxByTenant = streams
+                .SelectMany(s => s.Events.Select(e =>
+                    (Tenant: e.TenantId ?? s.TenantId ?? StorageConstants.DefaultTenantId, e.Sequence)))
+                .GroupBy(x => x.Tenant)
+                .Select(g => (Tenant: g.Key, Max: g.Max(x => x.Sequence)));
+
+            foreach (var (tenant, max) in maxByTenant)
+            {
+                await using var tenantCmd = conn.CreateCommand();
+                tenantCmd.CommandText = sql;
+                tenantCmd.Parameters.AddWithValue("name", HighWaterShardIdentity.PerTenant(tenant));
+                tenantCmd.Parameters.AddWithValue("seq", max);
+                await tenantCmd.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
+            }
+
+            return;
+        }
+
         var maxSequence = streams
             .SelectMany(s => s.Events)
             .Max(e => e.Sequence);
 
-        // #4681: the literal 'HighWaterMark' name is produced by HighWaterShardIdentity so
-        // any future change to the grammar lands in one place rather than in scattered SQL.
-        var sql = $@"
-INSERT INTO {schema}.mt_event_progression (name, last_seq_id)
-VALUES ('{HighWaterShardIdentity.StoreGlobal}', @seq)
-ON CONFLICT (name) DO UPDATE SET last_seq_id = GREATEST({schema}.mt_event_progression.last_seq_id, @seq)";
-
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
+        cmd.Parameters.AddWithValue("name", HighWaterShardIdentity.StoreGlobal);
         cmd.Parameters.AddWithValue("seq", maxSequence);
         await cmd.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
     }

--- a/src/Marten/Events/BulkEventAppender.cs
+++ b/src/Marten/Events/BulkEventAppender.cs
@@ -82,10 +82,13 @@ internal class BulkEventAppender
         var columns = buildEventColumns();
         var copySql = $"COPY {schema}.mt_events({string.Join(", ", columns.Select(c => $"\"{c}\""))}) FROM STDIN BINARY";
 
-        // Sequences are pulled a block at a time (not the whole tenant up front) so memory stays bounded even
-        // when the total event count is unknown. Blocks of max(batchSize, 1000) keep the round-trips low.
-        var sequenceBlock = Math.Max(batchSize, 1000);
-        var sequences = new Queue<long>(sequenceBlock);
+        // Sequences are pulled one block (batchSize) at a time — not the whole tenant up front — so memory
+        // stays bounded when the total event count is unknown. The COPY writer is (re)opened per block, and a
+        // block boundary is the ONLY place the nextval SELECT runs. That matters: a regular command cannot run
+        // on a connection that is mid-COPY (Npgsql throws "connection is already in state 'Copy'"), so the
+        // writer is always CLOSED before refillSequences and reopened afterwards. Same single connection, so
+        // no extra connection is taken from the tight per-shard pool.
+        var sequences = new Queue<long>(batchSize);
         long maxSequence = 0;
         var count = 0;
         NpgsqlBinaryImporter? writer = null;
@@ -96,9 +99,18 @@ internal class BulkEventAppender
             {
                 if (sequences.Count == 0)
                 {
-                    await refillSequences(conn, schema, sequences, sequenceBlock, cancellation)
-                        .ConfigureAwait(false);
+                    // Close the open COPY before the sequence SELECT, then start a fresh one for the next block.
+                    if (writer != null)
+                    {
+                        await writer.CompleteAsync(cancellation).ConfigureAwait(false);
+                        await writer.DisposeAsync().ConfigureAwait(false);
+                        writer = null;
+                    }
+
+                    await refillSequences(conn, schema, sequences, batchSize, cancellation).ConfigureAwait(false);
                 }
+
+                writer ??= await conn.BeginBinaryImportAsync(copySql, cancellation).ConfigureAwait(false);
 
                 var seq = sequences.Dequeue();
                 e.Sequence = seq;
@@ -116,18 +128,7 @@ internal class BulkEventAppender
                     e.DotNetTypeName = mapping.DotNetTypeName;
                 }
 
-                if (count % batchSize == 0)
-                {
-                    if (writer != null)
-                    {
-                        await writer.CompleteAsync(cancellation).ConfigureAwait(false);
-                        await writer.DisposeAsync().ConfigureAwait(false);
-                    }
-
-                    writer = await conn.BeginBinaryImportAsync(copySql, cancellation).ConfigureAwait(false);
-                }
-
-                await writer!.StartRowAsync(cancellation).ConfigureAwait(false);
+                await writer.StartRowAsync(cancellation).ConfigureAwait(false);
                 await writeEventRow(writer, e, e.StreamId, e.StreamKey, e.TenantId ?? tenantId, cancellation)
                     .ConfigureAwait(false);
                 count++;

--- a/src/Marten/Events/BulkEventStreamHeader.cs
+++ b/src/Marten/Events/BulkEventStreamHeader.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Marten.Events;
+
+/// <summary>
+/// Metadata for a single event stream, used to seed <c>mt_streams</c> during a streamed bulk import
+/// (<see cref="Marten.IDocumentStore.BulkInsertEventStreamAsync"/>). One header per stream is supplied up
+/// front — small and bounded even for a tenant with millions of events — and written before the events so
+/// the <c>mt_events</c> → <c>mt_streams</c> foreign key is satisfied while the events themselves stream in.
+/// </summary>
+public sealed class BulkEventStreamHeader
+{
+    /// <summary>Stream id for a store using <see cref="Marten.Events.StreamIdentity.AsGuid"/>.</summary>
+    public Guid Id { get; init; }
+
+    /// <summary>Stream key for a store using <see cref="Marten.Events.StreamIdentity.AsString"/>.</summary>
+    public string? Key { get; init; }
+
+    /// <summary>The stream's (final) version — the number of events on the stream.</summary>
+    public long Version { get; init; }
+
+    /// <summary>Optional aggregate CLR type; its Marten alias is written to <c>mt_streams.type</c>.</summary>
+    public Type? AggregateType { get; init; }
+
+    /// <summary>Optional pre-resolved aggregate alias; takes precedence over <see cref="AggregateType"/>.</summary>
+    public string? AggregateTypeName { get; init; }
+}

--- a/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
@@ -194,7 +194,6 @@ internal class HighWaterDetector: IHighWaterDetector
     private async Task<IReadOnlyList<HighWaterStatistics>> loadPerTenantStatistics(
         IReadOnlyCollection<string> tenantIds, CancellationToken token)
     {
-        var tenantsTable = _graph.Options.TenantPartitions!.TenantsTableName;
         var schema = _graph.DatabaseSchemaName;
         // #4681: the per-tenant high-water identity prefix is produced by
         // HighWaterShardIdentity rather than hand-rolled here, so any future
@@ -202,27 +201,31 @@ internal class HighWaterDetector: IHighWaterDetector
         // rule) only needs to land in one place.
         var highWaterPrefix = HighWaterShardIdentity.PerTenantPrefix;
 
-        // Single round-trip: for each requested tenant, join (mt_tenant_partitions
-        // → pg_sequences for that partition's mt_events_sequence_{suffix} →
-        // mt_event_progression for the per-tenant high-water row keyed by
-        // `'{HighWaterMark}:{tenantId}'`, matching Session 3's per-tenant naming
-        // convention for the high-water shard). LEFT JOINs preserve a row per
-        // input tenant even when the partition / sequence / progression row
-        // hasn't been created yet (returns null → treated as zero downstream).
+        // This method only runs under per-tenant event partitioning (the caller collapses to the
+        // store-global reading when the flag is off), so read each tenant's height from max(seq_id) of its
+        // own mt_events partition — NOT from the per-tenant sequence. Same reasoning as the store-global
+        // #4712 fix in HighWaterStatisticsDetector: under partitioning the per-tenant sequence
+        // (mt_events_sequence_{suffix}) is left at its initial value (last_value=1, is_called=false) for
+        // events appended via the shared sequence or reassigned by BulkInsertEventsAsync, so reading it
+        // reports a high-water of 0 for a fully-populated tenant and its projections never start. max(seq_id)
+        // is the authoritative committed height regardless of how the events were inserted, so a tenant with
+        // no persisted progression row yet still gets its true high-water and its per-tenant agent advances.
+        // The LEFT JOINs preserve a row per input tenant even when its partition / progression row does not
+        // exist yet (returns null → treated as zero downstream).
         var sql = $@"
 with inputs(tenant_id) as (select unnest(:tenants))
 select
     i.tenant_id,
-    coalesce(seq.last_value, 0)        as last_value,
+    coalesce(ev.max_seq_id, 0)         as last_value,
     coalesce(prog.last_seq_id, 0)      as last_seq_id,
     prog.last_updated                  as last_updated,
     transaction_timestamp()            as ""timestamp""
 from inputs i
-left join {tenantsTable} p
-    on p.partition_value = i.tenant_id
-left join pg_sequences seq
-    on seq.schemaname = '{schema}'
-    and seq.sequencename = 'mt_events_sequence_' || p.partition_suffix
+left join lateral (
+    select max(e.seq_id) as max_seq_id
+    from {schema}.mt_events e
+    where e.tenant_id = i.tenant_id
+) ev on true
 left join {schema}.mt_event_progression prog
     on prog.name = :prefix || i.tenant_id;";
 

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -302,6 +302,17 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     /// </summary>
     public bool UseDatabaseAffineAgentAssignment { get; set; }
 
+    /// <summary>
+    /// When <see cref="UseDatabaseAffineAgentAssignment"/> is on, the maximum number of nodes a single
+    /// shard database's agents may be spread across (the "mix" between strict affinity and even spreading).
+    /// 1 = strict affinity (a database pinned to one node — fewest connections, but a heavy database is
+    /// serialized on that node's pool). A higher value lets a database's per-tenant agents fan out across up
+    /// to N least-loaded nodes for more parallelism, at the cost of that database being reachable from up to
+    /// N nodes (server-side connection ceiling per database ≈ N × per-node pool). Set N so
+    /// databases × N × pool stays under the server's max_connections. Default 1. See JasperFx/marten#4806.
+    /// </summary>
+    public int DatabaseAffineAgentFanout { get; set; } = 1;
+
     public IMessageOutbox MessageOutbox { get; set; } = new NulloMessageOutbox();
 
 

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -291,6 +291,17 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     /// </summary>
     public bool UseTenantPartitionedEvents { get; set; }
 
+    /// <summary>
+    /// Opt-in (default false): when a node-distributed async daemon fans agents out per (shard, tenant)
+    /// under sharded tenancy, assign them with database affinity — every agent for the same shard database
+    /// runs on the same node — instead of spreading individual agents evenly. This bounds each node to the
+    /// shard databases it owns, so connection pools scale with the number of shard databases rather than
+    /// nodes × databases (which otherwise exhausts a shared server's max_connections). Only takes effect
+    /// with <see cref="UseTenantPartitionedEvents"/> + sharded-database tenancy + a distribution-aware host
+    /// (e.g. Wolverine-managed event-subscription distribution). See JasperFx/marten#4806.
+    /// </summary>
+    public bool UseDatabaseAffineAgentAssignment { get; set; }
+
     public IMessageOutbox MessageOutbox { get; set; } = new NulloMessageOutbox();
 
 

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -302,17 +302,6 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     /// </summary>
     public bool UseDatabaseAffineAgentAssignment { get; set; }
 
-    /// <summary>
-    /// When <see cref="UseDatabaseAffineAgentAssignment"/> is on, the maximum number of nodes a single
-    /// shard database's agents may be spread across (the "mix" between strict affinity and even spreading).
-    /// 1 = strict affinity (a database pinned to one node — fewest connections, but a heavy database is
-    /// serialized on that node's pool). A higher value lets a database's per-tenant agents fan out across up
-    /// to N least-loaded nodes for more parallelism, at the cost of that database being reachable from up to
-    /// N nodes (server-side connection ceiling per database ≈ N × per-node pool). Set N so
-    /// databases × N × pool stays under the server's max_connections. Default 1. See JasperFx/marten#4806.
-    /// </summary>
-    public int DatabaseAffineAgentFanout { get; set; } = 1;
-
     public IMessageOutbox MessageOutbox { get; set; } = new NulloMessageOutbox();
 
 

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -141,17 +141,6 @@ namespace Marten.Events
         public bool UseDatabaseAffineAgentAssignment { get; set; }
 
         /// <summary>
-        /// When <see cref="UseDatabaseAffineAgentAssignment"/> is on, the max nodes a single shard database's
-        /// agents may fan out across — the "mix" between strict affinity and even spreading. 1 = strict
-        /// affinity (pin a database to one node: fewest connections, but a heavy database is serialized on
-        /// that node's pool). Higher = a database's per-tenant agents fan out across up to N least-loaded
-        /// nodes for more parallelism, so it is reachable from up to N nodes (server connection ceiling per
-        /// database ≈ N × per-node pool). Pick N so databases × N × pool stays under max_connections.
-        /// Default 1. See JasperFx/marten#4806.
-        /// </summary>
-        public int DatabaseAffineAgentFanout { get; set; }
-
-        /// <summary>
         /// Optional extension point to receive published messages as a side effect from
         /// aggregation projections
         /// </summary>

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -130,6 +130,17 @@ namespace Marten.Events
         public bool UseTenantPartitionedEvents { get; set; }
 
         /// <summary>
+        /// Opt-in (default false): when a node-distributed async daemon fans agents out per (shard, tenant)
+        /// under sharded tenancy, assign them with database affinity — every agent for one shard database on
+        /// the same node — so a node opens connection pools only to the databases it owns and pool count
+        /// scales with shard databases rather than nodes × databases (which otherwise exhausts a shared
+        /// server's max_connections). Only takes effect with <see cref="UseTenantPartitionedEvents"/> +
+        /// sharded-database tenancy + a distribution-aware host (e.g. Wolverine-managed event-subscription
+        /// distribution). See JasperFx/marten#4806.
+        /// </summary>
+        public bool UseDatabaseAffineAgentAssignment { get; set; }
+
+        /// <summary>
         /// Optional extension point to receive published messages as a side effect from
         /// aggregation projections
         /// </summary>

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -141,6 +141,17 @@ namespace Marten.Events
         public bool UseDatabaseAffineAgentAssignment { get; set; }
 
         /// <summary>
+        /// When <see cref="UseDatabaseAffineAgentAssignment"/> is on, the max nodes a single shard database's
+        /// agents may fan out across — the "mix" between strict affinity and even spreading. 1 = strict
+        /// affinity (pin a database to one node: fewest connections, but a heavy database is serialized on
+        /// that node's pool). Higher = a database's per-tenant agents fan out across up to N least-loaded
+        /// nodes for more parallelism, so it is reachable from up to N nodes (server connection ceiling per
+        /// database ≈ N × per-node pool). Pick N so databases × N × pool stays under max_connections.
+        /// Default 1. See JasperFx/marten#4806.
+        /// </summary>
+        public int DatabaseAffineAgentFanout { get; set; }
+
+        /// <summary>
         /// Optional extension point to receive published messages as a side effect from
         /// aggregation projections
         /// </summary>

--- a/src/Marten/Events/IReadOnlyEventStoreOptions.cs
+++ b/src/Marten/Events/IReadOnlyEventStoreOptions.cs
@@ -93,12 +93,6 @@ public interface IReadOnlyEventStoreOptions
     bool UseDatabaseAffineAgentAssignment { get; set; }
 
     /// <summary>
-    /// Max nodes a single shard database's agents may fan out across when database-affine assignment is on
-    /// (the "mix"; 1 = strict affinity). See IEventStoreOptions.DatabaseAffineAgentFanout. JasperFx/marten#4806.
-    /// </summary>
-    int DatabaseAffineAgentFanout { get; set; }
-
-    /// <summary>
     /// Optional extension point to receive published messages as a side effect from
     /// aggregation projections
     /// </summary>

--- a/src/Marten/Events/IReadOnlyEventStoreOptions.cs
+++ b/src/Marten/Events/IReadOnlyEventStoreOptions.cs
@@ -93,6 +93,12 @@ public interface IReadOnlyEventStoreOptions
     bool UseDatabaseAffineAgentAssignment { get; set; }
 
     /// <summary>
+    /// Max nodes a single shard database's agents may fan out across when database-affine assignment is on
+    /// (the "mix"; 1 = strict affinity). See IEventStoreOptions.DatabaseAffineAgentFanout. JasperFx/marten#4806.
+    /// </summary>
+    int DatabaseAffineAgentFanout { get; set; }
+
+    /// <summary>
     /// Optional extension point to receive published messages as a side effect from
     /// aggregation projections
     /// </summary>

--- a/src/Marten/Events/IReadOnlyEventStoreOptions.cs
+++ b/src/Marten/Events/IReadOnlyEventStoreOptions.cs
@@ -86,6 +86,13 @@ public interface IReadOnlyEventStoreOptions
     bool UseTenantPartitionedEvents { get; set; }
 
     /// <summary>
+    /// Opt-in (default false): assign per-(shard, tenant) daemon agents with database affinity under
+    /// sharded tenancy — see <see cref="IEventStoreOptions.UseDatabaseAffineAgentAssignment"/> on the
+    /// writable interface for the full contract. See JasperFx/marten#4806.
+    /// </summary>
+    bool UseDatabaseAffineAgentAssignment { get; set; }
+
+    /// <summary>
     /// Optional extension point to receive published messages as a side effect from
     /// aggregation projections
     /// </summary>

--- a/src/Marten/IDocumentStore.cs
+++ b/src/Marten/IDocumentStore.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Transactions;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
+using Marten.Events;
 using Marten.Events.Daemon;
 using Marten.Services;
 using Microsoft.Extensions.Logging;
@@ -324,6 +325,23 @@ public interface IDocumentStore: IDisposable, IAsyncDisposable
     /// <param name="cancellation"></param>
     Task BulkInsertEventsAsync(string tenantId, IReadOnlyList<StreamAction> streams, int batchSize = 1000,
         CancellationToken cancellation = default);
+
+    /// <summary>
+    ///     Streaming, order-preserving bulk import of an existing event log for a single tenant. Consumes
+    ///     <paramref name="orderedEvents" /> lazily in batches (bounded memory), so a tenant with millions of
+    ///     events imports without materializing them all. Events MUST be supplied in the order their
+    ///     <c>seq_id</c>s should be assigned (the source log's global order): each gets the next ascending
+    ///     sequence in arrival order, preserving cross-stream ordering. Per-stream versions are taken from the
+    ///     events; <paramref name="streamHeaders" /> seed <c>mt_streams</c> first (for the foreign key). One
+    ///     transaction per tenant. Intended for migrating an existing event store.
+    /// </summary>
+    /// <param name="tenantId">The tenant to insert events for</param>
+    /// <param name="streamHeaders">One header per stream, to seed mt_streams</param>
+    /// <param name="orderedEvents">The tenant's events, in the order seq_ids should be assigned</param>
+    /// <param name="batchSize">Number of rows per COPY batch and sequence-allocation block</param>
+    /// <param name="cancellation"></param>
+    Task BulkInsertEventStreamAsync(string tenantId, IReadOnlyList<BulkEventStreamHeader> streamHeaders,
+        IAsyncEnumerable<IEvent> orderedEvents, int batchSize = 1000, CancellationToken cancellation = default);
 
     /// <summary>
     ///     Build a new instance of the asynchronous projection daemon to use interactively

--- a/src/TenantPartitionedEventsTests/Config/database_affine_agent_assignment_gating.cs
+++ b/src/TenantPartitionedEventsTests/Config/database_affine_agent_assignment_gating.cs
@@ -9,12 +9,12 @@ using Xunit;
 namespace TenantPartitionedEventsTests.Config;
 
 /// <summary>
-/// JasperFx/marten#4806 — the opt-in database-affine agent-assignment knobs and how the
-/// <see cref="IEventStore"/> members they drive are gated. <c>UseDatabaseAffineAgentAssignment</c> only
+/// JasperFx/marten#4806 — the opt-in database-affine agent-assignment flag and how the
+/// <see cref="IEventStore"/> member it drives is gated. <c>UseDatabaseAffineAgentAssignment</c> only
 /// takes effect for a sharded per-tenant-partitioned store (the one tenancy where daemons fan agents out
 /// per (shard, tenant)); everywhere else <c>GroupAgentAssignmentsByDatabase</c> stays false so distribution
-/// behaves exactly as before. <c>MaxNodesPerDatabaseForAgents</c> mirrors the fan-out knob, clamped to >= 1.
-/// These are pure configuration assertions — building the store never opens a connection.
+/// behaves exactly as before. These are pure configuration assertions — building the store never opens a
+/// connection.
 /// </summary>
 public class database_affine_agent_assignment_gating
 {
@@ -22,12 +22,6 @@ public class database_affine_agent_assignment_gating
     public void use_database_affine_agent_assignment_defaults_to_false()
     {
         new StoreOptions().Events.UseDatabaseAffineAgentAssignment.ShouldBeFalse();
-    }
-
-    [Fact]
-    public void database_affine_agent_fanout_defaults_to_one()
-    {
-        new StoreOptions().Events.DatabaseAffineAgentFanout.ShouldBe(1);
     }
 
     [Fact]
@@ -64,21 +58,6 @@ public class database_affine_agent_assignment_gating
         var eventStore = (IEventStore)store;
         eventStore.DistributesAgentsPerTenant.ShouldBeTrue("per-tenant fan-out does not depend on the affinity flag");
         eventStore.GroupAgentAssignmentsByDatabase.ShouldBeFalse("affinity must be explicitly opted into");
-    }
-
-    [Theory]
-    [InlineData(0, 1)]  // clamped up — a fan-out below 1 makes no sense
-    [InlineData(1, 1)]
-    [InlineData(4, 4)]
-    public void max_nodes_per_database_clamps_the_fanout_to_at_least_one(int configured, int expected)
-    {
-        using var store = DocumentStore.For(opts =>
-        {
-            opts.Connection(ConnectionSource.ConnectionString);
-            opts.Events.DatabaseAffineAgentFanout = configured;
-        });
-
-        ((IEventStore)store).MaxNodesPerDatabaseForAgents.ShouldBe(expected);
     }
 
     // A sharded, per-tenant-partitioned store with two databases. Dummy connection strings — the assertions

--- a/src/TenantPartitionedEventsTests/Config/database_affine_agent_assignment_gating.cs
+++ b/src/TenantPartitionedEventsTests/Config/database_affine_agent_assignment_gating.cs
@@ -1,0 +1,103 @@
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Postgresql.Tables.Partitioning;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Config;
+
+/// <summary>
+/// JasperFx/marten#4806 — the opt-in database-affine agent-assignment knobs and how the
+/// <see cref="IEventStore"/> members they drive are gated. <c>UseDatabaseAffineAgentAssignment</c> only
+/// takes effect for a sharded per-tenant-partitioned store (the one tenancy where daemons fan agents out
+/// per (shard, tenant)); everywhere else <c>GroupAgentAssignmentsByDatabase</c> stays false so distribution
+/// behaves exactly as before. <c>MaxNodesPerDatabaseForAgents</c> mirrors the fan-out knob, clamped to >= 1.
+/// These are pure configuration assertions — building the store never opens a connection.
+/// </summary>
+public class database_affine_agent_assignment_gating
+{
+    [Fact]
+    public void use_database_affine_agent_assignment_defaults_to_false()
+    {
+        new StoreOptions().Events.UseDatabaseAffineAgentAssignment.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void database_affine_agent_fanout_defaults_to_one()
+    {
+        new StoreOptions().Events.DatabaseAffineAgentFanout.ShouldBe(1);
+    }
+
+    [Fact]
+    public void group_by_database_is_off_on_a_single_database_store_even_with_the_flag_on()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.UseDatabaseAffineAgentAssignment = true;
+        });
+
+        var eventStore = (IEventStore)store;
+        eventStore.GroupAgentAssignmentsByDatabase.ShouldBeFalse("affinity is only meaningful for a sharded store");
+        eventStore.DistributesAgentsPerTenant.ShouldBeFalse("a single-database store keeps one agent per database");
+    }
+
+    [Fact]
+    public void group_by_database_is_on_for_a_sharded_partitioned_store_with_the_flag_on()
+    {
+        using var store = ShardedStore(affine: true);
+
+        var eventStore = (IEventStore)store;
+        eventStore.DistributesAgentsPerTenant.ShouldBeTrue("sharded + per-tenant partitioning fans agents out per tenant");
+        eventStore.GroupAgentAssignmentsByDatabase.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void group_by_database_stays_off_for_a_sharded_store_when_the_flag_is_off()
+    {
+        using var store = ShardedStore(affine: false);
+
+        var eventStore = (IEventStore)store;
+        eventStore.DistributesAgentsPerTenant.ShouldBeTrue("per-tenant fan-out does not depend on the affinity flag");
+        eventStore.GroupAgentAssignmentsByDatabase.ShouldBeFalse("affinity must be explicitly opted into");
+    }
+
+    [Theory]
+    [InlineData(0, 1)]  // clamped up — a fan-out below 1 makes no sense
+    [InlineData(1, 1)]
+    [InlineData(4, 4)]
+    public void max_nodes_per_database_clamps_the_fanout_to_at_least_one(int configured, int expected)
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Events.DatabaseAffineAgentFanout = configured;
+        });
+
+        ((IEventStore)store).MaxNodesPerDatabaseForAgents.ShouldBe(expected);
+    }
+
+    // A sharded, per-tenant-partitioned store with two databases. Dummy connection strings — the assertions
+    // only read StoreOptions, so the store is never connected or provisioned.
+    private static IDocumentStore ShardedStore(bool affine) =>
+        DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "affine_gating";
+                x.PartitionSchemaName = "affine_gating_tenants";
+                x.AddDatabase("db1", ConnectionSource.ConnectionString);
+                x.AddDatabase("db2", ConnectionSource.ConnectionString);
+            });
+
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.UseDatabaseAffineAgentAssignment = affine;
+        });
+}

--- a/src/TenantPartitionedEventsTests/Daemon/vectorized_high_water_detection.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/vectorized_high_water_detection.cs
@@ -5,7 +5,9 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Daemon.HighWater;
 using Marten.Events.Daemon.HighWater;
 using Marten.Storage;
+using Marten.Testing.Harness;
 using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
 using Shouldly;
 using TenantPartitionedEventsTests.Fixtures;
 using Xunit;
@@ -157,6 +159,40 @@ public class vectorized_high_water_detection
 
         var next = await monitor.PollAsync(CancellationToken.None);
         next.Select(r => r.TenantId).ShouldBe(new[] { beta });
+    }
+
+    [Fact]
+    public async Task per_tenant_high_water_comes_from_max_seq_id_not_the_tenant_sequence()
+    {
+        // Same bug class as the store-global #4712 fix, but for the per-tenant reading: under sharded
+        // tenancy the append path does NOT advance the per-tenant mt_events_sequence_{suffix} (events draw
+        // their seq_id from the shared sequence, and BulkInsertEventsAsync reassigns per-tenant ranges
+        // directly), so the sequence reports a stale value while the tenant's true height lives in
+        // mt_events. DetectForTenantsAsync must derive HighestSequence from max(seq_id), NOT the sequence,
+        // otherwise a fully-populated tenant reads as high-water 0 and its per-tenant projections never
+        // start. Reproduce the stale sequence by force-resetting it after the append.
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+        await _fixture.AppendNEventsAsync(tenant, 7);
+
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            // last_value → 1 (is_called=false): what the sharded/global-sequence/bulk path leaves behind.
+            await using var reset = new NpgsqlCommand(
+                $"select setval('{_fixture.SchemaName}.mt_events_sequence_{tenant}', 1, false)", conn);
+            await reset.ExecuteScalarAsync();
+        }
+
+        var detector = new HighWaterDetector(
+            (MartenDatabase)_fixture.Store.Storage.Database, _fixture.Store.Options.EventGraph, NullLogger.Instance);
+
+        var vector = await ((IHighWaterDetector)detector).DetectForTenantsAsync(
+            new[] { tenant }, CancellationToken.None);
+
+        vector.TryGetStatistics(tenant, out var stat).ShouldBeTrue();
+        // Before the fix this read the stale sequence value (1); after it, the real committed height (7).
+        stat.HighestSequence.ShouldBe(7);
     }
 
     // ---- ICrossTenantRebuildSource ----

--- a/src/TenantPartitionedEventsTests/Regressions/bulk_insert_advances_per_tenant_high_water.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/bulk_insert_advances_per_tenant_high_water.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten.Events.Daemon.HighWater;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using TenantPartitionedEventsTests.Fixtures;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Regressions;
+
+/// <summary>
+/// BulkInsertEventsAsync (via BulkEventAppender) used to advance ONLY the store-global 'HighWaterMark'
+/// progression row. On a per-tenant-partitioned store that row is never read — the async daemon's
+/// per-tenant coordinators read "HighWaterMark:&lt;tenant&gt;" — so the bulk-loaded events were invisible
+/// to the high-water machinery until the next full detection poll recomputed them, and the store-global
+/// row was left holding a misleading max-across-all-tenants value.
+///
+/// After the fix, on a per-tenant-partitioned store the bulk appender advances each affected tenant's own
+/// "HighWaterMark:&lt;tenant&gt;" row (to that tenant's max seq_id), so the per-tenant projection catch-up
+/// can start immediately and nothing writes the meaningless store-global row.
+/// </summary>
+[Collection("guid-partitioned")]
+public class bulk_insert_advances_per_tenant_high_water
+{
+    private readonly GuidPartitionedFixture _fixture;
+
+    public bulk_insert_advances_per_tenant_high_water(GuidPartitionedFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task advances_the_per_tenant_row_to_the_tenants_max_seq_id()
+    {
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var streamId = Guid.NewGuid();
+        var action = StreamAction.Start(_fixture.Store.Events, streamId,
+            new TripStarted(streamId), new TripLeg(1.0), new TripLeg(2.0), new TripLeg(3.0), new TripLeg(4.0));
+        action.TenantId = tenant;
+
+        await _fixture.Store.BulkInsertEventsAsync(tenant, new[] { action });
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        // The tenant's true height = max(seq_id) among its bulk-loaded events.
+        long maxSeq;
+        await using (var cmd = new NpgsqlCommand(
+                         $"select max(seq_id) from {_fixture.SchemaName}.mt_events where tenant_id = @t", conn))
+        {
+            cmd.Parameters.AddWithValue("t", tenant);
+            maxSeq = (long)(await cmd.ExecuteScalarAsync())!;
+        }
+
+        maxSeq.ShouldBeGreaterThan(0);
+
+        // The per-tenant high-water row must be advanced to exactly that height.
+        await using (var cmd = new NpgsqlCommand(
+                         $"select last_seq_id from {_fixture.SchemaName}.mt_event_progression where name = @name", conn))
+        {
+            cmd.Parameters.AddWithValue("name", HighWaterShardIdentity.PerTenant(tenant));
+            var perTenant = await cmd.ExecuteScalarAsync();
+            perTenant.ShouldNotBeNull(
+                "bulk insert must write the per-tenant HighWaterMark:<tenant> row on a per-tenant-partitioned store");
+            ((long)perTenant!).ShouldBe(maxSeq);
+        }
+
+        // And it must not have advanced the store-global row to this tenant's height (nothing reads it here,
+        // and it would misrepresent a single tenant's max as the whole store's).
+        await using (var cmd = new NpgsqlCommand(
+                         $"select last_seq_id from {_fixture.SchemaName}.mt_event_progression where name = @name", conn))
+        {
+            cmd.Parameters.AddWithValue("name", HighWaterShardIdentity.StoreGlobal);
+            var global = await cmd.ExecuteScalarAsync();
+            if (global is not null)
+            {
+                ((long)global!).ShouldNotBe(maxSeq,
+                    "bulk insert on a per-tenant-partitioned store must not advance the store-global HighWaterMark");
+            }
+        }
+    }
+}

--- a/src/TenantPartitionedEventsTests/Regressions/bulk_insert_advances_store_global_high_water_on_non_partitioned_store.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/bulk_insert_advances_store_global_high_water_on_non_partitioned_store.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Events.Daemon.HighWater;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Regressions;
+
+/// <summary>
+/// The companion to <see cref="bulk_insert_advances_per_tenant_high_water"/>: the per-tenant high-water fix
+/// (commit on JasperFx/marten#4806's branch) added a per-tenant branch to BulkEventAppender but must leave
+/// the store-global behavior untouched for every non-partitioned store. This asserts that a plain store still
+/// advances the single store-global 'HighWaterMark' row to max(seq_id) after a bulk insert, and writes no
+/// 'HighWaterMark:&lt;tenant&gt;' row — so nothing regressed for the common case.
+/// </summary>
+public class bulk_insert_advances_store_global_high_water_on_non_partitioned_store
+{
+    public record Probe(int Value);
+
+    [Fact]
+    public async Task advances_the_store_global_row_and_writes_no_per_tenant_row()
+    {
+        var schema = $"tp_bulk_global_{Environment.ProcessId}_{Guid.NewGuid():N}".Substring(0, 40);
+        await using (var reset = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await reset.OpenAsync();
+            try { await reset.DropSchemaAsync(schema); } catch (Exception) { }
+        }
+
+        using var store = DocumentStore.For(o =>
+        {
+            o.Connection(ConnectionSource.ConnectionString);
+            o.DatabaseSchemaName = schema;
+            // UseTenantPartitionedEvents stays false — a single store-global high-water store.
+            o.Events.AddEventType<Probe>();
+        });
+
+        var streamId = Guid.NewGuid();
+        var action = StreamAction.Start(store.Events, streamId,
+            new Probe(1), new Probe(2), new Probe(3));
+
+        await store.BulkInsertEventsAsync(new[] { action });
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        long maxSeq;
+        await using (var cmd = new NpgsqlCommand($"select max(seq_id) from {schema}.mt_events", conn))
+        {
+            maxSeq = (long)(await cmd.ExecuteScalarAsync())!;
+        }
+
+        maxSeq.ShouldBeGreaterThan(0);
+
+        // The store-global row must be advanced to the store's height.
+        await using (var cmd = new NpgsqlCommand(
+                         $"select last_seq_id from {schema}.mt_event_progression where name = @name", conn))
+        {
+            cmd.Parameters.AddWithValue("name", HighWaterShardIdentity.StoreGlobal);
+            var global = await cmd.ExecuteScalarAsync();
+            global.ShouldNotBeNull("bulk insert on a non-partitioned store must advance the store-global HighWaterMark");
+            ((long)global!).ShouldBe(maxSeq);
+        }
+
+        // And no per-tenant machinery should appear — every progression row is the store-global one.
+        await using (var cmd = new NpgsqlCommand(
+                         $"select count(*) from {schema}.mt_event_progression where name like 'HighWaterMark:%'", conn))
+        {
+            var perTenantRows = (long)(await cmd.ExecuteScalarAsync())!;
+            perTenantRows.ShouldBe(0, "a non-partitioned store must not write any HighWaterMark:<tenant> row");
+        }
+    }
+}

--- a/src/TenantPartitionedEventsTests/Regressions/per_tenant_agent_start_routes_high_water.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/per_tenant_agent_start_routes_high_water.cs
@@ -1,0 +1,130 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Regressions;
+
+/// <summary>
+/// wolverine#3280 / JasperFx per-tenant agent start: under Wolverine-managed event-subscription
+/// distribution the daemon is driven by <c>StartAgentAsync("&lt;proj&gt;:V{n}:All:&lt;tenant&gt;")</c> for
+/// each per-tenant shard individually — NOT by <c>StartAllAsync</c> (which primes every tenant's ceiling
+/// up front). A per-tenant agent therefore starts with its ceiling unknown (high-water 0), and the
+/// per-tenant high-water poll only re-runs on a store-global high-water CHANGE tick. When a node starts
+/// after the store-global mark is already stable — the common case for a node that joins after catch-up —
+/// no further tick fires and the freshly-started agent would sit idle at 0 forever.
+///
+/// <para>
+/// The fix (JasperFxAsyncDaemon.StartAgentAsync) drives one per-tenant poll immediately after a
+/// per-tenant agent starts, so it is routed its own tenant's mark and advances. This test reproduces the
+/// "start individually, no following global tick" shape: append events for two tenants, then start each
+/// tenant's async agent one-by-one via the string overload (exactly what Wolverine calls) and assert both
+/// tenants' projections catch up. It composes with the per-tenant high-water reading from max(seq_id)
+/// (#4712-class fix) so the mark is correct even though the per-tenant sequence is never advanced.
+/// </para>
+/// </summary>
+public partial class per_tenant_agent_start_routes_high_water
+{
+    private static readonly string SchemaName = $"pt_agent_start_p{Environment.ProcessId}";
+
+    public class TenantTripDistance
+    {
+        public Guid Id { get; set; }
+        public double Distance { get; set; }
+        public int Version { get; set; }
+    }
+
+    public record TripStarted(Guid Id);
+    public record TripLeg(double Distance);
+
+    public partial class TenantTripDistanceProjection: SingleStreamProjection<TenantTripDistance, Guid>
+    {
+        public TenantTripDistanceProjection() => Name = "PtAgentStartTrip";
+        public void Apply(TenantTripDistance agg, TripLeg @event) => agg.Distance += @event.Distance;
+    }
+
+    [Fact]
+    public async Task starting_each_per_tenant_agent_individually_advances_its_projection()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = SchemaName;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Policies.AllDocumentsAreMultiTenanted();
+            opts.Projections.Add<TenantTripDistanceProjection>(ProjectionLifecycle.Async);
+            // Nested type name + tenant suffix overflows PG's 64-byte identifier limit; shorten it.
+            opts.Schema.For<TenantTripDistance>().Identity(x => x.Id).DocumentAlias("pt_agent_trip");
+        });
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+
+        var tenants = new[] { $"t_{Guid.NewGuid():N}"[..12], $"t_{Guid.NewGuid():N}"[..12] };
+        await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenants);
+
+        // A distinct stream per tenant, each with one TripLeg (Distance 1.0).
+        var streamByTenant = new Dictionary<string, Guid>();
+        foreach (var tenant in tenants)
+        {
+            var streamId = Guid.NewGuid();
+            streamByTenant[tenant] = streamId;
+            await using var session = store.LightweightSession(tenant);
+            session.Events.StartStream<TenantTripDistance>(streamId, new TripStarted(streamId), new TripLeg(1.0));
+            await session.SaveChangesAsync();
+        }
+
+        using var daemon = await store.BuildProjectionDaemonAsync();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        // Start the FIRST tenant's agent and let it fully catch up. Starting it also starts high-water
+        // detection, which advances the store-global mark to its final value and broadcasts it.
+        var first = tenants[0];
+        await daemon.StartAgentAsync(ShardName.Compose("PtAgentStartTrip", ShardName.All, first).Identity, CancellationToken.None);
+        await WaitForProjectionAsync(store, first, streamByTenant[first], cts.Token);
+
+        // Now start the SECOND tenant's agent. The store-global high-water is already at its final value, so
+        // HighWaterAgent will NOT broadcast again (it publishes only on change — HighWaterAgent.cs:209), and
+        // no store-global tick will ever fire the per-tenant poll for this agent. It therefore advances ONLY
+        // if StartAgentAsync itself drives a per-tenant poll after starting it (the fix). Under the pre-fix
+        // behavior it sits at high-water 0 forever and this wait times out — the deterministic regression.
+        var second = tenants[1];
+        await daemon.StartAgentAsync(ShardName.Compose("PtAgentStartTrip", ShardName.All, second).Identity, CancellationToken.None);
+        await WaitForProjectionAsync(store, second, streamByTenant[second], cts.Token);
+    }
+
+    private static async Task WaitForProjectionAsync(
+        IDocumentStore store, string tenant, Guid streamId, CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            await using var query = store.QuerySession(tenant);
+            var doc = await query.LoadAsync<TenantTripDistance>(streamId, token);
+            if (doc is { Distance: >= 1.0 })
+            {
+                return;
+            }
+
+            await Task.Delay(150, token);
+        }
+
+        throw new Xunit.Sdk.XunitException(
+            $"per-tenant agent for {tenant} never advanced its projection (stream {streamId}); " +
+            "its own high-water mark was not routed after StartAgentAsync.");
+    }
+}


### PR DESCRIPTION
Marten piece of the per-tenant agent distribution work for sharded + tenant-partitioned stores. Addresses JasperFx/wolverine#3280 and #4806; **depends on JasperFx/jasperfx#482**.

The branch has grown beyond the original surface-only scope — it now carries everything Marten needs to run (and migrate an existing event log onto) a sharded, per-tenant-partitioned store under managed distribution:

### Distribution surface
- `IEventStore.DistributesAgentsPerTenant` override: true only for `MultiTenantedWithShardedDatabases` + `UseTenantPartitionedEvents` — the one tenancy where tenants are co-located in a database with independent sequences. Everything else keeps one agent per database (unchanged).
- **Opt-in database-affine assignment** (#4806): new `StoreOptions.Events.UseDatabaseAffineAgentAssignment` (default `false`), surfaced as `IEventStore.GroupAgentAssignmentsByDatabase` and gated on sharded tenancy + per-tenant partitioning. Lets a distribution-aware host keep each shard database's agents on one node, so connection pools scale with the number of databases rather than nodes × databases.

### Per-tenant high-water correctness
- Per-tenant high water is read from `max(seq_id)` instead of the unused per-tenant sequence.
- `BulkInsertEventsAsync` advances each affected tenant's own `HighWaterMark:<tenant>` row on partitioned stores (the store-global row is never read there, and would hold a misleading cross-tenant max); non-partitioned stores are unchanged (regression-tested).

### Order-preserving streaming bulk import (migration support)
- New `IDocumentStore.BulkInsertEventStreamAsync(tenantId, streamHeaders, orderedEvents, …)`: streams an existing event log in bounded memory (no whole-tenant materialization / OOM) and assigns target `seq_id`s in arrival order, **preserving cross-stream ordering** — required by multi-stream projections/read models that compare `Sequence` across streams. `mt_streams` is seeded from the supplied headers first (FK), one transaction per tenant.
- The batch `BulkInsertAsync` path now assigns seq_ids globally in the events' existing `Sequence` order (stable sort, so fresh seeding with all-zero sequences is byte-for-byte unchanged); previously each stream got a contiguous seq_id block, silently flattening the original interleaving.
- COPY-state fix: sequence blocks are only fetched while no `mt_events` COPY is open on the connection (Npgsql rejects commands mid-COPY).

### Tests & docs
Config gating, high-water regressions (partitioned and non-partitioned), streaming + batch ordering incl. multi-block sequence refills; documentation for sharded multi-tenancy, per-tenant event partitioning, projection distribution, and bulk append.

**Merge order:** jasperfx#482 → this → Wolverine #3281. Builds against a locally-packed JasperFx.Events carrying #482.