### PR TITLE
 Fix async loader archived stream filtering

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4745_async_daemon_fetch_filters_archived_streams.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4745_async_daemon_fetch_filters_archived_streams.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventSourcingTests.Aggregation;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Marten;
@@ -18,7 +22,8 @@ namespace EventSourcingTests.Bugs;
 /// therefore could not partition-prune the archived <c>mt_streams</c> partition,
 /// and an archived stream's events could still surface if an event row's flag
 /// drifted out of sync with its stream. The loader now appends
-/// <c>and s.is_archived = FALSE</c> to the stream join whenever partitioning is on.
+/// <c>and s.is_archived = FALSE</c> to the stream join whenever partitioning is on
+/// unless the projection explicitly includes archived events.
 ///
 /// <para>
 /// These are pure SQL-shape assertions — <see cref="EventLoader"/> builds its
@@ -31,7 +36,7 @@ public class Bug_4745_async_daemon_fetch_filters_archived_streams
     private static string UniqueSchema() =>
         $"bug4745_{Guid.NewGuid().ToString("N")[..16]}_{Environment.ProcessId}";
 
-    private static EventLoader BuildLoader(bool usePartitioning)
+    private static EventLoader BuildLoader(bool usePartitioning, bool includeArchivedEvents = false)
     {
         var store = DocumentStore.For(o =>
         {
@@ -41,7 +46,7 @@ public class Bug_4745_async_daemon_fetch_filters_archived_streams
         });
 
         var db = (MartenDatabase)store.Storage.Database;
-        return new EventLoader(store, db, new AsyncOptions(), Array.Empty<ISqlFragment>());
+        return new EventLoader(store, db, new AsyncOptions(), Array.Empty<ISqlFragment>(), includeArchivedEvents);
     }
 
     [Fact]
@@ -55,6 +60,14 @@ public class Bug_4745_async_daemon_fetch_filters_archived_streams
     }
 
     [Fact]
+    public void fetch_sql_does_not_constrain_stream_is_archived_when_including_archived_events()
+    {
+        var loader = BuildLoader(usePartitioning: true, includeArchivedEvents: true);
+
+        loader.CommandText.ShouldNotContain("s.is_archived");
+    }
+
+    [Fact]
     public void fetch_sql_does_not_constrain_stream_is_archived_when_partitioning_is_off()
     {
         var loader = BuildLoader(usePartitioning: false);
@@ -62,5 +75,50 @@ public class Bug_4745_async_daemon_fetch_filters_archived_streams
         // Without partitioning, mt_streams is not partitioned by is_archived, so the
         // stream-level predicate adds no value and could miss an index.
         loader.CommandText.ShouldNotContain("s.is_archived");
+    }
+}
+
+public class Bug_4745_include_archived_events_with_archived_stream_partitioning:
+    OneOffConfigurationsContext, IAsyncLifetime
+{
+    public Bug_4745_include_archived_events_with_archived_stream_partitioning()
+    {
+        StoreOptions(opts => opts.Events.UseArchivedStreamPartitioning = true);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task event_loader_fetches_events_from_archived_stream_when_including_archived_events()
+    {
+        var stream = Guid.NewGuid();
+        theSession.Events.StartStream(stream, new AEvent(), new BEvent(), new CEvent());
+        await theSession.SaveChangesAsync();
+
+        theSession.Events.ArchiveStream(stream);
+        await theSession.SaveChangesAsync();
+
+        var fetcher = new EventLoader(theStore, (MartenDatabase)theStore.Tenancy.Default.Database, new AsyncOptions(),
+            Array.Empty<ISqlFragment>(), includeArchivedEvents: true);
+
+        var results = await fetcher.LoadAsync(
+            new EventRequest
+            {
+                Floor = 0,
+                BatchSize = 1000,
+                HighWater = long.MaxValue,
+                ErrorOptions = new ErrorHandlingOptions(),
+                Runtime = new NulloDaemonRuntime(),
+                Name = new ShardName("bug-4745", "All", 1)
+            },
+            CancellationToken.None);
+
+        results.Count.ShouldBe(3);
+        results.All(x => x.IsArchived).ShouldBeTrue();
     }
 }

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -407,7 +407,8 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
         ILogger loggerFactory, EventFilterable filtering, AsyncOptions shardOptions)
     {
         var filters = buildEventLoaderFilters(filtering).ToArray();
-        var inner = new EventLoader(this, (MartenDatabase)database, shardOptions, filters);
+        var inner = new EventLoader(this, (MartenDatabase)database, shardOptions, filters,
+            filtering.IncludeArchivedEvents);
         return new ResilientEventLoader(Options.ResiliencePipeline, inner, database);
     }
 
@@ -428,7 +429,8 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
         ILogger loggerFactory, EventFilterable filtering, AsyncOptions shardOptions, ShardName shardName)
     {
         var filters = buildEventLoaderFilters(filtering).ToArray();
-        var inner = new EventLoader(this, (MartenDatabase)database, shardOptions, filters, shardName);
+        var inner = new EventLoader(this, (MartenDatabase)database, shardOptions, filters,
+            filtering.IncludeArchivedEvents, shardName);
         return new ResilientEventLoader(Options.ResiliencePipeline, inner, database);
     }
 

--- a/src/Marten/Events/Daemon/Internals/EventLoader.cs
+++ b/src/Marten/Events/Daemon/Internals/EventLoader.cs
@@ -70,12 +70,24 @@ internal sealed class EventLoader: IEventLoader
     public string? TenantFilterValue { get; }
 
     public EventLoader(DocumentStore store, MartenDatabase database, AsyncOptions options, ISqlFragment[] filters)
-        : this(store, database, options, filters, shardName: null)
+        : this(store, database, options, filters, includeArchivedEvents: false, shardName: null)
+    {
+    }
+
+    public EventLoader(DocumentStore store, MartenDatabase database, AsyncOptions options, ISqlFragment[] filters,
+        bool includeArchivedEvents)
+        : this(store, database, options, filters, includeArchivedEvents, shardName: null)
     {
     }
 
     public EventLoader(DocumentStore store, MartenDatabase database, AsyncOptions options, ISqlFragment[] filters,
         ShardName? shardName)
+        : this(store, database, options, filters, includeArchivedEvents: false, shardName)
+    {
+    }
+
+    public EventLoader(DocumentStore store, MartenDatabase database, AsyncOptions options, ISqlFragment[] filters,
+        bool includeArchivedEvents, ShardName? shardName)
     {
         _store = store;
         Database = database;
@@ -101,11 +113,13 @@ internal sealed class EventLoader: IEventLoader
             builder.Append(" and d.tenant_id = s.tenant_id");
         }
 
-        if (_store.Options.Events.UseArchivedStreamPartitioning)
+        if (_store.Options.Events.UseArchivedStreamPartitioning && !includeArchivedEvents)
         {
             // #4745: when archived streams live in their own partition of mt_streams,
             // constrain the join so the planner can partition-prune the archived
             // mt_streams partition (the active partition is all the daemon needs).
+            // When IncludeArchivedEvents is true, the daemon explicitly needs both
+            // active and archived stream partitions, so do not add this predicate.
             // The event-row predicate (d.is_archived = false) only prunes the
             // mt_events archived partition; without this the planner must scan both
             // mt_streams partitions to resolve the join. Gated to the partitioned


### PR DESCRIPTION
 Respect IncludeArchivedEvents when archived stream partitioning is enabled so live async projections can read archived stream events instead of always applying the s.is_archived = false join predicate.