### PR TITLE
Scope AssertStreamVersion to tenant under conjoined tenancy

### DIFF
--- a/src/EventSourcingTests/FetchForWriting/always_enforce_consistency_conjoined_tenancy.cs
+++ b/src/EventSourcingTests/FetchForWriting/always_enforce_consistency_conjoined_tenancy.cs
@@ -1,0 +1,89 @@
+using System.Threading.Tasks;
+using EventSourcingTests.Aggregation;
+using JasperFx;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.FetchForWriting;
+
+public class always_enforce_consistency_conjoined_tenancy: OneOffConfigurationsContext
+{
+    // Under conjoined tenancy the same stream key can exist for multiple tenants.
+    // The AlwaysEnforceConsistency "assert version, append nothing" path must scope
+    // its version check to the fetching tenant, not read another tenant's same-keyed
+    // stream row. The "wrong" tenant here sorts first by (tenant_id, id) and is
+    // inserted first, so an unscoped query would read its version first.
+
+    [Fact]
+    public async Task enforce_consistency_no_events_scopes_to_tenant_happy_path()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+        }, true);
+
+        const string streamKey = "shared-key";
+
+        // Other tenant's same-keyed stream sits at version 5.
+        theSession.ForTenant("aaa-other").Events.StartStream<SimpleAggregateAsString>(streamKey,
+            new AEvent(), new BEvent(), new CEvent(), new DEvent(), new EEvent());
+
+        // Our tenant's stream sits at version 3.
+        theSession.ForTenant("zzz-target").Events.StartStream<SimpleAggregateAsString>(streamKey,
+            new AEvent(), new BEvent(), new CEvent());
+
+        await theSession.SaveChangesAsync();
+
+        var stream = await theSession.ForTenant("zzz-target").Events
+            .FetchForWriting<SimpleAggregateAsString>(streamKey);
+        stream.AlwaysEnforceConsistency = true;
+
+        // No events appended. Our tenant's version (3) has not changed, so the
+        // consistency check must succeed. If the check reads the other tenant's
+        // version (5), it throws a spurious ConcurrencyException.
+        await Should.NotThrowAsync(async () => await theSession.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task enforce_consistency_no_events_scopes_to_tenant_sad_path()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.StreamIdentity = StreamIdentity.AsString;
+        }, true);
+
+        const string streamKey = "shared-key";
+
+        // Other tenant's same-keyed stream sits at version 3 — coincidentally the
+        // same version our tenant will be fetched at.
+        theSession.ForTenant("aaa-other").Events.StartStream<SimpleAggregateAsString>(streamKey,
+            new AEvent(), new BEvent(), new CEvent());
+
+        theSession.ForTenant("zzz-target").Events.StartStream<SimpleAggregateAsString>(streamKey,
+            new AEvent(), new BEvent(), new CEvent());
+
+        await theSession.SaveChangesAsync();
+
+        var stream = await theSession.ForTenant("zzz-target").Events
+            .FetchForWriting<SimpleAggregateAsString>(streamKey);
+        stream.AlwaysEnforceConsistency = true;
+
+        // Our tenant's stream advances to version 4 out of band.
+        await using (var otherSession = theStore.LightweightSession("zzz-target"))
+        {
+            otherSession.Events.Append(streamKey, new DEvent());
+            await otherSession.SaveChangesAsync();
+        }
+
+        // Our tenant's version changed (3 -> 4), so the check must fail. If it reads
+        // the other tenant's still-at-3 row, it would miss the conflict (fail open).
+        await Should.ThrowAsync<ConcurrencyException>(async () => await theSession.SaveChangesAsync());
+    }
+}

--- a/src/Marten/Events/Operations/AssertStreamVersionById.cs
+++ b/src/Marten/Events/Operations/AssertStreamVersionById.cs
@@ -28,6 +28,12 @@ internal class AssertStreamVersionById: IStorageOperation
         builder.Append(_events.DatabaseSchemaName);
         builder.Append(".mt_streams where id = ");
         builder.AppendParameter(Stream.Id);
+
+        if (_events.TenancyStyle == TenancyStyle.Conjoined)
+        {
+            builder.Append(" and tenant_id = ");
+            builder.AppendParameter(Stream.TenantId);
+        }
     }
 
     public Type DocumentType => typeof(IEvent);

--- a/src/Marten/Events/Operations/AssertStreamVersionByKey.cs
+++ b/src/Marten/Events/Operations/AssertStreamVersionByKey.cs
@@ -28,6 +28,12 @@ internal class AssertStreamVersionByKey: IStorageOperation
         builder.Append(_events.DatabaseSchemaName);
         builder.Append(".mt_streams where id = ");
         builder.AppendParameter(Stream.Key!);
+
+        if (_events.TenancyStyle == TenancyStyle.Conjoined)
+        {
+            builder.Append(" and tenant_id = ");
+            builder.AppendParameter(Stream.TenantId);
+        }
     }
 
     public Type DocumentType => typeof(IEvent);


### PR DESCRIPTION
Fixes #4803

## Problem

Under `TenancyStyle.Conjoined`, the optimistic-concurrency "assert expected version" path queries `mt_streams` by stream id **without a `tenant_id` predicate**.

`AssertStreamVersionById` and `AssertStreamVersionByKey` build:

```sql
select version from {schema}.mt_streams where id = <param>
```

Under conjoined tenancy `mt_streams` has a composite PK `(tenant_id, id)` with `tenant_id` first, and the same stream id/key can exist for multiple tenants. Consequences:

- **Correctness:** `PostprocessAsync` reads only the first row returned (undefined ordering), so the version assertion can be evaluated against a *different tenant's* same-keyed stream — a spurious `ConcurrencyException`, or a missed conflict if the foreign row's version happens to match `ExpectedVersionOnServer`.
- **Performance:** with the leading PK column unconstrained the query cannot point-seek the PK; it degrades to a scan of the whole shared `mt_streams` table (O(total streams)), and defeats per-tenant partition pruning when `UseTenantPartitionedEvents` is enabled.

## When it runs

Only on the `AlwaysEnforceConsistency` + zero-events-appended path (`FetchForWriting<T>` → set `AlwaysEnforceConsistency = true` → `SaveChangesAsync` with no events). When events are appended, the correctly-scoped `UpdateStreamVersion` runs instead. Every sibling stream-by-id query (`UpdateStreamVersion`, the `AppendOptimistic`/`AppendExclusive` pre-reads) already adds `and tenant_id` under conjoined tenancy — these two operations were the outlier.

## Fix

Append `and tenant_id = <stream tenant>` in both `ConfigureCommand` methods when `TenancyStyle.Conjoined`, mirroring the sibling paths. `Stream.TenantId` is already populated before the op is queued, so this restores the PK point seek and scopes the check to the correct tenant in one change.

## Tests

Added `always_enforce_consistency_conjoined_tenancy` with two cases under conjoined + string identity, where another tenant holds a same-keyed stream that sorts/inserts first (so an unscoped query reads its row first):

- **happy path:** our tenant's version is unchanged → the check must succeed (previously threw a spurious `ConcurrencyException` from the other tenant's higher version).
- **sad path:** our tenant's stream advances out of band → the check must throw (previously missed the conflict by reading the other tenant's still-matching version).

Both fail on `master` and pass with the fix. Existing `always_enforce_consistency`, multi-tenancy, and FetchForWriting suites remain green (242 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)