### PR TITLE
perf(rls): wrap current_setting() in the generated tenant policy for per-statement evaluation

### DIFF
--- a/src/CoreTests/row_level_security_unit_tests.cs
+++ b/src/CoreTests/row_level_security_unit_tests.cs
@@ -142,8 +142,8 @@ public class row_level_security_unit_tests
         createSql.ShouldContain("ALTER TABLE public.mt_doc_target FORCE ROW LEVEL SECURITY;");
         createSql.ShouldContain("DROP POLICY IF EXISTS marten_tenant_isolation ON public.mt_doc_target;");
         createSql.ShouldContain("CREATE POLICY marten_tenant_isolation ON public.mt_doc_target");
-        createSql.ShouldContain("USING (tenant_id = current_setting('app.tenant_id'))");
-        createSql.ShouldContain("WITH CHECK (tenant_id = current_setting('app.tenant_id'));");
+        createSql.ShouldContain("USING (tenant_id = (select current_setting('app.tenant_id')))");
+        createSql.ShouldContain("WITH CHECK (tenant_id = (select current_setting('app.tenant_id')));");
 
         var dropWriter = new StringWriter();
         schemaObject.WriteDropStatement(new PostgresqlMigrator(), dropWriter);

--- a/src/Marten/Storage/RlsPolicySchemaObject.cs
+++ b/src/Marten/Storage/RlsPolicySchemaObject.cs
@@ -50,8 +50,8 @@ internal class RlsPolicySchemaObject: ISchemaObject
             writer.WriteLine($"ALTER TABLE {qualifiedTable} FORCE ROW LEVEL SECURITY;");
             writer.WriteLine($"DROP POLICY IF EXISTS {PolicyName} ON {qualifiedTable};");
             writer.WriteLine($"CREATE POLICY {PolicyName} ON {qualifiedTable}");
-            writer.WriteLine($"    USING (tenant_id = current_setting('{_settingName}'))");
-            writer.WriteLine($"    WITH CHECK (tenant_id = current_setting('{_settingName}'));");
+            writer.WriteLine($"    USING (tenant_id = (select current_setting('{_settingName}')))");
+            writer.WriteLine($"    WITH CHECK (tenant_id = (select current_setting('{_settingName}')));");
         }
         else
         {


### PR DESCRIPTION
Marten's conjoined-tenancy RLS generator (`RlsPolicySchemaObject`) emits `current_setting('<setting>')` **unwrapped** in the policy's `USING` / `WITH CHECK`. Postgres re-evaluates a bare `current_setting(...)` **once per row** the policy scans; wrapping it in a scalar subquery — `(select current_setting('<setting>'))` — makes it an InitPlan the planner evaluates **once per statement** and caches. It's predicate-equivalent (tenant isolation is unchanged) and the documented Postgres RLS performance pattern; the benefit grows with table size.

- Wraps the generated `USING` / `WITH CHECK` clauses in `RlsPolicySchemaObject`.
- Updates the two exact-string assertions in `row_level_security_unit_tests`. The integration tests use `ShouldContain("current_setting('<setting>'")` substring checks and the existing-policy detection pattern (`%current_setting('<setting>'%`) still match, so both are unaffected.

Spotted with [pgrls](https://github.com/pgrls/pgrls) (an open-source Postgres RLS analyzer). Happy to adjust.