### PR TITLE
Fix #4801 — tenant-scope the identity map (and version tracker) for ForTenant sessions

### DIFF
--- a/src/DocumentDbTests/Bugs/Bug_4801_identity_map_cross_tenant_load.cs
+++ b/src/DocumentDbTests/Bugs/Bug_4801_identity_map_cross_tenant_load.cs
@@ -24,6 +24,46 @@ public class Bug_4801_identity_map_cross_tenant_load: BugIntegrationContext
     }
 
     [Fact]
+    public async Task optimistic_concurrency_version_tracking_is_tenant_scoped()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Policies.AllDocumentsAreMultiTenanted();
+            opts.Schema.For<Doc>().UseOptimisticConcurrency(true);
+        });
+
+        var id = Guid.NewGuid();
+
+        await using (var seed = theStore.LightweightSession("A"))
+        {
+            seed.Store(new Doc { Id = id, Name = "tenant-A" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var seed = theStore.LightweightSession("B"))
+        {
+            // Independent inserts under conjoined tenancy produce different mt_version
+            // values for the same id per tenant.
+            seed.Store(new Doc { Id = id, Name = "tenant-B" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var session = theStore.DirtyTrackedSession("A");
+
+        var a = await session.ForTenant("A").LoadAsync<Doc>(id);
+        // Loading B into the same (previously shared) version tracker overwrote A's
+        // tracked version keyed by id.
+        await session.ForTenant("B").LoadAsync<Doc>(id);
+
+        a.Name = "tenant-A-updated";
+        session.ForTenant("A").Update(a);
+
+        // With a tenant-blind shared version tracker this asserts B's version and throws
+        // a spurious ConcurrencyException.
+        await Should.NotThrowAsync(() => session.SaveChangesAsync());
+    }
+
+    [Fact]
     public async Task load_across_tenants_via_for_tenant_dirty_tracking()
     {
         await configure();

--- a/src/DocumentDbTests/Bugs/Bug_4801_identity_map_cross_tenant_load.cs
+++ b/src/DocumentDbTests/Bugs/Bug_4801_identity_map_cross_tenant_load.cs
@@ -111,6 +111,29 @@ public class Bug_4801_identity_map_cross_tenant_load: BugIntegrationContext
     }
 
     [Fact]
+    public async Task for_tenant_matching_the_sessions_own_tenant_shares_the_identity_map()
+    {
+        await configure();
+
+        var id = Guid.NewGuid();
+
+        await using (var seed = theStore.LightweightSession("A"))
+        {
+            seed.Store(new Doc { Id = id, Name = "tenant-A" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var session = theStore.DirtyTrackedSession("A");
+
+        // Loading through the session and through ForTenant for the SAME tenant must
+        // resolve to the same tracked instance (shared identity map).
+        var direct = await session.LoadAsync<Doc>(id);
+        var viaForTenant = await session.ForTenant("A").LoadAsync<Doc>(id);
+
+        viaForTenant.ShouldBeSameAs(direct);
+    }
+
+    [Fact]
     public async Task load_across_tenants_via_for_tenant_identity_only()
     {
         await configure();

--- a/src/DocumentDbTests/Bugs/Bug_4801_identity_map_cross_tenant_load.cs
+++ b/src/DocumentDbTests/Bugs/Bug_4801_identity_map_cross_tenant_load.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DocumentDbTests.Bugs;
+
+public class Bug_4801_identity_map_cross_tenant_load: BugIntegrationContext
+{
+    public class Doc
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private async Task configure()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Policies.AllDocumentsAreMultiTenanted();
+        });
+    }
+
+    [Fact]
+    public async Task load_across_tenants_via_for_tenant_dirty_tracking()
+    {
+        await configure();
+
+        var id = Guid.NewGuid();
+
+        // Seed the same id with different content for two tenants
+        await using (var seed = theStore.LightweightSession("A"))
+        {
+            seed.Store(new Doc { Id = id, Name = "tenant-A" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var seed = theStore.LightweightSession("B"))
+        {
+            seed.Store(new Doc { Id = id, Name = "tenant-B" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var session = theStore.DirtyTrackedSession("A");
+
+        var a = await session.ForTenant("A").LoadAsync<Doc>(id);
+        a.ShouldNotBeNull();
+        a.Name.ShouldBe("tenant-A");
+
+        var b = await session.ForTenant("B").LoadAsync<Doc>(id);
+        b.ShouldNotBeNull();
+        b.Name.ShouldBe("tenant-B");
+    }
+
+    [Fact]
+    public async Task store_across_tenants_does_not_overwrite_other_tenant_cache()
+    {
+        await configure();
+
+        var id = Guid.NewGuid();
+
+        await using (var seed = theStore.LightweightSession("A"))
+        {
+            seed.Store(new Doc { Id = id, Name = "tenant-A" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var session = theStore.DirtyTrackedSession("A");
+
+        // Cache tenant A's instance in A's map
+        var a = await session.ForTenant("A").LoadAsync<Doc>(id);
+        a.Name.ShouldBe("tenant-A");
+
+        // Storing a new instance for the same id under tenant B must not clobber A's cache
+        session.ForTenant("B").Store(new Doc { Id = id, Name = "tenant-B" });
+
+        var stillA = await session.ForTenant("A").LoadAsync<Doc>(id);
+        stillA.Name.ShouldBe("tenant-A");
+    }
+
+    [Fact]
+    public async Task delete_via_for_tenant_ejects_only_that_tenants_cache()
+    {
+        await configure();
+
+        var id = Guid.NewGuid();
+
+        await using (var seed = theStore.LightweightSession("A"))
+        {
+            seed.Store(new Doc { Id = id, Name = "tenant-A" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var seed = theStore.LightweightSession("B"))
+        {
+            seed.Store(new Doc { Id = id, Name = "tenant-B" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var session = theStore.DirtyTrackedSession("A");
+
+        (await session.ForTenant("A").LoadAsync<Doc>(id)).Name.ShouldBe("tenant-A");
+        (await session.ForTenant("B").LoadAsync<Doc>(id)).Name.ShouldBe("tenant-B");
+
+        // Delete ejects id from A's own identity map; B's cached instance must be untouched
+        session.ForTenant("A").Delete<Doc>(id);
+
+        (await session.ForTenant("B").LoadAsync<Doc>(id)).Name.ShouldBe("tenant-B");
+    }
+
+    [Fact]
+    public async Task load_across_tenants_via_for_tenant_identity_only()
+    {
+        await configure();
+
+        var id = Guid.NewGuid();
+
+        await using (var seed = theStore.LightweightSession("A"))
+        {
+            seed.Store(new Doc { Id = id, Name = "tenant-A" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var seed = theStore.LightweightSession("B"))
+        {
+            seed.Store(new Doc { Id = id, Name = "tenant-B" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var session = theStore.IdentitySession("A");
+
+        var a = await session.ForTenant("A").LoadAsync<Doc>(id);
+        a.ShouldNotBeNull();
+        a.Name.ShouldBe("tenant-A");
+
+        var b = await session.ForTenant("B").LoadAsync<Doc>(id);
+        b.ShouldNotBeNull();
+        b.Name.ShouldBe("tenant-B");
+    }
+}

--- a/src/Marten/Internal/Sessions/NestedTenantQuerySession.cs
+++ b/src/Marten/Internal/Sessions/NestedTenantQuerySession.cs
@@ -15,9 +15,13 @@ internal class NestedTenantQuerySession: QuerySession, ITenantQueryOperations
         _parent = parent;
         Versions = parent.Versions;
 
-        // #4801 — Do NOT share the parent's identity map; keep it tenant-scoped. See
-        // NestedTenantSession for the full rationale. The base session already initializes
-        // ItemMap to a fresh dictionary, so leaving it un-shared is all that's needed.
+        // #4801 — Keep the identity map tenant-scoped; only share the parent's map when
+        // this nested session targets the parent's own tenant. See NestedTenantSession for
+        // the full rationale.
+        if (tenant.TenantId == parent.TenantId)
+        {
+            ItemMap = parent.ItemMap;
+        }
     }
 
     public IQuerySession Parent => _parent;

--- a/src/Marten/Internal/Sessions/NestedTenantQuerySession.cs
+++ b/src/Marten/Internal/Sessions/NestedTenantQuerySession.cs
@@ -14,7 +14,10 @@ internal class NestedTenantQuerySession: QuerySession, ITenantQueryOperations
         Listeners.AddRange(parent.Listeners);
         _parent = parent;
         Versions = parent.Versions;
-        ItemMap = parent.ItemMap;
+
+        // #4801 — Do NOT share the parent's identity map; keep it tenant-scoped. See
+        // NestedTenantSession for the full rationale. The base session already initializes
+        // ItemMap to a fresh dictionary, so leaving it un-shared is all that's needed.
     }
 
     public IQuerySession Parent => _parent;

--- a/src/Marten/Internal/Sessions/NestedTenantQuerySession.cs
+++ b/src/Marten/Internal/Sessions/NestedTenantQuerySession.cs
@@ -13,14 +13,14 @@ internal class NestedTenantQuerySession: QuerySession, ITenantQueryOperations
     {
         Listeners.AddRange(parent.Listeners);
         _parent = parent;
-        Versions = parent.Versions;
 
-        // #4801 — Keep the identity map tenant-scoped; only share the parent's map when
-        // this nested session targets the parent's own tenant. See NestedTenantSession for
-        // the full rationale.
+        // #4801 — Keep identity-map and version state tenant-scoped; only share the
+        // parent's when this nested session targets the parent's own tenant. See
+        // NestedTenantSession for the full rationale.
         if (tenant.TenantId == parent.TenantId)
         {
             ItemMap = parent.ItemMap;
+            Versions = parent.Versions;
         }
     }
 

--- a/src/Marten/Internal/Sessions/NestedTenantSession.cs
+++ b/src/Marten/Internal/Sessions/NestedTenantSession.cs
@@ -19,29 +19,46 @@ internal class NestedTenantSession: DocumentSessionBase, ITenantOperations
         Listeners.AddRange(parent.Listeners);
         _parent = parent;
         Versions = parent.Versions;
-        ItemMap = parent.ItemMap;
+
+        // #4801 — Do NOT share the parent's identity map. Under conjoined tenancy the
+        // same id maps to a different document per tenant, so a shared, tenant-blind
+        // ItemMap would return one tenant's cached instance for another tenant. ForTenant
+        // caches one nested session per tenant, so each tenant keeps its own map across
+        // repeated ForTenant(tenant) calls. The base session already initializes ItemMap
+        // to a fresh dictionary, so we simply leave it un-shared here.
     }
 
     public IDocumentSession Parent => _parent;
 
+    // #4801 — Eject from THIS nested session's own identity map (and any dirty tracker),
+    // not the parent's. The map is no longer shared with the parent, so delegating the
+    // eject to the parent would leave this tenant's cached instance in place. Calling
+    // RemoveDirtyTracker is a harmless no-op when the parent is not dirty-tracking.
     protected internal override void ejectById<T>(long id)
     {
-        _parent.ejectById<T>(id);
+        ejectFromThisSession<T>(id);
     }
 
     protected internal override void ejectById<T>(int id)
     {
-        _parent.ejectById<T>(id);
+        ejectFromThisSession<T>(id);
     }
 
     protected internal override void ejectById<T>(Guid id)
     {
-        _parent.ejectById<T>(id);
+        ejectFromThisSession<T>(id);
     }
 
     protected internal override void ejectById<T>(string id)
     {
-        _parent.ejectById<T>(id);
+        ejectFromThisSession<T>(id);
+    }
+
+    private void ejectFromThisSession<T>(object id) where T : notnull
+    {
+        var storage = StorageFor<T>();
+        storage.EjectById(this, id);
+        storage.RemoveDirtyTracker(this, id);
     }
 
     protected internal override void processChangeTrackers()

--- a/src/Marten/Internal/Sessions/NestedTenantSession.cs
+++ b/src/Marten/Internal/Sessions/NestedTenantSession.cs
@@ -20,12 +20,17 @@ internal class NestedTenantSession: DocumentSessionBase, ITenantOperations
         _parent = parent;
         Versions = parent.Versions;
 
-        // #4801 — Do NOT share the parent's identity map. Under conjoined tenancy the
-        // same id maps to a different document per tenant, so a shared, tenant-blind
-        // ItemMap would return one tenant's cached instance for another tenant. ForTenant
-        // caches one nested session per tenant, so each tenant keeps its own map across
-        // repeated ForTenant(tenant) calls. The base session already initializes ItemMap
-        // to a fresh dictionary, so we simply leave it un-shared here.
+        // #4801 — Under conjoined tenancy the same id maps to a different document per
+        // tenant, so a shared, tenant-blind ItemMap would return one tenant's cached
+        // instance for another tenant. Only share the parent's identity map when this
+        // nested session targets the parent's own tenant (so ForTenant(sameTenant) stays
+        // consistent with direct session access); otherwise keep the base session's fresh,
+        // tenant-isolated map. ForTenant caches one nested session per tenant, so each
+        // tenant's map persists across repeated ForTenant(tenant) calls.
+        if (tenant.TenantId == parent.TenantId)
+        {
+            ItemMap = parent.ItemMap;
+        }
     }
 
     public IDocumentSession Parent => _parent;

--- a/src/Marten/Internal/Sessions/NestedTenantSession.cs
+++ b/src/Marten/Internal/Sessions/NestedTenantSession.cs
@@ -18,18 +18,18 @@ internal class NestedTenantSession: DocumentSessionBase, ITenantOperations
     {
         Listeners.AddRange(parent.Listeners);
         _parent = parent;
-        Versions = parent.Versions;
 
         // #4801 — Under conjoined tenancy the same id maps to a different document per
-        // tenant, so a shared, tenant-blind ItemMap would return one tenant's cached
-        // instance for another tenant. Only share the parent's identity map when this
-        // nested session targets the parent's own tenant (so ForTenant(sameTenant) stays
-        // consistent with direct session access); otherwise keep the base session's fresh,
-        // tenant-isolated map. ForTenant caches one nested session per tenant, so each
-        // tenant's map persists across repeated ForTenant(tenant) calls.
+        // tenant, so tenant-blind identity/version state keyed only by id would return or
+        // assert one tenant's state for another tenant. Only share the parent's identity
+        // map and version tracker when this nested session targets the parent's own tenant
+        // (so ForTenant(sameTenant) stays consistent with direct session access); otherwise
+        // keep the base session's fresh, tenant-isolated state. ForTenant caches one nested
+        // session per tenant, so that state persists across repeated ForTenant(tenant) calls.
         if (tenant.TenantId == parent.TenantId)
         {
             ItemMap = parent.ItemMap;
+            Versions = parent.Versions;
         }
     }
 


### PR DESCRIPTION
Closes #4801.

## Problem

When a tracking session (`IdentityOnly` or `DirtyTracking`) is reused across tenants via `ForTenant`, `LoadAsync`/`LoadManyAsync` could return a document belonging to the **wrong** tenant. Under conjoined tenancy — where the same id legitimately maps to a different document per tenant — this returned stale/incorrect data.

Root cause: nested tenant sessions shared the parent session's `ItemMap`, which is keyed only by `(Type → Dictionary<TId,T>)` with no tenant component. The cache-miss path was already tenant-scoped (it queries with `session.TenantId`), but the cache-hit path was tenant-blind, so a second tenant's load hit the first tenant's cached instance. `Store()` and `Delete()`/eject through the shared map had the same collision.

The optimistic-concurrency `VersionTracker` (also keyed by `(Type, id)`, no tenant) was shared the same way, producing spurious `ConcurrencyException`s across tenants.

## Fix

Stop sharing the parent's per-tenant state with nested tenant sessions:

- **Identity map** — each nested tenant session keeps its own `ItemMap` (the base session already initializes a fresh one, and `ForTenant` caches one nested session per tenant, so the map persists correctly per tenant). `NestedTenantSession.ejectById` now ejects from its own session rather than delegating to the parent.
- **Same-tenant consistency** — when `ForTenant(tenantId)` targets the session's own tenant, the parent's `ItemMap`/`Versions` are shared so direct access and `ForTenant(sameTenant)` resolve the same tracked instance. Cross-tenant stays isolated.
- **Version tracker** — cross-tenant nested sessions get their own `VersionTracker`; the parent's is shared only for the parent's own tenant.

Everything routes through `session.ItemMap` / `session.Versions`, so this covers all the tenant-blind paths (`LoadAsync`, `LoadManyAsync`, `Store`-overwrite, `StoreDocumentInItemMap`, aggregate/fetch, OCC) without touching each call site.

`DocumentTracking.None` (lightweight) and `QueryOnly` were never affected — they don't cache on load.

## Commits

1. `Fix #4801` — tenant-scope the identity map for ForTenant sessions
2. Keep `ForTenant(sameTenant)` consistent with the parent session
3. Tenant-scope the version tracker for ForTenant sessions

## Tests

New regression tests in `Bug_4801_identity_map_cross_tenant_load` (each failing before the corresponding fix): cross-tenant `LoadAsync` (dirty + identity-only), cross-tenant `Store` not clobbering another tenant's cache, `Delete`/eject staying tenant-scoped, same-tenant `ForTenant` sharing the map, and cross-tenant OCC not throwing.

Full `DocumentDbTests` (1033 passed) and `MultiTenancyTests` (146 passed) suites green on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)