### PR TITLE
Fix #4796 — F# projections in the test suite + docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -242,6 +242,7 @@ const config: UserConfig<DefaultTheme.Config> = {
                     ]
                 },
                 { text: 'Event Projections', link: '/events/projections/event-projections' },
+                { text: 'Projections with F#', link: '/events/projections/fsharp' },
                 { text: 'Custom Projections', link: '/events/projections/custom' },
                 { text: 'Inline Projections', link: '/events/projections/inline' },
                 { text: 'Flat Table Projections', link: '/events/projections/flat' },

--- a/docs/events/projections/fsharp.md
+++ b/docs/events/projections/fsharp.md
@@ -1,0 +1,190 @@
+# F# Projections
+
+Marten is usable from F#, including for event sourcing projections — but F# projections have to be
+authored a little differently than their C# counterparts.
+
+## Why F# projections are different
+
+Starting with Marten 9.0, the runtime Roslyn code generation used in earlier versions was removed.
+Projection dispatch now happens one of two ways:
+
+1. The **conventional** `Apply` / `Create` / `ShouldDelete` methods are wired up at compile time by the
+   `JasperFx.Events` **Roslyn source generator**. Projection subclasses that use these convention methods
+   must be declared `partial` so the generator can emit the dispatcher into the other half of the class.
+2. The **explicit** `Evolve` / `EvolveAsync` (aggregations) and `ApplyAsync` (event projections) methods
+   are plain `virtual` methods that you `override`. No source generation is involved.
+
+F# supports **neither `partial` classes nor Roslyn source generators**, so the conventional
+`Apply`/`Create` path is unavailable. F# projections must therefore inherit from
+`SingleStreamProjection<TDoc, TId>`, `MultiStreamProjection<TDoc, TId>`, or `EventProjection` and
+**override the explicit `Evolve` / `EvolveAsync` / `ApplyAsync` methods**. This turns out to be a good fit
+for F#, since these methods lend themselves to idiomatic pattern matching over the event data.
+
+::: tip
+The same limitation applies to "self-aggregating" snapshot types (a document type that carries its own
+`Apply`/`Create`/`Evolve` methods and is registered with `Projections.Snapshot<T>()`). Those rely on the
+source generator, so for F# you should instead write a `SingleStreamProjection<TDoc, TId>` subclass that
+overrides `Evolve`, as shown below.
+:::
+
+All of the examples below live in the `FSharpProjections` project in the Marten repository and are
+exercised by the `EventSourcingTests` suite so that F# projection authoring stays a first-class,
+regression-tested citizen.
+
+## Single stream aggregation (synchronous `Evolve`)
+
+A single stream projection aggregates the events of one stream into one document. Override the synchronous
+`Evolve` method and return the new snapshot. The incoming `snapshot` is `null` for the first event of a
+stream, so provide a default:
+
+<!-- snippet: sample_fsharp_self_aggregating_projection -->
+<a id='snippet-sample_fsharp_self_aggregating_projection'></a>
+```fs
+/// Self-aggregating single stream projection using the synchronous Evolve path.
+/// This is the F# replacement for a conventional self-aggregating snapshot type.
+type AccountProjection() =
+    inherit SingleStreamProjection<Account, Guid>()
+
+    override _.Evolve(snapshot: Account, id: Guid, e: IEvent) : Account =
+        let current = snapshot |> orDefault { Id = id; Balance = 0m }
+        match e.Data with
+        | :? AccountCredited as credited -> { current with Balance = current.Balance + credited.Amount }
+        | :? AccountDebited as debited -> { current with Balance = current.Balance - debited.Amount }
+        | _ -> current
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/FSharpProjections/Projections.fs#L50-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_fsharp_self_aggregating_projection' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## Single stream aggregation (asynchronous `EvolveAsync`)
+
+Override `EvolveAsync` when you need asynchronous work while aggregating — for example, looking up
+reference data through the supplied `IQuerySession`:
+
+<!-- snippet: sample_fsharp_single_stream_async_projection -->
+<a id='snippet-sample_fsharp_single_stream_async_projection'></a>
+```fs
+/// Single stream projection using the asynchronous EvolveAsync path. The
+/// IQuerySession is available for reference data lookups if needed.
+type OrderSummaryProjection() =
+    inherit SingleStreamProjection<OrderSummary, Guid>()
+
+    override _.EvolveAsync
+        (snapshot: OrderSummary, id: Guid, _session: IQuerySession, e: IEvent, _ct: CancellationToken)
+        : ValueTask<OrderSummary> =
+        let current = snapshot |> orDefault { Id = id; ItemCount = 0; Shipped = false }
+        let updated =
+            match e.Data with
+            | :? OrderPlaced as placed -> { current with ItemCount = current.ItemCount + placed.Quantity }
+            | :? OrderShipped -> { current with Shipped = true }
+            | _ -> current
+        ValueTask<OrderSummary>(updated)
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/FSharpProjections/Projections.fs#L64-L80' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_fsharp_single_stream_async_projection' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## Multi stream aggregation
+
+A multi stream projection aggregates events from *many* streams into a single document, grouped by a
+document identity. Register the grouping in the constructor with `Identity<TEvent>(...)` (or
+`Identities<TEvent>(...)` when one event fans out to several documents), then override `Evolve`:
+
+<!-- snippet: sample_fsharp_multi_stream_projection -->
+<a id='snippet-sample_fsharp_multi_stream_projection'></a>
+```fs
+/// Multi stream projection using the synchronous Evolve path. Events from many
+/// streams are grouped by a document identity via Identity<TEvent>(...).
+type LocationOccupancyProjection() as self =
+    inherit MultiStreamProjection<LocationOccupancy, string>()
+
+    do
+        self.Identity<GuestArrived>(fun e -> e.Location)
+        self.Identity<GuestDeparted>(fun e -> e.Location)
+
+    override _.Evolve(snapshot: LocationOccupancy, id: string, e: IEvent) : LocationOccupancy =
+        let current = snapshot |> orDefault { Id = id; Guests = 0 }
+        match e.Data with
+        | :? GuestArrived -> { current with Guests = current.Guests + 1 }
+        | :? GuestDeparted -> { current with Guests = current.Guests - 1 }
+        | _ -> current
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/FSharpProjections/Projections.fs#L82-L98' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_fsharp_multi_stream_projection' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The asynchronous `EvolveAsync` path is available for multi stream projections too:
+
+<!-- snippet: sample_fsharp_multi_stream_async_projection -->
+<a id='snippet-sample_fsharp_multi_stream_async_projection'></a>
+```fs
+/// Multi stream projection using the asynchronous EvolveAsync path.
+type RegionRevenueProjection() as self =
+    inherit MultiStreamProjection<RegionRevenue, string>()
+
+    do self.Identity<SaleRecorded>(fun e -> e.Region)
+
+    override _.EvolveAsync
+        (snapshot: RegionRevenue, id: string, _session: IQuerySession, e: IEvent, _ct: CancellationToken)
+        : ValueTask<RegionRevenue> =
+        let current = snapshot |> orDefault { Id = id; Total = 0m }
+        let updated =
+            match e.Data with
+            | :? SaleRecorded as sale -> { current with Total = current.Total + sale.Amount }
+            | _ -> current
+        ValueTask<RegionRevenue>(updated)
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/FSharpProjections/Projections.fs#L100-L116' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_fsharp_multi_stream_async_projection' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## Event projections (`ApplyAsync`)
+
+An `EventProjection` does not aggregate into a single document — it reacts to each event and writes
+whatever documents it likes through the supplied `IDocumentOperations`. Override `ApplyAsync`:
+
+<!-- snippet: sample_fsharp_event_projection -->
+<a id='snippet-sample_fsharp_event_projection'></a>
+```fs
+/// Event projection overriding ApplyAsync directly.
+type UserEmailProjection() =
+    inherit EventProjection()
+
+    override _.ApplyAsync(operations: IDocumentOperations, e: IEvent, _ct: CancellationToken) : ValueTask =
+        match e.Data with
+        | :? EmailChanged as changed ->
+            operations.Store<UserEmail>({ Id = changed.UserId; Email = changed.Email })
+            ValueTask.CompletedTask
+        | _ -> ValueTask.CompletedTask
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/FSharpProjections/Projections.fs#L118-L129' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_fsharp_event_projection' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## Registering the projections
+
+F# projections are registered exactly like C# projections. From C#:
+
+```csharp
+using var store = DocumentStore.For(opts =>
+{
+    opts.Connection(connectionString);
+
+    opts.Projections.Add(new FSharpProjections.AccountProjection(), ProjectionLifecycle.Inline);
+    opts.Projections.Add(new FSharpProjections.LocationOccupancyProjection(), ProjectionLifecycle.Async);
+    opts.Projections.Add(new FSharpProjections.UserEmailProjection(), ProjectionLifecycle.Inline);
+});
+```
+
+Or from F#:
+
+```fsharp
+let store =
+    DocumentStore.For(fun opts ->
+        opts.Connection(connectionString)
+
+        opts.Projections.Add(AccountProjection(), ProjectionLifecycle.Inline)
+        opts.Projections.Add(LocationOccupancyProjection(), ProjectionLifecycle.Async)
+        opts.Projections.Add(UserEmailProjection(), ProjectionLifecycle.Inline))
+```
+
+::: tip
+Returning `null` from an aggregation's `Evolve`/`EvolveAsync` deletes the document (when one previously
+existed). Because F# records are non-nullable by default, handle the incoming `null` snapshot explicitly —
+the samples above use a small `orDefault` helper to substitute a fresh record for the first event.
+:::

--- a/src/EventSourcingTests/EventSourcingTests.csproj
+++ b/src/EventSourcingTests/EventSourcingTests.csproj
@@ -4,6 +4,7 @@
         <ProjectReference Include="..\Marten.Newtonsoft\Marten.Newtonsoft.csproj" />
         <ProjectReference Include="..\Marten.Testing.OtherAssembly\Marten.Testing.OtherAssembly.csproj" />
         <ProjectReference Include="..\Marten.Testing.ThirdAssembly\Marten.Testing.ThirdAssembly.csproj" />
+        <ProjectReference Include="..\FSharpProjections\FSharpProjections.fsproj" />
         <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 

--- a/src/EventSourcingTests/FSharp/fsharp_projections.cs
+++ b/src/EventSourcingTests/FSharp/fsharp_projections.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+using FS = FSharpProjections;
+
+namespace EventSourcingTests.FSharp;
+
+// #4796 — F# projections must override the explicit Evolve/EvolveAsync/ApplyAsync
+// methods (F# has no partial classes and no Roslyn source generators, so the
+// conventional Apply/Create convention methods are unavailable). These tests
+// exercise each F# authoring path so a regression that breaks F# projection
+// authoring is caught by the build + test suite.
+public class fsharp_projections : OneOffConfigurationsContext
+{
+    [Fact]
+    public async Task self_aggregating_single_stream_sync_evolve()
+    {
+        StoreOptions(opts => opts.Projections.Add(new FS.AccountProjection(), ProjectionLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId,
+            new FS.AccountCredited(100m),
+            new FS.AccountDebited(30m),
+            new FS.AccountCredited(5m));
+        await theSession.SaveChangesAsync();
+
+        var account = await theSession.LoadAsync<FS.Account>(streamId);
+        account.ShouldNotBeNull();
+        account.Balance.ShouldBe(75m);
+    }
+
+    [Fact]
+    public async Task single_stream_async_evolve()
+    {
+        StoreOptions(opts => opts.Projections.Add(new FS.OrderSummaryProjection(), ProjectionLifecycle.Inline));
+
+        var streamId = Guid.NewGuid();
+        theSession.Events.StartStream(streamId,
+            new FS.OrderPlaced(2),
+            new FS.OrderPlaced(3),
+            new FS.OrderShipped("DHL"));
+        await theSession.SaveChangesAsync();
+
+        var summary = await theSession.LoadAsync<FS.OrderSummary>(streamId);
+        summary.ShouldNotBeNull();
+        summary.ItemCount.ShouldBe(5);
+        summary.Shipped.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task multi_stream_sync_evolve()
+    {
+        StoreOptions(opts => opts.Projections.Add(new FS.LocationOccupancyProjection(), ProjectionLifecycle.Inline));
+
+        // Two separate streams, same location -> aggregated into one document keyed by location
+        theSession.Events.StartStream(Guid.NewGuid(), new FS.GuestArrived("HQ"), new FS.GuestArrived("HQ"));
+        theSession.Events.StartStream(Guid.NewGuid(), new FS.GuestArrived("HQ"), new FS.GuestDeparted("HQ"));
+        await theSession.SaveChangesAsync();
+
+        var occupancy = await theSession.LoadAsync<FS.LocationOccupancy>("HQ");
+        occupancy.ShouldNotBeNull();
+        occupancy.Guests.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task multi_stream_async_evolve()
+    {
+        StoreOptions(opts => opts.Projections.Add(new FS.RegionRevenueProjection(), ProjectionLifecycle.Inline));
+
+        theSession.Events.StartStream(Guid.NewGuid(), new FS.SaleRecorded("West", 100m));
+        theSession.Events.StartStream(Guid.NewGuid(), new FS.SaleRecorded("West", 250m));
+        await theSession.SaveChangesAsync();
+
+        var revenue = await theSession.LoadAsync<FS.RegionRevenue>("West");
+        revenue.ShouldNotBeNull();
+        revenue.Total.ShouldBe(350m);
+    }
+
+    [Fact]
+    public async Task event_projection_apply_async()
+    {
+        StoreOptions(opts => opts.Projections.Add(new FS.UserEmailProjection(), ProjectionLifecycle.Inline));
+
+        var userId = Guid.NewGuid();
+        theSession.Events.StartStream(Guid.NewGuid(),
+            new FS.EmailChanged(userId, "first@example.com"),
+            new FS.EmailChanged(userId, "second@example.com"));
+        await theSession.SaveChangesAsync();
+
+        var email = await theSession.LoadAsync<FS.UserEmail>(userId);
+        email.ShouldNotBeNull();
+        email.Email.ShouldBe("second@example.com");
+    }
+}

--- a/src/FSharpProjections/FSharpProjections.fsproj
+++ b/src/FSharpProjections/FSharpProjections.fsproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <!--
+      #4796: F# projection fixtures referenced by EventSourcingTests. Because F# supports
+      neither partial classes nor Roslyn source generators, F# projections must override the
+      explicit Evolve / EvolveAsync / ApplyAsync methods instead of the conventional
+      Apply/Create methods. This project exists so those authoring paths stay compiling and
+      are exercised by the test suite against every change.
+    -->
+
+    <PropertyGroup>
+        <!-- Directory.Build.props sets LangVersion=13.0 (a C# value); clear it for F#. -->
+        <LangVersion></LangVersion>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="Projections.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Marten\Marten.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" />
+    </ItemGroup>
+
+</Project>

--- a/src/FSharpProjections/Projections.fs
+++ b/src/FSharpProjections/Projections.fs
@@ -1,0 +1,129 @@
+namespace FSharpProjections
+
+open System
+open System.Threading
+open System.Threading.Tasks
+open JasperFx.Events
+open Marten
+open Marten.Events.Aggregation
+open Marten.Events.Projections
+
+// ---------------------------------------------------------------------------
+// #4796 — F# projection authoring.
+//
+// F# supports neither partial classes nor Roslyn source generators, so the
+// conventional Apply/Create convention methods (which are dispatched by the
+// compile-time JasperFx.Events source generator) are unavailable. Instead, F#
+// projections inherit from SingleStreamProjection / MultiStreamProjection /
+// EventProjection and OVERRIDE the explicit Evolve / EvolveAsync / ApplyAsync
+// methods. Pattern matching over the event data makes this idiomatic in F#.
+// ---------------------------------------------------------------------------
+
+// Events
+type AccountCredited = { Amount: decimal }
+type AccountDebited = { Amount: decimal }
+
+type OrderPlaced = { Quantity: int }
+type OrderShipped = { Carrier: string }
+
+type GuestArrived = { Location: string }
+type GuestDeparted = { Location: string }
+
+type SaleRecorded = { Region: string; Amount: decimal }
+
+type EmailChanged = { UserId: Guid; Email: string }
+
+// Aggregates / documents (immutable F# records)
+type Account = { Id: Guid; Balance: decimal }
+type OrderSummary = { Id: Guid; ItemCount: int; Shipped: bool }
+type LocationOccupancy = { Id: string; Guests: int }
+type RegionRevenue = { Id: string; Total: decimal }
+type UserEmail = { Id: Guid; Email: string }
+
+[<AutoOpen>]
+module internal NullHelpers =
+    /// Returns the current snapshot, or the fallback when the snapshot is null
+    /// (the first event for a stream/slice arrives with a null snapshot).
+    let inline orDefault (fallback: 'T) (snapshot: 'T) : 'T =
+        if isNull (box snapshot) then fallback else snapshot
+
+// begin-snippet: sample_fsharp_self_aggregating_projection
+/// Self-aggregating single stream projection using the synchronous Evolve path.
+/// This is the F# replacement for a conventional self-aggregating snapshot type.
+type AccountProjection() =
+    inherit SingleStreamProjection<Account, Guid>()
+
+    override _.Evolve(snapshot: Account, id: Guid, e: IEvent) : Account =
+        let current = snapshot |> orDefault { Id = id; Balance = 0m }
+        match e.Data with
+        | :? AccountCredited as credited -> { current with Balance = current.Balance + credited.Amount }
+        | :? AccountDebited as debited -> { current with Balance = current.Balance - debited.Amount }
+        | _ -> current
+// end-snippet
+
+// begin-snippet: sample_fsharp_single_stream_async_projection
+/// Single stream projection using the asynchronous EvolveAsync path. The
+/// IQuerySession is available for reference data lookups if needed.
+type OrderSummaryProjection() =
+    inherit SingleStreamProjection<OrderSummary, Guid>()
+
+    override _.EvolveAsync
+        (snapshot: OrderSummary, id: Guid, _session: IQuerySession, e: IEvent, _ct: CancellationToken)
+        : ValueTask<OrderSummary> =
+        let current = snapshot |> orDefault { Id = id; ItemCount = 0; Shipped = false }
+        let updated =
+            match e.Data with
+            | :? OrderPlaced as placed -> { current with ItemCount = current.ItemCount + placed.Quantity }
+            | :? OrderShipped -> { current with Shipped = true }
+            | _ -> current
+        ValueTask<OrderSummary>(updated)
+// end-snippet
+
+// begin-snippet: sample_fsharp_multi_stream_projection
+/// Multi stream projection using the synchronous Evolve path. Events from many
+/// streams are grouped by a document identity via Identity<TEvent>(...).
+type LocationOccupancyProjection() as self =
+    inherit MultiStreamProjection<LocationOccupancy, string>()
+
+    do
+        self.Identity<GuestArrived>(fun e -> e.Location)
+        self.Identity<GuestDeparted>(fun e -> e.Location)
+
+    override _.Evolve(snapshot: LocationOccupancy, id: string, e: IEvent) : LocationOccupancy =
+        let current = snapshot |> orDefault { Id = id; Guests = 0 }
+        match e.Data with
+        | :? GuestArrived -> { current with Guests = current.Guests + 1 }
+        | :? GuestDeparted -> { current with Guests = current.Guests - 1 }
+        | _ -> current
+// end-snippet
+
+// begin-snippet: sample_fsharp_multi_stream_async_projection
+/// Multi stream projection using the asynchronous EvolveAsync path.
+type RegionRevenueProjection() as self =
+    inherit MultiStreamProjection<RegionRevenue, string>()
+
+    do self.Identity<SaleRecorded>(fun e -> e.Region)
+
+    override _.EvolveAsync
+        (snapshot: RegionRevenue, id: string, _session: IQuerySession, e: IEvent, _ct: CancellationToken)
+        : ValueTask<RegionRevenue> =
+        let current = snapshot |> orDefault { Id = id; Total = 0m }
+        let updated =
+            match e.Data with
+            | :? SaleRecorded as sale -> { current with Total = current.Total + sale.Amount }
+            | _ -> current
+        ValueTask<RegionRevenue>(updated)
+// end-snippet
+
+// begin-snippet: sample_fsharp_event_projection
+/// Event projection overriding ApplyAsync directly.
+type UserEmailProjection() =
+    inherit EventProjection()
+
+    override _.ApplyAsync(operations: IDocumentOperations, e: IEvent, _ct: CancellationToken) : ValueTask =
+        match e.Data with
+        | :? EmailChanged as changed ->
+            operations.Store<UserEmail>({ Id = changed.UserId; Email = changed.Email })
+            ValueTask.CompletedTask
+        | _ -> ValueTask.CompletedTask
+// end-snippet

--- a/src/Marten.slnx
+++ b/src/Marten.slnx
@@ -66,6 +66,7 @@
     <Project Path="DaemonTests/DaemonTests.csproj" />
     <Project Path="DocumentDbTests/DocumentDbTests.csproj" />
     <Project Path="EventSourcingTests/EventSourcingTests.csproj" />
+    <Project Path="FSharpProjections/FSharpProjections.fsproj" />
     <Project Path="FSharpTypes/FSharpTypes.fsproj" />
     <Project Path="LinqTests/LinqTests.csproj" />
     <Project Path="LinqTestsTypes/LinqTestsTypes.csproj" />


### PR DESCRIPTION
Closes #4796.

## Background

With 9.0 removing runtime Roslyn code generation, projection dispatch is now either:
1. the compile-time `JasperFx.Events` **source generator** (conventional `Apply`/`Create`, which also requires `partial` classes), or
2. explicit `Evolve` / `EvolveAsync` / `ApplyAsync` **overrides** (plain virtual methods, no codegen).

F# supports neither `partial` classes nor Roslyn source generators, so F# users must use the explicit-override path. This PR adds F# projection fixtures + tests so that authoring path stays first-class and regression-tested, plus a docs page.

## What's here

**New `FSharpProjections` F# project** (`src/FSharpProjections`, wired into `Marten.slnx`) with projections covering every F# authoring path:
- `AccountProjection` — self-aggregating `SingleStreamProjection<Account, Guid>` via **sync `Evolve`** (the F# stand-in for a conventional self-aggregating snapshot type, which needs the source generator)
- `OrderSummaryProjection` — `SingleStreamProjection` via **`EvolveAsync`**
- `LocationOccupancyProjection` — `MultiStreamProjection<…, string>` with `Identity<TEvent>` grouping via **sync `Evolve`**
- `RegionRevenueProjection` — `MultiStreamProjection` via **`EvolveAsync`**
- `UserEmailProjection` — `EventProjection` overriding **`ApplyAsync`**

**Tests** — `EventSourcingTests/FSharp/fsharp_projections.cs` exercises each projection inline. Green on **net9.0 and net10.0** (5/5).

**Docs** — new `events/projections/fsharp.md` ("F# Projections"), wired into the Projections sidebar. It states that F# devs must override `Evolve`/`EvolveAsync`/`ApplyAsync` on `SingleStreamProjection`/`MultiStreamProjection`/`EventProjection` instead of the conventional `Apply`/`Create` methods, and explains the self-aggregating-snapshot caveat. Samples are mdsnippets-extracted from the compiled F# project (so they can't drift). markdownlint + cspell clean.

## Notes
- Confirmed via the JasperFx aggregation base that a subclass overriding `Evolve`/`EvolveAsync` dispatches through plain virtual calls (no source generator), which is exactly why this works in F#; the no-override path throws "no runtime fallback."

🤖 Generated with [Claude Code](https://claude.com/claude-code)