### PR TITLE
#4810 — introduce IStorageSession (agnostic operation/session context); retarget closed-shape binders + selectors

### DIFF
--- a/src/Marten/EventStorage/IEventMetadataBinder.cs
+++ b/src/Marten/EventStorage/IEventMetadataBinder.cs
@@ -57,7 +57,7 @@ public interface IEventMetadataBinder
     /// server-side-constant binders (timestamp / sequence under the
     /// quick-append paths).
     /// </summary>
-    void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IMartenSession session);
+    void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session);
 
     /// <summary>
     /// Per-event read-back hook called from the operation's

--- a/src/Marten/EventStorage/Metadata/CausationIdColumnBinder.cs
+++ b/src/Marten/EventStorage/Metadata/CausationIdColumnBinder.cs
@@ -23,7 +23,7 @@ internal sealed class CausationIdColumnBinder: IEventMetadataBinder
     public string ColumnName => "causation_id";
     public string ValueSql => "?";
 
-    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IMartenSession session)
+    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
     {
         pb.AppendParameter(@event.CausationId, NpgsqlDbType.Varchar);
     }

--- a/src/Marten/EventStorage/Metadata/CorrelationIdColumnBinder.cs
+++ b/src/Marten/EventStorage/Metadata/CorrelationIdColumnBinder.cs
@@ -15,7 +15,7 @@ internal sealed class CorrelationIdColumnBinder: IEventMetadataBinder
     public string ColumnName => "correlation_id";
     public string ValueSql => "?";
 
-    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IMartenSession session)
+    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
     {
         pb.AppendParameter(@event.CorrelationId, NpgsqlDbType.Varchar);
     }

--- a/src/Marten/EventStorage/Metadata/HeadersColumnBinder.cs
+++ b/src/Marten/EventStorage/Metadata/HeadersColumnBinder.cs
@@ -25,7 +25,7 @@ internal sealed class HeadersColumnBinder: IEventMetadataBinder
 
     public string ValueSql => "?";
 
-    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IMartenSession session)
+    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
     {
         // Mirrors the codegen path's emitted shape for the headers column:
         //

--- a/src/Marten/EventStorage/Metadata/SequenceColumnBinder.cs
+++ b/src/Marten/EventStorage/Metadata/SequenceColumnBinder.cs
@@ -32,7 +32,7 @@ internal sealed class SequenceColumnBinder: IEventMetadataBinder
     public string ColumnName => "seq_id";
     public string ValueSql => "?";
 
-    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IMartenSession session)
+    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
     {
         pb.AppendParameter(@event.Sequence, NpgsqlDbType.Bigint);
     }

--- a/src/Marten/EventStorage/Metadata/UserNameColumnBinder.cs
+++ b/src/Marten/EventStorage/Metadata/UserNameColumnBinder.cs
@@ -11,7 +11,7 @@ namespace Marten.EventStorage.Metadata;
 /// varchar column. Binds <see cref="IEvent.UserName"/> as a string parameter.
 /// </summary>
 /// <remarks>
-/// The session-level "user name" lives on <see cref="IMartenSession.LastModifiedBy"/>,
+/// The session-level "user name" lives on <see cref="IStorageSession.LastModifiedBy"/>,
 /// but the event appender plumbs that into the per-event
 /// <see cref="IEvent.UserName"/> before queuing the operation, and we bind
 /// off the event so the SQL stays self-contained.
@@ -21,7 +21,7 @@ internal sealed class UserNameColumnBinder: IEventMetadataBinder
     public string ColumnName => "user_name";
     public string ValueSql => "?";
 
-    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IMartenSession session)
+    public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
     {
         pb.AppendParameter(@event.UserName, NpgsqlDbType.Varchar);
     }

--- a/src/Marten/Internal/ClosedShape/ClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeDirtyTrackingSelector.cs
@@ -28,12 +28,12 @@ internal abstract class ClosedShapeDirtyTrackingSelector<T, TId>: ISelector<T>, 
     protected const int DataColumn = 1;
     protected const int FirstMetadataColumn = 2;
 
-    protected readonly IMartenSession _session;
+    protected readonly IStorageSession _session;
     protected readonly ISerializer _serializer;
     protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
     protected readonly Dictionary<TId, T> _identityMap;
 
-    protected ClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected ClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
     {
         _session = session;
         _serializer = session.Serializer;

--- a/src/Marten/Internal/ClosedShape/ClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeIdentityMapSelector.cs
@@ -26,12 +26,12 @@ internal abstract class ClosedShapeIdentityMapSelector<T, TId>: ISelector<T>, ID
     protected const int DataColumn = 1;
     protected const int FirstMetadataColumn = 2;
 
-    protected readonly IMartenSession _session;
+    protected readonly IStorageSession _session;
     protected readonly ISerializer _serializer;
     protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
     protected readonly Dictionary<TId, T> _identityMap;
 
-    protected ClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected ClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
     {
         _session = session;
         _serializer = session.Serializer;

--- a/src/Marten/Internal/ClosedShape/ClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeLightweightSelector.cs
@@ -28,11 +28,11 @@ internal abstract class ClosedShapeLightweightSelector<T, TId>: ISelector<T>, ID
     protected const int DataColumn = 1;
     protected const int FirstMetadataColumn = 2;
 
-    protected readonly IMartenSession _session;
+    protected readonly IStorageSession _session;
     protected readonly ISerializer _serializer;
     protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
 
-    protected ClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected ClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
     {
         _session = session;
         _serializer = session.Serializer;

--- a/src/Marten/Internal/ClosedShape/ClosedShapeQueryOnlySelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeQueryOnlySelector.cs
@@ -23,11 +23,11 @@ internal abstract class ClosedShapeQueryOnlySelector<T, TId>: ISelector<T>
     protected const int DataColumn = 0;
     protected const int FirstMetadataColumn = 1;
 
-    protected readonly IMartenSession _session;
+    protected readonly IStorageSession _session;
     protected readonly ISerializer _serializer;
     protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
 
-    protected ClosedShapeQueryOnlySelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected ClosedShapeQueryOnlySelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
     {
         _session = session;
         _serializer = session.Serializer;

--- a/src/Marten/Internal/ClosedShape/DocumentCausationIdBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentCausationIdBinder.cs
@@ -14,7 +14,7 @@ namespace Marten.Internal.ClosedShape;
 
 /// <summary>
 /// <see cref="IDocumentMetadataBinder{TDoc}"/> for the <c>causation_id</c>
-/// column. Value comes from <see cref="IMartenSession.CausationId"/> on
+/// column. Value comes from <see cref="IStorageSession.CausationId"/> on
 /// every write; read path projects the stored value onto the document's
 /// <c>[CausationId]</c>-annotated member when one exists.
 /// </summary>
@@ -35,16 +35,16 @@ internal sealed class DocumentCausationIdBinder<TDoc>: IDocumentMetadataBinder<T
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
     {
         parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
         parameter.Value = (object?)session.CausationId ?? DBNull.Value;
     }
 
-    public void ApplyToDocument(TDoc document, IMartenSession session)
+    public void ApplyToDocument(TDoc document, IStorageSession session)
         => _setter?.Invoke(document, session.CausationId);
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         if (_setter is null) return;
         if (reader.IsDBNull(columnOrdinal)) return;

--- a/src/Marten/Internal/ClosedShape/DocumentCorrelationIdBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentCorrelationIdBinder.cs
@@ -15,7 +15,7 @@ namespace Marten.Internal.ClosedShape;
 /// <summary>
 /// <see cref="IDocumentMetadataBinder{TDoc}"/> for the
 /// <c>correlation_id</c> column. The value comes from
-/// <see cref="IMartenSession.CorrelationId"/> on every write — not from
+/// <see cref="IStorageSession.CorrelationId"/> on every write — not from
 /// the document — mirroring the codegen path's
 /// <c>setStringParameter(_, session.CorrelationId)</c> emit. On read the
 /// stored value is projected back onto the document's
@@ -38,16 +38,16 @@ internal sealed class DocumentCorrelationIdBinder<TDoc>: IDocumentMetadataBinder
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
     {
         parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
         parameter.Value = (object?)session.CorrelationId ?? DBNull.Value;
     }
 
-    public void ApplyToDocument(TDoc document, IMartenSession session)
+    public void ApplyToDocument(TDoc document, IStorageSession session)
         => _setter?.Invoke(document, session.CorrelationId);
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         if (_setter is null) return;
         if (reader.IsDBNull(columnOrdinal)) return;

--- a/src/Marten/Internal/ClosedShape/DocumentCreatedAtBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentCreatedAtBinder.cs
@@ -50,11 +50,11 @@ internal sealed class DocumentCreatedAtBinder<TDoc>: IDocumentMetadataBinder<TDo
     // "never written client-side" invariant honest.
     public string ValueSql => "transaction_timestamp()";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
         => throw new NotSupportedException(
             "mt_created_at has a server-side DEFAULT and is never written through this binder.");
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         if (_setter is null) return;
         if (reader.IsDBNull(columnOrdinal)) return;

--- a/src/Marten/Internal/ClosedShape/DocumentDocTypeBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDocTypeBinder.cs
@@ -41,14 +41,14 @@ internal sealed class DocumentDocTypeBinder<TDoc>: IDocumentMetadataBinder<TDoc>
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
     {
         var alias = _aliasCache.GetOrAdd(document.GetType(), t => _mapping.AliasFor(t));
         parameter.Value = alias;
         parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
     }
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         // No-op — the alias is read directly by the selector to dispatch
         // deserialization to the right subclass type, not projected onto

--- a/src/Marten/Internal/ClosedShape/DocumentDotNetTypeBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDotNetTypeBinder.cs
@@ -26,13 +26,13 @@ internal sealed class DocumentDotNetTypeBinder<TDoc>: IDocumentMetadataBinder<TD
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
     {
         parameter.Value = ResolveTypeName(document);
         parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
     }
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         // No-op — dotnet_type isn't projected back onto the document.
     }

--- a/src/Marten/Internal/ClosedShape/DocumentDuplicatedFieldBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDuplicatedFieldBinder.cs
@@ -62,7 +62,7 @@ internal sealed class DocumentDuplicatedFieldBinder<TDoc>: IDocumentMetadataBind
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
     {
         parameter.NpgsqlDbType = _field.DbType;
 
@@ -100,7 +100,7 @@ internal sealed class DocumentDuplicatedFieldBinder<TDoc>: IDocumentMetadataBind
         parameter.Value = current;
     }
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         // No-op — duplicated columns aren't in the document SELECT.
         // The canonical value is deserialized from the data column.

--- a/src/Marten/Internal/ClosedShape/DocumentHeadersBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentHeadersBinder.cs
@@ -39,10 +39,10 @@ internal sealed class DocumentHeadersBinder<TDoc>: IDocumentMetadataBinder<TDoc>
 
     public string ValueSql => "?";
 
-    public void ApplyToDocument(TDoc document, IMartenSession session)
+    public void ApplyToDocument(TDoc document, IStorageSession session)
         => _setter?.Invoke(document, session.Headers);
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
     {
         // Mirror the codegen path's setHeaderParameter: use the session's
         // cached UTF-8 byte[] when available (DocumentSessionBase
@@ -76,7 +76,7 @@ internal sealed class DocumentHeadersBinder<TDoc>: IDocumentMetadataBinder<TDoc>
         }
     }
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         if (_setter is null) return;
         if (reader.IsDBNull(columnOrdinal)) return;

--- a/src/Marten/Internal/ClosedShape/DocumentLastModifiedBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentLastModifiedBinder.cs
@@ -35,13 +35,13 @@ internal sealed class DocumentLastModifiedBinder<TDoc>: IDocumentMetadataBinder<
 
     public string ValueSql => "transaction_timestamp()";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
     {
         // No-op — IsServerSide is true; the operation skips this binder
         // in its write loop. The SQL literal in ValueSql does the work.
     }
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         if (_setter is null) return;
         if (reader.IsDBNull(columnOrdinal)) return;

--- a/src/Marten/Internal/ClosedShape/DocumentLastModifiedByBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentLastModifiedByBinder.cs
@@ -15,7 +15,7 @@ namespace Marten.Internal.ClosedShape;
 /// <summary>
 /// <see cref="IDocumentMetadataBinder{TDoc}"/> for the
 /// <c>last_modified_by</c> column. Value comes from
-/// <see cref="IMartenSession.LastModifiedBy"/> (alias of
+/// <see cref="IStorageSession.LastModifiedBy"/> (alias of
 /// <c>CurrentUserName</c>) on every write; read path projects the stored
 /// value onto the document's <c>[LastModifiedBy]</c>-annotated member
 /// when one exists.
@@ -37,7 +37,7 @@ internal sealed class DocumentLastModifiedByBinder<TDoc>: IDocumentMetadataBinde
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
     {
         parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
         // IMetadataContext.LastModifiedBy is the alias of CurrentUserName;
@@ -45,10 +45,10 @@ internal sealed class DocumentLastModifiedByBinder<TDoc>: IDocumentMetadataBinde
         parameter.Value = (object?)session.CurrentUserName ?? DBNull.Value;
     }
 
-    public void ApplyToDocument(TDoc document, IMartenSession session)
+    public void ApplyToDocument(TDoc document, IStorageSession session)
         => _setter?.Invoke(document, session.CurrentUserName);
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         if (_setter is null) return;
         if (reader.IsDBNull(columnOrdinal)) return;

--- a/src/Marten/Internal/ClosedShape/DocumentRevisionBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentRevisionBinder.cs
@@ -70,7 +70,7 @@ internal sealed class DocumentRevisionBinder<TDoc>: IDocumentMetadataBinder<TDoc
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
     {
         if (_columnDbType == NpgsqlDbType.Integer)
         {
@@ -84,7 +84,7 @@ internal sealed class DocumentRevisionBinder<TDoc>: IDocumentMetadataBinder<TDoc
         }
     }
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         if (_setter is null) return;
         if (reader.IsDBNull(columnOrdinal)) return;

--- a/src/Marten/Internal/ClosedShape/DocumentSoftDeletedAtBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentSoftDeletedAtBinder.cs
@@ -36,13 +36,13 @@ internal sealed class DocumentSoftDeletedAtBinder<TDoc>: IDocumentMetadataBinder
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
     {
         parameter.Value = DBNull.Value;
         parameter.NpgsqlDbType = NpgsqlDbType.TimestampTz;
     }
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         if (_setter is null) return;
         if (reader.IsDBNull(columnOrdinal))

--- a/src/Marten/Internal/ClosedShape/DocumentSoftDeletedBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentSoftDeletedBinder.cs
@@ -41,13 +41,13 @@ internal sealed class DocumentSoftDeletedBinder<TDoc>: IDocumentMetadataBinder<T
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
     {
         parameter.Value = false;
         parameter.NpgsqlDbType = NpgsqlDbType.Boolean;
     }
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         if (_setter is null) return;
         if (reader.IsDBNull(columnOrdinal)) return;

--- a/src/Marten/Internal/ClosedShape/DocumentTenantIdBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentTenantIdBinder.cs
@@ -38,11 +38,11 @@ internal sealed class DocumentTenantIdBinder<TDoc>: IDocumentMetadataBinder<TDoc
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
         => throw new NotSupportedException(
             "tenant_id is bound directly by the storage operation; this binder is read-only.");
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         if (_setter is null) return;
         if (reader.IsDBNull(columnOrdinal)) return;

--- a/src/Marten/Internal/ClosedShape/DocumentVersionBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentVersionBinder.cs
@@ -44,7 +44,7 @@ internal sealed class DocumentVersionBinder<TDoc>: IDocumentMetadataBinder<TDoc>
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session)
+    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
     {
         var newVersion = CombGuidIdGeneration.NewGuid();
         _setter?.Invoke(document, newVersion);
@@ -53,7 +53,7 @@ internal sealed class DocumentVersionBinder<TDoc>: IDocumentMetadataBinder<TDoc>
         parameter.NpgsqlDbType = NpgsqlDbType.Uuid;
     }
 
-    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session)
+    public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)
     {
         if (_setter is null) return;
         if (reader.IsDBNull(columnOrdinal)) return;

--- a/src/Marten/Internal/ClosedShape/FlatClosedShapeQueryOnlySelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatClosedShapeQueryOnlySelector.cs
@@ -14,7 +14,7 @@ internal sealed class FlatClosedShapeQueryOnlySelector<T, TId>: ClosedShapeQuery
     where T : notnull
     where TId : notnull
 {
-    public FlatClosedShapeQueryOnlySelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public FlatClosedShapeQueryOnlySelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }

--- a/src/Marten/Internal/ClosedShape/FlatNumericClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatNumericClosedShapeDirtyTrackingSelector.cs
@@ -12,7 +12,7 @@ internal sealed class FlatNumericClosedShapeDirtyTrackingSelector<T, TId>: Numer
     where T : notnull
     where TId : notnull
 {
-    public FlatNumericClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public FlatNumericClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }

--- a/src/Marten/Internal/ClosedShape/FlatNumericClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatNumericClosedShapeIdentityMapSelector.cs
@@ -12,7 +12,7 @@ internal sealed class FlatNumericClosedShapeIdentityMapSelector<T, TId>: Numeric
     where T : notnull
     where TId : notnull
 {
-    public FlatNumericClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public FlatNumericClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }

--- a/src/Marten/Internal/ClosedShape/FlatNumericClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatNumericClosedShapeLightweightSelector.cs
@@ -12,7 +12,7 @@ internal sealed class FlatNumericClosedShapeLightweightSelector<T, TId>: Numeric
     where T : notnull
     where TId : notnull
 {
-    public FlatNumericClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public FlatNumericClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }

--- a/src/Marten/Internal/ClosedShape/FlatOptimisticClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatOptimisticClosedShapeDirtyTrackingSelector.cs
@@ -12,7 +12,7 @@ internal sealed class FlatOptimisticClosedShapeDirtyTrackingSelector<T, TId>: Op
     where T : notnull
     where TId : notnull
 {
-    public FlatOptimisticClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public FlatOptimisticClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }

--- a/src/Marten/Internal/ClosedShape/FlatOptimisticClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatOptimisticClosedShapeIdentityMapSelector.cs
@@ -12,7 +12,7 @@ internal sealed class FlatOptimisticClosedShapeIdentityMapSelector<T, TId>: Opti
     where T : notnull
     where TId : notnull
 {
-    public FlatOptimisticClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public FlatOptimisticClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }

--- a/src/Marten/Internal/ClosedShape/FlatOptimisticClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatOptimisticClosedShapeLightweightSelector.cs
@@ -12,7 +12,7 @@ internal sealed class FlatOptimisticClosedShapeLightweightSelector<T, TId>: Opti
     where T : notnull
     where TId : notnull
 {
-    public FlatOptimisticClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public FlatOptimisticClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }

--- a/src/Marten/Internal/ClosedShape/FlatUnversionedClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatUnversionedClosedShapeDirtyTrackingSelector.cs
@@ -12,7 +12,7 @@ internal sealed class FlatUnversionedClosedShapeDirtyTrackingSelector<T, TId>: U
     where T : notnull
     where TId : notnull
 {
-    public FlatUnversionedClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public FlatUnversionedClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }

--- a/src/Marten/Internal/ClosedShape/FlatUnversionedClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatUnversionedClosedShapeIdentityMapSelector.cs
@@ -12,7 +12,7 @@ internal sealed class FlatUnversionedClosedShapeIdentityMapSelector<T, TId>: Unv
     where T : notnull
     where TId : notnull
 {
-    public FlatUnversionedClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public FlatUnversionedClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }

--- a/src/Marten/Internal/ClosedShape/FlatUnversionedClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/FlatUnversionedClosedShapeLightweightSelector.cs
@@ -13,7 +13,7 @@ internal sealed class FlatUnversionedClosedShapeLightweightSelector<T, TId>: Unv
     where T : notnull
     where TId : notnull
 {
-    public FlatUnversionedClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public FlatUnversionedClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }

--- a/src/Marten/Internal/ClosedShape/HierarchicalClosedShapeQueryOnlySelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalClosedShapeQueryOnlySelector.cs
@@ -22,7 +22,7 @@ internal sealed class HierarchicalClosedShapeQueryOnlySelector<T, TId>: ClosedSh
     private readonly DocumentMapping _hierarchy;
     private readonly int _docTypeOrdinal;
 
-    public HierarchicalClosedShapeQueryOnlySelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public HierarchicalClosedShapeQueryOnlySelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         // The factory only constructs this leaf when HierarchyMapping is

--- a/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeDirtyTrackingSelector.cs
@@ -17,7 +17,7 @@ internal sealed class HierarchicalNumericClosedShapeDirtyTrackingSelector<T, TId
     private readonly DocumentMapping _hierarchy;
     private readonly int _docTypeOrdinal;
 
-    public HierarchicalNumericClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public HierarchicalNumericClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _hierarchy = descriptor.HierarchyMapping

--- a/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeIdentityMapSelector.cs
@@ -17,7 +17,7 @@ internal sealed class HierarchicalNumericClosedShapeIdentityMapSelector<T, TId>:
     private readonly DocumentMapping _hierarchy;
     private readonly int _docTypeOrdinal;
 
-    public HierarchicalNumericClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public HierarchicalNumericClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _hierarchy = descriptor.HierarchyMapping

--- a/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeLightweightSelector.cs
@@ -17,7 +17,7 @@ internal sealed class HierarchicalNumericClosedShapeLightweightSelector<T, TId>:
     private readonly DocumentMapping _hierarchy;
     private readonly int _docTypeOrdinal;
 
-    public HierarchicalNumericClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public HierarchicalNumericClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _hierarchy = descriptor.HierarchyMapping

--- a/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeDirtyTrackingSelector.cs
@@ -17,7 +17,7 @@ internal sealed class HierarchicalOptimisticClosedShapeDirtyTrackingSelector<T, 
     private readonly DocumentMapping _hierarchy;
     private readonly int _docTypeOrdinal;
 
-    public HierarchicalOptimisticClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public HierarchicalOptimisticClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _hierarchy = descriptor.HierarchyMapping

--- a/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeIdentityMapSelector.cs
@@ -17,7 +17,7 @@ internal sealed class HierarchicalOptimisticClosedShapeIdentityMapSelector<T, TI
     private readonly DocumentMapping _hierarchy;
     private readonly int _docTypeOrdinal;
 
-    public HierarchicalOptimisticClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public HierarchicalOptimisticClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _hierarchy = descriptor.HierarchyMapping

--- a/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeLightweightSelector.cs
@@ -17,7 +17,7 @@ internal sealed class HierarchicalOptimisticClosedShapeLightweightSelector<T, TI
     private readonly DocumentMapping _hierarchy;
     private readonly int _docTypeOrdinal;
 
-    public HierarchicalOptimisticClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public HierarchicalOptimisticClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _hierarchy = descriptor.HierarchyMapping

--- a/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeDirtyTrackingSelector.cs
@@ -17,7 +17,7 @@ internal sealed class HierarchicalUnversionedClosedShapeDirtyTrackingSelector<T,
     private readonly DocumentMapping _hierarchy;
     private readonly int _docTypeOrdinal;
 
-    public HierarchicalUnversionedClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public HierarchicalUnversionedClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _hierarchy = descriptor.HierarchyMapping

--- a/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeIdentityMapSelector.cs
@@ -17,7 +17,7 @@ internal sealed class HierarchicalUnversionedClosedShapeIdentityMapSelector<T, T
     private readonly DocumentMapping _hierarchy;
     private readonly int _docTypeOrdinal;
 
-    public HierarchicalUnversionedClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public HierarchicalUnversionedClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _hierarchy = descriptor.HierarchyMapping

--- a/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeLightweightSelector.cs
@@ -21,7 +21,7 @@ internal sealed class HierarchicalUnversionedClosedShapeLightweightSelector<T, T
     private readonly DocumentMapping _hierarchy;
     private readonly int _docTypeOrdinal;
 
-    public HierarchicalUnversionedClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    public HierarchicalUnversionedClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _hierarchy = descriptor.HierarchyMapping

--- a/src/Marten/Internal/ClosedShape/IDocumentMetadataBinder.cs
+++ b/src/Marten/Internal/ClosedShape/IDocumentMetadataBinder.cs
@@ -64,7 +64,7 @@ public interface IDocumentMetadataBinder<TDoc>
     /// binders don't get called here — their <see cref="ValueSql"/>
     /// fragment is in the SQL directly.
     /// </summary>
-    void BindParameter(NpgsqlParameter parameter, TDoc document, IMartenSession session);
+    void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session);
 
     /// <summary>
     /// Optional pre-serialization hook. Called once per write before the
@@ -75,7 +75,7 @@ public interface IDocumentMetadataBinder<TDoc>
     /// Default no-op; binders whose value isn't session-derived (Version,
     /// LastModified, soft-delete, etc.) don't override.
     /// </summary>
-    void ApplyToDocument(TDoc document, IMartenSession session) { }
+    void ApplyToDocument(TDoc document, IStorageSession session) { }
 
     /// <summary>
     /// Per-row read hook on the SELECT path. Called from the selector
@@ -89,7 +89,7 @@ public interface IDocumentMetadataBinder<TDoc>
     /// need to deserialize JSON values (e.g. Headers) via the configured
     /// <see cref="ISerializer"/>.
     /// </summary>
-    void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IMartenSession session);
+    void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session);
 
     /// <summary>
     /// W3 spike (M16): per-row write hook on the COPY (bulk) path. Each

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeDirtyTrackingSelector.cs
@@ -16,7 +16,7 @@ internal abstract class NumericClosedShapeDirtyTrackingSelector<T, TId>: ClosedS
 {
     private readonly Dictionary<TId, long> _revisions;
 
-    protected NumericClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected NumericClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _revisions = session.Versions.RevisionsFor<T, TId>();

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeIdentityMapSelector.cs
@@ -16,7 +16,7 @@ internal abstract class NumericClosedShapeIdentityMapSelector<T, TId>: ClosedSha
 {
     private readonly Dictionary<TId, long> _revisions;
 
-    protected NumericClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected NumericClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _revisions = session.Versions.RevisionsFor<T, TId>();

--- a/src/Marten/Internal/ClosedShape/NumericClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/NumericClosedShapeLightweightSelector.cs
@@ -17,7 +17,7 @@ internal abstract class NumericClosedShapeLightweightSelector<T, TId>: ClosedSha
 {
     private readonly Dictionary<TId, long> _revisions;
 
-    protected NumericClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected NumericClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _revisions = session.Versions.RevisionsFor<T, TId>();

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeDirtyTrackingSelector.cs
@@ -17,7 +17,7 @@ internal abstract class OptimisticClosedShapeDirtyTrackingSelector<T, TId>: Clos
 {
     private readonly Dictionary<TId, Guid> _versions;
 
-    protected OptimisticClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected OptimisticClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _versions = session.Versions.ForType<T, TId>();

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeIdentityMapSelector.cs
@@ -17,7 +17,7 @@ internal abstract class OptimisticClosedShapeIdentityMapSelector<T, TId>: Closed
 {
     private readonly Dictionary<TId, Guid> _versions;
 
-    protected OptimisticClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected OptimisticClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _versions = session.Versions.ForType<T, TId>();

--- a/src/Marten/Internal/ClosedShape/OptimisticClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticClosedShapeLightweightSelector.cs
@@ -18,7 +18,7 @@ internal abstract class OptimisticClosedShapeLightweightSelector<T, TId>: Closed
 {
     private readonly Dictionary<TId, Guid> _versions;
 
-    protected OptimisticClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected OptimisticClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
         _versions = session.Versions.ForType<T, TId>();

--- a/src/Marten/Internal/ClosedShape/UnversionedClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedClosedShapeDirtyTrackingSelector.cs
@@ -12,7 +12,7 @@ internal abstract class UnversionedClosedShapeDirtyTrackingSelector<T, TId>: Clo
     where T : notnull
     where TId : notnull
 {
-    protected UnversionedClosedShapeDirtyTrackingSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected UnversionedClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }

--- a/src/Marten/Internal/ClosedShape/UnversionedClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedClosedShapeIdentityMapSelector.cs
@@ -12,7 +12,7 @@ internal abstract class UnversionedClosedShapeIdentityMapSelector<T, TId>: Close
     where T : notnull
     where TId : notnull
 {
-    protected UnversionedClosedShapeIdentityMapSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected UnversionedClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }

--- a/src/Marten/Internal/ClosedShape/UnversionedClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedClosedShapeLightweightSelector.cs
@@ -13,7 +13,7 @@ internal abstract class UnversionedClosedShapeLightweightSelector<T, TId>: Close
     where T : notnull
     where TId : notnull
 {
-    protected UnversionedClosedShapeLightweightSelector(IMartenSession session, DocumentStorageDescriptor<T, TId> descriptor)
+    protected UnversionedClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
     }

--- a/src/Marten/Internal/DirtyTracking/ChangeTracker.cs
+++ b/src/Marten/Internal/DirtyTracking/ChangeTracker.cs
@@ -11,7 +11,7 @@ public class ChangeTracker<T>: IChangeTracker where T : notnull
     private readonly T _document;
     private string _json;
 
-    public ChangeTracker(IMartenSession session, T document)
+    public ChangeTracker(IStorageSession session, T document)
     {
         _document = document;
         _json = session.Serializer.ToCleanJson(document);

--- a/src/Marten/Internal/IMartenSession.cs
+++ b/src/Marten/Internal/IMartenSession.cs
@@ -1,44 +1,16 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx;
 using Marten.Events;
-using Marten.Internal.DirtyTracking;
-using Marten.Internal.Storage;
-using Marten.Services;
-using Marten.Storage;
 using Npgsql;
 
 namespace Marten.Internal;
 
-public interface IMartenSession: IDisposable, IAsyncDisposable, IMetadataContext
+public interface IMartenSession: IDisposable, IAsyncDisposable, IStorageSession
 {
-    ISerializer Serializer { get; }
-    Dictionary<Type, object> ItemMap { get; }
-    IMartenDatabase Database { get; }
-
-    VersionTracker Versions { get; }
-
-    StoreOptions Options { get; }
-
-    IList<IChangeTracker> ChangeTrackers { get; }
-
-    /// <summary>
-    ///     Override whether or not this session honors optimistic concurrency checks
-    /// </summary>
-    ConcurrencyChecks Concurrency { get; }
-
-    IDocumentStorage StorageFor(Type documentType);
-
-
-    void MarkAsAddedForStorage(object id, object document);
-
-    void MarkAsDocumentLoaded(object id, object document);
-    IDocumentStorage<T> StorageFor<T>() where T : notnull;
-
     IEventStorage EventStorage();
 
     string NextTempTableName();

--- a/src/Marten/Internal/IStorageSession.cs
+++ b/src/Marten/Internal/IStorageSession.cs
@@ -1,0 +1,55 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using JasperFx;
+using Marten.Internal.DirtyTracking;
+using Marten.Internal.Storage;
+using Marten.Services;
+using Marten.Storage;
+
+namespace Marten.Internal;
+
+/// <summary>
+///     Database-neutral operation/session context that Marten's closed-shape storage,
+///     operation, and selector code targets instead of <see cref="IMartenSession"/>.
+///     This is the gating seam (#4810) for extracting the closed-shape storage runtime
+///     into a shared package so alternate dialects (e.g. Polecat/SQL Server) can reuse it.
+/// </summary>
+/// <remarks>
+///     Deliberately exposes only the subset of members the closed-shape document + event
+///     storage code actually consumes. The unit-of-work metadata seam is the shared
+///     <see cref="IMetadataContext"/> (TenantId / correlation / causation / user name /
+///     headers) — the JasperFx interface Marten's session already implements.
+///     Members that are still Marten-typed (<see cref="ISerializer"/>,
+///     <see cref="IMartenDatabase"/>, <see cref="StoreOptions"/>) are intentionally left as
+///     the Marten types for now — a serializer seam and a database/sequence seam are tracked
+///     as separate W2 tasks. This interface only makes the code <em>targetable</em>; the
+///     physical move to a shared package is a later step.
+/// </remarks>
+public interface IStorageSession: IMetadataContext
+{
+    ISerializer Serializer { get; }
+
+    IMartenDatabase Database { get; }
+
+    StoreOptions Options { get; }
+
+    VersionTracker Versions { get; }
+
+    IList<IChangeTracker> ChangeTrackers { get; }
+
+    Dictionary<Type, object> ItemMap { get; }
+
+    /// <summary>
+    ///     Override whether or not this session honors optimistic concurrency checks
+    /// </summary>
+    ConcurrencyChecks Concurrency { get; }
+
+    IDocumentStorage StorageFor(Type documentType);
+
+    IDocumentStorage<T> StorageFor<T>() where T : notnull;
+
+    void MarkAsAddedForStorage(object id, object document);
+
+    void MarkAsDocumentLoaded(object id, object document);
+}


### PR DESCRIPTION
Progress on #4810 (W2 prerequisite for shared closed-shape storage). This PR delivers the **gating foundation** plus the first, self-contained slice of the retarget. It is green and has no public-API break; larger/out-of-scope pieces are called out as follow-ups.

## What this does

**1. Foundation — the agnostic contract (done-criterion #1)**
- New `Marten.Internal.IStorageSession` exposing only the subset of members the closed-shape document + event storage code actually consumes: `Serializer`, `Database`, `Options`, `Versions`, `ChangeTrackers`, `ItemMap`, `Concurrency`, `StorageFor`, `MarkAsAddedForStorage`, `MarkAsDocumentLoaded`.
- `IMartenSession : IStorageSession` — the moved members are inherited, so this is **source-compatible** (no behavior change). `EventStorage()`, `NextTempTableName()`, and `ExecuteReaderAsync(NpgsqlCommand)` stay on `IMartenSession`.

**2. First retarget slice (`IMartenSession` → `IStorageSession`)**
- The closed-shape metadata **binder** interfaces + all implementers: `IDocumentMetadataBinder`, `IEventMetadataBinder` (Causation/Correlation/Headers/UserName/Version/TenantId/... binders).
- All **33 closed-shape selectors** (identity-map / lightweight / query-only / dirty-tracking and their Numeric/Optimistic/Unversioned/Flat/Hierarchical variants) — the `_session` field + constructors.
- `ChangeTracker`'s constructor (uses only `Serializer`) narrowed to `IStorageSession`, so the dirty-tracking selectors retarget without dragging in the shared storage interface.

Callers pass an `IMartenSession` (which satisfies `IStorageSession`), so nothing downstream changes.

## Metadata-base decision

The contract's metadata seam is the shared **`JasperFx.IMetadataContext`**, not `IOperationContext`. `IOperationContext` was rejected during implementation because (a) inheriting it alongside Marten's existing `IMetadataContext` produces `CS0229` ambiguity on `TenantId`/`Headers`, and (b) closed-shape code reads `CurrentUserName`, which is `IMetadataContext`-only (`IOperationContext`'s `LastModifiedBy` is `[Obsolete]`). `IMetadataContext` is also a shared/agnostic JasperFx interface, so the code stays targetable; standardizing the shared package on `IOperationContext` can be a later cross-repo step.

## Deferred (follow-ups)

Per the issue's scope notes, these are intentionally **not** in this PR:
- The shared `IDocumentStorage` `Insert`/`Update`/`Upsert`/`Overwrite`/`BuildSelector` overrides — closed-shape storage inherits `Internal/Storage`, so retargeting those touches the deferred document-storage base.
- The `IStorageOperation : IQueryHandler` `ConfigureCommand(…, IMartenSession)` split (jasperfx#214, listed out-of-scope).
- The `ExecuteReaderAsync(NpgsqlCommand)` → `DbCommand`/neutral execution seam (not called by closed-shape/EventStorage — lives only in `Internal/Storage/*DocumentStorage.cs`).
- No files were moved to a shared package (explicitly a later W2 step). `IIdentification*.cs` untouched (owned by the parallel identity move).

## Verification
- Marten builds; **DocumentDbTests 1027 passed** (all storage modes / binders / selectors), **event metadata + append tests 160 passed** (net10).
- No public API break — everything is `Internal.*`; `IMartenSession` still exposes the same members via inheritance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)