### PR TITLE
#4810 — retarget write-path IDocumentStorage methods to IStorageSession

### DIFF
--- a/src/Marten/Events/EventDocumentStorage.cs
+++ b/src/Marten/Events/EventDocumentStorage.cs
@@ -90,12 +90,12 @@ public abstract class EventDocumentStorage: IEventStorage
         throw new NotSupportedException();
     }
 
-    public void EjectById(IMartenSession session, object id)
+    public void EjectById(IStorageSession session, object id)
     {
         // Nothing
     }
 
-    public void RemoveDirtyTracker(IMartenSession session, object id)
+    public void RemoveDirtyTracker(IStorageSession session, object id)
     {
         // Nothing
     }
@@ -178,47 +178,47 @@ public abstract class EventDocumentStorage: IEventStorage
 
     public Type IdType { get; }
 
-    public Guid? VersionFor(IEvent document, IMartenSession session)
+    public Guid? VersionFor(IEvent document, IStorageSession session)
     {
         return null;
     }
 
-    public void Store(IMartenSession session, IEvent document)
+    public void Store(IStorageSession session, IEvent document)
     {
         // Nothing
     }
 
-    public void Store(IMartenSession session, IEvent document, Guid? version)
+    public void Store(IStorageSession session, IEvent document, Guid? version)
     {
         // Nothing
     }
 
-    public void Store(IMartenSession session, IEvent document, long revision)
+    public void Store(IStorageSession session, IEvent document, long revision)
     {
         // Nothing
     }
 
-    public void Eject(IMartenSession session, IEvent document)
+    public void Eject(IStorageSession session, IEvent document)
     {
         // Nothing
     }
 
-    public IStorageOperation Update(IEvent document, IMartenSession session, string tenant)
+    public IStorageOperation Update(IEvent document, IStorageSession session, string tenant)
     {
         throw new NotSupportedException();
     }
 
-    public IStorageOperation Insert(IEvent document, IMartenSession session, string tenant)
+    public IStorageOperation Insert(IEvent document, IStorageSession session, string tenant)
     {
         throw new NotSupportedException();
     }
 
-    public IStorageOperation Upsert(IEvent document, IMartenSession session, string tenant)
+    public IStorageOperation Upsert(IEvent document, IStorageSession session, string tenant)
     {
         throw new NotSupportedException();
     }
 
-    public IStorageOperation Overwrite(IEvent document, IMartenSession session, string tenant)
+    public IStorageOperation Overwrite(IEvent document, IStorageSession session, string tenant)
     {
         throw new NotSupportedException();
     }

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -298,47 +298,47 @@ public class EventMapping<T>: EventMapping, IDocumentStorage<T> where T : class
 
     Type IDocumentStorage.IdType => _idType;
 
-    Guid? IDocumentStorage<T>.VersionFor(T document, IMartenSession session)
+    Guid? IDocumentStorage<T>.VersionFor(T document, IStorageSession session)
     {
         throw new NotSupportedException();
     }
 
-    void IDocumentStorage<T>.Store(IMartenSession session, T document)
+    void IDocumentStorage<T>.Store(IStorageSession session, T document)
     {
         throw new NotSupportedException();
     }
 
-    void IDocumentStorage<T>.Store(IMartenSession session, T document, Guid? version)
+    void IDocumentStorage<T>.Store(IStorageSession session, T document, Guid? version)
     {
         throw new NotSupportedException();
     }
 
-    public void Store(IMartenSession session, T document, long revision)
+    public void Store(IStorageSession session, T document, long revision)
     {
         throw new NotSupportedException();
     }
 
-    void IDocumentStorage<T>.Eject(IMartenSession session, T document)
+    void IDocumentStorage<T>.Eject(IStorageSession session, T document)
     {
         throw new NotSupportedException();
     }
 
-    IStorageOperation IDocumentStorage<T>.Update(T document, IMartenSession session, string tenant)
+    IStorageOperation IDocumentStorage<T>.Update(T document, IStorageSession session, string tenant)
     {
         throw new NotSupportedException();
     }
 
-    IStorageOperation IDocumentStorage<T>.Insert(T document, IMartenSession session, string tenant)
+    IStorageOperation IDocumentStorage<T>.Insert(T document, IStorageSession session, string tenant)
     {
         throw new NotSupportedException();
     }
 
-    IStorageOperation IDocumentStorage<T>.Upsert(T document, IMartenSession session, string tenant)
+    IStorageOperation IDocumentStorage<T>.Upsert(T document, IStorageSession session, string tenant)
     {
         throw new NotSupportedException();
     }
 
-    IStorageOperation IDocumentStorage<T>.Overwrite(T document, IMartenSession session, string tenant)
+    IStorageOperation IDocumentStorage<T>.Overwrite(T document, IStorageSession session, string tenant)
     {
         throw new NotSupportedException();
     }
@@ -369,12 +369,12 @@ public class EventMapping<T>: EventMapping, IDocumentStorage<T> where T : class
         throw new NotSupportedException();
     }
 
-    void IDocumentStorage<T>.EjectById(IMartenSession session, object id)
+    void IDocumentStorage<T>.EjectById(IStorageSession session, object id)
     {
         // Nothing
     }
 
-    void IDocumentStorage<T>.RemoveDirtyTracker(IMartenSession session, object id)
+    void IDocumentStorage<T>.RemoveDirtyTracker(IStorageSession session, object id)
     {
         // Nothing
     }

--- a/src/Marten/Internal/ClosedShape/NumericDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericDirtyCheckedClosedShapeStorage.cs
@@ -18,16 +18,16 @@ internal sealed class NumericDirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyChe
     {
     }
 
-    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Insert(TDoc document, IStorageSession session, string tenant)
         => new NumericClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
 
-    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Update(TDoc document, IStorageSession session, string tenant)
         => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
 
-    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Upsert(TDoc document, IStorageSession session, string tenant)
         => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, session.Versions.RevisionsFor<TDoc, TId>());
 
-    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenant)
         => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
 
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)

--- a/src/Marten/Internal/ClosedShape/NumericIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericIdentityMapClosedShapeStorage.cs
@@ -18,16 +18,16 @@ internal sealed class NumericIdentityMapClosedShapeStorage<TDoc, TId>: IdentityM
     {
     }
 
-    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Insert(TDoc document, IStorageSession session, string tenant)
         => new NumericClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
 
-    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Update(TDoc document, IStorageSession session, string tenant)
         => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
 
-    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Upsert(TDoc document, IStorageSession session, string tenant)
         => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, session.Versions.RevisionsFor<TDoc, TId>());
 
-    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenant)
         => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
 
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)

--- a/src/Marten/Internal/ClosedShape/NumericLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericLightweightClosedShapeStorage.cs
@@ -21,16 +21,16 @@ internal sealed class NumericLightweightClosedShapeStorage<TDoc, TId>: Lightweig
     {
     }
 
-    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Insert(TDoc document, IStorageSession session, string tenant)
         => new NumericClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
 
-    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Update(TDoc document, IStorageSession session, string tenant)
         => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
 
-    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Upsert(TDoc document, IStorageSession session, string tenant)
         => new NumericClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, session.Versions.RevisionsFor<TDoc, TId>());
 
-    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenant)
         => new NumericClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.RevisionsFor<TDoc, TId>());
 
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)

--- a/src/Marten/Internal/ClosedShape/OptimisticDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticDirtyCheckedClosedShapeStorage.cs
@@ -18,16 +18,16 @@ internal sealed class OptimisticDirtyCheckedClosedShapeStorage<TDoc, TId>: Dirty
     {
     }
 
-    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Insert(TDoc document, IStorageSession session, string tenant)
         => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
 
-    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Update(TDoc document, IStorageSession session, string tenant)
         => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
 
-    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Upsert(TDoc document, IStorageSession session, string tenant)
         => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, session.Versions.ForType<TDoc, TId>());
 
-    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenant)
         => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
 
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)

--- a/src/Marten/Internal/ClosedShape/OptimisticIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticIdentityMapClosedShapeStorage.cs
@@ -18,16 +18,16 @@ internal sealed class OptimisticIdentityMapClosedShapeStorage<TDoc, TId>: Identi
     {
     }
 
-    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Insert(TDoc document, IStorageSession session, string tenant)
         => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
 
-    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Update(TDoc document, IStorageSession session, string tenant)
         => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
 
-    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Upsert(TDoc document, IStorageSession session, string tenant)
         => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, session.Versions.ForType<TDoc, TId>());
 
-    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenant)
         => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
 
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)

--- a/src/Marten/Internal/ClosedShape/OptimisticLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticLightweightClosedShapeStorage.cs
@@ -21,16 +21,16 @@ internal sealed class OptimisticLightweightClosedShapeStorage<TDoc, TId>: Lightw
     {
     }
 
-    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Insert(TDoc document, IStorageSession session, string tenant)
         => new OptimisticClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
 
-    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Update(TDoc document, IStorageSession session, string tenant)
         => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
 
-    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Upsert(TDoc document, IStorageSession session, string tenant)
         => new OptimisticClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert, session.Versions.ForType<TDoc, TId>());
 
-    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenant)
         => new OptimisticClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, session.Versions.ForType<TDoc, TId>());
 
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)

--- a/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
@@ -46,16 +46,16 @@ public sealed class QueryOnlyClosedShapeStorage<TDoc, TId>: QueryOnlyDocumentSto
     public override Npgsql.NpgsqlParameter BuildManyIdParameter(TId[] ids)
         => ClosedShapeIdHelpers.BuildManyIdParameter(ids, _descriptor.Identification);
 
-    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Insert(TDoc document, IStorageSession session, string tenant)
         => throw new NotSupportedException("QueryOnly storage doesn't support Insert.");
 
-    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Update(TDoc document, IStorageSession session, string tenant)
         => throw new NotSupportedException("QueryOnly storage doesn't support Update.");
 
-    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Upsert(TDoc document, IStorageSession session, string tenant)
         => throw new NotSupportedException("QueryOnly storage doesn't support Upsert.");
 
-    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenant)
         => throw new NotSupportedException("QueryOnly storage doesn't support Overwrite.");
 
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)

--- a/src/Marten/Internal/ClosedShape/UnversionedDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedDirtyCheckedClosedShapeStorage.cs
@@ -18,16 +18,16 @@ internal sealed class UnversionedDirtyCheckedClosedShapeStorage<TDoc, TId>: Dirt
     {
     }
 
-    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Insert(TDoc document, IStorageSession session, string tenant)
         => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
-    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Update(TDoc document, IStorageSession session, string tenant)
         => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
-    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Upsert(TDoc document, IStorageSession session, string tenant)
         => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert);
 
-    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenant)
         => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)

--- a/src/Marten/Internal/ClosedShape/UnversionedIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedIdentityMapClosedShapeStorage.cs
@@ -18,16 +18,16 @@ internal sealed class UnversionedIdentityMapClosedShapeStorage<TDoc, TId>: Ident
     {
     }
 
-    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Insert(TDoc document, IStorageSession session, string tenant)
         => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
-    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Update(TDoc document, IStorageSession session, string tenant)
         => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
-    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Upsert(TDoc document, IStorageSession session, string tenant)
         => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert);
 
-    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenant)
         => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)

--- a/src/Marten/Internal/ClosedShape/UnversionedLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedLightweightClosedShapeStorage.cs
@@ -21,16 +21,16 @@ internal sealed class UnversionedLightweightClosedShapeStorage<TDoc, TId>: Light
     {
     }
 
-    public override IStorageOperation Insert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Insert(TDoc document, IStorageSession session, string tenant)
         => new UnversionedClosedShapeInsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
-    public override IStorageOperation Update(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Update(TDoc document, IStorageSession session, string tenant)
         => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
-    public override IStorageOperation Upsert(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Upsert(TDoc document, IStorageSession session, string tenant)
         => new UnversionedClosedShapeUpsertOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, OperationRole.Upsert);
 
-    public override IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenant)
+    public override IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenant)
         => new UnversionedClosedShapeOverwriteOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
     public override IStorageOperation OverwriteProjected(TDoc document, string tenant)

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -216,7 +216,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
         return new Deletion(this, HardDeleteFragment, ByIdFilter(id)) { Id = id };
     }
 
-    public void EjectById(IMartenSession session, object id)
+    public void EjectById(IStorageSession session, object id)
     {
         var typedId = (TId)id;
 
@@ -229,7 +229,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
         }
     }
 
-    public void RemoveDirtyTracker(IMartenSession session, object id)
+    public void RemoveDirtyTracker(IStorageSession session, object id)
     {
         session.ChangeTrackers.RemoveAll(x =>
         {
@@ -272,7 +272,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
 
     public Type IdType => typeof(TId);
 
-    public Guid? VersionFor(T document, IMartenSession session)
+    public Guid? VersionFor(T document, IStorageSession session)
     {
         if (document == null)
         {
@@ -282,15 +282,15 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
         return session.Versions.VersionFor<T, TId>(Identity(document));
     }
 
-    public abstract void Store(IMartenSession session, T document);
-    public abstract void Store(IMartenSession session, T document, Guid? version);
-    public abstract void Store(IMartenSession session, T document, long revision);
-    public abstract void Eject(IMartenSession session, T document);
-    public abstract IStorageOperation Update(T document, IMartenSession session, string tenant);
-    public abstract IStorageOperation Insert(T document, IMartenSession session, string tenant);
-    public abstract IStorageOperation Upsert(T document, IMartenSession session, string tenant);
+    public abstract void Store(IStorageSession session, T document);
+    public abstract void Store(IStorageSession session, T document, Guid? version);
+    public abstract void Store(IStorageSession session, T document, long revision);
+    public abstract void Eject(IStorageSession session, T document);
+    public abstract IStorageOperation Update(T document, IStorageSession session, string tenant);
+    public abstract IStorageOperation Insert(T document, IStorageSession session, string tenant);
+    public abstract IStorageOperation Upsert(T document, IStorageSession session, string tenant);
 
-    public abstract IStorageOperation Overwrite(T document, IMartenSession session, string tenant);
+    public abstract IStorageOperation Overwrite(T document, IStorageSession session, string tenant);
 
     /// <inheritdoc />
     public abstract IStorageOperation OverwriteProjected(T document, string tenant);

--- a/src/Marten/Internal/Storage/IDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IDocumentStorage.cs
@@ -95,19 +95,19 @@ public interface IDocumentStorage<T>: IDocumentStorage where T : notnull
     object IdentityFor(T document);
 
 
-    Guid? VersionFor(T document, IMartenSession session);
+    Guid? VersionFor(T document, IStorageSession session);
 
-    void Store(IMartenSession session, T document);
-    void Store(IMartenSession session, T document, Guid? version);
-    void Store(IMartenSession session, T document, long revision);
+    void Store(IStorageSession session, T document);
+    void Store(IStorageSession session, T document, Guid? version);
+    void Store(IStorageSession session, T document, long revision);
 
-    void Eject(IMartenSession session, T document);
+    void Eject(IStorageSession session, T document);
 
-    IStorageOperation Update(T document, IMartenSession session, string tenantId);
-    IStorageOperation Insert(T document, IMartenSession session, string tenantId);
-    IStorageOperation Upsert(T document, IMartenSession session, string tenantId);
+    IStorageOperation Update(T document, IStorageSession session, string tenantId);
+    IStorageOperation Insert(T document, IStorageSession session, string tenantId);
+    IStorageOperation Upsert(T document, IStorageSession session, string tenantId);
 
-    IStorageOperation Overwrite(T document, IMartenSession session, string tenantId);
+    IStorageOperation Overwrite(T document, IStorageSession session, string tenantId);
 
     /// <summary>
     /// Lighter-weight overwrite for projection storage. Builds the same Overwrite operation
@@ -143,8 +143,8 @@ public interface IDocumentStorage<T>: IDocumentStorage where T : notnull
     IDeletion DeleteForDocument(T document, string tenantId);
 
 
-    void EjectById(IMartenSession session, object id);
-    void RemoveDirtyTracker(IMartenSession session, object id);
+    void EjectById(IStorageSession session, object id);
+    void RemoveDirtyTracker(IStorageSession session, object id);
     IDeletion HardDeleteForDocument(T document, string tenantId);
 
     void SetIdentityFromString(T document, string identityString);

--- a/src/Marten/Internal/Storage/IdentityMapDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IdentityMapDocumentStorage.cs
@@ -22,7 +22,7 @@ public abstract class IdentityMapDocumentStorage<T, TId>: DocumentStorage<T, TId
     {
     }
 
-    public sealed override void Eject(IMartenSession session, T document)
+    public sealed override void Eject(IStorageSession session, T document)
     {
         var id = Identity(document);
         if (session.ItemMap.TryGetValue(typeof(T), out var items))
@@ -34,12 +34,12 @@ public abstract class IdentityMapDocumentStorage<T, TId>: DocumentStorage<T, TId
         }
     }
 
-    public sealed override void Store(IMartenSession session, T document)
+    public sealed override void Store(IStorageSession session, T document)
     {
         store(session, document, out var id);
     }
 
-    private void store(IMartenSession session, T document, out TId id)
+    private void store(IStorageSession session, T document, out TId id)
     {
         id = AssignIdentity(document, session.TenantId, session.Database);
         session.MarkAsAddedForStorage(id, document);
@@ -71,7 +71,7 @@ public abstract class IdentityMapDocumentStorage<T, TId>: DocumentStorage<T, TId
         }
     }
 
-    public sealed override void Store(IMartenSession session, T document, Guid? version)
+    public sealed override void Store(IStorageSession session, T document, Guid? version)
     {
         store(session, document, out var id);
 
@@ -85,7 +85,7 @@ public abstract class IdentityMapDocumentStorage<T, TId>: DocumentStorage<T, TId
         }
     }
 
-    public sealed override void Store(IMartenSession session, T document, long revision)
+    public sealed override void Store(IStorageSession session, T document, long revision)
     {
         store(session, document, out var id);
 

--- a/src/Marten/Internal/Storage/LightweightDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/LightweightDocumentStorage.cs
@@ -15,13 +15,13 @@ public abstract class LightweightDocumentStorage<T, TId>: DocumentStorage<T, TId
     {
     }
 
-    public sealed override void Store(IMartenSession session, T document)
+    public sealed override void Store(IStorageSession session, T document)
     {
         var id = AssignIdentity(document, session.TenantId, session.Database);
         session.MarkAsAddedForStorage(id, document);
     }
 
-    public sealed override void Store(IMartenSession session, T document, Guid? version)
+    public sealed override void Store(IStorageSession session, T document, Guid? version)
     {
         var id = AssignIdentity(document, session.TenantId, session.Database);
         session.MarkAsAddedForStorage(id, document);
@@ -36,7 +36,7 @@ public abstract class LightweightDocumentStorage<T, TId>: DocumentStorage<T, TId
         }
     }
 
-    public sealed override void Store(IMartenSession session, T document, long revision)
+    public sealed override void Store(IStorageSession session, T document, long revision)
     {
         var id = AssignIdentity(document, session.TenantId, session.Database);
         session.MarkAsAddedForStorage(id, document);
@@ -51,7 +51,7 @@ public abstract class LightweightDocumentStorage<T, TId>: DocumentStorage<T, TId
         }
     }
 
-    public sealed override void Eject(IMartenSession session, T document)
+    public sealed override void Eject(IStorageSession session, T document)
     {
         // Nothing!
     }

--- a/src/Marten/Internal/Storage/QueryOnlyDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/QueryOnlyDocumentStorage.cs
@@ -25,19 +25,19 @@ public abstract class QueryOnlyDocumentStorage<T, TId>: DocumentStorage<T, TId>,
         return new DataAndIdSelectClause<T>(this);
     }
 
-    public sealed override void Store(IMartenSession session, T document)
+    public sealed override void Store(IStorageSession session, T document)
     {
     }
 
-    public sealed override void Store(IMartenSession session, T document, Guid? version)
+    public sealed override void Store(IStorageSession session, T document, Guid? version)
     {
     }
 
-    public sealed override void Store(IMartenSession session, T document, long revision)
+    public sealed override void Store(IStorageSession session, T document, long revision)
     {
     }
 
-    public sealed override void Eject(IMartenSession session, T document)
+    public sealed override void Eject(IStorageSession session, T document)
     {
     }
 

--- a/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
@@ -122,47 +122,47 @@ internal class SubClassDocumentStorage<T, TRoot, TId>: IDocumentStorage<T, TId>,
 
     public Type IdType => typeof(TId);
 
-    public Guid? VersionFor(T document, IMartenSession session)
+    public Guid? VersionFor(T document, IStorageSession session)
     {
         return _parent.VersionFor(document, session);
     }
 
-    public void Store(IMartenSession session, T document)
+    public void Store(IStorageSession session, T document)
     {
         _parent.Store(session, document);
     }
 
-    public void Store(IMartenSession session, T document, Guid? version)
+    public void Store(IStorageSession session, T document, Guid? version)
     {
         _parent.Store(session, document, version);
     }
 
-    public void Store(IMartenSession session, T document, long revision)
+    public void Store(IStorageSession session, T document, long revision)
     {
         _parent.Store(session, document, revision);
     }
 
-    public void Eject(IMartenSession session, T document)
+    public void Eject(IStorageSession session, T document)
     {
         _parent.Eject(session, document);
     }
 
-    public IStorageOperation Update(T document, IMartenSession session, string tenant)
+    public IStorageOperation Update(T document, IStorageSession session, string tenant)
     {
         return _parent.Update(document, session, tenant);
     }
 
-    public IStorageOperation Insert(T document, IMartenSession session, string tenant)
+    public IStorageOperation Insert(T document, IStorageSession session, string tenant)
     {
         return _parent.Insert(document, session, tenant);
     }
 
-    public IStorageOperation Upsert(T document, IMartenSession session, string tenant)
+    public IStorageOperation Upsert(T document, IStorageSession session, string tenant)
     {
         return _parent.Upsert(document, session, tenant);
     }
 
-    public IStorageOperation Overwrite(T document, IMartenSession session, string tenant)
+    public IStorageOperation Overwrite(T document, IStorageSession session, string tenant)
     {
         return _parent.Overwrite(document, session, tenant);
     }
@@ -269,12 +269,12 @@ internal class SubClassDocumentStorage<T, TRoot, TId>: IDocumentStorage<T, TId>,
         return _parent.RawIdentityValue(id);
     }
 
-    public void EjectById(IMartenSession session, object id)
+    public void EjectById(IStorageSession session, object id)
     {
         _parent.EjectById(session, id);
     }
 
-    public void RemoveDirtyTracker(IMartenSession session, object id)
+    public void RemoveDirtyTracker(IStorageSession session, object id)
     {
         _parent.RemoveDirtyTracker(session, id);
     }

--- a/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
+++ b/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
@@ -116,26 +116,26 @@ internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: ID
 
     public object IdentityFor(TDoc document) => Inner.IdentityFor(document);
 
-    public Guid? VersionFor(TDoc document, IMartenSession session) => Inner.VersionFor(document, session);
+    public Guid? VersionFor(TDoc document, IStorageSession session) => Inner.VersionFor(document, session);
 
-    public void Store(IMartenSession session, TDoc document) => Inner.Store(session, document);
+    public void Store(IStorageSession session, TDoc document) => Inner.Store(session, document);
 
-    public void Store(IMartenSession session, TDoc document, Guid? version) => Inner.Store(session, document, version);
+    public void Store(IStorageSession session, TDoc document, Guid? version) => Inner.Store(session, document, version);
 
-    public void Store(IMartenSession session, TDoc document, long revision) => Inner.Store(session, document, revision);
+    public void Store(IStorageSession session, TDoc document, long revision) => Inner.Store(session, document, revision);
 
-    public void Eject(IMartenSession session, TDoc document) => Inner.Eject(session, document);
+    public void Eject(IStorageSession session, TDoc document) => Inner.Eject(session, document);
 
-    public IStorageOperation Update(TDoc document, IMartenSession session, string tenantId) =>
+    public IStorageOperation Update(TDoc document, IStorageSession session, string tenantId) =>
         Inner.Update(document, session, tenantId);
 
-    public IStorageOperation Insert(TDoc document, IMartenSession session, string tenantId)
+    public IStorageOperation Insert(TDoc document, IStorageSession session, string tenantId)
         => Inner.Insert(document, session, tenantId);
 
-    public IStorageOperation Upsert(TDoc document, IMartenSession session, string tenantId)
+    public IStorageOperation Upsert(TDoc document, IStorageSession session, string tenantId)
         => Inner.Upsert(document, session, tenantId);
 
-    public IStorageOperation Overwrite(TDoc document, IMartenSession session, string tenantId)
+    public IStorageOperation Overwrite(TDoc document, IStorageSession session, string tenantId)
         => Inner.Overwrite(document, session, tenantId);
 
     public IStorageOperation OverwriteProjected(TDoc document, string tenantId)
@@ -154,10 +154,10 @@ internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: ID
     public IDeletion DeleteForDocument(TDoc document, string tenantId)
         => Inner.DeleteForDocument(document, tenantId);
 
-    public void EjectById(IMartenSession session, object id)
+    public void EjectById(IStorageSession session, object id)
         => Inner.EjectById(session, id);
 
-    public void RemoveDirtyTracker(IMartenSession session, object id)
+    public void RemoveDirtyTracker(IStorageSession session, object id)
         => Inner.RemoveDirtyTracker(session, id);
 
     public IDeletion HardDeleteForDocument(TDoc document, string tenantId)


### PR DESCRIPTION
Continues #4810 (after #4812's `IStorageSession` foundation + binder/selector retarget). Marten-only, green, no public-API break.

## What this does

Narrows the document-storage **write path** from `IMartenSession` to the agnostic `IStorageSession` across `IDocumentStorage<T>` and every implementer (DocumentStorage base, Lightweight/IdentityMap/QueryOnly/DirtyChecked, SubClass, ValueTypeIdentified, EventMapping/EventDocumentStorage, and the closed-shape storage overrides):

`Store` (×3), `Eject`, `EjectById`, `RemoveDirtyTracker`, `VersionFor`, `Insert`, `Update`, `Upsert`, `Overwrite`

These only touch session state already on `IStorageSession` (`ItemMap` / `Versions` / `ChangeTrackers` / `TenantId` / `Database`), so callers passing an `IMartenSession` keep compiling.

## Intentionally deferred (kept `IMartenSession`)

- `LoadAsync` / `LoadManyAsync` — the read path calls `session.ExecuteReaderAsync(NpgsqlCommand)`; retargeting waits on the db-neutral execution seam.
- `FilterDocuments` — query-path helper, folded in with the read/select work.
- `ISelectClause.BuildSelector` / `BuildHandler` — shared with the LINQ pipeline (75+ handlers); a separate, larger pass.
- `IStorageOperation : IQueryHandler` `ConfigureCommand` — the jasperfx#214 split (out of scope in #4810).

## Verification
- Marten builds; **DocumentDbTests 1033 passed**, **ValueTypeTests 339 passed** (net10). No public API break — everything is `Internal.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)