### PR TITLE
#4819 — db-neutral serializer seam (IStorageSerializer) for the closed-shape storage runtime

### DIFF
--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -273,13 +273,13 @@ public class EventMapping<T>: EventMapping, IDocumentStorage<T> where T : class
 
     ISelector ISelectClause.BuildSelector(IStorageSession session)
     {
-        return new EventSelector<T>(session.Serializer);
+        return new EventSelector<T>((ISerializer)session.Serializer);
     }
 
     IQueryHandler<TResult> ISelectClause.BuildHandler<TResult>(IStorageSession session, ISqlFragment topStatement,
         ISqlFragment currentStatement)
     {
-        var selector = new EventSelector<T>(session.Serializer);
+        var selector = new EventSelector<T>((ISerializer)session.Serializer);
 
         return LinqQueryParser.BuildHandler<T, TResult>(selector, topStatement);
     }

--- a/src/Marten/Events/Operations/QuickAppendEventsOperationBase.cs
+++ b/src/Marten/Events/Operations/QuickAppendEventsOperationBase.cs
@@ -196,7 +196,7 @@ public abstract class QuickAppendEventsOperationBase : IStorageOperation, IExcep
     /// <see cref="ISerializer.WriteTo"/> + a pooled staging buffer. Avoids the intermediate
     /// <see cref="string"/> allocation that <see cref="ISerializer.ToJson"/> produces.
     /// </summary>
-    private static byte[] SerializeToUtf8(ISerializer serializer, object? value)
+    private static byte[] SerializeToUtf8(IStorageSerializer serializer, object? value)
     {
         using var buffer = new Services.PooledByteBufferWriter();
         serializer.WriteTo(buffer, value);

--- a/src/Marten/ISerializer.cs
+++ b/src/Marten/ISerializer.cs
@@ -32,8 +32,14 @@ public enum ValueCasting
     Relaxed
 }
 
-public interface ISerializer
+public interface ISerializer: IStorageSerializer
 {
+    // #4819: the db-neutral WriteToParameter(DbParameter) from IStorageSerializer bridges to
+    // Marten's Npgsql-typed WriteToParameter below. Every Marten serializer is Npgsql-backed, so
+    // the parameter is always an NpgsqlParameter at runtime.
+    void IStorageSerializer.WriteToParameter(DbParameter parameter, object? value)
+        => WriteToParameter((NpgsqlParameter)parameter, value);
+
     /// <summary>
     ///     Just gotta tell Marten if enum's are stored
     ///     as int's or string's in the JSON
@@ -51,25 +57,7 @@ public interface ISerializer
     ValueCasting ValueCasting { get; }
 
     /// <summary>
-    ///     Serialize the document object into a JSON string
-    /// </summary>
-    /// <param name="document"></param>
-    /// <returns></returns>
-    string ToJson(object? document);
-
-    /// <summary>
-    ///     Serialize <paramref name="value"/> directly into the supplied buffer writer as UTF-8 JSON.
-    ///     Skips the intermediate string materialization that <see cref="ToJson"/> round-trips through —
-    ///     prefer this on append / write hot paths.
-    /// </summary>
-    /// <remarks>
-    ///     Implementations must produce identical bytes to what <c>Encoding.UTF8.GetBytes(ToJson(value))</c>
-    ///     would emit, modulo whitespace/formatting decisions already baked into the serializer's options.
-    /// </remarks>
-    void WriteTo(IBufferWriter<byte> writer, object? value);
-
-    /// <summary>
-    ///     Convenience for the most common append-path use of <see cref="WriteTo"/>: serialize
+    ///     Convenience for the most common append-path use of <see cref="IStorageSerializer.WriteTo"/>: serialize
     ///     <paramref name="value"/> as UTF-8 JSON and bind the resulting bytes to <paramref name="parameter"/>
     ///     with <c>NpgsqlDbType.Jsonb</c>. Skips the round-trip through a .NET <see cref="string"/> that
     ///     <c>AppendParameter(ToJson(value))</c> incurs.
@@ -78,54 +66,8 @@ public interface ISerializer
     /// <param name="value">The value to serialize; <c>null</c> binds <see cref="DBNull"/>.</param>
     void WriteToParameter(NpgsqlParameter parameter, object? value);
 
-    /// <summary>
-    ///     Deserialize a JSON string stream into an object of type T
-    /// </summary>
-    T FromJson<T>(Stream stream);
-
-    /// <summary>
-    ///     Deserialize a JSON string into an object of type T
-    /// </summary>
-    T FromJson<T>(DbDataReader reader, int index);
-
-    /// <summary>
-    ///     Deserialize a JSON string stream into an object of type T
-    /// </summary>
-    ValueTask<T> FromJsonAsync<T>(Stream stream, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    ///     Deserialize a JSON string into an object of type T
-    /// </summary>
-    ValueTask<T> FromJsonAsync<T>(DbDataReader reader, int index, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    ///     Deserialize a JSON string stream into an object of type T
-    /// </summary>
-    object FromJson(Type type, Stream stream);
-
-    /// <summary>
-    ///     Deserialize a JSON string into the supplied Type
-    /// </summary>
-    object FromJson(Type type, DbDataReader reader, int index);
-
-    /// <summary>
-    ///     Deserialize a JSON string stream into an object of type T
-    /// </summary>
-    ValueTask<object> FromJsonAsync(Type type, Stream stream, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    ///     Deserialize a JSON string into the supplied Type
-    /// </summary>
-    ValueTask<object> FromJsonAsync(Type type, DbDataReader reader, int index,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    ///     Serialize a document without any extra
-    ///     type handling metadata
-    /// </summary>
-    /// <param name="document"></param>
-    /// <returns></returns>
-    string ToCleanJson(object? document);
+    // #4819: ToJson / ToCleanJson / the FromJson + FromJsonAsync family moved to the db-neutral
+    // IStorageSerializer base (they were already Npgsql-free — Stream / DbDataReader / Type).
 
     /// <summary>
     ///     UTF-8 / buffer-writer counterpart to <see cref="ToCleanJson"/>. Skips the

--- a/src/Marten/IStorageSerializer.cs
+++ b/src/Marten/IStorageSerializer.cs
@@ -1,0 +1,66 @@
+#nullable enable
+using System;
+using System.Buffers;
+using System.Data.Common;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Marten;
+
+/// <summary>
+///     Database-neutral serializer seam consumed by the closed-shape storage runtime (#4819,
+///     follow-up to #4810). Exposes only the JSON read/write members the storage / binders /
+///     selectors actually use, and — unlike <see cref="ISerializer"/> — carries no Npgsql-typed
+///     or Marten-only members. The one write hook that used to bind an <c>NpgsqlParameter</c> is
+///     surfaced here against the neutral <see cref="DbParameter"/>, mirroring the
+///     <see cref="Marten.Internal.IStorageSession.ExecuteReaderAsync(DbCommand, CancellationToken)"/>
+///     execution seam. Marten's <see cref="ISerializer"/> implements this; alternate dialects
+///     (e.g. Polecat) implement it over their own provider types.
+/// </summary>
+public interface IStorageSerializer
+{
+    /// <summary>Serialize the document object into a JSON string.</summary>
+    string ToJson(object? document);
+
+    /// <summary>
+    ///     Serialize <paramref name="value"/> directly into the supplied buffer writer as UTF-8 JSON —
+    ///     the allocation-free append/write hot path.
+    /// </summary>
+    void WriteTo(IBufferWriter<byte> writer, object? value);
+
+    /// <summary>Serialize a document without any extra type-handling metadata.</summary>
+    string ToCleanJson(object? document);
+
+    /// <summary>
+    ///     Serialize <paramref name="value"/> as UTF-8 JSON and bind it to the supplied parameter
+    ///     as JSONB. Db-neutral counterpart to <see cref="ISerializer.WriteToParameter"/> — the
+    ///     concrete implementation binds against its provider's parameter type.
+    /// </summary>
+    void WriteToParameter(DbParameter parameter, object? value);
+
+    /// <summary>Deserialize a JSON stream into an object of type T.</summary>
+    T FromJson<T>(Stream stream);
+
+    /// <summary>Deserialize the JSON at the reader's column index into an object of type T.</summary>
+    T FromJson<T>(DbDataReader reader, int index);
+
+    /// <summary>Deserialize a JSON stream into the supplied Type.</summary>
+    object FromJson(Type type, Stream stream);
+
+    /// <summary>Deserialize the JSON at the reader's column index into the supplied Type.</summary>
+    object FromJson(Type type, DbDataReader reader, int index);
+
+    /// <summary>Deserialize a JSON stream into an object of type T.</summary>
+    ValueTask<T> FromJsonAsync<T>(Stream stream, CancellationToken cancellationToken = default);
+
+    /// <summary>Deserialize the JSON at the reader's column index into an object of type T.</summary>
+    ValueTask<T> FromJsonAsync<T>(DbDataReader reader, int index, CancellationToken cancellationToken = default);
+
+    /// <summary>Deserialize a JSON stream into the supplied Type.</summary>
+    ValueTask<object> FromJsonAsync(Type type, Stream stream, CancellationToken cancellationToken = default);
+
+    /// <summary>Deserialize the JSON at the reader's column index into the supplied Type.</summary>
+    ValueTask<object> FromJsonAsync(Type type, DbDataReader reader, int index,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Marten/Internal/ClosedShape/ClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeDirtyTrackingSelector.cs
@@ -29,7 +29,7 @@ internal abstract class ClosedShapeDirtyTrackingSelector<T, TId>: ISelector<T>, 
     protected const int FirstMetadataColumn = 2;
 
     protected readonly IStorageSession _session;
-    protected readonly ISerializer _serializer;
+    protected readonly IStorageSerializer _serializer;
     protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
     protected readonly Dictionary<TId, T> _identityMap;
 

--- a/src/Marten/Internal/ClosedShape/ClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeIdentityMapSelector.cs
@@ -27,7 +27,7 @@ internal abstract class ClosedShapeIdentityMapSelector<T, TId>: ISelector<T>, ID
     protected const int FirstMetadataColumn = 2;
 
     protected readonly IStorageSession _session;
-    protected readonly ISerializer _serializer;
+    protected readonly IStorageSerializer _serializer;
     protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
     protected readonly Dictionary<TId, T> _identityMap;
 

--- a/src/Marten/Internal/ClosedShape/ClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeLightweightSelector.cs
@@ -29,7 +29,7 @@ internal abstract class ClosedShapeLightweightSelector<T, TId>: ISelector<T>, ID
     protected const int FirstMetadataColumn = 2;
 
     protected readonly IStorageSession _session;
-    protected readonly ISerializer _serializer;
+    protected readonly IStorageSerializer _serializer;
     protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
 
     protected ClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)

--- a/src/Marten/Internal/ClosedShape/ClosedShapeProjectionLoader.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeProjectionLoader.cs
@@ -51,7 +51,7 @@ internal static class ClosedShapeProjectionLoader<TDoc, TId>
     public static async Task<TDoc?> LoadAsync(
         NpgsqlCommand command,
         DocumentStorageDescriptor<TDoc, TId> descriptor,
-        ISerializer serializer,
+        IStorageSerializer serializer,
         IMartenDatabase database,
         CancellationToken token)
     {
@@ -77,7 +77,7 @@ internal static class ClosedShapeProjectionLoader<TDoc, TId>
     public static async Task<IReadOnlyList<TDoc>> LoadManyAsync(
         NpgsqlCommand command,
         DocumentStorageDescriptor<TDoc, TId> descriptor,
-        ISerializer serializer,
+        IStorageSerializer serializer,
         IMartenDatabase database,
         CancellationToken token)
     {
@@ -107,7 +107,7 @@ internal static class ClosedShapeProjectionLoader<TDoc, TId>
     private static async ValueTask<TDoc> readOneAsync(
         DbDataReader reader,
         DocumentStorageDescriptor<TDoc, TId> descriptor,
-        ISerializer serializer,
+        IStorageSerializer serializer,
         CancellationToken token)
     {
         // Hierarchical: dispatch via mt_doc_type alias just like

--- a/src/Marten/Internal/ClosedShape/ClosedShapeQueryOnlySelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeQueryOnlySelector.cs
@@ -24,7 +24,7 @@ internal abstract class ClosedShapeQueryOnlySelector<T, TId>: ISelector<T>
     protected const int FirstMetadataColumn = 1;
 
     protected readonly IStorageSession _session;
-    protected readonly ISerializer _serializer;
+    protected readonly IStorageSerializer _serializer;
     protected readonly DocumentStorageDescriptor<T, TId> _descriptor;
 
     protected ClosedShapeQueryOnlySelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)

--- a/src/Marten/Internal/ClosedShape/DocumentCausationIdBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentCausationIdBinder.cs
@@ -54,6 +54,6 @@ internal sealed class DocumentCausationIdBinder<TDoc>: IDocumentMetadataBinder<T
     }
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
         => writer.WriteNullAsync(cancellation);
 }

--- a/src/Marten/Internal/ClosedShape/DocumentCorrelationIdBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentCorrelationIdBinder.cs
@@ -57,7 +57,7 @@ internal sealed class DocumentCorrelationIdBinder<TDoc>: IDocumentMetadataBinder
     }
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
     {
         // Bulk loader has no session — no source for a correlation id.
         // Write null; mirrors the codegen path's bulk emit which writes a

--- a/src/Marten/Internal/ClosedShape/DocumentCreatedAtBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentCreatedAtBinder.cs
@@ -64,7 +64,7 @@ internal sealed class DocumentCreatedAtBinder<TDoc>: IDocumentMetadataBinder<TDo
     }
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
         => throw new NotSupportedException(
             "mt_created_at is filled by the column DEFAULT during bulk load; this binder is read-only.");
 }

--- a/src/Marten/Internal/ClosedShape/DocumentDocTypeBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDocTypeBinder.cs
@@ -56,7 +56,7 @@ internal sealed class DocumentDocTypeBinder<TDoc>: IDocumentMetadataBinder<TDoc>
     }
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
     {
         var alias = _aliasCache.GetOrAdd(document.GetType(), t => _mapping.AliasFor(t));
         return writer.WriteAsync(alias, NpgsqlDbType.Varchar, cancellation);

--- a/src/Marten/Internal/ClosedShape/DocumentDotNetTypeBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDotNetTypeBinder.cs
@@ -38,7 +38,7 @@ internal sealed class DocumentDotNetTypeBinder<TDoc>: IDocumentMetadataBinder<TD
     }
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
         => writer.WriteAsync(ResolveTypeName(document), NpgsqlDbType.Varchar, cancellation);
 
     private static string ResolveTypeName(TDoc document)

--- a/src/Marten/Internal/ClosedShape/DocumentDuplicatedFieldBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDuplicatedFieldBinder.cs
@@ -109,7 +109,7 @@ internal sealed class DocumentDuplicatedFieldBinder<TDoc>: IDocumentMetadataBind
     }
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
     {
         object? current = document;
         foreach (var member in _members)

--- a/src/Marten/Internal/ClosedShape/DocumentHeadersBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentHeadersBinder.cs
@@ -86,6 +86,6 @@ internal sealed class DocumentHeadersBinder<TDoc>: IDocumentMetadataBinder<TDoc>
     }
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
         => writer.WriteAsync<object>(DBNull.Value, NpgsqlDbType.Jsonb, cancellation);
 }

--- a/src/Marten/Internal/ClosedShape/DocumentLastModifiedBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentLastModifiedBinder.cs
@@ -51,7 +51,7 @@ internal sealed class DocumentLastModifiedBinder<TDoc>: IDocumentMetadataBinder<
     }
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
     {
         // COPY can't run transaction_timestamp() — compute client-side.
         // Slight skew vs. SQL writes that get the transaction's

--- a/src/Marten/Internal/ClosedShape/DocumentLastModifiedByBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentLastModifiedByBinder.cs
@@ -58,6 +58,6 @@ internal sealed class DocumentLastModifiedByBinder<TDoc>: IDocumentMetadataBinde
     }
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
         => writer.WriteNullAsync(cancellation);
 }

--- a/src/Marten/Internal/ClosedShape/DocumentRevisionBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentRevisionBinder.cs
@@ -103,7 +103,7 @@ internal sealed class DocumentRevisionBinder<TDoc>: IDocumentMetadataBinder<TDoc
         => _setter?.Invoke(document, revision);
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
     {
         // Bulk path defaults to revision 1 — matches the codegen
         // BulkLoader.GenerateBulkWriterCodeAsync's hard-coded "write

--- a/src/Marten/Internal/ClosedShape/DocumentSoftDeletedAtBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentSoftDeletedAtBinder.cs
@@ -56,6 +56,6 @@ internal sealed class DocumentSoftDeletedAtBinder<TDoc>: IDocumentMetadataBinder
     }
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
         => writer.WriteNullAsync(cancellation);
 }

--- a/src/Marten/Internal/ClosedShape/DocumentSoftDeletedBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentSoftDeletedBinder.cs
@@ -57,6 +57,6 @@ internal sealed class DocumentSoftDeletedBinder<TDoc>: IDocumentMetadataBinder<T
     }
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
         => writer.WriteAsync(false, NpgsqlDbType.Boolean, cancellation);
 }

--- a/src/Marten/Internal/ClosedShape/DocumentTenantIdBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentTenantIdBinder.cs
@@ -52,7 +52,7 @@ internal sealed class DocumentTenantIdBinder<TDoc>: IDocumentMetadataBinder<TDoc
     }
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
         => throw new NotSupportedException(
             "tenant_id is handled directly by the bulk loader; this binder is read-only.");
 }

--- a/src/Marten/Internal/ClosedShape/DocumentVersionBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentVersionBinder.cs
@@ -72,7 +72,7 @@ internal sealed class DocumentVersionBinder<TDoc>: IDocumentMetadataBinder<TDoc>
         => _setter?.Invoke(document, version);
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation)
+        IStorageSerializer serializer, CancellationToken cancellation)
     {
         var newVersion = CombGuidIdGeneration.NewGuid();
         _setter?.Invoke(document, newVersion);

--- a/src/Marten/Internal/ClosedShape/IDocumentMetadataBinder.cs
+++ b/src/Marten/Internal/ClosedShape/IDocumentMetadataBinder.cs
@@ -102,5 +102,5 @@ public interface IDocumentMetadataBinder<TDoc>
     /// LastModified case.
     /// </summary>
     Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        ISerializer serializer, CancellationToken cancellation);
+        IStorageSerializer serializer, CancellationToken cancellation);
 }

--- a/src/Marten/Internal/IMartenSession.cs
+++ b/src/Marten/Internal/IMartenSession.cs
@@ -11,6 +11,12 @@ namespace Marten.Internal;
 
 public interface IMartenSession: IDisposable, IAsyncDisposable, IStorageSession
 {
+    // #4819: closed-shape storage sees the db-neutral IStorageSerializer via IStorageSession;
+    // Marten's own code keeps the full ISerializer here (ValueCasting, ToJsonWithTypes, the
+    // buffer-writer overloads, etc.). Every Marten session returns an ISerializer, which satisfies
+    // both since ISerializer : IStorageSerializer.
+    new ISerializer Serializer { get; }
+
     IEventStorage EventStorage();
 
     /// <summary>

--- a/src/Marten/Internal/IStorageSession.cs
+++ b/src/Marten/Internal/IStorageSession.cs
@@ -31,7 +31,7 @@ namespace Marten.Internal;
 /// </remarks>
 public interface IStorageSession: IMetadataContext
 {
-    ISerializer Serializer { get; }
+    IStorageSerializer Serializer { get; }
 
     IMartenDatabase Database { get; }
 

--- a/src/Marten/Internal/Sessions/QuerySession.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.cs
@@ -32,6 +32,11 @@ public partial class QuerySession: IMartenSession, IQuerySession, ITenantedQuery
 
     public ISerializer Serializer { get; }
 
+    // #4819: the public ISerializer satisfies IMartenSession.Serializer (new ISerializer); this
+    // explicit impl satisfies the narrower IStorageSession.Serializer (IStorageSerializer) — C#
+    // interface implementation needs an exact return type, and ISerializer : IStorageSerializer.
+    IStorageSerializer IStorageSession.Serializer => Serializer;
+
     public StoreOptions Options { get; }
     public IQueryEventStore Events { get; }
 

--- a/src/Marten/Linq/Selectors/SerializationSelector.cs
+++ b/src/Marten/Linq/Selectors/SerializationSelector.cs
@@ -7,9 +7,9 @@ namespace Marten.Linq.Selectors;
 
 internal class SerializationSelector<T>: ISelector<T>
 {
-    private readonly ISerializer _serializer;
+    private readonly IStorageSerializer _serializer;
 
-    public SerializationSelector(ISerializer serializer)
+    public SerializationSelector(IStorageSerializer serializer)
     {
         _serializer = serializer;
     }

--- a/src/Marten/Linq/SqlGeneration/JoinSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/JoinSelectClause.cs
@@ -101,9 +101,9 @@ internal class JoinSelectClause<T>: ISelectClause, IScalarSelectClause where T :
     // throw "Column 'data' is null".
     private sealed class JoinDataSelector: ISelector<T>
     {
-        private readonly ISerializer _serializer;
+        private readonly IStorageSerializer _serializer;
 
-        public JoinDataSelector(ISerializer serializer)
+        public JoinDataSelector(IStorageSerializer serializer)
         {
             _serializer = serializer;
         }


### PR DESCRIPTION
Fixes #4819 (follow-up to the now-closed #4810). Removes the last serializer coupling that blocked moving the closed-shape storage runtime to a shared package. Marten-only, green, no public-API break.

## The seam

- New **`Marten.IStorageSerializer`** exposing exactly the members the storage runtime uses — all already db-neutral (`ToJson`, `ToCleanJson`, `WriteTo(IBufferWriter)`, and the `FromJson`/`FromJsonAsync` family over `Stream`/`DbDataReader`) — plus a **db-neutral `WriteToParameter(DbParameter)`** in place of the Npgsql-typed one, mirroring the `DbCommand` execution seam from #4815.
- **`ISerializer : IStorageSerializer`**: the moved members live on the seam; a default interface method bridges `WriteToParameter(DbParameter)` → Marten's existing `WriteToParameter(NpgsqlParameter)`, so the concrete serializers (`SystemTextJson`/`JsonNet`) are unchanged.
- **`IStorageSession.Serializer`** returns `IStorageSerializer`; **`IMartenSession`** re-declares `new ISerializer Serializer` so Marten's own code keeps the full type. `QuerySession` adds an explicit `IStorageSession.Serializer` impl (C# needs an exact return type).

## Retarget

The serializer-consuming storage runtime now uses `IStorageSerializer`: closed-shape selectors + binders (incl. the bulk `WriteToBulkAsync` param), event append (`SerializeToUtf8`), and the LINQ `SerializationSelector` / `Data`/`Join`/`SelectData` select clauses.

**Kept on `ISerializer`** (bridged / out of scope): `EventSelector` (coupled to `Func<ISerializer,…>` event mapping) and the Npgsql-coupled `BulkLoader`/`IBulkLoader` base (COPY infrastructure — a separate Npgsql concern, like the `NpgsqlBatch` execution path).

## Result

Closed-shape document + event storage no longer references Marten's `ISerializer` (only the Npgsql-bound bulk loader does).

## Verification
- No public-API break (`ISerializer` gains a base interface; every member is still reachable). Full solution builds **Debug + Release**; **DocumentDbTests 1033** (incl. bulk 60), **LinqTests 1312**, **CoreTests 458**, **EventSourcingTests 1421**, **ValueTypeTests 339**, **PatchingTests 122** green (net10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)