### PR TITLE
chore: update to Weasel 9.5.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -145,7 +145,9 @@
     <!-- 9.4.0 (marten#4811 / weasel#321 + #322): lifts the closed-shape IIdentification identity
          family into Weasel.Core.Identity (with the ISequenceSource sequence seam) so Marten and
          Polecat share it; Weasel.Core 9.4.0 flows in transitively. -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.4.0" />
+    <!-- 9.5.0 (weasel#323): adds a shared Weasel.Core.ISerializer base for the Critter Stack
+         dedupe. Weasel.Core 9.5.0 flows in transitively. -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.5.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
Bumps `Weasel.Postgresql` 9.4.0 → **9.5.0** (`Weasel.Core` 9.5.0 flows in transitively).

9.5.0 (weasel#323) adds a shared `Weasel.Core.ISerializer` base for the Critter Stack dedupe pillar. Nothing Marten consumes changes in a breaking way.

## Verification
- Full solution builds; **DocumentDbTests 1033**, **CoreTests 458** green (net10) against the released 9.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)