### PR TITLE
#4820 — split IStorageOperation off the LINQ IQueryHandler

### DIFF
--- a/src/Marten/Internal/Operations/IStorageOperation.cs
+++ b/src/Marten/Internal/Operations/IStorageOperation.cs
@@ -1,13 +1,17 @@
 #nullable enable
-using Marten.Linq.QueryHandlers;
+using Weasel.Postgresql;
 
 namespace Marten.Internal.Operations;
 
-// Subinterface over Weasel.Core.IStorageOperation. The three storage-op members
-// (DocumentType, PostprocessAsync, Role) come from Weasel.Core; ConfigureCommand
-// with the session-aware signature comes from IQueryHandler. Polecat layers its
-// own ICommandBuilder-only ConfigureCommand on the same Weasel.Core base — see
-// #4500 / Critter Stack 2026 dedupe pillar (jasperfx#214).
-public interface IStorageOperation: Weasel.Core.IStorageOperation, IQueryHandler
+// #4820: subinterface over Weasel.Core.IStorageOperation (DocumentType / PostprocessAsync /
+// Role). It now declares its OWN agnostic ConfigureCommand(ICommandBuilder, IStorageSession)
+// instead of inheriting it from Marten's LINQ IQueryHandler — decoupling the storage operations
+// from the LINQ query-handler contract so the closed-shape operation runtime is movable to a
+// shared package. The signature is identical to the one that used to come from IQueryHandler, so
+// the operation implementers are unchanged. (Aligns with the Critter Stack dedupe pillar,
+// jasperfx#214 — a Weasel.Core.IStorageOperation.ConfigureCommand member would let this collapse
+// into the shared base once it lands upstream.)
+public interface IStorageOperation: Weasel.Core.IStorageOperation
 {
+    void ConfigureCommand(ICommandBuilder builder, Marten.Internal.IStorageSession session);
 }


### PR DESCRIPTION
Fixes #4820. Marten-only, green, no public-API break.

## Background

Marten's `IStorageOperation : Weasel.Core.IStorageOperation, IQueryHandler`. Its `ConfigureCommand` came from the **LINQ** `IQueryHandler` contract (`Marten.Linq.QueryHandlers`), coupling the storage-operation runtime to the LINQ pipeline and blocking a clean extraction to a shared package.

I checked whether **Weasel 9.5.0** unblocks this by providing the member upstream: it does **not** — `Weasel.Core.IStorageOperation` in 9.5.0 still declares only `DocumentType`/`Role()`/`PostprocessAsync`, no `ConfigureCommand`. (9.5.0's new work is a shared `Weasel.Core.ISerializer` base, relevant to #4819.)

## This PR

Redeclare `IStorageOperation` over `Weasel.Core.IStorageOperation` with its **own** `void ConfigureCommand(ICommandBuilder, IStorageSession)` — the identical signature that used to come from `IQueryHandler` (agnostic since the #4817/#4818 LINQ retarget). 

- Nothing treated an `IStorageOperation` as an `IQueryHandler` (the only reference was its own declaration).
- All 32 implementers already had the matching `ConfigureCommand`, so **no implementer changes**.

This decouples the storage-operation runtime from the LINQ query-handler contract. It stays a Marten-defined member for now; aligns with jasperfx#214 — it can collapse into the shared `Weasel.Core.IStorageOperation` base once a `ConfigureCommand` member is added upstream.

## Verification
- Full solution builds **Debug + Release**; **DocumentDbTests 1033**, **EventSourcingTests 1421**, **CoreTests 458** green (net10). No public-API break — everything is `Internal.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)