### PR TITLE
#4825 (W2 story 1) — agnostic IVersionTracker seam for IStorageSession.Versions

### DIFF
--- a/src/Marten/Internal/IMartenSession.cs
+++ b/src/Marten/Internal/IMartenSession.cs
@@ -17,6 +17,10 @@ public interface IMartenSession: IDisposable, IAsyncDisposable, IStorageSession
     // both since ISerializer : IStorageSerializer.
     new ISerializer Serializer { get; }
 
+    // #4825: closed-shape storage sees the agnostic IVersionTracker via IStorageSession; Marten's
+    // own code keeps the concrete VersionTracker here.
+    new VersionTracker Versions { get; }
+
     IEventStorage EventStorage();
 
     /// <summary>

--- a/src/Marten/Internal/IStorageSession.cs
+++ b/src/Marten/Internal/IStorageSession.cs
@@ -37,7 +37,7 @@ public interface IStorageSession: IMetadataContext
 
     StoreOptions Options { get; }
 
-    VersionTracker Versions { get; }
+    IVersionTracker Versions { get; }
 
     IList<IChangeTracker> ChangeTrackers { get; }
 

--- a/src/Marten/Internal/IVersionTracker.cs
+++ b/src/Marten/Internal/IVersionTracker.cs
@@ -1,0 +1,30 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Marten.Internal;
+
+/// <summary>
+///     Agnostic optimistic-concurrency version/revision tracker seam consumed by the closed-shape
+///     storage runtime (#4825, part of the #4821 extraction epic). Every member is already
+///     database-neutral, so this is simply the existing <see cref="VersionTracker"/> surface lifted
+///     to an interface the storage code can target instead of the concrete Marten type.
+/// </summary>
+public interface IVersionTracker
+{
+    Dictionary<TId, long> RevisionsFor<TDoc, TId>() where TId : notnull;
+
+    Dictionary<TId, Guid> ForType<TDoc, TId>() where TId : notnull;
+
+    Guid? VersionFor<TDoc, TId>(TId id) where TId : notnull;
+
+    long? RevisionFor<TDoc, TId>(TId id) where TId : notnull;
+
+    void StoreVersion<TDoc, TId>(TId id, Guid guid) where TId : notnull;
+
+    void StoreRevision<TDoc, TId>(TId id, long revision) where TId : notnull;
+
+    void ClearVersion<TDoc, TId>(TId id) where TId : notnull;
+
+    void ClearRevision<TDoc, TId>(TId id) where TId : notnull;
+}

--- a/src/Marten/Internal/Sessions/QuerySession.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.cs
@@ -37,6 +37,10 @@ public partial class QuerySession: IMartenSession, IQuerySession, ITenantedQuery
     // interface implementation needs an exact return type, and ISerializer : IStorageSerializer.
     IStorageSerializer IStorageSession.Serializer => Serializer;
 
+    // #4825: concrete Versions satisfies IMartenSession (new VersionTracker); this explicit impl
+    // satisfies the narrower IStorageSession.Versions (IVersionTracker).
+    IVersionTracker IStorageSession.Versions => Versions;
+
     public StoreOptions Options { get; }
     public IQueryEventStore Events { get; }
 

--- a/src/Marten/Internal/VersionTracker.cs
+++ b/src/Marten/Internal/VersionTracker.cs
@@ -4,7 +4,7 @@ using Marten.Exceptions;
 
 namespace Marten.Internal;
 
-public class VersionTracker
+public class VersionTracker: IVersionTracker
 {
     private readonly Dictionary<Type, object> _byType = new();
 


### PR DESCRIPTION
First prerequisite of the #4821 extraction epic (Story 1). Marten-only, green, no public-API break.

`IStorageSession.Versions` returned Marten's concrete `VersionTracker`. Every member is already database-neutral (`Dictionary`/`Guid?`/`long?`/`void`, generic over `TDoc`/`TId`), so this lifts the full surface to an interface:

- New **`Marten.Internal.IVersionTracker`** (`ForType` / `RevisionsFor` / `VersionFor` / `RevisionFor` / `StoreVersion` / `StoreRevision` / `ClearVersion` / `ClearRevision`).
- `VersionTracker : IVersionTracker`.
- `IStorageSession.Versions` returns `IVersionTracker`; `IMartenSession` re-declares `new VersionTracker Versions` (Marten keeps the concrete type); `QuerySession` adds the explicit `IStorageSession.Versions` impl — mirroring the #4819 serializer seam.

No cascade (the seam is the full `VersionTracker` surface). Closed-shape storage no longer depends on the concrete type.

## Verification
- Full solution builds **Debug + Release**; **DocumentDbTests 1033**, **CoreTests 458**, **ValueTypeTests 339**, **EventSourcingTests 1421** green (net10). No public-API break — everything is `Internal.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)