### PR TITLE
#4826 — drop StoreOptions off the agnostic IStorageSession contract

### DIFF
--- a/src/Marten/Events/AggregateToExtensions.cs
+++ b/src/Marten/Events/AggregateToExtensions.cs
@@ -8,13 +8,15 @@ using JasperFx.Events;
 using Marten.Internal.Sessions;
 using Marten.Linq;
 
+using Marten.Internal;
+
 namespace Marten.Events;
 
 public static class AggregateToExtensions
 {
     private static void setIdentity<T>(QuerySession session, T aggregate, IEnumerable<IEvent> events) where T : class
     {
-        if (session.Options.Events.StreamIdentity == StreamIdentity.AsGuid)
+        if (((IMartenSession)session).Options.Events.StreamIdentity == StreamIdentity.AsGuid)
         {
             session.StorageFor<T, Guid>().SetIdentity(aggregate, events.Last().StreamId);
         }
@@ -42,7 +44,7 @@ public static class AggregateToExtensions
         }
 
         var session = queryable.As<MartenLinqQueryable<IEvent>>().Session;
-        var aggregator = session.Options.Projections.AggregatorFor<T>();
+        var aggregator = ((IMartenSession)session).Options.Projections.AggregatorFor<T>();
 
         var aggregate = await aggregator.BuildAsync(events, session, state, token).ConfigureAwait(false)!;
 

--- a/src/Marten/Events/Daemon/Internals/ProjectionBatch.cs
+++ b/src/Marten/Events/Daemon/Internals/ProjectionBatch.cs
@@ -11,6 +11,8 @@ using Marten.Events.Daemon.Progress;
 using Marten.Internal.Sessions;
 using Marten.Services;
 
+using Marten.Internal;
+
 namespace Marten.Events.Daemon.Internals;
 
 internal class ProjectionBatch: IProjectionBatch<IDocumentOperations, IQuerySession>
@@ -32,11 +34,11 @@ internal class ProjectionBatch: IProjectionBatch<IDocumentOperations, IQuerySess
     {
         if (range.SequenceFloor == 0)
         {
-            await _batch.Queue.PostAsync(new InsertProjectionProgress(_session.Options.EventGraph, range)).ConfigureAwait(false);
+            await _batch.Queue.PostAsync(new InsertProjectionProgress(((IMartenSession)_session).Options.EventGraph, range)).ConfigureAwait(false);
         }
         else
         {
-            await _batch.Queue.PostAsync(new UpdateProjectionProgress(_session.Options.EventGraph, range)).ConfigureAwait(false);
+            await _batch.Queue.PostAsync(new UpdateProjectionProgress(((IMartenSession)_session).Options.EventGraph, range)).ConfigureAwait(false);
         }
     }
 

--- a/src/Marten/Events/Daemon/Internals/ProjectionUpdateBatch.cs
+++ b/src/Marten/Events/Daemon/Internals/ProjectionUpdateBatch.cs
@@ -325,7 +325,7 @@ public class ProjectionUpdateBatch: IUpdateBatch, IAsyncDisposable, IDisposable,
             var eventStorage = _session.EventStorage();
             foreach (var stream in _streams)
             {
-                stream.PrepareEvents(0, _session.Options.EventGraph, new Queue<long>(), _session);
+                stream.PrepareEvents(0, ((IMartenSession)_session).Options.EventGraph, new Queue<long>(), _session);
 
                 var op = stream.ActionType == StreamActionType.Start ? eventStorage.InsertStream(stream) : eventStorage.QuickAppendEvents(stream);
                 applyOperation(op);
@@ -373,7 +373,7 @@ public class ProjectionUpdateBatch: IUpdateBatch, IAsyncDisposable, IDisposable,
         // Subsequent PRs dispatch the BulkWriter (binary COPY) path on this signal.
         FlushMode = BatchFlushModeClassifier.WithOperation(FlushMode, operation.Role());
 
-        if (_session != null && !_token.IsCancellationRequested && _current.Count >= Session.Options.UpdateBatchSize)
+        if (_session != null && !_token.IsCancellationRequested && _current.Count >= ((IMartenSession)Session).Options.UpdateBatchSize)
         {
             startNewPage(Session);
         }
@@ -421,7 +421,7 @@ public class ProjectionUpdateBatch: IUpdateBatch, IAsyncDisposable, IDisposable,
                 return _batch;
             }
 
-            _batch = await _session.Options.Events.MessageOutbox.CreateBatch(session).ConfigureAwait(false);
+            _batch = await ((IMartenSession)_session).Options.Events.MessageOutbox.CreateBatch(session).ConfigureAwait(false);
             Listeners.Add(_batch);
 
             return _batch;
@@ -439,7 +439,7 @@ public class ProjectionUpdateBatch: IUpdateBatch, IAsyncDisposable, IDisposable,
 
         var projectionSession = new ProjectionDocumentSession((DocumentStore)_session.DocumentStore, this, sessionOptions,
             ShardExecutionMode.Continuous);
-        _batch = await _session.Options.Events.MessageOutbox.CreateBatch(projectionSession).ConfigureAwait(false);
+        _batch = await ((IMartenSession)_session).Options.Events.MessageOutbox.CreateBatch(projectionSession).ConfigureAwait(false);
         Listeners.Add(_batch);
     }
 }

--- a/src/Marten/Events/EventStore.FetchForWriting.cs
+++ b/src/Marten/Events/EventStore.FetchForWriting.cs
@@ -261,11 +261,11 @@ internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityS
     {
         if (typeof(TId) == typeof(Guid))
         {
-            _session.Options.EventGraph.EnsureAsGuidStorage(_session);
+            ((IMartenSession)_session).Options.EventGraph.EnsureAsGuidStorage(_session);
         }
         else if (typeof(TId) == typeof(string))
         {
-            _session.Options.EventGraph.EnsureAsStringStorage(_session);
+            ((IMartenSession)_session).Options.EventGraph.EnsureAsStringStorage(_session);
         }
         // else: natural key type — event storage initialization deferred to the plan
 
@@ -276,7 +276,7 @@ internal partial class EventStore: IEventIdentityStrategy<Guid>, IEventIdentityS
             return (IAggregateFetchPlan<TDoc, TId>)stored;
         }
 
-        var plan = determineFetchPlan<TDoc, TId>(_session.Options);
+        var plan = determineFetchPlan<TDoc, TId>(((IMartenSession)_session).Options);
 
         _fetchStrategies = _fetchStrategies.AddOrUpdate(cacheKey, plan);
 

--- a/src/Marten/Events/EventStore.StreamCompacting.cs
+++ b/src/Marten/Events/EventStore.StreamCompacting.cs
@@ -71,15 +71,15 @@ internal static class StreamCompactingExecution
     internal static async Task ExecuteAsync<T>(this StreamCompactingRequest<T> request, DocumentSessionBase session)
         where T : class
     {
-        var logger = session.Options.LogFactory?.CreateLogger<StreamCompactingRequest<T>>() ??
-                     session.Options.DotNetLogger ?? NullLogger<StreamCompactingRequest<T>>.Instance;
+        var logger = ((IMartenSession)session).Options.LogFactory?.CreateLogger<StreamCompactingRequest<T>>() ??
+                     ((IMartenSession)session).Options.DotNetLogger ?? NullLogger<StreamCompactingRequest<T>>.Instance;
 
         // 1. Find the aggregator
         var aggregator = FindAggregator<T>(session);
 
         // 2. Find the events
         IReadOnlyList<IEvent> events;
-        if (session.Options.Events.StreamIdentity == StreamIdentity.AsGuid)
+        if (((IMartenSession)session).Options.Events.StreamIdentity == StreamIdentity.AsGuid)
         {
             events = await session.Events.FetchStreamAsync(request.StreamId!.Value, request.Version,
                 request.Timestamp, token: request.CancellationToken).ConfigureAwait(false);
@@ -112,7 +112,7 @@ internal static class StreamCompactingExecution
                 .ConfigureAwait(false);
         }
 
-        if (session.Options.Events.StreamIdentity == StreamIdentity.AsGuid)
+        if (((IMartenSession)session).Options.Events.StreamIdentity == StreamIdentity.AsGuid)
         {
             logger.LogInformation("Successfully archived events for Stream {Id} from Version {Version} and down",
                 request.StreamId, request.Version);
@@ -133,7 +133,7 @@ internal static class StreamCompactingExecution
 
     private static IAggregator<T, IQuerySession> FindAggregator<T>(DocumentSessionBase session) where T : class
     {
-        if (!session.Options.Projections.TryFindAggregate(typeof(T), out var projection))
+        if (!((IMartenSession)session).Options.Projections.TryFindAggregate(typeof(T), out var projection))
         {
             throw new InvalidOperationException("Unable to find an Aggregation Projection for type " +
                                                 typeof(T).FullNameInCode());
@@ -196,7 +196,7 @@ internal class DeleteEventsOperation: IStorageOperation, NoDataReturnedCall
 
     public void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
     {
-        builder.Append($"delete from {session.Options.Events.DatabaseSchemaName}.mt_events where seq_id = ANY(");
+        builder.Append($"delete from {((IMartenSession)session).Options.Events.DatabaseSchemaName}.mt_events where seq_id = ANY(");
         builder.AppendParameter(_sequences);
         builder.Append(")");
     }

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.ExpectedVersion.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.ExpectedVersion.cs
@@ -90,7 +90,7 @@ internal partial class FetchAsyncPlan<TDoc, TId>
                 : _identityStrategy.AppendToStream(document, session, id, version, cancellation);
 
             // This is an optimization for calling FetchForWriting, then immediately calling FetchLatest
-            if (session.Options.Events.UseIdentityMapForAggregates)
+            if (((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
             {
                 session.StoreDocumentInItemMap(id, stream);
             }

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.ForReading.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.ForReading.cs
@@ -21,7 +21,7 @@ internal partial class FetchAsyncPlan<TDoc, TId>
     public async ValueTask<TDoc?> FetchForReading(DocumentSessionBase session, TId id, CancellationToken cancellation)
     {
         // Optimization for having called FetchForWriting, then FetchLatest on same session in short order
-        if (session.Options.Events.UseIdentityMapForAggregates)
+        if (((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
         {
             if (session.TryGetAggregateFromIdentityMap<IEventStream<TDoc>, TId>(id, out var stream))
             {

--- a/src/Marten/Events/Fetching/FetchAsyncPlan.ForUpdate.cs
+++ b/src/Marten/Events/Fetching/FetchAsyncPlan.ForUpdate.cs
@@ -123,7 +123,7 @@ internal partial class FetchAsyncPlan<TDoc, TId>
                 : _identityStrategy.AppendToStream(document, session, id, version, cancellation);
 
             // This is an optimization for calling FetchForWriting, then immediately calling FetchLatest
-            if (session.Options.Events.UseIdentityMapForAggregates)
+            if (((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
             {
                 session.StoreDocumentInItemMap(id, stream);
             }

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.ExpectedVersion.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.ExpectedVersion.cs
@@ -63,7 +63,7 @@ internal partial class FetchInlinedPlan<TDoc, TId>
             var document = await handler.HandleAsync(reader, session, cancellation).ConfigureAwait(false);
 
             // As an optimization, put the document in the identity map for later
-            if (document != null && session.Options.Events.UseIdentityMapForAggregates)
+            if (document != null && ((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
             {
                 session.StoreDocumentInItemMap(id, document);
             }

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.ForReading.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.ForReading.cs
@@ -10,6 +10,8 @@ using Marten.Linq.QueryHandlers;
 using Weasel.Postgresql;
 using System.Diagnostics.CodeAnalysis;
 
+using Marten.Internal;
+
 namespace Marten.Events.Fetching;
 
 [UnconditionalSuppressMessage("Trimming", "IL2026",
@@ -51,7 +53,7 @@ internal partial class FetchInlinedPlan<TDoc, TId>
         if (pendingEvents is not { Count: > 0 }) return snapshot;
 
         // Build the aggregator on demand
-        var raw = session.Options.Projections.AggregatorFor<TDoc>();
+        var raw = ((IMartenSession)session).Options.Projections.AggregatorFor<TDoc>();
         var storage = findDocumentStorage(session);
         var aggregator = raw as IAggregator<TDoc, TId, IQuerySession>
                          ?? typeof(IdentityForwardingAggregator<,,,>)

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.ForUpdate.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.ForUpdate.cs
@@ -20,16 +20,16 @@ internal partial class FetchInlinedPlan<TDoc, TId>
         CancellationToken cancellation = default)
     {
         IDocumentStorage<TDoc, TId>? storage = null;
-        if (session.Options.Events.UseIdentityMapForAggregates)
+        if (((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
         {
-            storage = session.Options.ResolveCorrectedDocumentStorage<TDoc, TId>(DocumentTracking.IdentityOnly);
+            storage = ((IMartenSession)session).Options.ResolveCorrectedDocumentStorage<TDoc, TId>(DocumentTracking.IdentityOnly);
             // Opt into the identity map mechanics for this aggregate type just in case
             // you're using a lightweight session
             session.UseIdentityMapFor<TDoc>();
         }
         else
         {
-            storage = session.Options.ResolveCorrectedDocumentStorage<TDoc, TId>(session.TrackingMode);
+            storage = ((IMartenSession)session).Options.ResolveCorrectedDocumentStorage<TDoc, TId>(session.TrackingMode);
         }
 
         await _identityStrategy.EnsureEventStorageExists<TDoc>(session, cancellation).ConfigureAwait(false);
@@ -87,7 +87,7 @@ internal partial class FetchInlinedPlan<TDoc, TId>
             var document = await handler.HandleAsync(reader, session, cancellation).ConfigureAwait(false);
 
             // As an optimization, put the document in the identity map for later
-            if (document != null && session.Options.Events.UseIdentityMapForAggregates)
+            if (document != null && ((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
             {
                 session.StoreDocumentInItemMap(id, document);
             }

--- a/src/Marten/Events/Fetching/FetchInlinedPlan.cs
+++ b/src/Marten/Events/Fetching/FetchInlinedPlan.cs
@@ -38,9 +38,9 @@ internal partial class FetchInlinedPlan<TDoc, TId>: IAggregateFetchPlan<TDoc, TI
     private static IDocumentStorage<TDoc, TId> findDocumentStorage(QuerySession session)
     {
         IDocumentStorage<TDoc, TId>? storage = null;
-        if (session.Options.Events.UseIdentityMapForAggregates)
+        if (((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
         {
-            storage = session.Options.ResolveCorrectedDocumentStorage<TDoc, TId>(DocumentTracking.IdentityOnly);
+            storage = ((IMartenSession)session).Options.ResolveCorrectedDocumentStorage<TDoc, TId>(DocumentTracking.IdentityOnly);
             // Opt into the identity map mechanics for this aggregate type just in case
             // you're using a lightweight session
             session.UseIdentityMapFor<TDoc>();

--- a/src/Marten/Events/Fetching/FetchLivePlan.ExpectedVersion.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.ExpectedVersion.cs
@@ -66,7 +66,7 @@ internal partial class FetchLivePlan<TDoc, TId>
                 : _identityStrategy.AppendToStream(document, session, id, version, cancellation);
 
             // This is an optimization for calling FetchForWriting, then immediately calling FetchLatest
-            if (session.Options.Events.UseIdentityMapForAggregates)
+            if (((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
             {
                 session.StoreDocumentInItemMap(id, stream);
             }

--- a/src/Marten/Events/Fetching/FetchLivePlan.ForReading.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.ForReading.cs
@@ -18,7 +18,7 @@ internal partial class FetchLivePlan<TDoc, TId>
     public async ValueTask<TDoc?> FetchForReading(DocumentSessionBase session, TId id, CancellationToken cancellation)
     {
         // Optimization for having called FetchForWriting, then FetchLatest on same session in short order
-        if (session.Options.Events.UseIdentityMapForAggregates)
+        if (((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
         {
             if (session.TryGetAggregateFromIdentityMap<IEventStream<TDoc>, TId>(id, out var stream))
             {

--- a/src/Marten/Events/Fetching/FetchLivePlan.ForUpdate.cs
+++ b/src/Marten/Events/Fetching/FetchLivePlan.ForUpdate.cs
@@ -82,7 +82,7 @@ internal partial class FetchLivePlan<TDoc, TId>
                 : _identityStrategy.AppendToStream(document, session, id, version, cancellation);
 
             // This is an optimization for calling FetchForWriting, then immediately calling FetchLatest
-            if (session.Options.Events.UseIdentityMapForAggregates)
+            if (((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
             {
                 session.StoreDocumentInItemMap(id, stream);
             }

--- a/src/Marten/Events/Fetching/FetchNaturalKeyPlan.cs
+++ b/src/Marten/Events/Fetching/FetchNaturalKeyPlan.cs
@@ -431,7 +431,7 @@ internal class FetchNaturalKeyPlan<TDoc, TNaturalKey>: IAggregateFetchPlan<TDoc,
     private async Task<TDoc?> LoadDocumentById(DocumentSessionBase session, Guid streamId, CancellationToken cancellation)
     {
         IDocumentStorage<TDoc, Guid> storage;
-        if (session.Options.Events.UseIdentityMapForAggregates)
+        if (((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
         {
             storage = _options.ResolveCorrectedDocumentStorage<TDoc, Guid>(DocumentTracking.IdentityOnly);
             session.UseIdentityMapFor<TDoc>();
@@ -450,7 +450,7 @@ internal class FetchNaturalKeyPlan<TDoc, TNaturalKey>: IAggregateFetchPlan<TDoc,
             await session.ExecuteReaderAsync(docBuilder.Compile(), cancellation).ConfigureAwait(false);
         var document = await handler.HandleAsync(docReader, session, cancellation).ConfigureAwait(false);
 
-        if (document != null && session.Options.Events.UseIdentityMapForAggregates)
+        if (document != null && ((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
         {
             session.StoreDocumentInItemMap(streamId, document);
         }
@@ -498,7 +498,7 @@ internal class FetchNaturalKeyPlan<TDoc, TNaturalKey>: IAggregateFetchPlan<TDoc,
     private async Task<TDoc?> LoadDocumentByKey(DocumentSessionBase session, string streamKey, CancellationToken cancellation)
     {
         IDocumentStorage<TDoc, string> storage;
-        if (session.Options.Events.UseIdentityMapForAggregates)
+        if (((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
         {
             storage = _options.ResolveCorrectedDocumentStorage<TDoc, string>(DocumentTracking.IdentityOnly);
             session.UseIdentityMapFor<TDoc>();
@@ -517,7 +517,7 @@ internal class FetchNaturalKeyPlan<TDoc, TNaturalKey>: IAggregateFetchPlan<TDoc,
             await session.ExecuteReaderAsync(docBuilder.Compile(), cancellation).ConfigureAwait(false);
         var document = await handler.HandleAsync(docReader, session, cancellation).ConfigureAwait(false);
 
-        if (document != null && session.Options.Events.UseIdentityMapForAggregates)
+        if (document != null && ((IMartenSession)session).Options.Events.UseIdentityMapForAggregates)
         {
             session.StoreDocumentInItemMap(streamKey, document);
         }

--- a/src/Marten/Internal/CompiledQueries/QueryCompiler.cs
+++ b/src/Marten/Internal/CompiledQueries/QueryCompiler.cs
@@ -182,7 +182,7 @@ internal class QueryCompiler
 
         var plan = new CompiledQueryPlan(query.GetType(), typeof(TOut)){TenantId = session.TenantId};
 
-        assertValidityOfQueryType(plan, query.GetType(), session.Options);
+        assertValidityOfQueryType(plan, query.GetType(), ((IMartenSession)session).Options);
 
         // This *could* throw
         var queryTemplate = plan.CreateQueryTemplate(query);
@@ -223,7 +223,7 @@ internal class QueryCompiler
 
         var filters = topStatement.AllFilters().OfType<ICompiledQueryAwareFilter>().ToArray();
 
-        queryPlan.MatchParameters(session.Options, filters);
+        queryPlan.MatchParameters(((IMartenSession)session).Options, filters);
 
         return parser;
     }

--- a/src/Marten/Internal/IMartenSession.cs
+++ b/src/Marten/Internal/IMartenSession.cs
@@ -21,6 +21,10 @@ public interface IMartenSession: IDisposable, IAsyncDisposable, IStorageSession
     // own code keeps the concrete VersionTracker here.
     new VersionTracker Versions { get; }
 
+    // #4826: the closed-shape storage runtime never reads StoreOptions off the session, so Options
+    // stays on IMartenSession, not the agnostic IStorageSession contract (LINQ reads it via IMartenSession).
+    StoreOptions Options { get; }
+
     IEventStorage EventStorage();
 
     /// <summary>

--- a/src/Marten/Internal/IStorageSession.cs
+++ b/src/Marten/Internal/IStorageSession.cs
@@ -35,8 +35,6 @@ public interface IStorageSession: IMetadataContext
 
     IMartenDatabase Database { get; }
 
-    StoreOptions Options { get; }
-
     IVersionTracker Versions { get; }
 
     IList<IChangeTracker> ChangeTrackers { get; }

--- a/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs
+++ b/src/Marten/Internal/Sessions/DocumentSessionBase.ProjectionStorage.cs
@@ -133,7 +133,7 @@ internal class ProjectionStorage<TDoc, TId>: IProjectionStorage<TDoc, TId> where
         // path; the opt-in (true) case preserves the GH-3850 semantics and
         // accepts the documented race risk per the #4667 Phase 3 design note
         // ("opt-in is not safe for parallel projection workers").
-        if (_session.Options.EventGraph.UseIdentityMapForAggregates)
+        if (((IMartenSession)_session).Options.EventGraph.UseIdentityMapForAggregates)
         {
             // The aggregate may already be in the identity map from a prior
             // SaveChangesAsync on the same session — for example, a
@@ -169,7 +169,7 @@ internal class ProjectionStorage<TDoc, TId>: IProjectionStorage<TDoc, TId> where
         // preserves the inline-projection identity-map semantics by falling
         // through to the session-aware LoadManyAsync — at the cost of the
         // race the flag's design note already documents.
-        var docs = _session.Options.EventGraph.UseIdentityMapForAggregates
+        var docs = ((IMartenSession)_session).Options.EventGraph.UseIdentityMapForAggregates
             ? await _storage.LoadManyAsync(identities, _session, cancellationToken).ConfigureAwait(false)
             : await _storage.LoadManyProjectedAsync(identities, _session.Database, TenantId, cancellationToken).ConfigureAwait(false);
         return docs.ToDictionary(doc => _storage.Identity(doc));
@@ -216,30 +216,30 @@ internal class ProjectionStorage<TDoc, TId>: IProjectionStorage<TDoc, TId> where
         }
 
         Func<TId, ArchiveStreamOperation> builder = null;
-        if (_session.Options.Events.StreamIdentity == StreamIdentity.AsGuid)
+        if (((IMartenSession)_session).Options.Events.StreamIdentity == StreamIdentity.AsGuid)
         {
             if (typeof(TId) == typeof(Guid))
             {
-                builder = id => new ArchiveStreamOperation(_session.Options.EventGraph, id);
+                builder = id => new ArchiveStreamOperation(((IMartenSession)_session).Options.EventGraph, id);
             }
             else
             {
                 var valueType = ValueTypeInfo.ForType(typeof(TId));
                 var unWrapper = valueType.UnWrapper<TId, Guid>();
-                builder = id =>  new ArchiveStreamOperation(_session.Options.EventGraph, unWrapper(id));
+                builder = id =>  new ArchiveStreamOperation(((IMartenSession)_session).Options.EventGraph, unWrapper(id));
             }
         }
         else
         {
             if (typeof(TId) == typeof(string))
             {
-                builder = id => new ArchiveStreamOperation(_session.Options.EventGraph, id);
+                builder = id => new ArchiveStreamOperation(((IMartenSession)_session).Options.EventGraph, id);
             }
             else
             {
                 var valueType = ValueTypeInfo.ForType(typeof(TId));
                 var unWrapper = valueType.UnWrapper<TId, string>();
-                builder = id =>  new ArchiveStreamOperation(_session.Options.EventGraph, unWrapper(id));
+                builder = id =>  new ArchiveStreamOperation(((IMartenSession)_session).Options.EventGraph, unWrapper(id));
             }
         }
 
@@ -251,7 +251,7 @@ internal class ProjectionStorage<TDoc, TId>: IProjectionStorage<TDoc, TId> where
     public Task<TDoc?> LoadAsync(TId id, CancellationToken cancellation)
     {
         // #4667 Phase 2 — see LoadManyAsync above for rationale.
-        return _session.Options.EventGraph.UseIdentityMapForAggregates
+        return ((IMartenSession)_session).Options.EventGraph.UseIdentityMapForAggregates
             ? _storage.LoadAsync(id, _session, cancellation)
             : _storage.LoadProjectedAsync(id, _session.Database, TenantId, cancellation);
     }

--- a/src/Marten/Internal/UpdateBatch.cs
+++ b/src/Marten/Internal/UpdateBatch.cs
@@ -45,7 +45,7 @@ public class UpdateBatch: IUpdateBatch
             return Array.Empty<OperationPage>();
         }
 
-        if (_operations.Count < session.Options.UpdateBatchSize)
+        if (_operations.Count < ((IMartenSession)session).Options.UpdateBatchSize)
         {
             return new[] { new OperationPage(session, _operations) };
         }
@@ -55,7 +55,7 @@ public class UpdateBatch: IUpdateBatch
 
     private List<OperationPage> buildMultiplePages(IMartenSession session)
     {
-        var batchSize = session.Options.UpdateBatchSize;
+        var batchSize = ((IMartenSession)session).Options.UpdateBatchSize;
         var pageCount = (_operations.Count + batchSize - 1) / batchSize;
         var pages = new List<OperationPage>(pageCount);
 

--- a/src/Marten/Linq/Includes/IncludePlan.cs
+++ b/src/Marten/Linq/Includes/IncludePlan.cs
@@ -82,7 +82,7 @@ internal class IncludePlan<T>: IIncludePlan where T : notnull
             }
 
 
-            var parser = new WhereClauseParser(martenSession.Options, _storage.QueryMembers, filters);
+            var parser = new WhereClauseParser(((IMartenSession)martenSession).Options, _storage.QueryMembers, filters);
             parser.Visit(body);
         }
 

--- a/src/Marten/Linq/Parsing/LinqQueryParser.Handlers.cs
+++ b/src/Marten/Linq/Parsing/LinqQueryParser.Handlers.cs
@@ -10,6 +10,8 @@ using Marten.Linq.SqlGeneration;
 using Weasel.Postgresql.SqlGeneration;
 using System.Diagnostics.CodeAnalysis;
 
+using Marten.Internal;
+
 namespace Marten.Linq.Parsing;
 
 [UnconditionalSuppressMessage("Trimming", "IL2067",
@@ -68,7 +70,7 @@ internal partial class LinqQueryParser
     {
         if (!_collectionUsages.Any())
         {
-            var usage = new CollectionUsage(Session.Options, _provider.SourceType);
+            var usage = new CollectionUsage(((IMartenSession)Session).Options, _provider.SourceType);
             _collectionUsages.Insert(0, usage);
         }
 
@@ -101,7 +103,7 @@ internal partial class LinqQueryParser
     {
         if (!_collectionUsages.Any())
         {
-            var usage = new CollectionUsage(Session.Options, _provider.SourceType);
+            var usage = new CollectionUsage(((IMartenSession)Session).Options, _provider.SourceType);
             _collectionUsages.Insert(0, usage);
         }
 

--- a/src/Marten/Linq/Parsing/LinqQueryParser.Statements.cs
+++ b/src/Marten/Linq/Parsing/LinqQueryParser.Statements.cs
@@ -2,6 +2,8 @@
 using System.Linq;
 using Marten.Linq.SqlGeneration;
 
+using Marten.Internal;
+
 namespace Marten.Linq.Parsing;
 
 internal partial class LinqQueryParser
@@ -10,7 +12,7 @@ internal partial class LinqQueryParser
     {
         if (!_collectionUsages.Any())
         {
-            var usage = new CollectionUsage(Session.Options, _provider.SourceType);
+            var usage = new CollectionUsage(((IMartenSession)Session).Options, _provider.SourceType);
             _collectionUsages.Insert(0, usage);
         }
 

--- a/src/Marten/Linq/Parsing/LinqQueryParser.cs
+++ b/src/Marten/Linq/Parsing/LinqQueryParser.cs
@@ -45,7 +45,7 @@ internal partial class LinqQueryParser: ExpressionVisitor, ILinqQuery
         var elementType = argument.Type.GetGenericArguments()[0];
         if (CurrentUsage == null || CurrentUsage.ElementType != elementType)
         {
-            CurrentUsage = new CollectionUsage(Session.Options, elementType);
+            CurrentUsage = new CollectionUsage(((IMartenSession)Session).Options, elementType);
             _collectionUsages.Insert(0, CurrentUsage);
 
             return CurrentUsage;
@@ -57,7 +57,7 @@ internal partial class LinqQueryParser: ExpressionVisitor, ILinqQuery
     public CollectionUsage StartNewCollectionUsageFor(MethodCallExpression expression)
     {
         var elementType = expression.Arguments[0].Type.GetGenericArguments()[0];
-        CurrentUsage = new CollectionUsage(Session.Options, elementType);
+        CurrentUsage = new CollectionUsage(((IMartenSession)Session).Options, elementType);
         _collectionUsages.Insert(0, CurrentUsage);
 
         return CurrentUsage;
@@ -67,7 +67,7 @@ internal partial class LinqQueryParser: ExpressionVisitor, ILinqQuery
     {
         if (CurrentUsage == null || CurrentUsage.ElementType != elementType)
         {
-            CurrentUsage = new CollectionUsage(Session.Options, elementType);
+            CurrentUsage = new CollectionUsage(((IMartenSession)Session).Options, elementType);
             _collectionUsages.Insert(0, CurrentUsage);
 
             return CurrentUsage;

--- a/src/Marten/Linq/SqlGeneration/Statement.WhereParsing.cs
+++ b/src/Marten/Linq/SqlGeneration/Statement.WhereParsing.cs
@@ -54,7 +54,7 @@ public abstract partial class Statement: IWhereFragmentHolder
             return;
         }
 
-        var parser = new WhereClauseParser(session.Options, collection, this);
+        var parser = new WhereClauseParser(((IMartenSession)session).Options, collection, this);
         foreach (var expression in wheres) parser.Visit(expression);
 
         if (storage != null)


### PR DESCRIPTION
Story 2 of the #4821 closed-shape storage extraction epic.

## What
The closed-shape storage runtime never reads `StoreOptions` off the session — only Marten-resident code does (the LINQ pipeline in `LinqQueryParser`/`IncludePlan`/`Statement.WhereParsing`, plus event fetching + the projection daemon). This PR:

- Removes `StoreOptions Options` from the agnostic `IStorageSession` contract.
- Adds `StoreOptions Options` to `IMartenSession` (which every Marten session already exposes).
- Bridges the Marten-resident `Options` readers with `((IMartenSession)session).Options` casts. Every session flowing through those paths is a `QuerySession`/`DocumentSessionBase`, so the cast always holds.

Net effect: one more Marten type (`StoreOptions`) is off the interface the extractable storage runtime targets. Purely a compile-time type-narrowing refactor — no runtime behavior change.

## Verification
- `dotnet build src/Marten.slnx` clean in **Debug and Release**.
- **LinqTests** 1312 passed (exercises `LinqQueryParser`/`IncludePlan` bridges).
- **EventSourcingTests** 1421 passed (exercises the Events/ + daemon bridges).

Part of #4821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)