### PR TITLE
#4827 — agnostic database + provider-graph seam (IStorageDatabase)

### DIFF
--- a/src/Marten/Internal/ClosedShape/DirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/DirtyCheckedClosedShapeStorage.cs
@@ -32,7 +32,7 @@ public abstract class DirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyCheckedDoc
     public override TId Identity(TDoc document)
         => _descriptor.Identification.Identity(document);
 
-    public override TId AssignIdentity(TDoc document, string tenantId, IMartenDatabase database)
+    public override TId AssignIdentity(TDoc document, string tenantId, IStorageDatabase database)
         => _descriptor.Identification.AssignIfMissing(document, database);
 
     public override object RawIdentityValue(TId id)

--- a/src/Marten/Internal/ClosedShape/IdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/IdentityMapClosedShapeStorage.cs
@@ -32,7 +32,7 @@ public abstract class IdentityMapClosedShapeStorage<TDoc, TId>: IdentityMapDocum
     public override TId Identity(TDoc document)
         => _descriptor.Identification.Identity(document);
 
-    public override TId AssignIdentity(TDoc document, string tenantId, IMartenDatabase database)
+    public override TId AssignIdentity(TDoc document, string tenantId, IStorageDatabase database)
         => _descriptor.Identification.AssignIfMissing(document, database);
 
     public override object RawIdentityValue(TId id)

--- a/src/Marten/Internal/ClosedShape/LightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/LightweightClosedShapeStorage.cs
@@ -45,7 +45,7 @@ public abstract class LightweightClosedShapeStorage<TDoc, TId>: LightweightDocum
     public override TId Identity(TDoc document)
         => _descriptor.Identification.Identity(document);
 
-    public override TId AssignIdentity(TDoc document, string tenantId, IMartenDatabase database)
+    public override TId AssignIdentity(TDoc document, string tenantId, IStorageDatabase database)
         => _descriptor.Identification.AssignIfMissing(document, database);
 
     // M15: strong-typed wrappers need to bind the inner primitive

--- a/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
@@ -37,7 +37,7 @@ public sealed class QueryOnlyClosedShapeStorage<TDoc, TId>: QueryOnlyDocumentSto
     public override TId Identity(TDoc document)
         => _descriptor.Identification.Identity(document);
 
-    public override TId AssignIdentity(TDoc document, string tenantId, IMartenDatabase database)
+    public override TId AssignIdentity(TDoc document, string tenantId, IStorageDatabase database)
         => _descriptor.Identification.AssignIfMissing(document, database);
 
     public override object RawIdentityValue(TId id)

--- a/src/Marten/Internal/IMartenSession.cs
+++ b/src/Marten/Internal/IMartenSession.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx;
 using Marten.Events;
+using Marten.Storage;
 using Npgsql;
 
 namespace Marten.Internal;
@@ -24,6 +25,12 @@ public interface IMartenSession: IDisposable, IAsyncDisposable, IStorageSession
     // #4826: the closed-shape storage runtime never reads StoreOptions off the session, so Options
     // stays on IMartenSession, not the agnostic IStorageSession contract (LINQ reads it via IMartenSession).
     StoreOptions Options { get; }
+
+    // #4827: closed-shape storage sees the agnostic IStorageDatabase via IStorageSession (provider
+    // graph + sequence source); Marten's own code (projection read path, admin) keeps the full
+    // Npgsql-typed IMartenDatabase here. Every Marten session returns an IMartenDatabase, which
+    // satisfies both since IMartenDatabase : IStorageDatabase.
+    new IMartenDatabase Database { get; }
 
     IEventStorage EventStorage();
 

--- a/src/Marten/Internal/IStorageDatabase.cs
+++ b/src/Marten/Internal/IStorageDatabase.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using Weasel.Core.Sequences;
+
+namespace Marten.Internal;
+
+/// <summary>
+///     Database-neutral database accessor the closed-shape storage runtime targets instead of
+///     <see cref="Marten.Storage.IMartenDatabase"/> (#4827, part of the #4821 extraction epic).
+///     Exposes only the two db-neutral concerns the movable storage code consumes off the session's
+///     database: the <see cref="IProviderGraph"/> for document-provider lookup, and the
+///     <see cref="ISequenceSource"/> Hi-Lo/sequence seam (already agnostic from #4811) used by the
+///     Weasel.Core.Identity <c>AssignIfMissing</c> strategies.
+/// </summary>
+/// <remarks>
+///     Deliberately does <em>not</em> surface a connection factory: the projection-safe read path
+///     (<see cref="Marten.Internal.ClosedShape.ClosedShapeProjectionLoader"/>) still builds and runs
+///     Npgsql-typed commands, so it keeps taking the Npgsql-typed
+///     <see cref="Marten.Storage.IMartenDatabase"/> until the command/connection surface is made
+///     agnostic in a later story. Marten's <see cref="Marten.Storage.IMartenDatabase"/> implements
+///     this interface — its <c>Providers</c> and <c>ISequenceSource</c> members already satisfy it.
+/// </remarks>
+public interface IStorageDatabase: ISequenceSource
+{
+    IProviderGraph Providers { get; }
+}

--- a/src/Marten/Internal/IStorageSession.cs
+++ b/src/Marten/Internal/IStorageSession.cs
@@ -33,7 +33,7 @@ public interface IStorageSession: IMetadataContext
 {
     IStorageSerializer Serializer { get; }
 
-    IMartenDatabase Database { get; }
+    IStorageDatabase Database { get; }
 
     IVersionTracker Versions { get; }
 

--- a/src/Marten/Internal/Sessions/QuerySession.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.cs
@@ -60,6 +60,11 @@ public partial class QuerySession: IMartenSession, IQuerySession, ITenantedQuery
 
     public IMartenDatabase Database { get; protected set; }
 
+    // #4827: the public IMartenDatabase satisfies IMartenSession.Database (new IMartenDatabase);
+    // this explicit impl satisfies the narrower IStorageSession.Database (IStorageDatabase) —
+    // interface implementation needs an exact return type, and IMartenDatabase : IStorageDatabase.
+    IStorageDatabase IStorageSession.Database => Database;
+
 
 #nullable enable
 

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -264,7 +264,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
     public Type SourceType => typeof(T);
 
 
-    public abstract TId AssignIdentity(T document, string tenantId, IMartenDatabase database);
+    public abstract TId AssignIdentity(T document, string tenantId, IStorageDatabase database);
 
     public DbObjectName TableName { get; }
 

--- a/src/Marten/Internal/Storage/IDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IDocumentStorage.cs
@@ -177,7 +177,7 @@ public interface IDocumentStorage<T, TId>: IDocumentStorage<T>, IIdentitySetter<
     Task<IReadOnlyList<T>> LoadManyProjectedAsync(TId[] ids, IMartenDatabase database, string tenantId, CancellationToken token);
 
 
-    TId AssignIdentity(T document, string tenantId, IMartenDatabase database);
+    TId AssignIdentity(T document, string tenantId, IStorageDatabase database);
     ISqlFragment ByIdFilter(TId id);
     IDeletion HardDeleteForId(TId id, string tenantId);
     NpgsqlCommand BuildLoadCommand(TId id, string tenantId);

--- a/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
@@ -234,7 +234,7 @@ internal class SubClassDocumentStorage<T, TRoot, TId>: IDocumentStorage<T, TId>,
         return (await _parent.LoadManyProjectedAsync(ids, database, tenantId, token).ConfigureAwait(false)).OfType<T>().ToList();
     }
 
-    public TId AssignIdentity(T document, string tenantId, IMartenDatabase database)
+    public TId AssignIdentity(T document, string tenantId, IStorageDatabase database)
     {
         return _parent.AssignIdentity(document, tenantId, database);
     }

--- a/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
+++ b/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
@@ -188,7 +188,7 @@ internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: ID
     public Task<IReadOnlyList<TDoc>> LoadManyProjectedAsync(TSimple[] ids, IMartenDatabase database, string tenantId, CancellationToken token)
         => Inner.LoadManyProjectedAsync(ids.Select(_converter).ToArray(), database, tenantId, token);
 
-    public TSimple AssignIdentity(TDoc document, string tenantId, IMartenDatabase database)
+    public TSimple AssignIdentity(TDoc document, string tenantId, IStorageDatabase database)
         => _unwrapper(Inner.AssignIdentity(document, tenantId, database));
 
     public TSimple Identity(TDoc document) => _unwrapper(Inner.Identity(document));

--- a/src/Marten/Storage/IMartenDatabase.cs
+++ b/src/Marten/Storage/IMartenDatabase.cs
@@ -22,7 +22,7 @@ namespace Marten.Storage;
 ///     Governs the database structure and migration path for a single Marten database
 /// </summary>
 public interface IMartenDatabase: IDatabase, IConnectionSource<NpgsqlConnection>, IDocumentCleaner, IDisposable,
-    ISequenceSource
+    IStorageDatabase
 {
     /// <summary>
     ///     Used to create new Hilo sequences


### PR DESCRIPTION
Story 3 of the #4821 closed-shape storage extraction epic.

## What
`IStorageSession.Database` returned the Npgsql-typed `IMartenDatabase`. This introduces `IStorageDatabase` (`Marten.Internal`) exposing only the two db-neutral concerns the movable storage runtime reads off the session's database:

- `IProviderGraph Providers` — document-provider lookup.
- `ISequenceSource` (already agnostic from #4811) — the Hi-Lo/sequence seam the `Weasel.Core.Identity` `AssignIfMissing` strategies consume.

### Changes
- `IStorageDatabase : ISequenceSource { IProviderGraph Providers; }`.
- `IMartenDatabase : IStorageDatabase` — its existing `Providers` + `ISequenceSource` members already satisfy it, no new members.
- Narrow `IStorageSession.Database` → `IStorageDatabase`; add `new IMartenDatabase Database` to `IMartenSession`, with an explicit-interface impl on `QuerySession` (return-type covariance, same pattern already used for `Serializer`/`Versions`).
- Retarget `AssignIdentity(T, string, IMartenDatabase)` → `IStorageDatabase` across the storage hierarchy (`IDocumentStorage`, `DocumentStorage`, `SubClassDocumentStorage`, `ValueTypeIdentifiedDocumentStorage`, the 4 closed-shape storages). The param only ever feeds `AssignIfMissing(ISequenceSource)`.

The projection-safe read path (`ClosedShapeProjectionLoader`) still builds/runs Npgsql-typed commands, so it keeps taking `IMartenDatabase` (reached via the `IMartenSession`-typed session) until the command/connection surface is made agnostic in a later story.

No public-API break — `IMartenDatabase`/`IMartenSession` keep their full surface.

## Verification
- `dotnet build src/Marten.slnx` clean in **Debug and Release**.
- **DocumentDbTests** 1033 passed (exercises `AssignIdentity`/`Store`/`Load` + provider graph).
- **ValueTypeTests** 339 passed (`ValueTypeIdentifiedDocumentStorage.AssignIdentity`).

Part of #4821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)