### PR TITLE
#4829 (5a) — remove DocumentMapping from the descriptor + selector runtime

### DIFF
--- a/src/Marten/Internal/ClosedShape/ClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeDirtyTrackingSelector.cs
@@ -12,7 +12,7 @@ namespace Marten.Internal.ClosedShape;
 
 /// <summary>
 /// Abstract base for the per-<see cref="ConcurrencyMode"/> ×
-/// <see cref="DocumentStorageDescriptor{T,TId}.HierarchyMapping"/>
+/// <see cref="DocumentStorageDescriptor{T,TId}.ResolveDocumentType"/>
 /// closed-shape DirtyTracking <see cref="ISelector{T}"/>. Identity-map
 /// writes (like <see cref="ClosedShapeIdentityMapSelector{T, TId}"/>)
 /// plus a <see cref="ChangeTracker{T}"/> registered on the session per

--- a/src/Marten/Internal/ClosedShape/ClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeIdentityMapSelector.cs
@@ -11,7 +11,7 @@ namespace Marten.Internal.ClosedShape;
 
 /// <summary>
 /// Abstract base for the per-<see cref="ConcurrencyMode"/> ×
-/// <see cref="DocumentStorageDescriptor{T,TId}.HierarchyMapping"/>
+/// <see cref="DocumentStorageDescriptor{T,TId}.ResolveDocumentType"/>
 /// closed-shape IdentityMap <see cref="ISelector{T}"/>. Owns the
 /// identity-map cache init + lookup; sealed concurrency × hierarchy
 /// leaves override <c>CaptureVersion</c> + <c>ReadDocument</c> so the

--- a/src/Marten/Internal/ClosedShape/ClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeLightweightSelector.cs
@@ -10,7 +10,7 @@ namespace Marten.Internal.ClosedShape;
 
 /// <summary>
 /// Abstract base for the per-<see cref="ConcurrencyMode"/> ×
-/// <see cref="DocumentStorageDescriptor{T,TId}.HierarchyMapping"/>
+/// <see cref="DocumentStorageDescriptor{T,TId}.ResolveDocumentType"/>
 /// closed-shape Lightweight <see cref="ISelector{T}"/>. Owns the shared
 /// row-shape (id at col 0, data at col 1, metadata at 2+) plus
 /// metadata-apply. Sealed concurrency × hierarchy leaves provide

--- a/src/Marten/Internal/ClosedShape/ClosedShapeProjectionLoader.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeProjectionLoader.cs
@@ -112,11 +112,11 @@ internal static class ClosedShapeProjectionLoader<TDoc, TId>
     {
         // Hierarchical: dispatch via mt_doc_type alias just like
         // HierarchicalClosedShapeQueryOnlySelector. Flat: straight deserialize.
-        if (descriptor.HierarchyMapping is { } hierarchy)
+        if (descriptor.ResolveDocumentType is { } resolveType)
         {
             var docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
             var alias = await reader.GetFieldValueAsync<string>(docTypeOrdinal, token).ConfigureAwait(false);
-            return (TDoc)await serializer.FromJsonAsync(hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+            return (TDoc)await serializer.FromJsonAsync(resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
         }
 
         return await serializer.FromJsonAsync<TDoc>(reader, DataColumn, token).ConfigureAwait(false);

--- a/src/Marten/Internal/ClosedShape/ClosedShapeQueryOnlySelector.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeQueryOnlySelector.cs
@@ -14,7 +14,7 @@ namespace Marten.Internal.ClosedShape;
 /// writes — QueryOnly sessions don't track loaded docs.
 /// Sealed subclasses provide a monomorphic <c>ReadDocument</c> /
 /// <c>ReadDocumentAsync</c> so the per-row hot path doesn't branch on
-/// <c>HierarchyMapping</c> (#4659 Phase 2).
+/// <c>ResolveDocumentType</c> (#4659 Phase 2).
 /// </summary>
 internal abstract class ClosedShapeQueryOnlySelector<T, TId>: ISelector<T>
     where T : notnull

--- a/src/Marten/Internal/ClosedShape/DocumentStorageDescriptor.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentStorageDescriptor.cs
@@ -1,6 +1,5 @@
 #nullable enable
-using Marten.Schema;
-
+using System;
 using Weasel.Core.Identity;
 
 namespace Marten.Internal.ClosedShape;
@@ -65,7 +64,7 @@ public sealed class DocumentStorageDescriptor<TDoc, TId>
         DocumentVersionBinder<TDoc>? versionBinder,
         DocumentRevisionBinder<TDoc>? revisionBinder,
         int versionReadIndex,
-        Marten.Schema.DocumentMapping? hierarchyMapping,
+        Func<string, Type>? resolveDocumentType,
         int docTypeReadIndex,
         string tableName,
         IDocumentMetadataBinder<TDoc>[]? partitionPkBinders = null,
@@ -86,7 +85,7 @@ public sealed class DocumentStorageDescriptor<TDoc, TId>
         VersionBinder = versionBinder;
         RevisionBinder = revisionBinder;
         VersionReadIndex = versionReadIndex;
-        HierarchyMapping = hierarchyMapping;
+        ResolveDocumentType = resolveDocumentType;
         DocTypeReadIndex = docTypeReadIndex;
         PartitionPkBinders = partitionPkBinders ?? System.Array.Empty<IDocumentMetadataBinder<TDoc>>();
         UseVersionFromMatchingStream = useVersionFromMatchingStream;
@@ -251,12 +250,14 @@ public sealed class DocumentStorageDescriptor<TDoc, TId>
     public int VersionReadIndex { get; }
 
     /// <summary>
-    /// W3 spike (M11): the root <see cref="Marten.Schema.DocumentMapping"/>
-    /// when the mapping is hierarchical, otherwise <c>null</c>. Selectors
-    /// use it to resolve the <c>mt_doc_type</c> alias back to a .NET
-    /// <see cref="Type"/> for polymorphic deserialization.
+    /// W3 spike (M11): agnostic <c>mt_doc_type</c> alias → .NET <see cref="Type"/>
+    /// resolver, present when the mapping is hierarchical, otherwise <c>null</c>.
+    /// Selectors use it for polymorphic deserialization. #4829: this replaced a
+    /// direct <c>Marten.Schema.DocumentMapping</c> reference (the builder now
+    /// captures <c>mapping.TypeFor</c> as a delegate) so the movable descriptor +
+    /// selector runtime no longer depends on the Marten mapping type.
     /// </summary>
-    internal Marten.Schema.DocumentMapping? HierarchyMapping { get; }
+    internal Func<string, Type>? ResolveDocumentType { get; }
 
     /// <summary>
     /// W3 spike (M11): zero-based index of the <c>mt_doc_type</c> binder

--- a/src/Marten/Internal/ClosedShape/DocumentStorageDescriptorBuilder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentStorageDescriptorBuilder.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using JasperFx.Core;
@@ -39,7 +40,7 @@ internal static class DocumentStorageDescriptorBuilder
         DocumentRevisionBinder<TDoc>? revisionBinder = null;
         var versionReadIndex = -1;
         var docTypeReadIndex = -1;
-        DocumentMapping? hierarchyMapping = null;
+        Func<string, Type>? resolveDocumentType = null;
 
         // #4602: the version/revision column is the one metadata column whose
         // presence in the SELECT depends on the storage style — Version/Revision
@@ -55,7 +56,9 @@ internal static class DocumentStorageDescriptorBuilder
         // dispatch deserialization to the right subclass type.
         if (mapping.IsHierarchy())
         {
-            hierarchyMapping = mapping;
+            // #4829: capture the alias→Type lookup as an agnostic delegate so the
+            // descriptor + selectors don't hold the Marten DocumentMapping type.
+            resolveDocumentType = mapping.TypeFor;
             var docTypeBinder = new DocumentDocTypeBinder<TDoc>(mapping);
             writeBinders.Add(docTypeBinder);
             docTypeReadIndex = readBinders.Count;
@@ -292,7 +295,7 @@ internal static class DocumentStorageDescriptorBuilder
             versionBinder: versionBinder,
             revisionBinder: revisionBinder,
             versionReadIndex: versionReadIndex,
-            hierarchyMapping: hierarchyMapping,
+            resolveDocumentType: resolveDocumentType,
             docTypeReadIndex: docTypeReadIndex,
             tableName: mapping.TableName.Name,
             partitionPkBinders: partitionPkBinders,

--- a/src/Marten/Internal/ClosedShape/HierarchicalClosedShapeQueryOnlySelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalClosedShapeQueryOnlySelector.cs
@@ -3,7 +3,6 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.Schema;
 
 namespace Marten.Internal.ClosedShape;
 
@@ -11,7 +10,7 @@ namespace Marten.Internal.ClosedShape;
 /// Hierarchical QueryOnly selector. Reads the <c>mt_doc_type</c> alias
 /// from the descriptor's <see cref="DocumentStorageDescriptor{T,TId}.DocTypeReadIndex"/>
 /// and dispatches deserialization through the
-/// <see cref="DocumentStorageDescriptor{T,TId}.HierarchyMapping"/> root —
+/// <see cref="DocumentStorageDescriptor{T,TId}.ResolveDocumentType"/> root —
 /// the alias-to-.NET-type lookup the polymorphic JSON path needs.
 /// #4659 Phase 2 leaf.
 /// </summary>
@@ -19,17 +18,17 @@ internal sealed class HierarchicalClosedShapeQueryOnlySelector<T, TId>: ClosedSh
     where T : notnull
     where TId : notnull
 {
-    private readonly DocumentMapping _hierarchy;
+    private readonly Func<string, Type> _resolveType;
     private readonly int _docTypeOrdinal;
 
     public HierarchicalClosedShapeQueryOnlySelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
-        // The factory only constructs this leaf when HierarchyMapping is
+        // The factory only constructs this leaf when ResolveDocumentType is
         // non-null; capture it once to avoid the per-row pattern-match.
-        _hierarchy = descriptor.HierarchyMapping
+        _resolveType = descriptor.ResolveDocumentType
             ?? throw new InvalidOperationException(
-                "HierarchicalClosedShapeQueryOnlySelector requires a non-null descriptor.HierarchyMapping; " +
+                "HierarchicalClosedShapeQueryOnlySelector requires a non-null descriptor.ResolveDocumentType; " +
                 "the storage factory must dispatch to FlatClosedShapeQueryOnlySelector otherwise.");
         _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
     }
@@ -37,12 +36,12 @@ internal sealed class HierarchicalClosedShapeQueryOnlySelector<T, TId>: ClosedSh
     protected override T ReadDocument(DbDataReader reader)
     {
         var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
-        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
     }
 
     protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
     {
         var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
-        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
     }
 }

--- a/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeDirtyTrackingSelector.cs
@@ -3,7 +3,6 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.Schema;
 
 namespace Marten.Internal.ClosedShape;
 
@@ -14,27 +13,27 @@ internal sealed class HierarchicalNumericClosedShapeDirtyTrackingSelector<T, TId
     where T : notnull
     where TId : notnull
 {
-    private readonly DocumentMapping _hierarchy;
+    private readonly Func<string, Type> _resolveType;
     private readonly int _docTypeOrdinal;
 
     public HierarchicalNumericClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
-        _hierarchy = descriptor.HierarchyMapping
+        _resolveType = descriptor.ResolveDocumentType
             ?? throw new InvalidOperationException(
-                "HierarchicalNumericClosedShapeDirtyTrackingSelector requires a non-null descriptor.HierarchyMapping.");
+                "HierarchicalNumericClosedShapeDirtyTrackingSelector requires a non-null descriptor.ResolveDocumentType.");
         _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
     }
 
     protected override T ReadDocument(DbDataReader reader)
     {
         var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
-        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
     }
 
     protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
     {
         var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
-        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
     }
 }

--- a/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeIdentityMapSelector.cs
@@ -3,7 +3,6 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.Schema;
 
 namespace Marten.Internal.ClosedShape;
 
@@ -14,27 +13,27 @@ internal sealed class HierarchicalNumericClosedShapeIdentityMapSelector<T, TId>:
     where T : notnull
     where TId : notnull
 {
-    private readonly DocumentMapping _hierarchy;
+    private readonly Func<string, Type> _resolveType;
     private readonly int _docTypeOrdinal;
 
     public HierarchicalNumericClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
-        _hierarchy = descriptor.HierarchyMapping
+        _resolveType = descriptor.ResolveDocumentType
             ?? throw new InvalidOperationException(
-                "HierarchicalNumericClosedShapeIdentityMapSelector requires a non-null descriptor.HierarchyMapping.");
+                "HierarchicalNumericClosedShapeIdentityMapSelector requires a non-null descriptor.ResolveDocumentType.");
         _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
     }
 
     protected override T ReadDocument(DbDataReader reader)
     {
         var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
-        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
     }
 
     protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
     {
         var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
-        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
     }
 }

--- a/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalNumericClosedShapeLightweightSelector.cs
@@ -3,7 +3,6 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.Schema;
 
 namespace Marten.Internal.ClosedShape;
 
@@ -14,27 +13,27 @@ internal sealed class HierarchicalNumericClosedShapeLightweightSelector<T, TId>:
     where T : notnull
     where TId : notnull
 {
-    private readonly DocumentMapping _hierarchy;
+    private readonly Func<string, Type> _resolveType;
     private readonly int _docTypeOrdinal;
 
     public HierarchicalNumericClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
-        _hierarchy = descriptor.HierarchyMapping
+        _resolveType = descriptor.ResolveDocumentType
             ?? throw new InvalidOperationException(
-                "HierarchicalNumericClosedShapeLightweightSelector requires a non-null descriptor.HierarchyMapping.");
+                "HierarchicalNumericClosedShapeLightweightSelector requires a non-null descriptor.ResolveDocumentType.");
         _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
     }
 
     protected override T ReadDocument(DbDataReader reader)
     {
         var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
-        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
     }
 
     protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
     {
         var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
-        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
     }
 }

--- a/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeDirtyTrackingSelector.cs
@@ -3,7 +3,6 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.Schema;
 
 namespace Marten.Internal.ClosedShape;
 
@@ -14,27 +13,27 @@ internal sealed class HierarchicalOptimisticClosedShapeDirtyTrackingSelector<T, 
     where T : notnull
     where TId : notnull
 {
-    private readonly DocumentMapping _hierarchy;
+    private readonly Func<string, Type> _resolveType;
     private readonly int _docTypeOrdinal;
 
     public HierarchicalOptimisticClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
-        _hierarchy = descriptor.HierarchyMapping
+        _resolveType = descriptor.ResolveDocumentType
             ?? throw new InvalidOperationException(
-                "HierarchicalOptimisticClosedShapeDirtyTrackingSelector requires a non-null descriptor.HierarchyMapping.");
+                "HierarchicalOptimisticClosedShapeDirtyTrackingSelector requires a non-null descriptor.ResolveDocumentType.");
         _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
     }
 
     protected override T ReadDocument(DbDataReader reader)
     {
         var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
-        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
     }
 
     protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
     {
         var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
-        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
     }
 }

--- a/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeIdentityMapSelector.cs
@@ -3,7 +3,6 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.Schema;
 
 namespace Marten.Internal.ClosedShape;
 
@@ -14,27 +13,27 @@ internal sealed class HierarchicalOptimisticClosedShapeIdentityMapSelector<T, TI
     where T : notnull
     where TId : notnull
 {
-    private readonly DocumentMapping _hierarchy;
+    private readonly Func<string, Type> _resolveType;
     private readonly int _docTypeOrdinal;
 
     public HierarchicalOptimisticClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
-        _hierarchy = descriptor.HierarchyMapping
+        _resolveType = descriptor.ResolveDocumentType
             ?? throw new InvalidOperationException(
-                "HierarchicalOptimisticClosedShapeIdentityMapSelector requires a non-null descriptor.HierarchyMapping.");
+                "HierarchicalOptimisticClosedShapeIdentityMapSelector requires a non-null descriptor.ResolveDocumentType.");
         _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
     }
 
     protected override T ReadDocument(DbDataReader reader)
     {
         var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
-        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
     }
 
     protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
     {
         var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
-        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
     }
 }

--- a/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalOptimisticClosedShapeLightweightSelector.cs
@@ -3,7 +3,6 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.Schema;
 
 namespace Marten.Internal.ClosedShape;
 
@@ -14,27 +13,27 @@ internal sealed class HierarchicalOptimisticClosedShapeLightweightSelector<T, TI
     where T : notnull
     where TId : notnull
 {
-    private readonly DocumentMapping _hierarchy;
+    private readonly Func<string, Type> _resolveType;
     private readonly int _docTypeOrdinal;
 
     public HierarchicalOptimisticClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
-        _hierarchy = descriptor.HierarchyMapping
+        _resolveType = descriptor.ResolveDocumentType
             ?? throw new InvalidOperationException(
-                "HierarchicalOptimisticClosedShapeLightweightSelector requires a non-null descriptor.HierarchyMapping.");
+                "HierarchicalOptimisticClosedShapeLightweightSelector requires a non-null descriptor.ResolveDocumentType.");
         _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
     }
 
     protected override T ReadDocument(DbDataReader reader)
     {
         var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
-        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
     }
 
     protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
     {
         var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
-        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
     }
 }

--- a/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeDirtyTrackingSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeDirtyTrackingSelector.cs
@@ -3,7 +3,6 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.Schema;
 
 namespace Marten.Internal.ClosedShape;
 
@@ -14,27 +13,27 @@ internal sealed class HierarchicalUnversionedClosedShapeDirtyTrackingSelector<T,
     where T : notnull
     where TId : notnull
 {
-    private readonly DocumentMapping _hierarchy;
+    private readonly Func<string, Type> _resolveType;
     private readonly int _docTypeOrdinal;
 
     public HierarchicalUnversionedClosedShapeDirtyTrackingSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
-        _hierarchy = descriptor.HierarchyMapping
+        _resolveType = descriptor.ResolveDocumentType
             ?? throw new InvalidOperationException(
-                "HierarchicalUnversionedClosedShapeDirtyTrackingSelector requires a non-null descriptor.HierarchyMapping.");
+                "HierarchicalUnversionedClosedShapeDirtyTrackingSelector requires a non-null descriptor.ResolveDocumentType.");
         _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
     }
 
     protected override T ReadDocument(DbDataReader reader)
     {
         var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
-        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
     }
 
     protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
     {
         var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
-        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
     }
 }

--- a/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeIdentityMapSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeIdentityMapSelector.cs
@@ -3,7 +3,6 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.Schema;
 
 namespace Marten.Internal.ClosedShape;
 
@@ -14,27 +13,27 @@ internal sealed class HierarchicalUnversionedClosedShapeIdentityMapSelector<T, T
     where T : notnull
     where TId : notnull
 {
-    private readonly DocumentMapping _hierarchy;
+    private readonly Func<string, Type> _resolveType;
     private readonly int _docTypeOrdinal;
 
     public HierarchicalUnversionedClosedShapeIdentityMapSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
-        _hierarchy = descriptor.HierarchyMapping
+        _resolveType = descriptor.ResolveDocumentType
             ?? throw new InvalidOperationException(
-                "HierarchicalUnversionedClosedShapeIdentityMapSelector requires a non-null descriptor.HierarchyMapping.");
+                "HierarchicalUnversionedClosedShapeIdentityMapSelector requires a non-null descriptor.ResolveDocumentType.");
         _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
     }
 
     protected override T ReadDocument(DbDataReader reader)
     {
         var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
-        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
     }
 
     protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
     {
         var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
-        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
     }
 }

--- a/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeLightweightSelector.cs
+++ b/src/Marten/Internal/ClosedShape/HierarchicalUnversionedClosedShapeLightweightSelector.cs
@@ -3,7 +3,6 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Marten.Schema;
 
 namespace Marten.Internal.ClosedShape;
 
@@ -11,34 +10,34 @@ namespace Marten.Internal.ClosedShape;
 /// Hierarchical, Off-mode Lightweight selector. Reads <c>mt_doc_type</c>
 /// from the descriptor's <see cref="DocumentStorageDescriptor{T,TId}.DocTypeReadIndex"/>
 /// and dispatches deserialization through the
-/// <see cref="DocumentStorageDescriptor{T,TId}.HierarchyMapping"/> root.
+/// <see cref="DocumentStorageDescriptor{T,TId}.ResolveDocumentType"/> root.
 /// #4659 Phase 2 leaf.
 /// </summary>
 internal sealed class HierarchicalUnversionedClosedShapeLightweightSelector<T, TId>: UnversionedClosedShapeLightweightSelector<T, TId>
     where T : notnull
     where TId : notnull
 {
-    private readonly DocumentMapping _hierarchy;
+    private readonly Func<string, Type> _resolveType;
     private readonly int _docTypeOrdinal;
 
     public HierarchicalUnversionedClosedShapeLightweightSelector(IStorageSession session, DocumentStorageDescriptor<T, TId> descriptor)
         : base(session, descriptor)
     {
-        _hierarchy = descriptor.HierarchyMapping
+        _resolveType = descriptor.ResolveDocumentType
             ?? throw new InvalidOperationException(
-                "HierarchicalUnversionedClosedShapeLightweightSelector requires a non-null descriptor.HierarchyMapping.");
+                "HierarchicalUnversionedClosedShapeLightweightSelector requires a non-null descriptor.ResolveDocumentType.");
         _docTypeOrdinal = FirstMetadataColumn + descriptor.DocTypeReadIndex;
     }
 
     protected override T ReadDocument(DbDataReader reader)
     {
         var alias = reader.GetFieldValue<string>(_docTypeOrdinal);
-        return (T)_serializer.FromJson(_hierarchy.TypeFor(alias), reader, DataColumn);
+        return (T)_serializer.FromJson(_resolveType(alias), reader, DataColumn);
     }
 
     protected override async ValueTask<T> ReadDocumentAsync(DbDataReader reader, CancellationToken token)
     {
         var alias = await reader.GetFieldValueAsync<string>(_docTypeOrdinal, token).ConfigureAwait(false);
-        return (T)await _serializer.FromJsonAsync(_hierarchy.TypeFor(alias), reader, DataColumn, token).ConfigureAwait(false);
+        return (T)await _serializer.FromJsonAsync(_resolveType(alias), reader, DataColumn, token).ConfigureAwait(false);
     }
 }

--- a/src/Marten/Internal/ClosedShape/NumericDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericDirtyCheckedClosedShapeStorage.cs
@@ -44,7 +44,7 @@ internal sealed class NumericDirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyChe
         => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
     public override ISelector BuildSelector(IStorageSession session)
-        => _descriptor.HierarchyMapping is not null
+        => _descriptor.ResolveDocumentType is not null
             ? new HierarchicalNumericClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor)
             : new FlatNumericClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/NumericIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericIdentityMapClosedShapeStorage.cs
@@ -44,7 +44,7 @@ internal sealed class NumericIdentityMapClosedShapeStorage<TDoc, TId>: IdentityM
         => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
     public override ISelector BuildSelector(IStorageSession session)
-        => _descriptor.HierarchyMapping is not null
+        => _descriptor.ResolveDocumentType is not null
             ? new HierarchicalNumericClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor)
             : new FlatNumericClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/NumericLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/NumericLightweightClosedShapeStorage.cs
@@ -52,7 +52,7 @@ internal sealed class NumericLightweightClosedShapeStorage<TDoc, TId>: Lightweig
         => new NumericClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
     public override ISelector BuildSelector(IStorageSession session)
-        => _descriptor.HierarchyMapping is not null
+        => _descriptor.ResolveDocumentType is not null
             ? new HierarchicalNumericClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor)
             : new FlatNumericClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/OptimisticDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticDirtyCheckedClosedShapeStorage.cs
@@ -44,7 +44,7 @@ internal sealed class OptimisticDirtyCheckedClosedShapeStorage<TDoc, TId>: Dirty
         => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
     public override ISelector BuildSelector(IStorageSession session)
-        => _descriptor.HierarchyMapping is not null
+        => _descriptor.ResolveDocumentType is not null
             ? new HierarchicalOptimisticClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor)
             : new FlatOptimisticClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/OptimisticIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticIdentityMapClosedShapeStorage.cs
@@ -44,7 +44,7 @@ internal sealed class OptimisticIdentityMapClosedShapeStorage<TDoc, TId>: Identi
         => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
     public override ISelector BuildSelector(IStorageSession session)
-        => _descriptor.HierarchyMapping is not null
+        => _descriptor.ResolveDocumentType is not null
             ? new HierarchicalOptimisticClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor)
             : new FlatOptimisticClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/OptimisticLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/OptimisticLightweightClosedShapeStorage.cs
@@ -54,7 +54,7 @@ internal sealed class OptimisticLightweightClosedShapeStorage<TDoc, TId>: Lightw
         => new OptimisticClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor, null);
 
     public override ISelector BuildSelector(IStorageSession session)
-        => _descriptor.HierarchyMapping is not null
+        => _descriptor.ResolveDocumentType is not null
             ? new HierarchicalOptimisticClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor)
             : new FlatOptimisticClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
@@ -82,9 +82,9 @@ public sealed class QueryOnlyClosedShapeStorage<TDoc, TId>: QueryOnlyDocumentSto
 
     public override ISelector BuildSelector(IStorageSession session)
         // #4659 Phase 2: pick the Flat / Hierarchical selector ONCE per
-        // query — neither selector class branches on HierarchyMapping per
+        // query — neither selector class branches on ResolveDocumentType per
         // row.
-        => _descriptor.HierarchyMapping is not null
+        => _descriptor.ResolveDocumentType is not null
             ? new HierarchicalClosedShapeQueryOnlySelector<TDoc, TId>(session, _descriptor)
             : new FlatClosedShapeQueryOnlySelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/UnversionedDirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedDirtyCheckedClosedShapeStorage.cs
@@ -44,7 +44,7 @@ internal sealed class UnversionedDirtyCheckedClosedShapeStorage<TDoc, TId>: Dirt
         => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
     public override ISelector BuildSelector(IStorageSession session)
-        => _descriptor.HierarchyMapping is not null
+        => _descriptor.ResolveDocumentType is not null
             ? new HierarchicalUnversionedClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor)
             : new FlatUnversionedClosedShapeDirtyTrackingSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/UnversionedIdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedIdentityMapClosedShapeStorage.cs
@@ -44,7 +44,7 @@ internal sealed class UnversionedIdentityMapClosedShapeStorage<TDoc, TId>: Ident
         => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
     public override ISelector BuildSelector(IStorageSession session)
-        => _descriptor.HierarchyMapping is not null
+        => _descriptor.ResolveDocumentType is not null
             ? new HierarchicalUnversionedClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor)
             : new FlatUnversionedClosedShapeIdentityMapSelector<TDoc, TId>(session, _descriptor);
 }

--- a/src/Marten/Internal/ClosedShape/UnversionedLightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/UnversionedLightweightClosedShapeStorage.cs
@@ -49,7 +49,7 @@ internal sealed class UnversionedLightweightClosedShapeStorage<TDoc, TId>: Light
         => new UnversionedClosedShapeUpdateOperation<TDoc, TId>(document, Identity(document), tenant, _descriptor);
 
     public override ISelector BuildSelector(IStorageSession session)
-        => _descriptor.HierarchyMapping is not null
+        => _descriptor.ResolveDocumentType is not null
             ? new HierarchicalUnversionedClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor)
             : new FlatUnversionedClosedShapeLightweightSelector<TDoc, TId>(session, _descriptor);
 }


### PR DESCRIPTION
First increment of **Story 5** (abstract `DocumentMapping`) in the #4821 extraction epic. Reordered ahead of Story 4 (see epic comment) because `DocumentMapping` saturates the storage base, so the mapping seam has to land first.

## Insight
The `DocumentStorageDescriptor` is already the decoupling boundary: the (Marten-resident) `DocumentStorageDescriptorBuilder` compiles a `DocumentMapping` into the descriptor, and the movable runtime reads the *descriptor*. The one remaining `DocumentMapping` leak into that movable runtime was `DocumentStorageDescriptor.HierarchyMapping` (`Marten.Schema.DocumentMapping?`), used by the 10 hierarchical selectors + the projection loader purely for `mapping.TypeFor(alias)` — the `mt_doc_type` alias → .NET `Type` lookup for polymorphic deserialization.

## Change
Replace it with an agnostic `Func<string, Type>? ResolveDocumentType`:
- Builder captures `mapping.TypeFor` as a delegate when `mapping.IsHierarchy()`.
- Descriptor holds the delegate instead of the mapping.
- The 10 `Hierarchical*Selector`s hold `Func<string, Type> _resolveType` instead of `DocumentMapping _hierarchy`; `ClosedShapeProjectionLoader` resolves via the delegate. `using Marten.Schema;` dropped from all 10 selectors.
- The storage classes' hierarchical-vs-flat selector choice now null-checks `ResolveDocumentType`.

No behavior change — same alias→Type resolution, just via a delegate. The descriptor + selector runtime no longer references any Marten mapping type.

Remaining `DocumentMapping` leaks (deferred to later 5.x increments): `DocumentDocTypeBinder.AliasFor`, the storage classes' `_mapping.StoreOptions.Serializer()`, and the `DocumentStorage` base hierarchy (Story 4).

## Verification
- `dotnet build src/Marten.slnx` clean in **Debug and Release**.
- **DocumentDbTests** 1033 (hierarchical/polymorphic deserialization) and **EventSourcingTests** 1421 (projection-loader path) green on net10.

Part of #4821 / #4829.

🤖 Generated with [Claude Code](https://claude.com/claude-code)