### PR TITLE
#4829 (5b) — capture serializer + alias resolver on the descriptor

### DIFF
--- a/src/Marten/Internal/ClosedShape/DirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/DirtyCheckedClosedShapeStorage.cs
@@ -44,9 +44,9 @@ public abstract class DirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyCheckedDoc
     // #4667 Phase 2 — session-free projection load; see Lightweight peer.
     public override Task<TDoc?> LoadProjectedAsync(TId id, IMartenDatabase database, string tenantId, CancellationToken token)
         => ClosedShapeProjectionLoader<TDoc, TId>.LoadAsync(
-            BuildLoadCommand(id, tenantId), _descriptor, _mapping.StoreOptions.Serializer(), database, token);
+            BuildLoadCommand(id, tenantId), _descriptor, _descriptor.Serializer, database, token);
 
     public override Task<IReadOnlyList<TDoc>> LoadManyProjectedAsync(TId[] ids, IMartenDatabase database, string tenantId, CancellationToken token)
         => ClosedShapeProjectionLoader<TDoc, TId>.LoadManyAsync(
-            BuildLoadManyCommand(ids, tenantId), _descriptor, _mapping.StoreOptions.Serializer(), database, token);
+            BuildLoadManyCommand(ids, tenantId), _descriptor, _descriptor.Serializer, database, token);
 }

--- a/src/Marten/Internal/ClosedShape/DocumentDocTypeBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDocTypeBinder.cs
@@ -5,7 +5,6 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Internal;
-using Marten.Schema;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -14,9 +13,11 @@ namespace Marten.Internal.ClosedShape;
 /// <summary>
 /// W3 spike (M11): <see cref="IDocumentMetadataBinder{TDoc}"/> for the
 /// <c>mt_doc_type</c> column on a hierarchical mapping. Writes the
-/// runtime type's hierarchy alias (looked up via
-/// <see cref="DocumentMapping.AliasFor"/>); the alias drives the
-/// SubClass storage's WHERE filter and selector dispatch on read.
+/// runtime type's hierarchy alias (looked up via an agnostic
+/// <c>Func&lt;Type, string&gt;</c> the builder captures from
+/// <c>DocumentMapping.AliasFor</c> — #4829, so this binder no longer
+/// references the Marten mapping type); the alias drives the SubClass
+/// storage's WHERE filter and selector dispatch on read.
 /// </summary>
 /// <remarks>
 /// Read participation is handled directly by the selectors when the
@@ -29,12 +30,12 @@ namespace Marten.Internal.ClosedShape;
 internal sealed class DocumentDocTypeBinder<TDoc>: IDocumentMetadataBinder<TDoc>
     where TDoc : notnull
 {
-    private readonly DocumentMapping _mapping;
+    private readonly Func<Type, string> _resolveAlias;
     private readonly ConcurrentDictionary<Type, string> _aliasCache = new();
 
-    public DocumentDocTypeBinder(DocumentMapping mapping)
+    public DocumentDocTypeBinder(Func<Type, string> resolveAlias)
     {
-        _mapping = mapping;
+        _resolveAlias = resolveAlias;
     }
 
     public string ColumnName => Marten.Schema.SchemaConstants.DocumentTypeColumn;
@@ -43,7 +44,7 @@ internal sealed class DocumentDocTypeBinder<TDoc>: IDocumentMetadataBinder<TDoc>
 
     public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
     {
-        var alias = _aliasCache.GetOrAdd(document.GetType(), t => _mapping.AliasFor(t));
+        var alias = _aliasCache.GetOrAdd(document.GetType(), t => _resolveAlias(t));
         parameter.Value = alias;
         parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
     }
@@ -58,7 +59,7 @@ internal sealed class DocumentDocTypeBinder<TDoc>: IDocumentMetadataBinder<TDoc>
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
         IStorageSerializer serializer, CancellationToken cancellation)
     {
-        var alias = _aliasCache.GetOrAdd(document.GetType(), t => _mapping.AliasFor(t));
+        var alias = _aliasCache.GetOrAdd(document.GetType(), t => _resolveAlias(t));
         return writer.WriteAsync(alias, NpgsqlDbType.Varchar, cancellation);
     }
 }

--- a/src/Marten/Internal/ClosedShape/DocumentStorageDescriptor.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentStorageDescriptor.cs
@@ -51,6 +51,7 @@ public sealed class DocumentStorageDescriptor<TDoc, TId>
 {
     internal DocumentStorageDescriptor(
         IIdentification<TDoc, TId> identification,
+        IStorageSerializer serializer,
         IDocumentMetadataBinder<TDoc>[] clientSideWriteBinders,
         IDocumentMetadataBinder<TDoc>[] writeBinders,
         IDocumentMetadataBinder<TDoc>[] readBinders,
@@ -71,6 +72,7 @@ public sealed class DocumentStorageDescriptor<TDoc, TId>
         bool useVersionFromMatchingStream = false)
     {
         Identification = identification;
+        Serializer = serializer;
         ClientSideWriteBinders = clientSideWriteBinders;
         WriteBinders = writeBinders;
         ReadBinders = readBinders;
@@ -114,6 +116,15 @@ public sealed class DocumentStorageDescriptor<TDoc, TId>
     internal IDocumentMetadataBinder<TDoc>[] PartitionPkBinders { get; }
 
     public IIdentification<TDoc, TId> Identification { get; }
+
+    /// <summary>
+    /// #4829: the store-global serializer, captured on the descriptor so the
+    /// projection read path (<c>LoadProjectedAsync</c>/<c>LoadManyProjectedAsync</c>)
+    /// no longer reads <c>DocumentMapping.StoreOptions.Serializer()</c> — one fewer
+    /// Marten mapping reference in the movable storage runtime. Db-neutral
+    /// <see cref="IStorageSerializer"/> (#4819).
+    /// </summary>
+    public IStorageSerializer Serializer { get; }
 
     /// <summary>
     /// Subset of the metadata binders that consume a <c>?</c> parameter

--- a/src/Marten/Internal/ClosedShape/DocumentStorageDescriptorBuilder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentStorageDescriptorBuilder.cs
@@ -59,7 +59,7 @@ internal static class DocumentStorageDescriptorBuilder
             // #4829: capture the alias→Type lookup as an agnostic delegate so the
             // descriptor + selectors don't hold the Marten DocumentMapping type.
             resolveDocumentType = mapping.TypeFor;
-            var docTypeBinder = new DocumentDocTypeBinder<TDoc>(mapping);
+            var docTypeBinder = new DocumentDocTypeBinder<TDoc>(mapping.AliasFor);
             writeBinders.Add(docTypeBinder);
             docTypeReadIndex = readBinders.Count;
             readBinders.Add(docTypeBinder);
@@ -282,6 +282,7 @@ internal static class DocumentStorageDescriptorBuilder
 
         return new DocumentStorageDescriptor<TDoc, TId>(
             identification,
+            serializer: mapping.StoreOptions.Serializer(),
             clientSideWriteBinders: clientSide,
             writeBinders: writeArray,
             readBinders: readArray,

--- a/src/Marten/Internal/ClosedShape/IdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/IdentityMapClosedShapeStorage.cs
@@ -44,9 +44,9 @@ public abstract class IdentityMapClosedShapeStorage<TDoc, TId>: IdentityMapDocum
     // #4667 Phase 2 — session-free projection load; see Lightweight peer.
     public override Task<TDoc?> LoadProjectedAsync(TId id, IMartenDatabase database, string tenantId, CancellationToken token)
         => ClosedShapeProjectionLoader<TDoc, TId>.LoadAsync(
-            BuildLoadCommand(id, tenantId), _descriptor, _mapping.StoreOptions.Serializer(), database, token);
+            BuildLoadCommand(id, tenantId), _descriptor, _descriptor.Serializer, database, token);
 
     public override Task<IReadOnlyList<TDoc>> LoadManyProjectedAsync(TId[] ids, IMartenDatabase database, string tenantId, CancellationToken token)
         => ClosedShapeProjectionLoader<TDoc, TId>.LoadManyAsync(
-            BuildLoadManyCommand(ids, tenantId), _descriptor, _mapping.StoreOptions.Serializer(), database, token);
+            BuildLoadManyCommand(ids, tenantId), _descriptor, _descriptor.Serializer, database, token);
 }

--- a/src/Marten/Internal/ClosedShape/LightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/LightweightClosedShapeStorage.cs
@@ -62,9 +62,9 @@ public abstract class LightweightClosedShapeStorage<TDoc, TId>: LightweightDocum
     // ItemMap / ChangeTrackers per row. Shared with IdentityMap / DirtyChecked.
     public override Task<TDoc?> LoadProjectedAsync(TId id, IMartenDatabase database, string tenantId, CancellationToken token)
         => ClosedShapeProjectionLoader<TDoc, TId>.LoadAsync(
-            BuildLoadCommand(id, tenantId), _descriptor, _mapping.StoreOptions.Serializer(), database, token);
+            BuildLoadCommand(id, tenantId), _descriptor, _descriptor.Serializer, database, token);
 
     public override Task<IReadOnlyList<TDoc>> LoadManyProjectedAsync(TId[] ids, IMartenDatabase database, string tenantId, CancellationToken token)
         => ClosedShapeProjectionLoader<TDoc, TId>.LoadManyAsync(
-            BuildLoadManyCommand(ids, tenantId), _descriptor, _mapping.StoreOptions.Serializer(), database, token);
+            BuildLoadManyCommand(ids, tenantId), _descriptor, _descriptor.Serializer, database, token);
 }


### PR DESCRIPTION
Second increment of **Story 5** (abstract `DocumentMapping`) in the #4821 epic, continuing 5a's pattern: move the remaining `DocumentMapping` reads out of the movable closed-shape runtime by pre-capturing what they need on the Marten-built descriptor / as delegates.

## Two leaks removed
1. **Serializer** — the projection read path (`LoadProjectedAsync`/`LoadManyProjectedAsync` in the Lightweight/IdentityMap/DirtyChecked closed-shape storages) read `_mapping.StoreOptions.Serializer()` off the base `DocumentMapping` field. Add `IStorageSerializer Serializer` (db-neutral, #4819) to `DocumentStorageDescriptor`, populated by the builder from `mapping.StoreOptions.Serializer()`; the six sites now read `_descriptor.Serializer`.
2. **AliasFor** — `DocumentDocTypeBinder` held a `DocumentMapping` purely for `mapping.AliasFor(type)` (the write-side inverse of 5a's `TypeFor`). Replace with an agnostic `Func<Type, string>` the builder captures from `mapping.AliasFor`; `using Marten.Schema;` dropped from the binder.

No behavior change — same serializer, same type→alias resolution. The closed-shape selectors, binders, and projection read path are now free of the Marten mapping type; the residual `DocumentMapping` ctor params on the storage classes are just forwarded to the `DocumentStorage` base (Story 4).

## Verification
- `dotnet build src/Marten.slnx` clean in **Debug and Release**.
- **DocumentDbTests** 1033 and **EventSourcingTests** 1421 green on net10.

Part of #4821 / #4829.

🤖 Generated with [Claude Code](https://claude.com/claude-code)