### PR TITLE
#4828 (4a) — remove the QuerySession downcast from DocumentStorage.loadAsync

### DIFF
--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -482,13 +482,29 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
         }
     }
 
-    protected Task<T?> loadAsync(TId id, IStorageSession session, CancellationToken token)
+    protected async Task<T?> loadAsync(TId id, IStorageSession session, CancellationToken token)
     {
         var command = BuildLoadCommand(id, session.TenantId);
         var selector = (ISelector<T>)BuildSelector(session);
 
-        // TODO -- eliminate the downcast here!
-        return session.As<QuerySession>().LoadOneAsync(command, selector, token);
+        // #4828: read through the agnostic IStorageSession.ExecuteReaderAsync(DbCommand)
+        // execution seam (#4810) instead of downcasting to QuerySession.LoadOneAsync —
+        // mirrors the LoadManyAsync overrides. Behavior-identical to
+        // QuerySession.LoadOneAsync (execute → read one → resolve → close).
+        await using var reader = await session.ExecuteReaderAsync(command, token).ConfigureAwait(false);
+        try
+        {
+            if (!await reader.ReadAsync(token).ConfigureAwait(false))
+            {
+                return default;
+            }
+
+            return await selector.ResolveAsync(reader, token).ConfigureAwait(false);
+        }
+        finally
+        {
+            await reader.CloseAsync().ConfigureAwait(false);
+        }
     }
 }
 


### PR DESCRIPTION
First increment of **Story 4** (make the `DocumentStorage` base hierarchy movable) in the #4821 epic.

## What
The base's single-document read path (`DocumentStorage.loadAsync` — used by every non-closed-shape `LoadAsync` and by the closed-shape storages that inherit it) downcast the session to the concrete `QuerySession` to call its internal `LoadOneAsync`. This was the one Marten-session coupling in the base read path, carrying an explicit `// TODO -- eliminate the downcast here!`.

Route it through the agnostic `IStorageSession.ExecuteReaderAsync(DbCommand)` execution seam (#4810) instead — the exact pattern the `LoadManyAsync` overrides already use. `loadAsync` becomes `async`, executes the (Npgsql) load command via the `DbCommand` overload, reads one row, resolves via the selector, closes. **Behavior-identical** to the removed downcast (`QuerySession.LoadOneAsync` did the same execute→read→resolve→close). `QuerySession.LoadOneAsync` stays — still used by `JsonLoader`.

Net: the `DocumentStorage` base no longer references `QuerySession`.

Remaining Story 4 coupling (later increments): the pervasive `DocumentMapping _mapping`, the Npgsql command/parameter building on the public `IDocumentStorage` (bounded by the no-API-break rule), and the metadata-column model — which absorbs the rest of Story 5.

## Verification
- `dotnet build src/Marten.slnx` clean in **Debug and Release**.
- **DocumentDbTests** 1033, **ValueTypeTests** 339, **CoreTests** 458 green on net10 (all exercise the single-document `LoadAsync` path).

Part of #4821 / #4828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)