### PR TITLE
#4828 (4b) — make the DocumentStorage base hold no DocumentMapping

### DIFF
--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -48,37 +48,44 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
 
     protected readonly string _loadArraySql;
     protected readonly string _loaderSql;
-    protected readonly DocumentMapping _mapping;
     private readonly string _selectClause;
     private readonly string[] _selectFields;
     private ISqlFragment? _defaultWhere;
-    private MetadataColumn[]? _metadataColumns;
+    // #4828: computed once in the ctor from the mapping's schema table instead of
+    // lazily re-reading the mapping, so no DocumentMapping is retained on the base.
+    private readonly MetadataColumn[] _metadataColumns;
     protected Action<T, TId> _setter;
     protected Action<T, string> _setFromString = (_, _) => throw new NotSupportedException();
     protected Action<T, Guid> _setFromGuid = (_, _) => throw new NotSupportedException();
 
-
-    private readonly DocumentMapping _document;
+    // #4828: the DeleteStyle drives the soft-delete WHERE filters + the delete
+    // fragment. Stored so the base no longer reads DocumentMapping post-construction.
+    private readonly DeleteStyle _deleteStyle;
 
     public DocumentStorage(StorageStyle storageStyle, DocumentMapping document)
     {
-        _mapping = document;
-
+        // #4828: read everything the base needs off the mapping here, in the ctor,
+        // and store it in fields — so no DocumentMapping is retained. The closed-shape
+        // storages (the only concrete storages) never read the mapping themselves; this
+        // makes the base a self-contained, DocumentMapping-free hierarchy.
         TableName = document.TableName;
+        TenancyStyle = document.TenancyStyle;
+        DocumentType = document.DocumentType;
+        QueryMembers = document.QueryMembers;
+        _deleteStyle = document.DeleteStyle;
+        _metadataColumns = document.Schema.Table.Columns.OfType<MetadataColumn>().ToArray();
 
         determineDefaultWhereFragment();
 
         _idType = PostgresqlProvider.Instance.ToParameterType(typeof(TId));
 
-        var table = _mapping.Schema.Table;
+        var table = document.Schema.Table;
 
-        DuplicatedFields = _mapping.DuplicatedFields;
+        DuplicatedFields = document.DuplicatedFields;
 
         _selectFields = table.SelectColumns(storageStyle).Select(x => $"d.{x.Name}").ToArray();
         var fieldSelector = _selectFields.Join(", ");
         _selectClause = $"select {fieldSelector} from {document.TableName.QualifiedName} as d";
-
-        _document = document;
 
         _loaderSql =
             $"select {fieldSelector} from {document.TableName.QualifiedName} as d where id = $1";
@@ -86,7 +93,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
         _loadArraySql =
             $"select {fieldSelector} from {document.TableName.QualifiedName} as d where id = ANY($1)";
 
-        if (document.TenancyStyle == TenancyStyle.Conjoined)
+        if (TenancyStyle == TenancyStyle.Conjoined)
         {
             _loaderSql += $" and d.{TenantIdColumn.Name} = $2";
             _loadArraySql += $" and d.{TenantIdColumn.Name} = $2";
@@ -118,7 +125,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
             }
         }
 
-        DeleteFragment = _mapping.DeleteStyle == DeleteStyle.Remove
+        DeleteFragment = _deleteStyle == DeleteStyle.Remove
             ? new HardDelete(this)
             : new SoftDelete(this);
 
@@ -143,7 +150,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
             {
                 var duplicatedFields = DuplicatedFields.Select(x => "d." + x.ColumnName).Where(x => !_selectFields.Contains(x));
                 var allFields = _selectFields.Concat(duplicatedFields).ToArray();
-                return new DuplicatedFieldSelectClause(TableName.QualifiedName, $"select {allFields.Join(", ")} from {_document.TableName.QualifiedName} as d",
+                return new DuplicatedFieldSelectClause(TableName.QualifiedName, $"select {allFields.Join(", ")} from {TableName.QualifiedName} as d",
                     allFields, typeof(T), this);
             }
             else
@@ -155,10 +162,10 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
 
     MetadataColumn[] IHaveMetadataColumns.MetadataColumns()
     {
-        return _metadataColumns ??= _mapping.Schema.Table.Columns.OfType<MetadataColumn>().ToArray();
+        return _metadataColumns;
     }
 
-    public IQueryableMemberCollection QueryMembers => _mapping.QueryMembers;
+    public IQueryableMemberCollection QueryMembers { get; }
 
     public async Task TruncateDocumentStorageAsync(IMartenDatabase database, CancellationToken ct = default)
     {
@@ -192,9 +199,9 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
     }
 
 
-    public TenancyStyle TenancyStyle => _mapping.TenancyStyle;
+    public TenancyStyle TenancyStyle { get; }
 
-    public Type DocumentType => _mapping.DocumentType;
+    public Type DocumentType { get; }
 
     public IReadOnlyList<DuplicatedField> DuplicatedFields { get; }
 
@@ -409,7 +416,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public NpgsqlCommand BuildLoadCommand(TId id, string tenant)
     {
-        return _mapping.TenancyStyle == TenancyStyle.Conjoined
+        return TenancyStyle == TenancyStyle.Conjoined
             ? new NpgsqlCommand(_loaderSql) {
                 Parameters = {
                     ParameterForId(id),
@@ -429,7 +436,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
 
     public NpgsqlCommand BuildLoadManyCommand(TId[] ids, string tenant)
     {
-        return _mapping.TenancyStyle == TenancyStyle.Conjoined
+        return TenancyStyle == TenancyStyle.Conjoined
             ? new NpgsqlCommand(_loadArraySql) {
                 Parameters = {
                     BuildManyIdParameter(ids),
@@ -458,7 +465,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
 
     private IEnumerable<ISqlFragment> extraFilters(ISqlFragment query, IStorageSession session)
     {
-        if (_mapping.DeleteStyle == DeleteStyle.SoftDelete && !query.ContainsAny<ISoftDeletedFilter>())
+        if (_deleteStyle == DeleteStyle.SoftDelete && !query.ContainsAny<ISoftDeletedFilter>())
         {
             yield return ExcludeSoftDeletedFilter.Instance;
         }
@@ -471,7 +478,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
 
     private IEnumerable<ISqlFragment> defaultFilters()
     {
-        if (_mapping.DeleteStyle == DeleteStyle.SoftDelete)
+        if (_deleteStyle == DeleteStyle.SoftDelete)
         {
             yield return ExcludeSoftDeletedFilter.Instance;
         }


### PR DESCRIPTION
Second increment of **Story 4** (re-parent the closed-shape storage hierarchy onto a `DocumentMapping`-free base) in the #4821 epic.

## Key fact
The closed-shape storages are the **only** concrete document-storage classes (no live legacy codegen path), and they read nothing off the mapping — the `DocumentMapping` arg is only fed to the base ctor. So making `DocumentStorage<T,TId>` mapping-free makes the whole (sole) storage hierarchy mapping-free — no separate base or duplication needed. (This is why the epic's "re-parent onto an agnostic base" collapses to "make this base agnostic in place.")

## Change
The base previously kept `_mapping` (protected) + `_document` (private) fields and re-read them post-construction (the `TenancyStyle`/`DocumentType`/`QueryMembers` props, the `BuildLoad(Many)Command` conjoined check, the soft-delete WHERE filters, `MetadataColumns()`, the duplicated-field select clause). Read all of it off the mapping **once in the ctor** into fields, and drop both `DocumentMapping` fields:
- `TenancyStyle`/`DocumentType`/`QueryMembers` → get-only auto-props set in ctor.
- `_deleteStyle` field backs the delete fragment + soft-delete filters.
- `_metadataColumns` computed eagerly in the ctor (was lazy) from `document.Schema.Table.Columns.OfType<MetadataColumn>()`.
- The duplicated-field select clause uses the stored `TableName`.
- Tenancy/delete fields are set before `determineDefaultWhereFragment()` (which reads them), preserving ctor ordering.

Behavior-preserving (store-once vs read-repeatedly). The base ctor still *takes* a `DocumentMapping` to compute its state; removing that last ctor dependency (sourcing the precomputed state from the descriptor) is the next increment.

## Verification
- `dotnet build src/Marten.slnx` clean in **Debug and Release**.
- **DocumentDbTests** 1033 (soft-delete, metadata, duplicated fields, loads) and **MultiTenancyTests** 146 (conjoined tenancy — the `TenancyStyle` field path) green on net10.

Part of #4821 / #4828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)