### PR TITLE
#4828 (4c-1) — IStorageDialect strategy: route the single-id path through it

### DIFF
--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -22,7 +22,6 @@ using Marten.Services;
 using Marten.Storage;
 using Marten.Storage.Metadata;
 using Npgsql;
-using NpgsqlTypes;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
@@ -44,8 +43,6 @@ internal interface IHaveMetadataColumns
     Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMetadataColumns where T : notnull where TId : notnull
 {
-    private readonly NpgsqlDbType _idType;
-
     protected readonly string _loadArraySql;
     protected readonly string _loaderSql;
     private readonly string _selectClause;
@@ -62,6 +59,10 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
     // fragment. Stored so the base no longer reads DocumentMapping post-construction.
     private readonly DeleteStyle _deleteStyle;
 
+    // #4828: the ADO/SQL-dialect strategy. Postgres by default; the seam lets the movable base
+    // build load commands / id filters / interpret error codes without a direct Npgsql reference.
+    protected virtual IStorageDialect Dialect => PostgresStorageDialect<TId>.Instance;
+
     public DocumentStorage(StorageStyle storageStyle, DocumentMapping document)
     {
         // #4828: read everything the base needs off the mapping here, in the ctor,
@@ -76,8 +77,6 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
         _metadataColumns = document.Schema.Table.Columns.OfType<MetadataColumn>().ToArray();
 
         determineDefaultWhereFragment();
-
-        _idType = PostgresqlProvider.Instance.ToParameterType(typeof(TId));
 
         var table = document.Schema.Table;
 
@@ -174,12 +173,9 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
         {
             await database.RunSqlAsync(sql, ct).ConfigureAwait(false);
         }
-        catch (PostgresException e)
+        catch (Exception e) when (Dialect.IsUndefinedTable(e))
         {
-            if (e.SqlState != PostgresErrorCodes.UndefinedTable)
-            {
-                throw;
-            }
+            // the table doesn't exist yet — nothing to truncate
         }
     }
 
@@ -207,7 +203,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
 
     public ISqlFragment ByIdFilter(TId id)
     {
-        return new ByIdFilter(RawIdentityValue(id), _idType);
+        return Dialect.ByIdFilter(RawIdentityValue(id));
     }
 
     public IDeletion HardDeleteForId(TId id, string tenant)
@@ -415,22 +411,11 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public NpgsqlCommand BuildLoadCommand(TId id, string tenant)
-    {
-        return TenancyStyle == TenancyStyle.Conjoined
-            ? new NpgsqlCommand(_loaderSql) {
-                Parameters = {
-                    ParameterForId(id),
-                    new() { Value = tenant }
-                }
-            }
-            : new NpgsqlCommand(_loaderSql)
-            {
-                Parameters =
-                {
-                    ParameterForId(id)
-                }
-            };
-    }
+        // #4828: the (Postgres) dialect materializes the command; cast back to keep the public
+        // IDocumentStorage.BuildLoadCommand signature (NpgsqlCommand) until it is widened to DbCommand.
+        => (NpgsqlCommand)Dialect.BuildLoadCommand(_loaderSql,
+            RawIdentityValue(id),
+            TenancyStyle == TenancyStyle.Conjoined ? tenant : null);
 
     public virtual NpgsqlParameter BuildManyIdParameter(TId[] ids) => new() { Value = ids };
 

--- a/src/Marten/Internal/Storage/IStorageDialect.cs
+++ b/src/Marten/Internal/Storage/IStorageDialect.cs
@@ -1,0 +1,44 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Internal.Storage;
+
+/// <summary>
+///     #4828: the ADO/SQL-dialect strategy the (movable) <see cref="DocumentStorage{T,TId}"/>
+///     hierarchy delegates its provider-specific concerns to, instead of constructing
+///     <c>Npgsql*</c> types and emitting Postgres SQL directly. One implementation
+///     (<see cref="PostgresStorageDialect{TId}"/>) is injected per closed <c>TId</c>, keeping the
+///     storage base free of any direct Npgsql/Postgres reference so it can move to the shared
+///     package (part of the #4821 extraction epic).
+/// </summary>
+/// <remarks>
+///     Only the concerns whose result is genuinely dialect-specific live here — command/parameter
+///     materialization, the id-equality filter (which carries the provider parameter type), and
+///     provider error-code interpretation. The "mechanical" scalar parameter typing routes through
+///     Weasel's <c>IDatabaseProvider.ToParameterType</c>, and the document-body JSON parameter is
+///     already dialect-polymorphic via <see cref="IStorageSerializer.WriteToParameter(DbParameter, object?)"/>
+///     (#4819). The load-many / id-array path and the metadata-binder cluster are folded in by later
+///     increments.
+/// </remarks>
+public interface IStorageDialect
+{
+    /// <summary>
+    ///     Build a single-document load command over the storage's prebuilt loader SQL, binding the
+    ///     raw (already <c>ToRawSqlValue</c>'d) id and, for conjoined tenancy, the tenant id.
+    /// </summary>
+    DbCommand BuildLoadCommand(string loaderSql, object rawId, string? tenant);
+
+    /// <summary>
+    ///     The id-equality <see cref="ISqlFragment"/> for a raw id — carries the dialect's parameter
+    ///     type so the emitted predicate binds correctly.
+    /// </summary>
+    ISqlFragment ByIdFilter(object rawId);
+
+    /// <summary>
+    ///     True when the exception represents an "undefined table" (e.g. truncating a table that
+    ///     hasn't been created yet) — the one provider error code the storage base swallows.
+    /// </summary>
+    bool IsUndefinedTable(Exception exception);
+}

--- a/src/Marten/Internal/Storage/PostgresStorageDialect.cs
+++ b/src/Marten/Internal/Storage/PostgresStorageDialect.cs
@@ -1,0 +1,45 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using Marten.Linq.SqlGeneration.Filters;
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Internal.Storage;
+
+/// <summary>
+///     #4828: the Postgres implementation of <see cref="IStorageDialect"/> — the single place the
+///     movable <see cref="DocumentStorage{T,TId}"/> hierarchy's Npgsql command/parameter, id-filter,
+///     and Postgres error-code specifics live. Stateless per closed <c>TId</c>, so it is exposed as a
+///     per-<c>TId</c> singleton via <see cref="Instance"/>.
+/// </summary>
+internal sealed class PostgresStorageDialect<TId>: IStorageDialect
+{
+    public static readonly IStorageDialect Instance = new PostgresStorageDialect<TId>();
+
+    // The id-column parameter type — same lookup the storage ctor used for its _idType.
+    private static readonly NpgsqlDbType IdParameterType = PostgresqlProvider.Instance.ToParameterType(typeof(TId));
+
+    private PostgresStorageDialect()
+    {
+    }
+
+    public DbCommand BuildLoadCommand(string loaderSql, object rawId, string? tenant)
+    {
+        var command = new NpgsqlCommand(loaderSql);
+        command.Parameters.Add(new NpgsqlParameter { Value = rawId });
+        if (tenant is not null)
+        {
+            command.Parameters.Add(new NpgsqlParameter { Value = tenant });
+        }
+
+        return command;
+    }
+
+    public ISqlFragment ByIdFilter(object rawId) => new ByIdFilter(rawId, IdParameterType);
+
+    public bool IsUndefinedTable(Exception exception)
+        => exception is PostgresException pg && pg.SqlState == PostgresErrorCodes.UndefinedTable;
+}


### PR DESCRIPTION
First increment of the composition-based (**Strategy**) decoupling of the storage base's ADO/SQL-dialect axis, per the [#4821 design decision](https://github.com/JasperFx/marten/issues/4821) — composition over a generic superclass or `abstract` template methods (the ~13-leaf hierarchy makes abstract-method placement ugly; a single injected dialect avoids the class explosion).

## New seam
- **`IStorageDialect`** (movable) — the provider-specific concerns the storage base delegates to: `BuildLoadCommand(sql, rawId, tenant?)`, `ByIdFilter(rawId)`, `IsUndefinedTable(exception)`. Typed in `DbCommand`/`DbParameter`/`ISqlFragment` (Weasel) — no Npgsql.
- **`PostgresStorageDialect<TId>`** (Marten-resident) — the single home for the `NpgsqlCommand`/`NpgsqlParameter`/`ByIdFilter`/`PostgresException` specifics; stateless per-`TId` singleton.

## Wiring
`DocumentStorage<T,TId>` gets `protected virtual IStorageDialect Dialect => PostgresStorageDialect<TId>.Instance;` and routes through it:
- `ByIdFilter(id)` → `Dialect.ByIdFilter(RawIdentityValue(id))` — drops the `_idType` field (the dialect owns the id parameter type).
- `BuildLoadCommand(id, tenant)` → `(NpgsqlCommand)Dialect.BuildLoadCommand(...)`; the cast keeps the public `IDocumentStorage.BuildLoadCommand : NpgsqlCommand` signature (**no API break**) until it's deliberately widened to `DbCommand`.
- `TruncateDocumentStorageAsync` undefined-table swallow → `Dialect.IsUndefinedTable`.

## Deferred (next increments)
- The load-many / id-array path (`ParameterForId`, `BuildManyIdParameter`, `BuildLoadManyCommand`) — entangled with the closed-shape `BuildManyIdParameter` override + descriptor `Identification` (`Array | inner` typing).
- Flipping `Dialect` from a Postgres default to constructor-injected (removing the base's last Postgres reference).
- The metadata-binder cluster.

## Verification
- `dotnet build src/Marten.slnx` clean in **Debug and Release**.
- **DocumentDbTests** 1033 (load/delete/soft-delete/truncate), **EventSourcingTests** 1421 (projection `ByIdFilter`), **MultiTenancyTests** 146 (conjoined load command) green on net10.

Part of #4821 / #4828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)