### PR TITLE
#4828 (4c-3) — remove the base's last Postgres reference; dialect off the descriptor

### DIFF
--- a/src/Marten/Internal/ClosedShape/DirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/DirtyCheckedClosedShapeStorage.cs
@@ -23,6 +23,9 @@ public abstract class DirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyCheckedDoc
 {
     protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
 
+    // #4828: expose the descriptor's dialect as the base storage dialect (Strategy).
+    protected override IStorageDialect Dialect => _descriptor.Dialect;
+
     protected DirtyCheckedClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
         : base(mapping)
     {

--- a/src/Marten/Internal/ClosedShape/DocumentStorageDescriptor.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentStorageDescriptor.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using Marten.Internal.Storage;
 using Weasel.Core.Identity;
 
 namespace Marten.Internal.ClosedShape;
@@ -52,6 +53,7 @@ public sealed class DocumentStorageDescriptor<TDoc, TId>
     internal DocumentStorageDescriptor(
         IIdentification<TDoc, TId> identification,
         IStorageSerializer serializer,
+        IStorageDialect dialect,
         IDocumentMetadataBinder<TDoc>[] clientSideWriteBinders,
         IDocumentMetadataBinder<TDoc>[] writeBinders,
         IDocumentMetadataBinder<TDoc>[] readBinders,
@@ -73,6 +75,7 @@ public sealed class DocumentStorageDescriptor<TDoc, TId>
     {
         Identification = identification;
         Serializer = serializer;
+        Dialect = dialect;
         ClientSideWriteBinders = clientSideWriteBinders;
         WriteBinders = writeBinders;
         ReadBinders = readBinders;
@@ -125,6 +128,14 @@ public sealed class DocumentStorageDescriptor<TDoc, TId>
     /// <see cref="IStorageSerializer"/> (#4819).
     /// </summary>
     public IStorageSerializer Serializer { get; }
+
+    /// <summary>
+    /// #4828: the ADO/SQL-dialect strategy for this document type. The Marten-resident builder
+    /// supplies <c>PostgresStorageDialect&lt;TId&gt;.Instance</c>; the closed-shape storage classes
+    /// expose it as their <c>DocumentStorage.Dialect</c> so the movable base holds no direct
+    /// Postgres reference.
+    /// </summary>
+    public IStorageDialect Dialect { get; }
 
     /// <summary>
     /// Subset of the metadata binders that consume a <c>?</c> parameter

--- a/src/Marten/Internal/ClosedShape/DocumentStorageDescriptorBuilder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentStorageDescriptorBuilder.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using JasperFx.Core;
 using Marten.Schema;
 using Marten.Storage;
+using Marten.Internal.Storage;
 
 using Weasel.Core.Identity;
 
@@ -283,6 +284,7 @@ internal static class DocumentStorageDescriptorBuilder
         return new DocumentStorageDescriptor<TDoc, TId>(
             identification,
             serializer: mapping.StoreOptions.Serializer(),
+            dialect: PostgresStorageDialect<TId>.Instance,
             clientSideWriteBinders: clientSide,
             writeBinders: writeArray,
             readBinders: readArray,

--- a/src/Marten/Internal/ClosedShape/IdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/IdentityMapClosedShapeStorage.cs
@@ -23,6 +23,9 @@ public abstract class IdentityMapClosedShapeStorage<TDoc, TId>: IdentityMapDocum
 {
     protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
 
+    // #4828: expose the descriptor's dialect as the base storage dialect (Strategy).
+    protected override IStorageDialect Dialect => _descriptor.Dialect;
+
     protected IdentityMapClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
         : base(mapping)
     {

--- a/src/Marten/Internal/ClosedShape/LightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/LightweightClosedShapeStorage.cs
@@ -36,6 +36,9 @@ public abstract class LightweightClosedShapeStorage<TDoc, TId>: LightweightDocum
 {
     protected readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
 
+    // #4828: expose the descriptor's dialect as the base storage dialect (Strategy).
+    protected override IStorageDialect Dialect => _descriptor.Dialect;
+
     protected LightweightClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
         : base(mapping)
     {

--- a/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
@@ -28,6 +28,9 @@ public sealed class QueryOnlyClosedShapeStorage<TDoc, TId>: QueryOnlyDocumentSto
 {
     private readonly DocumentStorageDescriptor<TDoc, TId> _descriptor;
 
+    // #4828: expose the descriptor's dialect as the base storage dialect (Strategy).
+    protected override IStorageDialect Dialect => _descriptor.Dialect;
+
     public QueryOnlyClosedShapeStorage(DocumentMapping mapping, DocumentStorageDescriptor<TDoc, TId> descriptor)
         : base(mapping)
     {

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -60,9 +60,10 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
     // fragment. Stored so the base no longer reads DocumentMapping post-construction.
     private readonly DeleteStyle _deleteStyle;
 
-    // #4828: the ADO/SQL-dialect strategy. Postgres by default; the seam lets the movable base
-    // build load commands / id filters / interpret error codes without a direct Npgsql reference.
-    protected virtual IStorageDialect Dialect => PostgresStorageDialect<TId>.Instance;
+    // #4828: the ADO/SQL-dialect strategy — the movable base builds load commands / id filters /
+    // interprets error codes through it, with no direct Npgsql/Postgres reference. Supplied by the
+    // concrete (closed-shape) storages off their descriptor; see PostgresStorageDialect.
+    protected abstract IStorageDialect Dialect { get; }
 
     public DocumentStorage(StorageStyle storageStyle, DocumentMapping document)
     {


### PR DESCRIPTION
Third increment of the storage-dialect **Strategy** decoupling ([#4821](https://github.com/JasperFx/marten/issues/4821)). Makes `DocumentStorage.Dialect` abstract and sources the concrete dialect from the descriptor, so the movable base no longer names `PostgresStorageDialect` at all.

## Change
- `DocumentStorageDescriptor` carries `IStorageDialect Dialect`; the Marten-resident `DocumentStorageDescriptorBuilder` supplies `PostgresStorageDialect<TId>.Instance`.
- `DocumentStorage<T,TId>.Dialect`: `virtual … => PostgresStorageDialect<TId>.Instance` → `protected abstract IStorageDialect Dialect { get; }`.
- The four closed-shape shells (Lightweight/IdentityMap/DirtyChecked/QueryOnly `ClosedShapeStorage`) implement `Dialect => _descriptor.Dialect`; the ~13 concrete leaves inherit it. Chosen over threading the dialect through ~20 constructors — the shells already hold the descriptor.

## State
The base `DocumentStorage` hierarchy now has **zero direct Postgres reference** for the dialect axis; its only remaining Npgsql is the two `(NpgsqlCommand)` casts kept for the public `IDocumentStorage.BuildLoad*Command` signatures. Behavior-identical — same dialect instance, sourced from the descriptor instead of a base default.

Remaining on this axis: the metadata-binder cluster (`IDocumentMetadataBinder.BindParameter(NpgsqlParameter)` — jsonb/timestamptz), and eventually widening the public `BuildLoad*Command` to `DbCommand`.

## Verification
- `dotnet build src/Marten.slnx` clean in **Debug and Release**.
- **DocumentDbTests** 1033 (all four storage styles), **ValueTypeTests** 339, **EventSourcingTests** 1421 green on net10.

Part of #4821 / #4828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)