### PR TITLE
#4828 (4c-4) — dialect-neutral bulk vocabulary; drop NpgsqlBinaryImporter from the metadata binders

### DIFF
--- a/src/Marten/Internal/ClosedShape/ClosedShapeBulkLoader.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeBulkLoader.cs
@@ -261,11 +261,46 @@ internal sealed class ClosedShapeBulkLoader<TDoc, TId>: BulkLoader<TDoc, TId>
         var json = serializer.ToJson(document);
         await writer.WriteAsync(json, NpgsqlDbType.Jsonb, cancellation).ConfigureAwait(false);
 
-        // Each metadata binder writes its column value.
+        // Each metadata binder contributes its column value. The fixed metadata binders return a
+        // dialect-neutral BulkColumnValue; duplicated fields carry an arbitrary provider type and
+        // stay on the Postgres-native write (#4828).
         foreach (var binder in _descriptor.WriteBinders)
         {
-            await binder.WriteToBulkAsync(writer, document, serializer, cancellation).ConfigureAwait(false);
+            if (binder is DocumentDuplicatedFieldBinder<TDoc> duplicated)
+            {
+                await duplicated.WriteToBulkAsync(writer, document, serializer, cancellation).ConfigureAwait(false);
+            }
+            else
+            {
+                await WriteBulkValueAsync(writer, binder.GetBulkValue(document), cancellation).ConfigureAwait(false);
+            }
         }
+    }
+
+    private static Task WriteBulkValueAsync(NpgsqlBinaryImporter writer, BulkColumnValue column,
+        CancellationToken cancellation)
+    {
+        if (column.Value is null)
+        {
+            return writer.WriteNullAsync(cancellation);
+        }
+
+        var dbType = column.Type switch
+        {
+            StorageColumnType.String => NpgsqlDbType.Varchar,
+            StorageColumnType.Guid => NpgsqlDbType.Uuid,
+            StorageColumnType.Long => NpgsqlDbType.Bigint,
+            StorageColumnType.Int => NpgsqlDbType.Integer,
+            StorageColumnType.Boolean => NpgsqlDbType.Boolean,
+            StorageColumnType.Timestamp => NpgsqlDbType.TimestampTz,
+            StorageColumnType.Json => NpgsqlDbType.Jsonb,
+            _ => throw new ArgumentOutOfRangeException(nameof(column))
+        };
+
+        // DBNull → typed NULL of the column type (e.g. a JSONB null); otherwise the value itself.
+        return column.Value is DBNull
+            ? writer.WriteAsync<object>(DBNull.Value, dbType, cancellation)
+            : writer.WriteAsync(column.Value, dbType, cancellation);
     }
 
     private string ColumnList(bool includeExpectedVersion)

--- a/src/Marten/Internal/ClosedShape/DocumentCausationIdBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentCausationIdBinder.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Marten.Storage.Metadata;
 using Npgsql;
 using NpgsqlTypes;
@@ -53,7 +54,5 @@ internal sealed class DocumentCausationIdBinder<TDoc>: IDocumentMetadataBinder<T
         _setter(document, value);
     }
 
-    public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation)
-        => writer.WriteNullAsync(cancellation);
+    public BulkColumnValue GetBulkValue(TDoc document) => BulkColumnValue.Null;
 }

--- a/src/Marten/Internal/ClosedShape/DocumentCorrelationIdBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentCorrelationIdBinder.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Marten.Storage.Metadata;
 using Npgsql;
 using NpgsqlTypes;
@@ -56,13 +57,8 @@ internal sealed class DocumentCorrelationIdBinder<TDoc>: IDocumentMetadataBinder
         _setter(document, value);
     }
 
-    public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation)
-    {
-        // Bulk loader has no session — no source for a correlation id.
-        // Write null; mirrors the codegen path's bulk emit which writes a
-        // constant placeholder (the column was never session-aware on the
-        // COPY path).
-        return writer.WriteNullAsync(cancellation);
-    }
+    public BulkColumnValue GetBulkValue(TDoc document)
+        // Bulk loader has no session — no source for a correlation id. Write null;
+        // mirrors the codegen path's bulk emit (the column was never session-aware on COPY).
+        => BulkColumnValue.Null;
 }

--- a/src/Marten/Internal/ClosedShape/DocumentCreatedAtBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentCreatedAtBinder.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Npgsql;
 
 namespace Marten.Internal.ClosedShape;
@@ -63,8 +64,7 @@ internal sealed class DocumentCreatedAtBinder<TDoc>: IDocumentMetadataBinder<TDo
         _setter(document, ts);
     }
 
-    public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation)
+    public BulkColumnValue GetBulkValue(TDoc document)
         => throw new NotSupportedException(
             "mt_created_at is filled by the column DEFAULT during bulk load; this binder is read-only.");
 }

--- a/src/Marten/Internal/ClosedShape/DocumentDocTypeBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDocTypeBinder.cs
@@ -5,6 +5,7 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -56,10 +57,9 @@ internal sealed class DocumentDocTypeBinder<TDoc>: IDocumentMetadataBinder<TDoc>
         // the document.
     }
 
-    public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation)
+    public BulkColumnValue GetBulkValue(TDoc document)
     {
         var alias = _aliasCache.GetOrAdd(document.GetType(), t => _resolveAlias(t));
-        return writer.WriteAsync(alias, NpgsqlDbType.Varchar, cancellation);
+        return new BulkColumnValue(alias, StorageColumnType.String);
     }
 }

--- a/src/Marten/Internal/ClosedShape/DocumentDotNetTypeBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDotNetTypeBinder.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -37,9 +38,8 @@ internal sealed class DocumentDotNetTypeBinder<TDoc>: IDocumentMetadataBinder<TD
         // No-op — dotnet_type isn't projected back onto the document.
     }
 
-    public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation)
-        => writer.WriteAsync(ResolveTypeName(document), NpgsqlDbType.Varchar, cancellation);
+    public BulkColumnValue GetBulkValue(TDoc document)
+        => new(ResolveTypeName(document), StorageColumnType.String);
 
     private static string ResolveTypeName(TDoc document)
     {

--- a/src/Marten/Internal/ClosedShape/DocumentDuplicatedFieldBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDuplicatedFieldBinder.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Marten.Linq.Members;
 using Npgsql;
 using Weasel.Core;
@@ -107,6 +108,14 @@ internal sealed class DocumentDuplicatedFieldBinder<TDoc>: IDocumentMetadataBind
         // No-op — duplicated columns aren't in the document SELECT.
         // The canonical value is deserialized from the data column.
     }
+
+    // #4828: duplicated fields carry an arbitrary, user-overridable provider parameter type
+    // (_field.DbType), which can't be reduced to the neutral StorageColumnType vocabulary — so this
+    // binder is not part of the movable set. GetBulkValue is never called for it (the Postgres bulk
+    // loader special-cases it and calls WriteToBulkAsync directly); it throws to make that contract loud.
+    public BulkColumnValue GetBulkValue(TDoc document)
+        => throw new NotSupportedException(
+            "Duplicated fields use the Postgres-native bulk path (WriteToBulkAsync); GetBulkValue is not applicable.");
 
     public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
         IStorageSerializer serializer, CancellationToken cancellation)

--- a/src/Marten/Internal/ClosedShape/DocumentHeadersBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentHeadersBinder.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Marten.Internal.Sessions;
 using Marten.Storage.Metadata;
 using Npgsql;
@@ -85,7 +86,7 @@ internal sealed class DocumentHeadersBinder<TDoc>: IDocumentMetadataBinder<TDoc>
         _setter(document, headers);
     }
 
-    public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation)
-        => writer.WriteAsync<object>(DBNull.Value, NpgsqlDbType.Jsonb, cancellation);
+    public BulkColumnValue GetBulkValue(TDoc document)
+        // Headers aren't carried on the COPY path — write a typed JSONB null, as before.
+        => BulkColumnValue.TypedNull(StorageColumnType.Json);
 }

--- a/src/Marten/Internal/ClosedShape/DocumentLastModifiedBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentLastModifiedBinder.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -50,14 +51,13 @@ internal sealed class DocumentLastModifiedBinder<TDoc>: IDocumentMetadataBinder<
         _setter(document, ts);
     }
 
-    public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation)
+    public BulkColumnValue GetBulkValue(TDoc document)
     {
         // COPY can't run transaction_timestamp() — compute client-side.
         // Slight skew vs. SQL writes that get the transaction's
         // commit time; acceptable for the bulk path.
         var now = DateTimeOffset.UtcNow;
         _setter?.Invoke(document, now);
-        return writer.WriteAsync(now, NpgsqlDbType.TimestampTz, cancellation);
+        return new BulkColumnValue(now, StorageColumnType.Timestamp);
     }
 }

--- a/src/Marten/Internal/ClosedShape/DocumentLastModifiedByBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentLastModifiedByBinder.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Marten.Storage.Metadata;
 using Npgsql;
 using NpgsqlTypes;
@@ -57,7 +58,5 @@ internal sealed class DocumentLastModifiedByBinder<TDoc>: IDocumentMetadataBinde
         _setter(document, value);
     }
 
-    public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation)
-        => writer.WriteNullAsync(cancellation);
+    public BulkColumnValue GetBulkValue(TDoc document) => BulkColumnValue.Null;
 }

--- a/src/Marten/Internal/ClosedShape/DocumentRevisionBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentRevisionBinder.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -102,15 +103,14 @@ internal sealed class DocumentRevisionBinder<TDoc>: IDocumentMetadataBinder<TDoc
     public void ApplyRevisionTo(TDoc document, long revision)
         => _setter?.Invoke(document, revision);
 
-    public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation)
+    public BulkColumnValue GetBulkValue(TDoc document)
     {
         // Bulk path defaults to revision 1 — matches the codegen
         // BulkLoader.GenerateBulkWriterCodeAsync's hard-coded "write
         // (long)1" for RevisionArgument. The parameter type follows the column.
         _setter?.Invoke(document, 1L);
         return _columnDbType == NpgsqlDbType.Integer
-            ? writer.WriteAsync(1, NpgsqlDbType.Integer, cancellation)
-            : writer.WriteAsync(1L, NpgsqlDbType.Bigint, cancellation);
+            ? new BulkColumnValue(1, StorageColumnType.Int)
+            : new BulkColumnValue(1L, StorageColumnType.Long);
     }
 }

--- a/src/Marten/Internal/ClosedShape/DocumentSoftDeletedAtBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentSoftDeletedAtBinder.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -55,7 +56,5 @@ internal sealed class DocumentSoftDeletedAtBinder<TDoc>: IDocumentMetadataBinder
         _setter(document, value);
     }
 
-    public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation)
-        => writer.WriteNullAsync(cancellation);
+    public BulkColumnValue GetBulkValue(TDoc document) => BulkColumnValue.Null;
 }

--- a/src/Marten/Internal/ClosedShape/DocumentSoftDeletedBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentSoftDeletedBinder.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -56,7 +57,6 @@ internal sealed class DocumentSoftDeletedBinder<TDoc>: IDocumentMetadataBinder<T
         _setter(document, value);
     }
 
-    public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation)
-        => writer.WriteAsync(false, NpgsqlDbType.Boolean, cancellation);
+    public BulkColumnValue GetBulkValue(TDoc document)
+        => new(false, StorageColumnType.Boolean);
 }

--- a/src/Marten/Internal/ClosedShape/DocumentTenantIdBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentTenantIdBinder.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Marten.Storage.Metadata;
 using Npgsql;
 
@@ -51,8 +52,7 @@ internal sealed class DocumentTenantIdBinder<TDoc>: IDocumentMetadataBinder<TDoc
         _setter(document, value);
     }
 
-    public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation)
+    public BulkColumnValue GetBulkValue(TDoc document)
         => throw new NotSupportedException(
             "tenant_id is handled directly by the bulk loader; this binder is read-only.");
 }

--- a/src/Marten/Internal/ClosedShape/DocumentVersionBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentVersionBinder.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -71,11 +72,10 @@ internal sealed class DocumentVersionBinder<TDoc>: IDocumentMetadataBinder<TDoc>
     public void ApplyVersionTo(TDoc document, Guid version)
         => _setter?.Invoke(document, version);
 
-    public Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation)
+    public BulkColumnValue GetBulkValue(TDoc document)
     {
         var newVersion = CombGuidIdGeneration.NewGuid();
         _setter?.Invoke(document, newVersion);
-        return writer.WriteAsync(newVersion, NpgsqlDbType.Uuid, cancellation);
+        return new BulkColumnValue(newVersion, StorageColumnType.Guid);
     }
 }

--- a/src/Marten/Internal/ClosedShape/IDocumentMetadataBinder.cs
+++ b/src/Marten/Internal/ClosedShape/IDocumentMetadataBinder.cs
@@ -1,8 +1,7 @@
 #nullable enable
 using System.Data.Common;
-using System.Threading;
-using System.Threading.Tasks;
 using Marten.Internal;
+using Marten.Internal.Storage;
 using Npgsql;
 
 namespace Marten.Internal.ClosedShape;
@@ -92,15 +91,15 @@ public interface IDocumentMetadataBinder<TDoc>
     void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session);
 
     /// <summary>
-    /// W3 spike (M16): per-row write hook on the COPY (bulk) path. Each
-    /// binder produces a value + NpgsqlDbType and writes both to the
-    /// <see cref="NpgsqlBinaryImporter"/> in COPY column order. Unlike
-    /// <see cref="BindParameter"/>, server-side binders (e.g.
-    /// <c>transaction_timestamp()</c>) must compute a client-side value
-    /// here since COPY doesn't honor inline SQL literals — the override
-    /// produces <see cref="System.DateTimeOffset.UtcNow"/> for the
-    /// LastModified case.
+    /// #4828: the binder's contribution to a bulk-load row, as a dialect-neutral
+    /// <see cref="BulkColumnValue"/> (value + <see cref="StorageColumnType"/>) — replacing the
+    /// previous <c>WriteToBulkAsync(NpgsqlBinaryImporter, …)</c> so the metadata binders no longer
+    /// depend on the Npgsql COPY writer. The dialect-specific bulk loader maps the type to its
+    /// provider and writes. Like the old bulk path, server-side binders (e.g.
+    /// <c>transaction_timestamp()</c>) compute a client-side value here since COPY doesn't honor
+    /// inline SQL literals — the LastModified binder produces <see cref="System.DateTimeOffset.UtcNow"/>.
+    /// Any document mutation the value implies (version writeback, LastModified) happens as a side
+    /// effect of this call, exactly as it did in the old bulk write.
     /// </summary>
-    Task WriteToBulkAsync(NpgsqlBinaryImporter writer, TDoc document,
-        IStorageSerializer serializer, CancellationToken cancellation);
+    BulkColumnValue GetBulkValue(TDoc document);
 }

--- a/src/Marten/Internal/Storage/BulkColumnValue.cs
+++ b/src/Marten/Internal/Storage/BulkColumnValue.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+namespace Marten.Internal.Storage;
+
+/// <summary>
+///     #4828: a single column's contribution to a bulk-load row — the value plus its dialect-neutral
+///     <see cref="StorageColumnType"/>. Returned by <c>IDocumentMetadataBinder.GetBulkValue</c> so the
+///     dialect-specific bulk loader can write it with its native mechanism, replacing the binders'
+///     direct <c>NpgsqlBinaryImporter</c> coupling.
+/// </summary>
+/// <remarks>
+///     <see cref="Value"/> semantics:
+///     <list type="bullet">
+///         <item><c>null</c> → write an untyped SQL NULL.</item>
+///         <item><see cref="System.DBNull"/> → write a typed NULL of <see cref="Type"/>.</item>
+///         <item>otherwise → write the value as <see cref="Type"/>.</item>
+///     </list>
+/// </remarks>
+public readonly struct BulkColumnValue
+{
+    /// <summary>An untyped NULL (the loader writes a plain NULL, no provider type).</summary>
+    public static readonly BulkColumnValue Null = new(null, default);
+
+    public BulkColumnValue(object? value, StorageColumnType type)
+    {
+        Value = value;
+        Type = type;
+    }
+
+    public object? Value { get; }
+
+    public StorageColumnType Type { get; }
+
+    /// <summary>A typed NULL of the given column type (e.g. a JSONB null).</summary>
+    public static BulkColumnValue TypedNull(StorageColumnType type) => new(System.DBNull.Value, type);
+}

--- a/src/Marten/Internal/Storage/StorageColumnType.cs
+++ b/src/Marten/Internal/Storage/StorageColumnType.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+namespace Marten.Internal.Storage;
+
+/// <summary>
+///     #4828: the small, dialect-neutral vocabulary of logical column types the metadata binders
+///     use when contributing a value to the bulk-load path. A dialect maps each to its own provider
+///     parameter type (Postgres: <c>NpgsqlDbType</c>; SQL Server: <c>SqlDbType</c>). This is the
+///     seam that lets the fixed Marten metadata binders drop their direct
+///     <c>NpgsqlBinaryImporter</c>/<c>NpgsqlDbType</c> dependency so they can move to a shared package.
+/// </summary>
+/// <remarks>
+///     Deliberately covers only the fixed metadata columns' types. User-defined duplicated fields
+///     carry an arbitrary, user-overridable provider type (<see cref="Linq.Members.DuplicatedField.DbType"/>)
+///     that cannot be reduced to this set, so their bulk writing stays on the Postgres-native path.
+/// </remarks>
+public enum StorageColumnType
+{
+    String,
+    Guid,
+    Long,
+    Int,
+    Boolean,
+    Timestamp,
+    Json
+}


### PR DESCRIPTION
**Direction B** of the bulk-writer spike ([#4821](https://github.com/JasperFx/marten/issues/4821)). Rather than a lowest-common-denominator "portable bulk sink" over two genuinely different mechanisms (Postgres COPY **push** vs SQL Server `SqlBulkCopy` **pull**), remove the Npgsql COPY writer from the binder contract and let the dialect-specific bulk loader own the writing.

## Change
- New neutral vocabulary (movable): `StorageColumnType { String, Guid, Long, Int, Boolean, Timestamp, Json }` and `BulkColumnValue { object? Value, StorageColumnType Type }`.
- `IDocumentMetadataBinder<TDoc>`: `Task WriteToBulkAsync(NpgsqlBinaryImporter, …)` → `BulkColumnValue GetBulkValue(TDoc)`. The 12 fixed metadata binders return a neutral value, preserving the same document side effects (version writeback, LastModified `UtcNow`). No `NpgsqlBinaryImporter` on the metadata binders' write path.
- `ClosedShapeBulkLoader` (Postgres-resident) maps `StorageColumnType` → `NpgsqlDbType` and drives `NpgsqlBinaryImporter`, exactly reproducing the previous per-column types (incl. the JSONB typed-null for headers and the Bigint/Integer revision split).

## The duplicated-field boundary
`DocumentDuplicatedFieldBinder` stays Postgres-specific: duplicated fields carry an arbitrary, **user-overridable** provider type (`DuplicatedField.DbType`) that can't reduce to the neutral vocabulary. It keeps a native `WriteToBulkAsync`, the loader special-cases it, and its `GetBulkValue` throws. Duplicated fields are a Postgres indexing feature — this is the honest boundary.

## Net
The fixed metadata binders lose their last **write-path** Npgsql dependency (`WriteToBulkAsync`/`NpgsqlBinaryImporter`). The remaining `BindParameter(NpgsqlParameter)` is the separate param-binding surface. Bulk *loading* stays per-dialect (correct — always Npgsql-coupled at connection + strategy level).

## Verification
- `dotnet build src/Marten.slnx` clean in **Debug and Release**.
- **Bulk-insert suite 60** (version/revision/timestamps/jsonb headers/duplicated fields/subclass/optimistic/composite-PK), **DocumentDbTests 1033**, **ValueTypeTests 339** green on net10.

Part of #4821 / #4828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)