### PR TITLE
#4828 (4c-5) — IDocumentMetadataBinder.BindParameter over DbParameter (Npgsql-free contract)

### DIFF
--- a/src/Marten/Internal/ClosedShape/DocumentCausationIdBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentCausationIdBinder.cs
@@ -36,9 +36,9 @@ internal sealed class DocumentCausationIdBinder<TDoc>: IDocumentMetadataBinder<T
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
     {
-        parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
+        ((NpgsqlParameter)parameter).NpgsqlDbType = NpgsqlDbType.Varchar;
         parameter.Value = (object?)session.CausationId ?? DBNull.Value;
     }
 

--- a/src/Marten/Internal/ClosedShape/DocumentCorrelationIdBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentCorrelationIdBinder.cs
@@ -39,9 +39,9 @@ internal sealed class DocumentCorrelationIdBinder<TDoc>: IDocumentMetadataBinder
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
     {
-        parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
+        ((NpgsqlParameter)parameter).NpgsqlDbType = NpgsqlDbType.Varchar;
         parameter.Value = (object?)session.CorrelationId ?? DBNull.Value;
     }
 

--- a/src/Marten/Internal/ClosedShape/DocumentCreatedAtBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentCreatedAtBinder.cs
@@ -51,7 +51,7 @@ internal sealed class DocumentCreatedAtBinder<TDoc>: IDocumentMetadataBinder<TDo
     // "never written client-side" invariant honest.
     public string ValueSql => "transaction_timestamp()";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
         => throw new NotSupportedException(
             "mt_created_at has a server-side DEFAULT and is never written through this binder.");
 

--- a/src/Marten/Internal/ClosedShape/DocumentDocTypeBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDocTypeBinder.cs
@@ -43,11 +43,11 @@ internal sealed class DocumentDocTypeBinder<TDoc>: IDocumentMetadataBinder<TDoc>
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
     {
         var alias = _aliasCache.GetOrAdd(document.GetType(), t => _resolveAlias(t));
         parameter.Value = alias;
-        parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
+        ((NpgsqlParameter)parameter).NpgsqlDbType = NpgsqlDbType.Varchar;
     }
 
     public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)

--- a/src/Marten/Internal/ClosedShape/DocumentDotNetTypeBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDotNetTypeBinder.cs
@@ -27,10 +27,10 @@ internal sealed class DocumentDotNetTypeBinder<TDoc>: IDocumentMetadataBinder<TD
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
     {
         parameter.Value = ResolveTypeName(document);
-        parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
+        ((NpgsqlParameter)parameter).NpgsqlDbType = NpgsqlDbType.Varchar;
     }
 
     public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)

--- a/src/Marten/Internal/ClosedShape/DocumentDuplicatedFieldBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentDuplicatedFieldBinder.cs
@@ -65,9 +65,9 @@ internal sealed class DocumentDuplicatedFieldBinder<TDoc>: IDocumentMetadataBind
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
     {
-        parameter.NpgsqlDbType = _field.DbType;
+        ((NpgsqlParameter)parameter).NpgsqlDbType = _field.DbType;
 
         object? current = document;
         foreach (var member in _members)

--- a/src/Marten/Internal/ClosedShape/DocumentHeadersBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentHeadersBinder.cs
@@ -43,7 +43,7 @@ internal sealed class DocumentHeadersBinder<TDoc>: IDocumentMetadataBinder<TDoc>
     public void ApplyToDocument(TDoc document, IStorageSession session)
         => _setter?.Invoke(document, session.Headers);
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
     {
         // Mirror the codegen path's setHeaderParameter: use the session's
         // cached UTF-8 byte[] when available (DocumentSessionBase
@@ -55,12 +55,12 @@ internal sealed class DocumentHeadersBinder<TDoc>: IDocumentMetadataBinder<TDoc>
             var cachedBytes = docSession.GetCachedSerializedHeaders();
             if (cachedBytes is null)
             {
-                parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+                ((NpgsqlParameter)parameter).NpgsqlDbType = NpgsqlDbType.Jsonb;
                 parameter.Value = DBNull.Value;
             }
             else
             {
-                parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+                ((NpgsqlParameter)parameter).NpgsqlDbType = NpgsqlDbType.Jsonb;
                 parameter.Value = cachedBytes;
             }
             return;
@@ -68,7 +68,7 @@ internal sealed class DocumentHeadersBinder<TDoc>: IDocumentMetadataBinder<TDoc>
 
         if (session.Headers is null)
         {
-            parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+            ((NpgsqlParameter)parameter).NpgsqlDbType = NpgsqlDbType.Jsonb;
             parameter.Value = DBNull.Value;
         }
         else

--- a/src/Marten/Internal/ClosedShape/DocumentLastModifiedBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentLastModifiedBinder.cs
@@ -36,7 +36,7 @@ internal sealed class DocumentLastModifiedBinder<TDoc>: IDocumentMetadataBinder<
 
     public string ValueSql => "transaction_timestamp()";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
     {
         // No-op — IsServerSide is true; the operation skips this binder
         // in its write loop. The SQL literal in ValueSql does the work.

--- a/src/Marten/Internal/ClosedShape/DocumentLastModifiedByBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentLastModifiedByBinder.cs
@@ -38,9 +38,9 @@ internal sealed class DocumentLastModifiedByBinder<TDoc>: IDocumentMetadataBinde
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
     {
-        parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
+        ((NpgsqlParameter)parameter).NpgsqlDbType = NpgsqlDbType.Varchar;
         // IMetadataContext.LastModifiedBy is the alias of CurrentUserName;
         // prefer CurrentUserName since the former is marked [Obsolete].
         parameter.Value = (object?)session.CurrentUserName ?? DBNull.Value;

--- a/src/Marten/Internal/ClosedShape/DocumentRevisionBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentRevisionBinder.cs
@@ -71,17 +71,17 @@ internal sealed class DocumentRevisionBinder<TDoc>: IDocumentMetadataBinder<TDoc
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
     {
         if (_columnDbType == NpgsqlDbType.Integer)
         {
             parameter.Value = 0;
-            parameter.NpgsqlDbType = NpgsqlDbType.Integer;
+            ((NpgsqlParameter)parameter).NpgsqlDbType = NpgsqlDbType.Integer;
         }
         else
         {
             parameter.Value = 0L;
-            parameter.NpgsqlDbType = NpgsqlDbType.Bigint;
+            ((NpgsqlParameter)parameter).NpgsqlDbType = NpgsqlDbType.Bigint;
         }
     }
 

--- a/src/Marten/Internal/ClosedShape/DocumentSoftDeletedAtBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentSoftDeletedAtBinder.cs
@@ -37,10 +37,10 @@ internal sealed class DocumentSoftDeletedAtBinder<TDoc>: IDocumentMetadataBinder
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
     {
         parameter.Value = DBNull.Value;
-        parameter.NpgsqlDbType = NpgsqlDbType.TimestampTz;
+        ((NpgsqlParameter)parameter).NpgsqlDbType = NpgsqlDbType.TimestampTz;
     }
 
     public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)

--- a/src/Marten/Internal/ClosedShape/DocumentSoftDeletedBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentSoftDeletedBinder.cs
@@ -42,10 +42,10 @@ internal sealed class DocumentSoftDeletedBinder<TDoc>: IDocumentMetadataBinder<T
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
     {
         parameter.Value = false;
-        parameter.NpgsqlDbType = NpgsqlDbType.Boolean;
+        ((NpgsqlParameter)parameter).NpgsqlDbType = NpgsqlDbType.Boolean;
     }
 
     public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)

--- a/src/Marten/Internal/ClosedShape/DocumentTenantIdBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentTenantIdBinder.cs
@@ -39,7 +39,7 @@ internal sealed class DocumentTenantIdBinder<TDoc>: IDocumentMetadataBinder<TDoc
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
         => throw new NotSupportedException(
             "tenant_id is bound directly by the storage operation; this binder is read-only.");
 

--- a/src/Marten/Internal/ClosedShape/DocumentVersionBinder.cs
+++ b/src/Marten/Internal/ClosedShape/DocumentVersionBinder.cs
@@ -45,13 +45,13 @@ internal sealed class DocumentVersionBinder<TDoc>: IDocumentMetadataBinder<TDoc>
 
     public string ValueSql => "?";
 
-    public void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session)
+    public void BindParameter(DbParameter parameter, TDoc document, IStorageSession session)
     {
         var newVersion = CombGuidIdGeneration.NewGuid();
         _setter?.Invoke(document, newVersion);
 
         parameter.Value = newVersion;
-        parameter.NpgsqlDbType = NpgsqlDbType.Uuid;
+        ((NpgsqlParameter)parameter).NpgsqlDbType = NpgsqlDbType.Uuid;
     }
 
     public void Apply(DbDataReader reader, int columnOrdinal, TDoc document, IStorageSession session)

--- a/src/Marten/Internal/ClosedShape/IDocumentMetadataBinder.cs
+++ b/src/Marten/Internal/ClosedShape/IDocumentMetadataBinder.cs
@@ -2,7 +2,6 @@
 using System.Data.Common;
 using Marten.Internal;
 using Marten.Internal.Storage;
-using Npgsql;
 
 namespace Marten.Internal.ClosedShape;
 
@@ -56,14 +55,14 @@ public interface IDocumentMetadataBinder<TDoc>
     bool IsServerSide => ValueSql != "?";
 
     /// <summary>
-    /// Per-row write hook on the INSERT / UPSERT path. The storage
-    /// operation pre-allocates the <see cref="NpgsqlParameter"/> via
-    /// <c>ICommandBuilder.AppendWithParameters("…, ?, …", '?')</c> and
-    /// hands the parameter to each client-side binder in order. Server-side
-    /// binders don't get called here — their <see cref="ValueSql"/>
-    /// fragment is in the SQL directly.
+    /// Per-row write hook on the INSERT / UPSERT path. The storage operation pre-allocates the
+    /// parameter via <c>ICommandBuilder.AppendWithParameters("…, ?, …", '?')</c> and hands it to each
+    /// client-side binder in order. Server-side binders don't get called here — their
+    /// <see cref="ValueSql"/> fragment is in the SQL directly. #4828: the parameter is typed as the
+    /// db-neutral <see cref="DbParameter"/> so the binder contract no longer names Npgsql; the
+    /// concrete (Postgres) binders set the provider type on the underlying <c>NpgsqlParameter</c>.
     /// </summary>
-    void BindParameter(NpgsqlParameter parameter, TDoc document, IStorageSession session);
+    void BindParameter(DbParameter parameter, TDoc document, IStorageSession session);
 
     /// <summary>
     /// Optional pre-serialization hook. Called once per write before the


### PR DESCRIPTION
Widens the metadata-binder write hook from `BindParameter(NpgsqlParameter)` to `BindParameter(DbParameter)`, completing the **db-neutral `IDocumentMetadataBinder` contract** (the read hook `Apply(DbDataReader)` and the bulk hook `GetBulkValue` were already neutral after #4842). Same shape as `IStorageDialect`: the interface names no Npgsql type; the concrete Postgres binders set the provider type on the underlying `NpgsqlParameter` via a cast.

## Change
- `IDocumentMetadataBinder<TDoc>.BindParameter(NpgsqlParameter)` → `(DbParameter)`; dropped `using Npgsql;` from the interface.
- The 10 type-setting binders cast `((NpgsqlParameter)parameter).NpgsqlDbType = …`; `parameter.Value` stays on the base `DbParameter`. `DocumentHeadersBinder` already routed its serialized value through `IStorageSerializer.WriteToParameter(DbParameter)` (#4819).
- Operation call sites unchanged — the operations still get `NpgsqlParameter[]` from Weasel's `ICommandBuilder.AppendWithParameters` and pass each slot as a `DbParameter` (an `NpgsqlParameter` is one).

Behavior-identical (same provider types, via a cast).

## Still gated
Full operation-layer neutrality — the operations holding `DbParameter[]`, and `DocumentRevisionBinder.ColumnDbType` (which the Numeric operations read) — stays gated on **JasperFx/weasel#324** (`ICommandBuilder.AppendWithParameters` → `DbParameter[]`). This PR does the Marten-side interface half.

## Verification
- `dotnet build src/Marten.slnx` clean in **Debug and Release**.
- **DocumentDbTests 1033**, **ValueTypeTests 339**, **EventSourcingTests 1421** green on net10 (BindParameter fires on every metadata column of every write).

Part of #4821 / #4828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)