### PR TITLE
chore: bump Weasel.Postgresql 9.5.0 → 9.6.0 (weasel#324)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -147,7 +147,10 @@
          Polecat share it; Weasel.Core 9.4.0 flows in transitively. -->
     <!-- 9.5.0 (weasel#323): adds a shared Weasel.Core.ISerializer base for the Critter Stack
          dedupe. Weasel.Core 9.5.0 flows in transitively. -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.5.0" />
+    <!-- 9.6.0 (weasel#324): adds DbParameter[]-returning AppendWithDbParameters to the non-generic
+         ICommandBuilder, unblocking the closed-shape operation param path (#4821/#4828). Weasel.Core
+         9.6.0 flows in transitively. -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.6.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
+++ b/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
@@ -9,6 +9,7 @@ using Marten.Exceptions;
 using Marten.Linq;
 using Marten.Linq.Includes;
 using Marten.Linq.QueryHandlers;
+using System.Data.Common;
 using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
@@ -282,6 +283,14 @@ public class CompiledQueryPlan : ICommandBuilder
 
         return parameters;
     }
+
+    // weasel#324: DbParameter[]-returning overloads. The recorded parameters are NpgsqlParameters,
+    // which are DbParameters — delegate to the existing recording logic and return via array covariance.
+    DbParameter[] ICommandBuilder.AppendWithDbParameters(string text)
+        => ((ICommandBuilder)this).AppendWithParameters(text);
+
+    DbParameter[] ICommandBuilder.AppendWithDbParameters(string text, char placeholder)
+        => ((ICommandBuilder)this).AppendWithParameters(text, placeholder);
 
     void ICommandBuilder.StartNewCommand()
     {


### PR DESCRIPTION
Consumes **weasel#324**, which adds `DbParameter[]`-returning `AppendWithDbParameters` to the non-generic `Weasel.Postgresql.ICommandBuilder` — the surface that unblocks the closed-shape operation parameter path (#4821 / #4828, follow-up PR).

The new interface members require `CompiledQueryPlan` (Marten's recording `ICommandBuilder`) to implement them; it delegates to the existing `AppendWithParameters` recording logic and returns via array covariance (an `NpgsqlParameter[]` is a `DbParameter[]`).

## Verification
- `dotnet build src/Marten.slnx` clean in **Debug and Release**.
- **CoreTests 458**, **LinqTests 1312** (compiled queries exercise `CompiledQueryPlan`) green on net10.

Part of #4821 / #4828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)