### PR TITLE
Per-tenant high water from max(seq_id), not the unused per-tenant sequence

### DIFF
--- a/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
@@ -194,7 +194,6 @@ internal class HighWaterDetector: IHighWaterDetector
     private async Task<IReadOnlyList<HighWaterStatistics>> loadPerTenantStatistics(
         IReadOnlyCollection<string> tenantIds, CancellationToken token)
     {
-        var tenantsTable = _graph.Options.TenantPartitions!.TenantsTableName;
         var schema = _graph.DatabaseSchemaName;
         // #4681: the per-tenant high-water identity prefix is produced by
         // HighWaterShardIdentity rather than hand-rolled here, so any future
@@ -202,27 +201,31 @@ internal class HighWaterDetector: IHighWaterDetector
         // rule) only needs to land in one place.
         var highWaterPrefix = HighWaterShardIdentity.PerTenantPrefix;
 
-        // Single round-trip: for each requested tenant, join (mt_tenant_partitions
-        // → pg_sequences for that partition's mt_events_sequence_{suffix} →
-        // mt_event_progression for the per-tenant high-water row keyed by
-        // `'{HighWaterMark}:{tenantId}'`, matching Session 3's per-tenant naming
-        // convention for the high-water shard). LEFT JOINs preserve a row per
-        // input tenant even when the partition / sequence / progression row
-        // hasn't been created yet (returns null → treated as zero downstream).
+        // This method only runs under per-tenant event partitioning (the caller collapses to the
+        // store-global reading when the flag is off), so read each tenant's height from max(seq_id) of its
+        // own mt_events partition — NOT from the per-tenant sequence. Same reasoning as the store-global
+        // #4712 fix in HighWaterStatisticsDetector: under partitioning the per-tenant sequence
+        // (mt_events_sequence_{suffix}) is left at its initial value (last_value=1, is_called=false) for
+        // events appended via the shared sequence or reassigned by BulkInsertEventsAsync, so reading it
+        // reports a high-water of 0 for a fully-populated tenant and its projections never start. max(seq_id)
+        // is the authoritative committed height regardless of how the events were inserted, so a tenant with
+        // no persisted progression row yet still gets its true high-water and its per-tenant agent advances.
+        // The LEFT JOINs preserve a row per input tenant even when its partition / progression row does not
+        // exist yet (returns null → treated as zero downstream).
         var sql = $@"
 with inputs(tenant_id) as (select unnest(:tenants))
 select
     i.tenant_id,
-    coalesce(seq.last_value, 0)        as last_value,
+    coalesce(ev.max_seq_id, 0)         as last_value,
     coalesce(prog.last_seq_id, 0)      as last_seq_id,
     prog.last_updated                  as last_updated,
     transaction_timestamp()            as ""timestamp""
 from inputs i
-left join {tenantsTable} p
-    on p.partition_value = i.tenant_id
-left join pg_sequences seq
-    on seq.schemaname = '{schema}'
-    and seq.sequencename = 'mt_events_sequence_' || p.partition_suffix
+left join lateral (
+    select max(e.seq_id) as max_seq_id
+    from {schema}.mt_events e
+    where e.tenant_id = i.tenant_id
+) ev on true
 left join {schema}.mt_event_progression prog
     on prog.name = :prefix || i.tenant_id;";
 

--- a/src/TenantPartitionedEventsTests/Daemon/vectorized_high_water_detection.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/vectorized_high_water_detection.cs
@@ -5,7 +5,9 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Daemon.HighWater;
 using Marten.Events.Daemon.HighWater;
 using Marten.Storage;
+using Marten.Testing.Harness;
 using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
 using Shouldly;
 using TenantPartitionedEventsTests.Fixtures;
 using Xunit;
@@ -157,6 +159,40 @@ public class vectorized_high_water_detection
 
         var next = await monitor.PollAsync(CancellationToken.None);
         next.Select(r => r.TenantId).ShouldBe(new[] { beta });
+    }
+
+    [Fact]
+    public async Task per_tenant_high_water_comes_from_max_seq_id_not_the_tenant_sequence()
+    {
+        // Same bug class as the store-global #4712 fix, but for the per-tenant reading: under sharded
+        // tenancy the append path does NOT advance the per-tenant mt_events_sequence_{suffix} (events draw
+        // their seq_id from the shared sequence, and BulkInsertEventsAsync reassigns per-tenant ranges
+        // directly), so the sequence reports a stale value while the tenant's true height lives in
+        // mt_events. DetectForTenantsAsync must derive HighestSequence from max(seq_id), NOT the sequence,
+        // otherwise a fully-populated tenant reads as high-water 0 and its per-tenant projections never
+        // start. Reproduce the stale sequence by force-resetting it after the append.
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+        await _fixture.AppendNEventsAsync(tenant, 7);
+
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            // last_value → 1 (is_called=false): what the sharded/global-sequence/bulk path leaves behind.
+            await using var reset = new NpgsqlCommand(
+                $"select setval('{_fixture.SchemaName}.mt_events_sequence_{tenant}', 1, false)", conn);
+            await reset.ExecuteScalarAsync();
+        }
+
+        var detector = new HighWaterDetector(
+            (MartenDatabase)_fixture.Store.Storage.Database, _fixture.Store.Options.EventGraph, NullLogger.Instance);
+
+        var vector = await ((IHighWaterDetector)detector).DetectForTenantsAsync(
+            new[] { tenant }, CancellationToken.None);
+
+        vector.TryGetStatistics(tenant, out var stat).ShouldBeTrue();
+        // Before the fix this read the stale sequence value (1); after it, the real committed height (7).
+        stat.HighestSequence.ShouldBe(7);
     }
 
     // ---- ICrossTenantRebuildSource ----


### PR DESCRIPTION
## Problem

Under `UseTenantPartitionedEvents`, the vectorized per-tenant high-water statistics (`HighWaterDetector.loadPerTenantStatistics`) read each tenant's height from `pg_sequences` via the `mt_tenant_partitions` catalog join — i.e. from the per-tenant `mt_events_sequence_<suffix>` sequence. That sequence can be stale or entirely unused: under sharded tenancy the append path draws `seq_id` from the store-global `mt_events_sequence`, and bulk imports / migrations (`BulkInsertEventsAsync`) reassign per-tenant ranges directly, leaving the per-tenant sequence at its initial `last_value=1, is_called=false`. A tenant with events but no partition-catalog row reports zero as well. Either way the per-tenant high-water detector reads a stale height and per-tenant progression never advances.

This is the same bug class as #4705 / #4712 (sequence/statistics diverging from committed reality under partitioning), now fixed for the vectorized per-tenant path.

## Fix

`loadPerTenantStatistics` now derives each tenant's high water from committed `max(seq_id)` per tenant, via a `left join lateral (select max(e.seq_id) from mt_events e where e.tenant_id = i.tenant_id)`. The predicate on `tenant_id` prunes the scan to the tenant's list partition, and the `(seq_id, tenant_id)` PK makes the `max(seq_id)` read cheap. The `mt_tenant_partitions` → `pg_sequences` join is gone. LEFT JOIN semantics are preserved: a tenant with no events (or no progression row yet) still yields a row with zeros.

Covered by a new regression test in `vectorized_high_water_detection` that force-resets the per-tenant sequence to the stale state after appending and asserts `DetectForTenantsAsync` reports the true committed height.

## Provenance

Carved out of #4799, which is being split into standalone PRs. Authored by @erdtsieck — cherry-picked with authorship preserved. A companion end-to-end test (`per_tenant_agent_start_routes_high_water`) depends on an unreleased JasperFx.Events daemon change (JasperFx/jasperfx#482) and will follow in a later PR.

Part of the per-tenant event partitioning epic JasperFx/jasperfx#486.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
