### PR TITLE
Story 6: consume the shared Weasel.Core SQL-generation contract (weasel#327 / Weasel 9.7.0)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -150,7 +150,10 @@
     <!-- 9.6.0 (weasel#324): adds DbParameter[]-returning AppendWithDbParameters to the non-generic
          ICommandBuilder, unblocking the closed-shape operation param path (#4821/#4828). Weasel.Core
          9.6.0 flows in transitively. -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.6.0" />
+    <!-- 9.7.0 (weasel#327): shared Weasel.Core SQL-gen contract (neutral ICommandBuilder +
+         ISqlFragment) that the Postgres/SqlServer ones derive from. Marten disambiguates the new
+         simple-name collision via a GlobalUsings alias to the Weasel.Postgresql types (API-preserving). -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.7.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/EventSourcingTests/QuickAppend/quick_appending_events_workflow_specs.cs
+++ b/src/EventSourcingTests/QuickAppend/quick_appending_events_workflow_specs.cs
@@ -23,6 +23,8 @@ using Marten.Testing.Harness;
 using Shouldly;
 using Weasel.Core;
 using Weasel.Postgresql;
+using ICommandBuilder = Weasel.Postgresql.ICommandBuilder;
+using ISqlFragment = Weasel.Postgresql.SqlGeneration.ISqlFragment;
 using Xunit;
 
 namespace EventSourcingTests.QuickAppend;

--- a/src/EventSourcingTests/appending_events_workflow_specs.cs
+++ b/src/EventSourcingTests/appending_events_workflow_specs.cs
@@ -26,6 +26,8 @@ using Marten.Testing.Harness;
 using Shouldly;
 using Weasel.Core;
 using Weasel.Postgresql;
+using ICommandBuilder = Weasel.Postgresql.ICommandBuilder;
+using ISqlFragment = Weasel.Postgresql.SqlGeneration.ISqlFragment;
 using Xunit;
 
 namespace EventSourcingTests;

--- a/src/Marten/GlobalUsings.cs
+++ b/src/Marten/GlobalUsings.cs
@@ -1,0 +1,10 @@
+// #4821 Story 6 / weasel#327: the shared Weasel.Core SQL-generation contract introduced
+// Weasel.Core.ICommandBuilder + Weasel.Core.SqlGeneration.ISqlFragment, which now collide by
+// simple name with the Weasel.Postgresql equivalents in the many files that import both
+// namespaces. Marten's SQL-generation implementers target the Postgres-typed contracts (the
+// dialect ISqlFragment forwards the neutral Apply via a default interface method), so alias the
+// simple names to the Postgresql types assembly-wide. Movable code that should target the neutral
+// Weasel.Core contract fully-qualifies it, which overrides these aliases.
+global using ICommandBuilder = Weasel.Postgresql.ICommandBuilder;
+global using ISqlFragment = Weasel.Postgresql.SqlGeneration.ISqlFragment;
+global using ICompoundFragment = Weasel.Postgresql.SqlGeneration.ICompoundFragment;

--- a/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
+++ b/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
@@ -154,7 +154,7 @@ public class CompiledQueryPlan : ICommandBuilder
 
     private CommandPlan _current;
 
-    string ICommandBuilder.LastParameterName => _current.Parameters.LastOrDefault()?.Parameter.ParameterName;
+    string Weasel.Core.ICommandBuilder.LastParameterName => _current.Parameters.LastOrDefault()?.Parameter.ParameterName;
 
     private CommandPlan appendCommand()
     {
@@ -164,14 +164,14 @@ public class CompiledQueryPlan : ICommandBuilder
         return plan;
     }
 
-    void ICommandBuilder.Append(string sql)
+    void Weasel.Core.ICommandBuilder.Append(string sql)
     {
         _current ??= appendCommand();
 
         _current.CommandText += sql;
     }
 
-    void ICommandBuilder.Append(char character)
+    void Weasel.Core.ICommandBuilder.Append(char character)
     {
         _current ??= appendCommand();
         _current.CommandText += character;
@@ -237,7 +237,7 @@ public class CompiledQueryPlan : ICommandBuilder
         return usage.Parameter;
     }
 
-    void ICommandBuilder.AppendParameters(params object[] parameters)
+    void Weasel.Core.ICommandBuilder.AppendParameters(params object[] parameters)
     {
         _current ??= appendCommand();
         throw new NotSupportedException();
@@ -286,18 +286,18 @@ public class CompiledQueryPlan : ICommandBuilder
 
     // weasel#324: DbParameter[]-returning overloads. The recorded parameters are NpgsqlParameters,
     // which are DbParameters — delegate to the existing recording logic and return via array covariance.
-    DbParameter[] ICommandBuilder.AppendWithDbParameters(string text)
+    DbParameter[] Weasel.Core.ICommandBuilder.AppendWithDbParameters(string text)
         => ((ICommandBuilder)this).AppendWithParameters(text);
 
-    DbParameter[] ICommandBuilder.AppendWithDbParameters(string text, char placeholder)
+    DbParameter[] Weasel.Core.ICommandBuilder.AppendWithDbParameters(string text, char placeholder)
         => ((ICommandBuilder)this).AppendWithParameters(text, placeholder);
 
-    void ICommandBuilder.StartNewCommand()
+    void Weasel.Core.ICommandBuilder.StartNewCommand()
     {
         _current = appendCommand();
     }
 
-    void ICommandBuilder.AddParameters(object parameters)
+    void Weasel.Core.ICommandBuilder.AddParameters(object parameters)
     {
         throw new NotSupportedException(
             "No, just no. Marten does not support parameters via anonymous objects in compiled queries");

--- a/src/Marten/Linq/Members/Dictionaries/DictionaryValuesContainFilter.cs
+++ b/src/Marten/Linq/Members/Dictionaries/DictionaryValuesContainFilter.cs
@@ -5,7 +5,6 @@ using Marten.Linq.SqlGeneration.Filters;
 using Weasel.Postgresql;
 using CommandBuilder = Weasel.Postgresql.CommandBuilder;
 using ConstantExpression = System.Linq.Expressions.ConstantExpression;
-using ISqlFragment = Weasel.Postgresql.SqlGeneration.ISqlFragment;
 
 
 namespace Marten.Linq.Members.Dictionaries;


### PR DESCRIPTION
Weasel 9.7.0 (**weasel#327**) adds a dialect-neutral SQL-generation substrate in `Weasel.Core` — `Weasel.Core.ICommandBuilder` + `Weasel.Core.SqlGeneration.ISqlFragment`, which the Postgres/SqlServer ones now derive from (the dialect `ISqlFragment` forwards the neutral `Apply` via a default interface method). Consuming it in Marten is **API-preserving** — no public signature changes; `IStorageOperation`/`IDocumentStorage` keep their `Weasel.Postgresql`-typed members.

## The collision, resolved without API change
Adding same-named types to `Weasel.Core` introduces a simple-name collision in the many files importing both `Weasel.Core` and `Weasel.Postgresql`. Resolved via:
- **`GlobalUsings.cs`** — alias `ICommandBuilder`/`ISqlFragment`/`ICompoundFragment` to the `Weasel.Postgresql` types assembly-wide (using-aliases win over namespace imports, so bare uses resolve to the Postgres types Marten already exposed).
- **`CompiledQueryPlan`** (the one type that *implements* `ICommandBuilder`) — re-qualify the explicit impls of the members #327 moved up to `Weasel.Core.ICommandBuilder` (`Append`/`AppendWithDbParameters`/`AppendParameters`/`AddParameters`/`StartNewCommand`/`LastParameterName`); the `NpgsqlParameter`-typed `AppendParameter`/`AppendWithParameters` stay on the Postgresql interface. Explicit impls aren't public surface → no API change.
- Dropped a redundant local `ISqlFragment` alias; aliased two `EventSourcingTests` fakes.

Bumps `Weasel.Postgresql` 9.6.0 → 9.7.0 (Weasel.Core flows transitively).

## Validation
Validated against a local Weasel pack before the official publish, then re-confirmed against the published **9.7.0**:
- `dotnet build src/Marten.slnx` clean in **Debug and Release**.
- **CoreTests 458, DocumentDbTests 1033, LinqTests 1312, EventSourcingTests 1421** green on net10 (+ PatchingTests 122, MultiTenancyTests 146, ValueTypeTests 339 in local validation).

Part of #4821 (Story 6 groundwork). Note: this is the *consumption* of the shared substrate — the physical package move itself has a separate no-public-API-break design question tracked on #4830.

🤖 Generated with [Claude Code](https://claude.com/claude-code)