### PR TITLE
W2 gatekeeper (#4821): retarget IChangeTracker onto IStorageSession

### DIFF
--- a/src/Marten/Internal/DirtyTracking/ChangeTracker.cs
+++ b/src/Marten/Internal/DirtyTracking/ChangeTracker.cs
@@ -19,7 +19,7 @@ public class ChangeTracker<T>: IChangeTracker where T : notnull
 
     public object Document => _document;
 
-    public bool DetectChanges(IMartenSession session, [NotNullWhen(true)]out IStorageOperation? operation)
+    public bool DetectChanges(IStorageSession session, [NotNullWhen(true)]out IStorageOperation? operation)
     {
         var newJson = session.Serializer.ToCleanJson(_document);
 
@@ -54,7 +54,7 @@ public class ChangeTracker<T>: IChangeTracker where T : notnull
         return true;
     }
 
-    public void Reset(IMartenSession session)
+    public void Reset(IStorageSession session)
     {
         _json = session.Serializer.ToCleanJson(_document);
     }

--- a/src/Marten/Internal/DirtyTracking/IChangeTracker.cs
+++ b/src/Marten/Internal/DirtyTracking/IChangeTracker.cs
@@ -15,6 +15,6 @@ namespace Marten.Internal.DirtyTracking;
 public interface IChangeTracker
 {
     object Document { get; }
-    bool DetectChanges(IMartenSession session, [NotNullWhen(true)]out IStorageOperation?  operation);
-    void Reset(IMartenSession session);
+    bool DetectChanges(IStorageSession session, [NotNullWhen(true)]out IStorageOperation?  operation);
+    void Reset(IStorageSession session);
 }


### PR DESCRIPTION
Part of the **W2 closed-shape storage extraction** epic (#4821).

First of a short series of **gatekeeper refactors** that make a future physical move of `IStorageSession` (and the closed-shape storage runtime) into the shared **Weasel.Storage** package *bounded*. A dependency-closure analysis showed the move is currently unbounded because a handful of seams still drag Marten-only / Npgsql-only walls into the closure. This PR removes one of them.

### The seam
`IChangeTracker.DetectChanges` / `Reset` took the full `IMartenSession` — the **sole reason** the dirty-tracking seam pulls the entire session wall (~56 files) into the storage closure.

Both methods only ever touch members that already live on the narrower `IStorageSession`:
- `Serializer` (→ `IStorageSerializer`)
- `Database.Providers.StorageFor<T>()`
- `Concurrency`, `TenantId`
- the storage `Overwrite`/`Upsert` operations, which already take `IStorageSession`

The single implementation, `ChangeTracker<T>`, already receives `IStorageSession` in its constructor. `IMartenSession : IStorageSession`, so the two callers (`DirtyCheckingDocumentSession`, `UnitOfWork`) bind unchanged.

### Scope / risk
`Marten.Internal.*` surface only (publinternals). No behavior change.

### Validation
DocumentDbTests **1033** + CoreTests **458** green (net10); Debug + Release clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)