### PR TITLE
W2 gatekeeper (#4821): neutralize IDocumentStorage.DuplicatedFields

### DIFF
--- a/src/Marten/Events/EventDocumentStorage.cs
+++ b/src/Marten/Events/EventDocumentStorage.cs
@@ -13,6 +13,7 @@ using Marten.Exceptions;
 using Marten.Internal;
 using Marten.Internal.Operations;
 using Marten.Internal.Sessions;
+using Marten.Internal.Storage;
 using Marten.Linq;
 using Marten.Linq.Members;
 using Marten.Linq.Parsing;
@@ -167,7 +168,7 @@ public abstract class EventDocumentStorage: IEventStorage
     public bool UseOptimisticConcurrency { get; } = false;
     public IOperationFragment DeleteFragment => throw new NotSupportedException();
     public IOperationFragment HardDeleteFragment => throw new NotSupportedException();
-    public IReadOnlyList<DuplicatedField> DuplicatedFields { get; } = Array.Empty<DuplicatedField>();
+    public IReadOnlyList<IDuplicatedField> DuplicatedFields { get; } = Array.Empty<IDuplicatedField>();
     public DbObjectName TableName => _mapping.TableName;
     public Type DocumentType => typeof(IEvent);
 

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -238,6 +238,10 @@ public class EventMapping<T>: EventMapping, IDocumentStorage<T> where T : class
     [IgnoreDescription]
     public IQueryableMemberCollection QueryMembers { get; }
 
+    // The public DuplicatedFields (IReadOnlyList<DuplicatedField>) satisfies IDocumentMapping; the
+    // db-neutral IDocumentStorage surface sees it through the IDuplicatedField view (covariant).
+    IReadOnlyList<IDuplicatedField> IDocumentStorage.DuplicatedFields => DuplicatedFields;
+
     [IgnoreDescription]
     public ISelectClause SelectClauseWithDuplicatedFields => this;
     public bool UseNumericRevisions { get; } = false;

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -201,7 +201,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMe
 
     public Type DocumentType { get; }
 
-    public IReadOnlyList<DuplicatedField> DuplicatedFields { get; }
+    public IReadOnlyList<IDuplicatedField> DuplicatedFields { get; }
 
     public ISqlFragment ByIdFilter(TId id)
     {

--- a/src/Marten/Internal/Storage/IDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IDocumentStorage.cs
@@ -37,7 +37,7 @@ public interface IDocumentStorage: ISelectClause
     bool UseOptimisticConcurrency { get; }
     IOperationFragment DeleteFragment { get; }
     IOperationFragment HardDeleteFragment { get; }
-    IReadOnlyList<DuplicatedField> DuplicatedFields { get; }
+    IReadOnlyList<IDuplicatedField> DuplicatedFields { get; }
     DbObjectName TableName { get; }
     Type DocumentType { get; }
 

--- a/src/Marten/Internal/Storage/IDuplicatedField.cs
+++ b/src/Marten/Internal/Storage/IDuplicatedField.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System.Reflection;
+
+namespace Marten.Internal.Storage;
+
+/// <summary>
+///     Database-neutral view of a duplicated field that the closed-shape storage runtime
+///     consumes off <see cref="IDocumentStorage"/> — exposes only the members the storage /
+///     patch code needs (the resolved member chain, the column name, and the pre-rendered
+///     update fragment). Keeps the Npgsql-typed <c>DbType</c>/<c>PgType</c> and the LINQ member
+///     model on the concrete <c>Marten.Linq.Members.DuplicatedField</c> out of the storage
+///     surface, so the storage contract can move to the shared Weasel.Storage package (#4821).
+/// </summary>
+public interface IDuplicatedField
+{
+    /// <summary>The resolved member chain the duplicated column is derived from.</summary>
+    MemberInfo[] Members { get; }
+
+    /// <summary>The duplicated column's name.</summary>
+    string ColumnName { get; }
+
+    /// <summary>The <c>"col" = ...</c> assignment fragment used when patch/update SQL refreshes the column.</summary>
+    string UpdateSqlFragment();
+}

--- a/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
@@ -117,7 +117,7 @@ internal class SubClassDocumentStorage<T, TRoot, TId>: IDocumentStorage<T, TId>,
     public bool UseOptimisticConcurrency => _parent.UseOptimisticConcurrency;
     public IOperationFragment DeleteFragment => _parent.DeleteFragment;
     public IOperationFragment HardDeleteFragment { get; }
-    public IReadOnlyList<DuplicatedField> DuplicatedFields => _parent.DuplicatedFields;
+    public IReadOnlyList<IDuplicatedField> DuplicatedFields => _parent.DuplicatedFields;
     public DbObjectName TableName => _parent.TableName;
     public Type DocumentType => typeof(T);
 

--- a/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
+++ b/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
@@ -96,7 +96,7 @@ internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: ID
     public bool UseOptimisticConcurrency => Inner.UseOptimisticConcurrency;
     public IOperationFragment DeleteFragment => Inner.DeleteFragment;
     public IOperationFragment HardDeleteFragment => Inner.HardDeleteFragment;
-    public IReadOnlyList<DuplicatedField> DuplicatedFields => Inner.DuplicatedFields;
+    public IReadOnlyList<IDuplicatedField> DuplicatedFields => Inner.DuplicatedFields;
     public DbObjectName TableName => Inner.TableName;
     public Type DocumentType => Inner.DocumentType;
     public TenancyStyle TenancyStyle => Inner.TenancyStyle;

--- a/src/Marten/Linq/Members/DuplicatedField.cs
+++ b/src/Marten/Linq/Members/DuplicatedField.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Marten.Exceptions;
+using Marten.Internal.Storage;
 using Marten.Linq.Parsing;
 using Marten.Linq.Parsing.Operators;
 using Marten.Linq.SqlGeneration.Filters;
@@ -21,7 +22,7 @@ using Weasel.Postgresql.Tables;
 
 namespace Marten.Linq.Members;
 
-public class DuplicatedField: IQueryableMember, IComparableMember, IHasChildrenMembers
+public class DuplicatedField: IQueryableMember, IComparableMember, IHasChildrenMembers, IDuplicatedField
 {
     private readonly Func<object, object> _parseObject = o => o;
     private readonly bool useTimestampWithoutTimeZoneForDateTime;

--- a/src/Marten/Patching/PatchOperation.cs
+++ b/src/Marten/Patching/PatchOperation.cs
@@ -225,7 +225,7 @@ internal class PatchOperation: StatementOperation, NoDataReturnedCall
         writeWhereClause(builder);
     }
 
-    private bool IsFieldAffectedByPatchPath(DuplicatedField field, HashSet<string> modifiedPaths)
+    private bool IsFieldAffectedByPatchPath(IDuplicatedField field, HashSet<string> modifiedPaths)
     {
         // get the dot seperated path derived from field Members info
         var path = string.Join('.', field.Members.Select(x => x.Name.FormatCase(_serializer.Casing)));


### PR DESCRIPTION
Part of the **W2 closed-shape storage extraction** epic (#4821); second of the gatekeeper refactors that make a future physical move of the closed-shape storage contract into the Npgsql-free **Weasel.Storage** package bounded. (Gatekeeper #1 = #4850.)

### The seam
`IDocumentStorage` surfaced `IReadOnlyList<DuplicatedField>`. `DuplicatedField` (`Marten.Linq.Members`) both implements the whole LINQ member model **and** carries hard Npgsql — a public `NpgsqlDbType DbType` and `PostgresqlProvider` calls. The storage contract could never live in an Npgsql-free package while exposing that type.

### The change
Introduce a db-neutral **`IDuplicatedField`** — BCL-only, exactly the members the storage runtime consumes:
- `MemberInfo[] Members`
- `string ColumnName`
- `string UpdateSqlFragment()`

`DuplicatedField` implements it; the Npgsql-typed `DbType`/`PgType` and the LINQ member surface stay on the concrete class, off the storage contract. `IDocumentStorage.DuplicatedFields` is retyped to `IReadOnlyList<IDuplicatedField>`.

The `IDocumentMapping` side (`DocumentMapping`, `EventMapping`) keeps the concrete `DuplicatedField` (its tests read `MemberName` etc.). `EventMapping<T>` — which is *both* a mapping and a storage — adapts through an explicit `IDocumentStorage.DuplicatedFields` (covariant view).

### Consumers
Only two read the interface member's contents: `DocumentStorage.SelectClauseWithDuplicatedFields` (`ColumnName`) and `PatchOperation` (`Members` + `UpdateSqlFragment()`). Both covered.

### Scope / risk
`Marten.Internal.*` surface only (publinternals). No behavior change.

### Validation
DocumentDbTests **1033** + PatchingTests **122** + EventSourcingTests **1421** green (net10); Debug + Release clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)