### PR TITLE
Per-tenant sequence schema updates are additive-only (never drop existing sequences)

### DIFF
--- a/src/Marten/Events/Schema/PerTenantEventSequences.cs
+++ b/src/Marten/Events/Schema/PerTenantEventSequences.cs
@@ -86,9 +86,9 @@ internal class PerTenantEventSequences: ISchemaObject
     {
         // Single query — count of per-tenant sequences in this schema that
         // match our `mt_events_sequence_%` prefix. CreateDeltaAsync compares
-        // the count against expected; on mismatch the WriteUpdate path
-        // re-emits the IF-NOT-EXISTS create script which is safe to run
-        // against an already-partially-applied database.
+        // the count against expected; on mismatch the (additive-only, see
+        // CreateSequencesDelta) update path re-emits the IF-NOT-EXISTS create
+        // script which is safe to run against an already-partially-applied database.
         var schemaParam = builder.AddParameter(_events.DatabaseSchemaName).ParameterName;
         builder.Append(
             "select count(*) from information_schema.sequences where sequence_schema = :"
@@ -113,7 +113,40 @@ internal class PerTenantEventSequences: ISchemaObject
             ? SchemaPatchDifference.Update
             : SchemaPatchDifference.None;
 
-        return new SchemaObjectDelta(this, difference);
+        return new CreateSequencesDelta(this, difference);
+    }
+
+    /// <summary>
+    /// Additive-only update delta. The generic <see cref="SchemaObjectDelta"/> writes updates as
+    /// WriteDropStatement + WriteCreateStatement — for this wrapper that would DROP every existing
+    /// per-tenant sequence and recreate it at 1 whenever a NEW tenant's sequence is missing,
+    /// resetting live tenants' event sequences (seq_id reuse = silent event-store corruption).
+    /// A missing sequence only ever needs the IF-NOT-EXISTS creates; existing sequences must
+    /// never be touched by an update.
+    /// </summary>
+    private sealed class CreateSequencesDelta: ISchemaObjectDelta
+    {
+        public CreateSequencesDelta(PerTenantEventSequences sequences, SchemaPatchDifference difference)
+        {
+            SchemaObject = sequences;
+            Difference = difference;
+        }
+
+        public ISchemaObject SchemaObject { get; }
+        public SchemaPatchDifference Difference { get; }
+
+        public void WriteUpdate(Migrator rules, TextWriter writer)
+        {
+            SchemaObject.WriteCreateStatement(rules, writer);
+        }
+
+        public void WriteRollback(Migrator rules, TextWriter writer)
+        {
+        }
+
+        public void WriteRestorationOfPreviousState(Migrator rules, TextWriter writer)
+        {
+        }
     }
 
     public IEnumerable<DbObjectName> AllNames()

--- a/src/TenantPartitionedEventsTests/Regressions/schema_update_preserves_existing_per_tenant_sequences.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/schema_update_preserves_existing_per_tenant_sequences.cs
@@ -1,0 +1,125 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Regressions;
+
+/// <summary>
+/// A schema update that only needs to ADD a missing per-tenant event sequence must never touch the
+/// sequences that already exist. The generic <c>SchemaObjectDelta.WriteUpdate</c> writes updates as
+/// drop-then-create; routed through <c>PerTenantEventSequences</c> that emitted
+/// <c>DROP SEQUENCE IF EXISTS mt_events_sequence_{suffix}</c> for EVERY registered tenant whenever any
+/// ONE tenant's sequence was missing — resetting live tenants' event sequences to 1 (seq_id reuse =
+/// silent event-store corruption). Observed on the ZOD-1714 canary while 500 tenants were being
+/// provisioned: each shard's "All Configured Changes" saw the newest tenants' sequences as missing and
+/// re-emitted drop+create for all of them. The 42P07 partition-name failure in the same batch rolled it
+/// back before damage was done; with idempotent partition DDL (weasel#326) that accidental guard is
+/// gone, so the delta itself must be additive-only.
+/// </summary>
+public class schema_update_preserves_existing_per_tenant_sequences : IAsyncLifetime
+{
+    private const string TenantA = "tenant_a";
+    private const string TenantB = "tenant_b";
+
+    private string _schema = null!;
+    private DocumentStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        _schema = $"tp_seqpreserve_{Guid.NewGuid():N}".Substring(0, 32);
+
+        await using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
+        {
+            await conn.OpenAsync();
+            try { await conn.DropSchemaAsync(_schema); } catch { }
+        }
+
+        _store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = _schema;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Policies.AllDocumentsAreMultiTenanted();
+
+            opts.Events.AddEventType<SeqPreserveEvent>();
+        });
+
+        await _store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+    }
+
+    public Task DisposeAsync()
+    {
+        _store?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task adding_a_missing_sequence_does_not_reset_existing_ones()
+    {
+        await _store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, TenantA);
+        await _store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, TenantB);
+
+        // Advance tenant A's event sequence by appending real events.
+        await using (var session = _store.LightweightSession(TenantA))
+        {
+            session.Events.StartStream(Guid.NewGuid(), new SeqPreserveEvent(1), new SeqPreserveEvent(2));
+            await session.SaveChangesAsync();
+        }
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        var valueBefore = (long)(await conn
+            .CreateCommand($"select last_value from \"{_schema}\".\"mt_events_sequence_{TenantA}\"")
+            .ExecuteScalarAsync())!;
+        valueBefore.ShouldBeGreaterThanOrEqualTo(2);
+
+        // Simulate the canary scenario: a tenant is registered on the shared partition list but its
+        // sequence is missing in this database (mid-provisioning / a racing applier's stale snapshot),
+        // so the next schema apply computes an Update delta for the per-tenant sequences.
+        await conn.CreateCommand($"drop sequence \"{_schema}\".\"mt_events_sequence_{TenantB}\"")
+            .ExecuteNonQueryAsync();
+
+        await _store.Storage.Database.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // The missing sequence is (re)created...
+        var tenantBExists = await conn
+            .CreateCommand(
+                "select count(*) from information_schema.sequences " +
+                $"where sequence_schema = '{_schema}' and sequence_name = 'mt_events_sequence_{TenantB}'")
+            .ExecuteScalarAsync();
+        tenantBExists.ShouldBe(1L);
+
+        // ...and tenant A's sequence kept its value: the update was additive-only, no drop+recreate.
+        var valueAfter = (long)(await conn
+            .CreateCommand($"select last_value from \"{_schema}\".\"mt_events_sequence_{TenantA}\"")
+            .ExecuteScalarAsync())!;
+        valueAfter.ShouldBe(valueBefore);
+
+        // And the next append continues from where the sequence left off instead of colliding at 1.
+        await using (var session = _store.LightweightSession(TenantA))
+        {
+            session.Events.StartStream(Guid.NewGuid(), new SeqPreserveEvent(3));
+            await session.SaveChangesAsync();
+        }
+
+        var valueAfterAppend = (long)(await conn
+            .CreateCommand($"select last_value from \"{_schema}\".\"mt_events_sequence_{TenantA}\"")
+            .ExecuteScalarAsync())!;
+        valueAfterAppend.ShouldBeGreaterThan(valueBefore);
+    }
+}
+
+public record SeqPreserveEvent(int Number);


### PR DESCRIPTION
## Problem

`PerTenantEventSequences.CreateDeltaAsync` returns the generic `SchemaObjectDelta`, whose `WriteUpdate` writes **drop-then-create**. For this wrapper that means: whenever any ONE registered tenant's `mt_events_sequence_{suffix}` is missing from a database (a new tenant mid-provisioning, a racing applier's stale snapshot), the update script emits `DROP SEQUENCE IF EXISTS` + `CREATE SEQUENCE IF NOT EXISTS` for **every** registered tenant — resetting live tenants' event sequences to 1. The tenant's next quick-append then re-issues an already-used seq_id: a PK collision on its events partition, or an event silently below its high-water mark.

Observed in the field (production-copy environment, 500-tenant bulk provisioning under `MultiTenantedWithShardedDatabases` + `UseTenantPartitionedEvents`): every `All Configured Changes` batch re-emitted drop+create for all registered tenants. A 42P07 elsewhere in the same batch happened to roll the damage back — with idempotent partition DDL (weasel#326) that accidental guard disappears, so the delta itself must be additive-only.

## Fix

`PerTenantEventSequences` returns its own `CreateSequencesDelta` whose update path only re-runs the `CREATE SEQUENCE IF NOT EXISTS` script. Missing sequences are created; existing sequences are never touched.

## Test

`schema_update_preserves_existing_per_tenant_sequences`: registers two tenants, advances tenant A's sequence with real appends, drops tenant B's sequence to force an Update delta, applies — asserts B is recreated, A's `last_value` is untouched, and A's next live append continues after its imported height. Fails with the generic delta, passes with the additive one.

Part of the JasperFx/jasperfx#486 hardening cycle (field findings from the ZOD sharded-migration canary).