### PR TITLE
Bulk event import draws seq_ids from the tenant's own sequence under per-tenant partitioning

### DIFF
--- a/src/Marten/Events/BulkEventAppender.cs
+++ b/src/Marten/Events/BulkEventAppender.cs
@@ -42,11 +42,32 @@ internal class BulkEventAppender
 
         var schema = _events.DatabaseSchemaName;
 
-        // Step 1: Pre-allocate sequence numbers
-        var sequences = await fetchSequences(conn, schema, totalEvents, cancellation).ConfigureAwait(false);
+        // Steps 1+2: pre-allocate sequence numbers and assign them (with versions) to all events. Under
+        // per-tenant event partitioning each tenant MUST draw from its own mt_events_sequence_{suffix} —
+        // the same sequence the quick-append function uses for live appends. Drawing from the store-global
+        // sequence would leave every imported tenant's own sequence at 1, so the tenant's first live
+        // append re-issues an already-used seq_id (PK collision on its events partition).
+        if (_events.UseTenantPartitionedEvents)
+        {
+            foreach (var tenantGroup in streams.GroupBy(s => s.TenantId))
+            {
+                var tenantStreams = tenantGroup.ToList();
+                var tenantEventCount = tenantStreams.Sum(s => s.Events.Count);
+                if (tenantEventCount == 0) continue;
 
-        // Step 2: Assign versions and sequences to all events
-        assignVersionsAndSequences(streams, sequences);
+                var sequenceName = await resolveSequenceNameAsync(conn, schema, tenantGroup.Key, cancellation)
+                    .ConfigureAwait(false);
+                var tenantSequences = await fetchSequences(conn, sequenceName, tenantEventCount, cancellation)
+                    .ConfigureAwait(false);
+                assignVersionsAndSequences(tenantStreams, tenantSequences);
+            }
+        }
+        else
+        {
+            var sequences = await fetchSequences(conn, $"{schema}.mt_events_sequence", totalEvents, cancellation)
+                .ConfigureAwait(false);
+            assignVersionsAndSequences(streams, sequences);
+        }
 
         // Step 3: COPY streams
         await copyStreams(conn, schema, streams, batchSize, cancellation).ConfigureAwait(false);
@@ -58,13 +79,47 @@ internal class BulkEventAppender
         await updateHighWaterMark(conn, schema, streams, cancellation).ConfigureAwait(false);
     }
 
-    private async Task<Queue<long>> fetchSequences(
+    /// <summary>
+    /// The (schema-qualified) sequence that seq_ids for this tenant's events must be drawn from. Under
+    /// per-tenant event partitioning that is the tenant's own <c>mt_events_sequence_{suffix}</c> — the
+    /// suffix resolved from the tenants partition table exactly like the quick-append function does —
+    /// so the sequence's position stays consistent with the imported events and live appends continue
+    /// seamlessly after an import. Otherwise the store-global <c>mt_events_sequence</c>.
+    /// </summary>
+    private async Task<string> resolveSequenceNameAsync(
         NpgsqlConnection conn,
         string schema,
+        string? tenantId,
+        CancellationToken cancellation)
+    {
+        if (!_events.UseTenantPartitionedEvents || tenantId == null)
+        {
+            return $"{schema}.mt_events_sequence";
+        }
+
+        var tenantsTable = _events.Options.TenantPartitions!.TenantsTableName;
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"select partition_suffix from {tenantsTable} where partition_value = @tenant";
+        cmd.Parameters.AddWithValue("tenant", tenantId);
+        var suffix = await cmd.ExecuteScalarAsync(cancellation).ConfigureAwait(false) as string;
+
+        if (suffix == null)
+        {
+            throw new InvalidOperationException(
+                $"Tenant '{tenantId}' has no registered partition. Call AddMartenManagedTenantsAsync " +
+                "(or the sharded AddTenantToShardAsync) before bulk-importing its events.");
+        }
+
+        return $"{schema}.mt_events_sequence_{suffix}";
+    }
+
+    private async Task<Queue<long>> fetchSequences(
+        NpgsqlConnection conn,
+        string sequenceName,
         int count,
         CancellationToken cancellation)
     {
-        var sql = $"select nextval('{schema}.mt_events_sequence') from generate_series(1,{count})";
+        var sql = $"select nextval('{sequenceName}') from generate_series(1,{count})";
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
         await using var reader = await cmd.ExecuteReaderAsync(cancellation).ConfigureAwait(false);

--- a/src/TenantPartitionedEventsTests/Regressions/bulk_insert_draws_from_the_tenants_own_sequence.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/bulk_insert_draws_from_the_tenants_own_sequence.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using TenantPartitionedEventsTests.Fixtures;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Regressions;
+
+/// <summary>
+/// The bulk event import used to draw seq_ids from the STORE-GLOBAL <c>mt_events_sequence</c>. On a
+/// per-tenant-partitioned store live appends draw from the tenant's own
+/// <c>mt_events_sequence_{suffix}</c> instead (see QuickAppendEventFunction), so an import that bypasses
+/// it leaves that sequence at 1 while the tenant's events already occupy seq_ids 1..N: the tenant's
+/// FIRST live append after the import re-issues seq_id 1 — a primary-key collision on the tenant's
+/// events partition — and even a surviving append would land below the tenant's high-water mark and be
+/// silently skipped by the daemon. Caught by a production-copy spot check (ZOD-1714 canary): every
+/// migrated tenant had last_value = 1 with tens of thousands of imported events.
+///
+/// The import must draw from the tenant's own sequence, so its position ends exactly at the tenant's
+/// max seq_id and live appends continue seamlessly.
+/// </summary>
+[Collection("guid-partitioned")]
+public class bulk_insert_draws_from_the_tenants_own_sequence
+{
+    private readonly GuidPartitionedFixture _fixture;
+
+    public bulk_insert_draws_from_the_tenants_own_sequence(GuidPartitionedFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task the_tenants_sequence_ends_at_max_seq_id_and_a_live_append_continues_after_it()
+    {
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var streamId = Guid.NewGuid();
+        var action = StreamAction.Start(_fixture.Store.Events, streamId,
+            new TripStarted(streamId), new TripLeg(1.0), new TripLeg(2.0));
+        action.TenantId = tenant;
+
+        await _fixture.Store.BulkInsertEventsAsync(tenant, new[] { action });
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        long maxSeq;
+        await using (var cmd = new NpgsqlCommand(
+                         $"select max(seq_id) from {_fixture.SchemaName}.mt_events where tenant_id = @t", conn))
+        {
+            cmd.Parameters.AddWithValue("t", tenant);
+            maxSeq = (long)(await cmd.ExecuteScalarAsync())!;
+        }
+
+        maxSeq.ShouldBe(3);
+
+        // The tenant's OWN sequence supplied those seq_ids, so its position is the tenant's height.
+        await using (var cmd = new NpgsqlCommand(
+                         $"select last_value from {_fixture.SchemaName}.mt_events_sequence_{tenant}", conn))
+        {
+            ((long)(await cmd.ExecuteScalarAsync())!).ShouldBe(maxSeq,
+                "the bulk import must draw seq_ids from the tenant's own sequence — leaving it behind " +
+                "makes the tenant's first live append re-issue an already-used seq_id");
+        }
+
+        // The decisive behavior: a LIVE append directly after the import must succeed and continue
+        // numbering after the imported events (no PK collision, not below the high-water mark).
+        await using (var session = _fixture.Store.LightweightSession(tenant))
+        {
+            session.Events.Append(streamId, new TripLeg(3.0));
+            await session.SaveChangesAsync();
+        }
+
+        await using (var cmd = new NpgsqlCommand(
+                         $"select max(seq_id) from {_fixture.SchemaName}.mt_events where tenant_id = @t", conn))
+        {
+            cmd.Parameters.AddWithValue("t", tenant);
+            ((long)(await cmd.ExecuteScalarAsync())!).ShouldBe(maxSeq + 1);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Under `UseTenantPartitionedEvents`, live appends draw seq_ids from the tenant's own `mt_events_sequence_{suffix}` (see `QuickAppendEventFunction`), but `BulkInsertEventsAsync` pre-allocates from the **store-global** `mt_events_sequence`. After an import, every imported tenant's own sequence still sits at 1 while its events occupy seq_ids 1..N — the tenant's first live append re-issues seq_id 1 and dies on the primary key of its events partition.

Found by a spot check on a production-copy migration (500 tenants, sharded + tenant-partitioned): every imported tenant had `last_value = 1` with tens of thousands of imported events. This is the same allocation bug called out for the parked `BulkInsertEventStreamAsync` rework in JasperFx/jasperfx#486 (WS0), surfacing on the existing batch API.

## Fix

`BulkEventAppender` resolves the sequence per tenant from the tenants partition table — exactly the lookup the quick-append function performs — and groups mixed-tenant stream sets per tenant so each draws from its own sequence. Non-partitioned stores keep the store-global sequence, unchanged. A tenant without a registered partition fails fast with a pointer to `AddMartenManagedTenantsAsync`.

## Test

`bulk_insert_draws_from_the_tenants_own_sequence`: bulk-imports 3 events for a registered tenant, asserts the tenant's sequence `last_value` equals the max imported seq_id, then performs a LIVE append and asserts it lands at max+1 (no PK collision). Fails on master, passes with the fix.

Part of the JasperFx/jasperfx#486 hardening cycle (field findings from the ZOD sharded-migration canary).