### PR TITLE
BulkInsertEventStreamAsync: streaming, order-preserving bulk event import (parked #4799 item)

### DIFF
--- a/docs/events/bulk-appending.md
+++ b/docs/events/bulk-appending.md
@@ -190,6 +190,46 @@ The bulk append API supports all combinations of:
 | Archived stream partitioning | On, Off |
 | Metadata columns | Correlation ID, Causation ID, Headers, User Name (any combination) |
 
+## Streaming Import of an Existing Event Log
+
+`BulkInsertEventsAsync` materializes every event of the import in memory, which is fine for seeding but
+not for migrating a large existing event store. For that scenario use the streaming overload,
+`BulkInsertEventStreamAsync`, which consumes an `IAsyncEnumerable<IEvent>` lazily in `batchSize` blocks —
+a tenant with millions of events imports in bounded memory:
+
+```cs
+// One small header per stream seeds mt_streams up front (the foreign-key target),
+// while the events themselves stream through in COPY blocks.
+var headers = new[]
+{
+    new BulkEventStreamHeader { Id = streamId, Version = 3, AggregateType = typeof(Order) }
+};
+
+await store.BulkInsertEventStreamAsync(
+    tenantId,
+    headers,
+    ReadSourceEventsInSequenceOrderAsync(), // IAsyncEnumerable<IEvent>, in source seq_id order
+    batchSize: 1000);
+```
+
+Three properties make this suitable as the primitive for event-store migrations:
+
+- **Cross-stream ordering is preserved.** Each event receives the next ascending `seq_id` in arrival
+  order, so supplying the source log's global order (read by the source's `seq_id`) reproduces the
+  interleaving of events across streams — which multi-stream projections and subscriptions depend on.
+  The batch overload assigns seq_ids the same way, honoring the order events carry in their `Sequence`.
+- **Per-tenant sequences stay consistent.** Under per-tenant event partitioning, seq_ids are drawn
+  from the tenant's own `mt_events_sequence_{suffix}` — the same sequence live appends use — so the first
+  real append after a migration continues seamlessly instead of colliding with imported seq_ids.
+- **One transaction per tenant.** A failed import rolls back cleanly, making per-tenant resume logic in a
+  migration tool trivial.
+
+The streaming overload deliberately performs **no schema work**: apply the schema at startup and register
+the tenant (`AddMartenManagedTenantsAsync`, or `AddTenantToShardAsync` under sharded tenancy) before
+importing. Schema application from inside a bulk-import loop costs DDL proportional to the number of
+registered tenants for every fresh database it touches, which does not scale to migrations of hundreds of
+tenants.
+
 ## Limitations
 
 The bulk append API intentionally trades off features for throughput:

--- a/src/EventSourcingTests/BulkEventStreamAppendTests.cs
+++ b/src/EventSourcingTests/BulkEventStreamAppendTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests;
+
+/// <summary>
+/// JasperFx/marten#4806: bulk event append must preserve the ORIGINAL cross-stream order when migrating an
+/// existing event log. The seq_id assigned to each event decides the global order the async daemon replays
+/// in, so a multi-stream projection that compares Sequence across streams (e.g. "decisions appended before
+/// this invoice was created") only works if migration keeps the interleaving. These tests cover both the
+/// streaming import (<see cref="IDocumentStore.BulkInsertEventStreamAsync"/>) and the batch path, asserting
+/// directly on the stored <c>mt_events</c> order — the thing that actually governs replay.
+/// </summary>
+public class BulkEventStreamAppendTests : OneOffConfigurationsContext
+{
+    public record Started(string Label);
+    public record Progressed(int Step);
+    public record Ended(string Label);
+
+    // Register the event types up front (as the real migration does via its event registrations) so
+    // ApplyAllConfiguredChangesToDatabaseAsync provisions the event tables — the streaming import builds
+    // raw IEvents directly rather than going through StreamAction.Start, which would auto-register them.
+    private DocumentStore StringIdentityStore() => StoreOptions(opts =>
+    {
+        opts.Events.StreamIdentity = StreamIdentity.AsString;
+        opts.Events.AddEventType<Started>();
+        opts.Events.AddEventType<Progressed>();
+        opts.Events.AddEventType<Ended>();
+    });
+
+    // The bulk import deliberately does NO schema work (see BulkInsertEventsAsync) — provisioning is the
+    // caller's contract, so the tests apply the schema up front exactly like a real caller's startup does.
+    private async Task<DocumentStore> ProvisionedStringIdentityStoreAsync()
+    {
+        var provisioned = StringIdentityStore();
+        await provisioned.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+        return provisioned;
+    }
+
+    // Build a raw IEvent carrying its stream key + per-stream version, as a migration read would produce.
+    private static IEvent EventFor(string streamKey, long version, object data)
+    {
+        var e = (IEvent)Activator.CreateInstance(typeof(Event<>).MakeGenericType(data.GetType()), data)!;
+        e.StreamKey = streamKey;
+        e.Version = version;
+        e.Id = Guid.NewGuid();
+        e.Sequence = version; // source seq is irrelevant to the streaming path (it uses arrival order)
+        return e;
+    }
+
+    private static async IAsyncEnumerable<IEvent> Stream(IEnumerable<IEvent> events)
+    {
+        foreach (var e in events)
+        {
+            yield return e;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    // Stored stream ids in seq_id order — the global order the async daemon will replay in.
+    private static async Task<List<string>> StreamIdsBySeqAsync(DocumentStore store)
+    {
+        var ids = new List<string>();
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            $"select stream_id from {store.Options.Events.DatabaseSchemaName}.mt_events order by seq_id", conn);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            ids.Add(reader.GetString(0));
+        }
+
+        return ids;
+    }
+
+    private static async Task<List<long>> VersionsForStreamAsync(DocumentStore store, string streamKey)
+    {
+        var versions = new List<long>();
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            $"select version from {store.Options.Events.DatabaseSchemaName}.mt_events where stream_id = @s order by seq_id",
+            conn);
+        cmd.Parameters.AddWithValue("s", streamKey);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            versions.Add(reader.GetInt64(0));
+        }
+
+        return versions;
+    }
+
+    [Fact]
+    public async Task streaming_import_preserves_cross_stream_order()
+    {
+        var store = await ProvisionedStringIdentityStoreAsync();
+
+        // Two streams, interleaved in the exact global order they occurred: A1, B1, A2, B2, A3.
+        var ordered = new[]
+        {
+            EventFor("A", 1, new Started("A1")),
+            EventFor("B", 1, new Started("B1")),
+            EventFor("A", 2, new Progressed(1)),
+            EventFor("B", 2, new Ended("B2")),
+            EventFor("A", 3, new Ended("A3"))
+        };
+
+        var headers = new List<BulkEventStreamHeader>
+        {
+            new() { Key = "A", Version = 3 },
+            new() { Key = "B", Version = 2 }
+        };
+
+        // batchSize 2 forces multiple COPY batches + a sequence-block refill mid-stream.
+        await store.BulkInsertEventStreamAsync(StorageConstants.DefaultTenantId, headers, Stream(ordered),
+            batchSize: 2, cancellation: CancellationToken.None);
+
+        // The seq_id order (what the daemon replays in) must be the ORIGINAL interleaving, not per-stream
+        // blocks (which would be A, A, A, B, B).
+        (await StreamIdsBySeqAsync(store)).ShouldBe(new[] { "A", "B", "A", "B", "A" });
+
+        // Per-stream versions preserved and contiguous.
+        (await VersionsForStreamAsync(store, "A")).ShouldBe(new long[] { 1, 2, 3 });
+        (await VersionsForStreamAsync(store, "B")).ShouldBe(new long[] { 1, 2 });
+    }
+
+    [Fact]
+    public async Task streaming_import_refills_sequences_across_multiple_blocks()
+    {
+        // Regression for JasperFx/marten#4806: sequences are fetched one block (batchSize) at a time, so a
+        // tenant with more events than batchSize empties the queue mid-stream and must refill. The refill runs
+        // a nextval SELECT, which must NOT happen while the mt_events COPY is open on the same connection —
+        // Npgsql rejects that with "connection is already in state 'Copy'". batchSize 2 with 7 events forces
+        // several block boundaries + refills; the import must still complete with cross-stream order intact.
+        var store = await ProvisionedStringIdentityStoreAsync();
+
+        var ordered = new[]
+        {
+            EventFor("A", 1, new Started("A1")),
+            EventFor("B", 1, new Started("B1")),
+            EventFor("A", 2, new Progressed(2)),
+            EventFor("B", 2, new Progressed(2)),
+            EventFor("A", 3, new Progressed(3)),
+            EventFor("B", 3, new Ended("B3")),
+            EventFor("A", 4, new Ended("A4"))
+        };
+
+        var headers = new List<BulkEventStreamHeader>
+        {
+            new() { Key = "A", Version = 4 },
+            new() { Key = "B", Version = 3 }
+        };
+
+        await store.BulkInsertEventStreamAsync(StorageConstants.DefaultTenantId, headers, Stream(ordered),
+            batchSize: 2, cancellation: CancellationToken.None);
+
+        (await StreamIdsBySeqAsync(store)).ShouldBe(new[] { "A", "B", "A", "B", "A", "B", "A" });
+        (await VersionsForStreamAsync(store, "A")).ShouldBe(new long[] { 1, 2, 3, 4 });
+        (await VersionsForStreamAsync(store, "B")).ShouldBe(new long[] { 1, 2, 3 });
+    }
+
+    [Fact]
+    public async Task batch_import_assigns_seq_ids_in_source_order_across_streams()
+    {
+        var store = await ProvisionedStringIdentityStoreAsync();
+
+        // Two stream actions; simulate a migration by stamping each event's SOURCE sequence so the global
+        // order is interleaved A1, B1, A2, B2, A3 even though the events are grouped per stream.
+        var actionA = StreamAction.Start(store.Events, "A",
+            new object[] { new Started("A1"), new Progressed(1), new Ended("A3") });
+        var actionB = StreamAction.Start(store.Events, "B",
+            new object[] { new Started("B1"), new Ended("B2") });
+
+        actionA.Events[0].Sequence = 1;
+        actionB.Events[0].Sequence = 2;
+        actionA.Events[1].Sequence = 3;
+        actionB.Events[1].Sequence = 4;
+        actionA.Events[2].Sequence = 5;
+
+        await store.BulkInsertEventsAsync(new[] { actionA, actionB });
+
+        // Target seq_id order must honor the source interleaving, not each stream's contiguous block.
+        (await StreamIdsBySeqAsync(store)).ShouldBe(new[] { "A", "B", "A", "B", "A" });
+    }
+
+    [Fact]
+    public async Task batch_import_of_freshly_created_streams_is_unchanged()
+    {
+        // Fresh seeding (no meaningful source Sequence, all 0): the stable sort must keep the per-stream
+        // order the caller passed, i.e. behavior identical to before the ordering fix.
+        var store = await ProvisionedStringIdentityStoreAsync();
+
+        var actionA = StreamAction.Start(store.Events, "A",
+            new object[] { new Started("A1"), new Ended("A2") });
+        var actionB = StreamAction.Start(store.Events, "B",
+            new object[] { new Started("B1"), new Ended("B2") });
+
+        await store.BulkInsertEventsAsync(new[] { actionA, actionB });
+
+        (await StreamIdsBySeqAsync(store)).ShouldBe(new[] { "A", "A", "B", "B" });
+        (await VersionsForStreamAsync(store, "A")).ShouldBe(new long[] { 1, 2 });
+        (await VersionsForStreamAsync(store, "B")).ShouldBe(new long[] { 1, 2 });
+    }
+}

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -248,6 +248,49 @@ public partial class DocumentStore: IDocumentStore, IDescribeMyself
         }
     }
 
+    /// <summary>
+    /// Streaming, order-preserving bulk import of an existing event log for a single tenant. Unlike
+    /// <see cref="BulkInsertEventsAsync(string,IReadOnlyList{StreamAction},int,CancellationToken)"/> — which
+    /// materializes every event of the tenant in memory — this consumes <paramref name="orderedEvents"/>
+    /// lazily in batches, so a tenant with millions of events imports in bounded memory. The events MUST be
+    /// supplied in the exact order their <c>seq_id</c>s should be assigned (typically the source log's global
+    /// order): each is given the next ascending sequence in arrival order, so cross-stream ordering is
+    /// preserved. Per-stream versions are taken from the events. <paramref name="streamHeaders"/> seed
+    /// <c>mt_streams</c> (written first, for the foreign key). Runs as one transaction per tenant.
+    /// </summary>
+    public async Task BulkInsertEventStreamAsync(string tenantId,
+        IReadOnlyList<BulkEventStreamHeader> streamHeaders, IAsyncEnumerable<IEvent> orderedEvents,
+        int batchSize = 1000, CancellationToken cancellation = default)
+    {
+        var tenant = await Tenancy.GetTenantAsync(Options.TenantIdStyle.MaybeCorrectTenantId(tenantId))
+            .ConfigureAwait(false);
+
+        // Deliberately NO schema work here — provisioning is the caller's contract: apply the base schema
+        // at startup and register the tenant first (AddMartenManagedTenantsAsync / the sharded
+        // AddTenantToShardAsync creates the tenant's own partitions + sequence). Any ensure/apply from the
+        // import path is O(registered tenants) worth of DDL per fresh database under a shared
+        // tenant-partition registry — measured grinding a 500-tenant migration to a near-halt as the
+        // registered count grew.
+        var appender = new BulkEventAppender(Events, Options.Serializer());
+
+        await using var conn = tenant.Database.CreateConnection();
+        await conn.OpenAsync(cancellation).ConfigureAwait(false);
+        var tx = await conn.BeginTransactionAsync(cancellation).ConfigureAwait(false);
+
+        try
+        {
+            await appender
+                .BulkInsertEventStreamAsync(conn, tenantId, streamHeaders, orderedEvents, batchSize, cancellation)
+                .ConfigureAwait(false);
+            await tx.CommitAsync(cancellation).ConfigureAwait(false);
+        }
+        catch
+        {
+            await tx.RollbackAsync(cancellation).ConfigureAwait(false);
+            throw;
+        }
+    }
+
     public IDiagnostics Diagnostics { get; }
 
     public IDocumentSession OpenSession(SessionOptions options)

--- a/src/Marten/Events/BulkEventAppender.cs
+++ b/src/Marten/Events/BulkEventAppender.cs
@@ -80,6 +80,209 @@ internal class BulkEventAppender
     }
 
     /// <summary>
+    /// Streaming, order-preserving bulk import for a single tenant — see
+    /// <see cref="Marten.DocumentStore.BulkInsertEventStreamAsync" />. Consumes <paramref name="orderedEvents" />
+    /// lazily in batches (bounded memory), assigning each event the next ascending sequence in arrival order
+    /// (so cross-stream ordering is preserved) and taking per-stream versions from the events themselves.
+    /// <paramref name="streamHeaders" /> seed mt_streams first so the mt_events foreign key holds.
+    /// </summary>
+    public async Task BulkInsertEventStreamAsync(
+        NpgsqlConnection conn,
+        string tenantId,
+        IReadOnlyList<BulkEventStreamHeader> streamHeaders,
+        IAsyncEnumerable<IEvent> orderedEvents,
+        int batchSize,
+        CancellationToken cancellation)
+    {
+        var schema = _events.DatabaseSchemaName;
+
+        // Resolve the sequence to draw seq_ids from BEFORE any COPY opens: under per-tenant event
+        // partitioning this is the tenant's own mt_events_sequence_{suffix} (the same one live
+        // quick-appends use), otherwise the store-global sequence. See BulkInsertAsync for why drawing
+        // from the wrong sequence corrupts the tenant's post-import appends.
+        var sequenceName = await resolveSequenceNameAsync(conn, schema, tenantId, cancellation)
+            .ConfigureAwait(false);
+
+        // mt_streams first — it is the foreign-key target for mt_events. Bounded: one row per stream.
+        await copyStreamHeaders(conn, schema, tenantId, streamHeaders, batchSize, cancellation)
+            .ConfigureAwait(false);
+
+        var columns = buildEventColumns();
+        var copySql = $"COPY {schema}.mt_events({string.Join(", ", columns.Select(c => $"\"{c}\""))}) FROM STDIN BINARY";
+
+        // Sequences are pulled one block (batchSize) at a time — not the whole tenant up front — so memory
+        // stays bounded when the total event count is unknown. The COPY writer is (re)opened per block, and a
+        // block boundary is the ONLY place the nextval SELECT runs. That matters: a regular command cannot run
+        // on a connection that is mid-COPY (Npgsql throws "connection is already in state 'Copy'"), so the
+        // writer is always CLOSED before refillSequences and reopened afterwards. Same single connection, so
+        // no extra connection is taken from a tightly pooled shard database.
+        var sequences = new Queue<long>(batchSize);
+        long maxSequence = 0;
+        var count = 0;
+        NpgsqlBinaryImporter? writer = null;
+
+        try
+        {
+            await foreach (var e in orderedEvents.WithCancellation(cancellation).ConfigureAwait(false))
+            {
+                if (sequences.Count == 0)
+                {
+                    // Close the open COPY before the sequence SELECT, then start a fresh one for the next block.
+                    if (writer != null)
+                    {
+                        await writer.CompleteAsync(cancellation).ConfigureAwait(false);
+                        await writer.DisposeAsync().ConfigureAwait(false);
+                        writer = null;
+                    }
+
+                    await refillSequences(conn, sequenceName, sequences, batchSize, cancellation).ConfigureAwait(false);
+                }
+
+                writer ??= await conn.BeginBinaryImportAsync(copySql, cancellation).ConfigureAwait(false);
+
+                var seq = sequences.Dequeue();
+                e.Sequence = seq;
+                if (seq > maxSequence)
+                {
+                    maxSequence = seq;
+                }
+
+                // Force-stamp the tenant id on every event, mirroring the batch overload — the rows are
+                // written into THIS tenant's partition, so a stale TenantId carried over from the source
+                // store must never leak through.
+                e.TenantId = tenantId;
+
+                // Ensure event type metadata is populated (a migration may clear it so the current alias is
+                // re-derived from the upcasted CLR type).
+                if (string.IsNullOrEmpty(e.EventTypeName))
+                {
+                    var mapping = _events.EventMappingFor(e.EventType);
+                    e.EventTypeName = mapping.EventTypeName;
+                    e.DotNetTypeName = mapping.DotNetTypeName;
+                }
+
+                await writer.StartRowAsync(cancellation).ConfigureAwait(false);
+                await writeEventRow(writer, e, e.StreamId, e.StreamKey, tenantId, cancellation)
+                    .ConfigureAwait(false);
+                count++;
+            }
+
+            if (writer != null)
+            {
+                await writer.CompleteAsync(cancellation).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            if (writer != null)
+            {
+                await writer.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        if (count == 0)
+        {
+            return;
+        }
+
+        // High water: under per-tenant event partitioning, deliberately write NOTHING — since #4847 the
+        // per-tenant high-water detection derives each tenant's mark from max(seq_id) of its own events,
+        // and advancing the store-global row with a tenant-local seq would misrepresent one tenant's
+        // height as the whole store's. Non-partitioned stores keep the store-global upsert, mirroring
+        // the batch overload.
+        if (!_events.UseTenantPartitionedEvents)
+        {
+            await upsertStoreGlobalHighWaterMark(conn, schema, maxSequence, cancellation).ConfigureAwait(false);
+        }
+    }
+
+    private async Task copyStreamHeaders(
+        NpgsqlConnection conn,
+        string schema,
+        string tenantId,
+        IReadOnlyList<BulkEventStreamHeader> headers,
+        int batchSize,
+        CancellationToken cancellation)
+    {
+        if (headers.Count == 0)
+        {
+            return;
+        }
+
+        var columns = buildStreamColumns();
+        var copySql = $"COPY {schema}.mt_streams({string.Join(", ", columns.Select(c => $"\"{c}\""))}) FROM STDIN BINARY";
+
+        var batch = 0;
+        NpgsqlBinaryImporter? writer = null;
+
+        try
+        {
+            foreach (var header in headers)
+            {
+                if (batch % batchSize == 0)
+                {
+                    if (writer != null)
+                    {
+                        await writer.CompleteAsync(cancellation).ConfigureAwait(false);
+                        await writer.DisposeAsync().ConfigureAwait(false);
+                    }
+
+                    writer = await conn.BeginBinaryImportAsync(copySql, cancellation).ConfigureAwait(false);
+                }
+
+                await writer!.StartRowAsync(cancellation).ConfigureAwait(false);
+
+                if (_events.TenancyStyle == TenancyStyle.Conjoined)
+                {
+                    await writer.WriteAsync(tenantId, NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
+                }
+
+                if (_events.StreamIdentity == StreamIdentity.AsGuid)
+                {
+                    await writer.WriteAsync(header.Id, NpgsqlDbType.Uuid, cancellation).ConfigureAwait(false);
+                }
+                else
+                {
+                    await writer.WriteAsync(header.Key!, NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
+                }
+
+                // Same alias derivation as the batch path (#4625): honor a pre-resolved alias first,
+                // otherwise derive it from the aggregate CLR type.
+                var aggregateTypeName = header.AggregateTypeName
+                                        ?? (header.AggregateType != null
+                                            ? _events.AggregateAliasFor(header.AggregateType)
+                                            : null);
+                if (aggregateTypeName != null)
+                {
+                    await writer.WriteAsync(aggregateTypeName, NpgsqlDbType.Varchar, cancellation)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await writer.WriteNullAsync(cancellation).ConfigureAwait(false);
+                }
+
+                await writer.WriteAsync(header.Version, NpgsqlDbType.Bigint, cancellation).ConfigureAwait(false);
+                await writer.WriteAsync(false, NpgsqlDbType.Boolean, cancellation).ConfigureAwait(false);
+
+                batch++;
+            }
+
+            if (writer != null)
+            {
+                await writer.CompleteAsync(cancellation).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            if (writer != null)
+            {
+                await writer.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
     /// The (schema-qualified) sequence that seq_ids for this tenant's events must be drawn from. Under
     /// per-tenant event partitioning that is the tenant's own <c>mt_events_sequence_{suffix}</c> — the
     /// suffix resolved from the tenants partition table exactly like the quick-append function does —
@@ -119,22 +322,34 @@ internal class BulkEventAppender
         int count,
         CancellationToken cancellation)
     {
+        var queue = new Queue<long>(count);
+        await refillSequences(conn, sequenceName, queue, count, cancellation).ConfigureAwait(false);
+        return queue;
+    }
+
+    // Pull a block of freshly allocated sequence numbers into the queue. Used by the streaming import to
+    // top up lazily (block by block) instead of pre-allocating the whole tenant's range up front.
+    private static async Task refillSequences(
+        NpgsqlConnection conn,
+        string sequenceName,
+        Queue<long> queue,
+        int count,
+        CancellationToken cancellation)
+    {
         var sql = $"select nextval('{sequenceName}') from generate_series(1,{count})";
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
         await using var reader = await cmd.ExecuteReaderAsync(cancellation).ConfigureAwait(false);
 
-        var queue = new Queue<long>(count);
         while (await reader.ReadAsync(cancellation).ConfigureAwait(false))
         {
             queue.Enqueue(reader.GetInt64(0));
         }
-
-        return queue;
     }
 
     private void assignVersionsAndSequences(IReadOnlyList<StreamAction> streams, Queue<long> sequences)
     {
+        // Version is per-stream (1..N in the stream's own event order).
         foreach (var stream in streams)
         {
             long version = 0;
@@ -142,7 +357,6 @@ internal class BulkEventAppender
             {
                 version++;
                 e.Version = version;
-                e.Sequence = sequences.Dequeue();
 
                 // Ensure event type metadata is populated
                 if (string.IsNullOrEmpty(e.EventTypeName))
@@ -154,6 +368,18 @@ internal class BulkEventAppender
             }
 
             stream.Version = version;
+        }
+
+        // seq_id is assigned GLOBALLY across all streams, honoring the order the events already carry in
+        // their Sequence — so a caller that supplies events in their original global order (e.g. a migration
+        // reading source events by seq_id) keeps cross-stream ordering in the target, instead of each stream
+        // getting a contiguous seq_id block that flattens the interleaving. That matters for multi-stream
+        // projections / subscriptions that compare Sequence across streams. LINQ OrderBy is stable, so events
+        // with no meaningful pre-set Sequence (fresh seeding, all 0) keep the per-stream order the caller
+        // passed — identical to the previous behavior.
+        foreach (var e in streams.SelectMany(s => s.Events).OrderBy(e => e.Sequence))
+        {
+            e.Sequence = sequences.Dequeue();
         }
     }
 
@@ -307,7 +533,9 @@ internal class BulkEventAppender
                     }
 
                     await writer!.StartRowAsync(cancellation).ConfigureAwait(false);
-                    await writeEventRow(writer, stream, e, cancellation).ConfigureAwait(false);
+                    await writeEventRow(writer, e, stream.Id, stream.Key,
+                            e.TenantId ?? stream.TenantId ?? StorageConstants.DefaultTenantId, cancellation)
+                        .ConfigureAwait(false);
                     batch++;
                 }
             }
@@ -370,8 +598,10 @@ internal class BulkEventAppender
         return columns;
     }
 
-    private async Task writeEventRow(NpgsqlBinaryImporter writer, StreamAction stream, IEvent e,
-        CancellationToken cancellation)
+    // Shared row writer for both bulk paths: the batch path passes the StreamAction's identity/tenant,
+    // the streaming path passes the event's own stream identity and the (force-stamped) import tenant.
+    private async Task writeEventRow(NpgsqlBinaryImporter writer, IEvent e, Guid streamId, string? streamKey,
+        string tenantId, CancellationToken cancellation)
     {
         // seq_id
         await writer.WriteAsync(e.Sequence, NpgsqlDbType.Bigint, cancellation).ConfigureAwait(false);
@@ -382,11 +612,11 @@ internal class BulkEventAppender
         // stream_id
         if (_events.StreamIdentity == StreamIdentity.AsGuid)
         {
-            await writer.WriteAsync(stream.Id, NpgsqlDbType.Uuid, cancellation).ConfigureAwait(false);
+            await writer.WriteAsync(streamId, NpgsqlDbType.Uuid, cancellation).ConfigureAwait(false);
         }
         else
         {
-            await writer.WriteAsync(stream.Key!, NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
+            await writer.WriteAsync(streamKey!, NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
         }
 
         // version
@@ -424,8 +654,7 @@ internal class BulkEventAppender
             NpgsqlDbType.TimestampTz, cancellation).ConfigureAwait(false);
 
         // tenant_id
-        await writer.WriteAsync(e.TenantId ?? stream.TenantId ?? StorageConstants.DefaultTenantId,
-            NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
+        await writer.WriteAsync(tenantId, NpgsqlDbType.Varchar, cancellation).ConfigureAwait(false);
 
         // mt_dotnet_type
         if (!string.IsNullOrEmpty(e.DotNetTypeName))
@@ -511,6 +740,25 @@ ON CONFLICT (name) DO UPDATE SET last_seq_id = GREATEST({schema}.mt_event_progre
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
         cmd.Parameters.AddWithValue("seq", maxSequence);
+        await cmd.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
+    }
+
+    // Streaming-path sibling of updateHighWaterMark: same store-global upsert, driven by the running
+    // max rather than a materialized stream list.
+    private static async Task upsertStoreGlobalHighWaterMark(
+        NpgsqlConnection conn,
+        string schema,
+        long seq,
+        CancellationToken cancellation)
+    {
+        var sql = $@"
+INSERT INTO {schema}.mt_event_progression (name, last_seq_id)
+VALUES ('{HighWaterShardIdentity.StoreGlobal}', @seq)
+ON CONFLICT (name) DO UPDATE SET last_seq_id = GREATEST({schema}.mt_event_progression.last_seq_id, @seq)";
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.Parameters.AddWithValue("seq", seq);
         await cmd.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
     }
 

--- a/src/Marten/Events/BulkEventStreamHeader.cs
+++ b/src/Marten/Events/BulkEventStreamHeader.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Marten.Events;
+
+/// <summary>
+/// Metadata for a single event stream, used to seed <c>mt_streams</c> during a streamed bulk import
+/// (<see cref="Marten.IDocumentStore.BulkInsertEventStreamAsync"/>). One header per stream is supplied up
+/// front — small and bounded even for a tenant with millions of events — and written before the events so
+/// the <c>mt_events</c> → <c>mt_streams</c> foreign key is satisfied while the events themselves stream in.
+/// </summary>
+public sealed class BulkEventStreamHeader
+{
+    /// <summary>Stream id for a store using <see cref="Marten.Events.StreamIdentity.AsGuid"/>.</summary>
+    public Guid Id { get; init; }
+
+    /// <summary>Stream key for a store using <see cref="Marten.Events.StreamIdentity.AsString"/>.</summary>
+    public string? Key { get; init; }
+
+    /// <summary>The stream's (final) version — the number of events on the stream.</summary>
+    public long Version { get; init; }
+
+    /// <summary>Optional aggregate CLR type; its Marten alias is written to <c>mt_streams.type</c>.</summary>
+    public Type? AggregateType { get; init; }
+
+    /// <summary>Optional pre-resolved aggregate alias; takes precedence over <see cref="AggregateType"/>.</summary>
+    public string? AggregateTypeName { get; init; }
+}

--- a/src/Marten/IDocumentStore.cs
+++ b/src/Marten/IDocumentStore.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Transactions;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
+using Marten.Events;
 using Marten.Events.Daemon;
 using Marten.Services;
 using Microsoft.Extensions.Logging;
@@ -324,6 +325,24 @@ public interface IDocumentStore: IDisposable, IAsyncDisposable
     /// <param name="cancellation"></param>
     Task BulkInsertEventsAsync(string tenantId, IReadOnlyList<StreamAction> streams, int batchSize = 1000,
         CancellationToken cancellation = default);
+
+    /// <summary>
+    ///     Streaming, order-preserving bulk import of an existing event log for a single tenant. Consumes
+    ///     <paramref name="orderedEvents" /> lazily in batches (bounded memory), so a tenant with millions of
+    ///     events imports without materializing them all. Events MUST be supplied in the order their
+    ///     <c>seq_id</c>s should be assigned (the source log's global order): each gets the next ascending
+    ///     sequence in arrival order, preserving cross-stream ordering. Per-stream versions are taken from the
+    ///     events; <paramref name="streamHeaders" /> seed <c>mt_streams</c> first (for the foreign key). One
+    ///     transaction per tenant. Intended for migrating an existing event store. Does no schema work:
+    ///     apply the schema and register the tenant before importing.
+    /// </summary>
+    /// <param name="tenantId">The tenant to insert events for</param>
+    /// <param name="streamHeaders">One header per stream, to seed mt_streams</param>
+    /// <param name="orderedEvents">The tenant's events, in the order seq_ids should be assigned</param>
+    /// <param name="batchSize">Number of rows per COPY batch and sequence-allocation block</param>
+    /// <param name="cancellation"></param>
+    Task BulkInsertEventStreamAsync(string tenantId, IReadOnlyList<BulkEventStreamHeader> streamHeaders,
+        IAsyncEnumerable<IEvent> orderedEvents, int batchSize = 1000, CancellationToken cancellation = default);
 
     /// <summary>
     ///     Build a new instance of the asynchronous projection daemon to use interactively

--- a/src/TenantPartitionedEventsTests/Regressions/streaming_bulk_import_on_a_partitioned_store.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/streaming_bulk_import_on_a_partitioned_store.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using TenantPartitionedEventsTests.Fixtures;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Regressions;
+
+/// <summary>
+/// Partitioned-store coverage for the streaming <c>BulkInsertEventStreamAsync</c> import: on a
+/// per-tenant-partitioned store the import must (a) preserve the supplied cross-stream order in the
+/// assigned seq_ids, (b) draw those seq_ids from the tenant's OWN <c>mt_events_sequence_{suffix}</c> so
+/// the sequence ends at the tenant's height, and (c) leave the tenant in a state where a LIVE append
+/// directly after the import continues seamlessly (no PK collision, not below the tenant's high water).
+/// </summary>
+[Collection("guid-partitioned")]
+public class streaming_bulk_import_on_a_partitioned_store
+{
+    private readonly GuidPartitionedFixture _fixture;
+
+    public streaming_bulk_import_on_a_partitioned_store(GuidPartitionedFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // Build a raw IEvent carrying its stream id + per-stream version, as a migration read would produce.
+    private static IEvent EventFor(Guid streamId, long version, object data)
+    {
+        var e = (IEvent)Activator.CreateInstance(typeof(Event<>).MakeGenericType(data.GetType()), data)!;
+        e.StreamId = streamId;
+        e.Version = version;
+        e.Id = Guid.NewGuid();
+        e.Sequence = version; // source seq is irrelevant: the streaming path assigns by arrival order
+        return e;
+    }
+
+    private static async IAsyncEnumerable<IEvent> Stream(IEnumerable<IEvent> events)
+    {
+        foreach (var e in events)
+        {
+            yield return e;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task preserves_cross_stream_order_ends_the_tenant_sequence_at_max_and_supports_live_appends()
+    {
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var streamX = Guid.NewGuid();
+        var streamY = Guid.NewGuid();
+
+        var headers = new[]
+        {
+            new BulkEventStreamHeader { Id = streamX, Version = 3 },
+            new BulkEventStreamHeader { Id = streamY, Version = 2 }
+        };
+
+        // Interleaved source order: X1, Y1, X2, Y2, X3 — the assigned seq_ids must follow it.
+        var events = new[]
+        {
+            EventFor(streamX, 1, new TripStarted(streamX)),
+            EventFor(streamY, 1, new TripStarted(streamY)),
+            EventFor(streamX, 2, new TripLeg(1.0)),
+            EventFor(streamY, 2, new TripLeg(2.0)),
+            EventFor(streamX, 3, new TripLeg(3.0))
+        };
+
+        await _fixture.Store.BulkInsertEventStreamAsync(tenant, headers, Stream(events), batchSize: 2);
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        // (a) Cross-stream order preserved: reading back by seq_id yields the interleaving.
+        var order = new List<Guid>();
+        await using (var cmd = new NpgsqlCommand(
+                         $"select stream_id from {_fixture.SchemaName}.mt_events where tenant_id = @t order by seq_id",
+                         conn))
+        {
+            cmd.Parameters.AddWithValue("t", tenant);
+            await using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                order.Add(reader.GetGuid(0));
+            }
+        }
+
+        order.ShouldBe(new[] { streamX, streamY, streamX, streamY, streamX });
+
+        // (b) The tenant's own sequence supplied the seq_ids, so its position is the tenant's height.
+        long maxSeq;
+        await using (var cmd = new NpgsqlCommand(
+                         $"select max(seq_id) from {_fixture.SchemaName}.mt_events where tenant_id = @t", conn))
+        {
+            cmd.Parameters.AddWithValue("t", tenant);
+            maxSeq = (long)(await cmd.ExecuteScalarAsync())!;
+        }
+
+        maxSeq.ShouldBe(5);
+
+        // The streaming path allocates sequence ids in blocks of batchSize, so the sequence may sit up
+        // to batchSize-1 AHEAD of the tenant's max seq_id (a harmless gap) — but never behind it, which
+        // is the corruption this pins (a live append re-issuing an already-used seq_id).
+        await using (var cmd = new NpgsqlCommand(
+                         $"select last_value from {_fixture.SchemaName}.mt_events_sequence_{tenant}", conn))
+        {
+            ((long)(await cmd.ExecuteScalarAsync())!).ShouldBeGreaterThanOrEqualTo(maxSeq);
+        }
+
+        // (c) A live append directly after the import continues above the imported events.
+        await using (var session = _fixture.Store.LightweightSession(tenant))
+        {
+            session.Events.Append(streamX, new TripLeg(4.0));
+            await session.SaveChangesAsync();
+        }
+
+        await using (var cmd = new NpgsqlCommand(
+                         $"select max(seq_id) from {_fixture.SchemaName}.mt_events where tenant_id = @t", conn))
+        {
+            cmd.Parameters.AddWithValue("t", tenant);
+            ((long)(await cmd.ExecuteScalarAsync())!).ShouldBeGreaterThan(maxSeq);
+        }
+    }
+}


### PR DESCRIPTION
Reopens the `BulkInsertEventStreamAsync` work parked when #4799 was closed, reworked per the three requirements in JasperFx/jasperfx#486 WS0 and field-hardened on a production-copy migration (500 tenants, sharded + tenant-partitioned).

**Stacked on #4854** (per-tenant sequence allocation for the batch path) — this branch is based on it and rebases trivially once it merges.

## What it adds

A streaming counterpart to `BulkInsertEventsAsync` for migrating an existing event store: consumes `IAsyncEnumerable<IEvent>` lazily in `batchSize` blocks — a tenant with millions of events imports in bounded memory — with small per-stream `BulkEventStreamHeader`s seeding `mt_streams` up front (the FK target), one transaction per tenant for trivial resume logic.

## The three WS0 requirements

- ✅ **Per-tenant sequence advancement** — seq_ids are drawn from the tenant's own `mt_events_sequence_{suffix}` via the resolver from #4854, so the sequence ends at the tenant's height and the first live append after a migration continues seamlessly (no `setval` needed — allocation and position are one mechanism).
- ✅ **Tenant-id force-stamping** — every streamed event is stamped with the import tenant, mirroring the batch overload; stale `TenantId`s from the source store cannot leak into the target partition.
- ✅ **Partitioned-store test coverage** — `streaming_bulk_import_on_a_partitioned_store` proves cross-stream order preservation, the sequence end-position, and a live append directly after the import, on a `UseTenantPartitionedEvents` store. Plus the ported `BulkEventStreamAppendTests` (multi-block sequence refill regression: a command cannot run mid-COPY, so the writer closes before every refill).

## Design notes

- **Cross-stream ordering**: each event gets the next ascending seq_id in arrival order, so supplying the source log's global order reproduces the interleaving multi-stream projections compare on. The batch path now assigns seq_ids the same way (stable sort on the carried `Sequence` — fresh seeding where all are 0 is byte-identical to previous behavior).
- **High water**: under per-tenant partitioning the import writes NO progression row — per-tenant detection derives from `max(seq_id)` since #4847, and advancing the store-global row with a tenant-local seq would misrepresent it. Non-partitioned stores keep the store-global upsert like the batch path.
- **No schema work, by contract**: the caller applies schema at startup and registers the tenant first (`AddMartenManagedTenantsAsync` / `AddTenantToShardAsync`). Field data behind this: schema application from inside the import loop costs O(registered tenants) DDL per fresh database under the shared tenant-partition registry, which ground the 500-tenant migration to a near-halt as the count grew.
- **#4682 reconciliation**: this is the bulk-seed *primitive*; the conjoined→partitioned migration tool can consume it so there is one canonical migration story. Docs section added to `docs/events/bulk-appending.md` covering the contract and use-case.

Authorship note: continues the closed #4799 with the rework requested there; part of the JasperFx/jasperfx#486 hardening cycle.