### PR TITLE
W2 gatekeeper (#4821): segregate QueryMembers onto ILinqDocumentStorage

### DIFF
--- a/src/Marten/Events/EventDocumentStorage.cs
+++ b/src/Marten/Events/EventDocumentStorage.cs
@@ -35,7 +35,7 @@ namespace Marten.Events;
 ///     mapping for the event store in a running system. The actual implementation of this
 ///     base type is generated and compiled at runtime by Marten
 /// </summary>
-public abstract class EventDocumentStorage: IEventStorage
+public abstract class EventDocumentStorage: IEventStorage, ILinqDocumentStorage
 {
     private readonly ISqlFragment _defaultWhere;
     private readonly string[] _fields;

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -216,7 +216,7 @@ public abstract class EventMapping: EventTypeData, IDocumentMapping, IEventType
     }
 }
 
-public class EventMapping<T>: EventMapping, IDocumentStorage<T> where T : class
+public class EventMapping<T>: EventMapping, IDocumentStorage<T>, ILinqDocumentStorage where T : class
 {
     private readonly string _tableName;
     private readonly Type _idType;

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -42,7 +42,7 @@ internal interface IHaveMetadataColumns
 
 [UnconditionalSuppressMessage("Trimming", "IL2026",
     Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
-public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, IHaveMetadataColumns where T : notnull where TId : notnull
+public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, ILinqDocumentStorage, IHaveMetadataColumns where T : notnull where TId : notnull
 {
     protected readonly string _loadArraySql;
     protected readonly string _loaderSql;

--- a/src/Marten/Internal/Storage/IDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IDocumentStorage.cs
@@ -48,8 +48,6 @@ public interface IDocumentStorage: ISelectClause
 
     ISqlFragment? DefaultWhereFragment();
 
-    IQueryableMemberCollection QueryMembers { get; }
-
     /// <summary>
     /// Necessary (maybe) for usage within the temporary tables when using Includes()
     /// </summary>

--- a/src/Marten/Internal/Storage/ILinqDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/ILinqDocumentStorage.cs
@@ -1,0 +1,16 @@
+#nullable enable
+using Marten.Linq.Members;
+
+namespace Marten.Internal.Storage;
+
+/// <summary>
+///     Marten-side extension of the neutral <see cref="IDocumentStorage"/> contract that carries the
+///     LINQ query-translation member model (<see cref="IQueryableMemberCollection"/>). Kept off the
+///     movable <see cref="IDocumentStorage"/> surface so that contract can relocate to the db-agnostic
+///     Weasel.Storage package (#4821) without dragging Marten's LINQ member model — the LINQ query
+///     pipeline reaches <see cref="QueryMembers"/> through this facet instead.
+/// </summary>
+public interface ILinqDocumentStorage: IDocumentStorage
+{
+    IQueryableMemberCollection QueryMembers { get; }
+}

--- a/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
@@ -26,7 +26,7 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Internal.Storage;
 
-internal class SubClassDocumentStorage<T, TRoot, TId>: IDocumentStorage<T, TId>, IHaveMetadataColumns
+internal class SubClassDocumentStorage<T, TRoot, TId>: IDocumentStorage<T, TId>, ILinqDocumentStorage, IHaveMetadataColumns
     where T : notnull, TRoot where TId : notnull where TRoot : notnull
 {
     private readonly ISqlFragment? _defaultWhere;

--- a/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
+++ b/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
@@ -56,7 +56,7 @@ internal interface IValueTypeStorage<TDoc, TValueType>
 
 [UnconditionalSuppressMessage("Trimming", "IL2026",
     Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
-internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: IDocumentStorage<TDoc, TSimple>,  IValueTypeStorage<TDoc, TValueType> where TDoc : notnull where TSimple : notnull where TValueType : notnull
+internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: IDocumentStorage<TDoc, TSimple>, ILinqDocumentStorage, IValueTypeStorage<TDoc, TValueType> where TDoc : notnull where TSimple : notnull where TValueType : notnull
 {
     private readonly Func<TSimple, TValueType> _converter;
     private readonly Func<TValueType,TSimple> _unwrapper;
@@ -110,7 +110,7 @@ internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: ID
     public ISqlFragment DefaultWhereFragment()
         => Inner.DefaultWhereFragment();
 
-    public IQueryableMemberCollection QueryMembers => Inner.QueryMembers;
+    public IQueryableMemberCollection QueryMembers => ((ILinqDocumentStorage)Inner).QueryMembers;
     public ISelectClause SelectClauseWithDuplicatedFields => Inner.SelectClauseWithDuplicatedFields;
     public bool UseNumericRevisions => Inner.UseNumericRevisions;
     public object RawIdentityValue(object id) => Inner.RawIdentityValue(id);

--- a/src/Marten/Linq/CollectionUsage.Compilation.cs
+++ b/src/Marten/Linq/CollectionUsage.Compilation.cs
@@ -334,7 +334,7 @@ public partial class CollectionUsage
         }
 
         // 1. Convert the outer statement to a CTE
-        var outerStorage = session.StorageFor(ElementType);
+        var outerStorage = (ILinqDocumentStorage)session.StorageFor(ElementType);
         var outerCollection = outerStorage.QueryMembers;
 
         outerStatement.Mode = StatementMode.CommonTableExpression;
@@ -345,7 +345,7 @@ public partial class CollectionUsage
         outerStatement.SelectClause = outerStorage.SelectClauseWithDuplicatedFields;
 
         // 2. Create the inner CTE
-        var innerStorage = session.StorageFor(groupJoin.InnerElementType);
+        var innerStorage = (ILinqDocumentStorage)session.StorageFor(groupJoin.InnerElementType);
         var innerCollection = innerStorage.QueryMembers;
 
         var innerStatement = new SelectorStatement

--- a/src/Marten/Linq/Includes/IncludePlan.cs
+++ b/src/Marten/Linq/Includes/IncludePlan.cs
@@ -82,7 +82,7 @@ internal class IncludePlan<T>: IIncludePlan where T : notnull
             }
 
 
-            var parser = new WhereClauseParser(((IMartenSession)martenSession).Options, _storage.QueryMembers, filters);
+            var parser = new WhereClauseParser(((IMartenSession)martenSession).Options, ((ILinqDocumentStorage)_storage).QueryMembers, filters);
             parser.Visit(body);
         }
 

--- a/src/Marten/Linq/Includes/MartenQueryableIncludeBuilder.cs
+++ b/src/Marten/Linq/Includes/MartenQueryableIncludeBuilder.cs
@@ -52,7 +52,7 @@ internal class MartenQueryableIncludeBuilder<T, TInclude>: IMartenQueryableInclu
     internal IIncludePlan BuildInclude(Expression<Func<T, object>> idSource, Expression? where = null)
     {
         var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor(typeof(TInclude));
-        var identityMember = _martenLinqQueryable.Session.StorageFor(typeof(T)).QueryMembers.MemberFor(idSource);
+        var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(T))).QueryMembers.MemberFor(idSource);
 
         var include = new IncludePlan<TInclude>(storage, identityMember, _callback) { Where = where };
 
@@ -65,8 +65,8 @@ internal class MartenQueryableIncludeBuilder<T, TInclude>: IMartenQueryableInclu
         Expression? where = null)
     {
         var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor(typeof(TInclude));
-        var identityMember = _martenLinqQueryable.Session.StorageFor(typeof(T)).QueryMembers.MemberFor(idSource);
-        var mappingMember = _martenLinqQueryable.Session.StorageFor(typeof(TInclude)).QueryMembers.MemberFor(idMapping);
+        var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(T))).QueryMembers.MemberFor(idSource);
+        var mappingMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(TInclude))).QueryMembers.MemberFor(idMapping);
 
         var include = new IncludePlan<TInclude>(storage, identityMember, mappingMember, _callback) { Where = where };
 
@@ -177,7 +177,7 @@ internal class MartenQueryableIncludeBuilder<T, TKey, TInclude>
         var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor(typeof(TInclude));
         if (storage is IDocumentStorage<TInclude, TKey> typedStorage)
         {
-            var identityMember = _martenLinqQueryable.Session.StorageFor(typeof(T)).QueryMembers.MemberFor(idSource);
+            var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(T))).QueryMembers.MemberFor(idSource);
 
             void Callback(TInclude item)
             {
@@ -206,8 +206,8 @@ internal class MartenQueryableIncludeBuilder<T, TKey, TInclude>
 
         var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor(typeof(TInclude));
 
-        var identityMember = _martenLinqQueryable.Session.StorageFor(typeof(T)).QueryMembers.MemberFor(idSource);
-        var mappingMember = _martenLinqQueryable.Session.StorageFor(typeof(TInclude)).QueryMembers.MemberFor(idMapping);
+        var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(T))).QueryMembers.MemberFor(idSource);
+        var mappingMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(TInclude))).QueryMembers.MemberFor(idMapping);
 
         return new IncludePlan<TInclude>(storage, identityMember, mappingMember, Callback);
     }
@@ -230,8 +230,8 @@ internal class MartenQueryableIncludeBuilder<T, TKey, TInclude>
 
         var storage = (IDocumentStorage<TInclude>)_martenLinqQueryable.Session.StorageFor(typeof(TInclude));
 
-        var identityMember = _martenLinqQueryable.Session.StorageFor(typeof(T)).QueryMembers.MemberFor(idSource);
-        var mappingMember = _martenLinqQueryable.Session.StorageFor(typeof(TInclude)).QueryMembers.MemberFor(idMapping);
+        var identityMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(T))).QueryMembers.MemberFor(idSource);
+        var mappingMember = ((ILinqDocumentStorage)_martenLinqQueryable.Session.StorageFor(typeof(TInclude))).QueryMembers.MemberFor(idMapping);
 
         return new IncludePlan<TInclude>(storage, identityMember, mappingMember, Callback);
     }

--- a/src/Marten/Linq/Parsing/LinqQueryParser.Statements.cs
+++ b/src/Marten/Linq/Parsing/LinqQueryParser.Statements.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Marten.Linq.SqlGeneration;
 
 using Marten.Internal;
+using Marten.Internal.Storage;
 
 namespace Marten.Linq.Parsing;
 
@@ -23,7 +24,7 @@ internal partial class LinqQueryParser
             _collectionUsages[i - 1].Inner = _collectionUsages[i];
         }
 
-        var documentStorage = Session.StorageFor(top.ElementType);
+        var documentStorage = (ILinqDocumentStorage)Session.StorageFor(top.ElementType);
         var collection = documentStorage.QueryMembers;
 
         // In case the single value mode is passed through by the MartenLinqProvider

--- a/src/Marten/Linq/SqlGeneration/StatementOperation.cs
+++ b/src/Marten/Linq/SqlGeneration/StatementOperation.cs
@@ -78,7 +78,7 @@ internal class StatementOperation: Statement, IStorageOperation
             body = l.Body;
         }
 
-        ParseWhereClause(new[] { body }, session, _storage.QueryMembers, _storage);
+        ParseWhereClause(new[] { body }, session, ((ILinqDocumentStorage)_storage).QueryMembers, _storage);
 
         return Wheres.SingleOrDefault();
     }


### PR DESCRIPTION
Part of the **W2 closed-shape storage extraction** epic (#4821); third gatekeeper refactor toward relocating the neutral storage contract into the Npgsql-free **Weasel.Storage** package. (GK #1 = #4850, GK #2 = #4851.)

### The seam
`IDocumentStorage` exposed `IQueryableMemberCollection QueryMembers` — Marten's LINQ query-translation member model (`Marten.Linq.Members`). That coupling would block moving the neutral `IDocumentStorage` CRUD contract into a package that must not reference `Marten.Linq`.

### The change (interface segregation)
Introduce a Marten-side **`ILinqDocumentStorage : IDocumentStorage`** that carries `QueryMembers`, and remove the accessor from `IDocumentStorage`.

- **5 implementors** gain the facet — `DocumentStorage<T,TId>`, `SubClassDocumentStorage`, `ValueTypeIdentifiedDocumentStorage`, `EventDocumentStorage`, `EventMapping<T>`. Their existing property bodies satisfy it unchanged; `ValueTypeIdentifiedDocumentStorage` casts its `Inner` storage.
- **5 LINQ consumers** cast the storage reference they already hold to the facet — `StatementOperation`, `CollectionUsage`, `IncludePlan`, `MartenQueryableIncludeBuilder`, `LinqQueryParser`. No new parameters, no signature changes ripple out (because `ILinqDocumentStorage : IDocumentStorage`, downstream uses of the same variable keep binding).

The `IDocumentMapping` side (`DocumentMapping`/`SubClassMapping`/`EventMapping`/`EventQueryMapping`) has a *different* `QueryMembers` member and is untouched.

### Scope / risk
`Marten.Internal.*` surface only (publinternals). No behavior change — the same `IQueryableMemberCollection` instances flow through the same paths; only the accessor's declaring type moves.

### Validation
LinqTests **1312** + DocumentDbTests **1033** + ValueTypeTests **339** + EventSourcingTests **1421** green (net10); Debug + Release clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)