### PR TITLE
W2 gatekeeper (#4821): drop IMartenDatabase from IDocumentStorage

### DIFF
--- a/src/Marten/Events/EventDocumentStorage.cs
+++ b/src/Marten/Events/EventDocumentStorage.cs
@@ -79,7 +79,7 @@ public abstract class EventDocumentStorage: IEventStorage, ILinqDocumentStorage
 
     public EventGraph Events { get; }
 
-    public Task TruncateDocumentStorageAsync(IMartenDatabase database, CancellationToken ct = default)
+    public Task TruncateDocumentStorageAsync(IStorageDatabase database, CancellationToken ct = default)
     {
         return database.RunSqlAsync($"truncate table {Events.DatabaseSchemaName}.mt_streams cascade", ct: ct);
     }

--- a/src/Marten/Events/EventMapping.cs
+++ b/src/Marten/Events/EventMapping.cs
@@ -250,7 +250,7 @@ public class EventMapping<T>: EventMapping, IDocumentStorage<T>, ILinqDocumentSt
         return id;
     }
 
-    public Task TruncateDocumentStorageAsync(IMartenDatabase database, CancellationToken ct = default)
+    public Task TruncateDocumentStorageAsync(IStorageDatabase database, CancellationToken ct = default)
     {
         return database.RunSqlAsync($"delete from table {_tableName} where type = '{Alias}'", ct: ct);
     }

--- a/src/Marten/Internal/ClosedShape/ClosedShapeProjectionLoader.cs
+++ b/src/Marten/Internal/ClosedShape/ClosedShapeProjectionLoader.cs
@@ -51,10 +51,10 @@ internal static class ClosedShapeProjectionLoader<TDoc, TId>
         DbCommand command,
         DocumentStorageDescriptor<TDoc, TId> descriptor,
         IStorageSerializer serializer,
-        IMartenDatabase database,
+        IStorageDatabase database,
         CancellationToken token)
     {
-        await using var conn = database.CreateConnection();
+        await using var conn = database.CreateStorageConnection();
         await conn.OpenAsync(token).ConfigureAwait(false);
         try
         {
@@ -77,10 +77,10 @@ internal static class ClosedShapeProjectionLoader<TDoc, TId>
         DbCommand command,
         DocumentStorageDescriptor<TDoc, TId> descriptor,
         IStorageSerializer serializer,
-        IMartenDatabase database,
+        IStorageDatabase database,
         CancellationToken token)
     {
-        await using var conn = database.CreateConnection();
+        await using var conn = database.CreateStorageConnection();
         await conn.OpenAsync(token).ConfigureAwait(false);
         try
         {

--- a/src/Marten/Internal/ClosedShape/DirtyCheckedClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/DirtyCheckedClosedShapeStorage.cs
@@ -47,11 +47,11 @@ public abstract class DirtyCheckedClosedShapeStorage<TDoc, TId>: DirtyCheckedDoc
             _descriptor.Identification.RawSqlType);
 
     // #4667 Phase 2 — session-free projection load; see Lightweight peer.
-    public override Task<TDoc?> LoadProjectedAsync(TId id, IMartenDatabase database, string tenantId, CancellationToken token)
+    public override Task<TDoc?> LoadProjectedAsync(TId id, IStorageDatabase database, string tenantId, CancellationToken token)
         => ClosedShapeProjectionLoader<TDoc, TId>.LoadAsync(
             BuildLoadCommand(id, tenantId), _descriptor, _descriptor.Serializer, database, token);
 
-    public override Task<IReadOnlyList<TDoc>> LoadManyProjectedAsync(TId[] ids, IMartenDatabase database, string tenantId, CancellationToken token)
+    public override Task<IReadOnlyList<TDoc>> LoadManyProjectedAsync(TId[] ids, IStorageDatabase database, string tenantId, CancellationToken token)
         => ClosedShapeProjectionLoader<TDoc, TId>.LoadManyAsync(
             BuildLoadManyCommand(ids, tenantId), _descriptor, _descriptor.Serializer, database, token);
 }

--- a/src/Marten/Internal/ClosedShape/IdentityMapClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/IdentityMapClosedShapeStorage.cs
@@ -47,11 +47,11 @@ public abstract class IdentityMapClosedShapeStorage<TDoc, TId>: IdentityMapDocum
             _descriptor.Identification.RawSqlType);
 
     // #4667 Phase 2 — session-free projection load; see Lightweight peer.
-    public override Task<TDoc?> LoadProjectedAsync(TId id, IMartenDatabase database, string tenantId, CancellationToken token)
+    public override Task<TDoc?> LoadProjectedAsync(TId id, IStorageDatabase database, string tenantId, CancellationToken token)
         => ClosedShapeProjectionLoader<TDoc, TId>.LoadAsync(
             BuildLoadCommand(id, tenantId), _descriptor, _descriptor.Serializer, database, token);
 
-    public override Task<IReadOnlyList<TDoc>> LoadManyProjectedAsync(TId[] ids, IMartenDatabase database, string tenantId, CancellationToken token)
+    public override Task<IReadOnlyList<TDoc>> LoadManyProjectedAsync(TId[] ids, IStorageDatabase database, string tenantId, CancellationToken token)
         => ClosedShapeProjectionLoader<TDoc, TId>.LoadManyAsync(
             BuildLoadManyCommand(ids, tenantId), _descriptor, _descriptor.Serializer, database, token);
 }

--- a/src/Marten/Internal/ClosedShape/LightweightClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/LightweightClosedShapeStorage.cs
@@ -65,11 +65,11 @@ public abstract class LightweightClosedShapeStorage<TDoc, TId>: LightweightDocum
     // from the supplied database and deserializes the data column directly,
     // bypassing the session-aware BuildSelector path that writes versions /
     // ItemMap / ChangeTrackers per row. Shared with IdentityMap / DirtyChecked.
-    public override Task<TDoc?> LoadProjectedAsync(TId id, IMartenDatabase database, string tenantId, CancellationToken token)
+    public override Task<TDoc?> LoadProjectedAsync(TId id, IStorageDatabase database, string tenantId, CancellationToken token)
         => ClosedShapeProjectionLoader<TDoc, TId>.LoadAsync(
             BuildLoadCommand(id, tenantId), _descriptor, _descriptor.Serializer, database, token);
 
-    public override Task<IReadOnlyList<TDoc>> LoadManyProjectedAsync(TId[] ids, IMartenDatabase database, string tenantId, CancellationToken token)
+    public override Task<IReadOnlyList<TDoc>> LoadManyProjectedAsync(TId[] ids, IStorageDatabase database, string tenantId, CancellationToken token)
         => ClosedShapeProjectionLoader<TDoc, TId>.LoadManyAsync(
             BuildLoadManyCommand(ids, tenantId), _descriptor, _descriptor.Serializer, database, token);
 }

--- a/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
+++ b/src/Marten/Internal/ClosedShape/QueryOnlyClosedShapeStorage.cs
@@ -79,10 +79,10 @@ public sealed class QueryOnlyClosedShapeStorage<TDoc, TId>: QueryOnlyDocumentSto
     // #4667 Phase 2 — QueryOnly storages aren't used by the projection read
     // path; ProjectionStorage holds a writeable storage instance for the
     // projected document type, not a QueryOnly one.
-    public override System.Threading.Tasks.Task<TDoc?> LoadProjectedAsync(TId id, IMartenDatabase database, string tenantId, System.Threading.CancellationToken token)
+    public override System.Threading.Tasks.Task<TDoc?> LoadProjectedAsync(TId id, IStorageDatabase database, string tenantId, System.Threading.CancellationToken token)
         => throw new NotSupportedException("QueryOnly storage doesn't support LoadProjectedAsync.");
 
-    public override System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<TDoc>> LoadManyProjectedAsync(TId[] ids, IMartenDatabase database, string tenantId, System.Threading.CancellationToken token)
+    public override System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<TDoc>> LoadManyProjectedAsync(TId[] ids, IStorageDatabase database, string tenantId, System.Threading.CancellationToken token)
         => throw new NotSupportedException("QueryOnly storage doesn't support LoadManyProjectedAsync.");
 
     public override ISelector BuildSelector(IStorageSession session)

--- a/src/Marten/Internal/IStorageDatabase.cs
+++ b/src/Marten/Internal/IStorageDatabase.cs
@@ -1,4 +1,7 @@
 #nullable enable
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 using Weasel.Core.Sequences;
 
 namespace Marten.Internal;
@@ -22,4 +25,20 @@ namespace Marten.Internal;
 public interface IStorageDatabase: ISequenceSource
 {
     IProviderGraph Providers { get; }
+
+    /// <summary>
+    ///     Open a new database-neutral connection. The projection-safe closed-shape read path
+    ///     (<see cref="Marten.Internal.ClosedShape.ClosedShapeProjectionLoader{TDoc,TId}"/>) uses this to
+    ///     run its <see cref="DbCommand"/> off the session, so it targets the neutral
+    ///     <see cref="DbConnection"/> here instead of the Npgsql-typed
+    ///     <see cref="Marten.Storage.IMartenDatabase"/> connection factory. (Distinct name from the
+    ///     Npgsql-typed <c>CreateConnection</c> to avoid a same-signature return-type clash.)
+    /// </summary>
+    DbConnection CreateStorageConnection();
+
+    /// <summary>
+    ///     Execute a single SQL statement against a fresh connection. Used by the closed-shape
+    ///     <c>TruncateDocumentStorageAsync</c> path so it no longer needs the Npgsql-typed database.
+    /// </summary>
+    Task RunSqlAsync(string sql, CancellationToken ct = default);
 }

--- a/src/Marten/Internal/Storage/DocumentStorage.cs
+++ b/src/Marten/Internal/Storage/DocumentStorage.cs
@@ -168,7 +168,7 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, ILinqDo
 
     public IQueryableMemberCollection QueryMembers { get; }
 
-    public async Task TruncateDocumentStorageAsync(IMartenDatabase database, CancellationToken ct = default)
+    public async Task TruncateDocumentStorageAsync(IStorageDatabase database, CancellationToken ct = default)
     {
         var sql = $"truncate {TableName.QualifiedName} cascade";
         try
@@ -370,12 +370,12 @@ public abstract class DocumentStorage<T, TId>: IDocumentStorage<T, TId>, ILinqDo
     /// trackers. Non-closed-shape storages aren't reachable via the projection
     /// write path and don't need this overload.
     /// </remarks>
-    public virtual Task<T?> LoadProjectedAsync(TId id, IMartenDatabase database, string tenantId, CancellationToken token)
+    public virtual Task<T?> LoadProjectedAsync(TId id, IStorageDatabase database, string tenantId, CancellationToken token)
         => throw new NotSupportedException(
             $"{GetType().Name} doesn't implement LoadProjectedAsync. Closed-shape storage variants provide this for the async-daemon projection-safe read path (#4667 Phase 2).");
 
     /// <inheritdoc />
-    public virtual Task<IReadOnlyList<T>> LoadManyProjectedAsync(TId[] ids, IMartenDatabase database, string tenantId, CancellationToken token)
+    public virtual Task<IReadOnlyList<T>> LoadManyProjectedAsync(TId[] ids, IStorageDatabase database, string tenantId, CancellationToken token)
         => throw new NotSupportedException(
             $"{GetType().Name} doesn't implement LoadManyProjectedAsync. Closed-shape storage variants provide this for the async-daemon projection-safe read path (#4667 Phase 2).");
 

--- a/src/Marten/Internal/Storage/IDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IDocumentStorage.cs
@@ -42,7 +42,7 @@ public interface IDocumentStorage: ISelectClause
     Type DocumentType { get; }
 
     TenancyStyle TenancyStyle { get; }
-    Task TruncateDocumentStorageAsync(IMartenDatabase database, CancellationToken ct = default);
+    Task TruncateDocumentStorageAsync(IStorageDatabase database, CancellationToken ct = default);
 
     ISqlFragment FilterDocuments(ISqlFragment query, IStorageSession session);
 
@@ -167,13 +167,13 @@ public interface IDocumentStorage<T, TId>: IDocumentStorage<T>, IIdentitySetter<
     /// from parallel async-daemon slice handlers that share an
     /// <see cref="IMartenSession"/>.
     /// </summary>
-    Task<T?> LoadProjectedAsync(TId id, IMartenDatabase database, string tenantId, CancellationToken token);
+    Task<T?> LoadProjectedAsync(TId id, IStorageDatabase database, string tenantId, CancellationToken token);
 
     /// <summary>
     /// Session-free LoadMany for projection storage (#4667 Phase 2). See
     /// <see cref="LoadProjectedAsync"/>.
     /// </summary>
-    Task<IReadOnlyList<T>> LoadManyProjectedAsync(TId[] ids, IMartenDatabase database, string tenantId, CancellationToken token);
+    Task<IReadOnlyList<T>> LoadManyProjectedAsync(TId[] ids, IStorageDatabase database, string tenantId, CancellationToken token);
 
 
     TId AssignIdentity(T document, string tenantId, IStorageDatabase database);

--- a/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/SubClassDocumentStorage.cs
@@ -53,7 +53,7 @@ internal class SubClassDocumentStorage<T, TRoot, TId>: IDocumentStorage<T, TId>,
         return _parent.RawIdentityValue(id);
     }
 
-    public Task TruncateDocumentStorageAsync(IMartenDatabase database, CancellationToken ct = default)
+    public Task TruncateDocumentStorageAsync(IStorageDatabase database, CancellationToken ct = default)
     {
         return database.RunSqlAsync(
             $"delete from {_parent.TableName.QualifiedName} where {SchemaConstants.DocumentTypeColumn} = '{_mapping.Alias}'",
@@ -224,13 +224,13 @@ internal class SubClassDocumentStorage<T, TRoot, TId>: IDocumentStorage<T, TId>,
 
     // #4667 Phase 2 — delegate projection loads to the parent hierarchy storage
     // and downcast to the subclass like the session-aware path above.
-    public async Task<T?> LoadProjectedAsync(TId id, IMartenDatabase database, string tenantId, CancellationToken token)
+    public async Task<T?> LoadProjectedAsync(TId id, IStorageDatabase database, string tenantId, CancellationToken token)
     {
         var doc = await _parent.LoadProjectedAsync(id, database, tenantId, token).ConfigureAwait(false);
         return doc is T x ? x : default;
     }
 
-    public async Task<IReadOnlyList<T>> LoadManyProjectedAsync(TId[] ids, IMartenDatabase database, string tenantId, CancellationToken token)
+    public async Task<IReadOnlyList<T>> LoadManyProjectedAsync(TId[] ids, IStorageDatabase database, string tenantId, CancellationToken token)
     {
         return (await _parent.LoadManyProjectedAsync(ids, database, tenantId, token).ConfigureAwait(false)).OfType<T>().ToList();
     }

--- a/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
+++ b/src/Marten/Internal/ValueTypeIdentifiedDocumentStorage.cs
@@ -101,7 +101,7 @@ internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: ID
     public Type DocumentType => Inner.DocumentType;
     public TenancyStyle TenancyStyle => Inner.TenancyStyle;
 
-    public Task TruncateDocumentStorageAsync(IMartenDatabase database, CancellationToken ct = default)
+    public Task TruncateDocumentStorageAsync(IStorageDatabase database, CancellationToken ct = default)
         => Inner.TruncateDocumentStorageAsync(database, ct);
 
     public ISqlFragment FilterDocuments(ISqlFragment query, IStorageSession session)
@@ -183,10 +183,10 @@ internal class ValueTypeIdentifiedDocumentStorage<TDoc, TSimple, TValueType>: ID
         => Inner.LoadManyAsync(ids.Select(_converter).ToArray(), session, token);
 
     // #4667 Phase 2 — delegate to inner with the unwrapped id like the session-aware path.
-    public Task<TDoc?> LoadProjectedAsync(TSimple id, IMartenDatabase database, string tenantId, CancellationToken token)
+    public Task<TDoc?> LoadProjectedAsync(TSimple id, IStorageDatabase database, string tenantId, CancellationToken token)
         => Inner.LoadProjectedAsync(_converter(id), database, tenantId, token);
 
-    public Task<IReadOnlyList<TDoc>> LoadManyProjectedAsync(TSimple[] ids, IMartenDatabase database, string tenantId, CancellationToken token)
+    public Task<IReadOnlyList<TDoc>> LoadManyProjectedAsync(TSimple[] ids, IStorageDatabase database, string tenantId, CancellationToken token)
         => Inner.LoadManyProjectedAsync(ids.Select(_converter).ToArray(), database, tenantId, token);
 
     public TSimple AssignIdentity(TDoc document, string tenantId, IStorageDatabase database)

--- a/src/Marten/Storage/MartenDatabase.Execution.cs
+++ b/src/Marten/Storage/MartenDatabase.Execution.cs
@@ -2,6 +2,7 @@ using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using Marten.Internal;
 using Marten.Services;
 using Npgsql;
 
@@ -83,6 +84,27 @@ public partial class MartenDatabase : ISingleQueryRunner
         }
 
         return CreateConnection(Options.Advanced.MultiHostSettings.WriteSessionPreference);
+    }
+
+    // Neutral IStorageDatabase surface the closed-shape storage runtime targets. The public
+    // CreateConnection above returns the Npgsql-typed connection for Marten's own callers; this
+    // exposes it as a DbConnection so the movable storage code stays Npgsql-free.
+    DbConnection IStorageDatabase.CreateStorageConnection() => CreateConnection();
+
+    async Task IStorageDatabase.RunSqlAsync(string sql, CancellationToken ct)
+    {
+        await using var conn = CreateConnection();
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var command = conn.CreateCommand();
+            command.CommandText = sql;
+            await command.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
     }
 
 }

--- a/src/Marten/Storage/StandinDatabase.cs
+++ b/src/Marten/Storage/StandinDatabase.cs
@@ -225,6 +225,16 @@ internal class StandinDatabase: IMartenDatabase
         throw new NotImplementedException();
     }
 
+    System.Data.Common.DbConnection IStorageDatabase.CreateStorageConnection()
+    {
+        throw new NotImplementedException();
+    }
+
+    Task IStorageDatabase.RunSqlAsync(string sql, CancellationToken ct)
+    {
+        throw new NotImplementedException();
+    }
+
     public void Dispose()
     {
         ((IDisposable)Tracker)?.Dispose();


### PR DESCRIPTION
Part of the **W2 closed-shape storage extraction** epic (#4821); fourth gatekeeper refactor toward relocating the neutral storage contract into the Npgsql-free **Weasel.Storage** package. (GK #1 = #4850, #2 = #4851, #3 = #4858.)

### The seam
The last `IMartenDatabase` (Npgsql-typed) coupling on `IDocumentStorage` was its three database-taking methods:
- `TruncateDocumentStorageAsync`
- the projection-safe read path `LoadProjectedAsync` / `LoadManyProjectedAsync` (async-daemon rebuild)

### The change
Widen the neutral `IStorageDatabase` seam with exactly what those methods need, and narrow the three signatures (plus the closed-shape overrides, delegating storages, and `ClosedShapeProjectionLoader`) from `IMartenDatabase` → `IStorageDatabase`:

- **`DbConnection CreateStorageConnection()`** — the projection loader opens its off-session connection through this instead of the Npgsql-typed `IMartenDatabase.CreateConnection`. A distinct method name deliberately avoids a same-signature return-type clash with `IConnectionSource<NpgsqlConnection>.CreateConnection` (and keeps `ConnectionUsage`, a `Weasel.Postgresql` type, off the neutral seam).
- **`Task RunSqlAsync(string, CancellationToken)`** — the truncate path.

`MartenDatabase` implements both via **explicit interface impls** delegating to its existing Npgsql connection; `IMartenDatabase` keeps its `NpgsqlConnection CreateConnection` unchanged, so Marten's own callers are unaffected. `StandinDatabase` (codegen stand-in) gets throwing stubs.

Callers pass an `IMartenDatabase` where an `IStorageDatabase` is now expected — a widening, so they bind unchanged.

### Scope / risk
`Marten.Internal.*` surface (publinternals). No behavior change.

### Validation
DocumentDbTests **1033** + EventSourcingTests **1421** + DaemonTests **198** green (net10); Debug + Release clean.

With this, `IDocumentStorage` no longer references `IMartenDatabase` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)