### PR TITLE
W2 gatekeeper (#4821): neutralize IBulkLoader's NpgsqlConnection

### DIFF
--- a/src/Marten/Internal/ClosedShape/SpikeNotImplementedBulkLoader.cs
+++ b/src/Marten/Internal/ClosedShape/SpikeNotImplementedBulkLoader.cs
@@ -1,11 +1,11 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Schema.BulkLoading;
 using Marten.Storage;
-using Npgsql;
 
 namespace Marten.Internal.ClosedShape;
 
@@ -20,12 +20,12 @@ internal sealed class SpikeNotImplementedBulkLoader<T>: IBulkLoader<T>
     private const string Message =
         "Bulk insert isn't covered by the W3 spike's closed-shape document storage.";
 
-    public Task LoadAsync(Tenant tenant, ISerializer serializer, NpgsqlConnection conn, IEnumerable<T> documents,
+    public Task LoadAsync(Tenant tenant, ISerializer serializer, DbConnection conn, IEnumerable<T> documents,
         CancellationToken cancellation) => throw new NotSupportedException(Message);
 
     public string CreateTempTableForCopying() => throw new NotSupportedException(Message);
 
-    public Task LoadIntoTempTableAsync(Tenant tenant, ISerializer serializer, NpgsqlConnection conn,
+    public Task LoadIntoTempTableAsync(Tenant tenant, ISerializer serializer, DbConnection conn,
         IEnumerable<T> documents, CancellationToken cancellation) => throw new NotSupportedException(Message);
 
     public string CopyNewDocumentsFromTempTable() => throw new NotSupportedException(Message);

--- a/src/Marten/Internal/CodeGeneration/BulkLoader.cs
+++ b/src/Marten/Internal/CodeGeneration/BulkLoader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
@@ -19,11 +20,13 @@ public abstract class BulkLoader<T, TId>: IBulkLoader<T> where TId : notnull whe
         _storage = storage;
     }
 
-    public async Task LoadAsync(Tenant tenant, ISerializer serializer, NpgsqlConnection conn,
+    public async Task LoadAsync(Tenant tenant, ISerializer serializer, DbConnection conn,
         IEnumerable<T> documents,
         CancellationToken cancellation)
     {
-        await using var writer = await conn.BeginBinaryImportAsync(MainLoaderSql(), cancellation).ConfigureAwait(false);
+        // Bulk loading uses the Postgres COPY (binary import) protocol; the neutral IBulkLoader
+        // contract takes a DbConnection, so the Postgres loader casts to NpgsqlConnection here.
+        await using var writer = await ((NpgsqlConnection)conn).BeginBinaryImportAsync(MainLoaderSql(), cancellation).ConfigureAwait(false);
 
         foreach (var document in documents)
         {
@@ -38,11 +41,11 @@ public abstract class BulkLoader<T, TId>: IBulkLoader<T> where TId : notnull whe
 
     public abstract string CreateTempTableForCopying();
 
-    public async Task LoadIntoTempTableAsync(Tenant tenant, ISerializer serializer, NpgsqlConnection conn,
+    public async Task LoadIntoTempTableAsync(Tenant tenant, ISerializer serializer, DbConnection conn,
         IEnumerable<T> documents,
         CancellationToken cancellation)
     {
-        await using var writer = await conn.BeginBinaryImportAsync(TempLoaderSql(), cancellation).ConfigureAwait(false);
+        await using var writer = await ((NpgsqlConnection)conn).BeginBinaryImportAsync(TempLoaderSql(), cancellation).ConfigureAwait(false);
         foreach (var document in documents)
         {
             await writer.StartRowAsync(cancellation).ConfigureAwait(false);

--- a/src/Marten/Internal/CodeGeneration/SubClassBulkLoader.cs
+++ b/src/Marten/Internal/CodeGeneration/SubClassBulkLoader.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Schema.BulkLoading;
 using Marten.Storage;
-using Npgsql;
 
 namespace Marten.Internal.CodeGeneration;
 
@@ -17,7 +17,7 @@ public class SubClassBulkLoader<T, TRoot>: IBulkLoader<T> where T : TRoot
         _inner = inner;
     }
 
-    public Task LoadAsync(Tenant tenant, ISerializer serializer, NpgsqlConnection conn, IEnumerable<T> documents,
+    public Task LoadAsync(Tenant tenant, ISerializer serializer, DbConnection conn, IEnumerable<T> documents,
         CancellationToken cancellation)
     {
         return _inner.LoadAsync(tenant, serializer, conn, documents.OfType<TRoot>(), cancellation);
@@ -28,7 +28,7 @@ public class SubClassBulkLoader<T, TRoot>: IBulkLoader<T> where T : TRoot
         return _inner.CreateTempTableForCopying();
     }
 
-    public Task LoadIntoTempTableAsync(Tenant tenant, ISerializer serializer, NpgsqlConnection conn,
+    public Task LoadIntoTempTableAsync(Tenant tenant, ISerializer serializer, DbConnection conn,
         IEnumerable<T> documents,
         CancellationToken cancellation)
     {

--- a/src/Marten/Schema/BulkLoading/IBulkLoader.cs
+++ b/src/Marten/Schema/BulkLoading/IBulkLoader.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Marten.Storage;
-using Npgsql;
 
 namespace Marten.Schema.BulkLoading;
 
@@ -12,12 +12,12 @@ namespace Marten.Schema.BulkLoading;
 /// <typeparam name="T"></typeparam>
 public interface IBulkLoader<T>
 {
-    Task LoadAsync(Tenant tenant, ISerializer serializer, NpgsqlConnection conn, IEnumerable<T> documents,
+    Task LoadAsync(Tenant tenant, ISerializer serializer, DbConnection conn, IEnumerable<T> documents,
         CancellationToken cancellation);
 
     string CreateTempTableForCopying();
 
-    Task LoadIntoTempTableAsync(Tenant tenant, ISerializer serializer, NpgsqlConnection conn, IEnumerable<T> documents,
+    Task LoadIntoTempTableAsync(Tenant tenant, ISerializer serializer, DbConnection conn, IEnumerable<T> documents,
         CancellationToken cancellation);
 
     string CopyNewDocumentsFromTempTable();


### PR DESCRIPTION
Part of the **W2 closed-shape storage extraction** epic (#4821); fifth and final gatekeeper refactor toward relocating the neutral storage contract into the Npgsql-free **Weasel.Storage** package. (GK #1 = #4850, #2 = #4851, #3 = #4858, #4 = #4859.)

### The seam
`IBulkLoader<T>.LoadAsync` / `LoadIntoTempTableAsync` typed their connection parameter as `NpgsqlConnection` — the hard Npgsql coupling that `DocumentProvider<T>` (hence `IProviderGraph`) dragged into the storage closure.

### The change
Widen the two interface parameters to `System.Data.Common.DbConnection`. Bulk loading is inherently the Postgres COPY (binary import) protocol, so the Postgres implementation `BulkLoader<T,TId>` casts the `DbConnection` back to `NpgsqlConnection` internally for `BeginBinaryImportAsync` — the same dialect pattern `PostgresStorageDialect` uses. `SubClassBulkLoader` delegates unchanged; `SpikeNotImplementedBulkLoader`'s throwing stubs just retype. The `BulkInsertion` caller already passes an `NpgsqlConnection`, which binds to the `DbConnection` parameter (widening).

`IBulkLoader` no longer references Npgsql. Its remaining `Tenant`/`ISerializer` parameters are Marten types, not the hard Npgsql blocker — deferred with the runtime.

### Scope / risk
`Marten.Internal.*` / codegen surface (publinternals). No behavior change — the `BeginBinaryImportAsync` COPY path is byte-for-byte the same, just reached through a cast.

### Validation
DocumentDbTests **1033** (incl. 60 bulk-insert, subclass, composite-pk) + CoreTests **458** (incl. closed-shape bulk loader) green (net10); Debug + Release clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)