### PR TITLE
Fix #4862 — DistributesAgentsPerTenant for any tenant-partitioned store + TenantIds on the single-DB usage descriptor

### DIFF
--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -65,13 +65,17 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
         }
     }
 
-    // wolverine#3280: under sharded databases + per-tenant event partitioning, multiple tenants are
-    // co-located in one shard database and each draws its own mt_events_sequence_<tenant> (independent,
-    // overlapping). A single store-global high-water cannot track them, so node-distributed daemons must
-    // fan out one agent per (shard, tenant). Single-database partitioning and database-per-tenant do NOT
-    // need this (one agent per database already covers a single tenant or the single partitioned table).
+    // wolverine#3280 + #4862: under per-tenant event partitioning every tenant draws its own
+    // mt_events_sequence_<tenant> — independent, overlapping sequences co-located in the one events
+    // table. That is true for ANY database topology (a single conjoined database exactly as much as a
+    // shard housing multiple tenants), so a store-global agent has no correct progression semantics:
+    // the store-global high water is the max across partitions and silently skips a lagging tenant's
+    // events (#4862). Hosts that start agents per-identity (Wolverine-managed distribution's
+    // StartAgentAsync) must therefore fan out one agent per (database, tenant) whenever the store is
+    // tenant-partitioned. The native daemon is unaffected either way — its StartAllAsync already fans
+    // out per tenant internally.
     bool IEventStore.DistributesAgentsPerTenant
-        => Options.Events.UseTenantPartitionedEvents && Options.Tenancy is Storage.ShardedTenancy;
+        => Options.Events.UseTenantPartitionedEvents;
 
     async ValueTask<IReadOnlyList<IEventDatabase>> IEventStore.AllDatabases()
     {

--- a/src/Marten/Storage/MartenDatabase.CrossTenantRebuild.cs
+++ b/src/Marten/Storage/MartenDatabase.CrossTenantRebuild.cs
@@ -29,7 +29,22 @@ public partial class MartenDatabase : ICrossTenantRebuildSource
     /// would otherwise be skipped — that's the opposite of what
     /// "rebuild X everywhere" should do.
     /// </summary>
-    public async Task<IReadOnlyList<string>> FindRebuildTenantsAsync(string projectionName, CancellationToken token)
+    public Task<IReadOnlyList<string>> FindRebuildTenantsAsync(string projectionName, CancellationToken token)
+    {
+        return FetchManagedTenantIdsAsync(token);
+    }
+
+    /// <summary>
+    /// #4862 — the Marten-managed tenant list for this database, read fresh from the
+    /// <c>mt_tenant_partitions</c> lookup table. This is the single source of truth for
+    /// "which tenants live here" under Marten-managed partitioning; it backs both the
+    /// cross-tenant rebuild fan-out above and
+    /// <see cref="TenantPartitionedSingleDatabaseTenancy"/>'s usage descriptor
+    /// <c>TenantIds</c> (so hosts that distribute agents per tenant know which
+    /// tenants to start agents for).
+    /// Returns an empty list when Marten-managed partitioning isn't active.
+    /// </summary>
+    public async Task<IReadOnlyList<string>> FetchManagedTenantIdsAsync(CancellationToken token)
     {
         var tenantPartitions = Options.TenantPartitions;
         if (tenantPartitions == null)

--- a/src/Marten/Storage/TenantPartitionedSingleDatabaseTenancy.cs
+++ b/src/Marten/Storage/TenantPartitionedSingleDatabaseTenancy.cs
@@ -1,0 +1,68 @@
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using JasperFx.Descriptors;
+using Npgsql;
+
+namespace Marten.Storage;
+
+/// <summary>
+/// #4862 — the tenancy for the "single database + <c>Events.UseTenantPartitionedEvents</c>"
+/// permutation. Behaviorally identical to <see cref="DefaultTenancy"/> (one conjoined
+/// database, every tenant lives in it) except that <see cref="DescribeDatabasesAsync"/>
+/// surfaces the Marten-managed tenant list on the main database descriptor's
+/// <c>TenantIds</c>. Hosts that distribute agents per identity (Wolverine-managed event
+/// subscription distribution) enumerate the descriptor to fan agents out per tenant once
+/// <c>IEventStore.DistributesAgentsPerTenant</c> is on — DefaultTenancy leaves
+/// <c>TenantIds</c> empty (it has no per-tenant registration to copy from, unlike the
+/// Master-Table/SingleServer/Static/Sharded tenancies), so the broadened gate would fan
+/// out to nothing.
+/// </summary>
+/// <remarks>
+/// Deliberately a subclass of <see cref="DefaultTenancy"/> rather than a freestanding
+/// <see cref="ITenancy"/>: several behavior gates dispatch on the concrete type
+/// (<c>DocumentStore</c>'s lazy <c>Initialize()</c>, the
+/// <c>AdvancedOperations.AddMartenManagedTenantsAsync</c> /
+/// <c>RemoveMartenManagedTenantsAsync</c> routing, <c>TenantDataCleaner</c>,
+/// <c>ProjectionCoordinator</c>, <c>WaitForNonStaleProjectionDataAsync</c>) and this
+/// permutation must keep behaving as a single-database DefaultTenancy store for all of
+/// them. Re-listing <see cref="ITenancy"/> in the base list re-maps the interface's
+/// <c>DescribeDatabasesAsync</c> slot onto the override below while every other member
+/// stays the inherited DefaultTenancy implementation.
+/// </remarks>
+internal class TenantPartitionedSingleDatabaseTenancy: DefaultTenancy, ITenancy
+{
+    public TenantPartitionedSingleDatabaseTenancy(NpgsqlDataSource dataSource, StoreOptions options)
+        : base(dataSource, options)
+    {
+    }
+
+    public new async ValueTask<DatabaseUsage> DescribeDatabasesAsync(CancellationToken token)
+    {
+        var usage = await base.DescribeDatabasesAsync(token).ConfigureAwait(false);
+
+        // Read the authoritative tenant list fresh from the mt_tenant_partitions lookup
+        // table — the same source ICrossTenantRebuildSource.FindRebuildTenantsAsync uses —
+        // so tenants registered after the store was built (and by other nodes) are visible
+        // without any cache invalidation.
+        if (Options.TenantPartitions != null && Default.Database is MartenDatabase martenDatabase)
+        {
+            try
+            {
+                var tenantIds = await martenDatabase.FetchManagedTenantIdsAsync(token).ConfigureAwait(false);
+                foreach (var tenantId in tenantIds)
+                {
+                    usage.MainDatabase!.TenantIds.Fill(tenantId);
+                }
+            }
+            catch (NpgsqlException)
+            {
+                // Storage may not exist yet (mt_tenant_partitions not provisioned) —
+                // leave TenantIds empty rather than failing the whole description.
+            }
+        }
+
+        return usage;
+    }
+}

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -595,7 +595,21 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
         }
 
         _tenancy = new Lazy<ITenancy>(() =>
-            new DefaultTenancy(NpgsqlDataSourceFactory.Create(connectionString), this));
+        {
+            var dataSource = NpgsqlDataSourceFactory.Create(connectionString);
+
+            // #4862: this Lazy resolves on the first Tenancy access — during DocumentStore
+            // construction, after all user configuration has run — so the partitioning flag
+            // is settled by the time we choose. With per-tenant event partitioning on a
+            // plain single-database setup, swap in the tenancy whose usage descriptor
+            // surfaces the Marten-managed tenant list (TenantIds) so per-tenant agent
+            // distribution has tenants to fan out to. A user-supplied ITenancy — set via
+            // the Tenancy property or any of the MultiTenanted* helpers — replaces this
+            // Lazy wholesale and is never touched by this swap.
+            return Events.UseTenantPartitionedEvents
+                ? new TenantPartitionedSingleDatabaseTenancy(dataSource, this)
+                : new DefaultTenancy(dataSource, this);
+        });
     }
 
 

--- a/src/TenantPartitionedEventsTests/Config/distributes_agents_per_tenant_gating.cs
+++ b/src/TenantPartitionedEventsTests/Config/distributes_agents_per_tenant_gating.cs
@@ -8,17 +8,18 @@ using Xunit;
 namespace TenantPartitionedEventsTests.Config;
 
 /// <summary>
-/// wolverine#3280 — how <see cref="IEventStore.DistributesAgentsPerTenant"/> is gated. It only turns on
-/// for a sharded per-tenant-partitioned store (the one tenancy where multiple tenants are co-located in a
-/// shard database with independent per-tenant sequences, so node-distributed daemons must fan agents out
-/// per (shard, tenant)). Everywhere else it stays false so distribution behaves exactly as before: one
-/// agent per database. These are pure configuration assertions — building the store never opens a
-/// connection.
+/// wolverine#3280 + #4862 — how <see cref="IEventStore.DistributesAgentsPerTenant"/> is gated. It turns
+/// on for ANY per-tenant-partitioned store: independent, overlapping mt_events_sequence_&lt;tenant&gt;
+/// sequences co-located in one events table mean a store-global agent has no correct progression
+/// semantics, whether that table lives in a single conjoined database or a shard (#4862 showed the
+/// single-DB case silently skipping a lagging tenant's events under Wolverine-managed distribution).
+/// Without partitioning it stays false so distribution behaves exactly as before: one agent per
+/// database. These are pure configuration assertions — building the store never opens a connection.
 /// </summary>
 public class distributes_agents_per_tenant_gating
 {
     [Fact]
-    public void off_on_a_single_database_store_even_with_per_tenant_partitioning()
+    public void on_for_a_single_database_store_with_per_tenant_partitioning()
     {
         using var store = DocumentStore.For(opts =>
         {
@@ -27,8 +28,23 @@ public class distributes_agents_per_tenant_gating
             opts.Events.UseTenantPartitionedEvents = true;
         });
 
+        // #4862: flipped from false. Per-tenant sequences overlap in the single events table
+        // exactly as co-located tenants do in a shard, so per-identity agent starts must fan
+        // out per tenant here too.
         ((IEventStore)store).DistributesAgentsPerTenant
-            .ShouldBeFalse("a single-database store keeps one agent per database");
+            .ShouldBeTrue("single-database per-tenant partitioning still has overlapping per-tenant sequences");
+    }
+
+    [Fact]
+    public void off_by_default_on_a_plain_single_database_store()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+        });
+
+        ((IEventStore)store).DistributesAgentsPerTenant
+            .ShouldBeFalse("without per-tenant partitioning there is a single store-global sequence");
     }
 
     [Fact]

--- a/src/TenantPartitionedEventsTests/Config/single_db_usage_descriptor_tenant_ids.cs
+++ b/src/TenantPartitionedEventsTests/Config/single_db_usage_descriptor_tenant_ids.cs
@@ -1,0 +1,51 @@
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using Shouldly;
+using TenantPartitionedEventsTests.Fixtures;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Config;
+
+/// <summary>
+/// #4862 — a single-database store with <c>UseTenantPartitionedEvents</c> must surface its
+/// Marten-managed tenants on the usage descriptor's <c>TenantIds</c>. Hosts that distribute
+/// agents per identity (Wolverine-managed event subscription distribution) enumerate the
+/// descriptor to fan agents out per tenant once <see cref="IEventStore.DistributesAgentsPerTenant"/>
+/// is on — with an empty <c>TenantIds</c> the broadened gate would fan out to nothing.
+/// DefaultTenancy leaves the list empty (only Master-Table/SingleServer/Static/Sharded tenancies
+/// populate it) and stays completely untouched; instead the store bootstrap swaps in
+/// <see cref="Marten.Storage.TenantPartitionedSingleDatabaseTenancy"/> for this permutation, whose
+/// description reads the managed tenant-partition list — the same source
+/// <c>ICrossTenantRebuildSource.FindRebuildTenantsAsync</c> uses.
+/// </summary>
+[Collection("guid-partitioned")]
+public class single_db_usage_descriptor_tenant_ids
+{
+    private readonly GuidPartitionedFixture _fixture;
+
+    public single_db_usage_descriptor_tenant_ids(GuidPartitionedFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task usage_descriptor_carries_managed_tenants_in_tenant_ids()
+    {
+        var tenant1 = PartitionedFixtureBase.NewTenant();
+        var tenant2 = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant1, tenant2);
+
+        var usage = await ((IEventStore)_fixture.Store).TryCreateUsage(CancellationToken.None);
+
+        usage.ShouldNotBeNull();
+        usage.Database.Cardinality.ShouldBe(DatabaseCardinality.Single);
+        usage.Database.MainDatabase.ShouldNotBeNull();
+
+        // Fresh read from mt_tenant_partitions per description — tenants registered after the
+        // store was built (and by other nodes) are visible without any cache invalidation.
+        usage.Database.MainDatabase.TenantIds.ShouldContain(tenant1);
+        usage.Database.MainDatabase.TenantIds.ShouldContain(tenant2);
+    }
+}

--- a/src/TenantPartitionedEventsTests/Config/tenancy_swap_for_tenant_partitioned_single_database.cs
+++ b/src/TenantPartitionedEventsTests/Config/tenancy_swap_for_tenant_partitioned_single_database.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Schema;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Core.Migrations;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Config;
+
+/// <summary>
+/// #4862 — the store bootstrap swaps <see cref="DefaultTenancy"/> for
+/// <see cref="TenantPartitionedSingleDatabaseTenancy"/> ONLY for the
+/// "plain single database + <c>UseTenantPartitionedEvents</c>" permutation. The swap lives
+/// inside the lazy tenancy factory that <c>StoreOptions.Connection(string)</c> installs, so it
+/// resolves after all user configuration has run and can never clobber a user-supplied
+/// <see cref="ITenancy"/> (setting <c>opts.Tenancy</c> or using any MultiTenanted* helper
+/// replaces that Lazy wholesale). Pure configuration assertions — no store here ever needs
+/// provisioned schema.
+/// </summary>
+public class tenancy_swap_for_tenant_partitioned_single_database
+{
+    [Fact]
+    public void tenant_partitioned_single_database_store_gets_the_dedicated_tenancy()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+        });
+
+        // The subclass relationship matters: every `is DefaultTenancy` behavior gate
+        // (AddMartenManagedTenantsAsync routing, DocumentStore.Initialize, coordinator
+        // paths) must keep treating this store as a single-database DefaultTenancy store.
+        store.Options.Tenancy.ShouldBeOfType<TenantPartitionedSingleDatabaseTenancy>()
+            .ShouldBeAssignableTo<DefaultTenancy>();
+    }
+
+    [Fact]
+    public void plain_single_database_store_keeps_default_tenancy()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+        });
+
+        store.Options.Tenancy.ShouldBeOfType<DefaultTenancy>();
+    }
+
+    [Fact]
+    public void user_supplied_custom_tenancy_is_never_replaced()
+    {
+        var custom = new StubTenancy();
+
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+
+            // User-supplied tenancy AFTER Connection() — replaces the lazy default
+            // factory entirely, so the #4862 swap never sees it.
+            opts.Tenancy = custom;
+        });
+
+        store.Options.Tenancy.ShouldBeSameAs(custom);
+    }
+
+    // Minimal user-supplied ITenancy: enough for DocumentStore construction (which only
+    // touches Default/Cleaner lazily) — everything else throws. Mirrors the documented
+    // sample_custom_tenancy shape.
+    private class StubTenancy: ITenancy
+    {
+        public Tenant Default => throw new NotImplementedException();
+        public IDocumentCleaner Cleaner => throw new NotImplementedException();
+        public DatabaseCardinality Cardinality => DatabaseCardinality.Single;
+
+        public Tenant GetTenant(string tenantId) => throw new NotImplementedException();
+        public ValueTask<Tenant> GetTenantAsync(string tenantId) => throw new NotImplementedException();
+
+        public ValueTask<IMartenDatabase> FindOrCreateDatabase(string tenantIdOrDatabaseIdentifier) =>
+            throw new NotImplementedException();
+
+        public bool IsTenantStoredInCurrentDatabase(IMartenDatabase database, string tenantId) =>
+            throw new NotImplementedException();
+
+        public ValueTask<IReadOnlyList<IDatabase>> BuildDatabases() => throw new NotImplementedException();
+
+        public ValueTask<DatabaseUsage> DescribeDatabasesAsync(CancellationToken token) =>
+            throw new NotImplementedException();
+
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
Closes #4862. Part of the per-tenant event partitioning epic JasperFx/jasperfx#486 (WS1 distribution matrix — this was the single-DB × Wolverine-managed cell's silent data loss, found by an adversarial lagging-tenant probe).

## The two-part fix

**1. Broaden the `DistributesAgentsPerTenant` gate** (`DocumentStore.EventStore.cs`): now `Options.Events.UseTenantPartitionedEvents` alone — the `ShardedTenancy` requirement is dropped. Overlapping per-tenant sequences (`mt_events_sequence_{tenant}`, each from 1) mean a store-global agent has no correct progression semantics on *any* topology; hosts that start agents per-identity (Wolverine-managed distribution) must fan out per tenant. The native daemon was never affected — `StartAllAsync` fans out internally.

**2. A dedicated tenancy for the permutation — `DefaultTenancy` untouched (zero-line diff).** When a store is configured with a plain connection string **and** `Events.UseTenantPartitionedEvents`, the lazy tenancy factory in `StoreOptions.Connection(string)` resolves to the new internal `TenantPartitionedSingleDatabaseTenancy` instead of `DefaultTenancy` (the Lazy resolves after all configuration has run, and a user-supplied `ITenancy` replaces the factory wholesale, so custom tenancies are never touched). The new type subclasses `DefaultTenancy` — keeping every `is DefaultTenancy` behavior gate working unchanged (tenant registration routing in `AddMartenManagedTenantsAsync`/`RemoveMartenManagedTenantsAsync`, store initialization, cleanup, projection coordination; a freestanding implementation would have thrown on tenant registration for exactly this permutation) — and re-implements only `ITenancy.DescribeDatabasesAsync`: the usage descriptor's `MainDatabase.TenantIds` is populated from a fresh read of `mt_tenant_partitions` via the new `MartenDatabase.FetchManagedTenantIdsAsync`, the same single source `ICrossTenantRebuildSource.FindRebuildTenantsAsync` uses — deliberately not the in-memory partition cache, so per-tenant agent distribution observes tenants registered by other nodes. A documents-only managed-partitioning store (no partitioned events) keeps plain `DefaultTenancy`, matching the gate.

## Tests

- `Config/distributes_agents_per_tenant_gating`: single-DB partitioned flipped to `true` (#4862), plain single-DB store stays `false`, sharded-without-partitioning stays `false`.
- New `Config/single_db_usage_descriptor_tenant_ids`: two managed tenants → both present in `MainDatabase.TenantIds`, `Cardinality == Single`.
- `TenantPartitionedEventsTests`: **199/199 on net10.0 and net9.0** (one TFM per run).

## Downstream (next alpha)

Wolverine follow-up once this publishes: flip the pinned granularity expectations in `tenant_partitioned_distribution_granularity` / `tenant_partitioned_distribution_multinode` and promote the lagging-tenant probe to a regression test. Note for reviewers: `sharded_two_databases_affine_colocation`-style connection accounting is unaffected — fan-out multiplies agents, not pools, and #3328's cardinality gate keeps `Single`-cardinality stores on even distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
