### PR TITLE
Honor DaemonMode.ExternallyManaged — no warning, no Marten-hosted coordination (JasperFx 2.21.0)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -77,13 +77,16 @@
          node-distributed daemon hosts (Wolverine) to fan out one agent per (shard, tenant), plus the
          hardened per-tenant StartAgentAsync: tenant ceilings primed before start (SubscribeFromPresent
          no longer rewinds to 0), exact-identity precedence, loud failure on non-partitioned stores. -->
-    <PackageVersion Include="JasperFx" Version="2.20.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.20.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.20.0">
+    <!-- JasperFx 2.21.0: jasperfx#490 DaemonMode.ExternallyManaged (external hosts run projections;
+         store hosts no coordination and must not warn — wolverine#3290) + jasperfx#491 distributor-level
+         per-tenant shard expansion with coordinator reconciliation (jasperfx#489). -->
+    <PackageVersion Include="JasperFx" Version="2.21.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.21.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.21.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.20.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.21.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/CoreTests/daemon_mode_externally_managed.cs
+++ b/src/CoreTests/daemon_mode_externally_managed.cs
@@ -1,0 +1,208 @@
+using System;
+using System.IO;
+using System.Linq;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+// JFx.Events 2.0 introduced its own IProjectionCoordinator interface; alias to the
+// Marten-specific one these tests assert on (same trick as DaemonTests service_registrations).
+using IProjectionCoordinator = Marten.Events.Daemon.Coordination.IProjectionCoordinator;
+using ProjectionCoordinator = Marten.Events.Daemon.Coordination.ProjectionCoordinator;
+
+namespace CoreTests;
+
+// jasperfx#490: DaemonMode.ExternallyManaged = an external system (e.g. Wolverine's managed
+// event-subscription distribution) executes the async projections. The store itself hosts
+// no daemon coordination — the same runtime posture as Disabled — but it must NOT warn
+// that async projections will never run, because the external host runs them.
+public class daemon_mode_externally_managed
+{
+    [Fact]
+    public void async_mode_is_publicly_settable_through_projection_options()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            // This is the integration path: Wolverine (or any external host) sets the mode
+            // on StoreOptions directly rather than calling AddAsyncDaemon()
+            opts.Projections.AsyncMode = DaemonMode.ExternallyManaged;
+        });
+
+        store.Options.Projections.AsyncMode.ShouldBe(DaemonMode.ExternallyManaged);
+    }
+
+    [Fact]
+    public void does_not_warn_about_disabled_daemon_when_externally_managed()
+    {
+        var output = buildStoreWithAsyncProjectionCapturingConsole(DaemonMode.ExternallyManaged);
+
+        output.ShouldNotContain("Warning: The async daemon is disabled.");
+        output.ShouldNotContain("will not be executed without the async daemon enabled");
+    }
+
+    [Fact]
+    public void still_warns_about_disabled_daemon_when_disabled()
+    {
+        var output = buildStoreWithAsyncProjectionCapturingConsole(DaemonMode.Disabled);
+
+        output.ShouldContain("Warning: The async daemon is disabled.");
+        output.ShouldContain("will not be executed without the async daemon enabled");
+    }
+
+    [Fact]
+    public void setting_externally_managed_without_add_async_daemon_registers_no_coordination()
+    {
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DisableNpgsqlLogging = true;
+                    opts.Projections.AsyncMode = DaemonMode.ExternallyManaged;
+                });
+            }).Build();
+
+        host.Services.GetService<IProjectionCoordinator>().ShouldBeNull();
+        host.Services.GetServices<IHostedService>().OfType<ProjectionCoordinator>().Any().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void add_async_daemon_with_externally_managed_registers_no_coordination()
+    {
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DisableNpgsqlLogging = true;
+                }).AddAsyncDaemon(DaemonMode.ExternallyManaged);
+            }).Build();
+
+        host.Services.GetService<IProjectionCoordinator>().ShouldBeNull();
+        host.Services.GetService<JasperFx.Events.Daemon.IProjectionCoordinator>().ShouldBeNull();
+        host.Services.GetServices<IHostedService>().OfType<ProjectionCoordinator>().Any().ShouldBeFalse();
+
+        // ... but the mode itself is still carried honestly on the store options
+        var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
+        store.Options.Projections.AsyncMode.ShouldBe(DaemonMode.ExternallyManaged);
+    }
+
+    [Fact]
+    public void add_async_daemon_with_solo_is_unaffected()
+    {
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DisableNpgsqlLogging = true;
+                }).AddAsyncDaemon(DaemonMode.Solo);
+            }).Build();
+
+        var coordinator = host.Services.GetService<IProjectionCoordinator>()
+            .ShouldBeOfType<ProjectionCoordinator>();
+        coordinator.Mode.ShouldBe(DaemonMode.Solo);
+
+        host.Services.GetServices<IHostedService>().OfType<ProjectionCoordinator>().Any().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void add_async_daemon_with_hot_cold_is_unaffected()
+    {
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(opts =>
+                {
+                    opts.Connection(ConnectionSource.ConnectionString);
+                    opts.DisableNpgsqlLogging = true;
+                }).AddAsyncDaemon(DaemonMode.HotCold);
+            }).Build();
+
+        var coordinator = host.Services.GetService<IProjectionCoordinator>()
+            .ShouldBeOfType<ProjectionCoordinator>();
+        coordinator.Mode.ShouldBe(DaemonMode.HotCold);
+
+        host.Services.GetServices<IHostedService>().OfType<ProjectionCoordinator>().Any().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void add_async_daemon_on_ancillary_store_respects_externally_managed()
+    {
+        // Assert at the ServiceCollection level so nothing gets constructed
+        var services = new ServiceCollection();
+        services.AddMartenStore<IExternallyManagedAncillaryStore>(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DisableNpgsqlLogging = true;
+        }).AddAsyncDaemon(DaemonMode.ExternallyManaged);
+
+        services.Any(x =>
+                x.ServiceType ==
+                typeof(Marten.Events.Daemon.Coordination.IProjectionCoordinator<IExternallyManagedAncillaryStore>))
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void add_async_daemon_on_ancillary_store_with_solo_is_unaffected()
+    {
+        var services = new ServiceCollection();
+        services.AddMartenStore<IExternallyManagedAncillaryStore>(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DisableNpgsqlLogging = true;
+        }).AddAsyncDaemon(DaemonMode.Solo);
+
+        services.Any(x =>
+                x.ServiceType ==
+                typeof(Marten.Events.Daemon.Coordination.IProjectionCoordinator<IExternallyManagedAncillaryStore>))
+            .ShouldBeTrue();
+    }
+
+    private static string buildStoreWithAsyncProjectionCapturingConsole(DaemonMode mode)
+    {
+        // The "async daemon is disabled" warning is written straight to Console.Out from the
+        // DocumentStore constructor, so swap the console writer around construction
+        var original = Console.Out;
+        var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            using var store = DocumentStore.For(opts =>
+            {
+                opts.Connection(ConnectionSource.ConnectionString);
+                opts.DisableNpgsqlLogging = true;
+                opts.Projections.Snapshot<DaemonModeFlagView>(SnapshotLifecycle.Async);
+                opts.Projections.AsyncMode = mode;
+            });
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        return writer.ToString();
+    }
+}
+
+public interface IExternallyManagedAncillaryStore: IDocumentStore;
+
+public record DaemonModeFlagRaised(Guid Id);
+
+public record DaemonModeFlagView(Guid Id)
+{
+    public static DaemonModeFlagView Create(IEvent<DaemonModeFlagRaised> @event)
+    {
+        return new DaemonModeFlagView(@event.StreamId);
+    }
+}

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -513,6 +513,9 @@ public partial class DocumentStore: IDocumentStore, IDescribeMyself
 
     private void warnIfAsyncDaemonIsDisabledWithAsyncProjections()
     {
+        // Deliberately == Disabled, not != Solo/HotCold: DaemonMode.ExternallyManaged (jasperfx#490)
+        // means an external host (e.g. Wolverine's managed event-subscription distribution) runs the
+        // async projections, so they WILL execute — warning would be wrong there.
         if (Options.Projections.HasAnyAsyncProjections() && Options.Projections.AsyncMode == DaemonMode.Disabled)
         {
             Console.WriteLine("Warning: The async daemon is disabled.");

--- a/src/Marten/Events/Daemon/Coordination/ProjectionCoordinator.cs
+++ b/src/Marten/Events/Daemon/Coordination/ProjectionCoordinator.cs
@@ -97,6 +97,9 @@ public class ProjectionCoordinator: ProjectionCoordinatorBase, IProjectionCoordi
 
             default:
                 // DaemonMode.Disabled: no async daemon, so there is nothing to distribute.
+                // DaemonMode.ExternallyManaged (jasperfx#490): an external system (e.g. Wolverine's
+                // managed event-subscription distribution) executes the async projections, so this
+                // store hosts nothing either — same null-distributor posture as Disabled.
                 // ProjectionCoordinatorBase (JasperFx.Events) tolerates a null distributor as
                 // the "nothing to coordinate" state since jasperfx#352 — the ctor no longer
                 // throws, StartAsync no-ops, and StopAsync guards ReleaseAllLocks. A

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -511,7 +511,12 @@ public static class MartenServiceCollectionExtensions
         public MartenStoreExpression<T> AddAsyncDaemon(DaemonMode mode)
         {
             Services.ConfigureMarten<T>(opts => opts.Projections.AsyncMode = mode);
-            if (mode != DaemonMode.Disabled)
+
+            // Only Solo/HotCold mean "this process hosts the daemon". Disabled hosts nothing, and
+            // ExternallyManaged (jasperfx#490) means an external system (e.g. Wolverine's managed
+            // event-subscription distribution) executes the async projections — Marten must not
+            // register its own coordination for either.
+            if (mode is DaemonMode.Solo or DaemonMode.HotCold)
             {
                 Services.AddSingleton<Marten.Events.Daemon.Coordination.IProjectionCoordinator<T>, ProjectionCoordinator<T>>();
                 Services.AddSingleton<IHostedService>(s => s.GetRequiredService<Marten.Events.Daemon.Coordination.IProjectionCoordinator<T>>());
@@ -754,7 +759,11 @@ public static class MartenServiceCollectionExtensions
         {
             Services.ConfigureMarten(opts => opts.Projections.AsyncMode = mode);
 
-            if (mode != DaemonMode.Disabled)
+            // Only Solo/HotCold mean "this process hosts the daemon". Disabled hosts nothing, and
+            // ExternallyManaged (jasperfx#490) means an external system (e.g. Wolverine's managed
+            // event-subscription distribution) executes the async projections — Marten must not
+            // register its own coordination for either.
+            if (mode is DaemonMode.Solo or DaemonMode.HotCold)
             {
                 Services.AddSingleton<Marten.Events.Daemon.Coordination.IProjectionCoordinator, ProjectionCoordinator>();
                 Services.AddSingleton<IHostedService>(s => s.GetRequiredService<Marten.Events.Daemon.Coordination.IProjectionCoordinator>());


### PR DESCRIPTION
Marten leg of `DaemonMode.ExternallyManaged` (jasperfx#490; fixes the wolverine#3290 story after wolverine#3329's approach was rejected — recording `HotCold` from an integration activates Marten's own coordination in parallel). Part of epic JasperFx/jasperfx#486.

## What it does

- **Fixes two dangerous inverted gates**: both `AddAsyncDaemon` overloads (generic + non-generic, `MartenServiceCollectionExtensions`) registered the coordinator + hosted service on `mode != DaemonMode.Disabled` — under `ExternallyManaged` that would have hosted Marten coordination alongside the external host's, the exact hazard the enum exists to prevent. The gates are now `mode is DaemonMode.Solo or DaemonMode.HotCold`.
- **Warning gate**: `warnIfAsyncDaemonIsDisabledWithAsyncProjections` already fires only on `== Disabled`, so `ExternallyManaged` is silent — now documented as deliberate and pinned by regression tests.
- **`ProjectionCoordinator.BuildDistributor`**: `ExternallyManaged` falls to the null-distributor default (correct no-op posture); comment names it explicitly.
- Full reader audit of every `AsyncMode`/`DaemonMode` consumer in src/Marten is in the epic notes; everything else passes the new value through honestly (`OverrideDaemonModeToSolo` deliberately flips only `HotCold`, preserving integration-set modes).
- Consumes **JasperFx 2.21.0** (also carries jasperfx#491's distributor-level per-tenant expansion — consumed by a separate follow-up PR).

## Tests

New `CoreTests/daemon_mode_externally_managed` (9 tests, both TFMs): no console warning under `ExternallyManaged` (Disabled still warns); no `IProjectionCoordinator`/hosted coordination resolvable via either the direct-set or `AddAsyncDaemon(ExternallyManaged)` path, main + ancillary stores; `Solo`/`HotCold` behavior unchanged. CoreTests full suite green on net10.0.

Downstream: Wolverine's `MartenIntegration` + `PolecatIntegration` set the mode (branch ready, PRs after this ships in the next Marten alpha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)