### PR TITLE
Fix #4867 — per-tenant high-water advancement: gap walk + safe-harbor skip for the vectorized detector

### DIFF
--- a/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Diagnostics;
@@ -34,6 +35,15 @@ internal class HighWaterDetector: IHighWaterDetector
     private readonly MartenDatabase _database;
     private readonly EventGraph _graph;
     private readonly ProjectionOptions _settings;
+
+    // #4867: per-tenant stale clocks for the vectorized high-water path. When a tenant's mark is
+    // blocked by a gap immediately above it (an allocated-but-uncommitted — or rolled-back — seq_id),
+    // this records WHEN the detector first observed that tenant stuck at that mark, so the gap can be
+    // skipped once the tenant has been stale past StaleSequenceThreshold. This is the per-tenant
+    // analogue of HighWaterAgent's in-memory `_current` timestamp on the store-global path: the state
+    // is detector-scoped (one detector instance per running daemon) and resets on restart, which only
+    // means a stale tenant waits one fresh threshold before skipping — never that events are lost.
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _tenantStaleSince = new();
 
     public HighWaterDetector(MartenDatabase runner, EventGraph graph, ILogger logger)
     {
@@ -165,9 +175,10 @@ internal class HighWaterDetector: IHighWaterDetector
 
     /// <summary>
     /// Safe-zone variant of <see cref="DetectForTenantsAsync"/>. Same vectorized
-    /// shape; per-tenant independent gap detection is the caller's job
-    /// (<see cref="VectorizedHighWaterMonitor"/>). When the flag is off, inherit
-    /// the default interface impl (store-global safe-zone reading).
+    /// shape; per-tenant gap detection + stale-threshold skipping are internal to
+    /// <see cref="loadPerTenantStatistics"/> (#4867), so both variants share one
+    /// implementation. When the flag is off, inherit the default interface impl
+    /// (store-global safe-zone reading).
     /// </summary>
     public async Task<HighWaterVector> DetectInSafeZoneForTenantsAsync(
         IReadOnlyCollection<string> tenantIds, CancellationToken token)
@@ -183,10 +194,11 @@ internal class HighWaterDetector: IHighWaterDetector
             return new HighWaterVector([]);
         }
 
-        // The vectorized poll itself is the same; the daemon-level safe-zone
-        // behavior (skipping gaps for stale tenants) is layered on top by
-        // VectorizedHighWaterMonitor — store responsibility is just one
-        // round-trip per poll regardless of normal vs safe-zone mode.
+        // The vectorized poll is identical to DetectForTenantsAsync: per-tenant
+        // advancement, gap holding, and threshold-gated gap skipping all live
+        // inside loadPerTenantStatistics because the JasperFx coordinator drives
+        // only the normal poll (there is no daemon-level per-tenant safe-zone
+        // scheduling to defer to).
         var stats = await loadPerTenantStatistics(tenantIds, token).ConfigureAwait(false);
         return new HighWaterVector(stats);
     }
@@ -212,6 +224,13 @@ internal class HighWaterDetector: IHighWaterDetector
         // no persisted progression row yet still gets its true high-water and its per-tenant agent advances.
         // The LEFT JOINs preserve a row per input tenant even when its partition / progression row does not
         // exist yet (returns null → treated as zero downstream).
+        //
+        // #4867: the `walk` lateral is the per-tenant analogue of the store-global GapDetector — the
+        // highest committed seq_id reachable from the persisted mark without crossing a gap. Without it,
+        // CurrentMark was seeded straight from the persisted progression row, so a tenant's mark froze
+        // forever after the first persisted HighWaterMark:{tenant} row and second batches never projected.
+        // The walk is only computed when there is a persisted mark with committed events above it
+        // (the gates on prog.last_seq_id / ev.max_seq_id), so caught-up tenants stay cheap.
         var sql = $@"
 with inputs(tenant_id) as (select unnest(:tenants))
 select
@@ -219,7 +238,8 @@ select
     coalesce(ev.max_seq_id, 0)         as last_value,
     coalesce(prog.last_seq_id, 0)      as last_seq_id,
     prog.last_updated                  as last_updated,
-    transaction_timestamp()            as ""timestamp""
+    transaction_timestamp()            as ""timestamp"",
+    walk.current_bound                 as current_bound
 from inputs i
 left join lateral (
     select max(e.seq_id) as max_seq_id
@@ -227,47 +247,108 @@ left join lateral (
     where e.tenant_id = i.tenant_id
 ) ev on true
 left join {schema}.mt_event_progression prog
-    on prog.name = :prefix || i.tenant_id;";
+    on prog.name = :prefix || i.tenant_id
+left join lateral (
+    select coalesce(
+        (select g.seq_id
+         from (select e.seq_id,
+                      lead(e.seq_id) over (order by e.seq_id) as next_seq
+               from {schema}.mt_events e
+               where e.tenant_id = i.tenant_id
+                 and e.seq_id >= prog.last_seq_id) g
+         where g.next_seq is not null
+           and g.next_seq - g.seq_id > 1
+         order by g.seq_id
+         limit 1),
+        ev.max_seq_id
+    ) as current_bound
+    where coalesce(prog.last_seq_id, 0) > 0
+      and coalesce(ev.max_seq_id, 0) > prog.last_seq_id
+) walk on true;";
 
         await using var conn = _database.CreateConnection();
         await conn.OpenAsync(token).ConfigureAwait(false);
         try
         {
-            await using var cmd = conn.CreateCommand(sql)
-                .With("tenants", tenantIds.ToArray())
-                .With("prefix", highWaterPrefix);
-            await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
-
             var results = new List<HighWaterStatistics>(tenantIds.Count);
-            while (await reader.ReadAsync(token).ConfigureAwait(false))
+            var staleTenants = new List<HighWaterStatistics>();
+
+            await using (var cmd = conn.CreateCommand(sql)
+                             .With("tenants", tenantIds.ToArray())
+                             .With("prefix", highWaterPrefix))
             {
-                var tenantId = await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false);
-                var lastValue = await reader.GetFieldValueAsync<long>(1, token).ConfigureAwait(false);
-                var lastSeqId = await reader.GetFieldValueAsync<long>(2, token).ConfigureAwait(false);
+                await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
 
-                DateTimeOffset? lastUpdated = await reader.IsDBNullAsync(3, token).ConfigureAwait(false)
-                    ? null
-                    : await reader.GetFieldValueAsync<DateTimeOffset>(3, token).ConfigureAwait(false);
-                var timestamp = await reader.GetFieldValueAsync<DateTimeOffset>(4, token).ConfigureAwait(false);
-
-                // CurrentMark = the latest sequence the daemon may treat as
-                // "caught up". With per-tenant gap detection not yet wired in
-                // (a Phase 3 refinement), seed CurrentMark from the saved
-                // progression row when one exists, otherwise from the
-                // tenant's sequence last_value. SafeStartMark mirrors
-                // CurrentMark for the same reason — the safe-zone walker
-                // resumes from the last good mark.
-                var currentMark = lastSeqId > 0 ? lastSeqId : lastValue;
-                results.Add(new HighWaterStatistics
+                while (await reader.ReadAsync(token).ConfigureAwait(false))
                 {
-                    TenantId = tenantId,
-                    HighestSequence = lastValue,
-                    LastMark = lastSeqId,
-                    SafeStartMark = currentMark,
-                    CurrentMark = currentMark,
-                    LastUpdated = lastUpdated,
-                    Timestamp = timestamp
-                });
+                    var tenantId = await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false);
+                    var lastValue = await reader.GetFieldValueAsync<long>(1, token).ConfigureAwait(false);
+                    var lastSeqId = await reader.GetFieldValueAsync<long>(2, token).ConfigureAwait(false);
+
+                    DateTimeOffset? lastUpdated = await reader.IsDBNullAsync(3, token).ConfigureAwait(false)
+                        ? null
+                        : await reader.GetFieldValueAsync<DateTimeOffset>(3, token).ConfigureAwait(false);
+                    var timestamp = await reader.GetFieldValueAsync<DateTimeOffset>(4, token).ConfigureAwait(false);
+                    long? currentBound = await reader.IsDBNullAsync(5, token).ConfigureAwait(false)
+                        ? null
+                        : await reader.GetFieldValueAsync<long>(5, token).ConfigureAwait(false);
+
+                    var statistics = new HighWaterStatistics
+                    {
+                        TenantId = tenantId,
+                        HighestSequence = lastValue,
+                        LastMark = lastSeqId,
+                        LastUpdated = lastUpdated,
+                        Timestamp = timestamp
+                    };
+
+                    // CurrentMark = the latest sequence the daemon may treat as "caught up".
+                    // SafeStartMark mirrors CurrentMark — a per-tenant walker resumes from the
+                    // last good mark.
+                    if (lastSeqId == 0)
+                    {
+                        // No persisted progression row yet — seed from the tenant's committed
+                        // max(seq_id), exactly the pre-#4867 first-sighting behavior.
+                        statistics.CurrentMark = statistics.SafeStartMark = lastValue;
+                        _tenantStaleSince.TryRemove(tenantId, out _);
+                    }
+                    else if (lastValue <= lastSeqId)
+                    {
+                        // Caught up — and never rewind a persisted mark, even if committed
+                        // events were archived out from under it.
+                        statistics.CurrentMark = statistics.SafeStartMark = lastSeqId;
+                        _tenantStaleSince.TryRemove(tenantId, out _);
+                    }
+                    else if (currentBound > lastSeqId)
+                    {
+                        // #4867 THE fix: committed events reach contiguously above the persisted
+                        // mark, so advance immediately — this is what un-freezes a tenant's second
+                        // batch. The walk stops before any gap, so an allocated-but-uncommitted
+                        // lower seq_id is never silently skipped.
+                        statistics.CurrentMark = statistics.SafeStartMark = currentBound.Value;
+                        _tenantStaleSince.TryRemove(tenantId, out _);
+                    }
+                    else
+                    {
+                        // A gap sits immediately above the persisted mark (in-flight append or a
+                        // rolled-back sequence number). Hold the mark and let the stale clock run;
+                        // once the tenant has been stuck past StaleSequenceThreshold, skip the gap
+                        // below — the per-tenant mirror of the store-global DetectInSafeZone wait.
+                        statistics.CurrentMark = statistics.SafeStartMark = lastSeqId;
+                        var staleSince = _tenantStaleSince.GetOrAdd(tenantId, timestamp);
+                        if (timestamp.Subtract(staleSince) > _settings.StaleSequenceThreshold)
+                        {
+                            staleTenants.Add(statistics);
+                        }
+                    }
+
+                    results.Add(statistics);
+                }
+            }
+
+            foreach (var statistics in staleTenants)
+            {
+                await trySkipStaleTenantGapAsync(conn, statistics, token).ConfigureAwait(false);
             }
 
             return results;
@@ -276,6 +357,50 @@ left join {schema}.mt_event_progression prog
         {
             await conn.CloseAsync().ConfigureAwait(false);
         }
+    }
+
+    // #4867: safe-harbor skip for one tenant that has been stale past StaleSequenceThreshold. Walks the
+    // tenant's committed events from just above the stuck mark (the store-global equivalent is
+    // DetectInSafeZone's `_gapDetector.Start = SafeStartMark + 1`) and lands on the highest seq_id
+    // reachable without crossing ANOTHER gap, so multiple gaps are skipped one threshold at a time —
+    // the same iterative cadence as the store-global agent.
+    private async Task trySkipStaleTenantGapAsync(NpgsqlConnection conn, HighWaterStatistics statistics,
+        CancellationToken token)
+    {
+        var sql = $@"
+select coalesce(
+    (select g.seq_id
+     from (select e.seq_id,
+                  lead(e.seq_id) over (order by e.seq_id) as next_seq
+           from {_graph.DatabaseSchemaName}.mt_events e
+           where e.tenant_id = :tenant
+             and e.seq_id > :mark) g
+     where g.next_seq is not null
+       and g.next_seq - g.seq_id > 1
+     order by g.seq_id
+     limit 1),
+    (select max(e.seq_id)
+     from {_graph.DatabaseSchemaName}.mt_events e
+     where e.tenant_id = :tenant
+       and e.seq_id > :mark));";
+
+        await using var cmd = conn.CreateCommand(sql)
+            .With("tenant", statistics.TenantId!)
+            .With("mark", statistics.LastMark);
+
+        var raw = await cmd.ExecuteScalarAsync(token).ConfigureAwait(false);
+        if (raw is not long safeSequence || safeSequence <= statistics.LastMark)
+        {
+            return;
+        }
+
+        _logger.LogInformation(
+            "Daemon projection high water detection for tenant {TenantId} skipping a gap in the event sequence after being stale past the {Threshold} threshold, determined that the 'safe harbor' sequence is at {SafeHarborSequence}",
+            statistics.TenantId, _settings.StaleSequenceThreshold, safeSequence);
+
+        statistics.CurrentMark = statistics.SafeStartMark = safeSequence;
+        statistics.IncludesSkipping = true;
+        _tenantStaleSince.TryRemove(statistics.TenantId!, out _);
     }
 
     private async Task calculateHighWaterMark(HighWaterStatistics statistics, DetectionType detectionType,

--- a/src/TenantPartitionedEventsTests/Regressions/Bug_4867_per_tenant_high_water_advancement.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/Bug_4867_per_tenant_high_water_advancement.cs
@@ -1,0 +1,369 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Daemon.HighWater;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Daemon.HighWater;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Shouldly;
+using TenantPartitionedEventsTests.Fixtures;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Regressions;
+
+/// <summary>
+/// #4867 — under <c>UseTenantPartitionedEvents</c> a tenant's high-water mark froze permanently after
+/// the first persisted <c>HighWaterMark:{tenant}</c> row: <c>loadPerTenantStatistics</c> seeded
+/// <c>CurrentMark</c> straight from the persisted progression row whenever one existed (the tenant's
+/// committed <c>max(seq_id)</c> was only consulted before the first persist), and the vectorized
+/// per-tenant path had no advancement step at all. Any second batch of events for the tenant was
+/// never projected.
+///
+/// <para>
+/// This class pins the fixed detector contract directly (fast, detector-level, shared fixture):
+/// per-tenant <c>CurrentMark</c> now advances from the persisted mark toward the tenant's committed
+/// height through a per-tenant gap walk — the vectorized analogue of the store-global
+/// <c>GapDetector</c> — holding at a gap (in-flight or rolled-back seq_id) until the tenant has been
+/// stale past <c>StaleSequenceThreshold</c>, then skipping, mirroring <c>DetectInSafeZone</c>.
+/// The daemon-level end-to-end regression lives in
+/// <see cref="Bug_4867_second_batch_projects_under_continuous_daemon"/>.
+/// </para>
+/// </summary>
+[Collection("guid-partitioned")]
+public class Bug_4867_per_tenant_high_water_advancement
+{
+    private readonly GuidPartitionedFixture _fixture;
+
+    public Bug_4867_per_tenant_high_water_advancement(GuidPartitionedFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private HighWaterDetector newDetector() => new(
+        (MartenDatabase)_fixture.Store.Storage.Database, _fixture.Store.Options.EventGraph,
+        NullLogger.Instance);
+
+    private async Task<HighWaterStatistics> detectAsync(IHighWaterDetector detector, string tenant)
+    {
+        var vector = await detector.DetectForTenantsAsync(new[] { tenant }, CancellationToken.None);
+        vector.TryGetStatistics(tenant, out var statistics).ShouldBeTrue();
+        return statistics;
+    }
+
+    // THE core detector-level regression: before the fix, CurrentMark stayed pinned to the persisted
+    // progression row (6) forever; the second batch's committed height (11) was never reached.
+    [Fact]
+    public async Task current_mark_advances_from_the_persisted_row_to_the_committed_height()
+    {
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        IHighWaterDetector detector = newDetector();
+
+        // Batch 1: 6 events → seed reading (no progression row yet) = 6, then persist the mark the
+        // way TenantedHighWaterCoordinator does after every poll.
+        await _fixture.AppendNEventsAsync(tenant, 6);
+        (await detectAsync(detector, tenant)).CurrentMark.ShouldBe(6);
+        await detector.MarkHighWaterForTenantAsync(tenant, 6, CancellationToken.None);
+
+        // Batch 2: 5 more committed events (seq 7..11, contiguous). The very next poll must advance —
+        // no stale-threshold wait applies because there is no gap.
+        await _fixture.AppendNEventsAsync(tenant, 5);
+
+        var statistics = await detectAsync(detector, tenant);
+        statistics.LastMark.ShouldBe(6, "LastMark reflects the persisted HighWaterMark:{tenant} row");
+        statistics.HighestSequence.ShouldBe(11, "the tenant's committed max(seq_id)");
+        statistics.CurrentMark.ShouldBe(11,
+            "#4867: the per-tenant mark must advance from the persisted row to the committed height — " +
+            "before the fix it stayed frozen at 6 and second batches never projected");
+    }
+
+    [Fact]
+    public async Task gap_above_the_persisted_mark_holds_within_the_stale_threshold_then_skips_past_it()
+    {
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        // The stale clock is detector-instance state (the per-tenant analogue of HighWaterAgent's
+        // in-memory `_current`), so all polls in this test share one instance — exactly the daemon shape.
+        IHighWaterDetector detector = newDetector();
+
+        await _fixture.AppendNEventsAsync(tenant, 5);
+        await detector.MarkHighWaterForTenantAsync(tenant, 5, CancellationToken.None);
+
+        // Batch 2 = seq 6..10, then knock out seq 6 to simulate an allocated-but-never-committed
+        // sequence number (in-flight append that rolled back) sitting right above the mark.
+        await _fixture.AppendNEventsAsync(tenant, 5);
+        await deleteEventAsync(tenant, 6);
+
+        // Within the stale threshold the mark must HOLD at 5: max(seq_id) alone would say 10, but
+        // advancing across the gap immediately could silently skip a lower seq that is still in flight.
+        var held = await detectAsync(detector, tenant);
+        held.CurrentMark.ShouldBe(5, "a gap immediately above the mark holds the mark within the threshold");
+        held.IncludesSkipping.ShouldBeFalse();
+
+        (await detectAsync(detector, tenant)).CurrentMark.ShouldBe(5,
+            "an immediate second poll is still inside the stale threshold — no skip yet");
+
+        // Once the tenant has been observably stuck past StaleSequenceThreshold, the detector skips
+        // the gap to the tenant's safe-harbor sequence — the per-tenant mirror of DetectInSafeZone.
+        var threshold = _fixture.Store.Options.Projections.StaleSequenceThreshold;
+        await Task.Delay(threshold.Add(1500.Milliseconds()));
+
+        var skipped = await detectAsync(detector, tenant);
+        skipped.CurrentMark.ShouldBe(10,
+            "past the stale threshold the tenant's mark skips the dead gap and lands on the committed height");
+        skipped.IncludesSkipping.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task tenant_with_no_progression_row_still_seeds_from_committed_max_seq_id()
+    {
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+        await _fixture.AppendNEventsAsync(tenant, 3);
+
+        // Pre-#4867 first-sighting behavior is intact: no HighWaterMark:{tenant} row yet → seed the
+        // mark from the tenant's committed max(seq_id) so a fresh tenant's projections start at once.
+        var statistics = await detectAsync(newDetector(), tenant);
+        statistics.LastMark.ShouldBe(0);
+        statistics.CurrentMark.ShouldBe(3);
+        statistics.SafeStartMark.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task a_persisted_mark_is_never_rewound_below_itself()
+    {
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+        await _fixture.AppendNEventsAsync(tenant, 3);
+
+        // A mark ahead of the committed height (events archived/cleaned out from under it, or a
+        // previously skipped-to position) must hold, never rewind.
+        IHighWaterDetector detector = newDetector();
+        await detector.MarkHighWaterForTenantAsync(tenant, 99, CancellationToken.None);
+
+        var statistics = await detectAsync(detector, tenant);
+        statistics.CurrentMark.ShouldBe(99, "never rewind a persisted per-tenant mark");
+    }
+
+    private async Task deleteEventAsync(string tenant, long seqId)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await conn.CreateCommand(
+                $"delete from {_fixture.SchemaName}.mt_events where tenant_id = :t and seq_id = :s")
+            .With("t", tenant)
+            .With("s", seqId)
+            .ExecuteNonQueryAsync();
+    }
+}
+
+/// <summary>
+/// #4867 daemon-level end-to-end regression: a continuous daemon under per-tenant partitioning must
+/// keep projecting a tenant's SECOND batch of events after the first poll has persisted the
+/// <c>HighWaterMark:{tenant}</c> row. This is the exact shape that froze — essentially every existing
+/// test appended one batch per tenant before asserting, which is why the bug stayed hidden.
+/// </summary>
+public partial class Bug_4867_second_batch_projects_under_continuous_daemon
+{
+    public class Bug4867Trip { public Guid Id { get; set; } public double Distance { get; set; } }
+
+    public record Bug4867Started(Guid Id);
+    public record Bug4867Leg(double Distance);
+
+    public partial class Bug4867TripProjection: SingleStreamProjection<Bug4867Trip, Guid>
+    {
+        public Bug4867TripProjection() => Name = "Bug4867Trip";
+        public void Apply(Bug4867Trip a, Bug4867Leg e) => a.Distance += e.Distance;
+    }
+
+    private static DocumentStore buildStore(string schema)
+    {
+        return (DocumentStore)DocumentStore.For(o =>
+        {
+            o.Connection(ConnectionSource.ConnectionString);
+            o.DatabaseSchemaName = schema;
+            o.Events.TenancyStyle = TenancyStyle.Conjoined;
+            o.Events.UseTenantPartitionedEvents = true;
+            o.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            o.Policies.AllDocumentsAreMultiTenanted();
+
+            o.Schema.For<Bug4867Trip>().DocumentAlias("b4867_trip");
+            o.Projections.Add<Bug4867TripProjection>(ProjectionLifecycle.Async);
+        });
+    }
+
+    [Fact]
+    public async Task second_batch_for_a_tenant_projects_after_the_first_mark_is_persisted()
+    {
+        var schema = $"bug4867_a_p{Environment.ProcessId}";
+        using var store = buildStore(schema);
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+
+        const string tenant = "t4867_solo";
+        await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        // Batch 1: 3 events (seq 1..3) BEFORE the daemon starts.
+        var streamId = Guid.NewGuid();
+        await using (var session = store.LightweightSession(tenant))
+        {
+            session.Events.StartStream<Bug4867Trip>(streamId,
+                new Bug4867Started(streamId), new Bug4867Leg(1.0), new Bug4867Leg(2.0));
+            await session.SaveChangesAsync();
+        }
+
+        using var daemon = await store.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+
+        // Wait until batch 1 is projected AND the per-tenant high-water row has been PERSISTED —
+        // the persisted row is exactly what froze the mark before the fix, so batch 2 must land after it.
+        (await waitForAsync(30.Seconds(), async () =>
+                await readDistanceAsync(store, tenant, streamId) == 3.0 &&
+                await readTenantHighWaterAsync(schema, tenant) >= 3))
+            .ShouldBeTrue("batch 1 must project and the HighWaterMark:{tenant} row must be persisted");
+
+        // Batch 2: one more event (seq 4) while the daemon keeps running.
+        await using (var session = store.LightweightSession(tenant))
+        {
+            session.Events.Append(streamId, new Bug4867Leg(5.0));
+            await session.SaveChangesAsync();
+        }
+
+        // THE #4867 regression: before the fix the tenant's mark stayed frozen at 3 forever and this
+        // wait timed out — the second batch was never projected.
+        (await waitForAsync(30.Seconds(), async () =>
+                await readDistanceAsync(store, tenant, streamId) == 8.0))
+            .ShouldBeTrue(
+                "#4867: the tenant's second batch must project — the per-tenant high-water mark must " +
+                "advance past the first persisted HighWaterMark:{tenant} row");
+
+        // The persisted row itself advances too (the coordinator persists after routing, so give it
+        // its own short wait rather than racing the projection commit).
+        (await waitForAsync(10.Seconds(), async () =>
+                await readTenantHighWaterAsync(schema, tenant) == 4))
+            .ShouldBeTrue("the persisted per-tenant mark advances to the second batch's committed height");
+
+        await daemon.StopAllAsync();
+    }
+
+    [Fact]
+    public async Task second_batches_advance_independently_for_an_active_and_a_lagging_tenant()
+    {
+        var schema = $"bug4867_b_p{Environment.ProcessId}";
+        using var store = buildStore(schema);
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+
+        // Active tenant (taller per-tenant sequence) + lagging tenant (shorter). The lagging tenant's
+        // own appends never move the store-global max(seq_id) — its advancement must ride the shared
+        // vectorized poll and its OWN committed height, fully independent of the active tenant's mark.
+        const string active = "t4867_active";
+        const string lagging = "t4867_lag";
+        await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, active, lagging);
+
+        var activeStream = Guid.NewGuid();
+        var laggingStream = Guid.NewGuid();
+        await using (var session = store.LightweightSession(active))
+        {
+            session.Events.StartStream<Bug4867Trip>(activeStream,
+                new Bug4867Started(activeStream), new Bug4867Leg(1.0), new Bug4867Leg(1.0),
+                new Bug4867Leg(1.0), new Bug4867Leg(1.0)); // 5 events → seq 1..5, distance 4.0
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = store.LightweightSession(lagging))
+        {
+            session.Events.StartStream<Bug4867Trip>(laggingStream,
+                new Bug4867Started(laggingStream), new Bug4867Leg(1.0)); // 2 events → seq 1..2, distance 1.0
+            await session.SaveChangesAsync();
+        }
+
+        using var daemon = await store.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+
+        (await waitForAsync(30.Seconds(), async () =>
+                await readDistanceAsync(store, active, activeStream) == 4.0 &&
+                await readDistanceAsync(store, lagging, laggingStream) == 1.0 &&
+                await readTenantHighWaterAsync(schema, active) >= 5 &&
+                await readTenantHighWaterAsync(schema, lagging) >= 2))
+            .ShouldBeTrue("both tenants' first batches must project and both per-tenant marks must persist");
+
+        // Second batches for both — the lagging tenant first (seq 3, well below the active tenant's
+        // height of 5), then the active tenant (seq 6..7).
+        await using (var session = store.LightweightSession(lagging))
+        {
+            session.Events.Append(laggingStream, new Bug4867Leg(10.0));
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = store.LightweightSession(active))
+        {
+            session.Events.Append(activeStream, new Bug4867Leg(20.0), new Bug4867Leg(20.0));
+            await session.SaveChangesAsync();
+        }
+
+        (await waitForAsync(30.Seconds(), async () =>
+                await readDistanceAsync(store, active, activeStream) == 44.0 &&
+                await readDistanceAsync(store, lagging, laggingStream) == 11.0))
+            .ShouldBeTrue(
+                "#4867: each tenant's second batch must project independently — the lagging tenant " +
+                "advances against its OWN committed height even though it never moves the store-global max");
+
+        (await waitForAsync(10.Seconds(), async () =>
+                await readTenantHighWaterAsync(schema, active) == 7 &&
+                await readTenantHighWaterAsync(schema, lagging) == 3))
+            .ShouldBeTrue("each persisted per-tenant mark lands on its own tenant's committed height");
+
+        await daemon.StopAllAsync();
+    }
+
+    private static async Task<bool> waitForAsync(TimeSpan timeout, Func<Task<bool>> condition)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            if (await condition())
+            {
+                return true;
+            }
+
+            await Task.Delay(250);
+        }
+
+        return await condition();
+    }
+
+    private static async Task<double?> readDistanceAsync(DocumentStore store, string tenant, Guid id)
+    {
+        await using var session = store.QuerySession(tenant);
+        var doc = await session.LoadAsync<Bug4867Trip>(id);
+        return doc?.Distance;
+    }
+
+    private static async Task<long> readTenantHighWaterAsync(string schema, string tenant)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        var raw = await conn.CreateCommand(
+                $"select last_seq_id from {schema}.mt_event_progression where name = :n")
+            .With("n", $"HighWaterMark:{tenant}")
+            .ExecuteScalarAsync();
+        return raw is long v ? v : 0L;
+    }
+}


### PR DESCRIPTION
Closes #4867. Part of epic JasperFx/jasperfx#486 (found by the WS1 failover e2e). Marten-only — no JasperFx change needed.

## The bug

`loadPerTenantStatistics` seeded `CurrentMark` from the persisted `HighWaterMark:{tenant}` row with **no advancement step** (the deferred "Phase 3" per-tenant gap detection) — once a tenant's first mark persisted, every subsequent poll re-persisted it verbatim, and any second batch of events for that tenant was never projected. Latent in every continuously-running per-tenant-partitioned daemon; hidden because virtually every existing test appends exactly one batch per tenant.

## The fix (vectorized analogue of the store-global walker, same single round-trip)

1. **Per-tenant gap walk**: an additional `lateral` in the vectorized statistics query advances `CurrentMark` from the persisted mark to the highest committed seq_id reachable without crossing a gap — a contiguous second batch advances on the very next poll. SQL-gated so caught-up/no-row tenants pay nothing.
2. **Gap hold + safe-harbor skip**: a gap immediately above the mark (in-flight or rolled-back seq) holds the mark; a detector-scoped per-tenant stale clock (the vectorized analogue of `HighWaterAgent`'s in-memory timestamp — `last_updated` can't serve because the coordinator refreshes it on every poll) gates a tenant-scoped skip-past-dead-gap walk once stuck beyond `StaleSequenceThreshold`. Restart costs at most one fresh threshold wait; events are never lost.
3. **Preserved**: no-progression-row tenants keep the max(seq_id) seed byte-for-byte; marks never rewind; non-partitioned stores untouched (`Detect`/`DetectInSafeZone` unmodified).

## Failing-first proof + tests

With the fix stashed, the four advancement tests fail exactly as production does (THE regression `second_batch_for_a_tenant_projects_after_the_first_mark_is_persisted` times out frozen at the first batch's mark; `current_mark_advances_from_the_persisted_row` stays 6 expecting 11). New `Regressions/Bug_4867_per_tenant_high_water_advancement` (6 tests): detector-level advancement/gap-hold/skip + seed and never-rewind pins, daemon-level second-batch projection + active-vs-lagging tenant independence.

**Full `TenantPartitionedEventsTests`: 210/210 on net10.0 and 210/210 on net9.0** — including the pre-existing `vectorized_high_water_detection`, `Bug_4712`, `Bug_4717`, and `daemon_in_depth_under_partitioning` suites, none of which needed changes.

Follow-up filed separately (JasperFx side): the vectorized per-tenant poll is only driven off store-global mark *changes*, so a tenant appending below the global max may wait for unrelated activity to be re-polled — polling-cadence issue, distinct from this freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)