### PR TITLE
Native daemon distributes agents per tenant — consume jasperfx#491 (closes the native half of jasperfx#489)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -77,9 +77,16 @@
          node-distributed daemon hosts (Wolverine) to fan out one agent per (shard, tenant), plus the
          hardened per-tenant StartAgentAsync: tenant ceilings primed before start (SubscribeFromPresent
          no longer rewinds to 0), exact-identity precedence, loud failure on non-partitioned stores. -->
-    <!-- JasperFx 2.21.0: jasperfx#490 DaemonMode.ExternallyManaged (external hosts run projections;
-         store hosts no coordination and must not warn — wolverine#3290) + jasperfx#491 distributor-level
-         per-tenant shard expansion with coordinator reconciliation (jasperfx#489). -->
+    <!-- JasperFx 2.21.0: jasperfx#491 (epic jasperfx#486) — distributor-level per-tenant shard
+         expansion for the NATIVE daemon: the Solo / SingleTenant / MultiTenanted distributor
+         concretes grow a distributesAgentsPerTenant ctor overload that expands store-global shard
+         names into per-tenant ShardNames (PerTenantShardExpansion, re-evaluated every
+         BuildDistributionAsync so tenant add/remove converges on the leadership polling cycle),
+         and the coordinator reconciles running agents against the freshly built distribution
+         (stops agents whose identity disappeared). Marten threads
+         IEventStore.DistributesAgentsPerTenant into BuildDistributor (ProjectionCoordinator).
+         Also DaemonMode.ExternallyManaged (jasperfx#490, wolverine#3290 — external hosts run
+         projections; the store hosts no coordination and must not warn). -->
     <PackageVersion Include="JasperFx" Version="2.21.0" />
     <PackageVersion Include="JasperFx.Events" Version="2.21.0" />
     <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.21.0">

--- a/src/Marten/Events/Daemon/Coordination/ProjectionCoordinator.cs
+++ b/src/Marten/Events/Daemon/Coordination/ProjectionCoordinator.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using ImTools;
 using JasperFx.Core;
+using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Marten.Storage;
@@ -77,10 +78,19 @@ public class ProjectionCoordinator: ProjectionCoordinatorBase, IProjectionCoordi
             return databases.OfType<IProjectionDatabase>().ToList();
         };
 
+        // jasperfx#489/#491 (marten#4862): when the store is tenant-partitioned
+        // (IEventStore.DistributesAgentsPerTenant), the distributors expand each store-global
+        // shard name into per-tenant ShardNames from the database's own registered tenant list
+        // (MartenDatabase implements ICrossTenantRebuildSource over mt_tenant_partitions). The
+        // expansion is re-evaluated on every BuildDistributionAsync, so tenants added or removed
+        // at runtime converge on the coordinator's leadership polling cycle without a restart.
+        var distributesAgentsPerTenant = ((IEventStore)store).DistributesAgentsPerTenant;
+
         switch (projections.AsyncMode)
         {
             case DaemonMode.Solo:
-                return new SoloProjectionDistributor(allDatabases, allShards, setFactory, baseLockId);
+                return new SoloProjectionDistributor(allDatabases, allShards, setFactory, baseLockId,
+                    distributesAgentsPerTenant);
 
             case DaemonMode.HotCold:
                 var lockFactory = buildLockFactory(store);
@@ -89,11 +99,12 @@ public class ProjectionCoordinator: ProjectionCoordinatorBase, IProjectionCoordi
                     return new SingleTenantProjectionDistributor(
                         () => (IProjectionDatabase)store.Storage.Database,
                         allShards, lockFactory, setFactory,
-                        store.Options.EventGraph.DatabaseSchemaName, baseLockId);
+                        store.Options.EventGraph.DatabaseSchemaName, baseLockId,
+                        distributesAgentsPerTenant);
                 }
 
                 return new MultiTenantedProjectionDistributor(allDatabases, allShards, lockFactory, setFactory,
-                    baseLockId);
+                    baseLockId, distributesAgentsPerTenant);
 
             default:
                 // DaemonMode.Disabled: no async daemon, so there is nothing to distribute.

--- a/src/TenantPartitionedEventsTests/Daemon/dynamic_tenant_lifecycle_during_continuous_daemon.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/dynamic_tenant_lifecycle_during_continuous_daemon.cs
@@ -1,0 +1,242 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TenantPartitionedEventsTests.Daemon;
+
+/// <summary>
+/// JasperFx/jasperfx#486 WS1 — dynamic tenant lifecycle against a CONTINUOUSLY RUNNING daemon on a
+/// single per-tenant-partitioned database (DefaultTenancy + Conjoined + UseTenantPartitionedEvents).
+///
+/// <para>
+/// The WS1 baseline for a tenant that joins mid-run is: its partitions + per-tenant sequence are
+/// provisioned by <c>AddMartenManagedTenantsAsync</c>, and (once an agent addresses the tenant) a
+/// per-tenant <c>{Projection}:All:{tenant}</c> progression row and a <c>HighWaterMark:{tenant}</c>
+/// row appear and reach the tenant's own height — all WITHOUT restarting the daemon.
+/// </para>
+///
+/// <para>
+/// REALITY PINNED BY THIS TEST (JasperFx.Events 2.20.0): the daemon enumerates tenants for the
+/// per-tenant continuous fan-out ONLY inside <c>StartAllAsync</c>
+/// (<c>JasperFxAsyncDaemon.buildPerTenantContinuousAgents</c> → <c>ICrossTenantRebuildSource.FindRebuildTenantsAsync</c>).
+/// There is no mid-run tenant-discovery loop, so a tenant added after start is NOT picked up
+/// automatically. The mechanism that DOES work without a restart is the wolverine#3280 path:
+/// <c>StartAgentAsync("{Projection}:All:{tenant}")</c> resolves the base shard, activates the tenant
+/// in the vectorized high-water coordinator, and fans out the tenant agent — that is what an external
+/// distributor (e.g. Wolverine) is expected to call, and what this test drives explicitly.
+/// </para>
+/// </summary>
+public partial class dynamic_tenant_lifecycle_during_continuous_daemon
+{
+    private readonly ITestOutputHelper _output;
+
+    public dynamic_tenant_lifecycle_during_continuous_daemon(ITestOutputHelper output) => _output = output;
+
+    public class DynCounter { public Guid Id { get; set; } public int Count { get; set; } }
+
+    public record DynStarted(Guid Id);
+    public record DynBumped(string Label);
+
+    public partial class DynLifeProjection: SingleStreamProjection<DynCounter, Guid>
+    {
+        public const string ProjectionName = "DynLife";
+        public DynLifeProjection() => Name = ProjectionName;
+        public void Apply(DynCounter c, DynBumped e) => c.Count++;
+    }
+
+    private static readonly string Schema = $"ws1_dynlife_p{Environment.ProcessId}";
+
+    [Fact]
+    public async Task tenant_added_mid_run_catches_up_via_per_tenant_agent_start_and_removal_stops_tracking()
+    {
+        using var store = (DocumentStore)DocumentStore.For(o =>
+        {
+            o.Connection(ConnectionSource.ConnectionString);
+            o.DatabaseSchemaName = Schema;
+            o.DisableNpgsqlLogging = true;
+            o.Events.TenancyStyle = TenancyStyle.Conjoined;
+            o.Events.UseTenantPartitionedEvents = true;
+            o.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            o.Policies.AllDocumentsAreMultiTenanted();
+
+            o.Schema.For<DynCounter>().DocumentAlias("ws1_dyn_cnt");
+            o.Projections.Add<DynLifeProjection>(ProjectionLifecycle.Async);
+        });
+
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+
+        // ---- Phase 0: two initial tenants with different heights, daemon started AFTER seeding ----
+        const string tenantA = "dynlife_a";
+        const string tenantB = "dynlife_b";
+        await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenantA, tenantB);
+
+        var streamA = await AppendStreamAsync(store, tenantA, 4); // 1 DynStarted + 4 DynBumped = 5 events
+        var streamB = await AppendStreamAsync(store, tenantB, 2); // 3 events
+
+        using var daemon = await store.BuildProjectionDaemonAsync();
+        await daemon.StartAllAsync();
+
+        await WaitForProgressionAsync(rows =>
+            SeqOf(rows, $"{DynLifeProjection.ProjectionName}:All:{tenantA}") >= 5 &&
+            SeqOf(rows, $"{DynLifeProjection.ProjectionName}:All:{tenantB}") >= 3 &&
+            SeqOf(rows, $"HighWaterMark:{tenantA}") >= 5 &&
+            SeqOf(rows, $"HighWaterMark:{tenantB}") >= 3,
+            30.Seconds(), "initial tenants reach their own per-tenant heights");
+
+        // ---- Phase 1: a NEW tenant joins while the daemon keeps running ----
+        const string tenantC = "dynlife_c";
+        await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenantC);
+        var streamC = await AppendStreamAsync(store, tenantC, 3); // 4 events
+
+        // PINNED CURRENT BEHAVIOR: the running daemon does NOT discover the new tenant on its own.
+        // buildPerTenantContinuousAgents runs only inside StartAllAsync; the high-water poll loop
+        // (TenantedHighWaterCoordinator.PollAndRouteAsync) only polls tenants that already have a
+        // tenant-bearing agent on this node. Give it a generous-but-bounded window to prove the
+        // negative, then drive the supported no-restart path below. If a product change ever makes
+        // this pick up automatically, this assertion should be flipped to celebrate it.
+        await Task.Delay(5.Seconds());
+        var midRows = await ProgressionRowsAsync();
+        DumpRows("after adding tenant C, before explicit agent start", midRows);
+        midRows.Any(r => r.Name == $"{DynLifeProjection.ProjectionName}:All:{tenantC}").ShouldBeFalse(
+            "current behavior: a tenant added mid-run gets no per-tenant agent (tenant fan-out happens " +
+            "only in StartAllAsync) — if this now passes automatically, the daemon gained mid-run tenant " +
+            "discovery and this pin should be updated");
+
+        // The no-restart mechanism that DOES exist (wolverine#3280): explicitly start the per-tenant
+        // agent by its tenant-bearing identity. The daemon resolves the base shard, activates the
+        // tenant in the vectorized high-water monitor, and the new agent catches up from scratch.
+        await daemon.StartAgentAsync($"{DynLifeProjection.ProjectionName}:All:{tenantC}",
+            CancellationToken.None);
+
+        await WaitForProgressionAsync(rows =>
+            SeqOf(rows, $"{DynLifeProjection.ProjectionName}:All:{tenantC}") >= 4 &&
+            SeqOf(rows, $"HighWaterMark:{tenantC}") >= 4,
+            30.Seconds(), "tenant C catches up after an explicit per-tenant agent start, no restart");
+
+        // And the projection itself materialized for the new tenant — without any daemon restart.
+        await using (var query = store.QuerySession(tenantC))
+        {
+            var doc = await query.LoadAsync<DynCounter>(streamC);
+            doc.ShouldNotBeNull();
+            doc.Count.ShouldBe(3);
+        }
+
+        // The original tenants were untouched by the dynamic add.
+        await using (var query = store.QuerySession(tenantA))
+        {
+            (await query.LoadAsync<DynCounter>(streamA))!.Count.ShouldBe(4);
+        }
+
+        // ---- Phase 2: remove a tenant while the daemon keeps running ----
+        // RemoveMartenManagedTenantsAsync drops tenant B's partitions + per-tenant sequence and
+        // deletes its per-tenant progression rows (#4683 cleanup).
+        await store.Advanced.RemoveMartenManagedTenantsAsync(new[] { tenantB }, CancellationToken.None);
+
+        // PINNED CURRENT BEHAVIOR: removal does NOT stop the tenant's running agent — nothing in the
+        // remove path talks to the daemon. The agent stays registered (idle: its partitions are gone,
+        // so no events ever arrive again) and the polled-tenant set still contains B, but the #4683
+        // cleanup removed B's progression + high-water rows and nothing re-creates them: the
+        // vectorized detector no longer finds B's sequence, so no reading with CurrentMark > 0 is
+        // ever produced for B again (TenantedHighWaterCoordinator only persists marks > 0).
+        var agentsAfterRemoval = daemon.CurrentAgents().Select(x => x.Name.Identity).ToList();
+        _output.WriteLine("agents after removal: " + string.Join(", ", agentsAfterRemoval));
+        agentsAfterRemoval.ShouldContain($"{DynLifeProjection.ProjectionName}:All:{tenantB}",
+            "current behavior: removing a tenant does not stop its agent — it lingers idle; " +
+            "if this fails, tenant removal now reaps agents and this pin should be updated");
+
+        // B's progression + high-water rows are gone and STAY gone across further high-water polls.
+        await Task.Delay(2.Seconds());
+        var finalRows = await ProgressionRowsAsync();
+        DumpRows("after removing tenant B", finalRows);
+        finalRows.Any(r => r.Name == $"{DynLifeProjection.ProjectionName}:All:{tenantB}").ShouldBeFalse(
+            "the #4683 cleanup deletes the removed tenant's progression rows and the lingering agent " +
+            "must not re-create them");
+        finalRows.Any(r => r.Name == $"HighWaterMark:{tenantB}").ShouldBeFalse(
+            "the removed tenant's high-water row must not be re-persisted after removal");
+
+        // Survivors are unaffected by the removal.
+        SeqOf(finalRows, $"{DynLifeProjection.ProjectionName}:All:{tenantA}").ShouldBe(5);
+        SeqOf(finalRows, $"{DynLifeProjection.ProjectionName}:All:{tenantC}").ShouldBe(4);
+
+        await daemon.StopAllAsync();
+    }
+
+    private static async Task<Guid> AppendStreamAsync(DocumentStore store, string tenant, int bumps)
+    {
+        var id = Guid.NewGuid();
+        await using var session = store.LightweightSession(tenant);
+        var events = new object[] { new DynStarted(id) }
+            .Concat(Enumerable.Range(0, bumps).Select(i => (object)new DynBumped($"{tenant}-{i}")))
+            .ToArray();
+        session.Events.StartStream<DynCounter>(id, events);
+        await session.SaveChangesAsync();
+        return id;
+    }
+
+    private async Task WaitForProgressionAsync(
+        Func<List<(string Name, long Seq)>, bool> condition, TimeSpan timeout, string what)
+    {
+        var sw = Stopwatch.StartNew();
+        List<(string Name, long Seq)> rows = new();
+        while (sw.Elapsed < timeout)
+        {
+            rows = await ProgressionRowsAsync();
+            if (condition(rows))
+            {
+                return;
+            }
+
+            await Task.Delay(250);
+        }
+
+        DumpRows($"TIMED OUT waiting for: {what}", rows);
+        throw new TimeoutException($"Timed out after {timeout} waiting for: {what}");
+    }
+
+    private void DumpRows(string label, List<(string Name, long Seq)> rows)
+    {
+        _output.WriteLine($"=== {label} ===");
+        foreach (var (name, seq) in rows.OrderBy(r => r.Name))
+        {
+            _output.WriteLine($"{seq,6} | {name}");
+        }
+    }
+
+    private static long SeqOf(List<(string Name, long Seq)> rows, string name) =>
+        rows.FirstOrDefault(r => r.Name == name).Seq;
+
+    private static async Task<List<(string Name, long Seq)>> ProgressionRowsAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand(
+            $"select name, coalesce(last_seq_id,0) from {Schema}.mt_event_progression order by name");
+        await using var reader = await cmd.ExecuteReaderAsync();
+        var rows = new List<(string, long)>();
+        while (await reader.ReadAsync())
+        {
+            rows.Add((reader.GetString(0), reader.GetInt64(1)));
+        }
+
+        return rows;
+    }
+}

--- a/src/TenantPartitionedEventsTests/Daemon/dynamic_tenant_lifecycle_during_continuous_daemon.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/dynamic_tenant_lifecycle_during_continuous_daemon.cs
@@ -8,40 +8,52 @@ using System.Threading.Tasks;
 using JasperFx;
 using JasperFx.Core;
 using JasperFx.Events;
+using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Marten;
 using Marten.Events;
 using Marten.Events.Aggregation;
 using Marten.Events.Projections;
 using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Npgsql;
 using Shouldly;
 using Weasel.Core;
 using Xunit;
 using Xunit.Abstractions;
+using IProjectionCoordinator = Marten.Events.Daemon.Coordination.IProjectionCoordinator;
 
 namespace TenantPartitionedEventsTests.Daemon;
 
 /// <summary>
-/// JasperFx/jasperfx#486 WS1 — dynamic tenant lifecycle against a CONTINUOUSLY RUNNING daemon on a
-/// single per-tenant-partitioned database (DefaultTenancy + Conjoined + UseTenantPartitionedEvents).
+/// JasperFx/jasperfx#486 WS1 — dynamic tenant lifecycle against a CONTINUOUSLY RUNNING coordinator
+/// on a single per-tenant-partitioned database (DefaultTenancy + Conjoined +
+/// UseTenantPartitionedEvents), hosted via <c>AddAsyncDaemon(DaemonMode.Solo)</c> so the
+/// <c>SoloProjectionDistributor</c> per-tenant expansion path (jasperfx#491) is what drives agents.
 ///
 /// <para>
-/// The WS1 baseline for a tenant that joins mid-run is: its partitions + per-tenant sequence are
-/// provisioned by <c>AddMartenManagedTenantsAsync</c>, and (once an agent addresses the tenant) a
-/// per-tenant <c>{Projection}:All:{tenant}</c> progression row and a <c>HighWaterMark:{tenant}</c>
-/// row appear and reach the tenant's own height — all WITHOUT restarting the daemon.
-/// </para>
-///
-/// <para>
-/// REALITY PINNED BY THIS TEST (JasperFx.Events 2.20.0): the daemon enumerates tenants for the
-/// per-tenant continuous fan-out ONLY inside <c>StartAllAsync</c>
-/// (<c>JasperFxAsyncDaemon.buildPerTenantContinuousAgents</c> → <c>ICrossTenantRebuildSource.FindRebuildTenantsAsync</c>).
-/// There is no mid-run tenant-discovery loop, so a tenant added after start is NOT picked up
-/// automatically. The mechanism that DOES work without a restart is the wolverine#3280 path:
-/// <c>StartAgentAsync("{Projection}:All:{tenant}")</c> resolves the base shard, activates the tenant
-/// in the vectorized high-water coordinator, and fans out the tenant agent — that is what an external
-/// distributor (e.g. Wolverine) is expected to call, and what this test drives explicitly.
+/// As of JasperFx.Events 2.21.0 (jasperfx#491, consumed with Marten #4862's broadened
+/// <c>DistributesAgentsPerTenant</c> gate), the coordinator re-runs
+/// <c>BuildDistributionAsync</c> every leadership polling cycle and the distributor re-expands the
+/// store-global shard names from the database's CURRENT tenant registry
+/// (<c>mt_tenant_partitions</c> via <c>ICrossTenantRebuildSource</c>). So:
+/// <list type="bullet">
+///   <item>A tenant added mid-run (<c>AddMartenManagedTenantsAsync</c>, possibly from another
+///     process — here a separate client store) is discovered on the next polling cycle and its
+///     per-tenant agent starts WITHOUT a restart and WITHOUT the explicit per-tenant
+///     <c>StartAgentAsync</c> workaround (wolverine#3280) this test previously had to drive.</item>
+///   <item>A tenant removed mid-run (<c>RemoveMartenManagedTenantsAsync</c>) falls out of the next
+///     expansion and the coordinator's reconciliation pass REAPS its running agent (previously the
+///     agent lingered idle forever). The #4683 cleanup deletes its progression + high-water rows
+///     and nothing re-creates them.</item>
+/// </list>
+/// This test previously pinned the pre-#491 behavior (no mid-run discovery, lingering agent after
+/// removal) and was flipped when the fix landed. LeadershipPollingTime is tuned down to 250ms so
+/// convergence is fast and deterministic instead of sleeping the default window. NOTE the cadence
+/// caveat documented at Phase 1: the per-tenant high-water poll currently rides the GLOBAL
+/// high-water cadence, so the mid-run tenant is seeded above the store's global mark to converge
+/// deterministically on either side of the discovery-vs-append race.
 /// </para>
 /// </summary>
 public partial class dynamic_tenant_lifecycle_during_continuous_daemon
@@ -64,27 +76,36 @@ public partial class dynamic_tenant_lifecycle_during_continuous_daemon
 
     private static readonly string Schema = $"ws1_dynlife_p{Environment.ProcessId}";
 
-    [Fact]
-    public async Task tenant_added_mid_run_catches_up_via_per_tenant_agent_start_and_removal_stops_tracking()
+    private static void Configure(StoreOptions o)
     {
-        using var store = (DocumentStore)DocumentStore.For(o =>
-        {
-            o.Connection(ConnectionSource.ConnectionString);
-            o.DatabaseSchemaName = Schema;
-            o.DisableNpgsqlLogging = true;
-            o.Events.TenancyStyle = TenancyStyle.Conjoined;
-            o.Events.UseTenantPartitionedEvents = true;
-            o.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
-            o.Policies.AllDocumentsAreMultiTenanted();
+        o.Connection(ConnectionSource.ConnectionString);
+        o.DatabaseSchemaName = Schema;
+        o.DisableNpgsqlLogging = true;
+        o.Events.TenancyStyle = TenancyStyle.Conjoined;
+        o.Events.UseTenantPartitionedEvents = true;
+        o.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+        o.Policies.AllDocumentsAreMultiTenanted();
 
-            o.Schema.For<DynCounter>().DocumentAlias("ws1_dyn_cnt");
-            o.Projections.Add<DynLifeProjection>(ProjectionLifecycle.Async);
-        });
+        // The dynamic add/remove below converges on the coordinator's leadership polling cycle —
+        // tune it down so the test is fast and deterministic.
+        o.Projections.LeadershipPollingTime = 250;
+
+        o.Schema.For<DynCounter>().DocumentAlias("ws1_dyn_cnt");
+        o.Projections.Add<DynLifeProjection>(ProjectionLifecycle.Async);
+    }
+
+    [Fact]
+    public async Task tenant_added_mid_run_converges_via_coordinator_and_removal_reaps_the_agent()
+    {
+        // A plain client store handles seeding, tenant management, appends, and queries — the
+        // daemon runs in a separate host so tenant changes made "from outside" (another process,
+        // another node) are what the coordinator has to discover.
+        using var store = (DocumentStore)DocumentStore.For(Configure);
 
         await store.Advanced.Clean.CompletelyRemoveAllAsync();
         await store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
 
-        // ---- Phase 0: two initial tenants with different heights, daemon started AFTER seeding ----
+        // ---- Phase 0: two initial tenants with different heights, daemon host started AFTER seeding ----
         const string tenantA = "dynlife_a";
         const string tenantB = "dynlife_b";
         await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenantA, tenantB);
@@ -92,93 +113,122 @@ public partial class dynamic_tenant_lifecycle_during_continuous_daemon
         var streamA = await AppendStreamAsync(store, tenantA, 4); // 1 DynStarted + 4 DynBumped = 5 events
         var streamB = await AppendStreamAsync(store, tenantB, 2); // 3 events
 
-        using var daemon = await store.BuildProjectionDaemonAsync();
-        await daemon.StartAllAsync();
+        using var node = await new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(Configure).AddAsyncDaemon(DaemonMode.Solo);
+            }).StartAsync();
+        var daemon = node.Services.GetRequiredService<IProjectionCoordinator>().DaemonForMainDatabase();
 
-        await WaitForProgressionAsync(rows =>
-            SeqOf(rows, $"{DynLifeProjection.ProjectionName}:All:{tenantA}") >= 5 &&
-            SeqOf(rows, $"{DynLifeProjection.ProjectionName}:All:{tenantB}") >= 3 &&
-            SeqOf(rows, $"HighWaterMark:{tenantA}") >= 5 &&
-            SeqOf(rows, $"HighWaterMark:{tenantB}") >= 3,
-            30.Seconds(), "initial tenants reach their own per-tenant heights");
-
-        // ---- Phase 1: a NEW tenant joins while the daemon keeps running ----
-        const string tenantC = "dynlife_c";
-        await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenantC);
-        var streamC = await AppendStreamAsync(store, tenantC, 3); // 4 events
-
-        // PINNED CURRENT BEHAVIOR: the running daemon does NOT discover the new tenant on its own.
-        // buildPerTenantContinuousAgents runs only inside StartAllAsync; the high-water poll loop
-        // (TenantedHighWaterCoordinator.PollAndRouteAsync) only polls tenants that already have a
-        // tenant-bearing agent on this node. Give it a generous-but-bounded window to prove the
-        // negative, then drive the supported no-restart path below. If a product change ever makes
-        // this pick up automatically, this assertion should be flipped to celebrate it.
-        await Task.Delay(5.Seconds());
-        var midRows = await ProgressionRowsAsync();
-        DumpRows("after adding tenant C, before explicit agent start", midRows);
-        midRows.Any(r => r.Name == $"{DynLifeProjection.ProjectionName}:All:{tenantC}").ShouldBeFalse(
-            "current behavior: a tenant added mid-run gets no per-tenant agent (tenant fan-out happens " +
-            "only in StartAllAsync) — if this now passes automatically, the daemon gained mid-run tenant " +
-            "discovery and this pin should be updated");
-
-        // The no-restart mechanism that DOES exist (wolverine#3280): explicitly start the per-tenant
-        // agent by its tenant-bearing identity. The daemon resolves the base shard, activates the
-        // tenant in the vectorized high-water monitor, and the new agent catches up from scratch.
-        await daemon.StartAgentAsync($"{DynLifeProjection.ProjectionName}:All:{tenantC}",
-            CancellationToken.None);
-
-        await WaitForProgressionAsync(rows =>
-            SeqOf(rows, $"{DynLifeProjection.ProjectionName}:All:{tenantC}") >= 4 &&
-            SeqOf(rows, $"HighWaterMark:{tenantC}") >= 4,
-            30.Seconds(), "tenant C catches up after an explicit per-tenant agent start, no restart");
-
-        // And the projection itself materialized for the new tenant — without any daemon restart.
-        await using (var query = store.QuerySession(tenantC))
+        try
         {
-            var doc = await query.LoadAsync<DynCounter>(streamC);
-            doc.ShouldNotBeNull();
-            doc.Count.ShouldBe(3);
-        }
+            await WaitForProgressionAsync(rows =>
+                SeqOf(rows, $"{DynLifeProjection.ProjectionName}:All:{tenantA}") >= 5 &&
+                SeqOf(rows, $"{DynLifeProjection.ProjectionName}:All:{tenantB}") >= 3 &&
+                SeqOf(rows, $"HighWaterMark:{tenantA}") >= 5 &&
+                SeqOf(rows, $"HighWaterMark:{tenantB}") >= 3,
+                30.Seconds(), "initial tenants reach their own per-tenant heights");
 
-        // The original tenants were untouched by the dynamic add.
-        await using (var query = store.QuerySession(tenantA))
+            // jasperfx#491: the distributor expanded the store-global shard into per-tenant agents —
+            // no store-global agent runs.
+            var initialAgents = RunningAgents(daemon);
+            _output.WriteLine("agents after start: " + string.Join(", ", initialAgents));
+            initialAgents.OrderBy(x => x).ShouldBe(new[]
+            {
+                $"{DynLifeProjection.ProjectionName}:All:{tenantA}",
+                $"{DynLifeProjection.ProjectionName}:All:{tenantB}"
+            }.OrderBy(x => x));
+
+            // ---- Phase 1: a NEW tenant joins while the coordinator keeps running ----
+            // Tenant C is deliberately seeded ABOVE the store's current global high water (a is at
+            // 5, so C gets 7 events in its own overlapping sequence). KNOWN CADENCE GAP (jasperfx,
+            // observed against JasperFx.Events 2.21.0): the vectorized per-tenant high-water poll
+            // rides the GLOBAL high-water cadence — JasperFxAsyncDaemon only calls
+            // pollTenantHighWaterAsync when the store-global HighWaterMark shard state fires, which
+            // under overlapping per-tenant sequences only happens when max(seq_id) over the whole
+            // table moves. If the coordinator's discovery wins the race against this append (it
+            // polls every 250ms here), C's agent is primed at ceiling 0, and events that stay
+            // BELOW the global mark would never be routed to it — the agent stalls at 0
+            // indefinitely. Seeding C past the global mark forces a global high-water change, which
+            // triggers the per-tenant poll and converges C on EITHER side of the race. When the
+            // cadence gap is fixed upstream (per-tenant polls on the timer, not on global-mark
+            // change), C's height can go back below the global mark.
+            const string tenantC = "dynlife_c";
+            await store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenantC);
+            var streamC = await AppendStreamAsync(store, tenantC, 6); // 7 events > global HW of 5
+
+            // FLIPPED (was the pre-#491 pin): the running coordinator DOES discover the new tenant
+            // on its own — the next BuildDistributionAsync re-expands from mt_tenant_partitions and
+            // starts tenant C's agent, which catches up to the tenant's own height. No explicit
+            // per-tenant StartAgentAsync (wolverine#3280) workaround, no restart.
+            await WaitForProgressionAsync(rows =>
+                SeqOf(rows, $"{DynLifeProjection.ProjectionName}:All:{tenantC}") >= 7 &&
+                SeqOf(rows, $"HighWaterMark:{tenantC}") >= 7,
+                30.Seconds(),
+                "tenant C converges via the coordinator's own re-enumeration, no explicit agent start");
+
+            RunningAgents(daemon).ShouldContain($"{DynLifeProjection.ProjectionName}:All:{tenantC}",
+                "the coordinator's polling cycle must have started the new tenant's agent");
+
+            // And the projection itself materialized for the new tenant — without any restart.
+            await using (var query = store.QuerySession(tenantC))
+            {
+                var doc = await query.LoadAsync<DynCounter>(streamC);
+                doc.ShouldNotBeNull();
+                doc.Count.ShouldBe(6);
+            }
+
+            // The original tenants were untouched by the dynamic add.
+            await using (var query = store.QuerySession(tenantA))
+            {
+                (await query.LoadAsync<DynCounter>(streamA))!.Count.ShouldBe(4);
+            }
+
+            // ---- Phase 2: remove a tenant while the coordinator keeps running ----
+            // RemoveMartenManagedTenantsAsync drops tenant B's partitions + per-tenant sequence and
+            // deletes its per-tenant progression rows (#4683 cleanup).
+            await store.Advanced.RemoveMartenManagedTenantsAsync(new[] { tenantB }, CancellationToken.None);
+
+            // FLIPPED (was the pre-#491 lingering-agent pin): tenant B falls out of the next
+            // expansion, and the coordinator's reconciliation pass (reapOrphanedAgentsAsync) stops
+            // its agent within the polling window — removal now reaps instead of leaving the agent
+            // registered idle forever.
+            await WaitForConditionAsync(
+                () => !daemon.CurrentAgents().Any(x =>
+                    x.Name.Identity == $"{DynLifeProjection.ProjectionName}:All:{tenantB}"),
+                15.Seconds(),
+                "tenant B's agent is reaped by coordinator reconciliation after removal");
+            _output.WriteLine("agents after removal: " +
+                              string.Join(", ", daemon.CurrentAgents().Select(x => x.Name.Identity)));
+
+            // B's progression + high-water rows are gone and STAY gone across further polling
+            // cycles: the reaped agent no longer advances a progression row, and StopAgentAsync's
+            // syncTenantPolling drops B from the vectorized polled set so no HighWaterMark:B row is
+            // ever re-persisted.
+            await Task.Delay(2.Seconds());
+            var finalRows = await ProgressionRowsAsync();
+            DumpRows("after removing tenant B", finalRows);
+            finalRows.Any(r => r.Name == $"{DynLifeProjection.ProjectionName}:All:{tenantB}").ShouldBeFalse(
+                "the #4683 cleanup deletes the removed tenant's progression rows and the reaped " +
+                "agent must not re-create them");
+            finalRows.Any(r => r.Name == $"HighWaterMark:{tenantB}").ShouldBeFalse(
+                "the removed tenant's high-water row must not be re-persisted after removal");
+
+            // Survivors are unaffected by the removal.
+            SeqOf(finalRows, $"{DynLifeProjection.ProjectionName}:All:{tenantA}").ShouldBe(5);
+            SeqOf(finalRows, $"{DynLifeProjection.ProjectionName}:All:{tenantC}").ShouldBe(7);
+        }
+        finally
         {
-            (await query.LoadAsync<DynCounter>(streamA))!.Count.ShouldBe(4);
+            await node.StopAsync();
         }
-
-        // ---- Phase 2: remove a tenant while the daemon keeps running ----
-        // RemoveMartenManagedTenantsAsync drops tenant B's partitions + per-tenant sequence and
-        // deletes its per-tenant progression rows (#4683 cleanup).
-        await store.Advanced.RemoveMartenManagedTenantsAsync(new[] { tenantB }, CancellationToken.None);
-
-        // PINNED CURRENT BEHAVIOR: removal does NOT stop the tenant's running agent — nothing in the
-        // remove path talks to the daemon. The agent stays registered (idle: its partitions are gone,
-        // so no events ever arrive again) and the polled-tenant set still contains B, but the #4683
-        // cleanup removed B's progression + high-water rows and nothing re-creates them: the
-        // vectorized detector no longer finds B's sequence, so no reading with CurrentMark > 0 is
-        // ever produced for B again (TenantedHighWaterCoordinator only persists marks > 0).
-        var agentsAfterRemoval = daemon.CurrentAgents().Select(x => x.Name.Identity).ToList();
-        _output.WriteLine("agents after removal: " + string.Join(", ", agentsAfterRemoval));
-        agentsAfterRemoval.ShouldContain($"{DynLifeProjection.ProjectionName}:All:{tenantB}",
-            "current behavior: removing a tenant does not stop its agent — it lingers idle; " +
-            "if this fails, tenant removal now reaps agents and this pin should be updated");
-
-        // B's progression + high-water rows are gone and STAY gone across further high-water polls.
-        await Task.Delay(2.Seconds());
-        var finalRows = await ProgressionRowsAsync();
-        DumpRows("after removing tenant B", finalRows);
-        finalRows.Any(r => r.Name == $"{DynLifeProjection.ProjectionName}:All:{tenantB}").ShouldBeFalse(
-            "the #4683 cleanup deletes the removed tenant's progression rows and the lingering agent " +
-            "must not re-create them");
-        finalRows.Any(r => r.Name == $"HighWaterMark:{tenantB}").ShouldBeFalse(
-            "the removed tenant's high-water row must not be re-persisted after removal");
-
-        // Survivors are unaffected by the removal.
-        SeqOf(finalRows, $"{DynLifeProjection.ProjectionName}:All:{tenantA}").ShouldBe(5);
-        SeqOf(finalRows, $"{DynLifeProjection.ProjectionName}:All:{tenantC}").ShouldBe(4);
-
-        await daemon.StopAllAsync();
     }
+
+    private static IReadOnlyList<string> RunningAgents(IProjectionDaemon daemon) =>
+        daemon.CurrentAgents()
+            .Where(x => x.Status == AgentStatus.Running)
+            .Select(x => x.Name.Identity)
+            .ToList();
 
     private static async Task<Guid> AppendStreamAsync(DocumentStore store, string tenant, int bumps)
     {
@@ -209,6 +259,37 @@ public partial class dynamic_tenant_lifecycle_during_continuous_daemon
         }
 
         DumpRows($"TIMED OUT waiting for: {what}", rows);
+        await DumpEventsAsync();
+        throw new TimeoutException($"Timed out after {timeout} waiting for: {what}");
+    }
+
+    private async Task DumpEventsAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand(
+            $"select tenant_id, count(*), max(seq_id) from {Schema}.mt_events group by tenant_id order by tenant_id");
+        await using var reader = await cmd.ExecuteReaderAsync();
+        _output.WriteLine("=== mt_events by tenant ===");
+        while (await reader.ReadAsync())
+        {
+            _output.WriteLine($"{reader.GetString(0)} | count={reader.GetInt64(1)} | max_seq={reader.GetInt64(2)}");
+        }
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout, string what)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(250);
+        }
+
         throw new TimeoutException($"Timed out after {timeout} waiting for: {what}");
     }
 

--- a/src/TenantPartitionedEventsTests/Daemon/multi_node_hotcold_single_database_partitioned_events.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/multi_node_hotcold_single_database_partitioned_events.cs
@@ -33,25 +33,25 @@ namespace TenantPartitionedEventsTests.Daemon;
 /// async projections and three tenants of different heights.
 ///
 /// <para>
-/// DISTRIBUTION GRANULARITY OBSERVED AND PINNED HERE (JasperFx.Events 2.20.0 + Marten master):
-/// with DefaultTenancy the coordinator builds a <c>SingleTenantProjectionDistributor</c> — one
-/// advisory-lock-guarded <c>IProjectionSet</c> per STORE-GLOBAL shard name
-/// (<c>{Projection}:All</c>, no tenant slot). The set's names are what the winning node hands to
-/// <c>daemon.StartAgentAsync(identity)</c>, and that exact-identity path builds the STORE-GLOBAL
-/// agent — the per-tenant fan-out (<c>buildPerTenantContinuousAgents</c>) only runs inside
-/// <c>StartAllAsync</c>, which the native coordinator never calls. So:
+/// DISTRIBUTION GRANULARITY (JasperFx.Events 2.21.0, jasperfx#491 + Marten #4862): with
+/// DefaultTenancy the coordinator builds a <c>SingleTenantProjectionDistributor</c> — one
+/// advisory-lock-guarded <c>IProjectionSet</c> per STORE-GLOBAL shard name. Because the store is
+/// tenant-partitioned (<c>IEventStore.DistributesAgentsPerTenant</c>), the distributor now expands
+/// each store-global name into per-tenant <c>{Projection}:All:{tenant}</c> ShardNames at
+/// distribution-build time (<c>PerTenantShardExpansion</c>), and the winning node starts each
+/// tenant-bearing identity through <c>StartAgentAsync</c>'s per-tenant branch (jasperfx#487). So:
 /// <list type="bullet">
-///   <item>Placement granularity = whole projection: each <c>{Projection}:All</c> shard runs on
-///     exactly one node; different projections may land on different nodes. There is NO per-tenant
-///     spreading, and the winning node does NOT fan out per-tenant agents either.</item>
-///   <item>Progression is tracked by STORE-GLOBAL <c>{Projection}:All</c> rows against the global
-///     high-water mark. The WS1 per-tenant baseline (<c>{Projection}:All:{tenant}</c> +
-///     <c>HighWaterMark:{tenant}</c> rows) is NOT met under the native HotCold coordinator — that
-///     per-tenant shape today only comes from <c>StartAllAsync</c> (Solo/direct daemon, see
-///     Bug_4717_per_tenant_progression) or explicit per-tenant <c>StartAgentAsync</c> (Wolverine
-///     distribution, wolverine#3280). Closing that gap is the point of epic #486 WS1; when the
-///     product catches up, flip the per-tenant assertions below from absent to present.</item>
+///   <item>Lock granularity is unchanged — still one advisory lock per STORE-GLOBAL shard, so a
+///     projection's per-tenant agents all ride together on whichever node wins that projection's
+///     lock; different projections may still land on different nodes.</item>
+///   <item>The WS1 per-tenant baseline IS now met on this path: per-tenant
+///     <c>{Projection}:All:{tenant}</c> progression rows reach each tenant's OWN height (not the
+///     store-global max), <c>HighWaterMark:{tenant}</c> rows are persisted per tenant, and no
+///     store-global <c>{Projection}:All</c> agent ever runs (the expansion happens before the
+///     first agent start, and coordinator reconciliation would retire one anyway).</item>
 /// </list>
+/// This test previously pinned the pre-#491 store-global-only behavior; the assertions were
+/// flipped to the per-tenant baseline when the fix landed.
 /// </para>
 /// </summary>
 public partial class multi_node_hotcold_single_database_partitioned_events
@@ -105,7 +105,7 @@ public partial class multi_node_hotcold_single_database_partitioned_events
     }
 
     [Fact]
-    public async Task two_hotcold_nodes_split_store_global_shards_without_per_tenant_fan_out()
+    public async Task two_hotcold_nodes_fan_out_per_tenant_agents_under_store_global_shard_locks()
     {
         // Seed everything with a bootstrap store BEFORE any node starts, so the two hosts never race
         // on schema creation (the partitioned-schema path is the known 42P07/23505 hot spot).
@@ -142,12 +142,15 @@ public partial class multi_node_hotcold_single_database_partitioned_events
 
         try
         {
-            // Wait on progression state, not sleeps: both store-global shards must reach the GLOBAL
-            // high-water mark (max over the overlapping per-tenant sequences: 6 here).
+            // Wait on progression state, not sleeps: every (projection, tenant) pair must reach
+            // that tenant's OWN height — the WS1 per-tenant baseline, not the global max.
             var rows = await WaitForProgressionAsync(r =>
-                    SeqOf(r, $"{HcTripProjection.ProjectionName}:All") >= globalHighWater &&
-                    SeqOf(r, $"{HcTallyProjection.ProjectionName}:All") >= globalHighWater,
-                45.Seconds(), "both store-global projection shards reach the global high water");
+                    expectedHeight.All(p =>
+                        SeqOf(r, $"{HcTripProjection.ProjectionName}:All:{p.Key}") >= p.Value &&
+                        SeqOf(r, $"{HcTallyProjection.ProjectionName}:All:{p.Key}") >= p.Value &&
+                        SeqOf(r, $"HighWaterMark:{p.Key}") >= p.Value) &&
+                    SeqOf(r, "HighWaterMark") >= globalHighWater,
+                45.Seconds(), "every per-tenant projection shard reaches its tenant's own height");
             DumpRows("mt_event_progression once caught up", rows);
 
             // ---- Placement: which node runs what ----
@@ -156,47 +159,58 @@ public partial class multi_node_hotcold_single_database_partitioned_events
             _output.WriteLine($"node A agents: [{string.Join(", ", agentsA)}]");
             _output.WriteLine($"node B agents: [{string.Join(", ", agentsB)}]");
 
-            var allShardIdentities = new[]
-            {
-                $"{HcTripProjection.ProjectionName}:All", $"{HcTallyProjection.ProjectionName}:All"
-            };
+            var projections = new[] { HcTripProjection.ProjectionName, HcTallyProjection.ProjectionName };
+            var perTenantIdentities = projections
+                .SelectMany(p => tenants.Keys.Select(t => $"{p}:All:{t}"))
+                .ToArray();
 
-            // Every running agent is a STORE-GLOBAL shard — no agent carries a tenant slot. This is
-            // the observed distribution granularity: SingleTenantProjectionDistributor locks per
-            // store-global shard and the winner runs the store-global agent; nobody fans out
-            // per-tenant agents on this path.
-            agentsA.Concat(agentsB).ShouldAllBe(identity => allShardIdentities.Contains(identity));
+            // jasperfx#491: every running agent carries a tenant slot — the distributor expanded
+            // the store-global names before the winning node started anything, so no store-global
+            // {Projection}:All agent exists anywhere.
+            agentsA.Concat(agentsB).ShouldAllBe(identity => perTenantIdentities.Contains(identity));
 
-            // Each shard runs on EXACTLY one node (advisory lock exclusivity), and both shards run
-            // somewhere. Whether they split across the nodes or pile onto one is a lock race —
-            // don't assert the split, just exclusivity + coverage.
-            foreach (var identity in allShardIdentities)
+            // Lock granularity is unchanged: one advisory lock per STORE-GLOBAL shard, so each
+            // projection's per-tenant agents run TOGETHER on exactly one node. Whether the two
+            // projections split across the nodes or pile onto one is a lock race — assert
+            // exclusivity + completeness per projection, not the split.
+            foreach (var projection in projections)
             {
-                var owners = new[] { agentsA.Contains(identity), agentsB.Contains(identity) }
-                    .Count(x => x);
+                var tenantIdentities = tenants.Keys.Select(t => $"{projection}:All:{t}").ToArray();
+                var onA = agentsA.Where(tenantIdentities.Contains).ToList();
+                var onB = agentsB.Where(tenantIdentities.Contains).ToList();
+
+                var owners = new[] { onA.Any(), onB.Any() }.Count(x => x);
                 owners.ShouldBe(1,
-                    $"shard {identity} must be running on exactly one of the two HotCold nodes");
+                    $"projection {projection}'s per-tenant agents must all run on exactly one node " +
+                    "(they ride the projection's single store-global advisory lock)");
+
+                var winner = onA.Any() ? onA : onB;
+                winner.OrderBy(x => x).ShouldBe(tenantIdentities.OrderBy(x => x),
+                    $"the node owning {projection}'s lock must run one agent per tenant");
             }
 
-            // ---- WS1 per-tenant baseline: NOT met on this path today (see class doc) ----
+            // ---- WS1 per-tenant baseline: met on this path as of jasperfx#491 ----
             rows.Where(r => r.Name.StartsWith("Ws1Hc", StringComparison.Ordinal))
-                .ShouldAllBe(r => allShardIdentities.Contains(r.Name),
-                    "current behavior: only store-global {Projection}:All progression rows exist " +
-                    "under the native HotCold coordinator — no {Projection}:All:{tenant} rows. If " +
-                    "per-tenant rows now appear, native HotCold gained per-tenant fan-out and this " +
-                    "test should be rewritten to assert the WS1 per-tenant baseline");
-            rows.Any(r => r.Name.StartsWith("HighWaterMark:", StringComparison.Ordinal)).ShouldBeFalse(
-                "current behavior: no per-tenant HighWaterMark:{tenant} rows are persisted because " +
-                "no tenant ever enters the vectorized polled set on this path");
-            SeqOf(rows, "HighWaterMark").ShouldBe(globalHighWater,
-                "the store-global high-water row tracks max(seq_id) across the overlapping " +
-                "per-tenant sequences");
+                .ShouldAllBe(r => perTenantIdentities.Contains(r.Name),
+                    "per-tenant fan-out: every projection progression row is tenant-bearing — the " +
+                    "store-global {Projection}:All agent never ran, so no store-global row exists");
 
-            // ---- The documents themselves DO materialize correctly at this scale ----
-            // The store-global agent loads pages across all tenant partitions and the conjoined
-            // slicer groups by (tenant, stream), so with all events inside one page every tenant's
-            // aggregate is right. (The per-tenant progression gap bites on restart/catch-up
-            // semantics, not on this happy path.)
+            foreach (var (tenant, height) in expectedHeight)
+            {
+                SeqOf(rows, $"{HcTripProjection.ProjectionName}:All:{tenant}").ShouldBe(height,
+                    $"tenant {tenant}'s trip shard tracks the tenant's OWN sequence height");
+                SeqOf(rows, $"{HcTallyProjection.ProjectionName}:All:{tenant}").ShouldBe(height,
+                    $"tenant {tenant}'s tally shard tracks the tenant's OWN sequence height");
+                SeqOf(rows, $"HighWaterMark:{tenant}").ShouldBe(height,
+                    $"tenant {tenant} is in the vectorized polled set, so its own high-water row " +
+                    "is persisted at the tenant's own height");
+            }
+
+            SeqOf(rows, "HighWaterMark").ShouldBe(globalHighWater,
+                "the store-global high-water detector still runs alongside the per-tenant agents " +
+                "and tracks max(seq_id) across the overlapping per-tenant sequences");
+
+            // ---- The documents themselves materialize correctly per tenant ----
             using var verify = (DocumentStore)DocumentStore.For(Configure);
             foreach (var (tenant, legs) in tenants)
             {

--- a/src/TenantPartitionedEventsTests/Daemon/multi_node_hotcold_single_database_partitioned_events.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/multi_node_hotcold_single_database_partitioned_events.cs
@@ -1,0 +1,285 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+using Xunit.Abstractions;
+using IProjectionCoordinator = Marten.Events.Daemon.Coordination.IProjectionCoordinator;
+
+namespace TenantPartitionedEventsTests.Daemon;
+
+/// <summary>
+/// JasperFx/jasperfx#486 WS1 — native HotCold distribution matrix, cell "single database +
+/// UseTenantPartitionedEvents": ONE conjoined per-tenant-partitioned database, TWO IHost nodes both
+/// running <c>AddAsyncDaemon(DaemonMode.HotCold)</c> against the same schema + DaemonLockId, with two
+/// async projections and three tenants of different heights.
+///
+/// <para>
+/// DISTRIBUTION GRANULARITY OBSERVED AND PINNED HERE (JasperFx.Events 2.20.0 + Marten master):
+/// with DefaultTenancy the coordinator builds a <c>SingleTenantProjectionDistributor</c> — one
+/// advisory-lock-guarded <c>IProjectionSet</c> per STORE-GLOBAL shard name
+/// (<c>{Projection}:All</c>, no tenant slot). The set's names are what the winning node hands to
+/// <c>daemon.StartAgentAsync(identity)</c>, and that exact-identity path builds the STORE-GLOBAL
+/// agent — the per-tenant fan-out (<c>buildPerTenantContinuousAgents</c>) only runs inside
+/// <c>StartAllAsync</c>, which the native coordinator never calls. So:
+/// <list type="bullet">
+///   <item>Placement granularity = whole projection: each <c>{Projection}:All</c> shard runs on
+///     exactly one node; different projections may land on different nodes. There is NO per-tenant
+///     spreading, and the winning node does NOT fan out per-tenant agents either.</item>
+///   <item>Progression is tracked by STORE-GLOBAL <c>{Projection}:All</c> rows against the global
+///     high-water mark. The WS1 per-tenant baseline (<c>{Projection}:All:{tenant}</c> +
+///     <c>HighWaterMark:{tenant}</c> rows) is NOT met under the native HotCold coordinator — that
+///     per-tenant shape today only comes from <c>StartAllAsync</c> (Solo/direct daemon, see
+///     Bug_4717_per_tenant_progression) or explicit per-tenant <c>StartAgentAsync</c> (Wolverine
+///     distribution, wolverine#3280). Closing that gap is the point of epic #486 WS1; when the
+///     product catches up, flip the per-tenant assertions below from absent to present.</item>
+/// </list>
+/// </para>
+/// </summary>
+public partial class multi_node_hotcold_single_database_partitioned_events
+{
+    private readonly ITestOutputHelper _output;
+
+    public multi_node_hotcold_single_database_partitioned_events(ITestOutputHelper output)
+        => _output = output;
+
+    public class HcTrip { public Guid Id { get; set; } public double Distance { get; set; } }
+    public class HcTally { public Guid Id { get; set; } public int Count { get; set; } }
+
+    public record HcStarted(Guid Id);
+    public record HcLeg(double Distance);
+
+    public partial class HcTripProjection: SingleStreamProjection<HcTrip, Guid>
+    {
+        public const string ProjectionName = "Ws1HcTrip";
+        public HcTripProjection() => Name = ProjectionName;
+        public void Apply(HcTrip t, HcLeg e) => t.Distance += e.Distance;
+    }
+
+    public partial class HcTallyProjection: SingleStreamProjection<HcTally, Guid>
+    {
+        public const string ProjectionName = "Ws1HcTally";
+        public HcTallyProjection() => Name = ProjectionName;
+        public void Apply(HcTally t, HcLeg e) => t.Count++;
+    }
+
+    private static readonly string Schema = $"ws1_hcold_p{Environment.ProcessId}";
+    private const int LockId = 48611;
+
+    private static void Configure(StoreOptions o)
+    {
+        o.Connection(ConnectionSource.ConnectionString);
+        o.DatabaseSchemaName = Schema;
+        o.DisableNpgsqlLogging = true;
+        o.Events.TenancyStyle = TenancyStyle.Conjoined;
+        o.Events.UseTenantPartitionedEvents = true;
+        o.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+        o.Policies.AllDocumentsAreMultiTenanted();
+
+        o.Projections.DaemonLockId = LockId;
+        o.Projections.LeadershipPollingTime = 250;
+
+        o.Schema.For<HcTrip>().DocumentAlias("ws1_hc_trip");
+        o.Schema.For<HcTally>().DocumentAlias("ws1_hc_tally");
+
+        o.Projections.Add<HcTripProjection>(ProjectionLifecycle.Async);
+        o.Projections.Add<HcTallyProjection>(ProjectionLifecycle.Async);
+    }
+
+    [Fact]
+    public async Task two_hotcold_nodes_split_store_global_shards_without_per_tenant_fan_out()
+    {
+        // Seed everything with a bootstrap store BEFORE any node starts, so the two hosts never race
+        // on schema creation (the partitioned-schema path is the known 42P07/23505 hot spot).
+        var tenants = new Dictionary<string, int> { ["hc_t1"] = 5, ["hc_t2"] = 4, ["hc_t3"] = 3 };
+        var streams = new Dictionary<string, Guid>();
+
+        using (var bootstrap = (DocumentStore)DocumentStore.For(Configure))
+        {
+            await bootstrap.Advanced.Clean.CompletelyRemoveAllAsync();
+            await bootstrap.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+            await bootstrap.Advanced.AddMartenManagedTenantsAsync(
+                CancellationToken.None, tenants.Keys.ToArray());
+
+            foreach (var (tenant, legs) in tenants)
+            {
+                var id = Guid.NewGuid();
+                streams[tenant] = id;
+                await using var session = bootstrap.LightweightSession(tenant);
+                var events = new object[] { new HcStarted(id) }
+                    .Concat(Enumerable.Range(0, legs).Select(_ => (object)new HcLeg(1.0)))
+                    .ToArray();
+                session.Events.StartStream<HcTrip>(id, events);
+                await session.SaveChangesAsync();
+            }
+        }
+
+        // Per-tenant event heights: 1 HcStarted + N HcLeg per tenant, independent sequences.
+        var expectedHeight = tenants.ToDictionary(p => p.Key, p => (long)(p.Value + 1));
+        var globalHighWater = expectedHeight.Values.Max();
+
+        // TWO nodes in HotCold contention over the same schema + lock id.
+        using var nodeA = await StartNodeAsync();
+        using var nodeB = await StartNodeAsync();
+
+        try
+        {
+            // Wait on progression state, not sleeps: both store-global shards must reach the GLOBAL
+            // high-water mark (max over the overlapping per-tenant sequences: 6 here).
+            var rows = await WaitForProgressionAsync(r =>
+                    SeqOf(r, $"{HcTripProjection.ProjectionName}:All") >= globalHighWater &&
+                    SeqOf(r, $"{HcTallyProjection.ProjectionName}:All") >= globalHighWater,
+                45.Seconds(), "both store-global projection shards reach the global high water");
+            DumpRows("mt_event_progression once caught up", rows);
+
+            // ---- Placement: which node runs what ----
+            var agentsA = AgentIdentities(nodeA);
+            var agentsB = AgentIdentities(nodeB);
+            _output.WriteLine($"node A agents: [{string.Join(", ", agentsA)}]");
+            _output.WriteLine($"node B agents: [{string.Join(", ", agentsB)}]");
+
+            var allShardIdentities = new[]
+            {
+                $"{HcTripProjection.ProjectionName}:All", $"{HcTallyProjection.ProjectionName}:All"
+            };
+
+            // Every running agent is a STORE-GLOBAL shard — no agent carries a tenant slot. This is
+            // the observed distribution granularity: SingleTenantProjectionDistributor locks per
+            // store-global shard and the winner runs the store-global agent; nobody fans out
+            // per-tenant agents on this path.
+            agentsA.Concat(agentsB).ShouldAllBe(identity => allShardIdentities.Contains(identity));
+
+            // Each shard runs on EXACTLY one node (advisory lock exclusivity), and both shards run
+            // somewhere. Whether they split across the nodes or pile onto one is a lock race —
+            // don't assert the split, just exclusivity + coverage.
+            foreach (var identity in allShardIdentities)
+            {
+                var owners = new[] { agentsA.Contains(identity), agentsB.Contains(identity) }
+                    .Count(x => x);
+                owners.ShouldBe(1,
+                    $"shard {identity} must be running on exactly one of the two HotCold nodes");
+            }
+
+            // ---- WS1 per-tenant baseline: NOT met on this path today (see class doc) ----
+            rows.Where(r => r.Name.StartsWith("Ws1Hc", StringComparison.Ordinal))
+                .ShouldAllBe(r => allShardIdentities.Contains(r.Name),
+                    "current behavior: only store-global {Projection}:All progression rows exist " +
+                    "under the native HotCold coordinator — no {Projection}:All:{tenant} rows. If " +
+                    "per-tenant rows now appear, native HotCold gained per-tenant fan-out and this " +
+                    "test should be rewritten to assert the WS1 per-tenant baseline");
+            rows.Any(r => r.Name.StartsWith("HighWaterMark:", StringComparison.Ordinal)).ShouldBeFalse(
+                "current behavior: no per-tenant HighWaterMark:{tenant} rows are persisted because " +
+                "no tenant ever enters the vectorized polled set on this path");
+            SeqOf(rows, "HighWaterMark").ShouldBe(globalHighWater,
+                "the store-global high-water row tracks max(seq_id) across the overlapping " +
+                "per-tenant sequences");
+
+            // ---- The documents themselves DO materialize correctly at this scale ----
+            // The store-global agent loads pages across all tenant partitions and the conjoined
+            // slicer groups by (tenant, stream), so with all events inside one page every tenant's
+            // aggregate is right. (The per-tenant progression gap bites on restart/catch-up
+            // semantics, not on this happy path.)
+            using var verify = (DocumentStore)DocumentStore.For(Configure);
+            foreach (var (tenant, legs) in tenants)
+            {
+                await using var query = verify.QuerySession(tenant);
+                var trip = await query.LoadAsync<HcTrip>(streams[tenant]);
+                trip.ShouldNotBeNull($"tenant {tenant}'s HcTrip projection doc must materialize");
+                trip!.Distance.ShouldBe(legs);
+                var tally = await query.LoadAsync<HcTally>(streams[tenant]);
+                tally.ShouldNotBeNull($"tenant {tenant}'s HcTally projection doc must materialize");
+                tally!.Count.ShouldBe(legs);
+            }
+        }
+        finally
+        {
+            await nodeA.StopAsync();
+            await nodeB.StopAsync();
+        }
+    }
+
+    private static async Task<IHost> StartNodeAsync()
+    {
+        return await new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(Configure).AddAsyncDaemon(DaemonMode.HotCold);
+            }).StartAsync();
+    }
+
+    private static IReadOnlyList<string> AgentIdentities(IHost node)
+    {
+        var coordinator = node.Services.GetRequiredService<IProjectionCoordinator>();
+        return coordinator.DaemonForMainDatabase().CurrentAgents()
+            .Where(x => x.Status == AgentStatus.Running)
+            .Select(x => x.Name.Identity)
+            .OrderBy(x => x)
+            .ToList();
+    }
+
+    private async Task<List<(string Name, long Seq)>> WaitForProgressionAsync(
+        Func<List<(string Name, long Seq)>, bool> condition, TimeSpan timeout, string what)
+    {
+        var sw = Stopwatch.StartNew();
+        List<(string Name, long Seq)> rows = new();
+        while (sw.Elapsed < timeout)
+        {
+            rows = await ProgressionRowsAsync();
+            if (condition(rows))
+            {
+                return rows;
+            }
+
+            await Task.Delay(250);
+        }
+
+        DumpRows($"TIMED OUT waiting for: {what}", rows);
+        throw new TimeoutException($"Timed out after {timeout} waiting for: {what}");
+    }
+
+    private void DumpRows(string label, List<(string Name, long Seq)> rows)
+    {
+        _output.WriteLine($"=== {label} ===");
+        foreach (var (name, seq) in rows.OrderBy(r => r.Name))
+        {
+            _output.WriteLine($"{seq,6} | {name}");
+        }
+    }
+
+    private static long SeqOf(List<(string Name, long Seq)> rows, string name) =>
+        rows.FirstOrDefault(r => r.Name == name).Seq;
+
+    private static async Task<List<(string Name, long Seq)>> ProgressionRowsAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand(
+            $"select name, coalesce(last_seq_id,0) from {Schema}.mt_event_progression order by name");
+        await using var reader = await cmd.ExecuteReaderAsync();
+        var rows = new List<(string, long)>();
+        while (await reader.ReadAsync())
+        {
+            rows.Add((reader.GetString(0), reader.GetInt64(1)));
+        }
+
+        return rows;
+    }
+}

--- a/src/TenantPartitionedEventsTests/Sharded/dynamic_tenant_lifecycle_on_shard_during_daemon.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/dynamic_tenant_lifecycle_on_shard_during_daemon.cs
@@ -8,25 +8,29 @@ using System.Threading.Tasks;
 using JasperFx;
 using JasperFx.Core;
 using JasperFx.Events;
+using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Marten;
 using Marten.Events;
-using Marten.Events.Aggregation;
 using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Npgsql;
 using Shouldly;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Xunit;
 using Xunit.Abstractions;
+using IProjectionCoordinator = Marten.Events.Daemon.Coordination.IProjectionCoordinator;
 
 namespace TenantPartitionedEventsTests.Sharded;
 
 /// <summary>
-/// JasperFx/jasperfx#486 WS1 — dynamic tenant lifecycle on a SHARD database while its daemon keeps
-/// running: sharded/pooled tenancy (<c>MultiTenantedWithShardedDatabases</c>) +
-/// <c>UseTenantPartitionedEvents</c>, one shard daemon started for the shard's initial tenant, then
-/// <c>AddTenantToShardAsync</c> assigns a NEW tenant to the SAME shard mid-run.
+/// JasperFx/jasperfx#486 WS1 — dynamic tenant lifecycle on a SHARD database while a HotCold
+/// coordinator node keeps running: sharded/pooled tenancy (<c>MultiTenantedWithShardedDatabases</c>)
+/// + <c>UseTenantPartitionedEvents</c>, one coordinator node started for the shard's initial
+/// tenant, then <c>AddTenantToShardAsync</c> assigns a NEW tenant to the SAME shard mid-run from a
+/// separate client store.
 ///
 /// <para>
 /// Pins, in order:
@@ -34,17 +38,17 @@ namespace TenantPartitionedEventsTests.Sharded;
 ///   <item><c>AddTenantToShardAsync</c> mid-run provisions the new tenant's partitions AND its
 ///     per-tenant <c>mt_events_sequence_{suffix}</c> on the target shard database immediately —
 ///     appends for the new tenant work right away (no MT002).</item>
-///   <item>CURRENT BEHAVIOR (JasperFx.Events 2.20.0): the RUNNING shard daemon does NOT discover the
-///     new tenant on its own — per-tenant fan-out (<c>buildPerTenantContinuousAgents</c>) only runs
-///     inside <c>StartAllAsync</c>; the high-water poll loop only polls tenants that already have a
-///     tenant-bearing agent. Same gap as the single-database flavor
-///     (<c>dynamic_tenant_lifecycle_during_continuous_daemon</c>).</item>
-///   <item>The no-restart path that DOES work (wolverine#3280):
-///     <c>StartAgentAsync("{Projection}:All:{tenant}")</c> fans out the tenant agent on the running
-///     daemon. The new tenant's <c>{Projection}:All:{tenant}</c> and <c>HighWaterMark:{tenant}</c>
-///     rows then appear in the SHARD database's own <c>mt_event_progression</c> (per-shard, no
-///     cross-shard coordination) and the projection catches up to the tenant's own height.</item>
+///   <item>FLIPPED (was the pre-jasperfx#491 pin): the RUNNING coordinator node DOES discover the
+///     new tenant on its own. The <c>MultiTenantedProjectionDistributor</c> re-expands each shard
+///     database's set from that database's own tenant registry on every leadership polling cycle
+///     (jasperfx#491, consumed via Marten #4862's <c>DistributesAgentsPerTenant</c>), so the new
+///     tenant's <c>{Projection}:All:{tenant}</c> and <c>HighWaterMark:{tenant}</c> rows appear in
+///     the SHARD database's own <c>mt_event_progression</c> and the projection catches up to the
+///     tenant's own height — WITHOUT a restart and WITHOUT the explicit per-tenant
+///     <c>StartAgentAsync</c> (wolverine#3280) workaround this test previously had to drive.</item>
 /// </list>
+/// LeadershipPollingTime is tuned down to 250ms so the mid-run discovery converges fast and
+/// deterministically instead of sleeping the default window.
 /// </para>
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
@@ -53,6 +57,8 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
     private readonly ShardedPartitionedFixture _fixture;
     private readonly ITestOutputHelper _output;
     private DocumentStore _store = null!;
+
+    private const int LockId = 48619;
 
     public dynamic_tenant_lifecycle_on_shard_during_daemon(
         ShardedPartitionedFixture fixture, ITestOutputHelper output)
@@ -84,33 +90,48 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
         }
     }
 
+    private void Configure(StoreOptions opts)
+    {
+        opts.MultiTenantedWithShardedDatabases(x =>
+        {
+            x.ConnectionString = ConnectionSource.ConnectionString;
+            x.SchemaName = "sharded";
+            x.PartitionSchemaName = "tenants";
+            foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+            {
+                x.AddDatabase(dbName, connStr);
+            }
+        });
+
+        opts.AutoCreateSchemaObjects = AutoCreate.All;
+        opts.DisableNpgsqlLogging = true;
+        opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+        opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+        opts.Events.UseTenantPartitionedEvents = true;
+        opts.Events.AddEventType<ShardedDaemonEvent>();
+
+        opts.Projections.DaemonLockId = LockId;
+        // Mid-run tenant discovery converges on the coordinator's leadership polling cycle —
+        // tune it down so the test is fast and deterministic.
+        opts.Projections.LeadershipPollingTime = 250;
+
+        opts.Projections.Add<ShardedDaemonProjection>(ProjectionLifecycle.Async);
+        opts.Schema.For<ShardedDaemonCounter>().DocumentAlias("ws1dyn_sdc");
+    }
+
     [Fact]
     public async Task tenant_added_to_shard_mid_run_is_provisioned_and_catches_up_without_daemon_restart()
     {
-        _store = (DocumentStore)DocumentStore.For(opts =>
-        {
-            opts.MultiTenantedWithShardedDatabases(x =>
-            {
-                x.ConnectionString = ConnectionSource.ConnectionString;
-                x.SchemaName = "sharded";
-                x.PartitionSchemaName = "tenants";
-                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
-                {
-                    x.AddDatabase(dbName, connStr);
-                }
-            });
+        _store = (DocumentStore)DocumentStore.For(Configure);
 
-            opts.AutoCreateSchemaObjects = AutoCreate.All;
-            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
-            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
-            opts.Events.UseTenantPartitionedEvents = true;
-            opts.Events.AddEventType<ShardedDaemonEvent>();
+        // Materialize the FULL schema (including the projection document tables) on every shard
+        // database BEFORE registering tenants, so AddTenantToShardAsync adds each tenant's list
+        // partition to the doc tables too — the coordinator node below is a FRESH store whose lazy
+        // table creation does not hydrate partitions from the shard's own registry (see the matrix
+        // test multi_node_hotcold_sharded_partitioned_events for the 23514 details).
+        await _store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
 
-            opts.Projections.Add<ShardedDaemonProjection>(ProjectionLifecycle.Async);
-            opts.Schema.For<ShardedDaemonCounter>().DocumentAlias("ws1dyn_sdc");
-        });
-
-        // ---- Phase 0: one initial tenant on shard A, daemon running, caught up ----
+        // ---- Phase 0: one initial tenant on shard A, coordinator node running, caught up ----
         var shard = _fixture.DbNames[0];
         var shardConnStr = _fixture.ConnectionStrings[shard];
         const string tenant1 = "ws1dyn_t1";
@@ -127,80 +148,97 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
             await session.SaveChangesAsync();
         }
 
-        using var daemon = await _store.BuildProjectionDaemonAsync(tenant1);
-        await daemon.StartAllAsync();
-
-        await WaitForProgressionAsync(shardConnStr, rows =>
-                SeqOf(rows, $"{ShardedDaemonProjection.ProjectionName}:All:{tenant1}") >= 3 &&
-                SeqOf(rows, $"HighWaterMark:{tenant1}") >= 3,
-            30.Seconds(), "initial tenant reaches its own height on shard A");
-
-        // ---- Phase 1: a NEW tenant joins the SAME shard while the daemon keeps running ----
-        await _store.Advanced.AddTenantToShardAsync(tenant2, shard, CancellationToken.None);
-
-        // Pin 1: partitions + the per-tenant sequence exist on the shard database immediately.
-        (await SequenceExistsAsync(shardConnStr, $"mt_events_sequence_{tenant2}")).ShouldBeTrue(
-            $"AddTenantToShardAsync must provision mt_events_sequence_{tenant2} on shard {shard}");
-
-        // ... so appending for the new tenant works right away (Quick append would raise MT002
-        // against an unregistered tenant partition).
-        var stream2 = Guid.NewGuid();
-        await using (var session = _store.LightweightSession(tenant2))
-        {
-            session.Events.StartStream<ShardedDaemonCounter>(stream2,
-                new ShardedDaemonEvent("t2-1"), new ShardedDaemonEvent("t2-2"));
-            await session.SaveChangesAsync();
-        }
-
-        // Pin 2 — CURRENT BEHAVIOR: the running shard daemon does not pick the new tenant up on its
-        // own (tenant fan-out only happens in StartAllAsync). Bounded observation window, then the
-        // explicit no-restart path below. If this pin ever fails, the daemon gained mid-run tenant
-        // discovery — update this test to assert the automatic pickup instead.
-        await Task.Delay(5.Seconds());
-        var midRows = await ProgressionRowsAsync(shardConnStr);
-        DumpRows("shard A progression after adding tenant 2, before explicit agent start", midRows);
-        midRows.Any(r => r.Name == $"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}")
-            .ShouldBeFalse(
-                "current behavior: a tenant assigned to the shard mid-run gets no per-tenant agent " +
-                "until something calls StartAgentAsync for its tenant-bearing shard identity");
-
-        // Pin 3: the wolverine#3280 per-tenant identity start — the supported way to activate a new
-        // tenant on a RUNNING daemon, no restart.
-        await daemon.StartAgentAsync(
-            $"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}", CancellationToken.None);
-
-        var rows = await WaitForProgressionAsync(shardConnStr, r =>
-                SeqOf(r, $"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}") >= 2 &&
-                SeqOf(r, $"HighWaterMark:{tenant2}") >= 2,
-            30.Seconds(), "new tenant's per-tenant progression + high-water rows appear on shard A");
-        DumpRows("shard A progression once tenant 2 caught up", rows);
-
-        // The new tenant's projection materialized on its shard — without restarting the daemon.
-        ShardedDaemonCounter? doc2 = null;
-        var sw = Stopwatch.StartNew();
-        while (sw.Elapsed < 20.Seconds())
-        {
-            await using var query = _store.QuerySession(tenant2);
-            doc2 = await query.LoadAsync<ShardedDaemonCounter>(stream2);
-            if (doc2 is { EventCount: 2 })
+        using var node = await new HostBuilder()
+            .ConfigureServices(services =>
             {
-                break;
+                services.AddMarten(Configure).AddAsyncDaemon(DaemonMode.HotCold);
+            }).StartAsync();
+
+        try
+        {
+            await WaitForProgressionAsync(shardConnStr, rows =>
+                    SeqOf(rows, $"{ShardedDaemonProjection.ProjectionName}:All:{tenant1}") >= 3 &&
+                    SeqOf(rows, $"HighWaterMark:{tenant1}") >= 3,
+                30.Seconds(), "initial tenant reaches its own height on shard A");
+
+            // ---- Phase 1: a NEW tenant joins the SAME shard while the coordinator keeps running ----
+            await _store.Advanced.AddTenantToShardAsync(tenant2, shard, CancellationToken.None);
+
+            // Pin 1: partitions + the per-tenant sequence exist on the shard database immediately.
+            (await SequenceExistsAsync(shardConnStr, $"mt_events_sequence_{tenant2}")).ShouldBeTrue(
+                $"AddTenantToShardAsync must provision mt_events_sequence_{tenant2} on shard {shard}");
+
+            // ... so appending for the new tenant works right away (Quick append would raise MT002
+            // against an unregistered tenant partition). Tenant 2 is deliberately seeded ABOVE the
+            // shard's current global high water (tenant 1 is at 3, so tenant 2 gets 4 events in its
+            // own overlapping sequence): the vectorized per-tenant high-water poll rides the GLOBAL
+            // high-water cadence (fires only when max(seq_id) over the shard's whole events table
+            // moves), so if the coordinator's discovery wins the race against this append and
+            // primes tenant 2's agent at ceiling 0, events staying below the shard's global mark
+            // would never be routed to it. See the single-database flavor
+            // (dynamic_tenant_lifecycle_during_continuous_daemon) for the full cadence-gap notes.
+            var stream2 = Guid.NewGuid();
+            await using (var session = _store.LightweightSession(tenant2))
+            {
+                session.Events.StartStream<ShardedDaemonCounter>(stream2,
+                    new ShardedDaemonEvent("t2-1"), new ShardedDaemonEvent("t2-2"),
+                    new ShardedDaemonEvent("t2-3"), new ShardedDaemonEvent("t2-4"));
+                await session.SaveChangesAsync();
             }
 
-            await Task.Delay(250);
+            // Pin 2 — FLIPPED (was the pre-#491 negative pin + explicit StartAgentAsync): the
+            // running coordinator discovers the new tenant on its next leadership polling cycle —
+            // the shard database's set re-expands from its own tenants.mt_tenant_partitions
+            // registry and tenant 2's agent starts and catches up. No StartAgentAsync, no restart.
+            var rows = await WaitForProgressionAsync(shardConnStr, r =>
+                    SeqOf(r, $"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}") >= 4 &&
+                    SeqOf(r, $"HighWaterMark:{tenant2}") >= 4,
+                30.Seconds(),
+                "new tenant's per-tenant progression + high-water rows appear on shard A via the " +
+                "coordinator's own re-enumeration");
+            DumpRows("shard A progression once tenant 2 caught up", rows);
+
+            // The tenant-bearing agent really is running on the coordinator node's shard daemon.
+            var coordinator = node.Services.GetRequiredService<IProjectionCoordinator>();
+            var daemon = await coordinator.DaemonForDatabase(shard);
+            var agents = daemon.CurrentAgents()
+                .Where(x => x.Status == AgentStatus.Running)
+                .Select(x => x.Name.Identity)
+                .OrderBy(x => x)
+                .ToList();
+            _output.WriteLine($"shard A agents: [{string.Join(", ", agents)}]");
+            agents.ShouldContain($"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}",
+                "the coordinator's polling cycle must have started the new tenant's agent");
+
+            // The new tenant's projection materialized on its shard — without restarting anything.
+            ShardedDaemonCounter? doc2 = null;
+            var sw = Stopwatch.StartNew();
+            while (sw.Elapsed < 20.Seconds())
+            {
+                await using var query = _store.QuerySession(tenant2);
+                doc2 = await query.LoadAsync<ShardedDaemonCounter>(stream2);
+                if (doc2 is { EventCount: 4 })
+                {
+                    break;
+                }
+
+                await Task.Delay(250);
+            }
+
+            doc2.ShouldNotBeNull("tenant 2's projection doc must materialize on shard A");
+            doc2!.EventCount.ShouldBe(4);
+
+            // And the original tenant is untouched by the dynamic add — still at its own height.
+            SeqOf(rows, $"{ShardedDaemonProjection.ProjectionName}:All:{tenant1}").ShouldBe(3);
+            await using (var query = _store.QuerySession(tenant1))
+            {
+                (await query.LoadAsync<ShardedDaemonCounter>(stream1))!.EventCount.ShouldBe(3);
+            }
         }
-
-        doc2.ShouldNotBeNull("tenant 2's projection doc must materialize on shard A");
-        doc2!.EventCount.ShouldBe(2);
-
-        // And the original tenant is untouched by the dynamic add — still at its own height.
-        SeqOf(rows, $"{ShardedDaemonProjection.ProjectionName}:All:{tenant1}").ShouldBe(3);
-        await using (var query = _store.QuerySession(tenant1))
+        finally
         {
-            (await query.LoadAsync<ShardedDaemonCounter>(stream1))!.EventCount.ShouldBe(3);
+            await node.StopAsync();
         }
-
-        await daemon.StopAllAsync();
     }
 
     private static async Task<bool> SequenceExistsAsync(string connectionString, string sequenceName)

--- a/src/TenantPartitionedEventsTests/Sharded/dynamic_tenant_lifecycle_on_shard_during_daemon.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/dynamic_tenant_lifecycle_on_shard_during_daemon.cs
@@ -1,0 +1,269 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+/// <summary>
+/// JasperFx/jasperfx#486 WS1 — dynamic tenant lifecycle on a SHARD database while its daemon keeps
+/// running: sharded/pooled tenancy (<c>MultiTenantedWithShardedDatabases</c>) +
+/// <c>UseTenantPartitionedEvents</c>, one shard daemon started for the shard's initial tenant, then
+/// <c>AddTenantToShardAsync</c> assigns a NEW tenant to the SAME shard mid-run.
+///
+/// <para>
+/// Pins, in order:
+/// <list type="number">
+///   <item><c>AddTenantToShardAsync</c> mid-run provisions the new tenant's partitions AND its
+///     per-tenant <c>mt_events_sequence_{suffix}</c> on the target shard database immediately —
+///     appends for the new tenant work right away (no MT002).</item>
+///   <item>CURRENT BEHAVIOR (JasperFx.Events 2.20.0): the RUNNING shard daemon does NOT discover the
+///     new tenant on its own — per-tenant fan-out (<c>buildPerTenantContinuousAgents</c>) only runs
+///     inside <c>StartAllAsync</c>; the high-water poll loop only polls tenants that already have a
+///     tenant-bearing agent. Same gap as the single-database flavor
+///     (<c>dynamic_tenant_lifecycle_during_continuous_daemon</c>).</item>
+///   <item>The no-restart path that DOES work (wolverine#3280):
+///     <c>StartAgentAsync("{Projection}:All:{tenant}")</c> fans out the tenant agent on the running
+///     daemon. The new tenant's <c>{Projection}:All:{tenant}</c> and <c>HighWaterMark:{tenant}</c>
+///     rows then appear in the SHARD database's own <c>mt_event_progression</c> (per-shard, no
+///     cross-shard coordination) and the projection catches up to the tenant's own height.</item>
+/// </list>
+/// </para>
+/// </summary>
+[Collection("sharded-tenant-partitioned")]
+public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
+{
+    private readonly ShardedPartitionedFixture _fixture;
+    private readonly ITestOutputHelper _output;
+    private DocumentStore _store = null!;
+
+    public dynamic_tenant_lifecycle_on_shard_during_daemon(
+        ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_store != null!)
+        {
+            await _store.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task tenant_added_to_shard_mid_run_is_provisioned_and_catches_up_without_daemon_restart()
+    {
+        _store = (DocumentStore)DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded";
+                x.PartitionSchemaName = "tenants";
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+            });
+
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AddEventType<ShardedDaemonEvent>();
+
+            opts.Projections.Add<ShardedDaemonProjection>(ProjectionLifecycle.Async);
+            opts.Schema.For<ShardedDaemonCounter>().DocumentAlias("ws1dyn_sdc");
+        });
+
+        // ---- Phase 0: one initial tenant on shard A, daemon running, caught up ----
+        var shard = _fixture.DbNames[0];
+        var shardConnStr = _fixture.ConnectionStrings[shard];
+        const string tenant1 = "ws1dyn_t1";
+        const string tenant2 = "ws1dyn_t2";
+
+        await _store.Advanced.AddTenantToShardAsync(tenant1, shard, CancellationToken.None);
+
+        var stream1 = Guid.NewGuid();
+        await using (var session = _store.LightweightSession(tenant1))
+        {
+            session.Events.StartStream<ShardedDaemonCounter>(stream1,
+                new ShardedDaemonEvent("t1-1"), new ShardedDaemonEvent("t1-2"),
+                new ShardedDaemonEvent("t1-3"));
+            await session.SaveChangesAsync();
+        }
+
+        using var daemon = await _store.BuildProjectionDaemonAsync(tenant1);
+        await daemon.StartAllAsync();
+
+        await WaitForProgressionAsync(shardConnStr, rows =>
+                SeqOf(rows, $"{ShardedDaemonProjection.ProjectionName}:All:{tenant1}") >= 3 &&
+                SeqOf(rows, $"HighWaterMark:{tenant1}") >= 3,
+            30.Seconds(), "initial tenant reaches its own height on shard A");
+
+        // ---- Phase 1: a NEW tenant joins the SAME shard while the daemon keeps running ----
+        await _store.Advanced.AddTenantToShardAsync(tenant2, shard, CancellationToken.None);
+
+        // Pin 1: partitions + the per-tenant sequence exist on the shard database immediately.
+        (await SequenceExistsAsync(shardConnStr, $"mt_events_sequence_{tenant2}")).ShouldBeTrue(
+            $"AddTenantToShardAsync must provision mt_events_sequence_{tenant2} on shard {shard}");
+
+        // ... so appending for the new tenant works right away (Quick append would raise MT002
+        // against an unregistered tenant partition).
+        var stream2 = Guid.NewGuid();
+        await using (var session = _store.LightweightSession(tenant2))
+        {
+            session.Events.StartStream<ShardedDaemonCounter>(stream2,
+                new ShardedDaemonEvent("t2-1"), new ShardedDaemonEvent("t2-2"));
+            await session.SaveChangesAsync();
+        }
+
+        // Pin 2 — CURRENT BEHAVIOR: the running shard daemon does not pick the new tenant up on its
+        // own (tenant fan-out only happens in StartAllAsync). Bounded observation window, then the
+        // explicit no-restart path below. If this pin ever fails, the daemon gained mid-run tenant
+        // discovery — update this test to assert the automatic pickup instead.
+        await Task.Delay(5.Seconds());
+        var midRows = await ProgressionRowsAsync(shardConnStr);
+        DumpRows("shard A progression after adding tenant 2, before explicit agent start", midRows);
+        midRows.Any(r => r.Name == $"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}")
+            .ShouldBeFalse(
+                "current behavior: a tenant assigned to the shard mid-run gets no per-tenant agent " +
+                "until something calls StartAgentAsync for its tenant-bearing shard identity");
+
+        // Pin 3: the wolverine#3280 per-tenant identity start — the supported way to activate a new
+        // tenant on a RUNNING daemon, no restart.
+        await daemon.StartAgentAsync(
+            $"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}", CancellationToken.None);
+
+        var rows = await WaitForProgressionAsync(shardConnStr, r =>
+                SeqOf(r, $"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}") >= 2 &&
+                SeqOf(r, $"HighWaterMark:{tenant2}") >= 2,
+            30.Seconds(), "new tenant's per-tenant progression + high-water rows appear on shard A");
+        DumpRows("shard A progression once tenant 2 caught up", rows);
+
+        // The new tenant's projection materialized on its shard — without restarting the daemon.
+        ShardedDaemonCounter? doc2 = null;
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < 20.Seconds())
+        {
+            await using var query = _store.QuerySession(tenant2);
+            doc2 = await query.LoadAsync<ShardedDaemonCounter>(stream2);
+            if (doc2 is { EventCount: 2 })
+            {
+                break;
+            }
+
+            await Task.Delay(250);
+        }
+
+        doc2.ShouldNotBeNull("tenant 2's projection doc must materialize on shard A");
+        doc2!.EventCount.ShouldBe(2);
+
+        // And the original tenant is untouched by the dynamic add — still at its own height.
+        SeqOf(rows, $"{ShardedDaemonProjection.ProjectionName}:All:{tenant1}").ShouldBe(3);
+        await using (var query = _store.QuerySession(tenant1))
+        {
+            (await query.LoadAsync<ShardedDaemonCounter>(stream1))!.EventCount.ShouldBe(3);
+        }
+
+        await daemon.StopAllAsync();
+    }
+
+    private static async Task<bool> SequenceExistsAsync(string connectionString, string sequenceName)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand(
+            "select count(*) from pg_sequences where sequencename = :name");
+        cmd.Parameters.AddWithValue("name", sequenceName);
+        return (long)(await cmd.ExecuteScalarAsync())! > 0;
+    }
+
+    private async Task<List<(string Name, long Seq)>> WaitForProgressionAsync(
+        string connectionString, Func<List<(string Name, long Seq)>, bool> condition,
+        TimeSpan timeout, string what)
+    {
+        var sw = Stopwatch.StartNew();
+        List<(string Name, long Seq)> rows = new();
+        while (sw.Elapsed < timeout)
+        {
+            rows = await ProgressionRowsAsync(connectionString);
+            if (condition(rows))
+            {
+                return rows;
+            }
+
+            await Task.Delay(250);
+        }
+
+        DumpRows($"TIMED OUT waiting for: {what}", rows);
+        throw new TimeoutException($"Timed out after {timeout} waiting for: {what}");
+    }
+
+    private void DumpRows(string label, List<(string Name, long Seq)> rows)
+    {
+        _output.WriteLine($"=== {label} ===");
+        foreach (var (name, seq) in rows.OrderBy(r => r.Name))
+        {
+            _output.WriteLine($"{seq,6} | {name}");
+        }
+    }
+
+    private static long SeqOf(List<(string Name, long Seq)> rows, string name) =>
+        rows.FirstOrDefault(r => r.Name == name).Seq;
+
+    /// <summary>
+    /// Each shard database hosts its own event store in its public schema (the sharded model puts
+    /// mt_events / mt_event_progression there when the doc-side schema is "sharded"/"tenants").
+    /// </summary>
+    private static async Task<List<(string Name, long Seq)>> ProgressionRowsAsync(
+        string connectionString)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand(
+            "select name, coalesce(last_seq_id,0) from public.mt_event_progression order by name");
+        await using var reader = await cmd.ExecuteReaderAsync();
+        var rows = new List<(string, long)>();
+        while (await reader.ReadAsync())
+        {
+            rows.Add((reader.GetString(0), reader.GetInt64(1)));
+        }
+
+        return rows;
+    }
+}

--- a/src/TenantPartitionedEventsTests/Sharded/multi_node_hotcold_sharded_partitioned_events.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/multi_node_hotcold_sharded_partitioned_events.cs
@@ -33,25 +33,25 @@ namespace TenantPartitionedEventsTests.Sharded;
 /// <c>AddAsyncDaemon(DaemonMode.HotCold)</c> with the same DaemonLockId.
 ///
 /// <para>
-/// DISTRIBUTION GRANULARITY OBSERVED AND PINNED HERE (JasperFx.Events 2.20.0 + Marten master):
-/// non-default tenancy routes the coordinator to <c>MultiTenantedProjectionDistributor</c> — ONE
-/// advisory-lock-guarded <c>IProjectionSet</c> PER DATABASE carrying ALL the store-global shard
-/// names. So a shard database's projections run WHOLE on exactly one node (unlike the single-DB
-/// matrix cell, where the SingleTenant distributor can split individual projections across nodes),
-/// while different shard databases can land on different nodes.
+/// DISTRIBUTION GRANULARITY (JasperFx.Events 2.21.0, jasperfx#491 + Marten #4862): non-default
+/// tenancy routes the coordinator to <c>MultiTenantedProjectionDistributor</c> — ONE
+/// advisory-lock-guarded <c>IProjectionSet</c> PER DATABASE. So a shard database's projections run
+/// WHOLE on exactly one node (unlike the single-DB matrix cell, where the SingleTenant distributor
+/// can split individual projections across nodes), while different shard databases can land on
+/// different nodes.
 /// </para>
 ///
 /// <para>
-/// As in the single-database cell, the winning node hands each STORE-GLOBAL identity
-/// (<c>{Projection}:All</c>) to <c>StartAgentAsync</c>, whose exact-identity path builds the
-/// store-global agent — the per-tenant fan-out only runs inside <c>StartAllAsync</c>, which the
-/// native coordinator never calls. The WS1 per-tenant baseline (<c>{Projection}:All:{tenant}</c> +
-/// <c>HighWaterMark:{tenant}</c> rows per shard) is therefore NOT met on this path today, even
-/// though Marten explicitly marks this topology as needing per-tenant agents
-/// (<c>IEventStore.DistributesAgentsPerTenant</c> is true for ShardedTenancy +
-/// UseTenantPartitionedEvents — but only Wolverine-style external distributors consume it). When
-/// epic #486 teaches the native coordinator the per-tenant shape, flip the per-tenant assertions
-/// below from absent to present.
+/// Because the store is tenant-partitioned (<c>IEventStore.DistributesAgentsPerTenant</c>), each
+/// database's set now expands its store-global shard names into per-tenant
+/// <c>{Projection}:All:{tenant}</c> ShardNames from THAT shard database's own tenant registry
+/// (<c>PerTenantShardExpansion</c> over <c>ICrossTenantRebuildSource</c>), and the winning node
+/// starts each tenant-bearing identity through <c>StartAgentAsync</c>'s per-tenant branch
+/// (jasperfx#487). The WS1 per-tenant baseline is therefore met per shard: per-tenant progression
+/// rows reach each tenant's OWN height and <c>HighWaterMark:{tenant}</c> rows appear in the shard
+/// database's own <c>mt_event_progression</c>, with no store-global agent ever running. This test
+/// previously pinned the pre-#491 store-global-only behavior; the assertions were flipped when
+/// the fix landed.
 /// </para>
 /// </summary>
 [Collection("sharded-tenant-partitioned")]
@@ -136,7 +136,7 @@ public partial class multi_node_hotcold_sharded_partitioned_events: IAsyncLifeti
     }
 
     [Fact]
-    public async Task two_hotcold_nodes_own_whole_shard_databases_without_per_tenant_fan_out()
+    public async Task two_hotcold_nodes_own_whole_shard_databases_with_per_tenant_fan_out()
     {
         var shardA = _fixture.DbNames[0];
         var shardB = _fixture.DbNames[1];
@@ -192,63 +192,84 @@ public partial class multi_node_hotcold_sharded_partitioned_events: IAsyncLifeti
 
         try
         {
-            // Deterministic wait on per-shard progression state: each shard database's store-global
-            // shards must reach that shard's own high water (max over its overlapping per-tenant
-            // sequences).
+            var projections = new[] { ShTripProjection.ProjectionName, ShTallyProjection.ProjectionName };
+
+            // Deterministic wait on per-shard progression state: every (projection, tenant) pair on
+            // each shard database must reach that tenant's OWN height (the WS1 per-tenant baseline),
+            // and the shard's global high-water row its own max.
             var rowsByShard = new Dictionary<string, List<(string Name, long Seq)>>();
             foreach (var shard in new[] { shardA, shardB })
             {
+                var shardTenants = tenantsByShard[shard];
                 rowsByShard[shard] = await WaitForProgressionAsync(
                     _fixture.ConnectionStrings[shard], r =>
-                        SeqOf(r, $"{ShTripProjection.ProjectionName}:All") >= shardHighWater[shard] &&
-                        SeqOf(r, $"{ShTallyProjection.ProjectionName}:All") >= shardHighWater[shard],
-                    60.Seconds(), $"store-global shards reach high water {shardHighWater[shard]} on {shard}");
+                        shardTenants.Keys.All(t =>
+                            SeqOf(r, $"{ShTripProjection.ProjectionName}:All:{t}") >= expectedHeight[t] &&
+                            SeqOf(r, $"{ShTallyProjection.ProjectionName}:All:{t}") >= expectedHeight[t] &&
+                            SeqOf(r, $"HighWaterMark:{t}") >= expectedHeight[t]) &&
+                        SeqOf(r, "HighWaterMark") >= shardHighWater[shard],
+                    60.Seconds(), $"per-tenant shards reach their own heights on {shard}");
                 DumpRows($"{shard} mt_event_progression once caught up", rowsByShard[shard]);
             }
 
-            // ---- Placement: whole shard database per node ----
-            var allShardIdentities = new[]
-            {
-                $"{ShTripProjection.ProjectionName}:All", $"{ShTallyProjection.ProjectionName}:All"
-            };
-
+            // ---- Placement: whole shard database per node, per-tenant agents inside ----
             foreach (var shard in new[] { shardA, shardB })
             {
+                // jasperfx#491: the shard database's set expands into per-tenant identities from
+                // THAT database's own tenant registry — its winner runs one agent per
+                // (projection, tenant-on-this-shard), and no store-global agent exists.
+                var perTenantIdentities = projections
+                    .SelectMany(p => tenantsByShard[shard].Keys.Select(t => $"{p}:All:{t}"))
+                    .ToArray();
+
                 var onA = await AgentIdentitiesAsync(nodeA, shard);
                 var onB = await AgentIdentitiesAsync(nodeB, shard);
                 _output.WriteLine($"{shard}: node A runs [{string.Join(", ", onA)}], " +
                                   $"node B runs [{string.Join(", ", onB)}]");
 
-                // Only store-global agents run — no tenant-bearing agent identities on either node.
-                onA.Concat(onB).ShouldAllBe(identity => allShardIdentities.Contains(identity));
+                // Only tenant-bearing agents run, and only for THIS shard's tenants — the
+                // expansion never leaks another shard database's tenants into this set.
+                onA.Concat(onB).ShouldAllBe(identity => perTenantIdentities.Contains(identity));
 
                 // Per-database lock granularity: exactly one node owns the shard database, and it
-                // runs ALL of the database's shards — the set is never split across nodes. Which
-                // node wins which database is a lock race (the two databases CAN land on different
-                // nodes); assert exclusivity + completeness, not the split.
+                // runs ALL of the database's per-tenant agents — the set is never split across
+                // nodes. Which node wins which database is a lock race (the two databases CAN land
+                // on different nodes); assert exclusivity + completeness, not the split.
                 var owners = new[] { onA.Any(), onB.Any() }.Count(x => x);
                 owners.ShouldBe(1, $"{shard} must be owned by exactly one of the two HotCold nodes");
 
                 var winner = onA.Any() ? onA : onB;
-                winner.OrderBy(x => x).ShouldBe(allShardIdentities.OrderBy(x => x),
-                    $"the node owning {shard} must run ALL of that database's shards " +
+                winner.OrderBy(x => x).ShouldBe(perTenantIdentities.OrderBy(x => x),
+                    $"the node owning {shard} must run one agent per (projection, tenant) " +
                     "(MultiTenantedProjectionDistributor distributes whole databases)");
             }
 
-            // ---- WS1 per-tenant baseline: NOT met on this path today (see class doc) ----
+            // ---- WS1 per-tenant baseline: met per shard as of jasperfx#491 ----
             foreach (var shard in new[] { shardA, shardB })
             {
                 var rows = rowsByShard[shard];
+                var perTenantIdentities = projections
+                    .SelectMany(p => tenantsByShard[shard].Keys.Select(t => $"{p}:All:{t}"))
+                    .ToArray();
+
                 rows.Where(r => r.Name.StartsWith("Ws1Sh", StringComparison.Ordinal))
-                    .ShouldAllBe(r => allShardIdentities.Contains(r.Name),
-                        $"current behavior on {shard}: only store-global progression rows exist " +
-                        "under the native HotCold coordinator — no {Projection}:All:{tenant} rows. " +
-                        "If per-tenant rows now appear, the native coordinator gained per-tenant " +
-                        "fan-out and this test should assert the WS1 per-tenant baseline instead");
-                rows.Any(r => r.Name.StartsWith("HighWaterMark:", StringComparison.Ordinal))
-                    .ShouldBeFalse(
-                        $"current behavior on {shard}: no per-tenant HighWaterMark rows without " +
-                        "tenant-bearing agents");
+                    .ShouldAllBe(r => perTenantIdentities.Contains(r.Name),
+                        $"per-tenant fan-out on {shard}: every projection progression row is " +
+                        "tenant-bearing (no store-global {Projection}:All row) and belongs to one " +
+                        "of this shard's own tenants");
+
+                foreach (var tenant in tenantsByShard[shard].Keys)
+                {
+                    SeqOf(rows, $"{ShTripProjection.ProjectionName}:All:{tenant}")
+                        .ShouldBe(expectedHeight[tenant],
+                            $"tenant {tenant}'s trip shard tracks the tenant's OWN height on {shard}");
+                    SeqOf(rows, $"{ShTallyProjection.ProjectionName}:All:{tenant}")
+                        .ShouldBe(expectedHeight[tenant],
+                            $"tenant {tenant}'s tally shard tracks the tenant's OWN height on {shard}");
+                    SeqOf(rows, $"HighWaterMark:{tenant}").ShouldBe(expectedHeight[tenant],
+                        $"tenant {tenant}'s own high-water row is persisted on {shard}");
+                }
+
                 SeqOf(rows, "HighWaterMark").ShouldBe(shardHighWater[shard],
                     $"{shard}'s store-global high water = max over its tenants' overlapping heights");
             }
@@ -264,9 +285,6 @@ public partial class multi_node_hotcold_sharded_partitioned_events: IAsyncLifeti
                 tally.ShouldNotBeNull($"tenant {tenant}'s ShTally doc must materialize on its shard");
                 tally!.Count.ShouldBe(legs);
             }
-
-            _ = expectedHeight; // per-tenant heights are documented above; the per-tenant rows that
-                                // would carry them do not exist on this path today.
         }
         finally
         {

--- a/src/TenantPartitionedEventsTests/Sharded/multi_node_hotcold_sharded_partitioned_events.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/multi_node_hotcold_sharded_partitioned_events.cs
@@ -1,0 +1,347 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+using IProjectionCoordinator = Marten.Events.Daemon.Coordination.IProjectionCoordinator;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+/// <summary>
+/// JasperFx/jasperfx#486 WS1 — native HotCold distribution matrix, cell "sharded/pooled databases +
+/// UseTenantPartitionedEvents": TWO shard databases, two tenants per shard (different heights, so
+/// their per-tenant sequences overlap), two async projections, TWO IHost nodes both running
+/// <c>AddAsyncDaemon(DaemonMode.HotCold)</c> with the same DaemonLockId.
+///
+/// <para>
+/// DISTRIBUTION GRANULARITY OBSERVED AND PINNED HERE (JasperFx.Events 2.20.0 + Marten master):
+/// non-default tenancy routes the coordinator to <c>MultiTenantedProjectionDistributor</c> — ONE
+/// advisory-lock-guarded <c>IProjectionSet</c> PER DATABASE carrying ALL the store-global shard
+/// names. So a shard database's projections run WHOLE on exactly one node (unlike the single-DB
+/// matrix cell, where the SingleTenant distributor can split individual projections across nodes),
+/// while different shard databases can land on different nodes.
+/// </para>
+///
+/// <para>
+/// As in the single-database cell, the winning node hands each STORE-GLOBAL identity
+/// (<c>{Projection}:All</c>) to <c>StartAgentAsync</c>, whose exact-identity path builds the
+/// store-global agent — the per-tenant fan-out only runs inside <c>StartAllAsync</c>, which the
+/// native coordinator never calls. The WS1 per-tenant baseline (<c>{Projection}:All:{tenant}</c> +
+/// <c>HighWaterMark:{tenant}</c> rows per shard) is therefore NOT met on this path today, even
+/// though Marten explicitly marks this topology as needing per-tenant agents
+/// (<c>IEventStore.DistributesAgentsPerTenant</c> is true for ShardedTenancy +
+/// UseTenantPartitionedEvents — but only Wolverine-style external distributors consume it). When
+/// epic #486 teaches the native coordinator the per-tenant shape, flip the per-tenant assertions
+/// below from absent to present.
+/// </para>
+/// </summary>
+[Collection("sharded-tenant-partitioned")]
+public partial class multi_node_hotcold_sharded_partitioned_events: IAsyncLifetime
+{
+    private readonly ShardedPartitionedFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public multi_node_hotcold_sharded_partitioned_events(
+        ShardedPartitionedFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    public class ShTrip { public Guid Id { get; set; } public double Distance { get; set; } }
+    public class ShTally { public Guid Id { get; set; } public int Count { get; set; } }
+
+    public record ShStarted(Guid Id);
+    public record ShLeg(double Distance);
+
+    public partial class ShTripProjection: SingleStreamProjection<ShTrip, Guid>
+    {
+        public const string ProjectionName = "Ws1ShTrip";
+        public ShTripProjection() => Name = ProjectionName;
+        public void Apply(ShTrip t, ShLeg e) => t.Distance += e.Distance;
+    }
+
+    public partial class ShTallyProjection: SingleStreamProjection<ShTally, Guid>
+    {
+        public const string ProjectionName = "Ws1ShTally";
+        public ShTallyProjection() => Name = ProjectionName;
+        public void Apply(ShTally t, ShLeg e) => t.Count++;
+    }
+
+    private const int LockId = 48617;
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private void Configure(StoreOptions opts)
+    {
+        opts.MultiTenantedWithShardedDatabases(x =>
+        {
+            x.ConnectionString = ConnectionSource.ConnectionString;
+            x.SchemaName = "sharded";
+            x.PartitionSchemaName = "tenants";
+            foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+            {
+                x.AddDatabase(dbName, connStr);
+            }
+        });
+
+        opts.AutoCreateSchemaObjects = AutoCreate.All;
+        opts.DisableNpgsqlLogging = true;
+        opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+        opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+        opts.Events.UseTenantPartitionedEvents = true;
+
+        opts.Projections.DaemonLockId = LockId;
+        opts.Projections.LeadershipPollingTime = 250;
+
+        opts.Schema.For<ShTrip>().DocumentAlias("ws1sh_trip");
+        opts.Schema.For<ShTally>().DocumentAlias("ws1sh_tally");
+
+        opts.Projections.Add<ShTripProjection>(ProjectionLifecycle.Async);
+        opts.Projections.Add<ShTallyProjection>(ProjectionLifecycle.Async);
+    }
+
+    [Fact]
+    public async Task two_hotcold_nodes_own_whole_shard_databases_without_per_tenant_fan_out()
+    {
+        var shardA = _fixture.DbNames[0];
+        var shardB = _fixture.DbNames[1];
+
+        // Two tenants per shard, different heights so the per-tenant sequences overlap within a
+        // shard. 1 ShStarted + N ShLeg per tenant.
+        var tenantsByShard = new Dictionary<string, Dictionary<string, int>>
+        {
+            [shardA] = new() { ["ws1sh_a1"] = 4, ["ws1sh_a2"] = 2 },
+            [shardB] = new() { ["ws1sh_b1"] = 3, ["ws1sh_b2"] = 5 }
+        };
+        var expectedHeight = tenantsByShard.Values.SelectMany(x => x)
+            .ToDictionary(p => p.Key, p => (long)(p.Value + 1));
+        var shardHighWater = tenantsByShard.ToDictionary(
+            p => p.Key, p => p.Value.Values.Max(v => (long)(v + 1)));
+
+        // Bootstrap store provisions tenants + events BEFORE any node starts, and stays alive for
+        // the doc-side verification at the end.
+        var streams = new Dictionary<string, Guid>();
+        using var bootstrap = (DocumentStore)DocumentStore.For(Configure);
+
+        // Materialize the FULL schema (including the projection document tables) on every shard
+        // database BEFORE registering tenants, so AddTenantToShardAsync adds each tenant's list
+        // partition to the doc tables too. This ordering matters: a table that comes into existence
+        // AFTER its tenants joined the shard is created with ZERO partitions — the lazy/one-shot
+        // table creation on a fresh store instance does not hydrate partitions from the shard's own
+        // tenants.mt_tenant_partitions registry (observed: the HotCold nodes' daemons created
+        // mt_doc_* as empty partitioned tables and every projection write failed with 23514 "no
+        // partition of relation found for row"). That fresh-node provisioning gap is a product
+        // follow-up in the #4682/#4706 per-database-partition-state family, not this test's subject.
+        await bootstrap.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        foreach (var (shard, tenants) in tenantsByShard)
+        {
+            foreach (var (tenant, legs) in tenants)
+            {
+                await bootstrap.Advanced.AddTenantToShardAsync(tenant, shard, CancellationToken.None);
+
+                var id = Guid.NewGuid();
+                streams[tenant] = id;
+                await using var session = bootstrap.LightweightSession(tenant);
+                var events = new object[] { new ShStarted(id) }
+                    .Concat(Enumerable.Range(0, legs).Select(_ => (object)new ShLeg(1.0)))
+                    .ToArray();
+                session.Events.StartStream<ShTrip>(id, events);
+                await session.SaveChangesAsync();
+            }
+        }
+
+        // TWO nodes in HotCold contention over the same shard pool + lock id.
+        using var nodeA = await StartNodeAsync();
+        using var nodeB = await StartNodeAsync();
+
+        try
+        {
+            // Deterministic wait on per-shard progression state: each shard database's store-global
+            // shards must reach that shard's own high water (max over its overlapping per-tenant
+            // sequences).
+            var rowsByShard = new Dictionary<string, List<(string Name, long Seq)>>();
+            foreach (var shard in new[] { shardA, shardB })
+            {
+                rowsByShard[shard] = await WaitForProgressionAsync(
+                    _fixture.ConnectionStrings[shard], r =>
+                        SeqOf(r, $"{ShTripProjection.ProjectionName}:All") >= shardHighWater[shard] &&
+                        SeqOf(r, $"{ShTallyProjection.ProjectionName}:All") >= shardHighWater[shard],
+                    60.Seconds(), $"store-global shards reach high water {shardHighWater[shard]} on {shard}");
+                DumpRows($"{shard} mt_event_progression once caught up", rowsByShard[shard]);
+            }
+
+            // ---- Placement: whole shard database per node ----
+            var allShardIdentities = new[]
+            {
+                $"{ShTripProjection.ProjectionName}:All", $"{ShTallyProjection.ProjectionName}:All"
+            };
+
+            foreach (var shard in new[] { shardA, shardB })
+            {
+                var onA = await AgentIdentitiesAsync(nodeA, shard);
+                var onB = await AgentIdentitiesAsync(nodeB, shard);
+                _output.WriteLine($"{shard}: node A runs [{string.Join(", ", onA)}], " +
+                                  $"node B runs [{string.Join(", ", onB)}]");
+
+                // Only store-global agents run — no tenant-bearing agent identities on either node.
+                onA.Concat(onB).ShouldAllBe(identity => allShardIdentities.Contains(identity));
+
+                // Per-database lock granularity: exactly one node owns the shard database, and it
+                // runs ALL of the database's shards — the set is never split across nodes. Which
+                // node wins which database is a lock race (the two databases CAN land on different
+                // nodes); assert exclusivity + completeness, not the split.
+                var owners = new[] { onA.Any(), onB.Any() }.Count(x => x);
+                owners.ShouldBe(1, $"{shard} must be owned by exactly one of the two HotCold nodes");
+
+                var winner = onA.Any() ? onA : onB;
+                winner.OrderBy(x => x).ShouldBe(allShardIdentities.OrderBy(x => x),
+                    $"the node owning {shard} must run ALL of that database's shards " +
+                    "(MultiTenantedProjectionDistributor distributes whole databases)");
+            }
+
+            // ---- WS1 per-tenant baseline: NOT met on this path today (see class doc) ----
+            foreach (var shard in new[] { shardA, shardB })
+            {
+                var rows = rowsByShard[shard];
+                rows.Where(r => r.Name.StartsWith("Ws1Sh", StringComparison.Ordinal))
+                    .ShouldAllBe(r => allShardIdentities.Contains(r.Name),
+                        $"current behavior on {shard}: only store-global progression rows exist " +
+                        "under the native HotCold coordinator — no {Projection}:All:{tenant} rows. " +
+                        "If per-tenant rows now appear, the native coordinator gained per-tenant " +
+                        "fan-out and this test should assert the WS1 per-tenant baseline instead");
+                rows.Any(r => r.Name.StartsWith("HighWaterMark:", StringComparison.Ordinal))
+                    .ShouldBeFalse(
+                        $"current behavior on {shard}: no per-tenant HighWaterMark rows without " +
+                        "tenant-bearing agents");
+                SeqOf(rows, "HighWaterMark").ShouldBe(shardHighWater[shard],
+                    $"{shard}'s store-global high water = max over its tenants' overlapping heights");
+            }
+
+            // ---- Docs materialize per tenant on the right shard at this small scale ----
+            foreach (var (tenant, legs) in tenantsByShard.Values.SelectMany(x => x))
+            {
+                await using var query = bootstrap.QuerySession(tenant);
+                var trip = await query.LoadAsync<ShTrip>(streams[tenant]);
+                trip.ShouldNotBeNull($"tenant {tenant}'s ShTrip doc must materialize on its shard");
+                trip!.Distance.ShouldBe(legs);
+                var tally = await query.LoadAsync<ShTally>(streams[tenant]);
+                tally.ShouldNotBeNull($"tenant {tenant}'s ShTally doc must materialize on its shard");
+                tally!.Count.ShouldBe(legs);
+            }
+
+            _ = expectedHeight; // per-tenant heights are documented above; the per-tenant rows that
+                                // would carry them do not exist on this path today.
+        }
+        finally
+        {
+            await nodeA.StopAsync();
+            await nodeB.StopAsync();
+        }
+    }
+
+    private async Task<IHost> StartNodeAsync()
+    {
+        return await new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(Configure).AddAsyncDaemon(DaemonMode.HotCold);
+            }).StartAsync();
+    }
+
+    private static async Task<IReadOnlyList<string>> AgentIdentitiesAsync(IHost node, string dbName)
+    {
+        var coordinator = node.Services.GetRequiredService<IProjectionCoordinator>();
+        var daemon = await coordinator.DaemonForDatabase(dbName);
+        return daemon.CurrentAgents()
+            .Where(x => x.Status == AgentStatus.Running)
+            .Select(x => x.Name.Identity)
+            .OrderBy(x => x)
+            .ToList();
+    }
+
+    private async Task<List<(string Name, long Seq)>> WaitForProgressionAsync(
+        string connectionString, Func<List<(string Name, long Seq)>, bool> condition,
+        TimeSpan timeout, string what)
+    {
+        var sw = Stopwatch.StartNew();
+        List<(string Name, long Seq)> rows = new();
+        while (sw.Elapsed < timeout)
+        {
+            rows = await ProgressionRowsAsync(connectionString);
+            if (condition(rows))
+            {
+                return rows;
+            }
+
+            await Task.Delay(250);
+        }
+
+        DumpRows($"TIMED OUT waiting for: {what}", rows);
+        throw new TimeoutException($"Timed out after {timeout} waiting for: {what}");
+    }
+
+    private void DumpRows(string label, List<(string Name, long Seq)> rows)
+    {
+        _output.WriteLine($"=== {label} ===");
+        foreach (var (name, seq) in rows.OrderBy(r => r.Name))
+        {
+            _output.WriteLine($"{seq,6} | {name}");
+        }
+    }
+
+    private static long SeqOf(List<(string Name, long Seq)> rows, string name) =>
+        rows.FirstOrDefault(r => r.Name == name).Seq;
+
+    private static async Task<List<(string Name, long Seq)>> ProgressionRowsAsync(
+        string connectionString)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand(
+            "select name, coalesce(last_seq_id,0) from public.mt_event_progression order by name");
+        await using var reader = await cmd.ExecuteReaderAsync();
+        var rows = new List<(string, long)>();
+        while (await reader.ReadAsync())
+        {
+            rows.Add((reader.GetString(0), reader.GetInt64(1)));
+        }
+
+        return rows;
+    }
+}


### PR DESCRIPTION
Marten consumption of **JasperFx 2.21.0**'s distributor-level per-tenant shard expansion (jasperfx#491), closing the native-coordination side of jasperfx#489 for epic JasperFx/jasperfx#486 (WS1). Builds on #4864's broadened gate.

## Changes

- `ProjectionCoordinator.BuildDistributor` threads `IEventStore.DistributesAgentsPerTenant` into all three distributor constructions (Solo / SingleTenant HotCold / MultiTenanted HotCold) — the only construction sites in Marten. With the flag on, the JasperFx distributors expand store-global shards into per-tenant `ShardName`s from `mt_tenant_partitions` (re-evaluated every leadership polling cycle) and the coordinator reconciles running agents against each fresh distribution.
- All four JasperFx pins → **2.21.0**.

## The WS1 native matrix tests, flipped to the fixed baseline (all in `TenantPartitionedEventsTests`)

- **Multi-node HotCold, single DB**: every running agent is tenant-bearing (2 projections × 3 tenants); lock granularity preserved (each projection's tenant agents co-located under its store-global advisory lock, projections split across nodes); per-tenant progression rows at each tenant's own height, per-tenant `HighWaterMark:{tenant}` rows, **no** store-global progression row.
- **Multi-node HotCold, sharded**: same baseline per shard DB; expansion draws from each database's *own* tenant registry (no cross-shard leakage); whole-database-per-node placement preserved.
- **Dynamic tenant lifecycle (single-DB Solo + sharded HotCold)**: mid-run tenant add converges via coordinator re-enumeration — the explicit `StartAgentAsync` workaround is gone; removal now reaps the agent.

**214/214 on net10.0 and net9.0.**

## Known limitation baked into the dynamic tests (jasperfx#492)

Per-tenant high-water polling triggers only on store-global mark *changes*; when coordinator discovery outraces a new tenant's first append, the agent starts at ceiling 0 and stalls until unrelated global-mark movement (~50% flake without mitigation). Both dynamic tests seed the new tenant above the global mark with loud comments — delete the workaround when jasperfx#492 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)