### PR TITLE
Bump JasperFx to 2.22.0 — daemon connection governors (jasperfx#494–#496)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -87,13 +87,13 @@
          IEventStore.DistributesAgentsPerTenant into BuildDistributor (ProjectionCoordinator).
          Also DaemonMode.ExternallyManaged (jasperfx#490, wolverine#3290 — external hosts run
          projections; the store hosts no coordination and must not warn). -->
-    <PackageVersion Include="JasperFx" Version="2.21.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.21.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.21.1">
+    <PackageVersion Include="JasperFx" Version="2.22.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.22.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.22.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.21.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.22.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Part of epic jasperfx#486 (WS2 + WS3). Consumes JasperFx **2.22.0**, which bounds the async daemon's database connection footprint per database — on by default, no configuration required:

- `MaxConcurrentEventLoadsPerDatabase` (default 4) — event-load throttle (jasperfx#495)
- `MaxConcurrentBatchWritesPerDatabase` (default 4) — projection batch-write governor (jasperfx#496)
- `CrossTenantRebuild.RebuildEverywhereAsync` now defaults `maxParallelism` to 4 (was unbounded)

Measured with `Marten.ScaleTesting daemonload` (100 tenants × 2 async projections = 200 per-tenant agents, continuous append, single database): peak connections drop from 47–99 (racy) to a **deterministic 12–14**, with unchanged throughput and 100/100 tenant catch-up. Full measurement record on jasperfx#494.

Verified locally against the published packages: `TenantPartitionedEventsTests` 215/215 (net9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)