### PR TITLE
Rebuild concurrency cap wiring + per-cell cancellation contract (closes #4710)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -87,13 +87,13 @@
          IEventStore.DistributesAgentsPerTenant into BuildDistributor (ProjectionCoordinator).
          Also DaemonMode.ExternallyManaged (jasperfx#490, wolverine#3290 — external hosts run
          projections; the store hosts no coordination and must not warn). -->
-    <PackageVersion Include="JasperFx" Version="2.22.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.22.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.22.0">
+    <PackageVersion Include="JasperFx" Version="2.23.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.23.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.23.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.22.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.23.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/docs/events/projections/rebuilding.md
+++ b/docs/events/projections/rebuilding.md
@@ -49,6 +49,57 @@ public async Task RunRebuildAsync()
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/Marten.Testing/Examples/RebuildRunner.cs#L30-L44' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_rebuild-single-projection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Capping Rebuild Concurrency <Badge type="tip" text="9.13" />
+
+Rebuilding fans out one rebuild "cell" per (projection × tenant/shard). On a wide store — many projections, or
+`UseTenantPartitionedEvents` with many tenants — an unbounded fan-out can exhaust the database connection pool and
+thrash the buffer cache. Marten caps the number of cells that run concurrently against one database:
+
+```cs
+// Explicit cap
+opts.Projections.MaxConcurrentRebuildsPerDatabase = 6;
+```
+
+If you don't set it, Marten derives a conservative default from the Npgsql connection pool size:
+`max(1, MaxPoolSize / 8)` — e.g. a 100-connection pool (the Npgsql default) allows 12 concurrent rebuild cells, a
+20-connection pool allows 2. The fraction leaves headroom for application traffic during rebuild windows. Setting
+the knob to zero or a negative number opts back into the historical unbounded fan-out.
+
+Two things to know about the shape of the throttle:
+
+- **It caps rebuild only.** Continuous catch-up is governed separately by
+  `opts.Projections.MaxConcurrentEventLoadsPerDatabase` and `opts.Projections.MaxConcurrentBatchWritesPerDatabase`
+  (both default 4).
+- **It's a two-layer model.** The cap bounds how many cells run at once; each cell still uses its own internal
+  slice workers while it runs. A cap of 4 therefore means "4 rebuilding projections/tenants at a time," not 4
+  concurrent database operations.
+
+For one-off operational rebuilds, the `--max-concurrent` flag on the [command line](/configuration/cli) overrides
+the configured value for that run:
+
+```bash
+dotnet run -- projections rebuild --max-concurrent 2
+```
+
+The effective cap is surfaced to monitoring tools through the store's usage descriptor
+(`EventStoreUsage.MaxConcurrentRebuildsPerDatabase`), so tools like CritterWatch can size their own rebuild
+orchestration to match.
+
+## Cancelling a Rebuild <Badge type="tip" text="9.13" />
+
+`RebuildProjectionAsync` overloads accept a `CancellationToken`, including the per-tenant overload
+(`RebuildProjectionAsync(name, tenantId, token)`) used with per-tenant event partitioning. Cancellation honors
+this contract:
+
+- Cancelling an in-flight rebuild leaves the cell's `mt_event_progression` row in a consistent state — either
+  unchanged from before the rebuild or at the actual partial position the rebuild reached. Never a torn,
+  in-between state.
+- A subsequent `RebuildProjectionAsync` on the same (projection, tenant) cell completes successfully with no
+  manual intervention — a rebuild always starts by resetting the cell, so a cancelled rebuild can simply be
+  retried.
+
+This is what makes it safe for operational tooling to expose a "cancel" affordance on long-running rebuilds.
+
 ## Optimized Projection Rebuilds <Badge type="tip" text="7.30" />
 
 ::: tip

--- a/src/EventSourcingTests/rebuild_concurrency_cap_resolution.cs
+++ b/src/EventSourcingTests/rebuild_concurrency_cap_resolution.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests;
+
+// jasperfx#420 / marten#4710: resolution of the per-database rebuild concurrency cap
+// surfaced through IEventStore.MaxConcurrentRebuildsPerDatabase.
+public class rebuild_concurrency_cap_resolution
+{
+    private static DocumentStore storeWith(Action<StoreOptions> configure)
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "rebuild_cap";
+            configure(opts);
+        });
+    }
+
+    [Fact]
+    public void configured_value_wins_over_derived_default()
+    {
+        using var store = storeWith(opts => opts.Projections.MaxConcurrentRebuildsPerDatabase = 3);
+        ((IEventStore)store).MaxConcurrentRebuildsPerDatabase.ShouldBe(3);
+    }
+
+    [Fact]
+    public void non_positive_configured_value_disables_the_cap()
+    {
+        using var store = storeWith(opts => opts.Projections.MaxConcurrentRebuildsPerDatabase = 0);
+        ((IEventStore)store).MaxConcurrentRebuildsPerDatabase.ShouldBeNull();
+    }
+
+    [Fact]
+    public void derived_default_is_pool_size_over_eight_with_floor_of_one()
+    {
+        var connectionString = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+        {
+            MaxPoolSize = 64
+        }.ConnectionString;
+
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(connectionString);
+            opts.DatabaseSchemaName = "rebuild_cap";
+        });
+
+        ((IEventStore)store).MaxConcurrentRebuildsPerDatabase.ShouldBe(8);
+    }
+
+    [Fact]
+    public void derived_default_floors_at_one_for_tiny_pools()
+    {
+        var connectionString = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+        {
+            MaxPoolSize = 5
+        }.ConnectionString;
+
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(connectionString);
+            opts.DatabaseSchemaName = "rebuild_cap";
+        });
+
+        ((IEventStore)store).MaxConcurrentRebuildsPerDatabase.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task usage_descriptor_carries_the_effective_cap()
+    {
+        // jasperfx#434: CritterWatch#309's rebuild dispatcher reads the effective cap
+        // off the EventStoreUsage descriptor rather than guessing.
+        using var store = storeWith(opts => opts.Projections.MaxConcurrentRebuildsPerDatabase = 6);
+
+        var usage = await ((IEventStore)store).TryCreateUsage(CancellationToken.None);
+
+        usage.ShouldNotBeNull();
+        usage.MaxConcurrentRebuildsPerDatabase.ShouldBe(6);
+    }
+}

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -77,6 +77,37 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
     bool IEventStore.DistributesAgentsPerTenant
         => Options.Events.UseTenantPartitionedEvents;
 
+    // jasperfx#420 / marten#4710: the resolved per-database rebuild concurrency cap read by the
+    // CLI rebuild path (ProjectionHost.TryRebuildShardsAsync). Explicit configuration on
+    // StoreOptions.Projections wins; otherwise derive max(1, MaxPoolSize / 8) from the default
+    // database's Npgsql pool so a wide store cannot blow the connection pool during a rebuild
+    // while leaving headroom for application traffic. Falls back to null (the historical
+    // unbounded fan-out) when no pool signal is reachable.
+    int? IEventStore.MaxConcurrentRebuildsPerDatabase
+    {
+        get
+        {
+            if (Options.Projections.MaxConcurrentRebuildsPerDatabase.HasValue)
+            {
+                var configured = Options.Projections.MaxConcurrentRebuildsPerDatabase.Value;
+                return configured > 0 ? configured : null;
+            }
+
+            try
+            {
+                using var connection = Options.Tenancy.Default.Database.CreateConnection();
+                var poolSize = new NpgsqlConnectionStringBuilder(connection.ConnectionString).MaxPoolSize;
+                return Math.Max(1, poolSize / 8);
+            }
+            catch (Exception)
+            {
+                // No resolvable default database / connection string (e.g. tenancy models that
+                // cannot answer Default before runtime discovery) — stay unbounded.
+                return null;
+            }
+        }
+    }
+
     async ValueTask<IReadOnlyList<IEventDatabase>> IEventStore.AllDatabases()
     {
         // Straight delegation to ITenancy, mirroring IMartenStorage.AllDatabases(). The IMartenDatabase
@@ -569,6 +600,10 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
             SkipUnknownEvents = Options.Projections.RebuildErrors.SkipUnknownEvents,
             SkipSerializationErrors = Options.Projections.RebuildErrors.SkipSerializationErrors
         };
+
+        // jasperfx#434 / marten#4710: surface the effective rebuild cap so monitoring tools
+        // (CritterWatch#309's rebuild dispatcher) can size their orchestration off the wire.
+        usage.MaxConcurrentRebuildsPerDatabase = ((IEventStore)this).MaxConcurrentRebuildsPerDatabase;
 
         foreach (var eventMapping in Options.EventGraph.AllEvents())
         {

--- a/src/TenantPartitionedEventsTests/Daemon/per_tenant_rebuild_cancellation.cs
+++ b/src/TenantPartitionedEventsTests/Daemon/per_tenant_rebuild_cancellation.cs
@@ -1,0 +1,240 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using TenantPartitionedEventsTests.Fixtures;
+using Weasel.Core;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Daemon;
+
+/// <summary>
+/// marten#4710 (2): the per-cell rebuild cancellation contract CritterWatch#309's
+/// auto-resume path depends on. Cancelling
+/// <c>IProjectionDaemon.RebuildProjectionAsync(name, tenantId, ct)</c> mid-flight must
+/// leave <c>mt_event_progression</c> in a consistent state — the cell's progression is
+/// either unchanged from pre-rebuild or at an actual partial position, never an
+/// in-between torn state — and a subsequent rebuild of the same (projection, tenant)
+/// cell must complete successfully without manual intervention.
+///
+/// <para>
+/// Cancellation is made deterministic by gating the projection's ApplyAsync on a
+/// TaskCompletionSource: the test cancels while the rebuild is provably in-flight
+/// (first apply started, blocked on the gate), then releases the gate. No sleeps,
+/// no drain loops.
+/// </para>
+/// </summary>
+public class per_tenant_rebuild_cancellation: IAsyncLifetime
+{
+    private static readonly string SchemaName = $"rebuild_cancel_{Environment.ProcessId}";
+
+    private DocumentStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        _store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = SchemaName;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Policies.AllDocumentsAreMultiTenanted();
+
+            // Unique advisory-lock id so this store's daemon machinery never contends
+            // with the shared partitioned fixtures running in sibling collections.
+            opts.Projections.DaemonLockId = 4791;
+
+            opts.Projections.Add(new GatedPerEventProjection(), ProjectionLifecycle.Async,
+                GatedPerEventProjection.ProjectionName);
+            opts.Schema.For<TallyDoc>().DocumentAlias("cancel_tally");
+        });
+
+        await _store.Storage.Database.EnsureStorageExistsAsync(typeof(IEvent));
+    }
+
+    public Task DisposeAsync()
+    {
+        _store?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task cancelling_a_per_tenant_rebuild_leaves_progression_consistent_and_the_cell_rebuildable()
+    {
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        const int eventCount = 40;
+        await using (var session = _store.LightweightSession(tenant))
+        {
+            for (var i = 0; i < 4; i++)
+            {
+                var stream = Guid.NewGuid();
+                session.Events.StartStream(stream,
+                    Enumerable.Range(0, eventCount / 4).Select(_ => (object)new TallyEvent()).ToArray());
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        // Arm the gate BEFORE the rebuild starts: the first ApplyAsync signals Started
+        // and then blocks until the test releases it.
+        GatedPerEventProjection.Started = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        GatedPerEventProjection.Gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var cts = new CancellationTokenSource();
+        using var daemon = await _store.BuildProjectionDaemonAsync();
+
+        var rebuildTask = daemon.RebuildProjectionAsync(
+            GatedPerEventProjection.ProjectionName, tenant, cts.Token);
+
+        // Deterministically in-flight: the first apply has started and is parked on the gate.
+        (await Task.WhenAny(GatedPerEventProjection.Started.Task, Task.Delay(TimeSpan.FromSeconds(60))))
+            .ShouldBe(GatedPerEventProjection.Started.Task, "rebuild never reached the projection");
+
+        cts.Cancel();
+        GatedPerEventProjection.Gate.TrySetResult(true);
+
+        try
+        {
+            await rebuildTask;
+        }
+        catch (OperationCanceledException)
+        {
+            // Either outcome is acceptable — the contract is about the state left behind,
+            // not the exception shape.
+        }
+
+        // Consistency: every progression row for this cell is a readable, sane position —
+        // between 0 and the tenant's max appended sequence (per-tenant sequences are
+        // independent, so eventCount is this tenant's ceiling). "Torn" would surface as
+        // a value beyond the ceiling or an unreadable row.
+        var positions = await ReadCellProgressionsAsync(tenant);
+        foreach (var position in positions)
+        {
+            position.ShouldBeInRange(0, eventCount);
+        }
+
+        // The cell must be rebuildable afterwards with no manual repair.
+        GatedPerEventProjection.Gate = null;
+        GatedPerEventProjection.Started = null;
+
+        await daemon.RebuildProjectionAsync(GatedPerEventProjection.ProjectionName, tenant,
+            CancellationToken.None);
+
+        await using (var query = _store.QuerySession(tenant))
+        {
+            (await query.Query<TallyDoc>().CountAsync()).ShouldBe(eventCount,
+                "the follow-up rebuild must fully materialize the cell");
+        }
+    }
+
+    [Fact]
+    public async Task pre_cancelled_token_does_not_disturb_the_cell()
+    {
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        await using (var session = _store.LightweightSession(tenant))
+        {
+            session.Events.StartStream(Guid.NewGuid(), new TallyEvent(), new TallyEvent());
+            await session.SaveChangesAsync();
+        }
+
+        GatedPerEventProjection.Gate = null;
+        GatedPerEventProjection.Started = null;
+
+        using var daemon = await _store.BuildProjectionDaemonAsync();
+
+        using var cancelled = new CancellationTokenSource();
+        cancelled.Cancel();
+
+        try
+        {
+            await daemon.RebuildProjectionAsync(GatedPerEventProjection.ProjectionName, tenant,
+                cancelled.Token);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        // And the cell still rebuilds cleanly.
+        await daemon.RebuildProjectionAsync(GatedPerEventProjection.ProjectionName, tenant,
+            CancellationToken.None);
+
+        await using var query = _store.QuerySession(tenant);
+        (await query.Query<TallyDoc>().CountAsync()).ShouldBe(2);
+    }
+
+    private async Task<IReadOnlyList<long>> ReadCellProgressionsAsync(string tenantId)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            $"select last_seq_id from {SchemaName}.mt_event_progression where name like @name and name like @tenant";
+        cmd.Parameters.AddWithValue("name", GatedPerEventProjection.ProjectionName + "%");
+        cmd.Parameters.AddWithValue("tenant", "%" + tenantId + "%");
+
+        var results = new List<long>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            results.Add(reader.GetInt64(0));
+        }
+
+        return results;
+    }
+}
+
+public record TallyEvent;
+
+public class TallyDoc
+{
+    public Guid Id { get; set; }
+}
+
+/// <summary>
+/// Stores one TallyDoc per event so the post-rebuild doc count equals the event count
+/// regardless of batching. The static Gate/Started pair lets a test hold the first
+/// ApplyAsync mid-flight deterministically; both default to null (pass-through) so
+/// sibling tests are unaffected.
+/// </summary>
+public class GatedPerEventProjection: IProjection
+{
+    public const string ProjectionName = "GatedTally";
+
+    public static volatile TaskCompletionSource<bool>? Gate;
+    public static volatile TaskCompletionSource<bool>? Started;
+
+    public async Task ApplyAsync(IDocumentOperations operations, IReadOnlyList<IEvent> events,
+        CancellationToken cancellation)
+    {
+        Started?.TrySetResult(true);
+
+        var gate = Gate;
+        if (gate != null)
+        {
+            await gate.Task.ConfigureAwait(false);
+        }
+
+        foreach (var e in events.Where(x => x.Data is TallyEvent))
+        {
+            operations.Store(new TallyDoc { Id = e.Id });
+        }
+    }
+}


### PR DESCRIPTION
Closes #4710. Marten-side wiring for the per-database rebuild concurrency cap (jasperfx#420 / jasperfx#463, epic jasperfx#486 WS3), consuming **JasperFx 2.23.0**.

## What's here

### 1. Resolved rebuild cap on the store (`IEventStore.MaxConcurrentRebuildsPerDatabase` override)

`DocumentStore` resolves the effective per-database rebuild cap that the `projections rebuild` CLI path (`ProjectionHost.TryRebuildShardsAsync`) reads:

- **Explicit configuration wins**: `StoreOptions.Projections.MaxConcurrentRebuildsPerDatabase` (the new `DaemonSettings` knob from jasperfx#463, inherited via `ProjectionGraph` — no new Marten surface needed). Zero/negative opts back into the historical unbounded fan-out.
- **Derived default**: `max(1, MaxPoolSize / 8)` from the default database's Npgsql connection string — a 100-connection pool (Npgsql default) allows 12 concurrent rebuild cells, a 20-connection pool allows 2. Conservative by design to leave pool headroom for application traffic during rebuild windows.
- **Fallback**: `null` (unbounded, the historical behavior) when no pool signal is reachable.

The `--max-concurrent` CLI flag still overrides everything per operation (that precedence lives in JasperFx.Events).

### 2. Descriptor population (jasperfx#434 companion)

`TryCreateUsage` now populates `EventStoreUsage.MaxConcurrentRebuildsPerDatabase` with the resolved cap so monitoring tools (CritterWatch#309's rebuild dispatcher) can size their orchestration off the wire instead of falling back to a conservative 1.

### 3. Per-cell rebuild cancellation contract (#4710 part 2) — verified + pinned

The contract CritterWatch#309's auto-resume path depends on, now documented in `rebuilding.md` and pinned by `per_tenant_rebuild_cancellation` (TenantPartitionedEventsTests):

- Cancelling `RebuildProjectionAsync(name, tenantId, ct)` mid-flight leaves the cell's `mt_event_progression` in a consistent state (unchanged or actual partial position — never torn).
- A subsequent rebuild of the same (projection, tenant) cell completes successfully with no manual repair.

The mid-flight test is deterministic: the projection's `ApplyAsync` is TCS-gated, so cancellation provably fires while the rebuild is parked inside an apply — no sleeps, no drain loops. A pre-cancelled-token variant covers the trivial edge.

### 4. Docs

New `rebuilding.md` sections: **Capping Rebuild Concurrency** (knob, derived default + examples, two-layer concurrency model, rebuild-only scope vs the continuous-catch-up governors, `--max-concurrent`, descriptor surfacing) and **Cancelling a Rebuild** (the contract above).

## Tests

- `rebuild_concurrency_cap_resolution` (EventSourcingTests, 5): configured knob wins; non-positive disables; derived default = pool/8 (64 → 8); floors at 1 (pool 5 → 1); usage descriptor carries the effective cap.
- `per_tenant_rebuild_cancellation` (TenantPartitionedEventsTests, 2): the contract tests above.
- Full EventSourcingTests + TenantPartitionedEventsTests + CoreTests green on net9.0 (results below).

## Follow-ups (not here)

- Polecat companion: same override + descriptor population on Polecat's `DocumentStore` (jasperfx#434 companion list).
- Extending the cap to the intra-projection tenant/shard cross-product fan-out in `JasperFxAsyncDaemon` (tracked on jasperfx#420's follow-up list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
