### PR TITLE
Event-storage E0 pre-work for the Weasel.Storage move

### DIFF
--- a/src/Marten/EventStorage/ClosedShapeEventDocumentStorage.cs
+++ b/src/Marten/EventStorage/ClosedShapeEventDocumentStorage.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using JasperFx.Events;
 using Marten.Events;
 using Marten.Events.Schema;
+using Marten.EventStorage.Querying;
 using Marten.Internal;
 using Marten.Internal.Operations;
 using Marten.Linq.QueryHandlers;
@@ -126,9 +127,17 @@ internal sealed class ClosedShapeEventDocumentStorage: EventDocumentStorage
 
     public override IQueryHandler<StreamState> QueryForStream(StreamAction stream)
     {
+        // Implemented here rather than on EventStorage<TId> (E0 pre-work for
+        // the Weasel.Storage move): the stream-state lookup rides Marten's
+        // query-handler pipeline (IQueryHandler<T> / StreamStateQueryHandler),
+        // which stays Marten-local — and the implementation was identical
+        // across all three append-mode storages anyway. Keeping it on the
+        // adapter leaves the movable hierarchy purely write-side.
+        var tenantId = Events.TenancyStyle == TenancyStyle.Conjoined ? stream.TenantId : null;
+
         return Events.StreamIdentity == StreamIdentity.AsGuid
-            ? GuidStorage.QueryForStream(stream)
-            : StringStorage.QueryForStream(stream);
+            ? new ClosedShapeStreamStateQueryHandler<Guid>(StreamStateSelectSql, stream.Id, tenantId)
+            : new ClosedShapeStreamStateQueryHandler<string>(StreamStateSelectSql, stream.Key!, tenantId);
     }
 
     // Read-side: closed-shape implementation (#4411). Iterates the descriptor's

--- a/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
+++ b/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
@@ -57,7 +57,6 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             appendEventSqlSuffix: ")",
             insertStreamSql: BuildInsertStreamSql(graph),
             updateStreamVersionSql: BuildUpdateStreamVersionSql(graph),
-            streamStateSelectSql: Marten.EventStorage.StreamStateSql.Build(graph),
             // #4515 dispatch: binary events write a {} placeholder to `data`
             // (the canonical "valid but empty" jsonb) and the real payload to
             // `bdata`. JSON events write JSON to `data` and NULL to `bdata`.
@@ -293,7 +292,6 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             quickAppendEventsSql: BuildQuickAppendEventsSql(graph, serverTimestamps: false),
             insertStreamSql: BuildInsertStreamSql(graph),
             updateStreamVersionSql: BuildUpdateStreamVersionSql(graph),
-            streamStateSelectSql: Marten.EventStorage.StreamStateSql.Build(graph),
             // #4515 Phase 2: binary events write {} to data + real bytes to
             // bdata; JSON events write JSON to data + NULL to bdata. Same
             // dispatch shape as the Rich descriptor.
@@ -332,6 +330,11 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             MetadataBinders = quickMetadataBinders,
             AppendEventFullSqlSuffix = ")",
             AppendEventFullMetadataBinders = fullMetadataBinders,
+            // The Postgres batch shape: array parameters bound to the
+            // mt_quick_append_events function. Dialect-owned because the batch
+            // SQL + parameter shape are inherently provider-specific.
+            CreateQuickAppendEventsOperation = static (descriptor, stream) =>
+                new QuickAppendEventsOperation(descriptor, stream),
         };
     }
 
@@ -353,7 +356,6 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             quickAppendEventsWithServerTimestampsSql: BuildQuickAppendEventsSql(graph, serverTimestamps: true),
             insertStreamSql: BuildInsertStreamSql(graph),
             updateStreamVersionSql: BuildUpdateStreamVersionSql(graph),
-            streamStateSelectSql: Marten.EventStorage.StreamStateSql.Build(graph),
             // #4515 Phase 2: same dispatch as BuildQuickDescriptor.
             serializeEventData: e =>
             {
@@ -390,6 +392,8 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             MetadataBinders = quickMetadataBinders,
             AppendEventFullSqlSuffix = ")",
             AppendEventFullMetadataBinders = fullMetadataBinders,
+            CreateQuickAppendEventsOperation = static (descriptor, stream) =>
+                new QuickAppendEventsWithServerTimestampsOperation(descriptor, stream),
         };
     }
 

--- a/src/Marten/EventStorage/EventStorage.cs
+++ b/src/Marten/EventStorage/EventStorage.cs
@@ -3,7 +3,6 @@ using System;
 using JasperFx.Events;
 using Marten.Internal;
 using Marten.Internal.Operations;
-using Marten.Linq.QueryHandlers;
 
 namespace Marten.EventStorage;
 
@@ -83,7 +82,4 @@ public abstract class EventStorage<TId>
     /// the storage layer, not in the operation's per-call command build.
     /// </summary>
     public abstract IStorageOperation AssertStreamVersion(StreamAction stream);
-
-    /// <summary>Stream-state lookup query handler.</summary>
-    public abstract IQueryHandler<StreamState> QueryForStream(StreamAction stream);
 }

--- a/src/Marten/EventStorage/Quick/QuickEventStorage.cs
+++ b/src/Marten/EventStorage/Quick/QuickEventStorage.cs
@@ -1,10 +1,7 @@
 #nullable enable
-using System;
 using JasperFx.Events;
-using Marten.EventStorage.Querying;
 using Marten.Internal;
 using Marten.Internal.Operations;
-using Marten.Linq.QueryHandlers;
 
 namespace Marten.EventStorage.Quick;
 
@@ -51,7 +48,12 @@ internal sealed class QuickEventStorage<TId>: EventStorage<TId>
             @event);
 
     public override IStorageOperation QuickAppendEvents(StreamAction stream)
-        => new QuickAppendEventsOperation(_descriptor, stream);
+        // E0 prep for the Weasel.Storage move: the batched append operation is
+        // dialect-supplied. Postgres binds array parameters to the
+        // mt_quick_append_events function; another dialect may use an entirely
+        // different SQL shape (e.g. multi-row INSERT + OUTPUT on SQL Server),
+        // so the operation's construction lives on the descriptor, not here.
+        => _descriptor.CreateQuickAppendEventsOperation(_descriptor, stream);
 
     public override IStorageOperation InsertStream(StreamAction stream)
         => new QuickInsertStreamOperation(_descriptor, stream);
@@ -63,18 +65,4 @@ internal sealed class QuickEventStorage<TId>: EventStorage<TId>
         => _descriptor.IsTenancyConjoined
             ? new ConjoinedAssertStreamVersionOperation<TId>(_descriptor.AssertStreamVersionSql, stream)
             : new SingleTenantAssertStreamVersionOperation<TId>(_descriptor.AssertStreamVersionSql, stream);
-
-    public override IQueryHandler<StreamState> QueryForStream(StreamAction stream)
-    {
-        object streamIdentity = typeof(TId) == typeof(Guid)
-            ? stream.Id
-            : stream.Key!;
-
-        var tenantId = _descriptor.IsTenancyConjoined ? stream.TenantId : null;
-
-        return new ClosedShapeStreamStateQueryHandler<TId>(
-            _descriptor.StreamStateSelectSql,
-            (TId)streamIdentity,
-            tenantId);
-    }
 }

--- a/src/Marten/EventStorage/Quick/QuickEventStorageDescriptor.cs
+++ b/src/Marten/EventStorage/Quick/QuickEventStorageDescriptor.cs
@@ -37,14 +37,12 @@ public sealed class QuickEventStorageDescriptor
         string quickAppendEventsSql,
         string insertStreamSql,
         string updateStreamVersionSql,
-        string streamStateSelectSql,
         Func<IEvent, string> serializeEventData,
         Func<IEvent, byte[]?> serializeEventBdata)
     {
         QuickAppendEventsSql = quickAppendEventsSql;
         InsertStreamSql = insertStreamSql;
         UpdateStreamVersionSql = updateStreamVersionSql;
-        StreamStateSelectSql = streamStateSelectSql;
         SerializeEventData = serializeEventData;
         SerializeEventBdata = serializeEventBdata;
     }
@@ -61,7 +59,6 @@ public sealed class QuickEventStorageDescriptor
 
     public string InsertStreamSql { get; }
     public string UpdateStreamVersionSql { get; }
-    public string StreamStateSelectSql { get; }
     public Func<IEvent, string> SerializeEventData { get; }
 
     /// <summary>
@@ -181,4 +178,18 @@ public sealed class QuickEventStorageDescriptor
     public System.Action<Weasel.Postgresql.ICommandBuilder, StreamAction> ConfigureUpdateStreamVersionCommand { get; init; }
         = static (_, _) => throw new System.NotSupportedException(
             "QuickEventStorageDescriptor.ConfigureUpdateStreamVersionCommand was not installed by the dialect.");
+
+    /// <summary>
+    /// Creates the batched append operation for a stream. Dialect-installed —
+    /// the batch shape is inherently dialect-specific (Postgres binds
+    /// per-column array parameters to <c>mt_quick_append_events</c>; another
+    /// dialect may use a multi-row INSERT with an OUTPUT/RETURNING read-back),
+    /// so the operation type itself lives with the dialect rather than the
+    /// shared storage hierarchy. Takes the descriptor as an argument because
+    /// init-only slots can't close over the instance under construction.
+    /// </summary>
+    public System.Func<QuickEventStorageDescriptor, StreamAction, Marten.Internal.Operations.IStorageOperation>
+        CreateQuickAppendEventsOperation { get; init; }
+        = static (_, _) => throw new System.NotSupportedException(
+            "QuickEventStorageDescriptor.CreateQuickAppendEventsOperation was not installed by the dialect.");
 }

--- a/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorage.cs
+++ b/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorage.cs
@@ -1,10 +1,7 @@
 #nullable enable
-using System;
 using JasperFx.Events;
-using Marten.EventStorage.Querying;
 using Marten.Internal;
 using Marten.Internal.Operations;
-using Marten.Linq.QueryHandlers;
 
 namespace Marten.EventStorage.QuickWithServerTimestamps;
 
@@ -49,7 +46,8 @@ internal sealed class QuickWithServerTimestampsEventStorage<TId>: EventStorage<T
             @event);
 
     public override IStorageOperation QuickAppendEvents(StreamAction stream)
-        => new QuickAppendEventsWithServerTimestampsOperation(_descriptor, stream);
+        // Dialect-supplied — see Quick.QuickEventStorage<TId>.QuickAppendEvents.
+        => _descriptor.CreateQuickAppendEventsOperation(_descriptor, stream);
 
     public override IStorageOperation InsertStream(StreamAction stream)
         => new QuickWithServerTimestampsInsertStreamOperation(_descriptor, stream);
@@ -61,18 +59,4 @@ internal sealed class QuickWithServerTimestampsEventStorage<TId>: EventStorage<T
         => _descriptor.IsTenancyConjoined
             ? new ConjoinedAssertStreamVersionOperation<TId>(_descriptor.AssertStreamVersionSql, stream)
             : new SingleTenantAssertStreamVersionOperation<TId>(_descriptor.AssertStreamVersionSql, stream);
-
-    public override IQueryHandler<StreamState> QueryForStream(StreamAction stream)
-    {
-        object streamIdentity = typeof(TId) == typeof(Guid)
-            ? stream.Id
-            : stream.Key!;
-
-        var tenantId = _descriptor.IsTenancyConjoined ? stream.TenantId : null;
-
-        return new ClosedShapeStreamStateQueryHandler<TId>(
-            _descriptor.StreamStateSelectSql,
-            (TId)streamIdentity,
-            tenantId);
-    }
 }

--- a/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorageDescriptor.cs
+++ b/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorageDescriptor.cs
@@ -28,14 +28,12 @@ public sealed class QuickWithServerTimestampsEventStorageDescriptor
         string quickAppendEventsWithServerTimestampsSql,
         string insertStreamSql,
         string updateStreamVersionSql,
-        string streamStateSelectSql,
         Func<IEvent, string> serializeEventData,
         Func<IEvent, byte[]?> serializeEventBdata)
     {
         QuickAppendEventsWithServerTimestampsSql = quickAppendEventsWithServerTimestampsSql;
         InsertStreamSql = insertStreamSql;
         UpdateStreamVersionSql = updateStreamVersionSql;
-        StreamStateSelectSql = streamStateSelectSql;
         SerializeEventData = serializeEventData;
         SerializeEventBdata = serializeEventBdata;
     }
@@ -48,7 +46,6 @@ public sealed class QuickWithServerTimestampsEventStorageDescriptor
 
     public string InsertStreamSql { get; }
     public string UpdateStreamVersionSql { get; }
-    public string StreamStateSelectSql { get; }
     public Func<IEvent, string> SerializeEventData { get; }
 
     /// <summary>
@@ -145,4 +142,13 @@ public sealed class QuickWithServerTimestampsEventStorageDescriptor
     public System.Action<Weasel.Postgresql.ICommandBuilder, StreamAction> ConfigureUpdateStreamVersionCommand { get; init; }
         = static (_, _) => throw new System.NotSupportedException(
             "QuickWithServerTimestampsEventStorageDescriptor.ConfigureUpdateStreamVersionCommand was not installed by the dialect.");
+
+    /// <summary>
+    /// Creates the batched append operation for a stream. Dialect-installed —
+    /// see <see cref="Quick.QuickEventStorageDescriptor.CreateQuickAppendEventsOperation"/>.
+    /// </summary>
+    public System.Func<QuickWithServerTimestampsEventStorageDescriptor, StreamAction, Marten.Internal.Operations.IStorageOperation>
+        CreateQuickAppendEventsOperation { get; init; }
+        = static (_, _) => throw new System.NotSupportedException(
+            "QuickWithServerTimestampsEventStorageDescriptor.CreateQuickAppendEventsOperation was not installed by the dialect.");
 }

--- a/src/Marten/EventStorage/Rich/RichEventStorage.cs
+++ b/src/Marten/EventStorage/Rich/RichEventStorage.cs
@@ -1,11 +1,9 @@
 #nullable enable
 using System;
 using JasperFx.Events;
-using Marten.EventStorage.Querying;
 using Marten.EventStorage.Quick;
 using Marten.Internal;
 using Marten.Internal.Operations;
-using Marten.Linq.QueryHandlers;
 
 namespace Marten.EventStorage.Rich;
 
@@ -63,20 +61,4 @@ internal sealed class RichEventStorage<TId>: EventStorage<TId>
         => _descriptor.IsTenancyConjoined
             ? new ConjoinedAssertStreamVersionOperation<TId>(_descriptor.AssertStreamVersionSql, stream)
             : new SingleTenantAssertStreamVersionOperation<TId>(_descriptor.AssertStreamVersionSql, stream);
-
-    public override IQueryHandler<StreamState> QueryForStream(StreamAction stream)
-    {
-        // Pick the per-call streamId — Guid streams use stream.Id; string
-        // streams use stream.Key. The base TId fixes which.
-        object streamIdentity = typeof(TId) == typeof(Guid)
-            ? stream.Id
-            : stream.Key!;
-
-        var tenantId = _descriptor.IsTenancyConjoined ? stream.TenantId : null;
-
-        return new ClosedShapeStreamStateQueryHandler<TId>(
-            _descriptor.StreamStateSelectSql,
-            (TId)streamIdentity,
-            tenantId);
-    }
 }

--- a/src/Marten/EventStorage/Rich/RichEventStorageDescriptor.cs
+++ b/src/Marten/EventStorage/Rich/RichEventStorageDescriptor.cs
@@ -24,7 +24,6 @@ public sealed class RichEventStorageDescriptor
         string appendEventSqlSuffix,
         string insertStreamSql,
         string updateStreamVersionSql,
-        string streamStateSelectSql,
         Func<IEvent, string> serializeEventData,
         Func<IEvent, byte[]?> serializeEventBdata,
         IEventMetadataBinder[] metadataBinders)
@@ -33,7 +32,6 @@ public sealed class RichEventStorageDescriptor
         AppendEventSqlSuffix = appendEventSqlSuffix;
         InsertStreamSql = insertStreamSql;
         UpdateStreamVersionSql = updateStreamVersionSql;
-        StreamStateSelectSql = streamStateSelectSql;
         SerializeEventData = serializeEventData;
         SerializeEventBdata = serializeEventBdata;
         MetadataBinders = metadataBinders;
@@ -43,7 +41,6 @@ public sealed class RichEventStorageDescriptor
     public string AppendEventSqlSuffix { get; }
     public string InsertStreamSql { get; }
     public string UpdateStreamVersionSql { get; }
-    public string StreamStateSelectSql { get; }
 
     /// <summary>
     ///     Serializer for the <c>data</c> jsonb column. Returns the full JSON


### PR DESCRIPTION
Part of the #4821 / #4830 follow-on: moving the closed-shape **event** storage (`src/Marten/EventStorage/`) into Weasel.Storage so Polecat can ship `SqlServerEventStoreDialect` (the last gate on polecat#273). This is the Marten-only pre-work slice — no Weasel dependency, no behavior change.

## What

1. **Hoist `QueryForStream` off `EventStorage<TId>`** into `ClosedShapeEventDocumentStorage`. The stream-state lookup rides Marten's query-handler pipeline (`IQueryHandler<T>` / `StreamStateQueryHandler`), which stays Marten-local — and the implementation was duplicated verbatim across all three append-mode storages. The movable hierarchy is now purely write-side, and the descriptors drop their now-dead `StreamStateSelectSql` slot (the adapter uses the base's `StreamStateSelectSql`).

2. **Batched quick-append becomes dialect-supplied** via a `CreateQuickAppendEventsOperation` factory slot on the Quick / QuickWithServerTimestamps descriptors, installed by `PostgresEventStoreDialect`. The batch shape is inherently provider-specific (Postgres binds per-column array parameters to `mt_quick_append_events`; SQL Server will use a multi-row INSERT + OUTPUT shape), so `QuickAppendEventsOperation` / `QuickAppendEventsOperationBase` stay Marten-local when the hierarchy moves — exactly like `PostgresStorageDialect` stayed on the document side.

## Validation

- EventSourcingTests: 1425 passed / 0 failed (net10)
- TenantPartitionedEventsTests: 215 passed / 0 failed (net10)
- Full `Marten.slnx` Debug + Release clean

Next slices (gated on Weasel): E1 neutral grouped-parameter builder in Weasel.Core, E2 descriptor-core move, E3 storage/ops move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)