### PR TITLE
Minimal-configuration audit + docs pass for the per-tenant partitioning surface (closes #4881, epic jasperfx#486 WS4)

### DIFF
--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -459,7 +459,7 @@ itself and requires no extra configuration. <Badge type="tip" text="9.13" />
 Sharded multi-tenancy also composes with
 [per-tenant event partitioning](/events/multitenancy#per-tenant-event-partitioning): sharding distributes tenants
 across the database pool, while `Events.UseTenantPartitionedEvents` physically isolates each tenant's events (and
-projection progress) *within* whichever database hosts that tenant, running one daemon agent per (database, tenant).
+projection progress) _within_ whichever database hosts that tenant, running one daemon agent per (database, tenant).
 
 ## Dynamically applying changes to tenants databases
 

--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -459,7 +459,7 @@ itself and requires no extra configuration. <Badge type="tip" text="9.13" />
 Sharded multi-tenancy also composes with
 [per-tenant event partitioning](/events/multitenancy#per-tenant-event-partitioning): sharding distributes tenants
 across the database pool, while `Events.UseTenantPartitionedEvents` physically isolates each tenant's events (and
-projection progress) _within_ whichever database hosts that tenant, running one daemon agent per (database, tenant).
+projection progress) *within* whichever database hosts that tenant, running one daemon agent per (database, tenant).
 
 ## Dynamically applying changes to tenants databases
 

--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -449,6 +449,18 @@ runs asynchronous projections across all of them. When new databases or tenants 
 the daemon's periodic health check picks them up and starts projection processing without any
 downtime or reconfiguration.
 
+When projection work is distributed across an application cluster — either by Marten's own daemon or by
+[Wolverine-managed projection distribution](https://wolverinefx.net/guide/durability/marten/distribution.html) —
+multi-database tenancies like this one get **database-affine assignment** automatically: all of one database's
+projection agents are grouped onto the same node, so the number of open connections per shard database stays flat
+instead of every node in the cluster holding connections to every database. This is derived from the tenancy model
+itself and requires no extra configuration. <Badge type="tip" text="9.13" />
+
+Sharded multi-tenancy also composes with
+[per-tenant event partitioning](/events/multitenancy#per-tenant-event-partitioning): sharding distributes tenants
+across the database pool, while `Events.UseTenantPartitionedEvents` physically isolates each tenant's events (and
+projection progress) *within* whichever database hosts that tenant, running one daemon agent per (database, tenant).
+
 ## Dynamically applying changes to tenants databases
 
 If you didn't call the `ApplyAllDatabaseChangesOnStartup` method, Marten would still try to create a database [upon the session creation](/documents/sessions). This action is invasive and can cause issues like timeouts, cold starts, or deadlocks. It also won't apply all defined changes upfront (so, e.g. [indexes](/documents/indexing/), [custom schema extensions](/schema/extensions)).

--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -171,6 +171,35 @@ When `UseTenantPartitionedEvents` is enabled, Marten:
   position for every active tenant in a single round trip — plus **per-tenant rebuild isolation**, so a projection can
   be rebuilt for a single tenant without tearing down or replaying every other tenant's progress.
 
+### What You Get Automatically <Badge type="tip" text="9.13" />
+
+`UseTenantPartitionedEvents` plus your tenancy choice is the whole opt-in — everything below is derived from that
+combination with no further configuration:
+
+* **One async daemon agent per (database, tenant).** The daemon runs each async projection or subscription
+  independently per tenant, so a lagging or rebuilding tenant never stalls its neighbors. This applies both to
+  Marten's own daemon and to [Wolverine-managed projection distribution](https://wolverinefx.net/guide/durability/marten/distribution.html),
+  which detects a tenant-partitioned store and automatically fans its distributed agents out per tenant across the
+  cluster.
+* **Tenant discovery on a plain single database.** With nothing but `opts.Connection(...)`, Marten quietly swaps in
+  a tenancy that reads the registered tenant list from the `mt_tenant_partitions` table, so per-tenant agent
+  distribution always has the current tenant set to fan out to — tenants added or removed at runtime converge
+  without a restart.
+* **Database-affine agent placement on multi-database tenancies.** When the store spans multiple databases (e.g.
+  [sharded multi-tenancy with database pooling](/configuration/multitenancy#sharded-multi-tenancy-with-database-pooling)),
+  distributed hosts group all of one database's agents on the same node, keeping the connection count per database
+  flat instead of every node holding connections to every database.
+* **Daemon connection governors.** The running daemon caps concurrent event loads and concurrent batch writes at 4
+  per database by default, so the connection footprint stays *O(databases)* rather than growing with
+  (projections × tenants). See [Daemon Connection Governors](/events/projections/async-daemon#daemon-connection-governors).
+* **A pool-derived rebuild cap.** Projection rebuilds fan out one cell per (projection × tenant), capped by default
+  at `max(1, MaxPoolSize / 8)` concurrent cells per database. See
+  [Capping Rebuild Concurrency](/events/projections/rebuilding#capping-rebuild-concurrency).
+* **Managed partition bookkeeping.** The `mt_tenant_partitions` lookup table and its management machinery are
+  created automatically — you do not need to also opt into
+  `Policies.PartitionMultiTenantedDocumentsUsingMartenManagement()` (though the two compose if you want partitioned
+  document tables too).
+
 ### Constraints
 
 Per-tenant partitioning is validated at `DocumentStore` construction. The following combinations throw immediately

--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -190,7 +190,7 @@ combination with no further configuration:
   distributed hosts group all of one database's agents on the same node, keeping the connection count per database
   flat instead of every node holding connections to every database.
 * **Daemon connection governors.** The running daemon caps concurrent event loads and concurrent batch writes at 4
-  per database by default, so the connection footprint stays *O(databases)* rather than growing with
+  per database by default, so the connection footprint stays _O(databases)_ rather than growing with
   (projections × tenants). See [Daemon Connection Governors](/events/projections/async-daemon#daemon-connection-governors).
 * **A pool-derived rebuild cap.** Projection rebuilds fan out one cell per (projection × tenant), capped by default
   at `max(1, MaxPoolSize / 8)` concurrent cells per database. See

--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -111,6 +111,34 @@ will end up running on the first process to start up. If your system requires be
 contact [JasperFx Software](https://jasperfx.net) about their "Critter Stack Pro" product.
 :::
 
+## Daemon Connection Governors <Badge type="tip" text="9.13" />
+
+Every running projection or subscription agent opens its own database session both to load pages of events and to
+commit each batch of projected documents plus its progression update. On a wide store — many projections, or
+[per-tenant event partitioning](/events/multitenancy#per-tenant-event-partitioning) where the daemon runs one agent
+per (projection × tenant) — an unbounded daemon can drive the connection pool's high-water mark toward the total
+agent count even though only a handful of loads or writes are ever active at the same instant.
+
+Marten therefore governs the daemon's concurrent database work out of the box with two caps, both applied per
+daemon instance (one daemon per store × database):
+
+```cs
+// These are the defaults — you don't need to set either one
+opts.Projections.MaxConcurrentEventLoadsPerDatabase = 4;
+opts.Projections.MaxConcurrentBatchWritesPerDatabase = 4;
+```
+
+* **`MaxConcurrentEventLoadsPerDatabase`** (default 4) caps how many agents may load pages of events from the
+  database concurrently. All of a daemon's agents share one throttle, collapsing the steady-state connection
+  footprint to *O(databases)* with no measured throughput cost.
+* **`MaxConcurrentBatchWritesPerDatabase`** (default 4) caps how many projection batches may execute their SQL
+  (the commit round trip) concurrently against one database.
+
+Setting either knob to zero or a negative number disables that governor and restores the historical unbounded
+behavior. The governors apply to continuous (running daemon) work only — projection rebuilds are capped separately
+by `MaxConcurrentRebuildsPerDatabase`, which derives its default from the Npgsql connection pool size. See
+[Capping Rebuild Concurrency](/events/projections/rebuilding#capping-rebuild-concurrency).
+
 ## Daemon Logging
 
 The daemon logs through the standard .Net `ILogger` interface service registered in your application's underlying DI container. In the case of the daemon having to skip

--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -130,7 +130,7 @@ opts.Projections.MaxConcurrentBatchWritesPerDatabase = 4;
 
 * **`MaxConcurrentEventLoadsPerDatabase`** (default 4) caps how many agents may load pages of events from the
   database concurrently. All of a daemon's agents share one throttle, collapsing the steady-state connection
-  footprint to *O(databases)* with no measured throughput cost.
+  footprint to _O(databases)_ with no measured throughput cost.
 * **`MaxConcurrentBatchWritesPerDatabase`** (default 4) caps how many projection batches may execute their SQL
   (the commit round trip) concurrently against one database.
 

--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -130,7 +130,7 @@ opts.Projections.MaxConcurrentBatchWritesPerDatabase = 4;
 
 * **`MaxConcurrentEventLoadsPerDatabase`** (default 4) caps how many agents may load pages of events from the
   database concurrently. All of a daemon's agents share one throttle, collapsing the steady-state connection
-  footprint to _O(databases)_ with no measured throughput cost.
+  footprint to *O(databases)* with no measured throughput cost.
 * **`MaxConcurrentBatchWritesPerDatabase`** (default 4) caps how many projection batches may execute their SQL
   (the commit round trip) concurrently against one database.
 

--- a/docs/events/projections/rebuilding.md
+++ b/docs/events/projections/rebuilding.md
@@ -69,7 +69,7 @@ Two things to know about the shape of the throttle:
 
 - **It caps rebuild only.** Continuous catch-up is governed separately by
   `opts.Projections.MaxConcurrentEventLoadsPerDatabase` and `opts.Projections.MaxConcurrentBatchWritesPerDatabase`
-  (both default 4).
+  (both default 4) — see [Daemon Connection Governors](/events/projections/async-daemon#daemon-connection-governors).
 - **It's a two-layer model.** The cap bounds how many cells run at once; each cell still uses its own internal
   slice workers while it runs. A cap of 4 therefore means "4 rebuilding projections/tenants at a time," not 4
   concurrent database operations.

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -285,9 +285,14 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
 
     /// <summary>
     /// Per-tenant partitioning master flag (CritterStack #209 / Marten #4596).
-    /// Phase 0 — surface only; opting in does not yet partition storage or
-    /// alter daemon behavior. Validated at <c>DocumentStore</c> construction
-    /// to reject combinations with <see cref="EventAppendMode.Rich"/>.
+    /// Partitions mt_events / mt_streams by tenant_id, gives each tenant its own
+    /// event sequence, keys mt_event_progression by (name, tenant_id), and runs
+    /// the async daemon with per-tenant high-water tracking, per-tenant agent
+    /// distribution, and per-tenant rebuild isolation. Validated at
+    /// <c>DocumentStore</c> construction: requires <see cref="TenancyStyle.Conjoined"/>
+    /// and a quick append mode (rejects <see cref="EventAppendMode.Rich"/> and
+    /// <see cref="UseArchivedStreamPartitioning"/>). See
+    /// <see cref="Marten.Events.IEventStoreOptions.UseTenantPartitionedEvents"/>.
     /// </summary>
     public bool UseTenantPartitionedEvents { get; set; }
 

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -113,9 +113,17 @@ namespace Marten.Events
         /// per-tenant rebuild isolation.
         ///
         /// <para>
-        /// Opt-in flag, defaults to false. Currently in Phase 0 — surface only.
-        /// The flag exists so consumer code can be written against the future
-        /// behavior, but enabling it is not yet meaningful at runtime.
+        /// Opt-in flag, defaults to false. Enabling it also turns on per-tenant
+        /// async-daemon agent distribution for hosts that distribute agents per
+        /// identity (see <c>IEventStore.DistributesAgentsPerTenant</c>) — no
+        /// further opt-in is needed. See
+        /// https://martendb.io/events/multitenancy#per-tenant-event-partitioning.
+        /// </para>
+        /// <para>
+        /// Constraint: requires <c>TenancyStyle.Conjoined</c> on the event
+        /// store. Setting this with <c>TenancyStyle.Single</c> throws at
+        /// <c>DocumentStore</c> construction — there is nothing to partition
+        /// by when every event lives in the default tenant.
         /// </para>
         /// <para>
         /// Constraint: only the quick append modes

--- a/src/Marten/Events/IReadOnlyEventStoreOptions.cs
+++ b/src/Marten/Events/IReadOnlyEventStoreOptions.cs
@@ -80,7 +80,7 @@ public interface IReadOnlyEventStoreOptions
 
     /// <summary>
     /// Per-tenant partitioning master flag (CritterStack #209 / Marten #4596).
-    /// Surface-only in Phase 0 — see <see cref="IEventStoreOptions.UseTenantPartitionedEvents"/>
+    /// See <see cref="IEventStoreOptions.UseTenantPartitionedEvents"/>
     /// on the writable interface for the full contract.
     /// </summary>
     bool UseTenantPartitionedEvents { get; set; }


### PR DESCRIPTION
Closes #4881 (epic [jasperfx#486](https://github.com/JasperFx/jasperfx/issues/486) WS4).

## Audit: does `UseTenantPartitionedEvents` + a tenancy choice give correct, connection-conserving behavior with no extra opt-in?

**Verdict: yes for everything distribution- and connection-related — all of it is derived automatically.** Two *prerequisites* remain manual but are validated with clear construction-time errors (see F2 below).

| Surface | Mechanism | Default / derivation | Remaining user knob | Verdict |
|---|---|---|---|---|
| Per-tenant agent fan-out | `IEventStore.DistributesAgentsPerTenant` == `Events.UseTenantPartitionedEvents` (`DocumentStore.EventStore.cs:77`); consumed by both the native distributors (`ProjectionCoordinator.cs:87`, re-expanded every distribution cycle) and Wolverine-managed distribution | Automatic when flag is on | **None** — no separate flag exists | ✅ fully automatic |
| Database-affine assignment (wolverine#3328) | `IEventStore.DatabaseCardinality` ⇒ `Options.Tenancy.Cardinality` (`DocumentStore.EventStore.cs:49`); Wolverine's `EventSubscriptionAgentFamily` groups agents by database key for `StaticMultiple`/`DynamicMultiple`, keeps even blue/green spread for `Single` | Automatic from tenancy model | **None** | ✅ fully automatic; **no WS0-era `UseDatabaseAffineAgentAssignment`-style residue found** (swept `DatabaseAffine`/`AffineAgent`/`DistributeAgentsPerTenant` across src) |
| Event-load governor | `DaemonSettings.MaxConcurrentEventLoadsPerDatabase` (jasperfx#494), per daemon instance (store × database) | **4**, on by default | `opts.Projections.MaxConcurrentEventLoadsPerDatabase` (≤0 disables) | ✅ on by default |
| Batch-write governor | `DaemonSettings.MaxConcurrentBatchWritesPerDatabase` (jasperfx#486 WS3) | **4**, on by default | `opts.Projections.MaxConcurrentBatchWritesPerDatabase` (≤0 disables) | ✅ on by default |
| Rebuild cap | `IEventStore.MaxConcurrentRebuildsPerDatabase` (`DocumentStore.EventStore.cs:86-109`): explicit >0 wins; 0/negative ⇒ unbounded; null ⇒ `max(1, MaxPoolSize/8)` from the default DB's Npgsql pool; falls back to unbounded when no pool signal | Pool-derived by default | `opts.Projections.MaxConcurrentRebuildsPerDatabase`; per-run CLI `--max-concurrent`; surfaced on `EventStoreUsage` | ✅ on by default |
| Single-DB tenant discovery | `Connection(...)` lazily swaps in `TenantPartitionedSingleDatabaseTenancy` when the flag is on (#4862, `StoreOptions.cs:609`), surfacing the `mt_tenant_partitions` tenant list on the usage descriptor (fresh read, no cache) | Automatic | None (user-supplied `ITenancy` replaces it wholesale, by design) | ✅ fully automatic |
| Partition bookkeeping | `Validate()` auto-creates `MartenManagedTenantListPartitions` when the flag is on and none exists (`StoreOptions.cs:881`) | Automatic | `Policies.PartitionMultiTenantedDocumentsUsingMartenManagement()` remains a *separate* opt-in for **document** tables (deliberate) | ✅ automatic for events |
| Event tenancy style | Validated: requires `TenancyStyle.Conjoined` | `MultiTenantedWithShardedDatabases()` auto-sets it; plain `Connection(...)` does **not** | `opts.Events.TenancyStyle` | ⚠ manual on single-DB, validated w/ clear error |
| Append mode | Validated: requires `Quick`/`QuickWithServerTimestamps` (per-tenant sequence pick lives in the quick-append function only) | **Never auto-set** — not even by the sharded helper | `opts.Events.AppendMode` | ⚠ manual everywhere, validated w/ clear error |

### Findings

- **F1 (fixed here): stale "Phase 0 — surface only" XML docs.** `IEventStoreOptions.UseTenantPartitionedEvents`, `IReadOnlyEventStoreOptions.UseTenantPartitionedEvents`, and `EventGraph.UseTenantPartitionedEvents` all still claimed *"enabling it is not yet meaningful at runtime."* Rewritten to describe the shipped contract (partitioned storage, per-tenant sequences/progression, per-tenant agent distribution, validation constraints). Doc-comment-only, no behavior change.
- **F2 (documented, deliberately not changed): quick append mode + conjoined tenancy are hidden prerequisites, not auto-derived.** The sharded helper auto-sets `Conjoined` but nothing ever auto-sets `AppendMode`. Auto-promoting `Rich → Quick` when the flag is set would silently change append semantics (sequence assignment timing, timestamp source), so the validation-with-good-error approach is kept; the minimal-config docs now show all three lines together. If we want true one-flag config, that is a separate behavioral decision.
- **F3 (fixed here): the WS2/WS3 continuous governors had no docs page.** `MaxConcurrentEventLoadsPerDatabase` / `MaxConcurrentBatchWritesPerDatabase` were only name-dropped in rebuilding.md. Added a "Daemon Connection Governors" section to async-daemon.md and cross-linked all three knobs both ways.
- **F4: no half-exposed WS0 residue.** All the WS0-era explicit opt-ins fell out cleanly in favor of derivation; nothing left to remove.

## Docs changes

- **events/multitenancy.md** — new **"What You Get Automatically"** <Badge 9.13> section under Per-Tenant Event Partitioning: per-tenant agent fan-out (native + Wolverine-managed), single-DB tenant discovery, database-affine placement, both daemon governors, pool-derived rebuild cap, auto-created partition bookkeeping; cross-links to the governor and rebuild-cap sections.
- **events/projections/async-daemon.md** — new **"Daemon Connection Governors"** <Badge 9.13> section (defaults, per-daemon-instance scope, ≤0-disables, rebuild-cap cross-link).
- **events/projections/rebuilding.md** — cross-link the continuous governors to the new async-daemon section.
- **configuration/multitenancy.md** — sharded-pooling page now documents automatic database-affine agent assignment <Badge 9.13> and composition with per-tenant event partitioning.

Badges use **9.13**, consistent with the WS3 rebuild-cap sections already on master. `npm run docs-build` passes; `src/Marten` builds clean (XML-doc-only code changes).

## Wolverine docs follow-up (not in this PR)

The Wolverine guide page `guide/durability/marten/distribution.html` should state that for a tenant-partitioned Marten store: (a) Wolverine-managed distribution automatically fans one agent per (database, tenant) via `IEventStore.DistributesAgentsPerTenant` — no opt-in; (b) database-affine assignment is automatic for multi-database stores (wolverine#3328); (c) Marten records `DaemonMode.ExternallyManaged` under Wolverine-managed distribution (wolverine#3290/#3330).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNfeNz73Q3EdiTgSeDbo96