### PR TITLE
Marten.ScaleTesting: per-batch measurement instrumentation (#4684 Phase E.3, epic jasperfx#486 WS6)

### DIFF
--- a/src/Marten.ScaleTesting/Commands/RebuildCommand.cs
+++ b/src/Marten.ScaleTesting/Commands/RebuildCommand.cs
@@ -78,6 +78,21 @@ public sealed class RebuildCommand: JasperFxAsyncCommand<RebuildInput>
             table.AddRow("Progression max waiters", lw.MaxConcurrentWaiters.ToString("N0"));
             table.AddRow("Progression max single-wait (ms)", lw.MaxSingleWaitMs.ToString("N0"));
             table.AddRow("Progression observed waiter-seconds", lw.ObservedWaiterSeconds.ToString("N1"));
+            var pb = snapshot.PerBatch;
+            table.AddRow("Batches observed", pb.BatchCount.ToString("N0"));
+            if (pb.BatchCount > 0)
+            {
+                table.AddRow("Batch p50 total/fetch/group/exec (ms)",
+                    $"{pb.P50.TotalMs:N0} / {pb.P50.EventFetchMs:N0} / {pb.P50.GroupingMs:N0} / {pb.P50.ExecutionMs:N0}");
+                table.AddRow("Batch p95 total/fetch/group/exec (ms)",
+                    $"{pb.P95.TotalMs:N0} / {pb.P95.EventFetchMs:N0} / {pb.P95.GroupingMs:N0} / {pb.P95.ExecutionMs:N0}");
+                table.AddRow("Batch p50/p95 DB round-trips", $"{pb.P50.RoundTripCount:N0} / {pb.P95.RoundTripCount:N0}");
+            }
+            foreach (var (projection, lookups) in snapshot.Lookups.OrderBy(x => x.Key))
+            {
+                table.AddRow($"Lookups: {projection}",
+                    $"{lookups.Lookups:N0} over {lookups.Events:N0} events ({lookups.LookupsPerEvent:N3}/event)");
+            }
         }
         AnsiConsole.Write(table);
 
@@ -92,13 +107,15 @@ public sealed class RebuildCommand: JasperFxAsyncCommand<RebuildInput>
         // have to remember the master toggle separately.
         var enabled = input.InstrumentFlag
             || !string.IsNullOrWhiteSpace(input.InstrumentTraceFlag)
-            || !string.IsNullOrWhiteSpace(input.InstrumentLockTraceFlag);
+            || !string.IsNullOrWhiteSpace(input.InstrumentLockTraceFlag)
+            || !string.IsNullOrWhiteSpace(input.InstrumentBatchTraceFlag);
         return new InstrumentationOptions
         {
             Enabled = enabled,
             ProgressSampleInterval = TimeSpan.FromSeconds(Math.Max(0.1, input.InstrumentSampleSecondsFlag)),
             TracePath = string.IsNullOrWhiteSpace(input.InstrumentTraceFlag) ? null : input.InstrumentTraceFlag,
-            LockTracePath = string.IsNullOrWhiteSpace(input.InstrumentLockTraceFlag) ? null : input.InstrumentLockTraceFlag
+            LockTracePath = string.IsNullOrWhiteSpace(input.InstrumentLockTraceFlag) ? null : input.InstrumentLockTraceFlag,
+            BatchTracePath = string.IsNullOrWhiteSpace(input.InstrumentBatchTraceFlag) ? null : input.InstrumentBatchTraceFlag
         };
     }
 
@@ -127,7 +144,16 @@ public sealed class RebuildCommand: JasperFxAsyncCommand<RebuildInput>
                 sampleCount = snapshot.Samples.Count,
                 npgsqlCommandCount = snapshot.NpgsqlCommandCount,
                 throughput = snapshot.Throughput,
-                progressionLockWaits = snapshot.ProgressionLockWaits
+                progressionLockWaits = snapshot.ProgressionLockWaits,
+                perBatch = new
+                {
+                    batches = snapshot.PerBatch.BatchCount,
+                    p50 = snapshot.PerBatch.P50,
+                    p95 = snapshot.PerBatch.P95,
+                    p99 = snapshot.PerBatch.P99,
+                    perShard = snapshot.PerBatch.PerShard
+                },
+                lookups = snapshot.Lookups
             }
         };
         await File.WriteAllTextAsync(path,

--- a/src/Marten.ScaleTesting/Commands/RebuildInput.cs
+++ b/src/Marten.ScaleTesting/Commands/RebuildInput.cs
@@ -20,6 +20,9 @@ public sealed class RebuildInput: NetCoreInput
     [Description("Optional CSV trace path for the progression lock-wait sampler (#4684 Phase E.2). One row per sample: timestamp, current waiter count on mt_event_progression, max single-waiter wait in ms. Implies --instrument.")]
     public string? InstrumentLockTraceFlag { get; set; }
 
+    [Description("Optional CSV trace path for the per-batch breakdown (#4684 Phase E.3). One row per completed event page: shard, floor, ceiling, events, loading/grouping/execution ms, DB round-trips. Implies --instrument.")]
+    public string? InstrumentBatchTraceFlag { get; set; }
+
     [Description("Sample interval for the progression poller when --instrument is on. Default 1s. Lower for finer-grained percentiles; raise to keep harness overhead negligible on multi-hour runs.")]
     public double InstrumentSampleSecondsFlag { get; set; } = 1.0;
 

--- a/src/Marten.ScaleTesting/Commands/StressCommand.cs
+++ b/src/Marten.ScaleTesting/Commands/StressCommand.cs
@@ -182,13 +182,15 @@ public sealed class StressCommand: JasperFxAsyncCommand<StressInput>
     {
         var enabled = input.InstrumentFlag
             || !string.IsNullOrWhiteSpace(input.InstrumentTraceFlag)
-            || !string.IsNullOrWhiteSpace(input.InstrumentLockTraceFlag);
+            || !string.IsNullOrWhiteSpace(input.InstrumentLockTraceFlag)
+            || !string.IsNullOrWhiteSpace(input.InstrumentBatchTraceFlag);
         return new InstrumentationOptions
         {
             Enabled = enabled,
             ProgressSampleInterval = TimeSpan.FromSeconds(Math.Max(0.1, input.InstrumentSampleSecondsFlag)),
             TracePath = string.IsNullOrWhiteSpace(input.InstrumentTraceFlag) ? null : input.InstrumentTraceFlag,
-            LockTracePath = string.IsNullOrWhiteSpace(input.InstrumentLockTraceFlag) ? null : input.InstrumentLockTraceFlag
+            LockTracePath = string.IsNullOrWhiteSpace(input.InstrumentLockTraceFlag) ? null : input.InstrumentLockTraceFlag,
+            BatchTracePath = string.IsNullOrWhiteSpace(input.InstrumentBatchTraceFlag) ? null : input.InstrumentBatchTraceFlag
         };
     }
 

--- a/src/Marten.ScaleTesting/Commands/StressInput.cs
+++ b/src/Marten.ScaleTesting/Commands/StressInput.cs
@@ -58,6 +58,9 @@ public sealed class StressInput: NetCoreInput
     [Description("Optional CSV trace path for the progression lock-wait sampler (#4684 Phase E.2). One row per sample: timestamp, current waiter count, max single-waiter wait in ms. Implies --instrument.")]
     public string? InstrumentLockTraceFlag { get; set; }
 
+    [Description("Optional CSV trace path for the per-batch breakdown (#4684 Phase E.3). One row per completed event page. Implies --instrument.")]
+    public string? InstrumentBatchTraceFlag { get; set; }
+
     [Description("Sample interval for the progression poller when --instrument is on. Default 1s.")]
     public double InstrumentSampleSecondsFlag { get; set; } = 1.0;
 

--- a/src/Marten.ScaleTesting/Domain/Stage2Projections.cs
+++ b/src/Marten.ScaleTesting/Domain/Stage2Projections.cs
@@ -130,6 +130,12 @@ public partial class AppointmentDetailsProjection: MultiStreamProjection<Appoint
                     }
                 }
 
+                // #4684 item 4: the escape-hatch business-key lookup — one batched query when
+                // any codes miss the slice cache, zero when the cache fully covers the page
+                Instrumentation.LookupCounters.Record(
+                    nameof(AppointmentDetailsProjection) + ".RoutingReason",
+                    missingCodes.Count > 0 ? 1 : 0, events.Count);
+
                 foreach (var slice in slices)
                 {
                     var codesInSlice = slice.Events()
@@ -290,7 +296,8 @@ public class AppointmentMetricsProjection: IProjection
         var groups = events
             .Where(e => e.Data is AppointmentRequested)
             .Select(e => (AppointmentRequested)e.Data)
-            .GroupBy(r => r.SpecialtyCode);
+            .GroupBy(r => r.SpecialtyCode)
+            .ToArray();
 
         foreach (var group in groups)
         {
@@ -299,5 +306,9 @@ public class AppointmentMetricsProjection: IProjection
             metrics.Count += group.Count();
             operations.Store(metrics);
         }
+
+        // #4684 item 4: one LoadAsync round-trip per specialty group in this invocation
+        Instrumentation.LookupCounters.Record(nameof(AppointmentMetricsProjection),
+            groups.Length, groups.Sum(g => g.Count()));
     }
 }

--- a/src/Marten.ScaleTesting/Instrumentation/BatchSpanSampler.cs
+++ b/src/Marten.ScaleTesting/Instrumentation/BatchSpanSampler.cs
@@ -1,0 +1,301 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Marten.ScaleTesting.Instrumentation;
+
+/// <summary>
+/// #4684 Phase E.3: per-batch wall-clock breakdown, consumed entirely from the harness side.
+///
+/// The daemon (JasperFx.Events <c>SubscriptionMetrics</c>) already emits three spans per event
+/// page on the store's <c>Marten</c> ActivitySource —
+/// <c>marten.{projection}.{shard}.page.loading</c> (event fetch from <c>mt_events</c>),
+/// <c>.page.grouping</c> (slicing / enrichment pre-processing) and
+/// <c>.page.execution</c> (projection user code + operation building + the SQL flush of the
+/// <c>ProjectionUpdateBatch</c>). Those spans only exist when something listens, so production
+/// runs pay nothing; this listener IS the something when <c>--instrument</c> is on.
+///
+/// Npgsql ≥ 8 emits one Activity per command under the <c>Npgsql</c> source, parented to
+/// whatever Activity is current — i.e. to the page span whose work issued the command. Walking
+/// the parent chain from each command span attributes DB round-trips to the page span that
+/// caused them, giving a per-batch round-trip count rather than the run-level total the
+/// E.1 <see cref="NpgsqlCommandCounter"/> reports.
+///
+/// Correlation: the three page spans for one batch share a shard prefix and an
+/// <c>event.floor</c> tag, so <c>(shard, floor)</c> stitches loading + grouping + execution
+/// back into one <see cref="BatchRecord"/>. Sequence floors are strictly monotonic per shard,
+/// so the key never collides within a run.
+/// </summary>
+internal sealed class BatchSpanSampler: IDisposable
+{
+    private const string PageMarker = ".page.";
+
+    private readonly ActivityListener _listener;
+    private readonly ConcurrentDictionary<string, StrongBox<long>> _roundTrips = new();
+    private readonly ConcurrentDictionary<(string Shard, long Floor), BatchAccumulator> _batches = new();
+    private bool _disposed;
+
+    private BatchSpanSampler(string martenSourceName)
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == martenSourceName || src.Name == "Npgsql",
+            // AllData so the page spans carry their page.size / event.floor / event.ceiling tags.
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = OnStopped
+        };
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    public static BatchSpanSampler Start(string martenSourceName = "Marten") => new(martenSourceName);
+
+    private void OnStopped(Activity activity)
+    {
+        if (activity.Source.Name == "Npgsql")
+        {
+            AttributeCommandToPageSpan(activity);
+            return;
+        }
+
+        var kindIndex = activity.OperationName.IndexOf(PageMarker, StringComparison.Ordinal);
+        if (kindIndex < 0)
+        {
+            return;
+        }
+
+        var shard = activity.OperationName[..kindIndex];
+        var kind = activity.OperationName[(kindIndex + PageMarker.Length)..];
+
+        long floor = ReadLongTag(activity, "event.floor");
+        var accumulator = _batches.GetOrAdd((shard, floor), _ => new BatchAccumulator());
+        var elapsedMs = activity.Duration.TotalMilliseconds;
+        var trips = _roundTrips.TryRemove(activity.SpanId.ToString(), out var box)
+            ? Interlocked.Read(ref box.Value)
+            : 0;
+
+        switch (kind)
+        {
+            case "loading":
+                accumulator.LoadingMs = elapsedMs;
+                accumulator.LoadingRoundTrips = trips;
+                break;
+            case "grouping":
+                accumulator.GroupingMs = elapsedMs;
+                accumulator.GroupingRoundTrips = trips;
+                break;
+            case "execution":
+                accumulator.ExecutionMs = elapsedMs;
+                accumulator.ExecutionRoundTrips = trips;
+                accumulator.Events = ReadLongTag(activity, "page.size");
+                accumulator.Ceiling = ReadLongTag(activity, "event.ceiling");
+                accumulator.CompletedAt = DateTimeOffset.UtcNow;
+                break;
+        }
+    }
+
+    private void AttributeCommandToPageSpan(Activity command)
+    {
+        // Connection lifecycle spans aren't round-trips issued by batch work
+        if (command.OperationName is "Npgsql.OpenConnection" or "Npgsql.CloseConnection")
+        {
+            return;
+        }
+
+        for (var parent = command.Parent; parent != null; parent = parent.Parent)
+        {
+            if (parent.Source.Name != "Npgsql"
+                && parent.OperationName.Contains(PageMarker, StringComparison.Ordinal))
+            {
+                var box = _roundTrips.GetOrAdd(parent.SpanId.ToString(), _ => new StrongBox<long>());
+                Interlocked.Increment(ref box.Value);
+                return;
+            }
+        }
+    }
+
+    private static long ReadLongTag(Activity activity, string tag)
+    {
+        var value = activity.GetTagItem(tag);
+        return value switch
+        {
+            null => 0,
+            long l => l,
+            int i => i,
+            string s when long.TryParse(s, out var parsed) => parsed,
+            _ => 0
+        };
+    }
+
+    /// <summary>
+    /// Roll the raw span records up into finished batches. Only batches that saw an execution
+    /// span count — a loading span with no matching execution at capture time is a batch still
+    /// in flight when the run stopped.
+    /// </summary>
+    public IReadOnlyList<BatchRecord> Capture(string? tracePath = null)
+    {
+        var records = _batches
+            .Where(kv => kv.Value.ExecutionMs.HasValue)
+            .Select(kv => new BatchRecord(
+                kv.Key.Shard,
+                kv.Key.Floor,
+                kv.Value.Ceiling,
+                kv.Value.Events,
+                kv.Value.LoadingMs ?? 0,
+                kv.Value.GroupingMs ?? 0,
+                kv.Value.ExecutionMs!.Value,
+                (kv.Value.LoadingMs ?? 0) + (kv.Value.GroupingMs ?? 0) + kv.Value.ExecutionMs!.Value,
+                kv.Value.LoadingRoundTrips + kv.Value.GroupingRoundTrips + kv.Value.ExecutionRoundTrips,
+                kv.Value.CompletedAt))
+            .OrderBy(r => r.CompletedAt)
+            .ToArray();
+
+        if (tracePath != null)
+        {
+            WriteTrace(tracePath, records);
+        }
+
+        return records;
+    }
+
+    private static void WriteTrace(string path, IReadOnlyList<BatchRecord> records)
+    {
+        using var writer = new StreamWriter(path, append: false);
+        writer.WriteLine("completed_at,shard,floor,ceiling,events,loading_ms,grouping_ms,execution_ms,total_ms,round_trips");
+        foreach (var r in records)
+        {
+            writer.WriteLine(string.Create(CultureInfo.InvariantCulture,
+                $"{r.CompletedAt:O},{r.Shard},{r.Floor},{r.Ceiling},{r.Events},{r.LoadingMs:F3},{r.GroupingMs:F3},{r.ExecutionMs:F3},{r.TotalMs:F3},{r.RoundTrips}"));
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _listener.Dispose();
+    }
+
+    private sealed class BatchAccumulator
+    {
+        public double? LoadingMs;
+        public double? GroupingMs;
+        public double? ExecutionMs;
+        public long LoadingRoundTrips;
+        public long GroupingRoundTrips;
+        public long ExecutionRoundTrips;
+        public long Events;
+        public long Ceiling;
+        public DateTimeOffset CompletedAt;
+    }
+
+    private sealed class StrongBox<T> where T : struct
+    {
+        public T Value;
+    }
+}
+
+/// <summary>One completed event page (batch) as seen by <see cref="BatchSpanSampler"/>.</summary>
+public sealed record BatchRecord(
+    string Shard,
+    long Floor,
+    long Ceiling,
+    long Events,
+    double LoadingMs,
+    double GroupingMs,
+    double ExecutionMs,
+    double TotalMs,
+    long RoundTrips,
+    DateTimeOffset CompletedAt);
+
+/// <summary>
+/// Percentile roll-up of the per-batch series, in the <c>perBatch.p50/p95/p99</c> shape the
+/// #4684 issue specifies for <c>metrics.json</c>.
+/// </summary>
+public sealed record BatchBreakdownStats(
+    int BatchCount,
+    BatchPercentileRow P50,
+    BatchPercentileRow P95,
+    BatchPercentileRow P99,
+    IReadOnlyDictionary<string, ShardBatchStats> PerShard)
+{
+    public static BatchBreakdownStats Empty { get; } = new(
+        0, BatchPercentileRow.Zero, BatchPercentileRow.Zero, BatchPercentileRow.Zero,
+        new Dictionary<string, ShardBatchStats>());
+
+    public static BatchBreakdownStats From(IReadOnlyList<BatchRecord> records)
+    {
+        if (records.Count == 0)
+        {
+            return Empty;
+        }
+
+        var perShard = records
+            .GroupBy(r => r.Shard)
+            .ToDictionary(
+                g => g.Key,
+                g => new ShardBatchStats(
+                    g.Count(),
+                    g.Sum(x => x.Events),
+                    Percentile(g.Select(x => x.TotalMs), 0.50),
+                    g.Average(x => x.Events),
+                    g.Average(x => x.RoundTrips)));
+
+        return new BatchBreakdownStats(
+            records.Count,
+            RowAt(records, 0.50),
+            RowAt(records, 0.95),
+            RowAt(records, 0.99),
+            perShard);
+    }
+
+    private static BatchPercentileRow RowAt(IReadOnlyList<BatchRecord> records, double q) =>
+        new(
+            Percentile(records.Select(r => r.TotalMs), q),
+            Percentile(records.Select(r => r.LoadingMs), q),
+            Percentile(records.Select(r => r.GroupingMs), q),
+            Percentile(records.Select(r => r.ExecutionMs), q),
+            Percentile(records.Select(r => (double)r.RoundTrips), q),
+            Percentile(records.Select(r => (double)r.Events), q));
+
+    private static double Percentile(IEnumerable<double> values, double q)
+    {
+        // Nearest-rank, matching ThroughputPercentiles — interpolation noise isn't worth it at
+        // harness sample volumes.
+        var sorted = values.OrderBy(x => x).ToArray();
+        if (sorted.Length == 0)
+        {
+            return 0;
+        }
+
+        var rank = (int)Math.Ceiling(q * sorted.Length);
+        return sorted[Math.Clamp(rank - 1, 0, sorted.Length - 1)];
+    }
+}
+
+/// <summary>One percentile's view of the per-batch breakdown.</summary>
+public sealed record BatchPercentileRow(
+    double TotalMs,
+    double EventFetchMs,
+    double GroupingMs,
+    double ExecutionMs,
+    double RoundTripCount,
+    double Events)
+{
+    public static BatchPercentileRow Zero { get; } = new(0, 0, 0, 0, 0, 0);
+}
+
+/// <summary>
+/// Per-shard batch summary. Under the composite executor each stage-crossing shard shows up
+/// separately, so this is also the per-stage timing view (#4684 item 6) to the extent the
+/// daemon exposes stages as shards.
+/// </summary>
+public sealed record ShardBatchStats(
+    int Batches,
+    long Events,
+    double TotalMsP50,
+    double MeanEventsPerBatch,
+    double MeanRoundTripsPerBatch);

--- a/src/Marten.ScaleTesting/Instrumentation/InstrumentationOptions.cs
+++ b/src/Marten.ScaleTesting/Instrumentation/InstrumentationOptions.cs
@@ -28,4 +28,10 @@ public sealed class InstrumentationOptions
     /// <c>--instrument-lock-trace &lt;path&gt;</c>; when null, only the rolled-up stats
     /// land in <c>metrics.json</c>.</summary>
     public string? LockTracePath { get; init; }
+
+    /// <summary>Optional CSV trace path for the per-batch breakdown (#4684 Phase E.3). One row
+    /// per completed event page: shard, floor/ceiling, event count, loading/grouping/execution
+    /// wall-clock and DB round-trip count. Set via <c>--instrument-batch-trace &lt;path&gt;</c>;
+    /// when null, only the p50/p95/p99 roll-up lands in <c>metrics.json</c>.</summary>
+    public string? BatchTracePath { get; init; }
 }

--- a/src/Marten.ScaleTesting/Instrumentation/LookupCounters.cs
+++ b/src/Marten.ScaleTesting/Instrumentation/LookupCounters.cs
@@ -1,0 +1,92 @@
+using System.Collections.Concurrent;
+
+namespace Marten.ScaleTesting.Instrumentation;
+
+/// <summary>
+/// #4684 item 4: quantify the "cross-aggregate lookups per event" pathology from inside
+/// projection user code. The harness owns its Telehealth projections, so the explicit lookup
+/// call sites (<c>operations.LoadAsync</c>, the <c>EnrichUsingEntityQuery</c> escape hatch)
+/// report here — one <see cref="Record"/> per Apply/Enrich invocation with the lookup count and
+/// the event count it served.
+///
+/// Static + toggle-gated: the projection classes are constructed by the daemon, so there's no
+/// clean DI path from the command into them. When <see cref="Enabled"/> is false (the default),
+/// call sites pay one branch and allocate nothing.
+///
+/// Limitations, documented rather than hidden: the declarative <c>EnrichWith&lt;T&gt;()...AddReferences()</c>
+/// lookups run inside JasperFx.Events and are NOT counted here — their round-trips do show up
+/// in the per-batch <c>grouping</c> round-trip count from <see cref="BatchSpanSampler"/>.
+/// </summary>
+public static class LookupCounters
+{
+    private static readonly ConcurrentQueue<(string Projection, int Lookups, int Events)> _samples = new();
+
+    /// <summary>Master toggle, flipped by RebuildInstrumentation. Off ⇒ Record is a no-op.</summary>
+    public static bool Enabled { get; set; }
+
+    public static void Record(string projection, int lookups, int events)
+    {
+        if (!Enabled)
+        {
+            return;
+        }
+
+        _samples.Enqueue((projection, lookups, events));
+    }
+
+    public static void Reset()
+    {
+        while (_samples.TryDequeue(out _))
+        {
+        }
+    }
+
+    public static IReadOnlyDictionary<string, LookupStats> Capture()
+    {
+        var byProjection = _samples
+            .GroupBy(s => s.Projection)
+            .ToDictionary(g => g.Key, g =>
+            {
+                var invocations = g.Count();
+                var lookups = g.Sum(x => (long)x.Lookups);
+                var events = g.Sum(x => (long)x.Events);
+
+                // per-event ratio distribution across invocations
+                var ratios = g
+                    .Where(x => x.Events > 0)
+                    .Select(x => (double)x.Lookups / x.Events)
+                    .OrderBy(x => x)
+                    .ToArray();
+
+                return new LookupStats(
+                    invocations,
+                    lookups,
+                    events,
+                    events > 0 ? (double)lookups / events : 0,
+                    PerEventPercentile(ratios, 0.50),
+                    PerEventPercentile(ratios, 0.95));
+            });
+
+        return byProjection;
+    }
+
+    private static double PerEventPercentile(IReadOnlyList<double> sorted, double q)
+    {
+        if (sorted.Count == 0)
+        {
+            return 0;
+        }
+
+        var rank = (int)Math.Ceiling(q * sorted.Count);
+        return sorted[Math.Clamp(rank - 1, 0, sorted.Count - 1)];
+    }
+}
+
+/// <summary>Lookup profile for one projection over a run.</summary>
+public sealed record LookupStats(
+    long Invocations,
+    long Lookups,
+    long Events,
+    double LookupsPerEvent,
+    double PerEventP50,
+    double PerEventP95);

--- a/src/Marten.ScaleTesting/Instrumentation/RebuildInstrumentation.cs
+++ b/src/Marten.ScaleTesting/Instrumentation/RebuildInstrumentation.cs
@@ -17,16 +17,19 @@ public sealed class RebuildInstrumentation : IAsyncDisposable
     private readonly ProgressSampler? _sampler;
     private readonly NpgsqlCommandCounter? _commands;
     private readonly ProgressionLockSampler? _lockSampler;
+    private readonly BatchSpanSampler? _batchSampler;
     private readonly Activity? _activity;
     private static readonly ActivitySource s_activitySource = new("Marten.ScaleTesting", "1.0");
 
     private RebuildInstrumentation(InstrumentationOptions options, ProgressSampler? sampler,
-        NpgsqlCommandCounter? commands, ProgressionLockSampler? lockSampler, Activity? activity)
+        NpgsqlCommandCounter? commands, ProgressionLockSampler? lockSampler,
+        BatchSpanSampler? batchSampler, Activity? activity)
     {
         _options = options;
         _sampler = sampler;
         _commands = commands;
         _lockSampler = lockSampler;
+        _batchSampler = batchSampler;
         _activity = activity;
     }
 
@@ -44,7 +47,7 @@ public sealed class RebuildInstrumentation : IAsyncDisposable
     {
         if (!options.Enabled)
         {
-            return new RebuildInstrumentation(options, null, null, null, null);
+            return new RebuildInstrumentation(options, null, null, null, null, null);
         }
 
         var activity = s_activitySource.StartActivity("scaletest.rebuild", ActivityKind.Internal);
@@ -58,7 +61,12 @@ public sealed class RebuildInstrumentation : IAsyncDisposable
         var lockSampler = ProgressionLockSampler.Start(
             connectionString, options.ProgressSampleInterval, options.LockTracePath, cancellation);
 
-        return new RebuildInstrumentation(options, sampler, commands, lockSampler, activity);
+        // E.3: listening to the Marten source is what turns the daemon's per-page spans on
+        var batchSampler = BatchSpanSampler.Start();
+        LookupCounters.Reset();
+        LookupCounters.Enabled = true;
+
+        return new RebuildInstrumentation(options, sampler, commands, lockSampler, batchSampler, activity);
     }
 
     /// <summary>
@@ -74,10 +82,19 @@ public sealed class RebuildInstrumentation : IAsyncDisposable
         var samples = _sampler != null ? await _sampler.StopAsync().ConfigureAwait(false) : Array.Empty<ProgressSample>();
         var commandCount = _commands?.Stop() ?? 0;
         var lockWait = _lockSampler != null ? await _lockSampler.StopAsync().ConfigureAwait(false) : LockWaitStats.Empty;
+
+        // E.3: roll the per-page spans up into per-batch breakdown + lookup profile
+        var batchRecords = _batchSampler?.Capture(_options.BatchTracePath) ?? Array.Empty<BatchRecord>();
+        _batchSampler?.Dispose();
+        LookupCounters.Enabled = false;
+        var lookups = LookupCounters.Capture();
+        LookupCounters.Reset();
+
         _activity?.SetTag("samples", samples.Length);
         _activity?.SetTag("npgsql.commands", commandCount);
         _activity?.SetTag("progression.max_waiters", lockWait.MaxConcurrentWaiters);
         _activity?.SetTag("progression.observed_waiter_seconds", lockWait.ObservedWaiterSeconds);
+        _activity?.SetTag("batches", batchRecords.Count);
         _activity?.Stop();
 
         return new Snapshot(
@@ -85,7 +102,9 @@ public sealed class RebuildInstrumentation : IAsyncDisposable
             Samples: samples,
             NpgsqlCommandCount: commandCount,
             Throughput: ThroughputPercentiles.From(samples),
-            ProgressionLockWaits: lockWait);
+            ProgressionLockWaits: lockWait,
+            PerBatch: BatchBreakdownStats.From(batchRecords),
+            Lookups: lookups);
     }
 
     public async ValueTask DisposeAsync()
@@ -101,6 +120,8 @@ public sealed class RebuildInstrumentation : IAsyncDisposable
             await _lockSampler.DisposeAsync().ConfigureAwait(false);
         }
         _commands?.Dispose();
+        _batchSampler?.Dispose();
+        LookupCounters.Enabled = false;
         _activity?.Dispose();
     }
 
@@ -110,10 +131,13 @@ public sealed class RebuildInstrumentation : IAsyncDisposable
         IReadOnlyList<ProgressSample> Samples,
         long NpgsqlCommandCount,
         ThroughputPercentiles Throughput,
-        LockWaitStats ProgressionLockWaits)
+        LockWaitStats ProgressionLockWaits,
+        BatchBreakdownStats PerBatch,
+        IReadOnlyDictionary<string, LookupStats> Lookups)
     {
         public static Snapshot Disabled { get; } =
-            new(false, Array.Empty<ProgressSample>(), 0, ThroughputPercentiles.Empty, LockWaitStats.Empty);
+            new(false, Array.Empty<ProgressSample>(), 0, ThroughputPercentiles.Empty, LockWaitStats.Empty,
+                BatchBreakdownStats.Empty, new Dictionary<string, LookupStats>());
     }
 }
 

--- a/src/Marten.ScaleTesting/README.md
+++ b/src/Marten.ScaleTesting/README.md
@@ -42,12 +42,13 @@ Override with the `marten_testing_database` env var.
 * **Phase C:** `validate` (single-shard baseline diff) + `stress` (chain `seed` + `rebuild` + `validate`) + JSON metrics sink.
 * **Phase D:** use it. Drive the daemon-thread-safety fixes against the harness — each fix should hold the crash gate AND not regress rebuild time.
 * **Phase E.1:** per-period throughput sampling + Npgsql round-trip counting via `--instrument`. Surfaces p50/p95/p99/max throughput + total command count in the console summary and `--metrics` JSON; per-sample CSV trace under `--instrument-trace`.
-* **Phase E.2:** progression-row lock-wait sampler. `pg_stat_activity` joined to `pg_locks` at each interval, counting ungranted lock holders on `mt_event_progression` that aren't our own session. Surfaces `MaxConcurrentWaiters`, `MaxSingleWaitMs`, and the approximation `ObservedWaiterSeconds = sum(waiter_count_per_sample) * sample_interval`. Per-sample CSV trace under `--instrument-lock-trace`. Out of scope and pinned as Phase E.3-E.4 follow-ups (need JasperFx-side hooks that don't exist yet): per-batch wall-clock breakdown, per-stage composite timing, `RecentlyUsedCache` hit/miss, lookup-count per `EvolveAsync`.
+* **Phase E.2:** progression-row lock-wait sampler. `pg_stat_activity` joined to `pg_locks` at each interval, counting ungranted lock holders on `mt_event_progression` that aren't our own session. Surfaces `MaxConcurrentWaiters`, `MaxSingleWaitMs`, and the approximation `ObservedWaiterSeconds = sum(waiter_count_per_sample) * sample_interval`. Per-sample CSV trace under `--instrument-lock-trace`.
+* **Phase E.3 (#4684 remainder):** per-batch wall-clock breakdown + per-batch DB round-trip attribution + lookup counting. The daemon (JasperFx.Events `SubscriptionMetrics`) already emits three spans per event page on the store's `Marten` ActivitySource — `.page.loading` (event fetch), `.page.grouping` (slicing/enrichment) and `.page.execution` (user code + operation building + batch flush) — but only when something listens. `BatchSpanSampler` is that listener under `--instrument`: it stitches the three spans per `(shard, floor)` into one `BatchRecord`, and attributes Npgsql command spans to their enclosing page span by walking the Activity parent chain, giving true per-batch round-trip counts. Output: `perBatch.p50/p95/p99` (total / eventFetch / grouping / execution ms + roundTripCount) plus a `perShard` roll-up in `metrics.json`; per-batch CSV under `--instrument-batch-trace`. `LookupCounters` (item 4) counts the explicit cross-aggregate lookups in the harness projections' own code (`AppointmentMetricsProjection`'s per-specialty `LoadAsync`, `AppointmentDetailsProjection`'s `EnrichUsingEntityQuery` escape hatch) as lookups-per-event distributions per projection. Still blocked on JasperFx-side seams and deliberately NOT approximated here: `RecentlyUsedCache` hit/miss counters (`AggregationRunner.CacheFor` hard-constructs the cache; no injection point) and per-stage timing inside a single composite batch (the composite executor runs stages within one `.page.execution` span; the declarative `EnrichWith<T>().AddReferences()` lookups likewise run inside JasperFx.Events and show up only in the per-batch `grouping`/`execution` round-trip counts).
 * **#4683 Fix 3 (this PR):** `dropcycle` subcommand. Exercises the drop-tenant cleanup (#4683) end-to-end against an isolated `UseTenantPartitionedEvents = true` store: registers N tenants, seeds events to populate the per-tenant sequence + progression rows, drops one, asserts the per-tenant artifacts are gone and peers + store-global rows survive. Optionally re-adds + re-seeds and verifies the sequence starts fresh at zero. 14 boolean checks; non-zero exit on any failure. Run via `dotnet run --project src/Marten.ScaleTesting -- dropcycle`.
 
 ## Measuring a rebuild
 
-Add `--instrument` to either subcommand to enable per-period sampling against `mt_event_progression`, Npgsql round-trip counting, and (E.2) `pg_stat_activity`-based progression lock-wait sampling. Default 1s sample interval; tune with `--instrument-sample-seconds`. The console summary picks up seven extra rows (throughput percentiles + total Npgsql commands + sample count + three lock-wait counters). `--metrics <path>` writes a JSON file with the rolled-up percentiles + lock-wait stats; `--instrument-trace <path>` adds per-sample progress CSV; `--instrument-lock-trace <path>` adds per-sample lock-wait CSV.
+Add `--instrument` to either subcommand to enable per-period sampling against `mt_event_progression`, Npgsql round-trip counting, (E.2) `pg_stat_activity`-based progression lock-wait sampling, and (E.3) the per-batch span sampler + lookup counters. Default 1s sample interval; tune with `--instrument-sample-seconds`. The console summary picks up seven extra rows (throughput percentiles + total Npgsql commands + sample count + three lock-wait counters). `--metrics <path>` writes a JSON file with the rolled-up percentiles + lock-wait stats; `--instrument-trace <path>` adds per-sample progress CSV; `--instrument-lock-trace <path>` adds per-sample lock-wait CSV.
 
 ```bash
 # Instrumented rebuild against existing seeded data, JSON + CSV output
@@ -91,6 +92,18 @@ dotnet run --project src/Marten.ScaleTesting -- daemonload \
       "MaxConcurrentWaiters": 0,
       "MaxSingleWaitMs": 0,
       "ObservedWaiterSeconds": 0.0
+    },
+    "perBatch": {
+      "batches": 23,
+      "p50": { "TotalMs": 67.6, "EventFetchMs": 7.4, "GroupingMs": 0.3, "ExecutionMs": 58.8, "RoundTripCount": 31, "Events": 500 },
+      "p95": { "...": "..." },
+      "p99": { "...": "..." },
+      "perShard": {
+        "marten.telehealthcomposite.all": { "Batches": 23, "Events": 11100, "TotalMsP50": 67.6, "MeanEventsPerBatch": 482.6, "MeanRoundTripsPerBatch": 29.7 }
+      }
+    },
+    "lookups": {
+      "AppointmentMetricsProjection": { "Invocations": 115, "Lookups": 636, "Events": 1075, "LookupsPerEvent": 0.59, "PerEventP50": 0.6, "PerEventP95": 0.88 }
     }
   }
 }


### PR DESCRIPTION
Phase E remainder of #4684 (epic jasperfx#486 WS6, `Marten.ScaleTesting` group).

## What's here

**Per-batch wall-clock breakdown + DB round-trip attribution (items 1 + 2)** — `BatchSpanSampler`. The daemon (JasperFx.Events `SubscriptionMetrics`) already emits three spans per event page on the store's `Marten` ActivitySource — `.page.loading` (event fetch from `mt_events`), `.page.grouping` (slicing/enrichment), `.page.execution` (projection user code + operation building + batch flush) — but only when a listener exists, so production runs pay nothing. Under `--instrument` the harness listens, stitches the three spans per `(shard, floor)` into one `BatchRecord`, and attributes Npgsql command spans (Npgsql ≥ 8 emits one Activity per command) to their enclosing page span by walking the Activity parent chain — giving **true per-batch round-trip counts**, not just the run-level total from E.1.

- `metrics.json` gains `instrumentation.perBatch` with `p50/p95/p99` rows (`TotalMs`, `EventFetchMs`, `GroupingMs`, `ExecutionMs`, `RoundTripCount`, `Events`) + a `perShard` roll-up
- `--instrument-batch-trace <path>` writes one CSV row per completed page for deep dives (both `rebuild` and `stress`)

**Lookup count per invocation (item 4)** — `LookupCounters`, recording from the harness projections' own explicit cross-aggregate lookup sites (`AppointmentMetricsProjection`'s per-specialty `LoadAsync`, `AppointmentDetailsProjection`'s `EnrichUsingEntityQuery` escape hatch). Reported per projection as totals + lookups-per-event p50/p95 in `metrics.json` under `instrumentation.lookups`.

**Items 5 (progression lock waits) and run-level round trips** already landed in Phase E.1/E.2 (#4875 lineage).

## Measured (local, 5 tenants × 11.1k events, TelehealthComposite)

| Metric | Value |
|---|---|
| Batches observed | 23 |
| Batch p50 total / fetch / group / exec | 68 / 7 / 0.3 / 59 ms |
| Batch p95 total / fetch / group / exec | 81 / 16 / 0.7 / 73 ms |
| Batch p50/p95 DB round-trips | 31 / 34 |
| Lookups: AppointmentMetricsProjection | 0.59/event (p95 0.88) |
| Lookups: AppointmentDetails.RoutingReason | 0.11/event |
| Overhead | instrumented 2.1s vs uninstrumented 2.3s — within noise; **0 when off** (listener never constructed) |

The exec-heavy p50 split (59 of 68 ms in `.page.execution`, which contains evolve + operation building + flush) is exactly the "where is time going" signal this phase was for.

## Deliberately NOT approximated (still blocked on JasperFx seams, documented in README)

- **Item 3 cache hit/miss**: `AggregationRunner.CacheFor` hard-constructs `RecentlyUsedCache` — no injection point for a counting wrapper (`AggregationCaching` is marked spike-only). Needs a small JasperFx.Events seam.
- **Item 6 per-stage timing inside one composite batch**: the composite executor runs all stages within a single `.page.execution` span. Per-shard timing is exposed (`perShard`), which covers stages to the extent the daemon exposes them as shards.

Leaving the issue open for those two once the JasperFx seams exist is Jeremy's call — everything harness-side implementable is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNfeNz73Q3EdiTgSeDbo96
