### PR TITLE
Sharded-aware AllProjectionProgress / ProjectionProgressFor (closes #4797)

### DIFF
--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -315,7 +315,7 @@ Both `AllProjectionProgress()` and `ProjectionProgressFor()` accept an optional 
 tenant id, the read targets the database containing that tenant. When the tenant id is omitted on
 a store with a single database, the default database is used. When the tenant id is omitted under
 multi-tenancy with multiple databases — including `MultiTenantedWithShardedDatabases()` — the read
-spans _every_ known database: `AllProjectionProgress()` concatenates each database's progression
+spans *every* known database: `AllProjectionProgress()` concatenates each database's progression
 rows (with `Events.UseTenantPartitionedEvents` the per-tenant rows carry the tenant id in their
 shard identity, `{Name}:{ShardKey}:{tenantId}`, so results remain attributable per tenant), and
 `ProjectionProgressFor()` returns the highest progression found for the shard name across the

--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -311,6 +311,18 @@ public static async Task ShowDaemonDiagnostics(IDocumentStore store)
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/CommandLineRunner/AsyncDaemonBootstrappingSamples.cs#L109-L128' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_daemondiagnostics' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+Both `AllProjectionProgress()` and `ProjectionProgressFor()` accept an optional tenant id. With a
+tenant id, the read targets the database containing that tenant. When the tenant id is omitted on
+a store with a single database, the default database is used. When the tenant id is omitted under
+multi-tenancy with multiple databases — including `MultiTenantedWithShardedDatabases()` — the read
+spans _every_ known database: `AllProjectionProgress()` concatenates each database's progression
+rows (with `Events.UseTenantPartitionedEvents` the per-tenant rows carry the tenant id in their
+shard identity, `{Name}:{ShardKey}:{tenantId}`, so results remain attributable per tenant), and
+`ProjectionProgressFor()` returns the highest progression found for the shard name across the
+databases. Since a tenant-qualified shard identity only ever exists in the one database that owns
+the tenant, `ProjectionProgressFor()` with such an identity returns that tenant's exact
+progression.
+
 ## Command Line Support
 
 If you're using [Marten's command line support](/configuration/cli), you have the new `projections` command to help

--- a/src/Marten/AdvancedOperations.cs
+++ b/src/Marten/AdvancedOperations.cs
@@ -186,18 +186,46 @@ public class AdvancedOperations
     /// <param name="token"></param>
     /// <param name="tenantId">
     ///     Specify the database containing this tenant id. If omitted, this method uses the default
-    ///     database
+    ///     database when the store has a single database, or spans <em>every</em> known database
+    ///     under multi-tenancy with multiple databases (including
+    ///     <c>MultiTenantedWithShardedDatabases</c>), concatenating each database's progression rows.
+    ///     Under <c>Events.UseTenantPartitionedEvents</c> the per-tenant rows carry the tenant id in
+    ///     their <c>ShardName.Identity</c> (<c>{Name}:{ShardKey}:{tenantId}</c>), so the aggregated
+    ///     result remains attributable per tenant. See
+    ///     <a href="https://github.com/JasperFx/marten/issues/4797">#4797</a>.
     /// </param>
     /// <returns></returns>
     public async Task<IReadOnlyList<ShardState>> AllProjectionProgress(string? tenantId = null,
         CancellationToken token = default)
     {
-        var database = tenantId == null
-            ? _store.Tenancy.Default.Database
-            : (await _store.Tenancy.GetTenantAsync(_store.Options.TenantIdStyle.MaybeCorrectTenantId(tenantId))
-                .ConfigureAwait(false)).Database;
+        if (tenantId != null)
+        {
+            var database =
+                (await _store.Tenancy.GetTenantAsync(_store.Options.TenantIdStyle.MaybeCorrectTenantId(tenantId))
+                    .ConfigureAwait(false)).Database;
+            return await database.AllProjectionProgress(token).ConfigureAwait(false);
+        }
 
-        return await database.AllProjectionProgress(token).ConfigureAwait(false);
+        // #4797: mirror WaitForNonStaleProjectionDataAsync's sharded-aware shape (#4366).
+        // A single-database store keeps today's default-database behavior; any
+        // multi-database tenancy (sharded, database per tenant, master-table, ...) has no
+        // usable "default" database — ShardedTenancy.Default even throws — so fan out
+        // across every database the store knows about and concatenate the results.
+        if (_store.Tenancy is DefaultTenancy)
+        {
+            return await _store.Tenancy.Default.Database.AllProjectionProgress(token).ConfigureAwait(false);
+        }
+
+        var databases = await _store.Storage.AllDatabases().ConfigureAwait(false);
+        assertHasDatabases(databases);
+
+        var states = new List<ShardState>();
+        foreach (var database in databases)
+        {
+            states.AddRange(await database.AllProjectionProgress(token).ConfigureAwait(false));
+        }
+
+        return states;
     }
 
     /// <summary>
@@ -205,20 +233,57 @@ public class AdvancedOperations
     /// </summary>
     /// <param name="tenantId">
     ///     Specify the database containing this tenant id. If omitted, this method uses the default
-    ///     database
+    ///     database when the store has a single database. Under multi-tenancy with multiple databases
+    ///     (including <c>MultiTenantedWithShardedDatabases</c>) an omitted tenant id spans
+    ///     <em>every</em> known database and returns the highest progression found for the shard
+    ///     name. With <c>Events.UseTenantPartitionedEvents</c>, a tenant-qualified
+    ///     <c>ShardName</c> identity (<c>{Name}:{ShardKey}:{tenantId}</c>) only ever exists in the
+    ///     single database that owns the tenant, so the result is that tenant's exact progression;
+    ///     databases without the row contribute 0. See
+    ///     <a href="https://github.com/JasperFx/marten/issues/4797">#4797</a>.
     /// </param>
     /// <param name="token"></param>
     /// <returns></returns>
     public async Task<long> ProjectionProgressFor(ShardName name, string? tenantId = null,
         CancellationToken token = default)
     {
-        var tenant = tenantId == null
-            ? _store.Tenancy.Default
-            : await _store.Tenancy.GetTenantAsync(_store.Options.TenantIdStyle.MaybeCorrectTenantId(tenantId))
+        if (tenantId != null)
+        {
+            var tenant = await _store.Tenancy
+                .GetTenantAsync(_store.Options.TenantIdStyle.MaybeCorrectTenantId(tenantId))
                 .ConfigureAwait(false);
-        var database = tenant.Database;
+            return await tenant.Database.ProjectionProgressFor(name, token).ConfigureAwait(false);
+        }
 
-        return await database.ProjectionProgressFor(name, token).ConfigureAwait(false);
+        // #4797: same sharded-aware fan-out as AllProjectionProgress above.
+        if (_store.Tenancy is DefaultTenancy)
+        {
+            return await _store.Tenancy.Default.Database.ProjectionProgressFor(name, token).ConfigureAwait(false);
+        }
+
+        var databases = await _store.Storage.AllDatabases().ConfigureAwait(false);
+        assertHasDatabases(databases);
+
+        var highest = 0L;
+        foreach (var database in databases)
+        {
+            var sequence = await database.ProjectionProgressFor(name, token).ConfigureAwait(false);
+            if (sequence > highest)
+            {
+                highest = sequence;
+            }
+        }
+
+        return highest;
+    }
+
+    private static void assertHasDatabases(IReadOnlyList<IMartenDatabase> databases)
+    {
+        if (databases.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "The document store has no databases registered with its tenancy. Either configure a tenancy strategy that exposes databases (e.g. MultiTenantedWithShardedDatabases) or invoke a specific tenant id overload.");
+        }
     }
 
     /// <summary>

--- a/src/Marten/Storage/MartenDatabase.EventStorage.cs
+++ b/src/Marten/Storage/MartenDatabase.EventStorage.cs
@@ -232,12 +232,9 @@ select count(*) from {Options.Events.DatabaseSchemaName}.mt_streams;
 
     /// <summary>
     ///     Check the current progress of all asynchronous projections
+    ///     within this database
     /// </summary>
     /// <param name="token"></param>
-    /// <param name="tenantId">
-    ///     Specify the database containing this tenant id. If omitted, this method uses the default
-    ///     database
-    /// </param>
     /// <returns></returns>
     public async Task<IReadOnlyList<ShardState>> AllProjectionProgress(
         CancellationToken token = default)
@@ -435,11 +432,9 @@ select count(*) from {Options.Events.DatabaseSchemaName}.mt_streams;
 
     /// <summary>
     ///     Check the current progress of a single projection or projection shard
+    ///     within this database
     /// </summary>
-    /// <param name="tenantId">
-    ///     Specify the database containing this tenant id. If omitted, this method uses the default
-    ///     database
-    /// </param>
+    /// <param name="name"></param>
     /// <param name="token"></param>
     /// <returns></returns>
     public async Task<long> ProjectionProgressFor(ShardName name,

--- a/src/TenantPartitionedEventsTests/Sharded/sharded_progress_reading_4797.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/sharded_progress_reading_4797.cs
@@ -1,0 +1,227 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+/// <summary>
+/// #4797 — under <c>MultiTenantedWithShardedDatabases</c> + <c>UseTenantPartitionedEvents</c>, the
+/// projection progress-reading APIs (<c>IDocumentStore.Advanced.AllProjectionProgress</c> /
+/// <c>ProjectionProgressFor</c>) used to fall back to <c>Tenancy.Default.Database</c> when the
+/// tenant id was omitted, and <c>ShardedTenancy.Default</c> throws <c>NotSupportedException</c> —
+/// so the calls threw every time even though their XML docs promised a default-database fallback.
+///
+/// <para>
+/// The fix mirrors <c>WaitForNonStaleProjectionDataAsync</c>'s sharded-aware shape (#4366): a null
+/// tenant id now fans out across every database the store knows about. <c>AllProjectionProgress</c>
+/// concatenates each shard's progression rows (per-tenant rows stay attributable via the
+/// <c>{Name}:{ShardKey}:{tenantId}</c> identity grammar); <c>ProjectionProgressFor</c> returns the
+/// highest progression found for the shard name — for a tenant-qualified identity that row only
+/// exists in the single shard owning the tenant, so the result is that tenant's exact progression.
+/// </para>
+///
+/// <para>
+/// Own-store: needs explicit per-shard tenant assignment via <c>AddTenantToShardAsync</c>. Uses its
+/// own schema names + daemon lock id so sibling agents sharing the physical shard databases don't
+/// collide with this test's objects.
+/// </para>
+/// </summary>
+[Collection("sharded-tenant-partitioned")]
+public class sharded_progress_reading_4797: IAsyncLifetime
+{
+    private const string MasterSchema = "sharded4797";
+    private const string PartitionSchema = "tenants4797";
+    private const string EventsSchema = "prog4797";
+    private const int LockId = 47971;
+
+    private readonly ShardedPartitionedFixture _fixture;
+    private IDocumentStore _store = null!;
+
+    public sharded_progress_reading_4797(ShardedPartitionedFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync(MasterSchema); } catch { }
+
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var shardConn = new NpgsqlConnection(connStr);
+            await shardConn.OpenAsync();
+            try { await shardConn.DropSchemaAsync(PartitionSchema); } catch { }
+            try { await shardConn.DropSchemaAsync(EventsSchema); } catch { }
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        _store?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task progress_reading_with_null_tenant_spans_all_shard_databases()
+    {
+        _store = DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = MasterSchema;
+                x.PartitionSchemaName = PartitionSchema;
+
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+            });
+
+            opts.DatabaseSchemaName = EventsSchema;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AddEventType<Progress4797Event>();
+
+            opts.Projections.Add<Progress4797Projection>(ProjectionLifecycle.Async);
+            opts.Projections.DaemonLockId = LockId;
+            opts.Schema.For<Progress4797Doc>().DocumentAlias("p4797_doc");
+        });
+
+        // This test uses its own DatabaseSchemaName (sibling isolation), so provision
+        // the schema in every shard database up front — AddTenantToShardAsync's
+        // per-tenant sequence DDL targets the events schema directly and does not
+        // lazily create it the way a first session would.
+        await _store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // Two tenants on two DIFFERENT shards so the progress rows genuinely
+        // live in separate databases and only a cross-shard read can see both.
+        var shardA = _fixture.DbNames[0];
+        var shardB = _fixture.DbNames[1];
+        await _store.Advanced.AddTenantToShardAsync("t4797_a", shardA, CancellationToken.None);
+        await _store.Advanced.AddTenantToShardAsync("t4797_b", shardB, CancellationToken.None);
+
+        var aStream = Guid.NewGuid();
+        await using (var session = _store.LightweightSession("t4797_a"))
+        {
+            session.Events.StartStream<Progress4797Doc>(aStream,
+                new Progress4797Event("a-1"), new Progress4797Event("a-2"), new Progress4797Event("a-3"));
+            await session.SaveChangesAsync();
+        }
+
+        var bStream = Guid.NewGuid();
+        await using (var session = _store.LightweightSession("t4797_b"))
+        {
+            session.Events.StartStream<Progress4797Doc>(bStream,
+                new Progress4797Event("b-1"), new Progress4797Event("b-2"));
+            await session.SaveChangesAsync();
+        }
+
+        // One daemon per shard (BuildProjectionDaemonAsync needs an explicit
+        // tenant/database under sharded tenancy).
+        using var daemonA = await _store.BuildProjectionDaemonAsync("t4797_a");
+        using var daemonB = await _store.BuildProjectionDaemonAsync("t4797_b");
+        await daemonA.StartAllAsync();
+        await daemonB.StartAllAsync();
+        await daemonA.WaitForNonStaleData(20.Seconds());
+        await daemonB.WaitForNonStaleData(20.Seconds());
+
+        // THE #4797 PIN: AllProjectionProgress() with an omitted tenant used to throw
+        // NotSupportedException out of ShardedTenancy.get_Default(). It must now fan out
+        // across the shard databases. Poll for the per-tenant rows — WaitForNonStaleData
+        // can return before a per-tenant agent commits its progression row on a
+        // partitioned store.
+        long SeqFor(IReadOnlyList<ShardState> states, string tenantId)
+            => states.SingleOrDefault(x =>
+                    x.ShardName.StartsWith(Progress4797Projection.ProjectionName + ":", StringComparison.Ordinal)
+                    && x.ShardName.EndsWith(":" + tenantId, StringComparison.Ordinal))
+                ?.Sequence ?? 0;
+
+        IReadOnlyList<ShardState> all = [];
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < 30.Seconds())
+        {
+            all = await _store.Advanced.AllProjectionProgress();
+            if (SeqFor(all, "t4797_a") >= 3 && SeqFor(all, "t4797_b") >= 2)
+            {
+                break;
+            }
+
+            await Task.Delay(250);
+        }
+
+        // Per-tenant projection rows from BOTH shard databases show up in one read,
+        // each at its own tenant's height (3 events for a, 2 for b — no bleed-over).
+        SeqFor(all, "t4797_a").ShouldBe(3,
+            "tenant a's projection progression row (shard A) must be included and at its own height");
+        SeqFor(all, "t4797_b").ShouldBe(2,
+            "tenant b's projection progression row (shard B) must be included and at its own height");
+
+        // The tenant-scoped overload keeps its documented "database containing this
+        // tenant id" semantics: it reads ONLY that tenant's shard database.
+        var onlyShardA = await _store.Advanced.AllProjectionProgress("t4797_a");
+        SeqFor(onlyShardA, "t4797_a").ShouldBe(3);
+        SeqFor(onlyShardA, "t4797_b").ShouldBe(0,
+            "tenant b lives on a different shard database, so its rows must not appear");
+
+        // ProjectionProgressFor with an omitted tenant also used to throw. For a
+        // tenant-qualified shard identity the row exists only in the owning shard,
+        // so the cross-shard read returns that tenant's exact progression.
+        var tenantAShard = ShardName.Compose(
+            Progress4797Projection.ProjectionName, "All", "t4797_a", 1);
+        (await _store.Advanced.ProjectionProgressFor(tenantAShard)).ShouldBe(3);
+
+        var tenantBShard = ShardName.Compose(
+            Progress4797Projection.ProjectionName, "All", "t4797_b", 1);
+        (await _store.Advanced.ProjectionProgressFor(tenantBShard)).ShouldBe(2);
+
+        // And the issue's literal repro: the store-global HighWaterMark identity exists
+        // per shard database; the null-tenant read returns the highest one instead of
+        // throwing. Shard A saw 3 events on its per-tenant sequence, so the max is >= 3.
+        var highWater = await _store.Advanced.ProjectionProgressFor(new ShardName(ShardState.HighWaterMark));
+        highWater.ShouldBeGreaterThanOrEqualTo(3);
+
+        // A shard identity that exists nowhere reports 0, not an exception.
+        (await _store.Advanced.ProjectionProgressFor(new ShardName("NoSuchProjection"))).ShouldBe(0);
+    }
+}
+
+public record Progress4797Event(string Label);
+
+public class Progress4797Doc
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+}
+
+public partial class Progress4797Projection: SingleStreamProjection<Progress4797Doc, Guid>
+{
+    public const string ProjectionName = "Progress4797";
+
+    public Progress4797Projection()
+    {
+        Name = ProjectionName;
+    }
+
+    public void Apply(Progress4797Doc doc, Progress4797Event _) => doc.Count++;
+}


### PR DESCRIPTION
Closes #4797. Companion design context: JasperFx/jasperfx#435.

## Problem

Under `MultiTenantedWithShardedDatabases` (+ `Events.UseTenantPartitionedEvents`), the projection progress-reading APIs had no sharded-aware mode. `IDocumentStore.Advanced.AllProjectionProgress(tenantId: null)` and `ProjectionProgressFor(shardName, tenantId: null)` both fell back to `_store.Tenancy.Default.Database`, and `ShardedTenancy.Default` throws:

```
System.NotSupportedException: Default tenant is not supported with sharded multi-tenancy. All operations require a tenant ID.
   at Marten.Storage.ShardedTenancy.get_Default()
```

So the calls threw every time when invoked the way their own XML docs described (omitting the tenant), leaking an internal accessor — inconsistent with `WaitForNonStaleProjectionDataAsync`, which was made sharded-aware in #4366/#4777.

## Fix

Mirror `WaitForNonStaleProjectionDataAsync`'s shape exactly (`AsyncProjectionTestingExtensions.WaitForNonStaleProjectionDataAsync(IDocumentStore, TimeSpan)`):

- **`DefaultTenancy` (single database): unchanged.** Null tenant id keeps reading the default database verbatim — every existing caller binds to the identical code path.
- **Any multi-database tenancy** (sharded, database-per-tenant, master-table, …) with a **null tenant id now fans out across `IMartenStorage.AllDatabases()`**:
  - `AllProjectionProgress()` concatenates each database's progression rows. Under `UseTenantPartitionedEvents` the per-tenant rows carry the tenant id in their `ShardName.Identity` (`{Name}:{ShardKey}:{tenantId}` grammar), so the aggregated result stays attributable per (database/tenant) — the "per-(database/tenant) ShardStates" shape the issue asks for.
  - `ProjectionProgressFor(name)` returns the **highest** progression found for the shard identity across the databases. A tenant-qualified identity only ever exists in the single shard database that owns the tenant, so the result is that tenant's exact progression; databases without the row contribute 0. The issue's literal repro (`ProjectionProgressFor(new ShardName(ShardState.HighWaterMark))`) now returns the highest shard HWM instead of throwing.
  - An empty database list throws a clear `InvalidOperationException` (same contract as `WaitForNonStaleProjectionDataAsync`).
- **The tenant-id overloads keep their documented "database containing this tenant id" routing unchanged.**
- Fixed the XML docs on both store-level methods (they promised a default-database fallback that cannot exist under sharded tenancy) and scrubbed the database-level methods' leftover docs describing a `tenantId` parameter that doesn't exist. Added the multi-database semantics to the async-daemon docs page's Diagnostics section.

## Tests

New `TenantPartitionedEventsTests/Sharded/sharded_progress_reading_4797` (issue-repro configuration: sharded tenancy + conjoined + `UseTenantPartitionedEvents`, two tenants on two different shard databases, async daemon catch-up per shard):

- `AllProjectionProgress()` (null tenant) spans both shard databases in one read, each tenant's row at its own height (3 vs 2 events, no bleed-over). Fails with the issue's exact `NotSupportedException` without the fix (verified red → green).
- `AllProjectionProgress("tenant")` still reads only that tenant's shard.
- `ProjectionProgressFor` with a tenant-qualified composed identity returns that tenant's exact progression across the fan-out; the `HighWaterMark` repro returns the max instead of throwing; an unknown identity returns 0.

Results: full `TenantPartitionedEventsTests` suite 218/218 passed (net9.0); targeted `DaemonTests` progress-reading suites (`projection_progression_operations`, `Internals.basic_functionality`) 16/16 passed.

## Relationship to JasperFx/jasperfx#435

Not required for this fix — everything lands against Marten's own `IMartenDatabase.AllProjectionProgress`/`ProjectionProgressFor`, no package pin changes. If/when jasperfx#435's read-only per-cell query ships, the natural JasperFx surface is the one already sketched there: `ValueTask<ProjectionProgressRow?> IEventDatabase.ReadProjectionProgressAsync(string projectionName, string? tenantId, CancellationToken)` returning `(ProjectionName, TenantId, Sequence, AgentStatus, LastHeartbeat)`. Marten's implementation would be a thin projection of the same `ProjectionProgressStatement` used here (single-row variant with the `name like '%:{tenantId}'` tenant filter), and this PR's fan-out would then also back a store-agnostic cross-database aggregate for CritterWatch. Deliberately not layered in now since #435 is downstream-paused pending CritterWatch 1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)