### PR TITLE
AddGlobalProjection under UseTenantPartitionedEvents: reserved '__default__' partition suffix (closes #4648)

### DIFF
--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -211,7 +211,7 @@ tenant's events _within_ whichever database hosts that tenant.
 Global projections registered with `AddGlobalProjection` (described earlier on this page) route their aggregate's
 events to the default tenant slot (`*DEFAULT*`) so that every tenant's contribution lands in one canonical,
 single-tenanted timeline. That sentinel value contains characters that are not legal in PostgreSQL identifiers, so it
-can never be a partition-table *suffix* — but a LIST partition *value* can be any string. Whenever a store has global
+can never be a partition-table _suffix_ — but a LIST partition _value_ can be any string. Whenever a store has global
 aggregates registered, `AddMartenManagedTenantsAsync` automatically provisions a partition for the `*DEFAULT*` tenant
 value using the reserved suffix `__default__` (`mt_events___default__`, `mt_streams___default__`, its own
 `mt_events_sequence___default__`, and so on) alongside the tenants you register. No extra registration call is

--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -206,6 +206,21 @@ model: sharding distributes tenants across a pool of databases, and per-tenant p
 tenant's events _within_ whichever database hosts that tenant.
 :::
 
+### Global Projections
+
+Global projections registered with `AddGlobalProjection` (described earlier on this page) route their aggregate's
+events to the default tenant slot (`*DEFAULT*`) so that every tenant's contribution lands in one canonical,
+single-tenanted timeline. That sentinel value contains characters that are not legal in PostgreSQL identifiers, so it
+can never be a partition-table *suffix* — but a LIST partition *value* can be any string. Whenever a store has global
+aggregates registered, `AddMartenManagedTenantsAsync` automatically provisions a partition for the `*DEFAULT*` tenant
+value using the reserved suffix `__default__` (`mt_events___default__`, `mt_streams___default__`, its own
+`mt_events_sequence___default__`, and so on) alongside the tenants you register. No extra registration call is
+needed. Two things to be aware of:
+
+* The reserved suffix `__default__` is rejected if you try to claim it for a regular tenant.
+* The `*DEFAULT*` slot appears in the `mt_tenant_partitions` registry — and therefore in tenant listings derived
+  from it — like any other tenant.
+
 ### Dropping Tenants
 
 Both routes that remove a tenant under `UseTenantPartitionedEvents` clean up the full

--- a/src/Marten/AdvancedOperations.cs
+++ b/src/Marten/AdvancedOperations.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using JasperFx;
 using JasperFx.Events;
 using JasperFx.Events.Projections;
 using JasperFx.MultiTenancy;
@@ -441,6 +442,38 @@ public class AdvancedOperations
                 "AddMartenManagedTenantsAsync supports DefaultTenancy and ShardedTenancy. " +
                 "MasterTableTenancy uses caller-supplied connection strings — call " +
                 "IServiceProvider.AddTenantAsync(tenantId, connectionValue) instead.");
+        }
+
+        // #4648: AddGlobalProjection routes its aggregate's events to the *DEFAULT* tenant
+        // slot (GlobalEventAppenderDecorator), and under UseTenantPartitionedEvents every
+        // tenant id that receives events must have a registered partition — otherwise the
+        // append raises MT002. The sentinel '*DEFAULT*' can never be its own partition
+        // SUFFIX (it contains characters that are illegal in PG identifiers), but a LIST
+        // partition VALUE can be any string — only the child table's NAME is
+        // identifier-constrained. So whenever this store has global aggregates registered,
+        // auto-provision the reserved '__default__' suffix for the '*DEFAULT*' partition
+        // value alongside whatever tenants the caller is registering. Idempotent: the
+        // partition upsert and CREATE SEQUENCE IF NOT EXISTS both tolerate re-registration.
+        if (_store.Options.Events.UseTenantPartitionedEvents
+            && _store.Options.EventGraph.GlobalAggregates.Any()
+            && !tenantIdToPartitionMapping.ContainsKey(StorageConstants.DefaultTenantId))
+        {
+            var conflict = tenantIdToPartitionMapping.FirstOrDefault(pair =>
+                pair.Value == MartenManagedTenantListPartitions.DefaultTenantSuffix);
+            if (conflict.Key != null)
+            {
+                throw new ArgumentException(
+                    $"The partition suffix '{MartenManagedTenantListPartitions.DefaultTenantSuffix}' is reserved " +
+                    $"for the default tenant partition backing global projections (AddGlobalProjection) and cannot " +
+                    $"be used for tenant '{conflict.Key}'.",
+                    nameof(tenantIdToPartitionMapping));
+            }
+
+            // Copy rather than mutating the caller's dictionary
+            tenantIdToPartitionMapping = new Dictionary<string, string>(tenantIdToPartitionMapping)
+            {
+                [StorageConstants.DefaultTenantId] = MartenManagedTenantListPartitions.DefaultTenantSuffix
+            };
         }
 
         AssertValidPostgresqlIdentifiers(tenantIdToPartitionMapping.Values);

--- a/src/Marten/Schema/MartenManagedTenantListPartitions.cs
+++ b/src/Marten/Schema/MartenManagedTenantListPartitions.cs
@@ -21,6 +21,19 @@ public class MartenManagedTenantListPartitions : IDocumentPolicy
     private readonly StoreOptions _options;
     public const string TableName = "mt_tenant_partitions";
 
+    /// <summary>
+    /// Reserved partition suffix backing the default-tenant (<c>*DEFAULT*</c>) slot that
+    /// global projections (<c>AddGlobalProjection</c>) write to under
+    /// <c>Events.UseTenantPartitionedEvents</c>. The sentinel tenant id itself contains
+    /// characters that are illegal in PostgreSQL identifiers so it can never be its own
+    /// partition-table suffix — but a LIST partition VALUE can be any string, so the
+    /// default tenant's rows live in partitions named with this fixed, identifier-legal
+    /// suffix instead (<c>mt_events___default__</c> etc.). Auto-provisioned by
+    /// <c>AdvancedOperations.AddMartenManagedTenantsAsync</c> whenever the store has
+    /// global aggregates registered. See https://github.com/JasperFx/marten/issues/4648.
+    /// </summary>
+    public const string DefaultTenantSuffix = "__default__";
+
     public MartenManagedTenantListPartitions(StoreOptions options, string? schemaName)
     {
         _options = options;

--- a/src/TenantPartitionedEventsTests/Projections/add_global_projection_under_partitioning.cs
+++ b/src/TenantPartitionedEventsTests/Projections/add_global_projection_under_partitioning.cs
@@ -82,32 +82,71 @@ public class add_global_projection_under_partitioning : IAsyncLifetime
     }
 
     [Fact]
-    public async Task append_to_global_aggregate_fails_with_MT002_under_partitioning_pin()
+    public async Task append_to_global_aggregate_succeeds_and_rolls_up_across_tenants()
     {
-        // The currently-broken surface: AddGlobalProjection's GlobalEventAppenderDecorator
-        // writes the global aggregate's events to the *DEFAULT* tenant slot
-        // (StorageConstants.DefaultTenantId). Under UseTenantPartitionedEvents,
-        // every tenant must be registered as a Postgres partition suffix —
-        // but `*DEFAULT*` contains characters PG identifiers can't carry, so
-        // it can't be registered. Writing therefore fails with MT002 from the
-        // mt_quick_append_events function.
-        //
-        // Pin this as a known-incompatible combination so a future fix —
-        // either (a) routing global-aggregate events through a non-partitioned
-        // sibling table, or (b) special-casing the default tenant inside the
-        // bulk function — flips the assertion intentionally.
-        await _store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "alpha");
+        // #4648 fix (flips the former MT002 pin): AddGlobalProjection's
+        // GlobalEventAppenderDecorator routes the global aggregate's events to the
+        // *DEFAULT* tenant slot. That sentinel can't be a partition-table SUFFIX
+        // (illegal identifier characters), but a LIST partition VALUE can be any
+        // string — so AddMartenManagedTenantsAsync now auto-provisions a reserved
+        // '__default__' suffix for the '*DEFAULT*' partition value whenever the
+        // store has global aggregates registered. The rerouted appends then land
+        // in a real partition (with their own per-tenant event sequence) instead
+        // of raising MT002.
+        await _store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, "alpha", "beta");
 
         var globalId = Guid.NewGuid();
 
-        await using var session = _store.LightweightSession("alpha");
-        session.Events.StartStream<GlobalCounter>(globalId,
-            new GlobalTickEvent("first"));
+        // Two different tenants funnel events into the SAME global stream
+        await using (var alpha = _store.LightweightSession("alpha"))
+        {
+            alpha.Events.StartStream<GlobalCounter>(globalId,
+                new GlobalTickEvent("first"), new GlobalTickEvent("second"));
+            await alpha.SaveChangesAsync();
+        }
 
-        var ex = await Should.ThrowAsync<Marten.Exceptions.MartenCommandException>(async () =>
-            await session.SaveChangesAsync());
-        ex.Message.ShouldContain("MT002");
-        ex.Message.ShouldContain("*DEFAULT*");
+        await using (var beta = _store.LightweightSession("beta"))
+        {
+            beta.Events.Append(globalId, new GlobalTickEvent("third"));
+            await beta.SaveChangesAsync();
+        }
+
+        // The inline global projection doc is single-tenanted, so it reads the
+        // same from any tenant's session — and reflects BOTH tenants' appends
+        await using (var reader = _store.QuerySession("beta"))
+        {
+            var counter = await reader.LoadAsync<GlobalCounter>(globalId);
+            counter.ShouldNotBeNull();
+            counter.TickCount.ShouldBe(3);
+        }
+
+        // The storage-level shape: the default tenant slot is registered with the
+        // reserved suffix and all three events live in its partition
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        var suffix = (string?)await conn.CreateCommand(
+                $"select partition_suffix from {_schema}.mt_tenant_partitions where partition_value = '{StorageConstants.DefaultTenantId}'")
+            .ExecuteScalarAsync();
+        suffix.ShouldBe("__default__");
+
+        var eventCount = (long)(await conn.CreateCommand(
+                $"select count(*) from {_schema}.mt_events___default__")
+            .ExecuteScalarAsync())!;
+        eventCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task reserved_default_suffix_is_rejected_for_regular_tenants()
+    {
+        // A regular tenant may not claim the '__default__' suffix reserved for the
+        // global-projection default tenant slot — a shared suffix would fold two
+        // partition VALUES into one partition table and corrupt tenant isolation.
+        var ex = await Should.ThrowAsync<ArgumentException>(() =>
+            _store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None,
+                new System.Collections.Generic.Dictionary<string, string> { ["acme"] = "__default__" }));
+
+        ex.Message.ShouldContain("reserved");
     }
 }
 


### PR DESCRIPTION
Closes #4648.

## Design pick: Option B — reserved partition suffix (over Option A's sibling non-partitioned table)

The deciding fact: **only the partition child-table *name* must be a legal PG identifier — a LIST partition *value* can be any string, `*DEFAULT*` included.** So the default-tenant slot never needed a second table; it needed a registry row mapping the `*DEFAULT*` partition value to an identifier-legal suffix.

Why B wins:

- **Every per-tenant mechanism keys off the `mt_tenant_partitions` registry** — the MT002 guard in `mt_quick_append_events`, `BulkEventAppender`'s per-tenant sequence resolution, the vectorized per-tenant high-water detector, `TenantPartitionedSingleDatabaseTenancy.DescribeDatabasesAsync`, and the tenant cleanup paths. One registry row (`*DEFAULT*` → `__default__`) makes all of them work for the global slot with zero special-casing. The quick-append function needed **no change at all**.
- **Option A is a parallel event store.** A sibling `mt_global_events` would need its own sequence, daemon `EventLoader` reading two tables, high-water across both, `FetchForWriting`/`AggregateStreamAsync` querying both, cleanup/rebuild wiring — and every future event-store feature would have to remember the second table. That cost recurs forever; B's cost is one reserved row.
- **Async lifecycle falls out for free under B**: the `*DEFAULT*` slot gets its own `mt_events_sequence___default__` and per-tenant HWM tracking exactly like any tenant, so async global projections ride the existing per-tenant daemon machinery.

The acknowledged con of B — a reserved tenant-shaped row leaking into partition listings — is mitigated by gating: the row is only provisioned when the store actually has global aggregates registered (`AddGlobalProjection` was called), and the reserved suffix is rejected if a regular tenant tries to claim it (a shared suffix would fold two partition values into one table and corrupt tenant isolation).

## What shipped

- `MartenManagedTenantListPartitions.DefaultTenantSuffix` (`__default__`) — the reserved, identifier-legal suffix constant.
- `AdvancedOperations.AddMartenManagedTenantsAsync` (DefaultTenancy path): when `Events.UseTenantPartitionedEvents` is on **and** the store has `GlobalAggregates`, auto-injects the `*DEFAULT*` → `__default__` mapping alongside the caller's tenants — creating the LIST partitions on all managed tables plus the per-tenant event sequence. Idempotent (partition upsert + `CREATE SEQUENCE IF NOT EXISTS`); the caller's dictionary is copied, not mutated. Throws a clear `ArgumentException` if a regular tenant claims the reserved suffix.
- Flipped the #4638 pin: `append_to_global_aggregate_fails_with_MT002_under_partitioning_pin` → `append_to_global_aggregate_succeeds_and_rolls_up_across_tenants`, asserting two tenants funneling into one global stream, the single-tenanted inline aggregate readable from any tenant session (TickCount == 3), the registry row, and all 3 events physically in `mt_events___default__`. Added `reserved_default_suffix_is_rejected_for_regular_tenants`.
- Docs: new "Global Projections" subsection under Per-Tenant Event Partitioning in `docs/events/multitenancy.md`.

## Scope notes

- **ShardedTenancy × global projections** stays out of scope: the sharded provisioning path is strictly 1:1 tenant↔suffix and a global aggregate under sharding poses a routing question (which shard owns the `*DEFAULT*` timeline?) that this issue doesn't answer. Unchanged behavior there.
- **No JasperFx.Events changes needed** — the fix is entirely Marten-side registry provisioning; `GlobalEventAppenderDecorator`'s rerouting behavior is untouched.
- Failing-first: reproduced the MT002 pin green on master before the fix, then flipped it.

## Test results

- `TenantPartitionedEventsTests` (net9.0): **218/218 passed** (full suite, includes the flipped + new tests)
- `EventSourcingTests` global-projection classes (`global_tenanted_streams_within_conjoined_tenancy`, `Bug_4270_*`, net9.0): **36/36 passed** — non-partitioned global projections unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNfeNz73Q3EdiTgSeDbo96