### PR TITLE
Conjoined → UseTenantPartitionedEvents migration: sequence-preserving bulk import + ConjoinedToPartitionedMigration (#4682, #4879)

### DIFF
--- a/docs/events/bulk-appending.md
+++ b/docs/events/bulk-appending.md
@@ -230,6 +230,38 @@ importing. Schema application from inside a bulk-import loop costs DDL proportio
 registered tenants for every fresh database it touches, which does not scale to migrations of hundreds of
 tenants.
 
+### Preserving Source Sequence Numbers
+
+By default the streaming import assigns **new** `seq_id`s (drawn from the target's sequence, in arrival
+order). When migrating between stores in the *same system* — most importantly the
+[conjoined → per-tenant-partitioned migration](/events/multitenancy#migrating-an-existing-conjoined-store) —
+renumbering history is exactly wrong: progression rows, downstream warehouses, audit logs, and any external
+consumer that captured a sequence position would all be invalidated. For that case pass
+`BulkEventSequenceMode.PreserveSourceSequence`:
+
+```cs
+await store.BulkInsertEventStreamAsync(
+    tenantId,
+    headers,
+    ReadSourceEventsInSequenceOrderAsync(), // MUST be strictly ascending by the carried Sequence
+    BulkEventSequenceMode.PreserveSourceSequence,
+    batchSize: 1000);
+```
+
+In this mode every event keeps the `Sequence` it carries — per-tenant gaps are fine and expected, since a
+conjoined source interleaves all tenants on one global sequence — and after the copy Marten:
+
+- **Advances the target sequence past the imported maximum** with `setval` (the tenant's own
+  `mt_events_sequence_{suffix}` under per-tenant partitioning, otherwise the store-global sequence), so the
+  first live append can never re-issue an imported `seq_id`.
+- **Seeds the tenant's `HighWaterMark:{tenantId}` progression row** at the imported maximum under
+  per-tenant event partitioning. This matters: gaps *below* a persisted high-water mark are never
+  revisited, so the daemon starts cleanly above the (gappy) imported history instead of gap-walking
+  through it.
+
+Events must arrive in strictly ascending `Sequence` order; anything else (including unnumbered events,
+which arrive as `0`) is rejected before commit.
+
 ## Limitations
 
 The bulk append API intentionally trades off features for throughput:

--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -230,3 +230,54 @@ untouched.
 The cleanup identifies per-tenant `mt_event_progression` rows by parsing the
 `ShardName` grammar rather than pattern-matching the name, so a projection whose name
 happens to end with a tenant id is never mistakenly deleted (#4683).
+
+### Migrating an Existing Conjoined Store
+
+::: warning
+The migration is **offline-first**: take source writes offline for the migration window. During the
+migration both the source and target event tables exist side by side, so plan for roughly 2x the current
+event-store disk usage — and take a backup first.
+:::
+
+There is one canonical path for moving an existing conjoined event store onto per-tenant partitioning:
+`ConjoinedToPartitionedMigration`, driven per tenant by the
+[sequence-preserving streaming bulk import](/events/bulk-appending#preserving-source-sequence-numbers).
+Point it at the existing store (the source) and a store configured with `UseTenantPartitionedEvents = true`
+in a **different schema or database** (the target — the source tables are never touched, so rolling back is
+simply "keep using the source"):
+
+```cs
+var migration = new ConjoinedToPartitionedMigration(sourceStore, targetStore)
+{
+    // Optional: rows per COPY batch (default 1000)
+    BatchSize = 5000,
+
+    // Optional: migrate only a subset of tenants (default: every tenant found in the source)
+    TenantIds = new[] { "tenant-a", "tenant-b" }
+};
+
+// Phase 1 — the dry run: per-tenant inventory (event count, stream count, max seq_id)
+// plus which tenants a resumed run would skip. Moves no data.
+var plan = await migration.BuildPlanAsync(cancellationToken);
+
+// Phase 2 — per-tenant copy: registers each tenant's partitions on the target, streams its
+// events across with their original seq_ids preserved, verifies row counts, and records
+// completion in the target's mt_tenant_migration_log table.
+var result = await migration.ExecuteAsync(cancellationToken);
+```
+
+The migration's **data policy is to never renumber historical events**. Every event keeps its original
+`seq_id` — per-tenant gaps are expected, because the conjoined source interleaved all tenants on one global
+sequence — so anything that captured a sequence position (progression rows, downstream warehouses, audit
+logs, external integrations) stays valid. Instead, for each tenant the migration:
+
+* advances the tenant's own `mt_events_sequence_{suffix}` past its imported maximum, so the first live
+  append after cut-over works on the first try (no primary-key or sequence collisions);
+* seeds the tenant's `HighWaterMark:{tenantId}` progression row at that maximum, so high-water detection
+  starts above the gappy imported history;
+* carries the `is_archived` flag across for both streams and events.
+
+Tenants are migrated **one at a time, each in a single transaction**. A failure rolls the in-flight tenant
+back cleanly; re-running `ExecuteAsync` skips tenants already recorded as completed in
+`mt_tenant_migration_log` and retries the failed one. Inline projection documents are *not* migrated —
+rebuild projections on the target after the copy (they replay from the migrated events).

--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -279,5 +279,5 @@ logs, external integrations) stays valid. Instead, for each tenant the migration
 
 Tenants are migrated **one at a time, each in a single transaction**. A failure rolls the in-flight tenant
 back cleanly; re-running `ExecuteAsync` skips tenants already recorded as completed in
-`mt_tenant_migration_log` and retries the failed one. Inline projection documents are *not* migrated —
+`mt_tenant_migration_log` and retries the failed one. Inline projection documents are _not_ migrated —
 rebuild projections on the target after the copy (they replay from the migrated events).

--- a/src/EventSourcingTests/BulkEventStreamAppendTests.cs
+++ b/src/EventSourcingTests/BulkEventStreamAppendTests.cs
@@ -216,4 +216,95 @@ public class BulkEventStreamAppendTests : OneOffConfigurationsContext
         (await VersionsForStreamAsync(store, "A")).ShouldBe(new long[] { 1, 2 });
         (await VersionsForStreamAsync(store, "B")).ShouldBe(new long[] { 1, 2 });
     }
+
+    // Stored seq_ids in order — for the sequence-preserving import the values themselves matter, not
+    // just their relative order.
+    private static async Task<List<long>> SeqIdsAsync(DocumentStore store)
+    {
+        var seqs = new List<long>();
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            $"select seq_id from {store.Options.Events.DatabaseSchemaName}.mt_events order by seq_id", conn);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            seqs.Add(reader.GetInt64(0));
+        }
+
+        return seqs;
+    }
+
+    [Fact]
+    public async Task streaming_import_can_preserve_the_source_seq_ids_and_advance_the_sequence()
+    {
+        // marten#4879/#4682: migration mode. The imported events keep the exact (gappy) seq_ids they carry
+        // — history is never renumbered — and mt_events_sequence is setval'd past the imported maximum so
+        // the first live append cannot re-issue an imported seq_id.
+        var store = await ProvisionedStringIdentityStoreAsync();
+
+        var ordered = new[]
+        {
+            EventFor("A", 1, new Started("A1")),
+            EventFor("B", 1, new Started("B1")),
+            EventFor("A", 2, new Ended("A2"))
+        };
+        ordered[0].Sequence = 5;
+        ordered[1].Sequence = 11;
+        ordered[2].Sequence = 30;
+
+        var headers = new List<BulkEventStreamHeader>
+        {
+            new() { Key = "A", Version = 2 },
+            new() { Key = "B", Version = 1 }
+        };
+
+        await store.BulkInsertEventStreamAsync(StorageConstants.DefaultTenantId, headers, Stream(ordered),
+            BulkEventSequenceMode.PreserveSourceSequence, batchSize: 2, cancellation: CancellationToken.None);
+
+        (await SeqIdsAsync(store)).ShouldBe(new long[] { 5, 11, 30 });
+
+        // A live append continues ABOVE the imported history on the first try.
+        await using (var session = store.LightweightSession())
+        {
+            session.Events.Append("A", new Ended("A3"));
+            await session.SaveChangesAsync();
+        }
+
+        var after = await SeqIdsAsync(store);
+        after.Count.ShouldBe(4);
+        after[^1].ShouldBeGreaterThan(30);
+
+        // The store-global high water mark is seeded at the imported maximum or above.
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            $"select last_seq_id from {store.Options.Events.DatabaseSchemaName}.mt_event_progression where name = 'HighWaterMark'",
+            conn);
+        ((long)(await cmd.ExecuteScalarAsync())!).ShouldBeGreaterThanOrEqualTo(30);
+    }
+
+    [Fact]
+    public async Task streaming_import_rejects_non_ascending_sequences_in_preserve_mode()
+    {
+        var store = await ProvisionedStringIdentityStoreAsync();
+
+        var ordered = new[]
+        {
+            EventFor("A", 1, new Started("A1")),
+            EventFor("A", 2, new Ended("A2"))
+        };
+        ordered[0].Sequence = 8;
+        ordered[1].Sequence = 8; // not strictly ascending
+
+        var headers = new List<BulkEventStreamHeader> { new() { Key = "A", Version = 2 } };
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            store.BulkInsertEventStreamAsync(StorageConstants.DefaultTenantId, headers, Stream(ordered),
+                BulkEventSequenceMode.PreserveSourceSequence, cancellation: CancellationToken.None));
+        ex.Message.ShouldContain("strictly ascending");
+
+        // Single transaction: nothing committed.
+        (await SeqIdsAsync(store)).ShouldBeEmpty();
+    }
 }

--- a/src/Marten/DocumentStore.cs
+++ b/src/Marten/DocumentStore.cs
@@ -258,9 +258,24 @@ public partial class DocumentStore: IDocumentStore, IDescribeMyself
     /// preserved. Per-stream versions are taken from the events. <paramref name="streamHeaders"/> seed
     /// <c>mt_streams</c> (written first, for the foreign key). Runs as one transaction per tenant.
     /// </summary>
-    public async Task BulkInsertEventStreamAsync(string tenantId,
+    public Task BulkInsertEventStreamAsync(string tenantId,
         IReadOnlyList<BulkEventStreamHeader> streamHeaders, IAsyncEnumerable<IEvent> orderedEvents,
         int batchSize = 1000, CancellationToken cancellation = default)
+    {
+        return BulkInsertEventStreamAsync(tenantId, streamHeaders, orderedEvents,
+            BulkEventSequenceMode.AssignFromSequence, batchSize, cancellation);
+    }
+
+    /// <summary>
+    /// Streaming, order-preserving bulk import with explicit <c>seq_id</c> assignment control.
+    /// <see cref="BulkEventSequenceMode.PreserveSourceSequence"/> keeps each event's carried
+    /// <c>Sequence</c> — the migration data policy is to never renumber history (marten#4682) —
+    /// then advances the target sequence past the imported maximum and, under per-tenant event
+    /// partitioning, seeds the tenant's <c>HighWaterMark:{tenant}</c> progression row.
+    /// </summary>
+    public async Task BulkInsertEventStreamAsync(string tenantId,
+        IReadOnlyList<BulkEventStreamHeader> streamHeaders, IAsyncEnumerable<IEvent> orderedEvents,
+        BulkEventSequenceMode sequenceMode, int batchSize = 1000, CancellationToken cancellation = default)
     {
         var tenant = await Tenancy.GetTenantAsync(Options.TenantIdStyle.MaybeCorrectTenantId(tenantId))
             .ConfigureAwait(false);
@@ -280,7 +295,8 @@ public partial class DocumentStore: IDocumentStore, IDescribeMyself
         try
         {
             await appender
-                .BulkInsertEventStreamAsync(conn, tenantId, streamHeaders, orderedEvents, batchSize, cancellation)
+                .BulkInsertEventStreamAsync(conn, tenantId, streamHeaders, orderedEvents, sequenceMode,
+                    batchSize, cancellation)
                 .ConfigureAwait(false);
             await tx.CommitAsync(cancellation).ConfigureAwait(false);
         }

--- a/src/Marten/Events/BulkEventAppender.cs
+++ b/src/Marten/Events/BulkEventAppender.cs
@@ -85,12 +85,16 @@ internal class BulkEventAppender
     /// lazily in batches (bounded memory), assigning each event the next ascending sequence in arrival order
     /// (so cross-stream ordering is preserved) and taking per-stream versions from the events themselves.
     /// <paramref name="streamHeaders" /> seed mt_streams first so the mt_events foreign key holds.
+    /// Under <see cref="BulkEventSequenceMode.PreserveSourceSequence"/> the events keep the Sequence they
+    /// already carry (a migration never renumbers history — see marten#4682's data policy) and the target
+    /// sequence is advanced past the imported maximum via setval instead of being drawn from.
     /// </summary>
     public async Task BulkInsertEventStreamAsync(
         NpgsqlConnection conn,
         string tenantId,
         IReadOnlyList<BulkEventStreamHeader> streamHeaders,
         IAsyncEnumerable<IEvent> orderedEvents,
+        BulkEventSequenceMode sequenceMode,
         int batchSize,
         CancellationToken cancellation)
     {
@@ -115,7 +119,10 @@ internal class BulkEventAppender
         // block boundary is the ONLY place the nextval SELECT runs. That matters: a regular command cannot run
         // on a connection that is mid-COPY (Npgsql throws "connection is already in state 'Copy'"), so the
         // writer is always CLOSED before refillSequences and reopened afterwards. Same single connection, so
-        // no extra connection is taken from a tightly pooled shard database.
+        // no extra connection is taken from a tightly pooled shard database. In PreserveSourceSequence mode
+        // there are no mid-stream sequence SELECTs at all — one COPY spans the whole import and the target
+        // sequence is advanced once at the end.
+        var preserveSequences = sequenceMode == BulkEventSequenceMode.PreserveSourceSequence;
         var sequences = new Queue<long>(batchSize);
         long maxSequence = 0;
         var count = 0;
@@ -125,22 +132,43 @@ internal class BulkEventAppender
         {
             await foreach (var e in orderedEvents.WithCancellation(cancellation).ConfigureAwait(false))
             {
-                if (sequences.Count == 0)
+                long seq;
+                if (preserveSequences)
                 {
-                    // Close the open COPY before the sequence SELECT, then start a fresh one for the next block.
-                    if (writer != null)
+                    // Migration mode: the event keeps the seq_id it already carries. Strictly ascending
+                    // arrival order is REQUIRED — it both guarantees the preserved cross-stream ordering
+                    // and catches a caller feeding unsorted (or unnumbered) source events, which would
+                    // otherwise silently corrupt the tenant's replay order. maxSequence starts at 0, so
+                    // the first event's Sequence must be positive.
+                    seq = e.Sequence;
+                    if (seq <= maxSequence)
                     {
-                        await writer.CompleteAsync(cancellation).ConfigureAwait(false);
-                        await writer.DisposeAsync().ConfigureAwait(false);
-                        writer = null;
+                        throw new InvalidOperationException(
+                            $"{nameof(BulkEventSequenceMode.PreserveSourceSequence)} requires the incoming events " +
+                            $"to carry strictly ascending, positive Sequence values, but got {seq} after {maxSequence}. " +
+                            "Supply the source events ordered by their original seq_id.");
+                    }
+                }
+                else
+                {
+                    if (sequences.Count == 0)
+                    {
+                        // Close the open COPY before the sequence SELECT, then start a fresh one for the next block.
+                        if (writer != null)
+                        {
+                            await writer.CompleteAsync(cancellation).ConfigureAwait(false);
+                            await writer.DisposeAsync().ConfigureAwait(false);
+                            writer = null;
+                        }
+
+                        await refillSequences(conn, sequenceName, sequences, batchSize, cancellation).ConfigureAwait(false);
                     }
 
-                    await refillSequences(conn, sequenceName, sequences, batchSize, cancellation).ConfigureAwait(false);
+                    seq = sequences.Dequeue();
                 }
 
                 writer ??= await conn.BeginBinaryImportAsync(copySql, cancellation).ConfigureAwait(false);
 
-                var seq = sequences.Dequeue();
                 e.Sequence = seq;
                 if (seq > maxSequence)
                 {
@@ -185,12 +213,33 @@ internal class BulkEventAppender
             return;
         }
 
-        // High water: under per-tenant event partitioning, deliberately write NOTHING — since #4847 the
-        // per-tenant high-water detection derives each tenant's mark from max(seq_id) of its own events,
-        // and advancing the store-global row with a tenant-local seq would misrepresent one tenant's
-        // height as the whole store's. Non-partitioned stores keep the store-global upsert, mirroring
-        // the batch overload.
-        if (!_events.UseTenantPartitionedEvents)
+        if (preserveSequences)
+        {
+            // The imported seq_ids were NOT drawn from the sequence, so advance it past the imported
+            // maximum — otherwise the tenant's first live append re-issues an already-used seq_id
+            // (PK collision on its events partition). GREATEST keeps an already-further-along sequence
+            // untouched.
+            await advanceSequencePastAsync(conn, sequenceName, maxSequence, cancellation).ConfigureAwait(false);
+        }
+
+        // High water: under per-tenant event partitioning, AssignFromSequence deliberately writes NOTHING —
+        // since #4847 the per-tenant high-water detection derives each tenant's mark from max(seq_id) of its
+        // own events, and advancing the store-global row with a tenant-local seq would misrepresent one
+        // tenant's height as the whole store's. PreserveSourceSequence DOES seed the tenant's own
+        // HighWaterMark:{tenant} progression row (marten#4682 Phase 2 step 8): a migrated tenant's seq_ids
+        // are extremely gappy (the conjoined source interleaved tenants on one global sequence), and without
+        // a persisted mark above that history the detector's gap-walk (#4867) has to grind through every
+        // hole before the tenant's projections can start. Gaps BELOW a persisted mark are never revisited.
+        // Non-partitioned stores keep the store-global upsert in both modes, mirroring the batch overload.
+        if (_events.UseTenantPartitionedEvents)
+        {
+            if (preserveSequences)
+            {
+                await upsertPerTenantHighWaterMark(conn, schema, tenantId, maxSequence, cancellation)
+                    .ConfigureAwait(false);
+            }
+        }
+        else
         {
             await upsertStoreGlobalHighWaterMark(conn, schema, maxSequence, cancellation).ConfigureAwait(false);
         }
@@ -263,7 +312,7 @@ internal class BulkEventAppender
                 }
 
                 await writer.WriteAsync(header.Version, NpgsqlDbType.Bigint, cancellation).ConfigureAwait(false);
-                await writer.WriteAsync(false, NpgsqlDbType.Boolean, cancellation).ConfigureAwait(false);
+                await writer.WriteAsync(header.IsArchived, NpgsqlDbType.Boolean, cancellation).ConfigureAwait(false);
 
                 batch++;
             }
@@ -740,6 +789,43 @@ ON CONFLICT (name) DO UPDATE SET last_seq_id = GREATEST({schema}.mt_event_progre
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
         cmd.Parameters.AddWithValue("seq", maxSequence);
+        await cmd.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
+    }
+
+    // PreserveSourceSequence only: push the (tenant or store-global) sequence past the imported maximum
+    // so live appends continue above the preserved history. setval(..., true) makes the NEXT nextval
+    // return seq + 1; GREATEST leaves a sequence that is already further along untouched.
+    private static async Task advanceSequencePastAsync(
+        NpgsqlConnection conn,
+        string sequenceName,
+        long seq,
+        CancellationToken cancellation)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            $"select setval('{sequenceName}', greatest((select last_value from {sequenceName}), @seq), true)";
+        cmd.Parameters.AddWithValue("seq", seq);
+        await cmd.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
+    }
+
+    // PreserveSourceSequence + per-tenant partitioning: seed the tenant's own high-water progression row.
+    // #4681: the identity is produced by HighWaterShardIdentity, never hand-rolled SQL concatenation.
+    private static async Task upsertPerTenantHighWaterMark(
+        NpgsqlConnection conn,
+        string schema,
+        string tenantId,
+        long seq,
+        CancellationToken cancellation)
+    {
+        var sql = $@"
+INSERT INTO {schema}.mt_event_progression (name, last_seq_id)
+VALUES (@name, @seq)
+ON CONFLICT (name) DO UPDATE SET last_seq_id = GREATEST({schema}.mt_event_progression.last_seq_id, @seq)";
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.Parameters.AddWithValue("name", HighWaterShardIdentity.PerTenant(tenantId));
+        cmd.Parameters.AddWithValue("seq", seq);
         await cmd.ExecuteNonQueryAsync(cancellation).ConfigureAwait(false);
     }
 

--- a/src/Marten/Events/BulkEventSequenceMode.cs
+++ b/src/Marten/Events/BulkEventSequenceMode.cs
@@ -1,0 +1,30 @@
+namespace Marten.Events;
+
+/// <summary>
+/// Governs how the streaming bulk event import (<see cref="Marten.IDocumentStore.BulkInsertEventStreamAsync"/>)
+/// assigns <c>seq_id</c> values to the imported events.
+/// </summary>
+public enum BulkEventSequenceMode
+{
+    /// <summary>
+    /// Default. Each imported event is assigned the next fresh value from the store's event sequence —
+    /// the tenant's own <c>mt_events_sequence_{suffix}</c> under per-tenant event partitioning, otherwise
+    /// the store-global <c>mt_events_sequence</c>. Cross-stream arrival order is preserved in the
+    /// assigned values, but the numbers themselves are new. Use for seeding fresh data or importing
+    /// from a source whose sequence numbers carry no meaning in the target.
+    /// </summary>
+    AssignFromSequence,
+
+    /// <summary>
+    /// Migration mode. Each imported event keeps the <c>Sequence</c> it already carries — historical
+    /// events are never renumbered, so progression rows, downstream warehouses, audit logs, and any
+    /// external consumer that captured a sequence position stay valid. The supplied events must arrive
+    /// in strictly ascending <c>Sequence</c> order (per-tenant gaps are fine and expected — a conjoined
+    /// source interleaves tenants on one global sequence). After the copy the target sequence is advanced
+    /// past the imported maximum via <c>setval</c> so the first live append can never re-issue an
+    /// imported <c>seq_id</c>, and under per-tenant event partitioning the tenant's
+    /// <c>HighWaterMark:{tenantId}</c> progression row is seeded at that maximum so high-water detection
+    /// starts from a persisted mark above the (gappy) imported history.
+    /// </summary>
+    PreserveSourceSequence
+}

--- a/src/Marten/Events/BulkEventStreamHeader.cs
+++ b/src/Marten/Events/BulkEventStreamHeader.cs
@@ -24,4 +24,10 @@ public sealed class BulkEventStreamHeader
 
     /// <summary>Optional pre-resolved aggregate alias; takes precedence over <see cref="AggregateType"/>.</summary>
     public string? AggregateTypeName { get; init; }
+
+    /// <summary>
+    /// Whether the stream is archived. A migration read should carry the source's
+    /// <c>mt_streams.is_archived</c> flag through so archived streams stay archived in the target.
+    /// </summary>
+    public bool IsArchived { get; init; }
 }

--- a/src/Marten/Events/TenantPartitioning/ConjoinedToPartitionedMigration.cs
+++ b/src/Marten/Events/TenantPartitioning/ConjoinedToPartitionedMigration.cs
@@ -1,0 +1,420 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Core.Reflection;
+using JasperFx.Events;
+using Marten.Events.Archiving;
+using Marten.Events.Daemon.HighWater;
+using Marten.Storage;
+using Npgsql;
+
+namespace Marten.Events.TenantPartitioning;
+
+/// <summary>
+/// The canonical migration from a conjoined event store to one using
+/// <c>Events.UseTenantPartitionedEvents</c> (marten#4682). Copies the source store's events tenant by
+/// tenant into the target's per-tenant partitions using the streaming bulk import
+/// (<see cref="IDocumentStore.BulkInsertEventStreamAsync(string,System.Collections.Generic.IReadOnlyList{BulkEventStreamHeader},System.Collections.Generic.IAsyncEnumerable{JasperFx.Events.IEvent},BulkEventSequenceMode,int,System.Threading.CancellationToken)"/>
+/// in <see cref="BulkEventSequenceMode.PreserveSourceSequence"/> mode, marten#4879) as the engine.
+///
+/// <para><b>Data policy (marten#4682):</b> historical events are never renumbered. Every event keeps its
+/// original <c>seq_id</c> — per-tenant gaps are expected, since the conjoined source interleaved all
+/// tenants on one global sequence — so progression rows, downstream warehouses, audit logs, and any
+/// external consumer that captured a sequence position stay valid. Each tenant's own
+/// <c>mt_events_sequence_{suffix}</c> is advanced past its imported maximum, so the first live append
+/// after migration can never collide, and each tenant's <c>HighWaterMark:{tenant}</c> progression row is
+/// seeded at that maximum.</para>
+///
+/// <para><b>Operational shape:</b> offline-first — take source writes offline for the migration window.
+/// The target is a separate schema (or database), so the source tables are never touched and rollback is
+/// simply "keep using the source". Tenants are migrated one at a time, each in a single transaction, and
+/// completions are recorded in the target's <c>mt_tenant_migration_log</c> table so a failed or
+/// interrupted run resumes where it left off (completed tenants are skipped, the in-flight tenant — whose
+/// transaction rolled back — is retried).</para>
+///
+/// <para>Version 1 supports single-database source and target stores (plain or
+/// tenant-partitioned <see cref="DefaultTenancy"/>). For sharded targets, register tenants via the
+/// sharded provisioning APIs and drive <c>BulkInsertEventStreamAsync</c> per tenant directly.</para>
+/// </summary>
+public class ConjoinedToPartitionedMigration
+{
+    /// <summary>Name of the migration-state table written to the target's event schema.</summary>
+    public const string LogTableName = "mt_tenant_migration_log";
+
+    private readonly DocumentStore _source;
+    private readonly DocumentStore _target;
+
+    public ConjoinedToPartitionedMigration(IDocumentStore source, IDocumentStore target)
+    {
+        _source = source.As<DocumentStore>();
+        _target = target.As<DocumentStore>();
+
+        validateStoreConfiguration();
+    }
+
+    /// <summary>Rows per COPY batch for the per-tenant event copy. Default 1000.</summary>
+    public int BatchSize { get; set; } = 1000;
+
+    /// <summary>
+    /// Optional subset of tenant ids to migrate. Default (null) migrates every tenant found in the
+    /// source's <c>mt_events</c> / <c>mt_streams</c>.
+    /// </summary>
+    public IReadOnlyList<string>? TenantIds { get; set; }
+
+    /// <summary>
+    /// Phase 1 — inventory + plan (the dry-run). Reads the source's per-tenant event/stream counts and max
+    /// <c>seq_id</c>s plus the target's migration log, but moves no data.
+    /// </summary>
+    public async Task<TenantMigrationPlan> BuildPlanAsync(CancellationToken token = default)
+    {
+        var sourceSchema = _source.Options.Events.DatabaseSchemaName;
+        var inventory = new Dictionary<string, (long Events, long Streams, long MaxSeq)>();
+
+        await using (var conn = _source.Tenancy.Default.Database.CreateConnection())
+        {
+            await conn.OpenAsync(token).ConfigureAwait(false);
+
+            await using (var cmd = new NpgsqlCommand(
+                             $"select tenant_id, count(*), max(seq_id) from {sourceSchema}.mt_events group by tenant_id",
+                             conn))
+            await using (var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+            {
+                while (await reader.ReadAsync(token).ConfigureAwait(false))
+                {
+                    inventory[reader.GetString(0)] = (reader.GetInt64(1), 0, reader.GetInt64(2));
+                }
+            }
+
+            await using (var cmd = new NpgsqlCommand(
+                             $"select tenant_id, count(*) from {sourceSchema}.mt_streams group by tenant_id",
+                             conn))
+            await using (var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false))
+            {
+                while (await reader.ReadAsync(token).ConfigureAwait(false))
+                {
+                    var tenantId = reader.GetString(0);
+                    var streams = reader.GetInt64(1);
+                    inventory[tenantId] = inventory.TryGetValue(tenantId, out var existing)
+                        ? (existing.Events, streams, existing.MaxSeq)
+                        : (0, streams, 0);
+                }
+            }
+        }
+
+        var completed = await readCompletedTenantsAsync(token).ConfigureAwait(false);
+
+        var tenantFilter = TenantIds?.ToHashSet();
+        var items = inventory
+            .Where(pair => tenantFilter == null || tenantFilter.Contains(pair.Key))
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .Select(pair => new TenantMigrationPlanItem(pair.Key, pair.Value.Events, pair.Value.Streams,
+                pair.Value.MaxSeq, completed.Contains(pair.Key)))
+            .ToList();
+
+        return new TenantMigrationPlan(items);
+    }
+
+    /// <summary>
+    /// Phase 2 — per-tenant copy. Migrates every pending tenant in the plan, one at a time, each in a
+    /// single transaction, recording completions in <c>mt_tenant_migration_log</c> (so re-running after a
+    /// failure resumes: completed tenants are skipped, the failed tenant is retried). Finishes by advancing
+    /// the target's store-global <c>HighWaterMark</c> progression row to the migrated maximum for
+    /// backward compatibility with legacy single-high-water readers.
+    /// </summary>
+    public async Task<TenantMigrationResult> ExecuteAsync(CancellationToken token = default)
+    {
+        await assertTargetIsNotTheSourceAsync(token).ConfigureAwait(false);
+        await ensureLogTableAsync(token).ConfigureAwait(false);
+
+        var plan = await BuildPlanAsync(token).ConfigureAwait(false);
+        var result = new TenantMigrationResult();
+
+        foreach (var item in plan.Tenants)
+        {
+            if (item.AlreadyCompleted)
+            {
+                result.SkippedTenants.Add(item.TenantId);
+                continue;
+            }
+
+            if (item.TenantId == StorageConstants.DefaultTenantId)
+            {
+                throw new InvalidOperationException(
+                    $"The source store carries rows under the default tenant id '{StorageConstants.DefaultTenantId}', " +
+                    "which cannot own a tenant partition. Re-home those rows to a real tenant id (or exclude them " +
+                    $"deliberately via {nameof(TenantIds)}) before migrating.");
+            }
+
+            await migrateTenantAsync(item, token).ConfigureAwait(false);
+
+            result.MigratedTenants.Add(item.TenantId);
+            result.EventsCopied += item.EventCount;
+        }
+
+        // Phase 3 (marten#4682): keep the store-global HighWaterMark row moving for anything that still
+        // reads the legacy single high water. Under per-tenant partitioning the detector itself works off
+        // the per-tenant rows / max(seq_id), so this is purely backward compatibility.
+        if (result.MigratedTenants.Count > 0)
+        {
+            var globalMax = plan.Tenants
+                .Where(x => result.MigratedTenants.Contains(x.TenantId))
+                .Max(x => x.MaxSequence);
+            await upsertStoreGlobalHighWaterAsync(globalMax, token).ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    private async Task migrateTenantAsync(TenantMigrationPlanItem item, CancellationToken token)
+    {
+        // Log first (completed = null): a crash mid-tenant leaves a visible in-flight row, and the
+        // re-run's plan still treats the tenant as pending because only completed rows are skipped.
+        await markTenantStartedAsync(item, token).ConfigureAwait(false);
+
+        // Idempotent: provisions the tenant's partitions + its own mt_events_sequence_{suffix} on the target.
+        await _target.Advanced.AddMartenManagedTenantsAsync(token, item.TenantId).ConfigureAwait(false);
+
+        var headers = await readStreamHeadersAsync(item.TenantId, token).ConfigureAwait(false);
+
+        // The engine (marten#4879): stream the tenant's events out of the source in their original global
+        // order and copy them into the target's tenant partition with their seq_ids preserved. Reading
+        // through QueryAllRawEvents applies the source store's upcasters/serialization exactly like any
+        // other read, and MaybeArchived() keeps archived events in the copy. One transaction per tenant —
+        // a failure rolls the whole tenant back for a clean retry.
+        await using (var session = _source.QuerySession(item.TenantId))
+        {
+            var orderedEvents = session.Events.QueryAllRawEvents()
+                .Where(x => x.MaybeArchived())
+                .OrderBy(x => x.Sequence)
+                .ToAsyncEnumerable(token);
+
+            await _target.BulkInsertEventStreamAsync(item.TenantId, headers, orderedEvents,
+                BulkEventSequenceMode.PreserveSourceSequence, BatchSize, token).ConfigureAwait(false);
+        }
+
+        await verifyTenantCopyAsync(item, token).ConfigureAwait(false);
+        await markTenantCompletedAsync(item.TenantId, token).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<BulkEventStreamHeader>> readStreamHeadersAsync(
+        string tenantId, CancellationToken token)
+    {
+        var sourceSchema = _source.Options.Events.DatabaseSchemaName;
+        var asGuid = _source.Options.Events.StreamIdentity == StreamIdentity.AsGuid;
+        var headers = new List<BulkEventStreamHeader>();
+
+        await using var conn = _source.Tenancy.Default.Database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        await using var cmd = new NpgsqlCommand(
+            $"select id, type, version, is_archived from {sourceSchema}.mt_streams where tenant_id = @tenant",
+            conn);
+        cmd.Parameters.AddWithValue("tenant", tenantId);
+
+        await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            headers.Add(new BulkEventStreamHeader
+            {
+                Id = asGuid ? reader.GetGuid(0) : default,
+                Key = asGuid ? null : reader.GetString(0),
+                AggregateTypeName = await reader.IsDBNullAsync(1, token).ConfigureAwait(false)
+                    ? null
+                    : reader.GetString(1),
+                Version = await reader.IsDBNullAsync(2, token).ConfigureAwait(false) ? 0 : reader.GetInt64(2),
+                IsArchived = !await reader.IsDBNullAsync(3, token).ConfigureAwait(false) && reader.GetBoolean(3)
+            });
+        }
+
+        return headers;
+    }
+
+    private async Task verifyTenantCopyAsync(TenantMigrationPlanItem item, CancellationToken token)
+    {
+        var targetSchema = _target.Options.Events.DatabaseSchemaName;
+
+        await using var conn = _target.Tenancy.Default.Database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        await using var cmd = new NpgsqlCommand(
+            $"select count(*) from {targetSchema}.mt_events where tenant_id = @tenant", conn);
+        cmd.Parameters.AddWithValue("tenant", item.TenantId);
+
+        var copied = (long)(await cmd.ExecuteScalarAsync(token).ConfigureAwait(false))!;
+        if (copied != item.EventCount)
+        {
+            throw new InvalidOperationException(
+                $"Tenant '{item.TenantId}' verification failed: the target holds {copied} events but the " +
+                $"Phase 1 inventory counted {item.EventCount}. Was the source written to during the migration " +
+                "window? The tenant is NOT marked completed; re-running the migration will retry it.");
+        }
+    }
+
+    private void validateStoreConfiguration()
+    {
+        if (_source.Options.Events.TenancyStyle != TenancyStyle.Conjoined)
+        {
+            throw new InvalidOperationException(
+                "The source store must use TenancyStyle.Conjoined for its events — that is the starting " +
+                "state this migration moves away from.");
+        }
+
+        if (_source.Options.Events.UseTenantPartitionedEvents)
+        {
+            throw new InvalidOperationException(
+                "The source store already uses per-tenant partitioned events. There is nothing to migrate.");
+        }
+
+        if (_target.Options.Events.TenancyStyle != TenancyStyle.Conjoined ||
+            !_target.Options.Events.UseTenantPartitionedEvents)
+        {
+            throw new InvalidOperationException(
+                "The target store must be configured with Events.TenancyStyle = TenancyStyle.Conjoined and " +
+                "Events.UseTenantPartitionedEvents = true.");
+        }
+
+        if (_source.Options.Events.StreamIdentity != _target.Options.Events.StreamIdentity)
+        {
+            throw new InvalidOperationException(
+                "The source and target stores must use the same StreamIdentity.");
+        }
+    }
+
+    private async Task assertTargetIsNotTheSourceAsync(CancellationToken token)
+    {
+        if (_source.Tenancy is not DefaultTenancy || _target.Tenancy is not DefaultTenancy)
+        {
+            throw new InvalidOperationException(
+                "Version 1 of the conjoined → partitioned migration supports single-database source and " +
+                "target stores. For sharded targets, provision tenants per shard and drive " +
+                $"{nameof(IDocumentStore.BulkInsertEventStreamAsync)} directly.");
+        }
+
+        if (_source.Options.Events.DatabaseSchemaName != _target.Options.Events.DatabaseSchemaName)
+        {
+            return;
+        }
+
+        await using var sourceConn = _source.Tenancy.Default.Database.CreateConnection();
+        await using var targetConn = _target.Tenancy.Default.Database.CreateConnection();
+        var source = new NpgsqlConnectionStringBuilder(sourceConn.ConnectionString);
+        var target = new NpgsqlConnectionStringBuilder(targetConn.ConnectionString);
+
+        if (string.Equals(source.Host, target.Host, StringComparison.OrdinalIgnoreCase)
+            && source.Port == target.Port
+            && string.Equals(source.Database, target.Database, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "The target store points at the same database AND the same event schema as the source. " +
+                "The migration copies side-by-side (the source tables stay untouched for rollback), so the " +
+                "target must use a different schema or database.");
+        }
+    }
+
+    private async Task ensureLogTableAsync(CancellationToken token)
+    {
+        var targetSchema = _target.Options.Events.DatabaseSchemaName;
+
+        await using var conn = _target.Tenancy.Default.Database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        await using var cmd = new NpgsqlCommand($@"
+create table if not exists {targetSchema}.{LogTableName} (
+    tenant_id varchar not null primary key,
+    source_max_seq_id bigint not null,
+    event_count bigint not null,
+    stream_count bigint not null,
+    started timestamp with time zone not null default (transaction_timestamp()),
+    completed timestamp with time zone
+)", conn);
+        await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+    }
+
+    private async Task<HashSet<string>> readCompletedTenantsAsync(CancellationToken token)
+    {
+        var targetSchema = _target.Options.Events.DatabaseSchemaName;
+        var completed = new HashSet<string>();
+
+        await using var conn = _target.Tenancy.Default.Database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        // to_regclass: the log table only exists once a migration has run; a fresh dry-run must not create it.
+        await using (var existsCmd = new NpgsqlCommand("select to_regclass(@name) is not null", conn))
+        {
+            existsCmd.Parameters.AddWithValue("name", $"{targetSchema}.{LogTableName}");
+            var exists = (bool)(await existsCmd.ExecuteScalarAsync(token).ConfigureAwait(false))!;
+            if (!exists)
+            {
+                return completed;
+            }
+        }
+
+        await using var cmd = new NpgsqlCommand(
+            $"select tenant_id from {targetSchema}.{LogTableName} where completed is not null", conn);
+        await using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            completed.Add(reader.GetString(0));
+        }
+
+        return completed;
+    }
+
+    private async Task markTenantStartedAsync(TenantMigrationPlanItem item, CancellationToken token)
+    {
+        var targetSchema = _target.Options.Events.DatabaseSchemaName;
+
+        await using var conn = _target.Tenancy.Default.Database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        await using var cmd = new NpgsqlCommand($@"
+insert into {targetSchema}.{LogTableName} (tenant_id, source_max_seq_id, event_count, stream_count)
+values (@tenant, @max, @events, @streams)
+on conflict (tenant_id) do update
+    set source_max_seq_id = excluded.source_max_seq_id,
+        event_count = excluded.event_count,
+        stream_count = excluded.stream_count,
+        started = transaction_timestamp(),
+        completed = null", conn);
+        cmd.Parameters.AddWithValue("tenant", item.TenantId);
+        cmd.Parameters.AddWithValue("max", item.MaxSequence);
+        cmd.Parameters.AddWithValue("events", item.EventCount);
+        cmd.Parameters.AddWithValue("streams", item.StreamCount);
+        await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+    }
+
+    private async Task markTenantCompletedAsync(string tenantId, CancellationToken token)
+    {
+        var targetSchema = _target.Options.Events.DatabaseSchemaName;
+
+        await using var conn = _target.Tenancy.Default.Database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        await using var cmd = new NpgsqlCommand(
+            $"update {targetSchema}.{LogTableName} set completed = transaction_timestamp() where tenant_id = @tenant",
+            conn);
+        cmd.Parameters.AddWithValue("tenant", tenantId);
+        await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+    }
+
+    private async Task upsertStoreGlobalHighWaterAsync(long seq, CancellationToken token)
+    {
+        var targetSchema = _target.Options.Events.DatabaseSchemaName;
+
+        await using var conn = _target.Tenancy.Default.Database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        // #4681: the literal identity comes from HighWaterShardIdentity, never hand-rolled.
+        await using var cmd = new NpgsqlCommand($@"
+INSERT INTO {targetSchema}.mt_event_progression (name, last_seq_id)
+VALUES ('{HighWaterShardIdentity.StoreGlobal}', @seq)
+ON CONFLICT (name) DO UPDATE SET last_seq_id = GREATEST({targetSchema}.mt_event_progression.last_seq_id, @seq)",
+            conn);
+        cmd.Parameters.AddWithValue("seq", seq);
+        await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+    }
+}

--- a/src/Marten/Events/TenantPartitioning/TenantMigrationPlan.cs
+++ b/src/Marten/Events/TenantPartitioning/TenantMigrationPlan.cs
@@ -1,0 +1,46 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Marten.Events.TenantPartitioning;
+
+/// <summary>
+/// One tenant's slice of the Phase 1 inventory for a conjoined → tenant-partitioned migration.
+/// </summary>
+/// <param name="TenantId">The tenant id as stored in the source's <c>tenant_id</c> columns</param>
+/// <param name="EventCount">Number of events (archived included) the source holds for this tenant</param>
+/// <param name="StreamCount">Number of <c>mt_streams</c> rows the source holds for this tenant</param>
+/// <param name="MaxSequence">The tenant's highest source <c>seq_id</c> (0 when the tenant has no events)</param>
+/// <param name="AlreadyCompleted">
+/// True when the target's <c>mt_tenant_migration_log</c> already records this tenant as completed,
+/// so a resumed run will skip it
+/// </param>
+public record TenantMigrationPlanItem(
+    string TenantId,
+    long EventCount,
+    long StreamCount,
+    long MaxSequence,
+    bool AlreadyCompleted);
+
+/// <summary>
+/// The Phase 1 inventory + plan for a conjoined → tenant-partitioned migration
+/// (<see cref="ConjoinedToPartitionedMigration.BuildPlanAsync"/>). Building the plan reads the
+/// source (and the target's migration log) but never moves data — it is the dry-run.
+/// </summary>
+public class TenantMigrationPlan
+{
+    public TenantMigrationPlan(IReadOnlyList<TenantMigrationPlanItem> tenants)
+    {
+        Tenants = tenants;
+    }
+
+    /// <summary>Per-tenant inventory in the order the migration will process them.</summary>
+    public IReadOnlyList<TenantMigrationPlanItem> Tenants { get; }
+
+    /// <summary>Total number of events across every tenant in the plan.</summary>
+    public long TotalEvents => Tenants.Sum(x => x.EventCount);
+
+    /// <summary>The tenants a run of the migration would actually move (not yet completed).</summary>
+    public IReadOnlyList<TenantMigrationPlanItem> PendingTenants =>
+        Tenants.Where(x => !x.AlreadyCompleted).ToList();
+}

--- a/src/Marten/Events/TenantPartitioning/TenantMigrationResult.cs
+++ b/src/Marten/Events/TenantPartitioning/TenantMigrationResult.cs
@@ -1,0 +1,19 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace Marten.Events.TenantPartitioning;
+
+/// <summary>
+/// Outcome of one <see cref="ConjoinedToPartitionedMigration.ExecuteAsync"/> run.
+/// </summary>
+public class TenantMigrationResult
+{
+    /// <summary>Tenants moved by THIS run, in completion order.</summary>
+    public List<string> MigratedTenants { get; } = new();
+
+    /// <summary>Tenants skipped by THIS run because the migration log already recorded them as completed.</summary>
+    public List<string> SkippedTenants { get; } = new();
+
+    /// <summary>Total events copied by this run.</summary>
+    public long EventsCopied { get; set; }
+}

--- a/src/Marten/IDocumentStore.cs
+++ b/src/Marten/IDocumentStore.cs
@@ -345,6 +345,26 @@ public interface IDocumentStore: IDisposable, IAsyncDisposable
         IAsyncEnumerable<IEvent> orderedEvents, int batchSize = 1000, CancellationToken cancellation = default);
 
     /// <summary>
+    ///     Streaming, order-preserving bulk import of an existing event log for a single tenant, with explicit
+    ///     control over <c>seq_id</c> assignment. <see cref="BulkEventSequenceMode.AssignFromSequence" /> is the
+    ///     behavior of the other overload; <see cref="BulkEventSequenceMode.PreserveSourceSequence" /> keeps each
+    ///     event's carried <c>Sequence</c> (historical events are never renumbered), requires strictly ascending
+    ///     input, advances the target sequence past the imported maximum, and — under per-tenant event
+    ///     partitioning — seeds the tenant's high-water progression row. This is the engine of the
+    ///     conjoined-to-partitioned migration. Does no schema work: apply the schema and register the tenant
+    ///     before importing.
+    /// </summary>
+    /// <param name="tenantId">The tenant to insert events for</param>
+    /// <param name="streamHeaders">One header per stream, to seed mt_streams</param>
+    /// <param name="orderedEvents">The tenant's events, in ascending target seq_id order</param>
+    /// <param name="sequenceMode">How seq_ids are assigned to the imported events</param>
+    /// <param name="batchSize">Number of rows per COPY batch and sequence-allocation block</param>
+    /// <param name="cancellation"></param>
+    Task BulkInsertEventStreamAsync(string tenantId, IReadOnlyList<BulkEventStreamHeader> streamHeaders,
+        IAsyncEnumerable<IEvent> orderedEvents, BulkEventSequenceMode sequenceMode, int batchSize = 1000,
+        CancellationToken cancellation = default);
+
+    /// <summary>
     ///     Build a new instance of the asynchronous projection daemon to use interactively
     ///     in your own code
     /// </summary>

--- a/src/TenantPartitionedEventsTests/Migration/conjoined_to_partitioned_migration.cs
+++ b/src/TenantPartitionedEventsTests/Migration/conjoined_to_partitioned_migration.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using Marten;
+using Marten.Events;
+using Marten.Events.TenantPartitioning;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using TenantPartitionedEventsTests.Fixtures;
+using Weasel.Core;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Migration;
+
+/// <summary>
+/// marten#4682 end-to-end: migrate a conjoined event store into a per-tenant-partitioned one via
+/// <see cref="ConjoinedToPartitionedMigration"/>, with <c>BulkInsertEventStreamAsync</c> in
+/// <see cref="BulkEventSequenceMode.PreserveSourceSequence"/> mode (marten#4879) as the engine.
+/// One source + one target store pair is shared by the whole class; per-fact isolation comes from
+/// fresh tenant ids plus the migration's <see cref="ConjoinedToPartitionedMigration.TenantIds"/> filter,
+/// so facts never see each other's tenants.
+/// </summary>
+public class conjoined_to_partitioned_migration: IAsyncLifetime
+{
+    public record Started(Guid Id);
+    public record Progressed(double Amount);
+
+    private readonly string _sourceSchema = $"cjp_src_p{Environment.ProcessId}";
+    private readonly string _targetSchema = $"cjp_tgt_p{Environment.ProcessId}";
+
+    private DocumentStore _source = null!;
+    private DocumentStore _target = null!;
+
+    public async Task InitializeAsync()
+    {
+        _source = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = _sourceSchema;
+            opts.AutoCreateSchemaObjects = AutoCreate.CreateOrUpdate;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AddEventType<Started>();
+            opts.Events.AddEventType<Progressed>();
+            opts.Projections.DaemonLockId = 74682001;
+        });
+
+        _target = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = _targetSchema;
+            opts.AutoCreateSchemaObjects = AutoCreate.CreateOrUpdate;
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Policies.AllDocumentsAreMultiTenanted();
+            opts.Events.AddEventType<Started>();
+            opts.Events.AddEventType<Progressed>();
+            opts.Projections.DaemonLockId = 74682002;
+        });
+
+        await _source.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+        await _target.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        _source?.Dispose();
+        _target?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Seed the SOURCE with interleaved appends across the given tenants — round-robin so each tenant's
+    /// slice of the shared global sequence is gappy, exactly like a real conjoined store. Returns one
+    /// stream id per tenant.
+    /// </summary>
+    private async Task<Dictionary<string, Guid>> seedInterleavedAsync(string[] tenants, int rounds)
+    {
+        var streams = tenants.ToDictionary(t => t, _ => Guid.NewGuid());
+
+        foreach (var tenant in tenants)
+        {
+            await using var session = _source.LightweightSession(tenant);
+            session.Events.StartStream(streams[tenant], new Started(streams[tenant]));
+            await session.SaveChangesAsync();
+        }
+
+        for (var round = 0; round < rounds; round++)
+        {
+            foreach (var tenant in tenants)
+            {
+                await using var session = _source.LightweightSession(tenant);
+                session.Events.Append(streams[tenant], new Progressed(round + 1));
+                await session.SaveChangesAsync();
+            }
+        }
+
+        return streams;
+    }
+
+    private async Task<List<long>> seqIdsAsync(string schema, string tenant)
+    {
+        var seqs = new List<long>();
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            $"select seq_id from {schema}.mt_events where tenant_id = @t order by seq_id", conn);
+        cmd.Parameters.AddWithValue("t", tenant);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            seqs.Add(reader.GetInt64(0));
+        }
+
+        return seqs;
+    }
+
+    private async Task<T?> scalarAsync<T>(string sql, params (string, object)[] parameters)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        foreach (var (name, value) in parameters)
+        {
+            cmd.Parameters.AddWithValue(name, value);
+        }
+
+        var raw = await cmd.ExecuteScalarAsync();
+        return raw is T typed ? typed : default;
+    }
+
+    [Fact]
+    public async Task migrates_a_conjoined_store_into_per_tenant_partitions_end_to_end()
+    {
+        var tenants = new[]
+        {
+            PartitionedFixtureBase.NewTenant(), PartitionedFixtureBase.NewTenant(),
+            PartitionedFixtureBase.NewTenant()
+        };
+        var streams = await seedInterleavedAsync(tenants, rounds: 3);
+
+        // Archive one tenant's stream: the archived flag must survive the migration on both the
+        // stream row and its events.
+        var archivedTenant = tenants[0];
+        await using (var session = _source.LightweightSession(archivedTenant))
+        {
+            session.Events.ArchiveStream(streams[archivedTenant]);
+            await session.SaveChangesAsync();
+        }
+
+        var migration = new ConjoinedToPartitionedMigration(_source, _target)
+        {
+            TenantIds = tenants, BatchSize = 2
+        };
+
+        // Phase 1 — the dry-run inventory matches the seeded reality and moves nothing.
+        var plan = await migration.BuildPlanAsync();
+        plan.Tenants.Count.ShouldBe(3);
+        plan.TotalEvents.ShouldBe(12); // 3 tenants x (1 Started + 3 Progressed)
+        foreach (var item in plan.Tenants)
+        {
+            item.EventCount.ShouldBe(4);
+            item.StreamCount.ShouldBe(1);
+            item.MaxSequence.ShouldBe((await seqIdsAsync(_sourceSchema, item.TenantId)).Max());
+            item.AlreadyCompleted.ShouldBeFalse();
+        }
+
+        // Tenant-scoped: the target schema is shared with the class's other facts.
+        foreach (var tenant in tenants)
+        {
+            (await seqIdsAsync(_targetSchema, tenant)).ShouldBeEmpty();
+        }
+
+        // Phase 2 — execute.
+        var result = await migration.ExecuteAsync();
+        result.MigratedTenants.Count.ShouldBe(3);
+        result.SkippedTenants.ShouldBeEmpty();
+        result.EventsCopied.ShouldBe(12);
+
+        foreach (var tenant in tenants)
+        {
+            var sourceSeqs = await seqIdsAsync(_sourceSchema, tenant);
+
+            // The data policy: seq_ids are EXACTLY the source's — gappy, never renumbered.
+            (await seqIdsAsync(_targetSchema, tenant)).ShouldBe(sourceSeqs);
+
+            // Per-tenant high water seeded at the tenant's max.
+            (await scalarAsync<long?>(
+                    $"select last_seq_id from {_targetSchema}.mt_event_progression where name = @n",
+                    ("n", $"HighWaterMark:{tenant}")))
+                .ShouldBe(sourceSeqs.Max());
+
+            // Migration log records completion.
+            (await scalarAsync<bool>(
+                    $"select completed is not null from {_targetSchema}.{ConjoinedToPartitionedMigration.LogTableName} where tenant_id = @t",
+                    ("t", tenant)))
+                .ShouldBeTrue();
+        }
+
+        // Archived flag survived on the stream row and its events.
+        (await scalarAsync<bool>(
+                $"select is_archived from {_targetSchema}.mt_streams where tenant_id = @t",
+                ("t", archivedTenant)))
+            .ShouldBeTrue();
+        (await scalarAsync<long>(
+                $"select count(*) from {_targetSchema}.mt_events where tenant_id = @t and is_archived",
+                ("t", archivedTenant)))
+            .ShouldBe(4);
+
+        // Store-global high water advanced to the migrated maximum (legacy readers).
+        var globalMax = plan.Tenants.Max(x => x.MaxSequence);
+        (await scalarAsync<long?>(
+                $"select last_seq_id from {_targetSchema}.mt_event_progression where name = @n",
+                ("n", "HighWaterMark")))
+            .ShouldBe(globalMax);
+
+        // The acceptance test that matters most (marten#4682): appending fresh events to every tenant
+        // works on the FIRST try — no PK collision, no sequence collision, lands above the history.
+        foreach (var tenant in tenants)
+        {
+            var maxBefore = (await seqIdsAsync(_targetSchema, tenant)).Max();
+            await using var session = _target.LightweightSession(tenant);
+            if (tenant == archivedTenant)
+            {
+                // The migrated stream is archived — and the target correctly refuses appends to it
+                // (the archived flag really came across) — so this tenant continues on a NEW stream.
+                session.Events.StartStream(Guid.NewGuid(), new Started(Guid.NewGuid()));
+            }
+            else
+            {
+                session.Events.Append(streams[tenant], new Progressed(99));
+            }
+
+            await session.SaveChangesAsync();
+
+            var after = await seqIdsAsync(_targetSchema, tenant);
+            after.Count.ShouldBe(5);
+            after.Max().ShouldBeGreaterThan(maxBefore);
+        }
+
+        // Reading the migrated stream back through the TARGET store yields the same events in order.
+        await using (var query = _target.QuerySession(tenants[1]))
+        {
+            var fetched = await query.Events.FetchStreamAsync(streams[tenants[1]]);
+            fetched.Count.ShouldBe(5); // 4 migrated + 1 live append
+            fetched[0].Data.ShouldBeOfType<Started>().Id.ShouldBe(streams[tenants[1]]);
+            fetched.Take(4).Select(x => x.Version).ShouldBe(new long[] { 1, 2, 3, 4 });
+        }
+
+        // Resume — a second run skips every completed tenant and moves nothing.
+        var secondRun = await new ConjoinedToPartitionedMigration(_source, _target)
+        {
+            TenantIds = tenants
+        }.ExecuteAsync();
+
+        secondRun.MigratedTenants.ShouldBeEmpty();
+        secondRun.SkippedTenants.Count.ShouldBe(3);
+        foreach (var tenant in tenants)
+        {
+            (await seqIdsAsync(_targetSchema, tenant)).Count.ShouldBe(5);
+        }
+    }
+
+    [Fact]
+    public async Task tenant_subset_migrates_only_the_requested_tenants()
+    {
+        var wanted = PartitionedFixtureBase.NewTenant();
+        var unwanted = PartitionedFixtureBase.NewTenant();
+        await seedInterleavedAsync(new[] { wanted, unwanted }, rounds: 1);
+
+        var result = await new ConjoinedToPartitionedMigration(_source, _target)
+        {
+            TenantIds = new[] { wanted }
+        }.ExecuteAsync();
+
+        result.MigratedTenants.ShouldBe(new[] { wanted });
+        (await seqIdsAsync(_targetSchema, wanted)).Count.ShouldBe(2);
+        (await seqIdsAsync(_targetSchema, unwanted)).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void source_must_be_conjoined_and_target_must_be_partitioned()
+    {
+        using var plainSource = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = _sourceSchema + "_plain";
+        });
+
+        Should.Throw<InvalidOperationException>(() => new ConjoinedToPartitionedMigration(plainSource, _target))
+            .Message.ShouldContain("Conjoined");
+
+        Should.Throw<InvalidOperationException>(() => new ConjoinedToPartitionedMigration(_source, _source))
+            .Message.ShouldContain("UseTenantPartitionedEvents");
+    }
+
+    [Fact]
+    public async Task refuses_to_run_when_target_is_the_same_database_and_schema()
+    {
+        using var sameSchemaTarget = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = _sourceSchema; // same schema, same database as the source
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Policies.AllDocumentsAreMultiTenanted();
+        });
+
+        var migration = new ConjoinedToPartitionedMigration(_source, sameSchemaTarget);
+        (await Should.ThrowAsync<InvalidOperationException>(() => migration.ExecuteAsync()))
+            .Message.ShouldContain("same database");
+    }
+}

--- a/src/TenantPartitionedEventsTests/Regressions/preserve_sequence_streaming_bulk_import.cs
+++ b/src/TenantPartitionedEventsTests/Regressions/preserve_sequence_streaming_bulk_import.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using TenantPartitionedEventsTests.Fixtures;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Regressions;
+
+/// <summary>
+/// marten#4879 — the migration flavor of the streaming bulk import. Under
+/// <see cref="BulkEventSequenceMode.PreserveSourceSequence"/> on a per-tenant-partitioned store the
+/// import must (a) keep the exact (gappy!) seq_ids the events carry — a conjoined source interleaved
+/// every tenant on one global sequence, so a single tenant's seq_ids are full of holes and MUST NOT be
+/// renumbered (marten#4682's data policy), (b) advance the tenant's own
+/// <c>mt_events_sequence_{suffix}</c> past the imported maximum via setval so the first live append never
+/// re-issues an imported seq_id, and (c) seed the tenant's <c>HighWaterMark:{tenant}</c> progression row
+/// at the imported maximum so high-water detection starts ABOVE the gappy history instead of gap-walking
+/// through it.
+/// </summary>
+[Collection("guid-partitioned")]
+public class preserve_sequence_streaming_bulk_import
+{
+    private readonly GuidPartitionedFixture _fixture;
+
+    public preserve_sequence_streaming_bulk_import(GuidPartitionedFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // Build a raw IEvent carrying its stream id, per-stream version, AND source seq_id — exactly what a
+    // migration read of a conjoined source produces.
+    private static IEvent EventFor(Guid streamId, long version, long sourceSequence, object data)
+    {
+        var e = (IEvent)Activator.CreateInstance(typeof(Event<>).MakeGenericType(data.GetType()), data)!;
+        e.StreamId = streamId;
+        e.Version = version;
+        e.Id = Guid.NewGuid();
+        e.Sequence = sourceSequence;
+        return e;
+    }
+
+    private static async IAsyncEnumerable<IEvent> Stream(IEnumerable<IEvent> events)
+    {
+        foreach (var e in events)
+        {
+            yield return e;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    private async Task<List<long>> SeqIdsForTenantAsync(string tenant)
+    {
+        var seqs = new List<long>();
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            $"select seq_id from {_fixture.SchemaName}.mt_events where tenant_id = @t order by seq_id", conn);
+        cmd.Parameters.AddWithValue("t", tenant);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            seqs.Add(reader.GetInt64(0));
+        }
+
+        return seqs;
+    }
+
+    [Fact]
+    public async Task preserves_gappy_source_seq_ids_advances_the_tenant_sequence_and_seeds_high_water()
+    {
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var streamX = Guid.NewGuid();
+        var streamY = Guid.NewGuid();
+
+        var headers = new[]
+        {
+            new BulkEventStreamHeader { Id = streamX, Version = 3 },
+            new BulkEventStreamHeader { Id = streamY, Version = 2 }
+        };
+
+        // Gappy source seq_ids, as a conjoined source's per-tenant slice really looks: other tenants own
+        // the holes. Interleaved X/Y to also pin cross-stream order preservation.
+        var events = new[]
+        {
+            EventFor(streamX, 1, 3, new TripStarted(streamX)),
+            EventFor(streamY, 1, 7, new TripStarted(streamY)),
+            EventFor(streamX, 2, 12, new TripLeg(1.0)),
+            EventFor(streamY, 2, 40, new TripLeg(2.0)),
+            EventFor(streamX, 3, 41, new TripLeg(3.0))
+        };
+
+        await _fixture.Store.BulkInsertEventStreamAsync(tenant, headers, Stream(events),
+            BulkEventSequenceMode.PreserveSourceSequence, batchSize: 2);
+
+        // (a) The seq_ids are EXACTLY the source values — never renumbered, gaps intact.
+        (await SeqIdsForTenantAsync(tenant)).ShouldBe(new long[] { 3, 7, 12, 40, 41 });
+
+        // (b) The tenant's own sequence was advanced past the imported maximum...
+        (await _fixture.ReadSequenceLastValueAsync(tenant, _fixture.SchemaName))
+            .ShouldBeGreaterThanOrEqualTo(41);
+
+        // ...so a live append lands ABOVE the imported history on the first try.
+        await using (var session = _fixture.Store.LightweightSession(tenant))
+        {
+            session.Events.Append(streamX, new TripLeg(4.0));
+            await session.SaveChangesAsync();
+        }
+
+        var afterAppend = await SeqIdsForTenantAsync(tenant);
+        afterAppend.Count.ShouldBe(6);
+        afterAppend[^1].ShouldBeGreaterThan(41);
+
+        // (c) The tenant's high-water progression row is seeded at the imported maximum.
+        var rows = await _fixture.ReadProgressionRowsAsync(_fixture.SchemaName, $"HighWaterMark:{tenant}");
+        rows.Count.ShouldBe(1);
+        rows[0].LastSeqId.ShouldBe(41);
+    }
+
+    [Fact]
+    public async Task rejects_events_that_are_not_strictly_ascending_and_commits_nothing()
+    {
+        var tenant = PartitionedFixtureBase.NewTenant();
+        await _fixture.Store.Advanced.AddMartenManagedTenantsAsync(CancellationToken.None, tenant);
+
+        var stream = Guid.NewGuid();
+        var headers = new[] { new BulkEventStreamHeader { Id = stream, Version = 2 } };
+
+        // 9 after 9 — a caller that forgot to order by the source seq_id (or fed unnumbered events, which
+        // arrive as 0) must be rejected rather than silently corrupting the tenant's replay order.
+        var events = new[]
+        {
+            EventFor(stream, 1, 9, new TripStarted(stream)),
+            EventFor(stream, 2, 9, new TripLeg(1.0))
+        };
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() =>
+            _fixture.Store.BulkInsertEventStreamAsync(tenant, headers, Stream(events),
+                BulkEventSequenceMode.PreserveSourceSequence));
+        ex.Message.ShouldContain("strictly ascending");
+
+        // The per-tenant transaction rolled back: nothing committed, clean retry possible.
+        (await _fixture.CountEventsForTenantAsync(tenant, _fixture.SchemaName)).ShouldBe(0);
+    }
+}


### PR DESCRIPTION
Delivers marten#4879 and the core of marten#4682 as **one canonical migration story**, per #4879's reconcile instruction: the streaming bulk import is the engine, and the migration tool drives it tenant by tenant.

Closes #4879. Advances #4682 (remaining scope listed below).

## The reconciliation

The streaming `BulkInsertEventStreamAsync` (landed in #4854/#4857) assigns **new** seq_ids from the tenant sequence — correct for seeding, but exactly wrong for #4682's data policy (**never renumber historical events**: progression rows, warehouses, audit logs, and external consumers that captured a sequence position must stay valid). The reconciliation is a second sequence mode on the primitive, and a migration tool built on it — replacing #4682's hand-rolled DETACH/ATTACH SQL design with the supported primitive as the single path.

## `BulkEventSequenceMode.PreserveSourceSequence` (the #4879 completion)

New overload: `BulkInsertEventStreamAsync(tenantId, headers, orderedEvents, BulkEventSequenceMode, batchSize, ct)`. In preserve mode:

- Every event keeps the `Sequence` it carries — per-tenant **gaps are expected** (a conjoined source interleaves all tenants on one global sequence). Input must be strictly ascending; unnumbered/unsorted events are rejected before commit.
- **Per-tenant sequence advancement via `setval`** (the issue's other branch; `nextval` allocation remains the default mode): the tenant's own `mt_events_sequence_{suffix}` — or the store-global sequence on non-partitioned stores — is pushed past the imported maximum with `GREATEST` semantics, so the first live append can never re-issue an imported seq_id.
- **Seeds the tenant's `HighWaterMark:{tenantId}` progression row** at the imported maximum (via `HighWaterShardIdentity`, the #4681 canonical producer — never hand-rolled). This is #4682 Phase 2 step 8, and it is load-bearing: gaps *below* a persisted mark are never revisited, so the daemon starts above the gappy history instead of gap-walking (#4867) through every hole another tenant owns.
- Tenant-id force-stamping and partitioned-store routing were already in place; `BulkEventStreamHeader` now also carries `IsArchived` so archived streams stay archived.

`AssignFromSequence` (default) behavior is byte-for-byte unchanged, including the deliberate no-HWM-write-under-partitioning from #4847.

## `ConjoinedToPartitionedMigration` (the #4682 tool)

`Marten.Events.TenantPartitioning.ConjoinedToPartitionedMigration(sourceStore, targetStore)` — offline-first, side-by-side: the target is a different schema or database (same schema + same database is refused), so the source tables are never touched and rollback is "keep using the source".

- **Phase 1 / dry-run** — `BuildPlanAsync()`: per-tenant event count, stream count, max seq_id, and which tenants a resumed run would skip. Moves no data.
- **Phase 2** — `ExecuteAsync()`: per tenant, sequentially, one transaction each: register the tenant's partitions + sequence (`AddMartenManagedTenantsAsync`), stream its events out of the source via `QueryAllRawEvents().Where(x => x.MaybeArchived()).OrderBy(x => x.Sequence).ToAsyncEnumerable()` (bounded memory, source upcasters applied), copy with `PreserveSourceSequence`, verify row counts, record completion in the target's `mt_tenant_migration_log`.
- **Resume** — re-running skips completed tenants and retries the failed one (whose transaction rolled back cleanly).
- **Phase 3 (partial)** — the store-global `HighWaterMark` row is advanced to the migrated maximum for legacy readers. No table-swap phase exists because the side-by-side model doesn't need one: cut over by pointing the app at the target store.
- Config validation up front: conjoined non-partitioned source, conjoined + `UseTenantPartitionedEvents` target, matching `StreamIdentity`, single-database (`DefaultTenancy`) stores in v1. Default-tenant (`*DEFAULT*`) rows are rejected with guidance.

## Tests (all green locally vs dockerized PG, net9.0)

- `TenantPartitionedEventsTests` **223/223** (full suite), including new:
  - `Regressions/preserve_sequence_streaming_bulk_import` — gappy seq_ids preserved exactly, tenant sequence advanced, first live append lands above history, `HighWaterMark:{tenant}` seeded, non-ascending input rejected with nothing committed.
  - `Migration/conjoined_to_partitioned_migration` — end-to-end: interleaved 3-tenant conjoined seed → plan inventory → execute → exact per-tenant seq_id equality with the source, HWM rows, archived stream+events carried across (the target correctly refuses appends to the migrated archived stream), first-try live appends per tenant, stream readback through the target, resume skips all completed tenants; plus tenant-subset, config-validation, and same-schema-refusal facts.
- `EventSourcingTests` bulk filter **31/31**, including new non-partitioned preserve-mode facts (seq_ids preserved + global sequence `setval`).
- `CoreTests` secondary-store proxy tests pass (the `IDocumentStore` interface grew a member); full `Marten.slnx` builds clean.

## Docs

- `docs/events/bulk-appending.md`: new "Preserving Source Sequence Numbers" section.
- `docs/events/multitenancy.md`: new "Migrating an Existing Conjoined Store" section — data policy, offline window, ~2x disk, backup, resume, rebuild-projections-after note.

## Remaining #4682 scope (deliberately not in this PR)

- **CLI subcommand** (`marten migrate-to-tenant-partitioning`): the JasperFx host-command model hands a command ONE configured store, but this migration needs two (source + target configs). Proposed shape: the host's store is the *target*; flags supply the source (`--source-schema` / `--source-connection`), plus `--dry-run`, `--tenants`, `--batch-size` mapping 1:1 onto the programmatic API. Skeleton deferred until that UX is agreed.
- **Scale validation** on the `Marten.ScaleTesting` harness (#4666) — 20M events / 50 tenants acceptance run.
- Kill-mid-run resume + induced-failure chaos tests at scale (the transactional per-tenant resume itself is covered here).
- Grace-period bookkeeping for retiring the *source* tables (side-by-side makes this an operator `DROP SCHEMA` after verification; documented).

No JasperFx-side changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNfeNz73Q3EdiTgSeDbo96