### PR TITLE
Sharded tenancy usage descriptor shrinks on tenant removal (closes #4868, #4880)

### DIFF
--- a/src/Marten/AdvancedOperations.cs
+++ b/src/Marten/AdvancedOperations.cs
@@ -596,8 +596,26 @@ public class AdvancedOperations
 
         if (_store.Tenancy is not DefaultTenancy)
         {
+            // #4880: route the sharded case to the full per-tenant removal path — the
+            // symmetric inverse of AddMartenManagedTenantsAsync's sharded routing. Under the
+            // sharded 1:1 tenant↔suffix shape, ShardedTenancy.RemoveTenantAsync drops the
+            // tenant's partitions + per-tenant event sequence + progression rows on its shard
+            // AND deletes the master-registry assignment row (see #4868 for the descriptor
+            // shrink that lets running hosts retire the tenant's daemon agents).
+            if (_store.Tenancy is ShardedTenancy shardedTenancy)
+            {
+                foreach (var suffix in suffixes)
+                {
+                    await shardedTenancy.RemoveTenantAsync(suffix, token).ConfigureAwait(false);
+                }
+
+                return;
+            }
+
             throw new InvalidOperationException(
-                "This option is not (yet) supported in combination with database per tenant multi-tenancy");
+                "RemoveMartenManagedTenantsAsync supports DefaultTenancy and ShardedTenancy. " +
+                "MasterTableTenancy tenants own their whole database — call " +
+                "IServiceProvider.RemoveTenantAsync(tenantId) instead.");
         }
 
         var database = (PostgresqlDatabase)_store.Tenancy.Default.Database;
@@ -653,6 +671,25 @@ public class AdvancedOperations
         // entry point and the store-agnostic JasperFx admin extension drive ONE code path
         // (auto-assign → createPartitionsForTenant → per-tenant event sequence).
         return sharded.AddTenantAsync(tenantId, ct);
+    }
+
+    /// <summary>
+    ///     Fully remove a tenant from the sharded pool — the symmetric inverse of
+    ///     <see cref="AddTenantToShardAsync(string, CancellationToken)"/>. Drops the tenant's list
+    ///     partitions (and, under <c>UseTenantPartitionedEvents</c>, its per-tenant event sequence
+    ///     and event-progression rows) from its shard database, deletes the master-registry
+    ///     assignment, and shrinks the store's usage descriptor so running hosts can retire the
+    ///     tenant's daemon agents without a restart (#4868/#4880). DESTRUCTIVE on the shard —
+    ///     use the <c>IDynamicTenantSource</c> disable lifecycle for a non-destructive soft-delete.
+    ///     Only available with sharded tenancy.
+    /// </summary>
+    public async Task RemoveTenantFromShardAsync(string tenantId, CancellationToken ct)
+    {
+        var sharded = _store.Options.Tenancy as ShardedTenancy
+            ?? throw new InvalidOperationException(
+                "RemoveTenantFromShardAsync is only available when using MultiTenantedWithShardedDatabases()");
+
+        await sharded.RemoveTenantAsync(tenantId, ct).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Marten/Storage/ShardedTenancy.cs
+++ b/src/Marten/Storage/ShardedTenancy.cs
@@ -200,11 +200,18 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
                     .CreateCommand($"select tenant_id, database_id from {_schemaName}.{TenantAssignmentTable.TableName} where {MartenTenantAssignmentTable.DisabledColumn} = false"))
                 .ExecuteReaderAsync().ConfigureAwait(false);
 
+            // #4868: the fresh assignment read below is the single source of truth for
+            // "which active tenants live on which shard" — collect it so the in-memory
+            // registry can be RECONCILED against it (shrunk, not just grown) afterwards.
+            var activeAssignments = new Dictionary<string, string>(StringComparer.Ordinal);
+
             while (await assignReader.ReadAsync().ConfigureAwait(false))
             {
                 var tenantId = await assignReader.GetFieldValueAsync<string>(0).ConfigureAwait(false);
                 tenantId = _options.TenantIdStyle.MaybeCorrectTenantId(tenantId);
                 var databaseId = await assignReader.GetFieldValueAsync<string>(1).ConfigureAwait(false);
+
+                activeAssignments[tenantId] = databaseId;
 
                 if (_databasesById.TryFind(databaseId, out var database))
                 {
@@ -214,6 +221,36 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
             }
 
             await assignReader.CloseAsync().ConfigureAwait(false);
+
+            // #4868: reconcile the in-memory registry against the fresh read. TenantIds /
+            // _tenantToDatabase used to be add-only (`Fill`), so a running store's usage
+            // descriptor (DescribeDatabasesAsync → TryCreateUsage) never shrank after
+            // RemoveTenantAsync / DisableTenantAsync — locally OR from another node — and
+            // hosts that retire per-tenant daemon agents off the descriptor's supported-set
+            // diff (Wolverine-managed distribution, per-cycle) could never see a tenant
+            // leave until a process restart. Pruning here makes every BuildDatabases /
+            // DescribeDatabasesAsync call a fresh-read re-enumeration, mirroring #4864's
+            // rationale for the single-database path: one source, invalidation-free.
+            foreach (var pair in _databasesById.Enumerate())
+            {
+                var staleTenantIds = pair.Value.TenantIds
+                    .Where(t => !activeAssignments.TryGetValue(t, out var assignedDb) ||
+                                !assignedDb.EqualsIgnoreCase(pair.Key))
+                    .ToArray();
+
+                foreach (var stale in staleTenantIds)
+                {
+                    pair.Value.TenantIds.Remove(stale);
+                }
+            }
+
+            foreach (var pair in _tenantToDatabase.Enumerate().ToArray())
+            {
+                if (!activeAssignments.ContainsKey(pair.Key))
+                {
+                    _tenantToDatabase = _tenantToDatabase.Remove(pair.Key);
+                }
+            }
         }
         finally
         {
@@ -383,16 +420,208 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
         }
     }
 
+    /// <summary>
+    /// #4868 / #4880: full removal of a tenant from the sharded pool — the symmetric inverse of
+    /// <see cref="AddTenantAsync(string, CancellationToken)"/> / <c>Advanced.AddTenantToShardAsync</c>.
+    /// <list type="bullet">
+    ///   <item>Drops the tenant's LIST partitions from all managed tables on its shard database,
+    ///     including the shard's own <c>mt_tenant_partitions</c> registry rows — so the native
+    ///     coordinator's per-tenant re-expansion (jasperfx#491's
+    ///     <c>PerTenantShardExpansion</c> over <c>ICrossTenantRebuildSource</c>) stops seeing the
+    ///     tenant and its running daemon agents are reaped on the next leadership polling cycle.</item>
+    ///   <item>Under <c>UseTenantPartitionedEvents</c>, also drops the tenant's
+    ///     <c>mt_events_sequence_{tenant}</c> and deletes its per-tenant
+    ///     <c>mt_event_progression</c> + <c>HighWaterMark:{tenant}</c> rows (the #4683 cleanup) —
+    ///     progression rows are CLEANED on removal, not retained; a re-added tenant starts fresh.</item>
+    ///   <item>Deletes the master-registry assignment row and recomputes the shard's
+    ///     <c>tenant_count</c> (mirrors #4763's recompute-on-reassignment).</item>
+    ///   <item>Shrinks the in-memory registry so this store's usage descriptor
+    ///     (<see cref="DescribeDatabasesAsync"/> → <c>TryCreateUsage</c>) stops reporting the
+    ///     tenant immediately — hosts that retire agents off the descriptor diff converge without
+    ///     a restart. Other nodes converge via the fresh-read reconciliation in
+    ///     <see cref="BuildDatabases"/>.</item>
+    /// </list>
+    /// This is DESTRUCTIVE on the shard (partition drop == data drop), matching the single-database
+    /// removal contract of <c>AdvancedOperations.RemoveMartenManagedTenantsAsync</c>. Use
+    /// <see cref="DisableTenantAsync"/> for the non-destructive soft-delete that retains all data
+    /// and progression state. Idempotent — a re-run for an unknown/already-removed tenant no-ops.
+    /// </summary>
     public async ValueTask RemoveTenantAsync(string tenantId, CancellationToken ct)
     {
         tenantId = _options.TenantIdStyle.MaybeCorrectTenantId(tenantId);
         await maybeApplyChanges().ConfigureAwait(false);
+
+        // Resolve the tenant's shard BEFORE deleting the assignment row — deliberately NOT
+        // filtered on the disabled flag, so removing a soft-deleted tenant still cleans its shard.
+        var databaseId = (await _dataSource.Value
+            .CreateCommand(
+                $"select database_id from {_schemaName}.{TenantAssignmentTable.TableName} where tenant_id = :id")
+            .With("id", tenantId)
+            .ExecuteScalarAsync(ct).ConfigureAwait(false)) as string;
+
+        if (databaseId != null)
+        {
+            // Ensure the shard database is materialized in the local cache (this store may never
+            // have resolved the tenant) — mirrors findOrAssignTenantDatabaseAsync's cache repair.
+            if (!_databasesById.TryFind(databaseId, out var database))
+            {
+                await BuildDatabases().ConfigureAwait(false);
+                _databasesById.TryFind(databaseId, out database);
+            }
+
+            if (database != null)
+            {
+                // Shard-side DDL FIRST (outside the master advisory lock — same rationale as
+                // AssignTenantAsync's partition DDL: the lock guards registry rows, not the
+                // shard-local idempotent DDL). If this throws, the assignment row is still
+                // intact and the removal can simply be re-run.
+                await dropPartitionsForTenant(database, tenantId, ct).ConfigureAwait(false);
+            }
+        }
 
         await _dataSource.Value
             .CreateCommand(
                 $"delete from {_schemaName}.{TenantAssignmentTable.TableName} where tenant_id = :id")
             .With("id", tenantId)
             .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+        if (databaseId != null)
+        {
+            // #4763-style recompute: without this the source shard's tenant_count stays
+            // permanently inflated after removals and UseSmallestDatabaseAssignment mis-ranks it.
+            await _dataSource.Value.CreateCommand(
+                    $"update {_schemaName}.{DatabasePoolTable.TableName} set tenant_count = (select count(*) from {_schemaName}.{TenantAssignmentTable.TableName} where database_id = :did and {MartenTenantAssignmentTable.DisabledColumn} = false) where database_id = :did")
+                .With("did", databaseId)
+                .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        }
+
+        // #4868: shrink the in-memory registry so DescribeDatabasesAsync stops reporting the
+        // tenant on THIS node immediately (other nodes shrink via BuildDatabases' fresh read).
+        _tenantToDatabase = _tenantToDatabase.Remove(tenantId);
+        if (databaseId != null && _databasesById.TryFind(databaseId, out var cached))
+        {
+            cached.TenantIds.Remove(tenantId);
+        }
+    }
+
+    /// <summary>
+    /// Drop the tenant's shard-side footprint — the mirror of <see cref="createPartitionsForTenant"/>.
+    /// Sharded provisioning has a 1:1 tenant↔partition-suffix shape (enforced in
+    /// <c>AdvancedOperations.AddMartenManagedTenantsAsync</c>'s sharded routing), so the suffix is
+    /// always the tenant id. Skips the partition drop when the shard's own
+    /// <c>mt_tenant_partitions</c> registry no longer knows the tenant (partial prior removal) so
+    /// re-runs stay safe, but always runs the #4683 sequence/progression cleanup, which is
+    /// idempotent by construction.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately NOT Weasel's <c>ManagedListPartitions.DropPartitionFromAllTables</c>: that
+    /// path interpolates the partition table name unquoted into the DETACH/DROP DDL, which fails
+    /// with 42601 for any tenant id that isn't a bare PostgreSQL identifier (hyphens, uppercase —
+    /// e.g. GUID-shaped or "tenant-a"-style ids). The sharded assignment path never restricted
+    /// tenant ids the way <c>AddMartenManagedTenantsAsync</c>'s
+    /// <c>AssertValidPostgresqlIdentifiers</c> does — the CREATE side quotes properly, so quoted
+    /// partitions exist in the wild and the drop must quote too. Fold this back into Weasel when
+    /// its drop path learns to quote (see the PR for #4868/#4880).
+    /// </remarks>
+    private async Task dropPartitionsForTenant(MartenDatabase database, string tenantId, CancellationToken ct)
+    {
+        if (_options.TenantPartitions == null)
+        {
+            return;
+        }
+
+        IReadOnlyList<string> registered;
+        try
+        {
+            registered = await database.FetchManagedTenantIdsAsync(ct).ConfigureAwait(false);
+        }
+        catch (NpgsqlException)
+        {
+            // The shard's partition registry table was never provisioned (assignment row
+            // committed but the partition DDL never ran) — nothing shard-side to drop.
+            return;
+        }
+
+        if (registered.Contains(tenantId, StringComparer.Ordinal))
+        {
+            var logger = _options.LogFactory?.CreateLogger<DocumentStore>() ?? NullLogger<DocumentStore>.Instance;
+
+            // Same table enumeration Weasel's managed drop uses — every table whose LIST
+            // partitioning is managed by this store's tenant-partition manager.
+            var tables = database.AllObjects().OfType<Table>()
+                .Where(x => x.Partitioning is ListPartitioning lp &&
+                            ReferenceEquals(lp.PartitionManager, _options.TenantPartitions.Partitions))
+                .ToArray();
+
+            await using var conn = database.CreateConnection();
+            await conn.OpenAsync(ct).ConfigureAwait(false);
+            try
+            {
+                // Remove the tenant from the shard's own registry FIRST (mirrors Weasel's
+                // ordering) — this is what the native coordinator's per-tenant re-expansion
+                // (ICrossTenantRebuildSource) reads, so the tenant's agents can be reaped even
+                // if a partition drop below fails midway.
+                await conn.CreateCommand(
+                        $"delete from {_options.TenantPartitions.TenantsTableName} where partition_value = :value")
+                    .With("value", tenantId)
+                    .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+                foreach (var table in tables)
+                {
+                    var quotedPartition = $"\"{table.Identifier.Schema}\".\"{table.Identifier.Name}_{tenantId}\"";
+
+                    var exists = await conn.CreateCommand("select to_regclass(:name)::text")
+                        .With("name", quotedPartition)
+                        .ExecuteScalarAsync(ct).ConfigureAwait(false);
+                    if (exists == null || exists == DBNull.Value)
+                    {
+                        continue;
+                    }
+
+                    // Best-effort DETACH (CONCURRENTLY first for lock-friendliness) — the DROP
+                    // TABLE below is authoritative either way: PostgreSQL drops an attached
+                    // partition directly, and IF EXISTS keeps re-runs safe.
+                    try
+                    {
+                        await conn.CreateCommand(
+                                $"alter table {table.Identifier.QualifiedName} detach partition {quotedPartition} CONCURRENTLY;")
+                            .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                    }
+                    catch (Exception)
+                    {
+                        try
+                        {
+                            await conn.CreateCommand(
+                                    $"alter table {table.Identifier.QualifiedName} detach partition {quotedPartition};")
+                                .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+                        }
+                        catch (Exception)
+                        {
+                            // already detached by a prior partial run — the drop below settles it
+                        }
+                    }
+
+                    await conn.CreateCommand($"drop table if exists {quotedPartition} cascade;")
+                        .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+
+                    logger.LogInformation(
+                        "Dropped partition {Partition} of {Table} for removed tenant {TenantId}",
+                        quotedPartition, table.Identifier.QualifiedName, tenantId);
+                }
+            }
+            finally
+            {
+                await conn.CloseAsync().ConfigureAwait(false);
+            }
+        }
+
+        // #4683 cleanup: the freestanding per-tenant event sequence and the tenant's
+        // mt_event_progression rows (per-projection + HighWaterMark:{tenant}) leak otherwise.
+        // Gated internally on UseTenantPartitionedEvents.
+        await Internal.PerTenantPartitionedCleanup.RunAsync(
+            _options, database, [tenantId],
+            new Dictionary<string, string> { [tenantId] = tenantId },
+            ct).ConfigureAwait(false);
     }
 
     #endregion
@@ -403,9 +632,8 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
     // surface (AddTenantAsync(tenantId, databaseId)) maps to AssignTenantAsync, and the
     // auto-assign override (AddTenantAsync(tenantId, ct) → string) maps to the same path
     // that Advanced.AddTenantToShardAsync(tenantId, ct) drives. The DisableTenantAsync /
-    // EnableTenantAsync / AllDisabledAsync surface is intentionally NOT yet implemented —
-    // the sharded tenant assignment table has no `disabled` column and no consumer needs
-    // those yet. Add column + lifecycle if/when a consumer surfaces.
+    // EnableTenantAsync / AllDisabledAsync soft-delete surface (#4607) is backed by the
+    // Marten-added `disabled` column on the assignment table.
 
     /// <summary>
     /// jasperfx#413 / #4598: store-agnostic FindAsync. For ShardedTenancy the "value" is
@@ -480,16 +708,37 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
         tenantId = _options.TenantIdStyle.MaybeCorrectTenantId(tenantId);
         await maybeApplyChanges().ConfigureAwait(false);
 
-        await _dataSource.Value
+        // `returning database_id` so the in-memory registry + pool counts can shrink below.
+        var databaseId = (await _dataSource.Value
             .CreateCommand(
-                $"update {_schemaName}.{TenantAssignmentTable.TableName} set {MartenTenantAssignmentTable.DisabledColumn} = true where tenant_id = :id")
+                $"update {_schemaName}.{TenantAssignmentTable.TableName} set {MartenTenantAssignmentTable.DisabledColumn} = true where tenant_id = :id returning database_id")
             .With("id", tenantId)
-            .ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
+            .ExecuteScalarAsync(CancellationToken.None).ConfigureAwait(false)) as string;
 
         // Evict from cache (and dispose only if no other tenant is using the same
         // shared shard database — sharded tenancy reuses one MartenDatabase per
         // assigned shard across tenants, unlike MasterTableTenancy's per-tenant DBs).
         _tenantToDatabase = _tenantToDatabase.Remove(tenantId);
+
+        if (databaseId != null)
+        {
+            // #4868: shrink the shard's in-memory TenantIds so this store's usage descriptor
+            // (DescribeDatabasesAsync → TryCreateUsage) stops reporting the disabled tenant —
+            // hosts that retire per-tenant daemon agents off the descriptor's supported-set
+            // diff converge without a restart. All data, partitions, and progression rows are
+            // RETAINED (soft-delete) — EnableTenantAsync restores everything in place.
+            if (_databasesById.TryFind(databaseId, out var database))
+            {
+                database.TenantIds.Remove(tenantId);
+            }
+
+            // Disabled tenants are excluded from assignment ranking (AssignTenantAsync's
+            // recompute filters on disabled = false), so keep tenant_count in step here too.
+            await _dataSource.Value.CreateCommand(
+                    $"update {_schemaName}.{DatabasePoolTable.TableName} set tenant_count = (select count(*) from {_schemaName}.{TenantAssignmentTable.TableName} where database_id = :did and {MartenTenantAssignmentTable.DisabledColumn} = false) where database_id = :did")
+                .With("did", databaseId)
+                .ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
+        }
     }
 
     /// <summary>
@@ -503,11 +752,29 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
         tenantId = _options.TenantIdStyle.MaybeCorrectTenantId(tenantId);
         await maybeApplyChanges().ConfigureAwait(false);
 
-        await _dataSource.Value
+        var databaseId = (await _dataSource.Value
             .CreateCommand(
-                $"update {_schemaName}.{TenantAssignmentTable.TableName} set {MartenTenantAssignmentTable.DisabledColumn} = false where tenant_id = :id")
+                $"update {_schemaName}.{TenantAssignmentTable.TableName} set {MartenTenantAssignmentTable.DisabledColumn} = false where tenant_id = :id returning database_id")
             .With("id", tenantId)
-            .ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
+            .ExecuteScalarAsync(CancellationToken.None).ConfigureAwait(false)) as string;
+
+        if (databaseId != null)
+        {
+            // #4868: symmetric with DisableTenantAsync — re-grow the in-memory registry
+            // eagerly so the usage descriptor reports the tenant again on this store
+            // without waiting for the next fresh-read reconciliation, and put the tenant
+            // back into the assignment-ranking count.
+            if (_databasesById.TryFind(databaseId, out var database))
+            {
+                database.TenantIds.Fill(tenantId);
+                _tenantToDatabase = _tenantToDatabase.AddOrUpdate(tenantId, database);
+            }
+
+            await _dataSource.Value.CreateCommand(
+                    $"update {_schemaName}.{DatabasePoolTable.TableName} set tenant_count = (select count(*) from {_schemaName}.{TenantAssignmentTable.TableName} where database_id = :did and {MartenTenantAssignmentTable.DisabledColumn} = false) where database_id = :did")
+                .With("did", databaseId)
+                .ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
+        }
     }
 
     Task IDynamicTenantSource<string>.RemoveTenantAsync(string tenantId)
@@ -748,8 +1015,17 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
 
         var list = _databasesById.Enumerate().Select(pair =>
         {
+            // MartenDatabase.Describe() already copies TenantIds onto the descriptor —
+            // Fill (not AddRange) so each tenant id appears exactly once. The BuildDatabases
+            // call above reconciled TenantIds against a fresh assignment read (#4868), so
+            // the descriptor shrinks after RemoveTenantAsync/DisableTenantAsync — including
+            // removals made from other nodes — without a restart.
             var descriptor = pair.Value.Describe();
-            descriptor.TenantIds.AddRange(pair.Value.TenantIds);
+            foreach (var tenantId in pair.Value.TenantIds)
+            {
+                descriptor.TenantIds.Fill(tenantId);
+            }
+
             return descriptor;
         }).ToList();
 

--- a/src/MultiTenancyTests/sharded_tenancy_remove_lifecycle_tests.cs
+++ b/src/MultiTenancyTests/sharded_tenancy_remove_lifecycle_tests.cs
@@ -1,0 +1,365 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Storage;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace MultiTenancyTests;
+
+/// <summary>
+/// #4868 / #4880 — the tenant REMOVE side of the sharded-tenancy lifecycle on a RUNNING store.
+/// Before the fix, <see cref="MartenDatabase.TenantIds"/> was add-only (`Fill` in
+/// <c>BuildDatabases</c>/<c>AssignTenantAsync</c>) and <c>DescribeDatabasesAsync</c> copied that
+/// in-memory list, so after <c>RemoveTenantAsync</c>/<c>DisableTenantAsync</c> a running store kept
+/// reporting the tenant in its usage descriptor (<c>TryCreateUsage</c>) forever — hosts that retire
+/// per-tenant daemon agents off the descriptor's supported-set diff (Wolverine-managed distribution)
+/// could never see a tenant leave until a process restart.
+///
+/// Also pins the removal contract carved out in #4880:
+/// <list type="bullet">
+///   <item>REMOVE is destructive on the shard — partitions, per-tenant sequence, and per-tenant
+///     progression rows are dropped/cleaned (mirrors the single-database
+///     <c>RemoveMartenManagedTenantsAsync</c> / #4683 semantics); a re-added tenant starts fresh.</item>
+///   <item>DISABLE is the non-destructive soft-delete — descriptor shrinks, all shard-side data
+///     and registry rows are retained, ENABLE restores in place.</item>
+/// </list>
+/// </summary>
+[Collection("sharded-tenancy")]
+public class sharded_tenancy_remove_lifecycle_tests: IAsyncLifetime
+{
+    private readonly ShardedTenancyFixture _fixture;
+    private IDocumentStore _store = null!;
+
+    public sharded_tenancy_remove_lifecycle_tests(ShardedTenancyFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedTenancyFixture.cleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        _store?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private IDocumentStore CreateStore()
+    {
+        _store = buildStore();
+        return _store;
+    }
+
+    private IDocumentStore buildStore()
+    {
+        return DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded";
+                x.PartitionSchemaName = "tenants";
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+            });
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.RegisterDocumentType<Target>();
+        });
+    }
+
+    private async Task applySchemaToAllShardsAsync()
+    {
+        var databases = await _store.Options.Tenancy.BuildDatabases();
+        foreach (var db in databases.OfType<IMartenDatabase>())
+        {
+            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+        }
+    }
+
+    private static IReadOnlyList<string> allTenantIds(DatabaseUsage usage)
+        => usage.Databases.SelectMany(d => d.TenantIds).ToList();
+
+    // ---- #4868: the usage descriptor must shrink on a RUNNING store ----
+
+    [Fact]
+    public async Task usage_descriptor_shrinks_after_RemoveTenantAsync_without_restart()
+    {
+        CreateStore();
+        await applySchemaToAllShardsAsync();
+        var sharded = (ShardedTenancy)_store.Options.Tenancy;
+
+        await _store.Advanced.AddTenantToShardAsync("rm_keep", CancellationToken.None);
+        await _store.Advanced.AddTenantToShardAsync("rm_gone", CancellationToken.None);
+
+        var before = await sharded.DescribeDatabasesAsync(CancellationToken.None);
+        allTenantIds(before).ShouldContain("rm_keep");
+        allTenantIds(before).ShouldContain("rm_gone");
+
+        await sharded.RemoveTenantAsync("rm_gone", CancellationToken.None);
+
+        // SAME store instance, no restart — this is exactly what #4868 pinned as broken.
+        var after = await sharded.DescribeDatabasesAsync(CancellationToken.None);
+        allTenantIds(after).ShouldNotContain("rm_gone");
+        allTenantIds(after).ShouldContain("rm_keep");
+    }
+
+    [Fact]
+    public async Task usage_descriptor_shrinks_on_disable_and_regrows_on_enable()
+    {
+        CreateStore();
+        await applySchemaToAllShardsAsync();
+        var sharded = (ShardedTenancy)_store.Options.Tenancy;
+        var source = (IDynamicTenantSource<string>)sharded;
+
+        var dbId = await source.AddTenantAsync("soft_tenant", CancellationToken.None);
+        allTenantIds(await sharded.DescribeDatabasesAsync(CancellationToken.None))
+            .ShouldContain("soft_tenant");
+
+        await source.DisableTenantAsync("soft_tenant");
+        allTenantIds(await sharded.DescribeDatabasesAsync(CancellationToken.None))
+            .ShouldNotContain("soft_tenant");
+
+        // DISABLE is non-destructive: partitions + shard registry rows are retained.
+        (await shardRegistryContainsAsync(dbId, "soft_tenant")).ShouldBeTrue(
+            "disable must NOT touch the shard's mt_tenant_partitions registry");
+        (await shardHasPartitionTablesForAsync(dbId, "soft_tenant")).ShouldBeTrue(
+            "disable must NOT drop the tenant's partitions");
+
+        await source.EnableTenantAsync("soft_tenant");
+        allTenantIds(await sharded.DescribeDatabasesAsync(CancellationToken.None))
+            .ShouldContain("soft_tenant");
+    }
+
+    [Fact]
+    public async Task descriptor_shrinks_when_tenant_removed_from_another_store_instance()
+    {
+        // The multi-node shape: node A keeps running while node B (another process/store)
+        // removes the tenant. Node A's next DescribeDatabasesAsync — every distribution
+        // cycle in a Wolverine-managed host — must re-enumerate fresh and see the tenant
+        // gone. This is the "fresh reads should be the source for sharded tenancy too"
+        // direction from #4868 (mirroring #4864's single-database rationale).
+        CreateStore();
+        await applySchemaToAllShardsAsync();
+        var nodeA = (ShardedTenancy)_store.Options.Tenancy;
+
+        await _store.Advanced.AddTenantToShardAsync("xnode_tenant", CancellationToken.None);
+
+        // Node A materializes the tenant into its in-memory registry.
+        allTenantIds(await nodeA.DescribeDatabasesAsync(CancellationToken.None))
+            .ShouldContain("xnode_tenant");
+
+        using (var storeB = buildStore())
+        {
+            var nodeB = (ShardedTenancy)storeB.Options.Tenancy;
+            await nodeB.RemoveTenantAsync("xnode_tenant", CancellationToken.None);
+        }
+
+        allTenantIds(await nodeA.DescribeDatabasesAsync(CancellationToken.None))
+            .ShouldNotContain("xnode_tenant");
+    }
+
+    [Fact]
+    public async Task descriptor_follows_a_tenant_reassigned_to_another_shard()
+    {
+        CreateStore();
+        await applySchemaToAllShardsAsync();
+        var sharded = (ShardedTenancy)_store.Options.Tenancy;
+
+        await sharded.AssignTenantAsync("mover", _fixture.DbNames[0], CancellationToken.None);
+        var before = await sharded.DescribeDatabasesAsync(CancellationToken.None);
+        before.Databases.Single(d => d.Identifier == _fixture.DbNames[0]).TenantIds.ShouldContain("mover");
+
+        await sharded.AssignTenantAsync("mover", _fixture.DbNames[1], CancellationToken.None);
+
+        // The fresh-read reconciliation must move the tenant between shard descriptors,
+        // not leave it reported on BOTH shards (the add-only `Fill` behavior).
+        var after = await sharded.DescribeDatabasesAsync(CancellationToken.None);
+        after.Databases.Single(d => d.Identifier == _fixture.DbNames[0]).TenantIds.ShouldNotContain("mover");
+        after.Databases.Single(d => d.Identifier == _fixture.DbNames[1]).TenantIds.ShouldContain("mover");
+    }
+
+    [Fact]
+    public async Task descriptor_reports_each_tenant_exactly_once()
+    {
+        CreateStore();
+        await applySchemaToAllShardsAsync();
+        var sharded = (ShardedTenancy)_store.Options.Tenancy;
+
+        await sharded.AssignTenantAsync("dupe_check", _fixture.DbNames[0], CancellationToken.None);
+        // A second describe re-runs BuildDatabases' Fill pass — the descriptor snapshot
+        // must still carry the tenant exactly once (Describe() + the explicit copy used
+        // to AddRange-duplicate every tenant id).
+        await sharded.DescribeDatabasesAsync(CancellationToken.None);
+        var usage = await sharded.DescribeDatabasesAsync(CancellationToken.None);
+
+        usage.Databases.Single(d => d.Identifier == _fixture.DbNames[0])
+            .TenantIds.Count(t => t == "dupe_check").ShouldBe(1);
+    }
+
+    // ---- #4880: the destructive removal contract on the shard ----
+
+    [Fact]
+    public async Task remove_drops_shard_partitions_registry_rows_and_recomputes_tenant_count()
+    {
+        CreateStore();
+        await applySchemaToAllShardsAsync();
+        var sharded = (ShardedTenancy)_store.Options.Tenancy;
+
+        await sharded.AssignTenantAsync("hard_gone", _fixture.DbNames[0], CancellationToken.None);
+        await sharded.AssignTenantAsync("hard_stays", _fixture.DbNames[0], CancellationToken.None);
+
+        (await shardHasPartitionTablesForAsync(_fixture.DbNames[0], "hard_gone")).ShouldBeTrue();
+        (await shardRegistryContainsAsync(_fixture.DbNames[0], "hard_gone")).ShouldBeTrue();
+
+        await _store.Advanced.RemoveTenantFromShardAsync("hard_gone", CancellationToken.None);
+
+        // Shard side: partitions + registry rows are gone (this is what lets the NATIVE
+        // coordinator's per-tenant re-expansion — jasperfx#491 over ICrossTenantRebuildSource —
+        // stop seeing the tenant and reap its agents), the surviving tenant is untouched.
+        (await shardHasPartitionTablesForAsync(_fixture.DbNames[0], "hard_gone")).ShouldBeFalse(
+            "removal must drop the tenant's list partitions from the shard");
+        (await shardRegistryContainsAsync(_fixture.DbNames[0], "hard_gone")).ShouldBeFalse(
+            "removal must remove the tenant from the shard's mt_tenant_partitions registry");
+        (await shardHasPartitionTablesForAsync(_fixture.DbNames[0], "hard_stays")).ShouldBeTrue();
+        (await shardRegistryContainsAsync(_fixture.DbNames[0], "hard_stays")).ShouldBeTrue();
+
+        // Master side: assignment row deleted, tenant_count recomputed (#4763-style).
+        (await sharded.FindDatabaseForTenantAsync("hard_gone", CancellationToken.None)).ShouldBeNull();
+        var pool = await sharded.ListDatabasesAsync(CancellationToken.None);
+        pool.First(d => d.DatabaseId == _fixture.DbNames[0]).TenantCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task tenant_count_shrinks_on_disable_and_regrows_on_enable()
+    {
+        CreateStore();
+        await applySchemaToAllShardsAsync();
+        var sharded = (ShardedTenancy)_store.Options.Tenancy;
+        var source = (IDynamicTenantSource<string>)sharded;
+
+        await sharded.AssignTenantAsync("count_soft", _fixture.DbNames[2], CancellationToken.None);
+        (await countFor(sharded, _fixture.DbNames[2])).ShouldBe(1);
+
+        // Disabled tenants are excluded from assignment ranking (AssignTenantAsync's recompute
+        // filters on disabled = false) — Disable/Enable must keep tenant_count in step.
+        await source.DisableTenantAsync("count_soft");
+        (await countFor(sharded, _fixture.DbNames[2])).ShouldBe(0);
+
+        await source.EnableTenantAsync("count_soft");
+        (await countFor(sharded, _fixture.DbNames[2])).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task remove_is_idempotent_and_a_removed_tenant_can_be_readded_fresh()
+    {
+        CreateStore();
+        await applySchemaToAllShardsAsync();
+        var sharded = (ShardedTenancy)_store.Options.Tenancy;
+
+        await sharded.AssignTenantAsync("recycled", _fixture.DbNames[1], CancellationToken.None);
+        await sharded.RemoveTenantAsync("recycled", CancellationToken.None);
+
+        // Re-runs (crash recovery, double-click in an admin UI) must no-op, not throw.
+        await sharded.RemoveTenantAsync("recycled", CancellationToken.None);
+        await sharded.RemoveTenantAsync("unknown_tenant_never_existed", CancellationToken.None);
+
+        // Re-adding provisions the tenant from scratch — fresh partitions, resolvable again.
+        var dbId = await _store.Advanced.AddTenantToShardAsync("recycled", CancellationToken.None);
+        (await shardHasPartitionTablesForAsync(dbId, "recycled")).ShouldBeTrue();
+        (await sharded.GetTenantAsync("recycled")).TenantId.ShouldBe("recycled");
+        allTenantIds(await sharded.DescribeDatabasesAsync(CancellationToken.None))
+            .ShouldContain("recycled");
+    }
+
+    [Fact]
+    public async Task removing_a_disabled_tenant_still_cleans_its_shard()
+    {
+        CreateStore();
+        await applySchemaToAllShardsAsync();
+        var sharded = (ShardedTenancy)_store.Options.Tenancy;
+        var source = (IDynamicTenantSource<string>)sharded;
+
+        await sharded.AssignTenantAsync("soft_then_hard", _fixture.DbNames[1], CancellationToken.None);
+        await source.DisableTenantAsync("soft_then_hard");
+
+        // The shard resolution is deliberately NOT filtered on the disabled flag here —
+        // disable-then-remove is the natural retire flow and must not leak shard partitions.
+        await sharded.RemoveTenantAsync("soft_then_hard", CancellationToken.None);
+
+        (await shardHasPartitionTablesForAsync(_fixture.DbNames[1], "soft_then_hard")).ShouldBeFalse();
+        (await shardRegistryContainsAsync(_fixture.DbNames[1], "soft_then_hard")).ShouldBeFalse();
+        (await source.AllDisabledAsync()).ShouldNotContain("soft_then_hard");
+    }
+
+    [Fact]
+    public async Task RemoveMartenManagedTenantsAsync_routes_to_the_sharded_removal_path()
+    {
+        // The store-agnostic admin surface (mirrors AddMartenManagedTenantsAsync's sharded
+        // routing) — one call, full removal, suffix == tenant id under the sharded 1:1 shape.
+        CreateStore();
+        await applySchemaToAllShardsAsync();
+        var sharded = (ShardedTenancy)_store.Options.Tenancy;
+
+        await sharded.AssignTenantAsync("managed_gone", _fixture.DbNames[2], CancellationToken.None);
+
+        await _store.Advanced.RemoveMartenManagedTenantsAsync(
+            new[] { "managed_gone" }, CancellationToken.None);
+
+        (await sharded.FindDatabaseForTenantAsync("managed_gone", CancellationToken.None)).ShouldBeNull();
+        (await shardRegistryContainsAsync(_fixture.DbNames[2], "managed_gone")).ShouldBeFalse();
+        allTenantIds(await sharded.DescribeDatabasesAsync(CancellationToken.None))
+            .ShouldNotContain("managed_gone");
+    }
+
+    // ---- helpers ----
+
+    private static async Task<int> countFor(ShardedTenancy sharded, string dbName)
+    {
+        var pool = await sharded.ListDatabasesAsync(CancellationToken.None);
+        return pool.First(d => d.DatabaseId == dbName).TenantCount;
+    }
+
+    private async Task<bool> shardHasPartitionTablesForAsync(string dbName, string tenantId)
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbName]);
+        await conn.OpenAsync();
+        var tables = await conn.ExistingTablesAsync();
+        return tables.Any(t => t.Name.EndsWith($"_{tenantId}", StringComparison.Ordinal));
+    }
+
+    private async Task<bool> shardRegistryContainsAsync(string dbName, string tenantId)
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbName]);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand(
+            "select count(*) from tenants.mt_tenant_partitions where partition_value = :id");
+        cmd.Parameters.AddWithValue("id", tenantId);
+        var count = (long)(await cmd.ExecuteScalarAsync())!;
+        return count > 0;
+    }
+}

--- a/src/TenantPartitionedEventsTests/Sharded/dynamic_tenant_lifecycle_on_shard_during_daemon.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/dynamic_tenant_lifecycle_on_shard_during_daemon.cs
@@ -46,6 +46,14 @@ namespace TenantPartitionedEventsTests.Sharded;
 ///     the SHARD database's own <c>mt_event_progression</c> and the projection catches up to the
 ///     tenant's own height — WITHOUT a restart and WITHOUT the explicit per-tenant
 ///     <c>StartAgentAsync</c> (wolverine#3280) workaround this test previously had to drive.</item>
+///   <item>#4868/#4880 — the REMOVE side of the lifecycle: <c>Advanced.RemoveTenantFromShardAsync</c>
+///     mid-run (from the separate client store) shrinks the client store's usage descriptor
+///     immediately (no restart), drops the tenant from the shard's own
+///     <c>mt_tenant_partitions</c> registry, and the RUNNING HotCold coordinator's next
+///     re-expansion stops producing the tenant's shard name — its agent is REAPED by
+///     the jasperfx#491 reconciliation pass (<c>reapOrphanedAgentsAsync</c>). The tenant's
+///     per-tenant progression + high-water rows are cleaned (#4683 semantics) and stay gone,
+///     while the surviving tenant keeps processing new events on the same shard daemon.</item>
 /// </list>
 /// LeadershipPollingTime is tuned down to 250ms so the mid-run discovery converges fast and
 /// deterministically instead of sleeping the default window.
@@ -232,11 +240,81 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
             {
                 (await query.LoadAsync<ShardedDaemonCounter>(stream1))!.EventCount.ShouldBe(3);
             }
+
+            // ---- Phase 2 (#4868 / #4880): REMOVE tenant 2 while the coordinator keeps running ----
+            await _store.Advanced.RemoveTenantFromShardAsync(tenant2, CancellationToken.None);
+
+            // #4868: the client store's own usage descriptor shrinks IMMEDIATELY — no restart.
+            // This is the signal Wolverine-managed distribution diffs per cycle to retire the
+            // tenant's agents (the descriptor used to be add-only and never shrank).
+            var clientUsage = await _store.Options.Tenancy.DescribeDatabasesAsync(CancellationToken.None);
+            clientUsage.Databases.SelectMany(x => x.TenantIds).ShouldNotContain(tenant2);
+            clientUsage.Databases.SelectMany(x => x.TenantIds).ShouldContain(tenant1);
+
+            // ... and so does a FRESH DescribeDatabasesAsync on the RUNNING coordinator node's
+            // store — the fresh-read reconciliation in BuildDatabases, i.e. the cross-node path.
+            var nodeStore = node.Services.GetRequiredService<IDocumentStore>();
+            var nodeUsage = await nodeStore.Options.Tenancy.DescribeDatabasesAsync(CancellationToken.None);
+            nodeUsage.Databases.SelectMany(x => x.TenantIds).ShouldNotContain(tenant2);
+
+            // #4880: the NATIVE HotCold coordinator retires the removed tenant's agent on its
+            // own — the shard's mt_tenant_partitions registry no longer lists tenant 2, the
+            // next leadership-cycle re-expansion (jasperfx#491's PerTenantShardExpansion) stops
+            // producing its shard name, and reapOrphanedAgentsAsync stops the running agent.
+            await WaitForConditionAsync(
+                () => daemon.CurrentAgents().All(x =>
+                    x.Name.Identity != $"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}"),
+                30.Seconds(),
+                "tenant 2's agent is reaped by coordinator reconciliation after removal");
+            _output.WriteLine("shard A agents after removal: " +
+                              string.Join(", ", daemon.CurrentAgents().Select(x => x.Name.Identity)));
+
+            // Progression-row contract on REMOVE (pinned by #4880): the tenant's per-tenant
+            // progression + high-water rows are CLEANED (#4683 semantics), and nothing
+            // re-creates them once the agent is reaped — a re-added tenant starts fresh.
+            var afterRemoval = await ProgressionRowsAsync(shardConnStr);
+            DumpRows("shard A progression after removing tenant 2", afterRemoval);
+            afterRemoval.Any(r => r.Name == $"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}")
+                .ShouldBeFalse("the removed tenant's projection progression rows must be cleaned");
+            afterRemoval.Any(r => r.Name == $"HighWaterMark:{tenant2}")
+                .ShouldBeFalse("the removed tenant's high-water row must be cleaned");
+
+            // The surviving tenant keeps processing NEW events on the same shard daemon —
+            // the reap didn't take the shard's other agents down with it.
+            await using (var session = _store.LightweightSession(tenant1))
+            {
+                session.Events.Append(stream1, new ShardedDaemonEvent("t1-4"));
+                await session.SaveChangesAsync();
+            }
+
+            var survivorRows = await WaitForProgressionAsync(shardConnStr, r =>
+                    SeqOf(r, $"{ShardedDaemonProjection.ProjectionName}:All:{tenant1}") >= 4,
+                30.Seconds(), "the surviving tenant's agent keeps catching up after the removal");
+
+            // ... and the removed tenant's rows never came back across those polling cycles.
+            survivorRows.Any(r => r.Name.EndsWith($":{tenant2}", StringComparison.Ordinal))
+                .ShouldBeFalse("no per-tenant progression rows may be re-persisted for the removed tenant");
         }
         finally
         {
             await node.StopAsync();
         }
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout, string what)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(250);
+        }
+
+        throw new TimeoutException($"Timed out after {timeout} waiting for: {what}");
     }
 
     private static async Task<bool> SequenceExistsAsync(string connectionString, string sequenceName)


### PR DESCRIPTION
## What & why

Closes #4868, delivers the #4880 REMOVE-lifecycle e2e.

Found by the WS1 runtime-churn e2e for epic jasperfx#486. The tenant-**ADD** side already converges end-to-end under Wolverine-managed distribution (new tenant → new per-tenant agent + progression rows, no restart). The **REMOVE** side could not: `MartenDatabase.TenantIds` was add-only (`Fill` in `BuildDatabases` / `AssignTenantAsync`) and `DescribeDatabasesAsync` copied that in-memory list, so after `ShardedTenancy.RemoveTenantAsync` / `DisableTenantAsync` a running store kept reporting the tenant in `IEventStore.TryCreateUsage`. Wolverine's supported-set diff (and the native coordinator's re-enumeration from jasperfx#491) never saw the tenant leave, and its agents ran until process restart.

## The fix (`ShardedTenancy`)

- **`BuildDatabases` reconciles** the in-memory registry against the fresh active-assignment read — it now **prunes** `TenantIds` / `_tenantToDatabase`, not just grows them. Every `BuildDatabases` / `DescribeDatabasesAsync` becomes a fresh-read re-enumeration, so a removal made from **another node** converges too. This is the "fresh reads should be the source for sharded tenancy" direction from #4868, mirroring #4864's single-database rationale (one source, invalidation-free).
- **`RemoveTenantAsync` is now the full symmetric inverse of `AddTenantAsync`**: drops the tenant's LIST partitions **and** its `mt_tenant_partitions` registry rows on the shard (so jasperfx#491's `PerTenantShardExpansion` over `ICrossTenantRebuildSource` stops producing the tenant's shard name and its agents get reaped), runs the #4683 per-tenant event-sequence + progression/high-water cleanup, deletes the master assignment row, recomputes `tenant_count` (#4763-style), and shrinks the in-memory registry immediately. Idempotent; cleans a soft-deleted tenant too.
- **`Disable` / `EnableTenantAsync`** now shrink / re-grow `TenantIds` + `tenant_count` so the descriptor tracks soft-delete state. Non-destructive — data, partitions, and progression rows are retained; `Enable` restores in place.
- **`DescribeDatabasesAsync`** uses `Fill` (was `AddRange`) so each tenant id appears exactly once.

### `AdvancedOperations`
- New **`RemoveTenantFromShardAsync`** — the documented inverse of `AddTenantToShardAsync`.
- **`RemoveMartenManagedTenantsAsync`** now routes the sharded case to the removal path (mirrors `AddMartenManagedTenantsAsync`'s existing sharded routing; suffix == tenant id under the sharded 1:1 shape).

## Progression-row contract on removal (#4880)

- **REMOVE is destructive** on the shard — partitions, per-tenant sequence, and per-tenant progression/high-water rows are dropped/cleaned (mirrors the single-DB `RemoveMartenManagedTenantsAsync` / #4683 semantics). A re-added tenant starts **fresh**.
- **DISABLE is the non-destructive soft-delete** — descriptor shrinks, all shard-side data + registry rows retained, `Enable` restores in place.

## Weasel note (deliberate local reimplementation)

The shard partition drop is a small **quoted** reimplementation rather than `Weasel.Postgresql`'s `ManagedListPartitions.DropPartitionFromAllTables`. That path interpolates the partition table name **unquoted** into the `DETACH` / `DROP` DDL and fails with `42601 syntax error` for any tenant id that isn't a bare PostgreSQL identifier (hyphens, uppercase, GUID-shaped) — and the sharded assignment path never restricted tenant ids the way `AddMartenManagedTenantsAsync`'s `AssertValidPostgresqlIdentifiers` does, so quoted partitions exist in the wild and the drop must quote too.

**JasperFx / Weasel ask:** teach `ManagedListPartitions.DropPartitionFromAllTables` (and `...ForValue`) to quote the partition identifier in the `DETACH PARTITION` / `DROP TABLE` DDL (it already quotes on the CREATE side). Once that ships, this local drop loop can fold back to the Weasel call.

## Tests

- **`sharded_tenancy_remove_lifecycle_tests`** (new, `MultiTenancyTests`, 10 tests): descriptor shrink after `RemoveTenantAsync` on the same running store; shrink-on-disable / regrow-on-enable; **cross-store-instance** removal (the multi-node shape); reassignment follows between shard descriptors; each tenant reported exactly once; destructive-removal contract (partitions + registry rows dropped, `tenant_count` recomputed); `tenant_count` shrink/regrow on disable/enable; idempotent removal + fresh re-add; removing a disabled tenant still cleans its shard; `RemoveMartenManagedTenantsAsync` routing.
- **`dynamic_tenant_lifecycle_on_shard_during_daemon` Phase 2** (extended e2e): while a **native HotCold coordinator** keeps running, `RemoveTenantFromShardAsync` mid-run shrinks the client store's descriptor immediately, a fresh describe on the running coordinator node's store also drops the tenant, the coordinator's jasperfx#491 re-expansion + `reapOrphanedAgentsAsync` **reaps the removed tenant's agent**, its progression + high-water rows are cleaned and stay gone, and the surviving tenant keeps processing new events on the same shard daemon.

Results (Postgres on 5432, one project / net9.0 at a time):
- `MultiTenancyTests` sharded surface: **33/33 passed** (10 new + 23 existing).
- `TenantPartitionedEventsTests` `Sharded` collection: **26/26 passed**. In a full-project run 3 sharded tests intermittently fail on the shared physical shard databases (`marten_shard_a/b/c`) under cross-collection load; all pass in isolation and the whole `Sharded` collection passes as a group — the known shared-resource flake for these suites, not a regression.

## Follow-up (NOT in this PR)

- **Wolverine-managed removal e2e** belongs in the `wolverine` repo — flip/extend wolverine#3334's churn test to cover removal (agents stop, no orphaned progression writes) against this descriptor-shrink signal. Tracked under jasperfx#486 WS1.
- **Weasel quoted-drop** fold-back described above.

Part of jasperfx#486 (WS1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)