### PR TITLE
Per-database tenant partition state for sharded stores (#4863, #4855)

### DIFF
--- a/src/Marten/AdvancedOperations.cs
+++ b/src/Marten/AdvancedOperations.cs
@@ -609,7 +609,7 @@ public class AdvancedOperations
         // clear the tenant from the partition registry, and we still need the suffix to drop
         // the freestanding mt_events_sequence_{suffix} afterwards.
         var capturedSuffixes = Marten.Internal.PerTenantPartitionedCleanup.CaptureSequenceSuffixes(
-            _store.Options, suffixes);
+            _store.Options, database, suffixes);
 
         await _store.Options.TenantPartitions.Partitions.DropPartitionFromAllTables(database, logger, suffixes,
             token).ConfigureAwait(false);

--- a/src/Marten/Internal/PerTenantPartitionedCleanup.cs
+++ b/src/Marten/Internal/PerTenantPartitionedCleanup.cs
@@ -34,11 +34,15 @@ internal static class PerTenantPartitionedCleanup
     /// existed).
     /// </summary>
     public static IReadOnlyDictionary<string, string> CaptureSequenceSuffixes(
-        StoreOptions options, IEnumerable<string> tenantIds)
+        StoreOptions options, Weasel.Core.Migrations.IDatabase database, IEnumerable<string> tenantIds)
     {
         var suffixes = new Dictionary<string, string>(StringComparer.Ordinal);
         if (!options.Events.UseTenantPartitionedEvents) return suffixes;
-        if (options.TenantPartitions?.Partitions.Partitions is not { } registry) return suffixes;
+
+        // #4863/#4855: resolve the suffix from the registry view of the database the tenant
+        // actually lives in — the store-wide snapshot may have been hydrated from a different
+        // database entirely under multi-database tenancy.
+        if (options.TenantPartitions?.Partitions.PartitionsFor(database) is not { } registry) return suffixes;
 
         foreach (var tenantId in tenantIds)
         {

--- a/src/Marten/Internal/TenantDataCleaner.cs
+++ b/src/Marten/Internal/TenantDataCleaner.cs
@@ -34,7 +34,7 @@ internal class TenantDataCleaner
         // drop the freestanding mt_events_sequence_{suffix} afterwards. The Weasel managed-list
         // partition registry may forget the tenant once DropPartitionFromAllTablesForValue runs.
         var capturedSuffixes = PerTenantPartitionedCleanup.CaptureSequenceSuffixes(
-            _store.Options, new[] { _tenantId });
+            _store.Options, database, new[] { _tenantId });
 
         if (_store.Options is { TenantPartitions: not null})
         {

--- a/src/Marten/Schema/DatabaseScopedTenantPartitions.cs
+++ b/src/Marten/Schema/DatabaseScopedTenantPartitions.cs
@@ -1,0 +1,390 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ImTools;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Weasel.Core;
+using Weasel.Core.Migrations;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Tables.Partitioning;
+
+namespace Marten.Schema;
+
+/// <summary>
+/// Ambient "which database is currently being migrated" marker for
+/// <see cref="DatabaseScopedTenantPartitions"/> (#4863/#4855).
+///
+/// <para>
+/// Weasel's <c>IListPartitionManager.Partitions()</c> is synchronous and parameterless, and the
+/// per-mapping <c>Table</c> singletons that carry the partitioning are shared across every shard
+/// database — so the only way to give the expected-partition set a per-database view without a
+/// Weasel API change is an ambient scope. <see cref="Marten.Storage.MartenDatabase"/> stamps the
+/// scope from its synchronous <c>BuildFeatureSchemas()</c> / <c>FindFeature()</c> overrides, which
+/// Weasel's <c>DatabaseBase</c> calls at the head of every migration operation
+/// (<c>ApplyAllConfiguredChangesToDatabaseAsync</c>, <c>ensureStorageExistsAsync</c>,
+/// <c>CreateMigrationAsync</c>, script generation). AsyncLocal writes in a synchronous callee flow
+/// onward through the caller's awaits, so the whole migration operation — including
+/// <c>WriteCreateStatement</c> / <c>CreateDelta</c> partition consultation deep inside Weasel —
+/// sees the right database. Concurrent applies to different databases are isolated per async flow.
+/// </para>
+/// </summary>
+internal static class TenantPartitionDatabaseScope
+{
+    private static readonly AsyncLocal<PostgresqlDatabase?> _current = new();
+
+    public static PostgresqlDatabase? Current
+    {
+        get => _current.Value;
+        set => _current.Value = value;
+    }
+}
+
+/// <summary>
+/// Per-database-aware specialization of Weasel's <see cref="ManagedListPartitions"/> for
+/// Marten-managed tenant partitioning (#4863/#4855).
+///
+/// <para>
+/// The base class keeps ONE store-wide partition dictionary and hydrates it at most once, from
+/// whichever database happens to be touched first. Under multi-database tenancy (sharded pools,
+/// master-table tenancy) that produced two families of bugs:
+/// #4863 — a table created lazily on a shard by a fresh store instance saw an EMPTY snapshot and
+/// was created partitioned with zero partitions (every write → 23514), because nothing ever read
+/// that shard's own <c>mt_tenant_partitions</c>; and
+/// #4855 — the store-shared snapshot fed every database's delta, so each shard materialized
+/// partitions (and per-tenant event sequences) for every tenant of the whole store — quadratic
+/// at scale.
+/// </para>
+///
+/// <para>
+/// This subclass keys partition state by database identifier, hydrated from each database's own
+/// <c>mt_tenant_partitions</c> table (via the per-database initializer that
+/// <c>MartenDatabase</c> registers, and eagerly on the add/drop entry points below). The
+/// re-implemented <see cref="IListPartitionManager"/> surface serves the ambient database's view
+/// when one is in scope and hydrated, falling back to the legacy store-wide snapshot otherwise —
+/// behavior only ever gets more precise, never less.
+/// </para>
+/// </summary>
+public class DatabaseScopedTenantPartitions: ManagedListPartitions, IListPartitionManager
+{
+    private sealed class DatabaseSet
+    {
+        public readonly SemaphoreSlim Lock = new(1);
+        public volatile bool Hydrated;
+
+        // Swapped copy-on-write under Lock; readers see a consistent snapshot.
+        public Dictionary<string, string> Values = new();
+    }
+
+    private readonly DbObjectName _tableName;
+    private ImHashMap<string, DatabaseSet> _databases = ImHashMap<string, DatabaseSet>.Empty;
+    private readonly object _databasesLock = new();
+
+    public DatabaseScopedTenantPartitions(string identifier, DbObjectName tableName): base(identifier, tableName)
+    {
+        _tableName = tableName;
+    }
+
+    private DatabaseSet setFor(string databaseIdentifier)
+    {
+        if (_databases.TryFind(databaseIdentifier, out var set))
+        {
+            return set;
+        }
+
+        lock (_databasesLock)
+        {
+            if (_databases.TryFind(databaseIdentifier, out set))
+            {
+                return set;
+            }
+
+            set = new DatabaseSet();
+            _databases = _databases.AddOrUpdate(databaseIdentifier, set);
+            return set;
+        }
+    }
+
+    /// <summary>
+    /// Read the authoritative tenant → partition-suffix registry of the given database from its
+    /// own <c>mt_tenant_partitions</c> table. No-op when this database was already hydrated,
+    /// unless <paramref name="force"/> refreshes the snapshot from the table.
+    /// </summary>
+    public async Task HydrateAsync(IDatabase database, NpgsqlConnection conn, CancellationToken token,
+        bool force = false)
+    {
+        var set = setFor(database.Identifier);
+        if (set.Hydrated && !force)
+        {
+            return;
+        }
+
+        await set.Lock.WaitAsync(token).ConfigureAwait(false);
+        try
+        {
+            if (set.Hydrated && !force)
+            {
+                return;
+            }
+
+            var values = new Dictionary<string, string>();
+            try
+            {
+                await using var reader = await conn
+                    .CreateCommand($"select partition_value, partition_suffix from {_tableName.QualifiedName}")
+                    .ExecuteReaderAsync(token).ConfigureAwait(false);
+
+                while (await reader.ReadAsync(token).ConfigureAwait(false))
+                {
+                    var value = await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false);
+                    var suffix = value.ToLowerInvariant();
+                    if (!await reader.IsDBNullAsync(1, token).ConfigureAwait(false))
+                    {
+                        suffix = (await reader.GetFieldValueAsync<string>(1, token).ConfigureAwait(false))
+                            .ToLowerInvariant();
+                    }
+
+                    values[value] = suffix;
+                }
+            }
+            catch (PostgresException e) when (e.SqlState == PostgresErrorCodes.UndefinedTable)
+            {
+                // Fresh database — the registry table doesn't exist yet, so this database
+                // genuinely has no tenants. An empty, hydrated set is the correct answer.
+            }
+
+            set.Values = values;
+            set.Hydrated = true;
+        }
+        finally
+        {
+            set.Lock.Release();
+        }
+    }
+
+    private async Task hydrateWithFreshConnectionAsync(PostgresqlDatabase database, CancellationToken token,
+        bool force = false)
+    {
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+        await HydrateAsync(database, conn, token, force).ConfigureAwait(false);
+        await conn.CloseAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// The tenant → partition-suffix view for a specific database: its own hydrated registry
+    /// snapshot when available, the legacy store-wide snapshot otherwise.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> PartitionsFor(IDatabase database)
+    {
+        if (_databases.TryFind(database.Identifier, out var set) && set.Hydrated)
+        {
+            return set.Values;
+        }
+
+        return base.Partitions;
+    }
+
+    private IReadOnlyDictionary<string, string>? tryScopedView()
+    {
+        var database = TenantPartitionDatabaseScope.Current;
+        if (database != null && _databases.TryFind(database.Identifier, out var set) && set.Hydrated)
+        {
+            return set.Values;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The expected partition set. When a database migration is in flight (ambient database scope
+    /// set and that database's registry hydrated), this is that database's OWN tenant set;
+    /// otherwise the legacy store-wide snapshot.
+    /// </summary>
+    public new ReadOnlyDictionary<string, string> Partitions
+    {
+        get
+        {
+            var scoped = tryScopedView();
+            return scoped != null
+                ? new ReadOnlyDictionary<string, string>((IDictionary<string, string>)scoped)
+                : base.Partitions;
+        }
+    }
+
+    IEnumerable<ListPartition> IListPartitionManager.Partitions()
+    {
+        var source = tryScopedView() ?? (IReadOnlyDictionary<string, string>)base.Partitions;
+
+        // Same shape as the base implementation: group values by suffix.
+        foreach (var group in source.GroupBy(x => x.Value))
+        {
+            yield return new ListPartition(group.Key, group.Select(x => $"'{x.Key}'").ToArray());
+        }
+    }
+
+    /// <summary>
+    /// Database-scoped counterpart of the base upsert: refreshes this database's view from its own
+    /// registry, merges the new values, and runs the base registry-write + additive table
+    /// reconciliation under the ambient database scope so the delta only ever expects THIS
+    /// database's tenants (#4855).
+    /// </summary>
+    public new async Task<TablePartitionStatus[]> AddPartitionToAllTables(ILogger logger,
+        PostgresqlDatabase database, Dictionary<string, string> values, CancellationToken token)
+    {
+        // Force-refresh so the expected set converges on the authoritative registry even when
+        // another node registered tenants on this database since we last looked.
+        await hydrateWithFreshConnectionAsync(database, token, force: true).ConfigureAwait(false);
+        mergeInto(database, values);
+
+        var prior = TenantPartitionDatabaseScope.Current;
+        TenantPartitionDatabaseScope.Current = database;
+        try
+        {
+            return await base.AddPartitionToAllTables(logger, database, values, token).ConfigureAwait(false);
+        }
+        finally
+        {
+            TenantPartitionDatabaseScope.Current = prior;
+        }
+    }
+
+    /// <summary>
+    /// Database-scoped counterpart of the base single-value upsert + reconcile.
+    /// </summary>
+    public new async Task AddPartitionToAllTables(PostgresqlDatabase database, string value, string? suffix,
+        CancellationToken token)
+    {
+        await hydrateWithFreshConnectionAsync(database, token, force: true).ConfigureAwait(false);
+        mergeInto(database, new Dictionary<string, string>
+        {
+            [value] = string.IsNullOrEmpty(suffix) ? value.ToLowerInvariant() : suffix
+        });
+
+        var prior = TenantPartitionDatabaseScope.Current;
+        TenantPartitionDatabaseScope.Current = database;
+        try
+        {
+            await base.AddPartitionToAllTables(database, value, suffix, token).ConfigureAwait(false);
+        }
+        finally
+        {
+            TenantPartitionDatabaseScope.Current = prior;
+        }
+    }
+
+    /// <summary>
+    /// Database-scoped counterpart of the base partition drop — removes the suffixes from this
+    /// database's view after the base drop deletes the registry rows and detaches the partitions.
+    /// </summary>
+    public new async Task DropPartitionFromAllTables(PostgresqlDatabase database, ILogger logger,
+        string[] suffixNames, CancellationToken token)
+    {
+        await hydrateWithFreshConnectionAsync(database, token, force: true).ConfigureAwait(false);
+
+        var prior = TenantPartitionDatabaseScope.Current;
+        TenantPartitionDatabaseScope.Current = database;
+        try
+        {
+            await base.DropPartitionFromAllTables(database, logger, suffixNames, token).ConfigureAwait(false);
+        }
+        finally
+        {
+            TenantPartitionDatabaseScope.Current = prior;
+        }
+
+        removeSuffixes(database, suffixNames);
+    }
+
+    /// <summary>
+    /// Database-scoped counterpart of the base by-value drop. Resolves the partition suffix from
+    /// THIS database's registry — the base implementation resolves from the store-wide snapshot,
+    /// which under sharded tenancy may have been hydrated from a different database entirely.
+    /// </summary>
+    public new async Task DropPartitionFromAllTablesForValue(PostgresqlDatabase database, ILogger logger,
+        string value, CancellationToken token)
+    {
+        await hydrateWithFreshConnectionAsync(database, token, force: true).ConfigureAwait(false);
+
+        if (_databases.TryFind(database.Identifier, out var set) && set.Hydrated
+            && set.Values.TryGetValue(value, out var suffix))
+        {
+            await DropPartitionFromAllTables(database, logger, [suffix], token).ConfigureAwait(false);
+            return;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(value),
+            $"Could not find a partition with the value '{value}' in database '{database.Identifier}'");
+    }
+
+    /// <summary>
+    /// Clears the hydration state of every per-database view (as well as the base store-wide
+    /// snapshot) so the next touch re-reads each database's own registry.
+    /// </summary>
+    public new void ForceReload()
+    {
+        base.ForceReload();
+        foreach (var entry in _databases.Enumerate())
+        {
+            entry.Value.Hydrated = false;
+        }
+    }
+
+    private void mergeInto(IDatabase database, Dictionary<string, string> values)
+    {
+        var set = setFor(database.Identifier);
+        lock (_databasesLock)
+        {
+            var updated = new Dictionary<string, string>(set.Values);
+            foreach (var pair in values)
+            {
+                updated[pair.Key] = pair.Value;
+            }
+
+            set.Values = updated;
+        }
+    }
+
+    private void removeSuffixes(IDatabase database, string[] suffixNames)
+    {
+        var set = setFor(database.Identifier);
+        lock (_databasesLock)
+        {
+            var updated = set.Values
+                .Where(pair => !suffixNames.Contains(pair.Value, StringComparer.OrdinalIgnoreCase))
+                .ToDictionary(pair => pair.Key, pair => pair.Value);
+
+            set.Values = updated;
+        }
+    }
+}
+
+/// <summary>
+/// Per-database initializer registered by <c>MartenDatabase</c> when Marten-managed tenant
+/// partitioning is active. Weasel's <c>DatabaseBase</c> runs registered initializers with a
+/// connection to THE database being migrated at the head of every migration operation — this is
+/// what guarantees a lazily-created table on a shard hydrates its partitions from that shard's own
+/// <c>mt_tenant_partitions</c> registry (#4863). Also runs the legacy base hydration so the
+/// store-wide fallback snapshot keeps its historical single-database behavior.
+/// </summary>
+internal class TenantPartitionsDatabaseInitializer: IDatabaseInitializer<NpgsqlConnection>
+{
+    private readonly IDatabase _database;
+    private readonly DatabaseScopedTenantPartitions _partitions;
+
+    public TenantPartitionsDatabaseInitializer(IDatabase database, DatabaseScopedTenantPartitions partitions)
+    {
+        _database = database;
+        _partitions = partitions;
+    }
+
+    public async Task InitializeAsync(NpgsqlConnection connection, CancellationToken token)
+    {
+        await _partitions.InitializeAsync(connection, token).ConfigureAwait(false);
+        await _partitions.HydrateAsync(_database, connection, token).ConfigureAwait(false);
+    }
+}

--- a/src/Marten/Schema/MartenManagedTenantListPartitions.cs
+++ b/src/Marten/Schema/MartenManagedTenantListPartitions.cs
@@ -32,14 +32,18 @@ public class MartenManagedTenantListPartitions : IDocumentPolicy
         // internal Table private — the wrapper is the public access point.
         TenantsTableName = new DbObjectName(schemaName ?? options.DatabaseSchemaName, TableName);
 
-        Partitions = new ManagedListPartitions("TenantIds", TenantsTableName);
+        // #4863/#4855: the database-scoped subclass keys the expected partition set per database,
+        // hydrated from each database's own mt_tenant_partitions — the plain Weasel
+        // ManagedListPartitions keeps one store-wide snapshot, which is wrong the moment a store
+        // spans multiple databases (sharded pools, master-table tenancy).
+        Partitions = new DatabaseScopedTenantPartitions("TenantIds", TenantsTableName);
 
         _options.Storage.Add(Partitions);
 
         _options.TenantPartitions = this;
     }
 
-    public ManagedListPartitions Partitions { get; }
+    public DatabaseScopedTenantPartitions Partitions { get; }
 
     /// <summary>
     /// Fully qualified name of the <c>mt_tenant_partitions</c> table this

--- a/src/Marten/Storage/DefaultTenancy.cs
+++ b/src/Marten/Storage/DefaultTenancy.cs
@@ -57,11 +57,10 @@ internal class DefaultTenancy: Tenancy, ITenancy
 
     internal void Initialize()
     {
+        // #4863: the Marten-managed tenant partition initializer is now registered inside the
+        // MartenDatabase constructor itself, so EVERY database of the store gets it — sharded
+        // pool databases included — not just this default one.
         var martenDatabase = new MartenDatabase(Options, _dataSource, Options.StoreName);
-        if (Options.TenantPartitions != null)
-        {
-            martenDatabase.AddInitializer(Options.TenantPartitions.Partitions);
-        }
 
         Default = new Tenant(StorageConstants.DefaultTenantId, martenDatabase);
     }

--- a/src/Marten/Storage/MartenDatabase.cs
+++ b/src/Marten/Storage/MartenDatabase.cs
@@ -35,6 +35,18 @@ public partial class MartenDatabase: PostgresqlDatabase, IMartenDatabase, IProje
         _features = options.Storage;
         Options = options;
 
+        // #4863: EVERY database of the store — not just DefaultTenancy's single database —
+        // must hydrate the Marten-managed tenant partition state from its OWN
+        // mt_tenant_partitions registry before migrations run against it. Without this,
+        // a table created lazily on a shard by a fresh store instance was created
+        // partitioned with zero partitions and every write failed with 23514.
+        // (Options.TenantPartitions is always set before any MartenDatabase exists:
+        // at config time for sharded tenancy, in StoreOptions.Validate() otherwise.)
+        if (options.TenantPartitions != null)
+        {
+            AddInitializer(new TenantPartitionsDatabaseInitializer(this, options.TenantPartitions.Partitions));
+        }
+
         resetSequences();
 
         Providers = options.Providers;
@@ -100,7 +112,24 @@ public partial class MartenDatabase: PostgresqlDatabase, IMartenDatabase, IProje
 
     public override IFeatureSchema[] BuildFeatureSchemas()
     {
+        markTenantPartitionScope();
         return Options.Storage.AllActiveFeatures(this).ToArray();
+    }
+
+    /// <summary>
+    /// #4863/#4855: stamp the ambient "database being migrated" scope for
+    /// <see cref="Marten.Schema.DatabaseScopedTenantPartitions"/>. Weasel's DatabaseBase calls
+    /// <c>BuildFeatureSchemas()</c> / <c>FindFeature()</c> synchronously at the head of every
+    /// migration operation on this database, and AsyncLocal writes from a synchronous callee flow
+    /// onward through the rest of that operation — so the partition manager's expected set can be
+    /// resolved per database even from Weasel internals that have no database parameter.
+    /// </summary>
+    private void markTenantPartitionScope()
+    {
+        if (Options.TenantPartitions != null && !ReferenceEquals(TenantPartitionDatabaseScope.Current, this))
+        {
+            TenantPartitionDatabaseScope.Current = this;
+        }
     }
 
     public void Dispose()
@@ -134,6 +163,7 @@ public partial class MartenDatabase: PostgresqlDatabase, IMartenDatabase, IProje
 
     public override IFeatureSchema FindFeature(Type featureType)
     {
+        markTenantPartitionScope();
         return _features.FindFeature(featureType);
     }
 

--- a/src/Marten/Storage/StorageFeatures.cs
+++ b/src/Marten/Storage/StorageFeatures.cs
@@ -467,6 +467,22 @@ public class StorageFeatures: IFeatureSchema, IDescribeMyself
             .Where(x => x.GetType().Assembly != GetType().Assembly).ToArray();
 
         foreach (var featureSchema in custom) yield return featureSchema;
+
+        // #4863/#4855: the Marten-managed tenant partition registry (mt_tenant_partitions) is
+        // registered as a feature, but its type — DatabaseScopedTenantPartitions — now lives in the
+        // Marten assembly, so the assembly-based `custom` filter above excludes it (the plain Weasel
+        // ManagedListPartitions it replaced was in the Weasel assembly and so slipped through). Yield
+        // it explicitly so the registry table is materialized on EVERY database of the store during a
+        // full apply, not only on databases that happen to get an explicit provisioning touch. Under
+        // sharded tenancy the projection coordinator reads each shard's own mt_tenant_partitions to
+        // expand per-tenant agents; a shard that never had that table created would fail every
+        // leadership polling cycle with 42P01. Guard against a double-yield in case a future partition
+        // manager type lands back in a non-Marten assembly (then `custom` would already include it).
+        var tenantPartitions = _options.TenantPartitions?.Partitions;
+        if (tenantPartitions != null && !custom.Contains(tenantPartitions))
+        {
+            yield return tenantPartitions;
+        }
     }
 
     internal bool SequenceIsRequired()

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4863_4855_per_database_partition_state.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4863_4855_per_database_partition_state.cs
@@ -1,0 +1,329 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+public class Doc4863A
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class Doc4863B
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public record Evt4863(string Name);
+
+/// <summary>
+/// Own collection + own schema names (NOT the shared "sharded-tenant-partitioned"
+/// fixture's public/tenants/sharded schemas) so these tests never race the other
+/// sharded tests — or sibling test runs — over shared schema state. The physical
+/// shard databases are reused; everything these tests create lives in the
+/// bug4863* schemas that only this class touches.
+/// </summary>
+[CollectionDefinition("per-db-partition-state", DisableParallelization = true)]
+public sealed class PerDbPartitionStateCollection: ICollectionFixture<PerDbPartitionStateFixture>;
+
+public sealed class PerDbPartitionStateFixture: IAsyncLifetime
+{
+    public const string ShardA = "marten_shard_a";
+    public const string ShardB = "marten_shard_b";
+
+    public Dictionary<string, string> ConnectionStrings { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        ConnectionStrings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var name in new[] { ShardA, ShardB })
+        {
+            if (!await conn.DatabaseExists(name))
+            {
+                await new DatabaseSpecification().BuildDatabase(conn, name);
+            }
+
+            ConnectionStrings[name] = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+            {
+                Database = name
+            }.ConnectionString;
+        }
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}
+
+/// <summary>
+/// #4863 + #4855 — the per-database partition-state family for sharded, Marten-managed
+/// tenant partitioning.
+///
+/// <para>
+/// #4863: a projection/document table created LAZILY by a fresh store instance (a node that
+/// joins after tenants were provisioned on that shard) must hydrate its per-tenant LIST
+/// partitions from the shard's own <c>mt_tenant_partitions</c> registry. Before the fix the
+/// lazy table-creation path consulted only the store-wide in-memory
+/// <c>ManagedListPartitions</c> snapshot (empty on a fresh node, because sharded tenancy
+/// never registered the registry initializer on its shard databases), so the table was
+/// created partitioned-by-tenant with ZERO partitions and every write failed with 23514.
+/// </para>
+///
+/// <para>
+/// #4855: every shard database materialized partitions for every registered tenant of the
+/// whole store — the store-shared partition dictionary fed each database's delta, so the
+/// first provisioning touch of a fresh shard created partitions (and, on full applies,
+/// per-tenant event sequences) for all foreign tenants too. Quadratic at scale. The
+/// per-database expected set must come from that database's own registry.
+/// </para>
+/// </summary>
+[Collection("per-db-partition-state")]
+public class Bug_4863_4855_per_database_partition_state: IAsyncLifetime
+{
+    private const string DocSchema = "bug4863";
+    private const string MasterSchema = "bug4863_master";
+    private const string TenantSchema = "bug4863_tenants";
+
+    private readonly PerDbPartitionStateFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public Bug_4863_4855_per_database_partition_state(PerDbPartitionStateFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync(MasterSchema); } catch { }
+
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var shardConn = new NpgsqlConnection(connStr);
+            await shardConn.OpenAsync();
+            try { await shardConn.DropSchemaAsync(DocSchema); } catch { }
+            try { await shardConn.DropSchemaAsync(TenantSchema); } catch { }
+
+            // The additive tenant-provisioning path (AddTenantToShardAsync →
+            // AddPartitionToAllTables → Table.MigrateAsync) creates tables but not
+            // schemas, so pre-create the non-public schemas the way a full apply would.
+            await shardConn.CreateCommand($"create schema if not exists {DocSchema}").ExecuteNonQueryAsync();
+            await shardConn.CreateCommand($"create schema if not exists {TenantSchema}").ExecuteNonQueryAsync();
+        }
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private DocumentStore BuildStore(Action<StoreOptions>? extra = null) => (DocumentStore)DocumentStore.For(opts =>
+    {
+        opts.MultiTenantedWithShardedDatabases(x =>
+        {
+            x.ConnectionString = ConnectionSource.ConnectionString;
+            x.SchemaName = MasterSchema;
+            x.PartitionSchemaName = TenantSchema;
+            foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+            {
+                x.AddDatabase(dbName, connStr);
+            }
+        });
+
+        opts.DatabaseSchemaName = DocSchema;
+        opts.AutoCreateSchemaObjects = AutoCreate.All;
+        opts.DisableNpgsqlLogging = true;
+        opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+        opts.Events.UseTenantPartitionedEvents = true;
+        // Activate the event store feature so mt_events / mt_streams / the per-tenant
+        // sequences participate in schema applies and the additive provisioning path.
+        opts.Events.AddEventType(typeof(Evt4863));
+        opts.Projections.DaemonLockId = 48635;
+
+        opts.Schema.For<Doc4863A>().DocumentAlias("bug4863_a");
+
+        extra?.Invoke(opts);
+    });
+
+    [Fact] // #4863
+    public async Task lazily_created_doc_table_on_a_fresh_node_hydrates_partitions_from_the_shards_own_registry()
+    {
+        // Node 1 provisions two tenants onto shard A and writes through the known doc type,
+        // so shard A's mt_tenant_partitions registry holds both tenants and the existing
+        // tables have their partitions.
+        using (var node1 = BuildStore())
+        {
+            await node1.Advanced.AddTenantToShardAsync("t4863_one", PerDbPartitionStateFixture.ShardA, CancellationToken.None);
+            await node1.Advanced.AddTenantToShardAsync("t4863_two", PerDbPartitionStateFixture.ShardA, CancellationToken.None);
+
+            await using var seed = node1.LightweightSession("t4863_one");
+            seed.Store(new Doc4863A { Id = Guid.NewGuid(), Name = "seeded" });
+            await seed.SaveChangesAsync();
+        }
+
+        // Node 2 is a FRESH store instance that additionally registers Doc4863B, whose
+        // table does not exist on the shard yet. The tenant is already assigned, so no
+        // provisioning path runs — the table is created lazily by the first write.
+        using var node2 = BuildStore(opts => opts.Schema.For<Doc4863B>().DocumentAlias("bug4863_b"));
+
+        await using var session = node2.LightweightSession("t4863_one");
+        session.Store(new Doc4863B { Id = Guid.NewGuid(), Name = "written by fresh node" });
+
+        // Before the fix: mt_doc_bug4863_b is created partitioned-by-tenant with ZERO
+        // partitions and this fails with 23514 "no partition of relation found for row".
+        await session.SaveChangesAsync();
+
+        // And the lazily-created table must hydrate partitions for EVERY tenant resident
+        // on the shard (from the shard's own registry), not just the writing tenant.
+        var partitions = await ListPartitions(PerDbPartitionStateFixture.ShardA, DocSchema, "mt_doc_bug4863_b");
+        partitions.ShouldContain("mt_doc_bug4863_b_t4863_one");
+        partitions.ShouldContain("mt_doc_bug4863_b_t4863_two");
+    }
+
+    [Fact] // #4855
+    public async Task a_shard_database_only_materializes_partitions_for_its_own_tenants()
+    {
+        using var store = BuildStore();
+
+        // Two tenants land on shard A first (provision + write, the real usage flow), so
+        // the store-wide in-memory snapshot holds them by the time shard B is first touched.
+        foreach (var tenant in new[] { "t4855_a1", "t4855_a2" })
+        {
+            await store.Advanced.AddTenantToShardAsync(tenant, PerDbPartitionStateFixture.ShardA, CancellationToken.None);
+            await using var session = store.LightweightSession(tenant);
+            session.Events.StartStream(Guid.NewGuid(), new Evt4863(tenant));
+            session.Store(new Doc4863A { Id = Guid.NewGuid(), Name = tenant });
+            await session.SaveChangesAsync();
+        }
+
+        // First touch of shard B — before the fix the lazily-created tables on shard B
+        // materialized partitions for t4855_a1/t4855_a2 as well (the store-shared
+        // expected set), i.e. the quadratic cross-product of #4855.
+        await store.Advanced.AddTenantToShardAsync("t4855_b1", PerDbPartitionStateFixture.ShardB, CancellationToken.None);
+        await using (var sessionB = store.LightweightSession("t4855_b1"))
+        {
+            sessionB.Events.StartStream(Guid.NewGuid(), new Evt4863("t4855_b1"));
+            sessionB.Store(new Doc4863A { Id = Guid.NewGuid(), Name = "t4855_b1" });
+            await sessionB.SaveChangesAsync();
+        }
+
+        var shardBStreams = await ListPartitions(PerDbPartitionStateFixture.ShardB, DocSchema, "mt_streams");
+        shardBStreams.ShouldBe(new[] { "mt_streams_t4855_b1" }, ignoreOrder: true,
+            customMessage: "shard B must only ever materialize partitions for tenants resident on shard B");
+
+        var shardBDocs = await ListPartitions(PerDbPartitionStateFixture.ShardB, DocSchema, "mt_doc_bug4863_a");
+        shardBDocs.ShouldBe(new[] { "mt_doc_bug4863_a_t4855_b1" }, ignoreOrder: true);
+
+        // Shard A keeps exactly its own two tenants.
+        var shardAStreams = await ListPartitions(PerDbPartitionStateFixture.ShardA, DocSchema, "mt_streams");
+        shardAStreams.ShouldBe(new[] { "mt_streams_t4855_a1", "mt_streams_t4855_a2" }, ignoreOrder: true);
+
+        // A full pod-startup style apply must not leak foreign tenants into shard B
+        // either — neither table partitions nor per-tenant event sequences.
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await ListPartitions(PerDbPartitionStateFixture.ShardB, DocSchema, "mt_streams"))
+            .ShouldBe(new[] { "mt_streams_t4855_b1" }, ignoreOrder: true,
+                customMessage: "a full apply re-materialized foreign tenant partitions on shard B");
+
+        var shardBSequences = await ListPerTenantSequences(PerDbPartitionStateFixture.ShardB, DocSchema);
+        shardBSequences.ShouldBe(new[] { "mt_events_sequence_t4855_b1" }, ignoreOrder: true,
+            customMessage: "a full apply created per-tenant event sequences on shard B for tenants that live on shard A");
+
+        // Sanity: writes work per shard after all of the above.
+        await using (var sa = store.LightweightSession("t4855_a1"))
+        {
+            sa.Events.StartStream(Guid.NewGuid(), new Evt4863("a1"));
+            sa.Store(new Doc4863A { Id = Guid.NewGuid(), Name = "a1" });
+            await sa.SaveChangesAsync();
+        }
+
+        await using (var sb = store.LightweightSession("t4855_b1"))
+        {
+            sb.Events.StartStream(Guid.NewGuid(), new Evt4863("b1"));
+            sb.Store(new Doc4863A { Id = Guid.NewGuid(), Name = "b1" });
+            await sb.SaveChangesAsync();
+        }
+    }
+
+    [Fact] // #4855 — fresh shard joins an established store
+    public async Task full_apply_on_a_fresh_shard_does_not_create_partitions_for_foreign_tenants()
+    {
+        using var store = BuildStore();
+
+        await store.Advanced.AddTenantToShardAsync("t4855_c1", PerDbPartitionStateFixture.ShardA, CancellationToken.None);
+        await store.Advanced.AddTenantToShardAsync("t4855_c2", PerDbPartitionStateFixture.ShardA, CancellationToken.None);
+
+        // Shard B has no tenants. A full apply (pod start) must create its parent tables
+        // EMPTY of tenant partitions — not with shard A's tenants.
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        (await ListPartitions(PerDbPartitionStateFixture.ShardB, DocSchema, "mt_streams"))
+            .ShouldBeEmpty("a fresh shard database materialized partitions for tenants assigned to another shard");
+
+        (await ListPerTenantSequences(PerDbPartitionStateFixture.ShardB, DocSchema))
+            .ShouldBeEmpty();
+
+        // And shard A got exactly its own.
+        (await ListPartitions(PerDbPartitionStateFixture.ShardA, DocSchema, "mt_streams"))
+            .ShouldBe(new[] { "mt_streams_t4855_c1", "mt_streams_t4855_c2" }, ignoreOrder: true);
+    }
+
+    private async Task<IReadOnlyList<string>> ListPartitions(string shard, string schema, string table)
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[shard]);
+        await conn.OpenAsync();
+
+        var list = new List<string>();
+        var cmd = conn.CreateCommand(
+            "select c.relname from pg_inherits i " +
+            "join pg_class c on c.oid = i.inhrelid " +
+            "join pg_class p on p.oid = i.inhparent " +
+            "join pg_namespace n on n.oid = p.relnamespace " +
+            "where n.nspname = :schema and p.relname = :table");
+        cmd.Parameters.AddWithValue("schema", schema);
+        cmd.Parameters.AddWithValue("table", table);
+        await using var reader = await cmd.ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
+        {
+            list.Add(await reader.GetFieldValueAsync<string>(0));
+        }
+
+        return list;
+    }
+
+    private async Task<IReadOnlyList<string>> ListPerTenantSequences(string shard, string schema)
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[shard]);
+        await conn.OpenAsync();
+
+        var list = new List<string>();
+        var cmd = conn.CreateCommand(
+            "select sequencename from pg_sequences where schemaname = :schema " +
+            "and sequencename like 'mt\\_events\\_sequence\\_%' escape '\\'");
+        cmd.Parameters.AddWithValue("schema", schema);
+        await using var reader = await cmd.ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
+        {
+            list.Add(await reader.GetFieldValueAsync<string>(0));
+        }
+
+        return list;
+    }
+}


### PR DESCRIPTION
## Summary

Under `MultiTenantedWithShardedDatabases` + Marten-managed tenant partitions, partition state was kept as **one store-wide in-memory snapshot** on the shared Weasel `ManagedListPartitions` instance. That single snapshot fed every database's partition delta, producing two field-reported bugs — the same per-database-partition-state subsystem, fixed coherently here.

### #4863 — lazily-created doc table on a shard gets zero partitions (23514)

A projection/document table created **lazily by a fresh store instance** (a node that joins after tenants were provisioned on that shard) was created partitioned-by-tenant with **zero partitions**, because nothing ever read that shard's own `mt_tenant_partitions` registry at table-creation time. Every projection write then failed with `23514: no partition of relation "mt_doc_*" found for row`.

### #4855 — every shard materializes partitions for every tenant (quadratic)

Every shard database materialized list partitions (and, under `UseTenantPartitionedEvents`, per-tenant `mt_events_sequence_{suffix}` sequences) for **every tenant registered anywhere in the store**, not just its own residents. The store-shared expected set minus a fresh database's actual partitions = the full cross-product, so the first provisioning touch of a fresh shard created partitions for all foreign tenants too. Quadratic at scale (field canary: 500 tenants × 55 tables × 512 databases ≈ 14M empty partitions).

## Fix

- **`DatabaseScopedTenantPartitions`** replaces the plain Weasel `ManagedListPartitions`. It keys partition state **per database**, hydrated from each database's **own** `mt_tenant_partitions` table.
- A per-database initializer (`TenantPartitionsDatabaseInitializer`) is now registered by **every** `MartenDatabase` — sharded pool databases included, not only `DefaultTenancy`'s single database. Weasel runs it against the database being migrated at the head of every migration op, so a lazily-created table hydrates partitions from that shard's registry (#4863).
- An **`AsyncLocal` database scope** — stamped by `MartenDatabase`'s synchronous `BuildFeatureSchemas()` / `FindFeature()` overrides, which Weasel calls at the head of every migration operation — lets the parameterless `IListPartitionManager.Partitions()` serve the ambient database's own tenant set to Weasel's table create / delta paths. The expected partition set for database D is therefore always exactly D's residents (#4855).
- `StorageFeatures.AllActiveFeatures` now yields the tenant-partition registry feature **explicitly**: its type moved into the Marten assembly, so the existing assembly-based "custom feature" filter (which the Weasel base type slipped through) would otherwise stop `mt_tenant_partitions` from being created on shards that never get an explicit provisioning touch — which broke the sharded projection coordinator's per-tenant agent expansion with `42P01`.
- Per-tenant cleanup (drop-tenant / `RemoveMartenManagedTenants`) resolves the partition suffix from the target database's own registry view rather than the store-wide snapshot.

## Tests

`src/TenantPartitionedEventsTests/Sharded/Bug_4863_4855_per_database_partition_state.cs`:
- lazy-table 23514 repro on a fresh node (#4863),
- quadratic cross-shard materialization: tenants on shard A must not create partitions on shard B (#4855),
- fresh-shard full-apply must not create foreign-tenant partitions or per-tenant sequences.

All three fail on `master` and pass with this change. Regression runs (net9.0, Marten docker Postgres): `TenantPartitionedEventsTests` **220/220**, `MultiTenancyTests` **146/146**, `CoreTests/Partitioning` **37/37**. This also fixes the fresh-node provisioning gap that `multi_node_hotcold_sharded_partitioned_events` and `dynamic_tenant_lifecycle_on_shard_during_daemon` documented as a `#4682`/`#4706` follow-up workaround.

Part of JasperFx/jasperfx#486 (WS1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)