### PR TITLE
Event-storage E1: de-Npgsql the closed-shape event binders + per-event ops (Weasel 9.14.0)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -170,8 +170,11 @@
     <!-- 9.8.0 (marten#4830 / weasel#329): new Weasel.Storage package holds the 5 neutral closed-shape
          storage contracts (IStorageDialect, StorageColumnType, BulkColumnValue, IStorageSerializer,
          IVersionTracker) lifted out of Marten so Marten and Polecat share them. -->
-    <PackageVersion Include="Weasel.Postgresql" Version="9.13.0" />
-    <PackageVersion Include="Weasel.Storage" Version="9.13.0" />
+    <!-- 9.14.0 (weasel#339): dialect-neutral grouped-parameter seam (Weasel.Core.IGroupedParameterBuilder
+         + ICommandBuilder.CreateGroupedParameterBuilder/AppendParameter(object)) + StorageColumnType.Binary,
+         so the closed-shape EVENT binders + per-event ops drop their direct Npgsql reference (#4821 event E1). -->
+    <PackageVersion Include="Weasel.Postgresql" Version="9.14.0" />
+    <PackageVersion Include="Weasel.Storage" Version="9.14.0" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
+++ b/src/Marten/EventStorage/Dialects/PostgresEventStoreDialect.cs
@@ -7,6 +7,7 @@ using JasperFx.Events;
 using Marten.EventStorage.Metadata;
 using Marten.EventStorage.Quick;
 using Marten.EventStorage.QuickWithServerTimestamps;
+using Marten.Internal.Storage;
 using Marten.EventStorage.Rich;
 using Marten.Events;
 using Marten.Events.Archiving;
@@ -42,12 +43,13 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
     public RichEventStorageDescriptor BuildRichDescriptor(EventGraph graph, ISerializer serializer)
     {
         var (orderedColumns, sqlPrefix) = BuildAppendEventFullColumnsAndPrefix(graph);
-        var metadataBinders = SelectRichMetadataBinders(orderedColumns);
+        var storageDialect = ResolveStorageDialect(graph);
+        var metadataBinders = SelectRichMetadataBinders(orderedColumns, storageDialect);
         // #4428: side-effect replay through EventSlice.BuildOperations calls
         // QuickAppendEventWithVersion on the Rich storage. That path uses the
         // same per-event INSERT shape but with a server-side seq_id nextval()
         // literal and no SequenceColumnBinder.
-        var metadataBindersWithoutSequence = SelectQuickModeMetadataBinders(orderedColumns);
+        var metadataBindersWithoutSequence = SelectQuickModeMetadataBinders(orderedColumns, storageDialect);
         var quickWithVersionSuffix = BuildAppendEventQuickWithVersionSuffix(graph);
         var isConjoined = graph.TenancyStyle == TenancyStyle.Conjoined;
         var isGuid = graph.StreamIdentity == StreamIdentity.AsGuid;
@@ -81,6 +83,7 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             IsTenancyConjoined = isConjoined,
             AssertStreamVersionSql = BuildAssertStreamVersionSql(graph),
             IsGuidStreamIdentity = isGuid,
+            Dialect = storageDialect,
             AppendEventQuickWithVersionSqlSuffix = quickWithVersionSuffix,
             MetadataBindersWithoutSequence = metadataBindersWithoutSequence,
             ConfigureInsertStreamCommand = BuildInsertStreamCommandConfigurer(graph, isConjoined, isGuid),
@@ -284,9 +287,10 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             = ReadQuickFlags(graph);
 
         var (orderedColumns, appendEventSqlPrefix) = BuildAppendEventFullColumnsAndPrefix(graph);
+        var storageDialect = ResolveStorageDialect(graph);
         var quickWithVersionSuffix = BuildAppendEventQuickWithVersionSuffix(graph);
-        var quickMetadataBinders = SelectQuickModeMetadataBinders(orderedColumns);
-        var fullMetadataBinders = SelectRichMetadataBinders(orderedColumns);
+        var quickMetadataBinders = SelectQuickModeMetadataBinders(orderedColumns, storageDialect);
+        var fullMetadataBinders = SelectRichMetadataBinders(orderedColumns, storageDialect);
 
         return new QuickEventStorageDescriptor(
             quickAppendEventsSql: BuildQuickAppendEventsSql(graph, serverTimestamps: false),
@@ -311,6 +315,7 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             })
         {
             IsGuidStreamIdentity = isGuid,
+            Dialect = storageDialect,
             IsTenancyConjoined = isConjoined,
             AssertStreamVersionSql = BuildAssertStreamVersionSql(graph),
             HasCausationId = hasCausation,
@@ -348,9 +353,10 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             = ReadQuickFlags(graph);
 
         var (orderedColumns, appendEventSqlPrefix) = BuildAppendEventFullColumnsAndPrefix(graph);
+        var storageDialect = ResolveStorageDialect(graph);
         var quickWithVersionSuffix = BuildAppendEventQuickWithVersionSuffix(graph);
-        var quickMetadataBinders = SelectQuickModeMetadataBinders(orderedColumns);
-        var fullMetadataBinders = SelectRichMetadataBinders(orderedColumns);
+        var quickMetadataBinders = SelectQuickModeMetadataBinders(orderedColumns, storageDialect);
+        var fullMetadataBinders = SelectRichMetadataBinders(orderedColumns, storageDialect);
 
         return new QuickWithServerTimestampsEventStorageDescriptor(
             quickAppendEventsWithServerTimestampsSql: BuildQuickAppendEventsSql(graph, serverTimestamps: true),
@@ -373,6 +379,7 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             })
         {
             IsGuidStreamIdentity = isGuid,
+            Dialect = storageDialect,
             IsTenancyConjoined = isConjoined,
             AssertStreamVersionSql = BuildAssertStreamVersionSql(graph),
             HasCausationId = hasCausation,
@@ -415,7 +422,8 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
     /// server-side <c>nextval(...)</c> literal in the SQL suffix, not a
     /// bound parameter.
     /// </summary>
-    private static IEventMetadataBinder[] SelectQuickModeMetadataBinders(IReadOnlyList<IEventTableColumn> orderedColumns)
+    private static IEventMetadataBinder[] SelectQuickModeMetadataBinders(
+        IReadOnlyList<IEventTableColumn> orderedColumns, IStorageDialect dialect)
     {
         var binders = new List<IEventMetadataBinder>(4);
         foreach (var column in orderedColumns)
@@ -430,19 +438,19 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
                     continue;
 
                 case "causation_id":
-                    binders.Add(new CausationIdColumnBinder());
+                    binders.Add(new CausationIdColumnBinder(dialect));
                     break;
 
                 case "correlation_id":
-                    binders.Add(new CorrelationIdColumnBinder());
+                    binders.Add(new CorrelationIdColumnBinder(dialect));
                     break;
 
                 case "user_name":
-                    binders.Add(new UserNameColumnBinder());
+                    binders.Add(new UserNameColumnBinder(dialect));
                     break;
 
                 case "headers":
-                    binders.Add(new HeadersColumnBinder());
+                    binders.Add(new HeadersColumnBinder(dialect));
                     break;
 
                 default:
@@ -505,13 +513,27 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
     }
 
     /// <summary>
+    /// The Postgres <see cref="IStorageDialect"/> the closed-shape event
+    /// binders + per-event ops use to set provider parameter types via
+    /// <see cref="IStorageDialect.SetParameterType"/> — keeping them free of a
+    /// direct Npgsql reference. <see cref="PostgresStorageDialect{TId}"/>'s
+    /// <c>SetParameterType</c> is stream-identity-independent, but the closed
+    /// generic is chosen to match the stream identity for clarity.
+    /// </summary>
+    private static IStorageDialect ResolveStorageDialect(EventGraph graph)
+        => graph.StreamIdentity == StreamIdentity.AsGuid
+            ? PostgresStorageDialect<System.Guid>.Instance
+            : PostgresStorageDialect<string>.Instance;
+
+    /// <summary>
     /// Picks the <see cref="IEventMetadataBinder"/> for each column past the
     /// core slice (id, stream_id/key, version, data, type, tenant_id,
     /// mt_dotnet_type). Order matches the dialect's column ordering, so the
     /// operation's per-column bind sequence (inlined core writes + metadata
     /// binder loop) stays aligned with the SQL.
     /// </summary>
-    private static IEventMetadataBinder[] SelectRichMetadataBinders(IReadOnlyList<IEventTableColumn> orderedColumns)
+    private static IEventMetadataBinder[] SelectRichMetadataBinders(
+        IReadOnlyList<IEventTableColumn> orderedColumns, IStorageDialect dialect)
     {
         // Selection by column NAME (not CLR type) because Marten's event-store
         // column model uses a single generic `EventTableColumn` class for
@@ -534,19 +556,19 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
             {
                 case "seq_id":
                 case "mt_events_sequence":
-                    binders.Add(new SequenceColumnBinder());
+                    binders.Add(new SequenceColumnBinder(dialect));
                     break;
 
                 case "causation_id":
-                    binders.Add(new CausationIdColumnBinder());
+                    binders.Add(new CausationIdColumnBinder(dialect));
                     break;
 
                 case "correlation_id":
-                    binders.Add(new CorrelationIdColumnBinder());
+                    binders.Add(new CorrelationIdColumnBinder(dialect));
                     break;
 
                 case "user_name":
-                    binders.Add(new UserNameColumnBinder());
+                    binders.Add(new UserNameColumnBinder(dialect));
                     break;
 
                 case "headers":
@@ -555,7 +577,7 @@ internal sealed class PostgresEventStoreDialect: IEventStoreSqlDialect
                     // HeadersColumn.ReadValueSync because the IEventTableColumn
                     // read surface doesn't yet thread ISerializer. Tracked as
                     // #4416 part 2.
-                    binders.Add(new HeadersColumnBinder());
+                    binders.Add(new HeadersColumnBinder(dialect));
                     break;
 
                 // TODO (#4416): remaining binders:

--- a/src/Marten/EventStorage/IEventMetadataBinder.cs
+++ b/src/Marten/EventStorage/IEventMetadataBinder.cs
@@ -2,7 +2,7 @@
 using System.Data.Common;
 using JasperFx.Events;
 using Marten.Internal;
-using Weasel.Postgresql;
+using Weasel.Core;
 
 namespace Marten.EventStorage;
 

--- a/src/Marten/EventStorage/Metadata/CausationIdColumnBinder.cs
+++ b/src/Marten/EventStorage/Metadata/CausationIdColumnBinder.cs
@@ -1,8 +1,8 @@
 #nullable enable
 using JasperFx.Events;
 using Marten.Internal;
-using NpgsqlTypes;
-using Weasel.Postgresql;
+using Weasel.Core;
+using Weasel.Storage;
 
 namespace Marten.EventStorage.Metadata;
 
@@ -20,11 +20,19 @@ namespace Marten.EventStorage.Metadata;
 /// </remarks>
 internal sealed class CausationIdColumnBinder: IEventMetadataBinder
 {
+    private readonly IStorageDialect _dialect;
+
+    public CausationIdColumnBinder(IStorageDialect dialect)
+    {
+        _dialect = dialect;
+    }
+
     public string ColumnName => "causation_id";
     public string ValueSql => "?";
 
     public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
     {
-        pb.AppendParameter(@event.CausationId, NpgsqlDbType.Varchar);
+        var parameter = pb.AppendParameter(@event.CausationId);
+        _dialect.SetParameterType(parameter, StorageColumnType.String);
     }
 }

--- a/src/Marten/EventStorage/Metadata/CorrelationIdColumnBinder.cs
+++ b/src/Marten/EventStorage/Metadata/CorrelationIdColumnBinder.cs
@@ -1,8 +1,8 @@
 #nullable enable
 using JasperFx.Events;
 using Marten.Internal;
-using NpgsqlTypes;
-using Weasel.Postgresql;
+using Weasel.Core;
+using Weasel.Storage;
 
 namespace Marten.EventStorage.Metadata;
 
@@ -12,11 +12,19 @@ namespace Marten.EventStorage.Metadata;
 /// </summary>
 internal sealed class CorrelationIdColumnBinder: IEventMetadataBinder
 {
+    private readonly IStorageDialect _dialect;
+
+    public CorrelationIdColumnBinder(IStorageDialect dialect)
+    {
+        _dialect = dialect;
+    }
+
     public string ColumnName => "correlation_id";
     public string ValueSql => "?";
 
     public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
     {
-        pb.AppendParameter(@event.CorrelationId, NpgsqlDbType.Varchar);
+        var parameter = pb.AppendParameter(@event.CorrelationId);
+        _dialect.SetParameterType(parameter, StorageColumnType.String);
     }
 }

--- a/src/Marten/EventStorage/Metadata/HeadersColumnBinder.cs
+++ b/src/Marten/EventStorage/Metadata/HeadersColumnBinder.cs
@@ -1,8 +1,8 @@
 #nullable enable
 using JasperFx.Events;
 using Marten.Internal;
-using NpgsqlTypes;
-using Weasel.Postgresql;
+using Weasel.Core;
+using Weasel.Storage;
 
 namespace Marten.EventStorage.Metadata;
 
@@ -21,6 +21,13 @@ namespace Marten.EventStorage.Metadata;
 /// </remarks>
 internal sealed class HeadersColumnBinder: IEventMetadataBinder
 {
+    private readonly IStorageDialect _dialect;
+
+    public HeadersColumnBinder(IStorageDialect dialect)
+    {
+        _dialect = dialect;
+    }
+
     public string ColumnName => "headers";
 
     public string ValueSql => "?";
@@ -32,15 +39,14 @@ internal sealed class HeadersColumnBinder: IEventMetadataBinder
         //     var parameter = parameterBuilder.AppendParameter<object>(DBNull.Value);
         //     session.Serializer.WriteToParameter(parameter, evt.Headers);
         //
-        // Using AppendParameter<object> (not AppendParameter<DBNull> via the
-        // raw DBNull static type) is important — Npgsql refuses to serialize
-        // DBNull as a typed parameter, but accepts object + DBNull.Value with
-        // NpgsqlDbType.Jsonb as a NULL jsonb. WriteToParameter then either
-        // writes the actual JSON bytes (skipping intermediate string
-        // allocation via ISerializer.WriteTo) or leaves the parameter at
-        // DBNull when Headers is null.
-        var parameter = pb.AppendParameter<object>(System.DBNull.Value);
-        parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+        // Bind a DBNull placeholder typed as the dialect's json column type,
+        // then let WriteToParameter fill in the actual JSON bytes (skipping
+        // the intermediate string allocation via ISerializer.WriteTo) or leave
+        // the parameter at DBNull when Headers is null. The neutral
+        // AppendParameter writes DBNull.Value as-is; the dialect maps
+        // StorageColumnType.Json to its provider json type (Postgres jsonb).
+        var parameter = pb.AppendParameter(System.DBNull.Value);
+        _dialect.SetParameterType(parameter, StorageColumnType.Json);
         session.Serializer.WriteToParameter(parameter, @event.Headers);
     }
 

--- a/src/Marten/EventStorage/Metadata/SequenceColumnBinder.cs
+++ b/src/Marten/EventStorage/Metadata/SequenceColumnBinder.cs
@@ -1,8 +1,8 @@
 #nullable enable
 using JasperFx.Events;
 using Marten.Internal;
-using NpgsqlTypes;
-using Weasel.Postgresql;
+using Weasel.Core;
+using Weasel.Storage;
 
 namespace Marten.EventStorage.Metadata;
 
@@ -29,11 +29,19 @@ namespace Marten.EventStorage.Metadata;
 /// </remarks>
 internal sealed class SequenceColumnBinder: IEventMetadataBinder
 {
+    private readonly IStorageDialect _dialect;
+
+    public SequenceColumnBinder(IStorageDialect dialect)
+    {
+        _dialect = dialect;
+    }
+
     public string ColumnName => "seq_id";
     public string ValueSql => "?";
 
     public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
     {
-        pb.AppendParameter(@event.Sequence, NpgsqlDbType.Bigint);
+        var parameter = pb.AppendParameter(@event.Sequence);
+        _dialect.SetParameterType(parameter, StorageColumnType.Long);
     }
 }

--- a/src/Marten/EventStorage/Metadata/UserNameColumnBinder.cs
+++ b/src/Marten/EventStorage/Metadata/UserNameColumnBinder.cs
@@ -1,8 +1,8 @@
 #nullable enable
 using JasperFx.Events;
 using Marten.Internal;
-using NpgsqlTypes;
-using Weasel.Postgresql;
+using Weasel.Core;
+using Weasel.Storage;
 
 namespace Marten.EventStorage.Metadata;
 
@@ -18,11 +18,19 @@ namespace Marten.EventStorage.Metadata;
 /// </remarks>
 internal sealed class UserNameColumnBinder: IEventMetadataBinder
 {
+    private readonly IStorageDialect _dialect;
+
+    public UserNameColumnBinder(IStorageDialect dialect)
+    {
+        _dialect = dialect;
+    }
+
     public string ColumnName => "user_name";
     public string ValueSql => "?";
 
     public void Bind(IGroupedParameterBuilder pb, StreamAction stream, IEvent @event, IStorageSession session)
     {
-        pb.AppendParameter(@event.UserName, NpgsqlDbType.Varchar);
+        var parameter = pb.AppendParameter(@event.UserName);
+        _dialect.SetParameterType(parameter, StorageColumnType.String);
     }
 }

--- a/src/Marten/EventStorage/Quick/QuickAppendEventWithVersionOperation.cs
+++ b/src/Marten/EventStorage/Quick/QuickAppendEventWithVersionOperation.cs
@@ -2,8 +2,8 @@
 using JasperFx.Events;
 using Marten.Events.Operations;
 using Marten.Internal;
-using NpgsqlTypes;
-using Weasel.Postgresql;
+using Weasel.Core;
+using Weasel.Storage;
 
 namespace Marten.EventStorage.Quick;
 
@@ -43,6 +43,7 @@ internal sealed class QuickAppendEventWithVersionOperation: AppendEventOperation
     private readonly bool _isGuidStreamIdentity;
     private readonly System.Func<IEvent, string> _serializeEventData;
     private readonly System.Func<IEvent, byte[]?> _serializeEventBdata;
+    private readonly IStorageDialect _dialect;
 
     public QuickAppendEventWithVersionOperation(
         string appendEventSqlPrefix,
@@ -51,6 +52,7 @@ internal sealed class QuickAppendEventWithVersionOperation: AppendEventOperation
         bool isGuidStreamIdentity,
         System.Func<IEvent, string> serializeEventData,
         System.Func<IEvent, byte[]?> serializeEventBdata,
+        IStorageDialect dialect,
         StreamAction stream,
         IEvent e)
         : base(stream, e)
@@ -61,36 +63,41 @@ internal sealed class QuickAppendEventWithVersionOperation: AppendEventOperation
         _isGuidStreamIdentity = isGuidStreamIdentity;
         _serializeEventData = serializeEventData;
         _serializeEventBdata = serializeEventBdata;
+        _dialect = dialect;
     }
 
     public override void ConfigureCommand(ICommandBuilder builder, IStorageSession session)
     {
         builder.Append(_appendEventSqlPrefix);
 
-        var pb = builder.CreateGroupedParameterBuilder(',');
+        var dialect = _dialect;
+        IGroupedParameterBuilder pb = builder.CreateGroupedParameterBuilder(',');
 
         // Core columns — same order + types as RichAppendEventOperation.
-        pb.AppendParameter(_serializeEventData(Event), NpgsqlDbType.Jsonb);
-        pb.AppendParameter(Event.EventTypeName, NpgsqlDbType.Varchar);
-        pb.AppendParameter(Event.DotNetTypeName, NpgsqlDbType.Varchar);
+        // Provider parameter types come from the dialect so the op carries no
+        // direct Npgsql reference.
+        dialect.SetParameterType(pb.AppendParameter(_serializeEventData(Event)), StorageColumnType.Json);
+        dialect.SetParameterType(pb.AppendParameter(Event.EventTypeName), StorageColumnType.String);
+        dialect.SetParameterType(pb.AppendParameter(Event.DotNetTypeName), StorageColumnType.String);
 
         // #4515: bdata bytea (nullable). NULL for JSON-serialized events;
         // bytes for binary-serialized events. Pinned at SELECT position 3
         // (right after mt_dotnet_type) by EventsTable.SelectColumns, so the
-        // bind sequence here mirrors that position.
+        // bind sequence here mirrors that position. The neutral AppendParameter
+        // writes a null byte[] as DBNull.
         var bdataBytes = _serializeEventBdata(Event);
-        pb.AppendParameter(bdataBytes ?? (object)System.DBNull.Value, NpgsqlDbType.Bytea);
+        dialect.SetParameterType(pb.AppendParameter(bdataBytes), StorageColumnType.Binary);
 
-        pb.AppendParameter(Event.Id, NpgsqlDbType.Uuid);
+        dialect.SetParameterType(pb.AppendParameter(Event.Id), StorageColumnType.Guid);
 
         if (_isGuidStreamIdentity)
-            pb.AppendParameter(Stream.Id, NpgsqlDbType.Uuid);
+            dialect.SetParameterType(pb.AppendParameter(Stream.Id), StorageColumnType.Guid);
         else
-            pb.AppendParameter(Stream.Key, NpgsqlDbType.Varchar);
+            dialect.SetParameterType(pb.AppendParameter(Stream.Key), StorageColumnType.String);
 
-        pb.AppendParameter(Event.Version, NpgsqlDbType.Bigint);
-        pb.AppendParameter(Event.Timestamp, NpgsqlDbType.TimestampTz);
-        pb.AppendParameter(Stream.TenantId, NpgsqlDbType.Varchar);
+        dialect.SetParameterType(pb.AppendParameter(Event.Version), StorageColumnType.Long);
+        dialect.SetParameterType(pb.AppendParameter(Event.Timestamp), StorageColumnType.Timestamp);
+        dialect.SetParameterType(pb.AppendParameter(Stream.TenantId), StorageColumnType.String);
 
         // Optional metadata binders (causation / correlation / headers /
         // user_name). The dialect's filtered list excludes SequenceColumnBinder

--- a/src/Marten/EventStorage/Quick/QuickEventStorage.cs
+++ b/src/Marten/EventStorage/Quick/QuickEventStorage.cs
@@ -33,6 +33,7 @@ internal sealed class QuickEventStorage<TId>: EventStorage<TId>
             _descriptor.IsGuidStreamIdentity,
             _descriptor.SerializeEventData,
             _descriptor.SerializeEventBdata,
+            _descriptor.Dialect,
             stream,
             @event);
 
@@ -44,6 +45,7 @@ internal sealed class QuickEventStorage<TId>: EventStorage<TId>
             _descriptor.IsGuidStreamIdentity,
             _descriptor.SerializeEventData,
             _descriptor.SerializeEventBdata,
+            _descriptor.Dialect,
             stream,
             @event);
 

--- a/src/Marten/EventStorage/Quick/QuickEventStorageDescriptor.cs
+++ b/src/Marten/EventStorage/Quick/QuickEventStorageDescriptor.cs
@@ -76,6 +76,15 @@ public sealed class QuickEventStorageDescriptor
     /// <summary>Guid stream identity (writeId) vs string identity (writeKey).</summary>
     public bool IsGuidStreamIdentity { get; init; }
 
+    /// <summary>
+    /// The storage dialect used to set provider parameter types on the
+    /// per-event QuickWithVersion INSERT's bound parameters
+    /// (<see cref="Weasel.Storage.IStorageDialect.SetParameterType"/>), keeping
+    /// the closed-shape ops free of any direct Npgsql reference. Installed by
+    /// the event dialect at descriptor-build time.
+    /// </summary>
+    public Weasel.Storage.IStorageDialect Dialect { get; init; } = default!;
+
     /// <summary>Conjoined-tenant — affects per-stream ops (InsertStream / UpdateStreamVersion / StreamState).</summary>
     public bool IsTenancyConjoined { get; init; }
 

--- a/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorage.cs
+++ b/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorage.cs
@@ -31,6 +31,7 @@ internal sealed class QuickWithServerTimestampsEventStorage<TId>: EventStorage<T
             _descriptor.IsGuidStreamIdentity,
             _descriptor.SerializeEventData,
             _descriptor.SerializeEventBdata,
+            _descriptor.Dialect,
             stream,
             @event);
 
@@ -42,6 +43,7 @@ internal sealed class QuickWithServerTimestampsEventStorage<TId>: EventStorage<T
             _descriptor.IsGuidStreamIdentity,
             _descriptor.SerializeEventData,
             _descriptor.SerializeEventBdata,
+            _descriptor.Dialect,
             stream,
             @event);
 

--- a/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorageDescriptor.cs
+++ b/src/Marten/EventStorage/QuickWithServerTimestamps/QuickWithServerTimestampsEventStorageDescriptor.cs
@@ -59,6 +59,15 @@ public sealed class QuickWithServerTimestampsEventStorageDescriptor
     /// <summary>Guid stream identity (writeId) vs string identity (writeKey).</summary>
     public bool IsGuidStreamIdentity { get; init; }
 
+    /// <summary>
+    /// The storage dialect used to set provider parameter types on the
+    /// per-event QuickWithVersion INSERT's bound parameters
+    /// (<see cref="Weasel.Storage.IStorageDialect.SetParameterType"/>), keeping
+    /// the closed-shape ops free of any direct Npgsql reference. Installed by
+    /// the event dialect at descriptor-build time.
+    /// </summary>
+    public Weasel.Storage.IStorageDialect Dialect { get; init; } = default!;
+
     /// <summary>Conjoined-tenant — affects per-stream ops (InsertStream / UpdateStreamVersion / StreamState).</summary>
     public bool IsTenancyConjoined { get; init; }
 

--- a/src/Marten/EventStorage/Rich/RichAppendEventOperation.cs
+++ b/src/Marten/EventStorage/Rich/RichAppendEventOperation.cs
@@ -2,8 +2,8 @@
 using JasperFx.Events;
 using Marten.Events.Operations;
 using Marten.Internal;
-using NpgsqlTypes;
-using Weasel.Postgresql;
+using Weasel.Core;
+using Weasel.Storage;
 
 namespace Marten.EventStorage.Rich;
 
@@ -45,46 +45,50 @@ internal sealed class RichAppendEventOperation: AppendEventOperationBase
     {
         builder.Append(_descriptor.AppendEventSqlPrefix);
 
-        var pb = builder.CreateGroupedParameterBuilder(',');
+        var dialect = _descriptor.Dialect;
+        IGroupedParameterBuilder pb = builder.CreateGroupedParameterBuilder(',');
 
         // --- Core columns, in the dialect's column order ---
         // Must match BuildAppendEventFullColumnsAndPrefix:
         //   data, type, mt_dotnet_type, id, stream_id, version, timestamp, tenant_id,
         //   then metadata binders (e.g., seq_id) at the end.
+        // Parameter provider types come from the dialect's SetParameterType so
+        // the op carries no direct Npgsql reference.
 
         // data — jsonb. Closed-shape uses the descriptor's serializer
         // closure (returns string). Source-gen target (#4413 hot-path
         // hardening) can switch to Serializer.WriteToParameter to skip the
         // intermediate UTF-16 allocation, matching codegen.
-        pb.AppendParameter(_descriptor.SerializeEventData(Event), NpgsqlDbType.Jsonb);
+        dialect.SetParameterType(pb.AppendParameter(_descriptor.SerializeEventData(Event)), StorageColumnType.Json);
 
-        pb.AppendParameter(Event.EventTypeName, NpgsqlDbType.Varchar);
-        pb.AppendParameter(Event.DotNetTypeName, NpgsqlDbType.Varchar);
+        dialect.SetParameterType(pb.AppendParameter(Event.EventTypeName), StorageColumnType.String);
+        dialect.SetParameterType(pb.AppendParameter(Event.DotNetTypeName), StorageColumnType.String);
 
         // #4515: bdata bytea (nullable). For JSON-serialized events this is
         // NULL; for binary-serialized events it carries the payload. Column
         // order matches EventsTable.SelectColumns — bdata is pinned at
-        // position 3 right after mt_dotnet_type.
+        // position 3 right after mt_dotnet_type. The neutral AppendParameter
+        // writes a null byte[] as DBNull.
         var bdataBytes = _descriptor.SerializeEventBdata(Event);
-        pb.AppendParameter(bdataBytes ?? (object)System.DBNull.Value, NpgsqlDbType.Bytea);
+        dialect.SetParameterType(pb.AppendParameter(bdataBytes), StorageColumnType.Binary);
 
-        pb.AppendParameter(Event.Id, NpgsqlDbType.Uuid);
+        dialect.SetParameterType(pb.AppendParameter(Event.Id), StorageColumnType.Guid);
 
         // stream_id — Guid streams use Stream.Id, string streams use Stream.Key.
         // The descriptor flag is set once at startup; per-call cost is a
         // branch-predictable field read.
         if (_descriptor.IsGuidStreamIdentity)
         {
-            pb.AppendParameter(Stream.Id, NpgsqlDbType.Uuid);
+            dialect.SetParameterType(pb.AppendParameter(Stream.Id), StorageColumnType.Guid);
         }
         else
         {
-            pb.AppendParameter(Stream.Key, NpgsqlDbType.Varchar);
+            dialect.SetParameterType(pb.AppendParameter(Stream.Key), StorageColumnType.String);
         }
 
-        pb.AppendParameter(Event.Version, NpgsqlDbType.Bigint);
-        pb.AppendParameter(Event.Timestamp, NpgsqlDbType.TimestampTz);
-        pb.AppendParameter(Stream.TenantId, NpgsqlDbType.Varchar);
+        dialect.SetParameterType(pb.AppendParameter(Event.Version), StorageColumnType.Long);
+        dialect.SetParameterType(pb.AppendParameter(Event.Timestamp), StorageColumnType.Timestamp);
+        dialect.SetParameterType(pb.AppendParameter(Stream.TenantId), StorageColumnType.String);
 
         // --- Metadata binders (seq_id + any optional metadata columns) ---
         // Order matches the metadata slice of the SQL prefix's column list.

--- a/src/Marten/EventStorage/Rich/RichEventStorage.cs
+++ b/src/Marten/EventStorage/Rich/RichEventStorage.cs
@@ -43,6 +43,7 @@ internal sealed class RichEventStorage<TId>: EventStorage<TId>
             _descriptor.IsGuidStreamIdentity,
             _descriptor.SerializeEventData,
             _descriptor.SerializeEventBdata,
+            _descriptor.Dialect,
             stream,
             @event);
 

--- a/src/Marten/EventStorage/Rich/RichEventStorageDescriptor.cs
+++ b/src/Marten/EventStorage/Rich/RichEventStorageDescriptor.cs
@@ -118,6 +118,15 @@ public sealed class RichEventStorageDescriptor
     public bool IsGuidStreamIdentity { get; init; }
 
     /// <summary>
+    /// The storage dialect used to set provider parameter types on the
+    /// per-event append operation's bound parameters
+    /// (<see cref="Weasel.Storage.IStorageDialect.SetParameterType"/>), keeping
+    /// the closed-shape ops free of any direct Npgsql reference. Installed by
+    /// the event dialect at descriptor-build time.
+    /// </summary>
+    public Weasel.Storage.IStorageDialect Dialect { get; init; } = default!;
+
+    /// <summary>
     /// Configures the <c>mt_streams</c> insert command. The closure owns
     /// the SQL shape (column list, parameter binds, tenancy/identity
     /// variants) and the actual <see cref="IGroupedParameterBuilder"/>

--- a/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
+++ b/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
@@ -224,6 +224,13 @@ public class CompiledQueryPlan : ICommandBuilder
         return appendParameter(value, dbType);
     }
 
+    // weasel#339: the neutral Weasel.Core.ICommandBuilder members are distinct
+    // interface slots from the Npgsql-typed Weasel.Postgresql ones above;
+    // delegate to the PG implementations (NpgsqlParameter derives from
+    // DbParameter, the PG grouped builder from the neutral one).
+    DbParameter Weasel.Core.ICommandBuilder.AppendParameter(object value)
+        => ((ICommandBuilder)this).AppendParameter(value);
+
     private NpgsqlParameter appendParameter(object value, NpgsqlDbType? dbType)
     {
         _current ??= appendCommand();
@@ -247,6 +254,9 @@ public class CompiledQueryPlan : ICommandBuilder
     {
         throw new NotSupportedException();
     }
+
+    Weasel.Core.IGroupedParameterBuilder Weasel.Core.ICommandBuilder.CreateGroupedParameterBuilder(char? separator)
+        => CreateGroupedParameterBuilder(separator);
 
     NpgsqlParameter[] ICommandBuilder.AppendWithParameters(string text)
     {

--- a/src/Marten/Internal/Storage/PostgresStorageDialect.cs
+++ b/src/Marten/Internal/Storage/PostgresStorageDialect.cs
@@ -74,6 +74,7 @@ internal sealed class PostgresStorageDialect<TId>: IStorageDialect
             StorageColumnType.Boolean => NpgsqlDbType.Boolean,
             StorageColumnType.Timestamp => NpgsqlDbType.TimestampTz,
             StorageColumnType.Json => NpgsqlDbType.Jsonb,
+            StorageColumnType.Binary => NpgsqlDbType.Bytea,
             _ => throw new ArgumentOutOfRangeException(nameof(type))
         };
 


### PR DESCRIPTION
Part of the #4821 / #4830 follow-on — moving the closed-shape **event** storage into Weasel.Storage so Polecat can ship its SQL Server event dialect. This is the event-side analog of the document **INC-3** increment: it consumes the new Weasel 9.14.0 neutral grouped-parameter seam to drop the direct Npgsql reference from the event metadata binders and the per-event append operations, **in place** (no file moves yet), leaving them ready for the E2/E3 physical move.

Follows E0 (#4885, merged).

## Upstream (already published)

Weasel **9.14.0** (weasel#339) added a dialect-neutral grouped-parameter seam — `Weasel.Core.IGroupedParameterBuilder`, `ICommandBuilder.CreateGroupedParameterBuilder(char?)` / `AppendParameter(object)` — plus `StorageColumnType.Binary`.

## Changes

- **`IEventMetadataBinder.Bind`** now takes the neutral `Weasel.Core.IGroupedParameterBuilder`.
- **The 5 metadata binders** (`Sequence` / `Headers` / `Causation` / `Correlation` / `UserName`) take a ctor-injected `IStorageDialect` and type their parameters via `SetParameterType(param, StorageColumnType.X)` instead of `NpgsqlDbType` — mirroring the document-side `DocumentCausationIdBinder` etc.
- **`RichAppendEventOperation`** and **`QuickAppendEventWithVersionOperation`** bind their core columns the same way. The QuickWithVersion op gains an `IStorageDialect` ctor param; all three descriptors carry a `Dialect` slot the event dialect installs, resolved per stream identity from `PostgresStorageDialect<TId>`.
- **`PostgresStorageDialect.SetParameterType`** maps the new `StorageColumnType.Binary` → `NpgsqlDbType.Bytea` (the event `bdata` column).
- **`CompiledQueryPlan`** implements the two new neutral `Weasel.Core.ICommandBuilder` members explicitly, delegating to its existing Npgsql-typed implementations (same disambiguation weasel#327 needed).

`PostgresEventStoreDialect` and the Quick bulk operation (`QuickAppendEventsOperation` — array params to `mt_quick_append_events`, `PostgresException` MT001/MT003) stay Postgres-local by design.

## Validation

- EventSourcingTests: 1430 passed / 0 failed (net10)
- TenantPartitionedEventsTests: 217 passed / 0 failed (net10)
- LinqTests compiled-query filter: 75 passed / 0 failed (net10) — covers the `CompiledQueryPlan` change
- Full `Marten.slnx` Debug + Release clean

Next: E2 moves the descriptor core + binders + `IEventStoreSqlDialect` into Weasel.Storage; E3 moves the storage hierarchy + ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)