### PR TITLE
Bump JasperFx to 2.24.0 (cross-product rebuild cap, jasperfx#498)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -87,13 +87,13 @@
          IEventStore.DistributesAgentsPerTenant into BuildDistributor (ProjectionCoordinator).
          Also DaemonMode.ExternallyManaged (jasperfx#490, wolverine#3290 — external hosts run
          projections; the store hosts no coordination and must not warn). -->
-    <PackageVersion Include="JasperFx" Version="2.23.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.23.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.23.0">
+    <PackageVersion Include="JasperFx" Version="2.24.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.24.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.24.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.23.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.24.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Consumes **JasperFx 2.24.0** — the intra-projection tenant/shard cross-product rebuild cap (jasperfx#497 / jasperfx#498, epic jasperfx#486 WS3 follow-up).

The cap surfaced in jasperfx#463 was projection-level; #498 extends it into `JasperFxAsyncDaemon`'s per-(tenant, shard) rebuild fan-out via one shared per-database budget, and — en route — fixed intra-database rebuild replay that had been accidentally serialized at 1. Marten's rebuild path picks this up transparently through `JasperFx.Events`.

All four JasperFx.* packages lockstepped 2.23.0 → 2.24.0. Marten core + DaemonTests build clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)