### PR TITLE
ShardedTenancy: fold tenant-partition drop back to Weasel's native by-value drop (weasel#338)

### DIFF
--- a/src/Marten/Storage/ShardedTenancy.cs
+++ b/src/Marten/Storage/ShardedTenancy.cs
@@ -514,14 +514,15 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
     /// idempotent by construction.
     /// </summary>
     /// <remarks>
-    /// Deliberately NOT Weasel's <c>ManagedListPartitions.DropPartitionFromAllTables</c>: that
-    /// path interpolates the partition table name unquoted into the DETACH/DROP DDL, which fails
-    /// with 42601 for any tenant id that isn't a bare PostgreSQL identifier (hyphens, uppercase —
-    /// e.g. GUID-shaped or "tenant-a"-style ids). The sharded assignment path never restricted
-    /// tenant ids the way <c>AddMartenManagedTenantsAsync</c>'s
-    /// <c>AssertValidPostgresqlIdentifiers</c> does — the CREATE side quotes properly, so quoted
-    /// partitions exist in the wild and the drop must quote too. Fold this back into Weasel when
-    /// its drop path learns to quote (see the PR for #4868/#4880).
+    /// Delegates to Weasel's database-scoped by-value drop
+    /// (<see cref="DatabaseScopedTenantPartitions.DropPartitionFromAllTablesForValue"/>): it resolves
+    /// the sanitized partition suffix from THIS shard's own <c>mt_tenant_partitions</c> registry,
+    /// deletes the registry row (what the coordinator's per-tenant re-expansion / ICrossTenantRebuildSource
+    /// reads, so agents can be reaped), and drops the partition — symmetric with the create path
+    /// (<c>AddPartitionToAllTables</c>). Previously a hand-rolled quoted DETACH/DROP loop lived here only
+    /// because the pre-9.16 native drop interpolated the partition name unquoted and failed with 42601
+    /// for hyphenated/GUID/uppercase tenant ids; weasel#338 (Weasel 9.16) fixed the native path to
+    /// sanitize identically to create, so this now folds back to the native drop.
     /// </remarks>
     private async Task dropPartitionsForTenant(MartenDatabase database, string tenantId, CancellationToken ct)
     {
@@ -542,76 +543,25 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
             return;
         }
 
+        // Guard on the shard's own registry: skip the native by-value drop (which throws
+        // ArgumentOutOfRangeException on an unknown value) when a partial prior removal already
+        // forgot the tenant, keeping re-runs idempotent.
         if (registered.Contains(tenantId, StringComparer.Ordinal))
         {
             var logger = _options.LogFactory?.CreateLogger<DocumentStore>() ?? NullLogger<DocumentStore>.Instance;
 
-            // Same table enumeration Weasel's managed drop uses — every table whose LIST
-            // partitioning is managed by this store's tenant-partition manager.
-            var tables = database.AllObjects().OfType<Table>()
-                .Where(x => x.Partitioning is ListPartitioning lp &&
-                            ReferenceEquals(lp.PartitionManager, _options.TenantPartitions.Partitions))
-                .ToArray();
-
-            await using var conn = database.CreateConnection();
-            await conn.OpenAsync(ct).ConfigureAwait(false);
             try
             {
-                // Remove the tenant from the shard's own registry FIRST (mirrors Weasel's
-                // ordering) — this is what the native coordinator's per-tenant re-expansion
-                // (ICrossTenantRebuildSource) reads, so the tenant's agents can be reaped even
-                // if a partition drop below fails midway.
-                await conn.CreateCommand(
-                        $"delete from {_options.TenantPartitions.TenantsTableName} where partition_value = :value")
-                    .With("value", tenantId)
-                    .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
-
-                foreach (var table in tables)
-                {
-                    var quotedPartition = $"\"{table.Identifier.Schema}\".\"{table.Identifier.Name}_{tenantId}\"";
-
-                    var exists = await conn.CreateCommand("select to_regclass(:name)::text")
-                        .With("name", quotedPartition)
-                        .ExecuteScalarAsync(ct).ConfigureAwait(false);
-                    if (exists == null || exists == DBNull.Value)
-                    {
-                        continue;
-                    }
-
-                    // Best-effort DETACH (CONCURRENTLY first for lock-friendliness) — the DROP
-                    // TABLE below is authoritative either way: PostgreSQL drops an attached
-                    // partition directly, and IF EXISTS keeps re-runs safe.
-                    try
-                    {
-                        await conn.CreateCommand(
-                                $"alter table {table.Identifier.QualifiedName} detach partition {quotedPartition} CONCURRENTLY;")
-                            .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
-                    }
-                    catch (Exception)
-                    {
-                        try
-                        {
-                            await conn.CreateCommand(
-                                    $"alter table {table.Identifier.QualifiedName} detach partition {quotedPartition};")
-                                .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
-                        }
-                        catch (Exception)
-                        {
-                            // already detached by a prior partial run — the drop below settles it
-                        }
-                    }
-
-                    await conn.CreateCommand($"drop table if exists {quotedPartition} cascade;")
-                        .ExecuteNonQueryAsync(ct).ConfigureAwait(false);
-
-                    logger.LogInformation(
-                        "Dropped partition {Partition} of {Table} for removed tenant {TenantId}",
-                        quotedPartition, table.Identifier.QualifiedName, tenantId);
-                }
+                await _options.TenantPartitions.Partitions.DropPartitionFromAllTablesForValue(
+                    database, logger, tenantId, ct).ConfigureAwait(false);
             }
-            finally
+            catch (PostgresException e) when (e.SqlState == PostgresErrorCodes.UndefinedTable)
             {
-                await conn.CloseAsync().ConfigureAwait(false);
+                // 42P01: a configured partition-parent table isn't physically present on this shard
+                // (registered tenant, but its doc/event tables were never migrated here). There is no
+                // partition to detach — mirror the resilience the former to_regclass-guarded drop had.
+                // The registry row is cleared by the native drop before it reaches the DDL, and the
+                // #4683 cleanup below still runs.
             }
         }
 

--- a/src/MultiTenancyTests/sharded_tenancy_remove_lifecycle_tests.cs
+++ b/src/MultiTenancyTests/sharded_tenancy_remove_lifecycle_tests.cs
@@ -336,7 +336,55 @@ public class sharded_tenancy_remove_lifecycle_tests: IAsyncLifetime
             .ShouldNotContain("managed_gone");
     }
 
+    [Fact]
+    public async Task remove_drops_the_sanitized_partition_for_a_hyphenated_tenant_id()
+    {
+        // weasel#338 regression, and the exact case the removed hand-rolled quoted DETACH/DROP
+        // existed to cover: before Weasel 9.16 the native drop interpolated the partition name
+        // unquoted and 42601'd on ids with hyphens/GUIDs. The native by-value drop now resolves
+        // the SANITIZED suffix from the shard's own registry, so a hyphenated tenant's partition
+        // (named with '-' → '_') is dropped and its raw-keyed registry row cleared — which is what
+        // lets the coordinator's per-tenant re-expansion stop seeing the tenant and reap its agents.
+        const string tenantId = "acme-corp-42";
+        var sanitized = sanitizeSuffix(tenantId); // "acme_corp_42"
+        sanitized.ShouldNotBe(tenantId, "the test id must actually require sanitization");
+
+        CreateStore();
+        await applySchemaToAllShardsAsync();
+        var sharded = (ShardedTenancy)_store.Options.Tenancy;
+
+        await sharded.AssignTenantAsync(tenantId, _fixture.DbNames[0], CancellationToken.None);
+
+        // Create sanitizes the table name; the registry keys on the raw partition_value.
+        (await shardHasPartitionTablesForSuffixAsync(_fixture.DbNames[0], sanitized)).ShouldBeTrue(
+            "create should have made a partition named with the sanitized suffix");
+        (await shardRegistryContainsAsync(_fixture.DbNames[0], tenantId)).ShouldBeTrue();
+
+        await sharded.RemoveTenantAsync(tenantId, CancellationToken.None);
+
+        (await shardHasPartitionTablesForSuffixAsync(_fixture.DbNames[0], sanitized)).ShouldBeFalse(
+            "the native by-value drop must resolve + drop the sanitized partition for a hyphenated id");
+        (await shardRegistryContainsAsync(_fixture.DbNames[0], tenantId)).ShouldBeFalse(
+            "removal must clear the hyphenated tenant's raw-keyed registry row so the reap can proceed");
+        (await sharded.FindDatabaseForTenantAsync(tenantId, CancellationToken.None)).ShouldBeNull();
+    }
+
     // ---- helpers ----
+
+    // Mirror of Weasel's internal ListPartition.SanitizeSuffix: lowercase, any char outside
+    // [a-z0-9_] → '_'. Kept in the test because Weasel does not expose it publicly.
+    private static string sanitizeSuffix(string suffix)
+        => new string(suffix.ToLowerInvariant()
+            .Select(c => (c is >= 'a' and <= 'z') || (c is >= '0' and <= '9') || c == '_' ? c : '_')
+            .ToArray());
+
+    private async Task<bool> shardHasPartitionTablesForSuffixAsync(string dbName, string suffix)
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbName]);
+        await conn.OpenAsync();
+        var tables = await conn.ExistingTablesAsync();
+        return tables.Any(t => t.Name.EndsWith($"_{suffix}", StringComparison.Ordinal));
+    }
 
     private static async Task<int> countFor(ShardedTenancy sharded, string dbName)
     {


### PR DESCRIPTION
Now that the E3 Weasel 9.16 consumption (#4901) is on master, this folds the sharded tenant-removal partition drop back onto Weasel's native path — the cleanup deferred while E3 was in flight.

## What changed
`ShardedTenancy.dropPartitionsForTenant` hand-rolled a quoted `DETACH`/`DROP` loop only because the pre-9.16 native `DropPartitionFromAllTables` interpolated the partition name unquoted and 42601'd on hyphenated/GUID/uppercase tenant ids. weasel#338 (in 9.16) fixed the native drop to **sanitize the suffix symmetric with the create path**, so this replaces the ~50-line loop with the database-scoped native call `DatabaseScopedTenantPartitions.DropPartitionFromAllTablesForValue(...)`.

## A latent bug this fixes
The old loop matched the **raw** (quoted) partition name (`"…_tenant-a"`) while the create path (`AddPartitionToAllTables`) **sanitizes** (`…_tenant_a`). So for a hyphenated/GUID tenant the loop's `to_regclass` check found nothing and **silently orphaned** the sanitized partition on removal. The native by-value drop resolves the sanitized suffix from the shard's own registry, so it drops the real table and clears the raw-keyed registry row. New test `remove_drops_the_sanitized_partition_for_a_hyphenated_tenant_id` pins this.

## Resilience preserved
The former loop's `to_regclass` pre-check made it resilient to a configured-but-not-physically-present parent table (registered tenant whose tables were never migrated to that shard). The native drop throws `42P01` there, so this keeps a **targeted catch** of that one SqlState. Filed **weasel#344** to harden the native drop; the catch can be removed once that lands.

## Tests (net9.0, Marten docker PG)
- `sharded_tenancy_remove_lifecycle_tests` **11/11** (incl. the new hyphenated case)
- all sharded `MultiTenancyTests` **34/34** — including `sharded_tenancy_soft_delete_tests.lifecycle_…` which removes a hyphenated tenant and surfaced the resilience gap (failing without the catch, green with it)
- `TenantPartitionedEventsTests` **228/228**

🤖 Generated with [Claude Code](https://claude.com/claude-code)