### PR TITLE
Don't dispose a caller-owned NpgsqlDataSource (#4874)

### DIFF
--- a/src/CoreTests/Bug_4874_shared_datasource_not_disposed.cs
+++ b/src/CoreTests/Bug_4874_shared_datasource_not_disposed.cs
@@ -1,0 +1,71 @@
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests;
+
+// #4874: Marten must not dispose a caller-owned NpgsqlDataSource. Two stores sharing one external
+// data source is the deterministic shape of the reported "pooled connection disposed underneath an
+// in-flight operation" abort — before the fix, disposing store A tore down the shared data source and
+// aborted store B's next operation.
+public class Bug_4874_shared_datasource_not_disposed
+{
+    [Fact]
+    public async Task disposing_one_store_does_not_abort_another_sharing_the_datasource()
+    {
+        await using var sharedDataSource = NpgsqlDataSource.Create(ConnectionSource.ConnectionString);
+
+        var storeA = DocumentStore.For(opts =>
+        {
+            opts.Connection(sharedDataSource);
+            opts.DatabaseSchemaName = "bug4874_shared";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        var storeB = DocumentStore.For(opts =>
+        {
+            opts.Connection(sharedDataSource);
+            opts.DatabaseSchemaName = "bug4874_shared";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        // Both stores are live against the shared data source.
+        await using (var session = storeA.LightweightSession())
+        {
+            session.Store(new Target { Id = System.Guid.NewGuid() });
+            await session.SaveChangesAsync();
+        }
+
+        await using (var session = storeB.QuerySession())
+        {
+            (await session.Query<Target>().CountAsync()).ShouldBeGreaterThanOrEqualTo(0);
+        }
+
+        // Tear down store A. It shares the caller-owned data source with store B, so it must NOT
+        // dispose it (per the Connection(NpgsqlDataSource) contract).
+        storeA.Dispose();
+
+        // Before the fix this threw ObjectDisposedException / a socket abort because store A had
+        // disposed the shared NpgsqlDataSource.
+        await using (var session = storeB.LightweightSession())
+        {
+            session.Store(new Target { Id = System.Guid.NewGuid() });
+            await Should.NotThrowAsync(async () => await session.SaveChangesAsync());
+        }
+
+        storeB.Dispose();
+
+        // The caller still owns the data source — it was never disposed by Marten and remains usable.
+        await using var conn = sharedDataSource.CreateConnection();
+        await Should.NotThrowAsync(async () => await conn.OpenAsync());
+    }
+
+    public class Target
+    {
+        public System.Guid Id { get; set; }
+    }
+}

--- a/src/Marten/Storage/MartenDatabase.cs
+++ b/src/Marten/Storage/MartenDatabase.cs
@@ -134,7 +134,14 @@ public partial class MartenDatabase: PostgresqlDatabase, IMartenDatabase, IProje
 
     public void Dispose()
     {
-        DataSource?.Dispose();
+        // #4874: never dispose a data source the caller owns (supplied via Connection(NpgsqlDataSource)
+        // / UseNpgsqlDataSource). Disposing it aborts every connection rented from it — fatal when the
+        // caller shares one across stores or a running daemon still holds connections.
+        if (Options.OwnsPrimaryDataSource)
+        {
+            DataSource?.Dispose();
+        }
+
         ((IDisposable)Tracker)?.Dispose();
     }
 

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -515,6 +515,14 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
     private Lazy<ITenancy>? _tenancy;
     private Func<string, NpgsqlDataSourceBuilder> _npgsqlDataSourceBuilderFactory = DefaultNpgsqlDataSourceBuilderFactory;
     private INpgsqlDataSourceFactory _npgsqlDataSourceFactory;
+
+    /// <summary>
+    /// #4874: false when the primary NpgsqlDataSource was supplied by the caller
+    /// (<see cref="Connection(NpgsqlDataSource)"/> / <c>UseNpgsqlDataSource</c>) and Marten must not
+    /// dispose it. True (default) when Marten built the data source from a connection string and owns
+    /// its lifetime.
+    /// </summary>
+    internal bool OwnsPrimaryDataSource { get; set; } = true;
     private readonly List<Type> _compiledQueryTypes = new();
 
     /// <summary>
@@ -620,7 +628,15 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
     ///     When doing that you need to handle data source disposal.
     /// </remarks>
     /// <param name="dataSource"></param>
-    public void Connection(NpgsqlDataSource dataSource) =>
+    public void Connection(NpgsqlDataSource dataSource)
+    {
+        // #4874: an externally-supplied data source is owned by the caller ("you need to handle
+        // data source disposal" — see the remarks on this method / Connection overloads). Marten
+        // must NOT dispose it on store/database teardown: disposing an NpgsqlDataSource aborts every
+        // physical connection rented from it, so if the caller shares one across stores (or keeps
+        // using it), a Marten teardown pulls the socket out from under an in-flight operation.
+        OwnsPrimaryDataSource = false;
+
         DataSourceFactory(
             new SingleNpgsqlDataSourceFactory(
                 NpgsqlDataSourceBuilderFactory,
@@ -628,6 +644,7 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
             ),
             dataSource.ConnectionString
         );
+    }
 
     /// <summary>
     ///     Supply a mechanism for resolving an NpgsqlConnection object based on the NpgsqlDataSource


### PR DESCRIPTION
Fixes one concrete, deterministic instance of #4874.

## Root cause
`MartenDatabase.Dispose()` disposed its `NpgsqlDataSource` **unconditionally**, contradicting the documented `Connection(NpgsqlDataSource)` / `UseNpgsqlDataSource` contract (*"you need to handle data source disposal"*). Disposing an `NpgsqlDataSource` aborts **every** physical connection rented from it — so when a caller shares one data source across stores (or a running daemon still holds connections), a Marten teardown pulls the socket out from under an in-flight operation. That is the `ObjectDisposedException` / "I/O operation aborted … application request" socket abort reported in #4874.

## Fix
Track ownership on `StoreOptions.OwnsPrimaryDataSource` — `false` when the data source is caller-supplied via `Connection(NpgsqlDataSource)` (which both `UseNpgsqlDataSource` overloads route through), `true` (default) when Marten builds it from a connection string and owns its lifetime — and guard the disposal.

## Test
`Bug_4874_shared_datasource_not_disposed`: two stores sharing one external `NpgsqlDataSource`; disposing one must not abort the other. **Failing-first** — throws `System.ObjectDisposedException` on `master`, green with the fix. Marten-owned (connection-string) data sources still dispose normally (default `OwnsPrimaryDataSource = true`); connection/session/store-options suites 31/32 green (1 pre-existing skip).

## Follow-up
The Weasel base `PostgresqlDatabase.DisposeAsync()` disposes the data source unconditionally too — the async path needs the same ownership guard. Filed as JasperFx/weasel (linked below).

Diagnostic branch available for the reporter to confirm their exact disposer in-suite (opt-in `MARTEN_TRACE_DATASOURCE_DISPOSAL=1` stack-trace capture) if their case is a Marten-owned data source disposed by a different path rather than a shared external one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)