### PR TITLE
#4874: guard the async NpgsqlDataSource disposal path too

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -181,7 +181,10 @@
     <!-- 9.16.0 (weasel#343): closed-shape EVENT storage hierarchy + operations + new neutral op
          bases moved into Weasel.Storage — EventStorage<TId>, the 3 storages, EventStorageBuilder,
          and the per-event/insert/update/assert ops — so Marten and Polecat share them (#4821 event E3). -->
-    <!-- 9.16.1: latest Weasel patch consumed for the 9.13.0-alpha.3 Marten alpha. -->
+    <!-- 9.16.1: latest Weasel patch consumed for the 9.13.0-alpha.3 Marten alpha. Also carries
+         weasel#345/#346: PostgresqlDatabase.DisposeAsync() honors an OwnsDataSource flag so a
+         caller-owned NpgsqlDataSource is not disposed on the async teardown path — the Weasel
+         sibling of marten#4874 (the sync path was guarded Marten-side by #4903). -->
     <PackageVersion Include="Weasel.Postgresql" Version="9.16.1" />
     <PackageVersion Include="Weasel.Storage" Version="9.16.1" />
     <PackageVersion Include="WolverineFx.Marten" Version="4.2.0" />

--- a/src/CoreTests/Bug_4874_shared_datasource_not_disposed.cs
+++ b/src/CoreTests/Bug_4874_shared_datasource_not_disposed.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using JasperFx;
 using Marten;
@@ -60,6 +61,53 @@ public class Bug_4874_shared_datasource_not_disposed
         storeB.Dispose();
 
         // The caller still owns the data source — it was never disposed by Marten and remains usable.
+        await using var conn = sharedDataSource.CreateConnection();
+        await Should.NotThrowAsync(async () => await conn.OpenAsync());
+    }
+
+    // #4874 async path: the sync MartenDatabase.Dispose() was guarded by #4903, but the inherited
+    // Weasel PostgresqlDatabase.DisposeAsync() disposed the data source unconditionally (weasel#345).
+    // Consuming the OwnsDataSource-aware Weasel base and flowing ownership through the constructor must
+    // make the async teardown honor the same caller-owned contract.
+    [Fact]
+    public async Task disposing_database_async_does_not_abort_another_store_sharing_the_datasource()
+    {
+        await using var sharedDataSource = NpgsqlDataSource.Create(ConnectionSource.ConnectionString);
+
+        var storeA = DocumentStore.For(opts =>
+        {
+            opts.Connection(sharedDataSource);
+            opts.DatabaseSchemaName = "bug4874_shared_async";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        var storeB = DocumentStore.For(opts =>
+        {
+            opts.Connection(sharedDataSource);
+            opts.DatabaseSchemaName = "bug4874_shared_async";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        await using (var session = storeA.LightweightSession())
+        {
+            session.Store(new Target { Id = Guid.NewGuid() });
+            await session.SaveChangesAsync();
+        }
+
+        // Tear down store A's database through the async disposal path (the inherited
+        // PostgresqlDatabase.DisposeAsync()). It shares the caller-owned data source with store B, so it
+        // must NOT dispose it. Before the fix this aborted store B's next operation.
+        await ((IAsyncDisposable)storeA.Tenancy.Default.Database).DisposeAsync();
+
+        await using (var session = storeB.LightweightSession())
+        {
+            session.Store(new Target { Id = Guid.NewGuid() });
+            await Should.NotThrowAsync(async () => await session.SaveChangesAsync());
+        }
+
+        storeB.Dispose();
+
+        // The caller still owns the data source — the async teardown never disposed it.
         await using var conn = sharedDataSource.CreateConnection();
         await Should.NotThrowAsync(async () => await conn.OpenAsync());
     }

--- a/src/Marten/Storage/MartenDatabase.cs
+++ b/src/Marten/Storage/MartenDatabase.cs
@@ -30,7 +30,11 @@ public partial class MartenDatabase: PostgresqlDatabase, IMartenDatabase, IProje
         StoreOptions options,
         NpgsqlDataSource npgsqlDataSource,
         string identifier
-    ): base(options, options.AutoCreateSchemaObjects, options.Advanced.Migrator, identifier, npgsqlDataSource)
+        // #4874: flow the data-source ownership into the Weasel base (weasel#345/#346) so the inherited
+        // async PostgresqlDatabase.DisposeAsync() also skips disposing a caller-owned NpgsqlDataSource —
+        // the sync MartenDatabase.Dispose() below was already guarded by #4903, but the async path was not.
+    ): base(options, options.AutoCreateSchemaObjects, options.Advanced.Migrator, identifier, npgsqlDataSource,
+        options.OwnsPrimaryDataSource)
     {
         _features = options.Storage;
         Options = options;
@@ -136,8 +140,10 @@ public partial class MartenDatabase: PostgresqlDatabase, IMartenDatabase, IProje
     {
         // #4874: never dispose a data source the caller owns (supplied via Connection(NpgsqlDataSource)
         // / UseNpgsqlDataSource). Disposing it aborts every connection rented from it — fatal when the
-        // caller shares one across stores or a running daemon still holds connections.
-        if (Options.OwnsPrimaryDataSource)
+        // caller shares one across stores or a running daemon still holds connections. OwnsDataSource is
+        // the Weasel base flag we set from Options.OwnsPrimaryDataSource in the constructor, so the sync
+        // and async (base DisposeAsync) teardown paths read the exact same ownership signal.
+        if (OwnsDataSource)
         {
             DataSource?.Dispose();
         }


### PR DESCRIPTION
Closes #4874.

## Background
[#4903](https://github.com/JasperFx/marten/pull/4903) fixed one concrete, deterministic instance of #4874 — the reported "pooled connection disposed underneath an in-flight operation" abort — by guarding the **sync** `MartenDatabase.Dispose()` so it never disposes a caller-owned `NpgsqlDataSource` (one supplied via `Connection(NpgsqlDataSource)` / `UseNpgsqlDataSource`, where the contract is *"you need to handle data source disposal"*).

That PR noted a follow-up: the Weasel base `PostgresqlDatabase.DisposeAsync()` disposed the data source **unconditionally** too, so the **async** teardown path was still unguarded. Disposing an `NpgsqlDataSource` aborts every physical connection rented from it — so when a caller shares one data source across stores (or a running daemon still holds connections), an async teardown pulls the socket out from under an in-flight operation. That is the `ObjectDisposedException` / `IOException` "I/O operation aborted … application request" socket abort reported in #4874.

## Fix
The Weasel side landed in **9.16.1** (weasel#345 / weasel#346): `PostgresqlDatabase` gained an `OwnsDataSource` notion and a 6-arg constructor, and `DisposeAsync()` now skips disposal when the data source is not owned. Marten is already pinned to 9.16.1.

This PR consumes that capability:
- `MartenDatabase` now passes `Options.OwnsPrimaryDataSource` into the new Weasel 6-arg base constructor, so the inherited async `PostgresqlDatabase.DisposeAsync()` honors the caller-owned contract.
- The sync `Dispose()` now reads the inherited `OwnsDataSource` flag (set from `Options.OwnsPrimaryDataSource` in the ctor) so both teardown paths share one ownership signal.

## Test
`Bug_4874_shared_datasource_not_disposed.disposing_database_async_does_not_abort_another_store_sharing_the_datasource`: two stores share one external `NpgsqlDataSource`; store A's database is torn down through the **async** `DisposeAsync()` path while store B keeps using the shared source. **Failing-first** — aborts on `master` (verified by reverting the ctor change: `ObjectDisposedException`), green with the fix. The existing sync test still passes; the connection/session/data-source teardown slice of CoreTests is 30/30 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)