### PR TITLE
#4904: don't drive a coordinator on forced catch-up under ExternallyManaged

### DIFF
--- a/src/EventSourcingTests/Bugs/Bug_4904_force_catch_up_under_externally_managed.cs
+++ b/src/EventSourcingTests/Bugs/Bug_4904_force_catch_up_under_externally_managed.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Bugs;
+
+// Regression guard for https://github.com/JasperFx/marten/issues/4904.
+//
+// Under DaemonMode.ExternallyManaged an external system (Wolverine's managed event-subscription
+// distribution) OWNS the projection agents and their assignment; Marten deliberately registers no
+// IProjectionCoordinator of its own (see AddAsyncDaemon — only Solo/HotCold register one).
+//
+// Before the #4904 mitigation, ForceAllMartenDaemonActivityToCatchUpAsync unconditionally resolved
+// IProjectionCoordinator and drove Pause -> Stop -> CatchUp. That was wrong under ExternallyManaged
+// in two ways:
+//   1. In a plain Marten host (no external coordinator registered) GetRequiredService<IProjectionCoordinator>()
+//      threw InvalidOperationException — reproduced directly by this in-repo test (fails on master, passes
+//      with the mitigation).
+//   2. Where Wolverine DID supply a coordinator, PauseAsync only stopped the running agent instances;
+//      Wolverine's supervisor immediately reassigned/restarted them, so the forced CatchUp and the
+//      restarted per-tenant agent both advanced the same <proj>:All:<tenant> mt_event_progression row
+//      -> ProgressionProgressOutOfOrderException (the actual field failure). That end-to-end race is
+//      Wolverine-dependent and belongs in Wolverine's own suite (the active-quiesce fix — the external
+//      coordinator suspending agent assignment during a forced catch-up — lives in that coordinator).
+//      It cannot be reproduced in Marten's test projects, which carry no Wolverine reference.
+//
+// The mitigation degrades ForceAll under ExternallyManaged to a read-only wait-for-non-stale that never
+// starts, stops, or drives an agent — so it can neither throw on the missing coordinator nor race the
+// externally-owned agents into an out-of-order progression write. This test pins that Marten-side contract.
+public class Bug_4904_force_catch_up_under_externally_managed
+{
+    public class LetterCounts
+    {
+        public Guid Id { get; set; }
+        public int ACount { get; set; }
+    }
+
+    public record AEvent;
+
+    public partial class LetterCountsProjection: SingleStreamProjection<LetterCounts, Guid>
+    {
+        public LetterCountsProjection() => Name = "LetterCounts4904";
+
+        public override LetterCounts Evolve(LetterCounts? snapshot, Guid id, IEvent e)
+        {
+            snapshot ??= new LetterCounts { Id = id };
+            if (e.Data is AEvent) snapshot.ACount++;
+            return snapshot;
+        }
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task force_catch_up_under_externally_managed_does_not_resolve_a_coordinator()
+    {
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(s =>
+            {
+                s.AddMarten(m =>
+                {
+                    m.Connection(ConnectionSource.ConnectionString);
+                    m.DatabaseSchemaName = "bug4904_externally_managed";
+                    m.Projections.Add<LetterCountsProjection>(ProjectionLifecycle.Async);
+                }).AddAsyncDaemon(DaemonMode.ExternallyManaged);
+            })
+            .StartAsync();
+
+        var store = host.Services.GetRequiredService<IDocumentStore>();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+        // No IProjectionCoordinator is registered under ExternallyManaged. On master ForceAll resolved it
+        // via GetRequiredService and threw InvalidOperationException before doing anything else. The
+        // mitigation must instead take the read-only ExternallyManaged branch and return cleanly.
+        // On master this line threw InvalidOperationException (no IProjectionCoordinator registered);
+        // with the mitigation it returns cleanly via the read-only ExternallyManaged branch.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var exceptions = await host.ForceAllMartenDaemonActivityToCatchUpAsync(cts.Token);
+        exceptions.ShouldBeEmpty();
+    }
+}

--- a/src/Marten/Events/AsyncProjectionTestingExtensions.cs
+++ b/src/Marten/Events/AsyncProjectionTestingExtensions.cs
@@ -382,6 +382,25 @@ public static class TestingExtensions
         CatchUpMode mode = CatchUpMode.AndResumeNormally)
     {
         var logger = services.GetService<ILogger<ProjectionDaemon>>() ?? new NullLogger<ProjectionDaemon>();
+
+        // #4904: under DaemonMode.ExternallyManaged an external system (e.g. Wolverine's managed
+        // event-subscription distribution) OWNS the projection agents and their assignment; Marten
+        // registers no coordinator of its own (see AddAsyncDaemon). Driving the usual
+        // Pause -> Stop -> CatchUp cycle here is unsafe: PauseAsync stops the running agent instances,
+        // but the external supervisor immediately reassigns/restarts them, so our CatchUpAsync and the
+        // restarted per-tenant agent both advance the same <proj>:All:<tenant> mt_event_progression row
+        // -> ProgressionProgressOutOfOrderException. We do not own the daemon, so we cannot "force" it;
+        // degrade to a read-only wait until the externally-run agents reach the current high-water mark.
+        // (The proper active-quiesce — the external coordinator suspending agent assignment during a
+        // forced catch-up — lives in that external coordinator, not here; tracked on #4904.)
+        if (services.GetService<IDocumentStore>() is DocumentStore
+            {
+                Options.Projections.AsyncMode: JasperFx.Events.Daemon.DaemonMode.ExternallyManaged
+            } externallyManagedStore)
+        {
+            return await waitForExternallyManagedCatchUpAsync(externallyManagedStore, cancellation).ConfigureAwait(false);
+        }
+
         var coordinator = services.GetRequiredService<IProjectionCoordinator>();
 
         // Has to be paused first
@@ -438,6 +457,40 @@ public static class TestingExtensions
             _ => false
         };
 
+    // #4904: read-only catch-up wait used when the daemon is externally managed (see both
+    // ForceAll... overloads). Iterates every database the store knows about and blocks until each
+    // one's registered projection shards reach that database's current high-water mark, reusing the
+    // exact non-stale bar the WaitForNonStale* helpers use — including the per-tenant-partitioned
+    // handling in WaitForNonStaleDataAsync. It never starts, stops, or drives an agent (the external
+    // system owns that), so it cannot race the running agents into an out-of-order progression write.
+    private static async Task<IReadOnlyList<Exception>> waitForExternallyManagedCatchUpAsync(
+        DocumentStore store, CancellationToken cancellation)
+    {
+        var databases = await store.Storage.AllDatabases().ConfigureAwait(false);
+        foreach (var database in databases.OfType<MartenDatabase>())
+        {
+            // Number of active projection shards, plus the high water mark; nothing to wait on otherwise.
+            var projectionsCount = database.Options.Projections.AllShards().Count + 1;
+            if (projectionsCount == 1)
+            {
+                continue;
+            }
+
+            var initial = await database.FetchEventStoreStatistics(cancellation).ConfigureAwait(false);
+
+            // No event activity on this database yet -> nothing to catch up to.
+            if (initial.EventCount == 0 || initial.EventSequenceNumber == 0)
+            {
+                continue;
+            }
+
+            using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
+            await database.WaitForNonStaleDataAsync(cancellationSource, projectionsCount, initial).ConfigureAwait(false);
+        }
+
+        return Array.Empty<Exception>();
+    }
+
         /// <summary>
     /// Force any Marten async daemons for an ancillary Marten store to immediately advance to the latest changes. This is strictly
     /// meant for test automation scenarios with small to medium sized databases
@@ -464,6 +517,18 @@ public static class TestingExtensions
         CatchUpMode mode = CatchUpMode.AndResumeNormally) where T : class, IDocumentStore
     {
         var logger = services.GetService<ILogger<ProjectionDaemon>>() ?? new NullLogger<ProjectionDaemon>();
+
+        // #4904: see the main-store overload above — under ExternallyManaged the ancillary store's
+        // agents are also externally owned, so forcing a second-writer CatchUp races the external
+        // supervisor. Degrade to a read-only wait for the ancillary store's databases.
+        if (services.GetService<T>() is DocumentStore
+            {
+                Options.Projections.AsyncMode: JasperFx.Events.Daemon.DaemonMode.ExternallyManaged
+            } externallyManagedStore)
+        {
+            return await waitForExternallyManagedCatchUpAsync(externallyManagedStore, cancellation).ConfigureAwait(false);
+        }
+
         var coordinator = services.GetRequiredService<IProjectionCoordinator<T>>();
         var daemons = await coordinator.AllDaemonsAsync().ConfigureAwait(false);
 


### PR DESCRIPTION
Part of #4904 (Marten-side mitigation; the full fix is Wolverine-side — see below).

## Problem
Under `DaemonMode.ExternallyManaged` (e.g. `UseWolverineManagedEventSubscriptionDistribution = true`) an external system owns the projection agents and their assignment, and Marten registers **no** `IProjectionCoordinator` of its own (`AddAsyncDaemon` only registers one for `Solo`/`HotCold`). Yet `ForceAllMartenDaemonActivityToCatchUpAsync` unconditionally resolved `IProjectionCoordinator` and drove `Pause -> Stop -> CatchUp`. Under this mode that was wrong two ways:

1. In a plain Marten host (no external coordinator registered) `GetRequiredService<IProjectionCoordinator>()` threw `InvalidOperationException`.
2. Where Wolverine supplied a coordinator, `PauseAsync` only stopped the running agent **instances**; Wolverine's supervisor immediately restarted them, so the forced `CatchUp` and the restarted per-tenant agent both advanced the same `<proj>:All:<tenant>` progression row → `ProgressionProgressOutOfOrderException` (the field failure in #4904).

## Change
Under `AsyncMode == ExternallyManaged`, `ForceAll` no longer resolves or drives a coordinator. It degrades to a **read-only** wait-for-non-stale across the store's databases, reusing `WaitForNonStaleDataAsync` (including the per-tenant-partitioned bar). It never starts, stops, or drives an agent, so it can neither throw on the missing coordinator nor race the externally-owned agents. Applied to both the main-store and ancillary (`<T>`) overloads.

## Test
`Bug_4904_force_catch_up_under_externally_managed` — an `ExternallyManaged` host with an async projection. On master this throws `InvalidOperationException: No service for type ...IProjectionCoordinator` (verified by neutralizing the mitigation); with the change it returns cleanly. Deterministic, no daemon-timing dependence.

## Not fully closed
The end-to-end progression race is Wolverine-dependent (it needs a Wolverine reference and can't be reproduced in Marten's test suite). The proper active fix — `WolverineProjectionCoordinator.PauseAsync()` suspending Wolverine's **agent-assignment supervisor** (not just `StopAllAsync()`) so it won't restart the agents mid-catch-up — is a Wolverine change tracked on #4904 (root-cause analysis posted there). This PR is defense-in-depth from the Marten side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)