### PR TITLE
#4874: make the tenancy hierarchy IAsyncDisposable so async store teardown is really async

### DIFF
--- a/src/CoreTests/Bug_4874_async_tenancy_disposal.cs
+++ b/src/CoreTests/Bug_4874_async_tenancy_disposal.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx;
+using Marten;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests;
+
+// #4874 (follow-up to #4903/#4905): DocumentStore.DisposeAsync() disposes the tenancy through
+// JasperFx's MaybeDisposeAllAsync, which prefers IAsyncDisposable and otherwise falls back to the
+// synchronous IDisposable chain. Before this change no tenancy implemented IAsyncDisposable, so async
+// store teardown ALWAYS fell back to the synchronous DefaultTenancy.Dispose() -> MartenDatabase.Dispose()
+// -> blocking NpgsqlDataSource.Dispose() chain, and the inherited async PostgresqlDatabase.DisposeAsync()
+// (guarded by #4905) was unreachable dead code. The tenancy hierarchy is now IAsyncDisposable so the
+// async teardown path is actually taken.
+//
+// NOTE: this does not by itself fix the reporter's owned-data-source ObjectDisposedException storm — that
+// is a separate disposal-ordering problem (the data source is disposed before the still-running async
+// daemon / durability loops stop renting connections). This change is the correct foundation for that.
+public class Bug_4874_async_tenancy_disposal
+{
+    // Load-bearing: fails on master (DefaultTenancy was IDisposable-only), passes with the fix.
+    [Fact]
+    public void default_tenancy_is_async_disposable()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "bug4874_async_tenancy";
+        });
+
+        store.Tenancy.ShouldBeAssignableTo<IAsyncDisposable>();
+    }
+
+    // Marten owns the data source (connection-string overload). Async teardown must run cleanly and
+    // actually dispose the owned data source, so the store is unusable afterward.
+    [Fact]
+    public async Task disposing_store_async_disposes_a_marten_owned_datasource()
+    {
+        var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = "bug4874_async_tenancy_owned";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(new Target { Id = Guid.NewGuid() });
+            await session.SaveChangesAsync();
+        }
+
+        await store.DisposeAsync();
+
+        // The owned data source was torn down by the async path — any further use that opens a
+        // connection throws.
+        await Should.ThrowAsync<ObjectDisposedException>(async () =>
+        {
+            await using var session = store.QuerySession();
+            await session.Query<Target>().AnyAsync();
+        });
+    }
+
+    // A caller-owned data source must survive async store teardown (the async path honors the same
+    // OwnsDataSource guard as the sync path). Guards the new tenancy/database async disposal code.
+    [Fact]
+    public async Task disposing_store_async_does_not_dispose_a_caller_owned_datasource()
+    {
+        await using var sharedDataSource = NpgsqlDataSource.Create(ConnectionSource.ConnectionString);
+
+        var storeA = DocumentStore.For(opts =>
+        {
+            opts.Connection(sharedDataSource);
+            opts.DatabaseSchemaName = "bug4874_async_tenancy_shared";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        var storeB = DocumentStore.For(opts =>
+        {
+            opts.Connection(sharedDataSource);
+            opts.DatabaseSchemaName = "bug4874_async_tenancy_shared";
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+        });
+
+        await using (var session = storeA.LightweightSession())
+        {
+            session.Store(new Target { Id = Guid.NewGuid() });
+            await session.SaveChangesAsync();
+        }
+
+        // Tear down store A via the async path — it must NOT dispose the caller-owned data source.
+        await storeA.DisposeAsync();
+
+        await using (var session = storeB.LightweightSession())
+        {
+            session.Store(new Target { Id = Guid.NewGuid() });
+            await Should.NotThrowAsync(async () => await session.SaveChangesAsync());
+        }
+
+        await storeB.DisposeAsync();
+
+        await using var conn = sharedDataSource.CreateConnection();
+        await Should.NotThrowAsync(async () => await conn.OpenAsync());
+    }
+
+    public class Target
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/src/Marten/Storage/DefaultTenancy.cs
+++ b/src/Marten/Storage/DefaultTenancy.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,7 +11,7 @@ using Weasel.Core.Migrations;
 
 namespace Marten.Storage;
 
-internal class DefaultTenancy: Tenancy, ITenancy
+internal class DefaultTenancy: Tenancy, ITenancy, IAsyncDisposable
 {
     private readonly NpgsqlDataSource _dataSource;
     private readonly StoreOptions _options;
@@ -68,6 +69,13 @@ internal class DefaultTenancy: Tenancy, ITenancy
     public void Dispose()
     {
         Default.Database.Dispose();
+    }
+
+    // #4874: prefer async teardown so DocumentStore.DisposeAsync() runs the database's
+    // OwnsDataSource-aware async disposal instead of falling back to the blocking sync chain.
+    public async ValueTask DisposeAsync()
+    {
+        await Default.Database.DisposeAsync().ConfigureAwait(false);
     }
 
     public DatabaseCardinality Cardinality => DatabaseCardinality.Single;

--- a/src/Marten/Storage/IMartenDatabase.cs
+++ b/src/Marten/Storage/IMartenDatabase.cs
@@ -22,7 +22,7 @@ namespace Marten.Storage;
 ///     Governs the database structure and migration path for a single Marten database
 /// </summary>
 public interface IMartenDatabase: IDatabase, IConnectionSource<NpgsqlConnection>, IDocumentCleaner, IDisposable,
-    IStorageDatabase
+    IAsyncDisposable, IStorageDatabase
 {
     /// <summary>
     ///     Used to create new Hilo sequences

--- a/src/Marten/Storage/MartenDatabase.cs
+++ b/src/Marten/Storage/MartenDatabase.cs
@@ -20,7 +20,7 @@ using Table = Weasel.Postgresql.Tables.Table;
 
 namespace Marten.Storage;
 
-public partial class MartenDatabase: PostgresqlDatabase, IMartenDatabase, IProjectionDatabase
+public partial class MartenDatabase: PostgresqlDatabase, IMartenDatabase, IProjectionDatabase, IAsyncDisposable
 {
     private readonly StorageFeatures _features;
 
@@ -149,6 +149,19 @@ public partial class MartenDatabase: PostgresqlDatabase, IMartenDatabase, IProje
         }
 
         ((IDisposable)Tracker)?.Dispose();
+    }
+
+    // #4874: DocumentStore.DisposeAsync() disposes the tenancy through JasperFx's MaybeDisposeAllAsync,
+    // which prefers IAsyncDisposable. Before this, MartenDatabase only exposed the inherited
+    // PostgresqlDatabase.DisposeAsync() (which disposes the data source but not Marten's tracker), and no
+    // tenancy implemented IAsyncDisposable — so async store teardown always fell back to the synchronous
+    // Dispose() chain and blocked on NpgsqlDataSource.Dispose(). Re-implement IAsyncDisposable here so the
+    // async path releases the tracker AND runs the base's OwnsDataSource-aware async data-source disposal
+    // (weasel#346), matching Dispose() above.
+    public new async ValueTask DisposeAsync()
+    {
+        ((IDisposable)Tracker)?.Dispose();
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 
     public override DatabaseDescriptor Describe()

--- a/src/Marten/Storage/MasterTableTenancy.cs
+++ b/src/Marten/Storage/MasterTableTenancy.cs
@@ -19,7 +19,7 @@ using Table = Weasel.Postgresql.Tables.Table;
 
 namespace Marten.Storage;
 
-public class MasterTableTenancy: ITenancy, ITenancyWithMasterDatabase, IDynamicTenantSource<string>
+public class MasterTableTenancy: ITenancy, ITenancyWithMasterDatabase, IDynamicTenantSource<string>, IAsyncDisposable
 {
     private readonly MasterTableTenancyOptions _configuration;
     private readonly Lazy<NpgsqlDataSource> _dataSource;
@@ -72,6 +72,21 @@ public class MasterTableTenancy: ITenancy, ITenancyWithMasterDatabase, IDynamicT
         if (_dataSource.IsValueCreated)
         {
             _dataSource.Value.Dispose();
+        }
+    }
+
+    // #4874: async teardown mirror of Dispose() so DocumentStore.DisposeAsync() runs each tenant
+    // database's OwnsDataSource-aware async disposal rather than the blocking sync chain.
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var entry in _databases.Enumerate())
+        {
+            await entry.Value.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (_dataSource.IsValueCreated)
+        {
+            await _dataSource.Value.DisposeAsync().ConfigureAwait(false);
         }
     }
 

--- a/src/Marten/Storage/ShardedTenancy.cs
+++ b/src/Marten/Storage/ShardedTenancy.cs
@@ -28,7 +28,7 @@ namespace Marten.Storage;
 /// with conjoined tenancy and native PG list partitioning per tenant within each database.
 /// </summary>
 public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatabasePool,
-    IDynamicTenantSource<string>
+    IDynamicTenantSource<string>, IAsyncDisposable
 {
     private readonly StoreOptions _options;
     private readonly ShardedTenancyOptions _configuration;
@@ -81,6 +81,21 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
         if (_dataSource.IsValueCreated)
         {
             _dataSource.Value.Dispose();
+        }
+    }
+
+    // #4874: async teardown mirror of Dispose() so DocumentStore.DisposeAsync() runs each shard
+    // database's OwnsDataSource-aware async disposal rather than the blocking sync chain.
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var entry in _databasesById.Enumerate())
+        {
+            await entry.Value.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (_dataSource.IsValueCreated)
+        {
+            await _dataSource.Value.DisposeAsync().ConfigureAwait(false);
         }
     }
 

--- a/src/Marten/Storage/SingleServerMultiTenancy.cs
+++ b/src/Marten/Storage/SingleServerMultiTenancy.cs
@@ -36,7 +36,7 @@ public interface ISingleServerMultiTenancy
 }
 
 internal class SingleServerMultiTenancy: SingleServerDatabaseCollection<MartenDatabase>, ITenancy,
-    ISingleServerMultiTenancy, ITenancyWithMasterDatabase
+    ISingleServerMultiTenancy, ITenancyWithMasterDatabase, IAsyncDisposable
 {
     private readonly Lazy<NpgsqlDataSource> _masterDataSource;
     private readonly StoreOptions _options;
@@ -85,6 +85,21 @@ internal class SingleServerMultiTenancy: SingleServerDatabaseCollection<MartenDa
         foreach (var entry in _tenants.Enumerate()) entry.Value.Database.Dispose();
 
         _default?.Database?.Dispose();
+    }
+
+    // #4874: async teardown mirror of Dispose() so DocumentStore.DisposeAsync() runs each tenant
+    // database's OwnsDataSource-aware async disposal rather than the blocking sync chain.
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var entry in _tenants.Enumerate())
+        {
+            await entry.Value.Database.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (_default?.Database != null)
+        {
+            await _default.Database.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     public ValueTask<IMartenDatabase> FindDatabase(DatabaseId id)

--- a/src/Marten/Storage/StandinDatabase.cs
+++ b/src/Marten/Storage/StandinDatabase.cs
@@ -239,4 +239,12 @@ internal class StandinDatabase: IMartenDatabase
     {
         ((IDisposable)Tracker)?.Dispose();
     }
+
+    // #4874: IMartenDatabase is IAsyncDisposable so async store teardown never falls back to the
+    // blocking sync chain. This stand-in holds no data source; just mirror Dispose().
+    public ValueTask DisposeAsync()
+    {
+        ((IDisposable)Tracker)?.Dispose();
+        return ValueTask.CompletedTask;
+    }
 }

--- a/src/Marten/Storage/StaticMultiTenancy.cs
+++ b/src/Marten/Storage/StaticMultiTenancy.cs
@@ -32,7 +32,7 @@ public interface IStaticMultiTenancy
     void AddSingleTenantDatabase(string connectionString, string tenantId);
 }
 
-public class StaticMultiTenancy: Tenancy, ITenancy, IStaticMultiTenancy
+public class StaticMultiTenancy: Tenancy, ITenancy, IStaticMultiTenancy, IAsyncDisposable
 {
     private readonly INpgsqlDataSourceFactory _dataSourceFactory;
     private ImHashMap<string, MartenDatabase> _databases = ImHashMap<string, MartenDatabase>.Empty;
@@ -74,6 +74,16 @@ public class StaticMultiTenancy: Tenancy, ITenancy, IStaticMultiTenancy
         foreach (var entry in _tenants.Enumerate())
         {
             entry.Value.Database.Dispose();
+        }
+    }
+
+    // #4874: async teardown mirror of Dispose() so DocumentStore.DisposeAsync() runs each tenant
+    // database's OwnsDataSource-aware async disposal rather than the blocking sync chain.
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var entry in _tenants.Enumerate())
+        {
+            await entry.Value.Database.DisposeAsync().ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
Follow-up to #4903 / #4905, prompted by [this #4874 report](https://github.com/JasperFx/marten/issues/4874#issuecomment-4914225627).

## Problem
`DocumentStore.DisposeAsync()` disposes the tenancy via JasperFx's `MaybeDisposeAllAsync`, which prefers `IAsyncDisposable` and otherwise falls back to the synchronous `IDisposable` chain. **No tenancy implemented `IAsyncDisposable`**, so async store teardown *always* fell back to the synchronous `DefaultTenancy.Dispose()` → `MartenDatabase.Dispose()` → blocking `NpgsqlDataSource.Dispose()` chain. Two consequences:

1. The inherited async `PostgresqlDatabase.DisposeAsync()` — the `OwnsDataSource`-guarded path added in #4905 — was **unreachable dead code** on real teardown.
2. Async host shutdown blocked on synchronous `NpgsqlDataSource.Dispose()` (sync-over-async).

Confirmed against source: `MaybeDisposeAllAsync` (`JasperFx/Core/DisposableExtensions.cs`) checks `IAsyncDisposable` first; `DocumentStore.DisposeAsync()` (`DocumentStore.cs:143`) passes the tenancy through it; every tenancy was `IDisposable`-only.

## Change
- `IMartenDatabase` now extends `IAsyncDisposable`. `MartenDatabase` re-implements it to release the tracker **and** run the base's guarded async data-source disposal (matching `Dispose()`). `StandinDatabase` gets a trivial async wrapper.
- `DefaultTenancy`, `ShardedTenancy`, `SingleServerMultiTenancy`, `MasterTableTenancy`, `StaticMultiTenancy` each implement `IAsyncDisposable`, mirroring their sync `Dispose()` but disposing databases (and any Marten-owned pool data source) asynchronously.

## Tests
`Bug_4874_async_tenancy_disposal` (CoreTests): the tenancy is `IAsyncDisposable` (load-bearing — fails on master); `store.DisposeAsync()` disposes a Marten-owned data source; and a caller-owned data source survives async store teardown.

## Scope / what this does NOT fix
The [report](https://github.com/JasperFx/marten/issues/4874#issuecomment-4914225627) is a **Marten-owned** data source (`opts.Connection(connectionString)`), where the `ObjectDisposedException` storm comes from **disposal ordering** — the data source is disposed before the still-running async daemon / durability loops stop renting connections. This PR is the correct foundation (async teardown now actually runs) but does **not** by itself fix that ordering; that is being tracked separately pending the reporter's host-shutdown details (whether `host.StopAsync()` runs before dispose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)