### PR TITLE
#4880: pin re-add-after-remove at the daemon level + document the runtime removal contract

### DIFF
--- a/docs/events/multitenancy.md
+++ b/docs/events/multitenancy.md
@@ -275,6 +275,41 @@ The cleanup identifies per-tenant `mt_event_progression` rows by parsing the
 `ShardName` grammar rather than pattern-matching the name, so a projection whose name
 happens to end with a tenant id is never mistakenly deleted (#4683).
 
+#### Removing tenants at runtime <Badge type="tip" text="9.13" />
+
+Under `MultiTenantedWithShardedDatabases()`, removing or disabling a tenant is honored by an
+**already-running** store — no process restart is required. Removal shrinks the store's usage
+descriptor (`DescribeDatabasesAsync`) immediately, and a running async daemon **retires that
+tenant's per-tenant projection agents on its next leadership cycle** (the coordinator re-expands
+each shard's agent set from that shard's own tenant registry and reaps the agents whose tenant is
+gone). The surviving tenants keep processing on the same shard daemon, and no further progression
+rows are written for the departed tenant.
+
+```cs
+// Destructive removal on the tenant's shard: unassigns the tenant, drops its partitions,
+// its per-tenant mt_events_sequence, and its per-tenant mt_event_progression rows. The
+// running daemon reaps the tenant's agents; a later re-add starts the tenant fresh (a new
+// per-tenant sequence starting at 1, no surviving projection state).
+await store.Advanced.RemoveTenantFromShardAsync("tenant-b", cancellationToken);
+
+// Re-adding the same tenant later provisions fresh partitions + sequence, and the running
+// daemon starts a new agent for it that catches up from the tenant's new (empty) baseline.
+await store.Advanced.AddTenantToShardAsync("tenant-b", cancellationToken);
+```
+
+::: tip
+`RemoveTenantFromShardAsync` is **destructive** — it drops the tenant's shard-side data. For a
+**non-destructive** soft-delete that only hides the tenant from the usage descriptor (its
+partitions, per-tenant sequence, and registry rows are all retained, and re-enabling restores it
+in place), use the sharded tenancy's `DisableTenantAsync` / `EnableTenantAsync` instead:
+
+```cs
+var tenancy = (IDynamicTenantSource<string>)store.Options.Tenancy;
+await tenancy.DisableTenantAsync("tenant-b");   // descriptor shrinks; shard data retained
+await tenancy.EnableTenantAsync("tenant-b");    // restored in place, no re-seeding needed
+```
+:::
+
 ### Migrating an Existing Conjoined Store
 
 ::: warning

--- a/src/TenantPartitionedEventsTests/Sharded/dynamic_tenant_lifecycle_on_shard_during_daemon.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/dynamic_tenant_lifecycle_on_shard_during_daemon.cs
@@ -294,6 +294,52 @@ public class dynamic_tenant_lifecycle_on_shard_during_daemon: IAsyncLifetime
             // ... and the removed tenant's rows never came back across those polling cycles.
             survivorRows.Any(r => r.Name.EndsWith($":{tenant2}", StringComparison.Ordinal))
                 .ShouldBeFalse("no per-tenant progression rows may be re-persisted for the removed tenant");
+
+            // ---- Phase 3 (#4880): RE-ADD tenant 2 after a destructive removal — the running
+            // coordinator gives it a FRESH agent that catches up from a fresh per-tenant sequence,
+            // pinning the "a re-added tenant starts fresh" half of the removal contract at the
+            // daemon level (the registry-level version lives in
+            // MultiTenancyTests/sharded_tenancy_remove_lifecycle_tests). ----
+            await _store.Advanced.AddTenantToShardAsync(tenant2, shard, CancellationToken.None);
+
+            // Re-add re-provisions the per-tenant sequence fresh (the old one was dropped on remove).
+            (await SequenceExistsAsync(shardConnStr, $"mt_events_sequence_{tenant2}")).ShouldBeTrue(
+                $"re-adding tenant 2 must re-provision mt_events_sequence_{tenant2} on shard {shard}");
+
+            var reStream2 = Guid.NewGuid();
+            await using (var session = _store.LightweightSession(tenant2))
+            {
+                session.Events.StartStream<ShardedDaemonCounter>(reStream2,
+                    new ShardedDaemonEvent("t2b-1"), new ShardedDaemonEvent("t2b-2"),
+                    new ShardedDaemonEvent("t2b-3"));
+                await session.SaveChangesAsync();
+            }
+
+            // The running coordinator re-discovers the re-added tenant on its next leadership cycle:
+            // a fresh {Projection}:All:tenant2 agent starts and catches up to the tenant's own height.
+            var readdedRows = await WaitForProgressionAsync(shardConnStr, r =>
+                    SeqOf(r, $"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}") >= 3 &&
+                    SeqOf(r, $"HighWaterMark:{tenant2}") >= 3,
+                30.Seconds(),
+                "the re-added tenant gets a FRESH agent + progression on the running coordinator");
+            DumpRows("shard A progression after re-adding tenant 2", readdedRows);
+
+            // Fresh start: the destructive remove dropped tenant 2's partitions, so the pre-removal
+            // projection doc is gone and only the 3 newly-appended events are projected.
+            await using (var query = _store.QuerySession(tenant2))
+            {
+                var reDoc = await query.LoadAsync<ShardedDaemonCounter>(reStream2);
+                reDoc.ShouldNotBeNull("the re-added tenant's projection doc must materialize on shard A");
+                reDoc!.EventCount.ShouldBe(3);
+
+                (await query.LoadAsync<ShardedDaemonCounter>(stream2))
+                    .ShouldBeNull("the pre-removal projection doc must not survive a destructive remove + re-add");
+            }
+
+            // The re-added tenant's agent is running again on the same shard daemon.
+            daemon.CurrentAgents().Select(x => x.Name.Identity)
+                .ShouldContain($"{ShardedDaemonProjection.ProjectionName}:All:{tenant2}",
+                    "the coordinator must start a fresh agent for the re-added tenant");
         }
         finally
         {


### PR DESCRIPTION
Part of #4880 (the Marten-side residue after #4893 landed the native REMOVE e2e; the Wolverine-managed variant remains a Wolverine-side hand-off).

## Context
When #4880 was filed it was blocked on #4868 (usage descriptor never shrank). #4868 is now closed, and #4893 already landed the bulk of #4880:
- `sharded_tenancy_remove_lifecycle_tests` (12 tests): descriptor shrinks on remove/disable without restart, cross-store-instance removal, reassignment, remove drops partitions/sequence/progression, `remove_is_idempotent_and_a_removed_tenant_can_be_readded_fresh`, disable/enable soft-delete, etc.
- `dynamic_tenant_lifecycle_on_shard_during_daemon` Phase 2: a **running HotCold coordinator** reaps a removed tenant's per-tenant agent via jasperfx#491 reconciliation; progression + high-water rows cleaned; survivor keeps running.

## This PR — the remaining Marten-side gaps
1. **Daemon-level re-add** (new coverage): extend the dynamic-lifecycle test with **Phase 3** — re-add the removed tenant while the coordinator keeps running. Pins that the re-added tenant gets a **fresh** per-tenant sequence, a **new** agent that catches up, the pre-removal projection doc is gone, and only the newly-appended events are projected. Registry-level re-add was already covered; the running-daemon re-add cycle was not.
2. **Docs**: a "Removing tenants at runtime" subsection in `docs/events/multitenancy.md` documenting the contract the issue asks to pin — `RemoveTenantFromShardAsync` is destructive and a running daemon retires the tenant's agents without a restart; re-add starts fresh; `DisableTenantAsync`/`EnableTenantAsync` are the non-destructive soft-delete.

Verified green (net10): `dynamic_tenant_lifecycle_on_shard_during_daemon` passes with Phase 3. markdownlint + cspell clean.

## Not in scope (hand-off)
The **Wolverine-managed distribution** removal e2e (flip/extend Wolverine's churn test so managed distribution retires the tenant's agents with no orphaned progression writes) is Wolverine-side and cannot be reproduced in Marten's test projects (no Wolverine reference). Tracked for the Wolverine repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)