### PR TITLE
#4883: sharded multi-node daemonload — cross-node HotCold distribution + redistribution

### DIFF
--- a/src/Marten.ScaleTesting/Commands/MultiNodeNodeCommand.cs
+++ b/src/Marten.ScaleTesting/Commands/MultiNodeNodeCommand.cs
@@ -29,7 +29,17 @@ public sealed class MultiNodeNodeCommand: JasperFxAsyncCommand<MultiNodeNodeInpu
         using var host = await new HostBuilder()
             .ConfigureServices(services =>
             {
-                services.AddMarten(opts => MultiNodeStore.Configure(opts, input.ProjectionsFlag, applicationName))
+                services.AddMarten(opts =>
+                    {
+                        if (input.DatabasesFlag > 1)
+                        {
+                            MultiNodeStore.ConfigureSharded(opts, input.ProjectionsFlag, input.DatabasesFlag, applicationName);
+                        }
+                        else
+                        {
+                            MultiNodeStore.Configure(opts, input.ProjectionsFlag, applicationName);
+                        }
+                    })
                     .AddAsyncDaemon(DaemonMode.HotCold);
             })
             .StartAsync()

--- a/src/Marten.ScaleTesting/Commands/MultiNodeNodeInput.cs
+++ b/src/Marten.ScaleTesting/Commands/MultiNodeNodeInput.cs
@@ -19,4 +19,7 @@ public sealed class MultiNodeNodeInput: NetCoreInput
 
     [Description("Number of async projections to register. MUST match the coordinator's value so all nodes contend on an identical projection set. Default: 2.")]
     public int ProjectionsFlag { get; set; } = 2;
+
+    [Description("Number of shard databases. 1 = single tenant-partitioned database (the default HotCold-failover scenario); >1 = sharded tenancy so the node builds a MultiTenantedWithShardedDatabases store and contends per-shard. MUST match the coordinator's value. Default: 1.")]
+    public int DatabasesFlag { get; set; } = 1;
 }

--- a/src/Marten.ScaleTesting/Commands/MultiNodeShardedCommand.cs
+++ b/src/Marten.ScaleTesting/Commands/MultiNodeShardedCommand.cs
@@ -1,0 +1,541 @@
+using System.Diagnostics;
+using System.Text.Json;
+using JasperFx;
+using JasperFx.CommandLine;
+using Marten.ScaleTesting.Instrumentation;
+using Npgsql;
+using Spectre.Console;
+
+namespace Marten.ScaleTesting.Commands;
+
+/// <summary>
+/// <c>daemonload-multinode-sharded</c>: the COORDINATOR role of the marten#4883 native-HotCold
+/// SHARDED multi-node scenario (epic jasperfx#486 WS6). Where <c>daemonload-multinode</c> runs one
+/// tenant-partitioned database (so HotCold gives a single leader + failover), this pools tenants
+/// across <c>--databases</c> shard databases via <c>MultiTenantedWithShardedDatabases</c>. Each
+/// shard database is its own leadership lock, so different nodes lead different shards — the
+/// cross-node agent distribution the epic's topology matrix calls for. Flow:
+/// <list type="number">
+///   <item>Create <c>--databases</c> shard DBs; provision the sharded store; pool <c>--tenants</c>
+///     tenants round-robin across the shards (per-tenant partition DDL + one seed event each)</item>
+///   <item>Launch <c>--nodes</c> child processes (<c>daemonload-node --databases N</c>), each an
+///     IHost running <c>AddAsyncDaemon(DaemonMode.HotCold)</c> over the same sharded store</item>
+///   <item>Append continuously across every tenant while sampling <c>pg_stat_activity</c> grouped by
+///     node Application Name × shard database</item>
+///   <item>Observe which node leads which shard (distribution); optionally kill a node that leads a
+///     shard (<c>--kill-node-after-seconds</c>) and verify its shards redistribute to survivors</item>
+///   <item>Stop, wait for per-tenant catch-up on every shard, report distribution + per-node×shard
+///     connection footprint + redistribution</item>
+/// </list>
+///
+/// WS6 assertions: HotCold spreads shard leadership across nodes; killing a node redistributes its
+/// shards with no tenant left stalled; every tenant's per-tenant progression reaches its own ceiling
+/// on its home shard; each node's per-shard connection footprint stays governed (O(databases-led)).
+/// </summary>
+[Description("marten#4883 (epic jasperfx#486 WS6): native-HotCold SHARDED multi-node daemonload. Pools tenants across N shard databases and launches M node processes, so HotCold distributes shard leadership across nodes; appends under load, optionally kills a node to exercise shard redistribution, and verifies per-tenant catch-up + per-node×shard connection footprint.", Name = "daemonload-multinode-sharded")]
+public sealed class MultiNodeShardedCommand: JasperFxAsyncCommand<MultiNodeShardedInput>
+{
+    public override async Task<bool> Execute(MultiNodeShardedInput input)
+    {
+        var totalElapsed = Stopwatch.StartNew();
+        var databaseCount = Math.Max(1, input.DatabasesFlag);
+        var shardNames = MultiNodeStore.ShardDatabaseNames(databaseCount);
+        var projectionNames = MultiNodeStore.ProjectionNames(input.ProjectionsFlag);
+        var tenants = MultiNodeStore.TenantIds(input.TenantsFlag);
+        var nodeCount = Math.Max(1, input.NodesFlag);
+
+        AnsiConsole.MarkupLine(
+            $"[blue]daemonload-multinode-sharded: nodes=[yellow]{nodeCount}[/] databases=[yellow]{databaseCount}[/] " +
+            $"tenants=[yellow]{tenants.Length}[/] projections=[yellow]{projectionNames.Length}[/] " +
+            $"duration=[yellow]{input.DurationSecondsFlag}s[/] killNodeAfter=[yellow]{input.KillNodeAfterSecondsFlag}s[/][/]");
+
+        if (input.WipeFlag)
+        {
+            await WipeAsync(shardNames).ConfigureAwait(false);
+        }
+
+        await EnsureShardDatabasesExistAsync(shardNames).ConfigureAwait(false);
+
+        // Round-robin, deterministic placement: tenant i lives on shard i % N.
+        var tenantsByShard = tenants
+            .Select((tenant, i) => (Tenant: tenant, Shard: shardNames[i % databaseCount]))
+            .GroupBy(x => x.Shard, x => x.Tenant)
+            .ToDictionary(g => g.Key, g => g.ToArray());
+        var shardConnectionStrings = shardNames.ToDictionary(
+            name => name,
+            name => new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString) { Database = name }.ConnectionString);
+
+        // ---- Provision (coordinator owns all schema + tenant + seed work) ----
+        using (var provisioning = Marten.DocumentStore.For(opts =>
+                   MultiNodeStore.ConfigureSharded(opts, input.ProjectionsFlag, databaseCount,
+                       MultiNodeStore.ApplicationBase + "-coordinator")))
+        {
+            await provisioning.Storage.ApplyAllConfiguredChangesToDatabaseAsync().ConfigureAwait(false);
+
+            AnsiConsole.MarkupLine(
+                $"[grey]Assigning {tenants.Length} tenants round-robin across {databaseCount} shard databases (per-tenant partition DDL — this can take a bit)...[/]");
+            for (var i = 0; i < tenants.Length; i++)
+            {
+                await provisioning.Advanced
+                    .AddTenantToShardAsync(tenants[i], shardNames[i % databaseCount], CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+
+            foreach (var tenant in tenants)
+            {
+                await using var session = provisioning.LightweightSession(tenant);
+                session.Events.StartStream(Guid.NewGuid(), new DaemonLoadEvent(tenant, 0));
+                await session.SaveChangesAsync().ConfigureAwait(false);
+            }
+        }
+
+        // ---- Launch node processes -------------------------------------------
+        var nodes = new List<NodeProcess>();
+        for (var i = 0; i < nodeCount; i++)
+        {
+            nodes.Add(await NodeProcess.LaunchAsync(i, input.ProjectionsFlag, databaseCount).ConfigureAwait(false));
+        }
+
+        AnsiConsole.MarkupLine($"[grey]{nodes.Count} node(s) up and contending for per-shard HotCold leadership.[/]");
+
+        using var cts = new CancellationTokenSource();
+        await using var sampler = NodeConnectionSampler.Start(
+            ConnectionSource.ConnectionString, MultiNodeStore.ApplicationBase,
+            TimeSpan.FromSeconds(Math.Max(0.1, input.SampleSecondsFlag)),
+            string.IsNullOrWhiteSpace(input.TraceFlag) ? null : input.TraceFlag,
+            cts.Token);
+
+        // ---- Continuous append load ------------------------------------------
+        var appended = 0L;
+        var appendFailures = 0L;
+        var appendElapsed = Stopwatch.StartNew();
+        using var appendStore = Marten.DocumentStore.For(opts =>
+            MultiNodeStore.ConfigureSharded(opts, input.ProjectionsFlag, databaseCount,
+                MultiNodeStore.ApplicationBase + "-coordinator"));
+
+        var writers = Enumerable.Range(0, Math.Max(1, input.WritersFlag))
+            .Select(w => Task.Run(() => AppendLoopAsync(appendStore, tenants, w, input, cts.Token,
+                () => Interlocked.Increment(ref appended),
+                () => Interlocked.Increment(ref appendFailures))))
+            .ToArray();
+
+        // Give leadership a moment to settle, then record the steady-state shard→node distribution.
+        await Task.Delay(TimeSpan.FromSeconds(Math.Min(10, input.DurationSecondsFlag / 2.0))).ConfigureAwait(false);
+        var distribution = await ShardLeadersAsync(shardNames).ConfigureAwait(false);
+
+        // ---- Optional node kill → shard redistribution -----------------------
+        var redistribution = new RedistributionResult();
+        var elapsedIntoRun = TimeSpan.FromSeconds(Math.Min(10, input.DurationSecondsFlag / 2.0));
+        if (input.KillNodeAfterSecondsFlag > 0 && input.KillNodeAfterSecondsFlag < input.DurationSecondsFlag)
+        {
+            var untilKill = TimeSpan.FromSeconds(input.KillNodeAfterSecondsFlag) - elapsedIntoRun;
+            if (untilKill > TimeSpan.Zero)
+            {
+                await Task.Delay(untilKill).ConfigureAwait(false);
+            }
+
+            redistribution = await KillNodeAndObserveRedistributionAsync(nodes, shardNames,
+                TimeSpan.FromSeconds(Math.Max(15, input.DurationSecondsFlag - input.KillNodeAfterSecondsFlag)))
+                .ConfigureAwait(false);
+
+            var remaining = TimeSpan.FromSeconds(input.DurationSecondsFlag) - TimeSpan.FromSeconds(input.KillNodeAfterSecondsFlag);
+            if (remaining > TimeSpan.Zero)
+            {
+                await Task.Delay(remaining).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            var remaining = TimeSpan.FromSeconds(input.DurationSecondsFlag) - elapsedIntoRun;
+            if (remaining > TimeSpan.Zero)
+            {
+                await Task.Delay(remaining).ConfigureAwait(false);
+            }
+        }
+
+        cts.Cancel();
+        await Task.WhenAll(writers).ConfigureAwait(false);
+        appendElapsed.Stop();
+
+        // ---- Catch-up + verification -----------------------------------------
+        AnsiConsole.MarkupLine(
+            $"[grey]Appends stopped ({appended:N0} events). Waiting for per-tenant catch-up on every shard...[/]");
+        var (caughtUp, stalled) = await WaitForShardedCatchUpAsync(shardConnectionStrings, tenantsByShard,
+            projectionNames, TimeSpan.FromSeconds(input.CatchUpTimeoutSecondsFlag)).ConfigureAwait(false);
+
+        var perNode = sampler.Capture();
+
+        // ---- Graceful node shutdown ------------------------------------------
+        foreach (var node in nodes)
+        {
+            node.RequestStop();
+        }
+        foreach (var node in nodes)
+        {
+            await node.WaitForExitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+        }
+
+        totalElapsed.Stop();
+
+        // ---- Report ----------------------------------------------------------
+        var appendRate = appended / Math.Max(0.001, appendElapsed.Elapsed.TotalSeconds);
+        // Only per-node × shard-database snapshots (exclude the coordinator app and the master DB).
+        var shardSet = shardNames.ToHashSet();
+        var nodeShardSnapshots = perNode
+            .Where(x => x.ApplicationName.Contains("-node") && shardSet.Contains(x.Database))
+            .ToArray();
+        var distinctLeaderNodes = distribution.Values.Where(v => v != null).Distinct().Count();
+
+        var table = new Table().AddColumn("Metric").AddColumn(new TableColumn("Value").RightAligned());
+        table.AddRow("Nodes launched", nodeCount.ToString("N0"));
+        table.AddRow("Shard databases", databaseCount.ToString("N0"));
+        table.AddRow("Tenants", tenants.Length.ToString("N0"));
+        table.AddRow("Async projections", projectionNames.Length.ToString("N0"));
+        table.AddRow("Tenant agents (projections × tenants)", (tenants.Length * projectionNames.Length).ToString("N0"));
+        table.AddRow("Events appended", appended.ToString("N0"));
+        table.AddRow("Append failures", appendFailures.ToString("N0"));
+        table.AddRow("Sustained append rate (events/sec)", appendRate.ToString("N0"));
+        foreach (var shard in shardNames)
+        {
+            var leader = distribution.TryGetValue(shard, out var l) ? l : null;
+            table.AddRow($"Leader of {shard}", leader ?? "[grey](none observed)[/]");
+        }
+        table.AddRow("Distinct leader nodes (distribution)",
+            $"{distinctLeaderNodes:N0} / {Math.Min(nodeCount, databaseCount):N0} possible");
+        foreach (var snapshot in nodeShardSnapshots.OrderBy(x => x.ApplicationName).ThenBy(x => x.Database))
+        {
+            table.AddRow($"{snapshot.ApplicationName} @ {snapshot.Database} peak conns",
+                $"{snapshot.MaxTotal:N0} (mean {snapshot.MeanTotal:N1})");
+        }
+        table.AddRow("Peak per single node×shard",
+            nodeShardSnapshots.Length > 0 ? nodeShardSnapshots.Max(x => x.MaxTotal).ToString("N0") : "0");
+        if (redistribution.Killed)
+        {
+            table.AddRow("Killed node", redistribution.KilledNode ?? "(none)");
+            table.AddRow("Shards it led", redistribution.OrphanedShards.Count > 0
+                ? string.Join(", ", redistribution.OrphanedShards) : "(none)");
+            table.AddRow("Shards redistributed", redistribution.Redistributed ? "[green]yes[/]" : "[red]NO[/]");
+        }
+        table.AddRow("Tenants caught up", $"{caughtUp.Count:N0} / {tenants.Length:N0}");
+        table.AddRow("Total elapsed", $"{totalElapsed.Elapsed.TotalSeconds:N1}s");
+        AnsiConsole.Write(table);
+
+        if (stalled.Count > 0)
+        {
+            AnsiConsole.MarkupLine(
+                $"[red]{stalled.Count} tenant(s) did not catch up within {input.CatchUpTimeoutSecondsFlag}s: " +
+                $"{string.Join(", ", stalled.Take(10))}{(stalled.Count > 10 ? ", ..." : "")}[/]");
+        }
+
+        await WriteMetricsAsync(input, nodeCount, databaseCount, tenants.Length, projectionNames.Length,
+            appended, appendRate, distribution, distinctLeaderNodes, nodeShardSnapshots, caughtUp.Count,
+            stalled, redistribution).ConfigureAwait(false);
+
+        // ---- Gates -----------------------------------------------------------
+        var connectionGatePassed = input.MaxConnectionsPerNodeShardFlag <= 0
+                                   || nodeShardSnapshots.All(x => x.MaxTotal <= input.MaxConnectionsPerNodeShardFlag);
+        if (!connectionGatePassed)
+        {
+            var worst = nodeShardSnapshots.MaxBy(x => x.MaxTotal)!;
+            AnsiConsole.MarkupLine(
+                $"[red]GATE FAILED: {worst.ApplicationName} @ {worst.Database} peak {worst.MaxTotal:N0} > " +
+                $"--max-connections-per-node-shard {input.MaxConnectionsPerNodeShardFlag:N0}.[/]");
+        }
+
+        // Distribution is a soft check by default (a fast node can transiently grab every shard).
+        var distributionExpected = nodeCount >= 2 && databaseCount >= 2;
+        var distributionPassed = !input.RequireDistributionFlag || !distributionExpected || distinctLeaderNodes >= 2;
+        if (!distributionPassed)
+        {
+            AnsiConsole.MarkupLine(
+                $"[red]GATE FAILED: shard leadership did not span >= 2 nodes ({distinctLeaderNodes} distinct leader node(s)).[/]");
+        }
+        else if (distributionExpected && distinctLeaderNodes < 2)
+        {
+            AnsiConsole.MarkupLine(
+                "[yellow]NOTE: all shards were led by a single node at the sampled instant — leadership did not spread across nodes this run.[/]");
+        }
+
+        var redistributionHealthy = !redistribution.Killed || redistribution.Redistributed;
+        var healthy = appendFailures == 0 && stalled.Count == 0 && redistributionHealthy;
+        if (!healthy)
+        {
+            AnsiConsole.MarkupLine("[red]Run unhealthy — see append failures / stalled tenants / redistribution above.[/]");
+        }
+
+        return connectionGatePassed && distributionPassed && healthy;
+    }
+
+    private static async Task AppendLoopAsync(IDocumentStore store, string[] tenants, int writerIndex,
+        MultiNodeShardedInput input, CancellationToken token, Action onAppended, Action onFailure)
+    {
+        var writerCount = Math.Max(1, input.WritersFlag);
+        var perWriterRate = Math.Max(1.0, (double)input.AppendRatePerSecondFlag / writerCount);
+        const int batchSize = 5;
+        var delay = TimeSpan.FromSeconds(batchSize / perWriterRate);
+
+        var sequence = 0;
+        var position = writerIndex;
+        while (!token.IsCancellationRequested)
+        {
+            var tenant = tenants[position % tenants.Length];
+            position += writerCount;
+
+            try
+            {
+                await using var session = store.LightweightSession(tenant);
+                var events = Enumerable.Range(0, batchSize)
+                    .Select(_ => new DaemonLoadEvent(tenant, ++sequence))
+                    .Cast<object>()
+                    .ToArray();
+                session.Events.StartStream(Guid.NewGuid(), events);
+                await session.SaveChangesAsync(token).ConfigureAwait(false);
+                for (var i = 0; i < batchSize; i++)
+                {
+                    onAppended();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception)
+            {
+                onFailure();
+            }
+
+            try
+            {
+                await Task.Delay(delay, token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// For each shard database, the node whose Application Name currently holds the most connections
+    /// on that database is its HotCold leader (a leader hosts that shard's per-tenant projection
+    /// agents; non-leaders don't connect to shards they don't lead). Returns shard → leader node app
+    /// name (null if no node has claimed the shard yet).
+    /// </summary>
+    private static async Task<Dictionary<string, string?>> ShardLeadersAsync(string[] shardNames)
+    {
+        var leaders = shardNames.ToDictionary(s => s, _ => (string?)null);
+
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync().ConfigureAwait(false);
+        await using var cmd = new NpgsqlCommand(
+            @"SELECT datname, application_name, count(*) AS c
+              FROM pg_stat_activity
+              WHERE datname = ANY(@shards)
+                AND application_name LIKE @prefix || '-node%'
+              GROUP BY datname, application_name;", conn);
+        cmd.Parameters.AddWithValue("shards", shardNames);
+        cmd.Parameters.AddWithValue("prefix", MultiNodeStore.ApplicationBase);
+
+        var byShard = new Dictionary<string, (string App, int Count)>();
+        await using (var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync().ConfigureAwait(false))
+            {
+                var db = reader.GetString(0);
+                var app = reader.GetString(1);
+                var count = Convert.ToInt32(reader.GetValue(2));
+                if (!byShard.TryGetValue(db, out var current) || count > current.Count)
+                {
+                    byShard[db] = (app, count);
+                }
+            }
+        }
+
+        foreach (var (shard, winner) in byShard)
+        {
+            leaders[shard] = winner.App;
+        }
+
+        return leaders;
+    }
+
+    private static async Task<RedistributionResult> KillNodeAndObserveRedistributionAsync(
+        List<NodeProcess> nodes, string[] shardNames, TimeSpan window)
+    {
+        var result = new RedistributionResult { Killed = true };
+
+        var leadersBefore = await ShardLeadersAsync(shardNames).ConfigureAwait(false);
+        // Pick a node that currently leads at least one shard.
+        var victimApp = leadersBefore.Values.FirstOrDefault(v => v != null
+            && nodes.Any(n => n.ApplicationName == v));
+        var victim = nodes.FirstOrDefault(n => n.ApplicationName == victimApp);
+        if (victim == null)
+        {
+            AnsiConsole.MarkupLine("[yellow]No node leads a shard yet — skipping the kill.[/]");
+            result.Killed = false;
+            return result;
+        }
+
+        result.KilledNode = victim.ApplicationName;
+        result.OrphanedShards = leadersBefore
+            .Where(kv => kv.Value == victim.ApplicationName)
+            .Select(kv => kv.Key)
+            .ToList();
+
+        AnsiConsole.MarkupLine(
+            $"[yellow]Killing {victim.ApplicationName} (pid {victim.Pid}), which leads {result.OrphanedShards.Count} shard(s): " +
+            $"{string.Join(", ", result.OrphanedShards)}...[/]");
+        victim.Kill();
+        nodes.Remove(victim);
+
+        // Poll until every orphaned shard has a NEW leader among the surviving nodes.
+        var deadline = DateTime.UtcNow + window;
+        while (DateTime.UtcNow < deadline)
+        {
+            var leadersNow = await ShardLeadersAsync(shardNames).ConfigureAwait(false);
+            var allReassigned = result.OrphanedShards.All(shard =>
+                leadersNow.TryGetValue(shard, out var leader)
+                && leader != null
+                && leader != victim.ApplicationName
+                && nodes.Any(n => n.ApplicationName == leader));
+
+            if (allReassigned)
+            {
+                result.Redistributed = true;
+                result.LeadersAfter = result.OrphanedShards.ToDictionary(s => s, s => leadersNow[s]);
+                AnsiConsole.MarkupLine("[green]All orphaned shards were redistributed to surviving nodes.[/]");
+                return result;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+        }
+
+        var final = await ShardLeadersAsync(shardNames).ConfigureAwait(false);
+        result.LeadersAfter = result.OrphanedShards.ToDictionary(s => s, s => final.GetValueOrDefault(s));
+        return result;
+    }
+
+    private static async Task<(HashSet<string> CaughtUp, List<string> Stalled)> WaitForShardedCatchUpAsync(
+        IReadOnlyDictionary<string, string> shardConnectionStrings,
+        IReadOnlyDictionary<string, string[]> tenantsByShard,
+        string[] projectionNames, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        HashSet<string> caughtUp;
+        List<string> stalled;
+
+        while (true)
+        {
+            caughtUp = new HashSet<string>();
+            stalled = new List<string>();
+
+            foreach (var (shard, connectionString) in shardConnectionStrings)
+            {
+                var (shardCaughtUp, shardStalled) = await DaemonLoadCommand.CheckCatchUpForSchemaAsync(
+                    connectionString, MultiNodeStore.Schema, tenantsByShard[shard], projectionNames)
+                    .ConfigureAwait(false);
+                caughtUp.UnionWith(shardCaughtUp);
+                stalled.AddRange(shardStalled);
+            }
+
+            if (stalled.Count == 0 || DateTime.UtcNow >= deadline)
+            {
+                return (caughtUp, stalled);
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task EnsureShardDatabasesExistAsync(string[] shardNames)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync().ConfigureAwait(false);
+
+        foreach (var name in shardNames)
+        {
+            await using var check = new NpgsqlCommand("SELECT 1 FROM pg_database WHERE datname = @name", conn);
+            check.Parameters.AddWithValue("name", name);
+            if (await check.ExecuteScalarAsync().ConfigureAwait(false) == null)
+            {
+                AnsiConsole.MarkupLine($"[grey]CREATE DATABASE {name}[/]");
+                await using var create = new NpgsqlCommand($"CREATE DATABASE \"{name}\"", conn);
+                await create.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async Task WipeAsync(string[] shardNames)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync().ConfigureAwait(false);
+
+        await using (var drop = new NpgsqlCommand($"drop schema if exists \"{MultiNodeStore.Schema}\" cascade", conn))
+        {
+            await drop.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+
+        foreach (var name in shardNames)
+        {
+            await using var dropDb = new NpgsqlCommand($"DROP DATABASE IF EXISTS \"{name}\" WITH (FORCE)", conn);
+            await dropDb.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static async Task WriteMetricsAsync(MultiNodeShardedInput input, int nodes, int databases,
+        int tenants, int projections, long appended, double appendRate,
+        IReadOnlyDictionary<string, string?> distribution, int distinctLeaderNodes,
+        IReadOnlyList<NodeConnectionSampler.NodeDatabaseSnapshot> nodeShardSnapshots,
+        int caughtUpTenants, List<string> stalledTenants, RedistributionResult redistribution)
+    {
+        if (string.IsNullOrWhiteSpace(input.MetricsFlag))
+        {
+            return;
+        }
+
+        var doc = new
+        {
+            scenario = "daemonload-multinode-sharded",
+            mode = "native-hotcold-sharded",
+            nodes,
+            databases,
+            tenants,
+            projections,
+            tenantAgents = tenants * projections,
+            durationSeconds = input.DurationSecondsFlag,
+            eventsAppended = appended,
+            appendRatePerSecond = appendRate,
+            shardLeaders = distribution.ToDictionary(kv => kv.Key, kv => kv.Value),
+            distinctLeaderNodes,
+            connectionsPerNodeShard = nodeShardSnapshots.ToDictionary(
+                x => $"{x.ApplicationName}@{x.Database}",
+                x => new { samples = x.SampleCount, maxTotal = x.MaxTotal, meanTotal = x.MeanTotal, maxBusy = x.MaxBusy }),
+            peakPerSingleNodeShard = nodeShardSnapshots.Count > 0 ? nodeShardSnapshots.Max(x => x.MaxTotal) : 0,
+            redistribution = new
+            {
+                requested = input.KillNodeAfterSecondsFlag > 0,
+                killed = redistribution.Killed,
+                killedNode = redistribution.KilledNode,
+                orphanedShards = redistribution.OrphanedShards,
+                redistributed = redistribution.Redistributed,
+                leadersAfter = redistribution.LeadersAfter
+            },
+            caughtUpTenants,
+            stalledTenants
+        };
+
+        await File.WriteAllTextAsync(input.MetricsFlag,
+                JsonSerializer.Serialize(doc, new JsonSerializerOptions { WriteIndented = true }))
+            .ConfigureAwait(false);
+        AnsiConsole.MarkupLine($"[grey]Metrics written to {input.MetricsFlag}[/]");
+    }
+
+    private sealed class RedistributionResult
+    {
+        public bool Killed;
+        public bool Redistributed;
+        public string? KilledNode;
+        public List<string> OrphanedShards = new();
+        public Dictionary<string, string?>? LeadersAfter;
+    }
+}

--- a/src/Marten.ScaleTesting/Commands/MultiNodeShardedInput.cs
+++ b/src/Marten.ScaleTesting/Commands/MultiNodeShardedInput.cs
@@ -1,0 +1,62 @@
+using JasperFx;
+using JasperFx.CommandLine;
+
+namespace Marten.ScaleTesting.Commands;
+
+/// <summary>
+/// Inputs for the <c>daemonload-multinode-sharded</c> subcommand — the COORDINATOR role of the
+/// marten#4883 native-HotCold SHARDED multi-node scenario (epic jasperfx#486 WS6). Provisions a
+/// <c>MultiTenantedWithShardedDatabases</c> store over <c>--databases</c> shard databases, pools
+/// <c>--tenants</c> tenants round-robin across them, launches <c>--nodes</c> HotCold daemon node
+/// processes, appends continuously, and verifies that leadership of the shard databases is
+/// DISTRIBUTED across the nodes (different nodes lead different shards), that killing a node
+/// redistributes its shards to survivors, that every tenant catches up on its own shard, and that
+/// each node's per-database connection footprint stays governed.
+/// </summary>
+public sealed class MultiNodeShardedInput: NetCoreInput
+{
+    [Description("Number of node processes to launch (native HotCold contention). Default: 2.")]
+    public int NodesFlag { get; set; } = 2;
+
+    [Description("Number of shard databases to pool tenants across on the same server. Leadership is negotiated per shard, so this is what makes agents distribute across nodes. Default: 2.")]
+    public int DatabasesFlag { get; set; } = 2;
+
+    [Description("Number of tenants to pool round-robin across the shard databases. Default: 40.")]
+    public int TenantsFlag { get; set; } = 40;
+
+    [Description("Number of async projections; each fans out one agent per tenant within each shard. Default: 2.")]
+    public int ProjectionsFlag { get; set; } = 2;
+
+    [Description("Seconds to keep the nodes running under continuous append load. Default: 90.")]
+    public int DurationSecondsFlag { get; set; } = 90;
+
+    [Description("Kill one node that currently leads at least one shard, this many seconds into the run, to exercise shard redistribution (0 = no kill). Default: 0.")]
+    public int KillNodeAfterSecondsFlag { get; set; }
+
+    [Description("Concurrent append writer tasks in the coordinator. Default: 4.")]
+    public int WritersFlag { get; set; } = 4;
+
+    [Description("Approximate total events appended per second across all writers. Default: 200.")]
+    public int AppendRatePerSecondFlag { get; set; } = 200;
+
+    [Description("pg_stat_activity sample interval in seconds. Default: 1.0.")]
+    public double SampleSecondsFlag { get; set; } = 1.0;
+
+    [Description("Seconds to wait after appends stop for every tenant's agents to catch up on every shard. Default: 90.")]
+    public int CatchUpTimeoutSecondsFlag { get; set; } = 90;
+
+    [Description("Fail (exit 1) if any single node's peak concurrent connections to a single shard database exceed this. WS6 expectation: per-node × per-database footprint stays governed (O(databases-led) per node). Default: 0 = report only.")]
+    public int MaxConnectionsPerNodeShardFlag { get; set; }
+
+    [Description("Fail (exit 1) if shard leadership does not span at least two distinct nodes at steady state. Off by default because a fast node can transiently grab every shard before the leadership poll rebalances. Default: false = report only.")]
+    public bool RequireDistributionFlag { get; set; }
+
+    [Description("Drop + recreate the dedicated schema and shard databases before the run. Default: false.")]
+    public bool WipeFlag { get; set; }
+
+    [Description("Optional path for a JSON metrics file.")]
+    public string? MetricsFlag { get; set; }
+
+    [Description("Optional path for a per-sample CSV connection trace (per node × database).")]
+    public string? TraceFlag { get; set; }
+}

--- a/src/Marten.ScaleTesting/Commands/MultiNodeStore.cs
+++ b/src/Marten.ScaleTesting/Commands/MultiNodeStore.cs
@@ -21,6 +21,13 @@ internal static class MultiNodeStore
     /// <summary>The shared advisory-lock id every node contends on for HotCold leadership.</summary>
     public const int DaemonLockId = 48620;
 
+    /// <summary>Prefix for the per-server shard databases in the sharded multi-node scenario.</summary>
+    public const string ShardDatabasePrefix = "scaletest_multinode_shard_";
+
+    /// <summary>Deterministic shard database names — reconstructable by every node from just the count.</summary>
+    public static string[] ShardDatabaseNames(int databaseCount) =>
+        Enumerable.Range(0, Math.Max(1, databaseCount)).Select(i => $"{ShardDatabasePrefix}{i}").ToArray();
+
     public static string[] ProjectionNames(int count) =>
         Enumerable.Range(0, Math.Max(1, count)).Select(i => $"NodeRollup{i}").ToArray();
 
@@ -48,6 +55,58 @@ internal static class MultiNodeStore
 
         // Tight leadership polling so failover redistribution is observable within a load run
         // rather than after a multi-second lease.
+        opts.Projections.DaemonLockId = DaemonLockId;
+        opts.Projections.LeadershipPollingTime = 500;
+
+        foreach (var name in ProjectionNames(projectionCount))
+        {
+            opts.Projections.Add(new DaemonLoadRollupProjection(name), ProjectionLifecycle.Async, name);
+        }
+    }
+
+    /// <summary>
+    /// Sharded variant for the marten#4883 sharded multi-node scenario: pools tenants across
+    /// <paramref name="databaseCount"/> shard databases on the same server via
+    /// <c>MultiTenantedWithShardedDatabases</c>. Every node builds a byte-identical sharded store
+    /// (deterministic shard names from the count alone, one shared DaemonLockId) so native HotCold
+    /// leadership is negotiated PER SHARD DATABASE — different nodes lead different shards, which is
+    /// the cross-node distribution this scenario exercises.
+    /// </summary>
+    public static void ConfigureSharded(StoreOptions opts, int projectionCount, int databaseCount,
+        string applicationName)
+    {
+        var shardNames = ShardDatabaseNames(databaseCount);
+        var masterConnectionString = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+        {
+            ApplicationName = applicationName
+        }.ConnectionString;
+
+        opts.MultiTenantedWithShardedDatabases(x =>
+        {
+            x.ConnectionString = masterConnectionString;
+            x.SchemaName = Schema;
+            x.ApplicationName = applicationName;
+            x.UseExplicitAssignment();
+
+            foreach (var name in shardNames)
+            {
+                var shardConnectionString = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString)
+                {
+                    Database = name,
+                    ApplicationName = applicationName
+                }.ConnectionString;
+                x.AddDatabase(name, shardConnectionString);
+            }
+        });
+
+        opts.DisableNpgsqlLogging = true;
+        opts.DatabaseSchemaName = Schema;
+        opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+        opts.Events.UseTenantPartitionedEvents = true;
+        opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+        opts.Policies.AllDocumentsAreMultiTenanted();
+        opts.Events.AddEventType<DaemonLoadEvent>();
+
         opts.Projections.DaemonLockId = DaemonLockId;
         opts.Projections.LeadershipPollingTime = 500;
 

--- a/src/Marten.ScaleTesting/Commands/NodeProcess.cs
+++ b/src/Marten.ScaleTesting/Commands/NodeProcess.cs
@@ -28,7 +28,7 @@ internal sealed class NodeProcess: IDisposable
     /// Launch a node process of this same binary and wait for its stdout <c>NODE_READY</c> line so
     /// the coordinator only starts sampling once the daemon is actually up.
     /// </summary>
-    public static async Task<NodeProcess> LaunchAsync(int nodeIndex, int projections)
+    public static async Task<NodeProcess> LaunchAsync(int nodeIndex, int projections, int databases = 1)
     {
         // Re-invoke the CURRENT assembly via `dotnet <thisdll> daemonload-node ...`. Using the
         // managed dll path (not the apphost) keeps this portable across the way `dotnet run`
@@ -48,6 +48,8 @@ internal sealed class NodeProcess: IDisposable
         psi.ArgumentList.Add(nodeIndex.ToString());
         psi.ArgumentList.Add("--projections");
         psi.ArgumentList.Add(projections.ToString());
+        psi.ArgumentList.Add("--databases");
+        psi.ArgumentList.Add(databases.ToString());
 
         var process = Process.Start(psi)
                       ?? throw new InvalidOperationException($"Failed to launch node {nodeIndex}");

--- a/src/Marten.ScaleTesting/README.md
+++ b/src/Marten.ScaleTesting/README.md
@@ -182,11 +182,38 @@ dotnet run --project src/Marten.ScaleTesting -- daemonload-multinode \
     --max-connections-per-node 16 --metrics daemonload-multinode.json --trace daemonload-multinode.csv
 ```
 
-To get agents running on DIFFERENT nodes simultaneously (rather than one hot leader), combine
-with the sharded topology — multiple shard databases, whose per-database locks CAN land on
-different nodes (that cross-node distribution variant, and the Wolverine-managed distribution mode
-from wolverine#3328, are the remaining WS6 multi-node work; the harness references only Marten,
-not Wolverine).
+To get agents running on DIFFERENT nodes simultaneously (rather than one hot leader), use the
+sharded topology below — multiple shard databases, whose per-database locks land on different
+nodes.
+
+### Sharded multi-node — cross-node distribution (marten#4883, epic jasperfx#486 WS6)
+
+`daemonload-multinode-sharded` pools `--tenants` tenants across `--databases` shard databases via
+`MultiTenantedWithShardedDatabases`, then launches `--nodes` HotCold node processes over that
+sharded store. Because each shard database is its own leadership lock, the distributor spreads
+shard leadership across nodes — node A leads `shard_0`, node B leads `shard_1` — which is the
+cross-node agent distribution the epic's topology matrix calls for (single-database HotCold above
+can only ever have one hot leader).
+
+It asserts: **distribution** (leadership spans multiple nodes; `--require-distribution` makes it a
+hard gate, off by default because a fast node can transiently grab every shard before the
+leadership poll rebalances); **redistribution** on `--kill-node-after-seconds` (a killed node's
+shards move to surviving nodes with no tenant stalled); **per-tenant catch-up** on every shard; and
+a **per-node × per-shard** connection footprint that stays governed (`--max-connections-per-node-shard`).
+
+```bash
+# 3 nodes over 3 shard databases (100 tenants pooled across them); kill a node 30s in and
+# verify its shards redistribute and every tenant catches up on its home shard.
+dotnet run --project src/Marten.ScaleTesting -- daemonload-multinode-sharded \
+    --nodes 3 --databases 3 --tenants 100 --projections 2 --duration-seconds 120 \
+    --kill-node-after-seconds 30 --wipe \
+    --max-connections-per-node-shard 16 --metrics daemonload-multinode-sharded.json \
+    --trace daemonload-multinode-sharded.csv
+```
+
+The remaining WS6 multi-node work is the Wolverine-managed distribution mode (automatic per-tenant
+fan-out + affinity from wolverine#3328); this harness references only Marten, not Wolverine, so
+that variant lives in Wolverine's own load suite.
 
 ## The `rebuildload` scenario (marten#4884, epic jasperfx#486 WS6/WS3)
 


### PR DESCRIPTION
Part of #4883 (native-HotCold multi-node; the Wolverine-managed variant remains a Wolverine-side hand-off).

## Context
`daemonload-multinode` already covers native HotCold over **one** tenant-partitioned database — but with a single database HotCold can only ever elect **one** hot leader (+ failover). The epic's topology matrix also wants agents **distributed across nodes**, which requires multiple shard databases whose per-database leadership locks can land on different nodes.

## This PR — `daemonload-multinode-sharded`
A new coordinator that pools `--tenants` tenants across `--databases` shard databases via `MultiTenantedWithShardedDatabases`, then launches `--nodes` HotCold node processes over that sharded store. Each shard DB is its own leadership lock, so leadership spreads across nodes.

Verifies:
- **Distribution** — shard leadership spans multiple nodes (observed via `pg_stat_activity` grouped by node app-name × shard db). `--require-distribution` makes it a hard gate; **soft by default** because a fast node can transiently grab every shard before the leadership poll rebalances.
- **Redistribution** — `--kill-node-after-seconds` kills a node that leads a shard; its shards must move to surviving nodes, no tenant stalled.
- **Per-tenant catch-up** on every shard, and a governed **per-node × per-shard** connection footprint (`--max-connections-per-node-shard`).

Plumbing: the `daemonload-node` worker role gains `--databases` (builds the sharded store when >1); `NodeProcess` passes it through. Reuses `NodeConnectionSampler` (already per node × database) and the sharded per-shard catch-up path.

## Smoke-verified locally (2 nodes × 2 shards × 4 tenants)
- Happy path: `node1` led `shard_0`, `node0` led `shard_1` → **2/2 distinct leader nodes**; 4/4 tenants caught up; 0 append failures; per-node×shard peak connections governed.
- Kill path: killed the node leading both shards → **"all orphaned shards redistributed to surviving nodes"**; 4/4 caught up. (That run also exercised the soft-distribution NOTE, since one node had grabbed both shards — exactly why distribution is report-only by default.)

## Not in scope (hand-off)
Wolverine-managed distribution multi-node (automatic per-tenant fan-out + affinity, wolverine#3328) — this harness references only Marten, so that variant belongs in Wolverine's load suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)