### PR TITLE
GetProjectionStatusesAsync resolves the named database instead of the default tenant

### DIFF
--- a/src/Marten/DocumentStore.EventStoreExplorer.cs
+++ b/src/Marten/DocumentStore.EventStoreExplorer.cs
@@ -333,18 +333,39 @@ public partial class DocumentStore
     }
 
     /// <summary>
-    /// #4596 Phase 1 Session 4 — override the jasperfx#407 default-throwing
-    /// per-tenant overload. Non-null <paramref name="tenantId"/> returns the
-    /// per-tenant slice of each registered projection: the shard identities
-    /// reported carry the trailing tenant suffix
-    /// (<c>{ProjName}:{ShardKey}:{tenantId}</c>) and their ProcessedSequence
-    /// comes from the matching tenant-bearing row in <c>mt_event_progression</c>.
-    /// Null preserves the today's-behavior "every registered shard, no tenant
-    /// suffix" semantics.
+    /// #4596 Phase 1 Session 4 — override the jasperfx#407 default-throwing per-tenant overload.
+    ///
+    /// <para>
+    /// The argument means one of two things, depending on how the store is tenanted, exactly as it does for
+    /// <see cref="BuildProjectionDaemonAsync(string?, ILogger?)"/>:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><b>Single database</b> (conjoined tenancy with per-tenant event partitioning): the argument names a
+    /// tenant co-located in the one database. Each registered projection reports its per-tenant slice — the shard
+    /// identities carry the trailing <c>{ProjName}:{ShardKey}:{tenantId}</c> suffix that Phase 1 Session 3 writes,
+    /// and their ProcessedSequence comes from the matching tenant-bearing progression row.</item>
+    /// <item><b>Database-per-tenant / sharded tenancy</b>: the argument names a physical database. Its shards are
+    /// NOT tenant-suffixed — each database runs its own daemon over the same shard identities — so the statuses
+    /// are read from that database with the plain shard names. This is the path that previously threw
+    /// <c>DefaultTenantUsageDisabledException</c>, because the session was always opened against the default
+    /// tenant no matter what was passed. See jasperfx#502.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// A null argument preserves the "every registered shard, no tenant suffix, default database" semantics.
+    /// </para>
     /// </summary>
     async Task<IReadOnlyList<ProjectionStatus>> IEventStore.GetProjectionStatusesAsync(string? tenantId, CancellationToken ct)
     {
-        await using var session = openExplorerSession();
+        // On a store spanning several databases the argument selects the physical database whose progression
+        // rows we read. On a single-database store it selects a tenant living inside the one database, and only
+        // then does the shard identity carry the tenant suffix.
+        var spansSeveralDatabases = Options.Tenancy.Cardinality != DatabaseCardinality.Single;
+        var shardsAreTenantScoped = tenantId != null && !spansSeveralDatabases;
+
+        await using var session = tenantId != null && spansSeveralDatabases
+            ? openExplorerSession(await Tenancy.FindOrCreateDatabase(tenantId).ConfigureAwait(false))
+            : openExplorerSession();
         await session.Database.EnsureStorageExistsAsync(typeof(IEvent), ct).ConfigureAwait(false);
 
         var schema = Options.EventGraph.DatabaseSchemaName;
@@ -358,13 +379,13 @@ public partial class DocumentStore
             var shardStatuses = new List<ShardStatus>(shards.Count);
             foreach (var shard in shards)
             {
-                // For per-tenant requests, compose the tenant-bearing ShardName
-                // so the reported identity AND the progression-row lookup both
-                // carry the trailing :tenantId suffix that Phase 1 Session 3
-                // writes for per-tenant shards.
-                var effectiveName = tenantId == null
-                    ? shard.Name
-                    : ShardName.Compose(shard.Name.Name, shard.Name.ShardKey, tenantId, shard.Name.Version);
+                // For a tenant co-located in a single database, compose the tenant-bearing ShardName so the
+                // reported identity AND the progression-row lookup both carry the trailing :tenantId suffix that
+                // Phase 1 Session 3 writes. A database-per-tenant store's shards carry no suffix — we already
+                // read them from that tenant's own database.
+                var effectiveName = shardsAreTenantScoped
+                    ? ShardName.Compose(shard.Name.Name, shard.Name.ShardKey, tenantId, shard.Name.Version)
+                    : shard.Name;
 
                 var processed = progression.TryGetValue(effectiveName.Identity, out var seq) ? seq : 0L;
                 shardStatuses.Add(new ShardStatus(
@@ -649,6 +670,17 @@ public partial class DocumentStore
             AllowAnyTenant = true,
             Tracking = DocumentTracking.None
         };
+        return (DocumentSessionBase)LightweightSession(sessionOptions);
+    }
+
+    /// <summary>
+    /// jasperfx#502 — an explorer session bound to one physical database. A store with a database per tenant
+    /// has no default tenant to resolve a session against, so the argument-less overload throws there.
+    /// </summary>
+    private DocumentSessionBase openExplorerSession(IMartenDatabase database)
+    {
+        var sessionOptions = SessionOptions.ForDatabase(database);
+        sessionOptions.Tracking = DocumentTracking.None;
         return (DocumentSessionBase)LightweightSession(sessionOptions);
     }
 

--- a/src/MultiTenancyTests/projection_statuses_per_database.cs
+++ b/src/MultiTenancyTests/projection_statuses_per_database.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Weasel.Postgresql.Migrations;
+using Xunit;
+
+namespace MultiTenancyTests;
+
+#region test-projection
+
+public record WidgetMade(string Name);
+
+public class WidgetTally
+{
+    public string Id { get; set; } = "tally";
+    public int Count { get; set; }
+}
+
+public partial class WidgetTallyProjection: MultiStreamProjection<WidgetTally, string>
+{
+    public WidgetTallyProjection()
+    {
+        Identity<WidgetMade>(_ => "tally");
+    }
+
+    public void Apply(WidgetMade _, WidgetTally tally) => tally.Count++;
+}
+
+#endregion
+
+/// <summary>
+/// jasperfx#502 — <c>IEventStore.GetProjectionStatusesAsync(tenantIdOrDatabaseIdentifier, ct)</c> used to open
+/// its session against the default tenant no matter what was passed, so on a database-per-tenant store it
+/// threw <c>DefaultTenantUsageDisabledException</c> — even when handed an identifier that
+/// <c>AllDatabases()</c> had just returned and that <c>BuildProjectionDaemonAsync(identifier)</c> accepts.
+///
+/// That call is the only store-agnostic way to ask "is this projection still registered?", so monitoring
+/// tools (CritterWatch) had to suppress orphan detection entirely for these stores: without a registry every
+/// live projection's progression row looks orphaned.
+/// </summary>
+[Collection("multi-tenancy")]
+public class projection_statuses_per_database: IAsyncLifetime
+{
+    // The test assembly runs once per target framework, concurrently, against the same Postgres. Give each
+    // run its own databases and schema so the two don't fight over DDL or over each other's event sequences.
+    private static readonly string Suffix = $"_net{Environment.Version.Major}";
+    private static readonly string TenantA = $"mt502_tenant_a{Suffix}";
+    private static readonly string TenantB = $"mt502_tenant_b{Suffix}";
+    private static readonly string MasterSchema = $"mt502_master{Suffix}";
+    private static readonly string SchemaName = $"mt502{Suffix}";
+
+    private IDocumentStore _store = null!;
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync(MasterSchema);
+        var tenantA = await CreateDatabaseIfNotExists(conn, TenantA);
+        var tenantB = await CreateDatabaseIfNotExists(conn, TenantB);
+        await conn.CloseAsync();
+
+        // Each run starts from sequence 0 so the assertions below are exact.
+        await DropSchemaAsync(tenantA);
+        await DropSchemaAsync(tenantB);
+
+        _store = DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedDatabasesWithMasterDatabaseTable(configure =>
+            {
+                configure.ConnectionString = ConnectionSource.ConnectionString;
+                configure.SchemaName = MasterSchema;
+                configure.RegisterDatabase("tenant-a", tenantA);
+                configure.RegisterDatabase("tenant-b", tenantB);
+            });
+
+            opts.DatabaseSchemaName = SchemaName;
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.DisableNpgsqlLogging = true;
+            opts.Projections.Add<WidgetTallyProjection>(ProjectionLifecycle.Async);
+        });
+
+        await _store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        _store.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private async Task AppendAsync(string tenantId, int count)
+    {
+        await using var session = _store.LightweightSession(tenantId);
+        for (var i = 0; i < count; i++)
+        {
+            session.Events.StartStream(Guid.NewGuid(), new WidgetMade($"{tenantId}-{i}"));
+        }
+
+        await session.SaveChangesAsync();
+    }
+
+    private async Task RunDaemonAsync(string tenantId)
+    {
+        var daemon = await ((IEventStore)_store).BuildProjectionDaemonAsync(tenantId);
+        await daemon.StartAllAsync();
+        await daemon.WaitForNonStaleData(TimeSpan.FromSeconds(30));
+        await daemon.StopAllAsync();
+    }
+
+    [Fact]
+    public async Task reads_each_databases_projection_statuses_without_a_default_tenant()
+    {
+        await AppendAsync("tenant-a", 5);
+        await AppendAsync("tenant-b", 2);
+        await RunDaemonAsync("tenant-a");
+        await RunDaemonAsync("tenant-b");
+
+        var store = (IEventStore)_store;
+
+        // Every database the store reports can be asked for its statuses. This threw before the fix.
+        foreach (var database in await store.AllDatabases())
+        {
+            var statuses = await store.GetProjectionStatusesAsync(database.Identifier, CancellationToken.None);
+            statuses.ShouldNotBeEmpty();
+        }
+
+        var alpha = await store.GetProjectionStatusesAsync("tenant-a", CancellationToken.None);
+        var beta = await store.GetProjectionStatusesAsync("tenant-b", CancellationToken.None);
+
+        // Each database reports its OWN progression, read from its own database.
+        SequenceFor(alpha).ShouldBe(5);
+        SequenceFor(beta).ShouldBe(2);
+
+        // And the head sequence is that database's, not some other's.
+        HeadFor(alpha).ShouldBe(5);
+        HeadFor(beta).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task a_database_per_tenant_stores_shards_are_not_tenant_suffixed()
+    {
+        await AppendAsync("tenant-a", 3);
+        await RunDaemonAsync("tenant-a");
+
+        var statuses = await ((IEventStore)_store)
+            .GetProjectionStatusesAsync("tenant-a", CancellationToken.None);
+
+        // Database-per-tenant runs one daemon per database over the SAME shard identities. Suffixing them
+        // with the tenant would name a shard that exists nowhere, and its progression lookup would miss.
+        var shard = statuses.Single(x => x.ProjectionName == nameof(WidgetTally)).Shards.Single();
+        shard.ShardName.ShouldBe("WidgetTally:All");
+        shard.ProcessedSequence.ShouldBe(3);
+    }
+
+    private static long SequenceFor(System.Collections.Generic.IReadOnlyList<ProjectionStatus> statuses)
+        => statuses.Single(x => x.ProjectionName == nameof(WidgetTally)).Shards.Single().ProcessedSequence;
+
+    private static long HeadFor(System.Collections.Generic.IReadOnlyList<ProjectionStatus> statuses)
+        => statuses.Single(x => x.ProjectionName == nameof(WidgetTally)).Shards.Single().EventStoreSequence;
+
+    private static async Task<string> CreateDatabaseIfNotExists(NpgsqlConnection conn, string databaseName)
+    {
+        var builder = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString);
+        if (!await conn.DatabaseExists(databaseName))
+        {
+            try
+            {
+                await new DatabaseSpecification().BuildDatabase(conn, databaseName);
+            }
+            catch (PostgresException e) when (e.SqlState is PostgresErrorCodes.DuplicateDatabase
+                                                  or PostgresErrorCodes.UniqueViolation)
+            {
+                // The test assembly runs once per target framework, concurrently; the check-then-create above
+                // is not atomic, so the loser of that race sees the database it wanted already there.
+            }
+        }
+
+        builder.Database = databaseName;
+        return builder.ConnectionString;
+    }
+
+    private static async Task DropSchemaAsync(string connectionString)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+        await conn.DropSchemaAsync(SchemaName);
+        await conn.CloseAsync();
+    }
+}


### PR DESCRIPTION
Fixes [jasperfx#502](https://github.com/JasperFx/jasperfx/issues/502).

## Problem

`IEventStore.GetProjectionStatusesAsync(tenantIdOrDatabaseIdentifier, ct)` always opened its explorer session against the **default tenant**, no matter what was passed. On a database-per-tenant store there is no default tenant, so it threw `DefaultTenantUsageDisabledException` — even when handed an identifier that `AllDatabases()` had just returned, and that `BuildProjectionDaemonAsync(identifier)` accepts happily.

The argument only ever reached the shard-name composition; it never reached session resolution.

```csharp
var store = (IEventStore)documentStore;   // MultiTenantedDatabasesWithMasterDatabaseTable

await store.GetProjectionStatusesAsync(ct);                        // throws
foreach (var db in await store.AllDatabases())
    await store.GetProjectionStatusesAsync(db.Identifier, ct);     // also throws
```

## Change

The argument now means what it means everywhere else in the API, resolved exactly the way `BuildProjectionDaemonAsync(string)` resolves it:

- **Single database** (conjoined tenancy with per-tenant event partitioning) — the argument names a tenant co-located in the one database. Shard identities keep the trailing `:tenantId` suffix and the progression lookup matches the tenant-bearing row. **Unchanged.**
- **Database-per-tenant / sharded tenancy** — the argument names a physical database. The session is opened against it, and its shards are **not** tenant-suffixed: each database runs its own daemon over the same shard identities, so suffixing would name a shard that exists nowhere and its progression lookup would miss.

The single/multi discrimination uses `Options.Tenancy.Cardinality`, matching the existing precedent in `DocumentStore.DocumentDiagnostics.cs`.

## Why it matters

This is the only store-agnostic way to enumerate the **registered** projections and their lifecycles. Consumers use it to answer *"is this progression row's projection still registered, or is it an orphan left behind by a rename or removal?"*

On a database-per-tenant store that question currently has no answer through the abstraction, so CritterWatch has had to suppress orphan detection entirely for those stores: without a registry, every live projection's progression row looks orphaned, and reporting that is worse than reporting nothing. The same gap costs the "registered but idle" baseline for a registered async projection with no running agent.

## Tests

New `MultiTenancyTests/projection_statuses_per_database`:

- Every database `AllDatabases()` reports can be asked for its statuses, and each returns **its own** progression and head sequence (tenant-a = 5, tenant-b = 2), read from its own database.
- A database-per-tenant store's shards are **not** tenant-suffixed (`WidgetTally:All`, not `WidgetTally:All:tenant-a`).

Both are red without the fix (`DefaultTenantUsageDisabledException`). The databases and schema are suffixed per target framework, because the test assembly runs once per TFM concurrently against the same Postgres.

Regression: `TenantPartitionedEventsTests/admin_api_tenant_overloads` 6/6 (the single-database per-tenant path), `EventSourcingTests` Explorer 21/21, full `MultiTenancyTests` 159/159.