### PR TITLE
fix: drain the projection coordinator on disposal (#4915)

### DIFF
--- a/src/CoreTests/Bug_4874_coordinator_drain_ordering.cs
+++ b/src/CoreTests/Bug_4874_coordinator_drain_ordering.cs
@@ -40,14 +40,19 @@ namespace CoreTests;
 // out from under an OpenAsync the coordinator loop's StopAsync did not drain.
 //
 // The fix is upstream and is now consumed on master:
-//   Priority 1 - Weasel 9.16.2 (weasel#349/#350): AdvisoryLock disposing-guard + swallow disposed-pool
-//                ObjectDisposedException in TryAttainLockAsync (return false = "not attained during shutdown").
+//   Priority 1 - Weasel (weasel#349/#350, then weasel#354): AdvisoryLock disposing-guard, plus a disposed
+//                data source treated as terminal in TryAttainLockAsync -- latch and rethrow. 9.16.2 swallowed
+//                the ObjectDisposedException and returned false instead, which read as "lock held elsewhere"
+//                and made the coordinator re-poll a dead pool forever; 9.16.3 restores the escape (marten#4915).
 //   Priority 2 - JasperFx 2.24.1 (jasperfx#499/#500): ProjectionCoordinatorBase.executeAsync returns on
 //                cancellation / treats ObjectDisposedException as terminal instead of re-polling.
+//   Priority 3 - marten#4923: ProjectionCoordinator drains its loop on disposal, so a host disposed without a
+//                graceful StopAsync cannot leave the loop polling a data source the container already killed.
 //
 // This test reproduces the abort in the reporter's shape (HotCold, connection-string / Marten-owned
-// source, boot+teardown under an active cold-node poll) and asserts zero PoolingDataSource aborts. It
-// failed on the pre-fix stack and passes now that Weasel 9.16.2 + JasperFx 2.24.1 are referenced.
+// source, boot+teardown under an active cold-node poll) and asserts zero leadership-poll aborts. It failed
+// on the pre-fix stack. Note that it exercises the GRACEFUL teardown (StopAsync then Dispose); the
+// dispose-without-stop shape is Bug_4915_coordinator_disposal_drain.
 [Collection("integration")]
 public class Bug_4874_coordinator_drain_ordering
 {
@@ -63,15 +68,20 @@ public class Bug_4874_coordinator_drain_ordering
     {
         const string schema = "bug4874_coordinator_drain";
 
-        // Count only the specific abort this bug produces: an OpenAsync against a disposed Npgsql pool.
+        // Count only the specific abort this bug produces: the coordinator's leadership poll opening a
+        // connection against a disposed Npgsql pool.
+        //
+        // #4915: this used to match ANY disposed-pool ObjectDisposedException in the process, which made the
+        // test fail in a full CoreTests run while passing in isolation -- other tests leak background work
+        // that touches their own disposed data sources, and AdvisoryLock.DisposeAsync benignly touches one
+        // too. FirstChanceException is AppDomain-wide, and CoreTests already runs serially, so the only fix is
+        // to attribute the abort to the poll. See DisposedPoolAborts.
         var aborts = new ConcurrentQueue<string>();
         void handler(object? sender, FirstChanceExceptionEventArgs e)
         {
-            if (e.Exception is ObjectDisposedException ode &&
-                (ode.ObjectName?.Contains("PoolingDataSource") == true ||
-                 ode.Message.Contains("PoolingDataSource")))
+            if (DisposedPoolAborts.IsAdvisoryLockPollAbort(e.Exception))
             {
-                aborts.Enqueue(ode.ToString());
+                aborts.Enqueue(e.Exception.ToString());
             }
         }
 
@@ -115,7 +125,7 @@ public class Bug_4874_coordinator_drain_ordering
         }
 
         aborts.Count.ShouldBe(0,
-            $"Expected no ObjectDisposedException('PoolingDataSource') aborts, but saw {aborts.Count}. " +
+            $"Expected no disposed-pool aborts on the leadership poll path, but saw {aborts.Count}. " +
             "The cold-node leadership poll opened a connection against an already-disposed data source " +
             "during teardown (see #4874).");
     }

--- a/src/CoreTests/Bug_4915_coordinator_disposal_drain.cs
+++ b/src/CoreTests/Bug_4915_coordinator_disposal_drain.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events.Aggregation;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreTests;
+
+// #4915, the near side of the #4874 case-B chain.
+//
+// IHost.Dispose() does not stop hosted services -- only StopAsync() does. So `using var host = ...`, and any
+// teardown that disposes without a graceful stop, tears the container down underneath a running projection
+// coordinator. The container disposes the DocumentStore and its owned NpgsqlDataSource, and the HotCold
+// leadership loop keeps polling AdvisoryLock.TryAttainLockAsync against a pool that is already gone.
+//
+// Before the fix, measured on this exact shape: a cold node disposed without StopAsync produced 210
+// disposed-pool ObjectDisposedExceptions in the 1.5 seconds after teardown, and kept going for the life of
+// the process (~140/s). The same host stopped with StopAsync() first produced zero. That asymmetry is the
+// bug: ProjectionCoordinator had no disposal at all, so the only thing that ever drained its loop was a
+// graceful stop.
+//
+// The fix makes ProjectionCoordinator IAsyncDisposable/IDisposable, draining the loop and releasing the
+// advisory locks. The coordinator is constructed from an IDocumentStore, so the container necessarily creates
+// the store first and disposes it last -- the coordinator drains while its data source is still alive.
+//
+// Weasel 9.16.3 (weasel#354) independently makes a disposed data source terminal inside
+// AdvisoryLock.TryAttainLockAsync, which drops the unfixed count from 210 to ~9 (one poll's worth of
+// async-frame rethrows) by letting ProjectionCoordinatorBase's terminate-on-ObjectDisposedException catch
+// finally fire. The two fixes are independent: either one alone brings this test to zero. This one keeps the
+// loop from outliving its data source; that one keeps a loop that does from churning.
+[Collection("integration")]
+public class Bug_4915_coordinator_disposal_drain
+{
+    private readonly ITestOutputHelper _output;
+
+    public Bug_4915_coordinator_disposal_drain(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // CoreTests runs serially ([assembly: CollectionBehavior(DisableTestParallelization = true)]), but other
+    // tests still produce disposed-pool ObjectDisposedExceptions of their own: leaked background work (daemon
+    // StopAllAsync, schema migrations, session reads), and -- benignly -- AdvisoryLock.DisposeAsync releasing a
+    // lock handle whose data source already went away, which Weasel swallows. FirstChanceException is an
+    // AppDomain-wide hook, so a bare "zero disposed-pool aborts" assertion counts all of that and flakes. That
+    // is why Bug_4874_coordinator_drain_ordering fails in a full run but passes alone.
+    //
+    // Attribute each abort to the leadership poll specifically -- TryAttainLockAsync re-opening a dead pool is
+    // the bug, and lock *disposal* touching one is not. The exception's own StackTrace is not populated at
+    // first-chance time, so walk the throwing thread's live stack.
+    private static bool IsAdvisoryLockPollAbort(Exception exception)
+    {
+        if (exception is not ObjectDisposedException ode) return false;
+
+        if (ode.ObjectName?.Contains("PoolingDataSource") != true &&
+            !ode.Message.Contains("PoolingDataSource"))
+        {
+            return false;
+        }
+
+        return new StackTrace(false).ToString().Contains("TryAttainLockAsync", StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task disposing_a_cold_node_without_stopasync_does_not_poll_the_disposed_datasource()
+    {
+        const string schema = "bug4915_coordinator_disposal";
+
+        var aborts = new ConcurrentQueue<string>();
+        var counting = false;
+
+        void handler(object? sender, FirstChanceExceptionEventArgs e)
+        {
+            if (!Volatile.Read(ref counting)) return;
+
+            if (IsAdvisoryLockPollAbort(e.Exception))
+            {
+                aborts.Enqueue(e.Exception.ToString());
+            }
+        }
+
+        AppDomain.CurrentDomain.FirstChanceException += handler;
+        try
+        {
+            // Hot node wins the single advisory lock and holds it, so the cold node below stays cold and keeps
+            // re-polling (and therefore re-opening) to try to attain it.
+            using var hot = BuildHost(schema);
+            await hot.StartAsync();
+            await Task.Delay(500);
+
+            var cold = BuildHost(schema);
+            await cold.StartAsync();
+
+            // Let the cold node lose the lock a few times, so its poll loop is definitely live.
+            await Task.Delay(400);
+
+            // The shape under test: dispose with NO graceful stop, exactly as `using var host = ...` does.
+            // This disposes the container, and with it the DocumentStore's owned NpgsqlDataSource.
+            cold.Dispose();
+
+            // Everything from here on is the churn window. A coordinator that outlived its data source
+            // re-opens the dead pool on every LeadershipPollingTime tick (50ms below), so 1.5s of silence
+            // is a meaningful signal: pre-fix this window held 210 aborts.
+            Volatile.Write(ref counting, true);
+            await Task.Delay(1500);
+            Volatile.Write(ref counting, false);
+
+            await hot.StopAsync();
+        }
+        finally
+        {
+            AppDomain.CurrentDomain.FirstChanceException -= handler;
+        }
+
+        foreach (var abort in aborts)
+        {
+            _output.WriteLine(abort);
+        }
+
+        aborts.Count.ShouldBe(0,
+            $"Expected no disposed-pool aborts on the AdvisoryLock poll path after disposing the cold node, but saw " +
+            $"{aborts.Count}. The projection coordinator's leadership loop outlived the data source the " +
+            "container disposed underneath it (see #4915).");
+    }
+
+    [Fact]
+    public async Task disposal_drains_a_loop_that_resumeasync_restarted_after_a_stop()
+    {
+        const string schema = "bug4915_resume_then_dispose";
+
+        var aborts = new ConcurrentQueue<string>();
+        var counting = false;
+
+        void handler(object? sender, FirstChanceExceptionEventArgs e)
+        {
+            if (!Volatile.Read(ref counting)) return;
+
+            if (IsAdvisoryLockPollAbort(e.Exception))
+            {
+                aborts.Enqueue(e.Exception.ToString());
+            }
+        }
+
+        AppDomain.CurrentDomain.FirstChanceException += handler;
+        try
+        {
+            using var hot = BuildHost(schema);
+            await hot.StartAsync();
+            await Task.Delay(500);
+
+            var cold = BuildHost(schema);
+            await cold.StartAsync();
+            await Task.Delay(200);
+
+            // Stop, then Resume: the coordinator builds a FRESH leadership loop. Disposal has to drain that
+            // one, not conclude from a stale "already stopped" flag that there is nothing left to do. Use
+            // StopAsync (not PauseAsync) because that is the call any such flag would be set from.
+            var coordinator = cold.Services.GetRequiredService<IProjectionCoordinator>();
+            await coordinator.StopAsync(CancellationToken.None);
+            await coordinator.ResumeAsync();
+            await Task.Delay(300);
+
+            cold.Dispose();
+
+            Volatile.Write(ref counting, true);
+            await Task.Delay(1500);
+            Volatile.Write(ref counting, false);
+
+            await hot.StopAsync();
+        }
+        finally
+        {
+            AppDomain.CurrentDomain.FirstChanceException -= handler;
+        }
+
+        foreach (var abort in aborts)
+        {
+            _output.WriteLine(abort);
+        }
+
+        aborts.Count.ShouldBe(0,
+            $"Expected no aborts after disposing a coordinator whose loop had been restarted by ResumeAsync, " +
+            $"but saw {aborts.Count} (see #4915).");
+    }
+
+    private static IHost BuildHost(string schema)
+    {
+        return Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMarten(opts =>
+                    {
+                        // Connection-string overload => Marten OWNS the NpgsqlDataSource, so container disposal
+                        // really does take the pool down with it.
+                        opts.Connection(ConnectionSource.ConnectionString);
+                        opts.DatabaseSchemaName = schema;
+                        opts.DisableNpgsqlLogging = true;
+
+                        // Poll aggressively so an undrained loop shows up immediately.
+                        opts.Projections.LeadershipPollingTime = 50;
+
+                        opts.Projections.Add(new Bug4915CounterProjection(), ProjectionLifecycle.Async);
+                    })
+                    // HotCold => a single advisory lock, so the second node stays cold and keeps polling.
+                    .AddAsyncDaemon(DaemonMode.HotCold);
+            })
+            .Build();
+    }
+}
+
+public record Bug4915Incremented;
+
+public class Bug4915Counter
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+}
+
+// Convention-based projection subclass => must be top-level + partial so the JasperFx source generator emits
+// its dispatcher (there is no runtime Apply/Create fallback).
+public partial class Bug4915CounterProjection: SingleStreamProjection<Bug4915Counter, Guid>
+{
+    public void Apply(Bug4915Counter snapshot, Bug4915Incremented _)
+    {
+        snapshot.Count++;
+    }
+}

--- a/src/CoreTests/Bug_4915_coordinator_disposal_drain.cs
+++ b/src/CoreTests/Bug_4915_coordinator_disposal_drain.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -50,29 +49,6 @@ public class Bug_4915_coordinator_disposal_drain
         _output = output;
     }
 
-    // CoreTests runs serially ([assembly: CollectionBehavior(DisableTestParallelization = true)]), but other
-    // tests still produce disposed-pool ObjectDisposedExceptions of their own: leaked background work (daemon
-    // StopAllAsync, schema migrations, session reads), and -- benignly -- AdvisoryLock.DisposeAsync releasing a
-    // lock handle whose data source already went away, which Weasel swallows. FirstChanceException is an
-    // AppDomain-wide hook, so a bare "zero disposed-pool aborts" assertion counts all of that and flakes. That
-    // is why Bug_4874_coordinator_drain_ordering fails in a full run but passes alone.
-    //
-    // Attribute each abort to the leadership poll specifically -- TryAttainLockAsync re-opening a dead pool is
-    // the bug, and lock *disposal* touching one is not. The exception's own StackTrace is not populated at
-    // first-chance time, so walk the throwing thread's live stack.
-    private static bool IsAdvisoryLockPollAbort(Exception exception)
-    {
-        if (exception is not ObjectDisposedException ode) return false;
-
-        if (ode.ObjectName?.Contains("PoolingDataSource") != true &&
-            !ode.Message.Contains("PoolingDataSource"))
-        {
-            return false;
-        }
-
-        return new StackTrace(false).ToString().Contains("TryAttainLockAsync", StringComparison.Ordinal);
-    }
-
     [Fact]
     public async Task disposing_a_cold_node_without_stopasync_does_not_poll_the_disposed_datasource()
     {
@@ -85,7 +61,7 @@ public class Bug_4915_coordinator_disposal_drain
         {
             if (!Volatile.Read(ref counting)) return;
 
-            if (IsAdvisoryLockPollAbort(e.Exception))
+            if (DisposedPoolAborts.IsAdvisoryLockPollAbort(e.Exception))
             {
                 aborts.Enqueue(e.Exception.ToString());
             }
@@ -147,7 +123,7 @@ public class Bug_4915_coordinator_disposal_drain
         {
             if (!Volatile.Read(ref counting)) return;
 
-            if (IsAdvisoryLockPollAbort(e.Exception))
+            if (DisposedPoolAborts.IsAdvisoryLockPollAbort(e.Exception))
             {
                 aborts.Enqueue(e.Exception.ToString());
             }

--- a/src/CoreTests/DisposedPoolAborts.cs
+++ b/src/CoreTests/DisposedPoolAborts.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Diagnostics;
+
+namespace CoreTests;
+
+/// <summary>
+/// Shared detector for the one abort that #4874 and #4915 are about: the projection coordinator's leadership
+/// poll re-opening a connection against an already-disposed Npgsql pool.
+/// </summary>
+/// <remarks>
+/// Both regression tests hook <c>AppDomain.CurrentDomain.FirstChanceException</c>, which is AppDomain-wide.
+/// Counting every disposed-pool <see cref="ObjectDisposedException"/> in the process therefore sweeps up noise
+/// that has nothing to do with either bug:
+///
+///   * other tests leak background work -- daemon StopAllAsync, schema migrations, session reads -- that
+///     touches their own disposed data sources at arbitrary later times, and
+///   * <c>Weasel.Postgresql.AdvisoryLock.DisposeAsync</c> benignly releases a lock handle whose data source
+///     already went away, which Weasel swallows by design.
+///
+/// CoreTests runs serially, so this is not a parallelism problem and cannot be fixed with a collection
+/// attribute. Attribute the abort to the poll instead: <c>TryAttainLockAsync</c> touching a dead pool is the
+/// bug; anything else touching one is not. The exception's own <see cref="Exception.StackTrace"/> is not yet
+/// populated when the first-chance hook runs, so walk the throwing thread's live stack.
+/// </remarks>
+public static class DisposedPoolAborts
+{
+    public static bool IsAdvisoryLockPollAbort(Exception exception)
+    {
+        if (exception is not ObjectDisposedException ode) return false;
+
+        if (ode.ObjectName?.Contains("PoolingDataSource") != true &&
+            !ode.Message.Contains("PoolingDataSource"))
+        {
+            return false;
+        }
+
+        return new StackTrace(false).ToString().Contains("TryAttainLockAsync", StringComparison.Ordinal);
+    }
+}

--- a/src/Marten/Events/Daemon/Coordination/ProjectionCoordinator.cs
+++ b/src/Marten/Events/Daemon/Coordination/ProjectionCoordinator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using ImTools;
 using JasperFx.Core;
@@ -8,6 +9,7 @@ using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Marten.Storage;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Polly;
@@ -26,10 +28,11 @@ public class ProjectionCoordinator<T>: ProjectionCoordinator, IProjectionCoordin
 // JasperFx.Events.Daemon.ProjectionCoordinatorBase. Marten supplies the distributor +
 // settings via the base ctor and implements the daemon-resolution seams, keeping its
 // own ImHashMap + double-checked-lock daemon cache.
-public class ProjectionCoordinator: ProjectionCoordinatorBase, IProjectionCoordinator
+public class ProjectionCoordinator: ProjectionCoordinatorBase, IProjectionCoordinator, IAsyncDisposable, IDisposable
 {
     private readonly System.Threading.Lock _daemonLock = new();
     private readonly ILogger _logger;
+    private int _disposed;
 
     private ImHashMap<string, IProjectionDaemon> _daemons = ImHashMap<string, IProjectionDaemon>.Empty;
 
@@ -163,6 +166,57 @@ public class ProjectionCoordinator: ProjectionCoordinatorBase, IProjectionCoordi
     {
         var all = await Store.Storage.AllDatabases().ConfigureAwait(false);
         return all.OfType<MartenDatabase>().Select(findDaemonForDatabase).ToList();
+    }
+
+    /// <summary>
+    ///     Drain the leadership loop and release the advisory locks, for hosts that are disposed without a
+    ///     preceding <see cref="ProjectionCoordinatorBase.StopAsync" />.
+    /// </summary>
+    /// <remarks>
+    ///     #4915. <see cref="IHostedService" /> only promises a StopAsync on graceful shutdown, and
+    ///     <c>IHost.Dispose()</c> does not stop hosted services — so the very common <c>using var host = ...</c>
+    ///     shape tears the container down underneath a running coordinator. The container then disposes the
+    ///     DocumentStore and, with it, the owned NpgsqlDataSource, while the leadership loop is still polling
+    ///     <see cref="Weasel.Postgresql.AdvisoryLock.TryAttainLockAsync" /> on its cadence. Every poll opened a
+    ///     connection against a dead pool.
+    ///
+    ///     The coordinator is constructed from an <see cref="IDocumentStore" />, so the container always creates
+    ///     (and therefore always disposes) the store around this object: reverse-order disposal runs this first,
+    ///     while the data source is still alive and the locks can still be released cleanly.
+    ///
+    ///     Weasel 9.16.3 (weasel#354) independently makes a disposed data source terminal rather than an endless
+    ///     "lock held elsewhere", so the loop can no longer churn even if it does outlive its data source. This
+    ///     is the near side of that fix: don't let it outlive the data source in the first place.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) == 1) return;
+
+        GC.SuppressFinalize(this);
+
+        try
+        {
+            // Unconditional, even after a graceful StopAsync. StopAsync is idempotent -- a cancelled token
+            // source, a completed runner, and an emptied lock dictionary all no-op -- and there is no hook to
+            // tell "already stopped" from "stopped, then ResumeAsync started a fresh loop", since neither
+            // StartAsync nor ResumeAsync is virtual on the base. Skipping on a stale flag would leak the very
+            // loop this method exists to drain.
+            await StopAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while draining the ProjectionCoordinator during disposal");
+        }
+    }
+
+    /// <summary>
+    ///     Synchronous disposal, for containers torn down through <see cref="IDisposable" />. Blocks on
+    ///     <see cref="DisposeAsync" />; the leadership loop runs on the thread pool with no captured context, so
+    ///     there is nothing here for the continuation to deadlock against.
+    /// </summary>
+    public void Dispose()
+    {
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
     }
 
     private IProjectionDaemon findDaemonForDatabase(MartenDatabase database)


### PR DESCRIPTION
Closes #4915 (with JasperFx/weasel#354).

## The gap

`IHostedService` only promises a `StopAsync` on graceful shutdown, and `IHost.Dispose()` does not stop hosted services. `ProjectionCoordinator` implemented **no disposal at all**, so `using var host = ...` — and any teardown that disposes without stopping — tears the container down underneath a running coordinator. The container disposes the `DocumentStore` and its owned `NpgsqlDataSource`, while the HotCold leadership loop keeps polling `AdvisoryLock.TryAttainLockAsync` on its cadence against a pool that is already gone.

Measured on a cold node contending with a lock-holding hot node, counting disposed-pool `ObjectDisposedException`s in the 1.5s after teardown:

| teardown | aborts |
|---|---|
| `await host.StopAsync()` then `host.Dispose()` | **0** |
| `host.Dispose()` alone | **210** (~140/s, sustained for the life of the process) |

That asymmetry is the bug, and it explains the reporter's observation in #4915 that "once a poller is in the disposed-source state it keeps churning for the rest of the process". `Bug_4874_coordinator_drain_ordering` could never reach it, because it stops gracefully first.

## The change

`ProjectionCoordinator` is now `IAsyncDisposable`/`IDisposable` and drains the loop and releases the advisory locks.

Ordering is safe by construction: the coordinator is built from an `IDocumentStore`, so the container necessarily creates the store *before* it and therefore disposes it *after* — reverse-order disposal runs the drain while the data source is still alive and the locks can still be released cleanly. The tests confirm this (a wrong order would surface as aborts from `ReleaseAllLocks`).

The drain is **unconditional**, not skipped after a graceful `StopAsync`. Neither `StartAsync` nor `ResumeAsync` is `virtual` on `ProjectionCoordinatorBase`, so there is no hook to distinguish "already stopped" from "stopped, then `ResumeAsync` started a fresh loop" — and skipping on a stale flag leaks exactly the loop this exists to drain. `StopAsync` is idempotent, so the second call is free. I wrote that optimization first, and `disposal_drains_a_loop_that_resumeasync_restarted_after_a_stop` catches it: 210 aborts with the flag, 0 without.

## Tests

`Bug_4915_coordinator_disposal_drain`, two tests, both red before / green after (399 and 189 aborts pre-fix).

They attribute aborts to the `TryAttainLockAsync` path rather than counting every disposed-pool `ObjectDisposedException` in the process. `CoreTests` runs serially, but other tests leak background work (daemon `StopAllAsync`, schema migrations, session reads) that touches their own disposed data sources later, and `AdvisoryLock.DisposeAsync` benignly touches one as well. A bare global count picks all of that up — which is precisely why `Bug_4874_coordinator_drain_ordering` passes in isolation but fails in a full-suite run today. Worth fixing there the same way in a follow-up.

## Validation

Full `CoreTests` on a clean database, net9.0: **475 passed, 1 failed**. The one failure, `describing_database_usage_from_DefaultTenancy.create_usage`, fails identically on stock `master` in this environment and is unrelated. `DaemonTests.Internals`: 55/55, twice.

## Relationship to weasel#354

Independent fixes for the same failure, from opposite sides:

| | Weasel 9.16.2 | Weasel + weasel#354 |
|---|---|---|
| Marten stock | 210 | 9 |
| Marten + this PR | 0 | 0 |

The 9 is one poll's worth of async-frame rethrows before jasperfx#500's terminate-on-`ObjectDisposedException` catch ends the loop. This PR keeps the loop from outliving its data source; weasel#354 keeps a loop that does from churning. Neither depends on the other, and this PR does not require a Weasel bump.

Reported, diagnosed, and bisected by @steve-ziegler in #4915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)