### PR TITLE
test: honor marten_testing_database in describing_database_usage_from_DefaultTenancy

### DIFF
--- a/src/CoreTests/describing_database_usage_from_DefaultTenancy.cs
+++ b/src/CoreTests/describing_database_usage_from_DefaultTenancy.cs
@@ -5,6 +5,7 @@ using JasperFx.Core.Reflection;
 using JasperFx.Descriptors;
 using Marten.Storage;
 using Marten.Testing.Harness;
+using Npgsql;
 using Shouldly;
 using Xunit;
 
@@ -25,11 +26,18 @@ public class describing_database_usage_from_DefaultTenancy : IntegrationContext
 
         description.Cardinality.ShouldBe(DatabaseCardinality.Single);
 
-        // ignore this if you aren't using the Marten Docker compose file
-        description.MainDatabase.DatabaseName.ShouldBe("marten_testing");
+        // Derive the database and server from whatever the suite is actually pointed at, rather than hard
+        // coding the values in the Marten docker compose file. `marten_testing_database` is a documented way
+        // to run against a different database, and this was the one test that did not honor it.
+        var expected = new NpgsqlConnectionStringBuilder(ConnectionSource.ConnectionString);
+
+        description.MainDatabase.DatabaseName.ShouldBe(expected.Database);
+        description.MainDatabase.ServerName.ShouldBe(expected.Host);
+
+        // These two are properties of the store, not of the connection: DefaultStoreFixture leaves
+        // DatabaseSchemaName at its default, and the provider is always Postgres.
         description.MainDatabase.SchemaOrNamespace.ShouldBe("public");
         description.MainDatabase.Engine.ShouldBe("PostgreSQL");
-        description.MainDatabase.ServerName.ShouldBe("localhost");
 
         description.Databases.Any().ShouldBeFalse();
     }


### PR DESCRIPTION
Small test-only fix. Not a product bug.

## The problem

`create_usage` hard codes the database name and host from the Marten docker compose file:

```csharp
// ignore this if you aren't using the Marten Docker compose file
description.MainDatabase.DatabaseName.ShouldBe("marten_testing");
...
description.MainDatabase.ServerName.ShouldBe("localhost");
```

`marten_testing_database` is a documented way to point the suite at a different database, and this is the one test that doesn't honor it. Point the suite anywhere else and it fails with a puzzling `"marten_testing" should be, but was "<yours>"` — which reads like a real defect in `DescribeDatabasesAsync` rather than a test assumption. The comment acknowledges it, but a comment doesn't stop the red.

This matters more than it looks: running `CoreTests` against a scratch database is the only way to get a clean run (the shared `marten_testing` database accumulates state from other work, which produces a dozen unrelated migration/index failures), so anyone doing that hits this immediately.

## The change

Derive the database and server from `ConnectionSource.ConnectionString` via `NpgsqlConnectionStringBuilder`. `SchemaOrNamespace` and `Engine` stay literal — those are properties of the store and the provider, not of the connection.

## Validation

| connection | before | after |
|---|---|---|
| default `marten_testing` / `localhost` | pass | pass |
| alternate database on `127.0.0.1` | **fail** | pass |

Full `CoreTests` on a clean database, net9.0: `473 passed, 1 failed`. The one remaining failure is `Bug_4874_coordinator_drain_ordering`, which fails on pristine `master` in a full run for an unrelated reason (it counts every disposed-pool `ObjectDisposedException` in the process through the AppDomain-wide `FirstChanceException` hook). That one is fixed separately in #4923; this PR is independent of it.

Grepped for the same hard coding elsewhere — this is the only test that does it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)