### PR TITLE
JSONPath + containment strategies for collection Any()/All()/Contains() predicates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
     # SQL no longer requires it.
     build:
       context: ./docker/postgres
+    # Postgres 17 keeps ~46MB of dynamic shared memory standing at boot
+    # (dynamic_shared_memory_type=posix backs it with /dev/shm), so Docker's
+    # default 64MB shm leaves parallel queries almost no headroom and the test
+    # suite can fail with "53100: could not resize shared memory segment"
+    shm_size: '512mb'
     ports:
       - "5432:5432"
     environment:

--- a/docs/documents/querying/linq/child-collections.md
+++ b/docs/documents/querying/linq/child-collections.md
@@ -89,6 +89,30 @@ Finally, you can query for child collections that do **not** contain a value:
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Bugs/Bug_561_negation_of_query_on_contains.cs#L81-L84' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_negated-contains-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## How Marten Translates Collection Predicates <Badge type="tip" text="9.15" />
+
+Marten picks the most index-friendly SQL strategy it can for a `Where()` clause that filters
+against a child collection, in this order:
+
+| Predicate shape | SQL strategy | GIN index eligible? |
+| --- | --- | --- |
+| Equalities combined with `&&`, e.g. `x.Lines.Any(l => l.Name == "a" && l.Number == 2)` | JSONB containment: `data -> 'Lines' @> '[{"Name":"a","Number":2}]'` | Yes |
+| Equalities combined with `\|\|`, e.g. `x.Lines.Any(l => l.Name == "a" \|\| l.Name == "b")` | OR of containment filters (`BitmapOr` over the index) | Yes |
+| Other comparisons (`>`, `<`, `>=`, `<=`, `!=`) and mixes, e.g. `x.Lines.Any(l => l.Name == "a" && l.Number > 5)` | JSONPath: `jsonb_path_exists(d.data, '$.Lines[*] ? (@.Name == $val1 && @.Number > $val2)', :params)` | No, but a single scan with a cheap per-row predicate |
+| Anything else (string methods like `StartsWith()`, member-to-member comparisons, `DateTime` values) | Explodes the collection into a common table expression and correlates on `ctid` | No |
+
+A couple of practical notes:
+
+- The containment strategies compare against `data -> 'CollectionName'`, so a GIN index needs to
+  be an *expression* index on that same expression to be used, e.g.
+  `CREATE INDEX ON mt_doc_order USING gin ((data -> 'Lines') jsonb_path_ops)`. A whole-document
+  index from `GinIndexJsonData()` will not accelerate child collection containment.
+- The JSONPath strategy passes all comparison values through the `vars` argument of
+  `jsonb_path_exists()`, so the SQL stays fully parameterized and works with compiled queries.
+- JSONPath comparisons follow C# semantics more closely than the older
+  common-table-expression strategy did: comparing a `null` member with `!=` matches, and range
+  comparisons against `null` or missing members do not.
+
 ## Querying within Value IEnumerables
 
 As of now, Marten allows you to do "contains" searches within Arrays, Lists & ILists of primitive values like string or numbers:

--- a/docs/documents/querying/linq/child-collections.md
+++ b/docs/documents/querying/linq/child-collections.md
@@ -98,8 +98,12 @@ against a child collection, in this order:
 | --- | --- | --- |
 | Equalities combined with `&&`, e.g. `x.Lines.Any(l => l.Name == "a" && l.Number == 2)` | JSONB containment: `data -> 'Lines' @> '[{"Name":"a","Number":2}]'` | Yes |
 | Equalities combined with `\|\|`, e.g. `x.Lines.Any(l => l.Name == "a" \|\| l.Name == "b")` | OR of containment filters (`BitmapOr` over the index) | Yes |
+| `Contains()` of a whole element, e.g. `x.Lines.Contains(line)` | JSONB containment: `d.data @> '{"Lines":[{...serialized element...}]}'`. Note: matches elements *containing* every serialized member of the argument, so documents written with extra/evolved properties still match | Yes, including whole-document `GinIndexJsonData()` indexes |
 | Other comparisons (`>`, `<`, `>=`, `<=`, `!=`) and mixes, e.g. `x.Lines.Any(l => l.Name == "a" && l.Number > 5)` | JSONPath: `jsonb_path_exists(d.data, '$.Lines[*] ? (@.Name == $val1 && @.Number > $val2)', :params)` | No, but a single scan with a cheap per-row predicate |
-| Anything else (string methods like `StartsWith()`, member-to-member comparisons, `DateTime` values) | Explodes the collection into a common table expression and correlates on `ctid` | No |
+| Case-sensitive `StartsWith()` | JSONPath `starts with $var` — fully parameterized, works in compiled queries | No |
+| `Contains()`/`EndsWith()` on strings and case-insensitive comparisons | JSONPath `like_regex` with the (escaped) search text embedded in the SQL. **Not usable in compiled queries** — the value cannot be re-bound, and Marten fails loudly if you try | No |
+| `All(predicate)` for any jsonpath-capable predicate | `NOT jsonb_path_exists(d.data, '$.Lines[*] ? (!(...))')` — vacuously true on empty collections, and elements with null/missing members fail string predicates just like in LINQ-to-objects | No |
+| Anything else (member-to-member comparisons, `DateTime` values) | Explodes the collection into a common table expression and correlates on `ctid` | No |
 
 A couple of practical notes:
 

--- a/src/LinqTests/ChildCollections/jsonpath_any_filters.cs
+++ b/src/LinqTests/ChildCollections/jsonpath_any_filters.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Linq;
+using Marten.Testing.Harness;
+using Shouldly;
+
+namespace LinqTests.ChildCollections;
+
+/// <summary>
+///     Coverage for the jsonb_path_exists() and OR-of-containment strategies that
+///     replaced the "explode + ctid" sub-query for collection Any(predicate) filters
+///     that cannot become a single JSONB containment (@>) filter
+/// </summary>
+public class jsonpath_any_filters: IntegrationContext
+{
+    private List<JsonPathOrder> _orders;
+
+    public jsonpath_any_filters(DefaultStoreFixture fixture): base(fixture)
+    {
+    }
+
+    private async Task seedOrders()
+    {
+        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(JsonPathOrder));
+
+        var random = new Random(20260710);
+        _orders = new List<JsonPathOrder>();
+
+        for (var i = 0; i < 50; i++)
+        {
+            var lines = new List<JsonPathOrderLine>();
+            for (var j = 0; j < 5; j++)
+            {
+                lines.Add(new JsonPathOrderLine
+                {
+                    ItemName = $"item-{random.Next(0, 20)}",
+                    Number = random.Next(0, 101),
+                    Subs = new List<JsonPathSubLine>
+                    {
+                        new() { Amount = random.Next(0, 101) }, new() { Amount = random.Next(0, 101) }
+                    }
+                });
+            }
+
+            _orders.Add(new JsonPathOrder
+            {
+                Id = Guid.NewGuid(),
+                Lines = lines,
+                Quantities = Enumerable.Range(0, 4).Select(_ => random.Next(0, 101)).ToList()
+            });
+        }
+
+        // an element with a null member to pin down comparison-with-null semantics
+        _orders.Add(new JsonPathOrder
+        {
+            Id = Guid.NewGuid(),
+            Lines = new List<JsonPathOrderLine>
+            {
+                new() { ItemName = null, Number = 1, Subs = new List<JsonPathSubLine>() }
+            },
+            Quantities = new List<int>()
+        });
+
+        theSession.Store(_orders.ToArray());
+        await theSession.SaveChangesAsync();
+    }
+
+    private async Task assertMatchesInMemory(
+        Expression<Func<JsonPathOrder, bool>> filter,
+        Func<JsonPathOrder, bool> inMemory)
+    {
+        var expected = _orders.Where(inMemory).Select(x => x.Id).OrderBy(x => x).ToArray();
+        var actual = (await theSession.Query<JsonPathOrder>().Where(filter).ToListAsync())
+            .Select(x => x.Id).OrderBy(x => x).ToArray();
+
+        expected.Any().ShouldBeTrue(); // guard against vacuous assertions
+        actual.ShouldBe(expected);
+    }
+
+    private string sqlFor(Expression<Func<JsonPathOrder, bool>> filter)
+    {
+        return theSession.Query<JsonPathOrder>().Where(filter).ToCommand().CommandText;
+    }
+
+    [Fact]
+    public async Task inequality_predicate_uses_jsonpath_and_matches_in_memory()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l => l.Number > 90));
+        sql.ShouldContain("jsonb_path_exists");
+        sql.ShouldNotContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.Number > 90),
+            x => x.Lines.Any(l => l.Number > 90));
+    }
+
+    [Fact]
+    public async Task or_of_equalities_uses_or_of_containment()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l => l.ItemName == "item-3" || l.ItemName == "item-7"));
+        sql.ShouldContain("@>");
+        sql.ShouldContain(" or ");
+        sql.ShouldNotContain("jsonb_path_exists");
+        sql.ShouldNotContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.ItemName == "item-3" || l.ItemName == "item-7"),
+            x => x.Lines.Any(l => l.ItemName == "item-3" || l.ItemName == "item-7"));
+    }
+
+    [Fact]
+    public async Task or_with_anded_branch_uses_or_of_containment()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l =>
+            l.ItemName == "item-3" || (l.ItemName == "item-7" && l.Number == 42)));
+        sql.ShouldContain("@>");
+        sql.ShouldNotContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.ItemName == "item-3" || (l.ItemName == "item-7" && l.Number == 42)),
+            x => x.Lines.Any(l => l.ItemName == "item-3" || (l.ItemName == "item-7" && l.Number == 42)));
+    }
+
+    [Fact]
+    public async Task mixed_and_predicate_uses_jsonpath_with_containment_prefilter()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l => l.ItemName == "item-3" && l.Number > 50));
+        sql.ShouldContain("jsonb_path_exists");
+        sql.ShouldContain("&&");
+
+        // the equality conjunct also goes out as a redundant, GIN-eligible
+        // containment pre-filter
+        sql.ShouldContain("@>");
+        sql.ShouldNotContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.ItemName == "item-3" && l.Number > 50),
+            x => x.Lines.Any(l => l.ItemName == "item-3" && l.Number > 50));
+    }
+
+    [Fact]
+    public async Task doubly_nested_mixed_and_still_flattens()
+    {
+        await seedOrders();
+
+        // the nested filter must not get the containment pre-filter treatment,
+        // or the outer Any() could no longer flatten it into a single jsonpath
+        var sql = sqlFor(x => x.Lines.Any(l => l.Subs.Any(s => s.Amount > 90 && s.Amount != 95)));
+        sql.ShouldContain("jsonb_path_exists");
+        sql.ShouldContain("Lines[*].Subs[*]");
+        sql.ShouldNotContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.Subs.Any(s => s.Amount > 90 && s.Amount != 95)),
+            x => x.Lines.Any(l => l.Subs.Any(s => s.Amount > 90 && s.Amount != 95)));
+    }
+
+    [Fact]
+    public async Task mixed_and_in_compiled_query_rebinds_both_parameters()
+    {
+        await seedOrders();
+
+        var first = await theSession.QueryAsync(new OrdersWithItemOver("item-3", 50));
+        var second = await theSession.QueryAsync(new OrdersWithItemOver("item-7", 80));
+
+        var expectedFirst = _orders
+            .Where(x => x.Lines.Any(l => l.ItemName == "item-3" && l.Number > 50))
+            .Select(x => x.Id).OrderBy(x => x);
+        var expectedSecond = _orders
+            .Where(x => x.Lines.Any(l => l.ItemName == "item-7" && l.Number > 80))
+            .Select(x => x.Id).OrderBy(x => x);
+
+        first.Select(x => x.Id).OrderBy(x => x).ShouldBe(expectedFirst);
+        second.Select(x => x.Id).OrderBy(x => x).ShouldBe(expectedSecond);
+    }
+
+    public class OrdersWithItemOver: ICompiledListQuery<JsonPathOrder>
+    {
+        public OrdersWithItemOver()
+        {
+        }
+
+        public OrdersWithItemOver(string itemName, int threshold)
+        {
+            ItemName = itemName;
+            Threshold = threshold;
+        }
+
+        public string ItemName { get; set; } = "item-1";
+        public int Threshold { get; set; } = 10;
+
+        public Expression<Func<IMartenQueryable<JsonPathOrder>, IEnumerable<JsonPathOrder>>> QueryIs()
+        {
+            return q => q.Where(x => x.Lines.Any(l => l.ItemName == ItemName && l.Number > Threshold));
+        }
+    }
+
+    [Fact]
+    public async Task not_equal_predicate_uses_jsonpath_with_csharp_null_semantics()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l => l.ItemName != "item-3"));
+        sql.ShouldContain("jsonb_path_exists");
+
+        // The document whose only line has ItemName == null must match, exactly
+        // like LINQ-to-objects (null != "item-3"), which the old explode/ctid
+        // strategy got wrong by SQL three-valued logic
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.ItemName != "item-3"),
+            x => x.Lines.Any(l => l.ItemName != "item-3"));
+    }
+
+    [Fact]
+    public async Task negated_any_with_inequality_wraps_not()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => !x.Lines.Any(l => l.Number > 90));
+        sql.ShouldContain("NOT(jsonb_path_exists");
+
+        await assertMatchesInMemory(
+            x => !x.Lines.Any(l => l.Number > 90),
+            x => !x.Lines.Any(l => l.Number > 90));
+    }
+
+    [Fact]
+    public async Task value_collection_inequality_is_now_supported()
+    {
+        await seedOrders();
+
+        // used to throw BadLinqExpressionException("Marten does not (yet) support
+        // the > operator in element member queries")
+        var sql = sqlFor(x => x.Quantities.Any(q => q > 95));
+        sql.ShouldContain("jsonb_path_exists");
+
+        await assertMatchesInMemory(
+            x => x.Quantities.Any(q => q > 95),
+            x => x.Quantities.Any(q => q > 95));
+    }
+
+    [Fact]
+    public async Task value_collection_or_of_equalities_uses_or_of_containment()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Quantities.Any(q => q == 3 || q == 5));
+        sql.ShouldContain("@>");
+        sql.ShouldNotContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Quantities.Any(q => q == 3 || q == 5),
+            x => x.Quantities.Any(q => q == 3 || q == 5));
+    }
+
+    [Fact]
+    public async Task doubly_nested_any_flattens_into_one_jsonpath()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l => l.Subs.Any(s => s.Amount > 90)));
+        sql.ShouldContain("jsonb_path_exists");
+        sql.ShouldContain("Lines[*].Subs[*]");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.Subs.Any(s => s.Amount > 90)),
+            x => x.Lines.Any(l => l.Subs.Any(s => s.Amount > 90)));
+    }
+
+    [Fact]
+    public async Task equality_control_still_uses_containment()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l => l.ItemName == "item-3"));
+        sql.ShouldContain("@>");
+        sql.ShouldNotContain("jsonb_path_exists");
+        sql.ShouldNotContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.ItemName == "item-3"),
+            x => x.Lines.Any(l => l.ItemName == "item-3"));
+    }
+
+    [Fact]
+    public async Task string_method_control_still_uses_sub_query()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l => l.ItemName.StartsWith("item-1")));
+        sql.ShouldContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.ItemName.StartsWith("item-1")),
+            x => x.Lines.Any(l => l.ItemName != null && l.ItemName.StartsWith("item-1")));
+    }
+
+    [Fact]
+    public async Task jsonpath_filter_in_compiled_query_rebinds_values()
+    {
+        await seedOrders();
+
+        var over90 = await theSession.QueryAsync(new OrdersWithLineOver(90));
+        var over99 = await theSession.QueryAsync(new OrdersWithLineOver(99));
+
+        var expected90 = _orders.Where(x => x.Lines.Any(l => l.Number > 90)).Select(x => x.Id).OrderBy(x => x);
+        var expected99 = _orders.Where(x => x.Lines.Any(l => l.Number > 99)).Select(x => x.Id).OrderBy(x => x);
+
+        over90.Select(x => x.Id).OrderBy(x => x).ShouldBe(expected90);
+        over99.Select(x => x.Id).OrderBy(x => x).ShouldBe(expected99);
+    }
+
+    public class OrdersWithLineOver: ICompiledListQuery<JsonPathOrder>
+    {
+        public OrdersWithLineOver()
+        {
+        }
+
+        public OrdersWithLineOver(int threshold)
+        {
+            Threshold = threshold;
+        }
+
+        public int Threshold { get; set; } = 50;
+
+        public Expression<Func<IMartenQueryable<JsonPathOrder>, IEnumerable<JsonPathOrder>>> QueryIs()
+        {
+            return q => q.Where(x => x.Lines.Any(l => l.Number > Threshold));
+        }
+    }
+}
+
+public class JsonPathOrder
+{
+    public Guid Id { get; set; }
+    public List<JsonPathOrderLine> Lines { get; set; } = new();
+    public List<int> Quantities { get; set; } = new();
+}
+
+public class JsonPathOrderLine
+{
+    public string ItemName { get; set; }
+    public int Number { get; set; }
+    public List<JsonPathSubLine> Subs { get; set; } = new();
+}
+
+public class JsonPathSubLine
+{
+    public int Amount { get; set; }
+}

--- a/src/LinqTests/ChildCollections/jsonpath_any_filters.cs
+++ b/src/LinqTests/ChildCollections/jsonpath_any_filters.cs
@@ -295,16 +295,18 @@ public class jsonpath_any_filters: IntegrationContext
     }
 
     [Fact]
-    public async Task string_method_control_still_uses_sub_query()
+    public async Task member_to_member_control_still_uses_sub_query()
     {
         await seedOrders();
 
-        var sql = sqlFor(x => x.Lines.Any(l => l.ItemName.StartsWith("item-1")));
+        // member-vs-member comparisons have no jsonpath rendering (the right side is
+        // a locator, not a constant) and stay on the sub-query strategy
+        var sql = sqlFor(x => x.Lines.Any(l => l.Number > l.Subs.Count));
         sql.ShouldContain("ctid");
 
         await assertMatchesInMemory(
-            x => x.Lines.Any(l => l.ItemName.StartsWith("item-1")),
-            x => x.Lines.Any(l => l.ItemName != null && l.ItemName.StartsWith("item-1")));
+            x => x.Lines.Any(l => l.Number > l.Subs.Count),
+            x => x.Lines.Any(l => l.Number > l.Subs.Count));
     }
 
     [Fact]
@@ -347,6 +349,7 @@ public class JsonPathOrder
     public Guid Id { get; set; }
     public List<JsonPathOrderLine> Lines { get; set; } = new();
     public List<int> Quantities { get; set; } = new();
+    public List<string> Tags { get; set; } = new();
 }
 
 public class JsonPathOrderLine

--- a/src/LinqTests/ChildCollections/jsonpath_string_all_contains_filters.cs
+++ b/src/LinqTests/ChildCollections/jsonpath_string_all_contains_filters.cs
@@ -1,0 +1,441 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Exceptions;
+using Marten.Linq;
+using Marten.Testing.Harness;
+using Shouldly;
+
+namespace LinqTests.ChildCollections;
+
+/// <summary>
+///     Coverage for the second wave of jsonpath strategies: string methods
+///     (starts with / like_regex), Contains() of complex elements via containment,
+///     and All(predicate) via negated jsonb_path_exists
+/// </summary>
+public class jsonpath_string_all_contains_filters: IntegrationContext
+{
+    private List<JsonPathOrder> _orders;
+
+    public jsonpath_string_all_contains_filters(DefaultStoreFixture fixture): base(fixture)
+    {
+    }
+
+    private async Task seedOrders()
+    {
+        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(JsonPathOrder));
+
+        var random = new Random(20260711);
+        _orders = new List<JsonPathOrder>();
+
+        for (var i = 0; i < 40; i++)
+        {
+            var lines = new List<JsonPathOrderLine>();
+            for (var j = 0; j < 5; j++)
+            {
+                lines.Add(new JsonPathOrderLine
+                {
+                    ItemName = $"item-{random.Next(0, 20)}",
+                    Number = random.Next(0, 101),
+                    Subs = new List<JsonPathSubLine>
+                    {
+                        new() { Amount = random.Next(0, 101) }, new() { Amount = random.Next(0, 101) }
+                    }
+                });
+            }
+
+            // a few docs carry the sentinel line used by the complex Contains() test
+            if (i % 10 == 0)
+            {
+                lines.Add(new JsonPathOrderLine
+                {
+                    ItemName = "sentinel", Number = -1, Subs = new List<JsonPathSubLine>()
+                });
+            }
+
+            _orders.Add(new JsonPathOrder
+            {
+                Id = Guid.NewGuid(),
+                Lines = lines,
+                Tags = Enumerable.Range(0, 3).Select(_ => $"tag-{random.Next(0, 10)}").ToList()
+            });
+        }
+
+        // a line with a null member — comparison-with-null semantics; also a null
+        // entry inside a scalar string collection
+        _orders.Add(new JsonPathOrder
+        {
+            Id = Guid.NewGuid(),
+            Lines = new List<JsonPathOrderLine>
+            {
+                new() { ItemName = null, Number = 1, Subs = new List<JsonPathSubLine>() }
+            },
+            Tags = new List<string> { "tag-1", null }
+        });
+
+        // an empty collection — All() must be vacuously true
+        _orders.Add(new JsonPathOrder { Id = Guid.NewGuid(), Lines = new List<JsonPathOrderLine>() });
+
+        // regex metacharacters, quotes, and backslashes — escaping coverage
+        _orders.Add(new JsonPathOrder
+        {
+            Id = Guid.NewGuid(),
+            Lines = new List<JsonPathOrderLine>
+            {
+                new() { ItemName = "we!rd (item) 50%", Number = 3, Subs = new List<JsonPathSubLine>() },
+                new() { ItemName = "it'em ok", Number = 4, Subs = new List<JsonPathSubLine>() },
+                new() { ItemName = "he said \"hi\" \\path", Number = 5, Subs = new List<JsonPathSubLine>() }
+            }
+        });
+
+        // uniform names so All(name == ...) is non-vacuous
+        _orders.Add(new JsonPathOrder
+        {
+            Id = Guid.NewGuid(),
+            Lines = Enumerable.Range(60, 4).Select(n => new JsonPathOrderLine
+            {
+                ItemName = "uniform", Number = n, Subs = new List<JsonPathSubLine>()
+            }).ToList()
+        });
+
+        // mixed casing for the case-insensitive tests
+        _orders.Add(new JsonPathOrder
+        {
+            Id = Guid.NewGuid(),
+            Lines = new List<JsonPathOrderLine>
+            {
+                new() { ItemName = "ITEM-MiXeD", Number = 42, Subs = new List<JsonPathSubLine>() }
+            }
+        });
+
+        theSession.Store(_orders.ToArray());
+        await theSession.SaveChangesAsync();
+    }
+
+    private async Task assertMatchesInMemory(
+        Expression<Func<JsonPathOrder, bool>> filter,
+        Func<JsonPathOrder, bool> inMemory)
+    {
+        var expected = _orders.Where(inMemory).Select(x => x.Id).OrderBy(x => x).ToArray();
+        var actual = (await theSession.Query<JsonPathOrder>().Where(filter).ToListAsync())
+            .Select(x => x.Id).OrderBy(x => x).ToArray();
+
+        expected.Any().ShouldBeTrue(); // guard against vacuous assertions
+        actual.ShouldBe(expected);
+    }
+
+    private string sqlFor(Expression<Func<JsonPathOrder, bool>> filter)
+    {
+        return theSession.Query<JsonPathOrder>().Where(filter).ToCommand().CommandText;
+    }
+
+    [Fact]
+    public async Task starts_with_uses_parameterized_jsonpath()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l => l.ItemName.StartsWith("item-1")));
+        sql.ShouldContain("jsonb_path_exists");
+        sql.ShouldContain("starts with $");
+        sql.ShouldNotContain("ctid");
+        sql.ShouldNotContain("like_regex");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.ItemName.StartsWith("item-1")),
+            x => x.Lines.Any(l => l.ItemName != null && l.ItemName.StartsWith("item-1")));
+    }
+
+    [Fact]
+    public async Task starts_with_ignore_case_uses_like_regex()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l => l.ItemName.StartsWith("item-m", StringComparison.OrdinalIgnoreCase)));
+        sql.ShouldContain("like_regex");
+        sql.ShouldContain("flag \"i\"");
+        sql.ShouldNotContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.ItemName.StartsWith("item-m", StringComparison.OrdinalIgnoreCase)),
+            x => x.Lines.Any(l =>
+                l.ItemName != null && l.ItemName.StartsWith("item-m", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
+    public async Task contains_uses_like_regex_and_escapes_metacharacters()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l => l.ItemName.Contains("(item)")));
+        sql.ShouldContain("like_regex");
+        sql.ShouldNotContain("ctid");
+
+        // "(item)" must match literally, not as a regex group
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.ItemName.Contains("(item)")),
+            x => x.Lines.Any(l => l.ItemName != null && l.ItemName.Contains("(item)")));
+    }
+
+    [Fact]
+    public async Task string_values_with_quotes_and_backslashes_are_safe()
+    {
+        await seedOrders();
+
+        // single quote inside the search value
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.ItemName.Contains("it'em")),
+            x => x.Lines.Any(l => l.ItemName != null && l.ItemName.Contains("it'em")));
+
+        // double quote and backslash inside the search value
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.ItemName.Contains("said \"hi\" \\path")),
+            x => x.Lines.Any(l => l.ItemName != null && l.ItemName.Contains("said \"hi\" \\path")));
+
+        // no match at all should still run cleanly (no SQL syntax explosion)
+        var none = await theSession.Query<JsonPathOrder>()
+            .Where(x => x.Lines.Any(l => l.ItemName.Contains("nope'; drop table students; --")))
+            .ToListAsync();
+        none.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ends_with_uses_anchored_like_regex()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l => l.ItemName.EndsWith("-19")));
+        sql.ShouldContain("like_regex");
+        sql.ShouldContain("$\"");
+        sql.ShouldNotContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.ItemName.EndsWith("-19")),
+            x => x.Lines.Any(l => l.ItemName != null && l.ItemName.EndsWith("-19")));
+    }
+
+    [Fact]
+    public async Task mixed_string_and_numeric_predicate_is_one_jsonpath()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l => l.ItemName.StartsWith("item-1") && l.Number > 50));
+        sql.ShouldContain("jsonb_path_exists");
+        sql.ShouldContain("&&");
+        sql.ShouldNotContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.ItemName.StartsWith("item-1") && l.Number > 50),
+            x => x.Lines.Any(l => l.ItemName != null && l.ItemName.StartsWith("item-1") && l.Number > 50));
+    }
+
+    [Fact]
+    public async Task compiled_query_with_starts_with_rebinds()
+    {
+        await seedOrders();
+
+        var one = await theSession.QueryAsync(new OrdersWithLineStartingWith("item-1"));
+        var two = await theSession.QueryAsync(new OrdersWithLineStartingWith("uni"));
+
+        var expectedOne = _orders
+            .Where(x => x.Lines.Any(l => l.ItemName != null && l.ItemName.StartsWith("item-1")))
+            .Select(x => x.Id).OrderBy(x => x);
+        var expectedTwo = _orders
+            .Where(x => x.Lines.Any(l => l.ItemName != null && l.ItemName.StartsWith("uni")))
+            .Select(x => x.Id).OrderBy(x => x);
+
+        one.Select(x => x.Id).OrderBy(x => x).ShouldBe(expectedOne);
+        two.Select(x => x.Id).OrderBy(x => x).ShouldBe(expectedTwo);
+    }
+
+    [Fact]
+    public async Task compiled_query_with_contains_fails_loudly()
+    {
+        await seedOrders();
+
+        // the search text is embedded in the SQL literal, so a compiled query could
+        // never re-bind it — this must be a descriptive error, not silently stale SQL
+        var ex = await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+        {
+            await theSession.QueryAsync(new OrdersWithLineContaining("item"));
+        });
+
+        ex.Message.ShouldContain("compiled query");
+    }
+
+    [Fact]
+    public async Task complex_element_contains_uses_containment()
+    {
+        await seedOrders();
+
+        var sentinel = new JsonPathOrderLine { ItemName = "sentinel", Number = -1, Subs = new List<JsonPathSubLine>() };
+        var sql = sqlFor(x => x.Lines.Contains(sentinel));
+        sql.ShouldContain("@>");
+        sql.ShouldNotContain("ctid");
+
+        // structural comparison in memory — Contains() by reference would never match
+        await assertMatchesInMemory(
+            x => x.Lines.Contains(sentinel),
+            x => x.Lines.Any(l => l.ItemName == "sentinel" && l.Number == -1));
+    }
+
+    [Fact]
+    public async Task all_with_inequality_uses_negated_jsonpath()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.All(l => l.Number > 10));
+        sql.ShouldContain("NOT(jsonb_path_exists");
+        sql.ShouldContain("!(");
+        sql.ShouldNotContain("ctid");
+
+        // the empty-Lines doc must match: All() is vacuously true
+        await assertMatchesInMemory(
+            x => x.Lines.All(l => l.Number > 10),
+            x => x.Lines.All(l => l.Number > 10));
+    }
+
+    [Fact]
+    public async Task negated_all_reverses_cleanly()
+    {
+        await seedOrders();
+
+        await assertMatchesInMemory(
+            x => !x.Lines.All(l => l.Number > 10),
+            x => !x.Lines.All(l => l.Number > 10));
+    }
+
+    [Fact]
+    public async Task all_with_equality_now_uses_jsonpath()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.All(l => l.ItemName == "uniform"));
+        sql.ShouldContain("NOT(jsonb_path_exists");
+
+        await assertMatchesInMemory(
+            x => x.Lines.All(l => l.ItemName == "uniform"),
+            x => x.Lines.All(l => l.ItemName == "uniform"));
+    }
+
+    [Fact]
+    public async Task all_with_string_method()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.All(l => l.ItemName.StartsWith("item")));
+        sql.ShouldContain("NOT(jsonb_path_exists");
+        sql.ShouldContain("starts with $");
+
+        // a null ItemName element fails the predicate on both sides
+        await assertMatchesInMemory(
+            x => x.Lines.All(l => l.ItemName.StartsWith("item")),
+            x => x.Lines.All(l => l.ItemName != null && l.ItemName.StartsWith("item")));
+    }
+
+    [Fact]
+    public async Task all_with_null_check_still_uses_legacy_path()
+    {
+        await seedOrders();
+
+        // IsNullFilter is not jsonpath-capable — must keep working via the legacy shapes
+        var docs = await theSession.Query<JsonPathOrder>()
+            .Where(x => x.Lines.All(l => l.ItemName == null))
+            .ToListAsync();
+
+        var expected = _orders
+            .Where(x => x.Lines.Any() && x.Lines.All(l => l.ItemName == null))
+            .Select(x => x.Id).OrderBy(x => x).ToArray();
+
+        expected.Any().ShouldBeTrue();
+        // legacy AllMembersAreNullFilter is not vacuously true on empty collections,
+        // so compare only against docs that have lines
+        docs.Select(x => x.Id).OrderBy(x => x).ToArray()
+            .Except(expected).Count().ShouldBeLessThanOrEqualTo(1);
+        expected.Except(docs.Select(x => x.Id)).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task scalar_string_collection_starts_with()
+    {
+        await seedOrders();
+
+        // Bug_834 regression shape: the element IS the string, so the jsonpath
+        // reference must be the bare @, not "@."
+        var sql = sqlFor(x => x.Tags.Any(t => t.StartsWith("tag-1")));
+        sql.ShouldContain("jsonb_path_exists");
+        sql.ShouldContain("(@ starts with $");
+
+        await assertMatchesInMemory(
+            x => x.Tags.Any(t => t.StartsWith("tag-1")),
+            x => x.Tags.Any(t => t != null && t.StartsWith("tag-1")));
+    }
+
+    [Fact]
+    public async Task scalar_string_collection_all_with_null_entry()
+    {
+        await seedOrders();
+
+        // the doc with a null tag entry must NOT satisfy All() — the type() guard
+        // makes the null element fail the predicate like it does in memory
+        await assertMatchesInMemory(
+            x => x.Tags.All(t => t.StartsWith("tag")),
+            x => x.Tags.All(t => t != null && t.StartsWith("tag")));
+    }
+
+    [Fact]
+    public async Task nested_all_inside_any_does_not_flatten()
+    {
+        await seedOrders();
+
+        var sql = sqlFor(x => x.Lines.Any(l => l.Subs.All(s => s.Amount > 5)));
+
+        // flattening NOT(exists($.Lines[*].Subs[*] ...)) would assert over every
+        // line's subs — this must stay a sub-query instead
+        sql.ShouldContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.Subs.All(s => s.Amount > 5)),
+            x => x.Lines.Any(l => l.Subs.All(s => s.Amount > 5)));
+    }
+
+    public class OrdersWithLineStartingWith: ICompiledListQuery<JsonPathOrder>
+    {
+        public OrdersWithLineStartingWith()
+        {
+        }
+
+        public OrdersWithLineStartingWith(string prefix)
+        {
+            Prefix = prefix;
+        }
+
+        public string Prefix { get; set; } = "a";
+
+        public Expression<Func<IMartenQueryable<JsonPathOrder>, IEnumerable<JsonPathOrder>>> QueryIs()
+        {
+            return q => q.Where(x => x.Lines.Any(l => l.ItemName.StartsWith(Prefix)));
+        }
+    }
+
+    public class OrdersWithLineContaining: ICompiledListQuery<JsonPathOrder>
+    {
+        public OrdersWithLineContaining()
+        {
+        }
+
+        public OrdersWithLineContaining(string fragment)
+        {
+            Fragment = fragment;
+        }
+
+        public string Fragment { get; set; } = "a";
+
+        public Expression<Func<IMartenQueryable<JsonPathOrder>, IEnumerable<JsonPathOrder>>> QueryIs()
+        {
+            return q => q.Where(x => x.Lines.Any(l => l.ItemName.Contains(Fragment)));
+        }
+    }
+}

--- a/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
+++ b/src/Marten/Internal/CompiledQueries/CompiledQueryPlan.cs
@@ -398,6 +398,16 @@ public class CompiledQueryPlan : ICommandBuilder
 
     public void MatchParameters(StoreOptions options, ICompiledQueryAwareFilter[] filters)
     {
+        // A filter can carry more than one member value inside a single parameter
+        // (jsonpath vars payloads, containment dictionaries), but the loop below
+        // stops at the first member that matches each parameter. Let every filter
+        // see every member value first so all of its captured values get associated
+        // with the right query member. TryMatchValue marking is idempotent.
+        foreach (var queryMember in QueryMembers)
+        {
+            queryMember.MarkFilterUsages(options, filters);
+        }
+
         foreach (var commandPlan in _commands)
         {
             foreach (var usage in commandPlan.Parameters)

--- a/src/Marten/Internal/CompiledQueries/IQueryMember.cs
+++ b/src/Marten/Internal/CompiledQueries/IQueryMember.cs
@@ -17,6 +17,15 @@ public interface IQueryMember
     bool TryMatch(NpgsqlParameter parameter, StoreOptions options, ICompiledQueryAwareFilter[] filters,
         out ICompiledQueryAwareFilter filter);
 
+    /// <summary>
+    ///     Offer this member's canned template value to every filter so that filters
+    ///     carrying multiple member values inside a single parameter (jsonpath vars
+    ///     payloads, containment dictionaries) can associate each of their captured
+    ///     values with the right query member. Parameter matching alone only pairs
+    ///     one member with one parameter.
+    /// </summary>
+    void MarkFilterUsages(StoreOptions options, ICompiledQueryAwareFilter[] filters);
+
     void TryWriteValue(UniqueValueSource valueSource, object query);
     object GetValueAsObject(object query);
 }

--- a/src/Marten/Internal/CompiledQueries/QueryMember.cs
+++ b/src/Marten/Internal/CompiledQueries/QueryMember.cs
@@ -43,16 +43,33 @@ internal abstract class QueryMember<T>: IQueryMember<T>
     public bool TryMatch(NpgsqlParameter parameter, StoreOptions options, ICompiledQueryAwareFilter[] filters,
         out ICompiledQueryAwareFilter filter)
     {
-        if (Type.IsEnum)
-        {
-            var parameterValue = options.Serializer().EnumStorage == EnumStorage.AsInteger
-                ? Value.As<int>()
-                : (object)Value.ToString();
+        return tryToFind(parameter, filters, comparableValue(options), out filter);
+    }
 
-            return tryToFind(parameter, filters, parameterValue, out filter);
+    public void MarkFilterUsages(StoreOptions options, ICompiledQueryAwareFilter[] filters)
+    {
+        var value = comparableValue(options);
+        if (value == null)
+        {
+            return;
         }
 
-        return tryToFind(parameter, filters, Value, out filter);
+        foreach (var filter in filters)
+        {
+            filter.TryMatchValue(value, Member);
+        }
+    }
+
+    private object comparableValue(StoreOptions options)
+    {
+        if (Type.IsEnum)
+        {
+            return options.Serializer().EnumStorage == EnumStorage.AsInteger
+                ? Value.As<int>()
+                : Value.ToString();
+        }
+
+        return Value;
     }
 
     public void TryWriteValue(UniqueValueSource valueSource, object query)

--- a/src/Marten/Linq/Members/ChildCollectionMember.cs
+++ b/src/Marten/Linq/Members/ChildCollectionMember.cs
@@ -119,6 +119,17 @@ public class ChildCollectionMember: QueryableMember, ICollectionMember, IQueryab
             var parser = new WhereClauseParser(_options, this, filter);
             parser.Visit(body);
 
+            // All(pred) == NOT EXISTS an element failing pred, which jsonb_path_exists
+            // renders in one scan for any jsonpath-capable predicate. The legacy
+            // AllCollectionConditionFilter shapes stay as the fallback (null checks,
+            // DateTime values)
+            if (filter.Wheres.Count == 1 &&
+                JsonPathExistsFilter.TryBuildForAll(filter.Wheres.Single(), this, options.Serializer(),
+                    out var jsonPath))
+            {
+                return jsonPath;
+            }
+
             filter.Compile(method);
 
             return filter;
@@ -133,6 +144,16 @@ public class ChildCollectionMember: QueryableMember, ICollectionMember, IQueryab
 
     public ISqlFragment ParseWhereForContains(MethodCallExpression body, IReadOnlyStoreOptions options)
     {
+        // Contains(complexObject) is exactly what JSONB containment does best. Note the
+        // containment semantics: an element matches when it contains every serialized
+        // member of the argument, so documents written with extra/evolved properties
+        // still match
+        var constant = body.Arguments.Last().ReduceToConstant();
+        if (constant.Value() != null)
+        {
+            return ContainmentWhereFilter.ForValue(this, constant.Value()!, options.Serializer());
+        }
+
         throw new BadLinqExpressionException(
             "Marten does not (yet) support contains queries through collections of element type " +
             ElementType.FullNameInCode());

--- a/src/Marten/Linq/Members/ChildCollectionWhereClause.cs
+++ b/src/Marten/Linq/Members/ChildCollectionWhereClause.cs
@@ -1,7 +1,9 @@
 #nullable enable
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JasperFx.Core;
+using Marten.Linq.Members.ValueCollections;
 using Marten.Linq.SqlGeneration.Filters;
 using Weasel.Postgresql.SqlGeneration;
 
@@ -67,6 +69,117 @@ internal class ChildCollectionWhereClause: IWhereFragmentHolder
             return filter;
         }
 
+        // The strategies below only apply to JSONB-backed collections. Duplicated
+        // array fields and dictionary members have their own storage semantics and
+        // keep the sub-query strategy
+        if (collectionMember is ChildCollectionMember or ValueCollectionMember)
+        {
+            // An OR spray of containment-eligible predicates beats a jsonpath filter
+            // because each branch stays eligible for a GIN index (BitmapOr)
+            if (tryBuildOrOfContainment(_fragment, collectionMember, serializer, out var orContainment))
+            {
+                return orContainment;
+            }
+
+            if (JsonPathExistsFilter.TryBuild(_fragment, collectionMember, serializer, out var jsonPath))
+            {
+                // Mixed AND (equality + something else): the equality conjuncts also go
+                // out as a logically redundant containment pre-filter so a GIN index can
+                // prune before the jsonpath predicate runs. Only at the document root —
+                // a nested filter must stay a single ICollectionAwareFilter so that an
+                // outer Any() can flatten it via MoveUnder()
+                if (collectionMember.Ancestors[0] is DocumentQueryableMemberCollection &&
+                    tryBuildContainmentPrefilter(_fragment, collectionMember, serializer, out var prefilter))
+                {
+                    return CompoundWhereFragment.And(prefilter, jsonPath);
+                }
+
+                return jsonPath;
+            }
+        }
+
         return new SubQueryFilter(collectionMember, _fragment);
+    }
+
+    private static bool tryBuildContainmentPrefilter(ISqlFragment fragment, ICollectionMember collectionMember,
+        ISerializer serializer, [NotNullWhen(true)]out ISqlFragment? prefilter)
+    {
+        prefilter = default;
+
+        if (fragment is not CompoundWhereFragment compound || !compound.Separator.ContainsIgnoreCase("and"))
+        {
+            return false;
+        }
+
+        var eligible = compound.Children
+            .OfType<ICollectionAware>()
+            .Where(x => x.CanReduceInChildCollection() && x.SupportsContainment())
+            .ToArray();
+
+        if (!eligible.Any())
+        {
+            return false;
+        }
+
+        var containment = new ContainmentWhereFilter(collectionMember, serializer)
+        {
+            Usage = ContainmentUsage.Collection
+        };
+        foreach (var child in eligible)
+        {
+            child.PlaceIntoContainmentFilter(containment);
+        }
+
+        prefilter = containment;
+        return true;
+    }
+
+    private static bool tryBuildOrOfContainment(ISqlFragment fragment, ICollectionMember collectionMember,
+        ISerializer serializer, [NotNullWhen(true)]out ISqlFragment? filter)
+    {
+        filter = default;
+
+        if (fragment is not CompoundWhereFragment compound || compound.Separator.ContainsIgnoreCase("and"))
+        {
+            return false;
+        }
+
+        var branches = new List<ISqlFragment>();
+        foreach (var child in compound.Children)
+        {
+            switch (child)
+            {
+                // ElementComparisonFilter reduces to its own single-value containment for
+                // = / != even though it reports SupportsContainment() == false (it cannot
+                // be merged with siblings), so CanReduceInChildCollection() is the gate here
+                case ICollectionAware aware when aware.CanReduceInChildCollection() &&
+                                                 (aware.SupportsContainment() || aware is ElementComparisonFilter):
+                    branches.Add(aware.BuildFragment(collectionMember, serializer));
+                    break;
+
+                case CompoundWhereFragment inner when inner.Separator.ContainsIgnoreCase("and") &&
+                                                      inner.Children.Any() &&
+                                                      inner.Children.All(x =>
+                                                          x is ICollectionAware ia &&
+                                                          ia.CanReduceInChildCollection() && ia.SupportsContainment()):
+                    var containment = new ContainmentWhereFilter(collectionMember, serializer)
+                    {
+                        Usage = ContainmentUsage.Collection
+                    };
+                    foreach (var ia in inner.Children.OfType<ICollectionAware>())
+                    {
+                        ia.PlaceIntoContainmentFilter(containment);
+                    }
+
+                    branches.Add(containment);
+                    break;
+
+                default:
+                    return false;
+            }
+        }
+
+        filter = CompoundWhereFragment.Or(branches.ToArray());
+        return true;
     }
 }

--- a/src/Marten/Linq/Members/ValueCollections/ElementComparisonFilter.cs
+++ b/src/Marten/Linq/Members/ValueCollections/ElementComparisonFilter.cs
@@ -28,6 +28,9 @@ internal class ElementComparisonFilter: ISqlFragment, ICollectionAware
 
     bool ICollectionAware.CanReduceInChildCollection()
     {
+        // Only = and != can become containment filters; other operators flow on
+        // to the jsonpath strategy instead of BuildFragment() blowing up
+        if (Op != "=" && Op != "!=") return false;
         if (Value == null) return false;
         if (Value.GetType().IsDateTime()) return false;
         if (Value is DateTimeOffset || Value is DateTimeOffset?) return false;

--- a/src/Marten/Linq/Members/ValueCollections/ElementComparisonFilter.cs
+++ b/src/Marten/Linq/Members/ValueCollections/ElementComparisonFilter.cs
@@ -69,7 +69,7 @@ internal class ElementComparisonFilter: ISqlFragment, ICollectionAware
         var parameter = parameters.AddJsonPathParameter(Value);
 
         builder.Append("@ ");
-        builder.Append(Op);
+        builder.Append(Op.CorrectJsonPathOperator());
         builder.Append(" ");
         builder.Append(parameter);
     }

--- a/src/Marten/Linq/Members/ValueCollections/ValueCollectionMember.cs
+++ b/src/Marten/Linq/Members/ValueCollections/ValueCollectionMember.cs
@@ -90,6 +90,29 @@ public class ValueCollectionMember: QueryableMember, ICollectionMember, IValueCo
 
     public ISqlFragment ParseWhereForAll(MethodCallExpression expression, IReadOnlyStoreOptions options)
     {
+        // Try the jsonpath strategy first for predicates beyond simple equality
+        // (inequalities, string methods). Null comparisons throw during element
+        // parsing, so those fall through to the legacy constant-based filters below
+        if (expression.Arguments.Last() is LambdaExpression l)
+        {
+            try
+            {
+                var whereClause = new ChildCollectionWhereClause();
+                var parser = new WhereClauseParser((StoreOptions)options, this, whereClause);
+                parser.Visit(l.Body);
+
+                if (whereClause.Fragment != null && JsonPathExistsFilter.TryBuildForAll(whereClause.Fragment, this,
+                        options.Serializer(), out var jsonPath))
+                {
+                    return jsonPath;
+                }
+            }
+            catch (BadLinqExpressionException)
+            {
+                // fall through to the legacy parsing
+            }
+        }
+
         var constant = expression.Arguments[1].ReduceToConstant();
 
         if (constant.Value() == null) return new AllValuesAreNullFilter(this);

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringComparisonParser.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringComparisonParser.cs
@@ -3,9 +3,11 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using JasperFx.Core;
 using Marten.Exceptions;
 using Marten.Linq.Members;
 using NpgsqlTypes;
+using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.Parsing.Methods.Strings;
@@ -98,5 +100,42 @@ internal abstract class StringComparisonParser: IMethodCallParser
         return raw.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
     }
 
+    /// <summary>
+    ///     Writes the jsonpath reference for a member inside a collection filter:
+    ///     "@.Member.Path" for element members, or the bare "@" when the collection
+    ///     element itself is the value being compared (scalar string collections)
+    /// </summary>
+    internal static void WriteJsonPathReference(IQueryableMember member, ICommandBuilder builder)
+    {
+        // a scalar collection element IS the value under test — its JsonPathSegment
+        // ("data") is only meaningful for the explode/unnest strategy
+        if (member is Marten.Linq.Members.ValueCollections.SimpleElementMember)
+        {
+            builder.Append("@");
+            return;
+        }
+
+        var path = member.WriteJsonPath();
+        builder.Append("@");
+        if (path.IsNotEmpty())
+        {
+            builder.Append(".");
+            builder.Append(path);
+        }
+    }
+
+    /// <summary>
+    ///     Prepares a raw search value for embedding inside a like_regex "..." pattern
+    ///     that itself lives inside a single-quoted SQL jsonpath literal. Regex-escapes
+    ///     first, then escapes for the jsonpath string literal (backslash, double quote),
+    ///     then doubles single quotes for the enclosing SQL string.
+    /// </summary>
+    public static string EscapeForJsonPathRegex(string raw)
+    {
+        return System.Text.RegularExpressions.Regex.Escape(raw)
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("'", "''");
+    }
 }
 

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringContains.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringContains.cs
@@ -1,10 +1,12 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JasperFx.Core.Reflection;
 using Marten.Internal.CompiledQueries;
 using Marten.Linq.Members;
+using Marten.Linq.SqlGeneration.Filters;
 using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
@@ -37,7 +39,8 @@ internal class StringContains: StringComparisonParser
     }
 }
 
-internal class StringContainsFilter: ISqlFragment, ICompiledQueryAwareFilter
+internal class StringContainsFilter: ISqlFragment, ICompiledQueryAwareFilter, ICollectionAware,
+    IInlinedJsonPathValueFilter, INegationGuardedJsonPathFilter
 {
     private readonly bool _caseInsensitive;
     private readonly IQueryableMember _member;
@@ -85,4 +88,47 @@ internal class StringContainsFilter: ISqlFragment, ICompiledQueryAwareFilter
     }
 
     public string ParameterName { get; private set; }
+
+    // like_regex patterns cannot come from the vars parameter
+    bool IInlinedJsonPathValueFilter.JsonPathValueIsInlined => true;
+
+    public bool CanReduceInChildCollection() => false;
+
+    public ICollectionAwareFilter BuildFragment(ICollectionMember member, ISerializer serializer)
+    {
+        throw new NotSupportedException();
+    }
+
+    public bool SupportsContainment() => false;
+
+    public void PlaceIntoContainmentFilter(ContainmentWhereFilter filter)
+    {
+        throw new NotSupportedException();
+    }
+
+    public bool CanBeJsonPathFilter() => _rawValue != null;
+
+    public void BuildJsonPathFilter(ICommandBuilder builder, Dictionary<string, object> parameters)
+    {
+        StringComparisonParser.WriteJsonPathReference(_member, builder);
+        builder.Append(" like_regex \"");
+        builder.Append(StringComparisonParser.EscapeForJsonPathRegex(_rawValue));
+        builder.Append(_caseInsensitive ? "\" flag \"i\"" : "\"");
+    }
+
+    public IEnumerable<DictionaryValueUsage> Values()
+    {
+        yield return new DictionaryValueUsage(_rawValue);
+    }
+
+    // "not containing" must also match elements whose member is null or missing —
+    // jsonpath string ops evaluate to UNKNOWN there, so guard on the value type first
+    public void BuildNegatedJsonPathFilter(ICommandBuilder builder, Dictionary<string, object> parameters)
+    {
+        builder.Append("(!(");
+        StringComparisonParser.WriteJsonPathReference(_member, builder);
+        builder.Append(".type() == \"string\") || !(");
+        BuildJsonPathFilter(builder, parameters);
+        builder.Append("))");
+    }
 }

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringEndsWith.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringEndsWith.cs
@@ -1,9 +1,11 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using JasperFx.Core.Reflection;
 using Marten.Internal.CompiledQueries;
 using Marten.Linq.Members;
+using Marten.Linq.SqlGeneration.Filters;
 using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
@@ -31,8 +33,10 @@ internal class StringEndsWith: StringComparisonParser
     }
 }
 
-internal class StringEndsWithFilter: ISqlFragment, ICompiledQueryAwareFilter
+internal class StringEndsWithFilter: ISqlFragment, ICompiledQueryAwareFilter, ICollectionAware,
+    IInlinedJsonPathValueFilter, INegationGuardedJsonPathFilter
 {
+    private readonly bool _caseInsensitive;
     private readonly IQueryableMember _member;
     private readonly string _operator;
     private readonly object _rawValue;
@@ -40,6 +44,7 @@ internal class StringEndsWithFilter: ISqlFragment, ICompiledQueryAwareFilter
 
     public StringEndsWithFilter(bool caseInsensitive, IQueryableMember member, CommandParameter value)
     {
+        _caseInsensitive = caseInsensitive;
         _member = member;
         _rawValue = value.Value;
 
@@ -83,6 +88,49 @@ internal class StringEndsWithFilter: ISqlFragment, ICompiledQueryAwareFilter
     }
 
     public string ParameterName { get; private set; }
+
+    // like_regex patterns cannot come from the vars parameter
+    bool IInlinedJsonPathValueFilter.JsonPathValueIsInlined => true;
+
+    public bool CanReduceInChildCollection() => false;
+
+    public ICollectionAwareFilter BuildFragment(ICollectionMember member, ISerializer serializer)
+    {
+        throw new NotSupportedException();
+    }
+
+    public bool SupportsContainment() => false;
+
+    public void PlaceIntoContainmentFilter(ContainmentWhereFilter filter)
+    {
+        throw new NotSupportedException();
+    }
+
+    public bool CanBeJsonPathFilter() => _rawValue is string;
+
+    public void BuildJsonPathFilter(ICommandBuilder builder, Dictionary<string, object> parameters)
+    {
+        StringComparisonParser.WriteJsonPathReference(_member, builder);
+        builder.Append(" like_regex \"");
+        builder.Append(StringComparisonParser.EscapeForJsonPathRegex((string)_rawValue));
+        builder.Append(_caseInsensitive ? "$\" flag \"i\"" : "$\"");
+    }
+
+    public IEnumerable<DictionaryValueUsage> Values()
+    {
+        yield return new DictionaryValueUsage(_rawValue);
+    }
+
+    // "not ending with" must also match elements whose member is null or missing —
+    // jsonpath string ops evaluate to UNKNOWN there, so guard on the value type first
+    public void BuildNegatedJsonPathFilter(ICommandBuilder builder, Dictionary<string, object> parameters)
+    {
+        builder.Append("(!(");
+        StringComparisonParser.WriteJsonPathReference(_member, builder);
+        builder.Append(".type() == \"string\") || !(");
+        BuildJsonPathFilter(builder, parameters);
+        builder.Append("))");
+    }
 }
 
 

--- a/src/Marten/Linq/Parsing/Methods/Strings/StringStartsWith.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/StringStartsWith.cs
@@ -1,9 +1,11 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using JasperFx.Core.Reflection;
 using Marten.Internal.CompiledQueries;
 using Marten.Linq.Members;
+using Marten.Linq.SqlGeneration.Filters;
 using Npgsql;
 using NpgsqlTypes;
 using Weasel.Postgresql;
@@ -26,8 +28,10 @@ internal class StringStartsWith: StringComparisonParser
     }
 }
 
-internal class StringStartsWithFilter: ISqlFragment, ICompiledQueryAwareFilter
+internal class StringStartsWithFilter: ISqlFragment, ICompiledQueryAwareFilter, ICollectionAware,
+    IInlinedJsonPathValueFilter, INegationGuardedJsonPathFilter
 {
+    private readonly bool _caseInsensitive;
     private readonly IQueryableMember _member;
     private readonly string _operator;
     private readonly string _rawValue;
@@ -35,6 +39,7 @@ internal class StringStartsWithFilter: ISqlFragment, ICompiledQueryAwareFilter
 
     public StringStartsWithFilter(bool caseInsensitive, IQueryableMember member, CommandParameter value)
     {
+        _caseInsensitive = caseInsensitive;
         _member = member;
         _rawValue = value.Value as string;
         _operator = caseInsensitive
@@ -71,5 +76,60 @@ internal class StringStartsWithFilter: ISqlFragment, ICompiledQueryAwareFilter
             parameter.NpgsqlDbType = NpgsqlDbType.Varchar;
             parameter.Value = $"{StringComparisonParser.EscapeValue(raw)}%";
         };
+    }
+
+    // The case-sensitive form rides the parameterized jsonpath `starts with $var`;
+    // the case-insensitive form has to inline a like_regex pattern
+    bool IInlinedJsonPathValueFilter.JsonPathValueIsInlined => _caseInsensitive;
+
+    public bool CanReduceInChildCollection() => false;
+
+    public ICollectionAwareFilter BuildFragment(ICollectionMember member,
+        ISerializer serializer)
+    {
+        throw new NotSupportedException();
+    }
+
+    public bool SupportsContainment() => false;
+
+    public void PlaceIntoContainmentFilter(ContainmentWhereFilter filter)
+    {
+        throw new NotSupportedException();
+    }
+
+    public bool CanBeJsonPathFilter() => _rawValue != null;
+
+    public void BuildJsonPathFilter(ICommandBuilder builder,
+        Dictionary<string, object> parameters)
+    {
+        StringComparisonParser.WriteJsonPathReference(_member, builder);
+
+        if (_caseInsensitive)
+        {
+            builder.Append(" like_regex \"^");
+            builder.Append(StringComparisonParser.EscapeForJsonPathRegex(_rawValue));
+            builder.Append("\" flag \"i\"");
+        }
+        else
+        {
+            builder.Append(" starts with ");
+            builder.Append(parameters.AddJsonPathParameter(_rawValue));
+        }
+    }
+
+    public IEnumerable<DictionaryValueUsage> Values()
+    {
+        yield return new DictionaryValueUsage(_rawValue);
+    }
+
+    // "not starting with" must also match elements whose member is null or missing —
+    // jsonpath string ops evaluate to UNKNOWN there, so guard on the value type first
+    public void BuildNegatedJsonPathFilter(ICommandBuilder builder, Dictionary<string, object> parameters)
+    {
+        builder.Append("(!(");
+        StringComparisonParser.WriteJsonPathReference(_member, builder);
+        builder.Append(".type() == \"string\") || !(");
+        BuildJsonPathFilter(builder, parameters);
+        builder.Append("))");
     }
 }

--- a/src/Marten/Linq/SqlGeneration/Filters/JsonPathExistsFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/JsonPathExistsFilter.cs
@@ -17,15 +17,41 @@ using Weasel.Postgresql.SqlGeneration;
 namespace Marten.Linq.SqlGeneration.Filters;
 
 /// <summary>
+///     Implemented by filters whose jsonpath rendering has to bake the comparison
+///     value into the jsonpath string literal (like_regex patterns cannot be
+///     supplied through the vars parameter). Compiled queries can never re-bind
+///     such a value, so the jsonpath machinery fails loudly instead of silently
+///     reusing a stale value.
+/// </summary>
+internal interface IInlinedJsonPathValueFilter
+{
+    bool JsonPathValueIsInlined { get; }
+}
+
+/// <summary>
+///     jsonpath string operations (starts with / like_regex) evaluate to UNKNOWN on
+///     null or missing members, so a bare !(...) negation silently skips those
+///     elements — wrong for All(predicate), where a null member must FAIL the
+///     predicate like it does in LINQ-to-objects. Implementors render their own
+///     null-guarded negation instead.
+/// </summary>
+internal interface INegationGuardedJsonPathFilter
+{
+    void BuildNegatedJsonPathFilter(ICommandBuilder builder, Dictionary<string, object> parameters);
+}
+
+/// <summary>
 ///     Translates a child collection Any(predicate) that cannot be reduced to JSONB
 ///     containment (@>) into a single jsonb_path_exists() predicate instead of the
 ///     much more expensive "explode the collection into a CTE and correlate on ctid"
 ///     sub-query strategy. Values are passed through the jsonpath vars parameter so
-///     the SQL stays parameterized.
+///     the SQL stays parameterized. Also serves All(predicate) as
+///     NOT jsonb_path_exists('$.coll[*] ? (!(predicate))').
 /// </summary>
 internal class JsonPathExistsFilter: ISqlFragment, ICollectionAwareFilter, ICompiledQueryAwareFilter,
     IReversibleWhereFragment
 {
+    private readonly bool _negatePredicate;
     private readonly ISqlFragment _predicate;
     private readonly ISerializer _serializer;
     private string _collectionPath;
@@ -33,12 +59,24 @@ internal class JsonPathExistsFilter: ISqlFragment, ICollectionAwareFilter, IComp
     private Dictionary<string, object>? _dict;
     private List<DictionaryValueUsage>? _usages;
 
-    private JsonPathExistsFilter(ICollectionMember collection, ISqlFragment predicate, ISerializer serializer)
+    private JsonPathExistsFilter(ICollectionMember collection, ISqlFragment predicate, ISerializer serializer,
+        bool negatePredicate = false)
     {
         CollectionMember = collection;
         _predicate = predicate;
         _serializer = serializer;
+        _negatePredicate = negatePredicate;
+        IsNot = negatePredicate;
+
+        // ChildCollectionMember's segment is "Member[*]", but scalar value collections
+        // write a bare "Member" — normalize so the filter always iterates elements
+        // explicitly instead of leaning on lax-mode array unwrapping
         _collectionPath = collection.WriteJsonPath();
+        if (!_collectionPath.EndsWith("[*]"))
+        {
+            _collectionPath += "[*]";
+        }
+
         _documentColumn = collection.Ancestors[0].RawLocator;
     }
 
@@ -56,6 +94,23 @@ internal class JsonPathExistsFilter: ISqlFragment, ICollectionAwareFilter, IComp
         }
 
         filter = new JsonPathExistsFilter(collectionMember, fragment, serializer);
+        return true;
+    }
+
+    /// <summary>
+    ///     All(predicate) == NOT EXISTS an element failing the predicate. Vacuously
+    ///     true on empty collections, matching LINQ-to-objects semantics.
+    /// </summary>
+    public static bool TryBuildForAll(ISqlFragment fragment, ICollectionMember collectionMember,
+        ISerializer serializer, [NotNullWhen(true)] out JsonPathExistsFilter? filter)
+    {
+        filter = default;
+        if (!canRender(fragment))
+        {
+            return false;
+        }
+
+        filter = new JsonPathExistsFilter(collectionMember, fragment, serializer, negatePredicate: true);
         return true;
     }
 
@@ -105,7 +160,14 @@ internal class JsonPathExistsFilter: ISqlFragment, ICollectionAwareFilter, IComp
         builder.Append(" ? (");
 
         _dict = new Dictionary<string, object>();
-        writePredicate(builder, _predicate);
+        if (_negatePredicate)
+        {
+            writeNegatedPredicate(builder, _predicate);
+        }
+        else
+        {
+            writePredicate(builder, _predicate);
+        }
 
         builder.Append(")'");
 
@@ -156,8 +218,63 @@ internal class JsonPathExistsFilter: ISqlFragment, ICollectionAwareFilter, IComp
         }
     }
 
+    /// <summary>
+    ///     Renders NOT(predicate) with the negation distributed De Morgan style so that
+    ///     each leaf can apply its own null guard. Kleene 3-valued logic makes the
+    ///     distribution itself equivalence-preserving; the per-leaf guards are what
+    ///     turn UNKNOWN (null/missing member under a string operation) into a definite
+    ///     "fails the predicate".
+    /// </summary>
+    private void writeNegatedPredicate(ICommandBuilder builder, ISqlFragment fragment)
+    {
+        switch (fragment)
+        {
+            case CompoundWhereFragment compound:
+                // !(a && b) == !a || !b ; !(a || b) == !a && !b
+                var separator = compound.Separator.ContainsIgnoreCase("and") ? " || " : " && ";
+                builder.Append("(");
+                var first = true;
+                foreach (var child in compound.Children)
+                {
+                    if (!first)
+                    {
+                        builder.Append(separator);
+                    }
+
+                    writeNegatedPredicate(builder, child);
+                    first = false;
+                }
+
+                builder.Append(")");
+                break;
+
+            case INegationGuardedJsonPathFilter guarded:
+                guarded.BuildNegatedJsonPathFilter(builder, _dict!);
+                break;
+
+            case ICollectionAware aware:
+                builder.Append("!(");
+                aware.BuildJsonPathFilter(builder, _dict!);
+                builder.Append(")");
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Fragment {fragment} cannot be rendered as a jsonpath predicate. This is a Marten bug — TryBuildForAll should have rejected it.");
+        }
+    }
+
     public ISqlFragment MoveUnder(ICollectionMember ancestorCollection)
     {
+        // A NEGATED filter must not flatten: NOT(exists($.M[*].B[*] ? pred)) asserts
+        // over every middle's bottoms, which is stronger than Any(m => !m.B.Any(pred))
+        // or Any(m => m.B.All(pred)). Those nest through the explode strategy instead,
+        // where this fragment renders correctly against the exploded element.
+        if (IsNot || _negatePredicate)
+        {
+            return new SubQueryFilter(ancestorCollection, this);
+        }
+
         // An existence test over a doubly-nested collection flattens cleanly:
         // exists(middle.bottoms[*] ? pred) == '$.Middles[*].Bottoms[*] ? pred'
         _collectionPath = ancestorCollection.WriteJsonPath() + "." + _collectionPath;
@@ -178,6 +295,19 @@ internal class JsonPathExistsFilter: ISqlFragment, ICollectionAwareFilter, IComp
         var usage = _usages.FirstOrDefault(x => x.Value.Equals(value));
         if (usage != null)
         {
+            // A compiled query member value that lands in a leaf whose rendering bakes
+            // the value into the jsonpath literal (like_regex) can never be re-bound —
+            // fail loudly at plan time instead of silently reusing the stale value
+            foreach (var leaf in collectLeaves(_predicate))
+            {
+                if (leaf is IInlinedJsonPathValueFilter { JsonPathValueIsInlined: true } &&
+                    leaf.Values().Any(v => v.Value.Equals(value)))
+                {
+                    throw new Marten.Exceptions.BadLinqExpressionException(
+                        "string.Contains()/EndsWith() and case-insensitive string comparisons inside a collection predicate embed the search text in the SQL, so a compiled query cannot re-bind the value between executions. Use a case-sensitive StartsWith(), move the filter out of the compiled query, or query with session.Query<T>() instead.");
+                }
+            }
+
             usage.QueryMember = member;
             return true;
         }

--- a/src/Marten/Linq/SqlGeneration/Filters/JsonPathExistsFilter.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/JsonPathExistsFilter.cs
@@ -1,0 +1,224 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using Marten.Internal.CompiledQueries;
+using Marten.Linq.Members;
+using Marten.Linq.Parsing;
+using Npgsql;
+using NpgsqlTypes;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.SqlGeneration.Filters;
+
+/// <summary>
+///     Translates a child collection Any(predicate) that cannot be reduced to JSONB
+///     containment (@>) into a single jsonb_path_exists() predicate instead of the
+///     much more expensive "explode the collection into a CTE and correlate on ctid"
+///     sub-query strategy. Values are passed through the jsonpath vars parameter so
+///     the SQL stays parameterized.
+/// </summary>
+internal class JsonPathExistsFilter: ISqlFragment, ICollectionAwareFilter, ICompiledQueryAwareFilter,
+    IReversibleWhereFragment
+{
+    private readonly ISqlFragment _predicate;
+    private readonly ISerializer _serializer;
+    private string _collectionPath;
+    private string _documentColumn;
+    private Dictionary<string, object>? _dict;
+    private List<DictionaryValueUsage>? _usages;
+
+    private JsonPathExistsFilter(ICollectionMember collection, ISqlFragment predicate, ISerializer serializer)
+    {
+        CollectionMember = collection;
+        _predicate = predicate;
+        _serializer = serializer;
+        _collectionPath = collection.WriteJsonPath();
+        _documentColumn = collection.Ancestors[0].RawLocator;
+    }
+
+    public bool IsNot { get; private set; }
+
+    public ICollectionMember CollectionMember { get; }
+
+    public static bool TryBuild(ISqlFragment fragment, ICollectionMember collectionMember, ISerializer serializer,
+        [NotNullWhen(true)] out JsonPathExistsFilter? filter)
+    {
+        filter = default;
+        if (!canRender(fragment))
+        {
+            return false;
+        }
+
+        filter = new JsonPathExistsFilter(collectionMember, fragment, serializer);
+        return true;
+    }
+
+    private static bool canRender(ISqlFragment fragment)
+    {
+        switch (fragment)
+        {
+            case ICollectionAware aware when aware.CanBeJsonPathFilter():
+                return aware.Values().All(x => isSafeValue(x.Value));
+
+            case CompoundWhereFragment compound:
+                return compound.Children.Any() && compound.Children.All(canRender);
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool isSafeValue(object? value)
+    {
+        if (value == null)
+        {
+            return false;
+        }
+
+        // Serialized date representations do not reliably compare with the
+        // jsonpath operators, so those predicates stay on the sub-query strategy
+        if (value.GetType().IsDateTime() || value is DateTimeOffset)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        if (IsNot)
+        {
+            builder.Append("NOT(");
+        }
+
+        builder.Append("jsonb_path_exists(");
+        builder.Append(_documentColumn);
+        builder.Append(", '$.");
+        builder.Append(_collectionPath);
+        builder.Append(" ? (");
+
+        _dict = new Dictionary<string, object>();
+        writePredicate(builder, _predicate);
+
+        builder.Append(")'");
+
+        if (_dict.Count > 0)
+        {
+            builder.Append(", ");
+            builder.AppendParameter(_serializer.ToCleanJson(_dict), NpgsqlDbType.Jsonb);
+            ParameterName = builder.LastParameterName;
+        }
+
+        builder.Append(")");
+
+        if (IsNot)
+        {
+            builder.Append(")");
+        }
+    }
+
+    private void writePredicate(ICommandBuilder builder, ISqlFragment fragment)
+    {
+        switch (fragment)
+        {
+            case CompoundWhereFragment compound:
+                var separator = compound.Separator.ContainsIgnoreCase("and") ? " && " : " || ";
+                builder.Append("(");
+                var first = true;
+                foreach (var child in compound.Children)
+                {
+                    if (!first)
+                    {
+                        builder.Append(separator);
+                    }
+
+                    writePredicate(builder, child);
+                    first = false;
+                }
+
+                builder.Append(")");
+                break;
+
+            case ICollectionAware aware:
+                aware.BuildJsonPathFilter(builder, _dict!);
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Fragment {fragment} cannot be rendered as a jsonpath predicate. This is a Marten bug — TryBuild should have rejected it.");
+        }
+    }
+
+    public ISqlFragment MoveUnder(ICollectionMember ancestorCollection)
+    {
+        // An existence test over a doubly-nested collection flattens cleanly:
+        // exists(middle.bottoms[*] ? pred) == '$.Middles[*].Bottoms[*] ? pred'
+        _collectionPath = ancestorCollection.WriteJsonPath() + "." + _collectionPath;
+        _documentColumn = ancestorCollection.Ancestors[0].RawLocator;
+        return this;
+    }
+
+    public ISqlFragment Reverse()
+    {
+        IsNot = !IsNot;
+        return this;
+    }
+
+    public bool TryMatchValue(object value, MemberInfo member)
+    {
+        _usages ??= collectLeaves(_predicate).SelectMany(x => x.Values()).ToList();
+
+        var usage = _usages.FirstOrDefault(x => x.Value.Equals(value));
+        if (usage != null)
+        {
+            usage.QueryMember = member;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<ICollectionAware> collectLeaves(ISqlFragment fragment)
+    {
+        switch (fragment)
+        {
+            case CompoundWhereFragment compound:
+                foreach (var child in compound.Children)
+                foreach (var leaf in collectLeaves(child))
+                {
+                    yield return leaf;
+                }
+
+                break;
+
+            case ICollectionAware aware:
+                yield return aware;
+                break;
+        }
+    }
+
+    public Action<NpgsqlParameter, object> BuildSetter()
+    {
+        // Same ordering caveat as ChildCollectionJsonPathCountFilter: BuildSetter can
+        // run before Apply() has rendered the SQL and populated _dict, so capture
+        // deferred accessors; the dictionary and usages are shared by reference.
+        var dictRef = new Func<Dictionary<string, object>?>(() => _dict);
+        var usagesRef = new Func<List<DictionaryValueUsage>?>(() => _usages);
+        var serializer = _serializer;
+        return (parameter, query) =>
+        {
+            var payload = CompiledQueryDictionaryBuilder.Build(dictRef(), usagesRef(), query, default);
+            parameter.NpgsqlDbType = NpgsqlDbType.Jsonb;
+            parameter.Value = payload is null ? DBNull.Value : (object)serializer.ToCleanJson(payload);
+        };
+    }
+
+    public string? ParameterName { get; private set; }
+}


### PR DESCRIPTION
Deep-dive follow-through on sub-collection query SQL efficiency. Collection predicates that could not reduce to a single JSONB containment filter previously fell to the brute-force strategy (explode every document's collection via `jsonb_array_elements` into a CTE, correlate back on `d.ctid`), which no index can help — and several common shapes threw `BadLinqExpressionException` outright.

## Commit 1: the new strategy tiers for `Any(predicate)`

`ChildCollectionWhereClause` now tries, in GIN-friendliness order:

1. JSONB containment `@>` (unchanged)
2. **OR-of-containment** for `||`-of-equalities — each branch stays GIN-eligible, the planner answers with a `BitmapOr`
3. **`jsonb_path_exists(d.data, '$.Coll[*] ? (...)', vars)`** for any jsonpath-capable predicate (inequalities, `!=`, mixed AND/OR trees); values ride the `vars` parameter so SQL stays fully parameterized, and nested `Any()` chains flatten into a single path. Mixed-AND predicates also emit their equality conjuncts as a redundant containment pre-filter so a GIN index can prune first
4. The explode/ctid sub-query as fallback

`Quantities.Any(q => q > 98)` (scalar collections with `<`/`>`/`<=`/`>=`) used to throw; it now works via the jsonpath tier.

Also fixes a pre-existing compiled-query bug: `CompiledQueryPlan.MatchParameters` paired each parameter with the first matching query member only, so filters carrying several member values inside one parameter silently reused plan-time values for the rest on later executions (latent in `ChildCollectionJsonPathCountFilter` too). A `MarkFilterUsages` sweep now offers every member's template value to every filter before matching.

## Commit 2: string methods, complex-element `Contains()`, general `All()`

- Case-sensitive `StartsWith()` → parameterized jsonpath `starts with $var` (compiled-query safe)
- `Contains()`/`EndsWith()`/case-insensitive comparisons → `like_regex` with the regex-escaped text embedded in the SQL literal (PostgreSQL does not accept `like_regex` patterns via `vars`); compiled queries using these fail loudly at plan time instead of silently reusing stale SQL
- `Lines.Contains(complexObject)` → whole-document containment `d.data @> '{"Lines":[{...}]}'` instead of throwing — served directly by a `GinIndexJsonData()` index
- `All(predicate)` generalizes from three hardcoded shapes to any jsonpath-capable predicate via `NOT jsonb_path_exists('$ ? (!(pred))')`, with the negation distributed De Morgan style so string-operation leaves apply a `type()` null-guard (jsonpath string ops evaluate to UNKNOWN on null/missing members; LINQ-to-objects fails those elements). Vacuously true on empty collections; negated filters nest through the sub-query strategy instead of flattening (which would strengthen the assertion) — a shape that previously threw

## Benchmarks (100k docs × 8 children each, PostgreSQL 17)

| scenario | before | after |
|---|---:|---:|
| `Any(== a \|\| == b)` + expression GIN | 464ms | **7.6ms** |
| `Any(== a && > 50)` + expression GIN | 445ms | **2.5ms** |
| `Any(l => l.Number > 95)` | 568ms | 169ms |
| `Any(l => l.ItemName.StartsWith("x"))` | 470ms | **82ms** |
| `All(l => l.Number > 40)` | 451ms | **41ms** |
| `Lines.Contains(element)` + `GinIndexJsonData()` | threw | **2.8ms** |
| `Quantities.Any(q => q > 98)` | threw | 80ms |
| equality containment / fallback controls | — | unchanged |

31 new tests across two files (strategy assertions + in-memory result parity, null semantics, injection-safety for quotes/backslashes/regex metacharacters, compiled-query rebinding and the loud-failure guard, nested flattening and non-flattening). Full LinqTests: 1349/1350 (1 pre-existing skip). Docs updated with a strategy table, and `docker-compose.yml` gains `shm_size: 512mb` (PG17 keeps ~46MB standing DSM; the 64MB Docker default caused sporadic 53100 failures in the suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCpsgx7amReQkNmiE2X7Ha