### PR TITLE
Add GinIndexJsonDataMember() for member-scoped expression GIN indexes

### DIFF
--- a/docs/documents/indexing/gin-gist-indexes.md
+++ b/docs/documents/indexing/gin-gist-indexes.md
@@ -48,3 +48,28 @@ var store = DocumentStore.For(options =>
 <!-- endSnippet -->
 
 **Marten may be changed to make the GIN index on the data field be automatic in the future.**
+
+## GIN Indexes for Child Collections <Badge type="tip" text="9.15" />
+
+Containment filters against a child collection — what Marten generates for
+`Where(x => x.Children.Any(c => c.Name == "x"))` — compare against the expression
+`data -> 'Children'`, which the whole-document index from `GinIndexJsonData()` cannot serve.
+Use `GinIndexJsonDataMember()` to create an expression GIN index scoped to one member:
+
+```cs
+var store = DocumentStore.For(options =>
+{
+    // CREATE INDEX ... ON mt_doc_order USING gin ((data -> 'Lines') jsonb_path_ops)
+    options.Schema.For<Order>().GinIndexJsonDataMember(x => x.Lines);
+
+    // Nested member paths follow the JSON structure
+    options.Schema.For<Order>().GinIndexJsonDataMember(x => x.Customer.Addresses);
+});
+```
+
+The member-scoped index is substantially smaller than the whole-document index and accelerates
+the containment (`@>`) strategies described in
+[querying within child collections](/documents/querying/linq/child-collections#how-marten-translates-collection-predicates-),
+including equality `Any()` predicates, OR-of-equality predicates, and the equality pre-filter of
+mixed predicates. Whole-element `Contains()` queries anchor at the document root and are served
+by the plain `GinIndexJsonData()` index instead.

--- a/src/DocumentDbTests/Indexes/gin_index_on_json_data_member.cs
+++ b/src/DocumentDbTests/Indexes/gin_index_on_json_data_member.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql.Tables;
+using Xunit;
+
+namespace DocumentDbTests.Indexes;
+
+public class gin_index_on_json_data_member: OneOffConfigurationsContext
+{
+    [Fact]
+    public void generates_expression_gin_index_ddl()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<GinOrder>().GinIndexJsonDataMember(x => x.Lines);
+        });
+
+        var mapping = theStore.StorageFeatures.MappingFor(typeof(GinOrder));
+        var index = mapping.Indexes.OfType<Marten.Schema.DocumentIndex>()
+            .Single(x => x.Method == IndexMethod.gin);
+
+        var ddl = index.ToDDL(theStore.StorageFeatures.MappingFor(typeof(GinOrder)).Schema.Table);
+
+        ddl.ShouldContain("USING gin");
+        ddl.ShouldContain("(data -> 'Lines') jsonb_path_ops");
+    }
+
+    [Fact]
+    public async Task database_round_trip_is_idempotent()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<GinOrder>().GinIndexJsonDataMember(x => x.Lines);
+        });
+
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        // a canonicalization mismatch between our DDL and what Postgres reports
+        // back would flag a spurious index rebuild here
+        await Should.NotThrowAsync(async () =>
+            await theStore.Storage.Database.AssertDatabaseMatchesConfigurationAsync());
+    }
+
+    [Fact]
+    public async Task containment_query_uses_the_expression_index()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<GinOrder>().GinIndexJsonDataMember(x => x.Lines);
+        });
+
+        var orders = Enumerable.Range(0, 100).Select(i => new GinOrder
+        {
+            Id = Guid.NewGuid(),
+            Lines = new List<GinOrderLine> { new() { ItemName = $"item-{i % 10}" } }
+        }).ToArray();
+
+        await theStore.BulkInsertDocumentsAsync(orders);
+
+        await using var session = theStore.QuerySession();
+
+        // correctness through the index
+        var hits = await session.Query<GinOrder>()
+            .Where(x => x.Lines.Any(l => l.ItemName == "item-3"))
+            .ToListAsync();
+        hits.Count.ShouldBe(10);
+
+        // prove the planner can use the expression index for the containment filter
+        var cmd = session.Query<GinOrder>()
+            .Where(x => x.Lines.Any(l => l.ItemName == "item-3"))
+            .ToCommand();
+
+        var plan = new List<string>();
+        var conn = new Npgsql.NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try
+        {
+            await using (var setup = conn.CreateCommand())
+            {
+                setup.CommandText = "SET enable_seqscan = off";
+                await setup.ExecuteNonQueryAsync();
+            }
+
+            await using var explain = conn.CreateCommand();
+            explain.CommandText = "EXPLAIN " + cmd.CommandText;
+            foreach (Npgsql.NpgsqlParameter p in cmd.Parameters)
+            {
+                explain.Parameters.Add(new Npgsql.NpgsqlParameter(p.ParameterName, p.NpgsqlDbType)
+                {
+                    Value = p.Value
+                });
+            }
+
+            await using var reader = await explain.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                plan.Add(reader.GetString(0));
+            }
+        }
+        finally
+        {
+            await conn.CloseAsync();
+            await conn.DisposeAsync();
+        }
+
+        var planText = string.Join("\n", plan);
+        planText.ShouldContain("_idx_lines_gin");
+    }
+
+    [Fact]
+    public void nested_member_paths_walk_the_arrow_chain()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<GinOrder>().GinIndexJsonDataMember(x => x.Customer.Addresses);
+        });
+
+        var mapping = theStore.StorageFeatures.MappingFor(typeof(GinOrder));
+        var index = mapping.Indexes.OfType<Marten.Schema.DocumentIndex>()
+            .Single(x => x.Method == IndexMethod.gin);
+
+        var ddl = index.ToDDL(mapping.Schema.Table);
+        ddl.ShouldContain("(data -> 'Customer' -> 'Addresses') jsonb_path_ops");
+    }
+}
+
+public class GinOrder
+{
+    public Guid Id { get; set; }
+    public List<GinOrderLine> Lines { get; set; } = new();
+    public GinCustomer Customer { get; set; } = new();
+}
+
+public class GinOrderLine
+{
+    public string ItemName { get; set; }
+}
+
+public class GinCustomer
+{
+    public List<string> Addresses { get; set; } = new();
+}

--- a/src/Marten/MartenRegistry.cs
+++ b/src/Marten/MartenRegistry.cs
@@ -620,6 +620,35 @@ public class MartenRegistry
         }
 
         /// <summary>
+        ///     Adds a Postgresql GIN index over a single member of the JSONB data, e.g.
+        ///     (data -> 'Children') jsonb_path_ops. Use this to accelerate containment
+        ///     filters against a child collection — Any() predicates with equality
+        ///     conditions compare against data -> 'Children' directly, which the
+        ///     whole-document index from GinIndexJsonData() cannot serve
+        /// </summary>
+        /// <param name="memberExpression">The collection (or object) member to index</param>
+        /// <param name="configureIndex"></param>
+        public DocumentMappingExpression<T> GinIndexJsonDataMember(Expression<Func<T, object>> memberExpression,
+            Action<DocumentIndex>? configureIndex = null)
+        {
+            var members = MemberFinder.Determine(memberExpression);
+            if (!members.Any())
+            {
+                throw new ArgumentOutOfRangeException(nameof(memberExpression),
+                    $"Marten is not able to determine a member from expression '{memberExpression}'");
+            }
+
+            _builder.Alter = mapping =>
+            {
+                var index = mapping.AddGinIndexToDataMember(members);
+
+                configureIndex?.Invoke(index);
+            };
+
+            return this;
+        }
+
+        /// <summary>
         ///     Programmatically directs Marten to map this type to a hierarchy of types
         /// </summary>
         /// <param name="subclassType"></param>

--- a/src/Marten/Schema/DocumentMapping.cs
+++ b/src/Marten/Schema/DocumentMapping.cs
@@ -475,6 +475,47 @@ public partial class DocumentMapping: IDocumentMapping, IDocumentType
         return index;
     }
 
+    /// <summary>
+    ///     Adds a GIN index over one member of the JSONB data, e.g.
+    ///     (data -> 'Children') jsonb_path_ops. Child collection containment filters
+    ///     compare against exactly this expression, which a whole-document GIN index
+    ///     cannot serve
+    /// </summary>
+    public DocumentIndex AddGinIndexToDataMember(MemberInfo[] members)
+    {
+        // resolve through the queryable member tree so the index expression uses the
+        // same serialized property names the generated SQL will use
+        IQueryableMember member = QueryMembers.FindMember(members[0]);
+        for (var i = 1; i < members.Length; i++)
+        {
+            if (member is not IHasChildrenMembers parent)
+            {
+                throw new ArgumentOutOfRangeException(nameof(members),
+                    $"Marten cannot build a GIN index through member '{member.MemberName}' of type {member.MemberType.FullNameInCode()}");
+            }
+
+            member = parent.FindMember(members[i]);
+        }
+
+        var segments = member.Ancestors
+            .Select(x => x.MemberName)
+            .Where(x => x.IsNotEmpty())
+            .Append(member.MemberName)
+            .ToArray();
+
+        var path = segments.Select(x => $" -> '{x}'").Join("");
+
+        var index = new DocumentIndex(this, "data")
+        {
+            Method = IndexMethod.gin, Mask = $"(?{path}) jsonb_path_ops"
+        };
+        index.Name = $"{TableName.Name}_idx_{segments.Join("_").ToLowerInvariant()}_gin";
+
+        Indexes.Add(index);
+
+        return index;
+    }
+
     public DocumentIndex AddLastModifiedIndex(Action<DocumentIndex>? configure = null)
     {
         var index = new DocumentIndex(this, SchemaConstants.LastModifiedColumn);


### PR DESCRIPTION
Follow-up to #4928. Child collection containment filters compare against the expression `data -> 'Children'`, which the whole-document GIN index from `GinIndexJsonData()` cannot serve — the #4928 benchmarks showed equality `Any()` at 40–49ms with the whole-document index versus 2.5–7.6ms with a member-scoped expression index.

```csharp
options.Schema.For<Order>().GinIndexJsonDataMember(x => x.Lines);
// CREATE INDEX ... ON mt_doc_order USING gin ((data -> 'Lines') jsonb_path_ops)

options.Schema.For<Order>().GinIndexJsonDataMember(x => x.Customer.Addresses);
// nested paths follow the JSON structure
```

Member paths resolve through the same casing-aware queryable member tree the LINQ provider uses, so the index expression always matches the generated SQL. It's a distinct method name rather than a `GinIndexJsonData()` overload because the existing `configureIndex` lambdas (`idx => idx.Method = ...`) would bind to an `Expression` parameter and break compilation of existing callers.

Tests cover the DDL shape, nested member paths, schema round-trip idempotency (no spurious rebuilds from expression canonicalization drift), and an EXPLAIN plan proving the planner uses the index for a containment query. Docs added to the GIN/GiST indexing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCpsgx7amReQkNmiE2X7Ha