### PR TITLE
fix: reverse AoT generic-constraint break in AddEventType/QueryRawEventDataOnly; route mapping construction through GenericFactoryCache

### DIFF
--- a/src/EventSourcingTests/EventGraphTests.cs
+++ b/src/EventSourcingTests/EventGraphTests.cs
@@ -203,6 +203,32 @@ public class EventGraphTests
         theGraph.EnableEventSkippingInProjectionsOrSubscriptions.ShouldBeFalse();
     }
 
+    [Fact]
+    public void generic_add_event_type_registers_the_same_mapping_as_the_type_overload()
+    {
+        theGraph.AddEventType<AEvent>();
+        theGraph.AllEvents().ShouldContain(x => x.DocumentType == typeof(AEvent));
+    }
+
+    // #4917 follow-up: AddEventType<TEvent> and QueryRawEventDataOnly<T> are intentionally NOT constrained to
+    // `where T : class`. This method won't compile if either constraint is tightened back, because a
+    // `where T : notnull` type parameter does not satisfy `where T : class` -- which is exactly the generic
+    // relay pattern in downstream code that the tightening broke. The QueryRawEventDataOnly reference is a
+    // compile-time check only; it lives in a delegate that is never invoked, so the null store is never used.
+    private static void notnull_relay_still_compiles<T>(IEventStoreOptions options, Marten.Events.IQueryEventStore events)
+        where T : notnull
+    {
+        options.AddEventType<T>();
+        _ = new Action(() => events.QueryRawEventDataOnly<T>());
+    }
+
+    [Fact]
+    public void generic_relay_over_a_notnull_type_parameter_registers_the_event()
+    {
+        notnull_relay_still_compiles<AEvent>(theGraph, events: null!);
+        theGraph.AllEvents().ShouldContain(x => x.DocumentType == typeof(AEvent));
+    }
+
     public class HouseRemodeling
     {
         public Guid Id { get; set; }

--- a/src/Marten/Events/EventGraph.cs
+++ b/src/Marten/Events/EventGraph.cs
@@ -79,7 +79,17 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
         Options = options;
         _events.OnMissing = eventType =>
         {
-            var mapping = typeof(EventMapping<>).CloseAndBuildAs<EventMapping>(this, eventType);
+            // #4917 follow-up: build EventMapping<eventType> through GenericFactoryCache rather than a raw
+            // CloseAndBuildAs. GenericFactoryCache caches a compiled factory delegate per closed type, so the
+            // MakeGenericType + Activator reflection runs once per event type instead of on every cache miss,
+            // and it is the delegate-cached pattern the rest of Marten already funnels this kind of open-generic
+            // construction through. The [DynamicDependency] on this constructor is what actually keeps
+            // EventMapping<>'s constructor from being trimmed; without it Activator throws MissingMethodException.
+            var mapping = GenericFactoryCache.BuildAs<EventMapping>(
+                typeof(EventMapping<>),
+                eventType,
+                this,
+                static closed => parent => (EventMapping)Activator.CreateInstance(closed, parent)!);
             Options.Storage.AddMapping(mapping);
 
             return mapping;
@@ -370,18 +380,14 @@ public partial class EventGraph: EventRegistry, IEventStoreOptions, IReadOnlyEve
     /// </summary>
     /// <typeparam name="TEvent"></typeparam>
     /// <returns>Event store options, to allow fluent definition</returns>
-    public IEventStoreOptions AddEventType<TEvent>() where TEvent : class
+    public IEventStoreOptions AddEventType<TEvent>()
     {
-        // Constructs EventMapping<TEvent> statically so trimming / Native AOT
-        // preserves its constructor. 
-        _events.Fill(typeof(TEvent), _ =>
-        {
-            var mapping = new EventMapping<TEvent>(this);
-            Options.Storage.AddMapping(mapping);
-
-            return mapping;
-        });
-
+        // Keep the historical, unconstrained signature (#4917 had tightened this to `where TEvent : class` so it
+        // could new up EventMapping<TEvent> directly -- EventMapping<T> is class-constrained -- but that was a
+        // source-breaking change for callers with a `where T : notnull` generic relay). Route through the
+        // runtime-Type overload instead; construction goes through the GenericFactoryCache factory in the
+        // constructor, and the [DynamicDependency] there keeps it trim-safe.
+        AddEventType(typeof(TEvent));
         return this;
     }
 

--- a/src/Marten/Events/IEventStoreOptions.cs
+++ b/src/Marten/Events/IEventStoreOptions.cs
@@ -222,9 +222,9 @@ namespace Marten.Events
         ///     the event type. It can also be used for the event namespace migration.
         ///     See more in <a href="https://martendb.io/events/versioning.html#namespace-migration">documentation</a>
         /// </summary>
-        /// <typeparam name="TEvent">CLR event type. Must be a reference type.</typeparam>
+        /// <typeparam name="TEvent">CLR event type</typeparam>
         /// <returns>Event store options, to allow fluent definition</returns>
-        IEventStoreOptions AddEventType<TEvent>() where TEvent : class;
+        IEventStoreOptions AddEventType<TEvent>();
 
         /// <summary>
         ///     Register an event type with Marten. This isn't strictly necessary for normal usage,

--- a/src/Marten/Events/IQueryEventStore.cs
+++ b/src/Marten/Events/IQueryEventStore.cs
@@ -21,7 +21,7 @@ public interface IQueryEventStore : JasperFx.Events.IQueryEventStore
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    IMartenQueryable<T> QueryRawEventDataOnly<T>() where T : class;
+    IMartenQueryable<T> QueryRawEventDataOnly<T>() where T : notnull;
 
     /// <summary>
     ///     Query directly against the raw event data across all event types.

--- a/src/Marten/Events/QueryEventStore.cs
+++ b/src/Marten/Events/QueryEventStore.cs
@@ -183,7 +183,7 @@ internal class QueryEventStore: IQueryEventStore, IReadOnlyEventStore
         return aggregate;
     }
 
-    public IMartenQueryable<T> QueryRawEventDataOnly<T>() where T : class
+    public IMartenQueryable<T> QueryRawEventDataOnly<T>() where T : notnull
     {
         _store.Events.AddEventType<T>();
 


### PR DESCRIPTION
Follow-up to #4917. Keeps that PR's real fix, reverses its two side effects.

## What #4917 got right, and what it cost

The genuine bug #4917 fixed: `EventMapping<>`'s constructor was being trimmed, so `Activator` threw `MissingMethodException` when the event graph built a mapping at `StoreOptions` construction. The durable fix for that is the `[DynamicDependency(PublicConstructors, typeof(EventMapping<>))]` root on the `EventGraph` constructor — **kept here unchanged.**

To get there, #4917 also did two things that are worth undoing:

1. Tightened `IEventStoreOptions.AddEventType<TEvent>()` from unconstrained to `where TEvent : class`, and `IQueryEventStore.QueryRawEventDataOnly<T>()` from `where T : notnull` to `where T : class` — so the generic overload could statically `new EventMapping<TEvent>()`.
2. Left the runtime-`Type` construction path on a raw `CloseAndBuildAs`.

## 1. Reverting the constraint break

`where T : class` on a public interface is **source-breaking**. Any downstream generic relay declared `where T : notnull` — e.g.

```csharp
void Register<T>(IEventStoreOptions o) where T : notnull => o.AddEventType<T>();
```

stops compiling against a `class`-constrained target, because `notnull` does not satisfy `class`. `QueryRawEventDataOnly` had the same effect going `notnull → class`.

Both signatures are reverted (`AddEventType` back to unconstrained, `QueryRawEventDataOnly` back to `notnull`). Since `EventMapping<T>` is itself `where T : class`, the generic `AddEventType<TEvent>()` can no longer `new` it up directly, so it routes through the runtime-`Type` overload exactly as it did before #4917.

A regression test in `EventGraphTests` pins a `where T : notnull` relay into both methods — it **fails to compile** if either constraint is tightened again (verified: re-adding `where TEvent : class` breaks the build).

## 2. Replacing CloseAndBuildAs

The one remaining construction site — `_events.OnMissing` — moves from a raw `CloseAndBuildAs` to `GenericFactoryCache.BuildAs`, the delegate-cached, per-closed-type factory that the rest of Marten already funnels open-generic construction through (`DocumentSessionBase`, `QuerySession.Load`, `Delete<T>`, etc.).

To be precise about what this does and doesn't do: it's still reflection under the hood (`MakeGenericType` + `Activator`), because the `Type` path only has a runtime `Type` — there's no compile-time type to instantiate statically. What changes is that the factory delegate is **built once per event type and cached** instead of reflecting on every cache miss, and it's now consistent with the codebase's standard pattern rather than a one-off. Trim/AoT-safety continues to rest on the retained `[DynamicDependency]` root, so the original `MissingMethodException` stays fixed.

Fully eliminating the reflection here would require a compile-time type at the call site — i.e. the `where T : class` constraint that #1 removes. The two asks trade off against each other, and this is the balance: loose public API, single cached reflective choke point, constructor rooted against trimming.

## Validation

Clean database, net9.0:
- `EventSourcingTests`: **1435 passed, 0 failed**, 7 skipped
- `CoreTests`: **476 passed, 0 failed**, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)