### PR TITLE
fix(#4926): drop the duplicate Attribute suffix on IsSoftDeletedMetadata

### DIFF
--- a/src/Marten/Schema/MetadataAttributes.cs
+++ b/src/Marten/Schema/MetadataAttributes.cs
@@ -44,7 +44,7 @@ public class TenantIdMetadataAttribute: MartenAttribute
 ///     Direct Marten to copy the is soft deleted metadata to this member
 /// </summary>
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-public class IsSoftDeletedMetadataAttributeAttribute: MartenAttribute
+public class IsSoftDeletedMetadataAttribute: MartenAttribute
 {
     public override void Modify(DocumentMapping mapping, MemberInfo member)
     {


### PR DESCRIPTION
Closes #4926.

The metadata attribute class was named `IsSoftDeletedMetadataAttributeAttribute`, so the .NET-conventional usage `[IsSoftDeletedMetadata]` did **not** compile — callers had to write the redundant `[IsSoftDeletedMetadataAttribute]`, out of step with every sibling (`LastModifiedMetadata`, `CreatedAtMetadata`, `SoftDeletedAtMetadata`, `TenantIdMetadata`, `DocumentTypeMetadata`).

Renamed the class to `IsSoftDeletedMetadataAttribute`.

**Source-compatible.** `[IsSoftDeletedMetadataAttribute]` still binds (now directly to the class name), and `[IsSoftDeletedMetadata]` now works too. The only thing that would break is a reference to the type's *full* name in code (e.g. `typeof(IsSoftDeletedMetadataAttributeAttribute)`) — there were none in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)