### PR TITLE
fix(#4924): quote the per-tenant event sequence name in schema-apply DDL

### DIFF
--- a/src/CoreTests/Partitioning/Bug_4924_hyphenated_tenant_id_sequence_name.cs
+++ b/src/CoreTests/Partitioning/Bug_4924_hyphenated_tenant_id_sequence_name.cs
@@ -1,0 +1,192 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.MultiTenancy;
+using Marten;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CoreTests.Partitioning;
+
+public record Bug4924WidgetMade(string Name);
+
+/// <summary>
+/// #4924 — under <c>UseTenantPartitionedEvents</c>, a tenant whose partition suffix contains a character
+/// that is illegal in an <em>unquoted</em> Postgres identifier (most commonly '-') made schema apply throw.
+///
+/// <para>
+/// Weasel stores the partition suffix as the tenant id verbatim
+/// (<c>ManagedListPartitions.AddPartitionToAllTables</c>: <c>suffix.IsEmpty() ? value.ToLowerInvariant() : suffix</c>)
+/// and sanitizes only the partition <em>table</em> name (<c>ListPartition.SanitizeSuffix</c>). Marten's
+/// <c>PerTenantEventSequences.WriteCreateStatement</c> then interpolated that raw suffix into an unquoted
+/// identifier, because Weasel's <c>SchemaUtils.QuoteName</c> quotes only reserved keywords and mixed-case
+/// names:
+/// </para>
+/// <code>CREATE SEQUENCE IF NOT EXISTS my_schema.mt_events_sequence_tenant-a;</code>
+/// <para>→ <c>42601: syntax error at or near "-"</c>, failing "All Configured Changes" for that database.</para>
+///
+/// <para>
+/// <b>Quote, do not sanitize.</b> Every other path that names this sequence already quotes it and keeps the
+/// raw suffix — <c>QuickAppendEventFunction</c> resolves it as
+/// <c>format('%I.%I', schema, 'mt_events_sequence_' || partition_suffix)</c> straight from the tenants
+/// table, and <c>EnsureSequencesAsync</c> / <c>PerTenantPartitionedCleanup</c> quote explicitly. Normalizing
+/// the name at create time would produce a sequence the append function could never find, trading the
+/// schema-apply error for <c>42P01 relation does not exist</c> on the first append. So the fix quotes the
+/// two schema-apply statements, matching the rest of the codebase.
+/// </para>
+///
+/// <para>
+/// This is orthogonal to the #4567 assertion on <c>AddMartenManagedTenantsAsync</c>, which rejects unsafe
+/// <em>suffixes</em> on the single-database path (use the <c>Guid[]</c> overload, which maps to the
+/// hyphen-free "N" form). Sharded tenancy has always accepted hyphenated tenant ids — its own tests use
+/// <c>tenant-a</c> — and derives the suffix from the tenant id verbatim. Such tenants were fine for document
+/// partitioning, and only broke once per-tenant event sequences entered the picture.
+/// </para>
+/// </summary>
+public class Bug_4924_hyphenated_tenant_id_sequence_name: IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _schema = "bug4924_p" + Environment.ProcessId;
+    private readonly string _partitionSchema = "bug4924_tenants_p" + Environment.ProcessId;
+
+    public Bug_4924_hyphenated_tenant_id_sequence_name(ITestOutputHelper output) => _output = output;
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync(_partitionSchema); } catch { }
+        try { await conn.DropSchemaAsync(_schema); } catch { }
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private DocumentStore BuildStore() => (DocumentStore)DocumentStore.For(opts =>
+    {
+        opts.Connection(ConnectionSource.ConnectionString);
+        opts.DatabaseSchemaName = _schema;
+        opts.DisableNpgsqlLogging = true;
+
+        opts.Policies.AllDocumentsAreMultiTenanted();
+        opts.Policies.PartitionMultiTenantedDocumentsUsingMartenManagement(_partitionSchema);
+
+        opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+        opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+        opts.Events.UseTenantPartitionedEvents = true;
+        // Activate the events feature so schema apply actually emits the event tables and the per-tenant
+        // sequences. Without a registered event type the feature is inactive and these tests are vacuous.
+        opts.Events.AddEventType(typeof(Bug4924WidgetMade));
+
+        opts.AutoCreateSchemaObjects = AutoCreate.All;
+    });
+
+    /// <summary>
+    /// A database carrying a hyphenated <c>partition_suffix</c> — which sharded tenancy produces for a
+    /// <c>tenant-a</c>, and which no API prevents — must still be migratable. Schema apply re-emits every
+    /// registered tenant's CREATE SEQUENCE on each run, so an unquoted identifier wedged that database
+    /// permanently: 42601, on every subsequent apply, for every store sharing the schema.
+    /// </summary>
+    [Theory]
+    [InlineData("tenant-a")]
+    [InlineData("6f1a3c2e-5b1d-4f0a-9c3e-8d7b6a5f4e3c")] // the GUID shape, which is all hyphens
+    public async Task schema_apply_handles_a_partition_suffix_that_needs_quoting(string tenantId)
+    {
+        await using var store = BuildStore();
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await RegisterRawSuffixAsync(tenantId);
+
+        await using var reopened = BuildStore();
+        var partitions = reopened.Options.TenantPartitions!.Partitions;
+        await partitions.InitializeAsync((PostgresqlDatabase)reopened.Storage.Database, CancellationToken.None);
+        partitions.Partitions.ShouldContainKey(tenantId);
+
+        await Should.NotThrowAsync(() => reopened.Storage.ApplyAllConfiguredChangesToDatabaseAsync());
+
+        // Created under the RAW name — anything else and the quick-append function's format('%I') lookup,
+        // which reads partition_suffix straight from the tenants table, would miss it.
+        (await SequenceCountAsync($"mt_events_sequence_{tenantId}")).ShouldBe(1L);
+        _output.WriteLine($"schema apply created \"{_schema}\".\"mt_events_sequence_{tenantId}\"");
+    }
+
+    /// <summary>
+    /// Re-applying schema over a live hyphenated tenant must stay idempotent. The additive-only delta means
+    /// existing sequences are never dropped and recreated — doing so would reset a live tenant's seq_id and
+    /// silently corrupt its event store.
+    /// </summary>
+    [Fact]
+    public async Task re_applying_schema_does_not_reset_a_hyphenated_tenants_sequence()
+    {
+        const string tenantId = "tenant-a";
+
+        await using var store = BuildStore();
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+        await RegisterRawSuffixAsync(tenantId);
+
+        await using var reopened = BuildStore();
+        var partitions = reopened.Options.TenantPartitions!.Partitions;
+        await partitions.InitializeAsync((PostgresqlDatabase)reopened.Storage.Database, CancellationToken.None);
+        await reopened.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await AdvanceSequenceAsync(tenantId);
+        var before = await LastValueAsync(tenantId);
+
+        await reopened.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+        var after = await LastValueAsync(tenantId);
+
+        _output.WriteLine($"sequence last_value before={before} after={after}");
+        after.ShouldBe(before, "re-applying schema must not recreate (and reset) a live tenant's sequence");
+    }
+
+    /// <summary>Register the tenant the way sharded tenancy does: the raw tenant id as the partition suffix.</summary>
+    private async Task RegisterRawSuffixAsync(string tenantId)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var insert = conn.CreateCommand();
+        insert.CommandText =
+            $"insert into {_partitionSchema}.mt_tenant_partitions (partition_value, partition_suffix) " +
+            "values (@v, @s) on conflict do nothing";
+        insert.Parameters.AddWithValue("v", tenantId);
+        insert.Parameters.AddWithValue("s", tenantId);
+        await insert.ExecuteNonQueryAsync();
+    }
+
+    private async Task<long> SequenceCountAsync(string sequenceName)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "select count(*) from information_schema.sequences where sequence_schema = @s and sequence_name = @n";
+        cmd.Parameters.AddWithValue("s", _schema);
+        cmd.Parameters.AddWithValue("n", sequenceName);
+        return (long)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    private async Task AdvanceSequenceAsync(string tenantId)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"select nextval('\"{_schema}\".\"mt_events_sequence_{tenantId}\"')";
+        await cmd.ExecuteScalarAsync();
+    }
+
+    private async Task<long> LastValueAsync(string tenantId)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"select last_value from \"{_schema}\".\"mt_events_sequence_{tenantId}\"";
+        return (long)(await cmd.ExecuteScalarAsync())!;
+    }
+}

--- a/src/Marten/Events/Schema/PerTenantEventSequences.cs
+++ b/src/Marten/Events/Schema/PerTenantEventSequences.cs
@@ -47,19 +47,43 @@ internal class PerTenantEventSequences: ISchemaObject
 
     public DbObjectName Identifier { get; }
 
-    private IEnumerable<Sequence> currentSequences()
+    /// <summary>
+    /// The schema-qualified, <b>quoted</b> name of one tenant's event sequence.
+    ///
+    /// <para>
+    /// The partition suffix is the tenant id verbatim (Weasel's
+    /// <c>ManagedListPartitions.AddPartitionToAllTables</c> stores
+    /// <c>suffix.IsEmpty() ? value.ToLowerInvariant() : suffix</c>), so it can contain characters that are
+    /// illegal in an <em>unquoted</em> Postgres identifier — most commonly '-', which every GUID tenant id
+    /// has. The name must therefore always be quoted in DDL. See #4924.
+    /// </para>
+    ///
+    /// <para>
+    /// Quote, do <b>not</b> sanitize. <c>QuickAppendEventFunction</c> resolves this sequence at append time
+    /// as <c>format('%I.%I', schema, 'mt_events_sequence_' || partition_suffix)</c>, reading the raw suffix
+    /// straight out of the tenants table. Normalizing the name here (e.g. '-' → '_') would create a sequence
+    /// the append function can never find, trading a schema-apply failure for a
+    /// <c>42P01 relation does not exist</c> on the first append.
+    /// </para>
+    /// </summary>
+    internal static string QuotedSequenceName(string eventSchema, string partitionSuffix)
+        => $"\"{eventSchema}\".\"mt_events_sequence_{partitionSuffix}\"";
+
+    /// <summary>
+    /// The partition suffix of every tenant currently registered on the shared partition manager.
+    /// `Options.TenantPartitions` is the MartenManagedTenantListPartitions wrapper; its `.Partitions` is the
+    /// underlying Weasel ManagedListPartitions; that exposes a `.Partitions`
+    /// ReadOnlyDictionary&lt;tenantValue, partitionSuffix&gt;. Triple-`Partitions` is unfortunate but each
+    /// level names something different.
+    /// </summary>
+    private IEnumerable<string> currentPartitionSuffixes()
     {
-        // `Options.TenantPartitions` is the MartenManagedTenantListPartitions wrapper;
-        // its `.Partitions` is the underlying Weasel ManagedListPartitions; that
-        // exposes a `.Partitions` ReadOnlyDictionary<tenantValue, partitionSuffix>.
-        // Triple-`Partitions` is unfortunate but each level names something different.
         var partitions = _events.Options.TenantPartitions?.Partitions.Partitions;
         if (partitions == null) yield break;
 
         foreach (var pair in partitions)
         {
-            yield return new Sequence(new PostgresqlObjectName(
-                _events.DatabaseSchemaName, $"mt_events_sequence_{pair.Value}"));
+            yield return pair.Value;
         }
     }
 
@@ -68,17 +92,19 @@ internal class PerTenantEventSequences: ISchemaObject
         // IF NOT EXISTS keeps the statement idempotent — both for the initial
         // schema apply and for the AdvancedOperations.AddMartenManagedTenantsAsync
         // re-apply that fires after a new partition has been registered.
-        foreach (var seq in currentSequences())
+        foreach (var suffix in currentPartitionSuffixes())
         {
-            writer.WriteLine($"CREATE SEQUENCE IF NOT EXISTS {seq.Identifier};");
+            writer.WriteLine(
+                $"CREATE SEQUENCE IF NOT EXISTS {QuotedSequenceName(_events.DatabaseSchemaName, suffix)};");
         }
     }
 
     public void WriteDropStatement(Migrator rules, TextWriter writer)
     {
-        foreach (var seq in currentSequences())
+        foreach (var suffix in currentPartitionSuffixes())
         {
-            writer.WriteLine($"DROP SEQUENCE IF EXISTS {seq.Identifier};");
+            writer.WriteLine(
+                $"DROP SEQUENCE IF EXISTS {QuotedSequenceName(_events.DatabaseSchemaName, suffix)};");
         }
     }
 
@@ -104,7 +130,7 @@ internal class PerTenantEventSequences: ISchemaObject
             actualCount = await reader.GetFieldValueAsync<long>(0, ct).ConfigureAwait(false);
         }
 
-        var expectedCount = currentSequences().Count();
+        var expectedCount = currentPartitionSuffixes().Count();
 
         // The IF-NOT-EXISTS shape means we only ever ADD sequences from the
         // schema-apply path; removal is handled by the partition-drop path.
@@ -151,9 +177,9 @@ internal class PerTenantEventSequences: ISchemaObject
 
     public IEnumerable<DbObjectName> AllNames()
     {
-        foreach (var seq in currentSequences())
+        foreach (var suffix in currentPartitionSuffixes())
         {
-            yield return seq.Identifier;
+            yield return new PostgresqlObjectName(_events.DatabaseSchemaName, $"mt_events_sequence_{suffix}");
         }
     }
 
@@ -191,7 +217,7 @@ internal class PerTenantEventSequences: ISchemaObject
         await conn.OpenAsync(token).ConfigureAwait(false);
         foreach (var suffix in partitionSuffixes)
         {
-            var sequenceName = $"\"{eventSchema}\".\"mt_events_sequence_{suffix}\"";
+            var sequenceName = QuotedSequenceName(eventSchema, suffix);
             try
             {
                 await conn

--- a/src/Marten/Internal/PerTenantPartitionedCleanup.cs
+++ b/src/Marten/Internal/PerTenantPartitionedCleanup.cs
@@ -87,7 +87,10 @@ internal static class PerTenantPartitionedCleanup
         foreach (var suffix in capturedSequenceSuffixes.Values)
         {
             builder.StartNewCommand();
-            builder.Append($"DROP SEQUENCE IF EXISTS \"{eventsSchema}\".\"mt_events_sequence_{suffix}\"");
+            // #4924 — one place builds this name, so the quoting cannot drift between the create and drop
+            // paths. The suffix is the raw tenant id and may contain '-'.
+            builder.Append(
+                $"DROP SEQUENCE IF EXISTS {Events.Schema.PerTenantEventSequences.QuotedSequenceName(eventsSchema, suffix)}");
         }
 
         if (progressionRows.Count > 0)


### PR DESCRIPTION
Closes #4924.

Under `Events.UseTenantPartitionedEvents = true`, registering a tenant whose partition suffix contains a character illegal in an **unquoted** Postgres identifier — most importantly `-`, so **every GUID tenant id** — made `ApplyAllConfiguredChangesToDatabaseAsync()` throw:

```
CREATE SEQUENCE IF NOT EXISTS my_schema.mt_events_sequence_tenant-a;
 ---> 42601: syntax error at or near "-"
```

### Root cause
Weasel stores the partition suffix as the tenant id **verbatim** (`ManagedListPartitions.AddPartitionToAllTables`), sanitizing only the partition *table* name. `PerTenantEventSequences.WriteCreateStatement` then interpolated that raw suffix into an **unquoted** identifier, because Weasel's `SchemaUtils.QuoteName` quotes only reserved keywords and mixed-case names.

### Quote, do not sanitize
Every *other* path that names this sequence already quotes it and keeps the raw suffix — `QuickAppendEventFunction` resolves it as `format('%I.%I', schema, 'mt_events_sequence_' || partition_suffix)` straight from the tenants table, and `EnsureSequencesAsync` / `PerTenantPartitionedCleanup` quote explicitly. Normalizing the name at create time would produce a sequence the append function could never find, trading the schema-apply error for `42P01 relation does not exist` on the first append.

So `WriteCreateStatement`/`WriteDropStatement` now emit the quoted form, via a single `QuotedSequenceName` helper that `EnsureSequencesAsync` and `PerTenantPartitionedCleanup` also route through, so the quoting cannot drift between the create and drop paths.

### Tests
`Bug_4924_hyphenated_tenant_id_sequence_name` — schema apply over a registered hyphenated/GUID suffix whose sequence is missing (the state a dropped-and-recreated event schema leaves behind), plus idempotence so a re-apply cannot drop and reset a live tenant's sequence. Verified red before / green after (3/3 passing locally).

Found while debugging JasperFx/CritterWatch#681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)