### PR TITLE
Aggregates in collection predicates, Regex.IsMatch(), and LINQ quick wins

### DIFF
--- a/docs/documents/querying/linq/child-collections.md
+++ b/docs/documents/querying/linq/child-collections.md
@@ -102,6 +102,7 @@ against a child collection, in this order:
 | Other comparisons (`>`, `<`, `>=`, `<=`, `!=`) and mixes, e.g. `x.Lines.Any(l => l.Name == "a" && l.Number > 5)` | JSONPath: `jsonb_path_exists(d.data, '$.Lines[*] ? (@.Name == $val1 && @.Number > $val2)', :params)` | No, but a single scan with a cheap per-row predicate |
 | Case-sensitive `StartsWith()` | JSONPath `starts with $var` — fully parameterized, works in compiled queries | No |
 | `Contains()`/`EndsWith()` on strings and case-insensitive comparisons | JSONPath `like_regex` with the (escaped) search text embedded in the SQL. **Not usable in compiled queries** — the value cannot be re-bound, and Marten fails loudly if you try | No |
+| Aggregates in predicates, e.g. `x.Lines.Sum(l => l.Number) > 100` (also `Min`/`Max`/`Average`, and parameterless overloads on scalar collections) | Correlated scalar subquery: `(SELECT COALESCE(SUM(...), 0) FROM ... ) > :arg`. `Sum()` over an empty collection is 0 like LINQ-to-objects; `Min`/`Max`/`Average` over an empty collection simply fail the comparison (C# would throw) | No |
 | `All(predicate)` for any jsonpath-capable predicate | `NOT jsonb_path_exists(d.data, '$.Lines[*] ? (!(...))')` — vacuously true on empty collections, and elements with null/missing members fail string predicates just like in LINQ-to-objects | No |
 | Anything else (member-to-member comparisons, `DateTime` values) | Correlated `EXISTS (SELECT 1 FROM ...)` over the exploded elements | No |
 

--- a/docs/documents/querying/linq/strings.md
+++ b/docs/documents/querying/linq/strings.md
@@ -49,3 +49,23 @@ A shorthand for case-insensitive string matching is provided through `EqualsIgno
 <!-- endSnippet -->
 
 Marten translates `EqualsIgnoreCase` to a PostgreSQL case-insensitive pattern-match (`~~*`, equivalent to `ILIKE`) rather than a .NET culture-aware comparison.
+
+## Regular Expressions <Badge type="tip" text="9.15" />
+
+`Regex.IsMatch()` translates to the PostgreSQL regex match operator (`~`, or `~*` for
+`RegexOptions.IgnoreCase` — the only supported option) on top-level members, and to a jsonpath
+`like_regex` predicate inside collection filters:
+
+```cs
+// WHERE d.data ->> 'UserName' ~ :pattern
+session.Query<User>().Where(x => Regex.IsMatch(x.UserName, "^[a-z]+-\\d+$"));
+
+// jsonb_path_exists(d.data, '$.Lines[*] ? (@.ItemName like_regex "...")')
+session.Query<Order>().Where(x => x.Lines.Any(l => Regex.IsMatch(l.ItemName, "^item-1\\d$")));
+```
+
+Two caveats: PostgreSQL regular expressions are POSIX-flavored (`like_regex` is the SQL/JSON
+XQuery subset), so exotic .NET-specific constructs may behave differently. And inside collection
+filters the pattern is embedded in the SQL, so a compiled query cannot re-bind it between
+executions — Marten fails loudly if a compiled query member feeds such a pattern. Top-level
+`Regex.IsMatch()` stays fully parameterized and works in compiled queries.

--- a/src/LinqTests/Bugs/hashset_contains.cs
+++ b/src/LinqTests/Bugs/hashset_contains.cs
@@ -9,7 +9,7 @@ namespace LinqTests.Bugs;
 
 public class hashset_contains: BugIntegrationContext
 {
-    [Fact(Skip = "TODO: Fix it on the linq branch")]
+    [Fact]
     public async Task Can_query_by_hashset_contains()
     {
         var value = Guid.NewGuid().ToString();

--- a/src/LinqTests/ChildCollections/collection_aggregate_predicates.cs
+++ b/src/LinqTests/ChildCollections/collection_aggregate_predicates.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Linq;
+using Marten.Testing.Harness;
+using Shouldly;
+
+namespace LinqTests.ChildCollections;
+
+/// <summary>
+///     Coverage for aggregate functions (Sum/Min/Max/Average) over child collections
+///     inside Where() clauses, translated to correlated scalar subqueries
+/// </summary>
+public class collection_aggregate_predicates: IntegrationContext
+{
+    private List<JsonPathOrder> _orders;
+
+    public collection_aggregate_predicates(DefaultStoreFixture fixture): base(fixture)
+    {
+    }
+
+    private async Task seedOrders()
+    {
+        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(JsonPathOrder));
+
+        var random = new Random(20260712);
+        _orders = new List<JsonPathOrder>();
+
+        for (var i = 0; i < 40; i++)
+        {
+            _orders.Add(new JsonPathOrder
+            {
+                Id = Guid.NewGuid(),
+                Lines = Enumerable.Range(0, random.Next(1, 6)).Select(_ => new JsonPathOrderLine
+                {
+                    ItemName = $"item-{random.Next(0, 10)}",
+                    Number = random.Next(0, 101),
+                    Subs = Enumerable.Range(0, random.Next(0, 4))
+                        .Select(_ => new JsonPathSubLine { Amount = random.Next(0, 101) }).ToList()
+                }).ToList(),
+                Quantities = Enumerable.Range(0, random.Next(0, 5)).Select(_ => random.Next(0, 101)).ToList()
+            });
+        }
+
+        // empty collections — Sum() must be 0, Min/Max/Average unmatched
+        _orders.Add(new JsonPathOrder
+        {
+            Id = Guid.NewGuid(), Lines = new List<JsonPathOrderLine>(), Quantities = new List<int>()
+        });
+
+        theSession.Store(_orders.ToArray());
+        await theSession.SaveChangesAsync();
+    }
+
+    private async Task assertMatchesInMemory(
+        Expression<Func<JsonPathOrder, bool>> filter,
+        Func<JsonPathOrder, bool> inMemory)
+    {
+        var expected = _orders.Where(inMemory).Select(x => x.Id).OrderBy(x => x).ToArray();
+        var actual = (await theSession.Query<JsonPathOrder>().Where(filter).ToListAsync())
+            .Select(x => x.Id).OrderBy(x => x).ToArray();
+
+        expected.Any().ShouldBeTrue();
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task sum_with_selector()
+    {
+        await seedOrders();
+
+        var sql = theSession.Query<JsonPathOrder>()
+            .Where(x => x.Lines.Sum(l => l.Number) > 150)
+            .ToCommand().CommandText;
+        sql.ShouldContain("COALESCE(SUM(");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Sum(l => l.Number) > 150,
+            x => x.Lines.Sum(l => l.Number) > 150);
+    }
+
+    [Fact]
+    public async Task sum_over_empty_collection_is_zero()
+    {
+        await seedOrders();
+
+        // the empty-Lines doc must match == 0, exactly like LINQ-to-objects
+        await assertMatchesInMemory(
+            x => x.Lines.Sum(l => l.Number) == 0,
+            x => x.Lines.Sum(l => l.Number) == 0);
+    }
+
+    [Fact]
+    public async Task min_with_selector()
+    {
+        await seedOrders();
+
+        // C# Min() over an empty collection throws; the SQL translation simply
+        // fails the comparison, so guard the in-memory comparator the same way
+        await assertMatchesInMemory(
+            x => x.Lines.Min(l => l.Number) >= 20,
+            x => x.Lines.Any() && x.Lines.Min(l => l.Number) >= 20);
+    }
+
+    [Fact]
+    public async Task max_with_selector()
+    {
+        await seedOrders();
+
+        await assertMatchesInMemory(
+            x => x.Lines.Max(l => l.Number) < 80,
+            x => x.Lines.Any() && x.Lines.Max(l => l.Number) < 80);
+    }
+
+    [Fact]
+    public async Task average_with_selector()
+    {
+        await seedOrders();
+
+        await assertMatchesInMemory(
+            x => x.Lines.Average(l => l.Number) > 60,
+            x => x.Lines.Any() && x.Lines.Average(l => l.Number) > 60);
+    }
+
+    [Fact]
+    public async Task sum_over_scalar_value_collection()
+    {
+        await seedOrders();
+
+        await assertMatchesInMemory(
+            x => x.Quantities.Sum() > 120,
+            x => x.Quantities.Sum() > 120);
+    }
+
+    [Fact]
+    public async Task max_over_scalar_value_collection()
+    {
+        await seedOrders();
+
+        await assertMatchesInMemory(
+            x => x.Quantities.Max() > 90,
+            x => x.Quantities.Any() && x.Quantities.Max() > 90);
+    }
+
+    [Fact]
+    public async Task aggregate_selector_through_nested_member()
+    {
+        await seedOrders();
+
+        // Subs.Count resolves to jsonb_array_length against the element
+        await assertMatchesInMemory(
+            x => x.Lines.Sum(l => l.Subs.Count) >= 6,
+            x => x.Lines.Sum(l => l.Subs.Count) >= 6);
+    }
+
+    [Fact]
+    public async Task combined_with_other_filters()
+    {
+        await seedOrders();
+
+        await assertMatchesInMemory(
+            x => x.Lines.Sum(l => l.Number) > 100 && x.Lines.Any(l => l.Number > 90),
+            x => x.Lines.Sum(l => l.Number) > 100 && x.Lines.Any(l => l.Number > 90));
+    }
+
+    [Fact]
+    public async Task aggregate_in_compiled_query_rebinds()
+    {
+        await seedOrders();
+
+        var over100 = await theSession.QueryAsync(new OrdersWithLineSumOver(100));
+        var over300 = await theSession.QueryAsync(new OrdersWithLineSumOver(300));
+
+        var expected100 = _orders.Where(x => x.Lines.Sum(l => l.Number) > 100).Select(x => x.Id).OrderBy(x => x);
+        var expected300 = _orders.Where(x => x.Lines.Sum(l => l.Number) > 300).Select(x => x.Id).OrderBy(x => x);
+
+        over100.Select(x => x.Id).OrderBy(x => x).ShouldBe(expected100);
+        over300.Select(x => x.Id).OrderBy(x => x).ShouldBe(expected300);
+    }
+
+    public class OrdersWithLineSumOver: ICompiledListQuery<JsonPathOrder>
+    {
+        public OrdersWithLineSumOver()
+        {
+        }
+
+        public OrdersWithLineSumOver(int threshold)
+        {
+            Threshold = threshold;
+        }
+
+        public int Threshold { get; set; } = 50;
+
+        public Expression<Func<IMartenQueryable<JsonPathOrder>, IEnumerable<JsonPathOrder>>> QueryIs()
+        {
+            return q => q.Where(x => x.Lines.Sum(l => l.Number) > Threshold);
+        }
+    }
+}

--- a/src/LinqTests/ChildCollections/collection_filter_improvements.cs
+++ b/src/LinqTests/ChildCollections/collection_filter_improvements.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+
+namespace LinqTests.ChildCollections;
+
+/// <summary>
+///     Coverage for the quick-win batch: ?| for string-collection IsOneOf and
+///     ICollectionAware CollectionIsEmpty (nested IsEmpty() reduction)
+/// </summary>
+public class collection_filter_improvements: IntegrationContext
+{
+    private List<JsonPathOrder> _orders;
+
+    public collection_filter_improvements(DefaultStoreFixture fixture): base(fixture)
+    {
+    }
+
+    private async Task seedOrders()
+    {
+        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(JsonPathOrder));
+
+        var random = new Random(20260714);
+        _orders = new List<JsonPathOrder>();
+
+        for (var i = 0; i < 30; i++)
+        {
+            _orders.Add(new JsonPathOrder
+            {
+                Id = Guid.NewGuid(),
+                Tags = Enumerable.Range(0, 3).Select(_ => $"tag-{random.Next(0, 12)}").ToList(),
+                Lines = Enumerable.Range(0, 3).Select(_ => new JsonPathOrderLine
+                {
+                    ItemName = $"item-{random.Next(0, 10)}",
+                    Number = random.Next(0, 101),
+                    // roughly a third of lines get an empty Subs collection
+                    Subs = random.Next(0, 3) == 0
+                        ? new List<JsonPathSubLine>()
+                        : new List<JsonPathSubLine> { new() { Amount = random.Next(0, 101) } }
+                }).ToList()
+            });
+        }
+
+        theSession.Store(_orders.ToArray());
+        await theSession.SaveChangesAsync();
+    }
+
+    private async Task assertMatchesInMemory(
+        Expression<Func<JsonPathOrder, bool>> filter,
+        Func<JsonPathOrder, bool> inMemory)
+    {
+        var expected = _orders.Where(inMemory).Select(x => x.Id).OrderBy(x => x).ToArray();
+        var actual = (await theSession.Query<JsonPathOrder>().Where(filter).ToListAsync())
+            .Select(x => x.Id).OrderBy(x => x).ToArray();
+
+        expected.Any().ShouldBeTrue();
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task string_collection_is_one_of_uses_jsonb_any_key_operator()
+    {
+        await seedOrders();
+
+        var sql = theSession.Query<JsonPathOrder>()
+            .Where(x => x.Tags.IsOneOf(new List<string> { "tag-1", "tag-2" }))
+            .ToCommand().CommandText;
+
+        sql.ShouldContain(" ?| ");
+        sql.ShouldNotContain("&&");
+
+        await assertMatchesInMemory(
+            x => x.Tags.IsOneOf(new List<string> { "tag-1", "tag-2" }),
+            x => x.Tags.Any(t => t == "tag-1" || t == "tag-2"));
+    }
+
+    [Fact]
+    public async Task numeric_collection_is_one_of_keeps_array_overlap()
+    {
+        await seedOrders();
+
+        var sql = theSession.Query<JsonPathOrder>()
+            .Where(x => x.Quantities.IsOneOf(new List<int> { 1, 2, 3 }))
+            .ToCommand().CommandText;
+
+        sql.ShouldContain("&&");
+    }
+
+    [Fact]
+    public async Task nested_is_empty_reduces_to_jsonpath()
+    {
+        await seedOrders();
+
+        var sql = theSession.Query<JsonPathOrder>()
+            .Where(x => x.Lines.Any(l => l.Subs.IsEmpty()))
+            .ToCommand().CommandText;
+
+        sql.ShouldContain("@?");
+        sql.ShouldContain("size() == 0");
+        sql.ShouldNotContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => l.Subs.IsEmpty()),
+            x => x.Lines.Any(l => l.Subs == null || !l.Subs.Any()));
+    }
+
+    [Fact]
+    public async Task negated_nested_is_empty()
+    {
+        await seedOrders();
+
+        await assertMatchesInMemory(
+            x => !x.Lines.Any(l => l.Subs.IsEmpty()),
+            x => !x.Lines.Any(l => l.Subs == null || !l.Subs.Any()));
+    }
+}

--- a/src/LinqTests/Operators/compare_to_operator.cs
+++ b/src/LinqTests/Operators/compare_to_operator.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Exceptions;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+
+namespace LinqTests.Operators;
+
+/// <summary>
+///     Retrofit coverage for #4920, which generalized CompareTo() translation from
+///     string-only to any instance CompareTo(other): int — exercised here across the
+///     primitive types Marten stores
+/// </summary>
+public class compare_to_operator: IntegrationContext
+{
+    private Target[] _targets;
+
+    public compare_to_operator(DefaultStoreFixture fixture): base(fixture)
+    {
+    }
+
+    private async Task seed()
+    {
+        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Target));
+
+        _targets = Enumerable.Range(1, 20).Select(i => new Target
+        {
+            Id = Guid.NewGuid(),
+            Number = i,
+            Long = i * 1000L,
+            Double = i * 1.5,
+            Decimal = i * 2.5m,
+            Float = i * 0.5f,
+            String = $"name-{i:D2}",
+            Date = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Unspecified).AddDays(i),
+            DateOffset = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero).AddDays(i),
+            Color = (Colors)(i % 3)
+        }).ToArray();
+
+        theSession.Store(_targets);
+        await theSession.SaveChangesAsync();
+    }
+
+    private async Task assertCount(System.Linq.Expressions.Expression<Func<Target, bool>> filter, int expected)
+    {
+        expected.ShouldBeGreaterThan(0);
+        var actual = await theSession.Query<Target>().Where(filter).CountAsync();
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task int_compare_to()
+    {
+        await seed();
+        await assertCount(x => x.Number.CompareTo(10) > 0, _targets.Count(x => x.Number.CompareTo(10) > 0));
+        await assertCount(x => x.Number.CompareTo(10) <= 0, _targets.Count(x => x.Number.CompareTo(10) <= 0));
+        await assertCount(x => x.Number.CompareTo(10) == 0, _targets.Count(x => x.Number.CompareTo(10) == 0));
+    }
+
+    [Fact]
+    public async Task long_compare_to()
+    {
+        await seed();
+        await assertCount(x => x.Long.CompareTo(7000L) >= 0, _targets.Count(x => x.Long.CompareTo(7000L) >= 0));
+    }
+
+    [Fact]
+    public async Task double_compare_to()
+    {
+        await seed();
+        await assertCount(x => x.Double.CompareTo(15.0) < 0, _targets.Count(x => x.Double.CompareTo(15.0) < 0));
+    }
+
+    [Fact]
+    public async Task decimal_compare_to()
+    {
+        await seed();
+        await assertCount(x => x.Decimal.CompareTo(25.0m) > 0, _targets.Count(x => x.Decimal.CompareTo(25.0m) > 0));
+    }
+
+    [Fact]
+    public async Task float_compare_to()
+    {
+        await seed();
+        await assertCount(x => x.Float.CompareTo(5.0f) < 0, _targets.Count(x => x.Float.CompareTo(5.0f) < 0));
+    }
+
+    [Fact]
+    public async Task datetime_compare_to()
+    {
+        await seed();
+        var pivot = new DateTime(2026, 1, 11, 0, 0, 0, DateTimeKind.Unspecified);
+        await assertCount(x => x.Date.CompareTo(pivot) > 0, _targets.Count(x => x.Date.CompareTo(pivot) > 0));
+    }
+
+    [Fact]
+    public async Task datetimeoffset_compare_to()
+    {
+        await seed();
+        var pivot = new DateTimeOffset(2026, 1, 11, 0, 0, 0, TimeSpan.Zero);
+        await assertCount(x => x.DateOffset.CompareTo(pivot) <= 0,
+            _targets.Count(x => x.DateOffset.CompareTo(pivot) <= 0));
+    }
+
+    [Fact]
+    public async Task string_compare_to_still_works()
+    {
+        await seed();
+        await assertCount(x => x.String.CompareTo("name-10") > 0,
+            _targets.Count(x => string.Compare(x.String, "name-10", StringComparison.Ordinal) > 0));
+    }
+
+    [Fact]
+    public async Task constant_receiver_compare_to_member()
+    {
+        await seed();
+        // the comparison can sit on either side
+        await assertCount(x => 10.CompareTo(x.Number) > 0, _targets.Count(x => 10.CompareTo(x.Number) > 0));
+    }
+
+    [Fact]
+    public async Task compare_to_against_non_zero_throws()
+    {
+        await seed();
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+        {
+            await theSession.Query<Target>().Where(x => x.Number.CompareTo(10) > 1).ToListAsync();
+        });
+    }
+}

--- a/src/LinqTests/Operators/regex_is_match.cs
+++ b/src/LinqTests/Operators/regex_is_match.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using LinqTests.ChildCollections;
+using Marten;
+using Marten.Exceptions;
+using Marten.Linq;
+using Marten.Testing.Harness;
+using Shouldly;
+
+namespace LinqTests.Operators;
+
+public class regex_is_match: IntegrationContext
+{
+    private List<JsonPathOrder> _orders;
+
+    public regex_is_match(DefaultStoreFixture fixture): base(fixture)
+    {
+    }
+
+    private async Task seedOrders()
+    {
+        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(JsonPathOrder));
+
+        var random = new Random(20260713);
+        _orders = new List<JsonPathOrder>();
+
+        for (var i = 0; i < 30; i++)
+        {
+            _orders.Add(new JsonPathOrder
+            {
+                Id = Guid.NewGuid(),
+                Lines = Enumerable.Range(0, 4).Select(_ => new JsonPathOrderLine
+                {
+                    ItemName = $"item-{random.Next(0, 30)}", Number = random.Next(0, 101)
+                }).ToList(),
+                Tags = new List<string> { $"tag-{random.Next(0, 10)}", $"TAG-{random.Next(0, 10)}" }
+            });
+        }
+
+        // a null inside a scalar collection for the negation semantics
+        _orders.Add(new JsonPathOrder
+        {
+            Id = Guid.NewGuid(),
+            Lines = new List<JsonPathOrderLine> { new() { ItemName = null, Number = 1 } },
+            Tags = new List<string> { null, "tag-1" }
+        });
+
+        theSession.Store(_orders.ToArray());
+        await theSession.SaveChangesAsync();
+    }
+
+    private async Task assertMatchesInMemory(
+        Expression<Func<JsonPathOrder, bool>> filter,
+        Func<JsonPathOrder, bool> inMemory)
+    {
+        var expected = _orders.Where(inMemory).Select(x => x.Id).OrderBy(x => x).ToArray();
+        var actual = (await theSession.Query<JsonPathOrder>().Where(filter).ToListAsync())
+            .Select(x => x.Id).OrderBy(x => x).ToArray();
+
+        expected.Any().ShouldBeTrue();
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task top_level_member_uses_posix_operator()
+    {
+        await seedOrders();
+
+        // top level == first tag? no — use a collection-free assertion via Lines[0]?
+        // Simplest top-level string member on this type is via Any() — instead assert
+        // the operator on a scalar element inside the collection filter is like_regex,
+        // and the parameterized ~ shape with a whole-document type in the next test
+        var sql = theSession.Query<JsonPathOrder>()
+            .Where(x => x.Tags.Any(t => Regex.IsMatch(t, "^tag-[12]$")))
+            .ToCommand().CommandText;
+        sql.ShouldContain("like_regex");
+
+        await assertMatchesInMemory(
+            x => x.Tags.Any(t => Regex.IsMatch(t, "^tag-[12]$")),
+            x => x.Tags.Any(t => t != null && Regex.IsMatch(t, "^tag-[12]$")));
+    }
+
+    [Fact]
+    public async Task top_level_string_member()
+    {
+        await seedOrders();
+
+        var users = new[]
+        {
+            new RegexUser { Id = Guid.NewGuid(), UserName = "alice-42" },
+            new RegexUser { Id = Guid.NewGuid(), UserName = "bob.99" },
+            new RegexUser { Id = Guid.NewGuid(), UserName = "Carol-7" }
+        };
+        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(RegexUser));
+        theSession.Store(users);
+        await theSession.SaveChangesAsync();
+
+        var sql = theSession.Query<RegexUser>()
+            .Where(x => Regex.IsMatch(x.UserName, "^[a-z]+-\\d+$"))
+            .ToCommand().CommandText;
+        sql.ShouldContain(" ~ ");
+
+        var matching = await theSession.Query<RegexUser>()
+            .Where(x => Regex.IsMatch(x.UserName, "^[a-z]+-\\d+$"))
+            .ToListAsync();
+        matching.Single().UserName.ShouldBe("alice-42");
+
+        // case-insensitive flavor
+        var insensitive = await theSession.Query<RegexUser>()
+            .Where(x => Regex.IsMatch(x.UserName, "^[a-z]+-\\d+$", RegexOptions.IgnoreCase))
+            .ToListAsync();
+        insensitive.Select(x => x.UserName).OrderBy(x => x)
+            .ShouldBe(new[] { "Carol-7", "alice-42" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task inside_child_collection_predicate()
+    {
+        await seedOrders();
+
+        var sql = theSession.Query<JsonPathOrder>()
+            .Where(x => x.Lines.Any(l => Regex.IsMatch(l.ItemName, "^item-1\\d$")))
+            .ToCommand().CommandText;
+        sql.ShouldContain("jsonb_path_exists");
+        sql.ShouldContain("like_regex");
+        sql.ShouldNotContain("ctid");
+
+        await assertMatchesInMemory(
+            x => x.Lines.Any(l => Regex.IsMatch(l.ItemName, "^item-1\\d$")),
+            x => x.Lines.Any(l => l.ItemName != null && Regex.IsMatch(l.ItemName, "^item-1\\d$")));
+    }
+
+    [Fact]
+    public async Task all_with_regex_treats_null_as_failing()
+    {
+        await seedOrders();
+
+        await assertMatchesInMemory(
+            x => x.Tags.All(t => Regex.IsMatch(t, "^(tag|TAG)-\\d$")),
+            x => x.Tags.All(t => t != null && Regex.IsMatch(t, "^(tag|TAG)-\\d$")));
+    }
+
+    [Fact]
+    public async Task unsupported_regex_options_throw()
+    {
+        await seedOrders();
+
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+        {
+            await theSession.Query<JsonPathOrder>()
+                .Where(x => x.Lines.Any(l => Regex.IsMatch(l.ItemName, "x", RegexOptions.Multiline)))
+                .ToListAsync();
+        });
+    }
+
+    [Fact]
+    public async Task compiled_query_with_collection_regex_fails_loudly()
+    {
+        await seedOrders();
+
+        var ex = await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+        {
+            await theSession.QueryAsync(new OrdersMatchingPattern("^item"));
+        });
+
+        ex.Message.ShouldContain("compiled query");
+    }
+
+    public class OrdersMatchingPattern: ICompiledListQuery<JsonPathOrder>
+    {
+        public OrdersMatchingPattern()
+        {
+        }
+
+        public OrdersMatchingPattern(string pattern)
+        {
+            Pattern = pattern;
+        }
+
+        public string Pattern { get; set; } = "a";
+
+        public Expression<Func<IMartenQueryable<JsonPathOrder>, IEnumerable<JsonPathOrder>>> QueryIs()
+        {
+            return q => q.Where(x => x.Lines.Any(l => Regex.IsMatch(l.ItemName, Pattern)));
+        }
+    }
+}
+
+public class RegexUser
+{
+    public Guid Id { get; set; }
+    public string UserName { get; set; }
+}

--- a/src/Marten/Linq/Members/ChildCollectionMember.cs
+++ b/src/Marten/Linq/Members/ChildCollectionMember.cs
@@ -24,7 +24,7 @@ namespace Marten.Linq.Members;
 [UnconditionalSuppressMessage("AOT", "IL3050",
     Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class ChildCollectionMember: QueryableMember, ICollectionMember, IQueryableMemberCollection,
-    IExistsElementSource
+    IExistsElementSource, IAggregateableCollection
 {
     private readonly IQueryableMember _count;
     private readonly StoreOptions _options;
@@ -63,6 +63,31 @@ public class ChildCollectionMember: QueryableMember, ICollectionMember, IQueryab
     public ISqlFragment NotEmpty { get; }
 
     string? IExistsElementSource.ExplodedElementSource => $"select elem.value as data from {_arraySelector} as elem";
+
+    public IComparableMember ParseComparableForAggregate(string function, Expression? selector)
+    {
+        if (selector is not LambdaExpression lambda)
+        {
+            throw new BadLinqExpressionException(
+                $"Marten needs a member selector to translate {function}() over collection '{MemberName}', e.g. Sum(x => x.Amount)");
+        }
+
+        var members = MemberFinder.Determine(lambda.Body, "Invalid aggregate selector");
+        IQueryableMember member = FindMember(members[0]);
+        for (var i = 1; i < members.Length; i++)
+        {
+            if (member is not IHasChildrenMembers parent)
+            {
+                throw new BadLinqExpressionException(
+                    $"Marten cannot translate the {function}() selector '{lambda}'");
+            }
+
+            member = parent.FindMember(members[i]);
+        }
+
+        var source = ((IExistsElementSource)this).ExplodedElementSource!;
+        return new CollectionAggregateComparable(function, member.TypedLocator, source);
+    }
 
     public string ArrayLocator { get; set; }
 

--- a/src/Marten/Linq/Members/CollectionAggregateComparable.cs
+++ b/src/Marten/Linq/Members/CollectionAggregateComparable.cs
@@ -1,0 +1,90 @@
+#nullable enable
+using System.Linq.Expressions;
+using Marten.Exceptions;
+using Marten.Linq.Parsing;
+using Marten.Linq.SqlGeneration.Filters;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.Members;
+
+/// <summary>
+///     Implemented by collection members that can translate aggregate functions
+///     (Sum/Min/Max/Average) over their elements inside a Where() clause
+/// </summary>
+internal interface IAggregateableCollection
+{
+    IComparableMember ParseComparableForAggregate(string function, Expression? selector);
+}
+
+/// <summary>
+///     Translates Where(x => x.Items.Sum(i => i.Qty) &gt; n) and friends into a
+///     correlated scalar subquery over the exploded collection elements:
+///     (SELECT SUM(CAST(d.data ->> 'Qty' as integer)) FROM (&lt;elements&gt;) as d) &gt; :n
+/// </summary>
+internal class CollectionAggregateComparable: IComparableMember
+{
+    private readonly string _function;
+    private readonly string _valueLocator;
+    private readonly string _elementSource;
+
+    public CollectionAggregateComparable(string function, string valueLocator, string elementSource)
+    {
+        _function = function.ToUpperInvariant() == "AVERAGE" ? "AVG" : function.ToUpperInvariant();
+        _valueLocator = valueLocator;
+        _elementSource = elementSource;
+    }
+
+    public ISqlFragment CreateComparison(string op, ConstantExpression constant)
+    {
+        return new CollectionAggregateFilter(_function, _valueLocator, _elementSource, op, constant);
+    }
+}
+
+internal class CollectionAggregateFilter: ISqlFragment
+{
+    private readonly ConstantExpression _constant;
+    private readonly string _elementSource;
+    private readonly string _function;
+    private readonly string _op;
+    private readonly string _valueLocator;
+
+    public CollectionAggregateFilter(string function, string valueLocator, string elementSource, string op,
+        ConstantExpression constant)
+    {
+        _function = function;
+        _valueLocator = valueLocator;
+        _elementSource = elementSource;
+        _op = op;
+        _constant = constant;
+    }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        builder.Append("(SELECT ");
+
+        // LINQ-to-objects Sum() over an empty collection is 0, not null. Min/Max/
+        // Average over an empty collection throw in C#; SQL null makes the
+        // comparison false, which is the closest translation a filter can offer
+        if (_function == "SUM")
+        {
+            builder.Append("COALESCE(SUM(");
+            builder.Append(_valueLocator);
+            builder.Append("), 0)");
+        }
+        else
+        {
+            builder.Append(_function);
+            builder.Append("(");
+            builder.Append(_valueLocator);
+            builder.Append(")");
+        }
+
+        builder.Append(" FROM (");
+        builder.Append(_elementSource);
+        builder.Append(") as d) ");
+        builder.Append(_op);
+        builder.Append(" ");
+        builder.AppendParameter(_constant.Value());
+    }
+}

--- a/src/Marten/Linq/Members/ValueCollections/ValueCollectionMember.cs
+++ b/src/Marten/Linq/Members/ValueCollections/ValueCollectionMember.cs
@@ -25,7 +25,7 @@ namespace Marten.Linq.Members.ValueCollections;
 [UnconditionalSuppressMessage("AOT", "IL3050",
     Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
 public class ValueCollectionMember: QueryableMember, ICollectionMember, IValueCollectionMember, ISelectableMember,
-    IExistsElementSource
+    IExistsElementSource, IAggregateableCollection
 {
     private readonly IQueryableMember _count;
     private readonly WholeDataMember _wholeDataMember;
@@ -78,6 +78,23 @@ public class ValueCollectionMember: QueryableMember, ICollectionMember, IValueCo
     }
 
     string? IExistsElementSource.ExplodedElementSource => _explodedElementSource;
+
+    public IComparableMember ParseComparableForAggregate(string function, Expression? selector)
+    {
+        if (selector != null)
+        {
+            throw new BadLinqExpressionException(
+                $"Marten cannot translate a {function}() selector over the scalar value collection '{MemberName}' — use the parameterless overload");
+        }
+
+        if (_explodedElementSource == null)
+        {
+            throw new BadLinqExpressionException(
+                $"Marten cannot translate {function}() over collection '{MemberName}' of element type {ElementType.FullNameInCode()}");
+        }
+
+        return new CollectionAggregateComparable(function, "data", _explodedElementSource);
+    }
 
     /// <summary>
     /// Only used to craft children locators later

--- a/src/Marten/Linq/Parsing/Methods/CollectionIsOneOfFilter.cs
+++ b/src/Marten/Linq/Parsing/Methods/CollectionIsOneOfFilter.cs
@@ -25,6 +25,17 @@ internal class CollectionIsOneOfFilter: ISqlFragment
 
     public void Apply(ICommandBuilder builder)
     {
+        // string collections use the jsonb "contains any of these strings" operator,
+        // which the default GIN jsonb_ops operator class can serve (jsonb_path_ops
+        // cannot) — the array-overlap form below rebuilds a typed PG array per row
+        if (_collectionMember.ElementType == typeof(string))
+        {
+            builder.Append(_collectionMember.RawLocator);
+            builder.Append(" ?| ");
+            builder.AppendParameter(_values, NpgsqlDbType.Array | NpgsqlDbType.Text);
+            return;
+        }
+
         builder.Append(_collectionMember.ArrayLocator);
         builder.Append(" && ");
         builder.AppendParameter(_values, dbTypeFor(_collectionMember.ElementType));

--- a/src/Marten/Linq/Parsing/Methods/Strings/RegexIsMatch.cs
+++ b/src/Marten/Linq/Parsing/Methods/Strings/RegexIsMatch.cs
@@ -1,0 +1,133 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+using Marten.Exceptions;
+using Marten.Linq.Members;
+using Marten.Linq.SqlGeneration.Filters;
+using NpgsqlTypes;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.Parsing.Methods.Strings;
+
+/// <summary>
+///     Translates Regex.IsMatch(x.Member, pattern) to the PostgreSQL regex match
+///     operator (~ / ~* for RegexOptions.IgnoreCase) on top-level members, and to a
+///     jsonpath like_regex predicate inside collection filters. Note that PostgreSQL
+///     regular expressions are POSIX-flavored (and like_regex is the SQL/JSON XQuery
+///     subset) — most everyday patterns behave like .NET's, but the dialects are not
+///     identical
+/// </summary>
+internal class RegexIsMatch: IMethodCallParser
+{
+    public bool Matches(MethodCallExpression expression)
+    {
+        return expression.Method.DeclaringType == typeof(Regex)
+               && expression.Method.Name == nameof(Regex.IsMatch)
+               && expression.Method.IsStatic
+               && expression.Arguments.Count is 2 or 3
+               && expression.Arguments[0].Type == typeof(string);
+    }
+
+    public ISqlFragment Parse(IQueryableMemberCollection memberCollection, IReadOnlyStoreOptions options,
+        MethodCallExpression expression)
+    {
+        var member = memberCollection.MemberFor(expression.Arguments[0]);
+        var pattern = expression.Arguments[1].ReduceToConstant().Value() as string;
+
+        if (pattern == null)
+        {
+            throw new BadLinqExpressionException(
+                $"Marten needs a constant (or query-time resolvable) pattern for Regex.IsMatch(): '{expression}'");
+        }
+
+        var ignoreCase = false;
+        if (expression.Arguments.Count == 3)
+        {
+            var regexOptions = (RegexOptions)expression.Arguments[2].ReduceToConstant().Value()!;
+            ignoreCase = regexOptions.HasFlag(RegexOptions.IgnoreCase);
+
+            var unsupported = regexOptions & ~RegexOptions.IgnoreCase;
+            if (unsupported != RegexOptions.None)
+            {
+                throw new BadLinqExpressionException(
+                    $"Marten can only translate RegexOptions.IgnoreCase to SQL, not '{unsupported}'");
+            }
+        }
+
+        return new RegexIsMatchFilter(member, pattern, ignoreCase);
+    }
+}
+
+internal class RegexIsMatchFilter: ISqlFragment, ICollectionAware, IInlinedJsonPathValueFilter,
+    INegationGuardedJsonPathFilter
+{
+    private readonly bool _ignoreCase;
+    private readonly IQueryableMember _member;
+    private readonly string _pattern;
+
+    public RegexIsMatchFilter(IQueryableMember member, string pattern, bool ignoreCase)
+    {
+        _member = member;
+        _pattern = pattern;
+        _ignoreCase = ignoreCase;
+    }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        builder.Append(_member.RawLocator);
+        builder.Append(_ignoreCase ? " ~* " : " ~ ");
+        builder.AppendParameter(_pattern, NpgsqlDbType.Varchar);
+    }
+
+    // like_regex patterns cannot come from the vars parameter
+    bool IInlinedJsonPathValueFilter.JsonPathValueIsInlined => true;
+
+    public bool CanReduceInChildCollection() => false;
+
+    public ICollectionAwareFilter BuildFragment(ICollectionMember member, ISerializer serializer)
+    {
+        throw new NotSupportedException();
+    }
+
+    public bool SupportsContainment() => false;
+
+    public void PlaceIntoContainmentFilter(ContainmentWhereFilter filter)
+    {
+        throw new NotSupportedException();
+    }
+
+    public bool CanBeJsonPathFilter() => true;
+
+    public void BuildJsonPathFilter(ICommandBuilder builder, Dictionary<string, object> parameters)
+    {
+        StringComparisonParser.WriteJsonPathReference(_member, builder);
+        builder.Append(" like_regex \"");
+
+        // the value IS a regex pattern — escape only for the jsonpath string literal
+        // and the enclosing SQL string, never Regex.Escape
+        builder.Append(_pattern
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("'", "''"));
+
+        builder.Append(_ignoreCase ? "\" flag \"i\"" : "\"");
+    }
+
+    public IEnumerable<DictionaryValueUsage> Values()
+    {
+        yield return new DictionaryValueUsage(_pattern);
+    }
+
+    // a non-matching null/missing member must fail the predicate like it does in C#
+    public void BuildNegatedJsonPathFilter(ICommandBuilder builder, Dictionary<string, object> parameters)
+    {
+        builder.Append("(!(");
+        StringComparisonParser.WriteJsonPathReference(_member, builder);
+        builder.Append(".type() == \"string\") || !(");
+        BuildJsonPathFilter(builder, parameters);
+        builder.Append("))");
+    }
+}

--- a/src/Marten/Linq/Parsing/SimpleExpression.cs
+++ b/src/Marten/Linq/Parsing/SimpleExpression.cs
@@ -368,6 +368,20 @@ internal class SimpleExpression: ExpressionVisitor
             return null;
         }
 
+        if (node.Method.DeclaringType == typeof(Enumerable) &&
+            node.Method.Name is "Sum" or "Min" or "Max" or "Average")
+        {
+            if (_queryableMembers.MemberFor(node.Arguments[0]) is IAggregateableCollection aggregateable)
+            {
+                Comparable = aggregateable.ParseComparableForAggregate(node.Method.Name,
+                    node.Arguments.Count == 2 ? node.Arguments[1] : null);
+                return null;
+            }
+
+            throw new BadLinqExpressionException(
+                $"Marten cannot translate the {node.Method.Name}() aggregate over this collection: '{node}'");
+        }
+
         if (node.Method.Name == "get_Item" && node.Method.DeclaringType.Closes(typeof(IDictionary<,>)))
         {
             var dictMember = (IDictionaryMember)_queryableMembers.MemberFor(node.Object);

--- a/src/Marten/Linq/SqlGeneration/Filters/CollectionIsEmpty.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/CollectionIsEmpty.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using System;
+using System.Collections.Generic;
 using Marten.Linq.Members;
 using Marten.Linq.Parsing;
 using Weasel.Postgresql;
@@ -6,15 +8,13 @@ using Weasel.Postgresql.SqlGeneration;
 
 namespace Marten.Linq.SqlGeneration.Filters;
 
-// TODO -- make it ICollectionAware
-internal class CollectionIsEmpty: IReversibleWhereFragment
+internal class CollectionIsEmpty: IReversibleWhereFragment, ICollectionAware, ICollectionAwareFilter
 {
-    private readonly ICollectionMember _member;
     private readonly string _text;
 
     public CollectionIsEmpty(ICollectionMember member)
     {
-        _member = member;
+        CollectionMember = member;
         // deeply ashamed by the replace here, but it does work.
         var jsonPath = member.WriteJsonPath().Replace("[*]", "");
         _text = $"d.data @? '$ ? (@.{jsonPath} == null || @.{jsonPath}.size() == 0)'";
@@ -22,11 +22,56 @@ internal class CollectionIsEmpty: IReversibleWhereFragment
 
     public ISqlFragment Reverse()
     {
-        return _member.NotEmpty;
+        return CollectionMember.NotEmpty;
     }
 
     public void Apply(ICommandBuilder builder)
     {
         builder.Append(_text);
+    }
+
+    public bool CanReduceInChildCollection()
+    {
+        return true;
+    }
+
+    public ICollectionAwareFilter BuildFragment(ICollectionMember member, ISerializer serializer)
+    {
+        return this;
+    }
+
+    public bool SupportsContainment()
+    {
+        return false;
+    }
+
+    public void PlaceIntoContainmentFilter(ContainmentWhereFilter filter)
+    {
+        throw new NotSupportedException();
+    }
+
+    public bool CanBeJsonPathFilter()
+    {
+        return false;
+    }
+
+    public void BuildJsonPathFilter(ICommandBuilder builder, Dictionary<string, object> parameters)
+    {
+        throw new NotSupportedException();
+    }
+
+    public IEnumerable<DictionaryValueUsage> Values()
+    {
+        yield break;
+    }
+
+    public ICollectionMember CollectionMember { get; }
+
+    public ISqlFragment MoveUnder(ICollectionMember ancestorCollection)
+    {
+        var path = new List<IQueryableMember>(ancestorCollection.Ancestors);
+        path.Add(ancestorCollection);
+        path.Add(CollectionMember);
+        return new DeepCollectionIsEmpty(path);
     }
 }

--- a/src/Marten/Linq/SqlGeneration/Filters/DeepCollectionIsEmpty.cs
+++ b/src/Marten/Linq/SqlGeneration/Filters/DeepCollectionIsEmpty.cs
@@ -1,0 +1,43 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using JasperFx.Core;
+using Marten.Linq.Members;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.SqlGeneration.Filters;
+
+/// <summary>
+///     "Some ancestor element whose nested collection is empty". Unlike the
+///     not-empty case this cannot flatten to a total length check — a flattened
+///     length of zero would mean EVERY ancestor's collection is empty, not SOME
+/// </summary>
+internal class DeepCollectionIsEmpty: ISqlFragment
+{
+    public DeepCollectionIsEmpty(List<IQueryableMember> path)
+    {
+        Path = path;
+    }
+
+    public List<IQueryableMember> Path { get; }
+
+    public void Apply(ICommandBuilder builder)
+    {
+        var segments = Path.Where(x => x.JsonPathSegment.IsNotEmpty()).ToArray();
+        var final = segments.Last().JsonPathSegment.Replace("[*]", "");
+
+        builder.Append("d.data @? '$");
+        foreach (var member in segments.Take(segments.Length - 1))
+        {
+            builder.Append(".");
+            builder.Append(member.JsonPathSegment);
+        }
+
+        builder.Append(" ? (@.");
+        builder.Append(final);
+        builder.Append(" == null || @.");
+        builder.Append(final);
+        builder.Append(".size() == 0)'");
+    }
+}

--- a/src/Marten/LinqParsing.cs
+++ b/src/Marten/LinqParsing.cs
@@ -45,6 +45,7 @@ public class LinqParsing: IReadOnlyLinqParsing
         new StringIsNullOrEmpty(),
         new StringIsNullOrWhiteSpace(),
         new StringEquals(),
+        new RegexIsMatch(),
         new SimpleEqualsParser(),
         new AnySubQueryParser(),
 


### PR DESCRIPTION
Three commits continuing the collection-predicate strategy work (#4928/#4929/#4931):

## 1. Sum/Min/Max/Average over collections inside `Where()`

```csharp
session.Query<Order>().Where(x => x.Lines.Sum(l => l.Number) > 100);
// (SELECT COALESCE(SUM(CAST(d.data ->> 'Number' as integer)), 0) FROM (…elements…) as d) > :arg
```

Rides the element source the EXISTS strategy introduced. Selectors resolve through the queryable member tree (nested paths like `Sum(l => l.Subs.Count)` work), and parameterless overloads work on scalar collections (`x.Quantities.Sum() > n`). `Sum()` over an empty collection is `COALESCE`'d to 0 to match LINQ-to-objects; `Min`/`Max`/`Average` over empty yield SQL NULL and fail the comparison (C# would throw). Plain parameters — compiled queries re-bind thresholds for free. This was the biggest remaining EF-Core-parity gap from the sub-collection deep dive.

## 2. `Regex.IsMatch()`

Top-level members → parameterized `~` / `~*` (`RegexOptions.IgnoreCase` is the only supported option; anything else throws descriptively). Inside collection predicates → jsonpath `like_regex`, with the `type()` null-guard for negation/`All()` semantics and the loud plan-time failure if a compiled query member feeds the pattern. Patterns are escaped only for the jsonpath/SQL string literals, never `Regex.Escape`. Dialect caveat documented (POSIX / XQuery subset vs .NET).

## 3. Quick wins

- **Retrofits test coverage for #4920** (generalized `CompareTo()`), per review follow-up: int, long, double, decimal, float, DateTime, DateTimeOffset, string regression, constant receiver, and the non-zero guard — all pass, #4920 holds beyond its Guid test.
- `x.Tags.IsOneOf(...)` on **string collections** → `?|` (served by GIN `jsonb_ops`) instead of rebuilding a typed PG array per row for `&&`. Other element types keep the overlap translation.
- **`CollectionIsEmpty` is finally `ICollectionAware`** (the long-standing TODO): `x.Lines.Any(l => l.Subs.IsEmpty())` reduces to one jsonpath filter via the new `DeepCollectionIsEmpty` — with the deliberate asymmetry that deep is-empty cannot flatten to a total-length check like not-empty does.
- Unskips `hashset_contains` (works on current master; stale skip).

Deferred with a note: `Dictionary.Values.Any(pred)` via a jsonpath `$.dict.*` iterator.

24 new tests. Full LinqTests: 1382/1383 (one order-dependent flake in an F# option-list test, passes in isolation and its class 34/34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCpsgx7amReQkNmiE2X7Ha