### PR TITLE
fix(#4916): subclass queries use duplicated/id columns instead of JSONB

### DIFF
--- a/src/DocumentDbTests/Bugs/Bug_4916_subclass_duplicated_and_base_field_uses_column.cs
+++ b/src/DocumentDbTests/Bugs/Bug_4916_subclass_duplicated_and_base_field_uses_column.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Linq;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DocumentDbTests.Bugs;
+
+public record Bug4916Animal(Guid Id, Guid FarmId);
+
+public record Bug4916Cow(Guid Id, Guid FarmId): Bug4916Animal(Id, FarmId);
+
+/// <summary>
+/// #4916 — a subclass query that filters on a Duplicate()'d field or the base id emitted a JSONB filter
+/// (<c>CAST(d.data -&gt;&gt; 'FarmId' as uuid)</c>) instead of the real column (<c>d.farm_id</c> / <c>d.id</c>).
+/// A subclass shares the parent's table, but <c>SubClassMapping</c> built its own empty queryable-member
+/// collection that never inherited the parent's duplicated fields or id member, so every member fell through
+/// to the JSONB factory. Querying the parent type resolved the columns correctly the whole time.
+/// </summary>
+public class Bug_4916_subclass_duplicated_and_base_field_uses_column: BugIntegrationContext
+{
+    private void configure() =>
+        StoreOptions(o => o.Schema.For<Bug4916Animal>().AddSubClass<Bug4916Cow>().Duplicate(x => x.FarmId));
+
+    [Fact]
+    public void subclass_query_on_a_duplicated_field_uses_the_column_not_jsonb()
+    {
+        configure();
+
+        var id = Guid.NewGuid();
+        var sql = theSession.Query<Bug4916Cow>().Where(x => x.FarmId == id)
+            .ToCommand(FetchType.FetchMany).CommandText;
+
+        sql.ShouldContain("farm_id = :p0", Case.Insensitive);
+        sql.ShouldNotContain("data ->> 'FarmId'", Case.Insensitive);
+    }
+
+    [Fact]
+    public void subclass_query_on_the_base_id_uses_the_id_column_not_jsonb()
+    {
+        configure();
+
+        var id = Guid.NewGuid();
+        var sql = theSession.Query<Bug4916Cow>().Where(x => x.Id == id)
+            .ToCommand(FetchType.FetchMany).CommandText;
+
+        sql.ShouldContain("d.id = :p0", Case.Insensitive);
+        sql.ShouldNotContain("data ->> 'Id'", Case.Insensitive);
+    }
+
+    [Fact]
+    public void parent_query_is_unchanged()
+    {
+        configure();
+
+        var id = Guid.NewGuid();
+        var sql = theSession.Query<Bug4916Animal>().Where(x => x.FarmId == id)
+            .ToCommand(FetchType.FetchMany).CommandText;
+
+        sql.ShouldContain("farm_id = :p0", Case.Insensitive);
+        sql.ShouldNotContain("data ->> 'FarmId'", Case.Insensitive);
+    }
+
+    [Fact]
+    public async Task subclass_query_on_a_duplicated_field_round_trips()
+    {
+        configure();
+
+        var farmId = Guid.NewGuid();
+        var cow = new Bug4916Cow(Guid.NewGuid(), farmId);
+        theSession.Store(cow);
+        await theSession.SaveChangesAsync();
+
+        var loaded = await theSession.Query<Bug4916Cow>().Where(x => x.FarmId == farmId).ToListAsync();
+        loaded.ShouldHaveSingleItem().Id.ShouldBe(cow.Id);
+
+        var byId = await theSession.Query<Bug4916Cow>().Where(x => x.Id == cow.Id).ToListAsync();
+        byId.ShouldHaveSingleItem().FarmId.ShouldBe(farmId);
+    }
+}

--- a/src/Marten/Linq/Members/DocumentQueryableMemberCollection.cs
+++ b/src/Marten/Linq/Members/DocumentQueryableMemberCollection.cs
@@ -9,6 +9,7 @@ using ImTools;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Marten.Linq.Parsing.Operators;
+using Marten.Linq.SoftDeletes;
 using Marten.Schema;
 using Marten.Storage;
 using Weasel.Postgresql;
@@ -19,12 +20,28 @@ namespace Marten.Linq.Members;
 internal class DocumentQueryableMemberCollection: IQueryableMemberCollection, IQueryableMember
 {
     private readonly StoreOptions _options;
+    private readonly DocumentQueryableMemberCollection? _inheritedMembers;
     private ImHashMap<string, IQueryableMember> _members = ImHashMap<string, IQueryableMember>.Empty;
 
     public DocumentQueryableMemberCollection(IDocumentMapping mapping, StoreOptions options)
+        : this(mapping, options, null)
+    {
+    }
+
+    /// <summary>
+    /// For a subclass mapping. A subclass shares its parent's physical table, so the parent's
+    /// column-backed members — duplicated fields, the id column, the soft-delete flag — resolve to real
+    /// columns (<c>d.&lt;column&gt;</c>) that are valid verbatim in a subclass query. Inheriting them lets a
+    /// <c>Query&lt;Subclass&gt;()</c> filter hit the index instead of falling through to a JSONB member
+    /// (<c>CAST(d.data -&gt;&gt; '...')</c>). See #4916. The inheritance is consulted lazily at query time
+    /// because the parent registers these members during store compilation, after this collection is built.
+    /// </summary>
+    public DocumentQueryableMemberCollection(IDocumentMapping mapping, StoreOptions options,
+        DocumentQueryableMemberCollection? inheritedMembers)
     {
         _options = options;
         ElementType = mapping.DocumentType;
+        _inheritedMembers = inheritedMembers;
     }
 
     public TenancyStyle TenancyStyle { get; set; } = TenancyStyle.Single;
@@ -82,10 +99,38 @@ internal class DocumentQueryableMemberCollection: IQueryableMemberCollection, IQ
             return m;
         }
 
+        // #4916: a subclass query resolves its members against this (initially empty) collection, so a
+        // duplicated field or the base id — registered only on the parent mapping — would otherwise fall
+        // through to a JSONB member. Reuse the parent's column-backed member instead; it locates a real
+        // column on the table both share.
+        if (_inheritedMembers != null && _inheritedMembers.TryFindColumnBackedMember(member.Name, out var inherited))
+        {
+            _members = _members.AddOrUpdate(member.Name, inherited);
+            return inherited;
+        }
+
         m = _options.CreateQueryableMember(member, this);
         _members = _members.AddOrUpdate(member.Name, m);
 
         return m;
+    }
+
+    /// <summary>
+    /// Whether this collection already holds a member for <paramref name="name"/> that is backed by a real
+    /// column on the document table (a duplicated field, the id, or the soft-delete flag) rather than a JSONB
+    /// locator. A subclass collection reuses exactly these from its parent; see the inheriting constructor.
+    /// Only members registered up front (never lazily-created JSONB members) are considered, so the parent's
+    /// own query history cannot leak a <c>d.data -&gt;&gt; ...</c> member into a subclass query.
+    /// </summary>
+    internal bool TryFindColumnBackedMember(string name, out IQueryableMember member)
+    {
+        if (_members.TryFind(name, out member!) && member is DuplicatedField or IdMember or IsSoftDeletedMember)
+        {
+            return true;
+        }
+
+        member = null!;
+        return false;
     }
 
     public void ReplaceMember(MemberInfo member, IQueryableMember queryableMember)

--- a/src/Marten/Schema/SubClassMapping.cs
+++ b/src/Marten/Schema/SubClassMapping.cs
@@ -28,7 +28,11 @@ public class SubClassMapping: IDocumentMapping
         Alias = alias ?? GetTypeMartenAlias(documentType);
         Aliases = new[] { Alias };
 
-        QueryMembers = new DocumentQueryableMemberCollection(this, storeOptions);
+        // #4916: inherit the parent's column-backed members (duplicated fields, the id column, the
+        // soft-delete flag) so a subclass query filtering on one of them hits the shared table's column
+        // instead of falling through to JSONB. Resolved lazily — the parent registers these during store
+        // compilation, after this constructor runs.
+        QueryMembers = new DocumentQueryableMemberCollection(this, storeOptions, parent.QueryMembers);
     }
 
     public SubClassMapping(Type documentType, DocumentMapping parent, StoreOptions storeOptions,


### PR DESCRIPTION
Closes #4916.

Filtering a **subclass** query on a `Duplicate()`'d field or the base id emitted a JSONB filter instead of the real column:

```csharp
o.Schema.For<Animal>().AddSubClass<Cow>().Duplicate(x => x.FarmId);

Query<Cow>().Where(x => x.FarmId == id)
//  was:  ... and CAST(d.data ->> 'FarmId' as uuid) = :p0
//  now:  ... and d.farm_id = :p0
Query<Cow>().Where(x => x.Id == id)      // also missed the PK index
//  was:  ... and CAST(d.data ->> 'Id' as uuid) = :p0
//  now:  ... and d.id = :p0
```

### Root cause
A subclass query resolves its members against `SubClassMapping`'s **own** `DocumentQueryableMemberCollection`, which was constructed empty and never inherited the duplicated fields or id member registered on the parent `DocumentMapping`. So every member fell through to the JSONB factory. Querying the *parent* type resolved both to real columns the whole time — a subclass shares the parent's physical table, so those columns are valid in a subclass query too.

### Fix
`SubClassMapping` now passes the parent's collection to the subclass collection, which consults it in `FindMember` before creating a JSONB member — but only for **column-backed** member types (`DuplicatedField`/`DuplicatedValueTypeField`, `IdMember`/`StrongTypedIdMember`, `IsSoftDeletedMember`), so the parent's own lazily-created JSONB members can never leak into a subclass query. The lookup is **lazy** (at query time), because the parent registers these members during store compilation — after the `SubClassMapping` is constructed.

Parent-type queries are untouched (the parent's own collection is unchanged), and subclass-only members still resolve locally against the subclass's `ElementType`.

### Tests
`Bug_4916_subclass_duplicated_and_base_field_uses_column` — SQL assertions for the duplicated field and the base id on a subclass query, a parent-query-unchanged guard, and a round-trip (store a `Cow`, query by `FarmId` and by `Id`). 4/4 passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)