### PR TITLE
Migrate the remaining All() shapes and duplicated array fields onto the EXISTS strategy

### DIFF
--- a/src/LinqTests/ChildCollections/all_exists_migration.cs
+++ b/src/LinqTests/ChildCollections/all_exists_migration.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+
+namespace LinqTests.ChildCollections;
+
+/// <summary>
+///     The All() shapes the jsonpath tier rejects — null checks and DateTime
+///     comparisons — now translate to NOT EXISTS over the exploded elements, and
+///     duplicated array fields participate in the EXISTS strategy
+/// </summary>
+public class all_exists_migration: OneOffConfigurationsContext
+{
+    private List<JsonPathOrder> _orders;
+
+    private async Task seedOrders()
+    {
+        var random = new Random(20260715);
+        _orders = new List<JsonPathOrder>();
+
+        var baseline = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+
+        for (var i = 0; i < 30; i++)
+        {
+            _orders.Add(new JsonPathOrder
+            {
+                Id = Guid.NewGuid(),
+                Lines = Enumerable.Range(0, random.Next(1, 4)).Select(_ => new JsonPathOrderLine
+                {
+                    ItemName = random.Next(0, 4) == 0 ? null : $"item-{random.Next(0, 10)}",
+                    Number = random.Next(0, 101),
+                    At = random.Next(0, 5) == 0 ? null : baseline.AddDays(random.Next(0, 60))
+                }).ToList()
+            });
+        }
+
+        // empty collection — All() is vacuously true
+        _orders.Add(new JsonPathOrder { Id = Guid.NewGuid(), Lines = new List<JsonPathOrderLine>() });
+
+        theSession.Store(_orders.ToArray());
+        await theSession.SaveChangesAsync();
+    }
+
+    private async Task assertMatchesInMemory(
+        Expression<Func<JsonPathOrder, bool>> filter,
+        Func<JsonPathOrder, bool> inMemory)
+    {
+        var expected = _orders.Where(inMemory).Select(x => x.Id).OrderBy(x => x).ToArray();
+        var actual = (await theSession.Query<JsonPathOrder>().Where(filter).ToListAsync())
+            .Select(x => x.Id).OrderBy(x => x).ToArray();
+
+        expected.Any().ShouldBeTrue();
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task all_with_null_check_uses_not_exists()
+    {
+        await seedOrders();
+
+        var sql = theSession.Query<JsonPathOrder>()
+            .Where(x => x.Lines.All(l => l.ItemName == null))
+            .ToCommand().CommandText;
+        sql.ShouldContain("NOT(EXISTS (SELECT 1 FROM");
+        sql.ShouldContain("is not null");
+        sql.ShouldNotContain("ctid");
+
+        // vacuously true for the empty-Lines doc, like LINQ-to-objects
+        await assertMatchesInMemory(
+            x => x.Lines.All(l => l.ItemName == null),
+            x => x.Lines.All(l => l.ItemName == null));
+    }
+
+    [Fact]
+    public async Task all_with_not_null_check_uses_not_exists()
+    {
+        await seedOrders();
+
+        var sql = theSession.Query<JsonPathOrder>()
+            .Where(x => x.Lines.All(l => l.ItemName != null))
+            .ToCommand().CommandText;
+        sql.ShouldContain("NOT(EXISTS (SELECT 1 FROM");
+
+        await assertMatchesInMemory(
+            x => x.Lines.All(l => l.ItemName != null),
+            x => x.Lines.All(l => l.ItemName != null));
+    }
+
+    [Fact]
+    public async Task all_with_datetime_comparison_uses_not_exists()
+    {
+        await seedOrders();
+
+        var pivot = new DateTime(2026, 1, 31, 0, 0, 0, DateTimeKind.Unspecified);
+
+        var sql = theSession.Query<JsonPathOrder>()
+            .Where(x => x.Lines.All(l => l.At < pivot))
+            .ToCommand().CommandText;
+        sql.ShouldContain("NOT(EXISTS (SELECT 1 FROM");
+        sql.ShouldNotContain("ctid");
+
+        // a null At fails the comparison on both sides, and the null-safe failing
+        // predicate (is null OR >=) keeps that semantic in SQL
+        await assertMatchesInMemory(
+            x => x.Lines.All(l => l.At < pivot),
+            x => x.Lines.All(l => l.At.HasValue && l.At < pivot));
+    }
+
+    [Fact]
+    public async Task value_collection_datetime_inequality_now_works()
+    {
+        // DateTime element predicates are rejected by the jsonpath tier (serialized
+        // date strings do not compare reliably) and previously had NO working
+        // strategy — ElementComparisonFilter could not render itself as plain SQL
+        var baseline = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Unspecified);
+        var docs = Enumerable.Range(0, 15).Select(i => new DateListDoc
+        {
+            Id = Guid.NewGuid(),
+            Stamps = new List<DateTime> { baseline.AddDays(i), baseline.AddDays(i + 30) }
+        }).ToArray();
+        await theStore.BulkInsertDocumentsAsync(docs);
+
+        var pivot = baseline.AddDays(40);
+        var expected = docs.Where(x => x.Stamps.Any(s => s > pivot)).Select(x => x.Id).OrderBy(x => x).ToArray();
+        var actual = (await theSession.Query<DateListDoc>().Where(x => x.Stamps.Any(s => s > pivot)).ToListAsync())
+            .Select(x => x.Id).OrderBy(x => x).ToArray();
+
+        expected.Any().ShouldBeTrue();
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task duplicated_array_field_inequality_uses_exists()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Schema.For<DupArrayDoc>().Duplicate(x => x.Scores);
+        });
+
+        var docs = Enumerable.Range(0, 20).Select(i => new DupArrayDoc
+        {
+            Id = Guid.NewGuid(), Scores = new[] { i, i * 3, 100 - i }
+        }).ToArray();
+        await theStore.BulkInsertDocumentsAsync(docs);
+
+        var sql = theSession.Query<DupArrayDoc>()
+            .Where(x => x.Scores.Any(s => s > 90))
+            .ToCommand().CommandText;
+        sql.ShouldContain("EXISTS (SELECT 1 FROM");
+        sql.ShouldContain("unnest(");
+        sql.ShouldNotContain("ctid");
+
+        var expected = docs.Where(x => x.Scores.Any(s => s > 90)).Select(x => x.Id).OrderBy(x => x).ToArray();
+        var actual = (await theSession.Query<DupArrayDoc>().Where(x => x.Scores.Any(s => s > 90)).ToListAsync())
+            .Select(x => x.Id).OrderBy(x => x).ToArray();
+
+        expected.Any().ShouldBeTrue();
+        actual.ShouldBe(expected);
+    }
+}
+
+public class DateListDoc
+{
+    public Guid Id { get; set; }
+    public List<DateTime> Stamps { get; set; } = new();
+}
+
+public class DupArrayDoc
+{
+    public Guid Id { get; set; }
+    public int[] Scores { get; set; }
+}

--- a/src/LinqTests/ChildCollections/jsonpath_any_filters.cs
+++ b/src/LinqTests/ChildCollections/jsonpath_any_filters.cs
@@ -372,6 +372,7 @@ public class JsonPathOrderLine
 {
     public string ItemName { get; set; }
     public int Number { get; set; }
+    public DateTime? At { get; set; }
     public List<JsonPathSubLine> Subs { get; set; } = new();
 }
 

--- a/src/Marten/Linq/Members/ChildCollectionMember.cs
+++ b/src/Marten/Linq/Members/ChildCollectionMember.cs
@@ -158,6 +158,19 @@ public class ChildCollectionMember: QueryableMember, ICollectionMember, IQueryab
                 return jsonPath;
             }
 
+            // Predicates the jsonpath tier rejects (DateTime values, null checks) become
+            // NOT EXISTS (an element failing the predicate) — vacuously true on empty
+            // collections, and a null member fails a comparison exactly like the old
+            // "value = ALL(array)" translation did
+            if (filter.Wheres.Count == 1 && this is IExistsElementSource { ExplodedElementSource: not null } source)
+            {
+                var failing = tryBuildFailingPredicate(filter.Wheres.Single());
+                if (failing != null)
+                {
+                    return new ExistsCollectionFilter(this, failing, source.ExplodedElementSource!) { Not = true };
+                }
+            }
+
             filter.Compile(method);
 
             return filter;
@@ -168,6 +181,26 @@ public class ChildCollectionMember: QueryableMember, ICollectionMember, IQueryab
         }
 
 
+    }
+
+    private static ISqlFragment? tryBuildFailingPredicate(ISqlFragment fragment)
+    {
+        switch (fragment)
+        {
+            case MemberComparisonFilter { Right: CommandParameter } comparison:
+                return CompoundWhereFragment.Or(new IsNullFilter(comparison.Member),
+                    new ComparisonFilter(comparison.Member, comparison.Right,
+                        ComparisonFilter.OppositeOperators[comparison.Op]));
+
+            case IsNullFilter isNull:
+                return new IsNotNullFilter(isNull.Member);
+
+            case IsNotNullFilter isNotNull:
+                return new IsNullFilter(isNotNull.Member);
+
+            default:
+                return null;
+        }
     }
 
     public ISqlFragment ParseWhereForContains(MethodCallExpression body, IReadOnlyStoreOptions options)

--- a/src/Marten/Linq/Members/DuplicatedArrayField.cs
+++ b/src/Marten/Linq/Members/DuplicatedArrayField.cs
@@ -23,7 +23,8 @@ namespace Marten.Linq.Members;
     Justification = "Class-level: consumes RUC-annotated members (ISerializer, JasperFx.Events aggregator graph, CloseAndBuildAs / GenericFactoryCache fallbacks, FastExpressionCompiler). Document/event/projection types flow in from StoreOptions / Schema.For<T>() / projection registration and are preserved per the AOT publishing guide; AOT consumers supply a source-generator-backed serializer + pre-generated codegen artifacts.")]
 [UnconditionalSuppressMessage("AOT", "IL3050",
     Justification = "Class-level: uses Type.MakeGenericType / MethodInfo.MakeGenericMethod / Activator.CreateInstance / FastExpressionCompiler — runtime code generation. AOT consumers pre-generate codegen artifacts (codegen write) and supply source-generator-backed serializer impls per the AOT publishing guide.")]
-internal class DuplicatedArrayField: DuplicatedField, ICollectionMember, IQueryableMemberCollection
+internal class DuplicatedArrayField: DuplicatedField, ICollectionMember, IQueryableMemberCollection,
+    IExistsElementSource, IValueCollectionMember
 {
     public DuplicatedArrayField(EnumStorage enumStorage, QueryableMember innerMember, bool useTimestampWithoutTimeZoneForDateTime = true, bool notNull = false) : base(enumStorage, innerMember, useTimestampWithoutTimeZoneForDateTime, notNull)
     {
@@ -54,6 +55,8 @@ internal class DuplicatedArrayField: DuplicatedField, ICollectionMember, IQuerya
 
     public ISqlFragment IsEmpty { get; }
     public ISqlFragment NotEmpty { get; }
+
+    string? IExistsElementSource.ExplodedElementSource => $"select elem as data from unnest({TypedLocator}) as elem";
 
     public Type ElementType { get; }
     public string ExplodeLocator { get; }

--- a/src/Marten/Linq/Members/ValueCollections/ElementComparisonFilter.cs
+++ b/src/Marten/Linq/Members/ValueCollections/ElementComparisonFilter.cs
@@ -76,6 +76,12 @@ internal class ElementComparisonFilter: ISqlFragment, ICollectionAware
 
     void ISqlFragment.Apply(ICommandBuilder builder)
     {
-        throw new NotSupportedException();
+        // rendered inside an exploded-element context (correlated EXISTS derived
+        // table or the legacy explode CTE), where the element is the typed "data"
+        // column
+        builder.Append("data ");
+        builder.Append(Op);
+        builder.Append(" ");
+        builder.AppendParameter(Value);
     }
 }


### PR DESCRIPTION
Follow-up to #4931/#4935 — the last two users of the legacy explode/ctid machinery move onto correlated EXISTS:

- **`All(predicate)` shapes the jsonpath tier rejects** (null checks, DateTime comparisons) translate to `NOT EXISTS` (an element failing the predicate), with null-safe failing predicates (`m is null OR m <opposite-op> v`) so a null member fails an equality-`All` exactly like the old `value = ALL(array)` translation did. Vacuously true on empty collections. DateTime `All()` comparisons are a new capability — the old `AllCollectionConditionFilter` accepted only equality and null checks.
- **`DuplicatedArrayField`** implements `IExistsElementSource` (`unnest` of the duplicated column) and `IValueCollectionMember`, so bare element predicates (`x.Scores.Any(s => s > 90)`) now parse and run against the duplicated column instead of throwing at member resolution.
- **`ElementComparisonFilter` gains a real `Apply`** against the exploded `data` element column. It always threw `NotSupportedException` before, which meant value-collection DateTime inequalities (`x.Stamps.Any(s => s > pivot)`) had **no working strategy on any path** — the jsonpath tier rightly rejects serialized date comparisons and the fallback then blew up rendering the inner predicate. Fixed with a regression test.

Full LinqTests: 1388/1388, zero skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCpsgx7amReQkNmiE2X7Ha