### PR TITLE
Support indexing into complex child collections in Where() clauses

### DIFF
--- a/docs/documents/querying/linq/child-collections.md
+++ b/docs/documents/querying/linq/child-collections.md
@@ -104,6 +104,7 @@ against a child collection, in this order:
 | `Contains()`/`EndsWith()` on strings and case-insensitive comparisons | JSONPath `like_regex` with the (escaped) search text embedded in the SQL. **Not usable in compiled queries** — the value cannot be re-bound, and Marten fails loudly if you try | No |
 | Aggregates in predicates, e.g. `x.Lines.Sum(l => l.Number) > 100` (also `Min`/`Max`/`Average`, and parameterless overloads on scalar collections) | Correlated scalar subquery: `(SELECT COALESCE(SUM(...), 0) FROM ... ) > :arg`. `Sum()` over an empty collection is 0 like LINQ-to-objects; `Min`/`Max`/`Average` over an empty collection simply fail the comparison (C# would throw) | No |
 | `All(predicate)` for any jsonpath-capable predicate | `NOT jsonb_path_exists(d.data, '$.Lines[*] ? (!(...))')` — vacuously true on empty collections, and elements with null/missing members fail string predicates just like in LINQ-to-objects | No |
+| Indexing into a collection, e.g. `x.Lines[0].Name == "x"`, `x.Lines.ElementAt(1).Number > 5` | Plain JSON path navigation: `data -> 'Lines' -> 0 ->> 'Name'`. Out-of-range indexes yield SQL NULL and simply don't match | Via computed/duplicated indexes only |
 | Anything else (member-to-member comparisons, `DateTime` values) | Correlated `EXISTS (SELECT 1 FROM ...)` over the exploded elements | No |
 
 A couple of practical notes:

--- a/src/LinqTests/ChildCollections/collection_indexing.cs
+++ b/src/LinqTests/ChildCollections/collection_indexing.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+
+namespace LinqTests.ChildCollections;
+
+/// <summary>
+///     Indexing into complex child collections inside Where() clauses:
+///     x.Lines[0].Name, x.Lines.ElementAt(n).Number, and List indexers on
+///     scalar collections
+/// </summary>
+public class collection_indexing: IntegrationContext
+{
+    private List<JsonPathOrder> _orders;
+
+    public collection_indexing(DefaultStoreFixture fixture): base(fixture)
+    {
+    }
+
+    private async Task seedOrders()
+    {
+        await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(JsonPathOrder));
+
+        var random = new Random(20260716);
+        _orders = new List<JsonPathOrder>();
+
+        for (var i = 0; i < 30; i++)
+        {
+            _orders.Add(new JsonPathOrder
+            {
+                Id = Guid.NewGuid(),
+                Lines = Enumerable.Range(0, random.Next(1, 4)).Select(n => new JsonPathOrderLine
+                {
+                    ItemName = $"item-{random.Next(0, 10)}", Number = random.Next(0, 101)
+                }).ToList(),
+                Tags = Enumerable.Range(0, random.Next(1, 4)).Select(_ => $"tag-{random.Next(0, 10)}").ToList()
+            });
+        }
+
+        // an empty one — out-of-range index access must simply not match
+        _orders.Add(new JsonPathOrder
+        {
+            Id = Guid.NewGuid(), Lines = new List<JsonPathOrderLine>(), Tags = new List<string>()
+        });
+
+        theSession.Store(_orders.ToArray());
+        await theSession.SaveChangesAsync();
+    }
+
+    private async Task assertMatchesInMemory(
+        Expression<Func<JsonPathOrder, bool>> filter,
+        Func<JsonPathOrder, bool> inMemory)
+    {
+        var expected = _orders.Where(inMemory).Select(x => x.Id).OrderBy(x => x).ToArray();
+        var actual = (await theSession.Query<JsonPathOrder>().Where(filter).ToListAsync())
+            .Select(x => x.Id).OrderBy(x => x).ToArray();
+
+        expected.Any().ShouldBeTrue();
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task list_indexer_into_complex_element_member()
+    {
+        await seedOrders();
+
+        var sql = theSession.Query<JsonPathOrder>()
+            .Where(x => x.Lines[0].ItemName == "item-3")
+            .ToCommand().CommandText;
+        sql.ShouldContain("-> 'Lines' -> 0 ->> 'ItemName'");
+
+        await assertMatchesInMemory(
+            x => x.Lines[0].ItemName == "item-3",
+            x => x.Lines.Count > 0 && x.Lines[0].ItemName == "item-3");
+    }
+
+    [Fact]
+    public async Task list_indexer_with_numeric_comparison()
+    {
+        await seedOrders();
+
+        await assertMatchesInMemory(
+            x => x.Lines[1].Number > 50,
+            x => x.Lines.Count > 1 && x.Lines[1].Number > 50);
+    }
+
+    [Fact]
+    public async Task element_at_into_complex_element()
+    {
+        await seedOrders();
+
+        await assertMatchesInMemory(
+            x => x.Lines.ElementAt(1).Number > 50,
+            x => x.Lines.Count > 1 && x.Lines[1].Number > 50);
+    }
+
+    [Fact]
+    public async Task list_indexer_on_scalar_collection()
+    {
+        await seedOrders();
+
+        await assertMatchesInMemory(
+            x => x.Tags[0] == "tag-4",
+            x => x.Tags.Count > 0 && x.Tags[0] == "tag-4");
+    }
+
+    [Fact]
+    public async Task variable_index_reduces_to_constant()
+    {
+        await seedOrders();
+
+        var index = 0;
+        await assertMatchesInMemory(
+            x => x.Lines[index].ItemName == "item-3",
+            x => x.Lines.Count > 0 && x.Lines[0].ItemName == "item-3");
+    }
+
+    [Fact]
+    public async Task out_of_range_index_simply_does_not_match()
+    {
+        await seedOrders();
+
+        // no document has ten lines — json -> 9 yields SQL NULL, never a match or error
+        var docs = await theSession.Query<JsonPathOrder>()
+            .Where(x => x.Lines[9].ItemName == "item-3")
+            .ToListAsync();
+        docs.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task indexed_element_null_check()
+    {
+        await seedOrders();
+
+        // "second line is absent" — matches docs with fewer than two lines
+        await assertMatchesInMemory(
+            x => x.Lines[1] == null,
+            x => x.Lines.Count <= 1);
+    }
+}

--- a/src/Marten/Linq/Members/ChildCollectionMember.cs
+++ b/src/Marten/Linq/Members/ChildCollectionMember.cs
@@ -10,6 +10,7 @@ using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Marten.Exceptions;
 using Marten.Internal;
+using Marten.Linq.Members.ValueCollections;
 using Marten.Linq.Parsing;
 using Marten.Linq.SqlGeneration;
 using Marten.Linq.SqlGeneration.Filters;
@@ -223,6 +224,20 @@ public class ChildCollectionMember: QueryableMember, ICollectionMember, IQueryab
 
     public override IQueryableMember FindMember(MemberInfo member)
     {
+        if (member is ArrayIndexMember indexMember)
+        {
+            var key = $"ArrayIndex[{indexMember.Index}]";
+            if (_members.TryFind(key, out var indexed))
+            {
+                return indexed;
+            }
+
+            indexed = new ChildDocumentAtIndex(_options, this, _options.Serializer().Casing, indexMember,
+                ElementType);
+            _members = _members.AddOrUpdate(key, indexed);
+            return indexed;
+        }
+
         if (_members.TryFind(member.Name, out var m))
         {
             return m;

--- a/src/Marten/Linq/Members/ChildDocumentAtIndex.cs
+++ b/src/Marten/Linq/Members/ChildDocumentAtIndex.cs
@@ -1,0 +1,80 @@
+#nullable enable
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using ImTools;
+using Marten.Exceptions;
+using Marten.Linq.Members.ValueCollections;
+using Marten.Linq.SqlGeneration.Filters;
+using Weasel.Postgresql.SqlGeneration;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Marten.Linq.Members;
+
+/// <summary>
+///     One complex element of a child collection addressed by position, e.g.
+///     x.Children[2] or x.Children.ElementAt(2) — locator "d.data -> 'Children' -> 2".
+///     Member access chains through it like any other child document
+/// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Class-level: consumes RUC-annotated members through StoreOptions.CreateQueryableMember; document types are preserved per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("AOT", "IL3050",
+    Justification = "Class-level: member creation goes through StoreOptions.CreateQueryableMember (runtime codegen); AOT consumers pre-generate codegen artifacts.")]
+internal class ChildDocumentAtIndex: QueryableMember, IQueryableMemberCollection, IComparableMember
+{
+    private readonly StoreOptions _options;
+    private ImHashMap<string, IQueryableMember> _members = ImHashMap<string, IQueryableMember>.Empty;
+
+    public ChildDocumentAtIndex(StoreOptions options, IQueryableMember parent, Casing casing,
+        ArrayIndexMember member, Type elementType): base(parent, casing, member)
+    {
+        _options = options;
+        ElementType = elementType;
+
+        RawLocator = TypedLocator = $"{parent.TypedLocator} -> {member.Index}";
+        NullTestLocator = RawLocator;
+    }
+
+    public Type ElementType { get; }
+
+    public override ISqlFragment CreateComparison(string op, ConstantExpression constant)
+    {
+        if (constant == null || constant.Value == null)
+        {
+            switch (op)
+            {
+                case "=":
+                    return new IsNullFilter(this);
+
+                case "!=":
+                    return new IsNotNullFilter(this);
+            }
+        }
+
+        throw new BadLinqExpressionException(
+            $"Marten can only compare an indexed collection element to null directly — query on its members instead, e.g. x.Children[{((ArrayIndexMember)Member).Index}].Name");
+    }
+
+    public override IQueryableMember FindMember(MemberInfo member)
+    {
+        if (_members.TryFind(member.Name, out var m))
+        {
+            return m;
+        }
+
+        m = _options.CreateQueryableMember(member, this);
+        _members = _members.AddOrUpdate(member.Name, m);
+
+        return m;
+    }
+
+    public System.Collections.Generic.IEnumerator<IQueryableMember> GetEnumerator()
+    {
+        return System.Linq.Enumerable.Select(_members.Enumerate(), x => x.Value).GetEnumerator();
+    }
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+}

--- a/src/Marten/Linq/Parsing/SimpleExpression.cs
+++ b/src/Marten/Linq/Parsing/SimpleExpression.cs
@@ -382,6 +382,27 @@ internal class SimpleExpression: ExpressionVisitor
                 $"Marten cannot translate the {node.Method.Name}() aggregate over this collection: '{node}'");
         }
 
+        if (node.Method.Name == "get_Item" && node.Object != null && node.Arguments.Count == 1 &&
+            node.Arguments[0].Type == typeof(int) &&
+            !node.Method.DeclaringType.Closes(typeof(IDictionary<,>)))
+        {
+            var listIndex = (int)node.Arguments[0].ReduceToConstant().Value!;
+            Members.Insert(0, new ArrayIndexMember(listIndex));
+
+            Visit(node.Object);
+            return null;
+        }
+
+        if (node.Method.DeclaringType == typeof(Enumerable) && node.Method.Name == "ElementAt" &&
+            node.Arguments.Count == 2 && node.Arguments[1].Type == typeof(int))
+        {
+            var elementIndex = (int)node.Arguments[1].ReduceToConstant().Value!;
+            Members.Insert(0, new ArrayIndexMember(elementIndex));
+
+            Visit(node.Arguments[0]);
+            return null;
+        }
+
         if (node.Method.Name == "get_Item" && node.Method.DeclaringType.Closes(typeof(IDictionary<,>)))
         {
             var dictMember = (IDictionaryMember)_queryableMembers.MemberFor(node.Object);


### PR DESCRIPTION
Last piece of the collection-predicate arc (#4928…#4937). `x.Lines[0].ItemName == "x"`, `x.Lines.ElementAt(1).Number > 5`, and List indexers on scalar collections translate to plain JSON path navigation:

```sql
where d.data -> 'Lines' -> 0 ->> 'ItemName' = :arg
```

Array indexing already parsed via `ArrayIndexMember`; this adds the List `get_Item` and `Enumerable.ElementAt` routes in `SimpleExpression` (indexes go through `ReduceToConstant`, so variables work) and a `ChildDocumentAtIndex` member so complex elements chain member access like any child document. Out-of-range indexes yield SQL NULL and simply don't match; `x.Lines[1] == null` answers "is there no second element". Docs row added to the strategy table.

Full LinqTests: 1395/1395, zero skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCpsgx7amReQkNmiE2X7Ha