### PR TITLE
release: 9.14.1 — consume JasperFx 2.26.0 (high-water fix #4913)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.14.0</Version>
+        <Version>9.14.1</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -90,14 +90,20 @@
          JasperFx 2.24.1: jasperfx#499/#500 (marten#4874 case B) — ProjectionCoordinatorBase.executeAsync
          terminates the leadership loop on a disposed data source / wrapped cancellation instead of
          re-polling, so a cold HotCold node's advisory-lock poll no longer spins OpenAsync against a
-         data source being disposed during shutdown. Pairs with Weasel 9.16.2 (weasel#349). -->
-    <PackageVersion Include="JasperFx" Version="2.24.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.24.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.24.1">
+         data source being disposed during shutdown. Pairs with Weasel 9.16.2 (weasel#349).
+         JasperFx 2.25.0: jasperfx#501 (CritterWatch#678) — every published ShardState is stamped with
+         its owning database identifier.
+         JasperFx 2.26.0: jasperfx#4913 (marten#4913) — under UseTenantPartitionedEvents the store-global
+         HighWaterAgent no longer runs its recurring max(seq_id)-over-mt_events scan (which fanned out
+         across every tenant partition each tick); tenant high water is driven per-tenant by the
+         coordinator + the jasperfx#492 timer, so the global mark is only seeded once at startup. -->
+    <PackageVersion Include="JasperFx" Version="2.26.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.26.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.26.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.24.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.26.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Cuts **Marten 9.14.1** and upgrades the JasperFx package family 2.24.1 → 2.26.0.

### JasperFx 2.26.0 — closes #4913
Under `UseTenantPartitionedEvents`, the store-global `HighWaterAgent` continuously ran `select coalesce(max(seq_id),0) from mt_events` — an unfiltered scan that fans out across **every tenant partition** on every poll (250ms–1s), per database. That store-global mark is not consumed to advance tenant projections (they advance per-tenant via `TenantedHighWaterCoordinator` + the jasperfx#492 poll timer), so JasperFx 2.26.0 (JasperFx/jasperfx#504) seeds it once at startup and **skips the recurring scan under partitioning**. Non-partitioned stores are unaffected.

2.26.0 also carries 2.25.0's `ShardState.DatabaseIdentifier` (jasperfx#501).

### Version
`9.14.0` → `9.14.1`; JasperFx / JasperFx.Events / JasperFx.Events.SourceGenerator / JasperFx.SourceGenerator all → 2.26.0. Builds clean against the newly-published packages locally.

Release notes covering the full 9.14.1 changelog (the LINQ improvements, #4916, #4924, #4915, #4917, #4913) will accompany the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)