### PR TITLE
GH-4942: run the idempotent provisioning repair on the sharded auto-assign path

### DIFF
--- a/src/Marten/Storage/ShardedTenancy.cs
+++ b/src/Marten/Storage/ShardedTenancy.cs
@@ -425,7 +425,9 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
         // bulk migration measured ~26s between tenant starts on exactly this, while the median tenant's
         // actual work took 4s) and pushes concurrent waiters past their command timeout. Crash-safety is
         // unchanged: with the assignment row committed but partitions missing, a re-run of
-        // AssignTenantAsync (or any idempotent provisioning repair) completes the tenant.
+        // AssignTenantAsync (or any idempotent provisioning repair) completes the tenant — and since
+        // #4942 the auto-assign path (findOrAssignTenantDatabaseAsync) runs the same repair on first
+        // sight of an already-assigned tenant, so both AddTenantToShardAsync overloads honor it.
         if (_databasesById.TryFind(databaseId, out var database))
         {
             database.TenantIds.Fill(tenantId);
@@ -790,6 +792,13 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
         await maybeApplyChanges().ConfigureAwait(false);
         await maybeSeedDatabases().ConfigureAwait(false);
 
+        // #4942: remember whether THIS process had already resolved the tenant before this call.
+        // The existing-assignment repair below runs only on first sight per process — the callers
+        // on the hot path (GetTenant/GetTenantAsync/FindOrCreateDatabase) consult _tenantToDatabase
+        // before ever reaching this method, so the repair costs at most one batch of IF NOT EXISTS
+        // catalog checks per tenant per process.
+        var previouslyKnown = _tenantToDatabase.TryFind(tenantId, out _);
+
         // Step 1: Check assignment table
         var databaseId = await FindDatabaseForTenantAsync(tenantId, CancellationToken.None)
             .ConfigureAwait(false);
@@ -798,6 +807,21 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
         {
             database.TenantIds.Fill(tenantId);
             _tenantToDatabase = _tenantToDatabase.AddOrUpdate(tenantId, database);
+
+            // #4942: an existing assignment row is NOT proof the tenant was fully provisioned —
+            // AssignTenantAsync/this method commit the registry row BEFORE the (idempotent,
+            // potentially slow) partition DDL, so a crash or failure in between leaves the tenant
+            // half-provisioned: assignment present, list partitions and/or the per-tenant event
+            // sequence missing. This path used to return early and never repair such a tenant,
+            // so every write to a missing document partition failed with 23514 forever (the
+            // explicit AssignTenantAsync overload always re-ran the repair; the auto-assign path
+            // did not). Run the same idempotent repair here, guarded to first sight per process.
+            if (!previouslyKnown)
+            {
+                await createPartitionsForTenant(database, tenantId, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+
             return database;
         }
 
@@ -807,6 +831,12 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
 
         await conn.CreateCommand($"select pg_advisory_lock({AdvisoryLockKey})")
             .ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
+
+        // #4942: tracks whether the tenant turned out to already have an active assignment under
+        // the lock (raced a concurrent assigner, or its shard database wasn't materialized locally
+        // at Step 1) — those tenants get the same guarded repair as Step 1 instead of the
+        // unconditional fresh-assignment provisioning.
+        var foundExistingAssignment = false;
 
         try
         {
@@ -846,59 +876,61 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
             {
                 database.TenantIds.Fill(tenantId);
                 _tenantToDatabase = _tenantToDatabase.AddOrUpdate(tenantId, database);
-                return database;
+                foundExistingAssignment = true;
             }
-
-            // Get available databases
-            var availableDatabases = new List<PooledDatabase>();
-            await using var reader = await ((DbCommand)conn
-                    .CreateCommand(
-                        $"select database_id, connection_string, is_full, tenant_count from {_schemaName}.{DatabasePoolTable.TableName} where is_full = false"))
-                .ExecuteReaderAsync(CancellationToken.None).ConfigureAwait(false);
-
-            while (await reader.ReadAsync().ConfigureAwait(false))
+            else
             {
-                availableDatabases.Add(new PooledDatabase(
-                    await reader.GetFieldValueAsync<string>(0).ConfigureAwait(false),
-                    await reader.GetFieldValueAsync<string>(1).ConfigureAwait(false),
-                    false,
-                    await reader.GetFieldValueAsync<int>(3).ConfigureAwait(false)
-                ));
-            }
+                // Get available databases
+                var availableDatabases = new List<PooledDatabase>();
+                await using var reader = await ((DbCommand)conn
+                        .CreateCommand(
+                            $"select database_id, connection_string, is_full, tenant_count from {_schemaName}.{DatabasePoolTable.TableName} where is_full = false"))
+                    .ExecuteReaderAsync(CancellationToken.None).ConfigureAwait(false);
 
-            await reader.CloseAsync().ConfigureAwait(false);
+                while (await reader.ReadAsync().ConfigureAwait(false))
+                {
+                    availableDatabases.Add(new PooledDatabase(
+                        await reader.GetFieldValueAsync<string>(0).ConfigureAwait(false),
+                        await reader.GetFieldValueAsync<string>(1).ConfigureAwait(false),
+                        false,
+                        await reader.GetFieldValueAsync<int>(3).ConfigureAwait(false)
+                    ));
+                }
 
-            // Run assignment strategy
-            var assignedDbId = await _configuration.AssignmentStrategy
-                .AssignTenantToDatabaseAsync(tenantId, availableDatabases).ConfigureAwait(false);
+                await reader.CloseAsync().ConfigureAwait(false);
 
-            // Write assignment
-            await conn.CreateCommand(
-                    $"insert into {_schemaName}.{TenantAssignmentTable.TableName} (tenant_id, database_id) values (:tid, :did) on conflict (tenant_id) do update set database_id = :did")
-                .With("tid", tenantId)
-                .With("did", assignedDbId)
-                .ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
+                // Run assignment strategy
+                var assignedDbId = await _configuration.AssignmentStrategy
+                    .AssignTenantToDatabaseAsync(tenantId, availableDatabases).ConfigureAwait(false);
 
-            // Update tenant count
-            await conn.CreateCommand(
-                    $"update {_schemaName}.{DatabasePoolTable.TableName} set tenant_count = tenant_count + 1 where database_id = :did")
-                .With("did", assignedDbId)
-                .ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
+                // Write assignment
+                await conn.CreateCommand(
+                        $"insert into {_schemaName}.{TenantAssignmentTable.TableName} (tenant_id, database_id) values (:tid, :did) on conflict (tenant_id) do update set database_id = :did")
+                    .With("tid", tenantId)
+                    .With("did", assignedDbId)
+                    .ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
 
-            // Ensure database is in cache
-            if (!_databasesById.TryFind(assignedDbId, out database))
-            {
-                // Need to build it from the pool
-                await BuildDatabases().ConfigureAwait(false);
+                // Update tenant count
+                await conn.CreateCommand(
+                        $"update {_schemaName}.{DatabasePoolTable.TableName} set tenant_count = tenant_count + 1 where database_id = :did")
+                    .With("did", assignedDbId)
+                    .ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
+
+                // Ensure database is in cache
                 if (!_databasesById.TryFind(assignedDbId, out database))
                 {
-                    throw new InvalidOperationException(
-                        $"Database '{assignedDbId}' was assigned but could not be found in the pool");
+                    // Need to build it from the pool
+                    await BuildDatabases().ConfigureAwait(false);
+                    if (!_databasesById.TryFind(assignedDbId, out database))
+                    {
+                        throw new InvalidOperationException(
+                            $"Database '{assignedDbId}' was assigned but could not be found in the pool");
+                    }
                 }
-            }
 
-            database.TenantIds.Fill(tenantId);
-            _tenantToDatabase = _tenantToDatabase.AddOrUpdate(tenantId, database);
+                database.TenantIds.Fill(tenantId);
+                _tenantToDatabase = _tenantToDatabase.AddOrUpdate(tenantId, database);
+            }
         }
         finally
         {
@@ -909,8 +941,13 @@ public class ShardedTenancy : ITenancy, ITenancyWithMasterDatabase, ITenantDatab
 
         // Partition DDL outside the global registry lock — same rationale as AssignTenantAsync above:
         // the lock guards the registry rows, not the tenant's shard-local (idempotent) DDL, and holding
-        // it through the DDL serializes every tenant assignment store-wide.
-        await createPartitionsForTenant(database, tenantId, CancellationToken.None).ConfigureAwait(false);
+        // it through the DDL serializes every tenant assignment store-wide. For a fresh assignment this
+        // is the initial provisioning; for an existing assignment discovered under the lock it is the
+        // #4942 first-sight-per-process repair, same guard as Step 1.
+        if (!foundExistingAssignment || !previouslyKnown)
+        {
+            await createPartitionsForTenant(database, tenantId, CancellationToken.None).ConfigureAwait(false);
+        }
 
         return database;
     }

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4942_auto_assign_provisioning_repair.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4942_auto_assign_provisioning_repair.cs
@@ -1,0 +1,274 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using Marten;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+public class Bug4942Doc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// #4942 — the auto-assign path (<c>AddTenantToShardAsync(tenantId, ct)</c> →
+/// <c>findOrAssignTenantDatabaseAsync</c>) returned early as soon as an assignment row existed,
+/// skipping <c>createPartitionsForTenant</c> + <c>PerTenantEventSequences.EnsureSequencesAsync</c>
+/// entirely. A half-provisioned tenant (assignment row committed, partition DDL failed or
+/// interrupted — the crash window the "outside the advisory lock" comment documents) was therefore
+/// NEVER repaired by auto-assign: every write to a missing document partition failed with 23514
+/// forever, while the explicit <c>AddTenantToShardAsync(tenantId, databaseId)</c> overload always
+/// re-ran the idempotent repair. Reported from production: 71 partitioned document tables missing
+/// one tenant's list partitions ran silently broken for two days (see also #4941).
+///
+/// The fix runs the same idempotent repair on the existing-assignment paths, guarded to first
+/// sight of the tenant per process (the <c>_tenantToDatabase</c> cache), so the hot path pays at
+/// most one batch of IF NOT EXISTS catalog checks per tenant per process.
+/// </summary>
+[Collection("sharded-tenant-partitioned")]
+public class Bug_4942_auto_assign_provisioning_repair : IAsyncLifetime
+{
+    private readonly ShardedPartitionedFixture _fixture;
+    private readonly List<IDocumentStore> _stores = new();
+
+    public Bug_4942_auto_assign_provisioning_repair(ShardedPartitionedFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        foreach (var store in _stores)
+        {
+            store.Dispose();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private IDocumentStore BuildStore()
+    {
+        var store = DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded";
+                x.PartitionSchemaName = "tenants";
+
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+
+                x.UseSmallestDatabaseAssignment();
+            });
+
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AddEventType<ShardedTestEvent>();
+
+            opts.Schema.For<Bug4942Doc>()
+                .MultiTenantedWithPartitioning(x => x.ByList());
+        });
+
+        _stores.Add(store);
+        return store;
+    }
+
+    /// <summary>
+    /// Provision the tenant end to end on a first store ("process 1"), then damage it into the
+    /// exact half-provisioned state from the report: assignment row intact in the master
+    /// registry, but the tenant's document list partition and per-tenant event sequence gone
+    /// from its shard. Returns the assigned database id.
+    /// </summary>
+    private async Task<string> provisionThenDamageAsync(string tenantId)
+    {
+        var store = BuildStore();
+
+        // Production eager-apply shape (same as Bug_4706) — parent partitioned tables
+        // exist on every shard before any tenant is provisioned.
+        var databases = await store.Options.Tenancy.BuildDatabases();
+        foreach (var db in databases.OfType<IMartenDatabase>())
+        {
+            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+        }
+
+        var dbId = await store.Advanced.AddTenantToShardAsync(tenantId, CancellationToken.None);
+        dbId.ShouldNotBeNull();
+
+        // Fully provisioned: document partition + per-tenant event sequence both exist.
+        await assertDocPartitionExists(dbId, tenantId);
+        await assertSequenceState(dbId, tenantId, shouldExist: true, "after initial provisioning");
+
+        store.Dispose();
+        _stores.Remove(store);
+
+        await damageTenantAsync(dbId, tenantId);
+        return dbId;
+    }
+
+    private async Task damageTenantAsync(string dbId, string tenantId)
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await conn.OpenAsync();
+        await conn.CreateCommand($"drop table if exists public.mt_doc_bug4942doc_{tenantId}")
+            .ExecuteNonQueryAsync();
+        await conn.CreateCommand($"drop sequence if exists public.mt_events_sequence_{tenantId}")
+            .ExecuteNonQueryAsync();
+    }
+
+    [Fact]
+    public async Task auto_assign_overload_repairs_half_provisioned_tenant_in_new_process()
+    {
+        var tenantId = "t4942_kilo";
+        var dbId = await provisionThenDamageAsync(tenantId);
+
+        // "Process 2": a fresh store (cold tenant cache) calls the AUTO-ASSIGN overload — the
+        // one the reporter's conversion tool used. On master this returned early off the
+        // existing assignment row and never repaired anything.
+        var store2 = BuildStore();
+        var dbId2 = await store2.Advanced.AddTenantToShardAsync(tenantId, CancellationToken.None);
+        dbId2.ShouldBe(dbId);
+
+        // The idempotent repair must have recreated both halves of the damage.
+        await assertDocPartitionExists(dbId, tenantId);
+        await assertSequenceState(dbId, tenantId, shouldExist: true, "auto-assign must repair the per-tenant event sequence");
+
+        // And the tenant is actually writable again — pre-fix this Store/SaveChanges failed
+        // with 23514 'no partition of relation "mt_doc_bug4942doc"'.
+        await using (var session = store2.LightweightSession(tenantId))
+        {
+            session.Store(new Bug4942Doc { Id = Guid.NewGuid(), Name = "healed" });
+            session.Events.StartStream(Guid.NewGuid(), new ShardedTestEvent { Value = "healed" });
+            await session.SaveChangesAsync();
+        }
+
+        await using (var query = store2.QuerySession(tenantId))
+        {
+            (await query.Query<Bug4942Doc>().CountAsync()).ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public async Task lazy_tenant_resolution_repairs_on_first_sight()
+    {
+        var tenantId = "t4942_lima";
+        var dbId = await provisionThenDamageAsync(tenantId);
+
+        // "Process 2": plain tenant resolution (what every session opening does) — the purest
+        // findOrAssignTenantDatabaseAsync entry. No writes here, so nothing else (e.g. a lazy
+        // schema apply) can mask whether the resolution itself did the repair.
+        var store2 = BuildStore();
+        await store2.Options.Tenancy.GetTenantAsync(tenantId);
+
+        await assertDocPartitionExists(dbId, tenantId);
+        await assertSequenceState(dbId, tenantId, shouldExist: true, "first-sight tenant resolution must repair the sequence");
+    }
+
+    [Fact]
+    public async Task repair_runs_at_most_once_per_process_per_tenant()
+    {
+        var tenantId = "t4942_mike";
+        var store = BuildStore();
+
+        var dbId = await store.Advanced.AddTenantToShardAsync(tenantId, CancellationToken.None);
+        await assertSequenceState(dbId, tenantId, shouldExist: true, "after initial provisioning");
+
+        // Damage AFTER the tenant is already in this process's cache.
+        await damageTenantAsync(dbId, tenantId);
+
+        // Second auto-assign call in the SAME process: the tenant is in _tenantToDatabase, so
+        // the first-sight guard must skip the repair — no shard DDL round trip at all. The
+        // still-missing sequence is the direct observable for "no repair work happened".
+        await store.Advanced.AddTenantToShardAsync(tenantId, CancellationToken.None);
+        await assertSequenceState(dbId, tenantId, shouldExist: false,
+            "the once-per-process guard must skip the repair for an already-cached tenant");
+
+        // A fresh process DOES heal it — the guard defers the repair, it doesn't lose it.
+        var store2 = BuildStore();
+        await store2.Advanced.AddTenantToShardAsync(tenantId, CancellationToken.None);
+        await assertSequenceState(dbId, tenantId, shouldExist: true, "a new process must repair on first sight");
+    }
+
+    [Fact]
+    public async Task explicit_overload_repairs_even_when_tenant_is_cached()
+    {
+        var tenantId = "t4942_nov";
+        var store = BuildStore();
+
+        var databases = await store.Options.Tenancy.BuildDatabases();
+        foreach (var db in databases.OfType<IMartenDatabase>())
+        {
+            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+        }
+
+        var dbId = await store.Advanced.AddTenantToShardAsync(tenantId, CancellationToken.None);
+        await assertDocPartitionExists(dbId, tenantId);
+
+        await damageTenantAsync(dbId, tenantId);
+
+        // The explicit-target overload documents "a re-run ... completes the tenant" — it must
+        // keep repairing unconditionally, even in the same process with a warm cache (unlike
+        // the guarded auto-assign path above). Pins the pre-#4942 contract.
+        await store.Advanced.AddTenantToShardAsync(tenantId, dbId, CancellationToken.None);
+
+        await assertDocPartitionExists(dbId, tenantId);
+        await assertSequenceState(dbId, tenantId, shouldExist: true, "explicit re-assignment must always re-run the repair");
+    }
+
+    // ---- helpers ----
+
+    private async Task assertDocPartitionExists(string dbId, string tenantId)
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await conn.OpenAsync();
+        var tables = await conn.ExistingTablesAsync();
+        tables.Any(t => t.Name == $"mt_doc_bug4942doc_{tenantId}").ShouldBeTrue(
+            $"list partition 'mt_doc_bug4942doc_{tenantId}' must exist in shard '{dbId}'. Tables: {string.Join(", ", tables.Select(t => t.QualifiedName))}");
+    }
+
+    private async Task assertSequenceState(string dbId, string tenantId, bool shouldExist, string because)
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await conn.OpenAsync();
+        var count = (long)(await conn.CreateCommand(
+                "select count(*) from pg_sequences where schemaname = 'public' and sequencename = :n")
+            .With("n", $"mt_events_sequence_{tenantId}")
+            .ExecuteScalarAsync())!;
+        var expected = shouldExist ? 1L : 0L;
+        count.ShouldBe(expected,
+            $"sequence 'mt_events_sequence_{tenantId}' in shard '{dbId}': {because}");
+    }
+}


### PR DESCRIPTION
Closes GH-4942. Also resolves the root-cause leg of GH-4941 (the half-provisioned-tenant state that then failed silently).

## Root cause

`ShardedTenancy.findOrAssignTenantDatabaseAsync` returned early as soon as an assignment row existed — on both the Step 1 registry check and the under-advisory-lock re-check — skipping `createPartitionsForTenant` and `PerTenantEventSequences.EnsureSequencesAsync` entirely.

That early return is unsafe by design of the provisioning sequence itself: the assignment row is deliberately committed **before** the (idempotent, potentially slow) partition DDL, which runs outside the advisory lock. The comment above that block documents the crash-safety contract as *"with the assignment row committed but partitions missing, a re-run of AssignTenantAsync (or any idempotent provisioning repair) completes the tenant."* The explicit `AddTenantToShardAsync(tenantId, databaseId)` overload honored that contract; the auto-assign `AddTenantToShardAsync(tenantId, ct)` overload did not — a half-provisioned tenant (assignment row present, list partitions and/or per-tenant event sequence missing) was **never** repaired by auto-assign, so every write to a missing document partition failed with `23514 no partition of relation ...` forever.

Production impact from the report: 512-tenant `MultiTenantedWithShardedDatabases` + `UseTenantPartitionedEvents` deployment, one tenant with 71 partitioned document tables missing its list partitions, silently broken for two days (#4941 covers the silent presentation).

## Fix

Both existing-assignment paths in `findOrAssignTenantDatabaseAsync` now run the same idempotent `createPartitionsForTenant` (which includes `EnsureSequencesAsync` under `UseTenantPartitionedEvents`) that the fresh-assignment and explicit-assignment paths run. For the under-lock path the DDL still executes **outside** the advisory lock, per the existing rationale (the lock guards registry rows, not shard-local idempotent DDL).

## Hot-path guard

The repair only runs when the tenant was **not** already in the local `_tenantToDatabase` cache — i.e. at most once per process per tenant. The hot-path callers (`GetTenant` / `GetTenantAsync` / `FindOrCreateDatabase`) consult that cache before ever reaching `findOrAssignTenantDatabaseAsync`, so steady-state tenant resolution is unchanged; first sight of a tenant costs one batch of `IF NOT EXISTS` catalog checks. The explicit `AssignTenantAsync` overload keeps repairing unconditionally, matching its documented re-run semantics.

## Tests

New `TenantPartitionedEventsTests/Sharded/Bug_4942_auto_assign_provisioning_repair.cs` (4 tests, all verified to fail on master before the fix except the last, which pins pre-existing behavior):

- `auto_assign_overload_repairs_half_provisioned_tenant_in_new_process` — assignment row intact, document partition + per-tenant event sequence dropped; a fresh process calling the auto-assign overload recreates both and the tenant is writable again (pre-fix: 23514).
- `lazy_tenant_resolution_repairs_on_first_sight` — plain `GetTenantAsync` heals the same damage, asserted purely from the catalog (no writes that could mask it via lazy schema apply).
- `repair_runs_at_most_once_per_process_per_tenant` — with the tenant already cached, a second auto-assign call does no repair work (the dropped sequence stays dropped); a new process then heals it.
- `explicit_overload_repairs_even_when_tenant_is_cached` — `AddTenantToShardAsync(tenantId, databaseId)` keeps repairing unconditionally, warm cache or not.

Full `TenantPartitionedEventsTests` (232/232) and `MultiTenancyTests` (159/159) pass; full solution builds clean in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)