### PR TITLE
Share tenancy-neutral identity-map state across ForTenant sessions (#4947)

### DIFF
--- a/src/DocumentDbTests/Bugs/Bug_4947_for_tenant_tenantless_documents.cs
+++ b/src/DocumentDbTests/Bugs/Bug_4947_for_tenant_tenantless_documents.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DocumentDbTests.Bugs;
+
+public class Bug_4947_for_tenant_tenantless_documents: BugIntegrationContext
+{
+    public class GlobalDoc
+    {
+        public Guid Id { get; set; }
+        public string Label { get; set; }
+    }
+
+    public class TenantedDoc
+    {
+        public Guid Id { get; set; }
+        public string Label { get; set; }
+    }
+
+    [Fact]
+    public async Task pending_tenantless_document_is_visible_through_for_tenant()
+    {
+        // The exact scenario from GH-4947: identity session, Store() a tenancy-neutral
+        // document (not yet committed), then read it back through ForTenant()
+        await using var session = theStore.IdentitySession();
+
+        var doc = new GlobalDoc { Id = Guid.NewGuid(), Label = "foo" };
+        session.Store(doc);
+
+        var loaded = await session.ForTenant("bar").LoadAsync<GlobalDoc>(doc.Id);
+
+        loaded.ShouldNotBeNull();
+        loaded.ShouldBeSameAs(doc);
+    }
+
+    [Fact]
+    public async Task pending_tenantless_document_is_visible_through_load_many_for_tenant()
+    {
+        await using var session = theStore.IdentitySession();
+
+        var one = new GlobalDoc { Id = Guid.NewGuid(), Label = "one" };
+        var two = new GlobalDoc { Id = Guid.NewGuid(), Label = "two" };
+        session.Store(one, two);
+
+        var loaded = await session.ForTenant("bar").LoadManyAsync<GlobalDoc>(one.Id, two.Id);
+
+        loaded.Count.ShouldBe(2);
+        loaded.OrderBy(x => x.Label).Select(x => x.Label).ShouldBe(new[] { "one", "two" });
+    }
+
+    [Fact]
+    public async Task committed_tenantless_document_resolves_to_the_same_instance_across_tenants()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var seed = theStore.LightweightSession())
+        {
+            seed.Store(new GlobalDoc { Id = id, Label = "global" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var session = theStore.IdentitySession();
+
+        var viaA = await session.ForTenant("a").LoadAsync<GlobalDoc>(id);
+        viaA.ShouldNotBeNull();
+        viaA.Label.ShouldBe("global");
+
+        var viaB = await session.ForTenant("b").LoadAsync<GlobalDoc>(id);
+        viaB.ShouldNotBeNull();
+
+        // One document, one identity map entry -- every ForTenant view of the same identity
+        // session (and the session itself) must resolve the same tracked instance
+        viaB.ShouldBeSameAs(viaA);
+
+        var direct = await session.LoadAsync<GlobalDoc>(id);
+        direct.ShouldBeSameAs(viaA);
+    }
+
+    [Fact]
+    public async Task tenantless_document_stored_through_for_tenant_is_visible_to_the_parent_session()
+    {
+        await using var session = theStore.IdentitySession();
+
+        var doc = new GlobalDoc { Id = Guid.NewGuid(), Label = "foo" };
+        session.ForTenant("a").Store(doc);
+
+        (await session.LoadAsync<GlobalDoc>(doc.Id)).ShouldBeSameAs(doc);
+        (await session.ForTenant("b").LoadAsync<GlobalDoc>(doc.Id)).ShouldBeSameAs(doc);
+    }
+
+    [Fact]
+    public async Task conjoined_documents_stay_isolated_per_tenant()
+    {
+        // Guard rail for #4801: a conjoined document must NOT be shared across ForTenant views
+        StoreOptions(opts => opts.Schema.For<TenantedDoc>().MultiTenanted());
+
+        var id = Guid.NewGuid();
+
+        await using (var seed = theStore.LightweightSession("a"))
+        {
+            seed.Store(new TenantedDoc { Id = id, Label = "tenant-a" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var seed = theStore.LightweightSession("b"))
+        {
+            seed.Store(new TenantedDoc { Id = id, Label = "tenant-b" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var session = theStore.IdentitySession("a");
+
+        var a = await session.ForTenant("a").LoadAsync<TenantedDoc>(id);
+        a.Label.ShouldBe("tenant-a");
+
+        var b = await session.ForTenant("b").LoadAsync<TenantedDoc>(id);
+        b.Label.ShouldBe("tenant-b");
+
+        b.ShouldNotBeSameAs(a);
+    }
+
+    [Fact]
+    public async Task mixed_store_shares_only_the_tenancy_neutral_document()
+    {
+        StoreOptions(opts => opts.Schema.For<TenantedDoc>().MultiTenanted());
+
+        var globalId = Guid.NewGuid();
+        var tenantedId = Guid.NewGuid();
+
+        await using (var seed = theStore.LightweightSession("a"))
+        {
+            seed.Store(new GlobalDoc { Id = globalId, Label = "global" });
+            seed.Store(new TenantedDoc { Id = tenantedId, Label = "tenant-a" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var seed = theStore.LightweightSession("b"))
+        {
+            seed.Store(new TenantedDoc { Id = tenantedId, Label = "tenant-b" });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var session = theStore.IdentitySession("a");
+
+        var globalViaA = await session.ForTenant("a").LoadAsync<GlobalDoc>(globalId);
+        var tenantedViaA = await session.ForTenant("a").LoadAsync<TenantedDoc>(tenantedId);
+
+        var globalViaB = await session.ForTenant("b").LoadAsync<GlobalDoc>(globalId);
+        var tenantedViaB = await session.ForTenant("b").LoadAsync<TenantedDoc>(tenantedId);
+
+        globalViaB.ShouldBeSameAs(globalViaA);
+
+        tenantedViaA.Label.ShouldBe("tenant-a");
+        tenantedViaB.Label.ShouldBe("tenant-b");
+    }
+}

--- a/src/Marten/Internal/Sessions/NestedTenantQuerySession.cs
+++ b/src/Marten/Internal/Sessions/NestedTenantQuerySession.cs
@@ -28,6 +28,8 @@ internal class NestedTenantQuerySession: QuerySession, ITenantQueryOperations
 
     protected internal override IDocumentStorage<T> selectStorage<T>(DocumentProvider<T> provider)
     {
-        return _parent.selectStorage(provider);
+        var storage = _parent.selectStorage(provider);
+        this.ShareTenantNeutralStateWith(_parent, storage);
+        return storage;
     }
 }

--- a/src/Marten/Internal/Sessions/NestedTenantSession.cs
+++ b/src/Marten/Internal/Sessions/NestedTenantSession.cs
@@ -78,7 +78,9 @@ internal class NestedTenantSession: DocumentSessionBase, ITenantOperations
 
     protected internal override IDocumentStorage<T> selectStorage<T>(DocumentProvider<T> provider)
     {
-        return _parent.selectStorage(provider);
+        var storage = _parent.selectStorage(provider);
+        this.ShareTenantNeutralStateWith(_parent, storage);
+        return storage;
     }
 
     public override void Dispose()

--- a/src/Marten/Internal/Sessions/NestedTenantSessionState.cs
+++ b/src/Marten/Internal/Sessions/NestedTenantSessionState.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using Marten.Internal.Storage;
+using Marten.Storage;
+
+namespace Marten.Internal.Sessions;
+
+internal static class NestedTenantSessionState
+{
+    /// <summary>
+    ///     #4947 — a nested ForTenant() session keeps its own identity map / version tracker so that
+    ///     conjoined documents (where the same id means a different document per tenant) cannot bleed
+    ///     across tenants (#4801). Tenancy-neutral documents are the opposite case: there is exactly
+    ///     one document per id for the whole database, so the parent session and every ForTenant()
+    ///     view of it must see the very same tracked instance. Alias the parent's identity-map (and
+    ///     version) entry for this document type into the nested session the first time the type is
+    ///     used through the nested session — before any load/store can create a competing entry.
+    /// </summary>
+    internal static void ShareTenantNeutralStateWith<T>(this QuerySession nested, QuerySession parent,
+        IDocumentStorage<T> storage) where T : notnull
+    {
+        // Same tenant as the parent: the whole map/tracker is already shared wholesale
+        if (ReferenceEquals(nested.ItemMap, parent.ItemMap))
+        {
+            return;
+        }
+
+        // Only identity-mapped (identity map + dirty checking) storage tracks documents in the session
+        if (storage is not ISharedTenantNeutralSessionState shared)
+        {
+            return;
+        }
+
+        // Conjoined documents are genuinely per-tenant — keep them isolated (#4801)
+        if (shared.TenancyStyle == TenancyStyle.Conjoined)
+        {
+            return;
+        }
+
+        // Under database-per-tenant the same id in another tenant's database is a *different*
+        // document even for a tenancy-neutral doc type, so only share within one database.
+        if (!ReferenceEquals(nested.Database, parent.Database))
+        {
+            return;
+        }
+
+        shared.ShareTenantNeutralStateWith(parent, nested);
+    }
+}

--- a/src/Marten/Internal/Storage/IdentityMapDocumentStorage.cs
+++ b/src/Marten/Internal/Storage/IdentityMapDocumentStorage.cs
@@ -8,11 +8,28 @@ using Marten.Exceptions;
 using Marten.Internal.CodeGeneration;
 using Marten.Linq.Selectors;
 using Marten.Schema;
+using Marten.Storage;
 using Npgsql;
 
 namespace Marten.Internal.Storage;
 
-public abstract class IdentityMapDocumentStorage<T, TId>: DocumentStorage<T, TId> where T: notnull where TId: notnull
+/// <summary>
+///     #4947 — seam that lets a nested ForTenant() session share the parent session's identity map
+///     (and version state) for a *single document type* rather than all-or-nothing per session.
+/// </summary>
+internal interface ISharedTenantNeutralSessionState
+{
+    TenancyStyle TenancyStyle { get; }
+
+    /// <summary>
+    ///     Point the nested session's identity map / version entries for this document type at the
+    ///     very same underlying dictionaries used by the parent session. Only ever called for
+    ///     tenancy-neutral documents living in the same database.
+    /// </summary>
+    void ShareTenantNeutralStateWith(IStorageSession parent, IStorageSession nested);
+}
+
+public abstract class IdentityMapDocumentStorage<T, TId>: DocumentStorage<T, TId>, ISharedTenantNeutralSessionState where T: notnull where TId: notnull
 {
     public IdentityMapDocumentStorage(DocumentMapping document): this(StorageStyle.IdentityMap, document)
     {
@@ -21,6 +38,66 @@ public abstract class IdentityMapDocumentStorage<T, TId>: DocumentStorage<T, TId
     protected IdentityMapDocumentStorage(StorageStyle storageStyle, DocumentMapping document): base(storageStyle,
         document)
     {
+    }
+
+    void ISharedTenantNeutralSessionState.ShareTenantNeutralStateWith(IStorageSession parent, IStorageSession nested)
+    {
+        if (ReferenceEquals(parent.ItemMap, nested.ItemMap))
+        {
+            return;
+        }
+
+        shareIdentityMap(parent, nested);
+
+        if (UseOptimisticConcurrency || UseNumericRevisions)
+        {
+            shareVersions(parent, nested);
+        }
+    }
+
+    private static void shareIdentityMap(IStorageSession parent, IStorageSession nested)
+    {
+        if (parent.ItemMap.TryGetValue(typeof(T), out var items))
+        {
+            // A mismatched key type is diagnosed (and thrown on) by the normal storage paths --
+            // don't propagate a broken entry into the nested session here.
+            if (items is not Dictionary<TId, T>)
+            {
+                return;
+            }
+        }
+        else
+        {
+            items = new Dictionary<TId, T>();
+            parent.ItemMap[typeof(T)] = items;
+        }
+
+        nested.ItemMap[typeof(T)] = items;
+    }
+
+    private void shareVersions(IStorageSession parent, IStorageSession nested)
+    {
+        if (parent.Versions is not VersionTracker parentVersions ||
+            nested.Versions is not VersionTracker nestedVersions)
+        {
+            return;
+        }
+
+        if (ReferenceEquals(parentVersions, nestedVersions))
+        {
+            return;
+        }
+
+        if (!parentVersions.ByType.TryGetValue(typeof(T), out var versions))
+        {
+            versions = UseNumericRevisions
+                ? new Dictionary<TId, long>()
+                : new Dictionary<TId, Guid>();
+
+            parentVersions.ByType[typeof(T)] = versions;
+        }
+
+        nestedVersions.ByType[typeof(T)] = versions;
     }
 
     public sealed override void Eject(IStorageSession session, T document)

--- a/src/Marten/Internal/VersionTracker.cs
+++ b/src/Marten/Internal/VersionTracker.cs
@@ -8,6 +8,12 @@ public class VersionTracker: IVersionTracker
 {
     private readonly Dictionary<Type, object> _byType = new();
 
+    /// <summary>
+    ///     #4947 -- exposed so that a nested ForTenant() session can alias the parent session's
+    ///     version state for a tenancy-neutral document type instead of tracking its own copy.
+    /// </summary>
+    internal Dictionary<Type, object> ByType => _byType;
+
     public Dictionary<TId, long> RevisionsFor<TDoc, TId>() where TId : notnull
     {
         if (_byType.TryGetValue(typeof(TDoc), out var item))


### PR DESCRIPTION
Fixes #4947. **Correctness regression against the shipped 9.13/9.14/9.15 line** — targeting a 9.15.1 patch.

## The bug

A `ForTenant()` view of an identity- or dirty-tracked session stopped seeing **tenancy-neutral (global) documents** the parent session tracks. A global document has exactly one row per id for the whole database, so `LoadAsync` through the `ForTenant` view missed the identity map, went to the database, found nothing (in @dervagabund's repro the document is `Store()`d but not yet committed) and returned **`null`**.

Silent wrong answer, not an error. Reported working on **9.12.0**, broken on **9.15.0**.

## Root cause

Commit `74b11a461` (PR #4807, the fix for #4801) tenant-scoped the identity map and version tracker for `ForTenant` sessions:

`src/Marten/Internal/Sessions/NestedTenantSession.cs:29-33` — `ItemMap`/`Versions` are shared from the parent **only when `tenant.TenantId == parent.TenantId`**; any other tenant gets a fresh, empty `ItemMap`. Same in `NestedTenantQuerySession.cs:20-24`.

That was **right for conjoined documents** — where the same id means a *different* document per tenant — but it was applied **per session** rather than **per document type**, so it also isolated document types that are tenancy-neutral and must be shared. Broken since **9.13.0**.

## The fix

Sharing is now decided **per document type**. A nested `ForTenant` session aliases the parent's identity-map entry (and version-tracker entry) for a type only when **all** of these hold:

- the storage is **identity-mapped** (so it tracks documents at all — covers `DirtyCheckedDocumentStorage` via the same seam),
- the type is **NOT `Conjoined`** — #4801's isolation is preserved exactly, and
- the nested session's `Database` is the **same instance** as the parent's, because under **database-per-tenant** the same id in another tenant's database is a different document *even for a tenancy-neutral type*.

Aliasing happens in `selectStorage`, which runs on every `StorageFor<T>()` — i.e. before any load or store can create a competing map entry — so it is deterministic rather than order-dependent.

## Tests

`Bug_4947_for_tenant_tenantless_documents` — the reporter's repro, `LoadManyAsync`, committed-document instance identity, storing *through* `ForTenant`, plus **two guard rails asserting conjoined documents stay isolated**.

- **5 of the 6 fail on unmodified master** (the one that passes is the conjoined guard rail, as it should).
- The **`Bug_4801` suite still passes** — the isolation that fix introduced is intact.
- Full **`DocumentDbTests`: 1047 passed, 0 failed**.

## Honest caveats

- `SubClassDocumentStorage` does not implement the new seam, so a subclassed global document resolved *via the subclass type* won't have the parent's map aliased at that moment (it delegates to the root storage, which aliases when accessed through the root type). Judged out of scope for a minimal patch; untested edge.
- `EjectAllOfType` on a nested session removes the entry only from that session's `ItemMap`; for a now-shared global type the underlying dictionary is the parent's, so the parent keeps seeing it. Pre-existing asymmetry in the eject paths, unchanged in behavior here.
- Only `net9.0` was exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)