### PR TITLE
Database-driven tenant partition sweep (#4944)

### DIFF
--- a/src/Marten/Schema/DatabaseScopedTenantPartitions.cs
+++ b/src/Marten/Schema/DatabaseScopedTenantPartitions.cs
@@ -2,15 +2,19 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ImTools;
+using Marten.Storage.Metadata;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
 using Weasel.Core;
 using Weasel.Core.Migrations;
 using Weasel.Postgresql;
+using Weasel.Postgresql.Tables;
 using Weasel.Postgresql.Tables.Partitioning;
 
 namespace Marten.Schema;
@@ -88,6 +92,16 @@ public class DatabaseScopedTenantPartitions: ManagedListPartitions, IListPartiti
     {
         _tableName = tableName;
     }
+
+    /// <summary>
+    /// #4944 — should tenant provisioning enumerate the tenant-list-partitioned tables straight out of
+    /// the PostgreSQL catalog (scoped to the schemas this store owns) in addition to the tables the
+    /// calling store has registered? Defaults to <c>true</c>, which is what makes provisioning correct
+    /// from a store that does not register every document type (a conversion tool, an admin CLI, a
+    /// seeding job). Set to <c>false</c> to restrict provisioning to the calling store's own registered
+    /// tables — the pre-#4944 behavior.
+    /// </summary>
+    public bool SweepPartitionedTablesFromDatabase { get; set; } = true;
 
     private DatabaseSet setFor(string databaseIdentifier)
     {
@@ -249,7 +263,12 @@ public class DatabaseScopedTenantPartitions: ManagedListPartitions, IListPartiti
         TenantPartitionDatabaseScope.Current = database;
         try
         {
-            return await base.AddPartitionToAllTables(logger, database, values, token).ConfigureAwait(false);
+            var statuses = await base.AddPartitionToAllTables(logger, database, values, token).ConfigureAwait(false);
+
+            var swept = await sweepTablesDiscoveredInDatabaseAsync(logger, database, values, statuses, token)
+                .ConfigureAwait(false);
+
+            return swept.Count == 0 ? statuses : statuses.Concat(swept).ToArray();
         }
         finally
         {
@@ -264,21 +283,194 @@ public class DatabaseScopedTenantPartitions: ManagedListPartitions, IListPartiti
         CancellationToken token)
     {
         await hydrateWithFreshConnectionAsync(database, token, force: true).ConfigureAwait(false);
-        mergeInto(database, new Dictionary<string, string>
-        {
-            [value] = string.IsNullOrEmpty(suffix) ? value.ToLowerInvariant() : suffix
-        });
+
+        var resolvedSuffix = string.IsNullOrEmpty(suffix) ? value.ToLowerInvariant() : suffix!;
+        var values = new Dictionary<string, string> { [value] = resolvedSuffix };
+        mergeInto(database, values);
 
         var prior = TenantPartitionDatabaseScope.Current;
         TenantPartitionDatabaseScope.Current = database;
         try
         {
             await base.AddPartitionToAllTables(database, value, suffix, token).ConfigureAwait(false);
+
+            await sweepTablesDiscoveredInDatabaseAsync(NullLogger.Instance, database, values, [], token)
+                .ConfigureAwait(false);
         }
         finally
         {
             TenantPartitionDatabaseScope.Current = prior;
         }
+    }
+
+    /// <summary>
+    /// #4944 — the database-driven half of the partition sweep.
+    ///
+    /// <para>
+    /// The base sweep decides which tables need the new tenant's list partition by walking the
+    /// CALLING store's configured objects (<c>database.AllObjects().OfType&lt;Table&gt;()</c>). "All
+    /// tables" is therefore really "all tables THIS <c>StoreOptions</c> happens to know about", so any
+    /// auxiliary process that provisions tenants from a partially-registered store — a migration or
+    /// conversion tool, an admin CLI, a seeding job, all of which typically register only the event
+    /// types they need — silently under-provisions. The registry row and the event partitions get
+    /// written, the tenant looks provisioned, and the damage only surfaces when the APPLICATION's
+    /// projection daemon does its first document write into a partition that was never created:
+    /// <c>23514 no partition of relation ... found for row</c>. Reported from production against 512
+    /// tenant databases, where the provisioning tool created zero of the application's 71 partitioned
+    /// document tables (see #4943). Schema migration never heals it either: document partitions are
+    /// deliberately excluded from the table delta (<c>IgnorePartitionsInMigration</c>, #4706), so
+    /// partition creation is EXCLUSIVELY the provisioning path's job — which makes it critical that the
+    /// provisioning path is complete regardless of who calls it.
+    /// </para>
+    ///
+    /// <para>
+    /// So rather than trusting the caller's registrations, ask the database what is actually there:
+    /// enumerate the tenant-list-partitioned parents straight out of the PostgreSQL catalog and create
+    /// the tenant's partition on every one of them. <c>CREATE TABLE IF NOT EXISTS ... PARTITION OF ...</c>
+    /// is idempotent, so this is purely additive on top of whatever the base pass already did, and it is
+    /// independent of which process happens to call it. Combined with the #4942 idempotent repair it
+    /// also heals the "document type added after the tenant was provisioned" drift case.
+    /// </para>
+    ///
+    /// <para>
+    /// SCOPING — this is the dangerous part, and it is deliberately narrow. A shard database is very
+    /// often shared with other applications, and a sweep that grabbed every partitioned table it could
+    /// see would start bolting Marten tenant partitions onto a stranger's tables. Three filters, all
+    /// enforced in the catalog query itself, keep the sweep inside this store's own footprint:
+    /// <list type="number">
+    /// <item>SCHEMA — only schemas this store owns (<c>database.AllSchemaNames()</c>, i.e. the distinct
+    /// schemas of the store's own registered objects, which always includes the store's
+    /// <c>DatabaseSchemaName</c> where <c>mt_tenant_partitions</c> itself lives). Foreign schemas in a
+    /// shared database are never touched.</item>
+    /// <item>PARTITION SHAPE — only LIST-partitioned parents (<c>partstrat = 'l'</c>) with exactly ONE
+    /// partition key column (<c>partnatts = 1</c>) whose name is <c>tenant_id</c>. This is what makes the
+    /// sweep safe against Marten's own non-tenant partitioning: <c>UseArchivedStreamPartitioning</c>
+    /// list-partitions <c>mt_events</c>/<c>mt_streams</c> on <c>is_archived</c>, and
+    /// <c>MultiTenantedWithPartitioning(x =&gt; x.ByList())</c> on a duplicated field list-partitions on
+    /// that field — neither has a <c>tenant_id</c> key, so neither is swept. Hash- and range-partitioned
+    /// tables are excluded outright, as are tables that are themselves partitions of some other parent.</item>
+    /// <item>EXTERNAL MANAGEMENT — any table the calling store DOES know about and has explicitly marked
+    /// as externally partitioned (<c>ByExternallyManagedListPartitions()</c>, i.e. a
+    /// <c>ListPartitioning</c> whose manager is not this one) is subtracted from the discovered set.
+    /// "Marten, keep your hands off my partitions" is honored.</item>
+    /// </list>
+    /// </para>
+    ///
+    /// <para>
+    /// Residual, documented limitation: a document type registered into a NON-default schema that the
+    /// calling store does not register is invisible to filter (1), because a store cannot own a schema it
+    /// has never heard of. Single-schema stores (the overwhelming default, and the reporter's shape) are
+    /// fully covered. Likewise a table that the calling store does not know about AND that some other
+    /// store marked externally-managed cannot be distinguished from a Marten-managed one in the catalog;
+    /// set <see cref="SweepPartitionedTablesFromDatabase"/> to <c>false</c> to opt out of the sweep
+    /// entirely if that matters to you.
+    /// </para>
+    /// </summary>
+    private async Task<List<TablePartitionStatus>> sweepTablesDiscoveredInDatabaseAsync(ILogger logger,
+        PostgresqlDatabase database, IReadOnlyDictionary<string, string> values,
+        IReadOnlyCollection<TablePartitionStatus> alreadyHandled, CancellationToken token)
+    {
+        var list = new List<TablePartitionStatus>();
+        if (!SweepPartitionedTablesFromDatabase || values.Count == 0) return list;
+
+        // Filter (1): the schemas this store owns. Never sweep outside them.
+        var schemas = database.AllSchemaNames();
+        if (schemas.Length == 0) return list;
+
+        // Tables the base (options-driven) pass already created the partition on. Re-issuing the DDL
+        // would be harmless — it is all IF NOT EXISTS — but skipping them keeps the sweep to the
+        // genuinely-unknown tables, which is both cheaper and a smaller blast radius.
+        var handled = alreadyHandled.Select(x => x.Identifier.QualifiedName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Filter (3): honor ByExternallyManagedListPartitions() for tables this store can actually see.
+        foreach (var table in database.AllObjects().OfType<Table>())
+        {
+            if (table.Partitioning is ListPartitioning list2 && !ReferenceEquals(list2.PartitionManager, this))
+            {
+                handled.Add(table.Identifier.QualifiedName);
+            }
+        }
+
+        await using var conn = database.CreateConnection();
+        await conn.OpenAsync(token).ConfigureAwait(false);
+
+        try
+        {
+            var discovered = new List<DbObjectName>();
+
+            // Filter (1) + (2), enforced in the catalog query itself.
+            await using (var reader = await conn.CreateCommand(
+                                 """
+                                 select n.nspname, c.relname
+                                 from pg_catalog.pg_class c
+                                 join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+                                 join pg_catalog.pg_partitioned_table p on p.partrelid = c.oid
+                                 join pg_catalog.pg_attribute a on a.attrelid = c.oid and a.attnum = p.partattrs[0]
+                                 where c.relkind = 'p'
+                                   and n.nspname = any(:schemas)
+                                   and p.partstrat = 'l'
+                                   and p.partnatts = 1
+                                   and a.attname = :tenantColumn
+                                   and not exists (select 1 from pg_catalog.pg_inherits i where i.inhrelid = c.oid)
+                                 """)
+                             .With("schemas", schemas)
+                             .With("tenantColumn", TenantIdColumn.Name)
+                             .ExecuteReaderAsync(token).ConfigureAwait(false))
+            {
+                while (await reader.ReadAsync(token).ConfigureAwait(false))
+                {
+                    var schema = await reader.GetFieldValueAsync<string>(0, token).ConfigureAwait(false);
+                    var name = await reader.GetFieldValueAsync<string>(1, token).ConfigureAwait(false);
+
+                    var identifier = new DbObjectName(schema, name);
+                    if (handled.Contains(identifier.QualifiedName)) continue;
+
+                    discovered.Add(identifier);
+                }
+            }
+
+            foreach (var identifier in discovered)
+            {
+                // ListPartition.WriteCreateStatement only consults the parent's Identifier, so a bare
+                // Table shell over the catalog name is all the DDL needs — we deliberately do NOT try to
+                // reconstruct the unknown table's full definition, and we never run a table delta against
+                // it. Purely additive: CREATE TABLE IF NOT EXISTS <parent>_<suffix> PARTITION OF <parent>.
+                var parent = new Table(identifier);
+
+                try
+                {
+                    var writer = new StringWriter();
+                    foreach (var pair in values)
+                    {
+                        // Escape embedded single quotes in the tenant id, matching the defense-in-depth
+                        // stance of IListPartitionManager.Partitions() above.
+                        var partition = new ListPartition(pair.Value, $"'{pair.Key.Replace("'", "''")}'");
+                        ((IPartition)partition).WriteCreateStatement(writer, parent);
+                    }
+
+                    await conn.CreateCommand(writer.ToString()).ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                    list.Add(new TablePartitionStatus(identifier, PartitionMigrationStatus.Complete));
+
+                    logger.LogInformation(
+                        "Added tenant partitions to table {Table}, discovered from the database catalog rather than the calling store's configuration (#4944)",
+                        identifier.QualifiedName);
+                }
+                catch (Exception e)
+                {
+                    logger.LogError(e,
+                        "Error trying to add table partitions to {Table}, discovered from the database catalog (#4944)",
+                        identifier.QualifiedName);
+                    list.Add(new TablePartitionStatus(identifier, PartitionMigrationStatus.Failed));
+                }
+            }
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+
+        return list;
     }
 
     /// <summary>

--- a/src/TenantPartitionedEventsTests/Sharded/Bug_4944_database_driven_partition_sweep.cs
+++ b/src/TenantPartitionedEventsTests/Sharded/Bug_4944_database_driven_partition_sweep.cs
@@ -1,0 +1,350 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events;
+using Marten;
+using Marten.Schema;
+using Marten.Storage;
+using Marten.Testing.Harness;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Weasel.Postgresql;
+using Xunit;
+
+namespace TenantPartitionedEventsTests.Sharded;
+
+public class Bug4944Alpha
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class Bug4944Beta
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class Bug4944Gamma
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// #4944 — <c>AddPartitionToAllTables</c> decided which tables needed a new tenant's list partition by
+/// walking the CALLING store's <c>StoreOptions</c>, so "all tables" really meant "all tables this store
+/// happens to know about". A provisioning tool that doesn't register the application's full document
+/// graph — a conversion tool, an admin CLI, a seeding job, all of which typically register only the
+/// event types they need — therefore reported success while creating partitions for only a SUBSET of the
+/// partitioned tables. The registry row and the event partitions landed, the tenant looked provisioned,
+/// and the damage surfaced later as <c>23514 no partition of relation ...</c> on the APPLICATION's first
+/// document write. Found by @erdtsieck at 512 tenant databases, where the tool created zero of the
+/// application's 71 partitioned document tables (see #4943).
+///
+/// The fix makes the sweep database-driven: enumerate the tenant-list-partitioned parents from the
+/// PostgreSQL catalog and partition every one of them, scoped to the schemas the store owns.
+///
+/// The whole point of these tests is that provisioning happens from a store with a DELIBERATELY
+/// INCOMPLETE registration — a test that provisions from a fully-registered store proves nothing.
+/// </summary>
+[Collection("sharded-tenant-partitioned")]
+public class Bug_4944_database_driven_partition_sweep : IAsyncLifetime
+{
+    private readonly ShardedPartitionedFixture _fixture;
+    private readonly List<IDocumentStore> _stores = new();
+
+    public Bug_4944_database_driven_partition_sweep(ShardedPartitionedFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        try { await conn.DropSchemaAsync("sharded"); } catch { }
+
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var tenantConn = new NpgsqlConnection(connStr);
+            await tenantConn.OpenAsync();
+            try { await tenantConn.DropSchemaAsync("tenants"); } catch { }
+            await ShardedPartitionedFixture.CleanMartenObjectsInPublicSchema(tenantConn);
+
+            // The fixture's cleaner only knows how to drop mt_* objects; these tests plant
+            // non-Marten partitioned tables to prove the sweep does NOT touch them.
+            try { await tenantConn.DropSchemaAsync("foreign_app"); } catch { }
+            await tenantConn.CreateCommand("drop table if exists public.other_app_ledger cascade")
+                .ExecuteNonQueryAsync();
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        foreach (var store in _stores)
+        {
+            store.Dispose();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// The APPLICATION store: the full document graph, every doc type tenant-list-partitioned.
+    /// </summary>
+    private IDocumentStore BuildApplicationStore()
+    {
+        return buildStore(opts =>
+        {
+            opts.Schema.For<Bug4944Alpha>().MultiTenantedWithPartitioning(x => x.ByList());
+            opts.Schema.For<Bug4944Beta>().MultiTenantedWithPartitioning(x => x.ByList());
+            opts.Schema.For<Bug4944Gamma>().MultiTenantedWithPartitioning(x => x.ByList());
+        });
+    }
+
+    /// <summary>
+    /// The PROVISIONING TOOL store: the reporter's shape — same physical databases, same sharded
+    /// tenancy, same per-tenant event partitioning, but it registers NOT ONE of the application's
+    /// document types. Pre-fix, provisioning from this store created zero document partitions.
+    /// </summary>
+    private IDocumentStore BuildToolStore()
+    {
+        return buildStore(_ => { });
+    }
+
+    private IDocumentStore buildStore(Action<StoreOptions> configure)
+    {
+        var store = DocumentStore.For(opts =>
+        {
+            opts.MultiTenantedWithShardedDatabases(x =>
+            {
+                x.ConnectionString = ConnectionSource.ConnectionString;
+                x.SchemaName = "sharded";
+                x.PartitionSchemaName = "tenants";
+
+                foreach (var (dbName, connStr) in _fixture.ConnectionStrings)
+                {
+                    x.AddDatabase(dbName, connStr);
+                }
+
+                x.UseSmallestDatabaseAssignment();
+            });
+
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AppendMode = EventAppendMode.QuickWithServerTimestamps;
+            opts.Events.UseTenantPartitionedEvents = true;
+            opts.Events.AddEventType<ShardedTestEvent>();
+
+            configure(opts);
+        });
+
+        _stores.Add(store);
+        return store;
+    }
+
+    /// <summary>
+    /// Production eager-apply shape: the application creates its partitioned parent tables on every
+    /// shard (with zero partitions — no tenants yet) before any tenant is provisioned.
+    /// </summary>
+    private async Task applyApplicationSchemaAsync(IDocumentStore store)
+    {
+        var databases = await store.Options.Tenancy.BuildDatabases();
+        foreach (var db in databases.OfType<IMartenDatabase>())
+        {
+            await db.ApplyAllConfiguredChangesToDatabaseAsync();
+        }
+    }
+
+    [Fact]
+    public async Task tool_store_with_no_document_types_still_provisions_every_partitioned_table()
+    {
+        var tenantId = "t4944_alpha";
+
+        var app = BuildApplicationStore();
+        await applyApplicationSchemaAsync(app);
+
+        // The provisioning tool knows nothing about Alpha/Beta/Gamma. Pre-fix it created partitions
+        // for exactly zero of them and still reported success.
+        var tool = BuildToolStore();
+        var dbId = await tool.Advanced.AddTenantToShardAsync(tenantId, CancellationToken.None);
+        dbId.ShouldNotBeNull();
+
+        await assertPartitionExists(dbId, $"mt_doc_bug4944alpha_{tenantId}");
+        await assertPartitionExists(dbId, $"mt_doc_bug4944beta_{tenantId}");
+        await assertPartitionExists(dbId, $"mt_doc_bug4944gamma_{tenantId}");
+
+        // The acceptance test the reporter actually cared about: the APPLICATION can now write every
+        // document type for the tenant the TOOL provisioned. Pre-fix each of these failed with
+        // 23514 'no partition of relation "mt_doc_bug4944alpha" found for row'.
+        await using (var session = app.LightweightSession(tenantId))
+        {
+            session.Store(new Bug4944Alpha { Id = Guid.NewGuid(), Name = "a" });
+            session.Store(new Bug4944Beta { Id = Guid.NewGuid(), Name = "b" });
+            session.Store(new Bug4944Gamma { Id = Guid.NewGuid(), Name = "g" });
+            session.Events.StartStream(Guid.NewGuid(), new ShardedTestEvent { Value = "e" });
+            await session.SaveChangesAsync();
+        }
+
+        await using (var query = app.QuerySession(tenantId))
+        {
+            (await query.Query<Bug4944Alpha>().CountAsync()).ShouldBe(1);
+            (await query.Query<Bug4944Beta>().CountAsync()).ShouldBe(1);
+            (await query.Query<Bug4944Gamma>().CountAsync()).ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public async Task partially_registered_store_still_provisions_the_types_it_does_not_know()
+    {
+        var tenantId = "t4944_bravo";
+
+        var app = BuildApplicationStore();
+        await applyApplicationSchemaAsync(app);
+
+        // A store that registers a SUBSET — Alpha only. Beta and Gamma are the ones that must be
+        // rescued by the database-driven sweep rather than by the caller's registrations.
+        var partial = buildStore(opts =>
+        {
+            opts.Schema.For<Bug4944Alpha>().MultiTenantedWithPartitioning(x => x.ByList());
+        });
+
+        var dbId = await partial.Advanced.AddTenantToShardAsync(tenantId, CancellationToken.None);
+
+        await assertPartitionExists(dbId, $"mt_doc_bug4944alpha_{tenantId}");
+        await assertPartitionExists(dbId, $"mt_doc_bug4944beta_{tenantId}");
+        await assertPartitionExists(dbId, $"mt_doc_bug4944gamma_{tenantId}");
+    }
+
+    /// <summary>
+    /// Pins the pre-#4944 behavior behind the opt-out, which doubles as proof that these tests
+    /// genuinely exercise the new sweep: with the sweep disabled, the tool store under-provisions
+    /// exactly as reported.
+    /// </summary>
+    [Fact]
+    public async Task opting_out_of_the_sweep_restores_the_old_under_provisioning_behavior()
+    {
+        var tenantId = "t4944_charlie";
+
+        var app = BuildApplicationStore();
+        await applyApplicationSchemaAsync(app);
+
+        // Same tool store, but with the database-driven sweep turned off. Constructing the manager
+        // explicitly is exactly what StoreOptions does for UseTenantPartitionedEvents when the user
+        // hasn't already set one up, and it's the supported way to reach the toggle at config time.
+        var tool = buildStore(opts =>
+        {
+            var partitions = new MartenManagedTenantListPartitions(opts, schemaName: null);
+            partitions.Partitions.SweepPartitionedTablesFromDatabase = false;
+        });
+
+        var dbId = await tool.Advanced.AddTenantToShardAsync(tenantId, CancellationToken.None);
+
+        // The registry row and the event partitions land (that always worked) ...
+        await assertPartitionExists(dbId, $"mt_events_{tenantId}");
+
+        // ... but not one of the document tables the tool doesn't know about. This is the bug.
+        await assertPartitionMissing(dbId, $"mt_doc_bug4944alpha_{tenantId}");
+        await assertPartitionMissing(dbId, $"mt_doc_bug4944beta_{tenantId}");
+        await assertPartitionMissing(dbId, $"mt_doc_bug4944gamma_{tenantId}");
+    }
+
+    /// <summary>
+    /// The scoping guarantee. A shard database is routinely shared with other applications, and a
+    /// sweep that grabbed every list-partitioned table it could see would start bolting Marten tenant
+    /// partitions onto a stranger's tables. Two decoys, both shaped to be swept if the filters were
+    /// sloppy:
+    ///   * <c>foreign_app.their_ledger</c> — the EXACT shape the sweep looks for (LIST partitioned on a
+    ///     single <c>tenant_id</c> column), but in a schema the store does not own.
+    ///   * <c>public.other_app_ledger</c> — sitting in a schema the store DOES own, but list-partitioned
+    ///     on a non-tenant column, so it is not a tenant-partitioned table at all.
+    /// Neither may be touched.
+    /// </summary>
+    [Fact]
+    public async Task never_touches_partitioned_tables_outside_the_stores_schemas_or_shape()
+    {
+        var tenantId = "t4944_delta";
+
+        foreach (var connStr in _fixture.ConnectionStrings.Values)
+        {
+            await using var conn = new NpgsqlConnection(connStr);
+            await conn.OpenAsync();
+
+            await conn.CreateCommand("create schema if not exists foreign_app").ExecuteNonQueryAsync();
+            await conn.CreateCommand(
+                    "create table foreign_app.their_ledger (tenant_id varchar not null, amount int) partition by list (tenant_id)")
+                .ExecuteNonQueryAsync();
+
+            await conn.CreateCommand(
+                    "create table public.other_app_ledger (category varchar not null, amount int) partition by list (category)")
+                .ExecuteNonQueryAsync();
+        }
+
+        var app = BuildApplicationStore();
+        await applyApplicationSchemaAsync(app);
+
+        var tool = BuildToolStore();
+        var dbId = await tool.Advanced.AddTenantToShardAsync(tenantId, CancellationToken.None);
+
+        // The store's own tables were still swept — the scoping is narrow, not broken.
+        await assertPartitionExists(dbId, $"mt_doc_bug4944alpha_{tenantId}");
+
+        // A foreign schema is never swept, even though its table is the exact shape we look for.
+        await assertNoPartitionsOf(dbId, "foreign_app", "their_ledger");
+
+        // A table in OUR schema that isn't tenant-partitioned is never swept either.
+        await assertNoPartitionsOf(dbId, "public", "other_app_ledger");
+    }
+
+    // ---- helpers ----
+
+    private async Task assertPartitionExists(string dbId, string partitionTableName)
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await conn.OpenAsync();
+        var tables = await conn.ExistingTablesAsync();
+        tables.Any(t => t.Schema == "public" && t.Name == partitionTableName).ShouldBeTrue(
+            $"list partition '{partitionTableName}' must exist in shard '{dbId}'. Tables: {string.Join(", ", tables.Select(t => t.QualifiedName))}");
+    }
+
+    private async Task assertPartitionMissing(string dbId, string partitionTableName)
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await conn.OpenAsync();
+        var tables = await conn.ExistingTablesAsync();
+        tables.Any(t => t.Schema == "public" && t.Name == partitionTableName).ShouldBeFalse(
+            $"list partition '{partitionTableName}' must NOT exist in shard '{dbId}'");
+    }
+
+    /// <summary>
+    /// Assert the given partitioned parent has no child partitions at all — i.e. Marten never went
+    /// anywhere near it.
+    /// </summary>
+    private async Task assertNoPartitionsOf(string dbId, string schema, string tableName)
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionStrings[dbId]);
+        await conn.OpenAsync();
+
+        var count = (long)(await conn.CreateCommand(
+                """
+                select count(*)
+                from pg_catalog.pg_inherits i
+                join pg_catalog.pg_class parent on parent.oid = i.inhparent
+                join pg_catalog.pg_namespace n on n.oid = parent.relnamespace
+                where n.nspname = :schema and parent.relname = :table
+                """)
+            .With("schema", schema)
+            .With("table", tableName)
+            .ExecuteScalarAsync())!;
+
+        count.ShouldBe(0L,
+            $"the tenant-partition sweep must never add partitions to '{schema}.{tableName}' in shard '{dbId}'");
+    }
+}


### PR DESCRIPTION
Fixes #4944.

## Problem

`AddPartitionToAllTables` decided which tables needed a new tenant's list partition by walking the **calling store's `StoreOptions`**:

```csharp
var tables = database.AllObjects().OfType<Table>()
    .Where(x => x.Partitioning is ListPartitioning list && list.PartitionManager == this)
```

So "all tables" really meant "all tables *this* `StoreOptions` happens to know about". Any process that provisions tenants from a partially-registered store — a conversion tool, an admin CLI, a seeding job, all of which typically register only the event types they need — silently under-provisioned. The registry row and the event partitions landed, the tenant *looked* provisioned, and the damage only surfaced when the **application** did its first document write into a partition that was never created: `23514 no partition of relation ...`.

Schema migration never heals this either, by design: document partitions are excluded from the table delta (`IgnorePartitionsInMigration`, #4706), so partition creation is *exclusively* the provisioning path's job — which is exactly why that path has to be complete regardless of who calls it.

The workaround so far was "the provisioning tool must register every document type", which re-creates the schema knowledge in a second place and drifts as document types are added.

## Mechanism

Rather than trusting the caller's registrations, ask the database what is actually there. `DatabaseScopedTenantPartitions` now enumerates the tenant-list-partitioned parents straight out of the PostgreSQL catalog (`pg_partitioned_table` / `pg_class` / `pg_inherits`) and creates the tenant's partition on every one of them.

This is layered **purely additively** on top of the existing options-driven pass — `CREATE TABLE IF NOT EXISTS <parent>_<suffix> PARTITION OF <parent>` is idempotent, and tables the base pass already handled are skipped — so it is independent of which process happens to call it. Both provisioning entry points (`AdvancedOperations.AddMartenManagedTenantsAsync` and `ShardedTenancy.createPartitionsForTenant`) funnel through this one chokepoint, so both are fixed.

Combined with the #4942 idempotent repair, this also heals the "document type added after the tenant was provisioned" drift case.

Only the parent's `Identifier` is needed to emit the DDL, so the sweep never tries to reconstruct an unknown table's definition and never runs a table delta against it.

## How schema scoping is enforced

This is the dangerous part, and it is deliberately narrow — a shard database is routinely shared with other applications, and a sweep that grabbed every partitioned table it could see would start bolting Marten tenant partitions onto a stranger's tables. Three filters, all enforced **in the catalog query itself**:

1. **Schema** — only schemas this store owns (`database.AllSchemaNames()`, i.e. the distinct schemas of the store's own registered objects, which always includes the `DatabaseSchemaName` where `mt_tenant_partitions` itself lives). Foreign schemas in a shared database are never touched.
2. **Partition shape** — only LIST-partitioned parents (`partstrat = 'l'`) with exactly **one** partition key column (`partnatts = 1`) whose name is `tenant_id`. This is what keeps the sweep off Marten's *own* non-tenant partitioning: `UseArchivedStreamPartitioning` list-partitions `mt_events`/`mt_streams` on `is_archived`, and `MultiTenantedWithPartitioning(x => x.ByList())` on a duplicated field list-partitions on that field — neither has a `tenant_id` key, so neither is swept. Hash- and range-partitioned tables are excluded outright, as are tables that are themselves partitions of another parent.
3. **External management** — any table the calling store *does* know about and has marked `ByExternallyManagedListPartitions()` is subtracted. "Marten, keep your hands off my partitions" is honored.

`SweepPartitionedTablesFromDatabase` (default `true`) opts back out to the old, options-only behavior.

### Documented residual limitation

A document type registered into a **non-default schema that the calling store does not register** stays invisible to filter (1) — a store cannot own a schema it has never heard of. Single-schema stores (the overwhelming default, and the reporter's shape) are fully covered. This is called out in the XML docs on the sweep.

## Scope note

Done entirely inside Marten — **no Weasel change is required**. Everything the sweep needs (`ListPartition`, `IPartition.WriteCreateStatement`, `Table`, `IDatabase.AllSchemaNames()`) is already public API, and `DatabaseScopedTenantPartitions` already shadows both `AddPartitionToAllTables` overloads. So this ships with 9.15.2 rather than gating on a Weasel release. Hoisting the enumeration primitive into `ManagedListPartitions` for other Weasel consumers remains available as a follow-up.

## Tests

`src/TenantPartitionedEventsTests/Sharded/Bug_4944_database_driven_partition_sweep.cs`. The whole point is that provisioning happens from a store with a **deliberately incomplete** registration — a test that provisions from a fully-registered store proves nothing:

- `tool_store_with_no_document_types_still_provisions_every_partitioned_table` — the reporter's exact shape. The app store registers and applies three tenant-partitioned document types; a tool store registering **zero** of them provisions the tenant; all three partitions must exist, and the **application** must then be able to write all three doc types (pre-fix: `23514`).
- `partially_registered_store_still_provisions_the_types_it_does_not_know` — a store registering a strict subset (1 of 3) must still provision all 3.
- `never_touches_partitioned_tables_outside_the_stores_schemas_or_shape` — the negative. Two decoys, both shaped to be swept if the filters were sloppy: `foreign_app.their_ledger` (the *exact* shape the sweep looks for — LIST on a single `tenant_id` column — but in a schema the store does not own) and `public.other_app_ledger` (in a schema the store *does* own, but list-partitioned on a non-tenant column). Neither may gain a single partition, while the store's own tables are still swept.
- `opting_out_of_the_sweep_restores_the_old_under_provisioning_behavior` — pins the pre-#4944 behavior behind the toggle, and doubles as proof the other tests genuinely exercise the new sweep: with the sweep off, the tool store under-provisions exactly as reported.

**Results:** TenantPartitionedEventsTests 236/236 (run twice), CoreTests partitioning 41/41, MultiTenancyTests 159/159.

Found by @erdtsieck at 512 tenant databases; see #4943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)