### PR TITLE
release prep: 9.15.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.15.1</Version>
+        <Version>9.15.2</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>


### PR DESCRIPTION
Patch release. Both fixes come out of the same 512-tenant-database production deployment reported by @erdtsieck.

## [#4946](https://github.com/JasperFx/marten/issues/4946) — bulk event insert ran a full schema apply per batch ([#4949](https://github.com/JasperFx/marten/pull/4949))

The batch `BulkInsertEventsAsync` overloads opened with `Storage.ApplyAllConfiguredChangesToDatabaseAsync()` on **every call**. That is not a cheap check — it calls `Tenancy.BuildDatabases()` and runs a full schema delta across **every database in the store**. So a sharded store paid *one apply per database, per batch*: on the reporter's 512-database store, a ~1,000-event batch triggered 512 schema applies.

Import throughput collapsed to **~17 events/s** (the streaming overload, which has no such call, does >3,000/s) and the connection pool filled with backends parked on Weasel's partition-introspection query. A 686k-event tenant projected to ~11 hours.

The apply is now:
- **skipped entirely when `AutoCreate` is `None`** — it is a no-op by contract there, so only the introspection cost remained; and
- otherwise **run at most once per database the import actually touches**, memoized per `IMartenDatabase.Identifier`.

The shared apply deliberately does **not** take a caller's `CancellationToken`: the first caller to arrive owns the in-flight task every concurrent caller for that database awaits, so binding it to one caller's token would let a single cancelled batch fail sibling batches that were never cancelled. Each caller applies its own token at the await site instead.

The document bulk-insert path is unaffected — it routes through the ordinary per-feature `EnsureStorageExistsAsync` that Weasel memoizes, not a full-store delta.

## [#4944](https://github.com/JasperFx/marten/issues/4944) — database-driven tenant partition sweep ([#4950](https://github.com/JasperFx/marten/pull/4950))

`AddPartitionToAllTables` walked the **calling store's** `StoreOptions` to decide which tables needed a list partition for a new tenant. A provisioning tool built on a store that does not register every document type therefore **silently under-provisioned**, and the tenant later failed with a Postgres `23514` check-constraint violation on first write to the missing partition. The workaround — "the provisioning tool must register every document type" — re-created schema knowledge in a second place and drifted as types were added.

The sweep now enumerates tenant list-partitioned tables from the **database catalog**, so a partially-registered store still provisions every partitioned table.

Scoping is enforced inside the catalog query, not after the fact:
- **schema** — the store's own `AllSchemaNames()` only, so foreign tables in a shared database are never touched;
- **partition shape** — LIST strategy, single key column, named `tenant_id`. This is the filter that matters most: it keeps the sweep off Marten's *own* non-tenant list partitioning (`UseArchivedStreamPartitioning` keys `mt_events` on `is_archived`, and `ByList()` keys on its own field);
- **external management** — tables marked `ByExternallyManagedListPartitions()` are subtracted.

Opt-out via `SweepPartitionedTablesFromDatabase` (default on). No Weasel change required.

**Known limitation, documented:** a document type registered into a schema the *calling* store has never heard of stays invisible to the schema filter — a store cannot own a schema it does not know exists. Single-schema stores (the default, and the reporter's shape) are fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)