### PR TITLE
Parameterize non-string Select projection constants (SQL injection fix)

### DIFF
--- a/src/LinqTests/Bugs/select_projection_constant_sql_injection.cs
+++ b/src/LinqTests/Bugs/select_projection_constant_sql_injection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Marten;
 using Marten.Testing.Harness;
@@ -23,6 +24,18 @@ public class select_projection_constant_sql_injection : BugIntegrationContext
     public class Projection
     {
         public string Label { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public class ObjectProjection
+    {
+        public object Label { get; set; } = new();
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public class NumberProjection
+    {
+        public int Number { get; set; }
         public string Name { get; set; } = string.Empty;
     }
 
@@ -56,5 +69,68 @@ public class select_projection_constant_sql_injection : BugIntegrationContext
             .ToCommand();
 
         cmd.CommandText.ShouldContain("'O''Brien'");
+    }
+
+    // Security regression (incomplete-fix/type variant of the string case above): a non-string
+    // projection constant was emitted as raw.ToString() with no escaping or parameterization.
+    // An object-typed request property bound by System.Text.Json arrives as a JsonElement whose
+    // ToString() is attacker-controlled text, so it could break out of the jsonb_build_object
+    // SELECT list. The fix binds every non-string constant as a command parameter.
+    [Fact]
+    public async Task projected_jsonelement_constant_is_parameterized_not_injected()
+    {
+        theSession.Store(new Thing { Name = "first" });
+        await theSession.SaveChangesAsync();
+
+        // Mirrors an `object`-typed request property that System.Text.Json materializes as a JsonElement.
+        using var doc = JsonDocument.Parse("\"(select 1)) as evil, (select 1\"");
+        object label = doc.RootElement.Clone();
+
+        var results = await theSession.Query<Thing>()
+            .Select(x => new ObjectProjection { Label = label, Name = x.Name })
+            .ToListAsync();
+
+        // Treated as data, the value round-trips intact rather than injecting a phantom column.
+        results.Count.ShouldBe(1);
+        results[0].Label.ToString().ShouldBe("(select 1)) as evil, (select 1");
+        results[0].Name.ShouldBe("first");
+    }
+
+    [Fact]
+    public void projected_jsonelement_constant_is_bound_as_parameter()
+    {
+        using var doc = JsonDocument.Parse("\"(select secret from secrets limit 1)) --\"");
+        object label = doc.RootElement.Clone();
+
+        var cmd = theSession.Query<Thing>()
+            .Select(x => new ObjectProjection { Label = label, Name = x.Name })
+            .ToCommand();
+
+        // The attacker text must be absent from the SQL grammar and present in a parameter.
+        cmd.CommandText.ShouldNotContain("select secret");
+        cmd.Parameters.Count.ShouldBeGreaterThan(0);
+        cmd.Parameters.ShouldContain(p => Equals(p.Value, "(select secret from secrets limit 1)) --"));
+    }
+
+    [Fact]
+    public async Task projected_numeric_constant_is_bound_as_parameter()
+    {
+        theSession.Store(new Thing { Name = "first" });
+        await theSession.SaveChangesAsync();
+
+        var number = 42;
+
+        var cmd = theSession.Query<Thing>()
+            .Select(x => new NumberProjection { Number = number, Name = x.Name })
+            .ToCommand();
+
+        cmd.Parameters.ShouldContain(p => Equals(p.Value, 42));
+
+        // A numeric constant still round-trips as a JSON number, not a quoted string.
+        var results = await theSession.Query<Thing>()
+            .Select(x => new NumberProjection { Number = number, Name = x.Name })
+            .ToListAsync();
+
+        results.Single().Number.ShouldBe(42);
     }
 }

--- a/src/Marten/Linq/Parsing/SelectParser.cs
+++ b/src/Marten/Linq/Parsing/SelectParser.cs
@@ -88,7 +88,11 @@ internal class SelectParser: ExpressionVisitor
         }
         else
         {
-            NewObject.Members[_currentField] = new LiteralSql(raw.ToString());
+            // The projected constant is a runtime value (ReduceToConstant evaluates captured
+            // locals), so it can be attacker-influenced. A non-string CLR type has no
+            // SQL-safe ToString() guarantee (e.g. a JsonElement bound from a request body),
+            // so bind it as a command parameter instead of inlining ToString() into the SQL.
+            NewObject.Members[_currentField] = new ConstantParameterSql(raw);
         }
 
         _currentField = null;

--- a/src/Marten/Linq/SqlGeneration/Literal.cs
+++ b/src/Marten/Linq/SqlGeneration/Literal.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using System;
+using System.Text.Json;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
 
@@ -17,4 +19,38 @@ public record LiteralSql(string Text) : ISqlFragment
         builder.Append(Text);
     }
 
+}
+
+/// <summary>
+/// Emits a captured runtime constant as a bound command parameter rather than
+/// inlined SQL text. Used for non-string projection constants so that
+/// attacker-influenced values (e.g. a JsonElement bound from a request body)
+/// cannot break out of the generated SQL. See CWE-89 hardening for Select projections.
+/// </summary>
+internal record ConstantParameterSql(object Value) : ISqlFragment
+{
+    public void Apply(ICommandBuilder builder)
+    {
+        builder.AppendParameter(Unwrap(Value));
+    }
+
+    // A System.Text.Json.JsonElement has no Npgsql type handler, so unwrap it to the
+    // underlying CLR scalar it represents before binding it as a parameter.
+    private static object Unwrap(object value)
+    {
+        if (value is JsonElement element)
+        {
+            return element.ValueKind switch
+            {
+                JsonValueKind.String => element.GetString()!,
+                JsonValueKind.Number => element.TryGetInt64(out var l) ? l : element.GetDecimal(),
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.Null => (object)DBNull.Value,
+                _ => element.GetRawText()
+            };
+        }
+
+        return value;
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a SQL injection in the LINQ `Select` projection path — an incomplete-fix/type variant of #4911.

`SelectParser.VisitConstant` escaped the **string** branch in #4911, but the **non-string fallback** still emitted `new LiteralSql(raw.ToString())` verbatim into the `jsonb_build_object` SELECT list. When an application captures a non-string, attacker-influenced projection constant — e.g. an `object`-typed request property that System.Text.Json materializes as a `JsonElement` — its `ToString()` text reaches the generated SQL with no escaping or parameterization, allowing a scalar subquery, injected `FROM`, and trailing comment to execute within the statement (CWE-89).

## Fix

- New internal `ConstantParameterSql` fragment binds the constant via `builder.AppendParameter(...)` instead of inlining `ToString()`. It unwraps a `JsonElement` to its underlying CLR scalar first, since Npgsql has no `JsonElement` type handler.
- `SelectParser`'s non-string branch now routes through it. Numeric/bool constants stay correctly typed inside `jsonb_build_object` (a number stays a JSON number, not a quoted string).

## Tests

`select_projection_constant_sql_injection.cs` gains regression coverage:
- a `JsonElement` disclosure payload round-trips as inert data (no phantom column / injection);
- the attacker bytes are absent from `CommandText` and present in a bound parameter;
- a numeric constant is parameterized and still returns as a JSON number.

5/5 green; full Select/projection LINQ suite (173 tests) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)