### PR TITLE
Support Where Any on collections when using strongly typed Ids

### DIFF
--- a/src/Marten/Linq/Members/ValueTypeMember.cs
+++ b/src/Marten/Linq/Members/ValueTypeMember.cs
@@ -2,9 +2,11 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using JasperFx.CodeGeneration;
 using JasperFx.Core.Reflection;
 using Marten.Exceptions;
 using Marten.Internal;
@@ -13,7 +15,6 @@ using Marten.Linq.SqlGeneration.Filters;
 using Weasel.Core;
 using Weasel.Postgresql;
 using Weasel.Postgresql.SqlGeneration;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Members;
 
@@ -63,10 +64,14 @@ public class ValueTypeMember<TOuter, TInner>: SimpleCastMember, IValueTypeMember
     public override void PlaceValueInDictionaryForContainment(Dictionary<string, object> dict,
         ConstantExpression constant)
     {
-        var rawValue = constant.Value;
-        if (rawValue is TOuter value)
+        switch (constant.Value)
         {
-            dict[MemberName] = _valueSource(value);
+            case TOuter outer:
+                dict[MemberName] = _valueSource(outer);
+                break;
+            case TInner inner:
+                dict[MemberName] = inner;
+                break;
         }
     }
 

--- a/src/ValueTypeTests/VogenIds/guid_based_document_operations.cs
+++ b/src/ValueTypeTests/VogenIds/guid_based_document_operations.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using JasperFx.Core;
@@ -224,6 +225,68 @@ public class guid_id_document_operations : IDisposable, IAsyncDisposable
         loaded
             .Name.ShouldBe(invoice.Name);
     }
+
+    [Fact]
+    public async Task use_in_LINQ_where_any_clause()
+    {
+        await theStore.Advanced.ResetAllData();
+
+        var item1Id = InvoiceId.From(Guid.CreateVersion7());
+        var item2Id = InvoiceId.From(Guid.CreateVersion7());
+
+        var schedule1 = new Schedule
+        {
+            Id = InvoiceId.From(Guid.CreateVersion7()),
+            Name = "Schedule 1",
+            Items = [
+                new ScheduleItem { Id = item1Id, Name = "Item 1"  },
+                new ScheduleItem { Id = item2Id, Name = "Item 2"  },
+            ]
+        };
+
+        theSession.Store(schedule1);
+
+        var item3Id = InvoiceId.From(Guid.CreateVersion7());
+        var item4Id = InvoiceId.From(Guid.CreateVersion7());
+
+        var schedule2 = new Schedule
+        {
+            Id = InvoiceId.From(Guid.CreateVersion7()),
+            Name = "Schedule 2",
+            Items = [
+                new ScheduleItem { Id = item3Id, Name = "Item 3"  },
+                new ScheduleItem { Id = item4Id, Name = "Item 4"  },
+            ]
+        };
+
+        theSession.Store(schedule2);
+
+        await theSession.SaveChangesAsync();
+
+        var query = theSession.Query<Schedule>().Where(s => s.Items.Any(i => i.Id == item1Id));
+
+        var cmd = query.ToCommand();
+
+        var loaded = await query.ToListAsync();
+
+        loaded.Count.ShouldBe(1);
+        loaded.First().Name.ShouldBe(schedule1.Name);
+    }
+
+
+    public class Schedule
+    {
+        public InvoiceId Id { get; set; }
+        public string Name { get; set; }
+        public ICollection<ScheduleItem> Items { get; set; }
+    }
+
+    public class ScheduleItem
+    {
+        public InvoiceId Id { get; set; }
+        public string Name { get; set; }
+    }
+
 
     [Fact]
     public async Task use_in_LINQ_order_clause()


### PR DESCRIPTION
Fixes the bug detailed in [this Issue](https://github.com/jasperFx/marten/issues/3985) i.e. Where(x => x.Items.Any(i => i.Id == query.Id))

Adds support for retrieving the inner value of the strongly typed Id.

Fixes #3985