### PR TITLE
Bump JasperFx to 2.28.0; declare EventProjection doc types for rebuild teardown (#4685 COPY)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -102,13 +102,13 @@
          CancellationExceptions.IsCancellationLike instead of discarding every exception type while a
          shard CTS is cancelled; jasperfx#505 — source-gen evolver two-statement fix for the
          GetUninitializedObject cast (rides in the bundled JasperFx.Events.SourceGenerator analyzer). -->
-    <PackageVersion Include="JasperFx" Version="2.27.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.27.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.27.0">
+    <PackageVersion Include="JasperFx" Version="2.28.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.28.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.28.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.27.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.28.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/docs/events/projections/event-projections.md
+++ b/docs/events/projections/event-projections.md
@@ -137,6 +137,30 @@ The `Project()` methods can accept these arguments:
 
 The return value must be either `void` or `Task` depending on whether or not the method needs to be asynchronous
 
+## Rebuilds and Document Teardown
+
+::: warning
+Because an `EventProjection` writes documents through *ad-hoc* `IDocumentOperations` calls (`ops.Insert`, `ops.Store`, etc.) inside its `Project()` / `Create()` methods, Marten **cannot infer which document types the projection produces**. Unlike a single-stream or multi-stream aggregation (whose view type is known), an `EventProjection` therefore does **not** automatically wipe its documents when the projection is rebuilt.
+
+If you rebuild an `EventProjection` and want the previously-written documents cleared first (the normal rebuild semantics), **declare each written document type explicitly** so it participates in the rebuild teardown:
+
+```cs
+public class MyProjection: EventProjection
+{
+    public MyProjection()
+    {
+        // Tell Marten this projection writes MyDoc, so a rebuild TRUNCATEs it first
+        Options.DeleteViewTypeOnTeardown<MyDoc>();
+    }
+
+    public void Project(SomethingHappened e, IDocumentOperations ops)
+        => ops.Insert(new MyDoc { Id = e.Id /* ... */ });
+}
+```
+
+Without this declaration the old documents survive the rebuild. The per-row rebuild path tolerates that (re-inserting an existing id upserts), but the INSERT-only [binary `COPY` rebuild](/events/projections/rebuilding) (`Projections.RebuildWithBulkCopy`) requires an empty target table and will fail with a duplicate-key error. This is a long-standing `EventProjection` limitation, not specific to bulk-copy rebuilds.
+:::
+
 ## Identifying the Event Parameter
 
 In both the `Create()` and `Project()` conventions above, the event parameter can be named anything — Marten identifies it **by type**, not by name. Given `Project(StopEvent1 e, IDocumentOperations ops)`, `StopEvent1` is the event because it's the only concrete event type in the signature (`IDocumentOperations` is an interface and is never treated as the event). The same applies to `IEvent<T>`, which is always recognized as the event regardless of the parameter name.

--- a/src/DaemonTests/rebuild_with_bulk_copy_inserts.cs
+++ b/src/DaemonTests/rebuild_with_bulk_copy_inserts.cs
@@ -463,6 +463,12 @@ public partial class BulkCopyInsertProjection: EventProjection
     public BulkCopyInsertProjection()
     {
         Name = ProjectionName;
+
+        // EventProjection cannot infer the document types it writes through ad-hoc ops.Insert/ops.Store,
+        // so it does not know to wipe them on rebuild. Declare the written type explicitly so the rebuild
+        // teardown TRUNCATEs it first — otherwise the INSERT-only binary COPY rebuild collides with docs a
+        // prior run left behind (duplicate key). This is a long-standing EventProjection limitation.
+        Options.DeleteViewTypeOnTeardown<BulkCopyDoc>();
     }
 
     public void Project(ItemAdded e, IDocumentOperations ops)
@@ -480,6 +486,10 @@ public partial class InsertAndDeleteProjection: EventProjection
     public InsertAndDeleteProjection()
     {
         Name = ProjectionName;
+
+        // See BulkCopyInsertProjection: an EventProjection must declare the doc types it writes ad-hoc so the
+        // rebuild teardown clears them.
+        Options.DeleteViewTypeOnTeardown<BulkCopyDoc>();
     }
 
     public void Project(ItemAdded e, IDocumentOperations ops)


### PR DESCRIPTION
Lands the JasperFx **2.27.0 → 2.28.0** bump and fixes a **pre-existing** binary-COPY rebuild bug that 2.28.0 unmasks.

## What 2.28.0 brings
- **jasperfx#524** — `HighWaterAgent` treats `IDaemonWakeup` as untrusted (guards every `WaitAsync` in the poll loop) and the restart watchdog observes the real unwrapped loop task, so a wakeup throw can't permanently freeze projection progress and a faulted loop self-heals. (Completes the defense-in-depth behind the `PostgresqlListenWakeup` fix in #4965 / #4961.)
- **jasperfx#525** — opt-in deferred single-flush rebuild writes, **default off** (no behavior change).
- **jasperfx#522** — `TimeoutAfterAsync` no longer swallows a rebuild fault.

## The pre-existing bug #522 surfaced
`rebuild_with_bulk_copy_inserts` (the #4685 binary-COPY rebuild tests) began failing with `23505 duplicate key`. Root cause, confirmed with a direct detector run at **V2.27.0, #480, and 2.28.0** (the collision fires at all three — 2.27.0 just **swallowed** the fault, so the test passed *falsely*):

An **`EventProjection`** writes documents via ad-hoc `ops.Insert`/`ops.Store`, so Marten **cannot infer** which document types it produces and never wiped them on rebuild. The per-row path tolerated stale docs (re-insert upserts), but the **INSERT-only binary COPY** rebuild assumes a truncated table and collides. This is a **long-standing `EventProjection` limitation**, not a regression, and (per maintainer direction) not something we change — an `EventProjection` must declare the types it writes.

## Fix
- The affected test projections declare their written type: `Options.DeleteViewTypeOnTeardown<BulkCopyDoc>()`, so the rebuild TRUNCATEs it first.
- `docs/events/projections/event-projections.md` documents the requirement (and that INSERT-only COPY rebuilds require it).

Verified: all 9 `rebuild_with_bulk_copy_inserts` tests pass against the **published** JasperFx.Events 2.28.0 (net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)