### PR TITLE
fix(#4966): update natural key on projection rebuild (JasperFx 2.28.1)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -101,14 +101,18 @@
          failures are loud, dead consumers throw from Post), and teardown catch clauses classify via
          CancellationExceptions.IsCancellationLike instead of discarding every exception type while a
          shard CTS is cancelled; jasperfx#505 — source-gen evolver two-statement fix for the
-         GetUninitializedObject cast (rides in the bundled JasperFx.Events.SourceGenerator analyzer). -->
-    <PackageVersion Include="JasperFx" Version="2.28.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.28.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.28.0">
+         GetUninitializedObject cast (rides in the bundled JasperFx.Events.SourceGenerator analyzer).
+         JasperFx 2.28.1: jasperfx#528 (marten#4966) — natural-key discovery now builds an event
+         mapping for a two-arg static evolve method (static TDoc Apply(TEvent e, TDoc current)), so a
+         natural key that CHANGES via an update event is written to mt_natural_key_X on live append and
+         rebuild; previously only the create event's key was ever recorded. -->
+    <PackageVersion Include="JasperFx" Version="2.28.1" />
+    <PackageVersion Include="JasperFx.Events" Version="2.28.1" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.28.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.28.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.28.1" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/DaemonTests/Aggregations/rebuild_projection_with_natural_key_update.cs
+++ b/src/DaemonTests/Aggregations/rebuild_projection_with_natural_key_update.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DaemonTests.Aggregations;
+
+public class Bug_4966_natural_key_update_on_projection_rebuild: DaemonContext
+{
+    private const string schemaName = "rebuild_natural_key_update";
+
+    public Bug_4966_natural_key_update_on_projection_rebuild(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    public sealed record ProductCode(string Value);
+
+    public sealed record ProductRegistered(Guid ProductId, string ProductCode);
+
+    public sealed record ProductCodeChanged(Guid ProductId, string NewProductCode);
+
+    public sealed record Product
+    {
+        public Guid Id { get; set; }
+
+        [NaturalKey]
+        public ProductCode Code { get; set; }
+
+        [NaturalKeySource]
+        public static Product Create(ProductRegistered e)
+        {
+            return new Product
+            {
+                Id = e.ProductId,
+                Code = new ProductCode(e.ProductCode)
+            };
+        }
+
+        [NaturalKeySource]
+        public static Product Apply(ProductCodeChanged e, Product product)
+        {
+            return product with
+            {
+                Code = new ProductCode(e.NewProductCode)
+            };
+        }
+    }
+
+    private static void ConfigureStore(StoreOptions opts)
+    {
+        opts.Connection(ConnectionSource.ConnectionString);
+        opts.DatabaseSchemaName = schemaName;
+        opts.Events.StreamIdentity = StreamIdentity.AsGuid;
+        opts.Events.AppendMode = EventAppendMode.Quick;
+        opts.Projections.Snapshot<Product>(SnapshotLifecycle.Async);
+    }
+
+
+    [Fact]
+    public async Task bug_4966_natural_key_should_be_updated_during_rebuild()
+    {
+        StoreOptions(ConfigureStore);
+        await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+
+        var streamId = Guid.NewGuid();
+        var originalCode = "PROD-001";
+        var newCode = "PROD-999";
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.StartStream<Product>(streamId, new ProductRegistered(streamId, originalCode));
+            await session.SaveChangesAsync();
+        }
+
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Events.Append(streamId, new ProductCodeChanged(streamId, newCode));
+            await session.SaveChangesAsync();
+        }
+
+        var daemon = await theStore.BuildProjectionDaemonAsync();
+        await daemon.RebuildProjectionAsync<Product>(CancellationToken.None);
+
+        await using (var session = theStore.LightweightSession())
+        {
+            var product = await session.Events.FetchLatest<Product, ProductCode>(new ProductCode(newCode));
+            product.ShouldNotBeNull();
+            product.Code.Value.ShouldBe(newCode);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A snapshot with a natural key that **changes** across events is not updated: the natural key is recorded once (from the create event) but never again when a later event changes it. `FetchLatest`-by-natural-key then can't find the stream under its new key — observed after a projection rebuild in #4966, but the same gap exists on live inline append.

## Root cause & fix (JasperFx)

The natural-key lookup table `mt_natural_key_X` is maintained from `NaturalKeyEventMapping`s discovered off the aggregate's `[NaturalKeySource]` methods. JasperFx's discovery silently skipped a **two-arg static evolve method** —

```csharp
[NaturalKeySource] public static Product Apply(ProductCodeChanged e, Product current)
    => current with { Code = new ProductCode(e.NewProductCode) };
```

— because the extractor builder only knew how to invoke a one-arg static factory; the two-arg call threw while composing and was swallowed. So the **update event got no mapping** and its key was never upserted.

Fixed in **[jasperfx#528](https://github.com/JasperFx/jasperfx/pull/528)** (extractor now binds one argument per parameter: event data → the event param, a fresh default aggregate → the `TDoc` param), released as **JasperFx 2.28.1**. This PR bumps the JasperFx packages to 2.28.1.

## Test

Includes the original reproduction from #4967 — thanks **@ytqsl** (retained as co-author). It **fails on 2.28.0** (`should not be null but was`) and **passes on 2.28.1**, verified locally against the published package.

---

Supersedes #4967. Closes #4966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)