### PR TITLE
test(#4963): verify + document the blue/green side-effect gate

### DIFF
--- a/docs/events/projections/rebuilding.md
+++ b/docs/events/projections/rebuilding.md
@@ -224,6 +224,58 @@ of old and new projection versions.
 For a deeper discussion of this deployment strategy, see
 [Projections, Consistency Models, and Zero Downtime Deployments](https://jeremydmiller.com/2025/03/26/projections-consistency-models-and-zero-downtime-deployments-with-the-critter-stack/).
 
+### Suppressing Side Effects During the Blue/Green Warm-up
+
+A projection that raises [side effects](/events/projections/side-effects) (appended events or
+published messages via `RaiseSideEffects()`) presents a problem for blue/green versioning: when the
+new version (`V{n+1}`) starts as `Async` it catches up over the **entire** event history — including
+the events the previous version already processed and already fired side effects for. Without a
+guard, deploying a new version re-emits every one of those side effects.
+
+Opt into `GateSideEffectsBehindPriorVersion` to prevent that:
+
+```cs
+public class TripProjection : SingleStreamProjection<Trip, Guid>
+{
+    public TripProjection()
+    {
+        Version = 3;
+
+        // Only fire side effects for events the prior version (V2) never processed
+        GateSideEffectsBehindPriorVersion = true;
+    }
+
+    // Apply(...) methods and RaiseSideEffects(...) as usual
+}
+```
+
+When the flag is on and a new version starts behind the highest prior version's persisted
+progression mark `N`, the daemon does the catch-up in two phases:
+
+1. **Warm-up** — replay `(current, N]` in **Rebuild** mode, so `RaiseSideEffects()` is suppressed
+   while the new version's documents are brought up to the same point the prior version reached.
+2. **Continuous** — hand off to normal continuous execution from `N`, so side effects fire only for
+   events past `N` — the ones the prior version never saw.
+
+Behavioral notes:
+
+- **Resume after interruption** — the trigger is *own progress `< N`*, not *own progress `== 0`*. If
+  the warm-up is interrupted (a crash or restart at `M < N`), the next start resumes the suppressed
+  replay over `(M, N]` rather than re-emitting side effects from the beginning.
+- **Failed warm-up leaves the shard paused** — if the warm-up replay throws, the shard is left
+  `Paused` with the exception attached and continuous execution does **not** start (so no side
+  effects fire over history the prior version already covered). Restarting the shard resumes the
+  suppressed warm-up from its persisted progress.
+- **Incompatible with `SubscribeFromPresent`** — subscribing from "present" deliberately ignores
+  persisted progression, so there is no prior mark to gate against. The gate is skipped and a warning
+  is logged.
+- **No-ops when not needed** — the gate never adds a warm-up phase for `Version == 1`, when the flag
+  is off, or when the new version's own progress is already at/past the prior mark (a plain resume).
+- **Accepted overlap window** — `N` is snapshotted when the new version starts. If an old version is
+  still running and advances past `N` afterward, the new version can re-emit side effects for that
+  `(N, old_final]` overlap. Stop the old version before (or as) the new one starts to avoid the
+  window; fully coordinated drain-and-handoff is a separate concern.
+
 ## Rebuilding a Single Stream <Badge type="tip" text="7.28" />
 
 A long standing request has been to be able to rebuild only a single stream or subset of streams

--- a/docs/events/projections/side-effects.md
+++ b/docs/events/projections/side-effects.md
@@ -98,6 +98,10 @@ A couple important facts about this new functionality:
 
 - The `RaiseSideEffects()` method is only called during _continuous_ asynchronous projection execution, and will not
   be called during projection rebuilds or `Inline` projection usage **unless you explicitly enable this behavior as shown below**
+- Side effects are also suppressed during the **blue/green warm-up phase** of a gated new projection version. When a
+  projection opts into `GateSideEffectsBehindPriorVersion`, a freshly deployed version first replays history the prior
+  version already processed in Rebuild mode (no side effects) and only fires side effects for events past the prior
+  version's mark. See [Suppressing Side Effects During the Blue/Green Warm-up](/events/projections/rebuilding#suppressing-side-effects-during-the-blue-green-warm-up).
 - Events emitted during the side effect method are _not_ immediately applied to the current projected document value by Marten
 - You _can_ alter the aggregate value or replace it yourself in this side effect method to reflect new events, but the onus
   is on you the user to apply idempotent updates to the aggregate based on these new events in the actual handlers for

--- a/src/DaemonTests/blue_green_side_effect_gate.cs
+++ b/src/DaemonTests/blue_green_side_effect_gate.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DaemonTests.Aggregations;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DaemonTests;
+
+// #4963 / jasperfx#480 acceptance against real Postgres: the opt-in blue/green side-effect gate. When a
+// NEW version of a projection opts into GateSideEffectsBehindPriorVersion and starts behind the highest
+// PRIOR version's persisted progression mark N, the daemon replays [floor..N] in Rebuild mode (side
+// effects suppressed) before starting Continuous from N — so RaiseSideEffects only fires for events the
+// previous version never processed. Each event here starts its own single-event stream, so a fired side
+// effect is observable per stream and the [<=N suppressed] / [(N..N+M] fires exactly once] boundary is
+// asserted directly against a recording outbox. (Resume-after-interruption, version-1, already-past and
+// failure paths are covered at the unit level in jasperfx BlueGreenSideEffectGateTests.)
+[Collection("blue_green_gate")]
+public class blue_green_side_effect_gate : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+
+    // Unique schema per test instance so the two versioned stores in one test share events + progression,
+    // while different test methods stay fully isolated (each xUnit method gets a fresh class instance).
+    private readonly string _schema = "bluegreen_gate_" + Guid.NewGuid().ToString("N")[..8];
+
+    public blue_green_side_effect_gate(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Fresh schema so the two versioned stores below share events + progression but start clean.
+        using var store = SeparateStore(_ => { });
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private DocumentStore SeparateStore(Action<StoreOptions> configure)
+        => DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.DatabaseSchemaName = _schema;
+            opts.Events.StreamIdentity = StreamIdentity.AsGuid;
+            configure(opts);
+        });
+
+    private static async Task<List<Guid>> AppendSingleEventStreams(IDocumentStore store, int count)
+    {
+        var ids = new List<Guid>();
+        await using var session = store.LightweightSession();
+        for (var i = 0; i < count; i++)
+        {
+            var id = Guid.NewGuid();
+            ids.Add(id);
+            session.Events.StartStream<GateTrip>(id, new GateTripStarted(id));
+        }
+
+        await session.SaveChangesAsync();
+        return ids;
+    }
+
+    private static List<Guid> FiredSideEffects(RecordingMessageOutbox outbox) =>
+        outbox.Batches.SelectMany(b => b.Messages).Select(m => m.message).OfType<GateTripActivated>()
+            .Select(x => x.Id).ToList();
+
+    [Fact]
+    public async Task fresh_deploy_suppresses_side_effects_up_to_the_prior_mark_then_fires_past_it()
+    {
+        const int N = 20;
+        const int M = 8;
+
+        // Blue: V2 with no opt-in. Run it to completion so its progression mark lands at N and its
+        // side effects fire for the whole [1..N] history.
+        var blueOutbox = new RecordingMessageOutbox();
+        using (var blue = SeparateStore(opts =>
+               {
+                   opts.Projections.Add(new GateTripProjection { Version = 2 }, ProjectionLifecycle.Async);
+                   opts.Events.MessageOutbox = blueOutbox;
+                   opts.Logger(new TestOutputMartenLogger(_output));
+               }))
+        {
+            await AppendSingleEventStreams(blue, N);
+
+            var blueDaemon = await blue.BuildProjectionDaemonAsync();
+            await blueDaemon.StartAllAsync();
+            await blueDaemon.Tracker.WaitForShardState("GateTrip:V2:All", N, 60.Seconds());
+            await blueDaemon.StopAllAsync();
+
+            FiredSideEffects(blueOutbox).Count.ShouldBe(N, "blue V2 fires side effects across its whole catch-up");
+        }
+
+        // Green: V3 opts into the gate. Append M more events, then start. The gate must replay [0..N] in
+        // Rebuild mode (no side effects) and only fire for the (N..N+M] tail.
+        var greenOutbox = new RecordingMessageOutbox();
+        using var green = SeparateStore(opts =>
+        {
+            opts.Projections.Add(new GateTripProjection { Version = 3, GateSideEffectsBehindPriorVersion = true },
+                ProjectionLifecycle.Async);
+            opts.Events.MessageOutbox = greenOutbox;
+            opts.Logger(new TestOutputMartenLogger(_output));
+        });
+
+        var tailIds = await AppendSingleEventStreams(green, M);
+
+        var greenDaemon = await green.BuildProjectionDaemonAsync();
+        await greenDaemon.StartAllAsync();
+        await greenDaemon.Tracker.WaitForShardState("GateTrip:V3:All", N + M, 60.Seconds());
+        await greenDaemon.StopAllAsync();
+
+        var fired = FiredSideEffects(greenOutbox);
+
+        // Exactly the M tail events fire side effects — nothing from the [1..N] history the prior
+        // version already processed.
+        fired.Count.ShouldBe(M);
+        fired.OrderBy(x => x).ShouldBe(tailIds.OrderBy(x => x));
+
+        // V3's documents are nonetheless correct over the FULL history (the warm-up applied [1..N]).
+        await using var query = green.QuerySession();
+        (await query.Query<GateTrip>().CountAsync()).ShouldBe(N + M);
+    }
+
+    [Fact]
+    public async Task without_the_opt_in_the_new_version_re_fires_side_effects_over_all_history()
+    {
+        const int N = 15;
+        const int M = 5;
+
+        var blueOutbox = new RecordingMessageOutbox();
+        using (var blue = SeparateStore(opts =>
+               {
+                   opts.Projections.Add(new GateTripProjection { Version = 2 }, ProjectionLifecycle.Async);
+                   opts.Events.MessageOutbox = blueOutbox;
+               }))
+        {
+            await AppendSingleEventStreams(blue, N);
+            var blueDaemon = await blue.BuildProjectionDaemonAsync();
+            await blueDaemon.StartAllAsync();
+            await blueDaemon.Tracker.WaitForShardState("GateTrip:V2:All", N, 60.Seconds());
+            await blueDaemon.StopAllAsync();
+        }
+
+        // V3 WITHOUT the opt-in: today's behavior — one continuous catch-up over the whole history, so
+        // side effects fire for all N+M events. This is exactly the re-emission the gate exists to avoid.
+        var greenOutbox = new RecordingMessageOutbox();
+        using var green = SeparateStore(opts =>
+        {
+            opts.Projections.Add(new GateTripProjection { Version = 3 }, ProjectionLifecycle.Async);
+            opts.Events.MessageOutbox = greenOutbox;
+        });
+
+        await AppendSingleEventStreams(green, M);
+
+        var greenDaemon = await green.BuildProjectionDaemonAsync();
+        await greenDaemon.StartAllAsync();
+        await greenDaemon.Tracker.WaitForShardState("GateTrip:V3:All", N + M, 60.Seconds());
+        await greenDaemon.StopAllAsync();
+
+        FiredSideEffects(greenOutbox).Count.ShouldBe(N + M);
+    }
+}
+
+public record GateTripStarted(Guid Id);
+
+public record GateTripActivated(Guid Id);
+
+public class GateTrip
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+}
+
+public partial class GateTripProjection : SingleStreamProjection<GateTrip, Guid>
+{
+    public void Apply(GateTrip trip, GateTripStarted _) => trip.Count++;
+
+    public override ValueTask RaiseSideEffects(IDocumentOperations operations, IEventSlice<GateTrip> slice)
+    {
+        // One observable side effect per stream that saw a Started event this batch. During a rebuild
+        // (and the blue/green warm-up, which runs in Rebuild mode) the daemon suppresses this.
+        if (slice.Events().OfType<IEvent<GateTripStarted>>().Any())
+        {
+            slice.PublishMessage(new GateTripActivated(slice.Snapshot?.Id ?? slice.Events().First().StreamId));
+        }
+
+        return new ValueTask();
+    }
+}


### PR DESCRIPTION
Downstream of JasperFx/jasperfx#480 (impl JasperFx/jasperfx#520). The opt-in blue/green side-effect gate — `GateSideEffectsBehindPriorVersion` on `ProjectionBase`/`AsyncOptions` — ships in **JasperFx.Events 2.28.1** and flows automatically through Marten's `ProjectionDaemon` (a `JasperFxAsyncDaemon` subclass). This PR is the Marten-side **verification + documentation**; no production code change was needed.

## Mechanism

When a projection opts in and a **new version** starts behind the highest **prior** version's persisted progression mark `N`:
1. **Warm-up** — replay `(current..N]` in Rebuild mode, so `RaiseSideEffects()` is suppressed while the new version's documents catch up.
2. **Continuous** — hand off from `N`, so side effects fire only for events the prior version never processed.

## Tests (`DaemonTests/blue_green_side_effect_gate.cs`, real Postgres)

Each event starts its own single-event stream, so a fired side effect is observable per global sequence and the boundary is asserted directly against a recording outbox.

- **`fresh_deploy_suppresses_side_effects_up_to_the_prior_mark_then_fires_past_it`** — V2 catches up to `N` (side effects fire for `[1..N]`); V3 with the gate replays `[0..N]` suppressed and fires **only** for the `(N..N+M]` tail, while V3's documents are correct over the full `N+M` history.
- **`without_the_opt_in_the_new_version_re_fires_side_effects_over_all_history`** — the contrast: a V3 *without* the opt-in re-fires side effects across all `N+M` events (the behavior the gate exists to avoid).

Resume-after-interruption, `Version == 1`, already-past, `SubscribeFromPresent` and failure paths are covered at the unit level in jasperfx `BlueGreenSideEffectGateTests`; this PR proves the mechanism flows through a real Marten `SingleStreamProjection` + daemon and documents it.

## Docs

- `rebuilding.md`: new "Suppressing Side Effects During the Blue/Green Warm-up" section (opt-in, mechanics, resume, failed-warm-up-pauses-the-shard, `SubscribeFromPresent` incompatibility, accepted overlap window).
- `side-effects.md`: note that side effects are suppressed during the blue/green warm-up, cross-linked to the versioning section.

Closes #4963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)