### PR TITLE
fix(#4964): hold the Normal high-water mark before a leading sequence gap

### DIFF
--- a/src/DaemonTests/Internals/GapDetectorTest.cs
+++ b/src/DaemonTests/Internals/GapDetectorTest.cs
@@ -75,6 +75,48 @@ public class GapDetectorTest: DaemonContext
         current.ShouldBe(NumberOfEvents);
     }
 
+    [Fact]
+    public async Task normal_path_holds_at_start_before_a_leading_gap_when_start_is_a_hole()
+    {
+        // #4964: the silent-skip blind spot. Delete a contiguous block so Start itself is a hole and the
+        // first committed sequence above it sits beyond Start + 1. The interior-gap query cannot see this
+        // (there is no visible row AT Start to pair with the first row above the gap), so without the hold
+        // it falls through to max(seq_id) and the Normal high-water mark crosses the invisible events with
+        // no trace. With HoldBeforeLeadingGap on (the Normal path), it must hold at Start instead.
+        NumberOfStreams = 10;
+        await PublishSingleThreaded();
+
+        var hole = NumberOfEvents / 2;
+        await deleteEvents(hole, hole + 1, hole + 2, hole + 3, hole + 4, hole + 5);
+
+        theGapDetector.Start = hole; // Start lands ON a hole
+        theGapDetector.HoldBeforeLeadingGap = true; // Normal detection path
+
+        var current = await _runner.Query(theGapDetector, CancellationToken.None);
+
+        current.ShouldBe(hole);
+    }
+
+    [Fact]
+    public async Task safe_zone_path_still_skips_a_leading_gap_forward_to_max()
+    {
+        // The SafeZone counterpart: with HoldBeforeLeadingGap off, the same hole state must keep the
+        // original skip-forward behavior so the SafeZone path can advance past a permanent hole (and
+        // record the skip). This guards against the #4964 hold leaking into the SafeZone path.
+        NumberOfStreams = 10;
+        await PublishSingleThreaded();
+
+        var hole = NumberOfEvents / 2;
+        await deleteEvents(hole, hole + 1, hole + 2, hole + 3, hole + 4, hole + 5);
+
+        theGapDetector.Start = hole;
+        theGapDetector.HoldBeforeLeadingGap = false; // SafeZone path
+
+        var current = await _runner.Query(theGapDetector, CancellationToken.None);
+
+        current.ShouldBe(NumberOfEvents);
+    }
+
     protected async Task deleteEvents(params long[] ids)
     {
         await using var conn = theStore.CreateConnection();

--- a/src/Marten/Events/Daemon/HighWater/GapDetector.cs
+++ b/src/Marten/Events/Daemon/HighWater/GapDetector.cs
@@ -18,9 +18,24 @@ internal class GapDetector: ISingleQueryHandler<long?>
 
     public long Start { get; set; }
 
+    /// <summary>
+    /// #4964: when true (the Normal high-water detection path), hold at <see cref="Start"/> instead of
+    /// advancing over a LEADING gap — a hole in the sequence immediately above <see cref="Start"/> whose
+    /// first committed row sits beyond <c>Start + 1</c>. The interior-gap query below only compares
+    /// consecutive VISIBLE rows, so it cannot see a gap when <see cref="Start"/> itself is a hole (there is
+    /// no visible row at <see cref="Start"/> to pair with the first row above the gap); it would then fall
+    /// through to <c>max(seq_id)</c> and advance the Normal high-water mark over a committed-but-not-yet-
+    /// visible event with no trace. Holding here keeps the Normal mark from ever crossing an unseen event:
+    /// a still-in-flight append fills the gap and the next poll advances normally, while a genuinely
+    /// permanent hole (a rolled-back append) is skipped — and recorded — by the SafeZone path once the mark
+    /// has been stale past the threshold. The SafeZone path leaves this false so it keeps skipping forward.
+    /// </summary>
+    public bool HoldBeforeLeadingGap { get; set; }
+
     public NpgsqlCommand BuildCommand()
     {
         var sql = $@"
+select min(seq_id) from {_graph.DatabaseSchemaName}.mt_events where seq_id > :start;
 select seq_id
 from   (select
                seq_id,
@@ -41,13 +56,29 @@ select max(seq_id) from {_graph.DatabaseSchemaName}.mt_events where seq_id >= :s
 
     public async Task<long?> HandleAsync(DbDataReader reader, CancellationToken token)
     {
-        // If there is a row, this tells us the first sequence gap
+        // (0) Leading-gap probe: the lowest committed sequence strictly above Start. In the Normal path,
+        // if it sits beyond Start + 1 there is a gap immediately above Start that the interior-gap query
+        // cannot see, so hold at Start rather than fall through to max and silently cross the gap.
+        long? firstAfterStart = null;
+        if (await reader.ReadAsync(token).ConfigureAwait(false)
+            && !await reader.IsDBNullAsync(0, token).ConfigureAwait(false))
+        {
+            firstAfterStart = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
+        }
+
+        if (HoldBeforeLeadingGap && firstAfterStart.HasValue && firstAfterStart.Value > Start + 1)
+        {
+            return Start;
+        }
+
+        // (1) If there is a row, this tells us the first interior sequence gap
+        await reader.NextResultAsync(token).ConfigureAwait(false);
         if (await reader.ReadAsync(token).ConfigureAwait(false))
         {
             return await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
         }
 
-        // use the latest sequence in the event table because there is NO gap
+        // (2) use the latest sequence in the event table because there is NO gap
         await reader.NextResultAsync(token).ConfigureAwait(false);
         if (!await reader.ReadAsync(token).ConfigureAwait(false))
         {

--- a/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
@@ -90,8 +90,10 @@ internal class HighWaterDetector: IHighWaterDetector
     {
         var statistics = await loadCurrentStatistics(token).ConfigureAwait(false);
 
-        // Skip gap and find next safe sequence
+        // Skip gap and find next safe sequence. #4964: the SafeZone path must NOT hold before a leading
+        // gap — its whole purpose is to skip forward past a stuck (permanent) hole and record the skip.
         _gapDetector.Start = statistics.SafeStartMark + 1;
+        _gapDetector.HoldBeforeLeadingGap = false;
 
         var safeSequence = await _runner.Query(_gapDetector, token).ConfigureAwait(false);
         if (safeSequence.HasValue)
@@ -419,7 +421,7 @@ select coalesce(
         }
         else
         {
-            statistics.CurrentMark = await findCurrentMark(statistics, token).ConfigureAwait(false);
+            statistics.CurrentMark = await findCurrentMark(statistics, detectionType, token).ConfigureAwait(false);
         }
 
         if (statistics.HasChanged)
@@ -588,10 +590,16 @@ select coalesce(
         return await _runner.Query(_highWaterStatisticsDetector, token).ConfigureAwait(false);
     }
 
-    private async Task<long> findCurrentMark(HighWaterStatistics statistics, CancellationToken token)
+    private async Task<long> findCurrentMark(HighWaterStatistics statistics, DetectionType detectionType,
+        CancellationToken token)
     {
         // look for the current mark
         _gapDetector.Start = statistics.SafeStartMark;
+
+        // #4964: only the Normal path holds before a leading gap. The SafeZone path deliberately skips
+        // forward past a permanent hole (and records the skip), so it must keep the old skip-to-max behavior.
+        _gapDetector.HoldBeforeLeadingGap = detectionType == DetectionType.Normal;
+
         long? current;
         try
         {


### PR DESCRIPTION
## The bug

The async daemon could **silently** advance the high-water mark over a committed-but-not-yet-visible event — sealing a skipped event with **no** `mt_high_water_skips` row, no `is_skipped`, no `daemon.skipping` metric, and no log line. (From the #4953 investigation.)

## Root cause

`GapDetector`'s interior-gap query only compares **consecutive visible rows**:

```sql
select seq_id from (select seq_id, lead(seq_id) over (order by seq_id) as no
                    from mt_events where seq_id >= :start) ct
where no is not null and no - seq_id > 1 limit 1;
select max(seq_id) from mt_events where seq_id >= :start;   -- fallback
```

When the detection `Start` lands **on a hole** — a rolled-back/allocated `seq_id`, or a SafeZone `HighestSequence - 32` boundary (GH-3865) that need not be a real event — a gap immediately above `Start` is invisible to query (1): there is no visible row *at* `Start` to pair with the first row above the gap. It falls through to `max(seq_id)`, and the **Normal** detection path (which records nothing) advances the mark across the gap.

## Fix

`GapDetector` gains a **leading-gap probe** (`min(seq_id) where seq_id > :start`) and a `HoldBeforeLeadingGap` flag. When the first committed sequence above `Start` sits beyond `Start + 1`, the Normal path **holds at `Start`** instead of advancing:

- a still-in-flight append fills the gap → the next poll advances normally;
- a genuinely **permanent** hole is skipped — **and recorded** via `MarkSkippingAsync` / `mt_high_water_skips` — by the existing **SafeZone** path once the mark has been stale past `StaleSequenceThreshold`.

So the Normal mark never crosses an unseen event, and **every** skip now flows through the observable SafeZone path.

The hold is **Normal-path only**: `HighWaterDetector.findCurrentMark` enables it for `DetectionType.Normal`; `DetectInSafeZone` explicitly disables it so the SafeZone path keeps its skip-forward-to-`max` behavior (its whole job is to break a permanent hole and record it).

## Tests

Existing `GapDetector` / high-water tests unchanged (verified locally). Two new `GapDetectorTest` cases:
- `normal_path_holds_at_start_before_a_leading_gap_when_start_is_a_hole` — the repro: `Start` on a hole with a leading gap holds at `Start` instead of leaping to `max`.
- `safe_zone_path_still_skips_a_leading_gap_forward_to_max` — guards that the hold does not leak into the SafeZone path.

Closes #4964.

🤖 Generated with [Claude Code](https://claude.com/claude-code)