### PR TITLE
feat(#4975): exact ReadProjectionProgressAsync(ShardName) override + JasperFx 2.29.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -105,14 +105,16 @@
          JasperFx 2.28.1: jasperfx#528 (marten#4966) — natural-key discovery now builds an event
          mapping for a two-arg static evolve method (static TDoc Apply(TEvent e, TDoc current)), so a
          natural key that CHANGES via an update event is written to mt_natural_key_X on live append and
-         rebuild; previously only the create event's key was ever recorded. -->
-    <PackageVersion Include="JasperFx" Version="2.28.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.28.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.28.1">
+         rebuild; previously only the create event's key was ever recorded.
+         JasperFx 2.29.0: jasperfx#529 (marten#4975) — exact ReadProjectionProgressAsync(ShardName) overload
+         on IEventDatabase (no version/shard collapsing), adopted by MartenDatabase here. -->
+    <PackageVersion Include="JasperFx" Version="2.29.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.29.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.29.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.28.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.29.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/DaemonTests/Internals/read_projection_progress.cs
+++ b/src/DaemonTests/Internals/read_projection_progress.cs
@@ -44,6 +44,10 @@ public class read_projection_progress : OneOffConfigurationsContext, IAsyncLifet
         ((IEventDatabase)theStore.Tenancy.Default.Database)
         .ReadProjectionProgressAsync(projectionName, tenantId, CancellationToken.None);
 
+    private ValueTask<ProjectionProgressRow?> read(ShardName name) =>
+        ((IEventDatabase)theStore.Tenancy.Default.Database)
+        .ReadProjectionProgressAsync(name, CancellationToken.None);
+
     [Fact]
     public async Task reads_the_store_global_row()
     {
@@ -102,5 +106,44 @@ public class read_projection_progress : OneOffConfigurationsContext, IAsyncLifet
 
         (await read("Orders", null))!.Sequence.ShouldBe(10);
         (await read("OrdersHistory", null))!.Sequence.ShouldBe(5);
+    }
+
+    // #4975 / jasperfx#529 — the exact ShardName overload does NO collapsing.
+    [Fact]
+    public async Task exact_shard_name_reads_the_specific_version_not_the_newest()
+    {
+        await seedProgression(
+            (ShardName.Compose("Orders", version: 2), 25),
+            (ShardName.Compose("Orders", version: 3), 40));
+
+        var v2 = await read(ShardName.Compose("Orders", version: 2));
+
+        v2.ShouldNotBeNull();
+        v2.Sequence.ShouldBe(25); // the exact V2 row, not the newest V3
+        v2.ProjectionName.ShouldBe("Orders");
+        v2.AgentStatus.ShouldBeNull();
+        v2.LastHeartbeat.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task exact_shard_name_returns_null_when_the_identity_does_not_exist()
+    {
+        await seedProgression((ShardName.Compose("Orders"), 10));
+
+        (await read(ShardName.Compose("Orders", version: 9))).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task exact_shard_name_distinguishes_tenant_rows()
+    {
+        await seedProgression(
+            (ShardName.Compose("Orders"), 10),
+            (ShardName.Compose("Orders", tenantId: "tenant1"), 99));
+
+        (await read(ShardName.Compose("Orders")))!.Sequence.ShouldBe(10);
+
+        var tenantRow = await read(ShardName.Compose("Orders", tenantId: "tenant1"));
+        tenantRow!.Sequence.ShouldBe(99);
+        tenantRow.TenantId.ShouldBe("tenant1");
     }
 }

--- a/src/Marten/Storage/MartenDatabase.EventStorage.cs
+++ b/src/Marten/Storage/MartenDatabase.EventStorage.cs
@@ -347,6 +347,46 @@ select count(*) from {Options.Events.DatabaseSchemaName}.mt_streams;
     }
 
     /// <summary>
+    /// #4975 / jasperfx#529 — exact per-cell progression read. Unlike the
+    /// <see cref="ReadProjectionProgressAsync(string,string?,CancellationToken)"/> overload this does no
+    /// version/shard collapsing: it looks up the single <c>mt_event_progression</c> row whose <c>name</c>
+    /// equals <paramref name="name"/>'s <see cref="ShardName.Identity"/> verbatim, so a blue/green deploy's
+    /// versions, a sliced projection's shard keys, and per-tenant partitions each address their own row.
+    /// A <see cref="ShardName.ShardKey"/> of <c>All</c> is the projection's global cell. Returns null when no
+    /// row exists for that identity; <see cref="ProjectionProgressRow.AgentStatus"/> and
+    /// <see cref="ProjectionProgressRow.LastHeartbeat"/> stay null (jasperfx#519).
+    /// </summary>
+    public async ValueTask<ProjectionProgressRow?> ReadProjectionProgressAsync(
+        ShardName name, CancellationToken token)
+    {
+        await EnsureStorageExistsAsync(typeof(IEvent), token).ConfigureAwait(false);
+
+        await using var conn = CreateConnection();
+        try
+        {
+            await conn.OpenAsync(token).ConfigureAwait(false);
+
+            var builder = new CommandBuilder();
+            builder.Append(
+                $"select last_seq_id from {Options.EventGraph.DatabaseSchemaName}.mt_event_progression where name = ");
+            builder.AppendParameter(name.Identity);
+
+            await using var reader = await conn.ExecuteReaderAsync(builder, token).ConfigureAwait(false);
+            if (!await reader.ReadAsync(token).ConfigureAwait(false))
+            {
+                return null;
+            }
+
+            var sequence = await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false);
+            return new ProjectionProgressRow(name.Name, name.TenantId, sequence, null, null);
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
     /// #4785 / jasperfx#473 — Marten override of the store-agnostic
     /// <see cref="IEventDatabase.DeleteProjectionProgressByShardNameAsync"/>
     /// (default impl throws). Drops the single <c>mt_event_progression</c> row


### PR DESCRIPTION
Follow-up to #4962. [JasperFx/jasperfx#529](https://github.com/JasperFx/jasperfx/pull/529) (JasperFx.Events **2.29.0**) adds an exact per-cell progression read; this implements it on `MartenDatabase`.

## What

`ReadProjectionProgressAsync(ShardName name, CancellationToken)` — a straight `where name = @name.Identity` lookup against `mt_event_progression`, **no version/shard collapsing** (the caller supplies the full `ShardName`, e.g. from `AllProjectionProgress`). A blue/green deploy's versions, a sliced projection's shard keys, and per-tenant partitions each address their own row; `ShardKey == "All"` is the projection's global cell. Returns `null` for an absent identity; `AgentStatus`/`LastHeartbeat` stay `null` (jasperfx#519).

Bumps the JasperFx packages **2.28.1 → 2.29.0**.

## Tests

Extends `read_projection_progress`: the exact overload reads the **specific** version (25 for V2, not the newest V3's 40), returns `null` for an absent identity, and distinguishes tenant rows. 8/8 pass locally against the published 2.29.0.

Closes #4975. Companion to the Polecat adoption (JasperFx/polecat#333) and the umbrella jasperfx#435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)