### PR TITLE
feat(#4978): re-point ITenanted at JasperFx.MultiTenancy.ITenanted

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -112,14 +112,16 @@
          COMMITTED ceiling via the new IHighWaterDetector.FetchCommittedHighWaterCeilingAsync DIM
          (overridden here with max(seq_id)) instead of looping DetectInSafeZone to the reserved
          last_value, and the loop is time-bounded — rebuild/catch-up during concurrent appends now
-         waits for in-flight events instead of pressuring detection to skip them. -->
-    <PackageVersion Include="JasperFx" Version="2.29.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.29.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.29.1">
+         waits for in-flight events instead of pressuring detection to skip them.
+         JasperFx 2.30.0: jasperfx#531 (marten#4978) — shared ITenanted marker promoted into
+         JasperFx.MultiTenancy; Marten.Metadata.ITenanted now derives from it. -->
+    <PackageVersion Include="JasperFx" Version="2.30.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.30.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.30.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.29.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.30.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/Marten/Metadata/ITenanted.cs
+++ b/src/Marten/Metadata/ITenanted.cs
@@ -7,9 +7,12 @@ namespace Marten.Metadata;
 /// <summary>
 ///     Optionally implement this interface on your Marten document
 ///     types to opt into conjoined tenancy and track the tenant id
-///     on the document itself
+///     on the document itself. Derives from the shared
+///     <see cref="JasperFx.MultiTenancy.ITenanted"/> marker (jasperfx#531)
+///     so the same marker drives conjoined behavior across Marten,
+///     Polecat, and Wolverine.
 /// </summary>
-public interface ITenanted : IHasTenantId
+public interface ITenanted : JasperFx.MultiTenancy.ITenanted
 {
 
 }


### PR DESCRIPTION
Closes #4978. Follow-up to JasperFx/jasperfx#531, part of the Wolverine conjoined EF Core multi-tenancy epic (JasperFx/wolverine#3465).

- Bumps JasperFx, JasperFx.Events, JasperFx.SourceGenerator, and JasperFx.Events.SourceGenerator to **2.30.0**
- `Marten.Metadata.ITenanted` now derives from the shared `JasperFx.MultiTenancy.ITenanted` marker instead of declaring `: IHasTenantId` directly — non-breaking for existing documents, and any Marten `ITenanted` document now also satisfies the cross-tool marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)