### PR TITLE
Fix extended progression opt-in clobber and frozen last_updated (#4981)

### DIFF
--- a/docs/events/projections/async-daemon.md
+++ b/docs/events/projections/async-daemon.md
@@ -561,19 +561,32 @@ by setting the toggle to true explicitly:
 opts.Events.EnableExtendedProgressionTracking = true;
 ```
 
-Marten implements the storage-agnostic
+Marten registers a storage-agnostic
 [`IEventStoreInstrumentation`](https://github.com/JasperFx/jasperfx/blob/main/src/JasperFx.Events/IEventStoreInstrumentation.cs)
-abstraction from JasperFx.Events 2.9.0 -- `Wolverine.CritterWatch.Marten` and
-similar satellite packages can flip the same toggle via the interface without
-referencing Marten's concrete `EventGraph`:
+adapter (from JasperFx.Events 2.9.0) in the container. Satellite packages such as
+`Wolverine.CritterWatch.Marten` enable the same columns by resolving that service
+from DI and setting the interface property -- no reference to Marten's concrete
+`EventGraph` required:
 
 ```cs
-((IEventStoreInstrumentation)opts.Events).ExtendedProgressionEnabled = true;
+builder.Services.AddSingleton<IConfigureMarten>(new EnableExtendedProgression());
+
+// ...
+
+public class EnableExtendedProgression: IConfigureMarten
+{
+    public void Configure(IServiceProvider services, StoreOptions options)
+    {
+        options.Events.EnableExtendedProgressionTracking = true;
+    }
+}
 ```
 
-Both names refer to the same underlying field. New code is encouraged to prefer
-the interface property; `EnableExtendedProgressionTracking` continues to work
-without deprecation warnings.
+The adapter's value is applied at store build and does **not** overwrite a direct
+`opts.Events.EnableExtendedProgressionTracking = true`, so the two opt-in paths
+compose. (Note that `opts.Events` -- Marten's `EventGraph` -- does not itself
+implement `IEventStoreInstrumentation`; use the `EnableExtendedProgressionTracking`
+property shown above.)
 
 ## Advanced Skipping Tracking <Badge type="tip" text="8.6" />
 

--- a/src/CoreTests/Events/EventGraph_IEventStoreInstrumentation.cs
+++ b/src/CoreTests/Events/EventGraph_IEventStoreInstrumentation.cs
@@ -40,6 +40,46 @@ public class EventGraph_IEventStoreInstrumentation
         store.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
     }
 
+    // #4981: AddMarten always registers the SetEventStoreInstrumentation adapter, whose
+    // Configure previously overwrote EnableExtendedProgressionTracking unconditionally -- so a
+    // direct opt-in inside AddMarten was silently clobbered back to false at store build.
+    [Fact]
+    public void direct_toggle_inside_add_marten_survives_store_build()
+    {
+        var collection = new ServiceCollection();
+        collection.AddMarten(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Events.EnableExtendedProgressionTracking = true;
+        });
+
+        using var provider = collection.BuildServiceProvider();
+        var store = provider.GetRequiredService<IDocumentStore>();
+
+        store.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+    }
+
+    // #4981: the adapter must apply, not clobber -- a direct opt-in and the DI-singleton opt-in
+    // (what CritterWatch uses) compose rather than fighting.
+    [Fact]
+    public void direct_toggle_and_di_singleton_toggle_compose()
+    {
+        var collection = new ServiceCollection();
+        collection.AddMarten(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Events.EnableExtendedProgressionTracking = true;
+        });
+
+        using var provider = collection.BuildServiceProvider();
+
+        // DI singleton left at its default (false) -- the direct toggle must still win.
+        provider.GetRequiredService<IEventStoreInstrumentation>().ExtendedProgressionEnabled.ShouldBeFalse();
+
+        var store = provider.GetRequiredService<IDocumentStore>();
+        store.Options.Events.EnableExtendedProgressionTracking.ShouldBeTrue();
+    }
+
     [Fact]
     public void build_store_with_progression_tracking_override_with_ancillary_store()
     {

--- a/src/DaemonTests/Bug_4981_projection_progress_last_updated_advances.cs
+++ b/src/DaemonTests/Bug_4981_projection_progress_last_updated_advances.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Core;
+using JasperFx.Events.Projections;
+using Marten.Events.Aggregation;
+using Npgsql;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DaemonTests;
+
+public record Bug4981Event();
+
+public class Bug4981Stream { public Guid Id { get; set; } }
+
+public partial class Bug4981Projection: SingleStreamProjection<Bug4981Stream, Guid>
+{
+    public void Apply(Bug4981Event @event, Bug4981Stream projection) { }
+}
+
+public class Bug_4981_projection_progress_last_updated_advances: DaemonContext
+{
+    public Bug_4981_projection_progress_last_updated_advances(ITestOutputHelper output): base(output)
+    {
+    }
+
+    private async Task<DateTime> lastUpdatedForAsync(string shardName)
+    {
+        await using var session = theStore.QuerySession();
+        var value = await session.Connection
+            .CreateCommand(
+                $"select last_updated from {theStore.Events.DatabaseSchemaName}.mt_event_progression where name = :name")
+            .With("name", shardName)
+            .ExecuteScalarAsync();
+
+        return (DateTime)value!;
+    }
+
+    [Fact]
+    public async Task last_updated_advances_as_a_projection_shard_processes_more_events()
+    {
+        StoreOptions(x => x.Projections.Add(new Bug4981Projection(), ProjectionLifecycle.Async));
+
+        var agent = await StartDaemon();
+
+        const string shard = "Bug4981Stream:All";
+
+        await using (var session = theStore.LightweightSession())
+        {
+            for (var i = 0; i < 50; i++)
+            {
+                session.Events.Append(Guid.NewGuid(), new Bug4981Event());
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        await agent.Tracker.WaitForShardState(new ShardState(shard, 50), 30.Seconds());
+        var firstUpdated = await lastUpdatedForAsync(shard);
+
+        // ensure a measurable clock gap so the second write's transaction_timestamp() differs
+        await Task.Delay(1.Seconds());
+
+        await using (var session = theStore.LightweightSession())
+        {
+            for (var i = 0; i < 50; i++)
+            {
+                session.Events.Append(Guid.NewGuid(), new Bug4981Event());
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        await agent.Tracker.WaitForShardState(new ShardState(shard, 100), 30.Seconds());
+        var secondUpdated = await lastUpdatedForAsync(shard);
+
+        // #4981: before the fix, UpdateProjectionProgress never touched last_updated, so this
+        // stayed frozen at the row's insert time and looked exactly like a stalled projection.
+        secondUpdated.ShouldBeGreaterThan(firstUpdated);
+    }
+}

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -183,7 +183,8 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
             else
             {
                 session.QueueSqlCommand(
-                    $"insert into {Options.EventGraph.ProgressionTable} (name, last_seq_id) values (?, ?) on conflict (name) do update set last_seq_id = ?",
+                    // #4981: keep last_updated in step with the rewound progress on the update branch
+                $"insert into {Options.EventGraph.ProgressionTable} (name, last_seq_id) values (?, ?) on conflict (name) do update set last_seq_id = ?, last_updated = transaction_timestamp()",
                     name.Identity, sequenceFloor, sequenceFloor);
             }
         }
@@ -205,7 +206,8 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
         if (sequenceFloor > 0)
         {
             session.QueueSqlCommand(
-                $"insert into {Options.EventGraph.ProgressionTable} (name, last_seq_id) values (?, ?) on conflict (name) do update set last_seq_id = ?",
+                // #4981: keep last_updated in step with the rewound progress on the update branch
+                $"insert into {Options.EventGraph.ProgressionTable} (name, last_seq_id) values (?, ?) on conflict (name) do update set last_seq_id = ?, last_updated = transaction_timestamp()",
                 shardName, sequenceFloor, sequenceFloor);
         }
 

--- a/src/Marten/Events/Daemon/Progress/UpdateProjectionProgress.cs
+++ b/src/Marten/Events/Daemon/Progress/UpdateProjectionProgress.cs
@@ -34,9 +34,13 @@ internal class UpdateProjectionProgress: IStorageOperation, AssertsOnCallback, N
         // through ShardName.Identity — per-tenant shards (Phase 2) get a
         // distinct Identity per (projection, shardKey, tenant) so the same
         // WHERE name = ? optimistic update naturally scopes to one tenant.
+        // #4981: advance last_updated on every progress write so it reflects the last time this
+        // shard actually moved. Previously only last_seq_id was set, so daemon shard rows froze
+        // last_updated at insert time and it looked exactly like a stalled projection. Matches
+        // HighWaterDetector / mt_mark_event_progression, which already use transaction_timestamp().
         var parameters =
             builder.AppendWithParameters(
-                $"update {_events.ProgressionTable} set last_seq_id = ? where name = ? and last_seq_id = ?");
+                $"update {_events.ProgressionTable} set last_seq_id = ?, last_updated = transaction_timestamp() where name = ? and last_seq_id = ?");
 
         parameters[0].Value = Range.SequenceCeiling;
         parameters[0].NpgsqlDbType = NpgsqlDbType.Bigint;

--- a/src/Marten/MartenServiceCollectionExtensions.cs
+++ b/src/Marten/MartenServiceCollectionExtensions.cs
@@ -1113,8 +1113,19 @@ internal class SetEventStoreInstrumentation: IConfigureMarten, IEventStoreInstru
 {
     public void Configure(IServiceProvider services, StoreOptions options)
     {
-        options.EventGraph.EnableExtendedProgressionTracking = ExtendedProgressionEnabled;
-        options.EventGraph.AppendObserver = AppendObserver;
+        // #4981: only apply the adapter's values, never overwrite. This adapter is always
+        // registered by AddMarten, so an unconditional assignment clobbered a direct
+        // `opts.Events.EnableExtendedProgressionTracking = true` (and any directly-set
+        // AppendObserver) back to the adapter defaults at store build.
+        if (ExtendedProgressionEnabled)
+        {
+            options.EventGraph.EnableExtendedProgressionTracking = true;
+        }
+
+        if (AppendObserver != null)
+        {
+            options.EventGraph.AppendObserver += AppendObserver;
+        }
     }
 
     public bool ExtendedProgressionEnabled { get; set; }
@@ -1125,8 +1136,16 @@ internal class SetEventStoreInstrumentation<T>: IConfigureMarten<T>, IEventStore
 {
     public void Configure(IServiceProvider services, StoreOptions options)
     {
-        options.EventGraph.EnableExtendedProgressionTracking = ExtendedProgressionEnabled;
-        options.EventGraph.AppendObserver = AppendObserver;
+        // #4981: see SetEventStoreInstrumentation.Configure — apply, do not clobber.
+        if (ExtendedProgressionEnabled)
+        {
+            options.EventGraph.EnableExtendedProgressionTracking = true;
+        }
+
+        if (AppendObserver != null)
+        {
+            options.EventGraph.AppendObserver += AppendObserver;
+        }
     }
 
     public bool ExtendedProgressionEnabled { get; set; }


### PR DESCRIPTION
Closes #4981.

Three defects around extended progression tracking / `mt_event_progression`, all fixed Marten-side.

### 1. `SetEventStoreInstrumentation` clobbered a direct opt-in
`AddMarten` always registers the `SetEventStoreInstrumentation` adapter (as both `IConfigureMarten` and `IEventStoreInstrumentation`). Its `Configure` unconditionally overwrote `EventGraph.EnableExtendedProgressionTracking` and `AppendObserver` with the adapter defaults (false/null) at store build, so a direct `opts.Events.EnableExtendedProgressionTracking = true` inside `AddMarten` was silently lost. It now **applies** its values rather than clobbering, so the direct toggle and the DI-singleton toggle (what CritterWatch uses) compose.

### 2. `last_updated` frozen at insert for daemon shard rows
`UpdateProjectionProgress` (and the `RewindSubscriptionProgress`/`RewindAgentProgress` upserts) set only `last_seq_id`, so projection shard rows froze `last_updated` at insert time while `HighWaterMark` advanced fine — it looked exactly like a stalled projection. They now set `last_updated = transaction_timestamp()`, matching `HighWaterDetector` / `mt_mark_event_progression`.

### 3. Docs opt-in snippet threw `InvalidCastException`
`docs/events/projections/async-daemon.md` cast `opts.Events` to `IEventStoreInstrumentation`, which `EventGraph` does not implement. Replaced with the real satellite path and noted that the direct toggle now composes (after fix 1).

### Tests
- `CoreTests` `EventGraph_IEventStoreInstrumentation`: direct toggle survives store build + composes with the DI singleton.
- `DaemonTests` `Bug_4981_projection_progress_last_updated_advances`: integration test asserting a projection shard's `last_updated` advances across two batches (fails pre-fix).
- Subscriptions suite (25 tests, exercises the rewind paths) green; docs lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)