### PR TITLE
Add high-water staleness health check (#4982, Phase 0)

### DIFF
--- a/src/DaemonTests.ManualOnly/HealthChecks/HighWaterHealthCheckTests.cs
+++ b/src/DaemonTests.ManualOnly/HealthChecks/HighWaterHealthCheckTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Core;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten.Events.Aggregation;
+using Marten.Events.Daemon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Npgsql;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using static Marten.Events.Daemon.HighWaterHealthCheckExtensions;
+
+namespace DaemonTests.ManualOnly.HealthChecks;
+
+public record HwFakeEvent();
+
+public class HwFakeStream { public Guid Id { get; set; } }
+
+public partial class HwFakeProjection: SingleStreamProjection<HwFakeStream, Guid>
+{
+    public void Apply(HwFakeEvent @event, HwFakeStream projection) { }
+}
+
+public class HighWaterHealthCheckTests: DaemonContext
+{
+    private FakeHealthCheckBuilderStub _builder = new();
+    private readonly TimeProvider _timeProvider = Substitute.For<TimeProvider>();
+    private readonly DateTimeOffset _now = DateTimeOffset.UtcNow;
+    private readonly HighWaterStateTracker _tracker = new();
+
+    public HighWaterHealthCheckTests(ITestOutputHelper output): base(output)
+    {
+        _output = output;
+        _timeProvider.GetUtcNow().Returns(_now);
+    }
+
+    private HighWaterHealthCheck buildCheck(TimeSpan? staleThreshold = null, long minimumGap = 1) =>
+        new(theStore, new HighWaterHealthCheckSettings(staleThreshold ?? 30.Seconds(), minimumGap), _timeProvider,
+            _tracker);
+
+    private async Task appendEventsAsync(int count)
+    {
+        await using var session = theStore.LightweightSession();
+        var stream = Guid.NewGuid();
+        for (var i = 0; i < count; i++)
+        {
+            session.Events.Append(stream, new HwFakeEvent());
+        }
+
+        await session.SaveChangesAsync();
+    }
+
+    private async Task seedHighWaterMarkAsync(long sequence)
+    {
+        var sql =
+            $"insert into {theStore.Events.DatabaseSchemaName}.mt_event_progression (name, last_seq_id, last_updated) " +
+            $"values ('HighWaterMark', {sequence}, now()) " +
+            "on conflict (name) do update set last_seq_id = excluded.last_seq_id";
+        await theSession.ExecuteAsync(new NpgsqlCommand(sql));
+    }
+
+    // ---- registration --------------------------------------------------------------------
+
+    [Fact]
+    public void registers_settings_timeprovider_tracker_and_check()
+    {
+        _builder = new();
+        _builder.AddMartenHighWaterHealthCheck(30.Seconds());
+
+        _builder.Services.ShouldContain(x => x.ServiceType == typeof(HighWaterHealthCheckSettings));
+        _builder.Services.ShouldContain(x => x.ServiceType == typeof(TimeProvider));
+        _builder.Services.ShouldContain(x => x.ServiceType == typeof(HighWaterStateTracker));
+
+        var services = _builder.Services.BuildServiceProvider();
+        services.GetServices<HealthCheckRegistration>()
+            .ShouldContain(reg => reg.Name == nameof(HighWaterHealthCheck));
+    }
+
+    // ---- gating --------------------------------------------------------------------------
+
+    [Fact]
+    public async Task healthy_when_no_async_projections_even_if_mark_is_stuck()
+    {
+        // no async projection registered -> the high-water agent runs nowhere, so a stuck mark is legitimate
+        await appendEventsAsync(20);
+        await seedHighWaterMarkAsync(1);
+
+        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task healthy_when_daemon_mode_is_disabled_even_if_mark_is_stuck()
+    {
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Disabled;
+        });
+        await appendEventsAsync(20);
+        await seedHighWaterMarkAsync(1);
+
+        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    // ---- signal --------------------------------------------------------------------------
+
+    [Fact]
+    public async Task healthy_when_mark_is_caught_up()
+    {
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+        });
+        await appendEventsAsync(20);
+        var highest = await theStore.Advanced.FetchEventStoreStatistics();
+        await seedHighWaterMarkAsync(highest.EventSequenceNumber);
+
+        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task healthy_within_grace_window_when_mark_first_seen_behind()
+    {
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+        });
+        await appendEventsAsync(20);
+        await seedHighWaterMarkAsync(1);
+
+        // first observation of the gap only starts the clock; not yet stale
+        var result = await buildCheck().CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task unhealthy_when_mark_stuck_behind_past_threshold()
+    {
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+        });
+        await appendEventsAsync(20);
+        await seedHighWaterMarkAsync(1);
+
+        var check = buildCheck(30.Seconds());
+
+        // first check records the stalled mark at _now
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+
+        // advance the clock past the threshold with the mark still stuck
+        _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task healthy_when_mark_advances_before_threshold()
+    {
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+        });
+        await appendEventsAsync(20);
+        await seedHighWaterMarkAsync(1);
+
+        var check = buildCheck(30.Seconds());
+
+        // first check: gap observed, clock starts
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+
+        // the mark advances (agent alive) and time moves forward past the threshold
+        await seedHighWaterMarkAsync(10);
+        _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
+
+        // the advance resets the clock, so it must not be reported stale
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+}

--- a/src/Marten.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
+++ b/src/Marten.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Daemon;
+using Marten.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Marten.Events.Daemon;
+
+/// <summary>
+///     Health check that detects a stalled or dead high-water agent — the failure mode in
+///     marten#4961 that <see cref="AsyncDaemonHealthCheckExtensions" /> cannot see. That check
+///     measures projection lag <em>against</em> the high-water mark, so when the high-water
+///     agent itself dies the mark freezes, projections catch up to the frozen value, and it
+///     reports Healthy. This check instead compares the high-water mark against the actual
+///     highest event sequence and reports Unhealthy only when the mark stops advancing while
+///     events keep accumulating past it.
+/// </summary>
+public static class HighWaterHealthCheckExtensions
+{
+    /// <summary>
+    ///     Adds a health check that reports <see cref="HealthCheckResult.Unhealthy" /> when the
+    ///     high-water mark has stopped advancing for at least <paramref name="staleThreshold" />
+    ///     while later events remain unprocessed — a strong signal that the high-water agent has
+    ///     died or wedged (marten#4961).
+    ///     <para>
+    ///         This is a Phase 0 (marten#4982) implementation built on the sequence-gap heuristic
+    ///         so it ships without an upstream dependency. A non-zero gap is normal transiently
+    ///         (the detector holds the mark inside a "safe harbor" behind in-flight/gapped
+    ///         sequences), so the check trips only on a <em>sustained non-advance</em>, never on a
+    ///         single snapshot. The reading is store-global database state, so it is correct on any
+    ///         node regardless of which one runs the agent — it fails only when <em>no</em> node is
+    ///         advancing the mark.
+    ///     </para>
+    /// </summary>
+    /// <param name="builder"><see cref="IHealthChecksBuilder" /></param>
+    /// <param name="staleThreshold">
+    ///     How long the high-water mark may sit unchanged while behind the latest event sequence
+    ///     before the store is considered unhealthy. Defaults to 30 seconds.
+    /// </param>
+    /// <param name="minimumGap">
+    ///     The gap (highest event sequence minus high-water mark) that is treated as "caught up"
+    ///     and never trips the check, absorbing the normal safe-harbor lag. Defaults to 1.
+    /// </param>
+    public static IHealthChecksBuilder AddMartenHighWaterHealthCheck(
+        this IHealthChecksBuilder builder,
+        TimeSpan? staleThreshold = null,
+        long minimumGap = 1
+    )
+    {
+        builder.Services.AddSingleton(new HighWaterHealthCheckSettings(
+            staleThreshold ?? TimeSpan.FromSeconds(30), minimumGap));
+        builder.Services.TryAddSingleton(TimeProvider.System);
+        builder.Services.TryAddSingleton<HighWaterStateTracker>();
+        return builder.AddCheck<HighWaterHealthCheck>(
+            nameof(HighWaterHealthCheck),
+            tags: new[] { "Marten", "AsyncDaemon", "HighWater" }
+        );
+    }
+
+    /// <summary>
+    ///     DI-injected settings for <see cref="HighWaterHealthCheck" />.
+    /// </summary>
+    public record HighWaterHealthCheckSettings(TimeSpan StaleThreshold, long MinimumGap);
+
+    /// <summary>
+    ///     Tracks, per database, when the high-water mark was first observed to be behind the
+    ///     latest event sequence and what value it held then, so a <em>sustained</em> non-advance
+    ///     can be distinguished from a transient safe-harbor gap across health check invocations.
+    /// </summary>
+    public class HighWaterStateTracker
+    {
+        public ConcurrentDictionary<string, (DateTimeOffset FirstObservedAt, long HighWaterMark)> Readings { get; } =
+            new();
+    }
+
+    /// <summary>
+    ///     Health check implementation.
+    /// </summary>
+    public class HighWaterHealthCheck: IHealthCheck
+    {
+        private const string HighWaterMarkShard = "HighWaterMark";
+
+        private readonly IDocumentStore _store;
+        private readonly TimeProvider _timeProvider;
+        private readonly TimeSpan _staleThreshold;
+        private readonly long _minimumGap;
+        private readonly HighWaterStateTracker _tracker;
+
+        public HighWaterHealthCheck(IDocumentStore store, HighWaterHealthCheckSettings settings,
+            TimeProvider timeProvider, HighWaterStateTracker tracker)
+        {
+            _store = store;
+            _timeProvider = timeProvider;
+            _staleThreshold = settings.StaleThreshold;
+            _minimumGap = settings.MinimumGap;
+            _tracker = tracker;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default
+        )
+        {
+            try
+            {
+                // Gate: the high-water mark is only expected to advance when this store is actually
+                // responsible for running the async daemon. Otherwise a frozen mark is legitimate
+                // and asserting on it would be a false positive.
+                if (_store.Options is not StoreOptions options)
+                {
+                    return HealthCheckResult.Healthy("Healthy");
+                }
+
+                var projections = options.Projections;
+
+                // No async projections or subscriptions -> no high-water agent runs anywhere.
+                if (!projections.HasAnyAsyncProjections())
+                {
+                    return HealthCheckResult.Healthy("No async projections or subscriptions are registered");
+                }
+
+                // Disabled / ExternallyManaged -> this store hosts no daemon, so it must not assert
+                // that some local agent is advancing the mark.
+                if (projections.AsyncMode is not (DaemonMode.Solo or DaemonMode.HotCold))
+                {
+                    return HealthCheckResult.Healthy(
+                        $"Async daemon mode is {projections.AsyncMode}; high-water is not advanced by this store");
+                }
+
+                var databases = await _store.Storage.AllDatabases().ConfigureAwait(false);
+
+                foreach (var database in databases)
+                {
+                    var result = await checkDatabaseAsync(database, cancellationToken).ConfigureAwait(false);
+                    if (result.Status != HealthStatus.Healthy)
+                    {
+                        return result;
+                    }
+                }
+
+                return HealthCheckResult.Healthy("Healthy");
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy($"Unhealthy: {ex.Message}", ex);
+            }
+        }
+
+        private async Task<HealthCheckResult> checkDatabaseAsync(IMartenDatabase database, CancellationToken token)
+        {
+            var allProgress = await database.AllProjectionProgress(token).ConfigureAwait(false);
+            var highWater = allProgress.FirstOrDefault(x => string.Equals(HighWaterMarkShard, x.ShardName));
+
+            // No HighWaterMark progression row yet -> the daemon has not started here. Nothing to assert.
+            if (highWater is null)
+            {
+                _tracker.Readings.TryRemove(database.Identifier, out _);
+                return HealthCheckResult.Healthy("Healthy");
+            }
+
+            var highest = await database.FetchHighestEventSequenceNumber(token).ConfigureAwait(false);
+            var gap = highest - highWater.Sequence;
+            var now = _timeProvider.GetUtcNow();
+
+            // Caught up (within the normal safe-harbor gap). Clear any stalled-mark tracking.
+            if (gap <= _minimumGap)
+            {
+                _tracker.Readings.TryRemove(database.Identifier, out _);
+                return HealthCheckResult.Healthy("Healthy");
+            }
+
+            // A gap exists. That is normal transiently; it is only a problem when the mark is NOT
+            // advancing while events keep piling up beyond it. Track the first time we saw a gap at
+            // this mark value; if the mark moves, reset the clock; if it stays put past the
+            // threshold, the high-water agent has almost certainly died or wedged.
+            var reading = _tracker.Readings.GetOrAdd(database.Identifier, _ => (now, highWater.Sequence));
+
+            if (reading.HighWaterMark != highWater.Sequence)
+            {
+                _tracker.Readings[database.Identifier] = (now, highWater.Sequence);
+                return HealthCheckResult.Healthy("Healthy");
+            }
+
+            if (now - reading.FirstObservedAt >= _staleThreshold)
+            {
+                return HealthCheckResult.Unhealthy(
+                    $"Unhealthy: the high-water mark for database '{database.Identifier}' has been stuck at {highWater.Sequence} with {gap} later event(s) unprocessed (highest sequence {highest}) for at least {_staleThreshold}. The high-water agent may have stopped (see marten#4961).");
+            }
+
+            return HealthCheckResult.Healthy("Healthy");
+        }
+    }
+}


### PR DESCRIPTION
Part of #4982 (follow-up to #4961). Phase 0.

### Problem
`AddMartenAsyncDaemonHealthCheck` measures each async projection's lag **against** the high-water mark. When the high-water agent itself dies (#4961) the mark freezes, projections catch up to the frozen value → lag 0 → it reports **Healthy**. It also returns Healthy when there is no `HighWaterMark` row at all. So there is no existing check that detects a dead/stalled high-water agent.

### This change
`AddMartenHighWaterHealthCheck(staleThreshold, minimumGap)` compares the high-water mark against the actual highest event sequence (`FetchHighestEventSequenceNumber`) and reports **Unhealthy** only when the mark stops advancing while events keep accumulating past it.

- A non-zero gap is normal transiently (the detector holds the mark inside a safe harbor behind in-flight/gapped sequences), so the check trips only on a **sustained non-advance**, tracked per-database across invocations — never on a single snapshot.
- The reading is store-global database state, so it is correct on any node regardless of which one runs the agent — it fails only when *no* node is advancing the mark.
- **Gated** to where a high-water agent is actually expected to run: `HasAnyAsyncProjections()` + `AsyncMode ∈ {Solo, HotCold}` (Disabled / ExternallyManaged / no async projections → Healthy). Report-only.

### Roadmap
This is the Phase 0 gap-heuristic implementation, which ships with no upstream dependency. A later phase swaps the primary signal to a liveness heartbeat on the high-water agent and adds an opt-in local restart, once JasperFx/jasperfx#539 lands.

### Tests
`DaemonTests.ManualOnly` `HighWaterHealthCheckTests` — 7 tests (registration, both gate paths, caught-up, grace window, stuck-past-threshold, advance-resets-clock). Green on net9.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)