### PR TITLE
Document AddMartenHighWaterHealthCheck (#4982)

### DIFF
--- a/docs/events/projections/healthchecks.md
+++ b/docs/events/projections/healthchecks.md
@@ -58,3 +58,41 @@ Services.AddHealthChecks().AddMartenAsyncDaemonHealthCheck(maxEventLag: 500, max
 // Map HealthCheck Endpoint
 app.MapHealthChecks("/health");
 ```
+
+## High-Water Staleness HealthCheck
+
+`AddMartenAsyncDaemonHealthCheck` measures each async projection's lag *against* the
+`HighWaterMark`. That makes it blind to a dead or wedged high-water agent: when the agent
+stops, the mark freezes, every projection catches up to that frozen value, the lag drops to
+zero, and the check reports **Healthy** — the exact inverse of what you want.
+
+`AddMartenHighWaterHealthCheck` closes that gap. Instead of comparing projections to the
+mark, it compares the `HighWaterMark` itself against the actual highest event sequence, and
+reports **Unhealthy** only when the mark *stops advancing* while later events keep piling up
+past it — a strong signal that the high-water agent has died (see
+[marten#4961](https://github.com/JasperFx/marten/issues/4961)).
+
+```cs
+// Add HealthCheck
+Services.AddHealthChecks().AddMartenHighWaterHealthCheck(staleThreshold: TimeSpan.FromSeconds(30));
+
+// Map HealthCheck Endpoint
+app.MapHealthChecks("/health");
+```
+
+The check is deliberately conservative to avoid false positives:
+
+- **Gating.** It reports Healthy (not applicable) unless the store actually runs the daemon —
+  it needs at least one `Async` projection or subscription registered, and an `AsyncMode` of
+  `Solo` or `HotCold`. `Disabled` and `ExternallyManaged` stores never assert on the mark.
+- **Sustained non-advance only.** A non-zero gap between the highest event sequence and the
+  mark is *normal* transiently (the detector deliberately holds the mark inside a "safe
+  harbor" behind in-flight or gapped sequences). The check therefore trips only when the mark
+  sits at the same value for at least `staleThreshold` (default 30 seconds) while events remain
+  unprocessed beyond it — never on a single snapshot.
+- **Store-global reading.** It reads database state, so it is correct on any node regardless of
+  which one runs the agent; it fails only when *no* node is advancing the mark.
+
+::: tip INFO
+This health check does **not** force the high-water mark forward — it is detection only.
+:::


### PR DESCRIPTION
Follow-up docs for #4982 (Phase 0). The high-water staleness health check landed in #4984 (code + tests, merged) but without user-facing documentation. This adds a **High-Water Staleness HealthCheck** section to `docs/events/projections/healthchecks.md`.

The new section covers:

- The blind spot in `AddMartenAsyncDaemonHealthCheck`: it measures projection lag *against* the `HighWaterMark`, so when the high-water agent itself dies (#4961) the mark freezes, projections catch up to the frozen value, and it reports Healthy — the inverse of what's wanted.
- `AddMartenHighWaterHealthCheck`, which compares the mark against the actual highest event sequence and reports Unhealthy only on a *sustained* non-advance while events pile up past the mark.
- Its conservative semantics: gating (async projections + `Solo`/`HotCold` only), sustained-non-advance-only (never a single snapshot), store-global reading, and that it never forces the mark forward.

markdownlint (`--disable MD009`) and cspell both pass locally.

Related: #4982, #4984, #4961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)