### PR TITLE
Upgrade JasperFx + JasperFx.Events to 2.32.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -114,14 +114,19 @@
          last_value, and the loop is time-bounded — rebuild/catch-up during concurrent appends now
          waits for in-flight events instead of pressuring detection to skip them.
          JasperFx 2.30.0: jasperfx#531 (marten#4978) — shared ITenanted marker promoted into
-         JasperFx.MultiTenancy; Marten.Metadata.ITenanted now derives from it. -->
-    <PackageVersion Include="JasperFx" Version="2.30.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.30.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.30.0">
+         JasperFx.MultiTenancy; Marten.Metadata.ITenanted now derives from it.
+         JasperFx 2.32.0: jasperfx#539 — HighWaterAgent liveness heartbeat, staleness surface, and
+         local restart seam (IProjectionDaemon.HighWaterLastPolledAt / IsHighWaterStale /
+         RestartHighWaterAgentAsync; DaemonSettings.HighWaterStalenessThreshold; ShardAction.Faulted/
+         Restarted). Also carries the jasperfx#540 faulted-start teardown that first shipped in 2.32.0.
+         Foundation for the Phase 2 high-water health check (marten#4986). -->
+    <PackageVersion Include="JasperFx" Version="2.32.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.32.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.32.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.30.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.32.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Rolls the JasperFx package pins forward **2.30.0 → 2.32.0**:

| Package | Was | Now |
|---|---|---|
| JasperFx | 2.30.0 | **2.32.0** |
| JasperFx.Events | 2.30.0 | **2.32.0** |
| JasperFx.Events.SourceGenerator | 2.30.0 | **2.32.0** |
| JasperFx.SourceGenerator | 2.30.0 | **2.32.0** |
| JasperFx.RuntimeCompiler | 5.0.0 | 5.0.0 (unchanged) |

### What 2.32.0 brings
- **jasperfx#539** — HighWaterAgent liveness heartbeat, staleness surface, and a local restart seam. New `IProjectionDaemon` members (`HighWaterLastPolledAt`, `IsHighWaterStale`, `RestartHighWaterAgentAsync`), `DaemonSettings.HighWaterStalenessThreshold` (30s), and `ShardAction.Faulted`/`Restarted`. Marten's `ProjectionDaemon : JasperFxAsyncDaemon` inherits all of it for free. This is the **foundation for the Phase 2 high-water health check (#4986)**.
- **jasperfx#540** — a faulted shard start is now torn down so it can't orphan the shard (companion to the #534 failure-cause propagation already in 2.31.0; this teardown half first ships in 2.32.0).

`src/Marten` and `src/Marten.AspNetCore` build clean against 2.32.0. Pure pin bump — no source changes.

Follow-up: #4986 (opt-in `autoRestart` + swap the high-water health check's primary signal to the new heartbeat) builds on this.