### PR TITLE
feat(#4986): high-water health check autoRestart + heartbeat primary signal

### DIFF
--- a/src/DaemonTests.ManualOnly/HealthChecks/HighWaterHealthCheckTests.cs
+++ b/src/DaemonTests.ManualOnly/HealthChecks/HighWaterHealthCheckTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using DaemonTests.TestingSupport;
 using JasperFx.Core;
@@ -39,9 +41,19 @@ public class HighWaterHealthCheckTests: DaemonContext
         _timeProvider.GetUtcNow().Returns(_now);
     }
 
-    private HighWaterHealthCheck buildCheck(TimeSpan? staleThreshold = null, long minimumGap = 1) =>
-        new(theStore, new HighWaterHealthCheckSettings(staleThreshold ?? 30.Seconds(), minimumGap), _timeProvider,
-            _tracker);
+    private HighWaterHealthCheck buildCheck(TimeSpan? staleThreshold = null, long minimumGap = 1,
+        bool autoRestart = false, IProjectionCoordinator? coordinator = null)
+    {
+        var services = new ServiceCollection();
+        if (coordinator != null)
+        {
+            services.AddSingleton(coordinator);
+        }
+
+        return new(theStore,
+            new HighWaterHealthCheckSettings(staleThreshold ?? 30.Seconds(), minimumGap, autoRestart), _timeProvider,
+            _tracker, services.BuildServiceProvider());
+    }
 
     private async Task appendEventsAsync(int count)
     {
@@ -61,6 +73,17 @@ public class HighWaterHealthCheckTests: DaemonContext
             $"insert into {theStore.Events.DatabaseSchemaName}.mt_event_progression (name, last_seq_id, last_updated) " +
             $"values ('HighWaterMark', {sequence}, now()) " +
             "on conflict (name) do update set last_seq_id = excluded.last_seq_id";
+        await theSession.ExecuteAsync(new NpgsqlCommand(sql));
+    }
+
+    // Seeds the HighWaterMark row's liveness heartbeat (jasperfx#539). Requires
+    // EnableExtendedProgressionTracking so the `heartbeat` column exists.
+    private async Task seedHighWaterHeartbeatAsync(long sequence, DateTimeOffset heartbeat)
+    {
+        var sql =
+            $"insert into {theStore.Events.DatabaseSchemaName}.mt_event_progression (name, last_seq_id, last_updated, heartbeat) " +
+            $"values ('HighWaterMark', {sequence}, now(), '{heartbeat:O}'::timestamptz) " +
+            "on conflict (name) do update set last_seq_id = excluded.last_seq_id, heartbeat = excluded.heartbeat";
         await theSession.ExecuteAsync(new NpgsqlCommand(sql));
     }
 
@@ -195,5 +218,122 @@ public class HighWaterHealthCheckTests: DaemonContext
         var result = await check.CheckHealthAsync(new HealthCheckContext());
 
         result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    // ---- heartbeat primary signal (marten#4986) ------------------------------------------
+
+    [Fact]
+    public async Task healthy_when_heartbeat_is_fresh_even_though_mark_is_behind()
+    {
+        // ExtendedProgression on -> the heartbeat is the primary signal. A fresh heartbeat means the
+        // agent is cycling, so a mark sitting behind the latest event is NOT unhealthy (unlike the gap
+        // heuristic, which would trip here).
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+            x.Events.EnableExtendedProgressionTracking = true;
+        });
+        await appendEventsAsync(20);
+        await seedHighWaterHeartbeatAsync(1, _now.AddSeconds(-5)); // mark stuck at 1, but heartbeat is 5s old
+
+        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task unhealthy_when_heartbeat_is_stale_even_though_mark_is_caught_up()
+    {
+        // A stale heartbeat means the loop stopped cycling. This trips even when the mark is fully caught
+        // up (gap == 0) — the case the gap heuristic is blind to.
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+            x.Events.EnableExtendedProgressionTracking = true;
+        });
+        await appendEventsAsync(20);
+        var stats = await theStore.Advanced.FetchEventStoreStatistics();
+        await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90)); // caught up, heartbeat 90s old
+
+        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    // ---- autoRestart remediation (marten#4986) -------------------------------------------
+
+    [Fact]
+    public async Task autorestart_triggers_a_restart_once_and_still_reports_unhealthy()
+    {
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+            x.Events.EnableExtendedProgressionTracking = true;
+        });
+        await appendEventsAsync(20);
+        var stats = await theStore.Advanced.FetchEventStoreStatistics();
+        await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90));
+
+        var daemon = Substitute.For<IProjectionDaemon>();
+        var coordinator = new FakeCoordinator(daemon);
+
+        var check = buildCheck(30.Seconds(), autoRestart: true, coordinator: coordinator);
+
+        // First stale cycle: restart the loop, still report Unhealthy so an alert fires.
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Unhealthy);
+        await daemon.Received(1).RestartHighWaterAgentAsync(Arg.Any<CancellationToken>());
+
+        // Second cycle inside the same staleness window: still Unhealthy, but NOT restarted again (capped).
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Unhealthy);
+        await daemon.Received(1).RestartHighWaterAgentAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task without_autorestart_no_restart_is_attempted()
+    {
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+            x.Events.EnableExtendedProgressionTracking = true;
+        });
+        await appendEventsAsync(20);
+        var stats = await theStore.Advanced.FetchEventStoreStatistics();
+        await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90));
+
+        var daemon = Substitute.For<IProjectionDaemon>();
+        var coordinator = new FakeCoordinator(daemon);
+
+        var result = await buildCheck(30.Seconds(), coordinator: coordinator).CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        await daemon.DidNotReceive().RestartHighWaterAgentAsync(Arg.Any<CancellationToken>());
+    }
+
+    // Minimal IProjectionCoordinator that hands back a single daemon — avoids mocking a ValueTask-returning
+    // member (CA2012) while letting the daemon itself stay an NSubstitute for Received(...) assertions.
+    private sealed class FakeCoordinator: IProjectionCoordinator
+    {
+        private readonly IProjectionDaemon _daemon;
+
+        public FakeCoordinator(IProjectionDaemon daemon) => _daemon = daemon;
+
+        public IProjectionDaemon DaemonForMainDatabase() => _daemon;
+
+        public ValueTask<IProjectionDaemon> DaemonForDatabase(string databaseIdentifier) => new(_daemon);
+
+        public ValueTask<IReadOnlyList<IProjectionDaemon>> AllDaemonsAsync() =>
+            new(new[] { _daemon });
+
+        public Task PauseAsync() => Task.CompletedTask;
+
+        public Task ResumeAsync() => Task.CompletedTask;
+
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 }

--- a/src/Marten.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
+++ b/src/Marten.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
@@ -16,44 +16,63 @@ namespace Marten.Events.Daemon;
 ///     marten#4961 that <see cref="AsyncDaemonHealthCheckExtensions" /> cannot see. That check
 ///     measures projection lag <em>against</em> the high-water mark, so when the high-water
 ///     agent itself dies the mark freezes, projections catch up to the frozen value, and it
-///     reports Healthy. This check instead compares the high-water mark against the actual
-///     highest event sequence and reports Unhealthy only when the mark stops advancing while
-///     events keep accumulating past it.
+///     reports Healthy. This check instead detects that the high-water agent has stopped and,
+///     optionally, restarts it.
+///     <para>
+///         Two staleness signals, best first (marten#4986):
+///         <list type="number">
+///             <item>
+///                 <b>Heartbeat age (primary).</b> When ExtendedProgression is enabled, the
+///                 high-water agent stamps a liveness heartbeat on the <c>HighWaterMark</c>
+///                 progression row on every completed poll cycle (JasperFx/jasperfx#539). Its age
+///                 is a direct signal that the loop is <em>cycling</em>, independent of whether the
+///                 mark <em>advances</em> — so a quiet store with no new events never trips it.
+///             </item>
+///             <item>
+///                 <b>Sequence gap (fallback).</b> When ExtendedProgression is off, no heartbeat is
+///                 persisted, so the check falls back to the original heuristic: the mark sitting
+///                 unchanged while later events pile up past it.
+///             </item>
+///         </list>
+///     </para>
 /// </summary>
 public static class HighWaterHealthCheckExtensions
 {
     /// <summary>
     ///     Adds a health check that reports <see cref="HealthCheckResult.Unhealthy" /> when the
-    ///     high-water mark has stopped advancing for at least <paramref name="staleThreshold" />
-    ///     while later events remain unprocessed — a strong signal that the high-water agent has
-    ///     died or wedged (marten#4961).
-    ///     <para>
-    ///         This is a Phase 0 (marten#4982) implementation built on the sequence-gap heuristic
-    ///         so it ships without an upstream dependency. A non-zero gap is normal transiently
-    ///         (the detector holds the mark inside a "safe harbor" behind in-flight/gapped
-    ///         sequences), so the check trips only on a <em>sustained non-advance</em>, never on a
-    ///         single snapshot. The reading is store-global database state, so it is correct on any
-    ///         node regardless of which one runs the agent — it fails only when <em>no</em> node is
-    ///         advancing the mark.
-    ///     </para>
+    ///     high-water agent has stopped for at least <paramref name="staleThreshold" /> — via its
+    ///     liveness heartbeat where available, otherwise via the sequence-gap heuristic
+    ///     (marten#4961 / marten#4986).
     /// </summary>
     /// <param name="builder"><see cref="IHealthChecksBuilder" /></param>
     /// <param name="staleThreshold">
-    ///     How long the high-water mark may sit unchanged while behind the latest event sequence
-    ///     before the store is considered unhealthy. Defaults to 30 seconds.
+    ///     How long the high-water agent may go without a heartbeat (or, on the fallback path, how
+    ///     long the mark may sit unchanged while behind the latest event sequence) before the store
+    ///     is considered unhealthy. Defaults to 30 seconds.
     /// </param>
     /// <param name="minimumGap">
-    ///     The gap (highest event sequence minus high-water mark) that is treated as "caught up"
-    ///     and never trips the check, absorbing the normal safe-harbor lag. Defaults to 1.
+    ///     Fallback path only: the gap (highest event sequence minus high-water mark) that is
+    ///     treated as "caught up" and never trips the check, absorbing the normal safe-harbor lag.
+    ///     Defaults to 1.
+    /// </param>
+    /// <param name="autoRestart">
+    ///     When <c>true</c>, an Unhealthy result also asks the local projection coordinator to
+    ///     restart the high-water agent's poll loop for the affected database
+    ///     (<see cref="IProjectionDaemon.RestartHighWaterAgentAsync" />). The restart never advances
+    ///     the mark and is capped to once per <paramref name="staleThreshold" /> window per database
+    ///     to avoid churn; the cycle is still reported <b>Unhealthy</b> so an alert fires. Defaults
+    ///     to <c>false</c> (detection only). Intended for single-writer (Solo) or leader nodes —
+    ///     the process running the health check must be the one hosting the daemon.
     /// </param>
     public static IHealthChecksBuilder AddMartenHighWaterHealthCheck(
         this IHealthChecksBuilder builder,
         TimeSpan? staleThreshold = null,
-        long minimumGap = 1
+        long minimumGap = 1,
+        bool autoRestart = false
     )
     {
         builder.Services.AddSingleton(new HighWaterHealthCheckSettings(
-            staleThreshold ?? TimeSpan.FromSeconds(30), minimumGap));
+            staleThreshold ?? TimeSpan.FromSeconds(30), minimumGap, autoRestart));
         builder.Services.TryAddSingleton(TimeProvider.System);
         builder.Services.TryAddSingleton<HighWaterStateTracker>();
         return builder.AddCheck<HighWaterHealthCheck>(
@@ -65,17 +84,20 @@ public static class HighWaterHealthCheckExtensions
     /// <summary>
     ///     DI-injected settings for <see cref="HighWaterHealthCheck" />.
     /// </summary>
-    public record HighWaterHealthCheckSettings(TimeSpan StaleThreshold, long MinimumGap);
+    public record HighWaterHealthCheckSettings(TimeSpan StaleThreshold, long MinimumGap, bool AutoRestart = false);
 
     /// <summary>
-    ///     Tracks, per database, when the high-water mark was first observed to be behind the
-    ///     latest event sequence and what value it held then, so a <em>sustained</em> non-advance
-    ///     can be distinguished from a transient safe-harbor gap across health check invocations.
+    ///     Tracks, per database, the fallback gap heuristic's "first observed a stuck mark" reading
+    ///     and (when <c>autoRestart</c> is on) the last auto-restart moment, so a <em>sustained</em>
+    ///     non-advance can be distinguished from a transient safe-harbor gap and restarts can be
+    ///     capped to once per staleness window across health check invocations.
     /// </summary>
     public class HighWaterStateTracker
     {
         public ConcurrentDictionary<string, (DateTimeOffset FirstObservedAt, long HighWaterMark)> Readings { get; } =
             new();
+
+        public ConcurrentDictionary<string, DateTimeOffset> Restarts { get; } = new();
     }
 
     /// <summary>
@@ -89,16 +111,20 @@ public static class HighWaterHealthCheckExtensions
         private readonly TimeProvider _timeProvider;
         private readonly TimeSpan _staleThreshold;
         private readonly long _minimumGap;
+        private readonly bool _autoRestart;
         private readonly HighWaterStateTracker _tracker;
+        private readonly IServiceProvider _services;
 
         public HighWaterHealthCheck(IDocumentStore store, HighWaterHealthCheckSettings settings,
-            TimeProvider timeProvider, HighWaterStateTracker tracker)
+            TimeProvider timeProvider, HighWaterStateTracker tracker, IServiceProvider services)
         {
             _store = store;
             _timeProvider = timeProvider;
             _staleThreshold = settings.StaleThreshold;
             _minimumGap = settings.MinimumGap;
+            _autoRestart = settings.AutoRestart;
             _tracker = tracker;
+            _services = services;
         }
 
         public async Task<HealthCheckResult> CheckHealthAsync(
@@ -159,40 +185,109 @@ public static class HighWaterHealthCheckExtensions
             // No HighWaterMark progression row yet -> the daemon has not started here. Nothing to assert.
             if (highWater is null)
             {
-                _tracker.Readings.TryRemove(database.Identifier, out _);
+                clearTracking(database.Identifier);
                 return HealthCheckResult.Healthy("Healthy");
             }
 
+            var now = _timeProvider.GetUtcNow();
+
+            // Phase 2 (marten#4986) primary signal: the liveness heartbeat (jasperfx#539). Present only
+            // when ExtendedProgression is enabled. Heartbeat age proves the poll loop is *cycling*
+            // independent of whether the mark *advances*, so a quiet store never trips it — a strictly
+            // better signal than the gap heuristic. Use it whenever it is available.
+            if (highWater.LastHeartbeat is { } lastHeartbeat)
+            {
+                // The gap tracker is only for the fallback path; keep it clear while on the heartbeat path.
+                _tracker.Readings.TryRemove(database.Identifier, out _);
+
+                var age = now - lastHeartbeat;
+                if (age < _staleThreshold)
+                {
+                    _tracker.Restarts.TryRemove(database.Identifier, out _);
+                    return HealthCheckResult.Healthy("Healthy");
+                }
+
+                var restartNote = await tryAutoRestartAsync(database.Identifier, now, token).ConfigureAwait(false);
+                return HealthCheckResult.Unhealthy(
+                    $"Unhealthy: the high-water agent for database '{database.Identifier}' last reported a liveness heartbeat {age.TotalSeconds:F0}s ago (at {lastHeartbeat:O}), exceeding the {_staleThreshold} staleness threshold. Its poll loop has stopped cycling (see JasperFx/jasperfx#539 / marten#4961).{restartNote}");
+            }
+
+            // Fallback (ExtendedProgression off): the sequence-gap heuristic. A non-zero gap is normal
+            // transiently (the detector holds the mark inside a "safe harbor" behind in-flight/gapped
+            // sequences), so this trips only on a sustained non-advance while events pile up past the mark.
             var highest = await database.FetchHighestEventSequenceNumber(token).ConfigureAwait(false);
             var gap = highest - highWater.Sequence;
-            var now = _timeProvider.GetUtcNow();
 
             // Caught up (within the normal safe-harbor gap). Clear any stalled-mark tracking.
             if (gap <= _minimumGap)
             {
-                _tracker.Readings.TryRemove(database.Identifier, out _);
+                clearTracking(database.Identifier);
                 return HealthCheckResult.Healthy("Healthy");
             }
 
-            // A gap exists. That is normal transiently; it is only a problem when the mark is NOT
-            // advancing while events keep piling up beyond it. Track the first time we saw a gap at
-            // this mark value; if the mark moves, reset the clock; if it stays put past the
-            // threshold, the high-water agent has almost certainly died or wedged.
+            // Track the first time we saw a gap at this mark value; if the mark moves, reset the clock; if
+            // it stays put past the threshold, the high-water agent has almost certainly died or wedged.
             var reading = _tracker.Readings.GetOrAdd(database.Identifier, _ => (now, highWater.Sequence));
 
             if (reading.HighWaterMark != highWater.Sequence)
             {
                 _tracker.Readings[database.Identifier] = (now, highWater.Sequence);
+                _tracker.Restarts.TryRemove(database.Identifier, out _);
                 return HealthCheckResult.Healthy("Healthy");
             }
 
             if (now - reading.FirstObservedAt >= _staleThreshold)
             {
+                var restartNote = await tryAutoRestartAsync(database.Identifier, now, token).ConfigureAwait(false);
                 return HealthCheckResult.Unhealthy(
-                    $"Unhealthy: the high-water mark for database '{database.Identifier}' has been stuck at {highWater.Sequence} with {gap} later event(s) unprocessed (highest sequence {highest}) for at least {_staleThreshold}. The high-water agent may have stopped (see marten#4961).");
+                    $"Unhealthy: the high-water mark for database '{database.Identifier}' has been stuck at {highWater.Sequence} with {gap} later event(s) unprocessed (highest sequence {highest}) for at least {_staleThreshold}. The high-water agent may have stopped (see marten#4961).{restartNote}");
             }
 
             return HealthCheckResult.Healthy("Healthy");
+        }
+
+        private void clearTracking(string databaseIdentifier)
+        {
+            _tracker.Readings.TryRemove(databaseIdentifier, out _);
+            _tracker.Restarts.TryRemove(databaseIdentifier, out _);
+        }
+
+        // marten#4986 item 1: opt-in remediation. Ask the local coordinator's daemon to restart the
+        // high-water poll loop for this database — loop only, never advancing the mark. Best-effort and
+        // capped to once per staleness window so the (faster) health-check cadence can't thrash a loop
+        // that legitimately needs longer to re-establish. The cycle is still reported Unhealthy by the
+        // caller so an alert fires regardless.
+        private async Task<string> tryAutoRestartAsync(string databaseIdentifier, DateTimeOffset now,
+            CancellationToken token)
+        {
+            if (!_autoRestart)
+            {
+                return string.Empty;
+            }
+
+            if (_tracker.Restarts.TryGetValue(databaseIdentifier, out var lastRestart) &&
+                now - lastRestart < _staleThreshold)
+            {
+                return " An auto-restart was already attempted within the current staleness window.";
+            }
+
+            var coordinator = _services.GetService<IProjectionCoordinator>();
+            if (coordinator is null)
+            {
+                return " (autoRestart is enabled but no IProjectionCoordinator is registered to restart the agent.)";
+            }
+
+            try
+            {
+                var daemon = await coordinator.DaemonForDatabase(databaseIdentifier).ConfigureAwait(false);
+                await daemon.RestartHighWaterAgentAsync(token).ConfigureAwait(false);
+                _tracker.Restarts[databaseIdentifier] = now;
+                return " An auto-restart of the high-water agent was triggered (the mark was NOT advanced).";
+            }
+            catch (Exception e)
+            {
+                return $" An auto-restart of the high-water agent was attempted but failed: {e.Message}.";
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #4986. Follow-up to #4982 (parent) / #4984 (detection) / #4985 (docs).

> **Stacked on #4987** (the JasperFx 2.32.0 bump). Base is `upgrade/jasperfx-2.32.0`; it will retarget to `master` once #4987 merges. The heartbeat surface (`ShardState.LastHeartbeat`, `IProjectionDaemon.RestartHighWaterAgentAsync`) ships in JasperFx **2.32.0** (jasperfx#539).

## 1. Opt-in `autoRestart` remediation

`AddMartenHighWaterHealthCheck(TimeSpan? staleThreshold = null, long minimumGap = 1, bool autoRestart = false)`.

When `autoRestart` is on and the check is Unhealthy, it asks the local `IProjectionCoordinator`'s daemon to `RestartHighWaterAgentAsync` for the affected database — **loop only, the mark is never advanced** — capped to **once per staleness window** per database to avoid churn. The cycle is still reported **Unhealthy** so an alert fires. Best-effort: no coordinator registered / restart throws → still Unhealthy, with a note. Intended for Solo / leader nodes (the health-check process must host the daemon).

## 2. Phase 2 — heartbeat is now the primary signal

When `EnableExtendedProgressionTracking` is on, the high-water agent stamps a liveness heartbeat on the `HighWaterMark` progression row every completed poll cycle (jasperfx#539). The check reads it from `AllProjectionProgress` and treats **heartbeat age** as the primary staleness signal:

- Fresh heartbeat → **Healthy**, even if the mark sits behind the latest event (a case the gap heuristic falsely trips).
- Stale heartbeat → **Unhealthy**, even when fully caught up, gap 0 (a case the gap heuristic is **blind** to — the exact marten#4961 failure).

The sequence-gap heuristic is retained as the **ExtendedProgression-off fallback**, unchanged.

## Tests
`DaemonTests.ManualOnly/HealthChecks/HighWaterHealthCheckTests` — 11 pass against Postgres: the 7 existing gap-heuristic tests plus fresh-heartbeat-healthy, stale-heartbeat-unhealthy-while-caught-up, autoRestart-restarts-once-still-unhealthy, and no-autoRestart-no-restart.

## Related
- Parity: JasperFx/polecat#341.
- Foundation: JasperFx/jasperfx#539 (2.32.0). Origin: #4961.