### PR TITLE
Wire the extended-progression write path (release 9.17.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>9.17.0</Version>
+        <Version>9.17.1</Version>
         <LangVersion>13.0</LangVersion>
         <Authors>Jeremy D. Miller;Babu Annamalai;Jaedyn Tonee</Authors>
         <PackageIconUrl>https://martendb.io/logo.png</PackageIconUrl>

--- a/src/CoreTests/Events/extended_progression_gate.cs
+++ b/src/CoreTests/Events/extended_progression_gate.cs
@@ -1,0 +1,34 @@
+using JasperFx.Events;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests.Events;
+
+// #750 regression guard. The async daemon's ExtendedProgressionWriter observer gates on
+// IEventStore.ExtendedProgressionEnabled, whose interface default is false. Marten's DocumentStore
+// must reflect the store opt-in here or the observer silently never fires and the extended
+// progression columns (heartbeat / agent_status / pause_reason / running_on_node) stay NULL --
+// exactly the "a feature that was built and never connected" failure #750 reported.
+public class extended_progression_gate
+{
+    [Fact]
+    public void event_store_reports_extended_progression_disabled_by_default()
+    {
+        using var store = DocumentStore.For(ConnectionSource.ConnectionString);
+        ((IEventStore)store).ExtendedProgressionEnabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void event_store_reflects_the_extended_progression_opt_in()
+    {
+        using var store = DocumentStore.For(opts =>
+        {
+            opts.Connection(ConnectionSource.ConnectionString);
+            opts.Events.EnableExtendedProgressionTracking = true;
+        });
+
+        ((IEventStore)store).ExtendedProgressionEnabled.ShouldBeTrue();
+    }
+}

--- a/src/Marten/DocumentStore.EventStore.cs
+++ b/src/Marten/DocumentStore.EventStore.cs
@@ -48,6 +48,13 @@ public partial class DocumentStore: IEventStore<IDocumentOperations, IQuerySessi
 
     DatabaseCardinality IEventStore.DatabaseCardinality => Options.Tenancy.Cardinality;
 
+    // #750: gate the daemon's ExtendedProgressionWriter observer on the store's opt-in — without this
+    // the observer (which reads IEventStore.ExtendedProgressionEnabled, default false) never fires and
+    // the heartbeat/agent_status/pause_reason/running_on_node columns stay NULL. Both the direct
+    // opt-in (opts.Events.EnableExtendedProgressionTracking) and CritterWatch's instrumentation
+    // adapter converge on this same flag (see SetEventStoreInstrumentation).
+    bool IEventStore.ExtendedProgressionEnabled => Options.EventGraph.EnableExtendedProgressionTracking;
+
     bool IEventStore.HasMultipleTenants
     {
         get

--- a/src/Marten/Schema/SQL/mt_mark_event_progression_extended.sql
+++ b/src/Marten/Schema/SQL/mt_mark_event_progression_extended.sql
@@ -2,11 +2,26 @@ CREATE
 OR REPLACE FUNCTION {databaseSchema}.mt_mark_event_progression_extended(name varchar, last_encountered bigint, p_heartbeat timestamp with time zone, p_agent_status varchar, p_pause_reason text, p_running_on_node integer) RETURNS VOID LANGUAGE plpgsql AS
 $function$
 BEGIN
-INSERT INTO {databaseSchema}.mt_event_progression (name, last_seq_id, last_updated, heartbeat, agent_status, pause_reason, running_on_node)
-VALUES (name, last_encountered, transaction_timestamp(), p_heartbeat, p_agent_status, p_pause_reason, p_running_on_node)
-ON CONFLICT ON CONSTRAINT pk_mt_event_progression
-    DO
-UPDATE SET last_seq_id = last_encountered, last_updated = transaction_timestamp(), heartbeat = p_heartbeat, agent_status = p_agent_status, pause_reason = p_pause_reason, running_on_node = p_running_on_node;
+-- Telemetry-only: decorate an EXISTING progression row's extended columns and nothing else.
+-- The progression row (name / last_seq_id / last_updated) is owned by the projection batch commit,
+-- so this write must never INSERT and never touch last_seq_id / last_updated:
+--   * a pre-emptive INSERT here races the batch's own first progress insert into a duplicate-key
+--     failure on pk_mt_event_progression (and a Started publication carries last_encountered = 0, which
+--     would seed the row's progress backwards);
+--   * updating last_seq_id on a throttled heartbeat would roll committed progress backwards -- the
+--     "clobber" defect.
+-- If no progression row exists yet the telemetry is simply skipped until the first commit creates it.
+-- The table-qualified column disambiguates it from the same-named `name` parameter (plpgsql's
+-- default variable_conflict = error would otherwise reject the bare `name`), while `$1` references
+-- that parameter positionally. The parameter is left named `name` so CREATE OR REPLACE never trips
+-- the "cannot rename input parameter" rule against a function an older release already installed.
+-- CritterWatch #750 / marten#4981.
+UPDATE {databaseSchema}.mt_event_progression
+SET heartbeat = p_heartbeat,
+    agent_status = p_agent_status,
+    pause_reason = p_pause_reason,
+    running_on_node = p_running_on_node
+WHERE mt_event_progression.name = $1;
 
 END;
 

--- a/src/Marten/Storage/MartenDatabase.EventStorage.cs
+++ b/src/Marten/Storage/MartenDatabase.EventStorage.cs
@@ -46,6 +46,38 @@ public partial class MartenDatabase : IEventDatabase
         }
     }
 
+    /// <summary>
+    ///     Persist the extended progression telemetry (heartbeat / agent_status / pause_reason /
+    ///     running_on_node) the async daemon publishes for a shard, via the
+    ///     <c>mt_mark_event_progression_extended</c> function. Driven by the JasperFx.Events
+    ///     <c>ExtendedProgressionWriter</c> observer on status transitions and throttled heartbeats
+    ///     (CritterWatch #750). The function updates only the telemetry columns on an existing row,
+    ///     so it never rolls back committed <c>last_seq_id</c>.
+    /// </summary>
+    public async Task WriteExtendedProgressionAsync(ShardState state, CancellationToken token = default)
+    {
+        await EnsureStorageExistsAsync(typeof(IEvent), token).ConfigureAwait(false);
+
+        await using var conn = CreateConnection();
+        try
+        {
+            await conn.OpenAsync(token).ConfigureAwait(false);
+            await conn.CreateCommand(
+                    $"select {Options.EventGraph.DatabaseSchemaName}.mt_mark_event_progression_extended(:name, :seq, :heartbeat, :status, :reason, :node)")
+                .With("name", state.ShardName, NpgsqlDbType.Varchar)
+                .With("seq", state.Sequence, NpgsqlDbType.Bigint)
+                .With("heartbeat", (object?)state.LastHeartbeat ?? DBNull.Value, NpgsqlDbType.TimestampTz)
+                .With("status", (object?)state.AgentStatus ?? DBNull.Value, NpgsqlDbType.Varchar)
+                .With("reason", (object?)state.PauseReason ?? DBNull.Value, NpgsqlDbType.Text)
+                .With("node", (object?)state.RunningOnNode ?? DBNull.Value, NpgsqlDbType.Integer)
+                .ExecuteNonQueryAsync(token).ConfigureAwait(false);
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
     public async Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token)
     {
         var sql =


### PR DESCRIPTION
Marten had the extended-progression telemetry feature (`heartbeat` / `agent_status` / `pause_reason` / `running_on_node` on `mt_event_progression`) built at three of four corners — schema, read path (`ShardStateSelector` / `ProjectionProgressStatement`), and runtime computation (the daemon publishes `ShardState` telemetry) — but **the persistence corner was never connected**, so the columns stayed NULL forever. Two gaps:

1. `MartenDatabase` never overrode `IEventDatabase.WriteExtendedProgressionAsync` — it inherited the JasperFx.Events base no-op.
2. The daemon's `ExtendedProgressionWriter` observer gates on `IEventStore.ExtendedProgressionEnabled` (interface default `false`), which `DocumentStore` never reflected — so the observer never fired even with the opt-in on.

### Changes
- **`MartenDatabase.WriteExtendedProgressionAsync`** — persists the published `ShardState` telemetry via `mt_mark_event_progression_extended`.
- **`DocumentStore.ExtendedProgressionEnabled => Options.EventGraph.EnableExtendedProgressionTracking`** — so the observer fires on the opt-in (both the direct `opts.Events.EnableExtendedProgressionTracking` and the `SetEventStoreInstrumentation` adapter converge on this flag).
- **`mt_mark_event_progression_extended` is now telemetry-ONLY on an existing row.** It previously did an `INSERT … ON CONFLICT DO UPDATE` that (a) pre-created the progression row, racing the projection batch's own first progress insert into a `pk_mt_event_progression` duplicate-key failure that killed the shard, and (b) rewrote `last_seq_id` on every heartbeat — a Started publication carries sequence `0`, so it rolled committed progress backwards (the **clobber** in marten#4981). It now `UPDATE`s only the four telemetry columns `WHERE mt_event_progression.name = $1`, never touching `last_seq_id` / `last_updated`; if no progression row exists yet the telemetry is skipped until the first commit creates it. Parameter names are unchanged so `CREATE OR REPLACE` stays valid against a function 9.17.0 already installed.
- **Regression guard** `extended_progression_gate` — asserts `DocumentStore` reflects the opt-in, so the observer can never silently go unwired again (the exact failure mode here).

### Verification
Clean-room daemon host (`AddMarten` + `AddAsyncDaemon(Solo)`, one async projection, `EnableExtendedProgressionTracking = true`), events appended, `mt_event_progression` sampled: on `9.17.0` all four columns NULL; with this change `heartbeat` is written and advances (~10s heartbeat cadence), `agent_status = Running`, `last_seq_id` / `last_updated` advance normally (no clobber, projection healthy). `running_on_node` is populated under a distribution layer (NULL under single-node Solo, as expected). `CoreTests` `EventGraph_IEventStoreInstrumentation` (5) + `extended_progression_gate` (2) green on net9.0 + net10.0.

Bumps `Directory.Build.props` to **9.17.1**. Resolves the write half of marten#4981 and unblocks CritterWatch #750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)