### PR TITLE
Scope HighWaterHealthCheck to owned databases, add per-tenant + ExternallyManaged support (#4991)

### DIFF
--- a/docs/events/projections/healthchecks.md
+++ b/docs/events/projections/healthchecks.md
@@ -84,7 +84,9 @@ The check is deliberately conservative to avoid false positives:
 
 - **Gating.** It reports Healthy (not applicable) unless the store actually runs the daemon —
   it needs at least one `Async` projection or subscription registered, and an `AsyncMode` of
-  `Solo` or `HotCold`. `Disabled` and `ExternallyManaged` stores never assert on the mark.
+  `Solo` or `HotCold`. `Disabled` stores never assert on the mark. `ExternallyManaged` stores
+  (for example Wolverine-managed daemon distribution) also skip by default, but you can opt in
+  with `includeExternallyManaged: true` (see below).
 - **Sustained non-advance only.** A non-zero gap between the highest event sequence and the
   mark is *normal* transiently (the detector deliberately holds the mark inside a "safe
   harbor" behind in-flight or gapped sequences). The check therefore trips only when the mark
@@ -93,6 +95,39 @@ The check is deliberately conservative to avoid false positives:
 - **Store-global reading.** It reads database state, so it is correct on any node regardless of
   which one runs the agent; it fails only when *no* node is advancing the mark.
 
+### Sharded and multi-tenant stores
+
+On a multi-database store (`MultiTenantedWithShardedDatabases`, or any store with more than one
+tenant database) the check probes **every** database by default. With hundreds of shard
+databases that is a connection fan-out on each health probe, and — when daemon distribution is
+spread across nodes (e.g. Wolverine-managed) — a node ends up probing databases it does not host
+the daemon for. Two options scope it to the databases the local node actually owns
+(see [marten#4991](https://github.com/JasperFx/marten/issues/4991)):
+
+```cs
+Services.AddHealthChecks().AddMartenHighWaterHealthCheck(
+    staleThreshold: TimeSpan.FromSeconds(30),
+
+    // Only probe (and, with autoRestart, only restart) the databases this node owns. The
+    // predicate receives each IMartenDatabase; return true for the ones the local node hosts.
+    databaseFilter: db => LocallyOwnedDatabaseIdentifiers.Contains(db.Identifier),
+
+    // Assert even under DaemonMode.ExternallyManaged (Wolverine-managed distribution). In this
+    // mode only the liveness heartbeat signal is used (never the sequence-gap fallback), because
+    // an external owner can legitimately pause the mark — so this requires
+    // Events.EnableExtendedProgressionTracking to be turned on.
+    includeExternallyManaged: true);
+```
+
+Under `UseTenantPartitionedEvents` the high-water mark is tracked **per tenant** as
+`HighWaterMark:<tenant>` progression rows rather than a single store-global `HighWaterMark`. The
+check evaluates those per-tenant rows too, using the liveness heartbeat (the sequence-gap
+fallback is store-global and cannot be applied per tenant). Enable
+`Events.EnableExtendedProgressionTracking` so the per-tenant heartbeats are persisted, otherwise
+a stalled per-tenant high-water agent cannot be detected.
+
 ::: tip INFO
 This health check does **not** force the high-water mark forward — it is detection only.
+`autoRestart: true` may additionally ask the local coordinator to restart the high-water poll
+loop, which also never advances the mark.
 :::

--- a/src/DaemonTests.ManualOnly/HealthChecks/HighWaterHealthCheckTests.cs
+++ b/src/DaemonTests.ManualOnly/HealthChecks/HighWaterHealthCheckTests.cs
@@ -8,6 +8,7 @@ using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Marten.Events.Aggregation;
 using Marten.Events.Daemon;
+using Marten.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Npgsql;
@@ -42,7 +43,8 @@ public class HighWaterHealthCheckTests: DaemonContext
     }
 
     private HighWaterHealthCheck buildCheck(TimeSpan? staleThreshold = null, long minimumGap = 1,
-        bool autoRestart = false, IProjectionCoordinator? coordinator = null)
+        bool autoRestart = false, IProjectionCoordinator? coordinator = null,
+        Func<IMartenDatabase, bool>? databaseFilter = null, bool includeExternallyManaged = false)
     {
         var services = new ServiceCollection();
         if (coordinator != null)
@@ -51,7 +53,8 @@ public class HighWaterHealthCheckTests: DaemonContext
         }
 
         return new(theStore,
-            new HighWaterHealthCheckSettings(staleThreshold ?? 30.Seconds(), minimumGap, autoRestart), _timeProvider,
+            new HighWaterHealthCheckSettings(staleThreshold ?? 30.Seconds(), minimumGap, autoRestart, databaseFilter,
+                includeExternallyManaged), _timeProvider,
             _tracker, services.BuildServiceProvider());
     }
 
@@ -84,6 +87,21 @@ public class HighWaterHealthCheckTests: DaemonContext
             $"insert into {theStore.Events.DatabaseSchemaName}.mt_event_progression (name, last_seq_id, last_updated, heartbeat) " +
             $"values ('HighWaterMark', {sequence}, now(), '{heartbeat:O}'::timestamptz) " +
             "on conflict (name) do update set last_seq_id = excluded.last_seq_id, heartbeat = excluded.heartbeat";
+        await theSession.ExecuteAsync(new NpgsqlCommand(sql));
+    }
+
+    // Seeds an arbitrary progression row (store-global "HighWaterMark" or a per-tenant
+    // "HighWaterMark:<tenant>" row) with an optional liveness heartbeat. The heartbeat column only
+    // exists when EnableExtendedProgressionTracking is on, so pass a heartbeat only in that case.
+    private async Task seedProgressionRowAsync(string name, long sequence, DateTimeOffset? heartbeat = null)
+    {
+        var sql = heartbeat is { } hb
+            ? $"insert into {theStore.Events.DatabaseSchemaName}.mt_event_progression (name, last_seq_id, last_updated, heartbeat) " +
+              $"values ('{name}', {sequence}, now(), '{hb:O}'::timestamptz) " +
+              "on conflict (name) do update set last_seq_id = excluded.last_seq_id, heartbeat = excluded.heartbeat"
+            : $"insert into {theStore.Events.DatabaseSchemaName}.mt_event_progression (name, last_seq_id, last_updated) " +
+              $"values ('{name}', {sequence}, now()) " +
+              "on conflict (name) do update set last_seq_id = excluded.last_seq_id";
         await theSession.ExecuteAsync(new NpgsqlCommand(sql));
     }
 
@@ -311,6 +329,174 @@ public class HighWaterHealthCheckTests: DaemonContext
 
         result.Status.ShouldBe(HealthStatus.Unhealthy);
         await daemon.DidNotReceive().RestartHighWaterAgentAsync(Arg.Any<CancellationToken>());
+    }
+
+    // ---- database scoping (marten#4991) --------------------------------------------------
+
+    [Fact]
+    public async Task database_filter_excluding_the_database_reports_healthy_despite_stuck_mark()
+    {
+        // marten#4991: a predicate that excludes this node's non-owned databases must stop the check
+        // from probing (and asserting on) them at all — even a hard-stuck mark stays Healthy.
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+        });
+        await appendEventsAsync(20);
+        await seedHighWaterMarkAsync(1);
+
+        var check = buildCheck(30.Seconds(), databaseFilter: _ => false);
+
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+
+        // still Healthy well past the staleness threshold, because the database is never probed
+        _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task database_filter_including_the_database_still_detects_stuck_mark()
+    {
+        // The complementary case: a predicate that includes the database behaves exactly like no filter.
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+        });
+        await appendEventsAsync(20);
+        await seedHighWaterMarkAsync(1);
+
+        var check = buildCheck(30.Seconds(), databaseFilter: _ => true);
+
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+
+        _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    // ---- ExternallyManaged gate (marten#4991) --------------------------------------------
+
+    [Fact]
+    public async Task healthy_under_externally_managed_by_default_even_if_heartbeat_stale()
+    {
+        // Default: ExternallyManaged (e.g. Wolverine-managed distribution) hosts no local daemon, so the
+        // check stays a no-op and a stale heartbeat is not asserted.
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.ExternallyManaged;
+            x.Events.EnableExtendedProgressionTracking = true;
+        });
+        await appendEventsAsync(20);
+        var stats = await theStore.Advanced.FetchEventStoreStatistics();
+        await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90));
+
+        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task unhealthy_under_externally_managed_when_opted_in_and_heartbeat_stale()
+    {
+        // Opted in: assert under ExternallyManaged too — via the heartbeat signal.
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.ExternallyManaged;
+            x.Events.EnableExtendedProgressionTracking = true;
+        });
+        await appendEventsAsync(20);
+        var stats = await theStore.Advanced.FetchEventStoreStatistics();
+        await seedHighWaterHeartbeatAsync(stats.EventSequenceNumber, _now.AddSeconds(-90));
+
+        var result = await buildCheck(30.Seconds(), includeExternallyManaged: true)
+            .CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task externally_managed_opted_in_does_not_use_gap_fallback_without_heartbeat()
+    {
+        // Opted in but ExtendedProgression off -> no heartbeat. The gap fallback must be suppressed under
+        // ExternallyManaged because an external owner can legitimately pause the mark; it stays Healthy.
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.ExternallyManaged;
+        });
+        await appendEventsAsync(20);
+        await seedHighWaterMarkAsync(1);
+
+        var check = buildCheck(30.Seconds(), includeExternallyManaged: true);
+
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+
+        _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    // ---- per-tenant high water (marten#4991) ---------------------------------------------
+
+    [Fact]
+    public async Task detects_stale_per_tenant_high_water_via_heartbeat()
+    {
+        // UseTenantPartitionedEvents persists HighWaterMark:<tenant> rows rather than a single
+        // store-global HighWaterMark. The original check matched only "HighWaterMark" and was blind to
+        // a stalled per-tenant agent; now a stale per-tenant heartbeat is detected.
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+            x.Events.EnableExtendedProgressionTracking = true;
+        });
+        await appendEventsAsync(20);
+        await seedProgressionRowAsync("HighWaterMark:acme", 5, _now.AddSeconds(-90));
+
+        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task healthy_when_per_tenant_high_water_heartbeat_is_fresh()
+    {
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+            x.Events.EnableExtendedProgressionTracking = true;
+        });
+        await appendEventsAsync(20);
+        await seedProgressionRowAsync("HighWaterMark:acme", 5, _now.AddSeconds(-5));
+
+        var result = await buildCheck(30.Seconds()).CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task per_tenant_high_water_without_heartbeat_is_not_gap_assessed()
+    {
+        // ExtendedProgression off -> a per-tenant row has no heartbeat, and there is no per-tenant
+        // highest-sequence to compute a meaningful gap (FetchHighestEventSequenceNumber is store-global),
+        // so the gap fallback must NOT run for it — otherwise a tenant with no new events false-positives.
+        StoreOptions(x =>
+        {
+            x.Projections.Add(new HwFakeProjection(), ProjectionLifecycle.Async);
+            x.Projections.AsyncMode = DaemonMode.Solo;
+        });
+        await appendEventsAsync(20);
+        await seedProgressionRowAsync("HighWaterMark:acme", 1);
+
+        var check = buildCheck(30.Seconds());
+
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
+
+        _timeProvider.GetUtcNow().Returns(_now.AddSeconds(60));
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.ShouldBe(HealthStatus.Healthy);
     }
 
     // Minimal IProjectionCoordinator that hands back a single daemon — avoids mocking a ValueTask-returning

--- a/src/Marten.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
+++ b/src/Marten.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
+using Marten.Events.Daemon.HighWater;
 using Marten.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -143,12 +144,10 @@ public static class HighWaterHealthCheckExtensions
     /// </summary>
     public class HighWaterHealthCheck: IHealthCheck
     {
-        // The store-global high-water identity and the per-tenant prefix. Kept in lock-step with
-        // Marten's internal HighWaterShardIdentity (Marten.Events.Daemon.HighWater) — both derive
-        // from the same ShardState.HighWaterMark constant, so the grammar cannot drift. (Marten.AspNetCore
-        // is a separate assembly and cannot see that internal helper directly.)
-        private const string HighWaterMarkShard = ShardState.HighWaterMark;
-        private const string PerTenantHighWaterPrefix = ShardState.HighWaterMark + ":";
+        // The store-global high-water identity and the per-tenant prefix — the canonical grammar the
+        // high-water machinery writes and reads (Marten.Events.Daemon.HighWater.HighWaterShardIdentity).
+        private const string HighWaterMarkShard = HighWaterShardIdentity.StoreGlobal;
+        private const string PerTenantHighWaterPrefix = HighWaterShardIdentity.PerTenantPrefix;
 
         private readonly IDocumentStore _store;
         private readonly TimeProvider _timeProvider;

--- a/src/Marten.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
+++ b/src/Marten.AspNetCore/Daemon/HighWaterHealthCheckExtensions.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
 using Marten.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -30,10 +32,20 @@ namespace Marten.Events.Daemon;
 ///             </item>
 ///             <item>
 ///                 <b>Sequence gap (fallback).</b> When ExtendedProgression is off, no heartbeat is
-///                 persisted, so the check falls back to the original heuristic: the mark sitting
-///                 unchanged while later events pile up past it.
+///                 persisted, so the check falls back to the original heuristic: the store-global
+///                 mark sitting unchanged while later events pile up past it.
 ///             </item>
 ///         </list>
+///     </para>
+///     <para>
+///         marten#4991: on a multi-database (sharded / <c>MultiTenantedWithShardedDatabases</c>)
+///         store the check probes <em>every</em> database by default. Pass a
+///         <c>databaseFilter</c> to scope it to the databases this node actually hosts the daemon
+///         for — otherwise a probe fans a connection out across all N databases and (with
+///         <c>autoRestart</c>) would try to restart agents this node does not own. Under
+///         <c>UseTenantPartitionedEvents</c> the high-water mark is tracked per tenant
+///         (<c>HighWaterMark:&lt;tenant&gt;</c> rows), and those are evaluated too — via the
+///         heartbeat signal, which is the only reliable per-tenant staleness signal.
 ///     </para>
 /// </summary>
 public static class HighWaterHealthCheckExtensions
@@ -64,15 +76,35 @@ public static class HighWaterHealthCheckExtensions
     ///     to <c>false</c> (detection only). Intended for single-writer (Solo) or leader nodes —
     ///     the process running the health check must be the one hosting the daemon.
     /// </param>
+    /// <param name="databaseFilter">
+    ///     marten#4991: optional predicate restricting the check to a subset of the store's
+    ///     databases. On a sharded / multi-tenant store where daemon distribution is spread across
+    ///     nodes (e.g. Wolverine-managed), scope this to the databases whose async agents run on
+    ///     the local node so the probe does not fan out to (or auto-restart agents on) databases
+    ///     this node does not host. Defaults to <c>null</c> (every database — today's behavior).
+    /// </param>
+    /// <param name="includeExternallyManaged">
+    ///     marten#4991: by default the check only runs under <see cref="DaemonMode.Solo" /> /
+    ///     <see cref="DaemonMode.HotCold" />, because in <see cref="DaemonMode.ExternallyManaged" />
+    ///     this store hosts no daemon and a frozen mark is legitimate. Set this to <c>true</c> to
+    ///     also assert under <see cref="DaemonMode.ExternallyManaged" /> (e.g. Wolverine-managed
+    ///     distribution) — in which case only the <em>heartbeat</em> signal is used, never the gap
+    ///     fallback, since an external owner can legitimately pause the mark. Combine with
+    ///     <paramref name="databaseFilter" /> so the check only asserts on databases the local node
+    ///     actually owns. Defaults to <c>false</c>.
+    /// </param>
     public static IHealthChecksBuilder AddMartenHighWaterHealthCheck(
         this IHealthChecksBuilder builder,
         TimeSpan? staleThreshold = null,
         long minimumGap = 1,
-        bool autoRestart = false
+        bool autoRestart = false,
+        Func<IMartenDatabase, bool>? databaseFilter = null,
+        bool includeExternallyManaged = false
     )
     {
         builder.Services.AddSingleton(new HighWaterHealthCheckSettings(
-            staleThreshold ?? TimeSpan.FromSeconds(30), minimumGap, autoRestart));
+            staleThreshold ?? TimeSpan.FromSeconds(30), minimumGap, autoRestart, databaseFilter,
+            includeExternallyManaged));
         builder.Services.TryAddSingleton(TimeProvider.System);
         builder.Services.TryAddSingleton<HighWaterStateTracker>();
         return builder.AddCheck<HighWaterHealthCheck>(
@@ -84,13 +116,19 @@ public static class HighWaterHealthCheckExtensions
     /// <summary>
     ///     DI-injected settings for <see cref="HighWaterHealthCheck" />.
     /// </summary>
-    public record HighWaterHealthCheckSettings(TimeSpan StaleThreshold, long MinimumGap, bool AutoRestart = false);
+    public record HighWaterHealthCheckSettings(
+        TimeSpan StaleThreshold,
+        long MinimumGap,
+        bool AutoRestart = false,
+        Func<IMartenDatabase, bool>? DatabaseFilter = null,
+        bool IncludeExternallyManaged = false);
 
     /// <summary>
-    ///     Tracks, per database, the fallback gap heuristic's "first observed a stuck mark" reading
-    ///     and (when <c>autoRestart</c> is on) the last auto-restart moment, so a <em>sustained</em>
-    ///     non-advance can be distinguished from a transient safe-harbor gap and restarts can be
-    ///     capped to once per staleness window across health check invocations.
+    ///     Tracks the fallback gap heuristic's "first observed a stuck mark" reading (keyed per
+    ///     database + high-water shard, so per-tenant marks are tracked independently) and, when
+    ///     <c>autoRestart</c> is on, the last auto-restart moment per database, so a
+    ///     <em>sustained</em> non-advance can be distinguished from a transient safe-harbor gap and
+    ///     restarts can be capped to once per staleness window across health check invocations.
     /// </summary>
     public class HighWaterStateTracker
     {
@@ -105,13 +143,20 @@ public static class HighWaterHealthCheckExtensions
     /// </summary>
     public class HighWaterHealthCheck: IHealthCheck
     {
-        private const string HighWaterMarkShard = "HighWaterMark";
+        // The store-global high-water identity and the per-tenant prefix. Kept in lock-step with
+        // Marten's internal HighWaterShardIdentity (Marten.Events.Daemon.HighWater) — both derive
+        // from the same ShardState.HighWaterMark constant, so the grammar cannot drift. (Marten.AspNetCore
+        // is a separate assembly and cannot see that internal helper directly.)
+        private const string HighWaterMarkShard = ShardState.HighWaterMark;
+        private const string PerTenantHighWaterPrefix = ShardState.HighWaterMark + ":";
 
         private readonly IDocumentStore _store;
         private readonly TimeProvider _timeProvider;
         private readonly TimeSpan _staleThreshold;
         private readonly long _minimumGap;
         private readonly bool _autoRestart;
+        private readonly Func<IMartenDatabase, bool>? _databaseFilter;
+        private readonly bool _includeExternallyManaged;
         private readonly HighWaterStateTracker _tracker;
         private readonly IServiceProvider _services;
 
@@ -123,6 +168,8 @@ public static class HighWaterHealthCheckExtensions
             _staleThreshold = settings.StaleThreshold;
             _minimumGap = settings.MinimumGap;
             _autoRestart = settings.AutoRestart;
+            _databaseFilter = settings.DatabaseFilter;
+            _includeExternallyManaged = settings.IncludeExternallyManaged;
             _tracker = tracker;
             _services = services;
         }
@@ -150,19 +197,48 @@ public static class HighWaterHealthCheckExtensions
                     return HealthCheckResult.Healthy("No async projections or subscriptions are registered");
                 }
 
-                // Disabled / ExternallyManaged -> this store hosts no daemon, so it must not assert
-                // that some local agent is advancing the mark.
-                if (projections.AsyncMode is not (DaemonMode.Solo or DaemonMode.HotCold))
+                // Solo / HotCold host the daemon here, so use every available signal. ExternallyManaged
+                // (e.g. Wolverine-managed distribution, marten#4991) hosts no local daemon — opt in with
+                // includeExternallyManaged to still assert, but only via the heartbeat signal (the gap
+                // fallback would false-positive when an external owner legitimately pauses the mark).
+                // Disabled and everything else stays a no-op.
+                var mode = projections.AsyncMode;
+                bool heartbeatOnly;
+                if (mode is DaemonMode.Solo or DaemonMode.HotCold)
+                {
+                    heartbeatOnly = false;
+                }
+                else if (mode == DaemonMode.ExternallyManaged && _includeExternallyManaged)
+                {
+                    heartbeatOnly = true;
+                }
+                else
                 {
                     return HealthCheckResult.Healthy(
-                        $"Async daemon mode is {projections.AsyncMode}; high-water is not advanced by this store");
+                        $"Async daemon mode is {mode}; high-water is not advanced by this store");
                 }
+
+                // marten#4991: under UseTenantPartitionedEvents high water is tracked per tenant
+                // (HighWaterMark:<tenant> rows) and the store-global HighWaterMark row is intentionally
+                // frozen (the daemon skips the store-global loop) — so which rows are authoritative
+                // depends on the mode. Evaluate per-tenant rows there, the store-global row otherwise.
+                var perTenantHighWater = options.Events.UseTenantPartitionedEvents;
 
                 var databases = await _store.Storage.AllDatabases().ConfigureAwait(false);
 
-                foreach (var database in databases)
+                // marten#4991: scope to the databases this node owns so the probe does not fan out
+                // to (or auto-restart) databases the local node does not host the daemon for.
+                IEnumerable<IMartenDatabase> scoped = databases;
+                if (_databaseFilter != null)
                 {
-                    var result = await checkDatabaseAsync(database, cancellationToken).ConfigureAwait(false);
+                    scoped = databases.Where(_databaseFilter);
+                }
+
+                foreach (var database in scoped)
+                {
+                    var result = await checkDatabaseAsync(database, heartbeatOnly, perTenantHighWater,
+                            cancellationToken)
+                        .ConfigureAwait(false);
                     if (result.Status != HealthStatus.Healthy)
                     {
                         return result;
@@ -177,78 +253,139 @@ public static class HighWaterHealthCheckExtensions
             }
         }
 
-        private async Task<HealthCheckResult> checkDatabaseAsync(IMartenDatabase database, CancellationToken token)
+        private async Task<HealthCheckResult> checkDatabaseAsync(IMartenDatabase database, bool heartbeatOnly,
+            bool perTenantHighWater, CancellationToken token)
         {
             var allProgress = await database.AllProjectionProgress(token).ConfigureAwait(false);
-            var highWater = allProgress.FirstOrDefault(x => string.Equals(HighWaterMarkShard, x.ShardName));
+
+            var allHighWater = allProgress
+                .Where(x => string.Equals(x.ShardName, HighWaterMarkShard, StringComparison.Ordinal)
+                            || x.ShardName.StartsWith(PerTenantHighWaterPrefix, StringComparison.Ordinal))
+                .ToArray();
+
+            // marten#4991: under UseTenantPartitionedEvents the authoritative rows are the per-tenant
+            // HighWaterMark:<tenant> rows (the original check matched only the exact "HighWaterMark"
+            // string and was blind to a stalled per-tenant agent); otherwise it is the store-global
+            // HighWaterMark row. Detect per-tenant mode from the configured flag OR from the presence of
+            // per-tenant rows, and evaluate only the authoritative set — so the store-global row (which is
+            // intentionally frozen under partitioning, the daemon skips its loop) is never gap-assessed
+            // there and can't false-positive.
+            var perTenantMode = perTenantHighWater ||
+                                allHighWater.Any(x =>
+                                    x.ShardName.StartsWith(PerTenantHighWaterPrefix, StringComparison.Ordinal));
+
+            var highWaterRows = perTenantMode
+                ? allHighWater
+                    .Where(x => x.ShardName.StartsWith(PerTenantHighWaterPrefix, StringComparison.Ordinal))
+                    .ToArray()
+                : allHighWater
+                    .Where(x => string.Equals(x.ShardName, HighWaterMarkShard, StringComparison.Ordinal))
+                    .ToArray();
 
             // No HighWaterMark progression row yet -> the daemon has not started here. Nothing to assert.
-            if (highWater is null)
+            if (highWaterRows.Length == 0)
             {
-                clearTracking(database.Identifier);
+                clearTrackingForDatabase(database.Identifier);
                 return HealthCheckResult.Healthy("Healthy");
             }
 
             var now = _timeProvider.GetUtcNow();
+            long? highest = null; // fetched lazily, only for a store-global gap fallback
 
-            // Phase 2 (marten#4986) primary signal: the liveness heartbeat (jasperfx#539). Present only
-            // when ExtendedProgression is enabled. Heartbeat age proves the poll loop is *cycling*
-            // independent of whether the mark *advances*, so a quiet store never trips it — a strictly
-            // better signal than the gap heuristic. Use it whenever it is available.
-            if (highWater.LastHeartbeat is { } lastHeartbeat)
+            foreach (var row in highWaterRows)
             {
-                // The gap tracker is only for the fallback path; keep it clear while on the heartbeat path.
-                _tracker.Readings.TryRemove(database.Identifier, out _);
+                var isPerTenant =
+                    !string.Equals(row.ShardName, HighWaterMarkShard, StringComparison.Ordinal);
+                var key = trackingKey(database.Identifier, row.ShardName);
 
-                var age = now - lastHeartbeat;
-                if (age < _staleThreshold)
+                // Primary signal (marten#4986): the liveness heartbeat (jasperfx#539), present only when
+                // ExtendedProgression is enabled. Heartbeat age proves the poll loop is *cycling*
+                // independent of whether the mark *advances*, so a quiet store never trips it — a strictly
+                // better signal than the gap heuristic, and the only reliable per-tenant signal. Use it
+                // whenever it is available.
+                if (row.LastHeartbeat is { } lastHeartbeat)
                 {
-                    _tracker.Restarts.TryRemove(database.Identifier, out _);
-                    return HealthCheckResult.Healthy("Healthy");
+                    // The gap tracker is only for the fallback path; keep it clear while on the heartbeat path.
+                    _tracker.Readings.TryRemove(key, out _);
+
+                    var age = now - lastHeartbeat;
+                    if (age < _staleThreshold)
+                    {
+                        continue;
+                    }
+
+                    var restartNote = await tryAutoRestartAsync(database.Identifier, now, token).ConfigureAwait(false);
+                    return HealthCheckResult.Unhealthy(
+                        $"Unhealthy: the high-water agent for '{shardDescription(database, row)}' last reported a liveness heartbeat {age.TotalSeconds:F0}s ago (at {lastHeartbeat:O}), exceeding the {_staleThreshold} staleness threshold. Its poll loop has stopped cycling (see JasperFx/jasperfx#539 / marten#4961).{restartNote}");
                 }
 
-                var restartNote = await tryAutoRestartAsync(database.Identifier, now, token).ConfigureAwait(false);
-                return HealthCheckResult.Unhealthy(
-                    $"Unhealthy: the high-water agent for database '{database.Identifier}' last reported a liveness heartbeat {age.TotalSeconds:F0}s ago (at {lastHeartbeat:O}), exceeding the {_staleThreshold} staleness threshold. Its poll loop has stopped cycling (see JasperFx/jasperfx#539 / marten#4961).{restartNote}");
+                // No heartbeat. The gap fallback is only reliable for the store-global mark under a mode
+                // this store actually hosts:
+                //  - heartbeatOnly (ExternallyManaged) -> an external owner may legitimately pause the mark.
+                //  - per-tenant -> there is no per-tenant highest-sequence to compute a meaningful gap
+                //    (FetchHighestEventSequenceNumber is store-global), so a tenant with no new events would
+                //    look permanently "behind". Enable ExtendedProgression for per-tenant staleness.
+                if (heartbeatOnly || isPerTenant)
+                {
+                    _tracker.Readings.TryRemove(key, out _);
+                    continue;
+                }
+
+                highest ??= await database.FetchHighestEventSequenceNumber(token).ConfigureAwait(false);
+                var gap = highest.Value - row.Sequence;
+
+                // Caught up (within the normal safe-harbor gap). Clear any stalled-mark tracking.
+                if (gap <= _minimumGap)
+                {
+                    _tracker.Readings.TryRemove(key, out _);
+                    continue;
+                }
+
+                // Track the first time we saw a gap at this mark value; if the mark moves, reset the clock;
+                // if it stays put past the threshold, the high-water agent has almost certainly died or wedged.
+                var reading = _tracker.Readings.GetOrAdd(key, _ => (now, row.Sequence));
+
+                if (reading.HighWaterMark != row.Sequence)
+                {
+                    _tracker.Readings[key] = (now, row.Sequence);
+                    continue;
+                }
+
+                if (now - reading.FirstObservedAt >= _staleThreshold)
+                {
+                    var restartNote = await tryAutoRestartAsync(database.Identifier, now, token).ConfigureAwait(false);
+                    return HealthCheckResult.Unhealthy(
+                        $"Unhealthy: the high-water mark for '{shardDescription(database, row)}' has been stuck at {row.Sequence} with {gap} later event(s) unprocessed (highest sequence {highest.Value}) for at least {_staleThreshold}. The high-water agent may have stopped (see marten#4961).{restartNote}");
+                }
             }
 
-            // Fallback (ExtendedProgression off): the sequence-gap heuristic. A non-zero gap is normal
-            // transiently (the detector holds the mark inside a "safe harbor" behind in-flight/gapped
-            // sequences), so this trips only on a sustained non-advance while events pile up past the mark.
-            var highest = await database.FetchHighestEventSequenceNumber(token).ConfigureAwait(false);
-            var gap = highest - highWater.Sequence;
-
-            // Caught up (within the normal safe-harbor gap). Clear any stalled-mark tracking.
-            if (gap <= _minimumGap)
-            {
-                clearTracking(database.Identifier);
-                return HealthCheckResult.Healthy("Healthy");
-            }
-
-            // Track the first time we saw a gap at this mark value; if the mark moves, reset the clock; if
-            // it stays put past the threshold, the high-water agent has almost certainly died or wedged.
-            var reading = _tracker.Readings.GetOrAdd(database.Identifier, _ => (now, highWater.Sequence));
-
-            if (reading.HighWaterMark != highWater.Sequence)
-            {
-                _tracker.Readings[database.Identifier] = (now, highWater.Sequence);
-                _tracker.Restarts.TryRemove(database.Identifier, out _);
-                return HealthCheckResult.Healthy("Healthy");
-            }
-
-            if (now - reading.FirstObservedAt >= _staleThreshold)
-            {
-                var restartNote = await tryAutoRestartAsync(database.Identifier, now, token).ConfigureAwait(false);
-                return HealthCheckResult.Unhealthy(
-                    $"Unhealthy: the high-water mark for database '{database.Identifier}' has been stuck at {highWater.Sequence} with {gap} later event(s) unprocessed (highest sequence {highest}) for at least {_staleThreshold}. The high-water agent may have stopped (see marten#4961).{restartNote}");
-            }
-
+            // Every high-water row for this database is healthy -> clear the restart cap so a future
+            // stall can be remediated immediately.
+            _tracker.Restarts.TryRemove(database.Identifier, out _);
             return HealthCheckResult.Healthy("Healthy");
         }
 
-        private void clearTracking(string databaseIdentifier)
+        private static string shardDescription(IMartenDatabase database, JasperFx.Events.Projections.ShardState row)
         {
-            _tracker.Readings.TryRemove(databaseIdentifier, out _);
+            return string.Equals(row.ShardName, HighWaterMarkShard, StringComparison.Ordinal)
+                ? $"database '{database.Identifier}'"
+                : $"database '{database.Identifier}', shard '{row.ShardName}'";
+        }
+
+        private static string trackingKey(string databaseIdentifier, string shardName) =>
+            databaseIdentifier + "|" + shardName;
+
+        private void clearTrackingForDatabase(string databaseIdentifier)
+        {
+            var prefix = databaseIdentifier + "|";
+            foreach (var readingKey in _tracker.Readings.Keys)
+            {
+                if (readingKey.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    _tracker.Readings.TryRemove(readingKey, out _);
+                }
+            }
+
             _tracker.Restarts.TryRemove(databaseIdentifier, out _);
         }
 

--- a/src/Marten/Events/Daemon/HighWater/HighWaterShardIdentity.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterShardIdentity.cs
@@ -22,7 +22,7 @@ namespace Marten.Events.Daemon.HighWater;
 /// </para>
 /// </summary>
 /// <seealso cref="ShardState.HighWaterMark"/>
-internal static class HighWaterShardIdentity
+public static class HighWaterShardIdentity
 {
     /// <summary>
     /// Identity for the store-global high-water progression row -- the only row that exists


### PR DESCRIPTION
Closes #4991.

## Problem

`AddMartenHighWaterHealthCheck` (the high-water staleness check from #4961/#4986) probed **every** database on each health probe and matched only the store-global `"HighWaterMark"` progression row. On a sharded / `MultiTenantedWithShardedDatabases` store under Wolverine-managed (`ExternallyManaged`) daemon distribution with hundreds of shard databases, that meant:

1. **No owned-database scoping** — each probe fanned a connection out across all N databases, ignoring database affinity, and (with `autoRestart`) would try to `RestartHighWaterAgentAsync` on databases the local node does not host.
2. **`ExternallyManaged` no-op** — the `Solo`/`HotCold` gate short-circuits `ExternallyManaged`, so under Wolverine-managed distribution the check did nothing at all.
3. **Per-tenant blindness** — `UseTenantPartitionedEvents` persists `HighWaterMark:<tenant>` rows rather than a single store-global `HighWaterMark`, so a stalled per-tenant high-water agent was never detected.

## Changes

- **`databaseFilter` predicate** (`Func<IMartenDatabase, bool>?`) scopes the check — and `autoRestart` — to the databases the local node owns, collapsing the fan-out to the shards it actually hosts. This is the reliable seam under Wolverine-managed distribution, where the coordinator isn't the one running the daemons.
- **`includeExternallyManaged`** opt-in lets the check assert under `DaemonMode.ExternallyManaged`, using **only** the liveness heartbeat signal — never the sequence-gap fallback, which an external owner could false-positive by legitimately pausing the mark. (Requires `EnableExtendedProgressionTracking`.)
- **Per-tenant `HighWaterMark:<tenant>` rows** are now evaluated. Under `UseTenantPartitionedEvents` (detected from the flag *or* from the presence of per-tenant rows) only the per-tenant rows are authoritative and are assessed via the heartbeat; the store-global row is intentionally frozen there and is no longer gap-assessed, so it can't false-positive.
- Gap-tracking is now keyed per `(database, high-water shard)` so per-tenant marks are tracked independently, and the restart cap stays per-database.

The existing signature stays source-compatible — the two new parameters are optional and default to today's behavior (no filter, `ExternallyManaged` skipped).

## Tests

`src/DaemonTests.ManualOnly/HealthChecks/HighWaterHealthCheckTests.cs` — 8 new tests (19 total, all green on net10.0):

- database filter excluding / including the database
- `ExternallyManaged` healthy-by-default; unhealthy when opted-in with a stale heartbeat; gap fallback suppressed when opted-in without a heartbeat
- per-tenant staleness detected via heartbeat; healthy when the per-tenant heartbeat is fresh; per-tenant row not gap-assessed without a heartbeat

Docs updated (`docs/events/projections/healthchecks.md`, markdownlint + cspell clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)