### PR TITLE
Surface JasperFx's GH-3521 application-assembly-reuse warning at startup (#4996)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -119,14 +119,19 @@
          local restart seam (IProjectionDaemon.HighWaterLastPolledAt / IsHighWaterStale /
          RestartHighWaterAgentAsync; DaemonSettings.HighWaterStalenessThreshold; ShardAction.Faulted/
          Restarted). Also carries the jasperfx#540 faulted-start teardown that first shipped in 2.32.0.
-         Foundation for the Phase 2 high-water health check (marten#4986). -->
-    <PackageVersion Include="JasperFx" Version="2.32.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.32.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.32.0">
+         Foundation for the Phase 2 high-water health check (marten#4986).
+         JasperFx 2.33.0: jasperfx#543 (GH-3521) — JasperFxOptions.ApplicationAssemblyReuseWarning
+         surfaces divergent process-pinned application-assembly reuse across multi-host test processes;
+         Marten buffers and logs it at startup (marten#4996). Also ships the step-instrumented
+         aggregation fold + MultiAggregateProjectionResult (jasperfx#547) and the serializable
+         EventTagQuery DCB source (jasperfx#548). -->
+    <PackageVersion Include="JasperFx" Version="2.33.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.33.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.33.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.32.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.33.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/CoreTests/jasper_fx_mechanics.cs
+++ b/src/CoreTests/jasper_fx_mechanics.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Concurrent;
 using JasperFx;
 using JasperFx.CommandLine.Descriptions;
 using JasperFx.Core.Reflection;
@@ -11,6 +12,7 @@ using Marten.Testing.Documents;
 using Marten.Testing.Harness;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 using Shouldly;
 using Weasel.Core.CommandLine;
@@ -432,7 +434,119 @@ public class jasper_fx_mechanics
         var first = host.Services.GetRequiredService<IFirstStore>().As<DocumentStore>();
         first.Options.Events.EnableExtendedProgressionTracking.ShouldBeFalse();
     }
+
+    [Fact]
+    public async Task divergent_application_assembly_reuse_warning_is_buffered_and_logged()
+    {
+        // GH-3521 (jasperfx#543 / marten#4996): a later host that adopts a process-pinned application
+        // assembly differing from where it was registered should get a startup warning. Force the
+        // divergence by pinning RememberedApplicationAssembly to a DIFFERENT assembly than the one this
+        // Marten host is registered from, then assert Marten buffers the warning onto StoreOptions and
+        // logs it once from MartenActivator.
+        var previous = JasperFxOptions.RememberedApplicationAssembly;
+        JasperFxOptions.RememberedApplicationAssembly = typeof(string).Assembly; // System.Private.CoreLib
+
+        var logs = new CapturingLoggerProvider();
+        try
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .ConfigureLogging(logging =>
+                {
+                    logging.AddProvider(logs);
+                    logging.SetMinimumLevel(LogLevel.Trace);
+                })
+                .ConfigureServices(services =>
+                {
+                    // ApplyAllDatabaseChangesOnStartup registers MartenActivator as the startup
+                    // hosted service — the always-on surface where the warning is logged.
+                    services.AddMarten(m =>
+                    {
+                        m.Connection(ConnectionSource.ConnectionString);
+                        m.DatabaseSchemaName = "assembly_reuse_warning";
+                    }).ApplyAllDatabaseChangesOnStartup();
+                }).StartAsync();
+
+            var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
+
+            // Buffered from JasperFxOptions during ReadJasperFxOptions...
+            store.Options.ApplicationAssemblyReuseWarning.ShouldNotBeNull();
+            store.Options.ApplicationAssemblyReuseWarning.ShouldContain("System.Private.CoreLib");
+
+            // ...and surfaced once at startup by MartenActivator.
+            logs.Messages.ShouldContain(x => x.Contains("System.Private.CoreLib"));
+        }
+        finally
+        {
+            JasperFxOptions.RememberedApplicationAssembly = previous;
+        }
+    }
+
+    [Fact]
+    public async Task no_reuse_warning_for_a_normal_single_host()
+    {
+        // The first (and only) host in the process pins its own assembly and never diverges, so nothing
+        // is buffered or logged. Guards against the warning firing spuriously in the common case.
+        var previous = JasperFxOptions.RememberedApplicationAssembly;
+        JasperFxOptions.RememberedApplicationAssembly = null;
+
+        try
+        {
+            using var host = await Host.CreateDefaultBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.AddMarten(m =>
+                    {
+                        m.Connection(ConnectionSource.ConnectionString);
+                        m.DatabaseSchemaName = "assembly_reuse_no_warning";
+                    });
+                }).StartAsync();
+
+            var store = host.Services.GetRequiredService<IDocumentStore>().As<DocumentStore>();
+            store.Options.ApplicationAssemblyReuseWarning.ShouldBeNull();
+        }
+        finally
+        {
+            JasperFxOptions.RememberedApplicationAssembly = previous;
+        }
+    }
 }
 
 public interface IFirstStore : IDocumentStore{}
 public interface ISecondStore : IDocumentStore{}
+
+internal class CapturingLoggerProvider: ILoggerProvider
+{
+    public ConcurrentQueue<string> Messages { get; } = new();
+
+    public ILogger CreateLogger(string categoryName) => new CapturingLogger(Messages);
+
+    public void Dispose()
+    {
+    }
+
+    private class CapturingLogger: ILogger
+    {
+        private readonly ConcurrentQueue<string> _messages;
+
+        public CapturingLogger(ConcurrentQueue<string> messages)
+        {
+            _messages = messages;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+            Func<TState, Exception, string> formatter)
+        {
+            _messages.Enqueue(formatter(state, exception));
+        }
+
+        private class NullScope: IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/Marten/Services/MartenActivator.cs
+++ b/src/Marten/Services/MartenActivator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx;
+using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using Marten.Schema;
 using Microsoft.Extensions.Hosting;
@@ -65,6 +66,14 @@ internal class MartenActivator: IHostedService, IGlobalLock<NpgsqlConnection>
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        // GH-3521 (jasperfx#543): surface the application-assembly-reuse warning buffered from
+        // JasperFxOptions during StoreOptions.ReadJasperFxOptions. Only non-null in the multi-host
+        // test-harness divergence case, so this stays silent for a normal single-host application.
+        if (Store.Options.ApplicationAssemblyReuseWarning.IsNotEmpty())
+        {
+            _logger.LogWarning("{ApplicationAssemblyReuseWarning}", Store.Options.ApplicationAssemblyReuseWarning);
+        }
+
         if (Store.Options.CreateDatabases != null)
         {
             var databaseGenerator = new DatabaseGenerator();

--- a/src/Marten/StoreOptions.cs
+++ b/src/Marten/StoreOptions.cs
@@ -327,6 +327,15 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
     /// </summary>
     public Assembly? ApplicationAssembly { get; set; }
 
+    /// <summary>
+    /// GH-3521 (jasperfx#543): buffered from <see cref="JasperFxOptions.ApplicationAssemblyReuseWarning"/>
+    /// during <see cref="ReadJasperFxOptions"/> and surfaced once at startup by
+    /// <see cref="Services.MartenActivator"/> (which has a logger). Non-null only when this host adopted an
+    /// application assembly pinned by an EARLIER host in the same process (a process-wide value) that differs
+    /// from where this store was registered — the multi-host test-harness divergence case. Null otherwise.
+    /// </summary>
+    internal string? ApplicationAssemblyReuseWarning { get; set; }
+
     internal void ReadJasperFxOptions(JasperFxOptions? options)
     {
         if (options == null) return;
@@ -337,6 +346,10 @@ public partial class StoreOptions: IReadOnlyStoreOptions, IMigrationLogger, IDoc
         }
 
         ApplicationAssembly ??= options.ApplicationAssembly;
+
+        // GH-3521: buffer JasperFx's application-assembly-reuse warning so MartenActivator can log it once
+        // at startup where a logger is available (JasperFx is a library with no always-on startup service).
+        ApplicationAssemblyReuseWarning ??= options.ApplicationAssemblyReuseWarning;
         _autoCreate ??= options.ActiveProfile.ResourceAutoCreate;
         _resourceMigrationFailureMode ??= options.ActiveProfile.ResourceMigrationFailureMode;
 


### PR DESCRIPTION
Closes #4996.

## What

Bumps JasperFx `2.32.0 → 2.33.0` (which contains [jasperfx#543](https://github.com/JasperFx/jasperfx/pull/543), the GH-3521 twin) and surfaces its new `JasperFxOptions.ApplicationAssemblyReuseWarning` through Marten.

JasperFx caches the scanned application assembly in a process-wide static pinned by whichever host starts **first**. In a test process that stands up multiple hosts across different assemblies, a later implicit host silently inherits the first host's assembly — an order-dependent failure that passes in isolation and fails in full-suite runs. jasperfx#543 makes JasperFx *detect* this and expose a ready-to-log message; because JasperFx has no always-on startup service, **consumers** surface it. Marten-only multi-host test processes got no signal today.

## How

- `StoreOptions.ReadJasperFxOptions` buffers `jasperfx.ApplicationAssemblyReuseWarning` when non-null (runs for the main store and every ancillary `AddMartenStore<T>`).
- `MartenActivator.StartAsync` logs it once at `Warning` level — it already holds `ILogger<MartenActivator>`, so no new hosted service is needed.

An explicit `StoreOptions` application assembly never diverges, and the first host never warns about itself, so this only fires in the genuine multi-host-divergence case.

## Tests

`jasper_fx_mechanics`:
- `divergent_application_assembly_reuse_warning_is_buffered_and_logged` — forces the divergence (pins `RememberedApplicationAssembly` to a different assembly than the one the host registers from), then asserts the warning is buffered onto `StoreOptions` **and** logged at startup.
- `no_reuse_warning_for_a_normal_single_host` — the common case stays silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)