### PR TITLE
AggregateToMany() LINQ operator — run an event query through a multi-stream projection (#4998)

### DIFF
--- a/src/EventSourcingTests/Explorer/aggregate_to_many_tests.cs
+++ b/src/EventSourcingTests/Explorer/aggregate_to_many_tests.cs
@@ -1,0 +1,218 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Grouping;
+using JasperFx.Events.Projections;
+using Marten;
+using Marten.Events;
+using Marten.Events.Aggregation;
+using Marten.Events.Projections;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+using System.Collections.Generic;
+
+namespace EventSourcingTests.Explorer;
+
+#region aggregate-to-many sample types
+
+public record MoneyDeposited(Guid AccountId, int Amount);
+public record AccountFrozen(Guid AccountId);
+
+public class Balance
+{
+    public Guid Id { get; set; }
+    public int Amount { get; set; }
+}
+
+public partial class BalanceProjection: MultiStreamProjection<Balance, Guid>
+{
+    public BalanceProjection()
+    {
+        Identity<MoneyDeposited>(e => e.AccountId);
+        Identity<AccountFrozen>(e => e.AccountId);
+    }
+
+    public void Apply(MoneyDeposited e, Balance b) => b.Amount += e.Amount;
+
+    public bool ShouldDelete(AccountFrozen e) => true;
+}
+
+public record LoyaltyEarned(Guid CardId, int Points);
+
+public class CardOwner
+{
+    public Guid Id { get; set; } // card id
+    public Guid MemberId { get; set; }
+}
+
+public class MemberLoyalty
+{
+    public Guid Id { get; set; }
+    public int Points { get; set; }
+}
+
+public partial class MemberLoyaltyProjection: MultiStreamProjection<MemberLoyalty, Guid>
+{
+    public MemberLoyaltyProjection()
+    {
+        CustomGrouping(new Grouper());
+    }
+
+    public void Apply(LoyaltyEarned e, MemberLoyalty agg) => agg.Points += e.Points;
+
+    public class Grouper: IAggregateGrouper<Guid>
+    {
+        public async Task Group(IQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<Guid> grouping)
+        {
+            var earned = events.OfType<IEvent<LoyaltyEarned>>().ToList();
+            if (earned.Count == 0) return;
+
+            var cardIds = earned.Select(e => e.Data.CardId).Distinct().ToArray();
+            var owners = await session.Query<CardOwner>().Where(x => cardIds.Contains(x.Id)).ToListAsync();
+            var map = owners.ToDictionary(x => x.Id, x => x.MemberId);
+
+            foreach (var e in earned)
+            {
+                if (map.TryGetValue(e.Data.CardId, out var member))
+                {
+                    grouping.AddEvent(member, e);
+                }
+            }
+        }
+    }
+}
+
+#endregion
+
+[Collection("OneOffs")]
+public class aggregate_to_many_tests: OneOffConfigurationsContext
+{
+    private void ConfigureStore()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.AddEventType<MoneyDeposited>();
+            opts.Events.AddEventType<AccountFrozen>();
+            opts.Events.AddEventType<LoyaltyEarned>();
+
+            opts.Projections.Add<BalanceProjection>(ProjectionLifecycle.Async);
+            opts.Projections.Add<MemberLoyaltyProjection>(ProjectionLifecycle.Async);
+        });
+    }
+
+    [Fact]
+    public async Task fans_a_cross_stream_query_out_to_one_aggregate_per_identity()
+    {
+        ConfigureStore();
+
+        var acctA = Guid.NewGuid();
+        var acctB = Guid.NewGuid();
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+
+        // acctA deposited across two streams; acctB in one — the fan-out keys on AccountId, not stream.
+        theSession.Events.Append(stream1, new MoneyDeposited(acctA, 100), new MoneyDeposited(acctB, 50));
+        theSession.Events.Append(stream2, new MoneyDeposited(acctA, 25));
+        await theSession.SaveChangesAsync();
+
+        var aggregates = await theSession.Events.QueryAllRawEvents()
+            .Where(e => e.StreamId == stream1 || e.StreamId == stream2)
+            .AggregateToManyAsync<Balance>();
+
+        aggregates.Count.ShouldBe(2);
+
+        // Identity is stamped on each aggregate...
+        aggregates.Single(x => x.Id == acctA).Amount.ShouldBe(125);
+        aggregates.Single(x => x.Id == acctB).Amount.ShouldBe(50);
+    }
+
+    [Fact]
+    public async Task excludes_aggregates_that_should_delete()
+    {
+        ConfigureStore();
+
+        var acctA = Guid.NewGuid();
+        var acctB = Guid.NewGuid();
+        var stream = Guid.NewGuid();
+
+        theSession.Events.Append(stream,
+            new MoneyDeposited(acctA, 100),
+            new MoneyDeposited(acctB, 200),
+            new AccountFrozen(acctB));
+        await theSession.SaveChangesAsync();
+
+        var aggregates = await theSession.Events.QueryAllRawEvents()
+            .Where(e => e.StreamId == stream)
+            .AggregateToManyAsync<Balance>();
+
+        // acctB is frozen (ShouldDelete) and so is absent; only acctA survives.
+        aggregates.Count.ShouldBe(1);
+        aggregates.Single().Id.ShouldBe(acctA);
+        aggregates.Single().Amount.ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task enrichment_reads_reference_data_from_the_live_session()
+    {
+        ConfigureStore();
+
+        var cardA = Guid.NewGuid();
+        var cardB = Guid.NewGuid();
+        var cardC = Guid.NewGuid();
+        var memberX = Guid.NewGuid();
+        var memberY = Guid.NewGuid();
+
+        // Present-day reference data the grouper reads during enrichment.
+        theSession.Store(new CardOwner { Id = cardA, MemberId = memberX });
+        theSession.Store(new CardOwner { Id = cardB, MemberId = memberX });
+        theSession.Store(new CardOwner { Id = cardC, MemberId = memberY });
+        await theSession.SaveChangesAsync();
+
+        var stream = Guid.NewGuid();
+        theSession.Events.Append(stream,
+            new LoyaltyEarned(cardA, 10),
+            new LoyaltyEarned(cardB, 5),
+            new LoyaltyEarned(cardC, 20));
+        await theSession.SaveChangesAsync();
+
+        var aggregates = await theSession.Events.QueryAllRawEvents()
+            .Where(e => e.StreamId == stream)
+            .AggregateToManyAsync<MemberLoyalty>();
+
+        // Member-keyed, not card-keyed — only possible because the grouper read CardOwner from the session.
+        aggregates.Count.ShouldBe(2);
+        aggregates.Single(x => x.Id == memberX).Points.ShouldBe(15);
+        aggregates.Single(x => x.Id == memberY).Points.ShouldBe(20);
+    }
+
+    [Fact]
+    public async Task empty_query_returns_empty_list()
+    {
+        ConfigureStore();
+
+        var aggregates = await theSession.Events.QueryAllRawEvents()
+            .Where(e => e.StreamId == Guid.NewGuid()) // matches nothing
+            .AggregateToManyAsync<Balance>();
+
+        aggregates.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task throws_when_no_projection_produces_the_aggregate_type()
+    {
+        ConfigureStore();
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+        {
+            await theSession.Events.QueryAllRawEvents().AggregateToManyAsync<UnrelatedAggregate>();
+        });
+    }
+
+    public class UnrelatedAggregate
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/src/Marten/Events/AggregateToExtensions.cs
+++ b/src/Marten/Events/AggregateToExtensions.cs
@@ -1,10 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
 using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Grouping;
+using JasperFx.Events.Projections;
+using Marten.Events.Aggregation;
 using Marten.Internal.Sessions;
 using Marten.Linq;
 
@@ -14,6 +20,9 @@ namespace Marten.Events;
 
 public static class AggregateToExtensions
 {
+    private static readonly MethodInfo AggregateManyMethod = typeof(AggregateToExtensions)
+        .GetMethod(nameof(aggregateManyAsync), BindingFlags.Static | BindingFlags.NonPublic)!;
+
     private static void setIdentity<T>(QuerySession session, T aggregate, IEnumerable<IEvent> events) where T : class
     {
         if (((IMartenSession)session).Options.Events.StreamIdentity == StreamIdentity.AsGuid)
@@ -67,5 +76,120 @@ public static class AggregateToExtensions
         return await AggregateToAsync(queryable.As<IMartenQueryable<IEvent>>(), state, token).ConfigureAwait(false);
     }
 
+    /// <summary>
+    ///     Run the events matched by this query through the multi-stream projection registered for
+    ///     <typeparamref name="T"/> and return the aggregate it produces for each resulting identity. This is
+    ///     the live-query twin of the projection step-through's multi-stream run: it drives the projection's
+    ///     REAL slicer/grouper and per-slice build (the same core the step-through uses, minus the step
+    ///     observer) against the live query session, so enrichment that reads reference data works for free.
+    ///     Contrast <see cref="AggregateToAsync{T}(IMartenQueryable{IEvent},T,CancellationToken)"/>, which folds
+    ///     every queried event into a single aggregate.
+    /// </summary>
+    public static async Task<IReadOnlyList<T>> AggregateToManyAsync<T>(this IMartenQueryable<IEvent> queryable,
+        CancellationToken token = new()) where T : class
+    {
+        var session = queryable.As<MartenLinqQueryable<IEvent>>().Session;
+        var options = ((IMartenSession)session).Options;
 
+        // Validate the projection up front (even for an empty result set) so a call for an aggregate type
+        // that has no registered projection is a clear programming error rather than a silent empty list.
+        var projection = options.Projections.All
+                             .OfType<IAggregateProjection>()
+                             .FirstOrDefault(x => x.AggregateType == typeof(T))
+                         ?? throw new ArgumentException(
+                             $"No aggregate projection is registered that produces '{typeof(T).FullNameInCode()}'. AggregateToMany() runs an event query through a registered (multi-stream) projection.",
+                             nameof(queryable));
+
+        var idType = findAggregateIdType(projection.GetType())
+                     ?? throw new ArgumentException(
+                         $"Projection '{projection.GetType().FullNameInCode()}' for '{typeof(T).FullNameInCode()}' is not a slicing aggregate projection that AggregateToMany() can drive.",
+                         nameof(queryable));
+
+        var events = await queryable.ToListAsync(token).ConfigureAwait(false);
+        if (events.Count == 0)
+        {
+            return Array.Empty<T>();
+        }
+
+        var closed = AggregateManyMethod.MakeGenericMethod(typeof(T), idType);
+        var task = (Task<IReadOnlyList<T>>)closed.Invoke(null, [projection, events, session, token])!;
+        return await task.ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///     Run the events matched by this query through the multi-stream projection registered for
+    ///     <typeparamref name="T"/> and return one aggregate per resulting identity.
+    /// </summary>
+    public static Task<IReadOnlyList<T>> AggregateToManyAsync<T>(this IQueryable<IEvent> queryable,
+        CancellationToken token = new()) where T : class
+    {
+        return queryable.As<IMartenQueryable<IEvent>>().AggregateToManyAsync<T>(token);
+    }
+
+    // TId is not statically known at the AggregateToManyAsync<T> call site, so drive the strongly-typed
+    // slice -> enrich -> build fold through a TId-closed helper invoked via reflection.
+    private static async Task<IReadOnlyList<T>> aggregateManyAsync<T, TId>(
+        JasperFxAggregationProjectionBase<T, TId, IDocumentOperations, IQuerySession> projection,
+        IReadOnlyList<IEvent> events,
+        QuerySession session,
+        CancellationToken token)
+        where T : class where TId : notnull
+    {
+        // The SAME building blocks the step-through fold uses (BuildTimelinesAsync): the projection's own
+        // slicer/grouper, then EnrichEventsAsync per group, then DetermineActionAsync (Create/Apply/
+        // ShouldDelete dispatch) per slice — so the live-query result can't diverge from the step-through.
+        var slicer = projection.BuildSlicer(session);
+        var groups = await slicer.SliceAsync(events).ConfigureAwait(false);
+
+        var identitySetter = new NulloIdentitySetter<T, TId>();
+        var storage = session.StorageFor<T, TId>();
+        var results = new List<T>();
+
+        foreach (var groupObject in groups)
+        {
+            if (groupObject is not SliceGroup<T, TId> group)
+            {
+                continue;
+            }
+
+            await projection.EnrichEventsAsync(group, session, token).ConfigureAwait(false);
+
+            foreach (var slice in group.Slices)
+            {
+                var (aggregate, action) = await projection
+                    .DetermineActionAsync(session, default, slice.Id, identitySetter, slice.Events(), token)
+                    .ConfigureAwait(false);
+
+                if (action == ActionType.Delete || aggregate is null)
+                {
+                    continue;
+                }
+
+                // The fold uses a Nullo identity setter, so stamp the aggregate's own id from the slice.
+                storage.SetIdentity(aggregate, slice.Id);
+                results.Add(aggregate);
+            }
+        }
+
+        return results;
+    }
+
+    // Walk the projection's base chain for the closed JasperFxAggregationProjectionBase<TDoc, TId, ...>
+    // and return its TId argument.
+    private static Type? findAggregateIdType(Type projectionType)
+    {
+        var type = projectionType;
+        while (type != null && type != typeof(object))
+        {
+            if (type.IsGenericType
+                && type.GetGenericTypeDefinition() == typeof(JasperFxAggregationProjectionBase<,,,>))
+            {
+                return type.GetGenericArguments()[1];
+            }
+
+            type = type.BaseType;
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
Closes #4998. Part of the CritterWatch projection-stepthrough epic.

## What

`AggregateToManyAsync<T>()` — a LINQ terminal over `IQueryable<IEvent>` / `IMartenQueryable<IEvent>` that runs the queried events through the **multi-stream** projection registered for `T` and returns the aggregate it produces for each resulting identity (`IReadOnlyList<T>`). The live-query twin of the projection step-through's multi-stream run.

```csharp
var balances = await session.Events.QueryAllRawEvents()
    .Where(e => e.Timestamp > cutoff)
    .AggregateToManyAsync<AccountBalance>();
```

Contrast the existing single-target `AggregateToAsync`, which folds every queried event into **one** aggregate.

## How

Built over the **same building blocks** the step-through fold (`BuildTimelinesAsync`) uses — the projection's own `BuildSlicer` → `EnrichEventsAsync` per group → `DetermineActionAsync` (the real `Create`/`Apply`/`ShouldDelete` dispatch) per slice — minus the step observer, so the live-query result can't diverge from the step-through. Because a live session drives slicing/enrichment, projections whose grouper reads reference data enrich for free.

`TId` isn't statically known at the `AggregateToMany<T>` call site, so the strongly-typed fold runs through a `TId`-closed helper resolved from the projection's `JasperFxAggregationProjectionBase<T, TId, …>` base and invoked via reflection. `ShouldDelete` slices are dropped from the result; each surviving aggregate has its identity stamped from its slice id.

## Tests

`aggregate_to_many_tests`:
- **fan-out** — a cross-stream query keyed by `AccountId` yields one identity-stamped aggregate per account.
- **ShouldDelete** — a frozen account is excluded from the result.
- **enrichment** — a session-backed grouper maps cards → members from persisted reference data, producing member-keyed aggregates.
- empty query → empty list; unknown aggregate type → `ArgumentException`.

## Follow-up

Polecat parity (a thin LINQ extension over the same shared fold core) is a separate cross-repo change, per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)