### PR TITLE
DCB tag operators in LINQ Where() over events (#4999)

### DIFF
--- a/src/EventSourcingTests/Dcb/dcb_tag_linq_where_tests.cs
+++ b/src/EventSourcingTests/Dcb/dcb_tag_linq_where_tests.cs
@@ -1,0 +1,163 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+using Marten;
+using Marten.Events;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace EventSourcingTests.Dcb;
+
+// Reuses the StudentId / CourseId tag types and the StudentEnrolled / AssignmentSubmitted events
+// declared in dcb_tag_query_and_consistency_tests.cs (same namespace).
+[Collection("OneOffs")]
+public class dcb_tag_linq_where_tests: OneOffConfigurationsContext
+{
+    private void ConfigureStore(DcbStorageMode mode = DcbStorageMode.TagTables)
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.DcbStorageMode = mode;
+
+            opts.Events.AddEventType<StudentEnrolled>();
+            opts.Events.AddEventType<AssignmentSubmitted>();
+
+            opts.Events.RegisterTagType<StudentId>("student");
+            opts.Events.RegisterTagType<CourseId>("course");
+        });
+    }
+
+    private async Task AppendTagged(Guid streamId, object eventData, params object[] tags)
+    {
+        var wrapped = theSession.Events.BuildEvent(eventData);
+        wrapped.WithTag(tags);
+        theSession.Events.Append(streamId, wrapped);
+        await theSession.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task has_tag_matches_only_events_carrying_that_tag_value()
+    {
+        ConfigureStore();
+
+        var alice = new StudentId(Guid.NewGuid());
+        var bob = new StudentId(Guid.NewGuid());
+
+        await AppendTagged(Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), alice);
+        await AppendTagged(Guid.NewGuid(), new StudentEnrolled("Bob", "Math"), bob);
+
+        var events = await theSession.Events.QueryAllRawEvents()
+            .Where(e => e.HasTag<StudentId>(alice))
+            .ToListAsync();
+
+        events.Count.ShouldBe(1);
+        events.Single().Data.ShouldBeOfType<StudentEnrolled>().StudentName.ShouldBe("Alice");
+    }
+
+    [Fact]
+    public async Task has_tag_composes_with_a_normal_event_predicate_in_one_where()
+    {
+        ConfigureStore();
+
+        var alice = new StudentId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        // Two events for Alice, both tagged with her StudentId, but of different event types.
+        await AppendTagged(streamId, new StudentEnrolled("Alice", "Math"), alice);
+        await AppendTagged(streamId, new AssignmentSubmitted("HW1", 95), alice);
+
+        // "Alice's events, but only the enrollments" — the tag predicate AND a normal event predicate.
+        var events = await theSession.Events.QueryAllRawEvents()
+            .Where(e => e.HasTag<StudentId>(alice) && e.EventTypesAre(typeof(StudentEnrolled)))
+            .ToListAsync();
+
+        events.Count.ShouldBe(1);
+        events.Single().Data.ShouldBeOfType<StudentEnrolled>();
+    }
+
+    [Fact]
+    public async Task has_tag_composes_with_a_timestamp_predicate()
+    {
+        ConfigureStore();
+
+        var alice = new StudentId(Guid.NewGuid());
+        await AppendTagged(Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), alice);
+
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-1);
+
+        var events = await theSession.Events.QueryAllRawEvents()
+            .Where(e => e.HasTag<StudentId>(alice) && e.Timestamp > cutoff)
+            .ToListAsync();
+
+        events.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task and_of_two_tag_predicates_requires_both_tags()
+    {
+        ConfigureStore();
+
+        var alice = new StudentId(Guid.NewGuid());
+        var math = new CourseId(Guid.NewGuid());
+
+        // Event 1 carries BOTH tags; event 2 carries only the student tag.
+        await AppendTagged(Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), alice, math);
+        await AppendTagged(Guid.NewGuid(), new StudentEnrolled("Alice", "Science"), alice);
+
+        var events = await theSession.Events.QueryAllRawEvents()
+            .Where(e => e.HasTag<StudentId>(alice) && e.HasTag<CourseId>(math))
+            .ToListAsync();
+
+        // Only the event tagged with both survives the AND.
+        events.Count.ShouldBe(1);
+        events.Single().Data.ShouldBeOfType<StudentEnrolled>().CourseName.ShouldBe("Math");
+    }
+
+    [Fact]
+    public async Task has_tag_works_in_hstore_storage_mode()
+    {
+        ConfigureStore(DcbStorageMode.HStore);
+
+        var alice = new StudentId(Guid.NewGuid());
+        var bob = new StudentId(Guid.NewGuid());
+        var math = new CourseId(Guid.NewGuid());
+
+        await AppendTagged(Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), alice, math);
+        await AppendTagged(Guid.NewGuid(), new StudentEnrolled("Bob", "Math"), bob);
+
+        // Single tag against the hstore column.
+        var byStudent = await theSession.Events.QueryAllRawEvents()
+            .Where(e => e.HasTag<StudentId>(alice))
+            .ToListAsync();
+        byStudent.Count.ShouldBe(1);
+        byStudent.Single().Data.ShouldBeOfType<StudentEnrolled>().StudentName.ShouldBe("Alice");
+
+        // AND of two tags, both resolved against the same hstore column.
+        var bothTags = await theSession.Events.QueryAllRawEvents()
+            .Where(e => e.HasTag<StudentId>(alice) && e.HasTag<CourseId>(math))
+            .ToListAsync();
+        bothTags.Count.ShouldBe(1);
+        bothTags.Single().Data.ShouldBeOfType<StudentEnrolled>().StudentName.ShouldBe("Alice");
+    }
+
+    [Fact]
+    public async Task has_tag_for_an_unregistered_tag_type_throws()
+    {
+        ConfigureStore();
+
+        var unknown = new UnregisteredTag(Guid.NewGuid());
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            await theSession.Events.QueryAllRawEvents()
+                .Where(e => e.HasTag<UnregisteredTag>(unknown))
+                .ToListAsync();
+        });
+    }
+
+    public record UnregisteredTag(Guid Value);
+}

--- a/src/Marten/Events/LinqExtensions.cs
+++ b/src/Marten/Events/LinqExtensions.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using JasperFx.Core.Reflection;
 using JasperFx.Events;
+using Marten.Events.Dcb;
 using Marten.Linq.Members;
 using Marten.Linq.Parsing;
 using Marten.Linq.Parsing.Methods;
@@ -21,6 +22,70 @@ public static class LinqExtensions
     public static bool EventTypesAre(this IEvent e, params Type[] types)
     {
         return e.Data.GetType().IsOneOf(types);
+    }
+
+    /// <summary>
+    /// LINQ filter over an event query (e.g. <c>session.Events.QueryAllRawEvents()</c>) that matches only
+    /// events carrying the given DCB tag value. Composes into the same <c>Where()</c> as ordinary event
+    /// predicates (timestamp, event type, stream), so one query can express "these events, matching these
+    /// tags". <typeparamref name="TTag"/> must be a registered tag type (see <c>RegisterTagType&lt;TTag&gt;()</c>).
+    /// AND-ing several <c>HasTag</c> calls with normal predicates is supported; for OR-across-tags or the
+    /// richer event-type interplay, use the <c>EventTagQuery</c> builder with <c>QueryByTagsAsync</c> instead.
+    /// This is a marker method recognized by the LINQ provider and cannot be invoked directly.
+    /// </summary>
+    public static bool HasTag<TTag>(this IEvent e, TTag value) where TTag : notnull
+    {
+        throw new NotSupportedException(
+            "IEvent.HasTag<TTag>() is a marker method for LINQ event queries and cannot be invoked directly. Use it inside session.Events.QueryAllRawEvents().Where(...).");
+    }
+}
+
+internal class HasTagParser: IMethodCallParser
+{
+    public bool Matches(MethodCallExpression expression)
+    {
+        return expression.Method.Name == nameof(LinqExtensions.HasTag)
+               && expression.Method.DeclaringType == typeof(LinqExtensions);
+    }
+
+    public ISqlFragment Parse(IQueryableMemberCollection memberCollection, IReadOnlyStoreOptions options,
+        MethodCallExpression expression)
+    {
+        var events = options.Events.As<EventGraph>();
+
+        var tagType = expression.Method.GetGenericArguments()[0];
+        var value = expression.Arguments.Last().Value()
+                    ?? throw new ArgumentException("HasTag() requires a non-null tag value.", nameof(expression));
+
+        var registration = events.FindTagType(tagType)
+                           ?? throw new InvalidOperationException(
+                               $"Tag type '{tagType.Name}' is not registered. Call RegisterTagType<{tagType.Name}>() first.");
+
+        // HStore mode: all tags live in a single hstore column on mt_events; match with containment.
+        if (events.DcbStorageMode == DcbStorageMode.HStore)
+        {
+            var stringValue = TagValueStringifier.Stringify(registration.ExtractValue(value));
+            return new WhereFragment("d.tags @> hstore(?, ?)", registration.TableSuffix, stringValue);
+        }
+
+        // TagTables mode (default): correlate to the per-tag table via seq_id, mirroring the JOIN that
+        // BuildTagQuerySql emits. The `d` alias is the mt_events table of the event query.
+        var extracted = registration.ExtractValue(value);
+        var schema = events.DatabaseSchemaName;
+        var suffix = registration.TableSuffix;
+
+        // Under conjoined tenancy seq_id is not unique across tenants (per-tenant sequences), so the
+        // correlated subquery must also match tenant_id; the outer event query is already tenant-scoped.
+        if (events.TenancyStyle == TenancyStyle.Conjoined)
+        {
+            return new WhereFragment(
+                $"d.seq_id in (select seq_id from {schema}.mt_event_tag_{suffix} where value = ? and tenant_id = d.tenant_id)",
+                extracted);
+        }
+
+        return new WhereFragment(
+            $"d.seq_id in (select seq_id from {schema}.mt_event_tag_{suffix} where value = ?)",
+            extracted);
     }
 }
 

--- a/src/Marten/LinqParsing.cs
+++ b/src/Marten/LinqParsing.cs
@@ -75,6 +75,7 @@ public class LinqParsing: IReadOnlyLinqParsing
         // event is archived
         new MaybeArchivedMethodCallParser(),
         new EventTypesAreParser(),
+        new HasTagParser(),
 
         // last modified
         new ModifiedSinceParser(),


### PR DESCRIPTION
Closes #4999. Part of the CritterWatch projection-stepthrough epic.

## What

`IEvent.HasTag<TTag>(value)` — a marker method recognized by the LINQ provider — so DCB tag predicates compose into the **same** `Where()` as ordinary event predicates (timestamp / event type / stream) when querying over events:

```csharp
session.Events.QueryAllRawEvents()
    .Where(e => e.HasTag<AccountId>(id) && e.Timestamp > cutoff)
```

This unification is what lets a single event-query control drive both "show me events" and "fold these through projection X" (the CritterWatch source-selector unification).

## How

- `HasTag<TTag>` is a marker extension on `IEvent` (throws if invoked directly).
- `HasTagParser : IMethodCallParser` (registered next to `EventTypesAreParser`) recognizes it and compiles it into the same tag SQL `BuildTagQuerySql` already emits:
  - **TagTables** (default): a correlated `d.seq_id in (select seq_id from {schema}.mt_event_tag_{suffix} where value = ? [and tenant_id = d.tenant_id])` subquery. The tenant correlation is emitted only under conjoined tenancy (where `seq_id` is per-tenant), mirroring `BuildTagQuerySql`.
  - **HStore**: a `d.tags @> hstore(?, ?)` containment predicate.
- Because each `HasTag` becomes an ordinary WHERE fragment, AND-ing several of them together and with normal event predicates just works.

## Scope (v1)

AND-of-tag-predicates + normal predicates, per the issue. `EventTagQuery` + `QueryByTagsAsync` remain the OR-across-tags / rich escape hatch — deliberately **not** subsumed into LINQ here.

## Tests

`dcb_tag_linq_where_tests`:
- `HasTag` matches only events carrying that tag value.
- composes with a normal event-type predicate, and with a timestamp predicate, in one `Where()`.
- AND of two tag predicates requires **both** tags.
- works in HStore storage mode (single tag + AND of two).
- unregistered tag type throws.

Existing `dcb_tag_query_and_consistency_tests` (24) stay green.

## Follow-up

Polecat parity (mirror the marker methods + parser in Polecat's LINQ provider) is a separate cross-repo change, per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)