### PR TITLE
Bump JasperFx to 2.33.1 for the running_on_node tracker seam (#5001)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -124,14 +124,18 @@
          surfaces divergent process-pinned application-assembly reuse across multi-host test processes;
          Marten buffers and logs it at startup (marten#4996). Also ships the step-instrumented
          aggregation fold + MultiAggregateProjectionResult (jasperfx#547) and the serializable
-         EventTagQuery DCB source (jasperfx#548). -->
-    <PackageVersion Include="JasperFx" Version="2.33.0" />
-    <PackageVersion Include="JasperFx.Events" Version="2.33.0" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.33.0">
+         EventTagQuery DCB source (jasperfx#548).
+         JasperFx 2.33.1: jasperfx#550/#551 (marten#5001) — ShardStateTracker.AssignedNodeNumber is
+         stamped onto every published ShardState, so a distribution layer (Wolverine-managed
+         subscription distribution) can drive the extended-progression running_on_node column. Marten's
+         WriteExtendedProgressionAsync already persists it; this bump makes the tracker seam available. -->
+    <PackageVersion Include="JasperFx" Version="2.33.1" />
+    <PackageVersion Include="JasperFx.Events" Version="2.33.1" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.33.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.33.0" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.33.1" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />


### PR DESCRIPTION
Part of #5001.

Bumps JasperFx `2.33.0 → 2.33.1`, which stamps `ShardStateTracker.AssignedNodeNumber` onto every published `ShardState` ([jasperfx#550](https://github.com/JasperFx/jasperfx/issues/550) / jasperfx#551).

Marten's `WriteExtendedProgressionAsync` already persists `running_on_node` from `ShardState.RunningOnNode`; this bump makes the tracker seam available so a distribution layer (Wolverine-managed subscription distribution) can set `daemon.Tracker.AssignedNodeNumber` and have it flow end-to-end into the column. No other Marten change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)