### PR TITLE
Token-capable maintenance connection for tenant database provisioning (#4994)

### DIFF
--- a/docs/configuration/azure-managed-identity.md
+++ b/docs/configuration/azure-managed-identity.md
@@ -80,6 +80,21 @@ builder.Services.AddMartenStore<IInvoicingStore>(opts =>
 
 Marten treats a caller-supplied `NpgsqlDataSource` — whether it arrives through `UseNpgsqlDataSource()` or `opts.Connection(NpgsqlDataSource)` — as owned by the caller. Marten will never dispose it, so a single instance is safe to share across the main store, ancillary stores, and your own non-Marten usage. Dispose it yourself when the application shuts down (the container does this for you when the data source is registered as a singleton).
 
-## Limitation: database provisioning
+## Database provisioning with a rotating credential
 
-Marten's tenant database provisioning (`StoreOptions.CreateDatabasesForTenants` and its `MaintenanceDatabase()` option, see [database management](/schema/#create-database)) builds plain `NpgsqlConnection` objects from connection strings and does not flow the data source or its token provider. On a server that only accepts Entra ID authentication, that provisioning path cannot log in on its own — create the databases through your own maintenance connection (or infrastructure tooling) instead, and let Marten manage the schema objects within them.
+Marten's tenant database provisioning (`StoreOptions.CreateDatabasesForTenants`, see [database management](/schema/#create-database)) opens a separate *maintenance* connection to create or drop tenant databases. By default that maintenance connection is built from a connection string, which — just like `opts.Connection(string)` — cannot carry a rotating credential. On a server that only accepts Entra ID authentication, provisioning would then fail to log in.
+
+Supply the maintenance connection as an `NpgsqlDataSource` instead. The `MaintenanceDatabase()` option has an overload that takes a caller-owned data source, so the same periodic password provider that authenticates your store connections also authenticates provisioning:
+
+<!-- snippet: sample_marten_create_database_with_datasource -->
+<a id='snippet-sample_marten_create_database_with_datasource'></a>
+```cs
+// Hand provisioning a caller-owned NpgsqlDataSource carrying, for example, an Entra ID
+// token provider. Point it at an administrative database ('postgres') whose principal
+// holds the CREATEDB privilege. Marten never disposes this data source.
+c.MaintenanceDatabase(maintenanceDataSource);
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/StressTests/create_database_Tests.cs#L125-L132' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_marten_create_database_with_datasource' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Point that data source at an administrative database (typically `postgres`) whose Entra principal holds the `CREATEDB` privilege — this is frequently a *different*, more privileged identity than the one your application uses at runtime, which is exactly why the maintenance data source is configured separately from the store connection. As with every caller-supplied `NpgsqlDataSource`, Marten never disposes it; dispose it yourself when the application shuts down.

--- a/docs/configuration/multitenancy.md
+++ b/docs/configuration/multitenancy.md
@@ -127,6 +127,17 @@ _host = await Host.CreateDefaultBuilder()
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/MultiTenancyTests/using_per_database_multitenancy.cs#L96-L123' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_using_single_server_multi_tenancy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+::: warning Rotating credentials (Entra ID / managed identity)
+The administration connection above is supplied as a plain connection string, so this on-the-fly
+`MultiTenantedWithSingleServer` provisioning path cannot authenticate to a server that only accepts a
+rotating credential (for example an Azure Entra ID access token). That support is still connection-string only.
+
+If instead you provision a known set of tenant databases up front through
+[`CreateDatabasesForTenants`](/schema/#create-database), you *can* use a rotating credential: its
+`MaintenanceDatabase()` option accepts a caller-owned `NpgsqlDataSource` carrying a periodic password
+provider. See [Azure Database for PostgreSQL with Entra ID](/configuration/azure-managed-identity#database-provisioning-with-a-rotating-credential).
+:::
+
 ## Master Table Tenancy Model
 
 ::: info

--- a/docs/schema/index.md
+++ b/docs/schema/index.md
@@ -127,3 +127,7 @@ await host.StartAsync();
 Databases are checked for existence upon store initialization. By default, connection attempts are made against the databases specified for tenants. If a connection attempt results in an invalid catalog error (3D000), database creation is triggered. `ITenantDatabaseCreationExpressions.CheckAgainstPgDatabase` can be used to alter this behavior to check for database existence from `pg_database`.
 
 Note that database creation requires the `CREATEDB` privilege. See PostgreSQL [CREATE DATABASE](https://www.postgresql.org/docs/current/static/sql-createdatabase.html) documentation for more.
+
+::: tip
+`MaintenanceDatabase()` also accepts a caller-owned `NpgsqlDataSource` instead of a connection string. Use that overload when the maintenance server authenticates with a rotating credential — for example an Azure Entra ID / managed-identity access token — so provisioning can log in through the data source's token provider. See [Azure Database for PostgreSQL with Entra ID](/configuration/azure-managed-identity#database-provisioning-with-a-rotating-credential).
+:::

--- a/src/Marten/Schema/DatabaseGenerator.cs
+++ b/src/Marten/Schema/DatabaseGenerator.cs
@@ -14,13 +14,37 @@ public sealed class DatabaseGenerator: IDatabaseCreationExpressions
 {
     private readonly Dictionary<string, TenantDatabaseCreationExpressions> _configurationPerTenant = new();
     private string _maintenanceDbConnectionString;
+    private NpgsqlDataSource _maintenanceDataSource;
 
     public IDatabaseCreationExpressions MaintenanceDatabase(string maintenanceDbConnectionString)
     {
         _maintenanceDbConnectionString = maintenanceDbConnectionString ??
                                          throw new ArgumentNullException(nameof(maintenanceDbConnectionString));
 
+        // last-writer-wins: a connection string supersedes a previously supplied data source
+        _maintenanceDataSource = null;
+
         return this;
+    }
+
+    public IDatabaseCreationExpressions MaintenanceDatabase(NpgsqlDataSource maintenanceDataSource)
+    {
+        _maintenanceDataSource = maintenanceDataSource ??
+                                 throw new ArgumentNullException(nameof(maintenanceDataSource));
+
+        // last-writer-wins: the data source supersedes a previously supplied connection string
+        _maintenanceDbConnectionString = null;
+
+        return this;
+    }
+
+    // #4994: rent the maintenance connection from a caller-supplied NpgsqlDataSource when one was
+    // provided (so an Entra ID / managed-identity token provider is honoured), otherwise open a plain
+    // connection from the maintenance connection string. The data source is caller-owned and never
+    // disposed here — only the returned connection is disposed by the caller.
+    private NpgsqlConnection createMaintenanceConnection(string maintenanceDb)
+    {
+        return _maintenanceDataSource?.CreateConnection() ?? new NpgsqlConnection(maintenanceDb);
     }
 
     public ITenantDatabaseCreationExpressions ForTenant(string tenantId = StorageConstants.DefaultTenantId)
@@ -60,7 +84,10 @@ public sealed class DatabaseGenerator: IDatabaseCreationExpressions
         {
             catalog = t.Database;
 
-            if (maintenanceDb == null)
+            // A caller-supplied maintenance data source already encodes where to connect, so only
+            // fall back to deriving a 'postgres' maintenance string from the tenant connection when
+            // neither a data source nor an explicit maintenance string was configured.
+            if (maintenanceDb == null && _maintenanceDataSource == null)
             {
                 var cstringBuilder = new NpgsqlConnectionStringBuilder(t.ConnectionString);
                 cstringBuilder.Database = "postgres";
@@ -88,7 +115,7 @@ public sealed class DatabaseGenerator: IDatabaseCreationExpressions
 
     private async Task<bool> IsNotInPgDatabase(string catalog, string maintenanceDb, CancellationToken ct = default)
     {
-        var connection = new NpgsqlConnection(maintenanceDb);
+        var connection = createMaintenanceConnection(maintenanceDb);
         await using var _ = connection.ConfigureAwait(false);
         await using var cmd = connection.CreateCommand("SELECT datname FROM pg_database where datname = @catalog");
         await using var __ = cmd.ConfigureAwait(false);
@@ -137,7 +164,7 @@ public sealed class DatabaseGenerator: IDatabaseCreationExpressions
             await dropCurrentDatabaseAsync(catalog, config, maintenanceDb, ct).ConfigureAwait(false);
         }
 
-        await using var connection = new NpgsqlConnection(maintenanceDb);
+        await using var connection = createMaintenanceConnection(maintenanceDb);
         await connection.OpenAsync(ct).ConfigureAwait(false);
         try
         {
@@ -151,7 +178,7 @@ public sealed class DatabaseGenerator: IDatabaseCreationExpressions
         }
     }
 
-    private static async Task dropCurrentDatabaseAsync(string catalog, TenantDatabaseCreationExpressions config,
+    private async Task dropCurrentDatabaseAsync(string catalog, TenantDatabaseCreationExpressions config,
         string maintenanceDb, CancellationToken ct)
     {
         var cmdText = string.Empty;
@@ -163,7 +190,7 @@ public sealed class DatabaseGenerator: IDatabaseCreationExpressions
 
         cmdText += $"DROP DATABASE IF EXISTS \"{catalog}\";";
 
-        await using var conn = new NpgsqlConnection(maintenanceDb);
+        await using var conn = createMaintenanceConnection(maintenanceDb);
         await conn.OpenAsync(ct).ConfigureAwait(false);
         await conn.CreateCommand(cmdText).ExecuteNonQueryAsync(ct).ConfigureAwait(false);
         await conn.CloseAsync().ConfigureAwait(false);

--- a/src/Marten/Schema/IDatabaseCreationExpressions.cs
+++ b/src/Marten/Schema/IDatabaseCreationExpressions.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using JasperFx;
+using Npgsql;
 
 namespace Marten.Schema;
 
@@ -13,4 +14,18 @@ public interface IDatabaseCreationExpressions
     ///     If not specified, the store connection string with 'postgres' as database is used.
     /// </summary>
     IDatabaseCreationExpressions MaintenanceDatabase(string maintenanceDbConnectionString);
+
+    /// <summary>
+    ///     Supply a caller-owned <see cref="NpgsqlDataSource" /> for the maintenance connection so that
+    ///     provisioning can authenticate with rotating credentials — for example an Azure Entra ID /
+    ///     managed-identity access token supplied through Npgsql's periodic password provider. Point the
+    ///     data source at an administrative database (typically <c>postgres</c>) whose principal holds the
+    ///     <c>CREATEDB</c> privilege. The data source is never disposed by Marten (matching
+    ///     <c>StoreOptions.Connection(NpgsqlDataSource)</c>); only the connections rented from it are.
+    /// </summary>
+    /// <remarks>
+    ///     Takes precedence over any connection string passed to <see cref="MaintenanceDatabase(string)" />;
+    ///     the two overloads are last-writer-wins.
+    /// </remarks>
+    IDatabaseCreationExpressions MaintenanceDatabase(NpgsqlDataSource maintenanceDataSource) => this;
 }

--- a/src/StressTests/create_database_Tests.cs
+++ b/src/StressTests/create_database_Tests.cs
@@ -103,6 +103,95 @@ public class create_database_Tests : IDisposable
     }
 
     [Fact]
+    public async Task can_create_new_database_using_a_maintenance_NpgsqlDataSource()
+    {
+        // #4994: the maintenance connection can be supplied as a caller-owned NpgsqlDataSource so that
+        // provisioning honours a rotating credential (e.g. an Azure Entra ID / managed-identity token
+        // provider registered on the data source builder). Here we just prove functional parity with the
+        // connection-string overload against the local server.
+        TryDropDb(dbName);
+
+        await using var maintenanceDataSource =
+            new NpgsqlDataSourceBuilder(ConnectionSource.ConnectionString).Build();
+
+        var dbCreated = false;
+
+        using var store = DocumentStore.For(storeOptions =>
+        {
+            storeOptions.Connection(dbToCreateConnectionString);
+
+            storeOptions.CreateDatabasesForTenants(c =>
+            {
+                #region sample_marten_create_database_with_datasource
+
+                // Hand provisioning a caller-owned NpgsqlDataSource carrying, for example, an Entra ID
+                // token provider. Point it at an administrative database ('postgres') whose principal
+                // holds the CREATEDB privilege. Marten never disposes this data source.
+                c.MaintenanceDatabase(maintenanceDataSource);
+
+                #endregion
+
+                c.ForTenant()
+                    .CheckAgainstPgDatabase()
+                    .DropExisting()
+                    .WithOwner("postgres")
+                    .WithEncoding("UTF-8")
+                    .ConnectionLimit(-1)
+                    .OnDatabaseCreated(_ =>
+                    {
+                        dbCreated = true;
+                    });
+            });
+        });
+
+        var databaseGenerator = new DatabaseGenerator();
+        await databaseGenerator.CreateDatabasesAsync(store.Tenancy, store.Options.CreateDatabases).ConfigureAwait(false);
+
+        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+        await store.Storage.Database.AssertDatabaseMatchesConfigurationAsync();
+        Assert.True(dbCreated);
+    }
+
+    [Fact]
+    public async Task maintenance_datasource_overload_wins_over_a_previously_set_connection_string()
+    {
+        // last-writer-wins: setting the data source after a connection string must route provisioning
+        // through the data source (and vice versa). Proven functionally by a successful create.
+        TryDropDb(dbName);
+
+        await using var maintenanceDataSource =
+            new NpgsqlDataSourceBuilder(ConnectionSource.ConnectionString).Build();
+
+        var dbCreated = false;
+
+        using var store = DocumentStore.For(storeOptions =>
+        {
+            storeOptions.Connection(dbToCreateConnectionString);
+
+            storeOptions.CreateDatabasesForTenants(c =>
+            {
+                // The bogus string would fail to connect; the later data source overload must supersede it.
+                c.MaintenanceDatabase("Host=nonexistent.invalid;Database=postgres;Username=nobody;Password=nope");
+                c.MaintenanceDatabase(maintenanceDataSource);
+
+                c.ForTenant()
+                    .CheckAgainstPgDatabase()
+                    .WithOwner("postgres")
+                    .WithEncoding("UTF-8")
+                    .ConnectionLimit(-1)
+                    .OnDatabaseCreated(_ => dbCreated = true);
+            });
+        });
+
+        var databaseGenerator = new DatabaseGenerator();
+        await databaseGenerator.CreateDatabasesAsync(store.Tenancy, store.Options.CreateDatabases).ConfigureAwait(false);
+
+        Assert.True(dbCreated);
+    }
+
+    [Fact]
     public async Task can_use_existing_database_without_calling_into_create()
     {
         var user1 = new User { FirstName = "User" };


### PR DESCRIPTION
Closes #4994

## Problem

`StoreOptions.CreateDatabasesForTenants` could not authenticate to a server that only accepts rotating credentials — for example Azure Database for PostgreSQL with Entra-only authentication, where the "password" is a short-lived access token. `DatabaseGenerator` builds every maintenance connection as a bare `new NpgsqlConnection(connectionString)` (the `pg_database` existence check, `CREATE DATABASE`, and `DROP DATABASE`), and a connection string can't carry a periodic password provider. #2787 brought token/managed-identity support to the store's own connections, but the provisioning path stayed string-only.

## Fix — shape 2 from the issue

Add a `MaintenanceDatabase(NpgsqlDataSource)` overload on `IDatabaseCreationExpressions`, implemented as a **default interface method** so external implementors stay source-compatible (`DatabaseGenerator` is the only in-repo implementation). When a data source is supplied, all three maintenance-connection sites rent from it, so a periodic password provider (Entra ID / managed identity) is honoured.

Design choices:

- **Caller-owned, never disposed** — matches the existing `Connection(NpgsqlDataSource)` contract; only the rented connections are disposed.
- **Separate maintenance data source is intentional, not a wart** — the maintenance connection targets a different database (`postgres`) and frequently a *more privileged* principal (needs `CREATEDB`) than the app runtime identity. So it stays configured independently of the store connection rather than being threaded through the tenant connection factory.
- **Last-writer-wins** between the string and data-source overloads (setting one clears the other).

## Tests

`src/StressTests/create_database_Tests.cs`:
- `can_create_new_database_using_a_maintenance_NpgsqlDataSource` — functional parity with the string overload against local Postgres.
- `maintenance_datasource_overload_wins_over_a_previously_set_connection_string` — precedence (a bogus string is superseded by a later data source).

Full `create_database_Tests` suite green (4/4, net9.0).

## Docs

- The Azure Entra ID guide's "Limitation: database provisioning" section becomes **"Database provisioning with a rotating credential"** with a working example (new `sample_marten_create_database_with_datasource` snippet).
- Schema-management docs cross-link to it. markdownlint + cspell clean.

Follow-up (not in this PR): Weasel's `SingleServerDatabaseCollection` has the same string-only maintenance connection for dynamic database-per-tenant and would take the same `NpgsqlDataSource` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)