### PR TITLE
Batched extended-progression telemetry write in one round trip (jasperfx#553)

### DIFF
--- a/src/DaemonTests/extended_progression_batch_write.cs
+++ b/src/DaemonTests/extended_progression_batch_write.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Core;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten.Events.Aggregation;
+using Marten.Storage;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DaemonTests;
+
+public record BatchTelemetryEvent();
+
+public class BatchTelemetryStream { public Guid Id { get; set; } }
+
+public partial class BatchTelemetryProjection: SingleStreamProjection<BatchTelemetryStream, Guid>
+{
+    public void Apply(BatchTelemetryEvent @event, BatchTelemetryStream projection) { }
+}
+
+public partial class OtherBatchTelemetryProjection: SingleStreamProjection<BatchTelemetryStream, Guid>
+{
+    public OtherBatchTelemetryProjection()
+    {
+        Name = "OtherBatchTelemetry";
+    }
+
+    public void Apply(BatchTelemetryEvent @event, BatchTelemetryStream projection) { }
+}
+
+// jasperfx#553 — the batched extended-progression write. The JasperFx.Events ExtendedProgressionWriter
+// coalesces every shard's heartbeat on a database into one batch per flush interval; Marten's overload
+// must land the whole batch in ONE round trip with the exact semantics of
+// mt_mark_event_progression_extended: update-only telemetry decoration of existing progression rows,
+// never INSERT, never touch last_seq_id / last_updated.
+public class extended_progression_batch_write: DaemonContext
+{
+    public extended_progression_batch_write(ITestOutputHelper output): base(output)
+    {
+    }
+
+    private async Task<(object? heartbeat, object? status, object? reason, object? node, object? seq)> readRowAsync(
+        string shard)
+    {
+        await using var session = theStore.QuerySession();
+        await using var reader = await session.Connection
+            .CreateCommand(
+                $"select heartbeat, agent_status, pause_reason, running_on_node, last_seq_id from {theStore.Events.DatabaseSchemaName}.mt_event_progression where name = :name")
+            .With("name", shard)
+            .ExecuteReaderAsync();
+
+        if (!await reader.ReadAsync()) return (null, null, null, null, null);
+
+        object? at(int i) => await0(reader.GetValue(i));
+        static object? await0(object raw) => raw is DBNull ? null : raw;
+
+        return (at(0), at(1), at(2), at(3), at(4));
+    }
+
+    private async Task<long> countRowsAsync()
+    {
+        await using var session = theStore.QuerySession();
+        var raw = await session.Connection
+            .CreateCommand($"select count(*) from {theStore.Events.DatabaseSchemaName}.mt_event_progression")
+            .ExecuteScalarAsync();
+        return Convert.ToInt64(raw);
+    }
+
+    private async Task startCaughtUpDaemonAsync()
+    {
+        StoreOptions(x =>
+        {
+            x.Events.EnableExtendedProgressionTracking = true;
+            x.Projections.Add(new BatchTelemetryProjection(), ProjectionLifecycle.Async);
+            x.Projections.Add(new OtherBatchTelemetryProjection(), ProjectionLifecycle.Async);
+        });
+
+        var daemon = await StartDaemon();
+
+        await using (var session = theStore.LightweightSession())
+        {
+            for (var i = 0; i < 10; i++)
+            {
+                session.Events.Append(Guid.NewGuid(), new BatchTelemetryEvent());
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        await daemon.Tracker.WaitForShardState(new ShardState("BatchTelemetryStream:All", 10), 30.Seconds());
+        await daemon.Tracker.WaitForShardState(new ShardState("OtherBatchTelemetry:All", 10), 30.Seconds());
+
+        // Stop the daemon so nothing else races telemetry writes into the rows we assert on
+        await daemon.StopAllAsync();
+    }
+
+    private static ShardState telemetry(string shard, string status, string? reason = null, int? node = null)
+    {
+        return new ShardState(shard, 10)
+        {
+            Action = ShardAction.Updated,
+            AgentStatus = status,
+            PauseReason = reason,
+            LastHeartbeat = DateTimeOffset.UtcNow,
+            RunningOnNode = node
+        };
+    }
+
+    [Fact]
+    public async Task updates_every_existing_row_in_one_batch()
+    {
+        await startCaughtUpDaemonAsync();
+
+        var database = (MartenDatabase)theStore.Storage.Database;
+
+        await database.WriteExtendedProgressionAsync([
+            telemetry("BatchTelemetryStream:All", "Running", node: 3),
+            telemetry("OtherBatchTelemetry:All", "Paused", "boom", node: 7)
+        ]);
+
+        var first = await readRowAsync("BatchTelemetryStream:All");
+        first.status.ShouldBe("Running");
+        first.heartbeat.ShouldNotBeNull();
+        first.reason.ShouldBeNull();
+        Convert.ToInt32(first.node).ShouldBe(3);
+
+        var second = await readRowAsync("OtherBatchTelemetry:All");
+        second.status.ShouldBe("Paused");
+        second.reason.ShouldBe("boom");
+        Convert.ToInt32(second.node).ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task never_inserts_a_row_and_never_touches_progression()
+    {
+        await startCaughtUpDaemonAsync();
+
+        var database = (MartenDatabase)theStore.Storage.Database;
+        var rowsBefore = await countRowsAsync();
+
+        await database.WriteExtendedProgressionAsync([
+            telemetry("BatchTelemetryStream:All", "Running"),
+            // A shard that has never committed progression: no row to decorate, must be skipped
+            // silently, exactly like the single-state function
+            telemetry("NoSuchProjection:All:98123456", "Running")
+        ]);
+
+        var updated = await readRowAsync("BatchTelemetryStream:All");
+        updated.status.ShouldBe("Running");
+        Convert.ToInt64(updated.seq).ShouldBe(10); // committed progress untouched
+
+        (await countRowsAsync()).ShouldBe(rowsBefore); // and nothing was inserted
+        var missing = await readRowAsync("NoSuchProjection:All:98123456");
+        missing.status.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task an_empty_batch_is_a_no_op_and_a_single_state_batch_delegates()
+    {
+        await startCaughtUpDaemonAsync();
+
+        var database = (MartenDatabase)theStore.Storage.Database;
+
+        await database.WriteExtendedProgressionAsync(Array.Empty<ShardState>());
+
+        await database.WriteExtendedProgressionAsync([
+            telemetry("BatchTelemetryStream:All", "Stopped")
+        ]);
+
+        var row = await readRowAsync("BatchTelemetryStream:All");
+        row.status.ShouldBe("Stopped");
+    }
+}

--- a/src/Marten/Storage/MartenDatabase.EventStorage.cs
+++ b/src/Marten/Storage/MartenDatabase.EventStorage.cs
@@ -78,6 +78,75 @@ public partial class MartenDatabase : IEventDatabase
         }
     }
 
+    /// <summary>
+    ///     Persist the extended progression telemetry for a whole batch of shards in ONE round trip on
+    ///     ONE rented connection. The JasperFx.Events <c>ExtendedProgressionWriter</c> coalesces every
+    ///     shard's heartbeat on a database into one batch per flush interval and drives this overload,
+    ///     because the per-shard single-row write does not scale under per-tenant agent fan-out
+    ///     (agents = projections × tenants — jasperfx#553). Deliberately a plain UPDATE ... FROM unnest
+    ///     join instead of a new batched database function, so no schema object is added and deployments
+    ///     running <c>AutoCreate.None</c> pick the batching up without a migration. Semantics match
+    ///     <c>mt_mark_event_progression_extended</c> exactly: update-only telemetry decoration of
+    ///     existing progression rows — never INSERT, never touch <c>last_seq_id</c> / <c>last_updated</c>,
+    ///     shards without a progression row yet are skipped silently.
+    /// </summary>
+    public async Task WriteExtendedProgressionAsync(IReadOnlyList<ShardState> states, CancellationToken token = default)
+    {
+        if (states.Count == 0)
+        {
+            return;
+        }
+
+        if (states.Count == 1)
+        {
+            await WriteExtendedProgressionAsync(states[0], token).ConfigureAwait(false);
+            return;
+        }
+
+        await EnsureStorageExistsAsync(typeof(IEvent), token).ConfigureAwait(false);
+
+        var names = new string[states.Count];
+        var heartbeats = new DateTimeOffset?[states.Count];
+        var statuses = new string?[states.Count];
+        var reasons = new string?[states.Count];
+        var nodes = new int?[states.Count];
+
+        for (var i = 0; i < states.Count; i++)
+        {
+            names[i] = states[i].ShardName;
+            heartbeats[i] = states[i].LastHeartbeat;
+            statuses[i] = states[i].AgentStatus;
+            reasons[i] = states[i].PauseReason;
+            nodes[i] = states[i].RunningOnNode;
+        }
+
+        await using var conn = CreateConnection();
+        try
+        {
+            await conn.OpenAsync(token).ConfigureAwait(false);
+            await conn.CreateCommand($"""
+                update {Options.EventGraph.DatabaseSchemaName}.mt_event_progression as p
+                set heartbeat = t.heartbeat,
+                    agent_status = t.agent_status,
+                    pause_reason = t.pause_reason,
+                    running_on_node = t.running_on_node
+                from unnest(:names, :heartbeats, :statuses, :reasons, :nodes)
+                    as t(name, heartbeat, agent_status, pause_reason, running_on_node)
+                where p.name = t.name
+                """)
+                .With("names", names, NpgsqlDbType.Array | NpgsqlDbType.Varchar)
+                .With("heartbeats", heartbeats, NpgsqlDbType.Array | NpgsqlDbType.TimestampTz)
+                .With("statuses", statuses, NpgsqlDbType.Array | NpgsqlDbType.Varchar)
+                .With("reasons", reasons, NpgsqlDbType.Array | NpgsqlDbType.Text)
+                .With("nodes", nodes, NpgsqlDbType.Array | NpgsqlDbType.Integer)
+                .ExecuteNonQueryAsync(token).ConfigureAwait(false);
+        }
+        finally
+        {
+            await conn.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
     public async Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token)
     {
         var sql =


### PR DESCRIPTION
The Marten half of jasperfx#553 (pairs with JasperFx/jasperfx PR "Batch extended-progression heartbeat writes per database flush interval").

The JasperFx.Events `ExtendedProgressionWriter` now coalesces every shard's heartbeat on a database into one batch per flush interval and drives a new batched `IEventDatabase.WriteExtendedProgressionAsync` overload, because the per-shard single-row write does not scale under per-tenant agent fan-out (agents = projections × tenants): on a sharded multi-tenant deployment the one-connection-rent-per-shard-per-interval write path produced ~780 `mt_mark_event_progression_extended` calls/sec per shard database and drove the server to its connection ceiling.

Marten's implementation lands the whole batch in **one round trip on one rented connection**, as a plain `UPDATE ... FROM unnest` join rather than a new batched database function — **no schema object is added**, so deployments running `AutoCreate.None` pick the batching up without a migration. Semantics match `mt_mark_event_progression_extended` exactly: update-only telemetry decoration of existing progression rows, never INSERT, never touch `last_seq_id` / `last_updated`, shards without a progression row are skipped silently. Single-state batches delegate to the existing function path.

The method compiles against JasperFx.Events 2.33.1 as a plain overload and becomes the interface implementation automatically once the dependency bumps to the JasperFx.Events release carrying the batched default interface member. Verified locally against a 2.33.2 pre-release pack of the JasperFx PR: the daemon → `ExtendedProgressionWriter` → `MartenDatabase` path dispatches into the batch overload and the existing `Bug_5001_running_on_node_persisted` tests still pass.

New `DaemonTests.extended_progression_batch_write` covers: multi-shard batch updates in one call, never-insert + progression untouched (missing shard skipped silently), and empty/single-state batches.
