### PR TITLE
feat: StreamPaged<T> - stream a paged JSON envelope in a single round-trip (fixes #5009)

### DIFF
--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -237,11 +237,12 @@ that dispatch any `IResult` return value), `Marten.AspNetCore` ships three typed
 result wrappers that carry the streaming behavior above as endpoint return values
 while also contributing correct OpenAPI metadata:
 
-| Type                 | Source                                           | Response shape    | 404 on miss?           |
-| -------------------- | ------------------------------------------------ | ----------------- | ---------------------- |
-| `StreamOne<T>`       | `IQueryable<T>` — regular Marten document query  | Single `T`        | yes                    |
-| `StreamMany<T>`      | `IQueryable<T>` — regular Marten document query  | JSON array `T[]`  | no (empty array = 200) |
-| `StreamAggregate<T>` | `IDocumentSession` + stream id — event-sourced   | Single `T`        | yes                    |
+| Type                 | Source                                          | Response shape      | 404 on miss?           |
+|----------------------|-------------------------------------------------|---------------------|------------------------|
+| `StreamOne<T>`       | `IQueryable<T>` — regular Marten document query | Single `T`          | yes                    |
+| `StreamMany<T>`      | `IQueryable<T>` — regular Marten document query | JSON array `T[]`    | no (empty array = 200) |
+| `StreamAggregate<T>` | `IDocumentSession` + stream id — event-sourced  | Single `T`          | yes                    |
+| `StreamPaged<T>`     | `IQueryable<T>` — regular Marten document query | Paged JSON envelope | no (empty page = 200)  |
 
 Each type implements both `IResult` (so ASP.NET Minimal API dispatches it via
 `ExecuteAsync`) and `IEndpointMetadataProvider` (so Swashbuckle, NSwag, and the
@@ -272,6 +273,34 @@ app.MapGet("/issues/open",
 
 Returns `200 application/json` with a JSON array body. An empty result set
 yields `[]`, not a 404 — matching the behavior of `WriteArray<T>`.
+
+### `StreamPaged<T>` — paged JSON envelope (single round trip) <Badge type="tip" text="9.18" />
+
+```csharp
+app.MapGet("/issues/paged/{pageNumber:int}/{pageSize:int}",
+    (int pageNumber, int pageSize, IQuerySession session) =>
+        new StreamPaged<Issue>(session.Query<Issue>().OrderBy(x => x.Description), pageNumber, pageSize));
+```
+
+Returns `200 application/json` with a single JSON envelope combining paging
+metadata and the matching documents for that page:
+
+```json
+{"pageNumber":3,"pageSize":25,"totalItemCount":1207,"pageCount":49,"hasNextPage":true,"hasPreviousPage":true,"items":[...]}
+```
+
+`pageNumber` is 1-based. `totalItemCount` and `pageCount` are computed from a
+`count(*) OVER()` window function added to the _same_ SQL query that fetches
+the page, so the whole response -- count and documents both -- comes from a
+single database round trip. Documents inside `items` are streamed as raw,
+already-persisted JSON, without a deserialize/serialize step. An empty page
+still returns `200` with `totalItemCount: 0`, `pageCount: 0`, and an empty
+`items` array -- never a `404`.
+
+Internally, `StreamPaged<T>` delegates to the `IQueryable<T>.StreamPagedJsonArray()`
+extension method described in the [Paging](/documents/querying/linq/paging) docs,
+which can also be used directly (e.g. from an MVC controller action) instead of
+through the `IResult` wrapper.
 
 ### `StreamAggregate<T>` — event-sourced aggregate (latest)
 

--- a/docs/documents/querying/linq/paging.md
+++ b/docs/documents/querying/linq/paging.md
@@ -90,3 +90,35 @@ where CAST(d.data ->> 'Number' as integer) > :arg0 LIMIT 5
 ```
 
 The `Stats()` Linq operator can be used in conjunction with `Include()` and within batch queries. Compiled queries also support `QueryStatistics` by declaring a `QueryStatistics Stats { get; } = new QueryStatistics()` property on the compiled query class.
+
+## Streaming a Paged JSON Envelope <Badge type="tip" text="9.18" />
+
+For HTTP endpoints that need to return a page of documents together with paging metadata,
+`Marten.AspNetCore` provides `StreamPagedJsonArray<T>()`, an `IQueryable<T>` extension method
+that writes a single JSON envelope straight to a `Stream`:
+
+```json
+{"pageNumber":3,"pageSize":25,"totalItemCount":1207,"pageCount":49,"hasNextPage":true,"hasPreviousPage":true,"items":[...]}
+```
+
+Like `Stats()` above, this uses the `count(*) OVER()` window function to get the total row
+count in the _same_ SQL query used to fetch the page of documents -- a single database round
+trip for the whole paged response. Unlike `Stats()` + `ToListAsync()` though, the matching
+documents are streamed as raw, already-persisted JSON directly into the `items` array without
+ever being deserialized into .NET objects or serialized back to JSON.
+
+```csharp
+var pageNumber = 3;
+var pageSize = 25;
+
+await theSession.Query<Target>()
+    .Where(x => x.Flag)
+    .StreamPagedJsonArray(httpResponseStream, pageNumber, pageSize);
+```
+
+If the page has zero matching rows, the envelope still comes back with a `200`-shaped body:
+`totalItemCount: 0`, `pageCount: 0`, `hasNextPage: false`, and an empty `items` array.
+
+For Minimal API / Wolverine.Http endpoints, prefer the higher-level `StreamPaged<T>` result
+type described in the [Marten.AspNetCore](/documents/aspnetcore) docs,
+which wraps this same extension method as an `IResult`.

--- a/src/DocumentDbTests/Reading/Json/streaming_json_results.cs
+++ b/src/DocumentDbTests/Reading/Json/streaming_json_results.cs
@@ -1057,4 +1057,148 @@ public class streaming_json_results : IntegrationContext
             actual.Length.ShouldBe(expected);
         }
     }
+
+    private class PagedEnvelope<T>
+    {
+        public int PageNumber { get; set; }
+        public int PageSize { get; set; }
+        public int TotalItemCount { get; set; }
+        public int PageCount { get; set; }
+        public bool HasNextPage { get; set; }
+        public bool HasPreviousPage { get; set; }
+        public T[] Items { get; set; }
+    }
+
+    private async Task<PagedEnvelope<Target>> streamPage(IQueryable<Target> queryable, int pageNumber, int pageSize)
+    {
+        var stream = new MemoryStream();
+        await queryable.StreamPagedJsonArray(stream, pageNumber, pageSize);
+        stream.Position = 0;
+
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        return await System.Text.Json.JsonSerializer.DeserializeAsync<PagedEnvelope<Target>>(stream, options);
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_first_page()
+    {
+        var targets = Target.GenerateRandomData(10).ToArray();
+        for (var i = 0; i < targets.Length; i++) targets[i].Number = i;
+        await theStore.BulkInsertAsync(targets);
+
+        var envelope = await streamPage(theSession.Query<Target>().OrderBy(x => x.Number), 1, 3);
+
+        envelope.PageNumber.ShouldBe(1);
+        envelope.PageSize.ShouldBe(3);
+        envelope.TotalItemCount.ShouldBe(10);
+        envelope.PageCount.ShouldBe(4);
+        envelope.HasNextPage.ShouldBeTrue();
+        envelope.HasPreviousPage.ShouldBeFalse();
+        envelope.Items.Length.ShouldBe(3);
+        envelope.Items.Select(x => x.Number).ShouldBe(new[] { 0, 1, 2 });
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_middle_page()
+    {
+        var targets = Target.GenerateRandomData(10).ToArray();
+        for (var i = 0; i < targets.Length; i++) targets[i].Number = i;
+        await theStore.BulkInsertAsync(targets);
+
+        var envelope = await streamPage(theSession.Query<Target>().OrderBy(x => x.Number), 2, 3);
+
+        envelope.PageNumber.ShouldBe(2);
+        envelope.PageSize.ShouldBe(3);
+        envelope.TotalItemCount.ShouldBe(10);
+        envelope.PageCount.ShouldBe(4);
+        envelope.HasNextPage.ShouldBeTrue();
+        envelope.HasPreviousPage.ShouldBeTrue();
+        envelope.Items.Length.ShouldBe(3);
+        envelope.Items.Select(x => x.Number).ShouldBe(new[] { 3, 4, 5 });
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_last_partial_page()
+    {
+        var targets = Target.GenerateRandomData(10).ToArray();
+        for (var i = 0; i < targets.Length; i++) targets[i].Number = i;
+        await theStore.BulkInsertAsync(targets);
+
+        var envelope = await streamPage(theSession.Query<Target>().OrderBy(x => x.Number), 4, 3);
+
+        envelope.PageNumber.ShouldBe(4);
+        envelope.PageSize.ShouldBe(3);
+        envelope.TotalItemCount.ShouldBe(10);
+        envelope.PageCount.ShouldBe(4);
+        envelope.HasNextPage.ShouldBeFalse();
+        envelope.HasPreviousPage.ShouldBeTrue();
+        envelope.Items.Length.ShouldBe(1);
+        envelope.Items.Select(x => x.Number).ShouldBe(new[] { 9 });
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_single_page()
+    {
+        var targets = Target.GenerateRandomData(5).ToArray();
+        await theStore.BulkInsertAsync(targets);
+
+        var envelope = await streamPage(theSession.Query<Target>(), 1, 25);
+
+        envelope.PageNumber.ShouldBe(1);
+        envelope.PageSize.ShouldBe(25);
+        envelope.TotalItemCount.ShouldBe(5);
+        envelope.PageCount.ShouldBe(1);
+        envelope.HasNextPage.ShouldBeFalse();
+        envelope.HasPreviousPage.ShouldBeFalse();
+        envelope.Items.Length.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_no_hits()
+    {
+        var envelope = await streamPage(theSession.Query<Target>().Where(x => x.Id == Guid.NewGuid()), 1, 10);
+
+        envelope.PageNumber.ShouldBe(1);
+        envelope.PageSize.ShouldBe(10);
+        envelope.TotalItemCount.ShouldBe(0);
+        envelope.PageCount.ShouldBe(0);
+        envelope.HasNextPage.ShouldBeFalse();
+        envelope.HasPreviousPage.ShouldBeFalse();
+        envelope.Items.ShouldNotBeNull();
+        envelope.Items.Length.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_no_hits_beyond_first_page_has_previous_page()
+    {
+        var envelope = await streamPage(theSession.Query<Target>().Where(x => x.Id == Guid.NewGuid()), 3, 10);
+
+        envelope.TotalItemCount.ShouldBe(0);
+        envelope.HasPreviousPage.ShouldBeTrue();
+        envelope.HasNextPage.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_throws_for_page_number_below_one()
+    {
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(async () =>
+        {
+            var stream = new MemoryStream();
+            await theSession.Query<Target>().StreamPagedJsonArray(stream, 0, 10);
+        });
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_throws_for_page_size_below_one()
+    {
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(async () =>
+        {
+            var stream = new MemoryStream();
+            await theSession.Query<Target>().StreamPagedJsonArray(stream, 1, 0);
+        });
+    }
 }

--- a/src/IssueService/StreamingMinimalEndpoints.cs
+++ b/src/IssueService/StreamingMinimalEndpoints.cs
@@ -53,6 +53,14 @@ public static class StreamingMinimalEndpoints
             (IQuerySession session)
                 => new StreamMany<Issue>(session.Query<Issue>().Where(x => x.Id == Guid.Empty)));
 
+        // --- StreamPaged<T> ---
+
+        app.MapGet("/minimal/issues/paged/{pageNumber:int}/{pageSize:int}",
+            (int pageNumber, int pageSize, IQuerySession session)
+                => new StreamPaged<Issue>(
+                    session.Query<Issue>().Where(x => x.Open).OrderBy(x => x.Description),
+                    pageNumber, pageSize));
+
         // --- StreamAggregate<T> ---
 
         app.MapGet("/minimal/order/{id:guid}",

--- a/src/Marten.AspNetCore.Testing/stream_paged_tests.cs
+++ b/src/Marten.AspNetCore.Testing/stream_paged_tests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Alba;
+using IssueService.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Marten.AspNetCore.Testing;
+
+/// <summary>
+/// Alba-based tests for <see cref="StreamPaged{T}"/> executing against a plain
+/// Minimal API endpoint (no Wolverine required).
+/// </summary>
+[Collection("integration")]
+public class stream_paged_tests: IntegrationContext
+{
+    private readonly IAlbaHost theHost;
+
+    public stream_paged_tests(AppFixture fixture) : base(fixture)
+    {
+        theHost = fixture.Host;
+    }
+
+    private class PagedEnvelope<T>
+    {
+        public int PageNumber { get; set; }
+        public int PageSize { get; set; }
+        public int TotalItemCount { get; set; }
+        public int PageCount { get; set; }
+        public bool HasNextPage { get; set; }
+        public bool HasPreviousPage { get; set; }
+        public T[] Items { get; set; }
+    }
+
+    private async Task seedOpenIssues(int count, string prefix)
+    {
+        await using var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        for (var i = 0; i < count; i++)
+        {
+            session.Store(new Issue { Description = $"{prefix}_{i:D3}", Open = true });
+        }
+
+        await session.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task first_page_of_multiple_pages()
+    {
+        await seedOpenIssues(10, "page1_" + Guid.NewGuid().ToString("N")[..8]);
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/issues/paged/1/3");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var envelope = result.ReadAsJson<PagedEnvelope<Issue>>();
+
+        envelope.PageNumber.ShouldBe(1);
+        envelope.PageSize.ShouldBe(3);
+        envelope.TotalItemCount.ShouldBe(10);
+        envelope.PageCount.ShouldBe(4);
+        envelope.HasNextPage.ShouldBeTrue();
+        envelope.HasPreviousPage.ShouldBeFalse();
+        envelope.Items.Length.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task middle_page_of_multiple_pages()
+    {
+        await seedOpenIssues(10, "page2_" + Guid.NewGuid().ToString("N")[..8]);
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/issues/paged/2/3");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var envelope = result.ReadAsJson<PagedEnvelope<Issue>>();
+
+        envelope.PageNumber.ShouldBe(2);
+        envelope.PageSize.ShouldBe(3);
+        envelope.TotalItemCount.ShouldBe(10);
+        envelope.PageCount.ShouldBe(4);
+        envelope.HasNextPage.ShouldBeTrue();
+        envelope.HasPreviousPage.ShouldBeTrue();
+        envelope.Items.Length.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task last_page_may_be_partial()
+    {
+        await seedOpenIssues(10, "page3_" + Guid.NewGuid().ToString("N")[..8]);
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/issues/paged/4/3");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var envelope = result.ReadAsJson<PagedEnvelope<Issue>>();
+
+        envelope.PageNumber.ShouldBe(4);
+        envelope.PageSize.ShouldBe(3);
+        envelope.TotalItemCount.ShouldBe(10);
+        envelope.PageCount.ShouldBe(4);
+        envelope.HasNextPage.ShouldBeFalse();
+        envelope.HasPreviousPage.ShouldBeTrue();
+        envelope.Items.Length.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task single_page_result()
+    {
+        await seedOpenIssues(3, "page4_" + Guid.NewGuid().ToString("N")[..8]);
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/issues/paged/1/25");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var envelope = result.ReadAsJson<PagedEnvelope<Issue>>();
+
+        envelope.PageNumber.ShouldBe(1);
+        envelope.PageSize.ShouldBe(25);
+        envelope.TotalItemCount.ShouldBe(3);
+        envelope.PageCount.ShouldBe(1);
+        envelope.HasNextPage.ShouldBeFalse();
+        envelope.HasPreviousPage.ShouldBeFalse();
+        envelope.Items.Length.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task empty_result_set()
+    {
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/issues/paged/1/10");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var envelope = result.ReadAsJson<PagedEnvelope<Issue>>();
+
+        envelope.PageNumber.ShouldBe(1);
+        envelope.PageSize.ShouldBe(10);
+        envelope.TotalItemCount.ShouldBe(0);
+        envelope.PageCount.ShouldBe(0);
+        envelope.HasNextPage.ShouldBeFalse();
+        envelope.HasPreviousPage.ShouldBeFalse();
+        envelope.Items.ShouldNotBeNull();
+        envelope.Items.Length.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task empty_result_set_on_page_beyond_first_reports_has_previous_page()
+    {
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/issues/paged/2/10");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var envelope = result.ReadAsJson<PagedEnvelope<Issue>>();
+
+        envelope.TotalItemCount.ShouldBe(0);
+        envelope.HasPreviousPage.ShouldBeTrue();
+        envelope.HasNextPage.ShouldBeFalse();
+        envelope.Items.Length.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task items_are_in_expected_order_across_pages()
+    {
+        var prefix = "order_" + Guid.NewGuid().ToString("N")[..8];
+        await seedOpenIssues(10, prefix);
+
+        var page1 = await theHost.Scenario(s => s.Get.Url("/minimal/issues/paged/1/5"));
+        var page2 = await theHost.Scenario(s => s.Get.Url("/minimal/issues/paged/2/5"));
+
+        var envelope1 = page1.ReadAsJson<PagedEnvelope<Issue>>();
+        var envelope2 = page2.ReadAsJson<PagedEnvelope<Issue>>();
+
+        var allDescriptions = envelope1.Items.Select(x => x.Description)
+            .Concat(envelope2.Items.Select(x => x.Description))
+            .ToArray();
+
+        allDescriptions.ShouldBe(allDescriptions.OrderBy(x => x).ToArray());
+        allDescriptions.Distinct().Count().ShouldBe(10);
+    }
+}

--- a/src/Marten.AspNetCore/QueryableExtensions.cs
+++ b/src/Marten.AspNetCore/QueryableExtensions.cs
@@ -67,6 +67,35 @@ public static class QueryableExtensions
     }
 
     /// <summary>
+    /// Write a single "page" of results from the Linq query as a JSON envelope -- containing
+    /// paging metadata (pageNumber, pageSize, totalItemCount, pageCount, hasNextPage,
+    /// hasPreviousPage) and the matching documents ("items") -- to the HttpContext response.
+    /// This is a single round-trip to the database: the total item count is retrieved via a
+    /// <c>count(*) OVER()</c> window function in the same query used to fetch the page of documents.
+    /// </summary>
+    /// <param name="queryable"></param>
+    /// <param name="context"></param>
+    /// <param name="pageNumber">1-based page number</param>
+    /// <param name="pageSize"></param>
+    /// <param name="contentType"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
+    /// <typeparam name="T"></typeparam>
+    public static async Task WritePaged<T>(
+        this IQueryable<T> queryable,
+        HttpContext context,
+        int pageNumber,
+        int pageSize,
+        string contentType = "application/json",
+        int onFoundStatus = 200
+    )
+    {
+        context.Response.StatusCode = onFoundStatus;
+        context.Response.ContentType = contentType;
+
+        await queryable.StreamPagedJsonArray(context.Response.Body, pageNumber, pageSize, context.RequestAborted).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Quickly write the JSON for a document by Id to an HttpContext. Will also handle status code mechanics
     /// </summary>
     /// <param name="json"></param>

--- a/src/Marten.AspNetCore/StreamPaged.cs
+++ b/src/Marten.AspNetCore/StreamPaged.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Marten.AspNetCore;
+
+/// <summary>
+/// Minimal-API / Wolverine.Http endpoint return value that streams a single "page" of
+/// documents from the Linq query, along with paging metadata, directly to the
+/// <see cref="HttpContext.Response"/> as a single JSON envelope:
+/// <code>
+/// {"pageNumber":3,"pageSize":25,"totalItemCount":1207,"pageCount":49,"hasNextPage":true,"hasPreviousPage":true,"items":[...]}
+/// </code>
+/// Uses <see cref="QueryableExtensions.WritePaged{T}"/> under the hood, which makes exactly
+/// one round trip to the database -- the total item count across all pages is retrieved via
+/// a <c>count(*) OVER()</c> window function in the same query used to fetch the page of
+/// documents, and the matching documents are streamed as raw, already-persisted JSON without
+/// a deserialize/serialize round-trip.
+/// <para>
+/// Unlike <see cref="StreamOne{T}"/>, this type never returns 404: an empty result
+/// set yields <c>totalItemCount: 0</c> and an empty <c>items</c> array with status
+/// <see cref="OnFoundStatus"/> (default 200).
+/// </para>
+/// </summary>
+/// <typeparam name="T">The document type contained in the page.</typeparam>
+public sealed class StreamPaged<T> : IResult, IEndpointMetadataProvider where T : notnull
+{
+    private readonly IQueryable<T> _queryable;
+    private readonly int _pageNumber;
+    private readonly int _pageSize;
+
+    /// <summary>
+    /// Create a <see cref="StreamPaged{T}"/> wrapping a Marten <see cref="IQueryable{T}"/>.
+    /// A single page of matching documents, plus paging metadata, is streamed as a JSON
+    /// envelope.
+    /// </summary>
+    /// <param name="queryable">The Marten Linq query to page over.</param>
+    /// <param name="pageNumber">1-based page number.</param>
+    /// <param name="pageSize">The number of items per page.</param>
+    public StreamPaged(IQueryable<T> queryable, int pageNumber, int pageSize)
+    {
+        _queryable = queryable ?? throw new ArgumentNullException(nameof(queryable));
+
+        if (pageNumber < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageNumber), $"pageNumber = {pageNumber}. PageNumber cannot be below 1.");
+        }
+
+        if (pageSize < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageSize), $"pageSize = {pageSize}. PageSize cannot be below 1.");
+        }
+
+        _pageNumber = pageNumber;
+        _pageSize = pageSize;
+    }
+
+    /// <summary>
+    /// Status code written with the response. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
+        return _queryable.WritePaged(httpContext, _pageNumber, _pageSize, ContentType, OnFoundStatus);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI correctly advertises a
+    /// <c>200</c> response with a paged envelope for this endpoint. No 404 is advertised
+    /// because an empty page is a valid response.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(PagedResult<T>), new[] { "application/json" }));
+    }
+}
+
+/// <summary>
+/// Shape of the JSON envelope streamed by <see cref="StreamPaged{T}"/>. Used only for
+/// OpenAPI metadata generation -- <see cref="StreamPaged{T}"/> itself streams the raw JSON
+/// directly and never materializes this type.
+/// </summary>
+/// <typeparam name="T">The document type contained in the page.</typeparam>
+public sealed class PagedResult<T>
+{
+    /// <summary>1-based page number.</summary>
+    public int PageNumber { get; set; }
+
+    /// <summary>The number of items per page.</summary>
+    public int PageSize { get; set; }
+
+    /// <summary>The total number of items across all pages.</summary>
+    public int TotalItemCount { get; set; }
+
+    /// <summary>The total number of pages.</summary>
+    public int PageCount { get; set; }
+
+    /// <summary>Whether there is a page after this one.</summary>
+    public bool HasNextPage { get; set; }
+
+    /// <summary>Whether there is a page before this one.</summary>
+    public bool HasPreviousPage { get; set; }
+
+    /// <summary>The documents on this page.</summary>
+    public T[] Items { get; set; } = Array.Empty<T>();
+}

--- a/src/Marten/Internal/Sessions/QuerySession.Execution.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Execution.cs
@@ -5,6 +5,7 @@ using System.Data.Common;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Marten.Linq;
 using Marten.Linq.QueryHandlers;
 using Marten.Linq.Selectors;
 using Marten.Services;
@@ -93,6 +94,21 @@ public partial class QuerySession
         try
         {
             return await reader.StreamMany(stream, token).ConfigureAwait(false);
+        }
+        finally
+        {
+            await reader.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
+    internal async Task<int> StreamPagedMany(DbCommand command, Stream stream, int pageNumber, int pageSize,
+        QueryStatistics statistics, CancellationToken token)
+    {
+        await using var reader = await ExecuteReaderAsync(command, token).ConfigureAwait(false);
+
+        try
+        {
+            return await reader.StreamPagedMany(stream, pageNumber, pageSize, statistics, token).ConfigureAwait(false);
         }
         finally
         {

--- a/src/Marten/Linq/MartenLinqQueryProvider.cs
+++ b/src/Marten/Linq/MartenLinqQueryProvider.cs
@@ -185,6 +185,26 @@ internal class MartenLinqQueryProvider: IQueryProvider
         return await _session.StreamMany(command, destination, token).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Stream a single "page" of results plus paging metadata (total item count, page count, etc.)
+    /// as a JSON envelope directly to <paramref name="destination"/> in one round trip to the database.
+    /// The total row count is retrieved via the same <c>count(*) OVER()</c> mechanism used by
+    /// <see cref="QueryStatistics"/> / <see cref="MartenLinqQueryable{T}.Stats"/>.
+    /// </summary>
+    public async Task<int> StreamPagedMany(Expression expression, Stream destination, int pageNumber, int pageSize,
+        QueryStatistics statistics, CancellationToken token)
+    {
+        var parser = new LinqQueryParser(this, _session, expression);
+
+        await EnsureStorageExistsAsync(parser, token).ConfigureAwait(false);
+
+        var statements = parser.BuildStatements();
+
+        var command = statements.Top.BuildCommand(_session);
+
+        return await _session.StreamPagedMany(command, destination, pageNumber, pageSize, statistics, token).ConfigureAwait(false);
+    }
+
     public async Task<bool> StreamOne(Expression expression, Stream destination, CancellationToken token)
     {
         var parser = new LinqQueryParser(this, _session, expression);

--- a/src/Marten/Linq/MartenLinqQueryable.cs
+++ b/src/Marten/Linq/MartenLinqQueryable.cs
@@ -252,6 +252,26 @@ internal class MartenLinqQueryable<T> : IOrderedQueryable<T>, IMartenQueryable<T
         return MartenProvider.StreamMany(Expression, destination, token);
     }
 
+    public Task<int> StreamPagedJsonArray(Stream destination, int pageNumber, int pageSize, CancellationToken token)
+    {
+        if (pageNumber < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageNumber), $"pageNumber = {pageNumber}. PageNumber cannot be below 1.");
+        }
+
+        if (pageSize < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageSize), $"pageSize = {pageSize}. PageSize cannot be below 1.");
+        }
+
+        Statistics = new QueryStatistics();
+        var statistics = Statistics;
+
+        var paged = ((IQueryable<T>)this).Skip((pageNumber - 1) * pageSize).Take(pageSize).As<MartenLinqQueryable<T>>();
+
+        return paged.MartenProvider.StreamPagedMany(paged.Expression, destination, pageNumber, pageSize, statistics, token);
+    }
+
     public NpgsqlCommand ToPreviewCommand(FetchType fetchType)
     {
         var parser = new LinqQueryParser(MartenProvider, Session, Expression);

--- a/src/Marten/QueryableExtensions.cs
+++ b/src/Marten/QueryableExtensions.cs
@@ -262,6 +262,27 @@ public static class QueryableExtensions
         return queryable.As<MartenLinqQueryable<T>>().ToJsonArray(token);
     }
 
+    /// <summary>
+    ///     Write a single "page" of results from the Linq query as a JSON envelope containing
+    ///     paging metadata (pageNumber, pageSize, totalItemCount, pageCount, hasNextPage,
+    ///     hasPreviousPage) and the raw persisted JSON for the matching documents ("items"),
+    ///     directly to the destination stream. This makes exactly one round trip to the
+    ///     database by using a <c>count(*) OVER()</c> window function to retrieve the total
+    ///     item count in the same query used to fetch the page of documents.
+    /// </summary>
+    /// <param name="queryable"></param>
+    /// <param name="destination"></param>
+    /// <param name="pageNumber">1-based page number</param>
+    /// <param name="pageSize"></param>
+    /// <param name="token"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns>The total number of items across all pages</returns>
+    public static Task<int> StreamPagedJsonArray<T>(this IQueryable<T> queryable, Stream destination, int pageNumber,
+        int pageSize, CancellationToken token = default) where T : notnull
+    {
+        return queryable.As<MartenLinqQueryable<T>>().StreamPagedJsonArray(destination, pageNumber, pageSize, token);
+    }
+
     public static Task StreamJsonFirst<T>(this IQueryable<T> queryable, Stream destination,
         CancellationToken token = default) where T : notnull
     {

--- a/src/Marten/Services/JsonStreamingExtensions.cs
+++ b/src/Marten/Services/JsonStreamingExtensions.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Data.Common;
+using Marten.Linq;
 using Marten.Util;
 
 namespace Marten.Services;
@@ -60,6 +61,58 @@ internal static class JsonStreamingExtensions
         await stream.WriteBytes(RightBracket, token).ConfigureAwait(false);
 
         return count;
+    }
+
+    /// <summary>
+    /// Streams a single "page" of documents plus paging metadata as a JSON envelope of the shape
+    /// <c>{"pageNumber":1,"pageSize":25,"totalItemCount":100,"pageCount":4,"hasNextPage":true,"hasPreviousPage":false,"items":[...]}</c>
+    /// directly to <paramref name="stream"/>. The reader is expected to have a <c>total_rows</c>
+    /// column (added by <c>count(*) OVER()</c>) alongside the document "data" column.
+    /// </summary>
+    internal static async Task<int> StreamPagedMany(this DbDataReader reader, Stream stream, int pageNumber,
+        int pageSize, QueryStatistics statistics, CancellationToken token)
+    {
+        var ordinal = reader.FieldCount == 1 ? 0 : reader.GetOrdinal("data");
+
+        await stream.WriteBytes(Encoding.UTF8.GetBytes($"{{\"pageNumber\":{pageNumber},\"pageSize\":{pageSize},"), token)
+            .ConfigureAwait(false);
+
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            statistics.TotalResults = 0;
+
+            await stream.WriteBytes(Encoding.UTF8.GetBytes(
+                    $"\"totalItemCount\":0,\"pageCount\":0,\"hasNextPage\":false,\"hasPreviousPage\":{(pageNumber > 1 ? "true" : "false")},\"items\":[]}}"),
+                    token)
+                .ConfigureAwait(false);
+
+            return 0;
+        }
+
+        var totalRowsOrdinal = reader.GetOrdinal("total_rows");
+        var totalItemCount = await reader.GetFieldValueAsync<int>(totalRowsOrdinal, token).ConfigureAwait(false);
+        statistics.TotalResults = totalItemCount;
+
+        var pageCount = totalItemCount > 0 ? (int)Math.Ceiling(totalItemCount / (double)pageSize) : 0;
+        var hasNextPage = pageNumber < pageCount;
+        var hasPreviousPage = pageNumber > 1;
+
+        await stream.WriteBytes(Encoding.UTF8.GetBytes(
+                $"\"totalItemCount\":{totalItemCount},\"pageCount\":{pageCount},\"hasNextPage\":{(hasNextPage ? "true" : "false")},\"hasPreviousPage\":{(hasPreviousPage ? "true" : "false")},\"items\":["),
+                token)
+            .ConfigureAwait(false);
+
+        await reader.WriteJsonValueAsync(ordinal, stream, token).ConfigureAwait(false);
+
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            await stream.WriteBytes(Comma, token).ConfigureAwait(false);
+            await reader.WriteJsonValueAsync(ordinal, stream, token).ConfigureAwait(false);
+        }
+
+        await stream.WriteBytes(Encoding.UTF8.GetBytes("]}"), token).ConfigureAwait(false);
+
+        return totalItemCount;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Adds a new `StreamPaged<T>` result type to `Marten.AspNetCore` that streams a paged list of documents plus paging metadata as a single JSON envelope directly to the HTTP response, in **one** database round trip:

```json
{"pageNumber":3,"pageSize":25,"totalItemCount":1207,"pageCount":49,"hasNextPage":true,"hasPreviousPage":true,"items":[...]}
```

Closes #5009.

## Implementation

- `Marten.Linq.MartenLinqQueryable<T>.StreamPagedJsonArray` - sets `Statistics`, applies `Skip`/`Take`, delegates to the provider.
- `MartenLinqQueryProvider.StreamPagedMany` - builds the LINQ statement/command (which includes `count(*) OVER() as total_rows` via `LinqConstants.StatsColumn` when `Statistics` is set), then executes via the session.
- `QuerySession.StreamPagedMany` + `JsonStreamingExtensions.StreamPagedMany` - reads `total_rows` from the first row of the `DbDataReader`, computes `pageCount`/`hasNextPage`/`hasPreviousPage` (mirroring `PagedList.ProcessResults`), writes the envelope prefix, then streams each row's raw document JSON straight into the `items` array without deserializing/reserializing documents.
- `QueryableExtensions.StreamPagedJsonArray<T>` (Marten core) - public entry point exposing the above.
- `Marten.AspNetCore.QueryableExtensions.WritePaged<T>` + `StreamPaged<T>` (`IResult` + `IEndpointMetadataProvider`, mirroring `StreamMany<T>`) - the minimal-API/Wolverine.Http-facing wrapper.

Zero-row result sets produce `totalItemCount: 0`, `pageCount: 0`, and an empty `items` array (`count(*) OVER()` is not present on any row when nothing matches).

## Tests

- `src/DocumentDbTests/Reading/Json/streaming_json_results.cs` - 8 new `[Fact]`s covering first/middle/last/single page, no-hits, and argument validation (`pageNumber < 1`, `pageSize < 1`). All passing.
- `src/Marten.AspNetCore.Testing/stream_paged_tests.cs` (new) - Alba HTTP-level tests against a new `/minimal/issues/paged/{pageNumber}/{pageSize}` endpoint added to `IssueService`.

## Docs

- `docs/documents/querying/linq/paging.md` - new "Streaming a Paged JSON Envelope" section describing `StreamPagedJsonArray<T>()`.
- `docs/documents/aspnetcore.md` - added `StreamPaged<T>` to the typed streaming result types table and a full usage subsection.
- Verified clean with `markdownlint-cli` (`--disable MD009`) and `cspell` against `docs/**/*.md`.

## Test status

- `DocumentDbTests` (both net9.0 and net10.0, run individually): all 8 new `stream_paged_json_array_*` tests pass.
- `Marten.AspNetCore.Testing`: the whole suite (including pre-existing `streaming_result_types_tests`) currently fails to boot the Alba test host on this branch's base commit due to an unrelated, pre-existing environment issue (`InvalidProjectionException: No source-generated dispatcher found for SingleStreamProjection<Order, Guid>`). Verified this failure is **not** caused by this change - it reproduces identically on a clean, unmodified checkout of `master`.

## Notes

- Running the two test TFMs (net9.0/net10.0) together via `dotnet test` in parallel against the same shared Postgres schema can cause cross-run data contention/deadlocks unrelated to this feature; running each TFM individually avoids this and both pass cleanly.
