### PR TITLE
feat: ETag / If-None-Match (304) support on StreamOne and StreamAggregate (fixes #5010)

### DIFF
--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -295,7 +295,7 @@ ids for stores configured with string-keyed streams.
   projected snapshot if one is configured). Use this when `T` is an
   event-sourced aggregate, not a stored document.
 
-### ETag / conditional request support (`If-None-Match` → `304`)
+### ETag / Conditional Requests <Badge type="tip" text="9.18" />
 
 ::: tip
 `StreamOne<T>` and `StreamAggregate<T>` support HTTP conditional requests.

--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -295,6 +295,61 @@ ids for stores configured with string-keyed streams.
   projected snapshot if one is configured). Use this when `T` is an
   event-sourced aggregate, not a stored document.
 
+### ETag / conditional request support (`If-None-Match` → `304`)
+
+::: tip
+`StreamOne<T>` and `StreamAggregate<T>` support HTTP conditional requests.
+`StreamMany<T>` does not — a collection-wide ETag is harder to derive cheaply
+and is out of scope for the initial implementation.
+:::
+
+Both `StreamOne<T>` and `StreamAggregate<T>` set an `ETag` response header
+by default and honor an incoming `If-None-Match` request header, responding
+`304 Not Modified` with an empty body when the client's cached version is
+still current:
+
+- For `StreamOne<T>`, the ETag is derived from the document's `mt_version`
+  (the same optimistic-concurrency version Marten tracks for every stored
+  document), formatted as a quoted GUID, e.g. `"3f2504e0-4f89-11d3-9a0c-0305e82c3301"`.
+- For `StreamAggregate<T>`, the ETag is derived from the event stream's
+  version (a `long`), formatted as a quoted integer, e.g. `"42"`. The version
+  is looked up before the aggregate is folded, so a cache hit (`304`) skips
+  that work entirely.
+
+```csharp
+app.MapGet("/issues/{id:guid}",
+    (Guid id, IQuerySession session) =>
+        new StreamOne<Issue>(session.Query<Issue>().Where(x => x.Id == id)));
+
+app.MapGet("/orders/{id:guid}",
+    (Guid id, IDocumentSession session) =>
+        new StreamAggregate<Order>(session, id));
+```
+
+A poller can send the previously-received `ETag` value back as `If-None-Match`:
+
+```http
+GET /issues/f47ac10b-58cc-4372-a567-0e02b2c3d479 HTTP/1.1
+If-None-Match: "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+```
+
+```http
+HTTP/1.1 304 Not Modified
+ETag: "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+```
+
+Set `EmitETag = false` to opt out and restore the pre-ETag behavior (no
+`ETag` header, no conditional-request handling):
+
+```csharp
+app.MapGet("/issues/{id:guid}",
+    (Guid id, IQuerySession session) =>
+        new StreamOne<Issue>(session.Query<Issue>().Where(x => x.Id == id))
+        {
+            EmitETag = false
+        });
+```
+
 ### Customizing status code and content type
 
 All three types expose init-only properties:

--- a/src/IssueService/IssueService.csproj
+++ b/src/IssueService/IssueService.csproj
@@ -11,6 +11,12 @@
         <ProjectReference Include="..\Marten.SourceGenerator\Marten.SourceGenerator.csproj"
                           OutputItemType="Analyzer"
                           ReferenceOutputAssembly="false" />
+        <!-- NuGet analyzer assets from JasperFx.Events (Marten's own aggregation-dispatcher
+             source generator) don't flow transitively across a ProjectReference to Marten.
+             Reference it directly here so SingleStreamProjection/Snapshot<T> types declared
+             in this project (e.g. Order) get their generated dispatcher, matching the pattern
+             used by EventSourcingTests.csproj. -->
+        <PackageReference Include="JasperFx.Events.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IssueService/StreamingMinimalEndpoints.cs
+++ b/src/IssueService/StreamingMinimalEndpoints.cs
@@ -42,6 +42,14 @@ public static class StreamingMinimalEndpoints
                     ContentType = "application/vnd.marten.issue+json"
                 });
 
+        // EmitETag = false opt-out
+        app.MapGet("/minimal/issue/{id:guid}/no-etag",
+            (Guid id, IQuerySession session)
+                => new StreamOne<Issue>(session.Query<Issue>().Where(x => x.Id == id))
+                {
+                    EmitETag = false
+                });
+
         // --- StreamMany<T> ---
 
         app.MapGet("/minimal/issues/open",

--- a/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
+++ b/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
@@ -117,6 +117,98 @@ public class streaming_result_types_tests: IntegrationContext
         });
     }
 
+    // ───────────────────────── StreamOne<T> ETag / If-None-Match ─────────────────────────
+
+    [Fact]
+    public async Task stream_one_sets_etag_header_on_hit()
+    {
+        var issue = new Issue { Description = "etag hit", Open = true };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{issue.Id}");
+            s.StatusCodeShouldBe(200);
+        });
+
+        result.Context.Response.Headers.ContainsKey("ETag").ShouldBeTrue();
+        result.Context.Response.Headers["ETag"].ToString().ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task stream_one_returns_304_when_if_none_match_matches_current_version()
+    {
+        var issue = new Issue { Description = "etag 304", Open = true };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        var first = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{issue.Id}");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var etag = first.Context.Response.Headers["ETag"].ToString();
+        etag.ShouldNotBeNullOrEmpty();
+
+        var second = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{issue.Id}");
+            s.WithRequestHeader("If-None-Match", etag);
+            s.StatusCodeShouldBe(304);
+        });
+
+        second.Context.Response.Headers["ETag"].ToString().ShouldBe(etag);
+        second.ReadAsText().ShouldBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task stream_one_returns_full_body_when_if_none_match_is_stale()
+    {
+        var issue = new Issue { Description = "etag stale", Open = true };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{issue.Id}");
+            s.WithRequestHeader("If-None-Match", "\"" + Guid.NewGuid().ToString("D") + "\"");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var read = result.ReadAsJson<Issue>();
+        read.Description.ShouldBe(issue.Description);
+    }
+
+    [Fact]
+    public async Task stream_one_suppresses_etag_when_emit_etag_is_false()
+    {
+        var issue = new Issue { Description = "no etag", Open = true };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{issue.Id}/no-etag");
+            s.StatusCodeShouldBe(200);
+        });
+
+        result.Context.Response.Headers.ContainsKey("ETag").ShouldBeFalse();
+    }
+
     // ───────────────────────── StreamMany<T> ─────────────────────────
 
     [Fact]
@@ -189,6 +281,69 @@ public class streaming_result_types_tests: IntegrationContext
             s.Get.Url($"/minimal/order/{Guid.NewGuid()}");
             s.StatusCodeShouldBe(404);
         });
+    }
+
+    // ───────────── StreamAggregate<T> ETag / If-None-Match ─────────────
+
+    [Fact]
+    public async Task stream_aggregate_sets_etag_header_on_hit()
+    {
+        var orderId = Guid.NewGuid();
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Events.StartStream<Order>(orderId, new OrderPlaced("Etag Book", 9.99m));
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}");
+            s.StatusCodeShouldBe(200);
+        });
+
+        result.Context.Response.Headers["ETag"].ToString().ShouldBe("\"1\"");
+    }
+
+    [Fact]
+    public async Task stream_aggregate_returns_304_when_if_none_match_matches_stream_version()
+    {
+        var orderId = Guid.NewGuid();
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Events.StartStream<Order>(orderId, new OrderPlaced("Cached Book", 5.00m));
+            await session.SaveChangesAsync();
+        }
+
+        var second = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}");
+            s.WithRequestHeader("If-None-Match", "\"1\"");
+            s.StatusCodeShouldBe(304);
+        });
+
+        second.Context.Response.Headers["ETag"].ToString().ShouldBe("\"1\"");
+        second.ReadAsText().ShouldBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task stream_aggregate_returns_full_body_when_if_none_match_is_stale()
+    {
+        var orderId = Guid.NewGuid();
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Events.StartStream<Order>(orderId, new OrderPlaced("Fresh Book", 15.00m));
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}");
+            s.WithRequestHeader("If-None-Match", "\"999\"");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var order = result.ReadAsJson<Order>();
+        order.Description.ShouldBe("Fresh Book");
     }
 
     // ───────────────────────── OpenAPI metadata ─────────────────────────

--- a/src/Marten.AspNetCore/ETagHelpers.cs
+++ b/src/Marten.AspNetCore/ETagHelpers.cs
@@ -1,0 +1,63 @@
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace Marten.AspNetCore;
+
+/// <summary>
+/// Shared helpers for formatting and matching HTTP ETags across the streaming
+/// result types (<see cref="StreamOne{T}"/>, <see cref="StreamAggregate{T}"/>).
+/// </summary>
+internal static class ETagHelpers
+{
+    /// <summary>
+    /// Format a Marten document's <c>mt_version</c> (a <see cref="Guid"/>) as a quoted
+    /// strong ETag value, e.g. <c>"3f2504e0-4f89-11d3-9a0c-0305e82c3301"</c>.
+    /// </summary>
+    public static string Format(Guid version) => $"\"{version:D}\"";
+
+    /// <summary>
+    /// Format an event stream's version (a <see cref="long"/>) as a quoted strong ETag
+    /// value, e.g. <c>"17"</c>.
+    /// </summary>
+    public static string Format(long version) => $"\"{version}\"";
+
+    /// <summary>
+    /// Checks whether the incoming request's <c>If-None-Match</c> header contains a value
+    /// that matches <paramref name="etag"/>. Handles the wildcard (<c>*</c>), multiple
+    /// comma-separated values, and weak (<c>W/</c>) validators by comparing the underlying
+    /// opaque tag.
+    /// </summary>
+    public static bool IfNoneMatchMatches(HttpContext context, string etag)
+    {
+        if (context == null) throw new ArgumentNullException(nameof(context));
+        if (string.IsNullOrEmpty(etag)) return false;
+
+        var values = context.Request.Headers["If-None-Match"];
+        if (values.Count == 0) return false;
+
+        foreach (var value in values)
+        {
+            if (string.IsNullOrEmpty(value)) continue;
+
+            foreach (var candidate in value.Split(','))
+            {
+                var trimmed = candidate.Trim();
+                if (trimmed.Length == 0) continue;
+
+                if (trimmed == "*") return true;
+
+                if (trimmed.StartsWith("W/", StringComparison.OrdinalIgnoreCase))
+                {
+                    trimmed = trimmed.Substring(2);
+                }
+
+                if (string.Equals(trimmed, etag, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Marten.AspNetCore/QueryableExtensions.cs
+++ b/src/Marten.AspNetCore/QueryableExtensions.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten.Events;
+using Marten.Internal;
 using Marten.Linq;
 using Microsoft.AspNetCore.Http;
 
@@ -12,37 +13,74 @@ public static class QueryableExtensions
 {
     /// <summary>
     /// Write the JSON contents of a single document response from the Linq query to the HttpContext response, with status code <paramref name="onFoundStatus"/> if found or
-    /// 404 if not found
+    /// 404 if not found.
+    /// <para>
+    /// When <paramref name="emitETag"/> is true (the default), the document's <c>mt_version</c>
+    /// is read via a follow-up metadata query and written as a quoted <c>ETag</c> response header.
+    /// If the incoming request's <c>If-None-Match</c> header matches that version, a <c>304 Not
+    /// Modified</c> is written instead, with an empty body.
+    /// </para>
     /// </summary>
     /// <param name="queryable"></param>
     /// <param name="context"></param>
     /// <param name="contentType"></param>
     /// <param name="onFoundStatus">Defaults to 200</param>
+    /// <param name="emitETag">Defaults to true. Set to false to skip the ETag/conditional-request support.</param>
     /// <typeparam name="T"></typeparam>
     public static async Task WriteSingle<T>(
         this IQueryable<T> queryable,
         HttpContext context,
         string contentType = "application/json",
-        int onFoundStatus = 200
-    )
+        int onFoundStatus = 200,
+        bool emitETag = true
+    ) where T : notnull
     {
         var stream = Marten.Internal.SharedMemoryStreamManager.GetStream();
         var found = await queryable.StreamJsonFirstOrDefault(stream, context.RequestAborted).ConfigureAwait(false);
 
-        if (found)
-        {
-            context.Response.StatusCode = onFoundStatus;
-            context.Response.ContentLength = stream.Length;
-            context.Response.ContentType = contentType;
-
-            stream.Position = 0;
-            await stream.CopyToAsync(context.Response.Body, context.RequestAborted).ConfigureAwait(false);
-        }
-        else
+        if (!found)
         {
             context.Response.StatusCode = 404;
             context.Response.ContentLength = 0;
+            return;
         }
+
+        if (emitETag)
+        {
+            // The queryable was built off a Marten session; walk back to it (internal access
+            // granted via [InternalsVisibleTo] on Marten's assembly) so we can look up the
+            // document's mt_version without asking the caller to plumb an IQuerySession through.
+            IMartenSession session = ((IMartenLinqQueryable)queryable).Session;
+
+            stream.Position = 0;
+            var entity = session.Serializer.FromJson<T>(stream);
+
+            var metadata = await ((IQuerySession)session)
+                .MetadataForAsync(entity, context.RequestAborted)
+                .ConfigureAwait(false);
+
+            if (metadata != null)
+            {
+                var etag = ETagHelpers.Format(metadata.CurrentVersion);
+
+                if (ETagHelpers.IfNoneMatchMatches(context, etag))
+                {
+                    context.Response.StatusCode = StatusCodes.Status304NotModified;
+                    context.Response.Headers["ETag"] = etag;
+                    context.Response.ContentLength = 0;
+                    return;
+                }
+
+                context.Response.Headers["ETag"] = etag;
+            }
+        }
+
+        context.Response.StatusCode = onFoundStatus;
+        context.Response.ContentLength = stream.Length;
+        context.Response.ContentType = contentType;
+
+        stream.Position = 0;
+        await stream.CopyToAsync(context.Response.Body, context.RequestAborted).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Marten.AspNetCore/StreamAggregate.cs
+++ b/src/Marten.AspNetCore/StreamAggregate.cs
@@ -67,11 +67,56 @@ public sealed class StreamAggregate<T> : IResult, IEndpointMetadataProvider wher
     /// </summary>
     public string ContentType { get; init; } = "application/json";
 
+    /// <summary>
+    /// Whether to emit an <c>ETag</c> response header derived from the event stream's
+    /// version, and honor an incoming <c>If-None-Match</c> request header by responding
+    /// <c>304 Not Modified</c> with an empty body when it matches. The stream version is
+    /// cheap to look up (an indexed read against <c>mt_streams</c>) and is fetched before
+    /// the aggregate snapshot/fold work, so a cache hit skips that work entirely. Defaults
+    /// to <c>true</c>. Set to <c>false</c> to opt out if a consumer's contract cannot
+    /// tolerate the extra header.
+    /// </summary>
+    public bool EmitETag { get; init; } = true;
+
     /// <inheritdoc />
-    public Task ExecuteAsync(HttpContext httpContext)
+    public async Task ExecuteAsync(HttpContext httpContext)
     {
         if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
 
+        if (!EmitETag)
+        {
+            await writeLatest(httpContext).ConfigureAwait(false);
+            return;
+        }
+
+        var state = _useGuid
+            ? await _session.Events.FetchStreamStateAsync(_guidId, httpContext.RequestAborted).ConfigureAwait(false)
+            : await _session.Events.FetchStreamStateAsync(_stringId!, httpContext.RequestAborted).ConfigureAwait(false);
+
+        if (state == null)
+        {
+            httpContext.Response.StatusCode = 404;
+            httpContext.Response.ContentLength = 0;
+            return;
+        }
+
+        var etag = ETagHelpers.Format(state.Version);
+
+        if (ETagHelpers.IfNoneMatchMatches(httpContext, etag))
+        {
+            httpContext.Response.StatusCode = StatusCodes.Status304NotModified;
+            httpContext.Response.Headers["ETag"] = etag;
+            httpContext.Response.ContentLength = 0;
+            return;
+        }
+
+        httpContext.Response.Headers["ETag"] = etag;
+
+        await writeLatest(httpContext).ConfigureAwait(false);
+    }
+
+    private Task writeLatest(HttpContext httpContext)
+    {
         return _useGuid
             ? _session.Events.WriteLatest<T>(_guidId, httpContext, ContentType, OnFoundStatus)
             : _session.Events.WriteLatest<T>(_stringId!, httpContext, ContentType, OnFoundStatus);
@@ -79,7 +124,7 @@ public sealed class StreamAggregate<T> : IResult, IEndpointMetadataProvider wher
 
     /// <summary>
     /// Populates endpoint metadata so OpenAPI correctly advertises a
-    /// <c>200: T</c> and <c>404</c> response for this endpoint.
+    /// <c>200: T</c>, <c>304</c>, and <c>404</c> response for this endpoint.
     /// </summary>
     public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
     {
@@ -87,6 +132,8 @@ public sealed class StreamAggregate<T> : IResult, IEndpointMetadataProvider wher
 
         builder.Metadata.Add(new ProducesResponseTypeMetadata(
             StatusCodes.Status200OK, typeof(T), new[] { "application/json" }));
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status304NotModified, typeof(void), Array.Empty<string>()));
         builder.Metadata.Add(new ProducesResponseTypeMetadata(
             StatusCodes.Status404NotFound, typeof(void), Array.Empty<string>()));
     }

--- a/src/Marten.AspNetCore/StreamOne.cs
+++ b/src/Marten.AspNetCore/StreamOne.cs
@@ -27,7 +27,7 @@ namespace Marten.AspNetCore;
 /// </para>
 /// </summary>
 /// <typeparam name="T">The document type to stream.</typeparam>
-public sealed class StreamOne<T> : IResult, IEndpointMetadataProvider
+public sealed class StreamOne<T> : IResult, IEndpointMetadataProvider where T : notnull
 {
     private readonly IQueryable<T> _queryable;
 
@@ -51,16 +51,25 @@ public sealed class StreamOne<T> : IResult, IEndpointMetadataProvider
     /// </summary>
     public string ContentType { get; init; } = "application/json";
 
+    /// <summary>
+    /// Whether to emit an <c>ETag</c> response header derived from the document's
+    /// <c>mt_version</c>, and honor an incoming <c>If-None-Match</c> request header by
+    /// responding <c>304 Not Modified</c> with an empty body when it matches. Defaults to
+    /// <c>true</c>. Set to <c>false</c> to opt out if a consumer's contract cannot tolerate
+    /// the extra header.
+    /// </summary>
+    public bool EmitETag { get; init; } = true;
+
     /// <inheritdoc />
     public Task ExecuteAsync(HttpContext httpContext)
     {
         if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
-        return _queryable.WriteSingle(httpContext, ContentType, OnFoundStatus);
+        return _queryable.WriteSingle(httpContext, ContentType, OnFoundStatus, EmitETag);
     }
 
     /// <summary>
     /// Populates endpoint metadata so OpenAPI correctly advertises a
-    /// <c>200: T</c> and <c>404</c> response for this endpoint.
+    /// <c>200: T</c>, <c>304</c>, and <c>404</c> response for this endpoint.
     /// </summary>
     public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
     {
@@ -68,6 +77,8 @@ public sealed class StreamOne<T> : IResult, IEndpointMetadataProvider
 
         builder.Metadata.Add(new ProducesResponseTypeMetadata(
             StatusCodes.Status200OK, typeof(T), new[] { "application/json" }));
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status304NotModified, typeof(void), Array.Empty<string>()));
         builder.Metadata.Add(new ProducesResponseTypeMetadata(
             StatusCodes.Status404NotFound, typeof(void), Array.Empty<string>()));
     }

--- a/src/Marten/Properties/AssemblyInfo.cs
+++ b/src/Marten/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using JasperFx.Core.TypeScanning;
 [assembly: InternalsVisibleTo("PatchingTests")]
 [assembly: InternalsVisibleTo("StressTests")]
 [assembly: InternalsVisibleTo("ContainerScopedProjectionTests")]
+[assembly: InternalsVisibleTo("Marten.AspNetCore")]


### PR DESCRIPTION
## Summary

Adds HTTP conditional-request support (`ETag` / `If-None-Match` -> `304 Not Modified`) to `StreamOne<T>` and `StreamAggregate<T>` in `Marten.AspNetCore`, so polling clients can avoid re-downloading unchanged documents/aggregates. Closes #5010.

### `StreamOne<T>`
- New `EmitETag` init-only property, defaults to `true`.
- When enabled, `WriteSingle<T>` deserializes the already-buffered JSON to get an entity instance, then calls the public `IQuerySession.MetadataForAsync<T>()` to read `mt_version` and format it as a quoted-GUID `ETag` header.
- If the incoming `If-None-Match` matches, responds `304` with an empty body instead of the JSON payload.
- Getting from the Linq queryable back to its owning session requires the internal `IMartenLinqQueryable.Session` property, so a scoped `[InternalsVisibleTo("Marten.AspNetCore")]` was added to Marten's `AssemblyInfo.cs`. Everything reached beyond that cast (`QuerySession`, `IMartenSession`, `IQuerySession`) is already public.

### `StreamAggregate<T>`
- New `EmitETag` init-only property, defaults to `true`.
- Uses the already-public `IEventStoreOperations.FetchStreamStateAsync` to cheaply read the stream's `long` version *before* folding/snapshot work, so a `304` cache hit skips that work entirely.
- ETag is a quoted integer, e.g. `"42"`.

### `StreamMany<T>`
Left out of scope for this PR, per the issue's own guidance that a collection-wide ETag is harder to derive cheaply -- happy to follow up separately if there's appetite for a weak `max(mt_version) + count` based ETag.

### Tests
Added Alba-based integration tests in `Marten.AspNetCore.Testing` covering, for both `StreamOne` and `StreamAggregate`:
- `ETag` header present on a normal hit
- `304` returned (empty body) when `If-None-Match` matches the current version
- Full `200` body returned when `If-None-Match` is stale
- `EmitETag = false` suppresses the header/behavior entirely (backwards-compatible opt-out)

All 53 tests in `Marten.AspNetCore.Testing` pass locally (net9.0 and net10.0).

### Incidental fix
While getting the test harness running, found `IssueService.csproj` was missing a direct `PackageReference` to `JasperFx.Events.SourceGenerator` as an analyzer -- NuGet analyzer assets don't flow transitively across a `ProjectReference` to `Marten`, so `SingleStreamProjection`/`Snapshot<T>` types declared in `IssueService` (like `Order`) had no generated dispatcher and every test touching an event-sourced aggregate failed with `InvalidProjectionException`. Fixed by adding the same analyzer reference `EventSourcingTests.csproj` already uses. This was a pre-existing issue unrelated to this feature, confirmed to reproduce on the unmodified baseline.

### Docs
Updated `docs/documents/aspnetcore.md` with a new "ETag / conditional request support" section explaining the behavior, the `EmitETag` opt-out, and a request/response example. `markdownlint` and `cspell` both pass clean on the full `docs/**/*.md` tree.
