### PR TITLE
feat: StreamPagedByCursor<T> - keyset-paginated raw JSON streaming (fixes #5012)

### DIFF
--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -237,11 +237,12 @@ that dispatch any `IResult` return value), `Marten.AspNetCore` ships three typed
 result wrappers that carry the streaming behavior above as endpoint return values
 while also contributing correct OpenAPI metadata:
 
-| Type                 | Source                                           | Response shape    | 404 on miss?           |
-| -------------------- | ------------------------------------------------ | ----------------- | ---------------------- |
-| `StreamOne<T>`       | `IQueryable<T>` — regular Marten document query  | Single `T`        | yes                    |
-| `StreamMany<T>`      | `IQueryable<T>` — regular Marten document query  | JSON array `T[]`  | no (empty array = 200) |
-| `StreamAggregate<T>` | `IDocumentSession` + stream id — event-sourced   | Single `T`        | yes                    |
+| Type                     | Source                                          | Response shape                 | 404 on miss?           |
+| ------------------------ | ----------------------------------------------- | ------------------------------ | ---------------------- |
+| `StreamOne<T>`           | `IQueryable<T>` — regular Marten document query | Single `T`                     | yes                    |
+| `StreamMany<T>`          | `IQueryable<T>` — regular Marten document query | JSON array `T[]`               | no (empty array = 200) |
+| `StreamAggregate<T>`     | `IDocumentSession` + stream id — event-sourced  | Single `T`                     | yes                    |
+| `StreamPagedByCursor<T>` | `IQueryable<T>` (with `OrderBy`/`ThenBy`)       | { "items": T[], "nextCursor" } | no (empty array = 200) |
 
 Each type implements both `IResult` (so ASP.NET Minimal API dispatches it via
 `ExecuteAsync`) and `IEndpointMetadataProvider` (so Swashbuckle, NSwag, and the
@@ -343,3 +344,103 @@ metadata advertises `200: TOut` (and `404` for `StreamOne`), where `TOut` is the
 compiled query's declared return type. Prefer compiled queries when the endpoint
 is on a hot path — Marten caches the compiled SQL and bypasses LINQ parsing on
 subsequent calls.
+
+## StreamPagedByCursor<T> — keyset-paginated streaming
+
+::: tip
+New in 9.0
+:::
+
+`StreamMany<T>` and `WriteArray()` stream an entire result set. For very large or
+open-ended result sets — infinite scroll UIs, data exports, catch-up feeds — you
+usually want to hand the client back a _page_ at a time instead, together with a
+token to fetch the next page. `StreamPagedByCursor<T>` is an `IResult` that does
+exactly that using **keyset (a.k.a. seek) pagination** rather than `Skip`/`Take`
+offsets. See [Keyset (Cursor) Pagination](/documents/querying/linq/paging#keyset-cursor-pagination)
+for a deeper explanation of how keyset pagination works and how it compares to
+offset-based paging.
+
+```csharp
+app.MapGet("/issues",
+    (IQuerySession session, string? cursor, int pageSize) =>
+        new StreamPagedByCursor<Issue>(
+            session.Query<Issue>().OrderBy(x => x.Description).ThenBy(x => x.Id),
+            cursor,
+            pageSize));
+```
+
+Call it the same way on every request; only the `cursor` query string value
+changes between calls:
+
+- **First request** — omit `cursor` (or pass `null`/empty). Marten runs
+  `ORDER BY ... LIMIT @pageSize` and returns the first page.
+- **Every later request** — pass the `nextCursor` value returned by the
+  previous call. Marten decodes it, translates it into a `WHERE` seek predicate
+  matching your `OrderBy`/`ThenBy` chain, and returns the next page at the same
+  cost regardless of how many pages have already been read.
+- **End of the result set** — when a page comes back with fewer than
+  `pageSize` rows, there is no `nextCursor`; stop paging.
+
+The response body is a small JSON envelope:
+
+```json
+{
+  "items": [{ "id": "...", "description": "..." }, { "id": "...", "description": "..." }],
+  "nextCursor": "v1:W3siRGVzY3JpcHRpb24iOiJEZXNjcmlwdGlvbiIsIklkIjoiLi4uIn1d"
+}
+```
+
+The same value is also written to a `Marten-Continuation` response header, so
+callers that would rather keep the body a plain array can read the cursor from
+there instead of parsing the envelope.
+
+### The `OrderBy`/`ThenBy` requirement
+
+The queryable passed to `StreamPagedByCursor<T>` **must** have at least one
+`OrderBy`/`OrderByDescending` clause, and the **last** ordering in the chain
+must be on a member that is guaranteed unique across the result set — normally
+the document's `Id`. This guarantees the cursor is deterministic: without a
+unique tie-breaker, rows that share the same leading sort key(s) could be
+skipped or repeated across pages.
+
+```csharp
+// Good: Description is not unique on its own, so Id is added as a tie-breaker
+session.Query<Issue>().OrderBy(x => x.Description).ThenBy(x => x.Id)
+
+// Throws InvalidOperationException: no OrderBy clause at all
+session.Query<Issue>()
+
+// Throws InvalidOperationException: terminal clause (Description) isn't unique
+session.Query<Issue>().OrderBy(x => x.Description)
+```
+
+Mixed ascending/descending orderings are supported — each `ThenBy`/`ThenByDescending`
+clause keeps its own direction when Marten builds the seek predicate:
+
+```csharp
+session.Query<Issue>()
+    .OrderByDescending(x => x.Description)
+    .ThenBy(x => x.Id)
+```
+
+### Constructor and options
+
+```csharp
+public StreamPagedByCursor(IQueryable<T> queryable, string? cursor, int pageSize)
+```
+
+Like the other typed result wrappers, it exposes init-only properties for
+customizing the response:
+
+```csharp
+app.MapGet("/issues",
+    (IQuerySession session, string? cursor, int pageSize) =>
+        new StreamPagedByCursor<Issue>(
+            session.Query<Issue>().OrderBy(x => x.Description).ThenBy(x => x.Id),
+            cursor,
+            pageSize)
+        {
+            OnFoundStatus = StatusCodes.Status200OK,
+            ContentType = "application/vnd.myapi.issue-page+json"
+        });
+```

--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -345,11 +345,7 @@ compiled query's declared return type. Prefer compiled queries when the endpoint
 is on a hot path — Marten caches the compiled SQL and bypasses LINQ parsing on
 subsequent calls.
 
-## StreamPagedByCursor<T> — keyset-paginated streaming
-
-::: tip
-New in 9.0
-:::
+## StreamPagedByCursor<T> — keyset-paginated streaming <Badge type="tip" text="9.18" />
 
 `StreamMany<T>` and `WriteArray()` stream an entire result set. For very large or
 open-ended result sets — infinite scroll UIs, data exports, catch-up feeds — you

--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -345,7 +345,7 @@ compiled query's declared return type. Prefer compiled queries when the endpoint
 is on a hot path — Marten caches the compiled SQL and bypasses LINQ parsing on
 subsequent calls.
 
-## StreamPagedByCursor<T> — keyset-paginated streaming <Badge type="tip" text="9.18" />
+## `StreamPagedByCursor<T>` — keyset-paginated streaming <Badge type="tip" text="9.18" />
 
 `StreamMany<T>` and `WriteArray()` stream an entire result set. For very large or
 open-ended result sets — infinite scroll UIs, data exports, catch-up feeds — you

--- a/docs/documents/querying/linq/paging.md
+++ b/docs/documents/querying/linq/paging.md
@@ -90,3 +90,43 @@ where CAST(d.data ->> 'Number' as integer) > :arg0 LIMIT 5
 ```
 
 The `Stats()` Linq operator can be used in conjunction with `Include()` and within batch queries. Compiled queries also support `QueryStatistics` by declaring a `QueryStatistics Stats { get; } = new QueryStatistics()` property on the compiled query class.
+
+## Keyset (Cursor) Pagination
+
+The paging shown above is **offset-based**: every page is fetched with `Skip(pageNumber * pageSize).Take(pageSize)`, typically paired with a `count(*) OVER()` window function (or a separate `count(*)` query) to compute the total row count. Offset paging is simple and lets you jump straight to an arbitrary page number, but the cost of `Skip()` grows with the offset — Postgres still has to walk and discard every skipped row — so deep pages against large tables get progressively slower, and a `count(*)` over a huge table isn't free either.
+
+**Keyset pagination** (also called "seek" pagination) avoids that by never skipping rows at all. Instead of an offset, each page carries a small **cursor**: the sort-key values of the last row you saw. The next page is fetched with a `WHERE` clause that seeks directly to "everything after that cursor", using the same index that satisfies your `ORDER BY`. That makes each page's cost roughly constant no matter how deep you are into the result set — ideal for infinite scroll, "load more", and export/catch-up style feeds where you only ever page forward and don't need to compute a total count or jump to a specific page number.
+
+Marten exposes keyset pagination as `ToJsonPageByCursorAsync<T>`, an extension method on `IQueryable<T>` that streams a page of raw document JSON plus the next cursor:
+
+```csharp
+// First page: pass cursor: null
+var firstPage = await session.Query<Issue>()
+    .OrderBy(x => x.Description).ThenBy(x => x.Id)
+    .ToJsonPageByCursorAsync(cursor: null, pageSize: 25);
+
+// firstPage.ItemsJson is a raw JSON array string: "[{...},{...},...]"
+// firstPage.NextCursor is an opaque token, or null if this was the last page
+
+// Next page: pass the previous page's cursor
+var secondPage = await session.Query<Issue>()
+    .OrderBy(x => x.Description).ThenBy(x => x.Id)
+    .ToJsonPageByCursorAsync(firstPage.NextCursor, pageSize: 25);
+```
+
+A few rules govern how the cursor is built and validated:
+
+- The queryable **must** have an `OrderBy`/`OrderByDescending` clause (optionally followed by `ThenBy`/`ThenByDescending` clauses) — Marten parses this ordering chain to know which column(s) to seek on. Without one, `ToJsonPageByCursorAsync` throws an `InvalidOperationException`.
+- The **last** ordering in the chain must be on a member guaranteed unique across the result set — typically the document's `Id`. This tie-breaker keeps pagination deterministic when earlier sort keys have duplicate values; if it's missing, Marten throws an `InvalidOperationException` telling you which `ThenBy` to add.
+- Mixed ascending/descending orderings are supported (e.g. `OrderByDescending(x => x.Date).ThenBy(x => x.Id)`) — each ordering keeps its own direction when the seek predicate is built.
+- A page with fewer than `pageSize` rows means you've reached the end of the result set — `NextCursor` will be `null`.
+- The cursor itself is an opaque, versioned, base64-encoded token — treat it as a black box and don't try to parse or construct one by hand.
+
+### Streaming keyset pages directly to an HTTP response
+
+If you're using [Marten.AspNetCore](/documents/aspnetcore), `StreamPagedByCursor<T>` wraps `ToJsonPageByCursorAsync<T>` as an `IResult` you can return straight from a Minimal API endpoint — see [StreamPagedByCursor\<T\>](/documents/aspnetcore#streampagedbycursor-t-keyset-paginated-streaming) for the full writeup, including the JSON envelope shape and the `Marten-Continuation` response header.
+
+### When to use keyset vs. offset pagination
+
+- Use **`ToPagedList`/`ToPagedListAsync`** (offset-based, above) when you need page numbers, jump-to-page navigation, or a total row/page count — typical of a classic paged grid UI.
+- Use **`ToJsonPageByCursorAsync`/`StreamPagedByCursor<T>`** (keyset-based) when you only ever page forward, don't need a total count or arbitrary page jumps, and want consistent performance no matter how deep the pagination goes — typical of infinite scroll, "load more" buttons, and bulk export/sync feeds.

--- a/docs/documents/querying/linq/paging.md
+++ b/docs/documents/querying/linq/paging.md
@@ -91,7 +91,7 @@ where CAST(d.data ->> 'Number' as integer) > :arg0 LIMIT 5
 
 The `Stats()` Linq operator can be used in conjunction with `Include()` and within batch queries. Compiled queries also support `QueryStatistics` by declaring a `QueryStatistics Stats { get; } = new QueryStatistics()` property on the compiled query class.
 
-## Keyset (Cursor) Pagination
+## Keyset (Cursor) Pagination <Badge type="tip" text="9.18" />
 
 The paging shown above is **offset-based**: every page is fetched with `Skip(pageNumber * pageSize).Take(pageSize)`, typically paired with a `count(*) OVER()` window function (or a separate `count(*)` query) to compute the total row count. Offset paging is simple and lets you jump straight to an arbitrary page number, but the cost of `Skip()` grows with the offset — Postgres still has to walk and discard every skipped row — so deep pages against large tables get progressively slower, and a `count(*)` over a huge table isn't free either.
 

--- a/src/DocumentDbTests/Reading/cursor_paging_tests.cs
+++ b/src/DocumentDbTests/Reading/cursor_paging_tests.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten.Linq.CursorPaging;
+using Marten.Testing.Documents;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DocumentDbTests.Reading;
+
+public class cursor_paging_tests: IntegrationContext
+{
+    public cursor_paging_tests(DefaultStoreFixture fixture) : base(fixture)
+    {
+    }
+
+    protected override async Task fixtureSetup()
+    {
+        await theStore.Advanced.ResetAllData();
+    }
+
+    private async Task seedUsers(params string[] firstNames)
+    {
+        foreach (var name in firstNames)
+        {
+            theSession.Store(new User { FirstName = name, LastName = "Smith" });
+        }
+
+        await theSession.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task first_page_with_no_cursor_returns_items_and_next_cursor()
+    {
+        await seedUsers("a", "b", "c", "d", "e");
+
+        var page = await theSession.Query<User>()
+            .OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+            .ToJsonPageByCursorAsync(cursor: null, pageSize: 2);
+
+        page.Count.ShouldBe(2);
+        page.NextCursor.ShouldNotBeNullOrEmpty();
+        page.ItemsJson.ShouldContain("\"a\"");
+        page.ItemsJson.ShouldContain("\"b\"");
+    }
+
+    [Fact]
+    public async Task subsequent_page_with_cursor_returns_next_items_with_no_overlap()
+    {
+        await seedUsers("a", "b", "c", "d", "e");
+
+        var first = await theSession.Query<User>()
+            .OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+            .ToJsonPageByCursorAsync(cursor: null, pageSize: 2);
+
+        var second = await theSession.Query<User>()
+            .OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+            .ToJsonPageByCursorAsync(first.NextCursor, pageSize: 2);
+
+        second.Count.ShouldBe(2);
+        second.ItemsJson.ShouldContain("\"c\"");
+        second.ItemsJson.ShouldContain("\"d\"");
+        second.ItemsJson.ShouldNotContain("\"a\"");
+        second.ItemsJson.ShouldNotContain("\"b\"");
+        second.NextCursor.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task last_page_has_fewer_rows_than_page_size_and_no_next_cursor()
+    {
+        await seedUsers("a", "b", "c", "d", "e");
+
+        var first = await theSession.Query<User>()
+            .OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+            .ToJsonPageByCursorAsync(cursor: null, pageSize: 2);
+
+        var second = await theSession.Query<User>()
+            .OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+            .ToJsonPageByCursorAsync(first.NextCursor, pageSize: 2);
+
+        var third = await theSession.Query<User>()
+            .OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+            .ToJsonPageByCursorAsync(second.NextCursor, pageSize: 2);
+
+        third.Count.ShouldBe(1);
+        third.ItemsJson.ShouldContain("\"e\"");
+        third.NextCursor.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task exact_multiple_of_page_size_ends_with_no_next_cursor()
+    {
+        await seedUsers("a", "b", "c", "d");
+
+        var first = await theSession.Query<User>()
+            .OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+            .ToJsonPageByCursorAsync(cursor: null, pageSize: 2);
+
+        first.NextCursor.ShouldNotBeNullOrEmpty();
+
+        var second = await theSession.Query<User>()
+            .OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+            .ToJsonPageByCursorAsync(first.NextCursor, pageSize: 2);
+
+        second.Count.ShouldBe(2);
+        second.NextCursor.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task empty_result_set_yields_empty_page_and_no_cursor()
+    {
+        await theStore.Advanced.ResetAllData();
+
+        var page = await theSession.Query<User>()
+            .OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+            .ToJsonPageByCursorAsync(cursor: null, pageSize: 5);
+
+        page.Count.ShouldBe(0);
+        page.ItemsJson.ShouldBe("[]");
+        page.NextCursor.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task mixed_sort_directions_paginate_correctly()
+    {
+        await seedUsers("a", "b", "c", "d", "e");
+
+        var first = await theSession.Query<User>()
+            .OrderByDescending(x => x.FirstName).ThenBy(x => x.Id)
+            .ToJsonPageByCursorAsync(cursor: null, pageSize: 2);
+
+        first.ItemsJson.ShouldContain("\"e\"");
+        first.ItemsJson.ShouldContain("\"d\"");
+        first.NextCursor.ShouldNotBeNullOrEmpty();
+
+        var second = await theSession.Query<User>()
+            .OrderByDescending(x => x.FirstName).ThenBy(x => x.Id)
+            .ToJsonPageByCursorAsync(first.NextCursor, pageSize: 2);
+
+        second.ItemsJson.ShouldContain("\"c\"");
+        second.ItemsJson.ShouldContain("\"b\"");
+
+        var third = await theSession.Query<User>()
+            .OrderByDescending(x => x.FirstName).ThenBy(x => x.Id)
+            .ToJsonPageByCursorAsync(second.NextCursor, pageSize: 2);
+
+        third.ItemsJson.ShouldContain("\"a\"");
+        third.NextCursor.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task duplicate_leading_sort_key_is_disambiguated_by_terminal_tie_breaker()
+    {
+        await seedUsers("same", "same", "same", "same", "same");
+
+        var seenCount = 0;
+        string? cursor = null;
+
+        for (var i = 0; i < 10; i++)
+        {
+            var page = await theSession.Query<User>()
+                .OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+                .ToJsonPageByCursorAsync(cursor, pageSize: 2);
+
+            seenCount += page.Count;
+            cursor = page.NextCursor;
+
+            if (cursor == null) break;
+        }
+
+        seenCount.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task missing_order_by_throws()
+    {
+        await seedUsers("a");
+
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await theSession.Query<User>().ToJsonPageByCursorAsync(cursor: null, pageSize: 2));
+    }
+
+    [Fact]
+    public async Task non_unique_terminal_sort_key_throws()
+    {
+        await seedUsers("a", "b");
+
+        // FirstName alone is not guaranteed unique - must end with a unique member (Id)
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await theSession.Query<User>().OrderBy(x => x.FirstName)
+                .ToJsonPageByCursorAsync(cursor: null, pageSize: 2));
+    }
+
+    [Fact]
+    public async Task non_positive_page_size_throws()
+    {
+        await seedUsers("a");
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(async () =>
+            await theSession.Query<User>().OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+                .ToJsonPageByCursorAsync(cursor: null, pageSize: 0));
+    }
+}

--- a/src/IssueService/StreamingMinimalEndpoints.cs
+++ b/src/IssueService/StreamingMinimalEndpoints.cs
@@ -42,14 +42,6 @@ public static class StreamingMinimalEndpoints
                     ContentType = "application/vnd.marten.issue+json"
                 });
 
-        // EmitETag = false opt-out
-        app.MapGet("/minimal/issue/{id:guid}/no-etag",
-            (Guid id, IQuerySession session)
-                => new StreamOne<Issue>(session.Query<Issue>().Where(x => x.Id == id))
-                {
-                    EmitETag = false
-                });
-
         // --- StreamMany<T> ---
 
         app.MapGet("/minimal/issues/open",

--- a/src/IssueService/StreamingMinimalEndpoints.cs
+++ b/src/IssueService/StreamingMinimalEndpoints.cs
@@ -42,6 +42,14 @@ public static class StreamingMinimalEndpoints
                     ContentType = "application/vnd.marten.issue+json"
                 });
 
+        // EmitETag = false opt-out
+        app.MapGet("/minimal/issue/{id:guid}/no-etag",
+            (Guid id, IQuerySession session)
+                => new StreamOne<Issue>(session.Query<Issue>().Where(x => x.Id == id))
+                {
+                    EmitETag = false
+                });
+
         // --- StreamMany<T> ---
 
         app.MapGet("/minimal/issues/open",
@@ -83,6 +91,23 @@ public static class StreamingMinimalEndpoints
             (IQuerySession session)
                 => new StreamMany<Issue, System.Collections.Generic.IEnumerable<Issue>>(
                     session, new OpenIssues()));
+
+        // --- StreamPagedByCursor<T> ---
+
+        app.MapGet("/minimal/issues/paged-cursor",
+            (IQuerySession session, int pageSize, string? cursor)
+                => new StreamPagedByCursor<Issue>(
+                    session.Query<Issue>().OrderBy(x => x.Description).ThenBy(x => x.Id),
+                    cursor,
+                    pageSize));
+
+        // Mixed sort directions: descending primary key, ascending tie-breaker
+        app.MapGet("/minimal/issues/paged-cursor-mixed",
+            (IQuerySession session, int pageSize, string? cursor)
+                => new StreamPagedByCursor<Issue>(
+                    session.Query<Issue>().OrderByDescending(x => x.Description).ThenBy(x => x.Id),
+                    cursor,
+                    pageSize));
 
         return app;
     }

--- a/src/Marten.AspNetCore.Testing/stream_paged_by_cursor_tests.cs
+++ b/src/Marten.AspNetCore.Testing/stream_paged_by_cursor_tests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Alba;
+using IssueService.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Marten.AspNetCore.Testing;
+
+/// <summary>
+/// Alba-based tests for <see cref="StreamPagedByCursor{T}"/> exercising keyset
+/// (seek) pagination through a plain Minimal API endpoint.
+/// </summary>
+[Collection("integration")]
+public class stream_paged_by_cursor_tests: IntegrationContext
+{
+    private readonly IAlbaHost theHost;
+
+    public stream_paged_by_cursor_tests(AppFixture fixture) : base(fixture)
+    {
+        theHost = fixture.Host;
+    }
+
+    private async Task SeedIssues(params string[] descriptions)
+    {
+        await using var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession();
+        foreach (var description in descriptions)
+        {
+            session.Store(new Issue { Description = description, Open = true });
+        }
+
+        await session.SaveChangesAsync();
+    }
+
+    private static CursorEnvelope ReadEnvelope(string body)
+    {
+        using var document = JsonDocument.Parse(body);
+        var root = document.RootElement;
+
+        var items = root.GetProperty("items").EnumerateArray()
+            .Select(x => x.GetProperty("Description").GetString()!)
+            .ToList();
+
+        var nextCursor = root.GetProperty("nextCursor").ValueKind == JsonValueKind.Null
+            ? null
+            : root.GetProperty("nextCursor").GetString();
+
+        return new CursorEnvelope(items, nextCursor);
+    }
+
+    private sealed record CursorEnvelope(List<string> Items, string? NextCursor);
+
+    [Fact]
+    public async Task first_page_returns_items_and_next_cursor_when_more_remain()
+    {
+        await SeedIssues("a", "b", "c", "d", "e");
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/issues/paged-cursor?pageSize=2");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var envelope = ReadEnvelope(result.ReadAsText());
+
+        envelope.Items.ShouldBe(new[] { "a", "b" });
+        envelope.NextCursor.ShouldNotBeNullOrEmpty();
+        result.Context.Response.Headers["Marten-Continuation"].ToString().ShouldBe(envelope.NextCursor);
+    }
+
+    [Fact]
+    public async Task subsequent_page_with_cursor_returns_next_items()
+    {
+        await SeedIssues("a", "b", "c", "d", "e");
+
+        var first = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/issues/paged-cursor?pageSize=2");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var firstEnvelope = ReadEnvelope(first.ReadAsText());
+
+        var second = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issues/paged-cursor?pageSize=2&cursor={Uri.EscapeDataString(firstEnvelope.NextCursor!)}");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var secondEnvelope = ReadEnvelope(second.ReadAsText());
+
+        secondEnvelope.Items.ShouldBe(new[] { "c", "d" });
+        secondEnvelope.NextCursor.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task last_page_returns_remaining_items_with_no_next_cursor()
+    {
+        await SeedIssues("a", "b", "c", "d", "e");
+
+        var first = await theHost.Scenario(s => s.Get.Url("/minimal/issues/paged-cursor?pageSize=2"));
+        var firstEnvelope = ReadEnvelope(first.ReadAsText());
+
+        var second = await theHost.Scenario(s =>
+            s.Get.Url($"/minimal/issues/paged-cursor?pageSize=2&cursor={Uri.EscapeDataString(firstEnvelope.NextCursor!)}"));
+        var secondEnvelope = ReadEnvelope(second.ReadAsText());
+
+        var third = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issues/paged-cursor?pageSize=2&cursor={Uri.EscapeDataString(secondEnvelope.NextCursor!)}");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var thirdEnvelope = ReadEnvelope(third.ReadAsText());
+
+        thirdEnvelope.Items.ShouldBe(new[] { "e" });
+        thirdEnvelope.NextCursor.ShouldBeNull();
+        third.Context.Response.Headers.ContainsKey("Marten-Continuation").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task exact_multiple_of_page_size_yields_no_next_cursor_on_final_page()
+    {
+        await SeedIssues("a", "b", "c", "d");
+
+        var first = await theHost.Scenario(s => s.Get.Url("/minimal/issues/paged-cursor?pageSize=2"));
+        var firstEnvelope = ReadEnvelope(first.ReadAsText());
+        firstEnvelope.NextCursor.ShouldNotBeNullOrEmpty();
+
+        var second = await theHost.Scenario(s =>
+            s.Get.Url($"/minimal/issues/paged-cursor?pageSize=2&cursor={Uri.EscapeDataString(firstEnvelope.NextCursor!)}"));
+        var secondEnvelope = ReadEnvelope(second.ReadAsText());
+
+        secondEnvelope.Items.ShouldBe(new[] { "c", "d" });
+        secondEnvelope.NextCursor.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task empty_result_set_returns_empty_items_and_no_cursor()
+    {
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/issues/paged-cursor?pageSize=5");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var envelope = ReadEnvelope(result.ReadAsText());
+
+        envelope.Items.ShouldBeEmpty();
+        envelope.NextCursor.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task mixed_sort_directions_paginate_correctly()
+    {
+        // OrderByDescending(Description).ThenBy(Id) — descending primary key, ascending tie-breaker
+        await SeedIssues("a", "b", "c", "d", "e");
+
+        var first = await theHost.Scenario(s => s.Get.Url("/minimal/issues/paged-cursor-mixed?pageSize=2"));
+        var firstEnvelope = ReadEnvelope(first.ReadAsText());
+        firstEnvelope.Items.ShouldBe(new[] { "e", "d" });
+        firstEnvelope.NextCursor.ShouldNotBeNullOrEmpty();
+
+        var second = await theHost.Scenario(s =>
+            s.Get.Url($"/minimal/issues/paged-cursor-mixed?pageSize=2&cursor={Uri.EscapeDataString(firstEnvelope.NextCursor!)}"));
+        var secondEnvelope = ReadEnvelope(second.ReadAsText());
+        secondEnvelope.Items.ShouldBe(new[] { "c", "b" });
+        secondEnvelope.NextCursor.ShouldNotBeNullOrEmpty();
+
+        var third = await theHost.Scenario(s =>
+            s.Get.Url($"/minimal/issues/paged-cursor-mixed?pageSize=2&cursor={Uri.EscapeDataString(secondEnvelope.NextCursor!)}"));
+        var thirdEnvelope = ReadEnvelope(third.ReadAsText());
+        thirdEnvelope.Items.ShouldBe(new[] { "a" });
+        thirdEnvelope.NextCursor.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task duplicate_leading_sort_key_values_are_disambiguated_by_terminal_tie_breaker()
+    {
+        // Several issues share the same Description; the ThenBy(Id) tie-breaker
+        // must still produce a stable, non-overlapping, exhaustive pagination.
+        await SeedIssues("same", "same", "same", "same", "same");
+
+        var seen = new List<string>();
+        string? cursor = null;
+        for (var i = 0; i < 10; i++)
+        {
+            var result = await theHost.Scenario(s =>
+            {
+                s.Get.Url(cursor == null
+                    ? "/minimal/issues/paged-cursor?pageSize=2"
+                    : $"/minimal/issues/paged-cursor?pageSize=2&cursor={Uri.EscapeDataString(cursor)}");
+            });
+
+            var envelope = ReadEnvelope(result.ReadAsText());
+            seen.AddRange(envelope.Items);
+            cursor = envelope.NextCursor;
+
+            if (cursor == null)
+            {
+                break;
+            }
+        }
+
+        seen.Count.ShouldBe(5);
+        seen.ShouldAllBe(x => x == "same");
+    }
+}

--- a/src/Marten.AspNetCore/StreamPagedByCursor.cs
+++ b/src/Marten.AspNetCore/StreamPagedByCursor.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Marten.Linq.CursorPaging;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Marten.AspNetCore;
+
+/// <summary>
+/// Minimal-API / Wolverine.Http endpoint return value that streams a keyset
+/// ("seek") paginated page of Marten documents, using an opaque continuation
+/// cursor instead of <c>Skip</c>/<c>Take</c> offsets. Unlike offset paging, each
+/// page costs the same regardless of how deep into the result set it is —
+/// making this a good fit for infinite scroll / bulk export scenarios.
+/// <para>
+/// The supplied <see cref="IQueryable{T}"/> must have an <c>OrderBy</c>/<c>ThenBy</c>
+/// chain applied, and the last ordering clause must be on a member guaranteed to
+/// be unique across the result set (typically the document identity) so that
+/// pagination is deterministic.
+/// </para>
+/// <para>
+/// The response body is a JSON envelope: <c>{"items":[...],"nextCursor":"..."}</c>.
+/// <c>nextCursor</c> is <c>null</c> once the end of the result set is reached
+/// (i.e. fewer than <see cref="PageSize"/> rows remained). The same value is
+/// also written to the <c>Marten-Continuation</c> response header when present,
+/// for callers that prefer reading it from headers over the envelope.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The document type contained in the page.</typeparam>
+public sealed class StreamPagedByCursor<T>: IResult, IEndpointMetadataProvider where T : notnull
+{
+    /// <summary>
+    /// Name of the response header the continuation cursor is echoed to, in
+    /// addition to being included in the JSON envelope.
+    /// </summary>
+    public const string ContinuationHeaderName = "Marten-Continuation";
+
+    private readonly IQueryable<T> _queryable;
+    private readonly string? _cursor;
+    private readonly int _pageSize;
+
+    /// <summary>
+    /// Create a <see cref="StreamPagedByCursor{T}"/> wrapping a Marten
+    /// <see cref="IQueryable{T}"/> that has an <c>OrderBy</c>/<c>ThenBy</c> chain applied.
+    /// </summary>
+    /// <param name="queryable">
+    /// The ordered queryable to page through. The final ordering clause must be
+    /// on a member guaranteed unique across the result set (typically the
+    /// document identity).
+    /// </param>
+    /// <param name="cursor">
+    /// The continuation cursor from a previous page's response, or <c>null</c>
+    /// for the first page.
+    /// </param>
+    /// <param name="pageSize">The maximum number of documents to return per page.</param>
+    public StreamPagedByCursor(IQueryable<T> queryable, string? cursor, int pageSize)
+    {
+        _queryable = queryable ?? throw new ArgumentNullException(nameof(queryable));
+        _cursor = cursor;
+        _pageSize = pageSize;
+    }
+
+    /// <summary>
+    /// Status code written with the response. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
+
+        var page = await _queryable.ToJsonPageByCursorAsync(_cursor, _pageSize, httpContext.RequestAborted)
+            .ConfigureAwait(false);
+
+        if (page.NextCursor != null)
+        {
+            httpContext.Response.Headers[ContinuationHeaderName] = page.NextCursor;
+        }
+
+        var nextCursorJson = page.NextCursor == null
+            ? "null"
+            : "\"" + page.NextCursor + "\"";
+
+        var envelope = "{\"items\":" + page.ItemsJson + ",\"nextCursor\":" + nextCursorJson + "}";
+        var bytes = Encoding.UTF8.GetBytes(envelope);
+
+        httpContext.Response.StatusCode = OnFoundStatus;
+        httpContext.Response.ContentType = ContentType;
+        httpContext.Response.ContentLength = bytes.Length;
+
+        await httpContext.Response.Body.WriteAsync(bytes, httpContext.RequestAborted).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI correctly advertises a
+    /// <c>200</c> response for this endpoint.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(void), new[] { "application/json" }));
+    }
+}

--- a/src/Marten/Linq/CursorPaging/CursorPageResult.cs
+++ b/src/Marten/Linq/CursorPaging/CursorPageResult.cs
@@ -1,0 +1,33 @@
+namespace Marten.Linq.CursorPaging;
+
+/// <summary>
+/// The result of a keyset (seek) paginated query executed through
+/// <see cref="CursorPagingQueryableExtensions.ToJsonPageByCursorAsync{T}"/>.
+/// </summary>
+public sealed class CursorPageResult
+{
+    public CursorPageResult(string itemsJson, int count, string? nextCursor)
+    {
+        ItemsJson = itemsJson;
+        Count = count;
+        NextCursor = nextCursor;
+    }
+
+    /// <summary>
+    /// The raw JSON array text (e.g. <c>[{"Id":...},{"Id":...}]</c>) for the
+    /// documents in this page. Will be <c>"[]"</c> for an empty page.
+    /// </summary>
+    public string ItemsJson { get; }
+
+    /// <summary>
+    /// The number of documents contained in <see cref="ItemsJson"/>.
+    /// </summary>
+    public int Count { get; }
+
+    /// <summary>
+    /// The opaque continuation cursor to request the next page, or <c>null</c>
+    /// if this page reached the end of the result set (fewer rows than the
+    /// requested page size were available).
+    /// </summary>
+    public string? NextCursor { get; }
+}

--- a/src/Marten/Linq/CursorPaging/CursorPagination.cs
+++ b/src/Marten/Linq/CursorPaging/CursorPagination.cs
@@ -1,0 +1,324 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Marten.Schema;
+
+namespace Marten.Linq.CursorPaging;
+
+/// <summary>
+/// A single OrderBy/OrderByDescending/ThenBy/ThenByDescending clause parsed out of
+/// a Linq expression tree, in the order it was originally applied.
+/// </summary>
+internal sealed class CursorOrdering
+{
+    public CursorOrdering(LambdaExpression selector, bool descending)
+    {
+        Selector = selector;
+        Descending = descending;
+    }
+
+    public LambdaExpression Selector { get; }
+    public bool Descending { get; }
+
+    /// <summary>
+    /// The CLR type produced by this ordering's key selector.
+    /// </summary>
+    public Type KeyType => Selector.ReturnType;
+
+    /// <summary>
+    /// The member (property/field) directly accessed by the key selector, if the
+    /// selector body is a simple member access (e.g. <c>x =&gt; x.Id</c>). Used to
+    /// validate the terminal ordering is unique.
+    /// </summary>
+    public MemberInfo? Member => (StripConvert(Selector.Body) as MemberExpression)?.Member;
+
+    private Delegate? _boxedAccessor;
+
+    /// <summary>
+    /// Extract this ordering's key value (boxed) from a materialized document instance.
+    /// The boxing delegate is compiled once and cached on first use.
+    /// </summary>
+    public object? GetValue(object document)
+    {
+        _boxedAccessor ??= BuildBoxedAccessor();
+        return _boxedAccessor.DynamicInvoke(document);
+    }
+
+    private Delegate BuildBoxedAccessor()
+    {
+        var parameter = Selector.Parameters[0];
+        var body = Expression.Convert(Selector.Body, typeof(object));
+        return Expression.Lambda(body, parameter).Compile();
+    }
+
+    private static Expression StripConvert(Expression expression)
+    {
+        while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
+        {
+            expression = unary.Operand;
+        }
+
+        return expression;
+    }
+}
+
+/// <summary>
+/// Parses the OrderBy/ThenBy chain out of a Marten Linq expression tree and builds
+/// the "seek" (a.k.a. keyset) <c>Where</c> predicate used to fetch the next page of
+/// results for <see cref="CursorPagingQueryableExtensions.ToJsonPageByCursorAsync{T}"/>.
+/// </summary>
+internal static class CursorPagination
+{
+    private const string CursorPrefix = "v1:";
+
+    /// <summary>
+    /// Walk the expression tree looking for a contiguous OrderBy/ThenBy chain and
+    /// return the orderings in the order they were originally declared.
+    /// </summary>
+    public static IReadOnlyList<CursorOrdering> ParseOrderings(Expression expression)
+    {
+        var orderings = new List<CursorOrdering>();
+
+        var current = expression;
+        while (current is MethodCallExpression { Method.DeclaringType: var declaringType } call
+               && declaringType == typeof(Queryable)
+               && call.Arguments.Count == 2
+               && IsOrderingMethod(call.Method.Name, out var descending))
+        {
+            var selector = (LambdaExpression)StripQuote(call.Arguments[1]);
+            orderings.Add(new CursorOrdering(selector, descending));
+
+            current = call.Arguments[0];
+
+            // OrderBy/OrderByDescending marks the start of the ordering chain;
+            // ThenBy/ThenByDescending can only be nested on top of it, so once we
+            // hit the root OrderBy call we're done collecting.
+            if (call.Method.Name is "OrderBy" or "OrderByDescending")
+            {
+                break;
+            }
+        }
+
+        orderings.Reverse();
+        return orderings;
+    }
+
+    private static bool IsOrderingMethod(string name, out bool descending)
+    {
+        switch (name)
+        {
+            case "OrderBy":
+            case "ThenBy":
+                descending = false;
+                return true;
+            case "OrderByDescending":
+            case "ThenByDescending":
+                descending = true;
+                return true;
+            default:
+                descending = false;
+                return false;
+        }
+    }
+
+    private static Expression StripQuote(Expression expression)
+    {
+        return expression is UnaryExpression { NodeType: ExpressionType.Quote } quote
+            ? quote.Operand
+            : expression;
+    }
+
+    /// <summary>
+    /// Guards against non-deterministic pagination: the last ordering in the chain
+    /// must be guaranteed unique (by default, the document's identity member) or
+    /// seek pagination can skip or repeat rows that share the same leading sort keys.
+    /// </summary>
+    public static void ValidateTerminalKeyIsUnique<T>(CursorOrdering terminal)
+    {
+        var idMember = DocumentMapping.FindIdMember(typeof(T));
+
+        if (idMember != null && terminal.Member != null && MemberNamesMatch(terminal.Member, idMember))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"StreamPagedByCursor<{typeof(T).Name}> requires the final OrderBy/ThenBy clause to be on a " +
+            $"member guaranteed to be unique across the result set (typically the document identity, " +
+            $"'{idMember?.Name ?? "Id"}'). Add '.ThenBy(x => x.{idMember?.Name ?? "Id"})' as the last " +
+            "ordering clause to make the sort deterministic for keyset pagination.");
+    }
+
+    private static bool MemberNamesMatch(MemberInfo a, MemberInfo b)
+    {
+        return string.Equals(a.Name, b.Name, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Build the composite "seek" predicate:
+    /// <c>(k1 &gt; v1) OR (k1 == v1 AND k2 &gt; v2) OR ... OR (k1==v1 AND ... AND kn &gt; vn)</c>
+    /// flipping &gt;/&lt; per ordering direction, given the cursor's decoded boundary values.
+    /// </summary>
+    public static Expression<Func<T, bool>> BuildSeekPredicate<T>(IReadOnlyList<CursorOrdering> orderings, object?[] values)
+    {
+        var parameter = Expression.Parameter(typeof(T), "x");
+
+        Expression? orExpression = null;
+
+        for (var i = 0; i < orderings.Count; i++)
+        {
+            Expression? andExpression = null;
+
+            for (var j = 0; j < i; j++)
+            {
+                var equals = BuildComparison(orderings[j], values[j], parameter, ComparisonKind.Equal);
+                andExpression = andExpression == null ? equals : Expression.AndAlso(andExpression, equals);
+            }
+
+            var comparison = BuildComparison(orderings[i], values[i], parameter,
+                orderings[i].Descending ? ComparisonKind.LessThan : ComparisonKind.GreaterThan);
+
+            andExpression = andExpression == null ? comparison : Expression.AndAlso(andExpression, comparison);
+
+            orExpression = orExpression == null ? andExpression : Expression.OrElse(orExpression, andExpression);
+        }
+
+        return Expression.Lambda<Func<T, bool>>(orExpression!, parameter);
+    }
+
+    private enum ComparisonKind
+    {
+        Equal,
+        GreaterThan,
+        LessThan
+    }
+
+    private static Expression BuildComparison(CursorOrdering ordering, object? value, ParameterExpression parameter,
+        ComparisonKind kind)
+    {
+        var left = new ReplaceParameterVisitor(ordering.Selector.Parameters[0], parameter).Visit(ordering.Selector.Body)!;
+        var right = Expression.Constant(value, left.Type);
+
+        if (kind == ComparisonKind.Equal)
+        {
+            // Equality is well-defined for every type via Expression.Equal (it falls back to Object.Equals
+            // for reference types that don't overload ==), unlike GreaterThan/LessThan.
+            return Expression.Equal(left, right);
+        }
+
+        // Expression.GreaterThan/LessThan only work for numeric primitives and types with overloaded
+        // comparison operators, which excludes ordinary types like string, Guid, or DateTimeOffset.
+        // Marten's own Linq provider already knows how to translate `x.CompareTo(y) > 0`/`< 0` into SQL
+        // comparisons (see Marten.Linq.Parsing.CompareToComparable), so route every non-equal comparison
+        // through that same shape instead of the raw binary operator.
+        var compareToMethod = left.Type.GetMethod("CompareTo", new[] { left.Type })
+            ?? left.Type.GetMethod("CompareTo", new[] { typeof(object) });
+
+        if (compareToMethod == null)
+        {
+            // Fall back to the raw operator for the rare key type with neither an overloaded operator
+            // nor an IComparable(<T>) implementation - this will throw a clear .NET exception if unsupported.
+            return kind == ComparisonKind.GreaterThan
+                ? Expression.GreaterThan(left, right)
+                : Expression.LessThan(left, right);
+        }
+
+        var compareArgument = compareToMethod.GetParameters()[0].ParameterType == typeof(object)
+            ? Expression.Convert(right, typeof(object))
+            : (Expression)right;
+
+        var compareCall = Expression.Call(left, compareToMethod, compareArgument);
+
+        return kind switch
+        {
+            ComparisonKind.GreaterThan => Expression.GreaterThan(compareCall, Expression.Constant(0)),
+            ComparisonKind.LessThan => Expression.LessThan(compareCall, Expression.Constant(0)),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
+        };
+    }
+
+    /// <summary>
+    /// Base64-encode (with a leading version marker) the boxed sort key values of
+    /// the last row in a page so they can be round-tripped back as the next
+    /// request's cursor.
+    /// </summary>
+    public static string EncodeCursor(object?[] values)
+    {
+        var json = JsonSerializer.Serialize(values);
+        var bytes = Encoding.UTF8.GetBytes(json);
+        return CursorPrefix + Convert.ToBase64String(bytes);
+    }
+
+    /// <summary>
+    /// Decode a cursor string produced by <see cref="EncodeCursor"/>, converting
+    /// each element back to the CLR type produced by its matching ordering's key
+    /// selector.
+    /// </summary>
+    public static object?[] DecodeCursor(string cursor, IReadOnlyList<CursorOrdering> orderings)
+    {
+        if (!cursor.StartsWith(CursorPrefix, StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Unrecognized cursor format.", nameof(cursor));
+        }
+
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(cursor[CursorPrefix.Length..]);
+        }
+        catch (FormatException e)
+        {
+            throw new ArgumentException("Invalid cursor.", nameof(cursor), e);
+        }
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(bytes);
+        }
+        catch (JsonException e)
+        {
+            throw new ArgumentException("Invalid cursor.", nameof(cursor), e);
+        }
+
+        using (document)
+        {
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Array || root.GetArrayLength() != orderings.Count)
+            {
+                throw new ArgumentException(
+                    "The supplied cursor does not match the ordering of the supplied queryable.", nameof(cursor));
+            }
+
+            var values = new object?[orderings.Count];
+            for (var i = 0; i < orderings.Count; i++)
+            {
+                values[i] = JsonSerializer.Deserialize(root[i].GetRawText(), orderings[i].KeyType);
+            }
+
+            return values;
+        }
+    }
+
+    private sealed class ReplaceParameterVisitor: ExpressionVisitor
+    {
+        private readonly ParameterExpression _from;
+        private readonly ParameterExpression _to;
+
+        public ReplaceParameterVisitor(ParameterExpression from, ParameterExpression to)
+        {
+            _from = from;
+            _to = to;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            return node == _from ? _to : base.VisitParameter(node);
+        }
+    }
+}

--- a/src/Marten/Linq/CursorPaging/CursorPagingQueryableExtensions.cs
+++ b/src/Marten/Linq/CursorPaging/CursorPagingQueryableExtensions.cs
@@ -1,0 +1,100 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Core.Reflection;
+using Marten.Linq;
+
+namespace Marten.Linq.CursorPaging;
+
+/// <summary>
+/// Keyset (seek) pagination support for Marten Linq queries: given an
+/// <see cref="IQueryable{T}"/> with an <c>OrderBy</c>/<c>ThenBy</c> chain applied,
+/// fetch pages at constant cost regardless of depth, using an opaque continuation
+/// cursor instead of <c>Skip</c>/<c>Take</c> offsets.
+/// </summary>
+public static class CursorPagingQueryableExtensions
+{
+    /// <summary>
+    /// Execute <paramref name="queryable"/> as a keyset-paginated page of results.
+    /// </summary>
+    /// <param name="queryable">
+    /// A Marten Linq queryable with at least one <c>OrderBy</c>/<c>ThenBy</c> clause
+    /// applied. The last ordering clause must be on a member guaranteed to be
+    /// unique across the result set (typically the document identity) so that
+    /// pagination is deterministic.
+    /// </param>
+    /// <param name="cursor">
+    /// The opaque continuation cursor from a previous call's
+    /// <see cref="CursorPageResult.NextCursor"/>, or <c>null</c>/empty for the
+    /// first page.
+    /// </param>
+    /// <param name="pageSize">The maximum number of documents to return in this page.</param>
+    /// <param name="token"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <exception cref="ArgumentOutOfRangeException">If <paramref name="pageSize"/> is not positive.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// If <paramref name="queryable"/> has no OrderBy clause, or the terminal
+    /// OrderBy/ThenBy clause is not on a member guaranteed to be unique.
+    /// </exception>
+    /// <exception cref="ArgumentException">If <paramref name="cursor"/> is malformed or does not match the ordering.</exception>
+    public static async Task<CursorPageResult> ToJsonPageByCursorAsync<T>(
+        this IQueryable<T> queryable,
+        string? cursor,
+        int pageSize,
+        CancellationToken token = default) where T : notnull
+    {
+        if (queryable == null) throw new ArgumentNullException(nameof(queryable));
+        if (pageSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "Page size must be greater than zero.");
+        }
+
+        var martenQueryable = queryable.As<MartenLinqQueryable<T>>();
+        var session = martenQueryable.Session;
+
+        var orderings = CursorPagination.ParseOrderings(queryable.Expression);
+        if (orderings.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"StreamPagedByCursor<{typeof(T).Name}> requires the supplied queryable to have at least one " +
+                "OrderBy/OrderByDescending clause so that keyset pagination is deterministic.");
+        }
+
+        CursorPagination.ValidateTerminalKeyIsUnique<T>(orderings[^1]);
+
+        var working = queryable;
+
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            var values = CursorPagination.DecodeCursor(cursor!, orderings);
+            var predicate = CursorPagination.BuildSeekPredicate<T>(orderings, values);
+            working = working.Where(predicate);
+        }
+
+        var fetched = await working.Take(pageSize + 1).ToListAsync<T>(token).ConfigureAwait(false);
+
+        var hasMore = fetched.Count > pageSize;
+        var items = hasMore ? fetched.Take(pageSize).ToList() : fetched.ToList();
+
+        string? nextCursor = null;
+        if (hasMore && items.Count > 0)
+        {
+            var lastItem = items[^1];
+            var values = new object?[orderings.Count];
+            for (var i = 0; i < orderings.Count; i++)
+            {
+                values[i] = orderings[i].GetValue(lastItem);
+            }
+
+            nextCursor = CursorPagination.EncodeCursor(values);
+        }
+
+        var itemsJson = items.Count == 0
+            ? "[]"
+            : "[" + string.Join(",", items.Select(i => session.Serializer.ToJson(i))) + "]";
+
+        return new CursorPageResult(itemsJson, items.Count, nextCursor);
+    }
+}


### PR DESCRIPTION
## Summary

Implements #5012: `StreamPagedByCursor<T>`, a keyset (seek) pagination companion to offset-based paging. Unlike `LIMIT`/`OFFSET` + `COUNT(*) OVER()`, seek pagination has constant cost at any page depth, which makes it a good fit for infinite scroll and export scenarios.

## What's included

- **`Marten.Linq.CursorPaging.CursorPagination`** (internal): parses the `OrderBy`/`ThenBy` chain off an `IQueryable<T>`'s expression tree, validates that the terminal ordering is on a member guaranteed to be unique (the document identity member, via `DocumentMapping.FindIdMember`), and builds the composite keyset seek predicate:
  `(k1 > v1) OR (k1 = v1 AND k2 > v2) OR ... OR (k1=v1 AND ... AND kn > vn)`, flipping `>`/`<` per ordering direction.
  - Non-primitive-comparable key types (`string`, `Guid`, `DateTimeOffset`, etc.) are compared via the `x.CompareTo(y) > 0` shape, which Marten's own Linq provider (`CompareToComparable`) already knows how to translate into SQL — so the seek predicate actually executes server-side in Postgres, not in memory.
- **`CursorPagingQueryableExtensions.ToJsonPageByCursorAsync<T>`** (public): the entry point. Decodes an opaque cursor, applies the seek `Where` clause when a cursor is present, fetches `pageSize + 1` rows to detect whether there's a next page without ever streaming the extra row, and encodes the last row's sort-key values into the next cursor (version-stamped, base64-encoded JSON).
- **`Marten.AspNetCore.StreamPagedByCursor<T>`**: an `IResult` that streams the page as a JSON envelope — `{"items":[...],"nextCursor":"..."}` — and also sets a `Marten-Continuation` response header with the same cursor value for callers that prefer a header-based contract.

## Behavior

1. First request (`cursor == null`): `ORDER BY ... LIMIT @pageSize`.
2. Subsequent requests: decodes the cursor and composes the seek predicate from the queryable's `OrderBy` chain.
3. Fewer rows than `pageSize` on a page → no `nextCursor` (end of set).
4. Refuses (`InvalidOperationException`) if there's no `OrderBy` clause, or if the terminal ordering isn't on a member guaranteed unique.

## Documentation

- `docs/documents/querying/linq/paging.md` — new "Keyset (Cursor) Pagination" section explaining `ToJsonPageByCursorAsync<T>`, keyset vs. offset pagination tradeoffs, the `OrderBy`/unique-terminal-key requirements, and when to use which.
- `docs/documents/aspnetcore.md` — new "StreamPagedByCursor<T>" section alongside the other typed streaming result types.

## Tests

- `src/DocumentDbTests/Reading/cursor_paging_tests.cs` — integration tests run against real Postgres, covering: first page, subsequent page, last page (fewer rows than page size), exact-multiple-of-page-size boundary, empty result set, mixed ascending/descending sort directions, duplicate-leading-key tie-breaking (exhaustive pagination through ties), and the validation errors (missing `OrderBy`, non-unique terminal key, non-positive page size). All pass against a live Postgres instance on both `net9.0` and `net10.0`.
- `src/Marten.AspNetCore.Testing/stream_paged_by_cursor_tests.cs` — Alba-hosted endpoint tests exercising the same scenarios through two new minimal API endpoints registered in `IssueService` (`/minimal/issues/paged-cursor`, `/minimal/issues/paged-cursor-mixed`).

### Known limitation

The Alba-hosted tests in `Marten.AspNetCore.Testing` currently cannot be executed in the sandbox this was developed in — **all** Alba-hosted tests in that project (including pre-existing, unrelated ones) fail at host startup with `JasperFx.Events.Projections.InvalidProjectionException: No source-generated dispatcher found for ... SingleStreamProjection<Order, Guid>`. Confirmed via `git stash` (reverting to a clean branch HEAD with zero changes) that this failure pre-exists and is unrelated to this PR — it looks like a source-generator/toolchain wiring issue local to that environment. The tests compile cleanly and are logically equivalent to the passing `DocumentDbTests` suite. Would appreciate a CI run to confirm they pass there.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
