### PR TITLE
feat: Translate simple LINQ Select() projections to jsonb_build_object (fixes #5011)

### DIFF
--- a/docs/documents/querying/linq/projections.md
+++ b/docs/documents/querying/linq/projections.md
@@ -99,6 +99,61 @@ public async Task transform_with_deep_properties()
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/LinqTests/Acceptance/select_clause_usage.cs#L321-L336' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_deep_properties_projection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+## Server-Side JSON Projections <Badge type="tip" text="9.18" />
+
+::: tip
+This optimization applies automatically. There is nothing you need to opt into -- Marten
+just tries to push as much of the projection down into SQL as it safely can.
+:::
+
+When a `Select()` projection is a "simple" transform -- meaning its constructor arguments
+and/or property initializers are made up **only** of direct (optionally nested) member
+accesses on the source document, with no method calls, arithmetic, string concatenation,
+casts, or conditional (`? :`) expressions -- Marten translates the whole projection into a
+single `jsonb_build_object(...)` expression that Postgres itself evaluates, rather than
+pulling the full document down to the client and reshaping it in .NET. For example:
+
+```cs
+var dtos = await session.Query<User>()
+    .Select(x => new UserName { Name = x.FirstName })
+    .ToListAsync();
+```
+
+is executed as something close to:
+
+```sql
+select jsonb_build_object('Name', d.data ->> 'FirstName') as data
+from mt_doc_user as d
+```
+
+The generated JSON key names follow the same naming policy (e.g. camelCase) as the rest of
+your serialized documents, and this also works through nested member access:
+
+```cs
+// x.Client.Name becomes d.data -> 'client' -> 'name'
+.Select(x => new { ClientName = x.Client.Name })
+```
+
+`Distinct()` composes naturally with this optimization, and is applied as `distinct on`/
+`distinct` over the generated `jsonb_build_object(...)` expression.
+
+Because the projected shape is built by Postgres as a `jsonb` value, it can be streamed
+directly to the client as raw JSON with no further (de)serialization on the Marten side --
+see [Query for Raw JSON](/documents/querying/query-json) for `ToJsonArray()`/`ToJsonFirst()`
+and the raw `StreamJsonArray()`/`StreamOne()`/`StreamMany()` methods on `IQueryable<T>`.
+
+### Projections That Can't Be Expressed in SQL
+
+If a `Select()` projection contains anything Marten can't safely translate into
+`jsonb_build_object(...)` -- a method call (`x.Name.ToUpper()`), arithmetic, string
+interpolation, a cast, or a conditional expression -- Marten instead deserializes the full
+source document and applies your original projection lambda on the client, exactly as it
+always has. This fallback always produces correct results, but because the underlying
+`data` column no longer matches the shape of `TResult`, it **cannot** be streamed as raw
+JSON: calling `StreamJsonArray()`/`StreamOne()`/`ToJsonArray()` (or similar) against such a
+projection will throw a `BadLinqExpressionException` telling you to use `ToListAsync()` (or
+another non-streaming method) instead.
+
 ## Chaining other Linq Methods
 
 After calling Select, you'd be able to chain other linq methods such as `First()`, `FirstOrDefault()`, `Single()` and so on, like so:

--- a/docs/documents/querying/query-json.md
+++ b/docs/documents/querying/query-json.md
@@ -91,6 +91,15 @@ public async Task when_get_json_then_raw_json_should_be_returned_async()
 
 Marten has the ability to combine the `AsJson()` mechanics to the result of a `Select()` transform:
 
+::: tip
+When a `Select()` projection is a "simple" flat member-access transform, Marten pushes the
+whole reshaping down into a single `jsonb_build_object(...)` SQL expression instead of
+deserializing the full document on the client, which is what makes the raw JSON results
+below possible without an extra serialization round trip. See
+[Projection Operators](/documents/querying/linq/projections) for the details and its
+limitations.
+:::
+
 <!-- snippet: sample_asjson-plus-select-1 -->
 <a id='snippet-sample_asjson-plus-select-1'></a>
 ```cs

--- a/src/LinqTests/Bugs/Bug_5011_jsonb_build_object_select_projection.cs
+++ b/src/LinqTests/Bugs/Bug_5011_jsonb_build_object_select_projection.cs
@@ -1,0 +1,147 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Exceptions;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+public class Bug_5011_jsonb_build_object_select_projection: BugIntegrationContext
+{
+    [Fact]
+    public async Task simple_select_uses_jsonb_build_object_and_can_stream_raw_json()
+    {
+        theSession.Store(new Target5011
+        {
+            Id = Guid.NewGuid(), Code = "abc", Name = "Widget"
+        });
+        await theSession.SaveChangesAsync();
+
+        var queryable = theSession.Query<Target5011>()
+            .Select(x => new Target5011Dto(x.Code, x.Name));
+
+        var command = queryable.ToCommand();
+        command.CommandText.ShouldContain("jsonb_build_object");
+
+        var results = await queryable.ToListAsync();
+        results.ShouldContain(x => x.Code == "abc" && x.Name == "Widget");
+
+        var stream = new MemoryStream();
+        await queryable.StreamJsonArray(stream, default);
+        stream.Position = 0;
+        var json = await new StreamReader(stream).ReadToEndAsync();
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.ValueKind.ShouldBe(JsonValueKind.Array);
+        doc.RootElement.GetArrayLength().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task property_names_follow_the_serializer_naming_policy()
+    {
+        theSession.Store(new Target5011 { Id = Guid.NewGuid(), Code = "abc", Name = "Widget" });
+        await theSession.SaveChangesAsync();
+
+        var queryable = theSession.Query<Target5011>()
+            .Select(x => new Target5011Dto(x.Code, x.Name));
+
+        var stream = new MemoryStream();
+        await queryable.StreamJsonArray(stream, default);
+        stream.Position = 0;
+        var json = await new StreamReader(stream).ReadToEndAsync();
+
+        // Default Marten serializer casing is camelCase
+        json.ShouldContain("\"code\"");
+        json.ShouldContain("\"name\"");
+    }
+
+    [Fact]
+    public async Task nested_member_access_projects_through_the_json_path()
+    {
+        theSession.Store(new Target5011
+        {
+            Id = Guid.NewGuid(), Code = "abc", Name = "Widget", Client = new Client5011 { Name = "Acme" }
+        });
+        await theSession.SaveChangesAsync();
+
+        var queryable = theSession.Query<Target5011>()
+            .Select(x => new { ClientName = x.Client!.Name });
+
+        var command = queryable.ToCommand();
+        command.CommandText.ShouldContain("jsonb_build_object");
+
+        var results = await queryable.ToListAsync();
+        results.ShouldContain(x => x.ClientName == "Acme");
+    }
+
+    [Fact]
+    public async Task method_call_in_select_falls_back_to_client_side_evaluation()
+    {
+        theSession.Store(new Target5011 { Id = Guid.NewGuid(), Code = "abc", Name = "Widget" });
+        await theSession.SaveChangesAsync();
+
+        var queryable = theSession.Query<Target5011>()
+            .Select(x => new Target5011Dto(x.Code!.ToUpper(), x.Name));
+
+        // Should NOT be translated into jsonb_build_object -- the ToUpper() call can't be
+        // expressed in SQL, so Marten must fall back to a client-side transform instead of
+        // silently dropping the operation.
+        var command = queryable.ToCommand();
+        command.CommandText.ShouldNotContain("jsonb_build_object");
+
+        var results = await queryable.ToListAsync();
+        results.ShouldContain(x => x.Code == "ABC" && x.Name == "Widget");
+    }
+
+    [Fact]
+    public async Task streaming_raw_json_is_refused_for_a_client_side_fallback_projection()
+    {
+        theSession.Store(new Target5011 { Id = Guid.NewGuid(), Code = "abc", Name = "Widget" });
+        await theSession.SaveChangesAsync();
+
+        var queryable = theSession.Query<Target5011>()
+            .Select(x => new Target5011Dto(x.Code!.ToUpper(), x.Name));
+
+        var stream = new MemoryStream();
+        await Should.ThrowAsync<BadLinqExpressionException>(async () =>
+            await queryable.StreamJsonArray(stream, default));
+    }
+
+    [Fact]
+    public async Task distinct_composes_with_the_jsonb_build_object_projection()
+    {
+        theSession.Store(new Target5011 { Id = Guid.NewGuid(), Code = "abc", Name = "Widget" });
+        theSession.Store(new Target5011 { Id = Guid.NewGuid(), Code = "abc", Name = "Widget" });
+        await theSession.SaveChangesAsync();
+
+        var queryable = theSession.Query<Target5011>()
+            .Select(x => new Target5011Dto(x.Code, x.Name))
+            .Distinct();
+
+        var command = queryable.ToCommand();
+        command.CommandText.ShouldContain("jsonb_build_object");
+
+        var results = await queryable.ToListAsync();
+        results.Count.ShouldBe(1);
+    }
+}
+
+public class Target5011
+{
+    public Guid Id { get; set; }
+    public string? Code { get; set; }
+    public string? Name { get; set; }
+    public Client5011? Client { get; set; }
+}
+
+public class Client5011
+{
+    public string? Name { get; set; }
+}
+
+public record Target5011Dto(string Code, string Name);

--- a/src/Marten/Linq/MartenLinqQueryProvider.cs
+++ b/src/Marten/Linq/MartenLinqQueryProvider.cs
@@ -107,7 +107,7 @@ internal class MartenLinqQueryProvider: IQueryProvider
         {
             var parser = new LinqQueryParser(this, _session, expression, mode);
 
-            var handler = parser.BuildHandler<TResult>();
+            var handler = parser.BuildHandler<TResult>(assertCanStreamRawJson: true);
 
             await EnsureStorageExistsAsync(parser, token).ConfigureAwait(false);
 
@@ -179,6 +179,7 @@ internal class MartenLinqQueryProvider: IQueryProvider
         await EnsureStorageExistsAsync(parser, token).ConfigureAwait(false);
 
         var statements = parser.BuildStatements();
+        LinqQueryParser.AssertCanStreamRawJson(statements.MainSelector);
 
         var command = statements.Top.BuildCommand(_session);
 
@@ -189,6 +190,7 @@ internal class MartenLinqQueryProvider: IQueryProvider
     {
         var parser = new LinqQueryParser(this, _session, expression);
         var statements = parser.BuildStatements();
+        LinqQueryParser.AssertCanStreamRawJson(statements.MainSelector);
 
         await EnsureStorageExistsAsync(parser, token).ConfigureAwait(false);
 

--- a/src/Marten/Linq/Parsing/LinqQueryParser.Handlers.cs
+++ b/src/Marten/Linq/Parsing/LinqQueryParser.Handlers.cs
@@ -10,6 +10,7 @@ using Marten.Linq.SqlGeneration;
 using Weasel.Postgresql.SqlGeneration;
 using System.Diagnostics.CodeAnalysis;
 
+using Marten.Exceptions;
 using Marten.Internal;
 
 namespace Marten.Linq.Parsing;
@@ -66,7 +67,7 @@ internal partial class LinqQueryParser
         return null;
     }
 
-    public IQueryHandler<TResult> BuildHandler<TResult>()
+    public IQueryHandler<TResult> BuildHandler<TResult>(bool assertCanStreamRawJson = false)
     {
         if (!_collectionUsages.Any())
         {
@@ -75,6 +76,11 @@ internal partial class LinqQueryParser
         }
 
         var statements = BuildStatements();
+
+        if (assertCanStreamRawJson)
+        {
+            AssertCanStreamRawJson(statements.MainSelector);
+        }
 
         var handler = buildHandlerForCurrentStatement<TResult>(statements.Top, statements.MainSelector);
 
@@ -87,6 +93,24 @@ internal partial class LinqQueryParser
         }
 
         return handler;
+    }
+
+    /// <summary>
+    /// GH-5011: raw JSON streaming (StreamJsonArray/StreamOne/StreamMany/StreamJsonFirst/etc.)
+    /// copies the bytes of the underlying "data" column directly to the caller without ever
+    /// invoking the query's selector. That's only correct when the "data" column actually
+    /// holds JSON shaped like the requested result (the stored document itself, or a
+    /// server-computed jsonb_build_object() projection). Select() projections that fell back
+    /// to a client-side compiled transform select the *source* document's JSON instead, so
+    /// streaming them raw would silently return the wrong shape -- refuse clearly instead.
+    /// </summary>
+    public static void AssertCanStreamRawJson(SelectorStatement selector)
+    {
+        if (selector.SelectClause is IClientSideProjectionSelectClause)
+        {
+            throw new BadLinqExpressionException(
+                "This Select() projection cannot be streamed as raw JSON because it requires client-side evaluation (method calls, arithmetic, casts, or conditional expressions are not supported). Use ToListAsync() or another non-streaming method instead.");
+        }
     }
 
     private IQueryHandler<TResult> buildHandlerForCurrentStatement<TResult>(Statement top, SelectorStatement selector)

--- a/src/Marten/Linq/Parsing/SelectParser.cs
+++ b/src/Marten/Linq/Parsing/SelectParser.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -13,6 +14,19 @@ using Weasel.Postgresql.SqlGeneration;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Marten.Linq.Parsing;
+
+/// <summary>
+/// Signals that a Select() projection is not a "simple" flat member-access transform
+/// (GH-5011) -- e.g. it contains a method call, arithmetic, a cast/conversion, or a
+/// conditional expression -- and cannot be translated to a server-side
+/// <c>jsonb_build_object(...)</c> expression. Callers catch this and fall back to
+/// compiling the original Select() lambda and applying it against the fully
+/// deserialized document on the client, so behavior is unchanged from before the
+/// jsonb_build_object optimization was introduced.
+/// </summary>
+internal sealed class SelectProjectionNotSimpleException: Exception
+{
+}
 
 [UnconditionalSuppressMessage("Trimming", "IL2075",
     Justification = "Class-level: PublicMethods/PublicProperties access via a Type obtained from object.GetType() / GetGenericArguments. Source instance is preserved at the StoreOptions / projection-registration boundary.")]
@@ -66,7 +80,29 @@ internal class SelectParser: ExpressionVisitor
                 return null;
         }
 
-        return base.VisitBinary(node);
+        // Any other binary node reaching here is arithmetic/computation (Add, Subtract,
+        // string concatenation via '+', comparisons used as a projected bool, etc.) that
+        // can't be proven equivalent to a jsonb_build_object() expression. Signal the
+        // caller to fall back to a client-side compiled transform (GH-5011) instead of
+        // silently dropping the operation and returning the raw member value.
+        throw new SelectProjectionNotSimpleException();
+    }
+
+    protected override Expression VisitUnary(UnaryExpression node)
+    {
+        // Casts/conversions (numeric narrowing/widening, boxing to object, enum-to-int,
+        // etc.) and other unary operators (negation, logical not) are computed
+        // expressions -- the underlying member's raw JSON value is not guaranteed to
+        // equal the converted value. Fall back to a client-side compiled transform
+        // (GH-5011) rather than silently ignoring the conversion.
+        throw new SelectProjectionNotSimpleException();
+    }
+
+    protected override Expression VisitConditional(ConditionalExpression node)
+    {
+        // Ternary/conditional expressions are computed expressions; fall back to a
+        // client-side compiled transform (GH-5011).
+        throw new SelectProjectionNotSimpleException();
     }
 
     protected override Expression VisitConstant(ConstantExpression node)
@@ -147,7 +183,11 @@ internal class SelectParser: ExpressionVisitor
             }
         }
 
-        return base.VisitMethodCall(node);
+        // Any other method call (string.ToUpper(), custom methods, LINQ helpers, etc.)
+        // is a computed expression that jsonb_build_object() cannot reproduce. Signal the
+        // caller to fall back to a client-side compiled transform (GH-5011) instead of
+        // silently dropping the call and returning the raw member value underneath it.
+        throw new SelectProjectionNotSimpleException();
     }
 
     protected override Expression VisitMember(MemberExpression node)

--- a/src/Marten/Linq/Parsing/SelectParser.cs
+++ b/src/Marten/Linq/Parsing/SelectParser.cs
@@ -24,7 +24,7 @@ namespace Marten.Linq.Parsing;
 /// deserialized document on the client, so behavior is unchanged from before the
 /// jsonb_build_object optimization was introduced.
 /// </summary>
-internal sealed class SelectProjectionNotSimpleException: Exception
+internal sealed class SelectProjectionNotSimpleException: MartenException
 {
 }
 

--- a/src/Marten/Linq/Parsing/SelectorVisitor.cs
+++ b/src/Marten/Linq/Parsing/SelectorVisitor.cs
@@ -124,11 +124,63 @@ public class SelectorVisitor: ExpressionVisitor
 
     public void ToSelectTransform(Expression selectExpression, ISerializer serializer)
     {
-        var visitor = new SelectParser(_serializer, _collection, selectExpression);
+        try
+        {
+            var visitor = new SelectParser(_serializer, _collection, selectExpression);
 
-        _statement.SelectClause =
-            typeof(SelectDataSelectClause<>).CloseAndBuildAs<ISelectClause>(_statement.SelectClause.FromObject,
-                visitor.NewObject,
-                selectExpression.Type);
+            _statement.SelectClause =
+                typeof(SelectDataSelectClause<>).CloseAndBuildAs<ISelectClause>(_statement.SelectClause.FromObject,
+                    visitor.NewObject,
+                    selectExpression.Type);
+        }
+        catch (SelectProjectionNotSimpleException)
+        {
+            // GH-5011: the Select() projection contains method calls, arithmetic, casts,
+            // or conditional expressions that can't be translated to a server-side
+            // jsonb_build_object() expression. Fall back to compiling the original
+            // Select() lambda and applying it against the fully deserialized source
+            // document on the client -- the same behavior Marten had before that
+            // optimization existed.
+            var parameter = ParameterFinder.FindIn(selectExpression);
+            if (parameter == null)
+            {
+                throw new Marten.Exceptions.BadLinqExpressionException(
+                    "Marten is not (yet) able to process this Select() transform");
+            }
+
+            var lambda = Expression.Lambda(selectExpression, parameter);
+            var compiled = lambda.Compile();
+
+            _statement.SelectClause =
+                typeof(LambdaSelectClause<,>).CloseAndBuildAs<ISelectClause>(_statement.SelectClause.FromObject,
+                    compiled,
+                    _collection.ElementType,
+                    selectExpression.Type);
+        }
+    }
+}
+
+/// <summary>
+/// Finds the first ParameterExpression referenced anywhere within an expression tree.
+/// Used by the GH-5011 client-side Select() fallback to recover the document parameter
+/// (e.g. the `x` in `x => new Dto(...)`) so the projection body can be re-wrapped into a
+/// compilable lambda after LinqOperator processing discarded the original
+/// LambdaExpression and kept only its body.
+/// </summary>
+internal sealed class ParameterFinder: ExpressionVisitor
+{
+    private ParameterExpression _found;
+
+    public static ParameterExpression FindIn(Expression expression)
+    {
+        var finder = new ParameterFinder();
+        finder.Visit(expression);
+        return finder._found;
+    }
+
+    protected override Expression VisitParameter(ParameterExpression node)
+    {
+        _found ??= node;
+        return base.VisitParameter(node);
     }
 }

--- a/src/Marten/Linq/Selectors/LambdaTransformSelector.cs
+++ b/src/Marten/Linq/Selectors/LambdaTransformSelector.cs
@@ -1,0 +1,41 @@
+#nullable enable
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Marten.Internal;
+
+namespace Marten.Linq.Selectors;
+
+/// <summary>
+/// Fallback selector for Select() projections that are not "simple" flat member
+/// accesses (GH-5011) -- e.g. they contain method calls, arithmetic, casts, or
+/// conditional expressions. The full source document is deserialized from the raw
+/// "data" column and the original Select() lambda (compiled once here) is then applied
+/// against it on the client, exactly as Marten did before the jsonb_build_object
+/// optimization existed for simple projections. Because the transform runs in .NET,
+/// results produced through this selector cannot be streamed as raw JSON.
+/// </summary>
+internal class LambdaTransformSelector<TSource, TResult>: ISelector<TResult> where TSource : notnull
+{
+    private readonly IStorageSerializer _serializer;
+    private readonly Func<TSource, TResult> _transform;
+
+    public LambdaTransformSelector(IStorageSerializer serializer, Func<TSource, TResult> transform)
+    {
+        _serializer = serializer;
+        _transform = transform;
+    }
+
+    public TResult Resolve(DbDataReader reader)
+    {
+        var source = _serializer.FromJson<TSource>(reader, 0);
+        return _transform(source);
+    }
+
+    public async Task<TResult> ResolveAsync(DbDataReader reader, CancellationToken token)
+    {
+        var source = await _serializer.FromJsonAsync<TSource>(reader, 0, token).ConfigureAwait(false);
+        return _transform(source);
+    }
+}

--- a/src/Marten/Linq/SqlGeneration/LambdaSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/LambdaSelectClause.cs
@@ -1,0 +1,126 @@
+#nullable enable
+using System;
+using JasperFx.Core;
+using Marten.Internal;
+using Marten.Linq.Parsing;
+using Marten.Linq.QueryHandlers;
+using Marten.Linq.Selectors;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.SqlGeneration;
+
+/// <summary>
+/// Marker interface for select clauses whose result is produced by executing .NET code
+/// against the fully deserialized source document rather than by a SQL expression the
+/// database computes directly (GH-5011). The "data" column for these clauses holds the
+/// *source* document's raw JSON, not the shape of <c>TResult</c>, so raw JSON streaming
+/// (StreamJsonArray/StreamOne/StreamMany/StreamJsonFirst/StreamJsonSingle) must refuse to
+/// operate on them -- doing so would copy the wrong bytes to the caller.
+/// </summary>
+internal interface IClientSideProjectionSelectClause
+{
+}
+
+/// <summary>
+/// Select clause used as a fallback when a Select() projection is not a "simple" flat
+/// member-access transform (GH-5011) -- i.e. it contains method calls, arithmetic,
+/// casts, or conditional expressions that can't be translated into a
+/// jsonb_build_object() SQL expression. The full source document is selected as-is and
+/// the original Select() lambda is compiled and applied against it on the client, which
+/// is exactly how Marten always projected before the jsonb_build_object optimization
+/// existed, so this is purely a fallback with no behavior change.
+/// </summary>
+internal class LambdaSelectClause<TSource, TResult>: ISelectClause, IScalarSelectClause,
+    IModifyableFromObject, IDistinctOnSelectClause, IClientSideProjectionSelectClause
+    where TSource : notnull
+    where TResult : notnull
+{
+    private readonly Func<TSource, TResult> _transform;
+
+    public LambdaSelectClause(string from, Func<TSource, TResult> transform)
+    {
+        FromObject = from;
+        _transform = transform;
+    }
+
+    public string? DistinctOn { get; set; }
+
+    public Type SelectedType => typeof(TResult);
+
+    public string FromObject { get; set; }
+
+    public string MemberName => "d.data";
+
+    public string? Operator { get; set; }
+
+    public void Apply(ICommandBuilder sql)
+    {
+        sql.Append("select ");
+
+        if (DistinctOn.IsNotEmpty())
+        {
+            sql.Append("distinct on (");
+            sql.Append(DistinctOn);
+            sql.Append(") ");
+        }
+
+        if (Operator.IsNotEmpty())
+        {
+            sql.Append(Operator);
+            sql.Append("(d.data)");
+        }
+        else
+        {
+            sql.Append("d.data");
+        }
+
+        sql.Append(" as data from ");
+        sql.Append(FromObject);
+        sql.Append(" as d");
+    }
+
+    public string[] SelectFields()
+    {
+        return new[] { "d.data" };
+    }
+
+    public ISelector BuildSelector(IStorageSession session)
+    {
+        return new LambdaTransformSelector<TSource, TResult>(session.Serializer, _transform);
+    }
+
+    public IQueryHandler<TResult2> BuildHandler<TResult2>(IStorageSession session, ISqlFragment statement,
+        ISqlFragment currentStatement) where TResult2 : notnull
+    {
+        var selector = new LambdaTransformSelector<TSource, TResult>(session.Serializer, _transform);
+
+        return LinqQueryParser.BuildHandler<TResult, TResult2>(selector, statement);
+    }
+
+    public ISelectClause UseStatistics(QueryStatistics statistics)
+    {
+        return new StatsSelectClause<TResult>(this, statistics);
+    }
+
+    public override string ToString()
+    {
+        return $"Client-side Select() transform from {FromObject}";
+    }
+
+    public void ApplyOperator(string op)
+    {
+        Operator = op;
+    }
+
+    public ISelectClause CloneToDouble()
+    {
+        throw new NotSupportedException(
+            "Aggregate operations (Sum/Min/Max/Average) are not supported against a Select() projection that requires client-side evaluation (GH-5011)");
+    }
+
+    public ISelectClause CloneToOtherTable(string tableName)
+    {
+        return new LambdaSelectClause<TSource, TResult>(tableName, _transform) { DistinctOn = DistinctOn, Operator = Operator };
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #5011.

When a .Select() projection is composed only of simple (optionally nested) member accesses on the source document - no method calls, arithmetic, casts, or conditional expressions - Marten now translates the whole projection into a single \jsonb_build_object(...)\ SQL expression that Postgres evaluates server-side, instead of pulling the full document to the client and reshaping it in .NET.

This allows eligible projected shapes to be streamed as raw JSON (\StreamJsonArray\/\StreamOne\/\StreamMany\/\ToJsonArray\/\ToJsonFirst\, etc.) with no additional (de)serialization.

### Behavior

- Output JSON property names follow the store's serializer naming policy (e.g. camelCase).
- Nested member access (\x.Client.Name\) is supported and maps to \d.data -> 'client' -> 'name'\.
- \Distinct()\ composes naturally with the optimization.
- Projections containing method calls, arithmetic, casts, or conditional expressions are **not** eligible for SQL translation. These now correctly fall back to a client-side transform (deserialize + apply the original lambda) instead of silently producing wrong results, which was a real bug found while implementing this: \SelectParser\ previously dropped unsupported expression shapes without falling back.
- Attempting to stream (\StreamJsonArray\/\StreamOne\/\StreamMany\) a projection that fell back to client-side evaluation now throws a \BadLinqExpressionException\ directing the caller to use \ToListAsync()\ (or similar) instead, rather than silently streaming incorrect JSON.

### Changes

- \src/Marten/Linq/Parsing/SelectParser.cs\: added \SelectProjectionNotSimpleException\; \VisitBinary\, \VisitUnary\, \VisitMethodCall\, \VisitConditional\ now throw for unsupported expression shapes instead of silently falling through.
- \src/Marten/Linq/Parsing/SelectorVisitor.cs\: catches the exception and builds a client-side fallback selector.
- \src/Marten/Linq/SqlGeneration/LambdaSelectClause.cs\ (new): fallback \ISelectClause\/\IClientSideProjectionSelectClause\ implementation.
- \src/Marten/Linq/Selectors/LambdaTransformSelector.cs\ (new): \ISelector<TResult>\ for the fallback path.
- \src/Marten/Linq/Parsing/LinqQueryParser.Handlers.cs\ / \src/Marten/Linq/MartenLinqQueryProvider.cs\: added a guard so streaming APIs reject non-simple (client-side-fallback) projections with a clear exception.
- \src/LinqTests/Bugs/Bug_5011_jsonb_build_object_select_projection.cs\ (new): tests covering simple-select SQL generation, naming-policy casing, nested member access, method-call fallback correctness, streaming refusal for ineligible projections, and \Distinct()\ composition.
- Documentation: \docs/documents/querying/linq/projections.md\ (new section explaining the optimization and fallback rules) and \docs/documents/querying/query-json.md\ (cross-reference note). Verified with \markdownlint-cli\ and \cspell\ locally, zero issues.

### Testing

All 1404 tests in \LinqTests\ and the 73 relevant \DocumentDbTests\ pass locally.