### PR TITLE
Implement tenant-scoped ReadStreamAsync / GetRecentStreamsAsync explorer overrides

### DIFF
--- a/src/EventSourcingTests/Explorer/event_store_explorer_tests.cs
+++ b/src/EventSourcingTests/Explorer/event_store_explorer_tests.cs
@@ -11,6 +11,7 @@ using JasperFx.Events.Tags;
 using Marten;
 using Marten.Testing.Harness;
 using Shouldly;
+using Weasel.Core;
 using Xunit;
 
 namespace EventSourcingTests.Explorer;
@@ -305,5 +306,95 @@ public class event_store_explorer_tests: OneOffConfigurationsContext
         usage!.DcbTagTypes.ShouldContain(t => t.Name == nameof(CustomerId));
         usage.RegisteredEventTypes.ShouldContain(e => e.Alias == "order_placed");
         usage.RegisteredEventTypes.ShouldContain(e => e.Alias == "item_added");
+    }
+
+    // #782 / jasperfx#503 — on a conjoined multi-tenant store the same stream id can live
+    // under two tenants. The tenant-less read returns an ambiguous union of both; the
+    // tenant-scoped overload must isolate each tenant's slice via a tenant_id predicate.
+    private void ConfigureConjoinedStore()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AddEventType<OrderPlaced>();
+            opts.Events.AddEventType<ItemAdded>();
+            opts.Policies.AllDocumentsAreMultiTenanted();
+        });
+    }
+
+    [Fact]
+    public async Task read_stream_is_isolated_per_tenant_on_conjoined_store()
+    {
+        ConfigureConjoinedStore();
+
+        // Same stream id under two tenants — the exact cross-tenant ambiguity #782 closes.
+        var streamId = Guid.NewGuid();
+
+        await using (var a = theStore.LightweightSession("tenant-a"))
+        {
+            a.Events.StartStream<Order>(streamId, new OrderPlaced("Alice"), new ItemAdded(new OrderItem("A-1", 1)));
+            await a.SaveChangesAsync();
+        }
+
+        await using (var b = theStore.LightweightSession("tenant-b"))
+        {
+            b.Events.StartStream<Order>(streamId, new OrderPlaced("Bob"));
+            await b.SaveChangesAsync();
+        }
+
+        var explorer = (IEventStore)theStore;
+
+        var tenantA = new List<EventRecord>();
+        await foreach (var e in explorer.ReadStreamAsync(streamId.ToString(), "tenant-a", CancellationToken.None))
+            tenantA.Add(e);
+
+        var tenantB = new List<EventRecord>();
+        await foreach (var e in explorer.ReadStreamAsync(streamId.ToString(), "tenant-b", CancellationToken.None))
+            tenantB.Add(e);
+
+        tenantA.Count.ShouldBe(2);
+        tenantA.ShouldAllBe(e => e.TenantId == "tenant-a");
+        tenantB.Count.ShouldBe(1);
+        tenantB.ShouldAllBe(e => e.TenantId == "tenant-b");
+
+        // The tenant-less overload is unchanged: it still reads across every tenant, so it
+        // sees the union — this is the ambiguity the tenant-scoped read exists to resolve.
+        var union = new List<EventRecord>();
+        await foreach (var e in explorer.ReadStreamAsync(streamId.ToString(), CancellationToken.None))
+            union.Add(e);
+        union.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task recent_streams_is_isolated_per_tenant_on_conjoined_store()
+    {
+        ConfigureConjoinedStore();
+
+        var streamA = Guid.NewGuid();
+        var streamB = Guid.NewGuid();
+
+        await using (var a = theStore.LightweightSession("tenant-a"))
+        {
+            a.Events.StartStream<Order>(streamA, new OrderPlaced("Alice"));
+            await a.SaveChangesAsync();
+        }
+
+        await using (var b = theStore.LightweightSession("tenant-b"))
+        {
+            b.Events.StartStream<Order>(streamB, new OrderPlaced("Bob"));
+            await b.SaveChangesAsync();
+        }
+
+        var explorer = (IEventStore)theStore;
+
+        var tenantA = await explorer.GetRecentStreamsAsync(50, "tenant-a", CancellationToken.None);
+        tenantA.ShouldAllBe(s => s.TenantId == "tenant-a");
+        tenantA.ShouldContain(s => s.StreamId == streamA.ToString());
+        tenantA.ShouldNotContain(s => s.StreamId == streamB.ToString());
+
+        var tenantB = await explorer.GetRecentStreamsAsync(50, "tenant-b", CancellationToken.None);
+        tenantB.ShouldAllBe(s => s.TenantId == "tenant-b");
+        tenantB.ShouldContain(s => s.StreamId == streamB.ToString());
+        tenantB.ShouldNotContain(s => s.StreamId == streamA.ToString());
     }
 }

--- a/src/Marten/DocumentStore.EventStoreExplorer.cs
+++ b/src/Marten/DocumentStore.EventStoreExplorer.cs
@@ -59,12 +59,35 @@ public partial class DocumentStore
     /// <see cref="RecentStreamsCap"/> regardless of the requested count to keep the
     /// explorer's stream-list view bounded. Archived streams are included.
     /// </remarks>
-    async Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(int count, CancellationToken ct)
+    Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(int count, CancellationToken ct)
+        => ((IEventStore)this).GetRecentStreamsAsync(count, null, ct);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// #782 / jasperfx#503 — tenant-scoped recent-streams listing, mirroring the two tenancy
+    /// models <see cref="IEventStore.GetProjectionStatusesAsync(string?,CancellationToken)"/>
+    /// distinguishes (jasperfx#502):
+    /// <list type="bullet">
+    /// <item><b>Single database</b> (conjoined tenancy): the tenant is co-located in the one
+    /// database, so the listing is bounded by a <c>tenant_id</c> predicate on the same
+    /// <c>AllowAnyTenant</c> explorer session.</item>
+    /// <item><b>Database-per-tenant / sharded</b>: the argument names a physical database, so
+    /// the session is opened against that tenant's own database and no <c>tenant_id</c> filter
+    /// is needed — every stream in that database already belongs to the tenant.</item>
+    /// </list>
+    /// A null <paramref name="tenantId"/> preserves the store-global (across every tenant) listing.
+    /// </remarks>
+    async Task<IReadOnlyList<StreamSummary>> IEventStore.GetRecentStreamsAsync(int count, string? tenantId, CancellationToken ct)
     {
         var limit = Math.Clamp(count, 0, RecentStreamsCap);
         if (limit == 0) return Array.Empty<StreamSummary>();
 
-        await using var session = openExplorerSession();
+        var spansSeveralDatabases = Options.Tenancy.Cardinality != DatabaseCardinality.Single;
+        var scopeByColumn = tenantId != null && !spansSeveralDatabases;
+
+        await using var session = tenantId != null && spansSeveralDatabases
+            ? openExplorerSession(await Tenancy.FindOrCreateDatabase(tenantId).ConfigureAwait(false))
+            : openExplorerSession();
         await session.Database.EnsureStorageExistsAsync(typeof(IEvent), ct).ConfigureAwait(false);
 
         // The leading six columns deliberately mirror IEventStorage.StreamStateSelectSql
@@ -74,21 +97,23 @@ public partial class DocumentStore
         // list against the selector's Resolve method; this site's matching SELECT is
         // verified by the explorer tests in EventSourcingTests/Explorer.
         var schema = Options.EventGraph.DatabaseSchemaName;
+        var tenantFilter = scopeByColumn ? "where tenant_id = @tenant_id " : "";
         var cmd = new NpgsqlCommand(
             $"select id, version, type, timestamp, created, is_archived, tenant_id from {schema}.mt_streams " +
-            "order by timestamp desc limit @limit");
+            $"{tenantFilter}order by timestamp desc limit @limit");
         cmd.Parameters.AddWithValue("limit", limit);
+        if (scopeByColumn) cmd.Parameters.AddWithValue("tenant_id", tenantId!);
 
         var summaries = new List<StreamSummary>(limit);
         await using var reader = await session.ExecuteReaderAsync(cmd, ct).ConfigureAwait(false);
         while (await reader.ReadAsync(ct).ConfigureAwait(false))
         {
             var row = await readStreamRowAsync(reader, ct).ConfigureAwait(false);
-            var tenantId = await reader.IsDBNullAsync(StreamStateColumnCount, ct).ConfigureAwait(false)
+            var tenant = await reader.IsDBNullAsync(StreamStateColumnCount, ct).ConfigureAwait(false)
                 ? null
                 : reader.GetString(StreamStateColumnCount);
 
-            summaries.Add(new StreamSummary(row.StreamId, row.StreamType, row.Version, row.Created, row.LastUpdated, tenantId));
+            summaries.Add(new StreamSummary(row.StreamId, row.StreamType, row.Version, row.Created, row.LastUpdated, tenant));
         }
 
         return summaries;
@@ -103,20 +128,42 @@ public partial class DocumentStore
     /// the per-event tag join would multiply the row cost — explorers that need tags
     /// should use <c>QueryByTagsAsync</c>.
     /// </remarks>
-    async IAsyncEnumerable<EventRecord> IEventStore.ReadStreamAsync(string streamId, [EnumeratorCancellation] CancellationToken ct)
+    IAsyncEnumerable<EventRecord> IEventStore.ReadStreamAsync(string streamId, CancellationToken ct)
+        => ((IEventStore)this).ReadStreamAsync(streamId, null, ct);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// #782 / jasperfx#503 — tenant-scoped stream read. On a conjoined multi-tenant store the
+    /// same stream id can exist under two tenants; the tenant-less overload reads across every
+    /// tenant and returns their ambiguous union. This overload isolates a single tenant, using
+    /// the same two-model scoping as
+    /// <see cref="IEventStore.GetProjectionStatusesAsync(string?,CancellationToken)"/>
+    /// (jasperfx#502): a <c>tenant_id</c> predicate for a tenant co-located in one database, or
+    /// the tenant's own database session for a database-per-tenant / sharded store. Null preserves
+    /// the store-global read.
+    /// </remarks>
+    async IAsyncEnumerable<EventRecord> IEventStore.ReadStreamAsync(
+        string streamId, string? tenantId, [EnumeratorCancellation] CancellationToken ct)
     {
+        var spansSeveralDatabases = Options.Tenancy.Cardinality != DatabaseCardinality.Single;
+        var scopeByColumn = tenantId != null && !spansSeveralDatabases;
+
         var schema = Options.EventGraph.DatabaseSchemaName;
+        var tenantFilter = scopeByColumn ? " and tenant_id = @tenant_id" : "";
         var sql =
             $"select id, seq_id, version, stream_id, type, data, timestamp, tenant_id " +
             $"from {schema}.mt_events " +
-            $"where stream_id = @stream_id " +
+            $"where stream_id = @stream_id{tenantFilter} " +
             $"order by version asc";
 
-        await using var session = openExplorerSession();
+        await using var session = tenantId != null && spansSeveralDatabases
+            ? openExplorerSession(await Tenancy.FindOrCreateDatabase(tenantId).ConfigureAwait(false))
+            : openExplorerSession();
         await session.Database.EnsureStorageExistsAsync(typeof(IEvent), ct).ConfigureAwait(false);
 
         var cmd = new NpgsqlCommand(sql);
         cmd.Parameters.AddWithValue("stream_id", parseStreamId(streamId));
+        if (scopeByColumn) cmd.Parameters.AddWithValue("tenant_id", tenantId!);
 
         await using var reader = await session.ExecuteReaderAsync(cmd, ct).ConfigureAwait(false);
         while (await reader.ReadAsync(ct).ConfigureAwait(false))


### PR DESCRIPTION
Fixes #5019.

Implements the two jasperfx#503 tenant-scoped `IEventStore` read overloads that currently fall through to the throwing interface default on a non-null tenant:

- `ReadStreamAsync(string streamId, string? tenantId, CancellationToken ct)`
- `GetRecentStreamsAsync(int count, string? tenantId, CancellationToken ct)`

### Approach
Both mirror the two-model scoping the existing `GetProjectionStatusesAsync(tenantId)` override uses (jasperfx#502):

- **Single database** (conjoined tenancy): a `where tenant_id = @tenant_id` predicate on the same `AllowAnyTenant` explorer session.
- **Database-per-tenant / sharded** (`Options.Tenancy.Cardinality != DatabaseCardinality.Single`): open the session against `Tenancy.FindOrCreateDatabase(tenantId)`; no column filter needed.
- **null tenant** → delegates to the tenant-less overload (byte-identical to today). The tenant-less overloads are now thin delegators.

### Why
On a conjoined multi-tenant store the same stream id can exist under two tenants, so the tenant-less `ReadStreamAsync` returns an ambiguous cross-tenant union. These overloads isolate a single tenant's slice.

### Tests
Two new `EventSourcingTests/Explorer` isolation tests (read-stream + recent-streams under two tenants on a conjoined store); the full explorer suite stays green (16/16).

### Consumer
CritterWatch's Event Store Explorer — JasperFx/CritterWatch#782. Companion: polecat#351 (same surface), jasperfx#555 (the `QueryByTagsAsync`/`EventQuery.TenantId` abstraction gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)