### PR TITLE
Tenant-scoped event/tag explorer reads (#5021) + prove the daemon-shutdown drain (#5024)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -129,13 +129,13 @@
          stamped onto every published ShardState, so a distribution layer (Wolverine-managed
          subscription distribution) can drive the extended-progression running_on_node column. Marten's
          WriteExtendedProgressionAsync already persists it; this bump makes the tracker seam available. -->
-    <PackageVersion Include="JasperFx" Version="2.33.1" />
-    <PackageVersion Include="JasperFx.Events" Version="2.33.1" />
-    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.33.1">
+    <PackageVersion Include="JasperFx" Version="2.34.0" />
+    <PackageVersion Include="JasperFx.Events" Version="2.34.0" />
+    <PackageVersion Include="JasperFx.Events.SourceGenerator" Version="2.34.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.33.1" />
+    <PackageVersion Include="JasperFx.SourceGenerator" Version="2.34.0" />
     <PackageVersion Include="Jil" Version="3.0.0-alpha2" />
     <PackageVersion Include="Lamar" Version="7.1.1" />
     <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />

--- a/src/DaemonTests/Bug_5024_extended_progression_survives_shutdown.cs
+++ b/src/DaemonTests/Bug_5024_extended_progression_survives_shutdown.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Marten.Events.Aggregation;
+using Marten.Storage;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Weasel.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DaemonTests;
+
+public record Bug5024Event();
+
+public class Bug5024Stream { public Guid Id { get; set; } }
+
+public partial class Bug5024Projection: SingleStreamProjection<Bug5024Stream, Guid>
+{
+    public void Apply(Bug5024Event @event, Bug5024Stream projection) { }
+}
+
+// #5024 Phase 3 — the Marten-side proof that the jasperfx#557 shutdown fix landed.
+//
+// The extended_progression_batch_write flake (#5022) had two shutdown-ordering symptoms, both upstream in
+// JasperFx.Events (jasperfx#557), both consumed here via the 2.34.0 bump:
+//
+//   Symptom 1 (the flake): the ExtendedProgressionWriter's drain was fire-and-forgotten on shutdown, so a
+//     terminal "Stopped" heartbeat queued during shutdown could land AFTER a later, deliberate write to
+//     mt_event_progression and clobber the row. jasperfx#557 makes the async stop path await the writer's
+//     drain, so once StopAllAsync returns every queued heartbeat has already been flushed and a subsequent
+//     deliberate write is the last writer.
+//
+//   Symptom 2: the shared BatchWriteThrottle SemaphoreSlim was disposed while an in-flight batch commit was
+//     still mid-finally, so its Release() threw ObjectDisposedException (seen logged on
+//     Bug_2074_recovering_from_errors). jasperfx#557 orders the throttle disposal after in-flight releases
+//     and guards the release sites.
+//
+// #5023 deliberately stopped exercising the live-then-stopped daemon to de-flake #5008; this test is the
+// live-daemon variant that is now deterministic *because* the upstream drain is awaited. It belongs in
+// Marten because the flake was reported against a Marten test surface (#5022).
+public class Bug_5024_extended_progression_survives_shutdown: DaemonContext
+{
+    public Bug_5024_extended_progression_survives_shutdown(ITestOutputHelper output): base(output)
+    {
+    }
+
+    private const string Shard = "Bug5024Stream:All";
+
+    private async Task<object?> readColumnAsync(string column)
+    {
+        await using var session = theStore.QuerySession();
+        var raw = await session.Connection
+            .CreateCommand(
+                $"select {column} from {theStore.Events.DatabaseSchemaName}.mt_event_progression where name = :name")
+            .With("name", Shard)
+            .ExecuteScalarAsync();
+
+        return raw is null or DBNull ? null : raw;
+    }
+
+    [Fact]
+    public async Task deliberate_write_after_shutdown_is_not_clobbered_by_a_late_stopped_heartbeat()
+    {
+        var logger = new CapturingLogger(_output);
+
+        StoreOptions(x =>
+        {
+            x.Events.EnableExtendedProgressionTracking = true;
+            x.Projections.Add(new Bug5024Projection(), ProjectionLifecycle.Async);
+        });
+
+        var database = theStore.Tenancy.Default.Database.As<MartenDatabase>();
+
+        // Start a live daemon carrying the capturing logger so any shutdown-time ObjectDisposedException
+        // (Symptom 2) is observable.
+        var daemon = database.StartProjectionDaemon(theStore, logger);
+        await daemon.StartAllAsync();
+
+        try
+        {
+            // Seed and let the shard catch up so its mt_event_progression row exists (the extended-progression
+            // write takes its UPDATE path against a real row).
+            await using (var session = theStore.LightweightSession())
+            {
+                for (var i = 0; i < 10; i++)
+                {
+                    session.Events.Append(Guid.NewGuid(), new Bug5024Event());
+                }
+
+                await session.SaveChangesAsync();
+            }
+
+            await daemon.Tracker.WaitForShardState(new ShardState(Shard, 10), 30.Seconds());
+
+            // The real shutdown path. Pre-jasperfx#557 the writer's drain was fire-and-forgotten here, so a
+            // terminal "Stopped" heartbeat could still be in flight after this returns. With the drain awaited,
+            // StopAllAsync returns only once every queued heartbeat has been flushed to the row.
+            await daemon.StopAllAsync();
+
+            // The deliberate, post-shutdown write. Because the drain is awaited above, this is unambiguously the
+            // last writer — no late "Stopped" heartbeat can land after it.
+            var deliberate = new ShardState(Shard, 10)
+            {
+                Action = ShardAction.Started,
+                AgentStatus = "Deliberate",
+                LastHeartbeat = DateTimeOffset.UtcNow
+            };
+            await database.WriteExtendedProgressionAsync(deliberate);
+
+            // Symptom 1: the deliberate value survives — a fire-and-forgotten "Stopped" heartbeat would have
+            // overwritten agent_status back to the terminal state here.
+            (await readColumnAsync("agent_status")).ShouldBe("Deliberate");
+
+            // Symptom 2: the batch-write throttle must not be disposed out from under an in-flight commit, so no
+            // ObjectDisposedException should reach the log across the daemon's lifetime.
+            logger.Exceptions.ShouldNotContain(e => e is ObjectDisposedException);
+        }
+        finally
+        {
+            daemon.Dispose();
+        }
+    }
+
+    // Minimal capturing ILogger — TestLogger<T> only echoes to output, so it can't be asserted against.
+    // Records every logged exception (thread-safe) and still forwards to the test output for debugging.
+    private sealed class CapturingLogger: ILogger
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly object _gate = new();
+        public List<Exception> Exceptions { get; } = new();
+
+        public CapturingLogger(ITestOutputHelper output) => _output = output;
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (exception != null)
+            {
+                lock (_gate)
+                {
+                    Exceptions.Add(exception);
+                }
+
+                _output.WriteLine($"{logLevel}: {formatter(state, exception)}");
+                _output.WriteLine(exception.ToString());
+            }
+            else
+            {
+                _output.WriteLine($"{logLevel}: {formatter(state, exception)}");
+            }
+        }
+
+        private sealed class NullScope: IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/EventSourcingTests/Explorer/event_store_explorer_tests.cs
+++ b/src/EventSourcingTests/Explorer/event_store_explorer_tests.cs
@@ -9,6 +9,7 @@ using JasperFx.Descriptors;
 using JasperFx.Events;
 using JasperFx.Events.Tags;
 using Marten;
+using Marten.Services;
 using Marten.Testing.Harness;
 using Shouldly;
 using Weasel.Core;
@@ -396,5 +397,115 @@ public class event_store_explorer_tests: OneOffConfigurationsContext
         tenantB.ShouldAllBe(s => s.TenantId == "tenant-b");
         tenantB.ShouldContain(s => s.StreamId == streamB.ToString());
         tenantB.ShouldNotContain(s => s.StreamId == streamA.ToString());
+    }
+
+    // #5021 / jasperfx#555 — the second pair of explorer read paths that #503 left untenanted.
+    // On a conjoined store the same tag value / the same event stream can exist under two tenants,
+    // so the tenant-less query resolves an ambiguous cross-tenant union; the tenant-scoped overloads
+    // must isolate each tenant's slice.
+    private void ConfigureConjoinedStoreWithTags()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+            opts.Events.AddEventType<OrderPlaced>();
+            opts.Events.AddEventType<CustomerNotified>();
+            opts.Events.RegisterTagType<CustomerId>("customer");
+            opts.Policies.AllDocumentsAreMultiTenanted();
+        });
+    }
+
+    [Fact]
+    public async Task query_by_tags_is_isolated_per_tenant_on_conjoined_store()
+    {
+        ConfigureConjoinedStoreWithTags();
+
+        // The SAME tag value is attached to an event under each tenant — the exact cross-tenant
+        // ambiguity #5021 closes for the DCB tag query.
+        var customerId = new CustomerId(Guid.NewGuid());
+
+        await using (var a = theStore.LightweightSession("tenant-a"))
+        {
+            var e = a.Events.BuildEvent(new CustomerNotified("welcome-a"));
+            e.WithTag(customerId);
+            a.Events.Append(Guid.NewGuid(), e);
+            await a.SaveChangesAsync();
+        }
+
+        await using (var b = theStore.LightweightSession("tenant-b"))
+        {
+            var e = b.Events.BuildEvent(new CustomerNotified("welcome-b"));
+            e.WithTag(customerId);
+            b.Events.Append(Guid.NewGuid(), e);
+            await b.SaveChangesAsync();
+        }
+
+        var explorer = (IEventStore)theStore;
+        var tags = new Dictionary<string, string> { { "CustomerId", customerId.Value.ToString() } };
+
+        var tenantA = new List<EventRecord>();
+        await foreach (var e in explorer.QueryByTagsAsync(tags, "tenant-a", CancellationToken.None))
+            tenantA.Add(e);
+
+        var tenantB = new List<EventRecord>();
+        await foreach (var e in explorer.QueryByTagsAsync(tags, "tenant-b", CancellationToken.None))
+            tenantB.Add(e);
+
+        tenantA.Count.ShouldBe(1);
+        tenantA.ShouldAllBe(e => e.TenantId == "tenant-a");
+        tenantA[0].Data.GetProperty("Subject").GetString().ShouldBe("welcome-a");
+
+        tenantB.Count.ShouldBe(1);
+        tenantB.ShouldAllBe(e => e.TenantId == "tenant-b");
+        tenantB[0].Data.GetProperty("Subject").GetString().ShouldBe("welcome-b");
+
+        // The tenant-less overload is unchanged: it still matches the tag across every tenant, so it
+        // sees the union — the ambiguity the tenant-scoped read exists to resolve.
+        var union = new List<EventRecord>();
+        await foreach (var e in explorer.QueryByTagsAsync(tags, CancellationToken.None))
+            union.Add(e);
+        union.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task query_events_honours_event_query_tenant_id_on_conjoined_store()
+    {
+        ConfigureConjoinedStoreWithTags();
+
+        await using (var a = theStore.LightweightSession("tenant-a"))
+        {
+            a.Events.StartStream<Order>(Guid.NewGuid(), new OrderPlaced("Alice"));
+            a.Events.StartStream<Order>(Guid.NewGuid(), new OrderPlaced("Amy"));
+            await a.SaveChangesAsync();
+        }
+
+        await using (var b = theStore.LightweightSession("tenant-b"))
+        {
+            b.Events.StartStream<Order>(Guid.NewGuid(), new OrderPlaced("Bob"));
+            await b.SaveChangesAsync();
+        }
+
+        // The Event Explorer reads across tenants through an AllowAnyTenant session, then scopes each
+        // query with EventQuery.TenantId. QueryEventsAsync lives on IReadOnlyEventStore (session-level).
+        await using var session = theStore.QuerySession(new SessionOptions { AllowAnyTenant = true });
+        var readStore = (IReadOnlyEventStore)session.Events;
+
+        var tenantA = await readStore.QueryEventsAsync(
+            new EventQuery { TenantId = "tenant-a", PageSize = 100 }, CancellationToken.None);
+        tenantA.TotalCount.ShouldBe(2);
+        tenantA.Events.ShouldAllBe(e => e.TenantId == "tenant-a");
+
+        var tenantB = await readStore.QueryEventsAsync(
+            new EventQuery { TenantId = "tenant-b", PageSize = 100 }, CancellationToken.None);
+        tenantB.TotalCount.ShouldBe(1);
+        tenantB.Events.ShouldAllBe(e => e.TenantId == "tenant-b");
+
+        // A null TenantId is left untouched — the query keeps the session's own tenancy rather than
+        // silently unioning tenants. On this AllowAnyTenant session that is the default tenant, under
+        // which nothing was written, so the store-global-by-null semantics are NOT assumed here (that is
+        // the pre-existing QueryEventsAsync contract, unchanged by #5021).
+        var defaultTenant = await readStore.QueryEventsAsync(
+            new EventQuery { PageSize = 100 }, CancellationToken.None);
+        defaultTenant.TotalCount.ShouldBe(0);
     }
 }

--- a/src/Marten/DocumentStore.EventStoreExplorer.cs
+++ b/src/Marten/DocumentStore.EventStoreExplorer.cs
@@ -230,13 +230,43 @@ public partial class DocumentStore
     /// going through Postgres' text cast. Throws <see cref="ArgumentException"/> when a
     /// tag name is not registered.
     /// </remarks>
+    IAsyncEnumerable<EventRecord> IEventStore.QueryByTagsAsync(
+        IReadOnlyDictionary<string, string> tags,
+        CancellationToken ct)
+        => ((IEventStore)this).QueryByTagsAsync(tags, null, ct);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// #5021 / jasperfx#555 — tenant-scoped DCB tag query, companion to the jasperfx#503 stream reads.
+    /// On a conjoined multi-tenant store the same tag value can be attached to events living under two
+    /// tenants, so the tenant-less overload resolves an ambiguous cross-tenant union. This overload
+    /// isolates a single tenant using the same two-model scoping as
+    /// <see cref="IEventStore.ReadStreamAsync(string,string?,CancellationToken)"/> and
+    /// <see cref="IEventStore.GetProjectionStatusesAsync(string?,CancellationToken)"/> (jasperfx#502):
+    /// <list type="bullet">
+    /// <item><b>Single database</b> (conjoined tenancy): the tenant is co-located in the one database,
+    /// so the outer <c>mt_events</c> scan is bounded by an <c>e.tenant_id</c> predicate on the same
+    /// <c>AllowAnyTenant</c> explorer session. The tag sub-selects need no tenant filter — they match by
+    /// the globally-unique <c>seq_id</c>, and the outer predicate discards any matched seq_id belonging
+    /// to another tenant.</item>
+    /// <item><b>Database-per-tenant / sharded</b>: the argument names a physical database, so the session
+    /// is opened against that tenant's own database and no <c>tenant_id</c> filter is needed.</item>
+    /// </list>
+    /// A null <paramref name="tenantId"/> preserves the store-global (across every tenant) query.
+    /// </remarks>
     async IAsyncEnumerable<EventRecord> IEventStore.QueryByTagsAsync(
         IReadOnlyDictionary<string, string> tags,
+        string? tenantId,
         [EnumeratorCancellation] CancellationToken ct)
     {
         if (tags == null) throw new ArgumentNullException(nameof(tags));
 
-        await using var session = openExplorerSession();
+        var spansSeveralDatabases = Options.Tenancy.Cardinality != DatabaseCardinality.Single;
+        var scopeByColumn = tenantId != null && !spansSeveralDatabases;
+
+        await using var session = tenantId != null && spansSeveralDatabases
+            ? openExplorerSession(await Tenancy.FindOrCreateDatabase(tenantId).ConfigureAwait(false))
+            : openExplorerSession();
         await session.Database.EnsureStorageExistsAsync(typeof(IEvent), ct).ConfigureAwait(false);
 
         if (tags.Count == 0) yield break;
@@ -264,14 +294,16 @@ public partial class DocumentStore
             idx++;
         }
 
+        var tenantFilter = scopeByColumn ? " and e.tenant_id = @tenant_id" : "";
         var sql =
             $"select e.id, e.seq_id, e.version, e.stream_id, e.type, e.data, e.timestamp, e.tenant_id " +
             $"from {schema}.mt_events e " +
-            $"where {subqueries.Join(" and ")} " +
+            $"where {subqueries.Join(" and ")}{tenantFilter} " +
             $"order by e.seq_id asc";
 
         var cmd = new NpgsqlCommand(sql);
         foreach (var p in parameters) cmd.Parameters.Add(p);
+        if (scopeByColumn) cmd.Parameters.AddWithValue("tenant_id", tenantId!);
 
         await using var reader = await session.ExecuteReaderAsync(cmd, ct).ConfigureAwait(false);
         while (await reader.ReadAsync(ct).ConfigureAwait(false))

--- a/src/Marten/Events/QueryEventStore.cs
+++ b/src/Marten/Events/QueryEventStore.cs
@@ -250,6 +250,19 @@ internal class QueryEventStore: IQueryEventStore, IReadOnlyEventStore
 
         var queryable = QueryAllRawEvents();
 
+        // #5021 / jasperfx#555 — honour the tenant scope the Event Explorer sets. On a conjoined
+        // multi-tenant store the same event can exist under two tenants, so the Explorer sets
+        // EventQuery.TenantId to isolate one tenant; TenantIsOneOf overrides the session's own tenant
+        // filter (the Explorer reads through an AllowAnyTenant session). A null TenantId is left
+        // untouched: the query keeps the session's existing tenancy — the store-global read on an
+        // AllowAnyTenant session, or the session's own tenant on a tenant-scoped session. This preserves
+        // the pre-existing QueryEventsAsync contract (TenantPartitionedEventsTests
+        // QueryEventsAsync_pages_only_within_the_querying_tenant) exactly.
+        if (query.TenantId != null)
+        {
+            queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.TenantIsOneOf(query.TenantId));
+        }
+
         if (query.EventTypeName != null)
         {
             queryable = (IMartenQueryable<IEvent>)queryable.Where(e => e.EventTypeName == query.EventTypeName);


### PR DESCRIPTION
Closes #5021. Addresses #5024 (Phase 3).

Bumps `JasperFx.Events` 2.33.1 → **2.34.0** to consume **jasperfx#555** (the two remaining tenant-scoped explorer read paths) and **jasperfx#557** (the extended-progression shutdown-drain fix), then implements and proves both from Marten's side.

## #5021 — the second pair of explorer reads jasperfx#503 left untenanted

On a conjoined `UseTenantPartitionedEvents` store the same tag / the same event can exist under two tenants, so an untenanted query reads an ambiguous cross-tenant union — the class of bug #5019/#5020 fixed for the stream reads. Mirrors the two-model scoping PR #5020 established.

- **`QueryByTagsAsync(tags, tenantId, ct)`** override in `DocumentStore.EventStoreExplorer.cs`:
  - **Single database** (conjoined): bounds the outer `mt_events` scan with an `e.tenant_id` predicate on the `AllowAnyTenant` explorer session. The tag sub-selects need no tenant filter — they match by the globally-unique `seq_id`, and the outer predicate discards any matched seq_id belonging to another tenant.
  - **Database-per-tenant / sharded**: opens the session against `Tenancy.FindOrCreateDatabase(tenantId)`; no column filter needed.
  - **null tenant** → delegates to the tenant-less overload, byte-identical to today.
- **`EventQuery.TenantId`** honoured in `QueryEventStore.QueryEventsAsync`: a set tenant scopes the query with `TenantIsOneOf` (overriding the session's own filter, as the Explorer reads through an `AllowAnyTenant` session); a **null** tenant is left untouched so the pre-existing per-tenant paging contract (`TenantPartitionedEventsTests.QueryEventsAsync_pages_only_within_the_querying_tenant`) is unchanged.
- **Tests**: the same tag (and the same event) under two tenants on a conjoined store reads each tenant's slice in isolation; full explorer suite stays green (18/18).

## #5024 Phase 3 — consume + prove the jasperfx#557 shutdown fix

`Bug_5024_extended_progression_survives_shutdown` drives the real live-then-stopped daemon path that #5023 deliberately stopped exercising to de-flake #5008:

- start a live daemon, catch it up, `StopAllAsync()`, then issue an explicit `WriteExtendedProgressionAsync`
- assert the row is **not** clobbered by a late `"Stopped"` heartbeat (Symptom 1)
- assert **no `ObjectDisposedException`** reached the log on shutdown (Symptom 2)

Deterministic *because* the upstream drain is now awaited — green across repeated runs (3/3 locally).

## Verification

- 2.34.0 confirmed to carry both jasperfx#555 (reflection: `IEventStore.QueryByTagsAsync(tags, string, ct)` + `EventQuery.TenantId`) and jasperfx#557 (`fix(#557): drain extended-progression writer on shutdown`).
- `EventSourcingTests` explorer suite: 18/18 green. `TenantPartitionedEventsTests` `QueryEventsAsync` contract: 2/2 green. `#5024` test: 3/3 green.

## Companion

- Abstraction: jasperfx#555 / jasperfx#557 (shipped in JasperFx.Events 2.34.0)
- Polecat parity: JasperFx/polecat#353
- Consumer: CritterWatch #798 §4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQ9NHbg31EWJmrQK9EN6i8