### PR TITLE
Harden StreamPaged<T> test coverage (#5026)

### DIFF
--- a/src/DocumentDbTests/Reading/Json/streaming_json_results.cs
+++ b/src/DocumentDbTests/Reading/Json/streaming_json_results.cs
@@ -1083,6 +1083,69 @@ public class streaming_json_results : IntegrationContext
         return await System.Text.Json.JsonSerializer.DeserializeAsync<PagedEnvelope<Target>>(stream, options);
     }
 
+    private async Task<string> streamPageRaw(IQueryable<Target> queryable, int pageNumber, int pageSize)
+    {
+        var stream = new MemoryStream();
+        await queryable.StreamPagedJsonArray(stream, pageNumber, pageSize);
+
+        return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_wire_format_is_camel_case()
+    {
+        var targets = Target.GenerateRandomData(10).ToArray();
+        for (var i = 0; i < targets.Length; i++) targets[i].Number = i;
+        await theStore.BulkInsertAsync(targets);
+
+        // Assert against the raw bytes so the client-facing JSON contract is pinned
+        // independently of any case-insensitive deserialization on the read side.
+        var json = await streamPageRaw(theSession.Query<Target>().OrderBy(x => x.Number), 1, 3);
+
+        json.ShouldContain("\"pageNumber\":");
+        json.ShouldContain("\"pageSize\":");
+        json.ShouldContain("\"totalItemCount\":");
+        json.ShouldContain("\"pageCount\":");
+        json.ShouldContain("\"hasNextPage\":");
+        json.ShouldContain("\"hasPreviousPage\":");
+        json.ShouldContain("\"items\":[");
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_page_beyond_end_of_nonempty_set()
+    {
+        var targets = Target.GenerateRandomData(10).ToArray();
+        for (var i = 0; i < targets.Length; i++) targets[i].Number = i;
+        await theStore.BulkInsertAsync(targets);
+
+        // Offset 12 > 10 rows: zero rows come back, so count(*) OVER() rides on no row
+        // and the envelope reports totalItemCount 0 even though items exist. This documents
+        // the window-function limitation (same quirk as PagedList) as an intentional contract.
+        var envelope = await streamPage(theSession.Query<Target>().OrderBy(x => x.Number), 5, 3);
+
+        envelope.Items.Length.ShouldBe(0);
+        envelope.TotalItemCount.ShouldBe(0);
+        envelope.HasNextPage.ShouldBeFalse();
+        envelope.HasPreviousPage.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task stream_paged_json_array_total_reflects_filter()
+    {
+        var targets = Target.GenerateRandomData(20).ToArray();
+        for (var i = 0; i < targets.Length; i++) targets[i].Number = i;
+        await theStore.BulkInsertAsync(targets);
+
+        // 8 matches (Number 0..7), paged 3 at a time — the total must reflect the filter,
+        // not the whole table.
+        var envelope = await streamPage(
+            theSession.Query<Target>().Where(x => x.Number < 8).OrderBy(x => x.Number), 1, 3);
+
+        envelope.TotalItemCount.ShouldBe(8);
+        envelope.PageCount.ShouldBe(3);
+        envelope.Items.Select(x => x.Number).ShouldBe(new[] { 0, 1, 2 });
+    }
+
     [Fact]
     public async Task stream_paged_json_array_first_page()
     {

--- a/src/Marten.AspNetCore.Testing/stream_paged_tests.cs
+++ b/src/Marten.AspNetCore.Testing/stream_paged_tests.cs
@@ -174,6 +174,52 @@ public class stream_paged_tests: IntegrationContext
     }
 
     [Fact]
+    public async Task wire_format_is_camel_case()
+    {
+        await seedOpenIssues(10, "casing_" + Guid.NewGuid().ToString("N")[..8]);
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/issues/paged/1/3");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        // Pin the client-facing contract against the raw body — ReadAsJson deserializes
+        // case-insensitively and would happily accept PascalCase too.
+        var json = result.ReadAsText();
+
+        json.ShouldContain("\"pageNumber\":");
+        json.ShouldContain("\"pageSize\":");
+        json.ShouldContain("\"totalItemCount\":");
+        json.ShouldContain("\"pageCount\":");
+        json.ShouldContain("\"hasNextPage\":");
+        json.ShouldContain("\"hasPreviousPage\":");
+        json.ShouldContain("\"items\":[");
+    }
+
+    [Fact]
+    public async Task page_beyond_end_of_nonempty_set()
+    {
+        await seedOpenIssues(10, "beyond_" + Guid.NewGuid().ToString("N")[..8]);
+
+        // Offset 12 > 10 rows: zero rows returned, so count(*) OVER() reports 0 even though
+        // items exist. Documents the same window-function limitation as PagedList.
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url("/minimal/issues/paged/5/3");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var envelope = result.ReadAsJson<PagedEnvelope<Issue>>();
+
+        envelope.Items.Length.ShouldBe(0);
+        envelope.TotalItemCount.ShouldBe(0);
+        envelope.HasNextPage.ShouldBeFalse();
+        envelope.HasPreviousPage.ShouldBeTrue();
+    }
+
+    [Fact]
     public async Task items_are_in_expected_order_across_pages()
     {
         var prefix = "order_" + Guid.NewGuid().ToString("N")[..8];


### PR DESCRIPTION
Closes #5026. Follow-up to #5014 (`StreamPaged<T>`).

Additive test coverage only — **no production change**. Pins three cases that the merged coverage left unguarded, at both the core (`StreamPagedJsonArray`) and endpoint (Alba) layers.

### 1. Wire-format casing (highest value)
Both test layers previously deserialized case-insensitively, so every test would still pass if the envelope emitted `PageNumber`/`Items` (PascalCase) instead of the documented camelCase. Added assertions against the **raw response bytes** (`stream.ToArray()` / `ReadAsText()`) that lock the client-facing contract: `pageNumber`, `pageSize`, `totalItemCount`, `pageCount`, `hasNextPage`, `hasPreviousPage`, `items`.

### 2. Page past the end of a non-empty set
`Skip(12)` over 10 rows returns zero rows, so `count(*) OVER()` rides on no row and the envelope reports `totalItemCount: 0` even though items exist. This documents the same window-function limitation `PagedList` has, as an intentional contract (`HasPreviousPage` true, `HasNextPage` false). Mirrored in the Alba layer.

### 3. Filtered query with a partial total
A `Where(x => x.Number < 8)`-narrowed query (the realistic production shape) must report the filtered total (8), not the whole table.

### Verification
- `DocumentDbTests` — 3 new facts green (net9.0).
- `Marten.AspNetCore.Testing` — 9/9 `stream_paged_tests` green (7 existing + 2 new, net9.0).

Kept in sync with the Polecat parity port (JasperFx/polecat#355), which already tracks case 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)