### PR TITLE
StreamOne<T> ETag: inline mt_version (one round trip) + drop notnull + ETag test hardening (#5027)

### DIFF
--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -340,6 +340,11 @@ still current:
 - For `StreamOne<T>`, the ETag is derived from the document's `mt_version`
   (the same optimistic-concurrency version Marten tracks for every stored
   document), formatted as a quoted GUID, e.g. `"3f2504e0-4f89-11d3-9a0c-0305e82c3301"`.
+  The `mt_version` value is read **inline with the document in the same single
+  database round trip** (piggy-backed onto the streaming query), so enabling the
+  ETag adds no extra query. Document types whose version metadata is disabled (no
+  `mt_version` column) simply emit no ETag. Because the document is streamed in that
+  one round trip, a `304` on `StreamOne<T>` saves response bandwidth but not the read.
 - For `StreamAggregate<T>`, the ETag is derived from the event stream's
   version (a `long`), formatted as a quoted integer, e.g. `"42"`. The version
   is looked up before the aggregate is folded, so a cache hit (`304`) skips

--- a/src/IssueService/Startup.cs
+++ b/src/IssueService/Startup.cs
@@ -45,6 +45,10 @@ public class Startup
                 options.DatabaseSchemaName = martenSettings.SchemaName;
             }
 
+            // A document type with version metadata disabled — used to prove StreamOne emits
+            // no ETag when there is no mt_version column to derive one from.
+            options.Schema.For<VersionlessDoc>().Metadata(m => m.Version.Enabled = false);
+
             if (martenSettings.UseStringStreamIdentity)
             {
                 options.Events.StreamIdentity = StreamIdentity.AsString;

--- a/src/IssueService/StreamingMinimalEndpoints.cs
+++ b/src/IssueService/StreamingMinimalEndpoints.cs
@@ -50,6 +50,12 @@ public static class StreamingMinimalEndpoints
                     EmitETag = false
                 });
 
+        // Document type whose version metadata is disabled — no mt_version column, so
+        // EmitETag = true (the default) must still emit NO ETag rather than a constant zero-Guid.
+        app.MapGet("/minimal/versionless/{id:guid}",
+            (Guid id, IQuerySession session)
+                => new StreamOne<VersionlessDoc>(session.Query<VersionlessDoc>().Where(x => x.Id == id)));
+
         // --- StreamMany<T> ---
 
         app.MapGet("/minimal/issues/open",
@@ -102,4 +108,14 @@ public static class StreamingMinimalEndpoints
 
         return app;
     }
+}
+
+/// <summary>
+/// A document type registered with version metadata disabled (no <c>mt_version</c> column),
+/// used to prove <see cref="StreamOne{T}"/> emits no ETag for versionless documents.
+/// </summary>
+public class VersionlessDoc
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
 }

--- a/src/Marten.AspNetCore.Testing/etag_helpers_tests.cs
+++ b/src/Marten.AspNetCore.Testing/etag_helpers_tests.cs
@@ -1,0 +1,117 @@
+using System;
+using Marten.AspNetCore;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+using Xunit;
+
+namespace Marten.AspNetCore.Testing;
+
+/// <summary>
+/// Unit coverage for the <see cref="ETagHelpers"/> logic branches that the Alba
+/// endpoint tests don't exercise directly: the <c>*</c> wildcard, <c>W/</c> weak
+/// validator stripping, and multi-value comma-separated <c>If-None-Match</c> lists.
+/// </summary>
+public class etag_helpers_tests
+{
+    private static HttpContext contextWithIfNoneMatch(params string[] values)
+    {
+        var context = new DefaultHttpContext();
+        if (values.Length > 0)
+        {
+            context.Request.Headers["If-None-Match"] = values;
+        }
+
+        return context;
+    }
+
+    [Fact]
+    public void format_guid_version_is_quoted_lowercase_d()
+    {
+        var version = Guid.Parse("3f2504e0-4f89-11d3-9a0c-0305e82c3301");
+        ETagHelpers.Format(version).ShouldBe("\"3f2504e0-4f89-11d3-9a0c-0305e82c3301\"");
+    }
+
+    [Fact]
+    public void format_long_version_is_quoted()
+    {
+        ETagHelpers.Format(17L).ShouldBe("\"17\"");
+    }
+
+    [Fact]
+    public void no_if_none_match_header_never_matches()
+    {
+        var context = contextWithIfNoneMatch();
+        ETagHelpers.IfNoneMatchMatches(context, "\"1\"").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void exact_match_returns_true()
+    {
+        var context = contextWithIfNoneMatch("\"1\"");
+        ETagHelpers.IfNoneMatchMatches(context, "\"1\"").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void non_matching_value_returns_false()
+    {
+        var context = contextWithIfNoneMatch("\"2\"");
+        ETagHelpers.IfNoneMatchMatches(context, "\"1\"").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void wildcard_matches_any_etag()
+    {
+        var context = contextWithIfNoneMatch("*");
+        ETagHelpers.IfNoneMatchMatches(context, "\"anything\"").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void weak_validator_prefix_is_stripped_before_comparison()
+    {
+        var context = contextWithIfNoneMatch("W/\"1\"");
+        ETagHelpers.IfNoneMatchMatches(context, "\"1\"").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void weak_validator_prefix_is_case_insensitive()
+    {
+        var context = contextWithIfNoneMatch("w/\"1\"");
+        ETagHelpers.IfNoneMatchMatches(context, "\"1\"").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void multi_value_comma_separated_list_matches_any_member()
+    {
+        var context = contextWithIfNoneMatch("\"7\", \"8\", \"1\"");
+        ETagHelpers.IfNoneMatchMatches(context, "\"1\"").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void multi_value_list_with_weak_members_matches()
+    {
+        var context = contextWithIfNoneMatch("W/\"7\", W/\"1\"");
+        ETagHelpers.IfNoneMatchMatches(context, "\"1\"").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void multi_value_list_with_no_match_returns_false()
+    {
+        var context = contextWithIfNoneMatch("\"7\", \"8\", \"9\"");
+        ETagHelpers.IfNoneMatchMatches(context, "\"1\"").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void multiple_header_values_are_all_considered()
+    {
+        // A client may send several If-None-Match header lines; any hit wins.
+        var context = contextWithIfNoneMatch("\"7\"", "\"1\"");
+        ETagHelpers.IfNoneMatchMatches(context, "\"1\"").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void empty_etag_never_matches()
+    {
+        var context = contextWithIfNoneMatch("*");
+        ETagHelpers.IfNoneMatchMatches(context, "").ShouldBeFalse();
+    }
+}

--- a/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
+++ b/src/Marten.AspNetCore.Testing/streaming_result_types_tests.cs
@@ -1,9 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Alba;
+using IssueService;
 using IssueService.Controllers;
+using Marten.AspNetCore;
+using Marten.Testing;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing;
@@ -207,6 +211,94 @@ public class streaming_result_types_tests: IntegrationContext
         });
 
         result.Context.Response.Headers.ContainsKey("ETag").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task stream_one_emits_no_etag_when_version_metadata_disabled()
+    {
+        // VersionlessDoc is registered with Metadata.Version.Enabled = false, so there is no
+        // mt_version column to derive an ETag from. EmitETag defaults to true, but the inline
+        // version read comes back null and no ETag (and no false 304) is produced.
+        var doc = new VersionlessDoc { Id = Guid.NewGuid(), Name = "no version column" };
+        await using (var session = theHost.Services.GetRequiredService<IDocumentStore>().LightweightSession())
+        {
+            session.Store(doc);
+            await session.SaveChangesAsync();
+        }
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/versionless/{doc.Id}");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        result.Context.Response.Headers.ContainsKey("ETag").ShouldBeFalse();
+
+        var read = result.ReadAsJson<VersionlessDoc>();
+        read.Name.ShouldBe(doc.Name);
+    }
+
+    [Fact]
+    public async Task stream_one_returns_404_without_etag_when_no_match()
+    {
+        // The 404 path must not leak an ETag header even with EmitETag on.
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/issue/{Guid.NewGuid()}");
+            s.StatusCodeShouldBe(404);
+        });
+
+        result.Context.Response.Headers.ContainsKey("ETag").ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task stream_one_with_etag_executes_a_single_db_command()
+    {
+        // Acceptance for #5027: with EmitETag = true (default), the document JSON and its
+        // mt_version come back in ONE round trip — no follow-up MetadataForAsync query.
+        var store = theHost.Services.GetRequiredService<IDocumentStore>();
+
+        var issue = new Issue { Description = "single command", Open = true };
+        await using (var session = store.LightweightSession())
+        {
+            session.Store(issue);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = store.QuerySession();
+        var logger = new CommandCountingLogger();
+        query.Logger = logger;
+
+        // Warm up storage-existence checks on this session so they don't count against us,
+        // then reset the counter to isolate the WriteSingle round trips.
+        await query.Query<Issue>().Where(x => x.Id == Guid.NewGuid())
+            .StreamJsonFirstOrDefault(new MemoryStream());
+        logger.Count = 0;
+
+        var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+
+        await query.Query<Issue>().Where(x => x.Id == issue.Id)
+            .WriteSingle(context, emitETag: true);
+
+        context.Response.StatusCode.ShouldBe(200);
+        context.Response.Headers.ContainsKey("ETag").ShouldBeTrue();
+        logger.Count.ShouldBe(1);
+    }
+
+    /// <summary>Minimal session logger that counts executed commands for the round-trip acceptance test.</summary>
+    private sealed class CommandCountingLogger: Marten.IMartenSessionLogger
+    {
+        public int Count { get; set; }
+
+        public void LogSuccess(Npgsql.NpgsqlCommand command) { }
+        public void LogFailure(Npgsql.NpgsqlCommand command, Exception ex) { }
+        public void LogSuccess(Npgsql.NpgsqlBatch batch) { }
+        public void LogFailure(Npgsql.NpgsqlBatch batch, Exception ex) { }
+        public void LogFailure(Exception ex, string message) { }
+        public void RecordSavedChanges(Marten.IDocumentSession session, Marten.Services.IChangeSet commit) { }
+        public void OnBeforeExecute(Npgsql.NpgsqlCommand command) => Count++;
+        public void OnBeforeExecute(Npgsql.NpgsqlBatch batch) => Count++;
     }
 
     // ───────────────────────── StreamMany<T> ─────────────────────────

--- a/src/Marten.AspNetCore/Properties/AssemblyInfo.cs
+++ b/src/Marten.AspNetCore/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Marten.Testing")]
+[assembly: InternalsVisibleTo("Marten.AspNetCore.Testing")]
 [assembly: InternalsVisibleTo("Marten.CommandLine")]
 [assembly: InternalsVisibleTo("Marten.PLv8")]
 [assembly: InternalsVisibleTo("Marten.PLv8.Testing")]

--- a/src/Marten.AspNetCore/QueryableExtensions.cs
+++ b/src/Marten.AspNetCore/QueryableExtensions.cs
@@ -16,9 +16,11 @@ public static class QueryableExtensions
     /// 404 if not found.
     /// <para>
     /// When <paramref name="emitETag"/> is true (the default), the document's <c>mt_version</c>
-    /// is read via a follow-up metadata query and written as a quoted <c>ETag</c> response header.
-    /// If the incoming request's <c>If-None-Match</c> header matches that version, a <c>304 Not
-    /// Modified</c> is written instead, with an empty body.
+    /// is read <b>inline with the document in the same single round trip</b> (piggy-backed onto the
+    /// streaming query, analogous to the <c>count(*) OVER()</c> stats column) and written as a quoted
+    /// <c>ETag</c> response header. If the incoming request's <c>If-None-Match</c> header matches that
+    /// version, a <c>304 Not Modified</c> is written instead, with an empty body. Document types with
+    /// version metadata disabled (no <c>mt_version</c> column) emit no ETag.
     /// </para>
     /// </summary>
     /// <param name="queryable"></param>
@@ -33,48 +35,59 @@ public static class QueryableExtensions
         string contentType = "application/json",
         int onFoundStatus = 200,
         bool emitETag = true
-    ) where T : notnull
+    )
     {
         var stream = Marten.Internal.SharedMemoryStreamManager.GetStream();
-        var found = await queryable.StreamJsonFirstOrDefault(stream, context.RequestAborted).ConfigureAwait(false);
 
-        if (!found)
+        if (!emitETag)
+        {
+            var found = await queryable.StreamJsonFirstOrDefault(stream, context.RequestAborted).ConfigureAwait(false);
+            if (!found)
+            {
+                context.Response.StatusCode = 404;
+                context.Response.ContentLength = 0;
+                return;
+            }
+
+            await writeBufferedBody(context, stream, contentType, onFoundStatus).ConfigureAwait(false);
+            return;
+        }
+
+        // Fetch the document JSON and its mt_version in a single round trip. The version rides
+        // on the same streaming query (see MartenLinqQueryProvider.StreamOneWithVersion), so there
+        // is no follow-up MetadataForAsync query and no re-deserialization of the buffered JSON.
+        var result = await ((MartenLinqQueryable<T>)queryable)
+            .StreamJsonFirstOrDefaultWithVersion(stream, context.RequestAborted)
+            .ConfigureAwait(false);
+
+        if (!result.Found)
         {
             context.Response.StatusCode = 404;
             context.Response.ContentLength = 0;
             return;
         }
 
-        if (emitETag)
+        if (result.Version.HasValue)
         {
-            // The queryable was built off a Marten session; walk back to it (internal access
-            // granted via [InternalsVisibleTo] on Marten's assembly) so we can look up the
-            // document's mt_version without asking the caller to plumb an IQuerySession through.
-            IMartenSession session = ((IMartenLinqQueryable)queryable).Session;
+            var etag = ETagHelpers.Format(result.Version.Value);
 
-            stream.Position = 0;
-            var entity = session.Serializer.FromJson<T>(stream);
-
-            var metadata = await ((IQuerySession)session)
-                .MetadataForAsync(entity, context.RequestAborted)
-                .ConfigureAwait(false);
-
-            if (metadata != null)
+            if (ETagHelpers.IfNoneMatchMatches(context, etag))
             {
-                var etag = ETagHelpers.Format(metadata.CurrentVersion);
-
-                if (ETagHelpers.IfNoneMatchMatches(context, etag))
-                {
-                    context.Response.StatusCode = StatusCodes.Status304NotModified;
-                    context.Response.Headers["ETag"] = etag;
-                    context.Response.ContentLength = 0;
-                    return;
-                }
-
+                context.Response.StatusCode = StatusCodes.Status304NotModified;
                 context.Response.Headers["ETag"] = etag;
+                context.Response.ContentLength = 0;
+                return;
             }
+
+            context.Response.Headers["ETag"] = etag;
         }
 
+        await writeBufferedBody(context, stream, contentType, onFoundStatus).ConfigureAwait(false);
+    }
+
+    private static async Task writeBufferedBody(HttpContext context, System.IO.Stream stream, string contentType,
+        int onFoundStatus)
+    {
         context.Response.StatusCode = onFoundStatus;
         context.Response.ContentLength = stream.Length;
         context.Response.ContentType = contentType;

--- a/src/Marten.AspNetCore/StreamOne.cs
+++ b/src/Marten.AspNetCore/StreamOne.cs
@@ -27,7 +27,7 @@ namespace Marten.AspNetCore;
 /// </para>
 /// </summary>
 /// <typeparam name="T">The document type to stream.</typeparam>
-public sealed class StreamOne<T> : IResult, IEndpointMetadataProvider where T : notnull
+public sealed class StreamOne<T> : IResult, IEndpointMetadataProvider
 {
     private readonly IQueryable<T> _queryable;
 

--- a/src/Marten/Internal/Sessions/QuerySession.Execution.cs
+++ b/src/Marten/Internal/Sessions/QuerySession.Execution.cs
@@ -87,6 +87,21 @@ public partial class QuerySession
         }
     }
 
+    internal async Task<(bool found, Guid? version)> StreamOneWithVersion(DbCommand command, Stream stream,
+        CancellationToken token)
+    {
+        await using var reader = await ExecuteReaderAsync(command, token).ConfigureAwait(false);
+
+        try
+        {
+            return await reader.StreamOneWithVersion(stream, token).ConfigureAwait(false);
+        }
+        finally
+        {
+            await reader.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
     internal async Task<int> StreamMany(DbCommand command, Stream stream, CancellationToken token)
     {
         await using var reader = await ExecuteReaderAsync(command, token).ConfigureAwait(false);

--- a/src/Marten/Linq/MartenLinqQueryProvider.cs
+++ b/src/Marten/Linq/MartenLinqQueryProvider.cs
@@ -13,11 +13,21 @@ using Marten.Internal.Sessions;
 using Marten.Linq.Parsing;
 using Marten.Linq.QueryHandlers;
 using Marten.Linq.Selectors;
+using Marten.Linq.SqlGeneration;
+using Marten.Schema;
 using Marten.Util;
 
 namespace Marten.Linq;
 
 internal record WaitForAggregate(TimeSpan Timeout, NonStaleDataTimeoutMode TimeoutMode = NonStaleDataTimeoutMode.ThrowException);
+
+/// <summary>
+/// Outcome of a single-document JSON stream that also read the document's <c>mt_version</c>
+/// inline. <see cref="Found"/> is false when the query matched no row; <see cref="Version"/>
+/// is null when the document type has no <c>mt_version</c> column (version metadata disabled)
+/// or the value was SQL NULL — in which case no ETag should be emitted.
+/// </summary>
+internal readonly record struct StreamOneJsonResult(bool Found, Guid? Version);
 
 internal class MartenLinqQueryProvider: IQueryProvider
 {
@@ -217,5 +227,47 @@ internal class MartenLinqQueryProvider: IQueryProvider
         var command = statement.BuildCommand(_session);
 
         return await _session.StreamOne(command, destination, token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Streams the first matching document as JSON AND reads its <c>mt_version</c> in the same
+    /// round trip — the version column is piggy-backed onto the streaming query via
+    /// <see cref="VersionSelectClause{T}"/> (analogous to the <c>count(*) OVER()</c> stats column),
+    /// so the ASP.NET Core <c>StreamOne</c> ETag support no longer needs a follow-up metadata query.
+    /// When the document type <typeparamref name="T"/> has no <c>mt_version</c> column (version
+    /// metadata disabled), the version column is not appended and <see cref="StreamOneJsonResult.Version"/>
+    /// comes back null so the caller emits no ETag.
+    /// </summary>
+    public async Task<StreamOneJsonResult> StreamOneWithVersion<T>(Expression expression, Stream destination,
+        CancellationToken token) where T : notnull
+    {
+        var parser = new LinqQueryParser(this, _session, expression);
+        var statements = parser.BuildStatements();
+
+        await EnsureStorageExistsAsync(parser, token).ConfigureAwait(false);
+
+        var statement = statements.Top;
+        var main = statements.MainSelector;
+        main.Limit = 1;
+
+        var versionEnabled = _session.Options.Storage.FindMapping(typeof(T)) is DocumentMapping
+        {
+            Metadata.Version.Enabled: true
+        };
+
+        if (!versionEnabled)
+        {
+            var plainCommand = statement.BuildCommand(_session);
+            var found = await _session.StreamOne(plainCommand, destination, token).ConfigureAwait(false);
+            return new StreamOneJsonResult(found, null);
+        }
+
+        main.SelectClause = new VersionSelectClause<T>(main.SelectClause);
+
+        var command = statement.BuildCommand(_session);
+        var (streamed, version) = await _session.StreamOneWithVersion(command, destination, token)
+            .ConfigureAwait(false);
+
+        return new StreamOneJsonResult(streamed, version);
     }
 }

--- a/src/Marten/Linq/MartenLinqQueryable.cs
+++ b/src/Marten/Linq/MartenLinqQueryable.cs
@@ -306,6 +306,17 @@ internal class MartenLinqQueryable<T> : IOrderedQueryable<T>, IMartenQueryable<T
         return MartenProvider.StreamJson<T>(destination, Expression, token, SingleValueMode.FirstOrDefault);
     }
 
+    /// <summary>
+    /// Streams the first matching document as JSON to <paramref name="destination"/> and reads its
+    /// <c>mt_version</c> in the SAME database round trip (see
+    /// <see cref="MartenLinqQueryProvider.StreamOneWithVersion{T}"/>). Used by the ASP.NET Core
+    /// <c>StreamOne</c> ETag support to avoid a follow-up metadata query.
+    /// </summary>
+    internal Task<StreamOneJsonResult> StreamJsonFirstOrDefaultWithVersion(Stream destination, CancellationToken token)
+    {
+        return MartenProvider.StreamOneWithVersion<T>(Expression, destination, token);
+    }
+
     public Task StreamJsonSingle(Stream destination, CancellationToken token)
     {
         return MartenProvider.StreamJson<T>(destination, Expression, token, SingleValueMode.Single);

--- a/src/Marten/Linq/SqlGeneration/VersionSelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/VersionSelectClause.cs
@@ -1,0 +1,82 @@
+#nullable enable
+using System;
+using System.Linq;
+using JasperFx.Core;
+using Marten.Internal;
+using Marten.Linq.QueryHandlers;
+using Marten.Linq.Selectors;
+using Marten.Schema;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.SqlGeneration;
+
+/// <summary>
+/// Decorates an inner <see cref="ISelectClause"/> so the streaming query also
+/// selects the document's <c>mt_version</c> column alongside its payload, letting the
+/// single-document JSON streaming path read the version in the SAME round trip
+/// (used by the ASP.NET Core <c>StreamOne</c> ETag support). Mirrors
+/// <see cref="StatsSelectClause{T}"/>, which appends <c>count(*) OVER()</c> the same way.
+/// <para>
+/// The version is aliased to <see cref="VersionAlias"/> (not the bare <c>mt_version</c>)
+/// so it never collides with an <c>mt_version</c> column the inner clause may already
+/// select (e.g. under optimistic concurrency).
+/// </para>
+/// </summary>
+internal static class VersionSelectClause
+{
+    /// <summary>
+    /// Result-set alias under which the piggy-backed <c>mt_version</c> value is returned.
+    /// </summary>
+    public const string VersionAlias = "mt_etag_version";
+}
+
+internal class VersionSelectClause<T>: ISelectClause, IModifyableFromObject where T : notnull
+{
+    private static readonly string VersionColumn =
+        $"d.{SchemaConstants.VersionColumn} as {VersionSelectClause.VersionAlias}";
+
+    public VersionSelectClause(ISelectClause inner)
+    {
+        Inner = inner;
+        FromObject = Inner.FromObject;
+    }
+
+    public ISelectClause Inner { get; }
+
+    public Type SelectedType => Inner.SelectedType;
+
+    public string FromObject { get; set; }
+
+    public void Apply(ICommandBuilder sql)
+    {
+        sql.Append("select ");
+        sql.Append(Inner.SelectFields().Join(", "));
+        sql.Append(", ");
+        sql.Append(VersionColumn);
+        sql.Append(" from ");
+        sql.Append(FromObject);
+        sql.Append(" as d");
+    }
+
+    public string[] SelectFields()
+    {
+        return Inner.SelectFields().Concat(new[] { VersionColumn }).ToArray();
+    }
+
+    public ISelector BuildSelector(IStorageSession session)
+    {
+        return Inner.BuildSelector(session);
+    }
+
+    public IQueryHandler<TResult> BuildHandler<TResult>(IStorageSession session, ISqlFragment topStatement,
+        ISqlFragment currentStatement) where TResult: notnull
+    {
+        return Inner.BuildHandler<TResult>(session, topStatement, currentStatement);
+    }
+
+    public ISelectClause UseStatistics(QueryStatistics statistics)
+    {
+        return Inner.UseStatistics(statistics);
+    }
+}

--- a/src/Marten/Services/JsonStreamingExtensions.cs
+++ b/src/Marten/Services/JsonStreamingExtensions.cs
@@ -32,6 +32,33 @@ internal static class JsonStreamingExtensions
         return 1;
     }
 
+    /// <summary>
+    /// Streams the first row's <c>data</c> column to <paramref name="stream"/> (as
+    /// <see cref="StreamOne"/> does) AND reads the piggy-backed <c>mt_version</c> value
+    /// aliased as <see cref="Marten.Linq.SqlGeneration.VersionSelectClause{T}.VersionAlias"/>,
+    /// so a single-document JSON stream and its version come back in one round trip.
+    /// Returns <c>found = false</c> when the query matched no row, and a null
+    /// <c>version</c> when the version column value was SQL NULL.
+    /// </summary>
+    internal static async Task<(bool found, Guid? version)> StreamOneWithVersion(this DbDataReader reader,
+        Stream stream, CancellationToken token)
+    {
+        if (!await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            return (false, null);
+        }
+
+        var dataOrdinal = reader.GetOrdinal("data");
+        await reader.WriteJsonValueAsync(dataOrdinal, stream, token).ConfigureAwait(false);
+
+        var versionOrdinal = reader.GetOrdinal(Marten.Linq.SqlGeneration.VersionSelectClause.VersionAlias);
+        Guid? version = await reader.IsDBNullAsync(versionOrdinal, token).ConfigureAwait(false)
+            ? null
+            : await reader.GetFieldValueAsync<Guid>(versionOrdinal, token).ConfigureAwait(false);
+
+        return (true, version);
+    }
+
     internal static ValueTask WriteBytes(this Stream stream, byte[] bytes, CancellationToken token)
     {
         return stream.WriteAsync(bytes, token);


### PR DESCRIPTION
Closes #5027. Follow-up to #5015 (ETag / If-None-Match). **Targets the 9.18 release.**

### Problem
`StreamOne<T>` computed its ETag *after* buffering the document JSON by (1) re-deserializing the buffer into a `T` and (2) issuing a **second DB round trip** — `MetadataForAsync<T>` — purely to read `mt_version`. So `EmitETag = true` (the default) meant two round trips per request. That second call is also the only reason `StreamOne<T>`/`WriteSingle<T>` had to tighten to `where T : notnull`.

### Fix — read `mt_version` inline (one round trip)
`mt_version` now rides on the **same** streaming query, using the same idea as the `count(*) OVER()` stats column #5014 uses:

- **`VersionSelectClause<T>`** — a decorator that appends `d.mt_version as mt_etag_version` to the single-document streaming select, mirroring `StatsSelectClause`. The dedicated alias avoids any collision with an `mt_version` column the inner clause may already select (optimistic concurrency / mapped `[Version]` member).
- **`MartenLinqQueryProvider.StreamOneWithVersion<T>`** builds the statement, wraps the main select clause with `VersionSelectClause<T>` **only when `mapping.Metadata.Version.Enabled`**, and reads the version off the same `DbDataReader` (`JsonStreamingExtensions.StreamOneWithVersion`) — returning `StreamOneJsonResult(found, version)`.
- **`WriteSingle`** uses that path: the `MetadataForAsync` query and the JSON re-deserialization are both gone.
- **Version-metadata-disabled doc types** (no `mt_version` column) come back with a null version → **no ETag** (guards against a constant `"00000000-…"` ETag causing false `304`s).

Because the body is streamed in that one round trip, a `304` on `StreamOne<T>` now saves bandwidth but not the read — documented, and unchanged from #5015's semantics.

### Constraint reversal
Dropped `where T : notnull` from `StreamOne<T>` and `WriteSingle<T>` (it existed only because `MetadataForAsync<T>` is `notnull`-constrained). Loosening a constraint is non-breaking, and this ships before 9.18 so the tightened form never reaches a release.

### Test hardening
- **`etag_helpers_tests`** — unit coverage for the `ETagHelpers` branches the endpoint tests skip: `*` wildcard, `W/` weak-validator stripping, multi-value comma lists, multiple header values (added `InternalsVisibleTo("Marten.AspNetCore.Testing")`).
- **Version-metadata-disabled** document (`VersionlessDoc`) emits no ETag.
- **404 path** emits no ETag.
- **Single-command acceptance**: `StreamOne` with `EmitETag = true` executes **exactly one** DB command (asserted via a command-counting session logger).

### Verification
- `Marten.AspNetCore.Testing` — 76/76 green (net9.0), including all pre-existing #5015 ETag scenarios (behavior unchanged) plus the new cases.
- `DocumentDbTests` `streaming_json_results` — 51/51 green (core streaming path unaffected).
- Both `net9.0` and `net10.0` build clean. Docs updated (`docs/documents/aspnetcore.md`); markdownlint + cspell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)