### PR TITLE
StreamPagedByCursor<T>: true raw-JSON streaming (drop hydrate+reserialize) + malformed-cursor 400 (#5029)

### DIFF
--- a/src/DocumentDbTests/Reading/cursor_paging_tests.cs
+++ b/src/DocumentDbTests/Reading/cursor_paging_tests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Marten;
 using Marten.Linq.CursorPaging;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
@@ -200,5 +202,43 @@ public class cursor_paging_tests: IntegrationContext
         await Should.ThrowAsync<ArgumentOutOfRangeException>(async () =>
             await theSession.Query<User>().OrderBy(x => x.FirstName).ThenBy(x => x.Id)
                 .ToJsonPageByCursorAsync(cursor: null, pageSize: 0));
+    }
+
+    [Fact]
+    public async Task items_json_is_byte_identical_to_stream_many()
+    {
+        await seedUsers("a", "b", "c", "d", "e");
+
+        // The cursor page must emit the raw persisted `data` column, byte-identical to what
+        // StreamMany produces for the same documents in the same order — no hydrate/re-serialize.
+        var page = await theSession.Query<User>()
+            .OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+            .ToJsonPageByCursorAsync(cursor: null, pageSize: 3);
+
+        var stream = new MemoryStream();
+        await theSession.Query<User>()
+            .OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+            .Take(3)
+            .StreamJsonArray(stream, default);
+        stream.Position = 0;
+        var streamManyJson = await new StreamReader(stream).ReadToEndAsync();
+
+        page.Count.ShouldBe(3);
+        page.ItemsJson.ShouldBe(streamManyJson);
+    }
+
+    [Fact]
+    public async Task malformed_cursor_value_that_cannot_bind_to_key_type_throws_argument_exception()
+    {
+        await seedUsers("a", "b", "c");
+
+        // A well-formed, correct-length cursor array whose terminal element ("not-a-guid")
+        // cannot bind to the Guid Id key. This must surface as a clean ArgumentException (=> 400),
+        // not an uncaught JsonException (=> 500). Cursors are client-supplied.
+        var tampered = CursorPagination.EncodeCursor(new object?[] { "a", "not-a-guid" });
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await theSession.Query<User>().OrderBy(x => x.FirstName).ThenBy(x => x.Id)
+                .ToJsonPageByCursorAsync(tampered, pageSize: 2));
     }
 }

--- a/src/Marten/Linq/CursorPaging/CursorPagination.cs
+++ b/src/Marten/Linq/CursorPaging/CursorPagination.cs
@@ -298,7 +298,17 @@ internal static class CursorPagination
             var values = new object?[orderings.Count];
             for (var i = 0; i < orderings.Count; i++)
             {
-                values[i] = JsonSerializer.Deserialize(root[i].GetRawText(), orderings[i].KeyType);
+                try
+                {
+                    values[i] = JsonSerializer.Deserialize(root[i].GetRawText(), orderings[i].KeyType);
+                }
+                catch (JsonException e)
+                {
+                    // Cursors are client-supplied: a well-formed JSON array whose element can't bind
+                    // to the key type (e.g. "abc" for a Guid key) must surface as a clean ArgumentException
+                    // (=> 400) rather than an uncaught JsonException (=> 500).
+                    throw new ArgumentException("Invalid cursor.", nameof(cursor), e);
+                }
             }
 
             return values;

--- a/src/Marten/Linq/CursorPaging/CursorPagingQueryableExtensions.cs
+++ b/src/Marten/Linq/CursorPaging/CursorPagingQueryableExtensions.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Core.Reflection;
+using Marten.Internal.Storage;
 using Marten.Linq;
+using Marten.Linq.Parsing;
 
 namespace Marten.Linq.CursorPaging;
 
@@ -73,28 +75,25 @@ public static class CursorPagingQueryableExtensions
             working = working.Where(predicate);
         }
 
-        var fetched = await working.Take(pageSize + 1).ToListAsync<T>(token).ConfigureAwait(false);
+        // Fetch one extra row so we can tell whether a further page exists.
+        working = working.Take(pageSize + 1);
 
-        var hasMore = fetched.Count > pageSize;
-        var items = hasMore ? fetched.Take(pageSize).ToList() : fetched.ToList();
-
-        string? nextCursor = null;
-        if (hasMore && items.Count > 0)
+        // Resolve each ordering to the SAME SQL locator the OrderBy chain uses, and append it to the
+        // page query as a projected column (the "extra column riding the page query" technique
+        // StreamPaged uses for count(*) OVER()). This lets us read the next cursor's key values off
+        // the reader instead of hydrating each document.
+        var queryMembers = ((ILinqDocumentStorage)session.StorageFor(typeof(T))).QueryMembers;
+        var keyColumns = new string[orderings.Count];
+        var keyTypes = new Type[orderings.Count];
+        for (var i = 0; i < orderings.Count; i++)
         {
-            var lastItem = items[^1];
-            var values = new object?[orderings.Count];
-            for (var i = 0; i < orderings.Count; i++)
-            {
-                values[i] = orderings[i].GetValue(lastItem);
-            }
-
-            nextCursor = CursorPagination.EncodeCursor(values);
+            var member = queryMembers.MemberFor(orderings[i].Selector.Body);
+            keyColumns[i] = $"{member.TypedLocator} as cursor_key_{i}";
+            keyTypes[i] = orderings[i].KeyType;
         }
 
-        var itemsJson = items.Count == 0
-            ? "[]"
-            : "[" + string.Join(",", items.Select(i => session.Serializer.ToJson(i))) + "]";
-
-        return new CursorPageResult(itemsJson, items.Count, nextCursor);
+        return await martenQueryable.MartenProvider
+            .StreamCursorPage(working.As<MartenLinqQueryable<T>>().Expression, keyColumns, keyTypes, pageSize, token)
+            .ConfigureAwait(false);
     }
 }

--- a/src/Marten/Linq/MartenLinqQueryProvider.cs
+++ b/src/Marten/Linq/MartenLinqQueryProvider.cs
@@ -10,11 +10,13 @@ using System.Threading.Tasks;
 using Marten.Events;
 using Marten.Exceptions;
 using Marten.Internal.Sessions;
+using Marten.Linq.CursorPaging;
 using Marten.Linq.Parsing;
 using Marten.Linq.QueryHandlers;
 using Marten.Linq.Selectors;
 using Marten.Linq.SqlGeneration;
 using Marten.Schema;
+using Marten.Services;
 using Marten.Util;
 
 namespace Marten.Linq;
@@ -194,6 +196,40 @@ internal class MartenLinqQueryProvider: IQueryProvider
         var command = statements.Top.BuildCommand(_session);
 
         return await _session.StreamMany(command, destination, token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Execute a keyset ("cursor") page: stream the matching documents' raw <c>data</c> JSON
+    /// (byte-identical to <see cref="StreamMany"/>) and read the ORDER BY key value(s) of the last
+    /// row inline via appended <c>cursor_key_N</c> columns, so the next cursor is built without
+    /// hydrating or re-serializing any document. <paramref name="keyColumns"/> are the pre-formatted
+    /// <c>&lt;locator&gt; as cursor_key_N</c> SELECT fragments; <paramref name="keyTypes"/> the CLR key
+    /// types used to read those columns back. The <paramref name="expression"/> must already carry
+    /// the seek <c>Where</c>, the OrderBy chain, and <c>Take(pageSize + 1)</c>.
+    /// </summary>
+    internal async Task<CursorPageResult> StreamCursorPage(Expression expression, IReadOnlyList<string> keyColumns,
+        Type[] keyTypes, int pageSize, CancellationToken token)
+    {
+        var parser = new LinqQueryParser(this, _session, expression);
+
+        await EnsureStorageExistsAsync(parser, token).ConfigureAwait(false);
+
+        var statements = parser.BuildStatements();
+        LinqQueryParser.AssertCanStreamRawJson(statements.MainSelector);
+
+        statements.MainSelector.SelectClause =
+            new CursorKeySelectClause(statements.MainSelector.SelectClause, keyColumns);
+
+        var command = statements.Top.BuildCommand(_session);
+
+        await using var reader = await _session.ExecuteReaderAsync(command, token).ConfigureAwait(false);
+        var read = await reader.StreamCursorKeyset(keyTypes, pageSize, token).ConfigureAwait(false);
+
+        var nextCursor = read is { HasMore: true, LastKeys: not null }
+            ? CursorPagination.EncodeCursor(read.LastKeys)
+            : null;
+
+        return new CursorPageResult(read.ItemsJson, read.Count, nextCursor);
     }
 
     /// <summary>

--- a/src/Marten/Linq/SqlGeneration/CursorKeySelectClause.cs
+++ b/src/Marten/Linq/SqlGeneration/CursorKeySelectClause.cs
@@ -1,0 +1,75 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JasperFx.Core;
+using Marten.Internal;
+using Marten.Linq.QueryHandlers;
+using Marten.Linq.Selectors;
+using Weasel.Postgresql;
+using Weasel.Postgresql.SqlGeneration;
+
+namespace Marten.Linq.SqlGeneration;
+
+/// <summary>
+/// Decorates an inner <see cref="ISelectClause"/> so a keyset ("cursor") page query also
+/// selects the ORDER BY key column(s) alongside the document <c>data</c>, letting the
+/// raw-JSON cursor-paging path read the next cursor's key values off the SAME
+/// <see cref="System.Data.Common.DbDataReader"/> row instead of hydrating each document.
+/// Mirrors <see cref="StatsSelectClause{T}"/> / <c>VersionSelectClause</c>, which append an
+/// extra projected column the same way. The appended columns are pre-formatted
+/// <c>&lt;locator&gt; as cursor_key_N</c> expressions supplied by the caller.
+/// </summary>
+internal class CursorKeySelectClause: ISelectClause, IModifyableFromObject
+{
+    private readonly IReadOnlyList<string> _keyColumns;
+
+    public CursorKeySelectClause(ISelectClause inner, IReadOnlyList<string> keyColumns)
+    {
+        Inner = inner;
+        _keyColumns = keyColumns;
+        FromObject = Inner.FromObject;
+    }
+
+    public ISelectClause Inner { get; }
+
+    public Type SelectedType => Inner.SelectedType;
+
+    public string FromObject { get; set; }
+
+    public void Apply(ICommandBuilder sql)
+    {
+        sql.Append("select ");
+        sql.Append(Inner.SelectFields().Join(", "));
+        foreach (var column in _keyColumns)
+        {
+            sql.Append(", ");
+            sql.Append(column);
+        }
+
+        sql.Append(" from ");
+        sql.Append(FromObject);
+        sql.Append(" as d");
+    }
+
+    public string[] SelectFields()
+    {
+        return Inner.SelectFields().Concat(_keyColumns).ToArray();
+    }
+
+    public ISelector BuildSelector(IStorageSession session)
+    {
+        return Inner.BuildSelector(session);
+    }
+
+    public IQueryHandler<TResult> BuildHandler<TResult>(IStorageSession session, ISqlFragment topStatement,
+        ISqlFragment currentStatement) where TResult: notnull
+    {
+        return Inner.BuildHandler<TResult>(session, topStatement, currentStatement);
+    }
+
+    public ISelectClause UseStatistics(QueryStatistics statistics)
+    {
+        return Inner.UseStatistics(statistics);
+    }
+}

--- a/src/Marten/Services/JsonStreamingExtensions.cs
+++ b/src/Marten/Services/JsonStreamingExtensions.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Data.Common;
+using JasperFx.Core;
 using Marten.Linq;
 using Marten.Util;
 
@@ -62,6 +63,112 @@ internal static class JsonStreamingExtensions
     internal static ValueTask WriteBytes(this Stream stream, byte[] bytes, CancellationToken token)
     {
         return stream.WriteAsync(bytes, token);
+    }
+
+    /// <summary>
+    /// Outcome of streaming one keyset ("cursor") page: the raw items JSON array (byte-identical
+    /// to <see cref="StreamMany"/>), the number of documents emitted, the ORDER BY key values of
+    /// the last emitted row (for building the next cursor), and whether a further page exists.
+    /// </summary>
+    internal readonly record struct CursorKeysetReadResult(string ItemsJson, int Count, object?[]? LastKeys, bool HasMore);
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, System.Reflection.MethodInfo>
+        _getFieldValueMethods = new();
+
+    /// <summary>
+    /// Streams the <c>data</c> column of a keyset-paged query as a raw JSON array (identical to
+    /// <see cref="StreamMany"/>) while reading the appended <c>cursor_key_N</c> columns for the last
+    /// emitted row off the same reader — so the next cursor is built without hydrating any document.
+    /// The command is expected to have fetched <paramref name="pageSize"/> + 1 rows; the extra row
+    /// (if present) is not emitted and only flags <see cref="CursorKeysetReadResult.HasMore"/>.
+    /// </summary>
+    internal static async Task<CursorKeysetReadResult> StreamCursorKeyset(this DbDataReader reader,
+        Type[] keyTypes, int pageSize, CancellationToken token)
+    {
+        var stream = Marten.Internal.SharedMemoryStreamManager.GetStream();
+
+        var dataOrdinal = reader.GetOrdinal("data");
+        var keyOrdinals = new int[keyTypes.Length];
+        for (var i = 0; i < keyTypes.Length; i++)
+        {
+            keyOrdinals[i] = reader.GetOrdinal($"cursor_key_{i}");
+        }
+
+        await stream.WriteBytes(LeftBracket, token).ConfigureAwait(false);
+
+        var count = 0;
+        var hasMore = false;
+        object?[]? lastKeys = null;
+
+        while (await reader.ReadAsync(token).ConfigureAwait(false))
+        {
+            // We fetched pageSize + 1 rows to detect a further page: the (pageSize + 1)th row is
+            // never emitted and only proves there is more to come.
+            if (count == pageSize)
+            {
+                hasMore = true;
+                break;
+            }
+
+            if (count > 0)
+            {
+                await stream.WriteBytes(Comma, token).ConfigureAwait(false);
+            }
+
+            // Read the raw data payload first (WriteJsonValueAsync uses reader.GetStream), then the
+            // appended key columns for the same row, which come after data in the SELECT ordinal order.
+            await reader.WriteJsonValueAsync(dataOrdinal, stream, token).ConfigureAwait(false);
+            lastKeys = await readCursorKeys(reader, keyOrdinals, keyTypes, token).ConfigureAwait(false);
+
+            count++;
+        }
+
+        await stream.WriteBytes(RightBracket, token).ConfigureAwait(false);
+
+        stream.Position = 0;
+        var itemsJson = await stream.ReadAllTextAsync().ConfigureAwait(false);
+
+        return new CursorKeysetReadResult(itemsJson, count, lastKeys, hasMore);
+    }
+
+    private static async Task<object?[]> readCursorKeys(DbDataReader reader, int[] keyOrdinals, Type[] keyTypes,
+        CancellationToken token)
+    {
+        var values = new object?[keyOrdinals.Length];
+        for (var i = 0; i < keyOrdinals.Length; i++)
+        {
+            var ordinal = keyOrdinals[i];
+            if (await reader.IsDBNullAsync(ordinal, token).ConfigureAwait(false))
+            {
+                values[i] = null;
+                continue;
+            }
+
+            values[i] = readTypedKey(reader, ordinal, keyTypes[i]);
+        }
+
+        return values;
+    }
+
+    private static object readTypedKey(DbDataReader reader, int ordinal, Type keyType)
+    {
+        var underlying = Nullable.GetUnderlyingType(keyType) ?? keyType;
+
+        if (underlying.IsEnum)
+        {
+            // Enum ordering keys can be persisted as their name (EnumStorage.AsString) or their
+            // integral (AsInteger). Either way, box the CLR enum so the cursor round-trips the same
+            // JSON the pre-#5029 hydrate-then-read path produced.
+            var raw = reader.GetValue(ordinal);
+            return raw is string name ? Enum.Parse(underlying, name) : Enum.ToObject(underlying, raw);
+        }
+
+        // reader.GetFieldValue<underlying>(ordinal): the appended column is cast to the proper PG
+        // type by the member's TypedLocator, so Npgsql materializes exactly the CLR key type.
+        var method = _getFieldValueMethods.GetOrAdd(underlying, static t =>
+            typeof(DbDataReader).GetMethod(nameof(DbDataReader.GetFieldValue))!.MakeGenericMethod(t));
+
+        return method.Invoke(reader, new object[] { ordinal })!;
     }
 
     internal static async Task<int> StreamMany(this DbDataReader reader, Stream stream, CancellationToken token)


### PR DESCRIPTION
Closes #5029. Follow-up to #5016 (`StreamPagedByCursor<T>` keyset pagination). **Targets 9.18.**

### Problem
`ToJsonPageByCursorAsync<T>` didn't actually stream raw JSON despite the name/docs. It `.ToListAsync<T>()`-hydrated every row, then `session.Serializer.ToJson(i)`-**re-serialized** each item — extra CPU, and the emitted JSON could differ from the stored JSON (serializer settings, property order, `$type`, computed/ignored members), so this endpoint's items weren't byte-consistent with `StreamMany`/`StreamPaged`.

### Fix — stream the raw `data` column, read keys off the reader
The page now passes the raw, already-persisted `data` column through untouched (same path `StreamMany`/`StreamPaged` use), and gets the next cursor's sort-key values **off the same `DbDataReader` row** instead of a hydrated object:

- **`CursorKeySelectClause`** decorates the page query's select clause to append `<TypedLocator> as cursor_key_N` for each ordering — the "extra projected column riding the page query" trick `StreamPaged` uses for `count(*) OVER()`. Each locator is resolved through the **same `IQueryableMember`** the `OrderBy` chain uses, so the appended column matches the sort key exactly.
- **`MartenLinqQueryProvider.StreamCursorPage`** builds/decorates the statement (asserting raw-JSON streamability like `StreamMany`) and executes it; **`JsonStreamingExtensions.StreamCursorKeyset`** streams the raw `data` into the `items` array **and** reads the `cursor_key_N` columns for the last emitted row, typed to each ordering's `KeyType` (enum-aware for `AsString`/`AsInteger`). No object hydration, no `ISerializer.ToJson`.

### Fold-in — malformed-cursor 400
`CursorPagination.DecodeCursor` now wraps the per-element `JsonSerializer.Deserialize(...)` bind (previously the one uncaught spot). A client-supplied, well-formed-array cursor whose value can't bind to the key type (e.g. `"abc"` for a `Guid` key) now surfaces as a clean `ArgumentException` (→ 400) instead of a `JsonException` (→ 500).

### Tests
- All existing `cursor_paging_tests` stay green (tie-breaking, mixed directions, end-of-set, validation, empty).
- **Byte-identical parity**: `ItemsJson` equals `StreamMany` output for the same documents/order.
- **Tampered cursor** → `ArgumentException`.
- Endpoint `stream_paged_by_cursor_tests` (Alba) 7/7 green.

Both `net9.0` and `net10.0` build clean. The `paging.md` docs already described raw-JSON streaming — this makes that literally true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)