### PR TITLE
StreamEventState + StreamEvents result types for Marten.AspNetCore

### DIFF
--- a/docs/documents/aspnetcore.md
+++ b/docs/documents/aspnetcore.md
@@ -233,7 +233,7 @@ bool found = await session.Events.StreamLatestJson<Order>(orderId, stream);
 ## Typed Streaming Result Types <Badge type="tip" text="8.x" />
 
 For Minimal API endpoints (and for frameworks like [Wolverine.Http](https://wolverinefx.net/guide/http/)
-that dispatch any `IResult` return value), `Marten.AspNetCore` ships five typed
+that dispatch any `IResult` return value), `Marten.AspNetCore` ships seven typed
 result wrappers that carry the streaming behavior above as endpoint return values
 while also contributing correct OpenAPI metadata:
 
@@ -244,13 +244,15 @@ while also contributing correct OpenAPI metadata:
 | `StreamAggregate<T>`     | `IDocumentSession` + stream id — event-sourced  | Single `T`                     | yes                    |
 | `StreamPaged<T>`         | `IQueryable<T>` — regular Marten document query | Paged JSON envelope            | no (empty page = 200)  |
 | `StreamPagedByCursor<T>` | `IQueryable<T>` (with `OrderBy`/`ThenBy`)       | { "items": T[], "nextCursor" } | no (empty array = 200) |
+| `StreamEventState`       | `IQuerySession` + stream id — event stream      | Single `StreamStateResponse`   | yes                    |
+| `StreamEvents`           | `IQuerySession` + stream id — event stream      | JSON array `EventResponse[]`   | yes (configurable)     |
 
 Each type implements both `IResult` (so ASP.NET Minimal API dispatches it via
 `ExecuteAsync`) and `IEndpointMetadataProvider` (so Swashbuckle, NSwag, and the
 built-in OpenAPI generator see the right response shape), while delegating the
-actual body write to `WriteSingle`/`WriteArray`/`WriteLatest`. Returning one
-from an endpoint is a concise, typed alternative to writing the HTTP handshake
-manually.
+actual body write to `WriteSingle`/`WriteArray`/`WriteLatest`/`WriteStreamState`/`WriteEvents`.
+Returning one from an endpoint is a concise, typed alternative to writing the HTTP
+handshake manually.
 
 ### `StreamOne<T>` — single document with 404 on miss
 
@@ -315,7 +317,122 @@ Returns `200 application/json` with the JSON of the latest projected aggregate
 state, or `404` if no stream exists. A constructor overload accepts `string`
 ids for stores configured with string-keyed streams.
 
-### StreamOne vs StreamAggregate
+### `StreamEventState` — event stream metadata <Badge type="tip" text="9.20" />
+
+Writes the high level metadata of a single event stream — Marten's `StreamState` — as JSON,
+or `404` when the stream does not exist:
+
+<!-- snippet: sample_minimal_api_stream_event_state -->
+<a id='snippet-sample_minimal_api_stream_event_state'></a>
+```cs
+app.MapGet("/minimal/order/{id:guid}/state",
+    (Guid id, IQuerySession session)
+        => new StreamEventState(session, id));
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/StreamingMinimalEndpoints.cs#L128-L134' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_minimal_api_stream_event_state' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+A constructor overload accepts a `string` stream key for stores configured with string-keyed
+streams.
+
+The response body is a **`StreamStateResponse`**, not `StreamState` itself. `StreamState.AggregateType`
+is a `System.Type`, and System.Text.Json refuses to serialize those outright
+(`Serialization and deserialization of 'System.Type' instances is not supported`), so the
+aggregate type is projected down to its simple name in `AggregateTypeName`:
+
+```json
+{
+  "id": "0198e1b4-5b1c-7a1e-9a3f-2f2f5b6c7d8e",
+  "key": null,
+  "version": 2,
+  "aggregateTypeName": "Order",
+  "lastTimestamp": "2026-07-26T09:41:02.113Z",
+  "created": "2026-07-26T09:41:02.098Z",
+  "isArchived": false
+}
+```
+
+### `StreamEvents` — raw events of a stream <Badge type="tip" text="9.20" />
+
+Writes the raw events of a single event stream as a JSON array:
+
+<!-- snippet: sample_minimal_api_stream_events -->
+<a id='snippet-sample_minimal_api_stream_events'></a>
+```cs
+app.MapGet("/minimal/order/{id:guid}/events",
+    (Guid id, IQuerySession session)
+        => new StreamEvents(session, id));
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/StreamingMinimalEndpoints.cs#L142-L148' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_minimal_api_stream_events' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+`StreamEvents` carries the same optional `version`, `timestamp`, and `fromVersion` filters as
+`FetchStreamAsync()`, and there is a `string` stream key overload as well.
+
+Elements are **`EventResponse`**, not `IEvent` itself — `IEvent.EventType` is a `System.Type` and
+hits the same System.Text.Json wall as above. Use `eventTypeName`, Marten's stable event type
+alias, to discriminate event types on the client. The assembly qualified .NET type name
+(`DotNetTypeName`) is deliberately left off the wire:
+
+```json
+[
+  {
+    "id": "0198e1b4-5b1c-7a1e-9a3f-2f2f5b6c7d8e",
+    "version": 1,
+    "sequence": 41,
+    "streamId": "0198e1b4-5b1c-7a1e-9a3f-2f2f5b6c7d8e",
+    "streamKey": null,
+    "eventTypeName": "order_placed",
+    "timestamp": "2026-07-26T09:41:02.098Z",
+    "tenantId": "*DEFAULT*",
+    "isArchived": false,
+    "causationId": null,
+    "correlationId": null,
+    "headers": null,
+    "data": { "description": "Widget", "amount": 99.95 }
+  }
+]
+```
+
+#### Empty streams: 404 or an empty array?
+
+`FetchStream` yields an empty list both for a stream that does not exist _and_ for a filter that
+excludes every event, and the two cannot be told apart. `StreamEvents` therefore exposes an
+`OnEmptyStatus` that defaults to `404`, matching the other single-resource results. Set it to
+`200` when running off the end of a stream is expected rather than exceptional — paging forward
+with `fromVersion`, for example:
+
+<!-- snippet: sample_minimal_api_stream_events_from_version -->
+<a id='snippet-sample_minimal_api_stream_events_from_version'></a>
+```cs
+// Paging forward through a stream: running off the end is expected, not a 404
+app.MapGet("/minimal/order/{id:guid}/events/from/{fromVersion:long}",
+    (Guid id, long fromVersion, IQuerySession session)
+        => new StreamEvents(session, id, fromVersion: fromVersion)
+        {
+            OnEmptyStatus = StatusCodes.Status200OK
+        });
+```
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/IssueService/StreamingMinimalEndpoints.cs#L154-L164' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_minimal_api_stream_events_from_version' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+#### Sharing a query plan with a batched query
+
+Both results are backed by the [`FetchStreamStatePlan` / `FetchStreamPlan` query plans](/events/querying#stream-query-plans),
+and both accept a pre-built plan. That lets a handler build the plan once and either batch it with
+other queries into a single round trip or hand it straight back as an HTTP result:
+
+```csharp
+var plan = new FetchStreamPlan(orderId, version: 5);
+
+// ...batch it alongside other queries
+var fetcher = batch.QueryByPlan(plan);
+
+// ...or return it from an endpoint
+return new StreamEvents(session, plan);
+```
+
+### Choosing between the result types
 
 - **`StreamOne<T>`** is for regular Marten documents — plain objects persisted
   via `session.Store()` and queried with `session.Query<T>()`. The query hits
@@ -324,6 +441,12 @@ ids for stores configured with string-keyed streams.
   latest aggregate state by folding events from the event store (or reads a
   projected snapshot if one is configured). Use this when `T` is an
   event-sourced aggregate, not a stored document.
+- **`StreamEventState`** returns a stream's _metadata_ — version, timestamps,
+  archived flag — rather than any projected state. Reach for it when a client
+  needs to know where a stream is up to, not what it currently looks like.
+- **`StreamEvents`** returns the stream's _raw events_. Use it for audit trails,
+  event-log style UIs, and debugging endpoints, rather than as the read model for
+  ordinary consumers — those are better served by `StreamAggregate<T>`.
 
 ### ETag / Conditional Requests <Badge type="tip" text="9.18" />
 

--- a/docs/events/querying.md
+++ b/docs/events/querying.md
@@ -299,6 +299,13 @@ public async Task use_both_plans_in_one_batch()
 <sup><a href='https://github.com/JasperFx/marten/blob/master/src/EventSourcingTests/fetching_stream_query_plans.cs#L105-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_fetch_stream_plans_in_batch' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+::: tip
+Both plans also back an ASP.NET Core endpoint return value —
+[`StreamEventState` and `StreamEvents`](/documents/aspnetcore#typed-streaming-result-types-) write the
+same data straight to an HTTP response, and accept a pre-built plan so a handler can share one plan
+between a batched query and its HTTP result.
+:::
+
 ## Fetch a Single Event
 
 You can fetch the information for a single event by id, including its version number within the stream, by using `IEventStore.LoadAsync()` as shown below:

--- a/src/IssueService/StreamingMinimalEndpoints.cs
+++ b/src/IssueService/StreamingMinimalEndpoints.cs
@@ -123,6 +123,51 @@ public static class StreamingMinimalEndpoints
                     cursor,
                     pageSize));
 
+        // --- StreamEventState ---
+
+        #region sample_minimal_api_stream_event_state
+
+        app.MapGet("/minimal/order/{id:guid}/state",
+            (Guid id, IQuerySession session)
+                => new StreamEventState(session, id));
+
+        #endregion
+
+        app.MapGet("/minimal/named-order/{id}/state",
+            (string id, IQuerySession session)
+                => new StreamEventState(session, id));
+
+        // --- StreamEvents ---
+
+        #region sample_minimal_api_stream_events
+
+        app.MapGet("/minimal/order/{id:guid}/events",
+            (Guid id, IQuerySession session)
+                => new StreamEvents(session, id));
+
+        #endregion
+
+        app.MapGet("/minimal/named-order/{id}/events",
+            (string id, IQuerySession session)
+                => new StreamEvents(session, id));
+
+        #region sample_minimal_api_stream_events_from_version
+
+        // Paging forward through a stream: running off the end is expected, not a 404
+        app.MapGet("/minimal/order/{id:guid}/events/from/{fromVersion:long}",
+            (Guid id, long fromVersion, IQuerySession session)
+                => new StreamEvents(session, id, fromVersion: fromVersion)
+                {
+                    OnEmptyStatus = StatusCodes.Status200OK
+                });
+
+        #endregion
+
+        // Version cap, and the plan-accepting constructor
+        app.MapGet("/minimal/order/{id:guid}/events/upto/{version:long}",
+            (Guid id, long version, IQuerySession session)
+                => new StreamEvents(session, new FetchStreamPlan(id, version)));
+
         return app;
     }
 }

--- a/src/Marten.AspNetCore.Testing/stream_event_result_types_tests.cs
+++ b/src/Marten.AspNetCore.Testing/stream_event_result_types_tests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Alba;
+using IssueService.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Marten.AspNetCore.Testing;
+
+/// <summary>
+/// Alba-based tests for <see cref="StreamEventState"/> and <see cref="StreamEvents"/> executing
+/// against plain Minimal API endpoints (no Wolverine required).
+/// </summary>
+[Collection("integration")]
+public class stream_event_result_types_tests: IntegrationContext
+{
+    private readonly IAlbaHost theHost;
+
+    public stream_event_result_types_tests(AppFixture fixture): base(fixture)
+    {
+        theHost = fixture.Host;
+    }
+
+    private async Task<Guid> anOrderStream(params object[] events)
+    {
+        var orderId = Guid.NewGuid();
+        var store = theHost.Services.GetRequiredService<IDocumentStore>();
+        await using var session = store.LightweightSession();
+        session.Events.StartStream<Order>(orderId, events);
+        await session.SaveChangesAsync();
+
+        return orderId;
+    }
+
+    // ───────────────────────── StreamEventState ─────────────────────────
+
+    [Fact]
+    public async Task stream_event_state_returns_metadata_for_an_existing_stream()
+    {
+        var orderId = await anOrderStream(new OrderPlaced("Widget", 99.95m), new OrderShipped());
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}/state");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var state = result.ReadAsJson<StreamStateResponse>();
+        state.ShouldNotBeNull();
+        state.Id.ShouldBe(orderId);
+        state.Version.ShouldBe(2);
+        state.IsArchived.ShouldBeFalse();
+        state.Created.ShouldBeGreaterThan(DateTimeOffset.MinValue);
+    }
+
+    [Fact]
+    public async Task stream_event_state_serializes_the_aggregate_type_as_a_name()
+    {
+        // StreamState.AggregateType is a System.Type, which System.Text.Json flatly refuses to
+        // serialize. StreamStateResponse projects it to a simple name instead.
+        var orderId = await anOrderStream(new OrderPlaced("Widget", 99.95m));
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}/state");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var state = result.ReadAsJson<StreamStateResponse>();
+        state.AggregateTypeName.ShouldBe(nameof(Order));
+    }
+
+    [Fact]
+    public async Task stream_event_state_sets_content_length()
+    {
+        var orderId = await anOrderStream(new OrderPlaced("Widget", 99.95m));
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}/state");
+            s.StatusCodeShouldBe(200);
+        });
+
+        result.Context.Response.ContentLength.HasValue.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task stream_event_state_returns_404_for_a_missing_stream()
+    {
+        await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{Guid.NewGuid()}/state");
+            s.StatusCodeShouldBe(404);
+        });
+    }
+
+    // ───────────────────────── StreamEvents ─────────────────────────
+
+    [Fact]
+    public async Task stream_events_returns_the_raw_events_as_a_json_array()
+    {
+        var orderId = await anOrderStream(new OrderPlaced("Widget", 99.95m), new OrderShipped());
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}/events");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        var events = result.ReadAsJson<List<EventResponse>>();
+        events.Count.ShouldBe(2);
+
+        events[0].Version.ShouldBe(1);
+        events[0].StreamId.ShouldBe(orderId);
+        events[0].EventTypeName.ShouldNotBeNullOrEmpty();
+        events[0].Timestamp.ShouldBeGreaterThan(DateTimeOffset.MinValue);
+
+        events[1].Version.ShouldBe(2);
+        events[1].EventTypeName.ShouldNotBe(events[0].EventTypeName);
+    }
+
+    [Fact]
+    public async Task stream_events_returns_404_for_a_missing_stream_by_default()
+    {
+        await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{Guid.NewGuid()}/events");
+            s.StatusCodeShouldBe(404);
+        });
+    }
+
+    [Fact]
+    public async Task stream_events_honors_a_version_cap_through_the_plan_constructor()
+    {
+        var orderId = await anOrderStream(new OrderPlaced("Widget", 99.95m), new OrderShipped());
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}/events/upto/1");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var events = result.ReadAsJson<List<EventResponse>>();
+        events.Count.ShouldBe(1);
+        events[0].Version.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task stream_events_can_opt_into_an_empty_array_instead_of_404()
+    {
+        var orderId = await anOrderStream(new OrderPlaced("Widget", 99.95m));
+
+        // fromVersion past the end of the stream — expected when paging forward, so this
+        // endpoint sets OnEmptyStatus to 200 rather than reporting the order as missing.
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}/events/from/99");
+            s.StatusCodeShouldBe(200);
+            s.ContentTypeShouldBe("application/json");
+        });
+
+        result.ReadAsJson<List<EventResponse>>().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task stream_events_carries_the_event_body_on_the_data_property()
+    {
+        var orderId = await anOrderStream(new OrderPlaced("Widget", 99.95m));
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}/events");
+            s.StatusCodeShouldBe(200);
+        });
+
+        var events = result.ReadAsJson<List<OrderPlacedEventResponse>>();
+        events[0].Data.Description.ShouldBe("Widget");
+        events[0].Data.Amount.ShouldBe(99.95m);
+    }
+
+    [Fact]
+    public async Task stream_events_sets_content_length()
+    {
+        var orderId = await anOrderStream(new OrderPlaced("Widget", 99.95m));
+
+        var result = await theHost.Scenario(s =>
+        {
+            s.Get.Url($"/minimal/order/{orderId}/events");
+            s.StatusCodeShouldBe(200);
+        });
+
+        result.Context.Response.ContentLength.HasValue.ShouldBeTrue();
+    }
+
+    // ───────────────────────── OpenAPI metadata ─────────────────────────
+
+    [Fact]
+    public void stream_event_state_endpoint_advertises_produces_response_and_404()
+    {
+        var metadata = EndpointMetadataFor("GET", "/minimal/order/{id:guid}/state");
+
+        metadata.OfType<IProducesResponseTypeMetadata>()
+            .ShouldContain(m => m.StatusCode == 200 && m.Type == typeof(StreamStateResponse));
+        metadata.OfType<IProducesResponseTypeMetadata>()
+            .ShouldContain(m => m.StatusCode == 404);
+    }
+
+    [Fact]
+    public void stream_events_endpoint_advertises_produces_array_and_404()
+    {
+        var metadata = EndpointMetadataFor("GET", "/minimal/order/{id:guid}/events");
+
+        metadata.OfType<IProducesResponseTypeMetadata>()
+            .ShouldContain(m => m.StatusCode == 200 && m.Type == typeof(EventResponse[]));
+        metadata.OfType<IProducesResponseTypeMetadata>()
+            .ShouldContain(m => m.StatusCode == 404);
+    }
+
+    private EndpointMetadataCollection EndpointMetadataFor(string method, string pattern)
+    {
+        var endpoint = theHost.Services.GetServices<EndpointDataSource>()
+            .SelectMany(x => x.Endpoints)
+            .OfType<RouteEndpoint>()
+            .FirstOrDefault(x =>
+                x.RoutePattern.RawText == pattern &&
+                x.Metadata.GetMetadata<HttpMethodMetadata>()!.HttpMethods.Contains(method));
+
+        endpoint.ShouldNotBeNull($"No endpoint found for {method} {pattern}");
+        return endpoint.Metadata;
+    }
+}
+
+/// <summary>
+/// Strongly-typed view of the wire shape so the test can assert on the event body itself.
+/// </summary>
+public class OrderPlacedEventResponse
+{
+    public long Version { get; set; }
+    public OrderPlaced Data { get; set; } = default!;
+}

--- a/src/Marten.AspNetCore/EventStreamResponses.cs
+++ b/src/Marten.AspNetCore/EventStreamResponses.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JasperFx.Events;
+
+namespace Marten.AspNetCore;
+
+#region sample_event_stream_response_types
+
+/// <summary>
+/// The HTTP wire shape written by <see cref="StreamEventState"/> for a single event stream's
+/// <see cref="StreamState"/> metadata.
+/// <para>
+/// <see cref="StreamState"/> is not written directly because <c>StreamState.AggregateType</c> is a
+/// <see cref="Type"/>, and System.Text.Json refuses to serialize <see cref="Type"/> instances
+/// ("Serialization and deserialization of 'System.Type' instances is not supported"). This record
+/// projects the aggregate type down to its simple name and is a stable contract for HTTP clients.
+/// </para>
+/// </summary>
+public sealed record StreamStateResponse
+{
+    /// <summary>Identity of the stream when using Guid identity; <see cref="Guid.Empty"/> for string-keyed streams.</summary>
+    public Guid Id { get; init; }
+
+    /// <summary>Identity of the stream when using string identity; null for Guid-keyed streams.</summary>
+    public string? Key { get; init; }
+
+    /// <summary>Current version of the stream, i.e. the count of events.</summary>
+    public long Version { get; init; }
+
+    /// <summary>Simple name of the aggregate type the stream was tagged with, when it was tagged at all.</summary>
+    public string? AggregateTypeName { get; init; }
+
+    /// <summary>The last time this stream was appended to.</summary>
+    public DateTimeOffset LastTimestamp { get; init; }
+
+    /// <summary>The time at which this stream was created.</summary>
+    public DateTimeOffset Created { get; init; }
+
+    /// <summary>Whether the stream has been archived.</summary>
+    public bool IsArchived { get; init; }
+
+    /// <summary>
+    /// Project a Marten <see cref="StreamState"/> onto the wire shape.
+    /// </summary>
+    public static StreamStateResponse From(StreamState state)
+    {
+        if (state == null) throw new ArgumentNullException(nameof(state));
+
+        return new StreamStateResponse
+        {
+            Id = state.Id,
+            Key = state.Key,
+            Version = state.Version,
+            AggregateTypeName = state.AggregateType?.Name,
+            LastTimestamp = state.LastTimestamp,
+            Created = state.Created,
+            IsArchived = state.IsArchived
+        };
+    }
+}
+
+/// <summary>
+/// The HTTP wire shape written by <see cref="StreamEvents"/> for one raw event in a stream.
+/// <para>
+/// <see cref="IEvent"/> is not written directly because <c>IEvent.EventType</c> is a
+/// <see cref="Type"/>, which System.Text.Json refuses to serialize. <c>DotNetTypeName</c> — the
+/// assembly qualified .NET type name — is deliberately left off the wire as well; use
+/// <see cref="EventTypeName"/>, Marten's stable event type alias, to discriminate event types on
+/// the client.
+/// </para>
+/// </summary>
+public sealed record EventResponse
+{
+    /// <summary>Unique identifier of the event.</summary>
+    public Guid Id { get; init; }
+
+    /// <summary>The event's position within its stream.</summary>
+    public long Version { get; init; }
+
+    /// <summary>The event's sequential position across the entire event store.</summary>
+    public long Sequence { get; init; }
+
+    /// <summary>Owning stream's id when using Guid identity; <see cref="Guid.Empty"/> otherwise.</summary>
+    public Guid StreamId { get; init; }
+
+    /// <summary>Owning stream's key when using string identity; null otherwise.</summary>
+    public string? StreamKey { get; init; }
+
+    /// <summary>Marten's event type alias — the stable discriminator for clients.</summary>
+    public string? EventTypeName { get; init; }
+
+    /// <summary>The UTC time at which the event was captured.</summary>
+    public DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>The owning tenant id.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>Whether the event has been archived.</summary>
+    public bool IsArchived { get; init; }
+
+    /// <summary>Optional causation id metadata.</summary>
+    public string? CausationId { get; init; }
+
+    /// <summary>Optional correlation id metadata.</summary>
+    public string? CorrelationId { get; init; }
+
+    /// <summary>Optional user defined metadata. Null when no headers were set.</summary>
+    public Dictionary<string, object>? Headers { get; init; }
+
+    /// <summary>The event body itself.</summary>
+    public object Data { get; init; } = default!;
+
+    /// <summary>
+    /// Project a Marten <see cref="IEvent"/> onto the wire shape.
+    /// </summary>
+    public static EventResponse From(IEvent @event)
+    {
+        if (@event == null) throw new ArgumentNullException(nameof(@event));
+
+        return new EventResponse
+        {
+            Id = @event.Id,
+            Version = @event.Version,
+            Sequence = @event.Sequence,
+            StreamId = @event.StreamId,
+            StreamKey = @event.StreamKey,
+            EventTypeName = @event.EventTypeName,
+            Timestamp = @event.Timestamp,
+            TenantId = @event.TenantId,
+            IsArchived = @event.IsArchived,
+            CausationId = @event.CausationId,
+            CorrelationId = @event.CorrelationId,
+            Headers = @event.Headers,
+            Data = @event.Data
+        };
+    }
+
+    /// <summary>
+    /// Project a list of Marten <see cref="IEvent"/> onto the wire shape.
+    /// </summary>
+    public static EventResponse[] From(IReadOnlyList<IEvent> events)
+    {
+        if (events == null) throw new ArgumentNullException(nameof(events));
+
+        return events.Select(From).ToArray();
+    }
+}
+
+#endregion

--- a/src/Marten.AspNetCore/QueryableExtensions.cs
+++ b/src/Marten.AspNetCore/QueryableExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -478,4 +479,110 @@ public static class QueryableExtensions
         }
     }
 
+    /// <summary>
+    /// Resolve a <see cref="FetchStreamStatePlan"/> and write the resulting stream metadata to the
+    /// HttpContext response as JSON, or 404 when the stream does not exist.
+    /// <para>
+    /// The response body is a <see cref="StreamStateResponse"/> rather than Marten's
+    /// <c>StreamState</c> — see that type for why.
+    /// </para>
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="plan"></param>
+    /// <param name="context"></param>
+    /// <param name="contentType"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
+    public static async Task WriteStreamState(
+        this IQuerySession session,
+        FetchStreamStatePlan plan,
+        HttpContext context,
+        string contentType = "application/json",
+        int onFoundStatus = 200
+    )
+    {
+        if (session == null) throw new ArgumentNullException(nameof(session));
+        if (plan == null) throw new ArgumentNullException(nameof(plan));
+        if (context == null) throw new ArgumentNullException(nameof(context));
+
+        var state = await plan.Fetch(session, context.RequestAborted).ConfigureAwait(false);
+
+        if (state == null)
+        {
+            context.Response.StatusCode = 404;
+            context.Response.ContentLength = 0;
+            return;
+        }
+
+        await writeJson(session, StreamStateResponse.From(state), context, contentType, onFoundStatus)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolve a <see cref="FetchStreamPlan"/> and write the resulting raw events to the HttpContext
+    /// response as a JSON array.
+    /// <para>
+    /// Marten's <c>FetchStream</c> yields an empty list both for a stream that does not exist and for
+    /// a filter that excludes every event, so the two cases cannot be told apart here.
+    /// <paramref name="onEmptyStatus"/> decides which answer the endpoint gives; it defaults to 404
+    /// to match the other single-resource results. Pass 200 to return an empty JSON array instead.
+    /// </para>
+    /// <para>
+    /// Each element is an <see cref="EventResponse"/> rather than Marten's <c>IEvent</c> — see that
+    /// type for why.
+    /// </para>
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="plan"></param>
+    /// <param name="context"></param>
+    /// <param name="contentType"></param>
+    /// <param name="onFoundStatus">Defaults to 200</param>
+    /// <param name="onEmptyStatus">Defaults to 404</param>
+    public static async Task WriteEvents(
+        this IQuerySession session,
+        FetchStreamPlan plan,
+        HttpContext context,
+        string contentType = "application/json",
+        int onFoundStatus = 200,
+        int onEmptyStatus = 404
+    )
+    {
+        if (session == null) throw new ArgumentNullException(nameof(session));
+        if (plan == null) throw new ArgumentNullException(nameof(plan));
+        if (context == null) throw new ArgumentNullException(nameof(context));
+
+        var events = await plan.Fetch(session, context.RequestAborted).ConfigureAwait(false);
+
+        if (events.Count == 0 && onEmptyStatus == 404)
+        {
+            context.Response.StatusCode = 404;
+            context.Response.ContentLength = 0;
+            return;
+        }
+
+        await writeJson(session, EventResponse.From(events), context, contentType,
+            events.Count == 0 ? onEmptyStatus : onFoundStatus).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Serialize <paramref name="value"/> with the store's configured serializer and write it to the
+    /// response, setting Content-Length. Buffers through a pooled <see cref="ArrayBufferWriter{T}"/>
+    /// so the JSON never round-trips through a .NET string.
+    /// </summary>
+    private static async Task writeJson(
+        IQuerySession session,
+        object value,
+        HttpContext context,
+        string contentType,
+        int statusCode)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        session.DocumentStore.Options.Serializer().WriteTo(buffer, value);
+
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = contentType;
+        context.Response.ContentLength = buffer.WrittenCount;
+
+        await context.Response.Body.WriteAsync(buffer.WrittenMemory, context.RequestAborted)
+            .ConfigureAwait(false);
+    }
 }

--- a/src/Marten.AspNetCore/StreamEventState.cs
+++ b/src/Marten.AspNetCore/StreamEventState.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Marten.AspNetCore;
+
+/// <summary>
+/// Minimal-API / Wolverine.Http endpoint return value that writes the high level metadata of a
+/// single event stream — Marten's <c>StreamState</c> — to the <see cref="HttpContext.Response"/>
+/// as JSON. Backed by <see cref="FetchStreamStatePlan"/>, the same query plan that can be batched
+/// through <c>IBatchedQuery.QueryByPlan()</c>.
+/// <para>
+/// Returns HTTP <c>404</c> when the stream does not exist, <see cref="OnFoundStatus"/> (default 200)
+/// when it does.
+/// </para>
+/// <para>
+/// The response body is a <see cref="StreamStateResponse"/>, not Marten's <c>StreamState</c>
+/// directly: <c>StreamState.AggregateType</c> is a <see cref="Type"/> and System.Text.Json refuses
+/// to serialize those, so the aggregate type is projected down to its simple name.
+/// </para>
+/// <para>
+/// <b>StreamEventState vs StreamAggregate.</b> Use <see cref="StreamEventState"/> when you want the
+/// stream's <i>metadata</i> — version, timestamps, archived flag. Use <see cref="StreamAggregate{T}"/>
+/// when you want the projected aggregate <i>state</i> built from the stream's events.
+/// </para>
+/// </summary>
+public sealed class StreamEventState: IResult, IEndpointMetadataProvider
+{
+    private readonly IQuerySession _session;
+    private readonly FetchStreamStatePlan _plan;
+
+    /// <summary>
+    /// Write the stream metadata for the Guid-identified stream <paramref name="streamId"/>.
+    /// </summary>
+    public StreamEventState(IQuerySession session, Guid streamId)
+        : this(session, new FetchStreamStatePlan(streamId))
+    {
+    }
+
+    /// <summary>
+    /// Write the stream metadata for the string-keyed stream <paramref name="streamKey"/>.
+    /// </summary>
+    public StreamEventState(IQuerySession session, string streamKey)
+        : this(session, new FetchStreamStatePlan(
+            streamKey ?? throw new ArgumentNullException(nameof(streamKey))))
+    {
+    }
+
+    /// <summary>
+    /// Write the stream metadata resolved by an existing <see cref="FetchStreamStatePlan"/>. Lets a
+    /// handler build the plan once and either batch it or return it straight from an endpoint.
+    /// </summary>
+    public StreamEventState(IQuerySession session, FetchStreamStatePlan plan)
+    {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _plan = plan ?? throw new ArgumentNullException(nameof(plan));
+    }
+
+    /// <summary>
+    /// Status code written when the stream is found. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
+
+        return _session.WriteStreamState(_plan, httpContext, ContentType, OnFoundStatus);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI correctly advertises a
+    /// <c>200: StreamStateResponse</c> and <c>404</c> response for this endpoint.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(StreamStateResponse), new[] { "application/json" }));
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status404NotFound, typeof(void), Array.Empty<string>()));
+    }
+}

--- a/src/Marten.AspNetCore/StreamEvents.cs
+++ b/src/Marten.AspNetCore/StreamEvents.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Marten.AspNetCore;
+
+/// <summary>
+/// Minimal-API / Wolverine.Http endpoint return value that writes the raw events of a single event
+/// stream to the <see cref="HttpContext.Response"/> as a JSON array. Backed by
+/// <see cref="FetchStreamPlan"/>, the same query plan that can be batched through
+/// <c>IBatchedQuery.QueryByPlan()</c>, and carrying the same optional <c>version</c>,
+/// <c>timestamp</c> and <c>fromVersion</c> filters as <c>FetchStreamAsync()</c>.
+/// <para>
+/// Marten's <c>FetchStream</c> yields an empty list both for a stream that does not exist and for a
+/// filter that excludes every event, so the two cannot be told apart here.
+/// <see cref="OnEmptyStatus"/> decides which answer the endpoint gives; it defaults to <c>404</c>
+/// to match the other single-resource results. Set it to 200 to return an empty JSON array instead
+/// — the right choice for an endpoint that pages through a stream with <c>fromVersion</c>, where
+/// running off the end is expected rather than exceptional.
+/// </para>
+/// <para>
+/// Elements are <see cref="EventResponse"/>, not Marten's <c>IEvent</c> directly:
+/// <c>IEvent.EventType</c> is a <see cref="Type"/> and System.Text.Json refuses to serialize those.
+/// Use <c>EventTypeName</c>, Marten's stable event type alias, to discriminate event types client
+/// side; the assembly qualified .NET type name is deliberately not written to the wire.
+/// </para>
+/// </summary>
+public sealed class StreamEvents: IResult, IEndpointMetadataProvider
+{
+    private readonly IQuerySession _session;
+    private readonly FetchStreamPlan _plan;
+
+    /// <summary>
+    /// Write the events of the Guid-identified stream <paramref name="streamId"/>.
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="streamId"></param>
+    /// <param name="version">If set, writes events up to and including this version</param>
+    /// <param name="timestamp">If set, writes events captured on or before this timestamp</param>
+    /// <param name="fromVersion">If set, writes events on or from this version</param>
+    public StreamEvents(IQuerySession session, Guid streamId, long version = 0,
+        DateTimeOffset? timestamp = null, long fromVersion = 0)
+        : this(session, new FetchStreamPlan(streamId, version, timestamp, fromVersion))
+    {
+    }
+
+    /// <summary>
+    /// Write the events of the string-keyed stream <paramref name="streamKey"/>.
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="streamKey"></param>
+    /// <param name="version">If set, writes events up to and including this version</param>
+    /// <param name="timestamp">If set, writes events captured on or before this timestamp</param>
+    /// <param name="fromVersion">If set, writes events on or from this version</param>
+    public StreamEvents(IQuerySession session, string streamKey, long version = 0,
+        DateTimeOffset? timestamp = null, long fromVersion = 0)
+        : this(session, new FetchStreamPlan(
+            streamKey ?? throw new ArgumentNullException(nameof(streamKey)), version, timestamp, fromVersion))
+    {
+    }
+
+    /// <summary>
+    /// Write the events resolved by an existing <see cref="FetchStreamPlan"/>. Lets a handler build
+    /// the plan once and either batch it or return it straight from an endpoint.
+    /// </summary>
+    public StreamEvents(IQuerySession session, FetchStreamPlan plan)
+    {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _plan = plan ?? throw new ArgumentNullException(nameof(plan));
+    }
+
+    /// <summary>
+    /// Status code written when the stream yields at least one event. Defaults to 200.
+    /// </summary>
+    public int OnFoundStatus { get; init; } = StatusCodes.Status200OK;
+
+    /// <summary>
+    /// Status code written when the stream yields no events at all. Defaults to 404.
+    /// Set to 200 to write an empty JSON array instead.
+    /// </summary>
+    public int OnEmptyStatus { get; init; } = StatusCodes.Status404NotFound;
+
+    /// <summary>
+    /// Response content type. Defaults to <c>application/json</c>.
+    /// </summary>
+    public string ContentType { get; init; } = "application/json";
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
+
+        return _session.WriteEvents(_plan, httpContext, ContentType, OnFoundStatus, OnEmptyStatus);
+    }
+
+    /// <summary>
+    /// Populates endpoint metadata so OpenAPI correctly advertises a
+    /// <c>200: EventResponse[]</c> and <c>404</c> response for this endpoint.
+    /// </summary>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status200OK, typeof(EventResponse[]), new[] { "application/json" }));
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status404NotFound, typeof(void), Array.Empty<string>()));
+    }
+}


### PR DESCRIPTION
Builds on the `FetchStreamStatePlan` / `FetchStreamPlan` query plans from #5043 (@uniquelau), now merged. That PR was conflicting on `docs/cSpell.json` — #5049 had landed `"jasperfx"` in the same slot in the words array — so I pushed the resolution to its branch and merged it; this PR has been rebased and now carries only the ASP.NET Core work.

## What this adds

The event-side siblings of `StreamAggregate<T>`, backed by those two plans. Both implement `IResult` and `IEndpointMetadataProvider` like the rest of the family:

```csharp
app.MapGet("/orders/{id:guid}/state",  (Guid id, IQuerySession s) => new StreamEventState(s, id));
app.MapGet("/orders/{id:guid}/events", (Guid id, IQuerySession s) => new StreamEvents(s, id));
```

Both also accept a **pre-built plan**, so a handler can share one plan between a batched query and its HTTP result:

```csharp
var plan = new FetchStreamPlan(orderId, version: 5);
var fetcher = batch.QueryByPlan(plan);   // batch it...
return new StreamEvents(session, plan);  // ...or return it
```

## Why the wire types aren't Marten's own

Neither `StreamState` nor `IEvent` can be written to the response directly. `StreamState.AggregateType` and `IEvent.EventType` are `System.Type`, and System.Text.Json refuses to serialize those:

```
NotSupportedException: Serialization and deserialization of 'System.Type' instances
is not supported. Path: $.AggregateType.
```

I verified this against the actual store serializer before designing around it — both types throw, so a result that serialized them naively would fail at runtime for every STJ user. `StreamStateResponse` and `EventResponse` project them onto stable wire shapes: the aggregate type reduces to its simple name, and `IEvent`'s assembly-qualified `DotNetTypeName` is deliberately left off the wire (`EventTypeName`, Marten's event type alias, is the discriminator clients should key on).

## Empty streams

`FetchStream` yields an empty list both for a stream that does not exist *and* for a filter that excludes every event, and the two cannot be told apart. `StreamEvents` therefore exposes `OnEmptyStatus`, defaulting to `404` to match the other single-resource results — set it to `200` when running off the end is expected, as when paging forward with `fromVersion`.

## Details

- Serialization buffers through an `ArrayBufferWriter<byte>` and `ISerializer.WriteTo`, so the JSON never round-trips through a .NET string; `Content-Length` is set on both.
- `WriteStreamState` / `WriteEvents` extension methods on `IQuerySession` carry the actual write, mirroring how `StreamOne` delegates to `WriteSingle`.
- `string` stream key overloads on both, and the `version` / `timestamp` / `fromVersion` filters on `StreamEvents`.

## Tests and docs

12 new Alba tests against real Minimal API endpoints, covering both results, the plan constructor, the `OnEmptyStatus` opt-out, `Content-Length`, the serialized event body, and OpenAPI metadata. Full `Marten.AspNetCore.Testing` suite: 97 passed, re-run green after the rebase.

Docs: the result-type table in `documents/aspnetcore.md` grows to seven entries, with new sections for both types (including the JSON each writes and the empty-stream discussion), the "StreamOne vs StreamAggregate" section becomes a four-way "Choosing between the result types", and `events/querying.md` cross-links from the query plan section. `markdownlint` and `cspell` clean over all of `docs/`.

Polecat parity tracked at JasperFx/polecat#370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)