### PR TITLE
fix(#4953): allocation fence keeps idle advisory-lock sessions from holding gap skips forever

### DIFF
--- a/src/DaemonTests/Bugs/Bug_4953_idle_advisory_lock_sessions_do_not_block_gap_skips.cs
+++ b/src/DaemonTests/Bugs/Bug_4953_idle_advisory_lock_sessions_do_not_block_gap_skips.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DaemonTests.TestingSupport;
+using JasperFx.Core;
+using JasperFx.Events;
+using Marten;
+using Marten.Events.Daemon.HighWater;
+using Marten.Storage;
+using Marten.Testing;
+using Marten.Testing.Harness;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Shouldly;
+using Weasel.Postgresql;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DaemonTests.Bugs;
+
+/// <summary>
+/// Follow-up to #4953: the gap-liveness gate must not be held hostage by open transactions that are
+/// provably NOT the gap's reserver. Wolverine's exclusive listeners park an advisory lock inside an
+/// idle-in-transaction session for the life of the process — to the unrefined probe every one of
+/// them is forever a "possible living reserver" (its xact_start predates any gap), so a genuinely
+/// dead gap never skips and projections freeze until a human intervenes. The allocation fence rules
+/// them out by proof: the detector remembers when the reserved last_value was still at or below the
+/// stuck mark, so any session that has executed nothing since then cannot have called nextval for a
+/// gap sequence.
+/// </summary>
+public class Bug_4953_idle_advisory_lock_sessions_do_not_block_gap_skips: DaemonContext
+{
+    private readonly ITestOutputHelper _output;
+
+    public Bug_4953_idle_advisory_lock_sessions_do_not_block_gap_skips(ITestOutputHelper output): base(output)
+    {
+        _output = output;
+    }
+
+    private string Schema => theStore.Events.DatabaseSchemaName;
+
+    #region helpers
+
+    private async Task<NpgsqlConnection> openConnection()
+    {
+        var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    // The Wolverine-style exclusive listener: an idle-in-transaction session that grabbed a
+    // transaction-scoped advisory lock long ago and will never run another statement.
+    private async Task<NpgsqlConnection> startIdleAdvisoryLockSession(long lockId)
+    {
+        var conn = await openConnection();
+        await conn.BeginTransactionAsync();
+        await conn.CreateCommand($"select pg_advisory_xact_lock({lockId})").ExecuteNonQueryAsync();
+        return conn;
+    }
+
+    private async Task appendEvents(int count)
+    {
+        await using var session = theStore.LightweightSession();
+        for (var i = 0; i < count; i++)
+        {
+            session.Events.StartStream(Guid.NewGuid(), new Bug4953GapEvent(Guid.NewGuid(), i + 1));
+        }
+
+        await session.SaveChangesAsync();
+    }
+
+    private async Task<long> scalar(string sql)
+    {
+        await using var conn = await openConnection();
+        var raw = await conn.CreateCommand(sql).ExecuteScalarAsync();
+        return raw is long l ? l : Convert.ToInt64(raw ?? 0L);
+    }
+
+    private async Task execute(string sql)
+    {
+        await using var conn = await openConnection();
+        await conn.CreateCommand(sql).ExecuteNonQueryAsync();
+    }
+
+    // Reserves the next sequence number and inserts its event row WITHOUT committing, exactly like
+    // an in-flight SaveChanges
+    private async Task<(NpgsqlConnection conn, NpgsqlTransaction tx, long seq)> startOutstandingAppend()
+    {
+        var conn = await openConnection();
+        var tx = await conn.BeginTransactionAsync();
+        var seq = (long)(await conn.CreateCommand($"select nextval('{Schema}.mt_events_sequence')")
+            .ExecuteScalarAsync())!;
+        await conn.CreateCommand($@"
+insert into {Schema}.mt_events(seq_id, id, stream_id, version, data, type, timestamp, tenant_id, mt_dotnet_type, is_archived)
+select {seq}, gen_random_uuid(), stream_id, 100000 + {seq}, data, type, now(), tenant_id, mt_dotnet_type, false
+from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
+        return (conn, tx, seq);
+    }
+
+    private HighWaterDetector buildDetector()
+    {
+        return new HighWaterDetector((MartenDatabase)theStore.Tenancy.Default.Database, theStore.Events,
+            NullLogger.Instance);
+    }
+
+    #endregion
+
+    [Fact]
+    public async Task dead_gap_skips_despite_an_ancient_idle_in_transaction_advisory_lock_session()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.StaleSequenceThreshold = 500.Milliseconds();
+        });
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        var listener = await startIdleAdvisoryLockSession(4953001);
+        try
+        {
+            await appendEvents(8);
+            await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+
+            var detector = buildDetector();
+
+            // A normal poll while the store is caught up — this is what gives the detector proof
+            // that no sequence number above 8 existed yet at this moment
+            var baseline = await detector.Detect(CancellationToken.None);
+            baseline.CurrentMark.ShouldBe(8);
+
+            // seq 9 is reserved and rolled back: a permanently dead hole
+            var (conn, tx, seq) = await startOutstandingAppend();
+            try
+            {
+                seq.ShouldBe(9);
+                await appendEvents(3); // 10..12 committed
+                await tx.RollbackAsync();
+            }
+            finally
+            {
+                await conn.DisposeAsync();
+            }
+
+            // First sighting of the gap — hold (threshold measured from first observation)
+            var first = await detector.DetectInSafeZone(CancellationToken.None);
+            first.CurrentMark.ShouldBe(8);
+
+            await Task.Delay(700);
+
+            // Threshold elapsed, and the ONLY open transaction from before the gap is the advisory
+            // lock listener, which has provably executed nothing since before seq 9 was allocated.
+            // The gap is dead: skip — with NO SkipStaleGapsDespiteLiveTransactionsAfter configured.
+            var second = await detector.DetectInSafeZone(CancellationToken.None);
+            _output.WriteLine($"After threshold with idle listener present: CurrentMark={second.CurrentMark}");
+            second.CurrentMark.ShouldBe(12);
+            second.IncludesSkipping.ShouldBeTrue();
+
+            var persisted = await scalar(
+                $"select coalesce(max(last_seq_id), 0) from {Schema}.mt_event_progression where name = 'HighWaterMark'");
+            persisted.ShouldBe(12);
+        }
+        finally
+        {
+            await listener.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task a_genuinely_live_reserver_still_holds_the_gap_when_the_fence_is_present()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.StaleSequenceThreshold = 500.Milliseconds();
+        });
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        var listener = await startIdleAdvisoryLockSession(4953002);
+        try
+        {
+            await appendEvents(8);
+            await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+
+            var detector = buildDetector();
+            (await detector.Detect(CancellationToken.None)).CurrentMark.ShouldBe(8);
+
+            // seq 9 reserved by a transaction that is STILL alive — it ran its statements after the
+            // fence, so the fence must not rule it out even while the idle listener IS ruled out
+            var (conn, tx, seq) = await startOutstandingAppend();
+            try
+            {
+                seq.ShouldBe(9);
+                await appendEvents(3); // 10..12 committed
+
+                var first = await detector.DetectInSafeZone(CancellationToken.None);
+                first.CurrentMark.ShouldBe(8);
+
+                await Task.Delay(700);
+                var second = await detector.DetectInSafeZone(CancellationToken.None);
+                _output.WriteLine($"Past threshold with live reserver: CurrentMark={second.CurrentMark}");
+                second.CurrentMark.ShouldBe(8);
+
+                // The reserver dies — NOW the gap is provably dead and the skip proceeds
+                await tx.RollbackAsync();
+            }
+            finally
+            {
+                await conn.DisposeAsync();
+            }
+
+            await Task.Delay(200);
+            var third = await detector.DetectInSafeZone(CancellationToken.None);
+            _output.WriteLine($"After reserver death: CurrentMark={third.CurrentMark}");
+            third.CurrentMark.ShouldBe(12);
+            third.IncludesSkipping.ShouldBeTrue();
+        }
+        finally
+        {
+            await listener.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task without_allocation_history_the_idle_session_conservatively_holds_the_gap()
+    {
+        StoreOptions(opts =>
+        {
+            opts.Projections.StaleSequenceThreshold = 500.Milliseconds();
+        });
+        theStore.EnsureStorageExists(typeof(IEvent));
+
+        var listener = await startIdleAdvisoryLockSession(4953003);
+        try
+        {
+            await appendEvents(8);
+            await execute($"select {Schema}.mt_mark_event_progression('HighWaterMark', 8)");
+
+            // The dead gap forms BEFORE the detector ever polls — a daemon restarted mid-gap has no
+            // proof of when the gap's sequence numbers were allocated, so the idle open transaction
+            // stays a candidate reserver and the hold remains (the documented conservative
+            // degradation; SkipStaleGapsDespiteLiveTransactionsAfter is the backstop here)
+            var (conn, tx, seq) = await startOutstandingAppend();
+            try
+            {
+                seq.ShouldBe(9);
+                await appendEvents(3); // 10..12 committed
+                await tx.RollbackAsync();
+            }
+            finally
+            {
+                await conn.DisposeAsync();
+            }
+
+            var detector = buildDetector();
+            var first = await detector.DetectInSafeZone(CancellationToken.None);
+            first.CurrentMark.ShouldBe(8);
+
+            await Task.Delay(700);
+            var second = await detector.DetectInSafeZone(CancellationToken.None);
+            _output.WriteLine($"Past threshold, fenceless: CurrentMark={second.CurrentMark}");
+            second.CurrentMark.ShouldBe(8);
+
+            var persisted = await scalar(
+                $"select coalesce(max(last_seq_id), 0) from {Schema}.mt_event_progression where name = 'HighWaterMark'");
+            persisted.ShouldBe(8);
+        }
+        finally
+        {
+            await listener.DisposeAsync();
+        }
+    }
+}

--- a/src/Marten/Events/Daemon/HighWater/GapLivenessProbe.cs
+++ b/src/Marten/Events/Daemon/HighWater/GapLivenessProbe.cs
@@ -14,15 +14,19 @@ namespace Marten.Events.Daemon.HighWater;
 /// first observed; if that transaction is still running the gap is merely OUTSTANDING (its event
 /// will commit later) and must not be skipped. Only when no candidate reserver remains — and the
 /// rows are still absent — is the gap proven permanently dead (the reserver rolled back).
+/// QuiescentSessionsIgnored counts old open transactions that were ruled OUT as reservers because
+/// they have provably executed nothing since before the gap's sequence numbers were allocated
+/// (e.g. Wolverine's idle-in-transaction advisory-lock listener sessions).
 /// </summary>
-internal record GapLiveness(long OldLockHolders, long OlderTransactions, long OlderWriteXids)
+internal record GapLiveness(long OldLockHolders, long OlderTransactions, long OlderWriteXids,
+    long QuiescentSessionsIgnored = 0)
 {
     public bool IndicatesLiveReserver => OldLockHolders > 0 || OlderTransactions > 0 || OlderWriteXids > 0;
 
     public override string ToString()
     {
         return
-            $"mt_events write locks held by transactions from before the gap: {OldLockHolders}, open transactions from before the gap: {OlderTransactions}, in-progress write transaction ids from before the gap: {OlderWriteXids}";
+            $"mt_events write locks held by transactions from before the gap: {OldLockHolders}, open transactions from before the gap: {OlderTransactions}, in-progress write transaction ids from before the gap: {OlderWriteXids}, idle-in-transaction sessions ruled out as reservers: {QuiescentSessionsIgnored}";
     }
 }
 
@@ -43,25 +47,53 @@ internal record GapLiveness(long OldLockHolders, long OlderTransactions, long Ol
 ///    xmax recorded at observation. Purely MVCC data — visible regardless of role/privileges — and
 ///    covers cross-role writers that the redacted pg_stat_activity clause cannot see.
 ///
-/// All three are proc-array/lock-table scans (monitoring-grade cost) and only run while a stale gap
-/// actually exists, at high-water poll cadence.
+/// The allocation fence rules candidate reservers out by proof rather than wall clock: the fence is
+/// the latest server time at which the detector observed the event sequence's reserved last_value at
+/// or below the stuck mark, so every sequence number inside the gap was allocated strictly AFTER the
+/// fence (sequence allocation is monotone; even a cached nextval block requires a statement at
+/// block-grab time). A session sitting in 'idle in transaction' whose last state change predates the
+/// fence has executed no statement since — it cannot have called nextval for any gap sequence and is
+/// excluded from all three clauses. This is what keeps permanently-idle open transactions
+/// (Wolverine's advisory-lock listener sessions, leaked ORM sessions, monitoring agents) from
+/// holding the gate forever, while a genuine reserver — which by definition executed nextval after
+/// the fence, bumping its state_change — is always kept. Without a fence (detector restarted
+/// mid-gap, per-tenant path) nothing is excluded: exactly the unfenced #4953 behavior.
+///
+/// All the sources are proc-array/lock-table scans (monitoring-grade cost) and only run while a
+/// stale gap actually exists, at high-water poll cadence.
 /// </summary>
 internal class GapLivenessProbe: ISingleQueryHandler<GapLiveness>
 {
     private readonly EventGraph _graph;
     private readonly DateTimeOffset _gapFirstObserved;
     private readonly long _xmaxAtObservation;
+    private readonly DateTimeOffset? _allocationFence;
 
-    public GapLivenessProbe(EventGraph graph, DateTimeOffset gapFirstObserved, long xmaxAtObservation)
+    public GapLivenessProbe(EventGraph graph, DateTimeOffset gapFirstObserved, long xmaxAtObservation,
+        DateTimeOffset? allocationFence = null)
     {
         _graph = graph;
         _gapFirstObserved = gapFirstObserved;
         _xmaxAtObservation = xmaxAtObservation;
+        _allocationFence = allocationFence;
     }
 
     public NpgsqlCommand BuildCommand()
     {
+        // quiescent = sessions provably idle since before the gap's sequence numbers were allocated
+        // (see the class doc). state/state_change are redacted for cross-role viewers without
+        // pg_read_all_stats — a redacted NULL never matches, degrading to "not excluded", which errs
+        // toward holding. The strict < keeps a reserver whose state_change could theoretically tie
+        // the fence timestamp. The xip exclusion maps 64-bit xid8 values back to 32-bit backend_xid
+        // via mod 2^32 (same epoch by construction — both are in progress right now).
         var sql = @"
+with quiescent as (
+  select a.pid, a.backend_xid
+    from pg_stat_activity a
+   where a.pid <> pg_backend_pid()
+     and a.state in ('idle in transaction', 'idle in transaction (aborted)')
+     and a.state_change < :fence
+)
 select
   (select count(*)
      from pg_locks l
@@ -72,6 +104,7 @@ select
       and l.pid <> pg_backend_pid()
       and l.database = (select d.oid from pg_database d where d.datname = current_database())
       and a.xact_start <= :first_observed
+      and l.pid not in (select q.pid from quiescent q)
       and l.relation in (select c.oid
                            from pg_class c
                            join pg_namespace n on n.oid = c.relnamespace
@@ -84,16 +117,29 @@ select
       and a.pid <> pg_backend_pid()
       and a.backend_type = 'client backend'
       and a.xact_start is not null
-      and a.xact_start <= :first_observed) as older_transactions,
+      and a.xact_start <= :first_observed
+      and a.pid not in (select q.pid from quiescent q)) as older_transactions,
   (select count(*)
      from pg_snapshot_xip(pg_current_snapshot()) as xip(xid)
-    where xip.xid::text::bigint < :xmax0) as older_write_xids
+    where xip.xid::text::bigint < :xmax0
+      and mod(xip.xid::text::bigint, 4294967296) not in
+          (select q.backend_xid::text::bigint from quiescent q where q.backend_xid is not null)) as older_write_xids,
+  (select count(*)
+     from pg_stat_activity a
+    where a.datname = current_database()
+      and a.pid <> pg_backend_pid()
+      and a.backend_type = 'client backend'
+      and a.xact_start is not null
+      and a.xact_start <= :first_observed
+      and a.pid in (select q.pid from quiescent q)) as quiescent_ignored
 ".Trim();
 
         var command = new NpgsqlCommand(sql);
         command.AddNamedParameter("first_observed", _gapFirstObserved);
         command.AddNamedParameter("schema", _graph.DatabaseSchemaName);
         command.AddNamedParameter("xmax0", _xmaxAtObservation);
+        // No fence ⇒ nothing qualifies as quiescent ⇒ exactly the unfenced behavior
+        command.AddNamedParameter("fence", _allocationFence ?? DateTimeOffset.MinValue);
 
         return command;
     }
@@ -108,6 +154,7 @@ select
         return new GapLiveness(
             await reader.GetFieldValueAsync<long>(0, token).ConfigureAwait(false),
             await reader.GetFieldValueAsync<long>(1, token).ConfigureAwait(false),
-            await reader.GetFieldValueAsync<long>(2, token).ConfigureAwait(false));
+            await reader.GetFieldValueAsync<long>(2, token).ConfigureAwait(false),
+            await reader.GetFieldValueAsync<long>(3, token).ConfigureAwait(false));
     }
 }

--- a/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
+++ b/src/Marten/Events/Daemon/HighWater/HighWaterDetector.cs
@@ -54,11 +54,29 @@ internal class HighWaterDetector: IHighWaterDetector
     // from Since (never from mt_event_progression.last_updated, which is arbitrarily old on an idle
     // store), Xmax fences the liveness probe to transactions that could have reserved the gap, and
     // ReservedCeiling bounds how far a proven-dead skip may advance — sequence numbers reserved AFTER
-    // the observation belong to newer transactions whose fate is not proven. Detector-scoped state:
-    // resets on restart, which only means a stuck gap waits one fresh threshold before skipping.
-    private sealed record StuckGapObservation(long Mark, DateTimeOffset Since, long Xmax, long ReservedCeiling);
+    // the observation belong to newer transactions whose fate is not proven. AllocationFence is the
+    // latest server time at which the reserved last_value was still at or below Mark (null when no
+    // such poll is in memory — e.g. the detector restarted while the gap already existed), letting
+    // the liveness probe rule out sessions that have provably executed nothing since before the
+    // gap's sequence numbers were even allocated. Detector-scoped state: resets on restart, which
+    // only means a stuck gap waits one fresh threshold before skipping.
+    private sealed record StuckGapObservation(long Mark, DateTimeOffset Since, long Xmax, long ReservedCeiling,
+        DateTimeOffset? AllocationFence);
 
     private StuckGapObservation? _stuckGap;
+
+    // #4953 follow-up: (server timestamp, reserved last_value) pairs from every statistics poll, so
+    // a stuck gap's AllocationFence can be looked up when it is first observed. Permanently-idle open
+    // transactions (Wolverine's advisory-lock listener sessions) otherwise satisfy the liveness
+    // probe's open-transaction clause forever and a genuinely dead gap never skips. Bounded and
+    // compacted: consecutive polls at the same last_value collapse to one entry keeping the LATEST
+    // timestamp (the fence wants the last moment the value was still that low). Guarded by its own
+    // lock — Detect (poll loop) and DetectInSafeZone (rebuild/catch-up) can run concurrently.
+    private readonly object _allocationHistoryLock = new();
+    private readonly List<AllocationObservation> _allocationHistory = new();
+    private const int AllocationHistoryCapacity = 128;
+
+    private sealed record AllocationObservation(DateTimeOffset Timestamp, long HighestSequence);
 
     public HighWaterDetector(MartenDatabase runner, EventGraph graph, ILogger logger)
     {
@@ -198,7 +216,8 @@ internal class HighWaterDetector: IHighWaterDetector
         }
 
         var liveness = await _runner
-            .Query(new GapLivenessProbe(_graph, observed.Since, observed.Xmax), token).ConfigureAwait(false);
+            .Query(new GapLivenessProbe(_graph, observed.Since, observed.Xmax, observed.AllocationFence), token)
+            .ConfigureAwait(false);
         if (liveness.IndicatesLiveReserver)
         {
             var cap = _settings.SkipStaleGapsDespiteLiveTransactionsAfter;
@@ -341,7 +360,8 @@ internal class HighWaterDetector: IHighWaterDetector
                 statistics.CurrentMark,
                 statistics.Timestamp,
                 (statistics as MartenHighWaterStatistics)?.CurrentXmax ?? 0,
-                statistics.HighestSequence);
+                statistics.HighestSequence,
+                findAllocationFence(statistics.CurrentMark));
         }
     }
 
@@ -607,6 +627,9 @@ select coalesce(
         // reserving transaction may still be alive is outstanding, not dead, and must not be skipped.
         // The lock/transaction/xip fencing is store-wide rather than per-tenant (a lock on any
         // mt_events partition blocks every tenant's skip), which errs on the conservative side.
+        // No allocation fence here: the vectorized poll reads committed max(seq_id) per tenant, not
+        // a reserved last_value, so there is no history to prove when the tenant's gap sequences
+        // were allocated — quiescent sessions are NOT ruled out on this path (conservative).
         if (_settings.UseTransactionEvidenceForGapSkipping
             && _tenantStaleSince.TryGetValue(statistics.TenantId!, out var observation))
         {
@@ -840,7 +863,71 @@ select coalesce(
 
     private async Task<HighWaterStatistics> loadCurrentStatistics(CancellationToken token)
     {
-        return await _runner.Query(_highWaterStatisticsDetector, token).ConfigureAwait(false);
+        var statistics = await _runner.Query(_highWaterStatisticsDetector, token).ConfigureAwait(false);
+        recordAllocationObservation(statistics);
+        return statistics;
+    }
+
+    // #4953 follow-up: feed the allocation history from every statistics poll — see _allocationHistory
+    private void recordAllocationObservation(HighWaterStatistics statistics)
+    {
+        // Under per-tenant event partitioning HighestSequence is the committed max(seq_id), NOT the
+        // reserved last_value (#4712) — "committed height <= mark at time T" says nothing about what
+        // was ALLOCATED by then, so no sound fence can be built from it.
+        if (_graph.UseTenantPartitionedEvents || statistics.Timestamp == default)
+        {
+            return;
+        }
+
+        lock (_allocationHistoryLock)
+        {
+            var count = _allocationHistory.Count;
+            if (count > 0)
+            {
+                var last = _allocationHistory[count - 1];
+                if (statistics.HighestSequence == last.HighestSequence)
+                {
+                    if (statistics.Timestamp > last.Timestamp)
+                    {
+                        _allocationHistory[count - 1] = last with { Timestamp = statistics.Timestamp };
+                    }
+
+                    return;
+                }
+
+                // Readings can complete out of order across concurrent callers; only ever append a
+                // strictly newer, strictly higher reading so the list stays monotone in both fields
+                if (statistics.HighestSequence < last.HighestSequence || statistics.Timestamp <= last.Timestamp)
+                {
+                    return;
+                }
+            }
+
+            _allocationHistory.Add(new AllocationObservation(statistics.Timestamp, statistics.HighestSequence));
+            if (_allocationHistory.Count > AllocationHistoryCapacity)
+            {
+                _allocationHistory.RemoveAt(0);
+            }
+        }
+    }
+
+    // The latest server time at which the reserved last_value was still at or below the stuck mark —
+    // every sequence number above the mark was allocated strictly after this moment. Null when no
+    // qualifying poll is in memory (detector started while the gap already existed).
+    private DateTimeOffset? findAllocationFence(long mark)
+    {
+        lock (_allocationHistoryLock)
+        {
+            for (var i = _allocationHistory.Count - 1; i >= 0; i--)
+            {
+                if (_allocationHistory[i].HighestSequence <= mark)
+                {
+                    return _allocationHistory[i].Timestamp;
+                }
+            }
+        }
+
+        return null;
     }
 
     private async Task<long> findCurrentMark(HighWaterStatistics statistics, DetectionType detectionType,


### PR DESCRIPTION
## The problem (field report, follow-up to #4953 / #4977)

The #4953 gap-liveness gate refuses to skip a stale sequence gap while **any** transaction that began before the gap was observed is still alive. That open-transaction clause is permanently satisfied by long-lived idle-in-transaction sessions that will never append an event — most notably Wolverine's exclusive-listener sessions parking a transaction-scoped advisory lock for the life of the process. A reporting user runs 57 such sessions fleet-wide: to the probe there is *always* a "possible living reserver," so a genuinely dead gap (killed connection, rolled-back append) held the high water mark **forever** with the default `SkipStaleGapsDespiteLiveTransactionsAfter = null`, freezing all async projections until they manually inserted tombstones.

## The fix: prove innocence instead of guessing by wall clock

- `HighWaterDetector` records `(server timestamp, reserved last_value)` from every statistics poll into a small compacted history (128 entries, detector-scoped).
- When a gap gets stuck, the observation now carries an **allocation fence**: the latest server time at which `last_value` was still at or below the stuck mark. Sequence allocation is monotone, so every sequence number inside the gap was allocated **strictly after** the fence (a cached `nextval` block still requires a statement at block-grab time).
- `GapLivenessProbe` excludes any session in `idle in transaction` whose `state_change` predates the fence from **all three** evidence clauses (`mt_events` locks, open transactions, in-progress xids): that session has provably executed no statement since before the gap's sequences existed, so it cannot have called `nextval` for any of them — no matter how ancient its `xact_start`.
- A genuine reserver by definition executed `nextval` after the fence, which bumps its `state_change`, so it is **always kept** — including long-running business transactions that append at the end (which is why a "transactions can't plausibly be that old" age cap was rejected as unsound).
- The probe result and hold/skip log lines now report `idle-in-transaction sessions ruled out as reservers: N`, so this failure mode is self-explanatory in the field.

## Degradation stays strictly conservative

No fence available → nothing is excluded, i.e. exactly the pre-existing #4953 behavior (hold until the `SkipStaleGapsDespiteLiveTransactionsAfter` backstop):

- detector restarted while the gap already existed (no allocation history yet),
- cross-role `pg_stat_activity` redaction without `pg_read_all_stats` (a NULL `state` never matches the quiescent filter),
- the per-tenant partitioned path (its vectorized poll reads committed `max(seq_id)`, not a reserved `last_value`, so no sound fence can be built — left as a follow-up).

## Testing

- 3 new regression tests in `DaemonTests/Bugs/Bug_4953_idle_advisory_lock_sessions_do_not_block_gap_skips.cs`:
  - dead gap skips despite an ancient idle advisory-lock session, with **no** escape-hatch cap configured — verified RED before the fix (mark pinned exactly like the field report);
  - a genuinely live reserver still holds the gap while the idle listener is ruled out, then skips after the reserver dies;
  - fenceless (restart-mid-gap) case conservatively holds — pins the documented degradation.
- Full DaemonTests suite: **253/253 green** (net10.0, parallelization disabled).

## Notes for reviewers

- The quiescent exclusion uses strict `state_change < fence` so a reserver whose state change could theoretically tie the fence timestamp is never excluded.
- The xip-clause exclusion maps 64-bit `xid8` values back to 32-bit `backend_xid` via `mod 2^32` — both are in progress right now, so same epoch by construction.
- Companion Wolverine issue (avoid parking `pg_advisory_xact_lock` in an idle transaction; never add keepalives inside such transactions since activity would legitimately re-promote the session to candidate reserver) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)