### PR TITLE
Fix NgramIndex to match NgramSearch's unaccent-aware mt_grams_vector expression

### DIFF
--- a/src/DocumentDbTests/Indexes/NgramSearchTests.cs
+++ b/src/DocumentDbTests/Indexes/NgramSearchTests.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
+using Npgsql;
 using Shouldly;
 using Xunit;
 
@@ -195,6 +197,59 @@ public class NgramSearchTests : Marten.Testing.Harness.OneOffConfigurationsConte
         result.Count.ShouldBe(2);
         result.ShouldContain(x => x.UserName == kierkegaard.UserName);
         result.ShouldContain(x => x.UserName == bjork.UserName);
+    }
+
+    [Fact]
+    public async Task ngram_search_uses_the_index_when_unaccent_is_enabled()
+    {
+        // Regression test for the NgramIndex / NgramSearch mismatch: NgramIndex used to
+        // always build its expression as mt_grams_vector(col) (implicit use_unaccent = false),
+        // while NgramSearch() always emitted mt_grams_vector(col, {UseNGramSearchWithUnaccent}).
+        // With UseNGramSearchWithUnaccent = true the query predicate and the indexed expression
+        // were different Postgres expressions, so the planner could never use the index.
+        var store = DocumentStore.For(_ =>
+        {
+            _.Connection(ConnectionSource.ConnectionString);
+            _.DatabaseSchemaName = "ngram_test_unaccent_index";
+            _.Schema.For<User>().NgramIndex(x => x.UserName);
+            _.Advanced.UseNGramSearchWithUnaccent = true;
+        });
+
+        await store.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
+
+        await using var session = store.QuerySession();
+
+        var cmd = session.Query<User>()
+            .Where(x => x.UserName.NgramSearch("term"))
+            .ToCommand();
+
+        var plan = new List<string>();
+        await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
+        await conn.OpenAsync();
+
+        await using (var setup = conn.CreateCommand())
+        {
+            setup.CommandText = "SET enable_seqscan = off";
+            await setup.ExecuteNonQueryAsync();
+        }
+
+        await using (var explain = conn.CreateCommand())
+        {
+            explain.CommandText = "EXPLAIN " + cmd.CommandText;
+            foreach (NpgsqlParameter p in cmd.Parameters)
+            {
+                explain.Parameters.Add(new NpgsqlParameter(p.ParameterName, p.NpgsqlDbType) { Value = p.Value });
+            }
+
+            await using var reader = await explain.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                plan.Add(reader.GetString(0));
+            }
+        }
+
+        var planText = string.Join("\n", plan);
+        planText.ShouldContain("idx_ngram");
     }
 
     [Fact]

--- a/src/Marten/Schema/NgramIndex.cs
+++ b/src/Marten/Schema/NgramIndex.cs
@@ -53,7 +53,15 @@ public class NgramIndex: IndexDefinition
         set => _dataConfig = value ?? DefaultDataConfig;
     }
 
-    public override string[] Columns => [$"{_parent.DatabaseSchemaName}.mt_grams_vector( {_dataConfig})"];
+    public override string[] Columns
+    {
+        get
+        {
+            var useUnaccent = _parent.StoreOptions.Advanced.UseNGramSearchWithUnaccent.ToString().ToUpperInvariant();
+            return [$"{_parent.DatabaseSchemaName}.mt_grams_vector({_dataConfig},{useUnaccent})"];
+        }
+    }
+
     protected override string deriveIndexName()
     {
         var lowerValue = _indexName?.ToLowerInvariant();

--- a/src/Marten/Schema/SQL/mt_safe_unaccent.sql
+++ b/src/Marten/Schema/SQL/mt_safe_unaccent.sql
@@ -6,7 +6,7 @@ OR REPLACE FUNCTION {databaseSchema}.mt_safe_unaccent(use_unaccent BOOLEAN, word
 AS $function$
 BEGIN
 IF use_unaccent THEN
-    RETURN unaccent(word);
+    RETURN public.unaccent(word);
 ELSE
     RETURN word;
 END IF;


### PR DESCRIPTION
Fixes #5059

Found this while chasing down why ngram search was slow in one of our apps even though we had `.NgramIndex(...)` set up. Turns out the index Marten builds and the query Marten runs don't actually match once you turn on `UseNGramSearchWithUnaccent`.

The index is created from `mt_grams_vector(col)` (one arg), which just falls back to Postgres's own default of `use_unaccent = false`. But `NgramSearch()` always writes its `WHERE` clause with the two-arg form, using whatever `UseNGramSearchWithUnaccent` is set to. So if you've turned that flag on, the index is built with `false` and the query asks for `true`, two different expressions as far as Postgres is concerned, so the planner can never use the index. Everything still returns correct results, it just quietly does a full scan instead, which is why nobody would notice from the tests alone.

The fix is small: `NgramIndex` just needs to look at the same `UseNGramSearchWithUnaccent` setting and build its expression the same way `NgramSearch()` does, so they always line up.

I also added a test that actually proves the index gets used (`EXPLAIN` with `enable_seqscan off`), instead of only checking that results come back correct, that's the gap that let this slip through in the first place.

One thing worth calling out for reviewers: if anyone's already running with `UseNGramSearchWithUnaccent = true`, their existing ngram index will get dropped and recreated the next time they apply schema changes, since the expression text is changing. That's expected, the old index was never actually doing anything for them anyway.

---
  Found and fixed one more issue while validating this locally.

  Once the NgramIndex fix lands, Postgres actually builds the ngram index with use_unaccent = TRUE (previously it always built with false, which is
  the bug this PR fixes). That means Postgres now really executes mt_grams_vector → mt_grams_array → mt_safe_unaccent → unaccent() against every row
  while building the index.

  Postgres 14+ resets search_path to pg_catalog, pg_temp during index build/maintenance operations (CREATE INDEX, REINDEX, VACUUM, ANALYZE), as a
  hardening against search-path hijacking. mt_safe_unaccent.sql called the bare unaccent(word), which works fine during normal query execution but
  fails during index build with:
 
  42883: function unaccent(text) does not exist

  That code path was silently dead before this PR, since the old broken index always built with use_unaccent = false and never called unaccent().

  The unaccent extension always installs into the public schema regardless of the store's configured schema. Marten registers it via new 
  Extension("unaccent"), and Weasel's Extension class hardcodes its identifier to public.<name> no matter what schema is passed.
