### PR TITLE
Fix OrderBy against a dictionary indexer dropping the key

### DIFF
--- a/src/LinqTests/Bugs/Bug_1219_ordering_by_attributes.cs
+++ b/src/LinqTests/Bugs/Bug_1219_ordering_by_attributes.cs
@@ -31,12 +31,7 @@ public class Bug_1219_ordering_by_attributes : IntegrationContext
         public Dictionary<int, int> Numbers = new Dictionary<int, int>();
     }
 
-    // Skip is assigned after RunFor so the RunFor setter cannot overwrite it.
-    [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft,
-        Skip = "https://github.com/JasperFx/marten/issues/5063 - OrderBy on a dictionary "
-             + "indexer drops the key and sorts by the whole JSON object. This test has "
-             + "never run: the v2 discoverer could not be resolved from a Compile-linked "
-             + "harness, so it was silently not discovered at all.")]
+    [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
     public async Task can_order_by_string_string_dictionaries()
     {
         var car1 = new Car {Attributes = {{"one", "5"},{"anumber", "5"},{"color", "red"}}};

--- a/src/LinqTests/Bugs/Bug_5063_ordering_by_dictionary_indexer.cs
+++ b/src/LinqTests/Bugs/Bug_5063_ordering_by_dictionary_indexer.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace LinqTests.Bugs;
+
+/// <summary>
+/// #5063 — OrderBy against a dictionary indexer used to drop the key and sort by the whole
+/// JSON object, so every key produced an identical ordering.
+///
+/// Every test here deliberately orders by a key that is <em>not</em> the first one in the
+/// dictionary. jsonb compares objects key by key, so sorting the whole object happens to
+/// agree with sorting by the first key — a test written against that key passes with or
+/// without the fix and proves nothing. That is exactly why the original defect survived.
+/// </summary>
+public class Bug_5063_ordering_by_dictionary_indexer: IntegrationContext
+{
+    public Bug_5063_ordering_by_dictionary_indexer(DefaultStoreFixture fixture): base(fixture)
+    {
+    }
+
+    public class Machine
+    {
+        public Guid Id { get; set; }
+
+        // "rank" sorts opposite to "zone", and "primary" opposite to "secondary".
+        public Dictionary<string, string> Tags { get; set; } = new();
+
+        public Dictionary<string, int> Readings { get; set; } = new();
+    }
+
+    protected override Task fixtureSetup()
+    {
+        return theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Machine));
+    }
+
+    private async Task seed()
+    {
+        var machines = new[]
+        {
+            new Machine
+            {
+                Tags = { { "rank", "1" }, { "zone", "d" } },
+                Readings = { { "primary", 10 }, { "secondary", 400 } }
+            },
+            new Machine
+            {
+                Tags = { { "rank", "2" }, { "zone", "c" } },
+                Readings = { { "primary", 20 }, { "secondary", 300 } }
+            },
+            new Machine
+            {
+                Tags = { { "rank", "3" }, { "zone", "b" } },
+                Readings = { { "primary", 30 }, { "secondary", 200 } }
+            },
+            new Machine
+            {
+                Tags = { { "rank", "4" }, { "zone", "a" } },
+                Readings = { { "primary", 40 }, { "secondary", 100 } }
+            }
+        };
+
+        theSession.Store(machines);
+        await theSession.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task orders_by_the_requested_key_not_the_whole_dictionary()
+    {
+        await seed();
+        await using var query = theStore.QuerySession();
+
+        var byZone = await query.Query<Machine>().OrderBy(x => x.Tags["zone"]).ToListAsync();
+        byZone.Select(x => x.Tags["zone"]).ShouldBe(new[] { "a", "b", "c", "d" });
+
+        // Same documents, different key, opposite order. Before the fix these two queries
+        // returned byte-identical orderings because the key never reached the ORDER BY.
+        var byRank = await query.Query<Machine>().OrderBy(x => x.Tags["rank"]).ToListAsync();
+        byRank.Select(x => x.Tags["rank"]).ShouldBe(new[] { "1", "2", "3", "4" });
+
+        byZone.Select(x => x.Id).ShouldNotBe(byRank.Select(x => x.Id));
+    }
+
+    [Fact]
+    public async Task orders_descending_by_the_requested_key()
+    {
+        await seed();
+        await using var query = theStore.QuerySession();
+
+        var results = await query.Query<Machine>().OrderByDescending(x => x.Tags["zone"]).ToListAsync();
+        results.Select(x => x.Tags["zone"]).ShouldBe(new[] { "d", "c", "b", "a" });
+    }
+
+    [Fact]
+    public async Task orders_by_a_non_string_dictionary_value()
+    {
+        await seed();
+        await using var query = theStore.QuerySession();
+
+        // Numeric values must also be cast, otherwise they sort lexically.
+        var results = await query.Query<Machine>().OrderBy(x => x.Readings["secondary"]).ToListAsync();
+        results.Select(x => x.Readings["secondary"]).ShouldBe(new[] { 100, 200, 300, 400 });
+    }
+}

--- a/src/Marten/Linq/Parsing/Operators/Ordering.cs
+++ b/src/Marten/Linq/Parsing/Operators/Ordering.cs
@@ -1,7 +1,10 @@
 #nullable enable
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using JasperFx.Core;
+using JasperFx.Core.Reflection;
 using Marten.Linq.Members;
+using Marten.Linq.Members.Dictionaries;
 
 namespace Marten.Linq.Parsing.Operators;
 
@@ -67,9 +70,50 @@ public class Ordering
 
         var member = MemberName.IsNotEmpty()
             ? collection.MemberFor(MemberName)
-            : collection.MemberFor(Expression, "Invalid OrderBy() expression");
+            : MemberForExpression(collection);
 
         return member.BuildOrderingExpression(this, CasingRule);
+    }
+
+    /// <summary>
+    /// Resolve the member being ordered by. A dictionary indexer (<c>x.Attributes["key"]</c>)
+    /// is a get_Item method call rather than a member access, so MemberFinder drops it and the
+    /// generic lookup lands on the dictionary itself — which orders by the whole JSON object
+    /// and silently ignores the key. Resolve it the same way the Where() path does. See #5063.
+    /// </summary>
+    private IQueryableMember MemberForExpression(IQueryableMemberCollection collection)
+    {
+        // The operator hands us the raw OrderBy argument, i.e. a quoted lambda. Unwrap to the
+        // body, then past any boxing conversion, to see whether it is an indexer access.
+        var expression = Expression;
+        while (true)
+        {
+            switch (expression)
+            {
+                case UnaryExpression { NodeType: ExpressionType.Quote or ExpressionType.Convert } unary:
+                    expression = unary.Operand;
+                    continue;
+                case LambdaExpression lambda:
+                    expression = lambda.Body;
+                    continue;
+            }
+
+            break;
+        }
+
+        if (expression is MethodCallExpression { Method.Name: "get_Item" } call
+            && call.Object != null
+            && call.Arguments.Count == 1
+            && call.Method.DeclaringType.Closes(typeof(IDictionary<,>))
+            && collection.MemberFor(call.Object) is IDictionaryMember dictionary)
+        {
+            return dictionary.MemberForKey(call.Arguments[0].Value());
+        }
+
+        // Deliberately the original expression, not the unwrapped one: the unwrapping above
+        // exists only to spot an indexer, and BadLinqExpressionException quotes whatever it
+        // is handed. Passing the body would drop the "x => " from the message.
+        return collection.MemberFor(Expression, "Invalid OrderBy() expression");
     }
 
     private string BuildNgramRankExpression(IQueryableMemberCollection collection)


### PR DESCRIPTION
Closes #5063.

`OrderBy(x => x.Attributes["key"])` emitted

```sql
order by d.data -> 'Attributes'
```

so it sorted by the whole JSON object and ignored the key. Every key returned a byte-identical ordering — `OrderBy(x => x.Tags["zone"])` and `OrderBy(x => x.Tags["rank"])` were indistinguishable.

## Cause

A dictionary indexer compiles to a `get_Item` **method call**, not a member access. `MemberFinder` only visits `MemberExpression`s, so the indexer was dropped and the generic lookup landed on the dictionary member itself. The `Where()` path already handled this in `SimpleExpression` via `IDictionaryMember.MemberForKey`; ordering never did.

## Fix

`Ordering` resolves the indexer the same way `Where()` does. Two details worth noting for review:

- The operator hands over the raw `OrderBy` argument — a *quoted lambda* — so the expression is unwrapped through `Quote`, `Lambda` and any boxing `Convert` before being inspected. My first attempt skipped this and never reached the indexer.
- The fallback still receives the **original** expression. `BadLinqExpressionException` quotes whatever it is handed, and passing the unwrapped body drops the `x => ` from the message — which `Bug_2213` asserts on exactly.

Resulting SQL:

| expression | before | after |
|---|---|---|
| `OrderBy(x => x.Tags["zone"])` | `order by d.data -> 'Tags'` | `order by d.data -> 'Tags' ->> 'zone'` |
| `OrderByDescending(x => x.Tags["zone"])` | `order by d.data -> 'Tags' desc` | `... ->> 'zone' desc` |
| `OrderBy(x => x.Readings["secondary"])` | `order by d.data -> 'Readings'` | `CAST(d.data -> 'Readings' ->> 'secondary' as integer)` |
| `OrderBy(x => x.Id)` | unchanged | unchanged |

## Why it went unnoticed for so long

jsonb compares objects key by key, so sorting the whole object agrees with sorting by the **first** key. Any query against that key looked perfectly correct.

`Bug_1219` only caught it because it asserts on two *different* keys — and that test had itself never executed until the xunit v3 migration (#5064) restored it. Its skip is removed here.

That same property made my first draft of the regression tests worthless: they queried the first key and passed with or without the fix. The tests as committed deliberately order by a key that is **not** first, and I verified all three fail without the fix and pass with it.

## Verification

- LinqTests 1421/1421 on net9.0 (three new tests, plus `Bug_1219` now running rather than skipped)
- DocumentDbTests 1086/1085, CoreTests 494/493 — unchanged