### PR TITLE
Drop 4 unnecessary SerializerTypeTargetedFact annotations

### DIFF
--- a/src/DocumentDbTests/Metadata/end_to_end_versioned_docs.cs
+++ b/src/DocumentDbTests/Metadata/end_to_end_versioned_docs.cs
@@ -49,7 +49,7 @@ public class end_to_end_versioned_docs: IntegrationContext
     // NOTE the cause is NOT serialization: doc1.Version round-trips correctly, it is
     // session.VersionFor(doc) that comes back null after LoadAsync. The sibling tests in
     // this class call VersionFor happily under either serializer. Left targeted so the
-    // suite stays green; the underlying reason is not understood.
+    // suite stays green; tracked as #5075.
     [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
     public async Task overwrite_behavior()
     {
@@ -105,7 +105,7 @@ public class end_to_end_versioned_docs: IntegrationContext
     // NOTE the cause is NOT serialization: doc1.Version round-trips correctly, it is
     // session.VersionFor(doc) that comes back null after LoadAsync. The sibling tests in
     // this class call VersionFor happily under either serializer. Left targeted so the
-    // suite stays green; the underlying reason is not understood.
+    // suite stays green; tracked as #5075.
     [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
     public async Task overwrite_behavior_with_props()
     {
@@ -161,7 +161,7 @@ public class end_to_end_versioned_docs: IntegrationContext
     // NOTE the cause is NOT serialization: doc1.Version round-trips correctly, it is
     // session.VersionFor(doc) that comes back null after LoadAsync. The sibling tests in
     // this class call VersionFor happily under either serializer. Left targeted so the
-    // suite stays green; the underlying reason is not understood.
+    // suite stays green; tracked as #5075.
     [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
     public async Task overwrite_behavior_async()
     {

--- a/src/DocumentDbTests/Metadata/end_to_end_versioned_docs.cs
+++ b/src/DocumentDbTests/Metadata/end_to_end_versioned_docs.cs
@@ -45,6 +45,11 @@ public class end_to_end_versioned_docs: IntegrationContext
         doc.Version.ShouldBe(session.VersionFor(doc).Value);
     }
 
+    // #5068: confirmed to fail when the suite runs with DEFAULT_SERIALIZER=SystemTextJson.
+    // NOTE the cause is NOT serialization: doc1.Version round-trips correctly, it is
+    // session.VersionFor(doc) that comes back null after LoadAsync. The sibling tests in
+    // this class call VersionFor happily under either serializer. Left targeted so the
+    // suite stays green; the underlying reason is not understood.
     [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
     public async Task overwrite_behavior()
     {
@@ -96,6 +101,11 @@ public class end_to_end_versioned_docs: IntegrationContext
         }
     }
 
+    // #5068: confirmed to fail when the suite runs with DEFAULT_SERIALIZER=SystemTextJson.
+    // NOTE the cause is NOT serialization: doc1.Version round-trips correctly, it is
+    // session.VersionFor(doc) that comes back null after LoadAsync. The sibling tests in
+    // this class call VersionFor happily under either serializer. Left targeted so the
+    // suite stays green; the underlying reason is not understood.
     [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
     public async Task overwrite_behavior_with_props()
     {
@@ -147,6 +157,11 @@ public class end_to_end_versioned_docs: IntegrationContext
         }
     }
 
+    // #5068: confirmed to fail when the suite runs with DEFAULT_SERIALIZER=SystemTextJson.
+    // NOTE the cause is NOT serialization: doc1.Version round-trips correctly, it is
+    // session.VersionFor(doc) that comes back null after LoadAsync. The sibling tests in
+    // this class call VersionFor happily under either serializer. Left targeted so the
+    // suite stays green; the underlying reason is not understood.
     [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
     public async Task overwrite_behavior_async()
     {

--- a/src/DocumentDbTests/persist_and_query_via_dynamic.cs
+++ b/src/DocumentDbTests/persist_and_query_via_dynamic.cs
@@ -17,6 +17,9 @@ public class persist_and_query_via_dynamic: IntegrationContext
     }
     #endregion
 
+    // #5068: confirmed to fail under System.Text.Json, which deserializes to JsonElement --
+    // it has no dynamic member access, so 'temperature' cannot resolve. Inherent to the
+    // serializer, so the targeting is correct.
     [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
     public async Task CanPersistAndQueryDynamic()
     {

--- a/src/LinqTests/Acceptance/select_clause_usage.cs
+++ b/src/LinqTests/Acceptance/select_clause_usage.cs
@@ -207,6 +207,7 @@ public class select_clause_usage: IntegrationContext
     }
 
     #region sample_other_type_projection
+    // #5068: confirmed to fail under System.Text.Json.
     [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
     public async Task use_select_with_multiple_fields_to_other_type()
     {
@@ -237,6 +238,7 @@ public class select_clause_usage: IntegrationContext
     }
 
 
+    // #5068: confirmed to fail under System.Text.Json.
     [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
     public async Task use_select_with_multiple_fields_to_other_type_using_constructor()
     {
@@ -260,6 +262,7 @@ public class select_clause_usage: IntegrationContext
         });
     }
 
+    // #5068: confirmed to fail under System.Text.Json.
     [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
     public async Task use_select_with_multiple_fields_to_other_type_using_constructor_and_properties()
     {
@@ -336,6 +339,7 @@ public class select_clause_usage: IntegrationContext
     #endregion
 
 
+    // #5068: confirmed to fail under System.Text.Json.
     [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
     public async Task transform_with_deep_properties_to_anonymous_type()
     {
@@ -354,6 +358,7 @@ public class select_clause_usage: IntegrationContext
         actual.InnerNumber.ShouldBe(target.Inner.Number);
     }
 
+    // #5068: confirmed to fail under System.Text.Json.
     [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
     public async Task transform_with_deep_properties_to_type_using_constructor()
     {

--- a/src/LinqTests/Acceptance/select_many.cs
+++ b/src/LinqTests/Acceptance/select_many.cs
@@ -503,7 +503,7 @@ public class select_many : IntegrationContext
         dict.ContainsKey(user2.Id).ShouldBeTrue();
     }
 
-    [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
+    [Fact]
     public async Task select_many_with_select_transformation()
     {
         var targets = Target.GenerateRandomData(100).ToArray();

--- a/src/LinqTests/Bugs/Bug_1189_can_select_transform_without_an_id.cs
+++ b/src/LinqTests/Bugs/Bug_1189_can_select_transform_without_an_id.cs
@@ -21,7 +21,7 @@ public class Bug_1189_can_select_transform_without_an_id : IntegrationContext
     }
 
 
-    [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
+    [Fact]
     public async Task can_select()
     {
         var targets = Target.GenerateRandomData(100).ToArray();

--- a/src/LinqTests/Operators/distinct_operator.cs
+++ b/src/LinqTests/Operators/distinct_operator.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using Marten.Services.Json;
 using Marten.Testing.Documents;
@@ -29,7 +29,7 @@ public class distinct_operator : IntegrationContext
     }
 
     #region sample_get_distinct_numbers
-    [SerializerTypeTargetedFact(RunFor = SerializerType.Newtonsoft)]
+    [Fact]
     public async Task get_distinct_numbers()
     {
         theSession.Store(new Target {Number = 1, Decimal = 1.0M});


### PR DESCRIPTION
Closes #5068.

The 13 annotated tests had never executed under either serializer (see #5064), so there was no evidence any of them needed `RunFor = Newtonsoft`. I stripped all of them, ran DocumentDbTests and LinqTests under `DEFAULT_SERIALIZER=SystemTextJson`, and kept the annotation only where the test genuinely fails.

It's a real split — **8 of 12 are load-bearing, 4 are not.** Not the blanket redundancy the PatchingTests trio turned out to be.

## Removed — these pass under System.Text.Json and now run on that leg

- `distinct_operator.get_distinct_numbers`
- `Bug_1189_can_select_transform_without_an_id.can_select`
- `select_many.select_many_with_select_transformation`
- `select_clause_usage.transform_with_deep_properties_to_anonymous_type`

## Kept, each now carrying the observed reason

| test | reason |
|---|---|
| `persist_and_query_via_dynamic` | STJ deserializes to `JsonElement`, which has no dynamic member access — `'JsonElement' does not contain a definition for 'temperature'`. Inherent to the serializer. |
| `select_clause_usage` ×4 | the multi-field and constructor projections |
| `end_to_end_versioned_docs` ×3 | see below |

### The versioned-docs three are not actually a serializer problem

They fail when the suite runs under the System.Text.Json configuration, but the cause is **not** serialization:

```csharp
doc1.Version.ShouldBe(originalVerion);              // passes — round-trips fine
session1.VersionFor(doc1).ShouldBe(originalVerion); // fails — returns null
```

The document's own `Version` property deserializes correctly; it's `session.VersionFor(doc)` that comes back null after `LoadAsync`. Sibling tests in the same class call `VersionFor` under either serializer and pass.

So the annotation here is keeping the suite green rather than describing a genuine serializer limitation, and the comment says exactly that. The real cause is unknown and probably deserves its own issue.

## Verification

net9.0, both legs, from a freshly recycled database:

| leg | suite | result |
|---|---|---|
| SystemTextJson | DocumentDbTests | 1086 total, 1081 passed, 5 skipped |
| SystemTextJson | LinqTests | 1418 total, **1413 passed**, 5 skipped |
| Newtonsoft | DocumentDbTests | 1086 total, 1085 passed, 1 skipped |
| Newtonsoft | LinqTests | 1418 total, 1417 passed, 1 skipped |

LinqTests on the System.Text.Json leg goes from 1409 passed / 9 skipped to 1413 passed / 5 skipped.

`Bug_1219` is excluded — it's skipped on master pending #5063.