### PR TITLE
Make DaemonTests honour DEFAULT_SERIALIZER

### DIFF
--- a/src/DaemonTests/Aggregations/Bug_5041_natural_key_source_discovery.cs
+++ b/src/DaemonTests/Aggregations/Bug_5041_natural_key_source_discovery.cs
@@ -65,6 +65,10 @@ public class Bug_5041_natural_key_source_discovery: DaemonContext
         [NaturalKey]
         public ProductCode Code { get; set; }
 
+        // Materialised deliberately: a lazy LINQ iterator assigned here is written by
+        // Newtonsoft's TypeNameHandling.Auto as  = the iterator's concrete type, which
+        // cannot be reconstructed, so the document writes fine and then fails every read.
+        // See #5076.
         public required IEnumerable<ProductCode> KnownCodes { get; set; }
 
         [NaturalKeySource]
@@ -87,6 +91,7 @@ public class Bug_5041_natural_key_source_discovery: DaemonContext
                 KnownCodes = product.KnownCodes
                     .Where(c => c.Value != e.Data.NewProductCode)
                     .Append(new ProductCode(e.Data.NewProductCode))
+                    .ToArray()
             };
         }
 
@@ -96,7 +101,8 @@ public class Bug_5041_natural_key_source_discovery: DaemonContext
             Code = new ProductCode(e.NewProductCode);
             KnownCodes = KnownCodes
                 .Where(c => c.Value != e.NewProductCode)
-                .Append(new ProductCode(e.NewProductCode));
+                .Append(new ProductCode(e.NewProductCode))
+                .ToArray();
         }
     }
 
@@ -113,6 +119,10 @@ public class Bug_5041_natural_key_source_discovery: DaemonContext
         [NaturalKey]
         public ProductCode Code { get; set; }
 
+        // Materialised deliberately: a lazy LINQ iterator assigned here is written by
+        // Newtonsoft's TypeNameHandling.Auto as  = the iterator's concrete type, which
+        // cannot be reconstructed, so the document writes fine and then fails every read.
+        // See #5076.
         public required IEnumerable<ProductCode> KnownCodes { get; set; }
 
         [NaturalKeySource]
@@ -142,6 +152,7 @@ public class Bug_5041_natural_key_source_discovery: DaemonContext
                 KnownCodes = product.KnownCodes
                     .Where(c => c.Value != e.Data.NewProductCode)
                     .Append(new ProductCode(e.Data.NewProductCode))
+                    .ToArray()
             };
         }
     }

--- a/src/DaemonTests/TestSetup.cs
+++ b/src/DaemonTests/TestSetup.cs
@@ -1,0 +1,23 @@
+using System.Runtime.CompilerServices;
+using Marten.Services.Json;
+using Marten.Testing.Harness;
+
+namespace Marten.AsyncDaemon.Testing;
+
+/// <summary>
+/// Pins the serializer this assembly's tests run against.
+/// </summary>
+/// <remarks>
+/// This used to be an <c>XunitTestFramework</c> subclass, but its
+/// <c>[assembly: TestFramework(...)]</c> named a type and assembly that stopped existing at
+/// some rename, so xunit could never load it and DaemonTests silently ran under
+/// System.Text.Json regardless of DEFAULT_SERIALIZER. See #5066.
+/// </remarks>
+internal static class TestSetup
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        SerializerFactory.DefaultSerializerType = TestsSettings.SerializerType;
+    }
+}


### PR DESCRIPTION
Closes #5066.

DaemonTests has never run under Newtonsoft. Its `TestSetup` declared

```csharp
[assembly: TestFramework("Marten.AsyncDaemon.TestSetup", "Marten.AsyncDaemon")]
```

while the actual type was `Marten.AsyncDaemon.Testing.TestSetup` in assembly `DaemonTests` — **both names wrong**, presumably stale from a rename. xunit could never load it, so `SerializerFactory.DefaultSerializerType` kept its `SystemTextJson` default no matter what `DEFAULT_SERIALIZER` said, including on the Newtonsoft CI leg.

#5064 deleted the dead file rather than repair it, deliberately — a framework migration shouldn't silently change which serializer a suite runs under. This restores it as a module initializer.

## What turning it on exposed

Exactly one real problem, in `Bug_5041`'s aggregate:

```csharp
KnownCodes = product.KnownCodes
    .Where(c => c.Value != e.Data.NewProductCode)
    .Append(new ProductCode(e.Data.NewProductCode));   // never materialised
```

Newtonsoft's `TypeNameHandling.Auto` emits `$type` whenever a member's runtime type differs from its declared type, so the document persisted as:

```json
"KnownCodes": {
    "$type": "System.Linq.Enumerable+AppendPrepend1Iterator`1[[...]], System.Linq",
    "$values": [ { "Value": "PROD-001" }, { "Value": "PROD-999" } ]
}
```

`AppendPrepend1Iterator` has no usable constructor, so the **write succeeded and every later read threw** `Cannot create and populate list type`. System.Text.Json ignores runtime types and writes a plain array, which is why this stayed hidden.

Materialising the three `Append` chains with `.ToArray()` fixes it, and is correct regardless of serializer.

The underlying trap — *any* lazy LINQ sequence assigned to a persisted member behaves this way, and the failure is delayed, misattributed and unrecoverable through Marten — is filed separately as **#5076**.

## Verification

net9.0, each leg from a freshly recycled database:

| leg | result | failures |
|---|---|---|
| Newtonsoft | 257 total, 255 passed | `blue_green_side_effect_gate` ×2 |
| SystemTextJson | 257 total, 256 passed | `blue_green_side_effect_gate` ×1 |

The only remaining failures are `blue_green_side_effect_gate`, the pre-existing flake tracked in #5065 — confirmed there to fail 3 out of 3 runs on master, independent of this change.

Worth noting for a suite that has never executed under Newtonsoft in its life, `Bug_5041` was the *only* thing hiding.