### PR TITLE
Write lazy LINQ sequences as plain arrays under Newtonsoft

### DIFF
--- a/src/DocumentDbTests/Bugs/Bug_5076_lazy_enumerable_round_trip.cs
+++ b/src/DocumentDbTests/Bugs/Bug_5076_lazy_enumerable_round_trip.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marten;
+using Marten.Newtonsoft;
+using Marten.Patching;
+using Marten.Testing.Harness;
+using Shouldly;
+using Xunit;
+
+namespace DocumentDbTests.Bugs;
+
+/// <summary>
+/// #5076 — a lazy LINQ sequence assigned to a persisted member used to be written by
+/// Newtonsoft's TypeNameHandling.Auto as $type = the iterator's concrete type. The write
+/// succeeded and every later read threw, because types like
+/// System.Linq.Enumerable+AppendPrepend1Iterator cannot be constructed.
+/// </summary>
+public class Bug_5076_lazy_enumerable_round_trip: BugIntegrationContext
+{
+    public class Basket
+    {
+        public Guid Id { get; set; }
+
+        // Declared as IEnumerable<T> on purpose: that is what makes Newtonsoft record the
+        // runtime type, and it is a perfectly ordinary way to model a read-only sequence.
+        public IEnumerable<string> Items { get; set; } = [];
+    }
+
+    private void useNewtonsoft() => StoreOptions(opts =>
+    {
+        // Pinned so the test means the same thing on both CI serializer legs.
+        opts.UseNewtonsoftForSerialization();
+        opts.Schema.For<Basket>();
+    });
+
+    [Fact]
+    public async Task can_read_back_a_document_holding_an_appended_sequence()
+    {
+        useNewtonsoft();
+
+        var basket = new Basket { Items = new[] { "first" }.Append("second") };
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(basket);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<Basket>(basket.Id);
+
+        loaded.ShouldNotBeNull();
+        loaded.Items.ShouldBe(new[] { "first", "second" });
+    }
+
+    [Fact]
+    public async Task can_read_back_a_document_holding_a_filtered_sequence()
+    {
+        useNewtonsoft();
+
+        var basket = new Basket { Items = new[] { "keep", "drop", "keep too" }.Where(x => x.StartsWith("keep")) };
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(basket);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<Basket>(basket.Id);
+
+        loaded.ShouldNotBeNull();
+        loaded.Items.ShouldBe(new[] { "keep", "keep too" });
+    }
+
+    [Fact]
+    public async Task a_materialised_sequence_still_round_trips()
+    {
+        useNewtonsoft();
+
+        var basket = new Basket { Items = new List<string> { "one", "two" } };
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(basket);
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<Basket>(basket.Id);
+
+        loaded.ShouldNotBeNull();
+        loaded.Items.ShouldBe(new[] { "one", "two" });
+    }
+
+    [Fact]
+    public async Task can_read_back_after_patching_with_a_lazy_sequence()
+    {
+        useNewtonsoft();
+
+        var basket = new Basket { Items = new[] { "original" } };
+
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Store(basket);
+            await session.SaveChangesAsync();
+        }
+
+        // Patch values go through the withTypes serializer, where TypeNameHandling.Objects
+        // stamps $type onto everything -- so a lazy sequence hits the same trap there.
+        await using (var session = theStore.LightweightSession())
+        {
+            session.Patch<Basket>(basket.Id).Set(x => x.Items, new[] { "a", "b", "skip" }.Where(x => x != "skip"));
+            await session.SaveChangesAsync();
+        }
+
+        await using var query = theStore.QuerySession();
+        var loaded = await query.LoadAsync<Basket>(basket.Id);
+
+        loaded.ShouldNotBeNull();
+        loaded.Items.ShouldBe(new[] { "a", "b" });
+    }
+}

--- a/src/Marten.Newtonsoft/Services/Json/JsonNetLazyEnumerableConverter.cs
+++ b/src/Marten.Newtonsoft/Services/Json/JsonNetLazyEnumerableConverter.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace Marten.Services.Json;
+
+/// <summary>
+///     Writes lazy LINQ sequences as plain JSON arrays.
+/// </summary>
+/// <remarks>
+///     <para>
+///     Marten's Newtonsoft settings use <see cref="TypeNameHandling.Auto"/>, which records
+///     <c>$type</c> whenever a value's runtime type differs from its declared type. LINQ operators
+///     return private iterator classes, so assigning one to a persisted member -- e.g.
+///     <c>IEnumerable&lt;T&gt; Codes { get; set; }</c> set from <c>.Where(...).Append(...)</c> --
+///     used to persist <c>$type</c> as something like
+///     <c>System.Linq.Enumerable+AppendPrepend1Iterator`1[[T]]</c>.
+///     </para>
+///     <para>
+///     Those types have no usable constructor, so the write succeeded and every later read of the
+///     document threw "Cannot create and populate list type". The stored payload was otherwise
+///     fine -- only the recorded type was unusable. See #5076.
+///     </para>
+///     <para>
+///     This converter only claims types that could never have been deserialized in the first
+///     place, so it turns a permanently unreadable document into a readable array and leaves
+///     every reconstructible collection (arrays, <c>List&lt;T&gt;</c>, user types) exactly as it
+///     was. Collection storage as a whole is a separate, opt-in concern -- see
+///     <see cref="JsonNetCollectionToArrayJsonConverter"/> and <c>CollectionStorage.AsArray</c>.
+///     </para>
+/// </remarks>
+public sealed class JsonNetLazyEnumerableConverter: JsonConverter
+{
+    public static readonly JsonNetLazyEnumerableConverter Instance = new();
+
+    /// <summary>
+    ///     Write only. These types never appear as a declared member type, so there is nothing to read.
+    /// </summary>
+    public override bool CanRead => false;
+
+    public override bool CanConvert(Type objectType)
+    {
+        if (objectType == null || !typeof(IEnumerable).IsAssignableFrom(objectType))
+        {
+            return false;
+        }
+
+        // Restricted to the framework's own non-public iterators. A user's internal collection
+        // type is left alone -- it may well be reconstructible, and suppressing its $type could
+        // break a legitimate polymorphic member.
+        if (objectType.Namespace is not "System.Linq")
+        {
+            return false;
+        }
+
+        return !objectType.IsPublic && !objectType.IsNestedPublic;
+    }
+
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        if (value is null)
+        {
+            writer.WriteNull();
+            return;
+        }
+
+        var items = ((IEnumerable)value).Cast<object>().ToArray();
+
+        // Materialise into an array of the element type rather than object[], so the element
+        // type matches what is written and Auto does not stamp $type onto each element.
+        var elementType = elementTypeOf(value.GetType()) ?? typeof(object);
+        var typed = Array.CreateInstance(elementType, items.Length);
+        for (var i = 0; i < items.Length; i++)
+        {
+            typed.SetValue(items[i], i);
+        }
+
+        serializer.Serialize(writer, typed, typed.GetType());
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object? existingValue,
+        JsonSerializer serializer) =>
+        throw new NotSupportedException(
+            $"{nameof(JsonNetLazyEnumerableConverter)} is write-only; {objectType} is never a declared member type.");
+
+    private static Type? elementTypeOf(Type type) =>
+        type.GetInterfaces()
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            ?.GetGenericArguments()[0];
+}

--- a/src/Marten.Newtonsoft/Services/JsonNetSerializer.cs
+++ b/src/Marten.Newtonsoft/Services/JsonNetSerializer.cs
@@ -45,7 +45,12 @@ public class JsonNetSerializer: ISerializer
         // ISO 8601 formatting of DateTime's is mandatory
         DateFormatHandling = DateFormatHandling.IsoDateFormat,
         MetadataPropertyHandling = MetadataPropertyHandling.ReadAhead,
-        ContractResolver = new JsonNetContractResolver()
+        ContractResolver = new JsonNetContractResolver(),
+
+        // TypeNameHandling.Auto would otherwise record a lazy LINQ iterator's concrete type,
+        // which cannot be reconstructed -- the document writes cleanly and then fails every
+        // read. See #5076.
+        Converters = { JsonNetLazyEnumerableConverter.Instance }
     };
 
     #endregion
@@ -56,7 +61,12 @@ public class JsonNetSerializer: ISerializer
     {
         TypeNameHandling = TypeNameHandling.Objects,
         DateFormatHandling = DateFormatHandling.IsoDateFormat,
-        ContractResolver = new JsonNetContractResolver()
+        ContractResolver = new JsonNetContractResolver(),
+
+        // Objects mode stamps $type onto everything, so a lazy LINQ sequence reaching this
+        // path -- PatchOperation writes polymorphic patch values through it -- hits the same
+        // unreadable-$type problem as the document serializer. See #5076.
+        Converters = { JsonNetLazyEnumerableConverter.Instance }
     };
 
     private readonly Lazy<JsonSerializer> _withTypes;


### PR DESCRIPTION
Closes #5076.

A lazy sequence assigned to a persisted member produced a document that **wrote cleanly and could then never be read back**:

```csharp
public IEnumerable<string> Items { get; set; }
...
Items = source.Where(...).Append(...);   // never materialised
```

```json
"Items": {
    "$type": "System.Linq.Enumerable+ArrayWhereIterator`1[[System.String]], System.Linq",
    "$values": [ ... ]
}
```

`TypeNameHandling.Auto` records `$type` whenever a value's runtime type differs from its declared type, and LINQ operators return private iterator classes with no usable constructor. The write succeeded; every later read threw `Cannot create and populate list type`. The payload itself was fine — only the recorded type was unusable — but every read path goes through the same deserializer, so the document was unrecoverable through Marten.

## The fix, and the one I did not take

Marten already had `JsonNetCollectionToArrayJsonConverter` for exactly this shape of problem — its own comment says *"without using custom JsonConverter, Newtonsoft.Json stores it as $type and $value."* But `JsonNetContractResolver` only attaches it when `CollectionStorage.AsArray` is opted into, so the default path was uncovered.

**Widening that converter to every `IEnumerable<T>` member was the tempting fix and is wrong here.** `List<T>` members currently persist as `{$type, $values}` and would become plain arrays — a change to stored shape for every existing user. That is a migration, not a bug fix.

So this adds a **write-only converter that claims only the framework's own non-public `System.Linq` iterators** — values that could never have been deserialized in the first place. Reconstructible collections are untouched and existing documents still read exactly as before. A user's own internal collection type is deliberately left alone: it may well be reconstructible, and suppressing its `$type` could break a legitimate polymorphic member.

Items are materialised into an array **of the element type** rather than `object[]`, so `Auto` does not stamp `$type` onto each element.

Registered on both settings that write type metadata — the document serializer (`Auto`) and the `withTypes` serializer (`Objects`), since `PatchOperation` writes polymorphic patch values through the latter and hits the identical trap.

## Verification

Four regression tests: an appended sequence, a filtered sequence, the patch path, and a materialised `List<T>` that proves the unchanged case stays unchanged. The first two and the patch one fail without the fix.

Clean solution rebuild, net9.0, each run from a freshly recycled database:

| leg | suite | result |
|---|---|---|
| Newtonsoft | DocumentDbTests | 1090 total, 1089 passed |
| Newtonsoft | PatchingTests | 123 total, 122 passed |
| Newtonsoft | CoreTests | 494 total, 493 passed |
| Newtonsoft | LinqTests | 1421 / 1421 |
| Newtonsoft | EventSourcingTests | 1478 total, 1471 passed |
| SystemTextJson | DocumentDbTests | 1090 total, 1085 passed |
| SystemTextJson | PatchingTests | 123 total, 122 passed |

Found while making DaemonTests honour `DEFAULT_SERIALIZER` (#5066) — its `Bug_5041` aggregate was doing exactly this, and it had gone unnoticed because that suite had only ever run under System.Text.Json.