### PR TITLE
Make store clearing an explicit, declarative opt-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,13 +112,23 @@ only passes while it happens to run before its siblings, and any change to test 
 into a failure. Several tests had to be fixed for exactly this reason; see
 [#5070](https://github.com/JasperFx/marten/issues/5070).
 
-If your assertions depend on a document type holding only what your test wrote, clear it explicitly:
+If your assertions depend on a document type holding only what your test wrote, say so explicitly.
+On `IntegrationContext` and `StoreContext<T>`, declare the types — they are cleared before each test
+in that class:
+
+```csharp
+protected override IEnumerable<Type> ClearedBeforeEachTest => [typeof(Target)];
+```
+
+`OneOffConfigurationsContext` and `BugIntegrationContext` build their store lazily from the test's own
+`StoreOptions(...)` call, so there is nothing to clear that early. Those clear inline, after
+configuring the store:
 
 ```csharp
 await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Target));
 ```
 
-Name the types you actually depend on rather than reaching for `ResetAllData()`.
+Either way, name the types you actually depend on rather than reaching for `ResetAllData()`.
 
 Note `BugIntegrationContext` pins **every** bug test across **every** suite to the single `bugs`
 schema, and CI runs several test projects sequentially against one database, so a global count there

--- a/src/DocumentDbTests/Bugs/Bug_187_not_assigning_id_in_BulkInsert_Tests.cs
+++ b/src/DocumentDbTests/Bugs/Bug_187_not_assigning_id_in_BulkInsert_Tests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Documents;
@@ -13,10 +15,7 @@ public class Bug_187_not_assigning_id_in_BulkInsert_Tests: IntegrationContext
     // Asserts on the global IntDoc count, and IntegrationContext shares one store across
     // the collection without clearing between tests, so any other test that writes an
     // IntDoc breaks this one. See #5070.
-    protected override Task fixtureSetup()
-    {
-        return theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(IntDoc));
-    }
+    protected override IEnumerable<Type> ClearedBeforeEachTest => [typeof(IntDoc)];
 
     [Fact]
     public async Task does_indeed_assign_the_id_during_bulk_insert()

--- a/src/DocumentDbTests/Deleting/delete_many_documents_by_query.cs
+++ b/src/DocumentDbTests/Deleting/delete_many_documents_by_query.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Marten;
@@ -15,10 +17,7 @@ public class delete_many_documents_by_query : IntegrationContext
     // count. IntegrationContext shares one store across the whole "integration" collection
     // and does not clear data between tests, so only whichever of them ran first could
     // pass. Clear the table per test instead of depending on execution order.
-    protected override Task fixtureSetup()
-    {
-        return theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Target));
-    }
+    protected override IEnumerable<Type> ClearedBeforeEachTest => [typeof(Target)];
 
     [Fact]
     public async Task can_delete_by_query()

--- a/src/DocumentDbTests/Reading/advanced_sql_query.cs
+++ b/src/DocumentDbTests/Reading/advanced_sql_query.cs
@@ -21,10 +21,7 @@ public class advanced_sql_query: IntegrationContext
     // from a later test trips an optimistic concurrency check. IntegrationContext shares
     // one store across the collection and does not clear between tests, so this only
     // worked while these tests happened to run in a favourable order.
-    protected override Task fixtureSetup()
-    {
-        return theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(DocWithMeta));
-    }
+    protected override IEnumerable<Type> ClearedBeforeEachTest => [typeof(DocWithMeta)];
 
     [Fact]
     public async Task can_query_scalar()

--- a/src/EventSourcingTests/Aggregation/AggregationContext.cs
+++ b/src/EventSourcingTests/Aggregation/AggregationContext.cs
@@ -23,10 +23,7 @@ public class AggregationContext : IntegrationContext
 
     }
 
-    protected override Task fixtureSetup()
-    {
-        return theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(MyAggregate));
-    }
+    protected override IEnumerable<Type> ClearedBeforeEachTest => [typeof(MyAggregate)];
 
     public void UsingDefinition<T>() where T : SingleStreamProjection<MyAggregate, Guid>, new()
     {

--- a/src/LinqTests/Acceptance/chained_where_clauses.cs
+++ b/src/LinqTests/Acceptance/chained_where_clauses.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+using System.Collections.Generic;
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Marten.Testing.Documents;
 using Marten.Testing.Harness;
@@ -8,6 +10,10 @@ namespace LinqTests.Acceptance;
 
 public class chained_where_clauses : IntegrationContext
 {
+    // Every test here stores Targets matching Number == 1 && String == "Foo" and then asserts
+    // the query returns exactly its own, so whichever runs second sees the other's rows too.
+    protected override IEnumerable<Type> ClearedBeforeEachTest => [typeof(Target)];
+
     [Fact]
     public async Task two_where_clauses()
     {

--- a/src/LinqTests/Bugs/Bug_1219_ordering_by_attributes.cs
+++ b/src/LinqTests/Bugs/Bug_1219_ordering_by_attributes.cs
@@ -18,10 +18,7 @@ public class Bug_1219_ordering_by_attributes : IntegrationContext
     // store, but IntegrationContext shares one store across the collection and never
     // clears it between tests. Clear Cars per test so the assertions describe only the
     // data this test wrote.
-    protected override Task fixtureSetup()
-    {
-        return theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Car));
-    }
+    protected override IEnumerable<Type> ClearedBeforeEachTest => [typeof(Car)];
 
     public class Car
     {

--- a/src/LinqTests/Bugs/Bug_5063_ordering_by_dictionary_indexer.cs
+++ b/src/LinqTests/Bugs/Bug_5063_ordering_by_dictionary_indexer.cs
@@ -34,10 +34,7 @@ public class Bug_5063_ordering_by_dictionary_indexer: IntegrationContext
         public Dictionary<string, int> Readings { get; set; } = new();
     }
 
-    protected override Task fixtureSetup()
-    {
-        return theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(Machine));
-    }
+    protected override IEnumerable<Type> ClearedBeforeEachTest => [typeof(Machine)];
 
     private async Task seed()
     {

--- a/src/Marten.Testing/Harness/IntegrationContext.cs
+++ b/src/Marten.Testing/Harness/IntegrationContext.cs
@@ -176,8 +176,40 @@ namespace Marten.Testing.Harness
 
         public async ValueTask InitializeAsync()
         {
+            foreach (var documentType in ClearedBeforeEachTest)
+            {
+                await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(documentType);
+            }
+
             await fixtureSetup();
         }
+
+        /// <summary>
+        /// Document types to delete before each test in this class.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The store here is shared across the whole "integration" collection and is deliberately
+        /// <em>not</em> cleared between tests -- doing that everywhere would cost more than it is
+        /// worth. The consequence is that a test asserting on a global count or ordering, e.g.
+        /// <c>Query&lt;Target&gt;().CountAsync()</c> with no filter, only passes while it happens to
+        /// run before its siblings. Several tests were fixed for exactly that reason; see #5070.
+        /// </para>
+        /// <para>
+        /// So opt in explicitly. Name only the types the assertions actually depend on rather than
+        /// resetting everything:
+        /// </para>
+        /// <code>
+        /// protected override IEnumerable&lt;Type&gt; ClearedBeforeEachTest => [typeof(Target)];
+        /// </code>
+        /// <para>
+        /// Contexts deriving from <see cref="OneOffConfigurationsContext"/> (including
+        /// <see cref="BugIntegrationContext"/>) build their store lazily from the test's own
+        /// <c>StoreOptions(...)</c> call, so there is nothing to clear this early. Those clear
+        /// inline, after configuring the store.
+        /// </para>
+        /// </remarks>
+        protected virtual IEnumerable<Type> ClearedBeforeEachTest => [];
 
         protected virtual Task fixtureSetup()
         {

--- a/src/Marten.Testing/Harness/StoreContext.cs
+++ b/src/Marten.Testing/Harness/StoreContext.cs
@@ -27,7 +27,19 @@ namespace Marten.Testing.Harness
         /// under xunit v3 a derived IAsyncLifetime suppresses the runner's Dispose() call,
         /// so the async teardown has to chain here.
         /// </remarks>
-        public virtual ValueTask InitializeAsync() => default;
+        /// <summary>
+        /// Document types to delete before each test in this class. See
+        /// <see cref="IntegrationContext.ClearedBeforeEachTest"/> for why this is opt-in.
+        /// </summary>
+        protected virtual IEnumerable<Type> ClearedBeforeEachTest => [];
+
+        public virtual async ValueTask InitializeAsync()
+        {
+            foreach (var documentType in ClearedBeforeEachTest)
+            {
+                await theStore.Advanced.Clean.DeleteDocumentsByTypeAsync(documentType);
+            }
+        }
 
         public virtual ValueTask DisposeAsync()
         {


### PR DESCRIPTION
Closes #5070.

Per the design call on the issue: **don't tear down every time** — tearing the data down between every test would make the suite too slow overall. Instead, fixtures explicitly request the state they depend on.

```csharp
protected override IEnumerable<Type> ClearedBeforeEachTest => [typeof(Target)];
```

`IntegrationContext` and `StoreContext<T>` honour it before each test. Name the types your assertions actually depend on rather than resetting everything.

The six existing hand-rolled `fixtureSetup` overrides that existed purely to clear one document type are converted to it, so there is one obvious pattern rather than a scattering of bespoke ones.

## Deliberately not everywhere

**Not** added to `OneOffConfigurationsContext` or `BugIntegrationContext`. Those build their store lazily from the test's own `StoreOptions(...)` call *inside the test body*, so clearing that early would force the store into existence with default options and actively break them. They clear inline, after configuring the store — and the docs say so.

## It fixes a test that is red on master today

`chained_where_clauses.two_where_clauses` and `three_where_clauses` both store Targets matching `Number == 1 && String == "Foo"`, and each asserts the query returns exactly its own two. Whichever runs second sees four.

I confirmed this reproduces **on master**, in isolation and in a full run, and that the file is untouched by this branch. One declarative line fixes it — a decent validation of the mechanism.

## The docs were actively wrong

`CLAUDE.md` claimed `IntegrationContext` *"deletes all data between tests"*. It never has — `DefaultStoreFixture` calls `CompletelyRemoveAllAsync()` exactly once when the fixture is built. That single sentence is the likely source of this whole recurring bug class.

Corrected here, along with the trade-off, both opt-in forms, and the `BugIntegrationContext` sharp edge (it pins every bug test in every suite to one shared `bugs` schema, while CI runs several projects sequentially against one database). Also split out as **#5081**, docs-only, so the correction can land without waiting on this.

## Verification

net9.0, each suite from a freshly recycled database:

| suite | result |
|---|---|
| DocumentDbTests | 1086 total, 1085 passed |
| LinqTests | **1421 / 1421** (1420 on master — see above) |
| EventSourcingTests | 1478 total, 1471 passed |
| CoreTests | 494 total, 493 passed |