### PR TITLE
#5067: adopt xUnit1051 per project, starting with DaemonTests

### DIFF
--- a/docs/events/projections/read-aggregates.md
+++ b/docs/events/projections/read-aggregates.md
@@ -33,7 +33,7 @@ var summaries = await _compositeSession
     .QueryForNonStaleData<BoardSummary>(10.Seconds())
     .ToListAsync();
 ```
-<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Composites/multi_stage_projections.cs#L317-L327' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_querying_for_non_stale_projection_data' title='Start of snippet'>anchor</a></sup>
+<sup><a href='https://github.com/JasperFx/marten/blob/master/src/DaemonTests/Composites/multi_stage_projections.cs#L322-L332' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_querying_for_non_stale_projection_data' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 To be clear though, if you need the latest version of a single stream projection, we recommend always

--- a/src/DaemonTests/Aggregations/Bug_5041_natural_key_source_discovery.cs
+++ b/src/DaemonTests/Aggregations/Bug_5041_natural_key_source_discovery.cs
@@ -204,7 +204,7 @@ public class Bug_5041_natural_key_source_discovery: DaemonContext
         await daemon.RebuildProjectionAsync<KeyFromEventProduct>(CancellationToken.None);
 
         await using var query = theStore.LightweightSession();
-        var product = await query.Events.FetchLatest<KeyFromEventProduct, ProductCode>(new ProductCode("PROD-999"));
+        var product = await query.Events.FetchLatest<KeyFromEventProduct, ProductCode>(new ProductCode("PROD-999"), TestContext.Current.CancellationToken);
         product.ShouldNotBeNull();
         product.Id.ShouldBe(streamId);
         product.Code.Value.ShouldBe("PROD-999");
@@ -214,7 +214,7 @@ public class Bug_5041_natural_key_source_discovery: DaemonContext
         // #5041 item 2 on a source shape that could not bind at all before jasperfx#571
         (await naturalKeysForStreamAsync("mt_natural_key_keyfromeventproduct", streamId))
             .ShouldBe(["PROD-999"]);
-        (await query.Events.FetchLatest<KeyFromEventProduct, ProductCode>(new ProductCode("PROD-001")))
+        (await query.Events.FetchLatest<KeyFromEventProduct, ProductCode>(new ProductCode("PROD-001"), TestContext.Current.CancellationToken))
             .ShouldBeNull();
     }
 
@@ -237,14 +237,14 @@ public class Bug_5041_natural_key_source_discovery: DaemonContext
         await daemon.RebuildProjectionAsync<Product>(CancellationToken.None);
 
         await using var query = theStore.LightweightSession();
-        var product = await query.Events.FetchLatest<Product, ProductCode>(new ProductCode("PROD-999"));
+        var product = await query.Events.FetchLatest<Product, ProductCode>(new ProductCode("PROD-999"), TestContext.Current.CancellationToken);
         product.ShouldNotBeNull();
         product.Id.ShouldBe(streamId);
         product.Code.Value.ShouldBe("PROD-999");
 
         // #5041 item 2 through an explicitly registered extractor
         (await naturalKeysForStreamAsync("mt_natural_key_product", streamId)).ShouldBe(["PROD-999"]);
-        (await query.Events.FetchLatest<Product, ProductCode>(new ProductCode("PROD-001")))
+        (await query.Events.FetchLatest<Product, ProductCode>(new ProductCode("PROD-001"), TestContext.Current.CancellationToken))
             .ShouldBeNull();
     }
 

--- a/src/DaemonTests/Aggregations/build_aggregate_multiple_projections.cs
+++ b/src/DaemonTests/Aggregations/build_aggregate_multiple_projections.cs
@@ -110,14 +110,14 @@ public partial class build_aggregate_multiple_projections: DaemonContext
         await using (var session = theStore.LightweightSession())
         {
             session.Events.StartStream(carStreamId, new CarNamed() { Value = "car-name-1" });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         //Create truck stream - Transaction 2
         await using (var session = theStore.LightweightSession())
         {
             session.Events.StartStream(truckStreamId, new TruckNamed() { Value = "truck-name-1" });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         //Send TruckNamed Event - Transaction 3
@@ -125,14 +125,14 @@ public partial class build_aggregate_multiple_projections: DaemonContext
         {
             session.Events.Append(truckStreamId, new TruckNamed() { Value = "truck-name-2" });
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         //Send CarNamed Event - Transaction 4
         await using (var session = theStore.LightweightSession())
         {
             session.Events.Append(carStreamId, new CarNamed() { Value = "car-name-2" });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         //Wait for shards and highwater agent to catchup on the events
@@ -144,8 +144,8 @@ public partial class build_aggregate_multiple_projections: DaemonContext
         //Assert results are latest
         await using (var session = theStore.QuerySession())
         {
-            var carName = (await session.Query<CarView>().FirstOrDefaultAsync())?.Name;
-            var truckName = (await session.Query<TruckView>().FirstOrDefaultAsync())?.Name;
+            var carName = (await session.Query<CarView>().FirstOrDefaultAsync(TestContext.Current.CancellationToken))?.Name;
+            var truckName = (await session.Query<TruckView>().FirstOrDefaultAsync(TestContext.Current.CancellationToken))?.Name;
 
             carName.ShouldBe("car-name-2");
             truckName.ShouldBe("truck-name-2");
@@ -174,7 +174,7 @@ public partial class build_aggregate_multiple_projections: DaemonContext
             }
 
             session.Events.StartStream(Guid.NewGuid(), events);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // create some gaps
@@ -195,7 +195,7 @@ public partial class build_aggregate_multiple_projections: DaemonContext
 
         try
         {
-            await daemon.RebuildProjectionAsync<CarProjection>(default);
+            await daemon.RebuildProjectionAsync<CarProjection>(TestContext.Current.CancellationToken);
         }
         catch (Exception ex)
         {
@@ -213,7 +213,7 @@ public partial class build_aggregate_multiple_projections: DaemonContext
             var waterMark = await GetHighWaterMark();
             var maxSeqId = await GetMaxSeqId();
 
-            var cars = await session.Query<CarView>().ToListAsync();
+            var cars = await session.Query<CarView>().ToListAsync(TestContext.Current.CancellationToken);
 
             waterMark.ShouldBe(maxSeqId);
             cars[cars.Count - 1].Name.ShouldBe("car-name-999");
@@ -242,7 +242,7 @@ public partial class build_aggregate_multiple_projections: DaemonContext
             }
 
             session.Events.StartStream(Guid.NewGuid(), events);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // create some gaps
@@ -261,7 +261,7 @@ public partial class build_aggregate_multiple_projections: DaemonContext
 
         try
         {
-            await daemon.RebuildProjectionAsync<CarProjection>(default);
+            await daemon.RebuildProjectionAsync<CarProjection>(TestContext.Current.CancellationToken);
         }
         catch (Exception ex)
         {
@@ -279,7 +279,7 @@ public partial class build_aggregate_multiple_projections: DaemonContext
             var waterMark = await GetHighWaterMark();
             var maxSeqId = await GetMaxSeqId();
 
-            var cars = await session.Query<CarView>().ToListAsync();
+            var cars = await session.Query<CarView>().ToListAsync(TestContext.Current.CancellationToken);
 
             waterMark.ShouldBe(maxSeqId);
             cars[cars.Count - 1].Name.ShouldBe("car-name-999");

--- a/src/DaemonTests/Aggregations/build_aggregate_projection.cs
+++ b/src/DaemonTests/Aggregations/build_aggregate_projection.cs
@@ -37,8 +37,8 @@ public class build_aggregate_projection: DaemonContext
             opts.DatabaseSchemaName = "simple_multi_tenancy";
         });
 
-        await store.Advanced.Clean.DeleteAllDocumentsAsync();
-        await store.Advanced.Clean.DeleteAllEventDataAsync();
+        await store.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         using var session = store.LightweightSession();
         session.ForTenant("blue").Events.StartStream<SimpleEntity>("one", new MTAEvent(), new MTBEvent());
@@ -49,7 +49,7 @@ public class build_aggregate_projection: DaemonContext
         session.ForTenant("red").Events.StartStream<SimpleEntity>("two", new MTBEvent(), new MTBEvent(), new MTBEvent());
         session.ForTenant("red").Events.StartStream<SimpleEntity>("five", new MTBEvent(), new MTBEvent(), new MTBEvent());
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await store.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -58,7 +58,7 @@ public class build_aggregate_projection: DaemonContext
         var blues = await session
             .Query<SimpleEntity>()
             .Where(x => x.TenantIsOneOf("blue"))
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         blues.Select(x => x.Id).OrderBy(x => x).ShouldBe(["one", "three", "two"]);
         var blueOne = blues.Single(x => x.Id == "one");
@@ -67,7 +67,7 @@ public class build_aggregate_projection: DaemonContext
         blueOne.B.ShouldBe(1);
 
         var redOne = await session.Query<SimpleEntity>().Where(x => x.TenantIsOneOf("red") && x.Id == "one")
-            .SingleAsync();
+            .SingleAsync(TestContext.Current.CancellationToken);
 
         redOne.A.ShouldBe(2);
         redOne.B.ShouldBe(1);
@@ -257,13 +257,13 @@ public class build_aggregate_projection: DaemonContext
         // This should be gone after a rebuild
         var trip = new Trip();
         theSession.Store(trip);
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await agent.RebuildProjectionAsync("TripCustomName", CancellationToken.None);
 
         await using var query = theStore.QuerySession();
         // Demonstrates that the Trip documents were deleted first
-        (await query.LoadAsync<Trip>(trip.Id)).ShouldBeNull();
+        (await query.LoadAsync<Trip>(trip.Id, TestContext.Current.CancellationToken)).ShouldBeNull();
     }
 
     [Fact]
@@ -349,11 +349,11 @@ public class build_aggregate_projection: DaemonContext
         {
             if (stream.Events.OfType<TripAborted>().Any())
             {
-                (await theSession.LoadAsync<Trip>(stream.StreamId)).ShouldBeNull();
+                (await theSession.LoadAsync<Trip>(stream.StreamId, TestContext.Current.CancellationToken)).ShouldBeNull();
             }
             else
             {
-                (await theSession.LoadAsync<Trip>(stream.StreamId)).ShouldNotBeNull();
+                (await theSession.LoadAsync<Trip>(stream.StreamId, TestContext.Current.CancellationToken)).ShouldNotBeNull();
             }
         }
     }
@@ -378,7 +378,7 @@ public class build_aggregate_projection: DaemonContext
 
         await waiter;
 
-        var days = await theSession.Query<Trip>().ToListAsync();
+        var days = await theSession.Query<Trip>().ToListAsync(TestContext.Current.CancellationToken);
 
         var notCriticalBreakdownStream = days[0].Id;
         var criticalBreakdownStream = days[1].Id;
@@ -386,7 +386,7 @@ public class build_aggregate_projection: DaemonContext
         theSession.Events.Append(notCriticalBreakdownStream, new Breakdown { IsCritical = false });
         theSession.Events.Append(criticalBreakdownStream, new Breakdown { IsCritical = true });
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var waiter2 = agent.Tracker.WaitForShardState(new ShardState("Trip:All", NumberOfEvents + 2), 300.Seconds());
 
@@ -395,8 +395,8 @@ public class build_aggregate_projection: DaemonContext
 
         await using var query = theStore.QuerySession();
 
-        (await query.LoadAsync<Trip>(notCriticalBreakdownStream)).ShouldNotBeNull();
-        (await query.LoadAsync<Trip>(criticalBreakdownStream)).ShouldBeNull();
+        (await query.LoadAsync<Trip>(notCriticalBreakdownStream, TestContext.Current.CancellationToken)).ShouldNotBeNull();
+        (await query.LoadAsync<Trip>(criticalBreakdownStream, TestContext.Current.CancellationToken)).ShouldBeNull();
     }
 
 
@@ -423,7 +423,7 @@ public class build_aggregate_projection: DaemonContext
         {
             session.Events.Append(shortTrip.StreamId, shortTrip.Events.ToArray());
             session.Events.Append(longTrip.StreamId, longTrip.Events.ToArray());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await waiter1;
@@ -434,7 +434,7 @@ public class build_aggregate_projection: DaemonContext
         // This should trigger a delete
         theSession.Events.Append(longTrip.StreamId, new VacationOver());
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var totalNumberOfEvents = initialCount + 2;
         var waiter2 = agent.Tracker.WaitForShardState(new ShardState("Trip:All", totalNumberOfEvents), 30.Seconds());
@@ -445,7 +445,7 @@ public class build_aggregate_projection: DaemonContext
         await using var query = theStore.QuerySession();
 
         // (await query.LoadAsync<Trip>(shortTrip.StreamId)).ShouldNotBeNull();
-        (await query.LoadAsync<Trip>(longTrip.StreamId)).ShouldBeNull();
+        (await query.LoadAsync<Trip>(longTrip.StreamId, TestContext.Current.CancellationToken)).ShouldBeNull();
     }
 
     [Fact]
@@ -465,9 +465,9 @@ public class build_aggregate_projection: DaemonContext
             session.Events.Append(id, new ContactEdited(id, "x"));
             session.Events.Append(Guid.NewGuid(), new RandomOtherEvent(Guid.NewGuid()));
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-            var contact = await session.LoadAsync<Contact>(id);
+            var contact = await session.LoadAsync<Contact>(id, TestContext.Current.CancellationToken);
             Assert.Equal("x", contact.Name);
         }
 
@@ -476,7 +476,7 @@ public class build_aggregate_projection: DaemonContext
         await daemon.RebuildProjectionAsync("Contact", CancellationToken.None);
 
         await using var session2 = theStore.LightweightSession("a");
-        var c = await session2.LoadAsync<Contact>(id);
+        var c = await session2.LoadAsync<Contact>(id, TestContext.Current.CancellationToken);
         Assert.Equal("x", c.Name);
     }
 
@@ -496,9 +496,9 @@ public class build_aggregate_projection: DaemonContext
             session.Events.StartStream(id, new FooCreated(id, "Foo"));
             session.Events.StartStream(Guid.NewGuid(), new BarCreated(Guid.NewGuid()));
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-            var foo = await session.LoadAsync<Foo>(id);
+            var foo = await session.LoadAsync<Foo>(id, TestContext.Current.CancellationToken);
             Assert.Equal("Foo", foo.Name);
         }
 
@@ -507,7 +507,7 @@ public class build_aggregate_projection: DaemonContext
         await daemon.RebuildProjectionAsync("Foo", CancellationToken.None);
 
         await using var session2 = theStore.LightweightSession("a");
-        var c = await session2.LoadAsync<Foo>(id);
+        var c = await session2.LoadAsync<Foo>(id, TestContext.Current.CancellationToken);
         Assert.Equal("Foo", c.Name);
     }
 
@@ -527,9 +527,9 @@ public class build_aggregate_projection: DaemonContext
             session.Events.StartStream(id, new FooCreated2(id, "Foo"));
             session.Events.StartStream(Guid.NewGuid(), new BarCreated(Guid.NewGuid()));
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-            var foo = await session.LoadAsync<Foo>(id);
+            var foo = await session.LoadAsync<Foo>(id, TestContext.Current.CancellationToken);
             Assert.Equal("Foo", foo.Name);
         }
 
@@ -538,7 +538,7 @@ public class build_aggregate_projection: DaemonContext
         await daemon.RebuildProjectionAsync("Foo", CancellationToken.None);
 
         await using var session2 = theStore.LightweightSession("a");
-        var c = await session2.LoadAsync<Foo>(id);
+        var c = await session2.LoadAsync<Foo>(id, TestContext.Current.CancellationToken);
         Assert.Equal("Foo", c.Name);
     }
 

--- a/src/DaemonTests/Aggregations/converting_projection_from_inline_to_async.cs
+++ b/src/DaemonTests/Aggregations/converting_projection_from_inline_to_async.cs
@@ -23,7 +23,7 @@ public class converting_projection_from_inline_to_async : OneOffConfigurationsCo
         var id1 = theSession.Events.StartStream<SimpleAggregate>(new MTAEvent(), new MTBEvent()).Id;
         var id2 = theSession.Events.StartStream<SimpleAggregate>(new MTBEvent(), new MTCEvent()).Id;
         var id3 = theSession.Events.StartStream<SimpleAggregate>(new MTCEvent(), new MTDEvent()).Id;
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var store2 = SeparateStore(opts =>
         {
@@ -49,13 +49,13 @@ public class converting_projection_from_inline_to_async : OneOffConfigurationsCo
         session.Events.Append(id1, new MTEEvent(), new MTEEvent());
         session.Events.Append(id2, new MTEEvent(), new MTEEvent());
         session.Events.Append(id3, new MTEEvent(), new MTEEvent());
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await daemon.WaitForNonStaleData(10.Seconds());
 
-        var aggregate1 = await session.LoadAsync<SimpleAggregate>(id1);
-        var aggregate2 = await session.LoadAsync<SimpleAggregate>(id2);
-        var aggregate3 = await session.LoadAsync<SimpleAggregate>(id3);
+        var aggregate1 = await session.LoadAsync<SimpleAggregate>(id1, TestContext.Current.CancellationToken);
+        var aggregate2 = await session.LoadAsync<SimpleAggregate>(id2, TestContext.Current.CancellationToken);
+        var aggregate3 = await session.LoadAsync<SimpleAggregate>(id3, TestContext.Current.CancellationToken);
 
         aggregate1.ShouldBe(new SimpleAggregate
         {

--- a/src/DaemonTests/Aggregations/custom_aggregation_in_async_daemon.cs
+++ b/src/DaemonTests/Aggregations/custom_aggregation_in_async_daemon.cs
@@ -34,8 +34,8 @@ public class custom_aggregation_in_async_daemon : OneOffConfigurationsContext
             opts.Logger(new TestOutputMartenLogger(_output));
         });
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         appendCustomEvent(1, 'a');
         appendCustomEvent(1, 'a');
@@ -49,21 +49,21 @@ public class custom_aggregation_in_async_daemon : OneOffConfigurationsContext
         appendCustomEvent(1, 'a');
         appendCustomEvent(1, 'a');
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync(logger:new TestLogger<IProjection>(_output));
         await daemon.StartAllAsync();
 
         await  daemon.Tracker.WaitForShardState("Custom:All", 11);
 
-        var agg1 = await theSession.LoadAsync<CustomAggregate>(1);
+        var agg1 = await theSession.LoadAsync<CustomAggregate>(1, TestContext.Current.CancellationToken);
         agg1
             .ShouldBe(new CustomAggregate{Id = 1, ACount = 4, BCount = 1, CCount = 1, DCount = 1});
 
-        (await theSession.LoadAsync<CustomAggregate>(2))
+        (await theSession.LoadAsync<CustomAggregate>(2, TestContext.Current.CancellationToken))
             .ShouldBe(new CustomAggregate{Id = 2, ACount = 2, BCount = 0, CCount = 0, DCount = 0});
 
-        (await theSession.LoadAsync<CustomAggregate>(3))
+        (await theSession.LoadAsync<CustomAggregate>(3, TestContext.Current.CancellationToken))
             .ShouldBe(new CustomAggregate{Id = 3, ACount = 0, BCount = 1, CCount = 0, DCount = 1});
 
     }
@@ -78,8 +78,8 @@ public class custom_aggregation_in_async_daemon : OneOffConfigurationsContext
             opts.Logger(new TestOutputMartenLogger(_output));
         });
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         appendCustomEvent(1, 'a');
         appendCustomEvent(1, 'a');
@@ -93,21 +93,21 @@ public class custom_aggregation_in_async_daemon : OneOffConfigurationsContext
         appendCustomEvent(1, 'a');
         appendCustomEvent(1, 'a');
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync(logger:new TestLogger<IProjection>(_output));
         await daemon.StartAllAsync();
 
         await  daemon.Tracker.WaitForShardState("Custom:All", 11);
 
-        var agg1 = await theSession.LoadAsync<CustomAggregate>(1);
+        var agg1 = await theSession.LoadAsync<CustomAggregate>(1, TestContext.Current.CancellationToken);
         agg1
             .ShouldBe(new CustomAggregate{Id = 1, ACount = 4, BCount = 1, CCount = 1, DCount = 1});
 
-        (await theSession.LoadAsync<CustomAggregate>(2))
+        (await theSession.LoadAsync<CustomAggregate>(2, TestContext.Current.CancellationToken))
             .ShouldBe(new CustomAggregate{Id = 2, ACount = 2, BCount = 0, CCount = 0, DCount = 0});
 
-        (await theSession.LoadAsync<CustomAggregate>(3))
+        (await theSession.LoadAsync<CustomAggregate>(3, TestContext.Current.CancellationToken))
             .ShouldBe(new CustomAggregate{Id = 3, ACount = 0, BCount = 1, CCount = 0, DCount = 1});
 
     }

--- a/src/DaemonTests/Aggregations/multi_stream_projections.cs
+++ b/src/DaemonTests/Aggregations/multi_stream_projections.cs
@@ -35,7 +35,7 @@ public partial class multi_stream_projections: DaemonContext
     {
         StoreOptions(x => x.Projections.Add(new DayProjection(), ProjectionLifecycle.Async));
 
-        await theStore.EnsureStorageExistsAsync(typeof(Day));
+        await theStore.EnsureStorageExistsAsync(typeof(Day), TestContext.Current.CancellationToken);
 
         using var agent = await StartDaemon();
 
@@ -46,9 +46,9 @@ public partial class multi_stream_projections: DaemonContext
 
         await agent.Tracker.WaitForShardState("Day:All", NumberOfEvents, 30.Seconds());
 
-        var days = await theSession.Query<Day>().ToListAsync();
+        var days = await theSession.Query<Day>().ToListAsync(TestContext.Current.CancellationToken);
 
-        var allEvents = await theSession.Events.QueryAllRawEvents().ToListAsync();
+        var allEvents = await theSession.Events.QueryAllRawEvents().ToListAsync(TestContext.Current.CancellationToken);
         var dayEvents = allEvents.Select(x => x.Data).OfType<IDayEvent>();
         var groups = dayEvents.GroupBy(x => x.Day).ToList();
 
@@ -92,18 +92,18 @@ public partial class multi_stream_projections: DaemonContext
         await using var session = theStore.LightweightSession();
 
         session.Events.StartStream(commonId, new Happened() { Id = commonId }, new Happened() { Id = commonId });
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         session.Events.StartStream(new Happened() { Id = commonId }, new Happened() { Id = commonId });
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var projection = await session.LoadAsync<Projection>(commonId);
+        var projection = await session.LoadAsync<Projection>(commonId, TestContext.Current.CancellationToken);
         var eventSequenceList = new List<long> { 1, 2, 3, 4 };
         projection.ShouldNotBeNull();
         projection.EventSequenceList.ShouldHaveTheSameElementsAs(eventSequenceList);
 
         await daemon.RebuildProjectionAsync<Projector>(CancellationToken.None);
-        projection = await session.LoadAsync<Projection>(commonId);
+        projection = await session.LoadAsync<Projection>(commonId, TestContext.Current.CancellationToken);
         projection.ShouldNotBeNull();
         projection.EventSequenceList.ShouldHaveTheSameElementsAs(eventSequenceList);
     }
@@ -158,7 +158,7 @@ public partial class multi_stream_projections: DaemonContext
             session.Events.Append(user2, new UserCreated { UserId = user2 });
             session.Events.Append(user3, new UserCreated { UserId = user3 });
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemon = await StartDaemon();
@@ -170,7 +170,7 @@ public partial class multi_stream_projections: DaemonContext
         await using (var session = theStore.LightweightSession())
         {
             session.Events.Append(issue1, new IssueCreated { UserId = user1, IssueId = issue1 });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // We need to ensure that the events are not processed in a single slice to hit the IsNew issue on multiple
@@ -180,7 +180,7 @@ public partial class multi_stream_projections: DaemonContext
         await using (var session = theStore.LightweightSession())
         {
             session.Events.Append(issue2, new IssueCreated { UserId = user1, IssueId = issue2 });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await daemon.Tracker.WaitForShardState("UserIssue:All", 5, 15.Seconds());
@@ -188,14 +188,14 @@ public partial class multi_stream_projections: DaemonContext
         await using (var session = theStore.LightweightSession())
         {
             session.Events.Append(issue3, new IssueCreated { UserId = user1, IssueId = issue3 });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await daemon.Tracker.WaitForShardState("UserIssue:All", 6, 15.Seconds());
 
         await using (var session = theStore.QuerySession())
         {
-            var doc = await session.LoadAsync<UserIssues>(user1);
+            var doc = await session.LoadAsync<UserIssues>(user1, TestContext.Current.CancellationToken);
             doc.Issues.Count.ShouldBe(3);
         }
     }

--- a/src/DaemonTests/Aggregations/multistream_data_teardown_on_rebuild.cs
+++ b/src/DaemonTests/Aggregations/multistream_data_teardown_on_rebuild.cs
@@ -122,17 +122,17 @@ public class MultiStreamDataTeardownOnRebuildTests
                 commonId,
                 new SomethingHappened() { Id = commonId }
             );
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-            var implementationA = await session.LoadAsync<ImplementationA>($"a-{commonId}");
-            var implementationB = await session.LoadAsync<ImplementationB>($"b-{commonId}");
+            var implementationA = await session.LoadAsync<ImplementationA>($"a-{commonId}", TestContext.Current.CancellationToken);
+            var implementationB = await session.LoadAsync<ImplementationB>($"b-{commonId}", TestContext.Current.CancellationToken);
 
             implementationA.ShouldNotBeNull();
             implementationB.ShouldNotBeNull();
 
             await daemon.RebuildProjectionAsync<ImplementationAProjection>(CancellationToken.None);
 
-            var implementationBAfterRebuildOfA = await session.LoadAsync<ImplementationB>($"b-{commonId}");
+            var implementationBAfterRebuildOfA = await session.LoadAsync<ImplementationB>($"b-{commonId}", TestContext.Current.CancellationToken);
 
             implementationBAfterRebuildOfA.ShouldNotBeNull();
         }
@@ -170,17 +170,17 @@ public class MultiStreamDataTeardownOnRebuildTests
                 commonId,
                 new SomethingHappened() { Id = commonId }
             );
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-            var implementationA = await session.LoadAsync<ImplementationA2>($"a2-{commonId}");
-            var implementationB = await session.LoadAsync<ImplementationB2>($"b2-{commonId}");
+            var implementationA = await session.LoadAsync<ImplementationA2>($"a2-{commonId}", TestContext.Current.CancellationToken);
+            var implementationB = await session.LoadAsync<ImplementationB2>($"b2-{commonId}", TestContext.Current.CancellationToken);
 
             implementationA.ShouldNotBeNull();
             implementationB.ShouldNotBeNull();
 
             await daemon.RebuildProjectionAsync<ImplementationA2Projection>(CancellationToken.None);
 
-            var implementationBAfterRebuildOfA = await session.LoadAsync<ImplementationB2>($"b2-{commonId}");
+            var implementationBAfterRebuildOfA = await session.LoadAsync<ImplementationB2>($"b2-{commonId}", TestContext.Current.CancellationToken);
 
             implementationBAfterRebuildOfA.ShouldNotBeNull();
         }

--- a/src/DaemonTests/Aggregations/rebuild_projection_with_natural_key_update.cs
+++ b/src/DaemonTests/Aggregations/rebuild_projection_with_natural_key_update.cs
@@ -69,8 +69,8 @@ public class Bug_4966_natural_key_update_on_projection_rebuild: DaemonContext
     {
         StoreOptions(ConfigureStore);
         await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var streamId = Guid.NewGuid();
         var originalCode = "PROD-001";
@@ -79,14 +79,14 @@ public class Bug_4966_natural_key_update_on_projection_rebuild: DaemonContext
         await using (var session = theStore.LightweightSession())
         {
             session.Events.StartStream<Product>(streamId, new ProductRegistered(streamId, originalCode));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
 
         await using (var session = theStore.LightweightSession())
         {
             session.Events.Append(streamId, new ProductCodeChanged(streamId, newCode));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var daemon = await theStore.BuildProjectionDaemonAsync();
@@ -94,7 +94,7 @@ public class Bug_4966_natural_key_update_on_projection_rebuild: DaemonContext
 
         await using (var session = theStore.LightweightSession())
         {
-            var product = await session.Events.FetchLatest<Product, ProductCode>(new ProductCode(newCode));
+            var product = await session.Events.FetchLatest<Product, ProductCode>(new ProductCode(newCode), TestContext.Current.CancellationToken);
             product.ShouldNotBeNull();
             product.Code.Value.ShouldBe(newCode);
         }
@@ -105,15 +105,15 @@ public class Bug_4966_natural_key_update_on_projection_rebuild: DaemonContext
     {
         StoreOptions(ConfigureStore);
         await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var streamId = Guid.NewGuid();
 
         await using (var session = theStore.LightweightSession())
         {
             session.Events.StartStream<Product>(streamId, new ProductRegistered(streamId, "PROD-001"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         (await naturalKeysForStream(streamId)).ShouldBe(["PROD-001"]);
@@ -121,7 +121,7 @@ public class Bug_4966_natural_key_update_on_projection_rebuild: DaemonContext
         await using (var session = theStore.LightweightSession())
         {
             session.Events.Append(streamId, new ProductCodeChanged(streamId, "PROD-999"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Before #5041 the retired PROD-001 row survived alongside PROD-999, permanently
@@ -134,8 +134,8 @@ public class Bug_4966_natural_key_update_on_projection_rebuild: DaemonContext
     {
         StoreOptions(ConfigureStore);
         await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var streamId = Guid.NewGuid();
 
@@ -143,7 +143,7 @@ public class Bug_4966_natural_key_update_on_projection_rebuild: DaemonContext
         {
             session.Events.StartStream<Product>(streamId, new ProductRegistered(streamId, "PROD-001"));
             session.Events.Append(streamId, new ProductCodeChanged(streamId, "PROD-999"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var daemon = await theStore.BuildProjectionDaemonAsync();
@@ -154,7 +154,7 @@ public class Bug_4966_natural_key_update_on_projection_rebuild: DaemonContext
         (await naturalKeysForStream(streamId)).ShouldBe(["PROD-999"]);
 
         await using var query = theStore.LightweightSession();
-        var product = await query.Events.FetchLatest<Product, ProductCode>(new ProductCode("PROD-999"));
+        var product = await query.Events.FetchLatest<Product, ProductCode>(new ProductCode("PROD-999"), TestContext.Current.CancellationToken);
         product.ShouldNotBeNull();
         product.Code.Value.ShouldBe("PROD-999");
     }
@@ -164,8 +164,8 @@ public class Bug_4966_natural_key_update_on_projection_rebuild: DaemonContext
     {
         StoreOptions(ConfigureStore);
         await theStore.Storage.ApplyAllConfiguredChangesToDatabaseAsync();
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var first = Guid.NewGuid();
         var second = Guid.NewGuid();
@@ -174,13 +174,13 @@ public class Bug_4966_natural_key_update_on_projection_rebuild: DaemonContext
         {
             session.Events.StartStream<Product>(first, new ProductRegistered(first, "PROD-001"));
             session.Events.Append(first, new ProductCodeChanged(first, "PROD-999"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await using (var session = theStore.LightweightSession())
         {
             session.Events.StartStream<Product>(second, new ProductRegistered(second, "PROD-001"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         (await naturalKeysForStream(first)).ShouldBe(["PROD-999"]);
@@ -191,7 +191,7 @@ public class Bug_4966_natural_key_update_on_projection_rebuild: DaemonContext
         await daemon.RebuildProjectionAsync<Product>(CancellationToken.None);
 
         await using var query = theStore.LightweightSession();
-        var reused = await query.Events.FetchLatest<Product, ProductCode>(new ProductCode("PROD-001"));
+        var reused = await query.Events.FetchLatest<Product, ProductCode>(new ProductCode("PROD-001"), TestContext.Current.CancellationToken);
         reused.ShouldNotBeNull();
         reused.Id.ShouldBe(second);
     }

--- a/src/DaemonTests/Aggregations/side_effects_in_aggregations.cs
+++ b/src/DaemonTests/Aggregations/side_effects_in_aggregations.cs
@@ -36,8 +36,8 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
             opts.Logger(new TestOutputMartenLogger(_output));
         });
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -45,31 +45,31 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         var streamId = Guid.NewGuid();
         theSession.Events.StartStream<SideEffects1>(streamId, new MTAEvent(),
             new MTAEvent(), new MTAEvent());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await daemon.WaitForNonStaleData(30.Seconds());
 
-        var version1 = await theSession.LoadAsync<SideEffects1>(streamId);
+        var version1 = await theSession.LoadAsync<SideEffects1>(streamId, TestContext.Current.CancellationToken);
         version1.A.ShouldBe(3);
         version1.B.ShouldBe(0);
 
         theSession.Events.Append(streamId, new MTAEvent(), new MTAEvent());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
 
         // Prove the BEevent side effect happened as expected
-        var state = await theSession.Events.FetchStreamStateAsync(streamId);
+        var state = await theSession.Events.FetchStreamStateAsync(streamId, TestContext.Current.CancellationToken);
         var tries = 0;
         while (state.Version != 6 && tries < 10)
         {
-            await Task.Delay(250.Milliseconds());
-            state = await theSession.Events.FetchStreamStateAsync(streamId);
+            await Task.Delay(250.Milliseconds(), TestContext.Current.CancellationToken);
+            state = await theSession.Events.FetchStreamStateAsync(streamId, TestContext.Current.CancellationToken);
             tries++;
         }
 
         await daemon.WaitForNonStaleData(30.Seconds());
 
-        var version2 = await theSession.LoadAsync<SideEffects1>(streamId);
+        var version2 = await theSession.LoadAsync<SideEffects1>(streamId, TestContext.Current.CancellationToken);
         version2.A.ShouldBe(5);
 
         // This proves that the aggregate was updated the new new event
@@ -94,8 +94,8 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
             opts.Events.MessageOutbox = outbox;
         });
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -103,17 +103,17 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         var streamId = Guid.NewGuid();
         theSession.Events.StartStream<SideEffects1>(streamId, new MTAEvent(),
             new MTAEvent(), new MTAEvent());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await daemon.WaitForNonStaleData(30.Seconds());
 
         theSession.Events.Append(streamId, new MTEEvent());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await daemon.WaitForNonStaleData(30.Seconds());
 
         // Should be deleted by now
-        var version1 = await theSession.LoadAsync<SideEffects1>(streamId);
+        var version1 = await theSession.LoadAsync<SideEffects1>(streamId, TestContext.Current.CancellationToken);
         version1.ShouldBeNull();
 
         outbox
@@ -133,8 +133,8 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
             opts.Logger(new TestOutputMartenLogger(_output));
         });
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -142,15 +142,15 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         var streamId = Guid.NewGuid();
         theSession.Events.StartStream<SideEffects1>(streamId, new MTAEvent(),
             new MTAEvent(), new MTAEvent(), new MTAEvent(), new MTAEvent());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Prove the BEevent side effect happened as expected
-        var state = await theSession.Events.FetchStreamStateAsync(streamId);
+        var state = await theSession.Events.FetchStreamStateAsync(streamId, TestContext.Current.CancellationToken);
         var tries = 0;
         while (state.Version != 6 && tries < 10)
         {
-            await Task.Delay(500.Milliseconds());
-            state = await theSession.Events.FetchStreamStateAsync(streamId);
+            await Task.Delay(500.Milliseconds(), TestContext.Current.CancellationToken);
+            state = await theSession.Events.FetchStreamStateAsync(streamId, TestContext.Current.CancellationToken);
             tries++;
         }
 
@@ -158,7 +158,7 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
 
         await daemon.WaitForNonStaleData(30.Seconds());
 
-        var version2 = await theSession.LoadAsync<SideEffects1>(streamId);
+        var version2 = await theSession.LoadAsync<SideEffects1>(streamId, TestContext.Current.CancellationToken);
         version2.A.ShouldBe(5);
 
         // This proves that the aggregate was updated the new new event
@@ -179,8 +179,8 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
             opts.Events.StreamIdentity = StreamIdentity.AsString;
         });
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -188,15 +188,15 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         var streamKey = Guid.NewGuid().ToString();
         theSession.Events.StartStream<SideEffects2>(streamKey, new MTAEvent(),
             new MTAEvent(), new MTAEvent(), new MTAEvent(), new MTAEvent());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Prove the BEevent side effect happened as expected
-        var state = await theSession.Events.FetchStreamStateAsync(streamKey);
+        var state = await theSession.Events.FetchStreamStateAsync(streamKey, TestContext.Current.CancellationToken);
         var tries = 0;
         while (state.Version != 6 && tries < 10)
         {
-            await Task.Delay(250.Milliseconds());
-            state = await theSession.Events.FetchStreamStateAsync(streamKey);
+            await Task.Delay(250.Milliseconds(), TestContext.Current.CancellationToken);
+            state = await theSession.Events.FetchStreamStateAsync(streamKey, TestContext.Current.CancellationToken);
             tries++;
         }
 
@@ -204,7 +204,7 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
 
         await daemon.WaitForNonStaleData(30.Seconds());
 
-        var version2 = await theSession.LoadAsync<SideEffects2>(streamKey);
+        var version2 = await theSession.LoadAsync<SideEffects2>(streamKey, TestContext.Current.CancellationToken);
         version2.A.ShouldBe(5);
 
         // This proves that the aggregate was updated the new new event
@@ -225,8 +225,8 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
             opts.Logger(new TestOutputMartenLogger(_output));
         });
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -234,31 +234,31 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         var streamKey = Guid.NewGuid().ToString();
         theSession.Events.StartStream<SideEffects2>(streamKey, new MTAEvent(),
             new MTAEvent(), new MTAEvent());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await daemon.WaitForNonStaleData(30.Seconds());
 
-        var version1 = await theSession.LoadAsync<SideEffects2>(streamKey);
+        var version1 = await theSession.LoadAsync<SideEffects2>(streamKey, TestContext.Current.CancellationToken);
         version1.A.ShouldBe(3);
         version1.B.ShouldBe(0);
 
         theSession.Events.Append(streamKey, new MTAEvent(), new MTAEvent());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
 
         // Prove the BEevent side effect happened as expected
-        var state = await theSession.Events.FetchStreamStateAsync(streamKey);
+        var state = await theSession.Events.FetchStreamStateAsync(streamKey, TestContext.Current.CancellationToken);
         var tries = 0;
         while (state.Version != 6 && tries < 10)
         {
-            await Task.Delay(250.Milliseconds());
-            state = await theSession.Events.FetchStreamStateAsync(streamKey);
+            await Task.Delay(250.Milliseconds(), TestContext.Current.CancellationToken);
+            state = await theSession.Events.FetchStreamStateAsync(streamKey, TestContext.Current.CancellationToken);
             tries++;
         }
 
         await daemon.WaitForNonStaleData(30.Seconds());
 
-        var version2 = await theSession.LoadAsync<SideEffects2>(streamKey);
+        var version2 = await theSession.LoadAsync<SideEffects2>(streamKey, TestContext.Current.CancellationToken);
         version2.A.ShouldBe(5);
 
         // This proves that the aggregate was updated the new new event
@@ -282,8 +282,8 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
             opts.Events.AppendMode = EventAppendMode.Quick;
         });
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -291,21 +291,21 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         var streamKey = Guid.NewGuid().ToString();
         theSession.Events.StartStream<SideEffects2>(streamKey, new MTAEvent(),
             new MTAEvent(), new MTAEvent(), new MTAEvent(), new MTAEvent());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Prove the BEevent side effect happened as expected
-        var state = await theSession.Events.FetchStreamStateAsync(streamKey);
+        var state = await theSession.Events.FetchStreamStateAsync(streamKey, TestContext.Current.CancellationToken);
         var tries = 0;
         while (state.Version != 6 && tries < 10)
         {
-            await Task.Delay(250.Milliseconds());
-            state = await theSession.Events.FetchStreamStateAsync(streamKey);
+            await Task.Delay(250.Milliseconds(), TestContext.Current.CancellationToken);
+            state = await theSession.Events.FetchStreamStateAsync(streamKey, TestContext.Current.CancellationToken);
             tries++;
         }
 
         await daemon.WaitForNonStaleData(30.Seconds());
 
-        var version1 = await theSession.LoadAsync<SideEffects2>(streamKey);
+        var version1 = await theSession.LoadAsync<SideEffects2>(streamKey, TestContext.Current.CancellationToken);
         version1.A.ShouldBe(5);
         version1.B.ShouldBe(1);
 
@@ -314,7 +314,7 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         await daemon.RebuildProjectionAsync<Projection2>(5.Seconds(), CancellationToken.None);
 
         // No changes!
-        var version2 = await theSession.LoadAsync<SideEffects2>(streamKey);
+        var version2 = await theSession.LoadAsync<SideEffects2>(streamKey, TestContext.Current.CancellationToken);
         version2.A.ShouldBe(5);
         version2.B.ShouldBe(1);
     }
@@ -330,8 +330,8 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
             opts.Events.MessageOutbox = outbox;
         });
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -343,7 +343,7 @@ public class side_effects_in_aggregations: OneOffConfigurationsContext
         theSession.Events.StartStream<SideEffects1>(stream1, new MTAEvent(), new MTAEvent());
         theSession.Events.StartStream<SideEffects1>(stream2, new MTAEvent(), new MTAEvent());
         theSession.Events.StartStream<SideEffects1>(stream3, new MTAEvent(), new MTAEvent(), new MTBEvent());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await daemon.WaitForNonStaleData(120.Seconds());
 

--- a/src/DaemonTests/Bug_4667_projection_load_async_parallel_no_race.cs
+++ b/src/DaemonTests/Bug_4667_projection_load_async_parallel_no_race.cs
@@ -47,7 +47,7 @@ public class Bug_4667_projection_load_async_parallel_no_race: BugIntegrationCont
             {
                 session.Store(new Bug4667Customer { Id = id, Name = $"customer-{id:N}" });
             }
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var streamIds = new Guid[streamCount];
@@ -63,7 +63,7 @@ public class Bug_4667_projection_load_async_parallel_no_race: BugIntegrationCont
                         .Select(j => (object)new Bug4667ItemPicked(customerId, j))
                         .ToArray());
             }
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();

--- a/src/DaemonTests/Bug_4838_projection_query_parallel_no_race.cs
+++ b/src/DaemonTests/Bug_4838_projection_query_parallel_no_race.cs
@@ -57,15 +57,15 @@ public class Bug_4838_projection_query_parallel_no_race: BugIntegrationContext
         {
             setup.Store(new Bug4838Question { Id = questionId, ProjectId = projectId });
             setup.Store(new Bug4838Block { Id = blockId, ProjectId = projectId });
-            await setup.SaveChangesAsync();
+            await setup.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         // Contrast case: a plain lightweight session DOES capture versions from the
         // very same queries, proving the assertions below detect the shared-state write.
         await using (var regular = (DocumentSessionBase)theStore.LightweightSession())
         {
-            await regular.Query<Bug4838Question>().Where(x => x.ProjectId == projectId).ToListAsync();
-            await regular.Query<Bug4838Block>().Where(x => x.ProjectId == projectId).ToListAsync();
+            await regular.Query<Bug4838Question>().Where(x => x.ProjectId == projectId).ToListAsync(TestContext.Current.CancellationToken);
+            await regular.Query<Bug4838Block>().Where(x => x.ProjectId == projectId).ToListAsync(TestContext.Current.CancellationToken);
 
             regular.Versions.RevisionFor<Bug4838Question, Guid>(questionId).ShouldNotBeNull();
             regular.Versions.VersionFor<Bug4838Block, Guid>(blockId).ShouldNotBeNull();
@@ -81,7 +81,7 @@ public class Bug_4838_projection_query_parallel_no_race: BugIntegrationContext
         {
             // Every public read entry point named by #4838: LINQ...
             var questions = await projectionSession.Query<Bug4838Question>()
-                .Where(x => x.ProjectId == projectId).ToListAsync();
+                .Where(x => x.ProjectId == projectId).ToListAsync(TestContext.Current.CancellationToken);
             questions.Single().Id.ShouldBe(questionId);
 
             // ...raw SQL...
@@ -95,7 +95,7 @@ public class Bug_4838_projection_query_parallel_no_race: BugIntegrationContext
                 .Where(x => x.ProjectId == projectId).ToList();
             var batchedBlocks = batchQuery.Query<Bug4838Block>()
                 .Where(x => x.ProjectId == projectId).ToList();
-            await batchQuery.Execute();
+            await batchQuery.Execute(TestContext.Current.CancellationToken);
             (await batchedQuestions).Single().Id.ShouldBe(questionId);
             (await batchedBlocks).Single().Id.ShouldBe(blockId);
 
@@ -158,7 +158,7 @@ public class Bug_4838_projection_query_parallel_no_race: BugIntegrationContext
                 }
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var streamIds = new Guid[streamCount];
@@ -175,7 +175,7 @@ public class Bug_4838_projection_query_parallel_no_race: BugIntegrationContext
                         .ToArray());
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();

--- a/src/DaemonTests/Bug_4981_projection_progress_last_updated_advances.cs
+++ b/src/DaemonTests/Bug_4981_projection_progress_last_updated_advances.cs
@@ -54,14 +54,14 @@ public class Bug_4981_projection_progress_last_updated_advances: DaemonContext
                 session.Events.Append(Guid.NewGuid(), new Bug4981Event());
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await agent.Tracker.WaitForShardState(new ShardState(shard, 50), 30.Seconds());
         var firstUpdated = await lastUpdatedForAsync(shard);
 
         // ensure a measurable clock gap so the second write's transaction_timestamp() differs
-        await Task.Delay(1.Seconds());
+        await Task.Delay(1.Seconds(), TestContext.Current.CancellationToken);
 
         await using (var session = theStore.LightweightSession())
         {
@@ -70,7 +70,7 @@ public class Bug_4981_projection_progress_last_updated_advances: DaemonContext
                 session.Events.Append(Guid.NewGuid(), new Bug4981Event());
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await agent.Tracker.WaitForShardState(new ShardState(shard, 100), 30.Seconds());

--- a/src/DaemonTests/Bug_5024_extended_progression_survives_shutdown.cs
+++ b/src/DaemonTests/Bug_5024_extended_progression_survives_shutdown.cs
@@ -93,7 +93,7 @@ public class Bug_5024_extended_progression_survives_shutdown: DaemonContext
                     session.Events.Append(Guid.NewGuid(), new Bug5024Event());
                 }
 
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
 
             await daemon.Tracker.WaitForShardState(new ShardState(Shard, 10), 30.Seconds());
@@ -111,7 +111,7 @@ public class Bug_5024_extended_progression_survives_shutdown: DaemonContext
                 AgentStatus = "Deliberate",
                 LastHeartbeat = DateTimeOffset.UtcNow
             };
-            await database.WriteExtendedProgressionAsync(deliberate);
+            await database.WriteExtendedProgressionAsync(deliberate, TestContext.Current.CancellationToken);
 
             // Symptom 1: the deliberate value survives — a fire-and-forgotten "Stopped" heartbeat would have
             // overwritten agent_status back to the terminal state here.

--- a/src/DaemonTests/Bug_5048_shard_failure_progression_columns.cs
+++ b/src/DaemonTests/Bug_5048_shard_failure_progression_columns.cs
@@ -133,7 +133,7 @@ public class Bug_5048_shard_failure_progression_columns: DaemonContext
         var database = (MartenDatabase)theStore.Storage.Database;
 
         await database.WriteExtendedProgressionAsync(
-            paused(ShardFailureCategory.EventSerialization, 4815, "failure_telemetry_event", "tenant-a"));
+            paused(ShardFailureCategory.EventSerialization, 4815, "failure_telemetry_event", "tenant-a"), TestContext.Current.CancellationToken);
 
         var row = await readFailureAsync();
 
@@ -152,12 +152,12 @@ public class Bug_5048_shard_failure_progression_columns: DaemonContext
         var database = (MartenDatabase)theStore.Storage.Database;
 
         await database.WriteExtendedProgressionAsync(
-            paused(ShardFailureCategory.ApplyEvent, 99, "failure_telemetry_event"));
+            paused(ShardFailureCategory.ApplyEvent, 99, "failure_telemetry_event"), TestContext.Current.CancellationToken);
         (await readFailureAsync()).category.ShouldNotBeNull();
 
         // A restart supersedes whatever paused the agent last. Without this, every supervisor built on
         // these columns alerts forever on a failure the operator already fixed.
-        await database.WriteExtendedProgressionAsync(withoutFailure(ShardAction.Started, "Running"));
+        await database.WriteExtendedProgressionAsync(withoutFailure(ShardAction.Started, "Running"), TestContext.Current.CancellationToken);
 
         var row = await readFailureAsync();
         row.category.ShouldBeNull();
@@ -173,13 +173,13 @@ public class Bug_5048_shard_failure_progression_columns: DaemonContext
         var database = (MartenDatabase)theStore.Storage.Database;
 
         await database.WriteExtendedProgressionAsync(
-            paused(ShardFailureCategory.EventSerialization, 4815, "failure_telemetry_event"));
+            paused(ShardFailureCategory.EventSerialization, 4815, "failure_telemetry_event"), TestContext.Current.CancellationToken);
 
         // This is the load-bearing case: SubscriptionAgent publishes a plain Stopped state (no Failure)
         // right behind the Paused one, and a heartbeat can arrive with no failure at all. An
         // unconditional write would erase the reason microseconds after recording it.
-        await database.WriteExtendedProgressionAsync(withoutFailure(ShardAction.Stopped, "Stopped"));
-        await database.WriteExtendedProgressionAsync(withoutFailure(ShardAction.Updated, "Running"));
+        await database.WriteExtendedProgressionAsync(withoutFailure(ShardAction.Stopped, "Stopped"), TestContext.Current.CancellationToken);
+        await database.WriteExtendedProgressionAsync(withoutFailure(ShardAction.Updated, "Running"), TestContext.Current.CancellationToken);
 
         var row = await readFailureAsync();
         row.category.ShouldBe(nameof(ShardFailureCategory.EventSerialization));
@@ -193,10 +193,10 @@ public class Bug_5048_shard_failure_progression_columns: DaemonContext
         var database = (MartenDatabase)theStore.Storage.Database;
 
         await database.WriteExtendedProgressionAsync(
-            paused(ShardFailureCategory.UnknownEventType, 1623, "trip_started", "tenant-b"));
+            paused(ShardFailureCategory.UnknownEventType, 1623, "trip_started", "tenant-b"), TestContext.Current.CancellationToken);
 
         // A poller must get the same shape as a live ShardState observer, not just "it's Paused"
-        var states = await database.AllProjectionProgress();
+        var states = await database.AllProjectionProgress(TestContext.Current.CancellationToken);
         var state = states.Single(x => x.ShardName == TheShard);
 
         state.Failure.ShouldNotBeNull();
@@ -217,9 +217,9 @@ public class Bug_5048_shard_failure_progression_columns: DaemonContext
         await seedProgressionRowAsync();
         var database = (MartenDatabase)theStore.Storage.Database;
 
-        await database.WriteExtendedProgressionAsync(withoutFailure(ShardAction.Started, "Running"));
+        await database.WriteExtendedProgressionAsync(withoutFailure(ShardAction.Started, "Running"), TestContext.Current.CancellationToken);
 
-        var states = await database.AllProjectionProgress();
+        var states = await database.AllProjectionProgress(TestContext.Current.CancellationToken);
         states.Single(x => x.ShardName == TheShard).Failure.ShouldBeNull();
     }
 
@@ -243,13 +243,13 @@ public class Bug_5048_shard_failure_progression_columns: DaemonContext
         await using (var session = theStore.LightweightSession())
         {
             session.Events.StartStream(streamId, new FailureTelemetryEvent(), new CorruptibleEvent());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         long corruptedSequence;
         await using (var session = theStore.QuerySession())
         {
-            var events = await session.Events.FetchStreamAsync(streamId);
+            var events = await session.Events.FetchStreamAsync(streamId, token: TestContext.Current.CancellationToken);
             corruptedSequence = events.Single(x => x.EventType == typeof(CorruptibleEvent)).Sequence;
         }
 
@@ -295,19 +295,19 @@ public class Bug_5048_shard_failure_progression_columns: DaemonContext
             {
                 Action = ShardAction.Paused, AgentStatus = "Paused", LastHeartbeat = DateTimeOffset.UtcNow
             }
-        ]);
+        ], TestContext.Current.CancellationToken);
 
         await using var session = theStore.QuerySession();
         var rows = Convert.ToInt64(await session.Connection
             .CreateCommand($"select count(*) from {theStore.Events.DatabaseSchemaName}.mt_event_progression")
-            .ExecuteScalarAsync());
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken));
         rows.ShouldBe(1);
 
         var sequence = Convert.ToInt64(await session.Connection
             .CreateCommand(
                 $"select last_seq_id from {theStore.Events.DatabaseSchemaName}.mt_event_progression where name = :name")
             .With("name", TheShard)
-            .ExecuteScalarAsync());
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken));
         sequence.ShouldBe(10); // committed progress untouched
     }
 }

--- a/src/DaemonTests/Bug_5055_5056_coordinator_double_stop.cs
+++ b/src/DaemonTests/Bug_5055_5056_coordinator_double_stop.cs
@@ -69,7 +69,7 @@ public class Bug_5055_5056_coordinator_double_stop: DaemonContext
                     session.Events.Append(Guid.NewGuid(), new Bug5055Event());
                 }
 
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
 
             var daemon = coordinator.DaemonForMainDatabase();

--- a/src/DaemonTests/Bug_catching_up_should_catch_marten_command_exceptions.cs
+++ b/src/DaemonTests/Bug_catching_up_should_catch_marten_command_exceptions.cs
@@ -27,7 +27,7 @@ public class Bug_catching_up_apply_errors: OneOffConfigurationsContext
         theSession.Events.StartStream<LetterCounts>(new AEvent(), new ThrowError(false), new CEvent(), new DEvent());
         theSession.Events.StartStream<LetterCounts>(new AEvent(), new BEvent(), new CEvent(), new DEvent());
         theSession.Events.StartStream<LetterCounts>(new AEvent(), new BEvent(), new ThrowError(true), new DEvent());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
 
@@ -56,7 +56,7 @@ public class Bug_catching_up_command_errors: OneOffConfigurationsContext
 
         var failOnSaveId = Guid.NewGuid();
         theSession.Events.StartStream<FailsOnSave>(new FailsOnSaveEventA());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
         var aggregated = await Should.ThrowAsync<AggregateException>(async () =>
@@ -67,7 +67,7 @@ public class Bug_catching_up_command_errors: OneOffConfigurationsContext
         aggregated.InnerExceptions[0].ShouldBeOfType<MartenCommandException>();
 
 
-        var failOnSave = await theSession.LoadAsync<FailsOnSave>(failOnSaveId);
+        var failOnSave = await theSession.LoadAsync<FailsOnSave>(failOnSaveId, TestContext.Current.CancellationToken);
         failOnSave.ShouldBeNull();
     }
 

--- a/src/DaemonTests/Bugs/Bug_1995_empty_batch_update_failure.cs
+++ b/src/DaemonTests/Bugs/Bug_1995_empty_batch_update_failure.cs
@@ -30,10 +30,10 @@ public class Bug_1995_empty_batch_update_failure : BugIntegrationContext
             theSession.Events.StartStream(id, new IssueCreated { Id = id });
         }
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
-        await daemon.RebuildProjectionAsync<IssueAggregateProjection>(default);
+        await daemon.RebuildProjectionAsync<IssueAggregateProjection>(TestContext.Current.CancellationToken);
     }
 }
 

--- a/src/DaemonTests/Bugs/Bug_2073_tenancy_problems.cs
+++ b/src/DaemonTests/Bugs/Bug_2073_tenancy_problems.cs
@@ -52,17 +52,17 @@ public class Bug_2073_tenancy_problems
             });
         });
 
-        using var host = await builder.StartAsync();
+        using var host = await builder.StartAsync(TestContext.Current.CancellationToken);
 
         var store = host.Services.GetRequiredService<IDocumentStore>();
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
         var daemon = (ProjectionDaemon)(await store.BuildProjectionDaemonAsync());
         await daemon.StartAllAsync();
 
         await using (var session = store.LightweightSession("tenant1"))
         {
             session.Events.Append(Guid.NewGuid().ToString(), new CreateDoc("a", "owner", "content"));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await daemon.Tracker.WaitForShardState("Document:All", 1);

--- a/src/DaemonTests/Bugs/Bug_2074_recovering_from_errors.cs
+++ b/src/DaemonTests/Bugs/Bug_2074_recovering_from_errors.cs
@@ -36,7 +36,7 @@ public class Bug_2074_recovering_from_errors
 
         var documentStore = provider.GetRequiredService<IDocumentStore>();
 
-        await documentStore.Advanced.Clean.CompletelyRemoveAllAsync();
+        await documentStore.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
 
         var logger = provider.GetRequiredService<ILogger<IProjectionDaemon>>();
         using var daemon = await documentStore.BuildProjectionDaemonAsync(logger: logger);
@@ -49,7 +49,7 @@ public class Bug_2074_recovering_from_errors
         await using (var session = documentStore.LightweightSession())
         {
             session.Events.Append(id, events);
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         await waiter;

--- a/src/DaemonTests/Bugs/Bug_2159_using_QuerySession_within_async_aggregation.cs
+++ b/src/DaemonTests/Bugs/Bug_2159_using_QuerySession_within_async_aggregation.cs
@@ -27,19 +27,19 @@ public class Bug_2159_using_QuerySession_within_async_aggregation : BugIntegrati
         var user = new User { UserName = "Blue"};
 
         theSession.Store(user);
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         theSession.Events.StartStream(streamId, new UserCreated());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
 
         theSession.Events.Append(streamId, new UserUpdated{UserId = user.Id});
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.RebuildProjectionAsync<UserAggregate>(CancellationToken.None);
 
-        var aggregate = await theSession.LoadAsync<MyAggregate>(streamId);
+        var aggregate = await theSession.LoadAsync<MyAggregate>(streamId, TestContext.Current.CancellationToken);
         aggregate.UpdatedBy.ShouldBe("Blue");
 
     }

--- a/src/DaemonTests/Bugs/Bug_2177_query_session_tenancy_in_daemon.cs
+++ b/src/DaemonTests/Bugs/Bug_2177_query_session_tenancy_in_daemon.cs
@@ -39,19 +39,19 @@ namespace DaemonTests.Bugs
 
             await using var session = theStore.LightweightSession(tenantId);
             session.Insert(new User { Id = userId, FirstName = "Tester", LastName = "McTestFace" });
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             await insertUserWithSameIdInOtherTenant(theStore, userId);
 
             session.Events.Append(ticketId, new TicketCreated(ticketId, "Test Projections"),
                 new TicketAssigned(ticketId, userId));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             using var daemon = await theStore.BuildProjectionDaemonAsync();
             await daemon.StartAllAsync();
             await daemon.WaitForNonStaleData(1.Minutes());
 
-            var projection = await session.LoadAsync<Ticket>(ticketId);
+            var projection = await session.LoadAsync<Ticket>(ticketId, TestContext.Current.CancellationToken);
             projection.User.ShouldNotBeNull();
             projection.User.FirstName.ShouldBe("Tester");
         }

--- a/src/DaemonTests/Bugs/Bug_2201_out_of_order_exception_with_hard_deletes.cs
+++ b/src/DaemonTests/Bugs/Bug_2201_out_of_order_exception_with_hard_deletes.cs
@@ -29,7 +29,7 @@ public partial class Bug_2201_out_of_order_exception_with_hard_deletes: BugInteg
             options.Projections.Add<TicketProjection>(ProjectionLifecycle.Async);
         });
 
-        await theStore.Advanced.Clean.CompletelyRemoveAllAsync();
+        await theStore.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -43,14 +43,14 @@ public partial class Bug_2201_out_of_order_exception_with_hard_deletes: BugInteg
             session.Events.Append(ticketId, new TicketCreated(ticketId, $"Ticket #{i}"));
         }
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         await daemon.WaitForNonStaleData(5.Seconds());
 
         session.Events.Append(ticketId, new TicketDeleted(ticketId));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         await daemon.WaitForNonStaleData(30.Seconds());
 
-        var ticket = await session.LoadAsync<Ticket>(ticketId);
+        var ticket = await session.LoadAsync<Ticket>(ticketId, TestContext.Current.CancellationToken);
         ticket.ShouldBeNull();
     }
 

--- a/src/DaemonTests/Bugs/Bug_2245_async_daemon_getting_stuck.cs
+++ b/src/DaemonTests/Bugs/Bug_2245_async_daemon_getting_stuck.cs
@@ -37,7 +37,7 @@ public partial class Bug_2245_async_daemon_getting_stuck : BugIntegrationContext
         // prove async daemon works on happy path
         theSession.Events.StartStream(Guid.NewGuid().ToString(),
             new CreatedEvent(Guid.NewGuid().ToString(), Guid.NewGuid().ToString()));
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await daemon.WaitForNonStaleData(10.Seconds());
 
@@ -50,7 +50,7 @@ public partial class Bug_2245_async_daemon_getting_stuck : BugIntegrationContext
             theSession.Events.StartStream(Guid.NewGuid().ToString(),
                 new UpdatedEvent(Guid.NewGuid().ToString(), Guid.NewGuid().ToString()));
 
-            await theSession.SaveChangesAsync();
+            await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
         catch (ApplyEventException e)
         {
@@ -68,7 +68,7 @@ public partial class Bug_2245_async_daemon_getting_stuck : BugIntegrationContext
 
         newSession.Events.StartStream(Guid.NewGuid().ToString(),
             new CreatedEvent(Guid.NewGuid().ToString(), Guid.NewGuid().ToString()));
-        await newSession.SaveChangesAsync();
+        await newSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await daemon.WaitForNonStaleData(10.Seconds());
     }

--- a/src/DaemonTests/Bugs/Bug_2597_rebuilding_a_projection_with_no_matching_events_but_other_non_matching_events.cs
+++ b/src/DaemonTests/Bugs/Bug_2597_rebuilding_a_projection_with_no_matching_events_but_other_non_matching_events.cs
@@ -27,7 +27,7 @@ public class Bug_2597_rebuilding_a_projection_with_no_matching_events_but_other_
             session.Events.Append(Guid.NewGuid(), new MTBEvent(), new MTCEvent(), new MTDEvent());
             session.Events.Append(Guid.NewGuid(), new MTBEvent(), new MTCEvent(), new MTDEvent());
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();

--- a/src/DaemonTests/Bugs/Bug_3059_double_application.cs
+++ b/src/DaemonTests/Bugs/Bug_3059_double_application.cs
@@ -28,8 +28,8 @@ public class Bug_3059_double_application
     {
         using (var conn = new NpgsqlConnection(ConnectionSource.ConnectionString))
         {
-            await conn.OpenAsync();
-            await conn.DropSchemaAsync("bug3059");
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
+            await conn.DropSchemaAsync("bug3059", TestContext.Current.CancellationToken);
             await conn.CloseAsync();
         }
 
@@ -46,7 +46,7 @@ public class Bug_3059_double_application
                     opts.Projections.Snapshot<IncidentDetailsSnapshotAsyncProjection>(SnapshotLifecycle.Async);
                 })
                 .AddAsyncDaemon(DaemonMode.Solo);
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         var store = host.Services.GetRequiredService<IDocumentStore>();
 
@@ -74,7 +74,7 @@ public class Bug_3059_double_application
 
         using (var session = store.LightweightSession())
         {
-            var document = await session.LoadAsync<IncidentDetailsSnapshotAsyncProjection>(logIncident.IncidentId);
+            var document = await session.LoadAsync<IncidentDetailsSnapshotAsyncProjection>(logIncident.IncidentId, TestContext.Current.CancellationToken);
 
             document.Aggregated.Category.ShouldBe(IncidentCategory.Database);
         }

--- a/src/DaemonTests/Bugs/Bug_3080_WaitForNonStaleData_should_work_dammit.cs
+++ b/src/DaemonTests/Bugs/Bug_3080_WaitForNonStaleData_should_work_dammit.cs
@@ -38,13 +38,13 @@ public partial class Bug_3080_WaitForNonStaleData_should_work_dammit
         var updated2 = new MyAggregateUpdated(id, "Updated 2");
 
         session.Events.StartStream<MyAggregate>(id, created, updated1, updated2);
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Append a few more
         var updated3 = new MyAggregateUpdated(id, "Updated 3");
         var updated4 = new MyAggregateUpdated(id, "Updated 4");
         session.Events.Append(id, updated3, updated4);
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
 
         // Wait for table projection

--- a/src/DaemonTests/Bugs/Bug_3764_fanout_and_transactions.cs
+++ b/src/DaemonTests/Bugs/Bug_3764_fanout_and_transactions.cs
@@ -35,7 +35,7 @@ public class Bug_3764_fanout_and_transactions : BugIntegrationContext
 
         session.Events.Append(trip.Id, tripStarted);
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var duration = random.Next(1, 20);
 
@@ -48,22 +48,22 @@ public class Bug_3764_fanout_and_transactions : BugIntegrationContext
             session.Events.Append(trip.Id, travel);
         }
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var tripEnded = new TripEnded{Day = startDay + duration};
 
         session.Events.Append(trip.Id, tripEnded);
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Load as Inline
-        var days = await session.Query<Day>().ToListAsync();
+        var days = await session.Query<Day>().ToListAsync(TestContext.Current.CancellationToken);
 
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.RebuildProjectionAsync<Day>(CancellationToken.None);
 
-        var expected = await session.Query<Day>().ToListAsync();
+        var expected = await session.Query<Day>().ToListAsync(TestContext.Current.CancellationToken);
 
         days.OrderBy(x => x.Id).ShouldBe(expected.OrderBy(x => x.Id));
 

--- a/src/DaemonTests/Bugs/Bug_3802_projection_rebuild_skips_document_in_skip_mode.cs
+++ b/src/DaemonTests/Bugs/Bug_3802_projection_rebuild_skips_document_in_skip_mode.cs
@@ -36,7 +36,7 @@ public class Bug_3802_projection_rebuild_skips_document_in_quick_mode: BugIntegr
         theSession.Events.StartStream<Company>(
             new CompanyCreated("JasperFx", "sales@jasperfx.com"));
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Let the daemon run so the async CompanyProjection can catch up
         using (var daemon = await theStore.BuildProjectionDaemonAsync())
@@ -46,9 +46,9 @@ public class Bug_3802_projection_rebuild_skips_document_in_quick_mode: BugIntegr
         }
 
         // Just making sure we have everything as expected
-        var allCompanies = await theSession.Query<Company>().ToListAsync();
+        var allCompanies = await theSession.Query<Company>().ToListAsync(TestContext.Current.CancellationToken);
         allCompanies.Count.ShouldBe(3);
-        var allCompanyEmails = await theSession.Query<CompanyUniqueEmail>().ToListAsync();
+        var allCompanyEmails = await theSession.Query<CompanyUniqueEmail>().ToListAsync(TestContext.Current.CancellationToken);
         allCompanyEmails.Count.ShouldBe(3);
 
         // Now comes the fun - rebuilding the projection
@@ -61,7 +61,7 @@ public class Bug_3802_projection_rebuild_skips_document_in_quick_mode: BugIntegr
         }
 
         // Count should be 3 again - but is it?
-        var allCompanyEmailsAfterRebuild = await theSession.Query<CompanyUniqueEmail>().ToListAsync();
+        var allCompanyEmailsAfterRebuild = await theSession.Query<CompanyUniqueEmail>().ToListAsync(TestContext.Current.CancellationToken);
         allCompanyEmailsAfterRebuild.Count.ShouldBe(3);
     }
 }

--- a/src/DaemonTests/Bugs/Bug_4428_rich_storage_side_effect_events.cs
+++ b/src/DaemonTests/Bugs/Bug_4428_rich_storage_side_effect_events.cs
@@ -40,8 +40,8 @@ public class Bug_4428_rich_storage_side_effect_events: OneOffConfigurationsConte
             opts.Projections.Add<Bug4428CounterProjection>(ProjectionLifecycle.Async);
         });
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -55,7 +55,7 @@ public class Bug_4428_rich_storage_side_effect_events: OneOffConfigurationsConte
             new Bug4428Incremented(),
             new Bug4428Incremented(),
             new Bug4428Incremented());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await daemon.WaitForNonStaleData(30.Seconds());
 
@@ -71,7 +71,7 @@ public class Bug_4428_rich_storage_side_effect_events: OneOffConfigurationsConte
         // test isn't trying to exercise.
         var rawEvents = await theSession.Events.QueryAllRawEvents()
             .Where(x => x.StreamId == streamId)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
         rawEvents.OfType<IEvent<Bug4428BonusAwarded>>().Count().ShouldBe(1);
     }
 }

--- a/src/DaemonTests/Bugs/Bug_4730_double_apply_with_out_of_order_stream.cs
+++ b/src/DaemonTests/Bugs/Bug_4730_double_apply_with_out_of_order_stream.cs
@@ -41,8 +41,8 @@ public class Bug_4730_double_apply_with_out_of_order_stream: OneOffConfiguration
                 ProjectionLifecycle.Async);
         });
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var streamOutOfOrder = Guid.NewGuid();
         var streamControl = Guid.NewGuid();
@@ -60,7 +60,7 @@ public class Bug_4730_double_apply_with_out_of_order_stream: OneOffConfiguration
             new Created4730(streamControl, t0),
             new Updated4730(streamControl, delta, t1));
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -77,7 +77,7 @@ public class Bug_4730_double_apply_with_out_of_order_stream: OneOffConfiguration
         }
 
         await using var query = theStore.QuerySession();
-        var control = await query.LoadAsync<AccountReadModel4730>(streamControl);
+        var control = await query.LoadAsync<AccountReadModel4730>(streamControl, TestContext.Current.CancellationToken);
 
         _output.WriteLine($"cacheLimit={cacheLimitPerTenant} control TotalDelta actual={control?.TotalDelta} expected={delta}");
 

--- a/src/DaemonTests/Bugs/Bug_4953_idle_advisory_lock_sessions_do_not_block_gap_skips.cs
+++ b/src/DaemonTests/Bugs/Bug_4953_idle_advisory_lock_sessions_do_not_block_gap_skips.cs
@@ -132,7 +132,7 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
             {
                 seq.ShouldBe(9);
                 await appendEvents(3); // 10..12 committed
-                await tx.RollbackAsync();
+                await tx.RollbackAsync(TestContext.Current.CancellationToken);
             }
             finally
             {
@@ -143,7 +143,7 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
             var first = await detector.DetectInSafeZone(CancellationToken.None);
             first.CurrentMark.ShouldBe(8);
 
-            await Task.Delay(700);
+            await Task.Delay(700, TestContext.Current.CancellationToken);
 
             // Threshold elapsed, and the ONLY open transaction from before the gap is the advisory
             // lock listener, which has provably executed nothing since before seq 9 was allocated.
@@ -192,20 +192,20 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
                 var first = await detector.DetectInSafeZone(CancellationToken.None);
                 first.CurrentMark.ShouldBe(8);
 
-                await Task.Delay(700);
+                await Task.Delay(700, TestContext.Current.CancellationToken);
                 var second = await detector.DetectInSafeZone(CancellationToken.None);
                 _output.WriteLine($"Past threshold with live reserver: CurrentMark={second.CurrentMark}");
                 second.CurrentMark.ShouldBe(8);
 
                 // The reserver dies — NOW the gap is provably dead and the skip proceeds
-                await tx.RollbackAsync();
+                await tx.RollbackAsync(TestContext.Current.CancellationToken);
             }
             finally
             {
                 await conn.DisposeAsync();
             }
 
-            await Task.Delay(200);
+            await Task.Delay(200, TestContext.Current.CancellationToken);
             var third = await detector.DetectInSafeZone(CancellationToken.None);
             _output.WriteLine($"After reserver death: CurrentMark={third.CurrentMark}");
             third.CurrentMark.ShouldBe(12);
@@ -241,7 +241,7 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
             {
                 seq.ShouldBe(9);
                 await appendEvents(3); // 10..12 committed
-                await tx.RollbackAsync();
+                await tx.RollbackAsync(TestContext.Current.CancellationToken);
             }
             finally
             {
@@ -252,7 +252,7 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
             var first = await detector.DetectInSafeZone(CancellationToken.None);
             first.CurrentMark.ShouldBe(8);
 
-            await Task.Delay(700);
+            await Task.Delay(700, TestContext.Current.CancellationToken);
             var second = await detector.DetectInSafeZone(CancellationToken.None);
             _output.WriteLine($"Past threshold, fenceless: CurrentMark={second.CurrentMark}");
             second.CurrentMark.ShouldBe(8);

--- a/src/DaemonTests/Bugs/Bug_4953_outstanding_sequence_gap_skips.cs
+++ b/src/DaemonTests/Bugs/Bug_4953_outstanding_sequence_gap_skips.cs
@@ -189,7 +189,7 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
 
             // Well past the stale threshold — must STILL hold, because the reserving transaction
             // is provably alive (RowExclusiveLock on mt_events + open transaction evidence)
-            await Task.Delay(700);
+            await Task.Delay(700, TestContext.Current.CancellationToken);
             var second = await detector.DetectInSafeZone(CancellationToken.None);
             _output.WriteLine($"After threshold with live reserver: CurrentMark={second.CurrentMark}");
             second.CurrentMark.ShouldBe(8);
@@ -223,7 +223,7 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
         {
             seq.ShouldBe(9);
             await appendEvents(3); // 10..12 committed
-            await tx.RollbackAsync(); // seq 9 is now a permanently dead hole
+            await tx.RollbackAsync(TestContext.Current.CancellationToken); // seq 9 is now a permanently dead hole
 
             var detector = buildDetector();
 
@@ -231,7 +231,7 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
             var first = await detector.DetectInSafeZone(CancellationToken.None);
             first.CurrentMark.ShouldBe(8);
 
-            await Task.Delay(700);
+            await Task.Delay(700, TestContext.Current.CancellationToken);
 
             // Threshold elapsed + no live reserver = provably dead: skip, and record the skip
             var second = await detector.DetectInSafeZone(CancellationToken.None);
@@ -289,13 +289,13 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
             first.CurrentMark.ShouldBe(8);
 
             // Still holding while the reserving transaction lives, even past the threshold
-            await Task.Delay(700);
+            await Task.Delay(700, TestContext.Current.CancellationToken);
             var second = await detector.DetectInSafeZone(CancellationToken.None);
             second.CurrentMark.ShouldBe(8);
 
             // Kill the whole tail: every reservation is now provably dead
-            await tx.RollbackAsync();
-            await Task.Delay(700);
+            await tx.RollbackAsync(TestContext.Current.CancellationToken);
+            await Task.Delay(700, TestContext.Current.CancellationToken);
 
             var third = await detector.DetectInSafeZone(CancellationToken.None);
             _output.WriteLine($"After tail death: CurrentMark={third.CurrentMark} (ceiling {lastValue})");
@@ -330,7 +330,7 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
                 session.Events.StartStream(Guid.NewGuid(), new Bug4953GapEvent(viewId, i + 1));
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         var (conn, tx, seq) = await startOutstandingAppend(); // seq 9 in flight
@@ -345,7 +345,7 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
                     session.Events.StartStream(Guid.NewGuid(), new Bug4953GapEvent(viewId, 10 + i));
                 }
 
-                await session.SaveChangesAsync(); // seqs 10..12 committed
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken); // seqs 10..12 committed
             }
 
             using var daemon = await StartDaemon();
@@ -355,7 +355,7 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
             {
                 await Task.Delay(2000);
                 await tx.CommitAsync();
-            });
+            }, TestContext.Current.CancellationToken);
 
             await daemon.RebuildProjectionAsync<Bug4953GapView>(CancellationToken.None);
             await release;
@@ -364,7 +364,7 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
 
             var persisted = await scalar($"select count(*) from {Schema}.mt_events");
             await using var query = theStore.QuerySession();
-            var views = await query.Query<Bug4953GapView>().ToListAsync();
+            var views = await query.Query<Bug4953GapView>().ToListAsync(TestContext.Current.CancellationToken);
             var projectedSequences = views.SelectMany(x => x.Sequences).OrderBy(x => x).ToArray();
 
             _output.WriteLine($"persisted={persisted}, projected=[{string.Join(",", projectedSequences)}]");
@@ -422,9 +422,9 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
                 await using var session = theStore.LightweightSession();
                 session.Events.StartStream(Guid.NewGuid(), new Bug4953GapEvent(viewId, 0));
                 await session.SaveChangesAsync();
-            });
+            }, TestContext.Current.CancellationToken);
 
-            await Task.Delay(300);
+            await Task.Delay(300, TestContext.Current.CancellationToken);
 
             // meanwhile 60 later events commit normally
             for (var i = 0; i < 20; i++)
@@ -433,7 +433,7 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
                 session.Events.StartStream(Guid.NewGuid(), new Bug4953GapEvent(viewId, i + 1));
                 session.Events.StartStream(Guid.NewGuid(), new Bug4953GapEvent(viewId, 100 + i));
                 session.Events.StartStream(Guid.NewGuid(), new Bug4953GapEvent(viewId, 200 + i));
-                await session.SaveChangesAsync();
+                await session.SaveChangesAsync(TestContext.Current.CancellationToken);
             }
 
             await slowAppend;
@@ -442,7 +442,7 @@ from {Schema}.mt_events where seq_id = 1").ExecuteNonQueryAsync();
 
             var persisted = await scalar($"select count(*) from {Schema}.mt_events");
             await using var query = theStore.QuerySession();
-            var views = await query.Query<Bug4953GapView>().ToListAsync();
+            var views = await query.Query<Bug4953GapView>().ToListAsync(TestContext.Current.CancellationToken);
             var projected = views.SelectMany(x => x.Sequences).Count();
 
             _output.WriteLine($"persisted={persisted}, projected={projected}");

--- a/src/DaemonTests/Bugs/Bug_deletewhere_should_remove_inserted_item.cs
+++ b/src/DaemonTests/Bugs/Bug_deletewhere_should_remove_inserted_item.cs
@@ -46,7 +46,7 @@ public class Bug_DeleteWhere_Operations_Should_Respect_Tenancy : BugIntegrationC
         session.Events.StartStream(createNormal);
         session.Events.StartStream(createHard);
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var createdProjections = await session.LoadManyAsync<DeletableProjection>(createNormal.Id, createHard.Id);
         Assert.Equal(2, createdProjections.Count);
@@ -54,19 +54,19 @@ public class Bug_DeleteWhere_Operations_Should_Respect_Tenancy : BugIntegrationC
         session.Events.StartStream(deleteNormal);
         session.Events.StartStream(deleteHard);
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var normalDeleteInline = await session.LoadAsync<DeletableProjection>(createNormal.Id);
-        var hardDeleteInline = await session.LoadAsync<DeletableProjection>(createHard.Id);
+        var normalDeleteInline = await session.LoadAsync<DeletableProjection>(createNormal.Id, TestContext.Current.CancellationToken);
+        var hardDeleteInline = await session.LoadAsync<DeletableProjection>(createHard.Id, TestContext.Current.CancellationToken);
         Assert.Null(normalDeleteInline);
         Assert.Null(hardDeleteInline);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
 
-        await daemon.RebuildProjectionAsync<DeletableEventProjection>(default);
+        await daemon.RebuildProjectionAsync<DeletableEventProjection>(TestContext.Current.CancellationToken);
 
-        var normalDeleteRebuilt = await session.LoadAsync<DeletableProjection>(createNormal.Id);
-        var hardDeleteRebuilt = await session.LoadAsync<DeletableProjection>(createHard.Id);
+        var normalDeleteRebuilt = await session.LoadAsync<DeletableProjection>(createNormal.Id, TestContext.Current.CancellationToken);
+        var hardDeleteRebuilt = await session.LoadAsync<DeletableProjection>(createHard.Id, TestContext.Current.CancellationToken);
         Assert.Null(normalDeleteRebuilt);
         Assert.Null(hardDeleteRebuilt);
     }

--- a/src/DaemonTests/Bugs/Bug_projection_base_settings_must_be_used_by_deamon.cs
+++ b/src/DaemonTests/Bugs/Bug_projection_base_settings_must_be_used_by_deamon.cs
@@ -35,9 +35,9 @@ public class Bug_projection_base_settings_must_be_used_by_deamon : BugIntegratio
 
         var aggId = Guid.NewGuid();
         theSession.Events.Append(aggId, new EventA(), new EventB());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
         theSession.Events.ArchiveStream(aggId);
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var deamon = await theStore.BuildProjectionDaemonAsync();
         await deamon.StartAllAsync();

--- a/src/DaemonTests/Bugs/Bug_sequential_rebuilds_throws_internally.cs
+++ b/src/DaemonTests/Bugs/Bug_sequential_rebuilds_throws_internally.cs
@@ -33,7 +33,7 @@ public partial class Bug_sequential_rebuilds_throws_internally: BugIntegrationCo
         theSession.Events.StartStream(stream,
             new CreatedEvent(Guid.NewGuid(), Guid.NewGuid().ToString()));
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var events = new List<UpdatedEvent>();
 
@@ -43,16 +43,16 @@ public partial class Bug_sequential_rebuilds_throws_internally: BugIntegrationCo
         }
 
         theSession.Events.Append(stream, events);
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var logger = _output.BuildLogger();
         using var daemon1 = await theStore.BuildProjectionDaemonAsync(logger: logger);
 
-        await daemon1.RebuildProjectionAsync("Bug_sequential_rebuilds_throws_internally.RandomProjection", default);
+        await daemon1.RebuildProjectionAsync("Bug_sequential_rebuilds_throws_internally.RandomProjection", TestContext.Current.CancellationToken);
 
         await daemon1.StopAllAsync();
 
-        await daemon1.RebuildProjectionAsync("Bug_sequential_rebuilds_throws_internally.RandomProjection", default);
+        await daemon1.RebuildProjectionAsync("Bug_sequential_rebuilds_throws_internally.RandomProjection", TestContext.Current.CancellationToken);
 
         await daemon1.StopAllAsync();
 

--- a/src/DaemonTests/Composites/Bug_4093_archived_in_composite_projections.cs
+++ b/src/DaemonTests/Composites/Bug_4093_archived_in_composite_projections.cs
@@ -58,7 +58,7 @@ public class Bug_4093_archived_in_composite_projections : DaemonContext
             // Baz stream with only its own events — Baz should have a doc, stream should NOT be archived
             session.Events.StartStream<Bug4093BazDoc>(bazStreamId, new Bug4093BazStarted());
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
@@ -68,14 +68,14 @@ public class Bug_4093_archived_in_composite_projections : DaemonContext
         await using var query = theStore.QuerySession();
 
         // Foo's doc exists and its stream is archived.
-        var foo = await query.LoadAsync<Bug4093FooDoc>(fooStreamId);
+        var foo = await query.LoadAsync<Bug4093FooDoc>(fooStreamId, TestContext.Current.CancellationToken);
         foo.ShouldNotBeNull();
 
         // Baz's doc exists for its own stream; it should NOT have a doc for the Foo stream.
-        var baz = await query.LoadAsync<Bug4093BazDoc>(bazStreamId);
+        var baz = await query.LoadAsync<Bug4093BazDoc>(bazStreamId, TestContext.Current.CancellationToken);
         baz.ShouldNotBeNull();
 
-        var phantomBaz = await query.LoadAsync<Bug4093BazDoc>(fooStreamId);
+        var phantomBaz = await query.LoadAsync<Bug4093BazDoc>(fooStreamId, TestContext.Current.CancellationToken);
         phantomBaz.ShouldBeNull(
             "Baz does not own the Foo stream; it must not have a doc under that id");
     }

--- a/src/DaemonTests/Composites/Bug_4329_fan_out_and_cache_limit.cs
+++ b/src/DaemonTests/Composites/Bug_4329_fan_out_and_cache_limit.cs
@@ -152,13 +152,13 @@ public class Bug_4329_fan_out_and_cache_limit: BugIntegrationContext
         var orderId = Guid.NewGuid();
         theSession.Events.StartStream<OrderSummary>(orderId, new OrderPlacedWithLineItems(productIds));
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
         await daemon.WaitForNonStaleData(30.Seconds());
 
-        var summary = await theSession.LoadAsync<OrderSummary>(orderId);
+        var summary = await theSession.LoadAsync<OrderSummary>(orderId, TestContext.Current.CancellationToken);
         summary.ShouldNotBeNull();
         summary.Lines.Count.ShouldBe(5);
         summary.Lines.Select(x => x.Sku).OrderBy(x => x).ShouldBe(skus.OrderBy(x => x));
@@ -198,13 +198,13 @@ public class Bug_4329_fan_out_and_cache_limit: BugIntegrationContext
         var orderId = Guid.NewGuid();
         theSession.Events.StartStream<OrderSummary>(orderId, new OrderPlacedWithLineItems(productIds));
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
         await daemon.WaitForNonStaleData(30.Seconds());
 
-        var summary = await theSession.LoadAsync<OrderSummary>(orderId);
+        var summary = await theSession.LoadAsync<OrderSummary>(orderId, TestContext.Current.CancellationToken);
         summary.ShouldNotBeNull();
         summary.Lines.Count.ShouldBe(productCount);
     }

--- a/src/DaemonTests/Composites/Bug_4329_try_find_upstream_cache.cs
+++ b/src/DaemonTests/Composites/Bug_4329_try_find_upstream_cache.cs
@@ -139,13 +139,13 @@ public class Bug_4329_try_find_upstream_cache: BugIntegrationContext
         theSession.Events.StartStream<Order>(orderId,
             new OrderPlaced(customerId, 99.95m),
             new OrderShipped("UPS"));
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
         await daemon.WaitForNonStaleData(30.Seconds());
 
-        var notification = await theSession.LoadAsync<OrderShippingNotification>(orderId);
+        var notification = await theSession.LoadAsync<OrderShippingNotification>(orderId, TestContext.Current.CancellationToken);
         notification.ShouldNotBeNull();
         notification.CustomerId.ShouldBe(customerId);
         notification.OrderTotal.ShouldBe(99.95m);

--- a/src/DaemonTests/Composites/Feature_4284_composite_projection_with_services.cs
+++ b/src/DaemonTests/Composites/Feature_4284_composite_projection_with_services.cs
@@ -37,28 +37,28 @@ public class Feature_4284_composite_projection_with_services
                     })
                     .ApplyAllDatabaseChangesOnStartup();
             })
-            .StartAsync();
+            .StartAsync(TestContext.Current.CancellationToken);
 
         var store = host.Services.GetRequiredService<IDocumentStore>();
-        await store.Advanced.Clean.CompletelyRemoveAllAsync();
+        await store.Advanced.Clean.CompletelyRemoveAllAsync(TestContext.Current.CancellationToken);
 
         await using var session = store.LightweightSession();
         var streamId = session.Events.StartStream<CompositeProduct>(
             new CompositeProductRegistered("Ankle Socks", "Socks")).Id;
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await store.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
         await daemon.WaitForNonStaleData(10.Seconds());
         await daemon.StopAllAsync();
 
-        var product = await session.LoadAsync<CompositeProduct>(streamId);
+        var product = await session.LoadAsync<CompositeProduct>(streamId, TestContext.Current.CancellationToken);
         product.ShouldNotBeNull();
         product.Name.ShouldBe("Ankle Socks");
         product.Category.ShouldBe("Socks");
         product.Price.ShouldBe(12.5);
 
-        var metric = await session.LoadAsync<CompositeProductMetric>(streamId);
+        var metric = await session.LoadAsync<CompositeProductMetric>(streamId, TestContext.Current.CancellationToken);
         metric.ShouldNotBeNull();
         metric.Price.ShouldBe(12.5);
     }

--- a/src/DaemonTests/Composites/composite_rebuild_suppresses_side_effects.cs
+++ b/src/DaemonTests/Composites/composite_rebuild_suppresses_side_effects.cs
@@ -47,8 +47,8 @@ public class composite_rebuild_suppresses_side_effects: DaemonContext
             });
         }, true);
 
-        await theStore.Advanced.Clean.DeleteAllDocumentsAsync();
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllDocumentsAsync(TestContext.Current.CancellationToken);
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
@@ -61,13 +61,13 @@ public class composite_rebuild_suppresses_side_effects: DaemonContext
             theSession.Events.StartStream<CsCounter>(id, new CsLeg(), new CsLeg(), new CsLeg());
         }
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await daemon.WaitForNonStaleData(30.Seconds());
 
         // Both stages materialized
-        (await theSession.Query<CsCounter>().CountAsync()).ShouldBe(10);
-        (await theSession.Query<CsNotice>().CountAsync()).ShouldBe(10);
+        (await theSession.Query<CsCounter>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(10);
+        (await theSession.Query<CsNotice>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(10);
 
         // The stage-2 member published a CsNoticed message per stream during continuous operation
         var publishedDuringContinuous = outbox.PublishedMessages.OfType<CsNoticed>().Count();
@@ -81,8 +81,8 @@ public class composite_rebuild_suppresses_side_effects: DaemonContext
         await daemon.RebuildProjectionAsync("SideEffectComposite", 60.Seconds(), CancellationToken.None);
 
         // The rebuild re-derived the read models...
-        (await theSession.Query<CsCounter>().CountAsync()).ShouldBe(10);
-        (await theSession.Query<CsNotice>().CountAsync()).ShouldBe(10);
+        (await theSession.Query<CsCounter>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(10);
+        (await theSession.Query<CsNotice>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(10);
 
         // ...but published NO additional side-effect messages. Before the #4729 fix the composite
         // members ran in Continuous mode during the rebuild and re-published all 10 CsNoticed messages.

--- a/src/DaemonTests/Composites/composite_single_pass_rebuild.cs
+++ b/src/DaemonTests/Composites/composite_single_pass_rebuild.cs
@@ -71,9 +71,9 @@ public class composite_single_pass_rebuild : DaemonContext
         // Every member's documents are correct after the single-pass rebuild —
         // the headline document-level correctness signal that couldn't live in
         // JasperFx.Events (no concrete event store there).
-        var trips = await theSession.Query<Trip>().ToListAsync();
-        var days = await theSession.Query<Day>().ToListAsync();
-        var metrics = await theSession.Query<TripMetrics>().ToListAsync();
+        var trips = await theSession.Query<Trip>().ToListAsync(TestContext.Current.CancellationToken);
+        var days = await theSession.Query<Day>().ToListAsync(TestContext.Current.CancellationToken);
+        var metrics = await theSession.Query<TripMetrics>().ToListAsync(TestContext.Current.CancellationToken);
 
         trips.Count.ShouldBe(NumberOfStreams,
             "the TripProjection stage wrote one document per stream");
@@ -86,7 +86,7 @@ public class composite_single_pass_rebuild : DaemonContext
         // shard {Name}:All — CompositeReplayExecutor calls
         // controller.MarkSuccessAsync(ceiling) per page and the composite shard
         // owns the row, not any of the members.
-        var progressions = await theStore.Advanced.AllProjectionProgress();
+        var progressions = await theStore.Advanced.AllProjectionProgress(token: TestContext.Current.CancellationToken);
         var compositeProgression = progressions.SingleOrDefault(x => x.ShardName == "TripsRebuild:All");
         compositeProgression.ShouldNotBeNull(
             "Composite single shard must have a progression row at the end of the rebuild");

--- a/src/DaemonTests/Composites/end_to_end_with_composite_projection.cs
+++ b/src/DaemonTests/Composites/end_to_end_with_composite_projection.cs
@@ -101,7 +101,7 @@ public class end_to_end_with_composite_projection : DaemonContext
         // so that's all good!
         await CheckAllExpectedAggregatesAgainstActuals();
 
-        var days = await theSession.Query<Day>().ToListAsync();
+        var days = await theSession.Query<Day>().ToListAsync(TestContext.Current.CancellationToken);
         var expected = Streams.SelectMany(x => x.Events).OfType<IDayEvent>().Select(x => x.Day)
             .Distinct().ToArray();
 
@@ -112,22 +112,22 @@ public class end_to_end_with_composite_projection : DaemonContext
         }
 
         // Verify the custom IProjection was executed within the composite
-        var tripMetrics = await theSession.Query<TripMetrics>().ToListAsync();
+        var tripMetrics = await theSession.Query<TripMetrics>().ToListAsync(TestContext.Current.CancellationToken);
         tripMetrics.Count.ShouldBeGreaterThan(0);
         tripMetrics.Any(m => m.TotalStarted > 0).ShouldBeTrue();
 
 
         // Persist all of the progressions of the constituent parts
-        var progressions = await theStore.Advanced.AllProjectionProgress();
+        var progressions = await theStore.Advanced.AllProjectionProgress(token: TestContext.Current.CancellationToken);
         progressions.Single(x => x.ShardName == "Trips:All").Sequence.ShouldBe(NumberOfEvents);
         progressions.Single(x => x.ShardName == "Trip:All").Sequence.ShouldBe(NumberOfEvents);
         progressions.Single(x => x.ShardName == "Day:All").Sequence.ShouldBe(NumberOfEvents);
 
-        var trips = await theSession.Query<Trip>().ToListAsync();
+        var trips = await theSession.Query<Trip>().ToListAsync(TestContext.Current.CancellationToken);
 
         var persisted = trips[0];
-        var latest = await theSession.Events.FetchLatest<Trip>(persisted.Id);
-        var stream = await theSession.Events.FetchForWriting<Trip>(persisted.Id);
+        var latest = await theSession.Events.FetchLatest<Trip>(persisted.Id, TestContext.Current.CancellationToken);
+        var stream = await theSession.Events.FetchForWriting<Trip>(persisted.Id, TestContext.Current.CancellationToken);
 
         latest.ShouldBe(persisted);
         stream.Aggregate.ShouldBe(persisted);

--- a/src/DaemonTests/Composites/multi_stage_projections.cs
+++ b/src/DaemonTests/Composites/multi_stage_projections.cs
@@ -313,6 +313,12 @@ public class multi_stage_projections(ITestOutputHelper output): DaemonContext(ou
             boardSummary.Board.ShouldNotBeNull();
         }
 
+        // This block is pulled into docs/events/projections/read-aggregates.md, so it stays
+        // free of TestContext.Current.CancellationToken -- threading a test-only cancellation
+        // token here would publish it to users as if it were guidance (#5067). The pragma sits
+        // OUTSIDE the region markers on purpose: anything inside them lands in the docs.
+#pragma warning disable xUnit1051
+
         #region sample_querying_for_non_stale_projection_data
 
         // _compositeSession is an IDocumentSession
@@ -321,9 +327,11 @@ public class multi_stage_projections(ITestOutputHelper output): DaemonContext(ou
             // is building the BoardSummary document to catch up to the point at which the
             // event store was at when you first tired to execute the LINQ query
             .QueryForNonStaleData<BoardSummary>(10.Seconds())
-            .ToListAsync(TestContext.Current.CancellationToken);
+            .ToListAsync();
 
         #endregion
+
+#pragma warning restore xUnit1051
 
         summaries.Count.ShouldBe(12);
 

--- a/src/DaemonTests/Composites/multi_stage_projections.cs
+++ b/src/DaemonTests/Composites/multi_stage_projections.cs
@@ -284,31 +284,31 @@ public class multi_stage_projections(ITestOutputHelper output): DaemonContext(ou
         await daemon.WaitForNonStaleData(30.Seconds());
 
         // All the Boards exist
-        (await _compositeSession.Query<Board>().CountAsync()).ShouldBe(12);
+        (await _compositeSession.Query<Board>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(12);
 
         // Built up ProviderShifts
-        (await _compositeSession.Query<ProviderShift>().CountAsync()).ShouldBeGreaterThan(0);
+        (await _compositeSession.Query<ProviderShift>().CountAsync(TestContext.Current.CancellationToken)).ShouldBeGreaterThan(0);
 
         await startAppointments();
         await daemon.WaitForNonStaleData(30.Seconds());
 
         // Got appointments
-        (await _compositeSession.Query<Appointment>().CountAsync()).ShouldBeGreaterThan(0);
+        (await _compositeSession.Query<Appointment>().CountAsync(TestContext.Current.CancellationToken)).ShouldBeGreaterThan(0);
 
         // Verify the custom IProjection counted appointment requests by specialty
-        var appointmentMetrics = await _compositeSession.Query<AppointmentMetrics>().ToListAsync();
+        var appointmentMetrics = await _compositeSession.Query<AppointmentMetrics>().ToListAsync(TestContext.Current.CancellationToken);
         appointmentMetrics.Count.ShouldBeGreaterThan(0);
         appointmentMetrics.ShouldAllBe(m => m.Count > 0);
 
         // Got details from the 2nd stage projection!
-        (await _compositeSession.Query<AppointmentDetails>().CountAsync()).ShouldBeGreaterThan(0);
-        (await _compositeSession.Query<AppointmentByExternalIdentifier>().CountAsync()).ShouldBeGreaterThan(0);
+        (await _compositeSession.Query<AppointmentDetails>().CountAsync(TestContext.Current.CancellationToken)).ShouldBeGreaterThan(0);
+        (await _compositeSession.Query<AppointmentByExternalIdentifier>().CountAsync(TestContext.Current.CancellationToken)).ShouldBeGreaterThan(0);
 
-        (await _compositeSession.Query<AppointmentDetails>().Where(x => x.RoutingReasonDescription != null).AnyAsync()).ShouldBeTrue();
+        (await _compositeSession.Query<AppointmentDetails>().Where(x => x.RoutingReasonDescription != null).AnyAsync(TestContext.Current.CancellationToken)).ShouldBeTrue();
 
         // See the downstream BoardSummary too!
-        (await _compositeSession.Query<BoardSummary>().CountAsync()).ShouldBeGreaterThan(0);
-        foreach (var boardSummary in await _compositeSession.Query<BoardSummary>().ToListAsync())
+        (await _compositeSession.Query<BoardSummary>().CountAsync(TestContext.Current.CancellationToken)).ShouldBeGreaterThan(0);
+        foreach (var boardSummary in await _compositeSession.Query<BoardSummary>().ToListAsync(TestContext.Current.CancellationToken))
         {
             boardSummary.Board.ShouldNotBeNull();
         }
@@ -321,7 +321,7 @@ public class multi_stage_projections(ITestOutputHelper output): DaemonContext(ou
             // is building the BoardSummary document to catch up to the point at which the
             // event store was at when you first tired to execute the LINQ query
             .QueryForNonStaleData<BoardSummary>(10.Seconds())
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         #endregion
 
@@ -338,15 +338,15 @@ public class multi_stage_projections(ITestOutputHelper output): DaemonContext(ou
 
         await daemon.StartAllAsync();
         // Now, let's cancel an appointment and see that AppointmentDetails is also deleted
-        var appointmentId = (await _compositeSession.Query<Appointment>().FirstAsync()).Id;
+        var appointmentId = (await _compositeSession.Query<Appointment>().FirstAsync(TestContext.Current.CancellationToken)).Id;
 
         _compositeSession.Events.Append(appointmentId, new AppointmentCancelled());
-        await _compositeSession.SaveChangesAsync();
+        await _compositeSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await theStore.WaitForNonStaleProjectionDataAsync(5.Seconds());
 
-        (await _compositeSession.LoadAsync<Appointment>(appointmentId)).ShouldBeNull();
-        (await _compositeSession.LoadAsync<AppointmentDetails>(appointmentId)).ShouldBeNull();
+        (await _compositeSession.LoadAsync<Appointment>(appointmentId, TestContext.Current.CancellationToken)).ShouldBeNull();
+        (await _compositeSession.LoadAsync<AppointmentDetails>(appointmentId, TestContext.Current.CancellationToken)).ShouldBeNull();
 
 
 
@@ -402,8 +402,8 @@ public class multi_stage_projections(ITestOutputHelper output): DaemonContext(ou
 
         // The downstream lookup-by-id projection should be fully populated, even
         // though the upstream cache is squeezed to 1 entry.
-        (await _compositeSession.Query<Appointment>().CountAsync()).ShouldBeGreaterThan(0);
-        (await _compositeSession.Query<AppointmentByExternalIdentifier>().CountAsync()).ShouldBeGreaterThan(0);
+        (await _compositeSession.Query<Appointment>().CountAsync(TestContext.Current.CancellationToken)).ShouldBeGreaterThan(0);
+        (await _compositeSession.Query<AppointmentByExternalIdentifier>().CountAsync(TestContext.Current.CancellationToken)).ShouldBeGreaterThan(0);
     }
 
     private static void verifyDescription(EventStoreUsage usage)

--- a/src/DaemonTests/DaemonTests.csproj
+++ b/src/DaemonTests/DaemonTests.csproj
@@ -2,6 +2,12 @@
 
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
+
+        <!-- This suite has been swept for xUnit1051 (#5067): every call that accepts a
+             CancellationToken is handed TestContext.Current.CancellationToken, so a hung
+             daemon test is cancelled and reported instead of hanging until CI's own timeout.
+             Keeping the rule ON guards the sweep. Must be set before Tests.props is imported. -->
+        <ThreadTestCancellationToken>true</ThreadTestCancellationToken>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Bogus" />

--- a/src/DaemonTests/EventProjections/EventProjectionWithCreate_follow_up_operations.cs
+++ b/src/DaemonTests/EventProjections/EventProjectionWithCreate_follow_up_operations.cs
@@ -23,15 +23,15 @@ public partial class EventProjectionWithCreate_follow_up_operations: DaemonConte
         await using var session = theStore.IdentitySession();
 
         session.Events.StartStream(entityId, new EntityCreated(entityId, "Some name"));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         session.Events.Append(entityId, new EntityNameUpdated(entityId, "New name"));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var agent = await StartDaemon();
 
         await agent.RebuildProjectionAsync(nameof(EntityProjection), CancellationToken.None);
 
-        var shoppingCartRebuilt = await session.LoadAsync<Entity>(entityId);
+        var shoppingCartRebuilt = await session.LoadAsync<Entity>(entityId, TestContext.Current.CancellationToken);
 
         shoppingCartRebuilt!.Id.ShouldBe(entityId);
         shoppingCartRebuilt.Name.ShouldBe("New name");
@@ -49,15 +49,15 @@ public partial class EventProjectionWithCreate_follow_up_operations: DaemonConte
         await using var session = theStore.IdentitySession();
 
         session.Events.StartStream(entityId, new EntityCreated(entityId, "Some name"));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         session.Events.Append(entityId, new EntityNameUpdated(entityId, "New name"));
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var daemon = await StartDaemon();
 
         await daemon.Tracker.WaitForShardState($"{nameof(EntityProjection)}:All", 2);
 
-        var entity = await session.LoadAsync<Entity>(entityId);
+        var entity = await session.LoadAsync<Entity>(entityId, TestContext.Current.CancellationToken);
 
         entity.ShouldNotBeNull();
 

--- a/src/DaemonTests/EventProjections/EventProjection_follow_up_operations.cs
+++ b/src/DaemonTests/EventProjections/EventProjection_follow_up_operations.cs
@@ -37,7 +37,7 @@ public partial class EventProjection_follow_up_operations: DaemonContext
 
         session.Events.Append(guid, new SomeOtherEntityWithNestedIdentifierPublished(guid));
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var agent = await StartDaemon();
 

--- a/src/DaemonTests/EventProjections/event_projection_scenario_tests.cs
+++ b/src/DaemonTests/EventProjections/event_projection_scenario_tests.cs
@@ -42,7 +42,7 @@ public class event_projection_scenario_tests : OneOffConfigurationsContext
             scenario.DocumentShouldNotExist<User>(id2);
             scenario.DocumentShouldExist<User>(id3);
 
-        });
+        }, TestContext.Current.CancellationToken);
     }
     [Fact]
     public async Task happy_path_test_with_inline_projection_multi_tenanted()
@@ -76,7 +76,7 @@ public class event_projection_scenario_tests : OneOffConfigurationsContext
             scenario.DocumentShouldNotExist<User>(id2);
             scenario.DocumentShouldExist<User>(id3);
 
-        });
+        }, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -88,16 +88,16 @@ public class event_projection_scenario_tests : OneOffConfigurationsContext
             opts.Events.TenancyStyle = TenancyStyle.Conjoined;
         });
 
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
         var id = Guid.NewGuid();
 
         await theStore.Advanced.EventProjectionScenario(scenario =>
         {
             scenario.Append(id, new CreateUser { UserId = id, UserName = "Kareem" });
             scenario.DocumentShouldNotExist<User>(id);
-        });
+        }, TestContext.Current.CancellationToken);
 
-        var user = await theSession.Events.AggregateStreamAsync<LiveUser>(id);
+        var user = await theSession.Events.AggregateStreamAsync<LiveUser>(id, token: TestContext.Current.CancellationToken);
         user.ShouldNotBeNull();
         user.UserName.ShouldBe("Kareem");
     }
@@ -177,7 +177,7 @@ public class event_projection_scenario_tests : OneOffConfigurationsContext
             opts.Projections.Add(new UserProjection(), ProjectionLifecycle.Inline);
         });
 
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         await theStore.Advanced.EventProjectionScenario(scenario =>
         {
@@ -199,7 +199,7 @@ public class event_projection_scenario_tests : OneOffConfigurationsContext
             scenario.DocumentShouldNotExist<User>(id2);
             scenario.DocumentShouldExist<User>(id3);
 
-        });
+        }, TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/src/DaemonTests/EventProjections/using_custom_projection_that_depends_on_identity_map_behavior.cs
+++ b/src/DaemonTests/EventProjections/using_custom_projection_that_depends_on_identity_map_behavior.cs
@@ -38,7 +38,7 @@ public class using_custom_projection_that_depends_on_identity_map_behavior: Daem
                 }));
         session.Events.Append(Guid.NewGuid(), new SomeOtherEntityWithNestedIdentifierPublished(guid));
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var agent = await StartDaemon();
 

--- a/src/DaemonTests/EventProjections/using_patches_in_async_mode.cs
+++ b/src/DaemonTests/EventProjections/using_patches_in_async_mode.cs
@@ -37,17 +37,17 @@ public class using_patches_in_async_mode : OneOffConfigurationsContext
             theSession.Events.StartStream<SimpleAggregate>(new StartAggregate(), new MTAEvent(), new MTAEvent(), new MTBEvent());
         }
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
         await daemon.WaitForNonStaleData(20.Seconds());
 
-        var aggregate1 = await theSession.LoadAsync<SimpleAggregate>(id1);
+        var aggregate1 = await theSession.LoadAsync<SimpleAggregate>(id1, TestContext.Current.CancellationToken);
         aggregate1.ACount.ShouldBe(2);
         aggregate1.BCount.ShouldBe(1);
 
-        var aggregate2 = await theSession.LoadAsync<SimpleAggregate>(id2);
+        var aggregate2 = await theSession.LoadAsync<SimpleAggregate>(id2, TestContext.Current.CancellationToken);
         aggregate2.CCount.ShouldBe(2);
 
 

--- a/src/DaemonTests/FlatTableProjections/end_to_end_with_flat_table_projections.cs
+++ b/src/DaemonTests/FlatTableProjections/end_to_end_with_flat_table_projections.cs
@@ -21,7 +21,7 @@ public class end_to_end_with_flat_table_projections : DaemonContext
         var streamId = Guid.NewGuid();
         theSession.Events.Append(streamId, new EventSourcingTests.Projections.Flattened.ValuesSet { A = 10, B = 10, C = 10, D = 10 });
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var valuesSubtracted = new EventSourcingTests.Projections.Flattened.ValuesSubtracted
         {
@@ -35,7 +35,7 @@ public class end_to_end_with_flat_table_projections : DaemonContext
 
         theSession.Events.Append(streamId, valuesSubtracted, valuesSubtracted2);
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
 

--- a/src/DaemonTests/Internals/Bug_4744_skip_ahead_min_query_joins_streams.cs
+++ b/src/DaemonTests/Internals/Bug_4744_skip_ahead_min_query_joins_streams.cs
@@ -25,11 +25,11 @@ public class Bug_4744_skip_ahead_min_query_joins_streams: OneOffConfigurationsCo
     [Fact]
     public async Task skip_ahead_probe_joins_streams_when_filtering_on_aggregate_type()
     {
-        await theStore.Advanced.Clean.DeleteAllEventDataAsync();
+        await theStore.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
 
         var streamId = Guid.NewGuid();
         theSession.Events.StartStream<Letters>(streamId, new MTAEvent(), new MTBEvent(), new MTCEvent());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var filters = new ISqlFragment[]
         {

--- a/src/DaemonTests/Internals/HighWaterAgentTests.cs
+++ b/src/DaemonTests/Internals/HighWaterAgentTests.cs
@@ -95,10 +95,10 @@ public class HighWaterAgentTests: DaemonContext
 
         using (var conn = theStore.Storage.Database.CreateConnection())
         {
-            await conn.OpenAsync();
+            await conn.OpenAsync(TestContext.Current.CancellationToken);
 
             // 32 is a magic number, that's the page size of the PostgreSQL sequence size
-            await conn.CreateCommand($"SELECT setval('daemon.mt_events_sequence', {NumberOfEvents + 37});").ExecuteNonQueryAsync();
+            await conn.CreateCommand($"SELECT setval('daemon.mt_events_sequence', {NumberOfEvents + 37});").ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
             await conn.CloseAsync();
         }
 

--- a/src/DaemonTests/Internals/basic_functionality.cs
+++ b/src/DaemonTests/Internals/basic_functionality.cs
@@ -97,21 +97,21 @@ public class basic_functionality: DaemonContext
 
         await daemon.StopAllAsync();
 
-        var highest = (await theStore.Advanced.AllProjectionProgress()).First().Sequence;
+        var highest = (await theStore.Advanced.AllProjectionProgress(token: TestContext.Current.CancellationToken)).First().Sequence;
 
         using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
 
         await conn.CreateCommand(
                 $"update {theStore.Options.DatabaseSchemaName}.mt_event_progression set last_seq_id = :seq")
             .With("seq", highest + 100)
-            .ExecuteNonQueryAsync();
+            .ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
 
         await conn.CloseAsync();
 
         await theStore.Advanced.TryCorrectProgressInDatabaseAsync(CancellationToken.None);
 
-        var stats = await theStore.Advanced.AllProjectionProgress();
+        var stats = await theStore.Advanced.AllProjectionProgress(token: TestContext.Current.CancellationToken);
         foreach (var shardState in stats)
         {
             shardState.Sequence.ShouldBe(highest);
@@ -247,7 +247,7 @@ public class basic_functionality: DaemonContext
         NumberOfStreams = 10;
         await PublishSingleThreaded();
 
-        var statistics = await theStore.Advanced.FetchEventStoreStatistics();
+        var statistics = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
 
         statistics.EventCount.ShouldBe(NumberOfEvents);
         statistics.StreamCount.ShouldBe(NumberOfStreams);
@@ -260,7 +260,7 @@ public class basic_functionality: DaemonContext
         NumberOfStreams = 100;
         await PublishMultiThreaded(10);
 
-        var statistics = await theStore.Advanced.FetchEventStoreStatistics();
+        var statistics = await theStore.Advanced.FetchEventStoreStatistics(token: TestContext.Current.CancellationToken);
 
         statistics.EventCount.ShouldBe(NumberOfEvents);
         statistics.StreamCount.ShouldBe(NumberOfStreams);

--- a/src/DaemonTests/Internals/detecting_the_high_water_mark.cs
+++ b/src/DaemonTests/Internals/detecting_the_high_water_mark.cs
@@ -80,7 +80,7 @@ public class HighWaterDetectorTests: DaemonContext
     public async Task second_run_detect_same_gap_when_stale(bool useAdvancedTracking)
     {
         StoreOptions(opts => opts.Events.EnableAdvancedAsyncTracking = useAdvancedTracking);
-        await theStore.EnsureStorageExistsAsync(typeof(IEvent));
+        await theStore.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         NumberOfStreams = 10;
         await PublishSingleThreaded();
@@ -105,7 +105,7 @@ public class HighWaterDetectorTests: DaemonContext
             opts.Events.EnableAdvancedAsyncTracking = useAdvancedTracking;
             opts.Projections.StaleSequenceThreshold = 500.Milliseconds();
         });
-        await theStore.EnsureStorageExistsAsync(typeof(IEvent));
+        await theStore.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         NumberOfStreams = 10;
         await PublishSingleThreaded();
@@ -127,7 +127,7 @@ public class HighWaterDetectorTests: DaemonContext
         var held = await theDetector.DetectInSafeZone(CancellationToken.None);
         held.CurrentMark.ShouldBe(NumberOfEvents - 101);
 
-        await Task.Delay(700);
+        await Task.Delay(700, TestContext.Current.CancellationToken);
 
         var statistics2 = await theDetector.DetectInSafeZone(CancellationToken.None);
 
@@ -145,7 +145,7 @@ public class HighWaterDetectorTests: DaemonContext
             opts.Events.EnableAdvancedAsyncTracking = useAdvancedTracking;
             opts.Projections.StaleSequenceThreshold = 500.Milliseconds();
         });
-        await theStore.EnsureStorageExistsAsync(typeof(IEvent));
+        await theStore.EnsureStorageExistsAsync(typeof(IEvent), TestContext.Current.CancellationToken);
 
         NumberOfStreams = 10;
         await PublishSingleThreaded();
@@ -160,7 +160,7 @@ public class HighWaterDetectorTests: DaemonContext
 
         statistics2.CurrentMark.ShouldBe(statistics.CurrentMark);
 
-        await Task.Delay(700);
+        await Task.Delay(700, TestContext.Current.CancellationToken);
 
         // Stuck past the threshold with no live transaction that could fill the tail: advance to the
         // reserved ceiling recorded when the gap was first observed — the whole dead tail, no magic -32
@@ -175,7 +175,7 @@ public class HighWaterDetectorTests: DaemonContext
         var statistics4 = await theDetector.DetectInSafeZone(CancellationToken.None);
         statistics4.CurrentMark.ShouldBe(statistics.CurrentMark + 20);
 
-        await Task.Delay(700);
+        await Task.Delay(700, TestContext.Current.CancellationToken);
 
         var statistics5 = await theDetector.DetectInSafeZone(CancellationToken.None);
         statistics5.CurrentMark.ShouldBe(statistics.CurrentMark + 40);

--- a/src/DaemonTests/Internals/fetching_events.cs
+++ b/src/DaemonTests/Internals/fetching_events.cs
@@ -74,7 +74,7 @@ public class fetching_events: OneOffConfigurationsContext, IAsyncLifetime
             e.Append(stream, new MTAEvent(), new MTBEvent(), new MTCEvent(), new MTDEvent());
         });
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         theRange.Events.Count.ShouldBe(4);
         var @event = theRange.Events[0];
@@ -94,7 +94,7 @@ public class fetching_events: OneOffConfigurationsContext, IAsyncLifetime
             e.Append(stream, new MTAEvent(), new MTBEvent(), new MTCEvent(), new MTDEvent());
         });
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         theRange.Events.Count.ShouldBe(4);
         var @event = theRange.Events[0];

--- a/src/DaemonTests/Internals/pausing_and_resuming_the_daemon.cs
+++ b/src/DaemonTests/Internals/pausing_and_resuming_the_daemon.cs
@@ -28,7 +28,7 @@ public class pausing_and_resuming_the_daemon
 
                     opts.Projections.Add<TestingSupport.TripProjection>(ProjectionLifecycle.Async);
                 }).AddAsyncDaemon(DaemonMode.Solo);
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         await host.PauseAllDaemonsAsync();
 
@@ -37,11 +37,11 @@ public class pausing_and_resuming_the_daemon
         await using var session = host.DocumentStore().LightweightSession();
         var id = session.Events.StartStream<TestingSupport.TripProjection>(new TripStarted()).Id;
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await host.WaitForNonStaleProjectionDataAsync(15.Seconds());
 
-        var trip = await session.LoadAsync<Trip>(id);
+        var trip = await session.LoadAsync<Trip>(id, TestContext.Current.CancellationToken);
         trip.ShouldNotBeNull();
     }
 }

--- a/src/DaemonTests/Internals/projection_progression_operations.cs
+++ b/src/DaemonTests/Internals/projection_progression_operations.cs
@@ -40,12 +40,12 @@ public class projection_progression_operations : OneOffConfigurationsContext, IA
         theSession.QueueOperation(operation1);
         theSession.QueueOperation(operation2);
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var progress1 = await theStore.Advanced.ProjectionProgressFor(new ShardName("one"));
+        var progress1 = await theStore.Advanced.ProjectionProgressFor(new ShardName("one"), token: TestContext.Current.CancellationToken);
         progress1.ShouldBe(12);
 
-        var progress2 = await theStore.Advanced.ProjectionProgressFor(new ShardName("two"));
+        var progress2 = await theStore.Advanced.ProjectionProgressFor(new ShardName("two"), token: TestContext.Current.CancellationToken);
         progress2.ShouldBe(25);
     }
 
@@ -56,15 +56,15 @@ public class projection_progression_operations : OneOffConfigurationsContext, IA
             new EventRange( new ShardName("three"), 12));
 
         theSession.QueueOperation(insertProjectionProgress);
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var updateProjectionProgress =
             new UpdateProjectionProgress(theStore.Events, new EventRange(new ShardName("three"), 12, 50, Substitute.For<ISubscriptionAgent>()));
 
         theSession.QueueOperation(updateProjectionProgress);
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("three"));
+        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("three"), token: TestContext.Current.CancellationToken);
         progress.ShouldBe(50);
     }
 
@@ -73,7 +73,7 @@ public class projection_progression_operations : OneOffConfigurationsContext, IA
     {
         var target = Target.Random();
         theSession.Store(target);
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var insertProjectionProgress = new InsertProjectionProgress(theStore.Events,
             new EventRange( new ShardName("three"), 12));
@@ -81,16 +81,16 @@ public class projection_progression_operations : OneOffConfigurationsContext, IA
 
         theSession.QueueOperation(insertProjectionProgress);
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var updateProjectionProgress =
             new UpdateProjectionProgress(theStore.Events, new EventRange(new ShardName("three"), 12, 50, Substitute.For<ISubscriptionAgent>()));
 
         theSession.QueueOperation(updateProjectionProgress);
         theSession.Delete(target);
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("three"));
+        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("three"), token: TestContext.Current.CancellationToken);
         progress.ShouldBe(50);
     }
 
@@ -101,7 +101,7 @@ public class projection_progression_operations : OneOffConfigurationsContext, IA
             new EventRange(new ShardName("four"), 12));
 
         theSession.QueueOperation(insertProjectionProgress);
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var updateProjectionProgress = new UpdateProjectionProgress(theStore.Events, new EventRange(new ShardName("four"), 5, 50, Substitute.For<ISubscriptionAgent>()));
 
@@ -114,7 +114,7 @@ public class projection_progression_operations : OneOffConfigurationsContext, IA
         ex.Message.ShouldContain("four");
 
         // Just verifying that the real progress didn't change
-        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("four"));
+        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("four"), token: TestContext.Current.CancellationToken);
         progress.ShouldBe(12);
     }
 
@@ -130,9 +130,9 @@ public class projection_progression_operations : OneOffConfigurationsContext, IA
         theSession.QueueOperation(operation1);
         theSession.QueueOperation(operation2);
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var progressions = await theStore.Advanced.AllProjectionProgress();
+        var progressions = await theStore.Advanced.AllProjectionProgress(token: TestContext.Current.CancellationToken);
 
         progressions.Any(x => x.ShardName == "five:All").ShouldBeTrue();
         progressions.Any(x => x.ShardName == "six:All").ShouldBeTrue();
@@ -141,7 +141,7 @@ public class projection_progression_operations : OneOffConfigurationsContext, IA
     [Fact]
     public async Task fetch_progress_does_not_exist_returns_0()
     {
-        var progress1 = await theStore.Advanced.ProjectionProgressFor(new ShardName("none"));
+        var progress1 = await theStore.Advanced.ProjectionProgressFor(new ShardName("none"), token: TestContext.Current.CancellationToken);
         progress1.ShouldBe(0);
     }
 

--- a/src/DaemonTests/MultiTenancy/multi_tenancy_by_database.cs
+++ b/src/DaemonTests/MultiTenancy/multi_tenancy_by_database.cs
@@ -149,23 +149,23 @@ public class multi_tenancy_by_database: IAsyncLifetime
 
         await using var session1 = theStore.LightweightSession("tenant1");
         session1.Events.Append(id, new MTAEvent(), new MTBEvent(), new MTBEvent());
-        await session1.SaveChangesAsync();
+        await session1.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await using var session3 = theStore.LightweightSession("tenant3");
         session3.Events.Append(id, new MTAEvent(), new MTAEvent(), new MTBEvent(), new MTBEvent());
-        await session3.SaveChangesAsync();
+        await session3.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await using var session4 = theStore.LightweightSession("tenant4");
         session4.Events.Append(id, new MTAEvent(), new MTBEvent(), new MTBEvent(), new MTBEvent());
-        await session4.SaveChangesAsync();
+        await session4.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await (await theStore.Storage.FindOrCreateDatabase("tenant1")).Tracker.WaitForShardState("AllGood:All", 3);
         await (await theStore.Storage.FindOrCreateDatabase("tenant3")).Tracker.WaitForShardState("AllGood:All", 4);
         await (await theStore.Storage.FindOrCreateDatabase("tenant4")).Tracker.WaitForShardState("AllGood:All", 4);
 
-        (await session1.LoadAsync<MyAggregate>(id)).ShouldBe(new MyAggregate { Id = id, ACount = 1, BCount = 2 });
-        (await session3.LoadAsync<MyAggregate>(id)).ShouldBe(new MyAggregate { Id = id, ACount = 2, BCount = 2 });
-        (await session4.LoadAsync<MyAggregate>(id)).ShouldBe(new MyAggregate { Id = id, ACount = 1, BCount = 3 });
+        (await session1.LoadAsync<MyAggregate>(id, TestContext.Current.CancellationToken)).ShouldBe(new MyAggregate { Id = id, ACount = 1, BCount = 2 });
+        (await session3.LoadAsync<MyAggregate>(id, TestContext.Current.CancellationToken)).ShouldBe(new MyAggregate { Id = id, ACount = 2, BCount = 2 });
+        (await session4.LoadAsync<MyAggregate>(id, TestContext.Current.CancellationToken)).ShouldBe(new MyAggregate { Id = id, ACount = 1, BCount = 3 });
     }
 }
 

--- a/src/DaemonTests/MultiTenancy/using_for_tenant_with_side_effects_and_subscriptions.cs
+++ b/src/DaemonTests/MultiTenancy/using_for_tenant_with_side_effects_and_subscriptions.cs
@@ -38,13 +38,13 @@ public class using_for_tenant_with_side_effects_and_subscriptions : OneOffConfig
 
         using var session = theStore.LightweightSession("green");
         session.Events.StartStream([new MTAEvent(), new MTBEvent(), new MTCEvent()]);
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
         await daemon.WaitForNonStaleData(5.Seconds());
 
-        var events = await theSession.Events.QueryAllRawEvents().Where(x => x.AnyTenant()).ToListAsync();
+        var events = await theSession.Events.QueryAllRawEvents().Where(x => x.AnyTenant()).ToListAsync(TestContext.Current.CancellationToken);
         events.Count.ShouldBe(6);
     }
 
@@ -61,13 +61,13 @@ public class using_for_tenant_with_side_effects_and_subscriptions : OneOffConfig
 
         using var session = theStore.LightweightSession("green");
         session.Events.StartStream([new MTAEvent(), new MTBEvent(), new MTCEvent()]);
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
         await daemon.StartAllAsync();
         await daemon.WaitForNonStaleData(5.Seconds());
 
-        var events = await theSession.Events.QueryAllRawEvents().Where(x => x.AnyTenant()).ToListAsync();
+        var events = await theSession.Events.QueryAllRawEvents().Where(x => x.AnyTenant()).ToListAsync(TestContext.Current.CancellationToken);
         events.Count.ShouldBe(6);
     }
 }

--- a/src/DaemonTests/Resiliency/dead_letter_count_read_tests.cs
+++ b/src/DaemonTests/Resiliency/dead_letter_count_read_tests.cs
@@ -49,7 +49,7 @@ public class dead_letter_count_read_tests : DaemonContext
 
         var events = theNames.Select(name => new NameEvent { Name = name }).OfType<object>().ToArray();
         theSession.Events.StartStream(Guid.NewGuid(), events);
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await daemon.Tracker.WaitForHighWaterMark(theNames.Length);
         await waiter1;
@@ -61,16 +61,16 @@ public class dead_letter_count_read_tests : DaemonContext
         var database = (IEventDatabase)theStore.Tenancy.Default.Database;
 
         // Bulk: one row per (ProjectionName, ShardKey)
-        var counts = await database.FetchDeadLetterCountsAsync();
+        var counts = await database.FetchDeadLetterCountsAsync(TestContext.Current.CancellationToken);
 
         counts.Single(x => x.ProjectionName == "NamedDocuments" && x.ShardKey == "All").Count.ShouldBe(6);
         counts.Single(x => x.ProjectionName == "CollateNames" && x.ShardKey == "All").Count.ShouldBe(4);
 
         // Per-shard
-        (await database.CountDeadLetterEventsAsync(new ShardName("NamedDocuments"))).ShouldBe(6);
-        (await database.CountDeadLetterEventsAsync(new ShardName("CollateNames"))).ShouldBe(4);
+        (await database.CountDeadLetterEventsAsync(new ShardName("NamedDocuments"), TestContext.Current.CancellationToken)).ShouldBe(6);
+        (await database.CountDeadLetterEventsAsync(new ShardName("CollateNames"), TestContext.Current.CancellationToken)).ShouldBe(4);
 
         // A shard with no dead letters returns 0
-        (await database.CountDeadLetterEventsAsync(new ShardName("DoesNotExist"))).ShouldBe(0);
+        (await database.CountDeadLetterEventsAsync(new ShardName("DoesNotExist"), TestContext.Current.CancellationToken)).ShouldBe(0);
     }
 }

--- a/src/DaemonTests/Resiliency/rebuilds_with_serialization_or_poison_pill_events.cs
+++ b/src/DaemonTests/Resiliency/rebuilds_with_serialization_or_poison_pill_events.cs
@@ -89,7 +89,7 @@ public class rebuilds_with_serialization_or_poison_pill_events: DaemonContext
 
         var deadLetters = await theSession.Query<DeadLetterEvent>()
             .Where(x => x.ShardName == "All" && x.ProjectionName == "Trip")
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         var badEventCount = Streams.SelectMany(x => x.Events).OfType<FailingEvent>().Count();
         deadLetters.Count.ShouldBe(badEventCount);
@@ -147,7 +147,7 @@ public class rebuilds_with_serialization_or_poison_pill_events: DaemonContext
         var deadLetters = await theSession
             .Query<DeadLetterEvent>()
             .Where(x => x.ProjectionName == "Trip")
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         var badEventCount = Streams.SelectMany(x => x.Events).OfType<FailingEvent>().Count();
         deadLetters.Count.ShouldBe(badEventCount);

--- a/src/DaemonTests/Resiliency/skipping_unknown_event_types_in_continuous_builds.cs
+++ b/src/DaemonTests/Resiliency/skipping_unknown_event_types_in_continuous_builds.cs
@@ -64,12 +64,12 @@ public class skipping_unknown_event_types_in_continuous_builds : IAsyncLifetime
         {
             session.Events.StartStream<MyAggregate>(streamId, new MTAEvent(), new MTAEvent(), new MTBEvent(), new MTBEvent(),
                 new MTCEvent(), new MTDEvent());
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
             // Rig up a bad, unknown event type
             session.QueueSqlCommand(
                 "update missing_events.mt_events set mt_dotnet_type = 'wrong, wrong' where version = 1");
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         _processor = await Host.CreateDefaultBuilder()
@@ -82,7 +82,7 @@ public class skipping_unknown_event_types_in_continuous_builds : IAsyncLifetime
                     opts.DatabaseSchemaName = "missing_events";
                     opts.Projections.Add(new WeirdCustomAggregation(), ProjectionLifecycle.Async);
                 }).AddAsyncDaemon(DaemonMode.Solo);
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         var daemon = _processor.Services.GetRequiredService<IProjectionCoordinator>().DaemonForMainDatabase();
         await daemon.WaitForShardToBeRunning("Weird:All", 10.Seconds());
@@ -90,7 +90,7 @@ public class skipping_unknown_event_types_in_continuous_builds : IAsyncLifetime
 
         await using (var session = _processor.DocumentStore().LightweightSession())
         {
-            var aggregate = await session.LoadAsync<MyAggregate>(streamId);
+            var aggregate = await session.LoadAsync<MyAggregate>(streamId, TestContext.Current.CancellationToken);
             aggregate.ShouldNotBeNull();
             aggregate.BCount.ShouldBe(2);
             aggregate.CCount.ShouldBe(1);

--- a/src/DaemonTests/Resiliency/when_skipping_events_in_daemon.cs
+++ b/src/DaemonTests/Resiliency/when_skipping_events_in_daemon.cs
@@ -102,7 +102,7 @@ public class when_skipping_events_in_daemon : DaemonContext
         var names = await theSession.Query<NamedDocument>()
             .OrderBy(x => x.Name)
             .Select(x => x.Name)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         var expected = theNames
             .OrderBy(x => x)
@@ -117,7 +117,7 @@ public class when_skipping_events_in_daemon : DaemonContext
     {
         await PublishTheEvents();
 
-        var jNames = await theSession.LoadAsync<NamesByLetter>("J");
+        var jNames = await theSession.LoadAsync<NamesByLetter>("J", TestContext.Current.CancellationToken);
 
         jNames.Names.OrderBy(x => x)
             .ShouldHaveTheSameElementsAs("Jack", "Jane", "Jeremy", "Jill");
@@ -136,7 +136,7 @@ public class when_skipping_events_in_daemon : DaemonContext
         // session to pipe Marten logging to the xUnit.Net output
         theSession.Logger = new TestOutputMartenLogger(_output);
         #endregion
-        var skipped = await theSession.Query<DeadLetterEvent>().ToListAsync();
+        var skipped = await theSession.Query<DeadLetterEvent>().ToListAsync(TestContext.Current.CancellationToken);
 
         skipped.Where(x => x.ProjectionName == "NamedDocuments" && x.ShardName == "All")
             .Select(x => x.EventSequence).OrderBy(x => x)
@@ -244,7 +244,7 @@ public class when_skipping_events_in_daemon_with_advanced_tracking : DaemonConte
         var names = await theSession.Query<NamedDocument>()
             .OrderBy(x => x.Name)
             .Select(x => x.Name)
-            .ToListAsync();
+            .ToListAsync(TestContext.Current.CancellationToken);
 
         var expected = theNames
             .OrderBy(x => x)
@@ -259,7 +259,7 @@ public class when_skipping_events_in_daemon_with_advanced_tracking : DaemonConte
     {
         await PublishTheEvents();
 
-        var jNames = await theSession.LoadAsync<NamesByLetter>("J");
+        var jNames = await theSession.LoadAsync<NamesByLetter>("J", TestContext.Current.CancellationToken);
 
         jNames.Names.OrderBy(x => x)
             .ShouldHaveTheSameElementsAs("Jack", "Jane", "Jeremy", "Jill");
@@ -274,7 +274,7 @@ public class when_skipping_events_in_daemon_with_advanced_tracking : DaemonConte
         await daemon.StopAllAsync();
 
         theSession.Logger = new TestOutputMartenLogger(_output);
-        var skipped = await theSession.Query<DeadLetterEvent>().ToListAsync();
+        var skipped = await theSession.Query<DeadLetterEvent>().ToListAsync(TestContext.Current.CancellationToken);
 
         skipped.Where(x => x.ProjectionName == "CollateNames" && x.ShardName == "All")
             .Select(x => x.EventSequence).OrderBy(x => x)

--- a/src/DaemonTests/Subscriptions/subscriptions_end_to_end.cs
+++ b/src/DaemonTests/Subscriptions/subscriptions_end_to_end.cs
@@ -67,13 +67,13 @@ public class subscriptions_end_to_end: OneOffConfigurationsContext
         theSession.Events.StartStream(Guid.NewGuid(), events3);
         theSession.Events.StartStream(Guid.NewGuid(), events4);
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await theStore.WaitForNonStaleProjectionDataAsync(20.Seconds());
 
         theSubscription.EventsEncountered.Count.ShouldBe(16);
 
-        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("Fake", "All", 1));
+        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("Fake", "All", 1), token: TestContext.Current.CancellationToken);
         progress.ShouldBe(16);
     }
 
@@ -112,7 +112,7 @@ public class subscriptions_end_to_end: OneOffConfigurationsContext
         theSession.Events.StartStream(Guid.NewGuid(), events3);
         theSession.Events.StartStream(Guid.NewGuid(), events4);
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await theStore.WaitForNonStaleProjectionDataAsync(20.Seconds());
 
@@ -126,7 +126,7 @@ public class subscriptions_end_to_end: OneOffConfigurationsContext
 
         using var daemon2 = await secondStore.BuildProjectionDaemonAsync();
         await daemon2.StartAllAsync();
-        await Task.Delay(2000); // yeah, I know
+        await Task.Delay(2000, TestContext.Current.CancellationToken); // yeah, I know
         await secondStore.WaitForNonStaleProjectionDataAsync(20.Seconds());
 
         secondSubscription.EventsEncountered.Count.ShouldBe(8);
@@ -164,7 +164,7 @@ public class subscriptions_end_to_end: OneOffConfigurationsContext
         theSession.Events.StartStream(Guid.NewGuid(), events3);
         theSession.Events.StartStream(Guid.NewGuid(), events4);
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await theStore.WaitForNonStaleProjectionDataAsync(20.Seconds());
 
@@ -176,7 +176,7 @@ public class subscriptions_end_to_end: OneOffConfigurationsContext
 
         theSubscription.EventsEncountered.Count.ShouldBe(16);
 
-        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("Fake", "All", 1));
+        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("Fake", "All", 1), token: TestContext.Current.CancellationToken);
         progress.ShouldBe(16);
     }
 
@@ -212,7 +212,7 @@ public class subscriptions_end_to_end: OneOffConfigurationsContext
         theSession.Events.StartStream(Guid.NewGuid(), events3);
         theSession.Events.StartStream(Guid.NewGuid(), events4);
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await theStore.WaitForNonStaleProjectionDataAsync(20.Seconds());
 
@@ -224,7 +224,7 @@ public class subscriptions_end_to_end: OneOffConfigurationsContext
 
         theSubscription.EventsEncountered.Count.ShouldBe(8);
 
-        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("Fake", "All", 1));
+        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("Fake", "All", 1), token: TestContext.Current.CancellationToken);
         progress.ShouldBe(16);
     }
 
@@ -260,7 +260,7 @@ public class subscriptions_end_to_end: OneOffConfigurationsContext
         theSession.Events.StartStream(Guid.NewGuid(), events3);
         theSession.Events.StartStream(Guid.NewGuid(), events4);
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await theStore.WaitForNonStaleProjectionDataAsync(20.Seconds());
 
@@ -302,7 +302,7 @@ public class subscriptions_end_to_end: OneOffConfigurationsContext
         theSession.Events.StartStream(Guid.NewGuid(), events3);
         theSession.Events.StartStream(Guid.NewGuid(), events4);
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await theStore.WaitForNonStaleProjectionDataAsync(20.Seconds());
 
@@ -311,7 +311,7 @@ public class subscriptions_end_to_end: OneOffConfigurationsContext
             .All(x => x.Data is EventSourcingTests.Aggregation.BEvent or EventSourcingTests.Aggregation.EEvent)
             .ShouldBeTrue();
 
-        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("Fake", "All", 1));
+        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("Fake", "All", 1), token: TestContext.Current.CancellationToken);
         progress.ShouldBe(16);
     }
 }
@@ -360,13 +360,13 @@ public class using_simple_subscription_registrations: OneOffConfigurationsContex
         theSession.Events.StartStream(Guid.NewGuid(), events3);
         theSession.Events.StartStream(Guid.NewGuid(), events4);
 
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await theStore.WaitForNonStaleProjectionDataAsync(20.Seconds());
 
         SimpleSubscription.EventsEncountered[1].Count.ShouldBe(16);
 
-        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("Simple", "All", 1));
+        var progress = await theStore.Advanced.ProjectionProgressFor(new ShardName("Simple", "All", 1), token: TestContext.Current.CancellationToken);
         progress.ShouldBe(16);
     }
 
@@ -386,7 +386,7 @@ public class using_simple_subscription_registrations: OneOffConfigurationsContex
                 }).AddAsyncDaemon(DaemonMode.Solo).AddSubscriptionWithServices<SimpleSubscription>(
                     ServiceLifetime.Singleton,
                     o => o.Name = "Simple2");
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
 
@@ -422,16 +422,16 @@ public class using_simple_subscription_registrations: OneOffConfigurationsContex
         session.Events.StartStream(Guid.NewGuid(), events3);
         session.Events.StartStream(Guid.NewGuid(), events4);
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await store.WaitForNonStaleProjectionDataAsync(60.Seconds());
 
         SimpleSubscription.EventsEncountered[1].Count.ShouldBeGreaterThanOrEqualTo(16);
 
-        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1));
+        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1), token: TestContext.Current.CancellationToken);
         progress.ShouldBeGreaterThanOrEqualTo(16);
 
-        await store.Advanced.Clean.DeleteAllEventDataAsync();
+        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -450,7 +450,7 @@ public class using_simple_subscription_registrations: OneOffConfigurationsContex
                 }).AddAsyncDaemon(DaemonMode.Solo).AddSubscriptionWithServices<SimpleSubscription>(
                     ServiceLifetime.Singleton,
                     o => o.Name = "Simple2");
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         var store = (DocumentStore)host.Services.GetRequiredService<ICustomStore>();
 
@@ -486,16 +486,16 @@ public class using_simple_subscription_registrations: OneOffConfigurationsContex
         session.Events.StartStream(Guid.NewGuid(), events3);
         session.Events.StartStream(Guid.NewGuid(), events4);
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await store.WaitForNonStaleProjectionDataAsync(60.Seconds());
 
         SimpleSubscription.EventsEncountered[1].Count.ShouldBeGreaterThanOrEqualTo(16);
 
-        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1));
+        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1), token: TestContext.Current.CancellationToken);
         progress.ShouldBeGreaterThanOrEqualTo(16);
 
-        await store.Advanced.Clean.DeleteAllEventDataAsync();
+        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
     }
 
     private async Task rewindState()
@@ -523,7 +523,7 @@ public class using_simple_subscription_registrations: OneOffConfigurationsContex
                 }).AddAsyncDaemon(DaemonMode.Solo).AddSubscriptionWithServices<SimpleSubscription>(
                     ServiceLifetime.Scoped,
                     o => o.Name = "Simple2");
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         var store = (DocumentStore)host.Services.GetRequiredService<IDocumentStore>();
 
@@ -559,16 +559,16 @@ public class using_simple_subscription_registrations: OneOffConfigurationsContex
         session.Events.StartStream(Guid.NewGuid(), events3);
         session.Events.StartStream(Guid.NewGuid(), events4);
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await store.WaitForNonStaleProjectionDataAsync(60.Seconds());
 
         SimpleSubscription.EventsEncountered.Sum(x => x.Count).ShouldBeGreaterThanOrEqualTo(16);
 
-        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1));
+        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1), token: TestContext.Current.CancellationToken);
         progress.ShouldBeGreaterThanOrEqualTo(16);
 
-        await store.Advanced.Clean.DeleteAllEventDataAsync();
+        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -585,7 +585,7 @@ public class using_simple_subscription_registrations: OneOffConfigurationsContex
                 }).AddAsyncDaemon(DaemonMode.Solo).AddSubscriptionWithServices<SimpleSubscription>(
                     ServiceLifetime.Scoped,
                     o => o.Name = "Simple2");
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         var capabilities = host.Services.GetServices<IEventStore>().ToArray();
         capabilities.Length.ShouldBe(1);
@@ -611,7 +611,7 @@ public class using_simple_subscription_registrations: OneOffConfigurationsContex
                 }).AddAsyncDaemon(DaemonMode.Solo).AddSubscriptionWithServices<SimpleSubscription>(
                     ServiceLifetime.Scoped,
                     o => o.Name = "Simple2");
-            }).StartAsync();
+            }).StartAsync(TestContext.Current.CancellationToken);
 
         var store = (DocumentStore)host.Services.GetRequiredService<ICustomStore>();
 
@@ -647,16 +647,16 @@ public class using_simple_subscription_registrations: OneOffConfigurationsContex
         session.Events.StartStream(Guid.NewGuid(), events3);
         session.Events.StartStream(Guid.NewGuid(), events4);
 
-        await session.SaveChangesAsync();
+        await session.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await store.WaitForNonStaleProjectionDataAsync(60.Seconds());
 
         SimpleSubscription.EventsEncountered.Sum(x => x.Count).ShouldBeGreaterThanOrEqualTo(16);
 
-        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1));
+        var progress = await store.Advanced.ProjectionProgressFor(new ShardName("Simple2", "All", 1), token: TestContext.Current.CancellationToken);
         progress.ShouldBeGreaterThanOrEqualTo(16);
 
-        await store.Advanced.Clean.DeleteAllEventDataAsync();
+        await store.Advanced.Clean.DeleteAllEventDataAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/src/DaemonTests/blue_green_side_effect_gate.cs
+++ b/src/DaemonTests/blue_green_side_effect_gate.cs
@@ -128,7 +128,7 @@ public class blue_green_side_effect_gate : IAsyncLifetime
 
         // V3's documents are nonetheless correct over the FULL history (the warm-up applied [1..N]).
         await using var query = green.QuerySession();
-        (await query.Query<GateTrip>().CountAsync()).ShouldBe(N + M);
+        (await query.Query<GateTrip>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(N + M);
     }
 
     [Fact]

--- a/src/DaemonTests/catching_up_mode_for_projections_and_subscriptions.cs
+++ b/src/DaemonTests/catching_up_mode_for_projections_and_subscriptions.cs
@@ -69,12 +69,12 @@ public class catching_up_mode_for_projections_and_subscriptions : OneOffConfigur
     public async Task have_the_expected_documents_from_EventProjection()
     {
         // EventProjection ran
-        (await theSession.Query<ADoc>().CountAsync()).ShouldBe(6);
+        (await theSession.Query<ADoc>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(6);
 
-        var sequences = (await theSession.Events.QueryAllRawEvents().ToListAsync())
+        var sequences = (await theSession.Events.QueryAllRawEvents().ToListAsync(TestContext.Current.CancellationToken))
             .OfType<IEvent<AEvent>>().Select(x => x.Sequence).ToArray();
 
-        var actuals = await theSession.Query<ADoc>().Select(x => x.Id).ToListAsync();
+        var actuals = await theSession.Query<ADoc>().Select(x => x.Id).ToListAsync(TestContext.Current.CancellationToken);
 
         actuals.ShouldBe(sequences);
     }
@@ -83,8 +83,8 @@ public class catching_up_mode_for_projections_and_subscriptions : OneOffConfigur
     public async Task aggregation_projection_can_catch_up()
     {
         // Aggregation too
-        (await theSession.Query<EventSourcingTests.Aggregation.LetterCounts>().CountAsync()).ShouldBe(5);
-        var counts = await theSession.LoadAsync<EventSourcingTests.Aggregation.LetterCounts>(streamId);
+        (await theSession.Query<EventSourcingTests.Aggregation.LetterCounts>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(5);
+        var counts = await theSession.LoadAsync<EventSourcingTests.Aggregation.LetterCounts>(streamId, TestContext.Current.CancellationToken);
         counts.ACount.ShouldBe(2);
         counts.BCount.ShouldBe(5);
         counts.CCount.ShouldBe(2);

--- a/src/DaemonTests/extended_progression_batch_write.cs
+++ b/src/DaemonTests/extended_progression_batch_write.cs
@@ -123,7 +123,7 @@ public class extended_progression_batch_write: DaemonContext
         await database.WriteExtendedProgressionAsync([
             telemetry("BatchTelemetryStream:All", "Running", node: 3),
             telemetry("OtherBatchTelemetry:All", "Paused", "boom", node: 7)
-        ]);
+        ], TestContext.Current.CancellationToken);
 
         var first = await readRowAsync("BatchTelemetryStream:All");
         first.status.ShouldBe("Running");
@@ -150,7 +150,7 @@ public class extended_progression_batch_write: DaemonContext
             // A shard that has never committed progression: no row to decorate, must be skipped
             // silently, exactly like the single-state function
             telemetry("NoSuchProjection:All:98123456", "Running")
-        ]);
+        ], TestContext.Current.CancellationToken);
 
         var updated = await readRowAsync("BatchTelemetryStream:All");
         updated.status.ShouldBe("Running");
@@ -168,11 +168,11 @@ public class extended_progression_batch_write: DaemonContext
 
         var database = (MartenDatabase)theStore.Storage.Database;
 
-        await database.WriteExtendedProgressionAsync(Array.Empty<ShardState>());
+        await database.WriteExtendedProgressionAsync(Array.Empty<ShardState>(), TestContext.Current.CancellationToken);
 
         await database.WriteExtendedProgressionAsync([
             telemetry("BatchTelemetryStream:All", "Stopped")
-        ]);
+        ], TestContext.Current.CancellationToken);
 
         var row = await readRowAsync("BatchTelemetryStream:All");
         row.status.ShouldBe("Stopped");

--- a/src/DaemonTests/rebuild_with_bulk_copy_inserts.cs
+++ b/src/DaemonTests/rebuild_with_bulk_copy_inserts.cs
@@ -86,7 +86,7 @@ public class rebuild_with_bulk_copy_inserts: OneOffConfigurationsContext
 
         // ...and yet every row landed, written by the COPY flush inside the batch transaction.
         await using var query = theStore.QuerySession();
-        var loaded = await query.Query<BulkCopyDoc>().ToListAsync();
+        var loaded = await query.Query<BulkCopyDoc>().ToListAsync(TestContext.Current.CancellationToken);
         loaded.Count.ShouldBe(docs.Length);
         loaded.Select(x => x.Id).OrderBy(x => x).ShouldBe(docs.Select(x => x.Id).OrderBy(x => x));
     }
@@ -126,7 +126,7 @@ public class rebuild_with_bulk_copy_inserts: OneOffConfigurationsContext
         await batch.DisposeAsync();
 
         await using var query = theStore.QuerySession();
-        var loaded = await query.Query<BulkCopyDoc>().ToListAsync();
+        var loaded = await query.Query<BulkCopyDoc>().ToListAsync(TestContext.Current.CancellationToken);
         loaded.Count.ShouldBe(2);
     }
 
@@ -155,7 +155,7 @@ public class rebuild_with_bulk_copy_inserts: OneOffConfigurationsContext
         await batch.DisposeAsync();
 
         await using var query = theStore.QuerySession();
-        (await query.Query<BulkCopyDoc>().CountAsync()).ShouldBe(2);
+        (await query.Query<BulkCopyDoc>().CountAsync(TestContext.Current.CancellationToken)).ShouldBe(2);
     }
 
     [Fact]
@@ -237,13 +237,13 @@ public class rebuild_with_bulk_copy_inserts: OneOffConfigurationsContext
 
         await using (var blueQuery = theStore.QuerySession("blue"))
         {
-            var docs = await blueQuery.Query<BulkCopyDoc>().ToListAsync();
+            var docs = await blueQuery.Query<BulkCopyDoc>().ToListAsync(TestContext.Current.CancellationToken);
             docs.Single().Id.ShouldBe(blueDoc.Id);
         }
 
         await using (var greenQuery = theStore.QuerySession("green"))
         {
-            var docs = await greenQuery.Query<BulkCopyDoc>().ToListAsync();
+            var docs = await greenQuery.Query<BulkCopyDoc>().ToListAsync(TestContext.Current.CancellationToken);
             docs.Single().Id.ShouldBe(greenDoc.Id);
         }
     }
@@ -329,11 +329,11 @@ public class rebuild_with_bulk_copy_inserts: OneOffConfigurationsContext
         // And the tenant_id column itself is correct row by row
         var table = theStore.Options.Storage.MappingFor(typeof(BulkCopyDoc)).TableName.QualifiedName;
         await using var conn = new NpgsqlConnection(ConnectionSource.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
         var mismatches = (long)(await conn
             .CreateCommand(
                 $"select count(*) from {table} where (data ->> 'Name' like 'blue%' and tenant_id != 'blue') or (data ->> 'Name' like 'green%' and tenant_id != 'green')")
-            .ExecuteScalarAsync())!;
+            .ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
         mismatches.ShouldBe(0);
     }
 
@@ -358,7 +358,7 @@ public class rebuild_with_bulk_copy_inserts: OneOffConfigurationsContext
             var removed = new ItemAdded(Guid.NewGuid(), "removed", 3);
             session.Events.Append(streamId, removed, new ItemRemoved(removed.Id));
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(TestContext.Current.CancellationToken);
         }
 
         using (var daemon = await theStore.BuildProjectionDaemonAsync())
@@ -367,7 +367,7 @@ public class rebuild_with_bulk_copy_inserts: OneOffConfigurationsContext
         }
 
         await using var query = theStore.QuerySession();
-        var docs = await query.Query<BulkCopyDoc>().ToListAsync();
+        var docs = await query.Query<BulkCopyDoc>().ToListAsync(TestContext.Current.CancellationToken);
         docs.Count.ShouldBe(2);
         docs.Select(x => x.Name).OrderBy(x => x).ShouldBe(new[] { "keep-1", "keep-2" });
     }

--- a/src/DaemonTests/rebuilding_an_inline_projection.cs
+++ b/src/DaemonTests/rebuilding_an_inline_projection.cs
@@ -25,7 +25,7 @@ public class rebuilding_an_inline_projection : DaemonContext
         var agent = await StartDaemon();
         await agent.RebuildProjectionAsync("Distance", CancellationToken.None);
 
-        var progress = await theStore.Advanced.AllProjectionProgress();
+        var progress = await theStore.Advanced.AllProjectionProgress(token: TestContext.Current.CancellationToken);
         progress.Any(x => x.ShardName.StartsWith("Distance")).ShouldBeFalse();
 
 

--- a/src/DaemonTests/wait_for_non_stale_data_error_cases.cs
+++ b/src/DaemonTests/wait_for_non_stale_data_error_cases.cs
@@ -30,7 +30,7 @@ public class wait_for_non_stale_data_error_cases : OneOffConfigurationsContext
         theSession.Events.StartStream<LetterCounts>(new AEvent(), new ThrowError(false), new CEvent(), new DEvent());
         theSession.Events.StartStream<LetterCounts>(new AEvent(), new BEvent(), new CEvent(), new DEvent());
         theSession.Events.StartStream<LetterCounts>(new AEvent(), new BEvent(), new ThrowError(true), new DEvent());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
 
@@ -59,7 +59,7 @@ public class wait_for_non_stale_data_error_cases : OneOffConfigurationsContext
 
         var failOnSaveId = Guid.NewGuid();
         theSession.Events.StartStream<FailsOnSave>(new FailsOnSaveEventA());
-        await theSession.SaveChangesAsync();
+        await theSession.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         using var daemon = await theStore.BuildProjectionDaemonAsync();
 
@@ -74,7 +74,7 @@ public class wait_for_non_stale_data_error_cases : OneOffConfigurationsContext
         aggregated.InnerExceptions[1].ShouldBeOfType<MartenCommandException>();
 
 
-        var failOnSave = await theSession.LoadAsync<FailsOnSave>(failOnSaveId);
+        var failOnSave = await theSession.LoadAsync<FailsOnSave>(failOnSaveId, TestContext.Current.CancellationToken);
         failOnSave.ShouldBeNull();
     }
 }

--- a/src/Tests.props
+++ b/src/Tests.props
@@ -10,12 +10,14 @@
         <OutputType>Exe</OutputType>
 
         <!-- xUnit1051: "pass TestContext.Current.CancellationToken to methods accepting a
-             CancellationToken". New in the v3 analyzers. There are ~5,650 candidate call
-             sites across the DB-heavy suites (2,955 of them plain SaveChangesAsync()), so
-             this is suppressed for the migration rather than swept. Threading real
-             cancellation tokens through the daemon/DB tests is a worthwhile follow-up, but
-             it is a behavioural change and must not ride along with a framework swap. -->
-        <NoWarn>$(NoWarn);xUnit1051</NoWarn>
+             CancellationToken". New in the v3 analyzers, and still suppressed by default
+             because there are ~5,650 candidate call sites across the DB-heavy suites (2,955
+             of them plain SaveChangesAsync()). The rule is being adopted per-project rather
+             than in one repo-wide sweep — a project that has been swept sets
+             <ThreadTestCancellationToken>true</ThreadTestCancellationToken> BEFORE importing
+             this file, which turns the warning back on so new unthreaded calls can't creep
+             back in. See #5067. -->
+        <NoWarn Condition="'$(ThreadTestCancellationToken)' != 'true'">$(NoWarn);xUnit1051</NoWarn>
 
         <!-- xunit.v3 supplies the entry point. Microsoft.NET.Test.Sdk will also emit a
              Microsoft Testing Platform entry point for anything flagged IsTestProject,


### PR DESCRIPTION
Closes the first and highest-value increment of #5067.

xUnit1051 ("pass `TestContext.Current.CancellationToken` to methods that accept one") was suppressed repo-wide in `src/Tests.props` during the xunit v3 migration (#5064) because the blast radius is large and the change is behavioural, not mechanical. This adopts it the way #5067 proposes: **per project, starting with DaemonTests**, where the payoff is largest — a hung daemon test now gets cancelled and reported instead of sitting until the CI job's own timeout.

## The mechanism

The suppression becomes an opt-*out*. A project that has been swept sets

```xml
<ThreadTestCancellationToken>true</ThreadTestCancellationToken>
```

before importing `Tests.props`, which turns the warning back on for that project so unthreaded calls cannot creep back in. Everything else keeps the existing suppression, so this PR changes no other suite.

## The sweep

All **440** sites the analyzer flags in DaemonTests are threaded. The edits were driven from the compiler's own diagnostic positions rather than from pattern matching, so nothing was guessed at and nothing eligible was missed — the build is at **0 xUnit1051 with the rule enforced**.

25 of the 440 need the named `token:` form, because these all take an optional argument *after* the token: `AllProjectionProgress`, `ProjectionProgressFor`, `FetchEventStoreStatistics`, `FetchStreamAsync`, `AggregateStreamAsync`. Marten's own code already uses `token:` for the same reason.

No teardown path was touched — every edit is inside a `[Fact]` body, so a cancelled token can't break cleanup.

## Verification

- Compiles clean on **net9.0 and net10.0** with the rule enforced; the only warnings are the pre-existing nullable ones.
- `DaemonTests` net9.0: **256 passed, 1 failed**. The single failure is `blue_green_side_effect_gate`, the pre-existing flake filed as #5065 — it asserts on line 101, which this PR does not touch, and it fails the same way on master.

## What is left on #5067

Solution-wide there are **7,930** flagged sites, not the ~5,650 estimated in the issue (that count covered six suites). Sweeping the rest turns up something the issue did not anticipate: **400 of those sites are inside `#region sample_*` blocks** that are pulled into the VitePress docs. Threading a test-only cancellation token there would publish it as guidance to users, so those sites have to be excluded rather than swept, and a project containing them can only enforce the rule with pragma bracketing placed outside the region markers.

That splits the remainder cleanly, and #5067 has been updated with the full table:

- **12 snippet-free projects (983 sites)** can be enforced outright, the same way this PR does DaemonTests.
- **9 projects with snippet content** — EventSourcingTests (2,537), DocumentDbTests (1,796), LinqTests (1,260), ValueTypeTests (520), CoreTests (461), PatchingTests (218) and three small ones — need the snippet decision made first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)